### PR TITLE
skip e2e tests that use zoo datasets

### DIFF
--- a/e2e-pw/src/oss/specs/color-scheme/color-scheme.spec.ts
+++ b/e2e-pw/src/oss/specs/color-scheme/color-scheme.spec.ts
@@ -33,6 +33,7 @@ const test = base.extend<{
 const datasetName = getUniqueDatasetNameWithPrefix("quickstart");
 
 test.describe("color scheme basic functionality with quickstart", () => {
+  test.skip(true, "THIS TEST USES ZOO DATASET. TODO: FIX IT");
   test.beforeAll(async ({ fiftyoneLoader }) => {
     await fiftyoneLoader.loadZooDataset("quickstart", datasetName, {
       max_samples: 5,

--- a/e2e-pw/src/oss/specs/display-options/display-options.spec.ts
+++ b/e2e-pw/src/oss/specs/display-options/display-options.spec.ts
@@ -21,6 +21,8 @@ const test = base.extend<{
 });
 
 test.describe("Display Options", () => {
+  test.skip(true, "THIS TEST USES ZOO DATASET. TODO: FIX IT");
+
   const datasetName = getUniqueDatasetNameWithPrefix("quickstart-groups");
 
   test.beforeAll(async ({ fiftyoneLoader }) => {

--- a/e2e-pw/src/oss/specs/sidebar/sidebar-cifar.spec.ts
+++ b/e2e-pw/src/oss/specs/sidebar/sidebar-cifar.spec.ts
@@ -15,6 +15,8 @@ const test = base.extend<{ sidebar: SidebarPom; grid: GridPom }>({
 });
 
 test.describe("classification-sidebar-filter-visibility", () => {
+  test.skip(true, "THIS TEST USES ZOO DATASET. TODO: FIX IT");
+
   test.beforeAll(async ({ fiftyoneLoader }) => {
     await fiftyoneLoader.loadZooDataset("cifar10", datasetName, {
       max_samples: 5,

--- a/e2e-pw/src/oss/specs/sidebar/sidebar.spec.ts
+++ b/e2e-pw/src/oss/specs/sidebar/sidebar.spec.ts
@@ -15,6 +15,8 @@ const test = base.extend<{ sidebar: SidebarPom; grid: GridPom }>({
 });
 
 test.describe("sidebar-filter-visibility", () => {
+  test.skip(true, "THIS TEST USES ZOO DATASET. TODO: FIX IT");
+
   test.beforeAll(async ({ fiftyoneLoader }) => {
     await fiftyoneLoader.loadZooDataset("quickstart", datasetName, {
       max_samples: 5,

--- a/e2e-pw/src/oss/specs/smoke-tests/quickstart-groups.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/quickstart-groups.spec.ts
@@ -31,6 +31,8 @@ const test = base.extend<{
 });
 
 test.describe("quickstart-groups", () => {
+  test.skip(true, "THIS TEST USES ZOO DATASET. TODO: FIX IT");
+
   test.beforeAll(async ({ fiftyoneLoader }) => {
     await fiftyoneLoader.loadZooDataset("quickstart-groups", datasetName, {
       max_samples: 12,

--- a/e2e-pw/src/oss/specs/smoke-tests/quickstart.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/quickstart.spec.ts
@@ -23,6 +23,8 @@ const test = base.extend<{
 });
 
 test.beforeAll(async ({ fiftyoneLoader }) => {
+  test.skip(true, "THIS TEST USES ZOO DATASET. TODO: FIX IT");
+
   await fiftyoneLoader.loadZooDataset("quickstart", datasetName, {
     max_samples: 5,
   });

--- a/e2e-pw/src/oss/specs/smoke-tests/tagger.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/tagger.spec.ts
@@ -28,6 +28,8 @@ const test = base.extend<{
 });
 
 test.describe("tag", () => {
+  test.skip(true, "THIS TEST USES ZOO DATASET. TODO: FIX IT");
+
   test.beforeAll(async ({ fiftyoneLoader }) => {
     await fiftyoneLoader.loadZooDataset("quickstart", datasetName, {
       max_samples: 5,


### PR DESCRIPTION
Because of google drive's rate limiting, zoo datasets are having a problem being downloaded. #4802 adds caching for zoo datasets and models, but until that PR is undrafted and stable, we'll just skip these tests so as to not block PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Skipped several tests across different functionalities due to reliance on an unavailable zoo dataset, ensuring that test execution flow remains stable while addressing dataset issues.
	- Tests affected include those for color scheme, display options, sidebar functionality, quickstart groups, and tagging features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->