### PR TITLE
fix off-by-one errors parsing stuff and thing instances

### DIFF
--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -1855,7 +1855,7 @@ def _parse_stuff_instance(mask, offset=None, frame_size=None):
     h = (ymax - ymin + 1) / height
 
     bbox = [x, y, w, h]
-    instance_mask = mask[ymin:ymax, xmin:xmax]
+    instance_mask = mask[ymin : (ymax + 1), xmin : (xmax + 1)]
 
     return bbox, instance_mask
 
@@ -1873,23 +1873,23 @@ def _parse_thing_instances(mask, offset=None, frame_size=None):
 
     labeled = skm.label(mask)
     objects = _find_slices(labeled)
-
     instances = []
-    for idx, (yslice, xslice) in objects.items():
+    for target, slc in objects.items():
+        yslice, xslice = slc
         xmin = xslice.start
-        xmax = xslice.stop
         ymin = yslice.start
-        ymax = yslice.stop
+        instance_offset = (
+            offset[0] + xmin,
+            offset[1] + ymin,
+        )
 
-        x = (xmin + x_offset) / width
-        y = (ymin + y_offset) / height
-        w = (xmax - xmin) / width
-        h = (ymax - ymin) / height
-
-        bbox = [x, y, w, h]
-        instance_mask = mask[ymin:ymax, xmin:xmax]
-
-        instances.append((bbox, instance_mask))
+        # use the labeled image mask so `_parse_stuff_instance()`
+        # can be re-used here
+        instance_mask = labeled[slc] == target
+        instance = _parse_stuff_instance(
+            instance_mask, instance_offset, frame_size
+        )
+        instances.append(instance)
 
     return instances
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix an off-by-one error that was causing masks for both stuff and thing instances to miss the last row and column when converting segmentations.

## How is this patch tested? If it is not, please explain why.

Added tests for both `_parse_stuff_instance()` and `_parse_thing_instances()` verifying that the resulting mask has the correct dimensions and matches the actual mask.

## Release Notes

-   [ ] No. You can skip the rest of this section.
-   [X] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fix an off-by-one error that was causing masks for both stuff and thing instances to miss the last row and column when converting segmentations.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [X] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved instance mask parsing to ensure full bounding box coverage.
	- Enhanced clarity and maintainability in the instance extraction process.

- **Bug Fixes**
	- Corrected slicing logic for instance masks to include maximum coordinates.

- **Tests**
	- Added unit tests for instance mask parsing, covering various scenarios including overlapping bounding boxes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->