### PR TITLE
Fix selection for group modal

### DIFF
--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -264,7 +264,6 @@ def handle_group_filter(
 
         for stage in stages:
             # add stages after flattening and group match
-
             if group_by and isinstance(stage, fosg.GroupBy) and filter.slices:
                 view = view.match(
                     {group_field + ".name": {"$in": filter.slices}}

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -264,11 +264,18 @@ def handle_group_filter(
 
         for stage in stages:
             # add stages after flattening and group match
+
             if group_by and isinstance(stage, fosg.GroupBy) and filter.slices:
                 view = view.match(
                     {group_field + ".name": {"$in": filter.slices}}
                 )
-            view = view._add_view_stage(stage, validate=False)
+
+            # if selecting a group, filter out select/reorder stages
+            if (
+                not filter.id
+                or type(stage) not in fosg._STAGES_THAT_SELECT_OR_REORDER
+            ):
+                view = view._add_view_stage(stage, validate=False)
 
     elif filter.id:
         view = fov.make_optimized_select_view(view, filter.id, groups=True)

--- a/tests/unittests/server_group_tests.py
+++ b/tests/unittests/server_group_tests.py
@@ -90,3 +90,34 @@ class ServerGroupTests(unittest.TestCase):
             GroupElementFilter(),
         )
         self.assertEqual(view._all_stages, [fo.Select(first)])
+
+    @drop_datasets
+    def test_group_selection(self):
+        dataset: fo.Dataset = fo.Dataset()
+        group = fo.Group()
+        one = fo.Sample(
+            filepath="image.png",
+            group=group.element("one"),
+        )
+        two = fo.Sample(
+            filepath="image.png",
+            group=group.element("two"),
+        )
+
+        dataset.add_samples([one, two])
+
+        selection = dataset.select(one.id)
+
+        with_slices, _ = fosv.handle_group_filter(
+            dataset,
+            selection,
+            GroupElementFilter(id=group.id, slices=["one", "two"]),
+        )
+        self.assertEqual(len(with_slices), 2)
+
+        without_slices, _ = fosv.handle_group_filter(
+            dataset,
+            selection,
+            GroupElementFilter(id=group.id, slices=["one", "two"]),
+        )
+        self.assertEqual(len(without_slices), 2)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Sample selection currently interferes with the group modal by filtering out slices that a user should still see

## How is this patch tested? If it is not, please explain why.

New `server_group_tests.py` case

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-groups")
# all slices should display in the modal
session = fo.launch_app(dataset.select(dataset.first().id))
``` 

## Release Notes

* Fixed missing slices in the expanded view for :ref:`grouped datasets <groups>` when a sample selection is present

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced group selection functionality for improved filtering in views.
  
- **Tests**
	- Added a new test case to validate group selection and filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->