### PR TITLE
Protect against infinitely growing content size batcher

### DIFF
--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1462,6 +1462,9 @@ class ContentSizeDynamicBatcher(BaseDynamicBatcher):
         progress=False,
         total=None,
     ):
+        # If unset or larger, max batch size must be 1 byte per object
+        if max_batch_size is None or max_batch_size > target_size:
+            max_batch_size = target_size
         super().__init__(
             iterable,
             target_size,

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -99,16 +99,16 @@ class BatcherTests(unittest.TestCase):
 
     def test_inexhaustible_content_size_batcher(self):
         batcher = fou.ContentSizeDynamicBatcher(
-            None, init_batch_size=100, target_size=10
+            None, init_batch_size=100, target_size=1000
         )
-        measurements = [1, 20, 10, 0.1, 11, 0]
+        measurements = [500, 2000, 1000, 0.1, 1100, 0]
         expected_batches = [
             100,
-            1_000,
-            500,
-            500,
-            50_000,
-            int(round(10 / 11 * 50_000)),
+            200,
+            100,
+            100,
+            1000,  # capped at 1000 or 1B per object
+            int(round(10 / 11 * 1000)),
         ]
         batches = []
         for m in measurements:
@@ -474,8 +474,9 @@ class TestLoadDataset(unittest.TestCase):
     @patch("fiftyone.core.dataset.dataset_exists")
     @patch("fiftyone.core.odm.get_db_conn")
     @patch("fiftyone.core.dataset.Dataset")
-    def test_load_dataset_by_id(self, mock_dataset, mock_get_db_conn,
-                                dataset_exists):
+    def test_load_dataset_by_id(
+        self, mock_dataset, mock_get_db_conn, dataset_exists
+    ):
         # Setup
         identifier = ObjectId()
         mock_db = MagicMock()
@@ -500,8 +501,9 @@ class TestLoadDataset(unittest.TestCase):
     @patch("fiftyone.core.dataset.dataset_exists")
     @patch("fiftyone.core.odm.get_db_conn")
     @patch("fiftyone.core.dataset.Dataset")
-    def test_load_dataset_by_alt_id(self, mock_dataset, mock_get_db_conn,
-                                    dataset_exists):
+    def test_load_dataset_by_alt_id(
+        self, mock_dataset, mock_get_db_conn, dataset_exists
+    ):
         # Setup
         identifier = "alt_id"
         mock_db = MagicMock()


### PR DESCRIPTION
## What changes are proposed in this pull request?

If content size batcher is not getting backpressure properly, it would just keep increasing batch size to infinity. Eventually causing problems.
If some versions were misaligned, this was possible to rear its ugly head in Teams.

Let's just cap the batcher (via `max_batch_size`) to `target_size`, which would mean 1 byte per object.


## How is this patch tested? If it is not, please explain why.
This is essentially what was happening (fixed backpressure) so let's just prevent it.
```python
import fiftyone as fo

batcher = fo.core.utils.ContentSizeDynamicBatcher(None, init_batch_size=100)

for _ in range(10):
  print(next(batcher))
  batcher.apply_backpressure(100 * 1024)
```

Before 👎🏼 
```
100
1024
10486
107377
1099540
11259290
115295130
1180622131
12089570621
123797203159
...
```
After 👍🏼 
```
100
1024
10486
107377
1048576
1048576
...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced batch processing by enforcing a maximum limit on the `max_batch_size` parameter, improving memory efficiency.
  
- **Bug Fixes**
	- Updated tests to reflect changes in batch processing logic, accommodating larger input sizes and ensuring expected outputs align with new parameters.

- **Documentation**
	- Improved readability of test function signatures for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->