### PR TITLE
Fix list_downloaded_zoo_datasets

### DIFF
--- a/e2e-pw/src/oss/specs/color-scheme/color-scheme.spec.ts
+++ b/e2e-pw/src/oss/specs/color-scheme/color-scheme.spec.ts
@@ -33,7 +33,6 @@ const test = base.extend<{
 const datasetName = getUniqueDatasetNameWithPrefix("quickstart");
 
 test.describe("color scheme basic functionality with quickstart", () => {
-  test.skip(true, "THIS TEST USES ZOO DATASET. TODO: FIX IT");
   test.beforeAll(async ({ fiftyoneLoader }) => {
     await fiftyoneLoader.loadZooDataset("quickstart", datasetName, {
       max_samples: 5,

--- a/e2e-pw/src/oss/specs/display-options/display-options.spec.ts
+++ b/e2e-pw/src/oss/specs/display-options/display-options.spec.ts
@@ -21,8 +21,6 @@ const test = base.extend<{
 });
 
 test.describe("Display Options", () => {
-  test.skip(true, "THIS TEST USES ZOO DATASET. TODO: FIX IT");
-
   const datasetName = getUniqueDatasetNameWithPrefix("quickstart-groups");
 
   test.beforeAll(async ({ fiftyoneLoader }) => {

--- a/e2e-pw/src/oss/specs/sidebar/sidebar-cifar.spec.ts
+++ b/e2e-pw/src/oss/specs/sidebar/sidebar-cifar.spec.ts
@@ -15,8 +15,6 @@ const test = base.extend<{ sidebar: SidebarPom; grid: GridPom }>({
 });
 
 test.describe("classification-sidebar-filter-visibility", () => {
-  test.skip(true, "THIS TEST USES ZOO DATASET. TODO: FIX IT");
-
   test.beforeAll(async ({ fiftyoneLoader }) => {
     await fiftyoneLoader.loadZooDataset("cifar10", datasetName, {
       max_samples: 5,

--- a/e2e-pw/src/oss/specs/sidebar/sidebar.spec.ts
+++ b/e2e-pw/src/oss/specs/sidebar/sidebar.spec.ts
@@ -15,8 +15,6 @@ const test = base.extend<{ sidebar: SidebarPom; grid: GridPom }>({
 });
 
 test.describe("sidebar-filter-visibility", () => {
-  test.skip(true, "THIS TEST USES ZOO DATASET. TODO: FIX IT");
-
   test.beforeAll(async ({ fiftyoneLoader }) => {
     await fiftyoneLoader.loadZooDataset("quickstart", datasetName, {
       max_samples: 5,

--- a/e2e-pw/src/oss/specs/smoke-tests/quickstart-groups.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/quickstart-groups.spec.ts
@@ -31,8 +31,6 @@ const test = base.extend<{
 });
 
 test.describe("quickstart-groups", () => {
-  test.skip(true, "THIS TEST USES ZOO DATASET. TODO: FIX IT");
-
   test.beforeAll(async ({ fiftyoneLoader }) => {
     await fiftyoneLoader.loadZooDataset("quickstart-groups", datasetName, {
       max_samples: 12,

--- a/e2e-pw/src/oss/specs/smoke-tests/quickstart.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/quickstart.spec.ts
@@ -23,8 +23,6 @@ const test = base.extend<{
 });
 
 test.beforeAll(async ({ fiftyoneLoader }) => {
-  test.skip(true, "THIS TEST USES ZOO DATASET. TODO: FIX IT");
-
   await fiftyoneLoader.loadZooDataset("quickstart", datasetName, {
     max_samples: 5,
   });

--- a/e2e-pw/src/oss/specs/smoke-tests/tagger.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/tagger.spec.ts
@@ -28,8 +28,6 @@ const test = base.extend<{
 });
 
 test.describe("tag", () => {
-  test.skip(true, "THIS TEST USES ZOO DATASET. TODO: FIX IT");
-
   test.beforeAll(async ({ fiftyoneLoader }) => {
     await fiftyoneLoader.loadZooDataset("quickstart", datasetName, {
       max_samples: 5,

--- a/fiftyone/zoo/datasets/__init__.py
+++ b/fiftyone/zoo/datasets/__init__.py
@@ -8,6 +8,7 @@ download via FiftyOne.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import OrderedDict
 import importlib
 import inspect
@@ -126,11 +127,11 @@ def list_downloaded_zoo_datasets():
         a dict mapping dataset names to
         (``dataset_dir``, :class:`ZooDatasetInfo`) tuples
     """
-    downloaded_datasets = {}
-
     root_dir = fo.config.dataset_zoo_dir
     if not root_dir or not os.path.isdir(root_dir):
-        return
+        return {}
+
+    downloaded_datasets = {}
 
     for dataset_dir, dirs, _ in os.walk(root_dir, followlinks=True):
         if dataset_dir == root_dir:


### PR DESCRIPTION
## What changes are proposed in this pull request?

`list_downloaded_zoo_datasets` should always return a `dict`. Fixes e2e tests

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the robustness of the dataset listing function by ensuring it consistently returns an empty dictionary when the specified directory is invalid, preventing potential errors in usage.
- **Tests**
	- Removed skip directives from multiple tests related to the zoo dataset, allowing them to execute and validate functionality as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->