### PR TITLE
Adding support for remotely-sourced zoo models

### DIFF
--- a/docs/scripts/make_model_zoo_docs.py
+++ b/docs/scripts/make_model_zoo_docs.py
@@ -23,17 +23,15 @@ logger = logging.getLogger(__name__)
 _HEADER = """
 .. _model-zoo-models:
 
-Available Zoo Models
-====================
+Built-In Zoo Models
+===================
 
 .. default-role:: code
 
-This page lists all of the models available in the Model Zoo.
+This page lists all of the natively available models in the FiftyOne Model Zoo.
 
-.. note::
-
-    Check out the :ref:`API reference <model-zoo-api>` for complete
-    instructions for using the Model Zoo.
+Check out the :ref:`API reference <model-zoo-api>` for complete instructions
+for using the Model Zoo.
 """
 
 

--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -2557,7 +2557,7 @@ Tools for working with the FiftyOne Model Zoo.
 .. code-block:: text
 
     fiftyone zoo models [-h] [--all-help]
-                        {list,find,info,requirements,download,apply,embed,delete}
+                        {list,find,info,requirements,download,apply,embed,delete,list-sources,register-source,delete-source}
                         ...
 
 **Arguments**
@@ -2569,8 +2569,8 @@ Tools for working with the FiftyOne Model Zoo.
       --all-help            show help recursively and exit
 
     available commands:
-      {list,find,info,requirements,download,apply,embed,delete}
-        list                List datasets in the FiftyOne Model Zoo.
+      {list,find,info,requirements,download,apply,embed,delete,register-source,delete-source}
+        list                List models in the FiftyOne Model Zoo.
         find                Locate the downloaded zoo model on disk.
         info                Print information about models in the FiftyOne Model Zoo.
         requirements        Handles package requirements for zoo models.
@@ -2578,17 +2578,20 @@ Tools for working with the FiftyOne Model Zoo.
         apply               Apply zoo models to datasets.
         embed               Generate embeddings for datasets with zoo models.
         delete              Deletes the local copy of the zoo model on disk.
+        list-sources        Lists remote zoo model sources that are registered locally.
+        register-source     Registers a remote source of zoo models.
+        delete-source       Deletes the remote source and all downloaded models associated with it.
 
 .. _cli-fiftyone-zoo-models-list:
 
 List models in zoo
 ~~~~~~~~~~~~~~~~~~
 
-List datasets in the FiftyOne Model Zoo.
+List models in the FiftyOne Model Zoo.
 
 .. code-block:: text
 
-    fiftyone zoo models list [-h] [-n] [-d] [-t TAG]
+    fiftyone zoo models list [-h] [-n] [-d] [-t TAGS] [-s SOURCE]
 
 **Arguments**
 
@@ -2600,6 +2603,8 @@ List datasets in the FiftyOne Model Zoo.
       -d, --downloaded-only
                             only show models that have been downloaded
       -t TAGS, --tags TAGS  only show models with the specified tag or list,of,tags
+      -s SOURCE, --source SOURCE
+                            only show models available from the specified remote source
 
 **Examples**
 
@@ -2622,6 +2627,11 @@ List datasets in the FiftyOne Model Zoo.
 
     # List available models with the given tag
     fiftyone zoo models list --tags <tag>
+
+.. code-block:: shell
+
+    # List available models from the given remote source
+    fiftyone zoo models list --source <source>
 
 .. _cli-fiftyone-zoo-models-find:
 
@@ -2731,28 +2741,51 @@ Download zoo models
 
 Download zoo models.
 
+When downloading remotely-sourced zoo models, you can provide any of the
+following:
+
+-   a GitHub repo URL like ``https://github.com/<user>/<repo>``
+-   a GitHub ref like ``https://github.com/<user>/<repo>/tree/<branch>`` or
+    ``https://github.com/<user>/<repo>/commit/<commit>``
+-   a GitHub ref string like ``<user>/<repo>[/<ref>]``
+
+.. note::
+
+    To download from a private GitHub repository that you have access to,
+    provide your GitHub personal access token by setting the ``GITHUB_TOKEN``
+    environment variable.
+
 .. code-block:: text
 
-    fiftyone zoo models download [-h] [-f] NAME
+    fiftyone zoo models download [-h] [-n MODEL_NAME] [-o] NAME_OR_URL
 
 **Arguments**
 
 .. code-block:: text
 
     positional arguments:
-      NAME                  the name of the zoo model
+      NAME_OR_URL           the name or remote location of the model
 
     optional arguments:
       -h, --help            show this help message and exit
-      -f, --force           whether to force download the model if it is already
-                            downloaded
+      -n MODEL_NAME, --model-name MODEL_NAME
+                            the specific model to download, if `name_or_url` is
+                            a remote source
+      -o, --overwrite       whether to overwrite any existing model files
 
 **Examples**
 
 .. code-block:: shell
 
-    # Download the zoo model
+    # Download a zoo model
     fiftyone zoo models download <name>
+
+.. code-block:: shell
+
+    # Download a remotely-sourced zoo model
+    fiftyone zoo models download https://github.com/<user>/<repo> \
+        --model-name <name>
+    fiftyone zoo models download <url> --model-name <name>
 
 .. _cli-fiftyone-zoo-models-apply:
 
@@ -2761,23 +2794,41 @@ Apply zoo models to datasets
 
 Apply zoo models to datasets.
 
+When applying remotely-sourced zoo models, you can provide any of the following
+formats:
+
+-   a GitHub repo URL like ``https://github.com/<user>/<repo>``
+-   a GitHub ref like ``https://github.com/<user>/<repo>/tree/<branch>`` or
+    ``https://github.com/<user>/<repo>/commit/<commit>``
+-   a GitHub ref string like ``<user>/<repo>[/<ref>]``
+-   a publicly accessible URL of an archive (eg zip or tar) file
+
+.. note::
+
+    To download from a private GitHub repository that you have access to,
+    provide your GitHub personal access token by setting the ``GITHUB_TOKEN``
+    environment variable.
+
 .. code-block:: text
 
-    fiftyone zoo models apply [-h] [-b BATCH_SIZE] [-t THRESH] [-l] [-i]
-                              [--error-level LEVEL]
-                              MODEL_NAME DATASET_NAME LABEL_FIELD
+    fiftyone zoo models apply [-h] [-n MODEL_NAME] [-b BATCH_SIZE] [-t THRESH]
+                              [-l] [-i] [--error-level LEVEL]
+                              NAME_OR_URL DATASET_NAME LABEL_FIELD
 
 **Arguments**
 
 .. code-block:: text
 
     positional arguments:
-      MODEL_NAME            the name of the zoo model
+      NAME_OR_URL           the name or remote location of the zoo model
       DATASET_NAME          the name of the FiftyOne dataset to process
       LABEL_FIELD           the name of the field in which to store the predictions
 
     optional arguments:
       -h, --help            show this help message and exit
+      -n MODEL_NAME, --model-name MODEL_NAME
+                            the specific model to apply, if `name_or_url` is a
+                            remote source
       -b BATCH_SIZE, --batch-size BATCH_SIZE
                             an optional batch size to use during inference
       -t THRESH, --confidence-thresh THRESH
@@ -2792,8 +2843,16 @@ Apply zoo models to datasets.
 
 .. code-block:: shell
 
-    # Apply the zoo model to the dataset
+    # Apply a zoo model to a dataset
     fiftyone zoo models apply <model-name> <dataset-name> <label-field>
+
+.. code-block:: shell
+
+    # Apply a remotely-sourced zoo model to a dataset
+    fiftyone zoo models apply https://github.com/<user>/<repo> \
+        <dataset-name> <label-field> --model-name <model-name>
+    fiftyone zoo models apply <url> \
+        <dataset-name> <label-field> --model-name <model-name>
 
 .. code-block:: shell
 
@@ -2811,23 +2870,41 @@ Generate embeddings with zoo models
 
 Generate embeddings for datasets with zoo models.
 
+When applying remotely-sourced zoo models, you can provide any of the following
+formats:
+
+-   a GitHub repo URL like ``https://github.com/<user>/<repo>``
+-   a GitHub ref like ``https://github.com/<user>/<repo>/tree/<branch>`` or
+    ``https://github.com/<user>/<repo>/commit/<commit>``
+-   a GitHub ref string like ``<user>/<repo>[/<ref>]``
+-   a publicly accessible URL of an archive (eg zip or tar) file
+
+.. note::
+
+    To download from a private GitHub repository that you have access to,
+    provide your GitHub personal access token by setting the ``GITHUB_TOKEN``
+    environment variable.
+
 .. code-block:: text
 
-    fiftyone zoo models embed [-h] [-b BATCH_SIZE] [-i]
+    fiftyone zoo models embed [-h] [-n MODEL_NAME] [-b BATCH_SIZE] [-i]
                               [--error-level LEVEL]
-                              MODEL_NAME DATASET_NAME EMBEDDINGS_FIELD
+                              NAME_OR_URL DATASET_NAME EMBEDDINGS_FIELD
 
 **Arguments**
 
 .. code-block:: text
 
     positional arguments:
-      MODEL_NAME            the name of the zoo model
+      NAME_OR_URL           the name or remote location of the zoo model
       DATASET_NAME          the name of the FiftyOne dataset to process
       EMBEDDINGS_FIELD      the name of the field in which to store the embeddings
 
     optional arguments:
       -h, --help            show this help message and exit
+      -n MODEL_NAME, --model-name MODEL_NAME
+                            the specific model to apply, if `name_or_url` is a
+                            remote source
       -b BATCH_SIZE, --batch-size BATCH_SIZE
                             an optional batch size to use during inference
       -i, --install         install any requirements for the zoo model
@@ -2838,8 +2915,16 @@ Generate embeddings for datasets with zoo models.
 
 .. code-block:: shell
 
-    # Generate embeddings for the dataset with the zoo model
+    # Generate embeddings for a dataset with a zoo model
     fiftyone zoo models embed <model-name> <dataset-name> <embeddings-field>
+
+.. code-block:: shell
+
+    # Generate embeddings for a dataset with a remotely-sourced zoo model
+    fiftyone zoo models embed https://github.com/<user>/<repo> \
+        <dataset-name> <embeddings-field> --model-name <model-name>
+    fiftyone zoo models embed <url> \
+        <dataset-name> <embeddings-field> --model-name <model-name>
 
 .. _cli-fiftyone-zoo-models-delete:
 
@@ -2868,3 +2953,102 @@ Deletes the local copy of the zoo model on disk.
 
     # Delete the zoo model from disk
     fiftyone zoo models delete <name>
+
+.. _cli-fiftyone-zoo-models-list-sources:
+
+List zoo model sources
+~~~~~~~~~~~~~~~~~~~~~~
+
+Lists remote zoo model sources that are registered locally.
+
+.. code-block:: text
+
+    fiftyone zoo models list-sources [-h]
+
+**Examples**
+
+.. code-block:: shell
+
+    # Lists the registered remote zoo model sources
+    fiftyone zoo models list-sources
+
+.. _cli-fiftyone-zoo-models-register-source:
+
+Register zoo model sources
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Registers a remote source of zoo models.
+
+You can provide any of the following formats:
+
+-   a GitHub repo URL like ``https://github.com/<user>/<repo>``
+-   a GitHub ref like ``https://github.com/<user>/<repo>/tree/<branch>`` or
+    ``https://github.com/<user>/<repo>/commit/<commit>``
+-   a GitHub ref string like ``<user>/<repo>[/<ref>]``
+-   a publicly accessible URL of an archive (eg zip or tar) file
+
+.. note::
+
+    To download from a private GitHub repository that you have access to,
+    provide your GitHub personal access token by setting the ``GITHUB_TOKEN``
+    environment variable.
+
+.. code-block:: text
+
+    fiftyone zoo models register-source [-h] [-o] URL_OR_GH_REPO
+
+**Arguments**
+
+.. code-block:: text
+
+    positional arguments:
+      URL_OR_GH_REPO   the remote source to register
+
+    optional arguments:
+      -h, --help       show this help message and exit
+      -o, --overwrite  whether to overwrite any existing files
+
+**Examples**
+
+.. code-block:: shell
+
+    # Register a remote zoo model source
+    fiftyone zoo models register-source https://github.com/<user>/<repo>
+    fiftyone zoo models register-source <url>
+
+.. _cli-fiftyone-zoo-models-delete-source:
+
+Delete zoo model sources
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Deletes the remote source and all downloaded models associated with it.
+
+You can provide any of the following formats:
+
+-   a GitHub repo URL like ``https://github.com/<user>/<repo>``
+-   a GitHub ref like ``https://github.com/<user>/<repo>/tree/<branch>`` or
+    ``https://github.com/<user>/<repo>/commit/<commit>``
+-   a GitHub ref string like ``<user>/<repo>[/<ref>]``
+-   a publicly accessible URL of an archive (eg zip or tar) file
+
+.. code-block:: text
+
+    fiftyone zoo models delete-source [-h] URL_OR_GH_REPO
+
+**Arguments**
+
+.. code-block:: text
+
+    positional arguments:
+      URL_OR_GH_REPO   the remote source to delete
+
+    optional arguments:
+      -h, --help       show this help message and exit
+
+**Examples**
+
+.. code-block:: shell
+
+    # Delete a remote zoo model source
+    fiftyone zoo models delete-source https://github.com/<user>/<repo>
+    fiftyone zoo models delete-source <url>

--- a/docs/source/user_guide/model_zoo/api.rst
+++ b/docs/source/user_guide/model_zoo/api.rst
@@ -5,13 +5,6 @@ Model Zoo API Reference
 
 .. default-role:: code
 
-This page describes the full API for working with the Model Zoo.
-
-.. _model-zoo-package:
-
-Model zoo package
------------------
-
 You can interact with the Model Zoo either via the Python library or the CLI.
 
 .. tabs::

--- a/docs/source/user_guide/model_zoo/design.rst
+++ b/docs/source/user_guide/model_zoo/design.rst
@@ -1,0 +1,360 @@
+.. _model-zoo-design-overview:
+
+Model Interface
+===============
+
+.. default-role:: code
+
+All models in the Model Zoo are exposed via the |Model| class, which defines a
+common interface for loading models and generating predictions with defined
+input and output data formats.
+
+.. note::
+
+    If you write a wrapper for your custom model that implements the |Model|
+    interface, then you can pass your models to built-in methods like
+    :meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`
+    and
+    :meth:`compute_embeddings() <fiftyone.core.collections.SampleCollection.compute_embeddings>`
+    too!
+
+    FiftyOne provides classes that make it easy to deploy models in custom
+    frameworks easy. For example, if you have a PyTorch model that processes
+    images, you can likely use
+    :class:`TorchImageModel <fiftyone.utils.torch.TorchImageModel>` to run it
+    using FiftyOne.
+
+.. _model-zoo-design-prediction:
+
+Prediction
+----------
+
+Inside built-in methods like
+:meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`,
+predictions of a |Model| instance are generated using the following pattern:
+
+.. tabs::
+
+  .. group-tab:: Image models
+
+    .. code-block:: python
+        :linenos:
+
+        import numpy as np
+        from PIL import Image
+
+        import fiftyone as fo
+
+        def read_rgb_image(path):
+            """Utility function that loads an image as an RGB numpy array."""
+            return np.asarray(Image.open(path).convert("rgb"))
+
+        # Load a `Model` instance that processes images
+        model = ...
+
+        # Load a FiftyOne dataset
+        dataset = fo.load_dataset(...)
+
+        # A sample field in which to store the predictions
+        label_field = "predictions"
+
+        # Perform prediction on all images in the dataset
+        with model:
+            for sample in dataset:
+                # Load image
+                img = read_rgb_image(sample.filepath)
+
+                # Perform prediction
+                labels = model.predict(img)
+
+                # Save labels
+                sample.add_labels(labels, label_field=label_field)
+                sample.save()
+
+  .. group-tab:: Video models
+
+    .. code-block:: python
+        :linenos:
+
+        import eta.core.video as etav
+
+        import fiftyone as fo
+
+        # Load a `Model` instance that processes videos
+        model = ...
+
+        # Load a FiftyOne dataset
+        dataset = fo.load_dataset(...)
+
+        # A sample field in which to store the predictions
+        label_field = "predictions"
+
+        # Perform prediction on all videos in the dataset
+        with model:
+            for sample in dataset:
+                # Perform prediction
+                with etav.FFmpegVideoReader(sample.filepath) as video_reader:
+                    labels = model.predict(video_reader)
+
+                # Save labels
+                sample.add_labels(labels, label_field=label_field)
+                sample.save()
+
+By convention, |Model| instances must implement the context manager interface,
+which handles any necessary setup and teardown required to use the model.
+
+Predictions are generated via the
+:meth:`Model.predict() <fiftyone.core.models.Model>` interface method, which
+takes an image/video as input and returns the predictions.
+
+In order to be compatible with built-in methods like
+:meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`,
+models should support the following basic signature of running inference and
+storing the output labels:
+
+.. code-block:: python
+    :linenos:
+
+    labels = model.predict(arg)
+    sample.add_labels(labels, label_field=label_field)
+
+where the model should, at minimum, support ``arg`` values that are:
+
+-   *Image models:* uint8 numpy arrays (HWC)
+
+-   *Video models:* ``eta.core.video.VideoReader`` instances
+
+and the output ``labels`` can be any of the following:
+
+-   A |Label| instance, in which case the labels are directly saved in the
+    specified ``label_field`` of the sample
+
+.. code-block:: python
+    :linenos:
+
+    # Single sample-level label
+    sample[label_field] = labels
+
+-   A dict mapping keys to |Label| instances. In this case, the labels are
+    added as follows:
+
+.. code-block:: python
+    :linenos:
+
+    # Multiple sample-level labels
+    for key, value in labels.items():
+        sample[label_key(key)] = value
+
+-   A dict mapping frame numbers to |Label| instances. In this case, the
+    provided labels are interpreted as frame-level labels that should be added
+    as follows:
+
+.. code-block:: python
+    :linenos:
+
+    # Single set of per-frame labels
+    sample.frames.merge(
+        {
+            frame_number: {label_field: label}
+            for frame_number, label in labels.items()
+        }
+    )
+
+-   A dict mapping frame numbers to dicts mapping keys to |Label| instances. In
+    this case, the provided labels are interpreted as frame-level labels that
+    should be added as follows:
+
+.. code-block:: python
+    :linenos:
+
+    # Multiple per-frame labels
+    sample.frames.merge(
+        {
+            frame_number: {label_key(k): v for k, v in frame_dict.items()}
+            for frame_number, frame_dict in labels.items()
+        }
+    )
+
+In the above snippets, the ``label_key`` function maps label dict keys to field
+names, and is defined from ``label_field`` as follows:
+
+.. code-block:: python
+    :linenos:
+
+    if isinstance(label_field, dict):
+        label_key = lambda k: label_field.get(k, k)
+    elif label_field is not None:
+        label_key = lambda k: label_field + "_" + k
+    else:
+        label_key = lambda k: k
+
+For models that support batching, the |Model| interface also provides a
+:meth:`predict_all() <fiftyone.core.models.Model.predict_all>` method that can
+provide an efficient implementation of predicting on a batch of data.
+
+.. note::
+
+    Built-in methods like
+    :meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`
+    provide a ``batch_size`` parameter that can be used to control the batch
+    size used when performing inference with models that support efficient
+    batching.
+
+.. note::
+
+    PyTorch models can implement the |TorchModelMixin| mixin, in which case
+    `DataLoaders <https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader>`_
+    are used to efficiently feed data to the models during inference.
+
+.. _model-zoo-design-embeddings:
+
+Embeddings
+----------
+
+Models that can compute embeddings for their input data can expose this
+capability by implementing the |EmbeddingsMixin| mixin.
+
+Inside built-in methods like
+:meth:`compute_embeddings() <fiftyone.core.collections.SampleCollection.compute_embeddings>`,
+embeddings for a collection of samples are generated using an analogous pattern
+to the prediction code shown above, except that the embeddings are generated
+using :meth:`Model.embed() <fiftyone.core.models.EmbeddingsMixin.embed>` in
+place of :meth:`Model.predict() <fiftyone.core.models.Model.predict>`.
+
+By convention,
+:meth:`Model.embed() <fiftyone.core.models.EmbeddingsMixin.embed>` should
+return a numpy array containing the embedding.
+
+.. note::
+
+    Embeddings are typically 1D vectors, but this is not strictly required.
+
+For models that support batching, the |EmbeddingsMixin| interface also provides
+a :meth:`embed_all() <fiftyone.core.models.Model.predict_all>` method that can
+provide an efficient implementation of embedding a batch of data.
+
+.. _model-zoo-design-logits:
+
+Logits
+------
+
+Models that generate logits for their predictions can expose them to FiftyOne
+by implementing the |LogitsMixin| mixin.
+
+Inside built-in methods like
+:meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`,
+if the user requests logits, the model's
+:meth:`store_logits <fiftyone.core.models.LogitsMixin.store_logits>`
+property is set to indicate that the model should store logits in the |Label|
+instances that it produces during inference.
+
+.. _model-zoo-custom-models:
+
+Custom models
+-------------
+
+FiftyOne provides a
+:class:`TorchImageModel <fiftyone.utils.torch.TorchImageModel>`
+class that you can use to load your own custom Torch model and pass it to
+built-in methods like
+:meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`
+and
+:meth:`compute_embeddings() <fiftyone.core.collections.SampleCollection.compute_embeddings>`.
+
+For example, the snippet below loads a pretrained model from `torchvision`
+and uses it both as a classifier and to generate image embeddings:
+
+.. code-block:: python
+    :linenos:
+
+    import os
+    import eta
+
+    import fiftyone as fo
+    import fiftyone.zoo as foz
+    import fiftyone.utils.torch as fout
+
+    dataset = foz.load_zoo_dataset("quickstart")
+
+    labels_path = os.path.join(
+        eta.constants.RESOURCES_DIR, "imagenet-labels-no-background.txt"
+    )
+    config = fout.TorchImageModelConfig(
+        {
+            "entrypoint_fcn": "torchvision.models.mobilenet.mobilenet_v2",
+            "entrypoint_args": {"weights": "MobileNet_V2_Weights.DEFAULT"},
+            "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
+            "labels_path": labels_path,
+            "image_min_dim": 224,
+            "image_max_dim": 2048,
+            "image_mean": [0.485, 0.456, 0.406],
+            "image_std": [0.229, 0.224, 0.225],
+            "embeddings_layer": "<classifier.1",
+        }
+    )
+    model = fout.TorchImageModel(config)
+
+    dataset.apply_model(model, label_field="imagenet")
+    embeddings = dataset.compute_embeddings(model)
+
+The necessary configuration is provided via the
+:class:`TorchImageModelConfig <fiftyone.utils.torch.TorchImageModelConfig>`
+class, which exposes a number of built-in mechanisms for defining the model to
+load and any necessary preprocessing and post-processing.
+
+Under the hood, the torch model is loaded via:
+
+.. code-block:: python
+
+    torch_model = entrypoint_fcn(**entrypoint_args)
+
+which is assumed to return a :class:`torch:torch.nn.Module` whose `__call__()`
+method directly accepts Torch tensors (NCHW) as input.
+
+The :class:`TorchImageModelConfig <fiftyone.utils.torch.TorchImageModelConfig>`
+class provides a number of built-in mechanisms for specifying the required
+preprocessing for your model, such as resizing and normalization. In the above
+example, `image_min_dim`, `image_max_dim`, `image_mean`, and `image_std` are
+used.
+
+The `output_processor_cls` parameter of
+:class:`TorchImageModelConfig <fiftyone.utils.torch.TorchImageModelConfig>`
+must be set to the fully-qualified class name of an
+:class:`OutputProcessor <fiftyone.utils.torch.OutputProcessor>` subclass that
+defines how to translate the model's raw output into the suitable FiftyOne
+|Label| types, and is instantiated as follows:
+
+.. code-block:: python
+
+    output_processor = output_processor_cls(classes=classes, **output_processor_args)
+
+where your model's classes can be specified via any of the `classes`,
+`labels_string`, or `labels_path` parameters of
+:class:`TorchImageModelConfig <fiftyone.utils.torch.TorchImageModelConfig>`.
+
+The following built-in output processors are available for use:
+
+- :class:`ClassifierOutputProcessor <fiftyone.utils.torch.ClassifierOutputProcessor>`
+- :class:`DetectorOutputProcessor <fiftyone.utils.torch.DetectorOutputProcessor>`
+- :class:`InstanceSegmenterOutputProcessor <fiftyone.utils.torch.InstanceSegmenterOutputProcessor>`
+- :class:`KeypointDetectorOutputProcessor <fiftyone.utils.torch.KeypointDetectorOutputProcessor>`
+- :class:`SemanticSegmenterOutputProcessor <fiftyone.utils.torch.SemanticSegmenterOutputProcessor>`
+
+or you can write your own
+:class:`OutputProcessor <fiftyone.utils.torch.OutputProcessor>` subclass.
+
+Finally, if you would like to pass your custom model to methods like
+:meth:`compute_embeddings() <fiftyone.core.collections.SampleCollection.compute_embeddings>`,
+set the `embeddings_layer` parameter to the name of a layer whose output to
+expose as embeddings (or prepend `<` to use the input tensor instead).
+
+.. note::
+
+    Did you know? You can also
+    :ref:`register your custom model <model-zoo-add>` under a name of your
+    choice so that it can be loaded and used as follows:
+
+    .. code-block:: python
+
+        model = foz.load_zoo_model("your-custom-model")
+        dataset.apply_model(model, label_field="predictions")

--- a/docs/source/user_guide/model_zoo/index.rst
+++ b/docs/source/user_guide/model_zoo/index.rst
@@ -5,13 +5,16 @@ FiftyOne Model Zoo
 
 .. default-role:: code
 
-FiftyOne provides a Model Zoo that contains a collection of pre-trained models
-that you can download and run inference on your FiftyOne Datasets via a few
-simple commands.
+The FiftyOne Model Zoo provides a powerful interface for downloading models
+and applying them to your FiftyOne datasets.
+
+It provides native access to hundreds of pre-trained models, and it also
+supports downloading arbitrary public or private models whose definitions are
+provided via GitHub repositories or URLs.
 
 .. note::
 
-    Zoo models may require additional packages such as TensorFlow or PyTorch
+    Zoo models may require additional packages such as PyTorch or TensorFlow
     (or specific versions of them) in order to be used. See
     :ref:`this section <model-zoo-requirements>` for more information on
     viewing/installing package requirements for models.
@@ -23,12 +26,11 @@ simple commands.
     may be erroneous. In such cases, you can
     :ref:`suppress error messages <model-zoo-load>`.
 
-Available models
-----------------
+Built-in models
+---------------
 
-The Model Zoo contains over 70 pre-trained models that you can apply to your
-datasets with a few simple commands. Click the link below to see all of the
-models in the zoo!
+The Model Zoo provides built-in access to hundreds of pre-trained models that
+you can apply to your datasets with a few simple commands.
 
 .. custombutton::
     :button_text: Explore the models in the zoo
@@ -36,17 +38,41 @@ models in the zoo!
 
 .. note::
 
-    Did you know? You can also
-    :ref:`pass custom models <model-zoo-custom-models>` to methods like
+    Did you know? You can also pass
+    :ref:`custom models <model-zoo-custom-models>` to methods like
     :meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`
-    and
-    :meth:`compute_embeddings() <fiftyone.core.collections.SampleCollection.compute_embeddings>`!
+    and :meth:`compute_embeddings() <fiftyone.core.collections.SampleCollection.compute_embeddings>`!
+
+Remotely-sourced models
+-----------------------
+
+The Model Zoo also supports downloading and applying models whose definitions
+are provided via GitHub repositories or URLs.
+
+.. custombutton::
+    :button_text: Learn how to download remote models
+    :button_link: remote.html
+
+Model interface
+---------------
+
+All models in the Model Zoo are exposed via the |Model| class, which defines a
+common interface for loading models and generating predictions with
+defined input and output data formats.
+
+.. custombutton::
+    :button_text: Grok the Model interface
+    :button_link: design.html
 
 API reference
 -------------
 
-Check out the :ref:`API reference <model-zoo-api>` for complete instructions
-for using the Model Zoo library.
+The Model Zoo can be accessed via the Python library and the CLI. Consult the
+API reference belwo to see how to download, apply, and manage zoo models.
+
+.. custombutton::
+    :button_text: Check out the API reference
+    :button_link: api.html
 
 .. _model-zoo-basic-recipe:
 
@@ -59,7 +85,7 @@ then apply it to a dataset (or a subset of the dataset specified by a
 |DatasetView|) using methods such as
 :meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`
 and
-:meth:`compute_embeddings() <fiftyone.core.collections.SampleCollection.compute_embeddings>`:
+:meth:`compute_embeddings() <fiftyone.core.collections.SampleCollection.compute_embeddings>`.
 
 Prediction
 ~~~~~~~~~~
@@ -68,7 +94,7 @@ The Model Zoo provides a number of convenient methods for generating
 predictions with zoo models for your datasets.
 
 For example, the code sample below shows a self-contained example of loading a
-Faster R-CNN PyTorch model from the model zoo and adding its predictions to the
+Faster R-CNN model from the model zoo and adding its predictions to the
 COCO-2017 dataset from the :ref:`Dataset Zoo <dataset-zoo>`:
 
 .. code-block:: python
@@ -78,22 +104,12 @@ COCO-2017 dataset from the :ref:`Dataset Zoo <dataset-zoo>`:
     import fiftyone.zoo as foz
 
     # List available zoo models
-    model_names = foz.list_zoo_models()
-    print(model_names)
+    print(foz.list_zoo_models())
 
-    #
-    # Load zoo model
-    #
-    # This will download the model from the web, if necessary, and ensure
-    # that any required packages are installed
-    #
+    # Download and load a model
     model = foz.load_zoo_model("faster-rcnn-resnet50-fpn-coco-torch")
 
-    #
     # Load some samples from the COCO-2017 validation split
-    #
-    # This will download the dataset from the web, if necessary
-    #
     dataset = foz.load_zoo_dataset(
         "coco-2017",
         split="validation",
@@ -119,59 +135,6 @@ COCO-2017 dataset from the :ref:`Dataset Zoo <dataset-zoo>`:
 
     # Visualize predictions in the App
     session = fo.launch_app(view=samples)
-
-.. image:: /images/model_zoo_predictions_coco_2017.png
-   :alt: Model Zoo Predictions
-   :align: center
-
-Logits
-~~~~~~
-
-Many classifiers in the Model Zoo can optionally store logits for their
-predictions.
-
-.. note::
-
-    Storing logits for predictions enables you to run Brain methods such as
-    :ref:`label mistakes <brain-label-mistakes>` and
-    :ref:`sample hardness <brain-sample-hardness>` on your datasets!
-
-You can check if a model exposes logits via
-:meth:`has_logits() <fiftyone.core.models.Model.has_logits>`:
-
-.. code-block:: python
-    :linenos:
-
-    import fiftyone.zoo as foz
-
-    # Load zoo model
-    model = foz.load_zoo_model("inception-v3-imagenet-torch")
-
-    # Check if model has logits
-    print(model.has_logits)  # True
-
-For models that expose logits, you can store logits for all predictions
-generated by
-:meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`
-by passing the optional ``store_logits=True`` argument:
-
-.. code-block:: python
-    :linenos:
-
-    import fiftyone.zoo as foz
-
-    # Load zoo model
-    model = foz.load_zoo_model("inception-v3-imagenet-torch")
-    print(model.has_logits)  # True
-
-    # Load zoo dataset
-    dataset = foz.load_zoo_dataset("imagenet-sample")
-
-    # Select some samples to process
-    samples = dataset.take(10)
-
-    # Generate predictions and populate their `logits` fields
-    samples.apply_model(model, store_logits=True)
 
 Embeddings
 ~~~~~~~~~~
@@ -226,365 +189,60 @@ You can also use
 to generate embeddings for image patches defined by another label field, e.g,.
 the detections generated by a detection model.
 
-.. _model-zoo-design-overview:
-
-Design overview
----------------
-
-All models in the FiftyOne Model Zoo are instances of the |Model| class, which
-defines a common interface for loading models and generating predictions with
-defined input and output data formats.
-
-.. note::
-
-    The following sections describe the interface that all models in the Model
-    Zoo implement. If you write a wrapper for your custom model that implements
-    the |Model| interface, then you can pass your models to builtin methods
-    like
-    :meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`
-    and
-    :meth:`compute_embeddings() <fiftyone.core.collections.SampleCollection.compute_embeddings>`
-    too!
-
-    FiftyOne provides classes that make it easy to deploy models in custom
-    frameworks easy. For example, if you have a PyTorch model that processes
-    images, you can likely use
-    :class:`TorchImageModel <fiftyone.utils.torch.TorchImageModel>` to run it
-    using FiftyOne.
-
-Prediction
-~~~~~~~~~~
-
-Inside builtin methods like
-:meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`,
-predictions of a |Model| instance are generated using the following pattern:
-
-.. tabs::
-
-  .. group-tab:: Image models
-
-    .. code-block:: python
-        :linenos:
-
-        import numpy as np
-        from PIL import Image
-
-        import fiftyone as fo
-
-        def read_rgb_image(path):
-            """Utility function that loads an image as an RGB numpy array."""
-            return np.asarray(Image.open(path).convert("rgb"))
-
-        # Load a `Model` instance that processes images
-        model = ...
-
-        # Load a FiftyOne dataset
-        dataset = fo.load_dataset(...)
-
-        # A sample field in which to store the predictions
-        label_field = "predictions"
-
-        # Perform prediction on all images in the dataset
-        with model:
-            for sample in dataset:
-                # Load image
-                img = read_rgb_image(sample.filepath)
-
-                # Perform prediction
-                labels = model.predict(img)
-
-                # Save labels
-                sample.add_labels(labels, label_field=label_field)
-                sample.save()
-
-  .. group-tab:: Video models
-
-    .. code-block:: python
-        :linenos:
-
-        import eta.core.video as etav
-
-        import fiftyone as fo
-
-        # Load a `Model` instance that processes videos
-        model = ...
-
-        # Load a FiftyOne dataset
-        dataset = fo.load_dataset(...)
-
-        # A sample field in which to store the predictions
-        label_field = "predictions"
-
-        # Perform prediction on all videos in the dataset
-        with model:
-            for sample in dataset:
-                # Perform prediction
-                with etav.FFmpegVideoReader(sample.filepath) as video_reader:
-                    labels = model.predict(video_reader)
-
-                # Save labels
-                sample.add_labels(labels, label_field=label_field)
-                sample.save()
-
-By convention, |Model| instances must implement the context manager interface,
-which handles any necessary setup and teardown required to use the model.
-
-Predictions are generated via the
-:meth:`Model.predict() <fiftyone.core.models.Model>` interface method, which
-takes an image/video as input and returns the predictions.
-
-In order to be compatible with builtin methods like
-:meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`,
-models should support the following basic signature of running inference and
-storing the output labels:
-
-.. code-block:: python
-    :linenos:
-
-    labels = model.predict(arg)
-    sample.add_labels(labels, label_field=label_field)
-
-where the model should, at minimum, support ``arg`` values that are:
-
--   *Image models:* uint8 numpy arrays (HWC)
-
--   *Video models:* ``eta.core.video.VideoReader`` instances
-
-and the output ``labels`` can be any of the following:
-
--   A |Label| instance, in which case the labels are directly saved in the
-    specified ``label_field`` of the sample
-
-.. code-block:: python
-    :linenos:
-
-    # Single sample-level label
-    sample[label_field] = labels
-
--   A dict mapping keys to |Label| instances. In this case, the labels are
-    added as follows:
-
-.. code-block:: python
-    :linenos:
-
-    # Multiple sample-level labels
-    for key, value in labels.items():
-        sample[label_key(key)] = value
-
--   A dict mapping frame numbers to |Label| instances. In this case, the
-    provided labels are interpreted as frame-level labels that should be added
-    as follows:
-
-.. code-block:: python
-    :linenos:
-
-    # Single set of per-frame labels
-    sample.frames.merge(
-        {
-            frame_number: {label_field: label}
-            for frame_number, label in labels.items()
-        }
-    )
-
--   A dict mapping frame numbers to dicts mapping keys to |Label| instances. In
-    this case, the provided labels are interpreted as frame-level labels that
-    should be added as follows:
-
-.. code-block:: python
-    :linenos:
-
-    # Multiple per-frame labels
-    sample.frames.merge(
-        {
-            frame_number: {label_key(k): v for k, v in frame_dict.items()}
-            for frame_number, frame_dict in labels.items()
-        }
-    )
-
-In the above snippets, the ``label_key`` function maps label dict keys to field
-names, and is defined from ``label_field`` as follows:
-
-.. code-block:: python
-    :linenos:
-
-    if isinstance(label_field, dict):
-        label_key = lambda k: label_field.get(k, k)
-    elif label_field is not None:
-        label_key = lambda k: label_field + "_" + k
-    else:
-        label_key = lambda k: k
-
-For models that support batching, the |Model| interface also provides a
-:meth:`predict_all() <fiftyone.core.models.Model.predict_all>` method that can
-provide an efficient implementation of predicting on a batch of data.
-
-.. note::
-
-    Builtin methods like
-    :meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`
-    provide a ``batch_size`` parameter that can be used to control the batch
-    size used when performing inference with models that support efficient
-    batching.
-
-.. note::
-
-    PyTorch models can implement the |TorchModelMixin| mixin, in which case
-    `DataLoaders <https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader>`_
-    are used to efficiently feed data to the models during inference.
-
 Logits
 ~~~~~~
 
-Models that generate logits for their predictions can expose them to FiftyOne
-by implementing the |LogitsMixin| mixin.
-
-Inside builtin methods like
-:meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`,
-if the user requests logits, the model's
-:meth:`store_logits <fiftyone.core.models.LogitsMixin.store_logits>`
-property is set to indicate that the model should store logits in the |Label|
-instances that it produces during inference.
-
-Embeddings
-~~~~~~~~~~
-
-Models that can compute embeddings for their input data can expose this
-capability by implementing the |EmbeddingsMixin| mixin.
-
-Inside builtin methods like
-:meth:`compute_embeddings() <fiftyone.core.collections.SampleCollection.compute_embeddings>`,
-embeddings for a collection of samples are generated using an analogous pattern
-to the prediction code shown above, except that the embeddings are generated
-using :meth:`Model.embed() <fiftyone.core.models.EmbeddingsMixin.embed>` in
-place of :meth:`Model.predict() <fiftyone.core.models.Model.predict>`.
-
-By convention,
-:meth:`Model.embed() <fiftyone.core.models.EmbeddingsMixin.embed>` should
-return a numpy array containing the embedding.
+Many classifiers in the Model Zoo can optionally store logits for their
+predictions.
 
 .. note::
 
-    Sample embeddings are typically 1D vectors, but this is not strictly
-    required.
+    Storing logits for predictions enables you to run Brain methods such as
+    :ref:`label mistakes <brain-label-mistakes>` and
+    :ref:`sample hardness <brain-sample-hardness>` on your datasets!
 
-For models that support batching, the |EmbeddingsMixin| interface also provides
-a :meth:`embed_all() <fiftyone.core.models.Model.predict_all>` method that can
-provide an efficient implementation of embedding a batch of data.
-
-.. _model-zoo-custom-models:
-
-Using custom models
--------------------
-
-FiftyOne provides a
-:class:`TorchImageModel <fiftyone.utils.torch.TorchImageModel>`
-class that you can use to load your own custom Torch model and pass it to
-builtin methods like
-:meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`
-and
-:meth:`compute_embeddings() <fiftyone.core.collections.SampleCollection.compute_embeddings>`.
-
-For example, the snippet below loads a pretrained model from `torchvision`
-and uses it both as a classifier and to generate image embeddings:
+You can check if a model exposes logits via
+:meth:`has_logits() <fiftyone.core.models.Model.has_logits>`:
 
 .. code-block:: python
     :linenos:
 
-    import os
-    import eta
-
-    import fiftyone as fo
     import fiftyone.zoo as foz
-    import fiftyone.utils.torch as fout
 
-    dataset = foz.load_zoo_dataset("quickstart")
+    # Load zoo model
+    model = foz.load_zoo_model("inception-v3-imagenet-torch")
 
-    labels_path = os.path.join(
-        eta.constants.RESOURCES_DIR, "imagenet-labels-no-background.txt"
-    )
-    config = fout.TorchImageModelConfig(
-        {
-            "entrypoint_fcn": "torchvision.models.mobilenet.mobilenet_v2",
-            "entrypoint_args": {"weights": "MobileNet_V2_Weights.DEFAULT"},
-            "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
-            "labels_path": labels_path,
-            "image_min_dim": 224,
-            "image_max_dim": 2048,
-            "image_mean": [0.485, 0.456, 0.406],
-            "image_std": [0.229, 0.224, 0.225],
-            "embeddings_layer": "<classifier.1",
-        }
-    )
-    model = fout.TorchImageModel(config)
+    # Check if model has logits
+    print(model.has_logits)  # True
 
-    dataset.apply_model(model, label_field="imagenet")
-    embeddings = dataset.compute_embeddings(model)
-
-The necessary configuration is provided via the
-:class:`TorchImageModelConfig <fiftyone.utils.torch.TorchImageModelConfig>`
-class, which exposes a number of builtin mechanisms for defining the model to
-load and any necessary preprocessing and post-processing.
-
-Under the hood, the torch model is loaded via:
+For models that expose logits, you can store logits for all predictions
+generated by
+:meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`
+by passing the optional ``store_logits=True`` argument:
 
 .. code-block:: python
+    :linenos:
 
-    torch_model = entrypoint_fcn(**entrypoint_args)
+    import fiftyone.zoo as foz
 
-which is assumed to return a :class:`torch:torch.nn.Module` whose `__call__()`
-method directly accepts Torch tensors (NCHW) as input.
+    # Load zoo model
+    model = foz.load_zoo_model("inception-v3-imagenet-torch")
+    print(model.has_logits)  # True
 
-The :class:`TorchImageModelConfig <fiftyone.utils.torch.TorchImageModelConfig>`
-class provides a number of builtin mechanisms for specifying the required
-preprocessing for your model, such as resizing and normalization. In the above
-example, `image_min_dim`, `image_max_dim`, `image_mean`, and `image_std` are
-used.
+    # Load zoo dataset
+    dataset = foz.load_zoo_dataset("imagenet-sample")
 
-The `output_processor_cls` parameter of
-:class:`TorchImageModelConfig <fiftyone.utils.torch.TorchImageModelConfig>`
-must be set to the fully-qualified class name of an
-:class:`OutputProcessor <fiftyone.utils.torch.OutputProcessor>` subclass that
-defines how to translate the model's raw output into the suitable FiftyOne
-|Label| types, and is instantiated as follows:
+    # Select some samples to process
+    samples = dataset.take(10)
 
-.. code-block:: python
-
-    output_processor = output_processor_cls(classes=classes, **output_processor_args)
-
-where your model's classes can be specified via any of the `classes`,
-`labels_string`, or `labels_path` parameters of
-:class:`TorchImageModelConfig <fiftyone.utils.torch.TorchImageModelConfig>`.
-
-The following builtin output processors are available for use:
-
-- :class:`ClassifierOutputProcessor <fiftyone.utils.torch.ClassifierOutputProcessor>`
-- :class:`DetectorOutputProcessor <fiftyone.utils.torch.DetectorOutputProcessor>`
-- :class:`InstanceSegmenterOutputProcessor <fiftyone.utils.torch.InstanceSegmenterOutputProcessor>`
-- :class:`KeypointDetectorOutputProcessor <fiftyone.utils.torch.KeypointDetectorOutputProcessor>`
-- :class:`SemanticSegmenterOutputProcessor <fiftyone.utils.torch.SemanticSegmenterOutputProcessor>`
-
-or you can write your own
-:class:`OutputProcessor <fiftyone.utils.torch.OutputProcessor>` subclass.
-
-Finally, if you would like to pass your custom model to methods like
-:meth:`compute_embeddings() <fiftyone.core.collections.SampleCollection.compute_embeddings>`,
-set the `embeddings_layer` parameter to the name of a layer whose output to
-expose as embeddings (or prepend `<` to use the input tensor instead).
-
-.. note::
-
-    Did you know? You can also
-    :ref:`register your custom model <model-zoo-add>` under a name of your
-    choice so that it can be loaded and used as follows:
-
-    .. code-block:: python
-
-        model = foz.load_zoo_model("your-custom-model")
-        dataset.apply_model(model, label_field="predictions")
+    # Generate predictions and populate their `logits` fields
+    samples.apply_model(model, store_logits=True)
 
 .. toctree::
    :maxdepth: 1
    :hidden:
 
+   Built-in models <models>
+   Remote models <remote>
+   Model interface <design>
    API reference <api>
-   Available models <models>

--- a/docs/source/user_guide/model_zoo/remote.rst
+++ b/docs/source/user_guide/model_zoo/remote.rst
@@ -1,0 +1,409 @@
+.. _model-zoo-remote:
+
+Remotely-Sourced Zoo Models
+===========================
+
+.. default-role:: code
+
+This page describes how to work with and create zoo models whose definitions
+are hosted via GitHub repositories or public URLs.
+
+.. note::
+
+    To download from a private GitHub repository that you have access to,
+    provide your GitHub personal access token by setting the ``GITHUB_TOKEN``
+    environment variable.
+
+.. _model-zoo-remote-usage:
+
+Working with remotely-sourced models
+------------------------------------
+
+Working with remotely-sourced zoo models is just like
+:ref:`built-in zoo models <model-zoo-models>`, as both varieties support
+the :ref:`full zoo API <model-zoo-api>`.
+
+When specifying remote sources, you can provide any of the following:
+
+-   A GitHub repo URL like ``https://github.com/<user>/<repo>``
+-   A GitHub ref like ``https://github.com/<user>/<repo>/tree/<branch>`` or
+    ``https://github.com/<user>/<repo>/commit/<commit>``
+-   A GitHub ref string like ``<user>/<repo>[/<ref>]``
+-   A publicly accessible URL of an archive (eg zip or tar) file
+
+Here's the basic recipe for working with remotely-sourced zoo models:
+
+.. tabs::
+
+  .. group-tab:: Python
+
+    Use :meth:`register_zoo_model_source() <fiftyone.zoo.models.register_zoo_model_source>`
+    to register a remote source of zoo models:
+
+    .. code-block:: python
+        :linenos:
+
+        import fiftyone as fo
+        import fiftyone.zoo as foz
+
+        foz.register_zoo_model_source("https://github.com/voxel51/ultralytics-models")
+
+    Use :meth:`list_zoo_model_sources() <fiftyone.zoo.models.list_zoo_model_sources>`
+    to list all remote sources that have been registered locally:
+
+    .. code-block:: python
+        :linenos:
+
+        remote_sources = foz.list_zoo_model_sources()
+
+        print(remote_sources)
+        # [..., "https://github.com/voxel51/ultralytics-models", ...]
+
+    Once you've registered a remote source, any models that it
+    :ref:`declares <model-zoo-remote-manifest>` will subsequently appear as
+    available zoo models when you call
+    :meth:`list_zoo_models() <fiftyone.zoo.models.list_zoo_models>`:
+
+    .. code-block:: python
+        :linenos:
+
+        available_models = foz.list_zoo_models()
+
+        print(available_models)
+        # [..., "voxel51/yolov10s-coco-torch", ...]
+
+    You can download a remote zoo model by calling
+    :meth:`download_zoo_model() <fiftyone.zoo.models.download_zoo_model>`:
+
+    .. code-block:: python
+        :linenos:
+
+        foz.download_zoo_model("voxel51/yolov10s-coco-torch")
+
+    You can also directly download a remote zoo model and implicitly register
+    its source via the following syntax:
+
+    .. code-block:: python
+        :linenos:
+
+        foz.download_zoo_model(
+            "https://github.com/voxel51/ultralytics-models",
+            model_name="voxel51/yolov10s-coco-torch",
+        )
+
+    You can load a remote zoo model and apply it to a dataset or view via
+    :meth:`load_zoo_model() <fiftyone.zoo.models.load_zoo_model>` and
+    :meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`:
+
+    .. code-block:: python
+        :linenos:
+
+        dataset = foz.load_zoo_dataset("quickstart")
+        model = foz.load_zoo_model("voxel51/yolov10s-coco-torch")
+
+        dataset.apply_model(model, label_field="yolov10")
+
+    You can delete the local copy of a remotely-sourced zoo model via
+    :meth:`delete_zoo_model() <fiftyone.zoo.models.delete_zoo_model>`:
+
+    .. code-block:: python
+        :linenos:
+
+        foz.delete_zoo_model("voxel51/yolov10s-coco-torch")
+
+    You can unregister a remote source of zoo models and delete any local
+    copies of models that it declares via
+    :meth:`delete_zoo_model_source() <fiftyone.zoo.models.delete_zoo_model_source>`:
+
+    .. code-block:: python
+        :linenos:
+
+        foz.delete_zoo_model_source("https://github.com/voxel51/ultralytics-models")
+
+  .. group-tab:: CLI
+
+    Use :ref:`fiftyone zoo models register-source <cli-fiftyone-zoo-models-register-source>`
+    to register a remote source of zoo models:
+
+    .. code-block:: shell
+
+        fiftyone zoo models register-source \
+            https://github.com/voxel51/ultralytics-models
+
+    Use :ref:`fiftyone zoo models list-sources <cli-fiftyone-zoo-models-list-sources>`
+    to list all remote sources that have been registered locally:
+
+    .. code-block:: shell
+
+        fiftyone zoo models list-sources
+
+        # contains a row for 'https://github.com/voxel51/ultralytics-models'
+
+    Once you've registered a remote source, any models that it
+    :ref:`declares <model-zoo-remote-manifest>` will subsequently appear as
+    available zoo models when you call
+    :ref:`fiftyone zoo models list <cli-fiftyone-zoo-models-list>`:
+
+    .. code-block:: shell
+
+        fiftyone zoo models list
+
+        # contains a row for 'voxel51/yolov10s-coco-torch'
+
+    You can download a remote zoo model by calling
+    :ref:`fiftyone zoo models download <cli-fiftyone-zoo-models-download>`:
+
+    .. code-block:: shell
+
+        fiftyone zoo models download voxel51/yolov10s-coco-torch
+
+    You can also directly download a remote zoo model and implicitly register
+    its source via the following syntax:
+
+    .. code-block:: shell
+
+        fiftyone zoo models \
+            download https://github.com/voxel51/ultralytics-models \
+            --model-name voxel51/yolov10s-coco-torch
+
+    You can load a remote zoo model and apply it to a dataset via
+    :ref:`fiftyone zoo models apply <cli-fiftyone-zoo-models-apply>`:
+
+    .. code-block:: shell
+
+        MODEL_NAME=voxel51/yolov10s-coco-torch
+        DATASET_NAME=quickstart
+        LABEL_FIELD=yolov10
+
+        fiftyone zoo models apply $MODEL_NAME $DATASET_NAME $LABEL_FIELD
+
+    You can delete the local copy of a remotely-sourced zoo model via
+    :ref:`fiftyone zoo models delete <cli-fiftyone-zoo-models-delete>`:
+
+    .. code-block:: shell
+
+        fiftyone zoo models delete voxel51/yolov10s-coco-torch
+
+    You can unregister a remote source of zoo models and delete any local
+    copies of models that it declares via
+    :ref:`fiftyone zoo models delete-source <cli-fiftyone-zoo-models-delete-source>`:
+
+    .. code-block:: shell
+
+        fiftyone zoo models delete-source https://github.com/voxel51/ultralytics-models
+
+.. _model-zoo-remote-creation:
+
+Creating remotely-sourced models
+--------------------------------
+
+A remote source of models is defined by a directory with the following contents:
+
+.. code-block:: text
+
+    manifest.json
+    __init__.py
+        def download_model(model_name, model_path):
+            pass
+
+        def load_model(model_name, model_path, **kwargs):
+            pass
+
+Each component is described in detail below.
+
+.. note::
+
+    By convention, model sources also contain an optional `README.md` file that
+    provides additional information about the models that it contains and
+    example syntaxes for downloading and working with them.
+
+.. _model-zoo-remote-manifest:
+
+manifest.json
+~~~~~~~~~~~~~
+
+The remote source's `manifest.json` file defines relevant metadata about the
+model(s) that it contains:
+
+.. table::
+    :widths: 20,10,70
+
+    +----------------------------------+-----------+-------------------------------------------------------------------------------------------+
+    | Field                            | Required? | Description                                                                               |
+    +==================================+===========+===========================================================================================+
+    | `name`                           |           | A name for the remote model source                                                        |
+    +----------------------------------+-----------+-------------------------------------------------------------------------------------------+
+    | `url`                            |           | The URL of the remote model source                                                        |
+    +----------------------------------+-----------+-------------------------------------------------------------------------------------------+
+    | `base_name`                      | **yes**   | The base name of the model (no version info)                                              |
+    +----------------------------------+-----------+-------------------------------------------------------------------------------------------+
+    | `base_filename`                  |           | The base filename or directory of the model (no version info), if applicable.             |
+    |                                  |           |                                                                                           |
+    |                                  |           | This is required in order for                                                             |
+    |                                  |           | :meth:`list_downloaded_zoo_models() <fiftyone.zoo.models.list_downloaded_zoo_models>`     |
+    |                                  |           | to detect the model and :meth:`delete_zoo_model() <fiftyone.zoo.models.delete_zoo_model>` |
+    |                                  |           | to delete the local copy if it is downloaded                                              |
+    +----------------------------------+-----------+-------------------------------------------------------------------------------------------+
+    | `author`                         |           | The author of the model                                                                   |
+    +----------------------------------+-----------+-------------------------------------------------------------------------------------------+
+    | `version`                        |           | The version of the model (if applicable).                                                 |
+    |                                  |           |                                                                                           |
+    |                                  |           | If a version is provided, then users can refer to a specific version of the model by      |
+    |                                  |           | appending ``@<ver>`` to its name when using methods like                                  |
+    |                                  |           | :meth:`load_zoo_model() <fiftyone.zoo.models.load_zoo_model>`, otherwise the latest       |
+    |                                  |           | version of the model is loaded by default                                                 |
+    +----------------------------------+-----------+-------------------------------------------------------------------------------------------+
+    | `url`                            |           | The URL at which the model is hosted                                                      |
+    +----------------------------------+-----------+-------------------------------------------------------------------------------------------+
+    | `license`                        |           | The license under which the model is distributed                                          |
+    +----------------------------------+-----------+-------------------------------------------------------------------------------------------+
+    | `source`                         |           | The original source of the model                                                          |
+    +----------------------------------+-----------+-------------------------------------------------------------------------------------------+
+    | `description`                    |           | A brief description of the model                                                          |
+    +----------------------------------+-----------+-------------------------------------------------------------------------------------------+
+    | `tags`                           |           | A list of tags for the model. Useful in conjunction with                                  |
+    |                                  |           | :meth:`list_zoo_models() <fiftyone.zoo.models.list_zoo_models>`                           |
+    +----------------------------------+-----------+-------------------------------------------------------------------------------------------+
+    | `size_bytes`                     |           | The size of the model on disk                                                             |
+    +----------------------------------+-----------+-------------------------------------------------------------------------------------------+
+    | `date_added`                     |           | The time that the model was added to the source                                           |
+    +----------------------------------+-----------+-------------------------------------------------------------------------------------------+
+    | `requirements`                   |           | JSON description of the model's package/runtime requirements                              |
+    +----------------------------------+-----------+-------------------------------------------------------------------------------------------+
+    | `manager`                        |           | A :class:`fiftyone.core.models.ModelManagerConfig` dict that describes the remote         |
+    |                                  |           | location of the model and how to download it. If this is not provided, then a             |
+    |                                  |           | :ref:`download_model() <model-zoo-remote-download-model>` function must be provided       |
+    +----------------------------------+-----------+-------------------------------------------------------------------------------------------+
+    | `default_deployment_config_dict` |           | A :class:`fiftyone.core.models.ModelConfig` dict describing how to load the model. If     |
+    |                                  |           | this is not provided, then a :ref:`load_model() <model-zoo-remote-load-model>` function   |
+    |                                  |           | must be provided                                                                          |
+    +----------------------------------+-----------+-------------------------------------------------------------------------------------------+
+
+Here's an exaxmple model manifest file that declares a single model:
+
+.. code-block:: json
+
+    {
+        "name": "voxel51/ultralytics",
+        "url": "https://github.com/voxel51/ultralytics-models",
+        "models": [
+            {
+                "base_name": "voxel51/yolov8s-coco-torch",
+                "base_filename": "yolov8s-coco.pt",
+                "author": "Ultralytics",
+                "license": "https://www.ultralytics.com/license",
+                "source": "https://docs.ultralytics.com/models/yolov8/",
+                "description": "Ultralytics YOLOv8s model trained on COCO",
+                "tags": ["detection", "coco", "torch", "yolo"],
+                "size_bytes": 22573363,
+                "date_added": "2024-03-11 19:22:51",
+                "requirements": {
+                    "packages": [
+                        "torch>=1.7.0",
+                        "torchvision>=0.8.1",
+                        "ultralytics"
+                    ],
+                    "cpu": {
+                        "support": true
+                    },
+                    "gpu": {
+                        "support": true
+                    }
+                }
+            }
+        ]
+    }
+
+.. _model-zoo-remote-download-model:
+
+Download model
+~~~~~~~~~~~~~~
+
+If a remote source contains model(s) that don't use the ``manager`` key in its
+:ref:`manifest <model-zoo-remote-manifest>`, then it must contain an
+``__init__.py`` file that defines a ``download_model()`` method with the
+signature below:
+
+.. code-block:: python
+    :linenos:
+
+    def download_model(model_name, model_path):
+        """Downloads the model.
+
+        Args:
+            model_name: the name of the model to download, as declared by the
+                ``base_name`` and optional ``version`` fields of the manifest
+            model_path: the absolute filename or directory to which to download the
+                model, as declared by the ``base_filename`` field of the manifest
+        """
+
+        # Determine where to download `model_name` from
+        url = ...
+
+        # Download `url` to `model_path`
+        ...
+
+This method is called under-the-hood when a user calls
+:meth:`download_zoo_model() <fiftyone.zoo.models.download_zoo_model>` or
+:meth:`load_zoo_model() <fiftyone.zoo.models.load_zoo_model>`, and its job is
+to download any relevant files from the web and organize and/or prepare
+them as necessary at the provided path.
+
+.. _model-zoo-remote-load-model:
+
+Load model
+~~~~~~~~~~
+
+If a remote source contains model(s) that don't use the
+``default_deployment_config_dict`` key in its
+:ref:`manifest <model-zoo-remote-manifest>`, then it must contain an
+``__init__.py`` file that defines a ``load_model()`` method with the signature
+below:
+
+.. code-block:: python
+    :linenos:
+
+    def load_model(model_name, model_path, **kwargs):
+        """Loads the model.
+
+        Args:
+            model_name: the name of the model to load, as declared by the
+                ``base_name`` and optional ``version`` fields of the manifest
+            model_path: the absolute filename or directory to which the model was
+                donwloaded, as declared by the ``base_filename`` field of the
+                manifest
+            **kwargs: optional keyword arguments that configure how the model
+                is loaded
+
+        Returns:
+            a :class:`fiftyone.core.models.Model`
+        """
+
+        # The directory containing this file
+        model_dir = os.path.dirname(model_path)
+
+        # Consturct the specified `Model` instance, generally by importing
+        # other modules in `model_dir`
+        model = ...
+
+        return model
+
+This method's job is to load the |Model| instance for the specified model whose
+associated weights are stored at the provided path.
+
+.. note::
+
+    Refer to :ref:`this page <model-zoo-design-overview>` for more information
+    about wrapping models in the |Model| interface.
+
+Remotely-sourced models can optionally support customized loading by accepting
+optional keyword arguments to their ``load_model()`` method.
+
+When
+:meth:`load_zoo_model(name_or_url, ..., **kwargs) <fiftyone.zoo.models.load_zoo_model>`
+is called, any `kwargs` are passed through to ``load_model(..., **kwargs)``.
+
+.. note::
+
+    Check out `voxel51/ultralytics-models <https://github.com/voxel51/ultralytics-models>`_
+    for an example of a remote model source.

--- a/docs/source/user_guide/model_zoo/remote.rst
+++ b/docs/source/user_guide/model_zoo/remote.rst
@@ -46,7 +46,7 @@ Here's the basic recipe for working with remotely-sourced zoo models:
         import fiftyone as fo
         import fiftyone.zoo as foz
 
-        foz.register_zoo_model_source("https://github.com/voxel51/ultralytics-models")
+        foz.register_zoo_model_source("https://github.com/voxel51/openai-clip")
 
     Use :meth:`list_zoo_model_sources() <fiftyone.zoo.models.list_zoo_model_sources>`
     to list all remote sources that have been registered locally:
@@ -57,7 +57,7 @@ Here's the basic recipe for working with remotely-sourced zoo models:
         remote_sources = foz.list_zoo_model_sources()
 
         print(remote_sources)
-        # [..., "https://github.com/voxel51/ultralytics-models", ...]
+        # [..., "https://github.com/voxel51/openai-clip", ...]
 
     Once you've registered a remote source, any models that it
     :ref:`declares <model-zoo-remote-manifest>` will subsequently appear as
@@ -70,7 +70,7 @@ Here's the basic recipe for working with remotely-sourced zoo models:
         available_models = foz.list_zoo_models()
 
         print(available_models)
-        # [..., "voxel51/yolov10s-coco-torch", ...]
+        # [..., "voxel51/clip-vit-base32-torch", ...]
 
     You can download a remote zoo model by calling
     :meth:`download_zoo_model() <fiftyone.zoo.models.download_zoo_model>`:
@@ -78,7 +78,7 @@ Here's the basic recipe for working with remotely-sourced zoo models:
     .. code-block:: python
         :linenos:
 
-        foz.download_zoo_model("voxel51/yolov10s-coco-torch")
+        foz.download_zoo_model("voxel51/clip-vit-base32-torch")
 
     You can also directly download a remote zoo model and implicitly register
     its source via the following syntax:
@@ -87,8 +87,8 @@ Here's the basic recipe for working with remotely-sourced zoo models:
         :linenos:
 
         foz.download_zoo_model(
-            "https://github.com/voxel51/ultralytics-models",
-            model_name="voxel51/yolov10s-coco-torch",
+            "https://github.com/voxel51/openai-clip",
+            model_name="voxel51/clip-vit-base32-torch",
         )
 
     You can load a remote zoo model and apply it to a dataset or view via
@@ -99,9 +99,9 @@ Here's the basic recipe for working with remotely-sourced zoo models:
         :linenos:
 
         dataset = foz.load_zoo_dataset("quickstart")
-        model = foz.load_zoo_model("voxel51/yolov10s-coco-torch")
+        model = foz.load_zoo_model("voxel51/clip-vit-base32-torch")
 
-        dataset.apply_model(model, label_field="yolov10")
+        dataset.apply_model(model, label_field="clip")
 
     You can delete the local copy of a remotely-sourced zoo model via
     :meth:`delete_zoo_model() <fiftyone.zoo.models.delete_zoo_model>`:
@@ -109,7 +109,7 @@ Here's the basic recipe for working with remotely-sourced zoo models:
     .. code-block:: python
         :linenos:
 
-        foz.delete_zoo_model("voxel51/yolov10s-coco-torch")
+        foz.delete_zoo_model("voxel51/clip-vit-base32-torch")
 
     You can unregister a remote source of zoo models and delete any local
     copies of models that it declares via
@@ -118,7 +118,7 @@ Here's the basic recipe for working with remotely-sourced zoo models:
     .. code-block:: python
         :linenos:
 
-        foz.delete_zoo_model_source("https://github.com/voxel51/ultralytics-models")
+        foz.delete_zoo_model_source("https://github.com/voxel51/openai-clip")
 
   .. group-tab:: CLI
 
@@ -128,7 +128,7 @@ Here's the basic recipe for working with remotely-sourced zoo models:
     .. code-block:: shell
 
         fiftyone zoo models register-source \
-            https://github.com/voxel51/ultralytics-models
+            https://github.com/voxel51/openai-clip
 
     Use :ref:`fiftyone zoo models list-sources <cli-fiftyone-zoo-models-list-sources>`
     to list all remote sources that have been registered locally:
@@ -137,7 +137,7 @@ Here's the basic recipe for working with remotely-sourced zoo models:
 
         fiftyone zoo models list-sources
 
-        # contains a row for 'https://github.com/voxel51/ultralytics-models'
+        # contains a row for 'https://github.com/voxel51/openai-clip'
 
     Once you've registered a remote source, any models that it
     :ref:`declares <model-zoo-remote-manifest>` will subsequently appear as
@@ -148,14 +148,14 @@ Here's the basic recipe for working with remotely-sourced zoo models:
 
         fiftyone zoo models list
 
-        # contains a row for 'voxel51/yolov10s-coco-torch'
+        # contains a row for 'voxel51/clip-vit-base32-torch'
 
     You can download a remote zoo model by calling
     :ref:`fiftyone zoo models download <cli-fiftyone-zoo-models-download>`:
 
     .. code-block:: shell
 
-        fiftyone zoo models download voxel51/yolov10s-coco-torch
+        fiftyone zoo models download voxel51/clip-vit-base32-torch
 
     You can also directly download a remote zoo model and implicitly register
     its source via the following syntax:
@@ -163,17 +163,17 @@ Here's the basic recipe for working with remotely-sourced zoo models:
     .. code-block:: shell
 
         fiftyone zoo models \
-            download https://github.com/voxel51/ultralytics-models \
-            --model-name voxel51/yolov10s-coco-torch
+            download https://github.com/voxel51/openai-clip \
+            --model-name voxel51/clip-vit-base32-torch
 
     You can load a remote zoo model and apply it to a dataset via
     :ref:`fiftyone zoo models apply <cli-fiftyone-zoo-models-apply>`:
 
     .. code-block:: shell
 
-        MODEL_NAME=voxel51/yolov10s-coco-torch
+        MODEL_NAME=voxel51/clip-vit-base32-torch
         DATASET_NAME=quickstart
-        LABEL_FIELD=yolov10
+        LABEL_FIELD=clip
 
         fiftyone zoo models apply $MODEL_NAME $DATASET_NAME $LABEL_FIELD
 
@@ -182,7 +182,7 @@ Here's the basic recipe for working with remotely-sourced zoo models:
 
     .. code-block:: shell
 
-        fiftyone zoo models delete voxel51/yolov10s-coco-torch
+        fiftyone zoo models delete voxel51/clip-vit-base32-torch
 
     You can unregister a remote source of zoo models and delete any local
     copies of models that it declares via
@@ -190,7 +190,7 @@ Here's the basic recipe for working with remotely-sourced zoo models:
 
     .. code-block:: shell
 
-        fiftyone zoo models delete-source https://github.com/voxel51/ultralytics-models
+        fiftyone zoo models delete-source https://github.com/voxel51/openai-clip
 
 .. _model-zoo-remote-creation:
 
@@ -284,25 +284,28 @@ Here's an exaxmple model manifest file that declares a single model:
 .. code-block:: json
 
     {
-        "name": "voxel51/ultralytics",
-        "url": "https://github.com/voxel51/ultralytics-models",
+        "name": "voxel51/openai-clip",
+        "url": "https://github.com/voxel51/openai-clip",
         "models": [
             {
-                "base_name": "voxel51/yolov8s-coco-torch",
-                "base_filename": "yolov8s-coco.pt",
-                "author": "Ultralytics",
-                "license": "https://www.ultralytics.com/license",
-                "source": "https://docs.ultralytics.com/models/yolov8/",
-                "description": "Ultralytics YOLOv8s model trained on COCO",
-                "tags": ["detection", "coco", "torch", "yolo"],
-                "size_bytes": 22573363,
-                "date_added": "2024-03-11 19:22:51",
+                "base_name": "voxel51/clip-vit-base32-torch",
+                "base_filename": "CLIP-ViT-B-32.pt",
+                "author": "OpenAI",
+                "license": "MIT",
+                "source": "https://github.com/openai/CLIP",
+                "description": "CLIP text/image encoder from Learning Transferable Visual Models From Natural Language Supervision (https://arxiv.org/abs/2103.00020) trained on 400M text-image pairs",
+                "tags": [
+                    "classification",
+                    "logits",
+                    "embeddings",
+                    "torch",
+                    "clip",
+                    "zero-shot"
+                ],
+                "size_bytes": 353976522,
+                "date_added": "2022-04-12 17:49:51",
                 "requirements": {
-                    "packages": [
-                        "torch>=1.7.0",
-                        "torchvision>=0.8.1",
-                        "ultralytics"
-                    ],
+                    "packages": ["torch", "torchvision"],
                     "cpu": {
                         "support": true
                     },
@@ -405,5 +408,5 @@ is called, any `kwargs` are passed through to ``load_model(..., **kwargs)``.
 
 .. note::
 
-    Check out `voxel51/ultralytics-models <https://github.com/voxel51/ultralytics-models>`_
+    Check out `voxel51/openai-clip <https://github.com/voxel51/openai-clip>`_
     for an example of a remote model source.

--- a/fiftyone/zoo/models/__init__.py
+++ b/fiftyone/zoo/models/__init__.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 def list_zoo_models(tags=None, source=None):
     """Returns the list of available models in the FiftyOne Model Zoo.
 
-    Also includes any remotely-sourced zoo models that you've downloaded.
+    Also includes models from any remote sources that you've registered.
 
     Example usage::
 
@@ -122,7 +122,7 @@ def is_zoo_model_downloaded(name):
 
 
 def download_zoo_model(name_or_url, model_name=None, overwrite=False):
-    """Downloads specified model from the FiftyOne Model Zoo.
+    """Downloads the specified model from the FiftyOne Model Zoo.
 
     If the model is already downloaded, it is not re-downloaded unless
     ``overwrite == True`` is specified.
@@ -361,8 +361,7 @@ def delete_zoo_model(name):
 
 
 def list_zoo_model_sources():
-    """Returns the list of remote zoo model sources that are registered
-    locally.
+    """Returns the list of remote model sources that are registered locally.
 
     Returns:
         the list of remote sources

--- a/fiftyone/zoo/models/__init__.py
+++ b/fiftyone/zoo/models/__init__.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 import importlib
 import logging
 import os
+import sys
 import weakref
 
 from eta.core.config import ConfigError
@@ -503,12 +504,13 @@ class RemoteZooModel(ZooModel):
             self.manager = RemoteModelManager(config)
 
 
-class RemoteModelManagerConfig(fom.ModelManagerConfig):
+class RemoteModelManagerConfig(etam.ModelManagerConfig):
     def __init__(self, d):
+        super().__init__(d)
         self.model_name = self.parse_string(d, "model_name")
 
 
-class RemoteModelManager(fom.ModelManager):
+class RemoteModelManager(etam.ModelManager):
     def _download_model(self, model_path):
         _download_remote_model(self.config.model_name, model_path)
 
@@ -542,7 +544,7 @@ def _import_zoo_module(model_dir):
     )
     spec = importlib.util.spec_from_file_location(module_name, module_path)
     module = importlib.util.module_from_spec(spec)
-    # sys.modules[module.__name__] = module
+    sys.modules[module.__name__] = module
     spec.loader.exec_module(module)
     return module
 

--- a/fiftyone/zoo/models/__init__.py
+++ b/fiftyone/zoo/models/__init__.py
@@ -7,6 +7,7 @@ The FiftyOne Model Zoo.
 """
 from collections import defaultdict
 from copy import deepcopy
+import importlib
 import logging
 import os
 import weakref
@@ -15,21 +16,25 @@ from eta.core.config import ConfigError
 import eta.core.learning as etal
 import eta.core.models as etam
 import eta.core.utils as etau
+import eta.core.web as etaw
 
 import fiftyone as fo
 import fiftyone.core.models as fom
+from fiftyone.utils.github import GitHubRepository
 
+
+MODELS_MANIEST_FILENAME = "manifest.json"
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_BUILTIN_MODELS_MANIFEST_PATT = os.path.join(_THIS_DIR, "manifest-*.json")
+_MODELS = weakref.WeakValueDictionary()
 
 logger = logging.getLogger(__name__)
 
 
-_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
-_MODELS_MANIFEST_PATT = os.path.join(_THIS_DIR, "manifest-*.json")
-_MODELS = weakref.WeakValueDictionary()
-
-
-def list_zoo_models(tags=None):
+def list_zoo_models(tags=None, source=None):
     """Returns the list of available models in the FiftyOne Model Zoo.
+
+    Also includes any remotely-sourced zoo models that you've downloaded.
 
     Example usage::
 
@@ -53,11 +58,23 @@ def list_zoo_models(tags=None):
     Args:
         tags (None): only include models that have the specified tag or list
             of tags
+        source (None): only include models available via the given remote
+            source
 
     Returns:
         a list of model names
     """
-    manifest = _load_zoo_models_manifest()
+    models = _list_zoo_models(tags=tags, source=source)
+    return sorted(model.name for model in models)
+
+
+def _list_zoo_models(tags=None, source=None):
+    manifest, remote_sources = _load_zoo_models_manifest()
+
+    if source is not None:
+        manifest = remote_sources.get(source, None)
+        if manifest is None:
+            return []
 
     if tags is not None:
         if etau.is_str(tags):
@@ -67,7 +84,7 @@ def list_zoo_models(tags=None):
 
         manifest = [model for model in manifest if tags.issubset(model.tags)]
 
-    return sorted([model.name for model in manifest])
+    return list(manifest)
 
 
 def list_downloaded_zoo_models():
@@ -76,7 +93,7 @@ def list_downloaded_zoo_models():
     Returns:
         a dict mapping model names to (model path, :class:`ZooModel`) tuples
     """
-    manifest = _load_zoo_models_manifest()
+    manifest, _ = _load_zoo_models_manifest()
     models_dir = fo.config.model_zoo_dir
 
     models = {}
@@ -93,8 +110,7 @@ def is_zoo_model_downloaded(name):
 
     Args:
         name: the name of the zoo model, which can have ``@<ver>`` appended to
-            refer to a specific version of the model. If no version is
-            specified, the latest version of the model is used
+            refer to a specific version of the model
 
     Returns:
         True/False
@@ -104,17 +120,31 @@ def is_zoo_model_downloaded(name):
     return model.is_in_dir(models_dir)
 
 
-def download_zoo_model(name, overwrite=False):
-    """Downloads the model of the given name from the FiftyOne Dataset Zoo.
+def download_zoo_model(name_or_url, model_name=None, overwrite=False):
+    """Downloads specified model from the FiftyOne Model Zoo.
 
     If the model is already downloaded, it is not re-downloaded unless
     ``overwrite == True`` is specified.
 
+    .. note::
+
+        To download from a private GitHub repository that you have access to,
+        provide your GitHub personal access token by setting the
+        ``GITHUB_TOKEN`` environment variable.
+
     Args:
-        name: the name of the zoo model, which can have ``@<ver>`` appended to
-            refer to a specific version of the model. If no version is
-            specified, the latest version of the model is used. Call
-            :func:`list_zoo_models` to see the available models
+        name_or_url: the name of the zoo model to download, which can have
+            ``@<ver>`` appended to refer to a specific version of the model, or
+            the remote source to download it from, which can be:
+
+            -   a GitHub repo URL like ``https://github.com/<user>/<repo>``
+            -   a GitHub ref like
+                ``https://github.com/<user>/<repo>/tree/<branch>`` or
+                ``https://github.com/<user>/<repo>/commit/<commit>``
+            -   a GitHub ref string like ``<user>/<repo>[/<ref>]``
+            -   a publicly accessible URL of an archive (eg zip or tar) file
+        model_name (None): the specific model to download, if ``name_or_url``
+            is a remote source
         overwrite (False): whether to overwrite any existing files
 
     Returns:
@@ -123,26 +153,27 @@ def download_zoo_model(name, overwrite=False):
         -   model: the :class:`ZooModel` for the model
         -   model_path: the path to the downloaded model on disk
     """
-    model, model_path = _get_model_in_dir(name)
+    model, model_path = _get_model_in_dir(name_or_url, model_name=model_name)
 
-    if not overwrite and is_zoo_model_downloaded(name):
-        logger.info("Model '%s' is already downloaded", name)
+    if not overwrite and is_zoo_model_downloaded(model.name):
+        logger.info("Model '%s' is already downloaded", model.name)
     elif model.manager is not None:
         model.manager.download_model(model_path, force=overwrite)
     else:
-        logger.info("Model '%s' downloading is not managed by FiftyOne", name)
+        logger.info(
+            "Model '%s' downloading is not managed by FiftyOne",
+            model.name,
+        )
 
     return model, model_path
 
 
 def install_zoo_model_requirements(name, error_level=None):
-    """Installs any package requirements for the zoo model with the given name.
+    """Installs any package requirements for the specified zoo model.
 
     Args:
         name: the name of the zoo model, which can have ``@<ver>`` appended to
-            refer to a specific version of the model. If no version is
-            specified, the latest version of the model is used. Call
-            :func:`list_zoo_models` to see the available models
+            refer to a specific version of the model
         error_level (None): the error level to use, defined as:
 
             -   0: raise error if a requirement install fails
@@ -159,14 +190,12 @@ def install_zoo_model_requirements(name, error_level=None):
 
 
 def ensure_zoo_model_requirements(name, error_level=None, log_success=True):
-    """Ensures that the package requirements for the zoo model with the given
-    name are satisfied.
+    """Ensures that the package requirements for the specified zoo model are
+    satisfied.
 
     Args:
         name: the name of the zoo model, which can have ``@<ver>`` appended to
-            refer to a specific version of the model. If no version is
-            specified, the latest version of the model is used. Call
-            :func:`list_zoo_models` to see the available models
+            refer to a specific version of the model
         error_level (None): the error level to use when installing/ensuring
             requirements, defined as:
 
@@ -186,7 +215,8 @@ def ensure_zoo_model_requirements(name, error_level=None, log_success=True):
 
 
 def load_zoo_model(
-    name,
+    name_or_url,
+    model_name=None,
     download_if_necessary=True,
     ensure_requirements=True,
     install_requirements=False,
@@ -194,22 +224,36 @@ def load_zoo_model(
     cache=True,
     **kwargs,
 ):
-    """Loads the model of the given name from the FiftyOne Model Zoo.
+    """Loads the specified model from the FiftyOne Model Zoo.
 
     By default, the model will be downloaded if necessary, and any documented
     package requirements will be checked to ensure that they are installed.
 
+    .. note::
+
+        To download from a private GitHub repository that you have access to,
+        provide your GitHub personal access token by setting the
+        ``GITHUB_TOKEN`` environment variable.
+
     Args:
-        name: the name of the zoo model, which can have ``@<ver>`` appended to
-            refer to a specific version of the model. If no version is
-            specified, the latest version of the model is downloaded. Call
-            :func:`list_zoo_models` to see the available models
-        download_if_necessary (True): whether to download the model if it is
-            not found in the specified directory
+        name_or_url: the name of the zoo model to load, which can have
+            ``@<ver>`` appended to refer to a specific version of the model, or
+            the remote source to load it from, which can be:
+
+            -   a GitHub repo URL like ``https://github.com/<user>/<repo>``
+            -   a GitHub ref like
+                ``https://github.com/<user>/<repo>/tree/<branch>`` or
+                ``https://github.com/<user>/<repo>/commit/<commit>``
+            -   a GitHub ref string like ``<user>/<repo>[/<ref>]``
+            -   a publicly accessible URL of an archive (eg zip or tar) file
+        model_name (None): the specific model to load, if ``name_or_url`` is a
+            remote source
+        download_if_necessary (True): whether to download the model if
+            necessary
         ensure_requirements (True): whether to ensure any requirements are
-            installed before loading the model. By default, this is True
-        install_requirements: whether to install any requirements before
-            loading the model. By default, this is False
+            installed before loading the model
+        install_requirements (False): whether to install any requirements
+            before loading the model
         error_level (None): the error level to use when installing/ensuring
             requirements, defined as:
 
@@ -220,13 +264,18 @@ def load_zoo_model(
             By default, ``fo.config.requirement_error_level`` is used
         cache (True): whether to store a weak reference to the model so that
             running this method again will return the same instance while the
-            model is still in use. If False, no weak reference is stored/used
+            model is still in use
         **kwargs: keyword arguments to inject into the model's ``Config``
             instance
 
     Returns:
         a :class:`fiftyone.core.models.Model`
     """
+    if model_name is not None:
+        name = model_name
+    else:
+        name = name_or_url
+
     if cache:
         key = _get_cache_key(name, **kwargs)
         if key is not None and key in _MODELS:
@@ -235,7 +284,7 @@ def load_zoo_model(
     if error_level is None:
         error_level = fo.config.requirement_error_level
 
-    model = _get_model(name)
+    model = _get_model(name_or_url, model_name=model_name)
     models_dir = fo.config.model_zoo_dir
 
     if model.manager is not None and not model.is_in_dir(models_dir):
@@ -252,7 +301,10 @@ def load_zoo_model(
     config_dict = deepcopy(model.default_deployment_config_dict)
     model_path = model.get_path_in_dir(models_dir)
 
-    model = fom.load_model(config_dict, model_path=model_path, **kwargs)
+    if isinstance(model, RemoteZooModel) and config_dict is None:
+        model = _load_remote_model(model.name, model_path, **kwargs)
+    else:
+        model = fom.load_model(config_dict, model_path=model_path, **kwargs)
 
     if cache and key is not None:
         _MODELS[key] = model
@@ -268,8 +320,7 @@ def find_zoo_model(name):
 
     Args:
         name: the name of the zoo model, which can have ``@<ver>`` appended to
-            refer to a specific version of the model. If no version is
-            specified, the latest version of the model is used
+            refer to a specific version of the model
 
     Returns:
         the path to the model on disk
@@ -285,11 +336,11 @@ def find_zoo_model(name):
 
 
 def get_zoo_model(name):
-    """Returns the :class:`ZooModel` instance for the model with the given
-    name.
+    """Returns the :class:`ZooModel` instance for the specified zoo model.
 
     Args:
-        name: the name of the zoo model
+        name: the name of the zoo model, which can have ``@<ver>`` appended to
+            refer to a specific version of the model
 
     Returns:
         a :class:`ZooModel`
@@ -302,11 +353,72 @@ def delete_zoo_model(name):
 
     Args:
         name: the name of the zoo model, which can have ``@<ver>`` appended to
-            refer to a specific version of the model. If no version is
-            specified, the latest version of the model is used
+            refer to a specific version of the model
     """
     model, model_path = _get_model_in_dir(name)
     model.flush_model(model_path)
+
+
+def list_zoo_model_sources():
+    """Returns the list of remote zoo model sources that are registered
+    locally.
+
+    Returns:
+        the list of remote sources
+    """
+    _, remote_sources = _load_zoo_models_manifest()
+    return sorted(remote_sources.keys())
+
+
+def register_zoo_model_source(url_or_gh_repo, overwrite=False):
+    """Registers a remote source of models, if necessary.
+
+    .. note::
+
+        To download from a private GitHub repository that you have access to,
+        provide your GitHub personal access token by setting the
+        ``GITHUB_TOKEN`` environment variable.
+
+    Args:
+        url_or_gh_repo: the remote source to register, which can be:
+
+            -   a GitHub repo URL like ``https://github.com/<user>/<repo>``
+            -   a GitHub ref like
+                ``https://github.com/<user>/<repo>/tree/<branch>`` or
+                ``https://github.com/<user>/<repo>/commit/<commit>``
+            -   a GitHub ref string like ``<user>/<repo>[/<ref>]``
+            -   a publicly accessible URL of an archive (eg zip or tar) file
+        overwrite (False): whether to overwrite any existing files
+    """
+    _parse_model_identifier(url_or_gh_repo, overwrite=overwrite)
+
+
+def delete_zoo_model_source(url_or_gh_repo):
+    """Deletes the specified remote source and all downloaded models associated
+    with it.
+
+    Args:
+        url_or_gh_repo: the remote source to delete, which can be:
+
+            -   a GitHub repo URL like ``https://github.com/<user>/<repo>``
+            -   a GitHub ref like
+                ``https://github.com/<user>/<repo>/tree/<branch>`` or
+                ``https://github.com/<user>/<repo>/commit/<commit>``
+            -   a GitHub ref string like ``<user>/<repo>[/<ref>]``
+            -   a publicly accessible URL of an archive (eg zip or tar) file
+    """
+    url = _normalize_ref(url_or_gh_repo)
+    _, remote_sources = _load_zoo_models_manifest()
+
+    manifest = remote_sources.get(url, None)
+    if manifest is not None:
+        models_dir = os.path.dirname(manifest.path)
+        if models_dir != fo.config.model_zoo_dir:
+            etau.delete_dir(models_dir)
+        else:
+            logger.warning("Cannot delete top-level model zoo directory")
+    else:
+        raise ValueError(f"Source '{url_or_gh_repo}' not found in the zoo")
 
 
 class HasZooModel(etal.HasPublishedModel):
@@ -354,22 +466,25 @@ class ZooModel(etam.Model):
 
     Args:
         base_name: the base name of the model (no version info)
-        base_filename (None): the base filename of the model (no version info),
-            if applicable
+        base_filename (None): the base filename or directory of the model
+            (no version info), if applicable
+        author (None): the author of the model
+        version (None): the version of the model
+        url (None): the URL at which the model is hosted
+        license (None): the license under which the model is distributed
+        source (None): the source of the model
+        description (None): the description of the model
+        tags (None): a list of tags for the model
+        size_bytes (None): the size of the model on disk
+        date_added (None): the datetime that the model was added to the zoo
+        requirements (None): the ``eta.core.models.ModelRequirements`` for the
+            model
         manager (None): the :class:`fiftyone.core.models.ModelManager` instance
             that describes the remote storage location of the model, if
             applicable
-        version (None): the version of the model
-        description (None): the description of the model
-        source (None): the source of the model
-        size_bytes (None): the size of the model on disk
         default_deployment_config_dict (None): a
             :class:`fiftyone.core.models.ModelConfig` dict describing the
             recommended settings for deploying the model
-        requirements (None): the ``eta.core.models.ModelRequirements`` for the
-            model
-        tags (None): a list of tags for the model
-        date_added (None): the datetime that the model was added to the zoo
     """
 
     _REQUIREMENT_ERROR_SUFFIX = (
@@ -377,6 +492,59 @@ class ZooModel(etam.Model):
         "`fiftyone.config.requirement_error_level` to 1 (warning) or 2 (ignore).\n"
         "See https://docs.voxel51.com/user_guide/config.html for details."
     )
+
+
+class RemoteZooModel(ZooModel):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if self.manager is None:
+            config = RemoteModelManagerConfig(dict(model_name=self.name))
+            self.manager = RemoteModelManager(config)
+
+
+class RemoteModelManagerConfig(fom.ModelManagerConfig):
+    def __init__(self, d):
+        self.model_name = self.parse_string(d, "model_name")
+
+
+class RemoteModelManager(fom.ModelManager):
+    def _download_model(self, model_path):
+        _download_remote_model(self.config.model_name, model_path)
+
+
+def _download_remote_model(model_name, model_path):
+    model_dir = os.path.dirname(model_path)
+
+    module = _import_zoo_module(model_dir)
+    if not hasattr(module, "download_model"):
+        raise ValueError(
+            f"Module {model_dir} has no 'download_model()' method"
+        )
+
+    module.download_model(model_name, model_path)
+
+
+def _load_remote_model(model_name, model_path, **kwargs):
+    model_dir = os.path.dirname(model_path)
+
+    module = _import_zoo_module(model_dir)
+    if not hasattr(module, "load_model"):
+        raise ValueError(f"Module {model_dir} has no 'load_model()' method")
+
+    return module.load_model(model_name, model_path, **kwargs)
+
+
+def _import_zoo_module(model_dir):
+    module_path = os.path.join(model_dir, "__init__.py")
+    module_name = os.path.relpath(model_dir, fo.config.model_zoo_dir).replace(
+        "/", "."
+    )
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    # sys.modules[module.__name__] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 class ZooModelsManifest(etam.ModelsManifest):
@@ -389,27 +557,188 @@ class ZooModelsManifest(etam.ModelsManifest):
     _MODEL_CLS = ZooModel
 
 
+class RemoteZooModelsManifest(ZooModelsManifest):
+    """Class that describes the collection of remotely-sourced models in the
+    FiftyOne Model Zoo.
+
+    Args:
+        models: a list of :class:`RemoteZooModel` instances
+    """
+
+    _MODEL_CLS = RemoteZooModel
+
+
 def _load_zoo_models_manifest():
     manifest = ZooModelsManifest()
+    remote_sources = {}
 
-    manifest_paths = etau.get_glob_matches(_MODELS_MANIFEST_PATT)
+    # Builtin manifests
+    manifest_paths = etau.get_glob_matches(_BUILTIN_MODELS_MANIFEST_PATT)
     if fo.config.model_zoo_manifest_paths:
         manifest_paths.extend(fo.config.model_zoo_manifest_paths)
 
+    # Custom manifests
     for manifest_path in manifest_paths:
-        manifest.merge(ZooModelsManifest.from_json(manifest_path))
+        _merge_manifest(manifest, manifest_path)
 
-    return manifest
+    # Remote manifests
+    for manifest_path in _iter_model_manifests():
+        _merge_remote_manifest(manifest, remote_sources, manifest_path)
+
+    return manifest, remote_sources
 
 
-def _get_model_in_dir(name):
-    model = _get_model(name)
+def _merge_manifest(manifest, manifest_path, sources=None):
+    try:
+        _manifest = ZooModelsManifest.from_json(manifest_path)
+    except Exception as e:
+        logger.warning(f"Failed to load manifest '{manifest_path}': {e}")
+        return
+
+    if sources is not None and _manifest.url is not None:
+        sources[manifest_path] = _manifest
+
+    manifest.merge(_manifest, error_level=1)
+
+
+def _merge_remote_manifest(manifest, sources, manifest_path):
+    try:
+        _manifest = RemoteZooModelsManifest.from_json(manifest_path)
+    except Exception as e:
+        logger.warning(f"Failed to load manifest '{manifest_path}': {e}")
+        return
+
+    if _manifest.url is not None:
+        _manifest.path = manifest_path
+        sources[_manifest.url] = _manifest
+
+    manifest.merge(_manifest, error_level=1)
+
+
+def _iter_model_manifests(root_dir=None):
+    if root_dir is None:
+        root_dir = fo.config.model_zoo_dir
+
+    if not root_dir or not os.path.isdir(root_dir):
+        return
+
+    for root, dirs, files in os.walk(root_dir, followlinks=True):
+        # Ignore hidden directories
+        dirs[:] = [d for d in dirs if not d.startswith(".")]
+
+        for file in files:
+            if os.path.basename(file) == MODELS_MANIEST_FILENAME:
+                yield os.path.join(root, file)
+
+                # Stop traversing `root` once we find a plugin
+                dirs[:] = []
+                break
+
+
+def _normalize_ref(url_or_gh_repo):
+    if etaw.is_url(url_or_gh_repo):
+        return url_or_gh_repo
+
+    return "https://github.com/" + url_or_gh_repo
+
+
+def _download_model_metadata(url_or_gh_repo, overwrite=False):
+    url = _normalize_ref(url_or_gh_repo)
+    if "github" in url:
+        repo = GitHubRepository(url_or_gh_repo)
+    else:
+        repo = None
+
+    with etau.TempDir() as tmpdir:
+        logger.info(f"Downloading {url_or_gh_repo}...")
+        try:
+            if repo is not None:
+                repo.download(tmpdir)
+            else:
+                _download_archive(url, tmpdir)
+        except Exception as e:
+            raise ValueError(
+                f"Failed to retrieve model metadata from '{url_or_gh_repo}'"
+            ) from e
+
+        manifest_paths = list(_iter_model_manifests(root_dir=tmpdir))
+
+        if not manifest_paths:
+            logger.info(f"No model manifests found in '{url_or_gh_repo}'")
+
+        for manifest_path in manifest_paths:
+            try:
+                manifest = ZooModelsManifest.from_json(manifest_path)
+            except Exception as e:
+                logger.warning(
+                    f"Failed to load manifest '{manifest_path}': {e}"
+                )
+                continue
+
+            if manifest.name is None:
+                logger.warning(
+                    f"Skipping manifest '{manifest_path}' with no 'name'"
+                )
+                continue
+
+            from_dir = os.path.dirname(manifest_path)
+            models_dir = os.path.join(fo.config.model_zoo_dir, manifest.subdir)
+            if os.path.isdir(models_dir):
+                if overwrite:
+                    logger.info(
+                        f"Overwriting existing model source '{models_dir}'"
+                    )
+                else:
+                    raise ValueError(
+                        f"A model source with name '{manifest.name}' already "
+                        "exists. Pass 'overwrite=True' if you wish to "
+                        "overwrite it"
+                    )
+
+            # We could be working with a specific branch or commit, so store it
+            manifest.url = url
+            manifest.write_json(manifest_path, pretty_print=True)
+
+            etau.copy_dir(from_dir, models_dir)
+
+
+def _download_archive(url, outdir):
+    archive_name = os.path.basename(url)
+    if not os.path.splitext(archive_name)[1]:
+        raise ValueError(f"Cannot infer appropriate archive type for '{url}'")
+
+    archive_path = os.path.join(outdir, archive_name)
+    etaw.download_file(url, path=archive_path)
+    etau.extract_archive(archive_path)
+
+
+def _get_model_in_dir(name_or_url, model_name=None):
+    model = _get_model(name_or_url, model_name=model_name)
     models_dir = fo.config.model_zoo_dir
     model_path = model.get_path_in_dir(models_dir)
     return model, model_path
 
 
-def _get_model(name):
+def _parse_model_identifier(url_or_gh_repo, overwrite=False):
+    url = _normalize_ref(url_or_gh_repo)
+
+    _, remote_sources = _load_zoo_models_manifest()
+
+    if overwrite or url not in remote_sources:
+        _download_model_metadata(url, overwrite=overwrite)
+
+
+def _get_model(name_or_url, model_name=None):
+    if model_name is not None:
+        name = model_name
+        url_or_gh_repo = name_or_url
+    else:
+        name = name_or_url
+        url_or_gh_repo = None
+
+    if url_or_gh_repo is not None:
+        _parse_model_identifier(url_or_gh_repo)
+
     if ZooModel.has_version_str(name):
         return _get_exact_model(name)
 
@@ -417,19 +746,19 @@ def _get_model(name):
 
 
 def _get_exact_model(name):
-    manifest = _load_zoo_models_manifest()
+    manifest, _ = _load_zoo_models_manifest()
     try:
         return manifest.get_model_with_name(name)
     except etam.ModelError:
-        raise ValueError("No model with name '%s' was found" % name)
+        raise ValueError(f"Model '{name}' not found in the zoo")
 
 
 def _get_latest_model(base_name):
-    manifest = _load_zoo_models_manifest()
+    manifest, _ = _load_zoo_models_manifest()
     try:
         return manifest.get_latest_model_with_base_name(base_name)
     except etam.ModelError:
-        raise ValueError("No models found with base name '%s'" % base_name)
+        raise ValueError(f"Model '{base_name}' not found in the zoo")
 
 
 def _get_cache_key(name, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ INSTALL_REQUIRES = [
     # internal packages
     "fiftyone-brain>=0.17.0,<0.18",
     "fiftyone-db>=0.4,<2.0",
-    "voxel51-eta>=0.12.7,<0.13",
+    "voxel51-eta>=0.13.0,<0.14",
 ]
 
 


### PR DESCRIPTION
Adds support for loading zoo models whose definitions are stored in a GitHub repository or publicly accessible URL! 🎉 

Example datasets published in this format:
- https://github.com/voxel51/openai-clip
- https://github.com/voxel51/ultralytics-models

## Notes

Requires https://github.com/voxel51/eta/pull/633

## Usage

```shell
fiftyone zoo models register-source https://github.com/voxel51/openai-clip
fiftyone zoo models list-sources
fiftyone zoo models list --source https://github.com/voxel51/openai-clip
```

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    max_samples=50,
    shuffle=True,
)

model = foz.load_zoo_model(
    "voxel51/clip-vit-base32-torch",
    text_prompt="A photo of a",
    classes=["person", "dog", "cat", "bird", "car", "tree", "chair"],
)

dataset.apply_model(model, label_field="predictions")

session = fo.launch_app(dataset)
```

```shell
fiftyone zoo models delete voxel51/clip-vit-base32-torch
fiftyone zoo models delete-source https://github.com/voxel51/openai-clip
```

## Creating remotely-sourced models

This is extensively documented in the PR, but the basic ingredients to defining a remotely-sourced zoo model are a `manifest.json` file:

```json
{
    "name": "voxel51/openai-clip",
    "url": "https://github.com/voxel51/openai-clip",
    "models": [
        {
            "base_name": "voxel51/clip-vit-base32-torch",
            "base_filename": "CLIP-ViT-B-32.pt",
            "author": "OpenAI",
            "license": "MIT",
            "source": "https://github.com/openai/CLIP",
            "description": "CLIP text/image encoder from Learning Transferable Visual Models From Natural Language Supervision (https://arxiv.org/abs/2103.00020) trained on 400M text-image pairs",
            "tags": [
                "classification",
                "logits",
                "embeddings",
                "torch",
                "clip",
                "zero-shot"
            ],
            "size_bytes": 353976522,
            "date_added": "2022-04-12 17:49:51",
            "requirements": {
                "packages": ["torch", "torchvision"],
                "cpu": {
                    "support": true
                },
                "gpu": {
                    "support": true
                }
            }
        }
    ]
}
```

and an `__init__.py` file that contains `download_model()` and `load_model()` methods:

```py
def download_model(model_name, model_path):
    """Downloads the model.

    Args:
        model_name: the name of the model to download, as declared by the
            ``base_name`` and optional ``version`` fields of the manifest
        model_path: the absolute filename or directory to which to download the
            model, as declared by the ``base_filename`` field of the manifest
    """

    # Determine where to download `model_name` from
    url = ...

    # Download `url` to `model_path`
    ...

def load_model(model_name, model_path, **kwargs):
    """Loads the model.

    Args:
        model_name: the name of the model to load, as declared by the
            ``base_name`` and optional ``version`` fields of the manifest
        model_path: the absolute filename or directory to which the model was
            donwloaded, as declared by the ``base_filename`` field of the
            manifest
        **kwargs: optional keyword arguments that configure how the model
            is loaded

    Returns:
        a :class:`fiftyone.core.models.Model`
    """

    # The directory containing this file
    model_dir = os.path.dirname(model_path)

    # Consturct the specified `Model` instance, generally by importing
    # other modules in `model_dir`
    model = ...

    return model
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced CLI commands for managing remote model sources, including `list-sources`, `register-source`, and `delete-source`.
	- Added functionality to download and apply models from remote sources, with improved command structure.
	- Introduced a comprehensive overview of the Model Zoo design, detailing model integration and prediction processes.

- **Documentation**
	- Updated documentation for the FiftyOne Model Zoo CLI and API to clarify new commands and functionalities.
	- Streamlined content in various sections to improve usability and focus on essential information.

- **Bug Fixes**
	- Improved error handling and logging for model registration and downloading processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->