### PR TITLE
Support large deletions by sample/frame IDs

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -4244,12 +4244,22 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         else:
             contains_videos = self._contains_videos(any_slice=True)
 
+        ops = []
         if sample_ids is not None:
-            d = {"_id": {"$in": [ObjectId(_id) for _id in sample_ids]}}
-        else:
-            d = {}
+            batch_size = fou.recommend_batch_size_for_value(
+                ObjectId(), max_size=100000
+            )
 
-        self._sample_collection.delete_many(d)
+            for _ids in fou.iter_batches(sample_ids, batch_size):
+                ops.append(
+                    DeleteMany(
+                        {"_id": {"$in": [ObjectId(_id) for _id in _ids]}}
+                    )
+                )
+        else:
+            ops.append(DeleteMany({}))
+
+        foo.bulk_write(ops, self._sample_collection)
         fos.Sample._reset_docs(
             self._sample_collection_name, sample_ids=sample_ids
         )
@@ -4336,9 +4346,19 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 frame_ids = view.values("frames.id", unwind=True)
 
         if frame_ids is not None:
-            self._frame_collection.delete_many(
-                {"_id": {"$in": [ObjectId(_id) for _id in frame_ids]}}
+            ops = []
+            batch_size = fou.recommend_batch_size_for_value(
+                ObjectId(), max_size=100000
             )
+
+            for _ids in fou.iter_batches(frame_ids, batch_size):
+                ops.append(
+                    DeleteMany(
+                        {"_id": {"$in": [ObjectId(_id) for _id in _ids]}}
+                    )
+                )
+
+            foo.bulk_write(ops, self._frame_collection)
             fofr.Frame._reset_docs_by_frame_id(
                 self._frame_collection_name, frame_ids
             )
@@ -4350,12 +4370,26 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
             sample_ids = view.values("id")
 
+        ops = []
         if sample_ids is not None:
-            d = {"_sample_id": {"$in": [ObjectId(_id) for _id in sample_ids]}}
-        else:
-            d = {}
+            batch_size = fou.recommend_batch_size_for_value(
+                ObjectId(), max_size=100000
+            )
 
-        self._frame_collection.delete_many(d)
+            for _ids in fou.iter_batches(sample_ids, batch_size):
+                ops.append(
+                    DeleteMany(
+                        {
+                            "_sample_id": {
+                                "$in": [ObjectId(_id) for _id in _ids]
+                            }
+                        }
+                    )
+                )
+        else:
+            ops.append(DeleteMany({}))
+
+        foo.bulk_write(ops, self._frame_collection)
         fofr.Frame._reset_docs(
             self._frame_collection_name, sample_ids=sample_ids
         )
@@ -4365,25 +4399,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if not sample_collection._contains_videos(any_slice=True):
             return
 
-        if self._is_clips:
-            if frame_ids is None and view is None:
-                view = self
-
-            if view is not None:
-                frame_ids = view.values("frames.id", unwind=True)
-
-        if frame_ids is not None:
-            self._frame_collection.delete_many(
-                {
-                    "_id": {
-                        "$not": {"$in": [ObjectId(_id) for _id in frame_ids]}
-                    }
-                }
-            )
-            fofr.Frame._reset_docs_by_frame_id(
-                self._frame_collection_name, frame_ids, keep=True
-            )
-            return
+        if self._is_clips and view is None:
+            view = self
 
         if view is None:
             return
@@ -4391,10 +4408,30 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if view.media_type == fom.GROUP:
             view = view.select_group_slices(media_type=fom.VIDEO)
 
-        sample_ids, frame_numbers = view.values(["id", "frames.frame_number"])
+        if view._is_clips:
+            sample_ids, frame_numbers = view.values(
+                ["sample_id", "frames.frame_number"]
+            )
+
+            # Handle multiple clips per sample
+            d = defaultdict(set)
+            for sample_id, fns in zip(sample_ids, frame_numbers):
+                d[sample_id].update(fns)
+
+            sample_ids, frame_numbers = zip(
+                *((sample_id, list(fns)) for sample_id, fns in d.items())
+            )
+        else:
+            sample_ids, frame_numbers = view.values(
+                ["id", "frames.frame_number"]
+            )
 
         ops = []
         for sample_id, fns in zip(sample_ids, frame_numbers):
+            # Note: this may fail if `fns` is too large (eg >100k frames), but
+            # to address this we'd need to do something like lookup all frame
+            # numbers on the dataset and reverse the $not in-memory, which
+            # would be quite expensive...
             ops.append(
                 DeleteMany(
                     {


### PR DESCRIPTION
The `delete_samples()` and `clear_frames()` methods did not currently handle the case where the user wants to delete >100k samples/frames. This patches that.

## Example usage

Unit tests should already cover these methods, but here's a quick test I ran live:

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart-video")

dataset.delete_samples(dataset[:2])
assert len(dataset) == 8

dataset[:2].clear_frames()
assert dataset[:2].values(F("frames").length()) == [0, 0]

frame_ids = dataset[2:4].values("frames.id", unwind=True)
dataset._clear_frames(frame_ids=frame_ids)
assert dataset[2:4].values(F("frames").length()) == [0, 0]

view = dataset[4:6].to_clips([[(1, 7),  (3, 10)], [(1, 10)]])
view.keep_frames()
assert dataset[4:6].values(F("frames").length()) == [10, 10]

view = dataset.match_frames(F("frame_number") <= 10)
view.keep_frames()
assert all(c <= 10 for c in dataset.values(F("frames").length()))

dataset.clear()
assert len(dataset) == 0
assert dataset.count("frames") == 0
```
