### PR TITLE
reduce modal action row button size for better fit

### DIFF
--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -554,7 +554,19 @@ const ModalActionsRowContainer = styled.div`
     opacity: 1;
     transition: opacity 0.1s ease-out;
   }
-}`;
+
+  svg {
+    font-size: 18px;
+  }
+
+  > div {
+    max-height: 24px;
+
+    > div:first-child {
+      max-height: 24px;
+    }
+  }
+`;
 
 const DraggableHandleIconContainer = styled.div`
   cursor: grab;


### PR DESCRIPTION
## What changes are proposed in this pull request?

reduce modal action row button size for better fit

## How is this patch tested? If it is not, please explain why.

Using modal in normal and fullscreen mode:

![image](https://github.com/user-attachments/assets/a361534e-0bed-469a-ae58-f3c4a6fd31b8)
![image](https://github.com/user-attachments/assets/e99b75b3-4395-4adc-a71c-211b99b186ff)


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced visual layout of the modal actions with improved styling for SVG icons and nested elements.

- **Style**
	- Introduced new CSS styles for consistent sizing and appearance of icons and div elements in the modal actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->