### PR TITLE
Add date fields to primitives sidebar group

### DIFF
--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -16,6 +16,7 @@ from fiftyone.core.fields import (
     BooleanField,
     ClassesField,
     ColorField,
+    DateField,
     DateTimeField,
     DictField,
     EmbeddedDocumentField,
@@ -583,7 +584,15 @@ def _parse_schema(
                     custom.append((name, paths))
         elif isinstance(
             field,
-            (ObjectIdField, IntField, FloatField, StringField, BooleanField),
+            (
+                ObjectIdField,
+                IntField,
+                FloatField,
+                StringField,
+                BooleanField,
+                DateField,
+                DateTimeField,
+            ),
         ):
             if frames:
                 other.append(name)


### PR DESCRIPTION
Tweaks the SDK's `default_sidebar_groups()` logic so that date fields are added to the `primitives` sidebar group rather than `other`.

This updated behavior matches how the App's corresponding default sidebar logic works.

```py
import fiftyone as fo
import fiftyone as foz

dataset = foz.load_zoo_dataset("quickstart")

# 'created_at' and 'last_modified_at' should be in 'primitives' group
print(fo.DatasetAppConfig.default_sidebar_groups(dataset))
```

```
...
<SidebarGroupDocument: {
     'name': 'primitives',
     'paths': ['id', 'filepath', 'created_at', 'last_modified_at'],
     'expanded': None,
}>,
...
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `DateField` type for improved handling of date-related data in dataset schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->