### PR TITLE
Adding MedSAM2 to the model zoo

### DIFF
--- a/docs/scripts/make_model_zoo_docs.py
+++ b/docs/scripts/make_model_zoo_docs.py
@@ -92,6 +92,13 @@ _MODEL_TEMPLATE = """
     from fiftyone import ViewField as F
 {% endif %}
 
+{% if 'med-sam' in name %}
+    from fiftyone import ViewField as F
+    from fiftyone.utils.huggingface import load_from_hub
+    
+    dataset = load_from_hub("Voxel51/BTCV-CT-as-video-MedSAM2-dataset")[:2]
+{% endif %}
+
 {% if 'imagenet' in name %}
     dataset = foz.load_zoo_dataset(
         "imagenet-sample",
@@ -109,6 +116,17 @@ _MODEL_TEMPLATE = """
         .set_field("frames.detections", None)
         .save()
     )
+{% elif 'med-sam' in name %}
+
+    # Retaining detections from a single frame in the middle
+    # Note that SAM2 only propagates segmentation masks forward in a video
+    (
+        dataset
+        .match_frames(F("frame_number") != 100)
+        .set_field("frames.gt_detections", None)
+        .save()
+    )
+
 {% else %}
     dataset = foz.load_zoo_dataset(
         "coco-2017",
@@ -133,7 +151,7 @@ _MODEL_TEMPLATE = """
     dataset.apply_model(model, label_field="auto")
 
     session = fo.launch_app(dataset)
-{% elif 'segment-anything' in tags and 'video' in tags %}
+{% elif 'segment-anything' in tags and 'video' in tags  and 'med-SAM' not in tags %}
     model = foz.load_zoo_model("{{ name }}")
 
     # Segment inside boxes and propagate to all frames
@@ -141,6 +159,17 @@ _MODEL_TEMPLATE = """
         model,
         label_field="segmentations",
         prompt_field="frames.detections",  # can contain Detections or Keypoints
+    )
+
+    session = fo.launch_app(dataset)
+{% elif 'med-sam' in name %}
+    model = foz.load_zoo_model("{{ name }}")
+
+    # Segment inside boxes and propagate to all frames
+    dataset.apply_model(
+        model,
+        label_field="pred_segmentations",
+        prompt_field="frames.gt_detections",
     )
 
     session = fo.launch_app(dataset)

--- a/fiftyone/utils/sam2.py
+++ b/fiftyone/utils/sam2.py
@@ -7,19 +7,18 @@ wrapper for the FiftyOne Model Zoo.
 |
 """
 
-import cv2
-import numpy as np
-
 import logging
 
+import cv2
 import eta.core.utils as etau
+import numpy as np
 
 import fiftyone.core.labels as fol
-import fiftyone.core.utils as fou
-import fiftyone.utils.torch as fout
-import fiftyone.utils.sam as fosam
-import fiftyone.zoo.models as fozm
 import fiftyone.core.models as fom
+import fiftyone.core.utils as fou
+import fiftyone.utils.sam as fosam
+import fiftyone.utils.torch as fout
+import fiftyone.zoo.models as fozm
 
 fou.ensure_torch()
 import torch

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -449,8 +449,8 @@
             "date_added": "2024-08-05 14:38:20"
         },
         {
-            "base_name": "MedSAM2-video-torch",
-            "base_filename": "MedSAM2_pretrain.pth",
+            "base_name": "med-sam-2-video-torch",
+            "base_filename": "med-sam-2_pretrain.pth",
             "version": null,
             "description": "Fine-tuned SAM2-hiera-tiny model from paper: Medical SAM 2 - Segment Medical Images as Video via Segment Anything Model 2 <https://arxiv.org/abs/2408.00874>`_",
             "source": "https://github.com/MedicineToken/Medical-SAM2",
@@ -482,7 +482,7 @@
                 "torch",
                 "zero-shot",
                 "video",
-                "MedSAM-2"
+                "med-SAM"
             ],
             "date_added": "2024-08-17 14:48:00"
         },

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -449,6 +449,44 @@
             "date_added": "2024-08-05 14:38:20"
         },
         {
+            "base_name": "MedSAM2-video-torch",
+            "base_filename": "MedSAM2_pretrain.pth",
+            "version": null,
+            "description": "Fine-tuned SAM2-hiera-tiny model from paper: Medical SAM 2 - Segment Medical Images as Video via Segment Anything Model 2 <https://arxiv.org/abs/2408.00874>`_",
+            "source": "https://github.com/MedicineToken/Medical-SAM2",
+            "size_bytes": 155906050,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://huggingface.co/jiayuanz3/MedSAM2_pretrain/resolve/main/MedSAM2_pretrain.pth?download=true"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.sam2.SegmentAnything2VideoModel",
+                "config": {
+                    "entrypoint_fcn": "sam2.build_sam.build_sam2_video_predictor",
+                    "entrypoint_args": { "model_cfg": "sam2_hiera_t.yaml" }
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": [
+                "segment-anything",
+                "torch",
+                "zero-shot",
+                "video",
+                "MedSAM-2"
+            ],
+            "date_added": "2024-08-17 14:48:00"
+        },
+        {
             "base_name": "deeplabv3-resnet50-coco-torch",
             "base_filename": "deeplabv3_resnet50_coco-cd0a2569.pth",
             "version": null,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adding MedSAM2 to the model ZOO by adding documentation to [this PR](https://github.com/voxel51/fiftyone/pull/4733) by Evatt Harvey Salinger.

## How is this patch tested? If it is not, please explain why.

Manually tested

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

This PR adds MedSAM2 to the FiftyOne Model Zoo. Detailed description in [this PR](https://github.com/voxel51/fiftyone/pull/4733).

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [x] Other: FiftyOne Zoo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for handling the "med-sam" dataset, including specific dataset loading and processing logic.
	- Enhanced model application capabilities for the "med-sam" dataset with tailored conditions.
	- Integrated session launch for the FiftyOne app post-dataset processing.
- **Refactor**
	- Reorganized import statements for improved structure in the utility scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->