### PR TITLE
Add the option of using panoptic segmentation masks

### DIFF
--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -8,6 +8,7 @@ Labels stored in dataset samples.
 from functools import partial
 import itertools
 import warnings
+import pathlib
 
 from bson import ObjectId
 import cv2
@@ -15,6 +16,7 @@ import numpy as np
 import scipy.ndimage as spn
 import skimage.measure as skm
 import skimage.segmentation as sks
+import tifffile
 
 import eta.core.frameutils as etaf
 import eta.core.image as etai
@@ -447,7 +449,9 @@ class Detection(_HasAttributesDict, _HasID, Label):
             **attributes,
         )
 
-    def to_segmentation(self, mask=None, frame_size=None, target=255):
+    def to_segmentation(
+        self, mask=None, frame_size=None, target=255, panoptic=False
+    ):
         """Returns a :class:`Segmentation` representation of this instance.
 
         The detection must have an instance mask, i.e., its :attr:`mask`
@@ -463,6 +467,7 @@ class Detection(_HasAttributesDict, _HasID, Label):
                 provided
             target (255): the pixel value or RGB hex string to use to render
                 the object
+            panoptic (False): whether to return a panoptic segmentation
 
         Returns:
             a :class:`Segmentation`
@@ -473,9 +478,14 @@ class Detection(_HasAttributesDict, _HasID, Label):
                 "be converted to segmentations"
             )
 
-        mask, target = _parse_segmentation_target(mask, frame_size, target)
+        mask, target = _parse_segmentation_target(
+            mask, frame_size, target, panoptic
+        )
         _render_instance(mask, self, target)
-        return Segmentation(mask=mask)
+        if panoptic:
+            instance_mask = (mask == target).astype(np.uint8)
+            mask = np.stack([mask, instance_mask], axis=-1)
+        return Segmentation(mask=mask, is_panoptic=panoptic)
 
     def to_shapely(self, frame_size=None):
         """Returns a Shapely representation of this instance.
@@ -557,7 +567,9 @@ class Detections(_HasLabelList, Label):
             ]
         )
 
-    def to_segmentation(self, mask=None, frame_size=None, mask_targets=None):
+    def to_segmentation(
+        self, mask=None, frame_size=None, mask_targets=None, panoptic=False
+    ):
         """Returns a :class:`Segmentation` representation of this instance.
 
         Only detections with instance masks (i.e., their :attr:`mask`
@@ -576,16 +588,19 @@ class Detections(_HasLabelList, Label):
                 object classes to render and which pixel values to use for each
                 class. If omitted, all objects are rendered with pixel value
                 255
+            panoptic (False): whether to return a panoptic segmentation
 
         Returns:
             a :class:`Segmentation`
         """
         mask, labels_to_targets = _parse_segmentation_mask_targets(
-            mask, frame_size, mask_targets
+            mask, frame_size, mask_targets, panoptic
         )
+        if panoptic:
+            instance_mask = mask.copy()
 
         # pylint: disable=not-an-iterable
-        for detection in self.detections:
+        for idx, detection in enumerate(self.detections):
             if detection.mask is None:
                 msg = "Skipping detection(s) with no instance mask"
                 warnings.warn(msg)
@@ -600,7 +615,13 @@ class Detections(_HasLabelList, Label):
 
             _render_instance(mask, detection, target)
 
-        return Segmentation(mask=mask)
+            if panoptic:
+                _render_instance(instance_mask, detection, idx + 1)
+
+        if panoptic:
+            mask = np.stack([mask, instance_mask], axis=-1)
+
+        return Segmentation(mask=mask, is_panoptic=panoptic)
 
 
 class Polyline(_HasAttributesDict, _HasID, Label):
@@ -680,7 +701,12 @@ class Polyline(_HasAttributesDict, _HasID, Label):
         )
 
     def to_segmentation(
-        self, mask=None, frame_size=None, target=255, thickness=1
+        self,
+        mask=None,
+        frame_size=None,
+        target=255,
+        thickness=1,
+        panoptic=False,
     ):
         """Returns a :class:`Segmentation` representation of this instance.
 
@@ -696,12 +722,18 @@ class Polyline(_HasAttributesDict, _HasID, Label):
                 the object
             thickness (1): the thickness, in pixels, at which to render
                 (non-filled) polylines
+            panoptic (False): whether to return a panoptic segmentation
 
         Returns:
             a :class:`Segmentation`
         """
-        mask, target = _parse_segmentation_target(mask, frame_size, target)
+        mask, target = _parse_segmentation_target(
+            mask, frame_size, target, panoptic
+        )
         _render_polyline(mask, self, target, thickness)
+        if panoptic:
+            instance_mask = (mask == target).astype(np.uint8)
+            mask = np.stack([mask, instance_mask], axis=-1)
         return Segmentation(mask=mask)
 
     def to_shapely(self, frame_size=None, filled=None):
@@ -907,7 +939,12 @@ class Polylines(_HasLabelList, Label):
         )
 
     def to_segmentation(
-        self, mask=None, frame_size=None, mask_targets=None, thickness=1
+        self,
+        mask=None,
+        frame_size=None,
+        mask_targets=None,
+        thickness=1,
+        panoptic=False,
     ):
         """Returns a :class:`Segmentation` representation of this instance.
 
@@ -926,16 +963,19 @@ class Polylines(_HasLabelList, Label):
                 255
             thickness (1): the thickness, in pixels, at which to render
                 (non-filled) polylines
+            panoptic (False): whether to return a panoptic segmentation
 
         Returns:
             a :class:`Segmentation`
         """
         mask, labels_to_targets = _parse_segmentation_mask_targets(
-            mask, frame_size, mask_targets
+            mask, frame_size, mask_targets, panoptic
         )
+        if panoptic:
+            instance_mask = mask.copy()
 
         # pylint: disable=not-an-iterable
-        for polyline in self.polylines:
+        for idx, polyline in enumerate(self.polylines):
             if labels_to_targets is not None:
                 target = labels_to_targets.get(polyline.label, None)
                 if target is None:
@@ -944,6 +984,12 @@ class Polylines(_HasLabelList, Label):
                 target = 255
 
             _render_polyline(mask, polyline, target, thickness)
+
+            if panoptic:
+                _render_polyline(instance_mask, polyline, idx + 1, thickness)
+
+        if panoptic:
+            mask = np.stack([mask, instance_mask], axis=-1)
 
         return Segmentation(mask=mask)
 
@@ -1004,21 +1050,36 @@ class _HasMedia(object):
 
 
 class Segmentation(_HasID, _HasMedia, Label):
-    """A semantic segmentation for an image.
+    """A segmentation for an image.
 
     Provide either the ``mask`` or ``mask_path`` argument to define the
     segmentation.
 
+    Set ``is_panoptic`` to ``True`` for panoptic segmentations, which
+    encode both class and instance labels. Otherwise this object
+    represents a semantic segmentation, which only encodes class
+    labels.
+
+    If ``is_panoptic`` is ``True``, ``mask`` must have two channels.
+    The first channel encodes the class, and the second the instance.
+    Grayscale (one channel) and RGB (three channel) masks are only
+    supported for semantic segmentation.
+
+    ``mask_path`` may be a file in TIFF or BigTIFF format, to allow
+    enough bit depth to represent large numbers of objects. They must use
+    the ".tif" or ".tiff" extension.
+
     Args:
-        mask (None): a numpy array with integer values encoding the semantic
-            labels
+        mask (None): a numpy array with integer values encoding the labels
         mask_path (None): the absolute path to the segmentation image on disk
+
     """
 
     _MEDIA_FIELD = "mask_path"
 
     mask = fof.ArrayField()
     mask_path = fof.StringField()
+    is_panoptic = fof.BooleanField()
 
     @property
     def has_mask(self):
@@ -1035,7 +1096,7 @@ class Segmentation(_HasID, _HasMedia, Label):
             return self.mask
 
         if self.mask_path is not None:
-            return _read_mask(self.mask_path)
+            return _read_mask(self.mask_path, self.is_panoptic)
 
         return None
 
@@ -1049,8 +1110,7 @@ class Segmentation(_HasID, _HasMedia, Label):
                 attribute after importing
         """
         if self.mask_path is not None:
-            self.mask = _read_mask(self.mask_path)
-
+            self.mask = _read_mask(self.mask_path, self.is_panoptic)
             if update:
                 self.mask_path = None
 
@@ -1083,6 +1143,9 @@ class Segmentation(_HasID, _HasMedia, Label):
         Note that any pixel values not in ``targets_map`` will be zero in the
         transformed mask.
 
+        If this is a panoptic segmentation, only the class labels will
+        be transformed.
+
         Args:
             targets_map: a dict mapping existing pixel values (2D masks) or RGB
                 hex strings (3D masks) to new pixel values or RGB hex strings.
@@ -1094,12 +1157,16 @@ class Segmentation(_HasID, _HasMedia, Label):
 
         Returns:
             the transformed mask
+
         """
         mask = self.get_mask()
         if mask is None:
             return
 
-        mask = _transform_mask(mask, targets_map)
+        if self.is_panoptic:
+            mask[:, :, 0] = _transform_mask(mask[:, :, 0], targets_map)
+        else:
+            mask = _transform_mask(mask, targets_map)
 
         if outpath is not None:
             _write_mask(mask, outpath)
@@ -1115,7 +1182,11 @@ class Segmentation(_HasID, _HasMedia, Label):
 
         return mask
 
-    def to_detections(self, mask_targets=None, mask_types="stuff"):
+    def to_detections(
+        self,
+        mask_targets=None,
+        mask_types=None,
+    ):
         """Returns a :class:`Detections` representation of this instance with
         instance masks populated.
 
@@ -1124,6 +1195,11 @@ class Segmentation(_HasID, _HasMedia, Label):
 
         Each ``"thing"`` class will result in one :class:`Detection` instance
         per connected region of that class in the segmentation.
+
+        For panoptic segmentations, instances with a "thing" class
+        each get a separate detection. Any pixels with that class but
+        without an instance label are processed according to connected
+        regions.
 
         Args:
             mask_targets (None): a dict mapping integer pixel values (2D masks)
@@ -1135,14 +1211,28 @@ class Segmentation(_HasID, _HasMedia, Label):
                 regions, each representing an instance of the thing). Can be
                 any of the following:
 
-                -   ``"stuff"`` if all classes are stuff classes
-                -   ``"thing"`` if all classes are thing classes
+                -   ``"stuff"`` if all classes are stuff
+                    classes. Ignores panoptic intances.
+                -   ``"thing"`` if all classes are thing classes. Panoptic
+                    instances are handled first, then any remaining labels
+                    are separated into connected components.
+                -   ``"panoptic"`` if all panoptic instances are thing classes
+                     and all remaining are stuff classes. Panoptic only.
+                -   ``"object"``: only keep panoptic object instances
                 -   a dict mapping pixel values (2D masks) or RGB hex strings
-                    (3D masks) to ``"stuff"`` or ``"thing"`` for each class
+                    (3D masks) to ``"stuff"``, ``"thing"``, ``"panoptic"``,
+                    or ``"object"`` for each class
+
+                Defaults to ``"stuff"`` for semantic segmentations and
+                ``"panoptic"`` for panoptic segmentations.
 
         Returns:
             a :class:`Detections`
+
         """
+        if mask_types is None:
+            mask_types = "panoptic" if self.is_panoptic else "stuff"
+
         detections = _segmentation_to_detections(
             self, mask_targets, mask_types
         )
@@ -1151,7 +1241,7 @@ class Segmentation(_HasID, _HasMedia, Label):
     def to_polylines(
         self,
         mask_targets=None,
-        mask_types="stuff",
+        mask_types=None,
         tolerance=2,
     ):
         """Returns a :class:`Polylines` representation of this instance.
@@ -1167,7 +1257,74 @@ class Segmentation(_HasID, _HasMedia, Label):
                 or RGB hex strings (3D masks) to label strings defining which
                 classes to generate detections for. If omitted, all labels are
                 assigned to their pixel values
-            mask_types ("stuff"): whether the classes are ``"stuff"``
+            mask_types (None): whether the classes are ``"stuff"``
+                (amorphous regions of pixels) or ``"thing"`` (connected
+                regions, each representing an instance of the thing). Can be
+                any of the following:
+
+                -   ``"stuff"`` if all classes are stuff classes
+                -   ``"thing"`` if all classes are thing classes. Panoptic
+                    instances are handled first, then any remaining labels
+                    are separated into connected components.
+                -   ``"panoptic"`` if all instances are thing classes and all
+                    remaining are stuff classes.
+                -   ``"object"``: only keep panoptic object instances
+                -   a dict mapping pixel values (2D masks) or RGB hex strings
+                    (3D masks) to ``"stuff"``, ``"thing"``, ``"object"``,
+                    or ``"panoptic"`` for each class
+
+                Defaults to ``"stuff"`` for semantic segmentations and
+                ``"panoptic"`` for panoptic segmentations.
+
+            tolerance (2): a tolerance, in pixels, when generating approximate
+                polylines for each region. Typical values are 1-3 pixels
+
+        Returns:
+            a :class:`Polylines`
+
+        """
+        if mask_types is None:
+            mask_types = "panoptic" if self.is_panoptic else "stuff"
+
+        polylines = _segmentation_to_polylines(
+            self, mask_targets, mask_types, tolerance
+        )
+        return Polylines(polylines=polylines)
+
+    def to_semantic(self, to_rgb=False):
+        """Convert panoptic segmentation to semantic.
+
+        Optionally converts the class integer values back to 3D pixel
+        values.
+
+        Args:
+            to_rgb (False): convert integer classes to RGB hex values
+
+        Returns:
+            a :class:`Segmentation`
+
+        """
+        mask = self.get_mask()
+        if self.is_panoptic:
+            mask = mask[..., 0]
+            if to_rgb:
+                mask = _int_array_to_rgb(mask)
+
+        return Segmentation(mask=mask, is_panoptic=False)
+
+    def to_panoptic(self, mask_types="thing"):
+        """Convert semantic segmentation to panoptic.
+
+        Each ``"stuff"`` class will be kept as-is.
+
+        Each ``"thing"`` class will result in one instance per
+        connected region of that class.
+
+        If the mask is 3D, its pixel values will be converted to the
+        integer value of the equivalend hex string.
+
+        Args:
+            mask_types ("thing"): whether the classes are ``"stuff"``
                 (amorphous regions of pixels) or ``"thing"`` (connected
                 regions, each representing an instance of the thing). Can be
                 any of the following:
@@ -1176,16 +1333,15 @@ class Segmentation(_HasID, _HasMedia, Label):
                 -   ``"thing"`` if all classes are thing classes
                 -   a dict mapping pixel values (2D masks) or RGB hex strings
                     (3D masks) to ``"stuff"`` or ``"thing"`` for each class
-            tolerance (2): a tolerance, in pixels, when generating approximate
-                polylines for each region. Typical values are 1-3 pixels
 
         Returns:
-            a :class:`Polylines`
+            a :class:`Segmentation`
+
         """
-        polylines = _segmentation_to_polylines(
-            self, mask_targets, mask_types, tolerance
-        )
-        return Polylines(polylines=polylines)
+        mask = self.get_mask()
+        if not self.is_panoptic:
+            mask = _mask_to_panoptic(mask, mask_types)
+        return Segmentation(mask=mask, is_panoptic=True)
 
 
 class Heatmap(_HasID, _HasMedia, Label):
@@ -1480,14 +1636,85 @@ _LABEL_LIST_TO_SINGLE_MAP = {
 }
 
 
-def _read_mask(mask_path):
+@staticmethod
+def _get_uint_dtype(maxval):
+    if maxval < 2**8:
+        return np.uint8
+    elif maxval < 2**16:
+        return np.uint16
+    elif maxval < 2**32:
+        return np.uint32
+    elif maxval < 2**64:
+        return np.uint64
+
+    raise ValueError(f"max value of {maxval} exceeds upper limit of 2^64")
+
+
+def _mask_to_image(mask):
+    shape_is_valid = False
+    if mask.ndim == 2:
+        shape_is_valid = True
+    elif mask.ndim == 3:
+        if mask.shape[-1] in (1, 2, 3):
+            shape_is_valid = True
+
+    if not shape_is_valid:
+        raise ValueError("unsupported detection mask shape: {mask.shape}")
+
+    allowed_types = (np.uint8, np.uint16, np.uint32, np.uint64)
+
+    if mask.dtype not in allowed_types:
+        raise ValueError(f"unsupported detection mask dtype: {mask.dtype}")
+
+    # cast to smallest dtype possible
+    maxval = mask.max()
+    if mask.ndim == 3 and mask.shape[-1] == 3 and maxval >= 2**16:
+        raise ValueError(
+            f"3-channel masks must be saved as a PNG, with a max bit"
+            f" dpeth of 16, but mask has max value of {maxval} >= 2**16"
+        )
+
+    dtype = _get_uint_dtype(maxval)
+    return mask.astype(dtype)
+
+
+def _get_extension(path):
+    extension = pathlib.Path(path).suffix
+    return extension
+
+
+def _read_mask(mask_path, panoptic=False):
     # pylint: disable=no-member
-    return foui.read(mask_path, flag=cv2.IMREAD_UNCHANGED)
+    extension = _get_extension(mask_path)
+    if extension in (".tif", ".tiff"):
+        mask = tifffile.imread(mask_path)
+    else:
+        mask = foui.read(mask_path, flag=cv2.IMREAD_UNCHANGED)
+
+    # do this here even though we're not writing a mask because it
+    # converts to smallest possible dtype, and also checks type
+    # and bounds
+    mask = _mask_to_image(mask)
+
+    if panoptic and mask.ndim == 3 and mask.shape[-1] == 3:
+        mask = mask[..., 0:2]
+
+    return mask
 
 
 def _write_mask(mask, mask_path):
+    extension = _get_extension(mask_path)
     mask = _mask_to_image(mask)
-    foui.write(mask, mask_path)
+    if extension in (".tif", ".tiff"):
+        bigtiff = mask.dtype == np.uint64
+        tifffile.imwrite(mask_path, mask, compression="zlib", bigtiff=bigtiff)
+    else:
+        if mask.ndim == 3 and mask.shape[-1] == 2:
+            # add empty third channel
+            mask = np.dstack(
+                (mask, np.zeros(mask.shape[:2], dtype=mask.dtype))
+            )
+        foui.write(mask, mask_path)
 
 
 def _transform_mask(in_mask, targets_map):
@@ -1531,18 +1758,6 @@ def _transform_mask(in_mask, targets_map):
     return out_mask
 
 
-def _mask_to_image(mask):
-    if mask.dtype in (np.uint8, np.uint16):
-        return mask
-
-    # Masks should contain integer values, so cast to the closest suitable
-    # unsigned type
-    if mask.max() <= 255:
-        return mask.astype(np.uint8)
-
-    return mask.astype(np.uint16)
-
-
 def _read_heatmap(map_path):
     # pylint: disable=no-member
     return foui.read(map_path, flag=cv2.IMREAD_UNCHANGED)
@@ -1572,11 +1787,14 @@ def _heatmap_to_image(map, range):
     return map.astype(np.uint8)
 
 
-def _parse_segmentation_target(mask, frame_size, target):
+def _parse_segmentation_target(mask, frame_size, target, panoptic):
     if target is not None:
         is_rgb = fof.is_rgb_target(target)
     else:
         is_rgb = False
+
+    if panoptic and is_rgb:
+        raise ValueError("panoptic segmentation cannot have RGB mask")
 
     if mask is None:
         if frame_size is None:
@@ -1599,11 +1817,14 @@ def _parse_segmentation_target(mask, frame_size, target):
     return mask, target
 
 
-def _parse_segmentation_mask_targets(mask, frame_size, mask_targets):
+def _parse_segmentation_mask_targets(mask, frame_size, mask_targets, panoptic):
     if mask_targets is not None:
         is_rgb = fof.is_rgb_mask_targets(mask_targets)
     else:
         is_rgb = False
+
+    if panoptic and is_rgb:
+        raise ValueError("panoptic segmentation cannot have RGB mask")
 
     if mask is None:
         if frame_size is None:
@@ -1676,6 +1897,80 @@ def _find_slices(mask):
     return dict((backward[idx + 1], slc) for idx, slc in enumerate(slices))
 
 
+def _get_label_and_type(target, mask_targets, mask_types, default):
+    if mask_targets is not None:
+        label = mask_targets.get(target, None)
+    else:
+        label = str(target)
+
+    label_type = mask_types.get(target, None)
+    if label_type is None:
+        label_type = default
+
+    return label, label_type
+
+
+def _mask_is_rgb(mask):
+    return mask.ndim == 3 and mask.shape[-1] == 3
+
+
+def _mask_to_panoptic(mask, mask_types):
+    """Convert semantic segmentation to panoptic segmentation."""
+    if isinstance(mask_types, dict):
+        default = None
+    else:
+        default = mask_types
+        mask_types = {}
+
+    mask = mask.squeeze()
+    if _mask_is_rgb(mask):
+        mask = _rgb_array_to_int(mask)
+        if mask_types is not None:
+            mask_types = {_hex_to_int(k): v for k, v in mask_types.items()}
+
+    panoptic_class_mask = np.zeros(mask.shape[:2], dtype=np.uint64)
+    panoptic_instance_mask = np.zeros(mask.shape[:2], dtype=np.uint64)
+
+    # ensure instance indices are unique across multiple classes
+    total_instances = 0
+
+    class_objects = _find_slices(mask)
+    for class_target, class_slices in class_objects.items():
+        label, label_type = _get_label_and_type(
+            class_target, None, mask_types, default
+        )
+        if label is None or label_type is None:
+            continue  # skip unknown class_target
+
+        class_mask = mask[class_slices] == class_target
+        panoptic_class_mask[class_slices][class_mask] = class_target
+
+        if label_type == "stuff":
+            pass
+        elif label_type == "thing":
+            labeled = skm.label(class_mask)
+            instance_objects = _find_slices(labeled)
+
+            for instance_target, instance_slices in instance_objects.items():
+                instance_mask = labeled[instance_slices] == instance_target
+                panoptic_instance_mask[class_slices][instance_slices][
+                    instance_mask
+                ] = (total_instances + instance_target)
+
+            total_instances += len(instance_objects)
+
+        else:
+            raise ValueError(
+                "Unsupported mask type '%s'. Supported values are "
+                "('stuff', 'thing')"
+            )
+
+    panoptic_mask = np.stack(
+        [panoptic_class_mask, panoptic_instance_mask], axis=-1
+    )
+    return panoptic_mask
+
+
 def _convert_segmentation(segmentation, mask_targets, mask_types, converter):
     """Convert segmentation to a collection of detections, polylines, etc.
 
@@ -1691,41 +1986,86 @@ def _convert_segmentation(segmentation, mask_targets, mask_types, converter):
         mask_types = {}
 
     mask = segmentation.get_mask()
-    is_rgb = mask.ndim == 3
+    mask = mask.squeeze()
 
-    if is_rgb:
+    if _mask_is_rgb(mask):
         # convert to int, like in transform_mask
         mask = _rgb_array_to_int(mask)
         if mask_targets is not None:
             mask_targets = {_hex_to_int(k): v for k, v in mask_targets.items()}
 
-    mask = mask.squeeze()
+    results = []
+    if segmentation.is_panoptic:
+        # handle all individual instances, zeroing them out as they
+        # are added.  any remaining segmentation pixels are handled
+        # like semantic segmentations.
+
+        if mask.ndim != 3 or mask.shape[-1] != 2:
+            raise ValueError(f"Unsupported panoptic mask shape: {mask.ndim}")
+
+        instances_mask = mask[:, :, 1]
+        mask = mask[:, :, 0].copy()  # class mask. copy so we can modify it.
+
+        instance_objects = _find_slices(instances_mask)
+        for idx, slices in instance_objects.items():
+            class_targets = list(
+                set(mask[slices][instances_mask[slices] == idx])
+            )
+            if len(class_targets) != 1:
+                raise ValueError(
+                    f"instance {idx} has multiple segmentation classes"
+                )
+            class_target = class_targets[0]
+            if class_target == 0:
+                raise ValueError(f"instance {idx} has no segmentation class")
+
+            label, label_type = _get_label_and_type(
+                class_target, mask_targets, mask_types, default
+            )
+            if label is None or label_type is None:
+                continue  # skip unknown target
+
+            if label_type == "stuff":
+                continue  # leave for semantic segmentation
+
+            label_mask = instances_mask[slices] == idx
+            offset = list(s.start for s in slices)[::-1]
+            frame_size = mask.shape[:2][::-1]
+            new_results = converter(
+                label_mask, label, label_type, offset, frame_size
+            )
+            results.extend(new_results)
+
+            # zero out this object in semantic segmentation
+            mask[slices][label_mask] = 0
+
+    # continue with semantic segmentation of remaining labels
     if mask.ndim != 2:
         raise ValueError(f"Unsupported mask dimensions: {mask.ndim}")
 
     objects = _find_slices(mask)
-    results = []
     for target, slices in objects.items():
-        if mask_targets is not None:
-            label = mask_targets.get(target, None)
+        label, label_type = _get_label_and_type(
+            target, mask_targets, mask_types, default
+        )
+        if label is None or label_type is None:
+            continue  # skip unknown target
 
-            if label is None:
-                continue  # skip unknown target
-        else:
-            label = str(target)
+        if (
+            label_type in ("panoptic", "object")
+            and not segmentation.is_panoptic
+        ):
+            raise ValueError(
+                f"Unsupported label type for semantic segmentation: {label_type}"
+            )
 
-        label_type = mask_types.get(target, None)
-
-        if label_type is None:
-            if default is None:
-                continue  # skip unknown type
-
-            label_type = default
+        if label_type == "object":
+            # skip semantic segmentations for this class
+            continue
 
         label_mask = mask[slices] == target
         offset = list(s.start for s in slices)[::-1]
         frame_size = mask.shape[:2][::-1]
-
         new_results = converter(
             label_mask, label, label_type, offset, frame_size
         )
@@ -1735,14 +2075,14 @@ def _convert_segmentation(segmentation, mask_targets, mask_types, converter):
 
 
 def _mask_to_detections(label_mask, label, label_type, offset, frame_size):
-    if label_type == "stuff":
+    if label_type in ("stuff", "panoptic", "object"):
         instances = [_parse_stuff_instance(label_mask, offset, frame_size)]
     elif label_type == "thing":
         instances = _parse_thing_instances(label_mask, offset, frame_size)
     else:
         raise ValueError(
-            "Unsupported mask type '%s'. Supported values are "
-            "('stuff', 'thing')"
+            f"Unsupported mask type '{label_type}'. Supported values are "
+            "('stuff', 'thing', 'panoptic', 'object')"
         )
 
     return list(
@@ -1761,14 +2101,14 @@ def _mask_to_polylines(
         frame_size=frame_size,
     )
 
-    if label_type == "stuff":
+    if label_type in ("stuff", "panoptic", "object"):
         polygons = [polygons]
     elif label_type == "thing":
         polygons = [[p] for p in polygons]
     else:
         raise ValueError(
-            "Unsupported mask type '%s'. Supported values are "
-            "('stuff', 'thing')"
+            f"Unsupported mask type '{label_type}'. Supported values are "
+            "('stuff', 'thing', 'panoptic', 'object')"
         )
 
     return list(

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -1297,6 +1297,9 @@ class Segmentation(_HasID, _HasMedia, Label):
         Optionally converts the class integer values back to 3D pixel
         values.
 
+        If self.is_panoptic is False, the original mask is returned
+        as-is.
+
         Args:
             to_rgb (False): convert integer classes to RGB hex values
 

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ INSTALL_REQUIRES = [
     "starlette>=0.24.0",
     "strawberry-graphql",
     "tabulate",
+    "tifffile",
     "xmltodict",
     "universal-analytics-python3>=1.0.1,<2",
     "pydash",

--- a/tests/unittests/label_tests.py
+++ b/tests/unittests/label_tests.py
@@ -6,6 +6,8 @@ FiftyOne Label-related unit tests.
 |
 """
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from bson import Binary, ObjectId
 import numpy as np
@@ -17,6 +19,45 @@ import fiftyone.utils.labels as foul
 from fiftyone import ViewField as F
 
 from decorators import drop_datasets
+
+
+def _make_panoptic(dtype=np.uint8):
+    max_value = np.iinfo(dtype).max
+
+    instance_mask = np.zeros((8, 8), dtype=dtype)
+    instance_mask[1:2, 1:2] = 1
+    instance_mask[2:3, 2:3] = 2
+    instance_mask[3:4, 3:4] = 3
+    class_mask = (instance_mask > 0).astype(dtype)
+
+    class_mask[4:5, 4:5] = 1
+    class_mask[5:6, 5:6] = max_value
+    class_mask[6:7, 6:7] = 1
+
+    panoptic_mask = np.stack([class_mask, instance_mask], axis=-1).astype(
+        dtype
+    )
+    seg = fo.Segmentation(mask=panoptic_mask, is_panoptic=True)
+
+    return seg
+
+
+def _make_1d_segmentation(dtype=np.uint8):
+    max_value = np.iinfo(dtype).max
+    mask = np.zeros((4, 4), dtype=dtype)
+    mask[0:2, 0:2] = 1
+    mask[2:4, 2:4] = max_value
+    seg = fo.Segmentation(mask=mask, is_panoptic=False)
+    return seg
+
+
+def _make_3d_segmentation(dtype=np.uint8):
+    max_value = np.iinfo(dtype).max
+    mask = np.zeros((4, 4, 3), dtype=dtype)
+    mask[0:2, 0:2, 2] = 1
+    mask[2:4, 2:4, :] = max_value
+    seg = fo.Segmentation(mask=mask, is_panoptic=False)
+    return seg
 
 
 class LabelTests(unittest.TestCase):
@@ -531,6 +572,153 @@ class LabelTests(unittest.TestCase):
         )
         rgb_to_rgb = focl._transform_mask(int_to_rgb, targets_map)
         nptest.assert_array_equal(rgb_to_rgb, np.zeros((3, 3, 3), dtype=int))
+
+    @drop_datasets
+    def test_panoptic_segmentation_conversion(self):
+        seg = _make_panoptic()
+        frame_size = seg.mask.shape[:2][::-1]
+        mask_targets = dict(
+            (int(idx), str(idx)) for idx in seg.mask[..., 0].flatten()
+        )
+
+        for mask_types in (
+            None,
+            "panoptic",
+            "stuff",
+            "thing",
+            "object",
+        ):
+            if mask_types is None:
+                n_expected = 5
+            elif mask_types == "panoptic":
+                n_expected = 5
+            elif mask_types == "stuff":
+                n_expected = 2
+            elif mask_types == "thing":
+                n_expected = 6
+            elif mask_types == "object":
+                n_expected = 3
+
+            dets = seg.to_detections(mask_types=mask_types)
+            self.assertEqual(len(dets.detections), n_expected)
+
+            sseg1 = dets.to_segmentation(
+                panoptic=False,
+                frame_size=frame_size,
+                mask_targets=mask_targets,
+            )
+            pseg1 = dets.to_segmentation(
+                panoptic=True, frame_size=frame_size, mask_targets=mask_targets
+            )
+            # TODO: check masks here
+
+            single_seg = dets.detections[0].to_segmentation(
+                panoptic=True, frame_size=frame_size
+            )
+
+            poly = seg.to_polylines(mask_types=mask_types, tolerance=0)
+            self.assertEqual(len(poly.polylines), n_expected)
+
+            sseg2 = poly.to_segmentation(
+                panoptic=False,
+                frame_size=frame_size,
+                mask_targets=mask_targets,
+            )
+            pseg2 = poly.to_segmentation(
+                panoptic=True, frame_size=frame_size, mask_targets=mask_targets
+            )
+            # TODO: check masks here
+
+            single_seg = poly.polylines[0].to_segmentation(
+                panoptic=True, frame_size=frame_size
+            )
+
+    def test_1d_segmentation_conversion(self):
+        # 1d to panoptic
+        seg = _make_1d_segmentation()
+        pseg = seg.to_panoptic()
+
+        class_mask = seg.mask
+        instance_mask = np.array(
+            [[1, 1, 0, 0], [1, 1, 0, 0], [0, 0, 2, 2], [0, 0, 2, 2]], dtype=int
+        )
+
+        assert np.all(pseg.mask[..., 0] == seg.mask)
+        assert np.all(pseg.mask[..., 1] == instance_mask)
+
+        # back to 1d semantic
+        seg2 = pseg.to_semantic()
+        assert np.all(seg2.mask == seg.mask)
+
+        # check that this throws an error
+        with self.assertRaises(ValueError):
+            seg2.to_detections(mask_types="panoptic")
+
+        # to rgb semantic
+        seg3 = pseg.to_semantic(to_rgb=True)
+        assert np.all(seg3.mask[..., 2] == seg.mask)
+        assert np.all(seg3.mask[..., 1] == 0)
+        assert np.all(seg3.mask[..., 0] == 0)
+
+    def test_3d_segmentation_conversion(self):
+        # 3d to panoptic
+        seg = _make_3d_segmentation()
+        pseg = seg.to_panoptic()
+
+        x = 2**24 - 1
+        class_mask = np.array(
+            [[1, 1, 0, 0], [1, 1, 0, 0], [0, 0, x, x], [0, 0, x, x]], dtype=int
+        )
+
+        instance_mask = np.array(
+            [[1, 1, 0, 0], [1, 1, 0, 0], [0, 0, 2, 2], [0, 0, 2, 2]], dtype=int
+        )
+
+        assert np.all(pseg.mask[..., 0] == class_mask)
+        assert np.all(pseg.mask[..., 1] == instance_mask)
+
+        seg2 = pseg.to_semantic(to_rgb=False)
+        assert np.all(seg2.mask == class_mask)
+
+        seg3 = pseg.to_semantic(to_rgb=True)
+        assert np.all(seg3.mask == seg.mask)
+
+    def test_segmentation_io(self):
+        def _test_io(dims, tif, dtype):
+            with TemporaryDirectory() as temp_dir:
+                if tif:
+                    mask_path = Path(temp_dir) / "mask.tif"
+                else:
+                    mask_path = Path(temp_dir) / "mask.tif"
+
+                mask_path = str(mask_path)
+
+                if dims == 1:
+                    seg = _make_1d_segmentation(dtype=dtype)
+                if dims == 2:
+                    seg = _make_panoptic(dtype=dtype)
+                if dims == 3:
+                    seg = _make_3d_segmentation(dtype=dtype)
+                seg.export_mask(mask_path, update=False)
+
+                seg2 = fo.Segmentation(
+                    mask_path=mask_path, is_panoptic=(dims == 2)
+                )
+                seg2.import_mask()
+
+                assert np.all(seg.mask == seg2.mask)
+
+        for dims in (1, 2, 3):
+            for tif in (False, True):
+                if dims == 3:
+                    dtypes = [np.uint8]
+                elif tif:
+                    dtypes = [np.uint8, np.uint16, np.uint32, np.uint64]
+                else:
+                    dtypes = [np.uint8, np.uint16]
+
+                for dtype in dtypes:
+                    _test_io(dims=dims, tif=tif, dtype=dtype)
 
 
 class LabelUtilsTests(unittest.TestCase):


### PR DESCRIPTION
[Panoptic segmentations](https://arxiv.org/abs/1801.00868) contain both instance objects and semantic segmentation. Instead of [PR#4500](https://github.com/voxel51/fiftyone/pull/4500), which implemented disk-backed detections as a new type of label, this PR extends the `Segmentation` class. It supports all the same functionality and more, so this PR replaces that one.

## What changes are proposed in this pull request?

This pull request modifies the `Segmentation` class to allow it to represent both semantic and panoptic segmentations. The `mask` attribute for panoptic segmentations must be a 2-channel array, where the first channel contains a semantic segmentation and the second channel contains an object index. It would have been cleaner to maintain two separate arrays -- one for semantic segmentation and one for objects -- but this implementation maintains backwards compatibility with the way semantic segmentations work, which is to keep everything in a single `mask` array or single image indicated by `mask_path`.

For instance, the following segmentation contains three objects, each with a different class (10, 20, and 30), as well as a region of "stuff" with another class (99):

```
class_mask = np.array([
    [10, 99, 20, 20],
    [10, 10, 99, 20],
    [30, 30, 99, 99],
    [30, 99, 99, 99],
])

instance_mask = np.array([
    [1, 0, 2, 2],
    [1, 1, 0, 2],
    [3, 3, 0, 0],
    [3, 0, 0, 0],
])

panoptic_mask = np.stack(
    [class_mask, instance_mask], axis=-1
)
segmentation = fo.Segmentation(mask=panoptic_mask, is_panoptic=True)
```

When saving to or loading  from an image, such as a PNG, the third channel is left empty for panoptic segmentations. Therefore the `is_panoptic` boolean is necessary to indicate whether the third channel is empty actually, or whether it represents all `0` values in the blue channel of an RGB segmentation mask.

This PR also adds the `tifffile` package to allow saving and loading two-channel TIFF images, which allows a higher bit depth for saving saving segmentation class indices or object labels.

Conversions to/from `Detection`, `Detections`, `Polyline`, and `Polylines` are implemented. Two more `mask_type` values are now recognized, in addition to the "stuff" and "thing" types, because there are a number of ways that panoptic segmentations can be converted to other labels:

* "stuff" - object instance labels are ignored. This option is identical to "stuff" on a normal semantic segmentation.
* "thing" - object instances are first converted to individual detections/polylines. Then any remaining connected regions are also converted to individual detections/polylines, just like converting "thing" semantic classes.
* "panoptic" - object instances are first converted to individual detections/polylines. Then any remaining regions are converted to one detection/polyline, just like converting "stuff" semantic classes. This option is called "panoptic" because it most closely aligns with the original intention of treating objects as "thing" and non-object regions as "stuff".
* "object" - i.e. objects only. Object instances are first converted to individual detections/polylines. Then any remaining regions are ignored.

I'm opening this PR so we can start a discussion about this approach and make sure it aligns with the FiftyOne team's expectations. Before final approval, the following should be implemented and tested:

* User documentation
* Evaluations need to be updated to work with panoptic segmentations. Panoptic Quality (PQ) should be implemented.
* Other code that imports or transforms segmentations needs to be updated to support the panoptic option.

## How is this patch tested? If it is not, please explain why.

There are unit tests for all possible conversions and saving/loading the semantic segmentations.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [X] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

The `Segmentation` class now supports panoptic segmentations, which indicate not only the segmentation class of a pixel but also which object to which it belongs.  Panoptic `Segmentation` objects can be converted to detections and polylines, as well as to semantic segmentations, and they can be saved as TIF files.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [X] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced panoptic segmentation functionality, allowing for the handling of instance masks alongside class masks.
	- Added methods to facilitate conversion between semantic and panoptic segmentations.

- **Bug Fixes**
	- Updated mask processing methods to correctly handle the new panoptic attribute.

- **Chores**
	- Added `tifffile` as a required dependency for handling TIFF files.

- **Tests**
	- Implemented unit tests for validating segmentation conversions, enhancing the testing framework for segmentation functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->