### PR TITLE
Merge v0.25.2 into develop

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -3,6 +3,15 @@ FiftyOne Release Notes
 
 .. default-role:: code
 
+
+FiftyOne 0.25.2
+---------------
+*Released September 19, 2024*
+
+* Require `pymongo<4.9` to fix database connections
+* Require `pydicom<3` for :ref:`DICOM datasets <DICOMDataset-import>`
+
+
 FiftyOne Teams 2.0.1
 --------------------
 *Released September 6, 2024*

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ INSTALL_REQUIRES = [
     "plotly>=4.14",
     "pprintpp",
     "psutil",
-    "pymongo>=3.12, <4.9",
+    "pymongo>=3.12,<4.9",
     "pytz",
     "PyYAML",
     "regex",


### PR DESCRIPTION
Merge `v0.25.2` into `develop`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced dependency requirements for `pymongo` (less than version 4.9) for improved database connection stability.
	- Introduced dependency requirements for `pydicom` (less than version 3) for better compatibility with DICOM datasets.
  
- **Chores**
	- Minor formatting update in the `setup.py` file for consistency in dependency declaration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->