### PR TITLE
it is time to deprecate python 3.8

### DIFF
--- a/.github/workflows/build-db.yml
+++ b/.github/workflows/build-db.yml
@@ -78,7 +78,7 @@ jobs:
           path: package/db/dist/*.whl
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: build
     env:
       FIFTYONE_DO_NOT_TRACK: true
@@ -90,16 +90,20 @@ jobs:
         with:
           name: dist-sdist
           path: downloads
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
       - name: Install fiftyone-db
         run: |
-          pip3 install downloads/fiftyone_db-*.tar.gz
+          pip install downloads/fiftyone_db-*.tar.gz
       - name: Install test dependencies
         run: |
-          pip3 install pytest
+          pip install pytest
       - name: Run tests
         run: |
           cd package/db/
-          python3 -m pytest --verbose tests/
+          python -m pytest --verbose tests/
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -53,10 +53,10 @@ jobs:
           path: fiftyone-teams
           token: ${{ secrets.TEAMS_GITHUB_PAT }}
           ref: main
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install pip dependencies
         run: |
           pip install --upgrade pip setuptools wheel build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,13 +33,10 @@ jobs:
           - ubuntu-latest-m
           - windows-latest
         python:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
         exclude:
-          - os: windows-latest
-            python: "3.8"
           - os: windows-latest
             python: "3.9"
           - os: windows-latest

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ to make adjustments. If you are working in Google Colab,
 
 You will need:
 
--   [Python](https://www.python.org) (3.8 - 3.11)
+-   [Python](https://www.python.org) (3.9 - 3.11)
 -   [Node.js](https://nodejs.org) - on Linux, we recommend using
     [nvm](https://github.com/nvm-sh/nvm) to install an up-to-date version.
 -   [Yarn](https://yarnpkg.com) - once Node.js is installed, you can

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ generate its documentation and API reference from source.
 
 In order to build the docs locally, you must:
 
-1.  Be running Python 3.8 or 3.9 in a
+1.  Be running Python 3.9 or 3.10 in a
     [virtual environment](https://docs.voxel51.com/getting_started/virtualenv.html)
 
 2.  Perform a developer install of `fiftyone`:

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ generate its documentation and API reference from source.
 
 In order to build the docs locally, you must:
 
-1.  Be running Python 3.9 or 3.10 in a
+1.  Be running Python 3.9 in a
     [virtual environment](https://docs.voxel51.com/getting_started/virtualenv.html)
 
 2.  Perform a developer install of `fiftyone`:

--- a/docs/source/deprecation.rst
+++ b/docs/source/deprecation.rst
@@ -17,15 +17,8 @@ are recommended for the best FiftyOne experience.
 
 Python 3.8
 ----------
-*Support Ends October 2024*
+*Support Ended October 2024*
 
 `Python 3.8 <https://devguide.python.org/versions/>`_
 transitions to `end-of-life` effective October of 2024. FiftyOne releases after
 September 30, 2024 will no longer support Python 3.8.
-
-Versions of `fiftyone` after 0.24.1, or after FiftyOne Teams SDK version 0.18.0,
-will provide a deprecation notice when `fiftyone` is imported using Python 3.8.
-
-You can disable this deprecation notice by setting the
-`FIFTYONE_PYTHON_38_DEPRECATION_NOTICE` environment variable to `false` prior
-to importing `fiftyone`.

--- a/docs/source/environments/index.rst
+++ b/docs/source/environments/index.rst
@@ -415,14 +415,13 @@ Next, build the image:
 
     docker build -t voxel51/fiftyone .
 
-The default image uses Ubuntu 20.04 and Python 3.8, but you can customize these
+The default image uses Python 3.11, but you can customize these
 via optional build arguments:
 
 .. code:: shell
 
     docker build \
-        --build-arg BASE_IMAGE=ubuntu:18.04 \
-        --build-arg PYTHON_VERSION=3.9 \
+        --build-arg PYTHON_VERSION=3.10 \
         -t voxel51/fiftyone .
 
 Refer to the

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -20,7 +20,7 @@ Prerequisites
 -------------
 
 You will need a working Python installation. FiftyOne currently requires
-**Python 3.8 - 3.11**
+**Python 3.9 - 3.11**
 
 
 On Linux, we recommend installing Python through your system package manager

--- a/docs/source/getting_started/troubleshooting.rst
+++ b/docs/source/getting_started/troubleshooting.rst
@@ -44,9 +44,9 @@ old, you may encounter errors like these:
 
 .. code-block:: text
 
-    fiftyone requires Python '>=3.8' but the running Python is 3.4.10
+    fiftyone requires Python '>=3.9' but the running Python is 3.4.10
 
-To resolve this, you will need to use Python 3.8 or newer, and pip 19.3 or
+To resolve this, you will need to use Python 3.9 or newer, and pip 19.3 or
 newer. See the :ref:`installation guide <installing-fiftyone>` for details. If
 you have installed a suitable version of Python in a virtual environment and
 still encounter this error, ensure that the virtual environment is activated.

--- a/docs/source/getting_started/virtualenv.rst
+++ b/docs/source/getting_started/virtualenv.rst
@@ -26,7 +26,7 @@ these commands:
    $ python --version
    Python 2.7.17
    $ python3 --version
-   Python 3.8.9
+   Python 3.9.20
 
 In this case, `python3` should be used in the next step.
 
@@ -71,7 +71,7 @@ of this guide. For example:
 .. code-block:: text
 
    $ python --version
-   Python 3.8.3
+   Python 3.9.20
 
 Also note that `python` and `pip` live inside the `env` folder (in this output,
 the path to the current folder is replaced with `...`):

--- a/fiftyone/__init__.py
+++ b/fiftyone/__init__.py
@@ -16,21 +16,6 @@ from sys import hexversion
 
 logger = logging.getLogger(__name__)
 
-# Python 3.8 goes EoL in October, 2024
-#  We should tell folks we won't support those Python versions after 9/24
-
-PYTHON_38_NOTICE = getenv(
-    'FIFTYONE_PYTHON_38_DEPRECATION_NOTICE', "True"
-) == "True"
-
-if hexversion < 0x30900f0 and hexversion >= 0x30800f0 and PYTHON_38_NOTICE:
-    logger.warning("***Python 3.8 Deprecation Notice***")
-    logger.warning("Python 3.8 will no longer be supported in new releases"
-                   " after October 1, 2024.")
-    logger.warning("Please upgrade to Python 3.9 or later.")
-    logger.warning("For additional details please see"
-                   " https://deprecation.voxel51.com")
-
 #
 # This statement allows multiple `fiftyone.XXX` packages to be installed in the
 # same environment and used simultaneously.

--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -320,11 +320,10 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     cmdclass=cmdclass,
 )

--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -165,7 +165,7 @@ def _get_download():
 MONGODB_BINARIES = ["mongod"]
 
 
-VERSION = "1.1.5"
+VERSION = "1.1.6"
 
 
 def get_version():

--- a/package/desktop/setup.py
+++ b/package/desktop/setup.py
@@ -187,11 +187,10 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     cmdclass=cmdclass,
 )

--- a/package/graphql/setup.py
+++ b/package/graphql/setup.py
@@ -52,10 +52,9 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
 )

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -16,7 +16,7 @@ pandas>=1.3
 plotly==5.17.0
 pprintpp==0.4.0
 psutil>=5.7.0
-pymongo>=3.12
+pymongo>=3.12,<4.9
 pydantic==2.6.4
 pytz==2022.1
 PyYAML==6.0.1

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -9,6 +9,7 @@ myst-parser==0.13.7
 nbsphinx==0.8.8
 sphinx-tabs==1.2.1
 Sphinx==3.5.4
-sphinxcontrib-napoleon==0.7
 sphinx-copybutton==0.4.0
 sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-napoleon==0.7

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -14,4 +14,5 @@ sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-napoleon==0.7
+sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -12,4 +12,5 @@ Sphinx==3.5.4
 sphinx-copybutton==0.4.0
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.6
 sphinxcontrib-napoleon==0.7

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -11,3 +11,4 @@ sphinx-tabs==1.2.1
 Sphinx==3.5.4
 sphinxcontrib-napoleon==0.7
 sphinx-copybutton==0.4.0
+sphinxcontrib-applehelp==1.0.4

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -12,5 +12,5 @@ Sphinx==3.5.4
 sphinx-copybutton==0.4.0
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
-sphinxcontrib-htmlhelp==2.0.6
+sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-napoleon==0.7

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -14,3 +14,4 @@ sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-napoleon==0.7
+sphinxcontrib-serializinghtml==1.1.5

--- a/setup.py
+++ b/setup.py
@@ -150,11 +150,10 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
     entry_points={"console_scripts": ["fiftyone=fiftyone.core.cli:main"]},
-    python_requires=">=3.8",
+    python_requires=">=3.9",
 )


### PR DESCRIPTION
## What changes are proposed in this pull request?

Deprecate python 3.8 as [as foretold by prophecy](https://docs.voxel51.com/deprecation.html#python-3-8)

## How is this patch tested? If it is not, please explain why.

Local Build

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Python 3.8 is no longer supported; see our [deprecation notices](https://docs.voxel51.com/deprecation.html#python-3-8) for details

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Updated Python version requirements across various documentation and setup files to support Python 3.9 and above.
	- Enhanced Docker image configuration to utilize Python 3.11.
	- Added support for generating Apple Help Book documentation and Devhelp documentation.

- **Bug Fixes**
	- Removed deprecated warnings for Python 3.8 from the codebase and documentation.

- **Documentation**
	- Clarified support status for Python versions in README and troubleshooting guides.
	- Updated installation instructions to reflect new Python version requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->