### PR TITLE
disable analytics.page() when url tracking disabled

### DIFF
--- a/app/packages/analytics/src/analytics.test.ts
+++ b/app/packages/analytics/src/analytics.test.ts
@@ -167,7 +167,6 @@ describe("Analytics", () => {
     });
     analytics.track("random_event", { uri: "@my_name/my_plugin/my_operator" });
     // segment should be called with properties.uri = "<redacted>"
-    console.log(mockSegment.track.mock.calls[0]);
     expect(mockSegment.track).toHaveBeenCalledWith(
       "random_event",
       { uri: "<redacted>" },
@@ -207,6 +206,32 @@ describe("Analytics", () => {
     analytics.track("custom_event");
     expect(mockSegment.track).toHaveBeenCalledWith("custom_event", undefined, {
       version: "1.0.0",
+    });
+  });
+  
+  describe("analytics.page()", () => {
+    it("should call segment.page()", () => {
+      analytics = new Analytics();
+      analytics.load({
+        writeKey: "test",
+        userId: "user",
+        userGroup: "group",
+        debug: false,
+      });
+      analytics.page("my_page");
+      expect(mockSegment.page).toHaveBeenCalled();
+    });
+    it("should be a no-op if disableUrlTracking is set to true", () => {
+      analytics = new Analytics();
+      analytics.load({
+        writeKey: "test",
+        userId: "user",
+        userGroup: "group",
+        debug: false,
+        disableUrlTracking: true,
+      });
+      analytics.page("my_page");
+      expect(mockSegment.page).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/packages/analytics/src/usingAnalytics.ts
+++ b/app/packages/analytics/src/usingAnalytics.ts
@@ -32,7 +32,7 @@ export class Analytics {
   private _debug = false;
   private _lastEventTimestamps: Record<string, number> = {}; // Tracks last event times
   private _debounceInterval = 1000; // Default debounce interval in milliseconds (5 seconds)
-  private _disableUrlTracking = false;
+  private _disableUrlTracking = false; // Disable tracking page URL and .page() calls
   private _redactedProperties: string[] = [];
   private _version?: string;
 
@@ -93,7 +93,7 @@ export class Analytics {
   }
 
   page(name?: string, properties?: {}) {
-    if (!this._segment) return;
+    if (!this._segment || this._disableUrlTracking) return;
     properties = this.redact(properties);
     this._segment.page(name, properties);
   }


### PR DESCRIPTION
## What changes are proposed in this pull request?

 Disables the `segment.page()` call when `disableUrlTracking` is `true`.

## How is this patch tested? If it is not, please explain why.

Added an automated test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced page tracking functionality with improved control over URL tracking based on user settings.
- **Bug Fixes**
	- Added tests to ensure correct behavior of the page tracking method under various conditions.
- **Documentation**
	- Updated logic in the Analytics class to clarify the conditions under which URL tracking is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->