### PR TITLE
Remove App-only note

### DIFF
--- a/docs/source/teams/roles_and_permissions.rst
+++ b/docs/source/teams/roles_and_permissions.rst
@@ -80,11 +80,6 @@ granted access (a dataset's
 Collaborators), and they may only be granted **Can view**,  **Can tag** 
 or **Can edit** access to datasets.
 
-.. note::
-    
-   For customers with App-only seats, Collaborators cannot be granted 
-   **Can edit** permissions.
-
 Collaborators cannot create new datasets, clone existing datasets, or view
 other users of the deployment. Collaborators may export datasets to which
 they've been granted access.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the documentation on Collaborator permissions to clarify access rights, removing the restriction related to App-only seats. This simplification enhances user understanding of Collaborator capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->