### PR TITLE
Adding builtin operators for more of the FO interface

### DIFF
--- a/docs/source/brain.rst
+++ b/docs/source/brain.rst
@@ -5,7 +5,7 @@ FiftyOne Brain
 
 .. default-role:: code
 
-The `FiftyOne Brain <https://github.com/voxel51/fiftyone-brain>` provides
+The `FiftyOne Brain <https://github.com/voxel51/fiftyone-brain>`_ provides
 powerful machine learning techniques that are designed to transform how you
 curate your data from an art into a measurable science.
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -643,33 +643,58 @@ class SampleCollection(object):
 
     def _sync_dataset_last_modified_at(self):
         dataset = self._root_dataset
-        if self.media_type == fom.GROUP:
-            samples = self.select_group_slices(media_type=fom.VIDEO)
-        else:
-            samples = self
+        curr_lma = dataset.last_modified_at
+        lma = self._get_last_modified_at()
 
-        results = samples._aggregate(
-            post_pipeline=[
+        if lma is not None and (curr_lma is None or lma > curr_lma):
+            dataset._doc.last_modified_at = lma
+            dataset._doc.save(virtual=True)
+
+    def _get_last_modified_at(self, frames=False):
+        if frames and not self._contains_videos(any_slice=True):
+            return
+
+        if isinstance(self, fod.Dataset):
+            # pylint:disable=no-member
+            dataset = self
+            if frames:
+                coll = dataset._frame_collection
+            else:
+                coll = dataset._sample_collection
+
+            pipeline = [
                 {"$sort": {"last_modified_at": -1}},
                 {"$limit": 1},
                 {"$project": {"last_modified_at": True}},
             ]
-        )
+
+            results = foo.aggregate(coll, pipeline)
+        else:
+            if self.media_type == fom.GROUP:
+                if frames:
+                    view = self.select_group_slices(media_type=fom.VIDEO)
+                else:
+                    view = self.select_group_slices(_allow_mixed=True)
+            else:
+                view = self
+
+            pipeline = [
+                {
+                    "$group": {
+                        "_id": None,
+                        "last_modified_at": {"$max": "$last_modified_at"},
+                    }
+                }
+            ]
+
+            results = view._aggregate(
+                frames_only=frames, post_pipeline=pipeline
+            )
 
         try:
-            last_modified_at = next(iter(results))["last_modified_at"]
+            return next(iter(results))["last_modified_at"]
         except:
-            last_modified_at = None
-
-        if last_modified_at is None:
-            return
-
-        if (
-            dataset.last_modified_at is None
-            or last_modified_at > dataset.last_modified_at
-        ):
-            dataset._doc.last_modified_at = last_modified_at
-            dataset._doc.save(virtual=True)
+            return None
 
     def stats(
         self,

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -4324,7 +4324,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         self._doc.reload("saved_views")
 
         self._doc.saved_views.append(view_doc)
-        self.save()
+        self._doc.last_modified_at = now
+        self._doc.save(virtual=True)
 
     def get_saved_view_info(self, name):
         """Loads the editable information about the saved view with the given
@@ -4625,7 +4626,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         self._doc.reload("workspaces")
 
         self._doc.workspaces.append(workspace_doc)
-        self.save()
+        self._doc.last_modified_at = now
+        self._doc.save(virtual=True)
 
     def load_workspace(self, name):
         """Loads the saved workspace with the given name.

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2068,17 +2068,15 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 update_indexes.append(path)
             elif self._is_frame_field(source_path):
                 if frames_last_modified_at is None:
-                    frames_last_modified_at, _ = self.bounds(
-                        "frames.last_modified_at"
+                    frames_last_modified_at = self._get_last_modified_at(
+                        frames=True
                     )
 
                 if frames_last_modified_at > last_modified_at:
                     update_indexes.append(path)
             else:
                 if samples_last_modified_at is None:
-                    _, samples_last_modified_at = self.bounds(
-                        "last_modified_at"
-                    )
+                    samples_last_modified_at = self._get_last_modified_at()
 
                 if samples_last_modified_at > last_modified_at:
                     update_indexes.append(path)

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1716,9 +1716,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 given ``path``
             sidebar_group (None): the name of a
                 :ref:`App sidebar group <app-sidebar-groups>` to which to add
-                the summary field, if necessary. By default, all summary fields
-                are added to a ``"summaries"`` group. You can pass ``False`` to
-                skip sidebar group modification
+                the summary field. By default, all summary fields are added to
+                a ``"summaries"`` group. You can pass ``False`` to skip sidebar
+                group modification
             include_counts (False): whether to include per-value counts when
                 summarizing categorical fields
             group_by (None): an optional attribute to group by when ``path``
@@ -1752,27 +1752,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 f"undeclared field '{path}'"
             )
 
-        _path, is_frame_field, list_fields, _, _ = self._parse_field_name(path)
-
         if field_name is None:
-            _chunks = _path.split(".")
-
-            chunks = []
-            if is_frame_field:
-                chunks.append("frames")
-
-            found_list = False
-            for i, _chunk in enumerate(_chunks, 1):
-                if ".".join(_chunks[:i]) in list_fields:
-                    found_list = True
-                    break
-                else:
-                    chunks.append(_chunk)
-
-            if found_list:
-                chunks.append(_chunks[-1])
-
-            field_name = "_".join(chunks)
+            field_name = self._get_default_summary_field_name(path)
 
         index_fields = []
         summary_info = {"path": path, "field_type": field_type}
@@ -1890,6 +1871,27 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         self._populate_summary_field(field_name, summary_info)
 
         return field_name
+
+    def _get_default_summary_field_name(self, path):
+        _path, is_frame_field, list_fields, _, _ = self._parse_field_name(path)
+        _chunks = _path.split(".")
+
+        chunks = []
+        if is_frame_field:
+            chunks.append("frames")
+
+        found_list = False
+        for i, _chunk in enumerate(_chunks, 1):
+            if ".".join(_chunks[:i]) in list_fields:
+                found_list = True
+                break
+            else:
+                chunks.append(_chunk)
+
+        if found_list:
+            chunks.append(_chunks[-1])
+
+        return "_".join(chunks)
 
     def _populate_summary_field(self, field_name, summary_info):
         path = summary_info["path"]

--- a/fiftyone/migrations/revisions/v1_0_0.py
+++ b/fiftyone/migrations/revisions/v1_0_0.py
@@ -5,62 +5,84 @@ FiftyOne v1.0.0 revision.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import logging
-
-
-logger = logging.getLogger(__name__)
+from datetime import datetime
 
 
 def up(db, dataset_name):
     match_d = {"name": dataset_name}
     dataset_dict = db.datasets.find_one(match_d)
 
+    now = datetime.utcnow()
+
     # Add `last_modified_at` property
     if "last_modified_at" not in dataset_dict:
-        dataset_dict["last_modified_at"] = None
+        dataset_dict["last_modified_at"] = now
 
-    add_samples_created_at = False
+    added_created_at_samples = False
+    added_last_modified_at_samples = False
     sample_fields = dataset_dict.get("sample_fields", [])
     if sample_fields:
-        add_samples_created_at = _up_fields(sample_fields)
+        (
+            added_created_at_samples,
+            added_last_modified_at_samples,
+        ) = _up_fields(dataset_name, sample_fields)
 
-    add_frames_created_at = False
+    added_created_at_frames = False
+    added_last_modified_at_frames = False
     frame_fields = dataset_dict.get("frame_fields", [])
     if frame_fields:
-        add_frames_created_at = _up_fields(frame_fields)
+        (
+            added_created_at_frames,
+            added_last_modified_at_frames,
+        ) = _up_fields(dataset_name, frame_fields)
 
     db.datasets.replace_one(match_d, dataset_dict)
 
     # Populate `Sample.created_at` values
-    if add_samples_created_at:
-        sample_collection_name = dataset_dict.get(
-            "sample_collection_name", None
+    sample_collection_name = dataset_dict.get("sample_collection_name", None)
+    if sample_collection_name:
+        _up_field_values(
+            db,
+            dataset_name,
+            sample_collection_name,
+            added_created_at_samples,
+            added_last_modified_at_samples,
+            now,
         )
-        if sample_collection_name:
-            _add_created_at(db, dataset_name, sample_collection_name)
 
     # Populate `Frame.created_at` values
-    if add_frames_created_at:
-        frame_collection_name = dataset_dict.get("frame_collection_name", None)
-        if frame_collection_name:
-            _add_created_at(db, dataset_name, frame_collection_name)
+    frame_collection_name = dataset_dict.get("frame_collection_name", None)
+    if frame_collection_name:
+        _up_field_values(
+            db,
+            dataset_name,
+            frame_collection_name,
+            added_created_at_frames,
+            added_last_modified_at_frames,
+            now,
+        )
 
 
 def down(db, dataset_name):
     pass
 
 
-def _up_fields(fields):
+def _up_fields(dataset_name, fields):
     found_created_at = False
     found_last_modified_at = False
 
     for field in fields:
         name = field.get("name", None)
-        found_created_at |= name == "created_at"
-        found_last_modified_at |= name == "last_modified_at"
-
-        # Add `read_only` property
-        if "read_only" not in field:
+        if name == "created_at":
+            # Existing 'created_at' field must be read-only DateTimeField
+            found_created_at = True
+            _up_read_only_datetime_field(dataset_name, field)
+        elif name == "last_modified_at":
+            # Existing 'last_modified_at' field must be read-only DateTimeField
+            found_last_modified_at = True
+            _up_read_only_datetime_field(dataset_name, field)
+        elif "read_only" not in field:
+            # Add `read_only` property
             field["read_only"] = False
 
     # Add `created_at` field
@@ -95,16 +117,48 @@ def _up_fields(fields):
             }
         )
 
-    return not found_created_at
+    added_created_at = not found_created_at
+    added_last_modified_at = not found_last_modified_at
+
+    return added_created_at, added_last_modified_at
 
 
-def _add_created_at(db, dataset_name, collection_name):
+def _up_read_only_datetime_field(dataset_name, field):
+    field_name = field.get("name", None)
+    ftype = field.get("ftype", None)
+    expected_ftype = "fiftyone.core.fields.DateTimeField"
+
+    if ftype != expected_ftype:
+        raise ValueError(
+            f"Cannot migrate dataset '{dataset_name}' to v1.0.0 because it "
+            f"has an existing '{field_name}' field of type "
+            f"{ftype} != {expected_ftype}"
+        )
+
+    field["read_only"] = True
+
+
+def _up_field_values(
+    db,
+    dataset_name,
+    collection_name,
+    set_created_at,
+    set_last_modified_at,
+    now,
+):
+    set_expr = {}
+    if set_created_at:
+        set_expr["created_at"] = {"$toDate": "$_id"}
+    if set_last_modified_at:
+        set_expr["last_modified_at"] = now
+
+    if not set_expr:
+        return
+
     try:
-        pipeline = [{"$set": {"created_at": {"$toDate": "$_id"}}}]
-        db[collection_name].update_many({}, pipeline)
+        db[collection_name].update_many({}, [{"$set": set_expr}])
     except Exception as e:
-        logger.warning(
-            "Failed to populate 'created_at' field for dataset %s. Reason: %s",
-            dataset_name,
-            e,
+        raise RuntimeError(
+            "Failed to populate 'created_at' and/or 'last_modified_at' fields "
+            f"for dataset '{dataset_name}'. Reason: {e}"
         )

--- a/fiftyone/migrations/revisions/v1_0_0.py
+++ b/fiftyone/migrations/revisions/v1_0_0.py
@@ -132,7 +132,8 @@ def _up_read_only_datetime_field(dataset_name, field):
         raise ValueError(
             f"Cannot migrate dataset '{dataset_name}' to v1.0.0 because it "
             f"has an existing '{field_name}' field of type "
-            f"{ftype} != {expected_ftype}"
+            f"{ftype} != {expected_ftype}. Please rename or delete the field "
+            "and try again"
         )
 
     field["read_only"] = True

--- a/fiftyone/migrations/revisions/v1_0_0.py
+++ b/fiftyone/migrations/revisions/v1_0_0.py
@@ -14,8 +14,8 @@ def up(db, dataset_name):
 
     now = datetime.utcnow()
 
-    # Add `last_modified_at` property
-    if "last_modified_at" not in dataset_dict:
+    # Populate `Dataset.last_modified_at`
+    if dataset_dict.get("last_modified_at", None) is None:
         dataset_dict["last_modified_at"] = now
 
     added_created_at_samples = False

--- a/fiftyone/operators/builtin.py
+++ b/fiftyone/operators/builtin.py
@@ -2111,6 +2111,52 @@ class DeleteWorkspace(foo.Operator):
         ctx.dataset.delete_workspace(name)
 
 
+class SyncLastModifiedAt(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="sync_last_modified_at",
+            label="Sync last modified at",
+            dynamic=True,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        instructions = """
+This operation updates the `last_modified_at` property of the dataset if
+necessary to incorporate any modification timestamps to its samples.
+        """
+
+        inputs.str(
+            "instructions",
+            default=instructions.strip(),
+            view=types.MarkdownView(read_only=True),
+        )
+
+        if ctx.dataset._has_frame_fields():
+            inputs.bool(
+                "include_frames",
+                default=True,
+                required=False,
+                label="Include frames",
+                description=(
+                    "Whether to sync the `last_modified_at` property of each "
+                    "video sample first if necessary to incorporate any "
+                    "modification timestamps to its frames"
+                ),
+            )
+
+        return types.Property(
+            inputs, view=types.View(label="Sync last modified at")
+        )
+
+    def execute(self, ctx):
+        include_frames = ctx.params.get("include_frames", True)
+
+        ctx.dataset.sync_last_modified_at(include_frames=include_frames)
+
+
 class ListFiles(foo.Operator):
     @property
     def config(self):
@@ -2258,5 +2304,6 @@ BUILTIN_OPERATORS = [
     SaveWorkspace(_builtin=True),
     EditWorkspaceInfo(_builtin=True),
     DeleteWorkspace(_builtin=True),
+    SyncLastModifiedAt(_builtin=True),
     ListFiles(_builtin=True),
 ]

--- a/fiftyone/operators/builtin.py
+++ b/fiftyone/operators/builtin.py
@@ -2122,9 +2122,10 @@ class ListFiles(foo.Operator):
 
     def execute(self, ctx):
         path = ctx.params.get("path", None)
-        list_filesystems = ctx.params.get("list_filesystems", False)
-        if list_filesystems:
-            return {"filesystems": list_fileystems()}
+        list_fs = ctx.params.get("list_filesystems", False)
+
+        if list_fs:
+            return {"filesystems": list_filesystems()}
 
         if path:
             try:
@@ -2141,7 +2142,7 @@ def get_default_path_for_filesystem(fs):
         raise ValueError("Unsupported file system '%s'" % fs)
 
 
-def list_fileystems():
+def list_filesystems():
     filesystems = fos.list_available_file_systems()
     results = []
     for fs in fos.FileSystem:

--- a/fiftyone/operators/builtin.py
+++ b/fiftyone/operators/builtin.py
@@ -433,10 +433,10 @@ class RenameSampleField(foo.Operator):
         )
 
     def execute(self, ctx):
-        ctx.dataset.rename_sample_field(
-            ctx.params.get("field_name", None),
-            ctx.params.get("new_field_name", None),
-        )
+        field_name = ctx.params["field_name"]
+        new_field_name = ctx.params["new_field_name"]
+
+        ctx.dataset.rename_sample_field(field_name, new_field_name)
         ctx.trigger("reload_dataset")
 
 
@@ -519,10 +519,10 @@ class RenameFrameField(foo.Operator):
         )
 
     def execute(self, ctx):
-        ctx.dataset.rename_frame_field(
-            ctx.params.get("field_name", None),
-            ctx.params.get("new_field_name", None),
-        )
+        field_name = ctx.params["field_name"]
+        new_field_name = ctx.params["new_field_name"]
+
+        ctx.dataset.rename_frame_field(field_name, new_field_name)
         ctx.trigger("reload_dataset")
 
 
@@ -614,8 +614,9 @@ class ClearSampleField(foo.Operator):
         )
 
     def execute(self, ctx):
+        field_name = ctx.params["field_name"]
 
-        ctx.dataset.clear_sample_field(ctx.params.get("field_name", None))
+        ctx.dataset.clear_sample_field(field_name)
         ctx.trigger("reload_dataset")
 
 
@@ -704,7 +705,9 @@ class ClearFrameField(foo.Operator):
         )
 
     def execute(self, ctx):
-        ctx.dataset.clear_frame_field(ctx.params.get("field_name", None))
+        field_name = ctx.params["field_name"]
+
+        ctx.dataset.clear_frame_field(field_name)
         ctx.trigger("reload_dataset")
 
 
@@ -884,7 +887,9 @@ class DeleteSampleField(foo.Operator):
         )
 
     def execute(self, ctx):
-        ctx.dataset.delete_sample_field(ctx.params.get("field_name", None))
+        field_name = ctx.params["field_name"]
+
+        ctx.dataset.delete_sample_field(field_name)
         ctx.trigger("reload_dataset")
 
 
@@ -942,7 +947,9 @@ class DeleteFrameField(foo.Operator):
         )
 
     def execute(self, ctx):
-        ctx.dataset.delete_frame_field(ctx.params.get("field_name", None))
+        field_name = ctx.params["field_name"]
+
+        ctx.dataset.delete_frame_field(field_name)
         ctx.trigger("reload_dataset")
 
 
@@ -1091,7 +1098,9 @@ class DropIndex(foo.Operator):
         return types.Property(inputs, view=types.View(label="Drop index"))
 
     def execute(self, ctx):
-        ctx.dataset.drop_index(ctx.params["index_name"])
+        index_name = ctx.params["index_name"]
+
+        ctx.dataset.drop_index(index_name)
 
 
 class CreateSummaryField(foo.Operator):
@@ -1284,7 +1293,9 @@ class UpdateSummaryField(foo.Operator):
         )
 
     def execute(self, ctx):
-        ctx.dataset.update_summary_field(ctx.params["field_name"])
+        field_name = ctx.params["field_name"]
+
+        ctx.dataset.update_summary_field(field_name)
         ctx.trigger("reload_dataset")
 
 
@@ -1367,7 +1378,9 @@ class DeleteSummaryField(foo.Operator):
         )
 
     def execute(self, ctx):
-        ctx.dataset.delete_summary_field(ctx.params["field_name"])
+        field_name = ctx.params["field_name"]
+
+        ctx.dataset.delete_summary_field(field_name)
         ctx.trigger("reload_dataset")
 
 
@@ -1424,9 +1437,10 @@ class AddGroupSlice(foo.Operator):
         return types.Property(inputs, view=types.View(label="Add group slice"))
 
     def execute(self, ctx):
-        ctx.dataset.add_group_slice(
-            ctx.params["name"], ctx.params["media_type"]
-        )
+        name = ctx.params["name"]
+        media_type = ctx.params["media_type"]
+
+        ctx.dataset.add_group_slice(name, media_type)
         ctx.trigger("reload_dataset")
 
 
@@ -1485,9 +1499,10 @@ class RenameGroupSlice(foo.Operator):
         )
 
     def execute(self, ctx):
-        ctx.dataset.rename_group_slice(
-            ctx.params["name"], ctx.params["new_name"]
-        )
+        name = ctx.params["name"]
+        new_name = ctx.params["new_name"]
+
+        ctx.dataset.rename_group_slice(name, new_name)
         ctx.trigger("reload_dataset")
 
 
@@ -1531,7 +1546,9 @@ class DeleteGroupSlice(foo.Operator):
         )
 
     def execute(self, ctx):
-        ctx.dataset.delete_group_slice(ctx.params["name"])
+        name = ctx.params["name"]
+
+        ctx.dataset.delete_group_slice(name)
         ctx.trigger("reload_dataset")
 
 
@@ -1587,7 +1604,9 @@ class LoadSavedView(foo.Operator):
         return types.Property(inputs, view=types.View(label="Load saved view"))
 
     def execute(self, ctx):
-        ctx.ops.set_view(name=ctx.params["name"])
+        name = ctx.params["name"]
+
+        ctx.ops.set_view(name=name)
 
 
 class SaveView(foo.Operator):
@@ -1794,7 +1813,9 @@ class DeleteSavedView(foo.Operator):
         )
 
     def execute(self, ctx):
-        ctx.dataset.delete_saved_view(ctx.params["name"])
+        name = ctx.params["name"]
+
+        ctx.dataset.delete_saved_view(name)
 
 
 class ListWorkspaces(foo.Operator):
@@ -1849,7 +1870,9 @@ class LoadWorkspace(foo.Operator):
         return types.Property(inputs, view=types.View(label="Load workspace"))
 
     def execute(self, ctx):
-        ctx.ops.set_spaces(name=ctx.params["name"])
+        name = ctx.params["name"]
+
+        ctx.ops.set_spaces(name=name)
 
 
 class SaveWorkspace(foo.Operator):
@@ -2083,7 +2106,9 @@ class DeleteWorkspace(foo.Operator):
         )
 
     def execute(self, ctx):
-        ctx.dataset.delete_workspace(ctx.params["name"])
+        name = ctx.params["name"]
+
+        ctx.dataset.delete_workspace(name)
 
 
 class ListFiles(foo.Operator):

--- a/fiftyone/operators/builtin.py
+++ b/fiftyone/operators/builtin.py
@@ -6,12 +6,123 @@ Builtin operators.
 |
 """
 
+import json
 import os
 
 import fiftyone as fo
+import fiftyone.core.media as fom
 import fiftyone.core.storage as fos
 import fiftyone.operators as foo
 import fiftyone.operators.types as types
+
+
+class EditFieldInfo(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="edit_field_info",
+            label="Edit field info",
+            dynamic=True,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        _edit_field_info_inputs(ctx, inputs)
+
+        return types.Property(inputs, view=types.View(label="Edit field info"))
+
+    def execute(self, ctx):
+        path = ctx.params["path"]
+        description = ctx.params.get("description", None)
+        info = ctx.params.get("info", None)
+        read_only = ctx.params.get("read_only", None)
+
+        field = ctx.dataset.get_field(path)
+
+        if description is not None:
+            field.description = description or None
+
+        if info is not None:
+            field.info = json.loads(info) if info else None
+
+        if read_only is not None:
+            field.read_only = read_only
+
+        field.save()
+        ctx.trigger("reload_dataset")
+
+
+def _edit_field_info_inputs(ctx, inputs):
+    schema = ctx.dataset.get_field_schema(flat=True)
+    if ctx.dataset._has_frame_fields():
+        frame_schema = ctx.dataset.get_frame_field_schema(flat=True)
+        schema.update(
+            {
+                ctx.dataset._FRAMES_PREFIX + path: field
+                for path, field in frame_schema.items()
+            }
+        )
+
+    path_selector = types.AutocompleteView()
+    for key in sorted(schema.keys()):
+        path_selector.add_choice(key, label=key)
+
+    inputs.enum(
+        "path",
+        path_selector.values(),
+        required=True,
+        label="Field",
+        view=path_selector,
+    )
+
+    path = ctx.params.get("path", None)
+    if path is None or path not in schema:
+        return
+
+    field = ctx.dataset.get_field(path)
+    if field is None:
+        return
+
+    if field.read_only:
+        inputs.view(
+            "msg",
+            types.Notice(label=f"The '{path}' field is read-only"),
+        )
+    else:
+        inputs.str(
+            "description",
+            default=field.description,
+            required=False,
+            label="Description",
+            description="An optional description for the field",
+        )
+
+        info_prop = inputs.str(
+            "info",
+            default=json.dumps(field.info, indent=4) if field.info else None,
+            required=False,
+            label="Description",
+            description="A dictionary of information about the field",
+            view=types.CodeView(),
+        )
+
+        info = ctx.params.get("info", None)
+
+        if info is not None:
+            try:
+                json.loads(info)
+            except:
+                info_prop.invalid = True
+                info_prop.error_message = "Invalid field info dict"
+
+    inputs.bool(
+        "read_only",
+        default=field.read_only,
+        required=False,
+        label="Read only",
+        description="Whether to mark the field as read-only",
+    )
 
 
 class CloneSelectedSamples(foo.Operator):
@@ -66,62 +177,241 @@ class CloneSampleField(foo.Operator):
         )
 
     def resolve_input(self, ctx):
-        field_name = ctx.params.get("field_name", None)
-        new_field_name = ctx.params.get("new_field_name", None)
         inputs = types.Object()
-        fields = ctx.dataset.get_field_schema(flat=True)
-        field_keys = list(fields.keys())
-        has_valid_field_name = field_name in field_keys
-        field_selector = types.AutocompleteView()
-        for key in field_keys:
-            field_selector.add_choice(key, label=key)
 
-        inputs.enum(
-            "field_name",
-            field_keys,
-            label="Choose a field",
-            description=(
-                "The field to copy. You can use dot notation "
-                "(embedded.field.name) to clone embedded fields"
-            ),
-            view=field_selector,
-            required=True,
-        )
-        if has_valid_field_name:
-            new_field_prop = inputs.str(
-                "new_field_name",
-                required=True,
-                label="New field",
-                description=(
-                    "The new field to create. You can use dot notation "
-                    "(embedded.field.name) to create embedded fields"
-                ),
-                default=f"{field_name}_copy",
-            )
-            if new_field_name and new_field_name in field_keys:
-                new_field_prop.invalid = True
-                new_field_prop.error_message = (
-                    f"Field '{new_field_name}' already exists"
-                )
-                inputs.str(
-                    "error",
-                    label="Error",
-                    view=types.Error(
-                        label="Field already exists",
-                        description=f"Field '{new_field_name}' already exists",
-                    ),
-                )
+        _clone_sample_field_inputs(ctx, inputs)
 
         return types.Property(
             inputs, view=types.View(label="Clone sample field")
         )
 
     def execute(self, ctx):
-        ctx.dataset.clone_sample_field(
-            ctx.params.get("field_name", None),
-            ctx.params.get("new_field_name", None),
-        )
+        field_name = ctx.params["field_name"]
+        new_field_name = ctx.params["new_field_name"]
+        target = ctx.params.get("target", None)
+
+        target_view = _get_target_view(ctx, target)
+
+        target_view.clone_sample_field(field_name, new_field_name)
         ctx.trigger("reload_dataset")
+
+
+def _clone_sample_field_inputs(ctx, inputs):
+    has_view = ctx.view != ctx.dataset.view()
+    has_selected = bool(ctx.selected)
+    default_target = None
+    if has_view or has_selected:
+        target_choices = types.RadioGroup()
+        target_choices.add_choice(
+            "DATASET",
+            label="Entire dataset",
+            description="Clone sample field for the entire dataset",
+        )
+
+        if has_view:
+            target_choices.add_choice(
+                "CURRENT_VIEW",
+                label="Current view",
+                description="Clone sample field for the current view",
+            )
+            default_target = "CURRENT_VIEW"
+
+        if has_selected:
+            target_choices.add_choice(
+                "SELECTED_SAMPLES",
+                label="Selected samples",
+                description="Clone sample field for the selected samples",
+            )
+            default_target = "SELECTED_SAMPLES"
+
+        inputs.enum(
+            "target",
+            target_choices.values(),
+            default=default_target,
+            view=target_choices,
+        )
+
+    target = ctx.params.get("target", default_target)
+    target_view = _get_target_view(ctx, target)
+
+    schema = target_view.get_field_schema(flat=True)
+    full_schema = ctx.dataset.get_field_schema(flat=True)
+
+    field_keys = sorted(schema.keys())
+    field_selector = types.AutocompleteView()
+    for key in field_keys:
+        field_selector.add_choice(key, label=key)
+
+    inputs.enum(
+        "field_name",
+        field_selector.values(),
+        label="Sample field",
+        description=(
+            "The field to copy. You can use `embedded.field.name` to clone "
+            "embedded fields"
+        ),
+        view=field_selector,
+        required=True,
+    )
+
+    field_name = ctx.params.get("field_name", None)
+    if field_name not in schema:
+        return
+
+    new_field_prop = inputs.str(
+        "new_field_name",
+        required=True,
+        label="New sample field",
+        description=(
+            "The new field to create. You can use `embedded.field.name` to "
+            "create embedded fields"
+        ),
+        default=f"{field_name}_copy",
+    )
+
+    new_field_name = ctx.params.get("new_field_name", None)
+
+    if new_field_name in full_schema:
+        new_field_prop.invalid = True
+        new_field_prop.error_message = (
+            f"Field '{new_field_name}' already exists"
+        )
+        inputs.str(
+            "error",
+            label="Error",
+            view=types.Error(
+                label="Field already exists",
+                description=f"Field '{new_field_name}' already exists",
+            ),
+        )
+
+
+class CloneFrameField(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="clone_frame_field",
+            label="Clone frame field",
+            dynamic=True,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        _clone_frame_field_inputs(ctx, inputs)
+
+        return types.Property(
+            inputs, view=types.View(label="Clone frame field")
+        )
+
+    def execute(self, ctx):
+        field_name = ctx.params["field_name"]
+        new_field_name = ctx.params["new_field_name"]
+        target = ctx.params.get("target", None)
+
+        target_view = _get_target_view(ctx, target)
+
+        target_view.clone_frame_field(field_name, new_field_name)
+        ctx.trigger("reload_dataset")
+
+
+def _clone_frame_field_inputs(ctx, inputs):
+    if not ctx.dataset._has_frame_fields():
+        prop = inputs.str(
+            "msg",
+            label="This dataset does not have frame fields",
+            view=types.Warning(),
+        )
+        prop.invalid = True
+        return
+
+    has_view = ctx.view != ctx.dataset.view()
+    has_selected = bool(ctx.selected)
+    default_target = None
+    if has_view or has_selected:
+        target_choices = types.RadioGroup()
+        target_choices.add_choice(
+            "DATASET",
+            label="Entire dataset",
+            description="Clone frame field for the entire dataset",
+        )
+
+        if has_view:
+            target_choices.add_choice(
+                "CURRENT_VIEW",
+                label="Current view",
+                description="Clone frame field for the current view",
+            )
+            default_target = "CURRENT_VIEW"
+
+        if has_selected:
+            target_choices.add_choice(
+                "SELECTED_SAMPLES",
+                label="Selected samples",
+                description="Clone frame field for the selected samples",
+            )
+            default_target = "SELECTED_SAMPLES"
+
+        inputs.enum(
+            "target",
+            target_choices.values(),
+            default=default_target,
+            view=target_choices,
+        )
+
+    target = ctx.params.get("target", default_target)
+    target_view = _get_target_view(ctx, target)
+
+    schema = target_view.get_frame_field_schema(flat=True)
+    full_schema = ctx.dataset.get_frame_field_schema(flat=True)
+
+    field_keys = sorted(schema.keys())
+    field_selector = types.AutocompleteView()
+    for key in field_keys:
+        field_selector.add_choice(key, label=key)
+
+    inputs.enum(
+        "field_name",
+        field_selector.values(),
+        label="Frame field",
+        description=(
+            "The frame field to copy. You can use `embedded.field.name` to "
+            "clone embedded frame fields"
+        ),
+        view=field_selector,
+        required=True,
+    )
+
+    field_name = ctx.params.get("field_name", None)
+    if field_name not in schema:
+        return
+
+    new_field_prop = inputs.str(
+        "new_field_name",
+        required=True,
+        label="New frame field",
+        description=(
+            "The new frame field to create. You can use `embedded.field.name` "
+            "to create embedded frame fields"
+        ),
+        default=f"{field_name}_copy",
+    )
+
+    new_field_name = ctx.params.get("new_field_name", None)
+
+    if new_field_name in full_schema:
+        new_field_prop.invalid = True
+        new_field_prop.error_message = (
+            f"Frame field '{new_field_name}' already exists"
+        )
+        inputs.str(
+            "error",
+            label="Error",
+            view=types.Error(
+                label="Frame field already exists",
+                description=f"Frame field '{new_field_name}' already exists",
+            ),
+        )
 
 
 class RenameSampleField(foo.Operator):
@@ -135,41 +425,8 @@ class RenameSampleField(foo.Operator):
 
     def resolve_input(self, ctx):
         inputs = types.Object()
-        fields = ctx.dataset.get_field_schema(flat=True)
-        field_keys = list(fields.keys())
-        field_selector = types.AutocompleteView()
-        for key in field_keys:
-            field_selector.add_choice(key, label=key)
 
-        inputs.enum(
-            "field_name",
-            field_keys,
-            label="Field to rename",
-            view=field_selector,
-            required=True,
-        )
-        field_name = ctx.params.get("field_name", None)
-        new_field_name = ctx.params.get("new_field_name", None)
-        if field_name and field_name in field_keys:
-            new_field_prop = inputs.str(
-                "new_field_name",
-                required=True,
-                label="New field name",
-                default=f"{field_name}_copy",
-            )
-            if new_field_name and new_field_name in field_keys:
-                new_field_prop.invalid = True
-                new_field_prop.error_message = (
-                    f"Field '{new_field_name}' already exists"
-                )
-                inputs.str(
-                    "error",
-                    label="Error",
-                    view=types.Error(
-                        label="Field already exists",
-                        description=f"Field '{new_field_name}' already exists",
-                    ),
-                )
+        _rename_sample_field_inputs(ctx, inputs)
 
         return types.Property(
             inputs, view=types.View(label="Rename sample field")
@@ -183,6 +440,161 @@ class RenameSampleField(foo.Operator):
         ctx.trigger("reload_dataset")
 
 
+def _rename_sample_field_inputs(ctx, inputs):
+    schema = _get_non_default_sample_fields(ctx.dataset)
+
+    if not schema:
+        prop = inputs.str(
+            "msg",
+            label="This dataset has no non-default sample fields",
+            view=types.Warning(),
+        )
+        prop.invalid = True
+        return
+
+    field_selector = types.AutocompleteView()
+    for key in sorted(schema.keys()):
+        field_selector.add_choice(key, label=key)
+
+    field_prop = inputs.enum(
+        "field_name",
+        field_selector.values(),
+        label="Sample field",
+        description="The sample field to rename",
+        view=field_selector,
+        required=True,
+    )
+
+    field_name = ctx.params.get("field_name", None)
+    if field_name not in schema:
+        return
+
+    field = ctx.dataset.get_field(field_name)
+    if field is not None and field.read_only:
+        field_prop.invalid = True
+        field_prop.error_message = f"Field '{field_name}' is read-only"
+        return
+
+    new_field_prop = inputs.str(
+        "new_field_name",
+        required=True,
+        label="New field name",
+        description="A new name for the field",
+        default=f"{field_name}_copy",
+    )
+
+    new_field_name = ctx.params.get("new_field_name", None)
+
+    if new_field_name in schema:
+        new_field_prop.invalid = True
+        new_field_prop.error_message = (
+            f"Field '{new_field_name}' already exists"
+        )
+        inputs.str(
+            "error",
+            label="Error",
+            view=types.Error(
+                label="Field already exists",
+                description=f"Field '{new_field_name}' already exists",
+            ),
+        )
+
+
+class RenameFrameField(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="rename_frame_field",
+            label="Rename frame field",
+            dynamic=True,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        _rename_frame_field_inputs(ctx, inputs)
+
+        return types.Property(
+            inputs, view=types.View(label="Rename frame field")
+        )
+
+    def execute(self, ctx):
+        ctx.dataset.rename_frame_field(
+            ctx.params.get("field_name", None),
+            ctx.params.get("new_field_name", None),
+        )
+        ctx.trigger("reload_dataset")
+
+
+def _rename_frame_field_inputs(ctx, inputs):
+    if not ctx.dataset._has_frame_fields():
+        prop = inputs.str(
+            "msg",
+            label="This dataset does not have frame fields",
+            view=types.Warning(),
+        )
+        prop.invalid = True
+        return
+
+    schema = _get_non_default_frame_fields(ctx.dataset)
+
+    if not schema:
+        prop = inputs.str(
+            "msg",
+            label="This dataset has no non-default frame fields",
+            view=types.Warning(),
+        )
+        prop.invalid = True
+        return
+
+    field_selector = types.AutocompleteView()
+    for key in sorted(schema.keys()):
+        field_selector.add_choice(key, label=key)
+
+    field_prop = inputs.enum(
+        "field_name",
+        field_selector.values(),
+        label="Frame field",
+        description="The frame field to rename",
+        view=field_selector,
+        required=True,
+    )
+
+    field_name = ctx.params.get("field_name", None)
+    if field_name not in schema:
+        return
+
+    field = ctx.dataset.get_field(ctx.dataset._FRAMES_PREFIX + field_name)
+    if field is not None and field.read_only:
+        field_prop.invalid = True
+        field_prop.error_message = f"Frame field '{field_name}' is read-only"
+        return
+
+    new_field_prop = inputs.str(
+        "new_field_name",
+        required=True,
+        label="New frame field name",
+        description="A new name for the field",
+        default=f"{field_name}_copy",
+    )
+
+    new_field_name = ctx.params.get("new_field_name", None)
+
+    if new_field_name in schema:
+        new_field_prop.invalid = True
+        new_field_prop.error_message = (
+            f"Frame field '{new_field_name}' already exists"
+        )
+        inputs.str(
+            "error",
+            label="Error",
+            view=types.Error(
+                label="Frame field already exists",
+                description=f"Frrame field '{new_field_name}' already exists",
+            ),
+        )
+
+
 class ClearSampleField(foo.Operator):
     @property
     def config(self):
@@ -194,27 +606,181 @@ class ClearSampleField(foo.Operator):
 
     def resolve_input(self, ctx):
         inputs = types.Object()
-        fields = ctx.dataset.get_field_schema(flat=True)
-        field_keys = list(fields.keys())
-        field_selector = types.AutocompleteView()
-        for key in field_keys:
-            field_selector.add_choice(key, label=key)
 
-        inputs.enum(
-            "field_name",
-            field_keys,
-            label="Field to clear",
-            view=field_selector,
-            required=True,
-        )
+        _clear_sample_field_inputs(ctx, inputs)
 
         return types.Property(
             inputs, view=types.View(label="Clear sample field")
         )
 
     def execute(self, ctx):
+
         ctx.dataset.clear_sample_field(ctx.params.get("field_name", None))
         ctx.trigger("reload_dataset")
+
+
+def _clear_sample_field_inputs(ctx, inputs):
+    has_view = ctx.view != ctx.dataset.view()
+    has_selected = bool(ctx.selected)
+    default_target = None
+    if has_view or has_selected:
+        target_choices = types.RadioGroup()
+        target_choices.add_choice(
+            "DATASET",
+            label="Entire dataset",
+            description="Clear sample field for the entire dataset",
+        )
+
+        if has_view:
+            target_choices.add_choice(
+                "CURRENT_VIEW",
+                label="Current view",
+                description="Clear sample field for the current view",
+            )
+            default_target = "CURRENT_VIEW"
+
+        if has_selected:
+            target_choices.add_choice(
+                "SELECTED_SAMPLES",
+                label="Selected samples",
+                description="Clear sample field for the selected samples",
+            )
+            default_target = "SELECTED_SAMPLES"
+
+        inputs.enum(
+            "target",
+            target_choices.values(),
+            default=default_target,
+            view=target_choices,
+        )
+
+    target = ctx.params.get("target", default_target)
+    target_view = _get_target_view(ctx, target)
+
+    schema = target_view.get_field_schema(flat=True)
+    schema.pop("id", None)
+    schema.pop("filepath", None)
+
+    field_keys = sorted(schema.keys())
+    field_selector = types.AutocompleteView()
+    for key in field_keys:
+        field_selector.add_choice(key, label=key)
+
+    field_prop = inputs.enum(
+        "field_name",
+        field_selector.values(),
+        label="Sample field",
+        description="The sample field to clear",
+        view=field_selector,
+        required=True,
+    )
+
+    field_name = ctx.params.get("field_name", None)
+    if field_name not in schema:
+        return
+
+    field = ctx.dataset.get_field(field_name)
+    if field is not None and field.read_only:
+        field_prop.invalid = True
+        field_prop.error_message = f"Field '{field_name}' is read-only"
+
+
+class ClearFrameField(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="clear_frame_field",
+            label="Clear frame field",
+            dynamic=True,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        _clear_frame_field_inputs(ctx, inputs)
+
+        return types.Property(
+            inputs, view=types.View(label="Clear frame field")
+        )
+
+    def execute(self, ctx):
+        ctx.dataset.clear_frame_field(ctx.params.get("field_name", None))
+        ctx.trigger("reload_dataset")
+
+
+def _clear_frame_field_inputs(ctx, inputs):
+    if not ctx.dataset._has_frame_fields():
+        prop = inputs.str(
+            "msg",
+            label="This dataset does not have frame fields",
+            view=types.Warning(),
+        )
+        prop.invalid = True
+        return
+
+    has_view = ctx.view != ctx.dataset.view()
+    has_selected = bool(ctx.selected)
+    default_target = None
+    if has_view or has_selected:
+        target_choices = types.RadioGroup()
+        target_choices.add_choice(
+            "DATASET",
+            label="Entire dataset",
+            description="Clear frame field for the entire dataset",
+        )
+
+        if has_view:
+            target_choices.add_choice(
+                "CURRENT_VIEW",
+                label="Current view",
+                description="Clear frame field for the current view",
+            )
+            default_target = "CURRENT_VIEW"
+
+        if has_selected:
+            target_choices.add_choice(
+                "SELECTED_SAMPLES",
+                label="Selected samples",
+                description="Clear frame field for the selected samples",
+            )
+            default_target = "SELECTED_SAMPLES"
+
+        inputs.enum(
+            "target",
+            target_choices.values(),
+            default=default_target,
+            view=target_choices,
+        )
+
+    target = ctx.params.get("target", default_target)
+    target_view = _get_target_view(ctx, target)
+
+    schema = target_view.get_frame_field_schema(flat=True)
+    schema.pop("id", None)
+    schema.pop("frame_number", None)
+
+    field_keys = sorted(schema.keys())
+    field_selector = types.AutocompleteView()
+    for key in field_keys:
+        field_selector.add_choice(key, label=key)
+
+    field_prop = inputs.enum(
+        "field_name",
+        field_selector.values(),
+        label="Frame field",
+        description="The frame field to clear",
+        view=field_selector,
+        required=True,
+    )
+
+    field_name = ctx.params.get("field_name", None)
+    if field_name not in schema:
+        return
+
+    field = ctx.dataset.get_field(ctx.dataset._FRAMES_PREFIX + field_name)
+    if field is not None and field.read_only:
+        field_prop.invalid = True
+        field_prop.error_message = f"Frame field '{field_name}' is read-only"
 
 
 class DeleteSelectedSamples(foo.Operator):
@@ -249,8 +815,7 @@ class DeleteSelectedSamples(foo.Operator):
         return types.Property(inputs, view=view)
 
     def execute(self, ctx):
-        num_samples = len(ctx.selected)
-        if num_samples == 0:
+        if not ctx.selected:
             return
 
         ctx.dataset.delete_samples(ctx.selected)
@@ -311,19 +876,8 @@ class DeleteSampleField(foo.Operator):
 
     def resolve_input(self, ctx):
         inputs = types.Object()
-        fields = ctx.dataset.get_field_schema(flat=True)
-        field_keys = list(fields.keys())
-        field_selector = types.AutocompleteView()
-        for key in field_keys:
-            field_selector.add_choice(key, label=key)
 
-        inputs.enum(
-            "field_name",
-            field_keys,
-            label="Field to delete",
-            view=field_selector,
-            required=True,
-        )
+        _delete_sample_field_inputs(ctx, inputs)
 
         return types.Property(
             inputs, view=types.View(label="Delete sample field")
@@ -334,23 +888,1202 @@ class DeleteSampleField(foo.Operator):
         ctx.trigger("reload_dataset")
 
 
-class PrintStdout(foo.Operator):
+def _delete_sample_field_inputs(ctx, inputs):
+    schema = _get_non_default_sample_fields(ctx.dataset)
+
+    if not schema:
+        prop = inputs.str(
+            "msg",
+            label="This dataset has no non-default sample fields",
+            view=types.Warning(),
+        )
+        prop.invalid = True
+        return
+
+    field_selector = types.AutocompleteView()
+    for key in sorted(schema.keys()):
+        field_selector.add_choice(key, label=key)
+
+    field_prop = inputs.enum(
+        "field_name",
+        field_selector.values(),
+        label="Sample field",
+        description="The sample field to delete",
+        view=field_selector,
+        required=True,
+    )
+
+    field_name = ctx.params.get("field_name", None)
+    if field_name not in schema:
+        return
+
+    field = ctx.dataset.get_field(field_name)
+    if field is not None and field.read_only:
+        field_prop.invalid = True
+        field_prop.error_message = f"Field '{field_name}' is read-only"
+
+
+class DeleteFrameField(foo.Operator):
     @property
     def config(self):
         return foo.OperatorConfig(
-            name="print_stdout",
-            label="Print to stdout",
-            unlisted=True,
+            name="delete_frame_field",
+            label="Delete frame field",
+            dynamic=True,
         )
 
     def resolve_input(self, ctx):
         inputs = types.Object()
-        inputs.str("msg", label="Message", required=True)
-        return types.Property(inputs, view=types.View(label="Print to stdout"))
+
+        _delete_frame_field_inputs(ctx, inputs)
+
+        return types.Property(
+            inputs, view=types.View(label="Delete frame field")
+        )
 
     def execute(self, ctx):
-        print(ctx.params.get("msg", None))
-        return {"msg": ctx.params.get("msg", None)}
+        ctx.dataset.delete_frame_field(ctx.params.get("field_name", None))
+        ctx.trigger("reload_dataset")
+
+
+def _delete_frame_field_inputs(ctx, inputs):
+    if not ctx.dataset._has_frame_fields():
+        prop = inputs.str(
+            "msg",
+            label="This dataset does not have frame fields",
+            view=types.Warning(),
+        )
+        prop.invalid = True
+        return
+
+    schema = _get_non_default_frame_fields(ctx.dataset)
+
+    if not schema:
+        prop = inputs.str(
+            "msg",
+            label="This dataset has no non-default frame fields",
+            view=types.Warning(),
+        )
+        prop.invalid = True
+        return
+
+    field_selector = types.AutocompleteView()
+    for key in sorted(schema.keys()):
+        field_selector.add_choice(key, label=key)
+
+    field_prop = inputs.enum(
+        "field_name",
+        field_selector.values(),
+        label="Frame field",
+        description="The frame field to delete",
+        view=field_selector,
+        required=True,
+    )
+
+    field_name = ctx.params.get("field_name", None)
+    if field_name not in schema:
+        return
+
+    field = ctx.dataset.get_field(ctx.dataset._FRAMES_PREFIX + field_name)
+    if field is not None and field.read_only:
+        field_prop.invalid = True
+        field_prop.error_message = f"Frame field '{field_name}' is read-only"
+
+
+class CreateIndex(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="create_index",
+            label="Create index",
+            dynamic=True,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        schema = ctx.dataset.get_field_schema(flat=True)
+        if ctx.dataset._has_frame_fields():
+            frame_schema = ctx.dataset.get_frame_field_schema(flat=True)
+            schema.update(
+                {
+                    ctx.dataset._FRAMES_PREFIX + path: field
+                    for path, field in frame_schema.items()
+                }
+            )
+
+        indexes = set(ctx.dataset.list_indexes())
+
+        field_keys = sorted(p for p in schema if p not in indexes)
+        field_selector = types.AutocompleteView()
+        for key in field_keys:
+            field_selector.add_choice(key, label=key)
+
+        inputs.enum(
+            "field_name",
+            field_selector.values(),
+            required=True,
+            label="Field name",
+            description="The field to index",
+            view=field_selector,
+        )
+
+        inputs.bool(
+            "unique",
+            default=False,
+            required=False,
+            label="Unique",
+            description="Whether to add a uniqueness constraint to the index",
+        )
+
+        return types.Property(inputs, view=types.View(label="Create index"))
+
+    def execute(self, ctx):
+        field_name = ctx.params["field_name"]
+        unique = ctx.params.get("unique", False)
+
+        ctx.dataset.create_index(field_name, unique=unique)
+
+
+class DropIndex(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="drop_index",
+            label="Drop index",
+            dynamic=True,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        indexes = ctx.dataset.list_indexes()
+
+        default_indexes = set(ctx.dataset._get_default_indexes())
+        if ctx.dataset._has_frame_fields():
+            default_indexes.update(
+                ctx.dataset._get_default_indexes(frames=True)
+            )
+
+        indexes = [i for i in indexes if i not in default_indexes]
+
+        if indexes:
+            index_selector = types.AutocompleteView()
+            for key in indexes:
+                index_selector.add_choice(key, label=key)
+
+            inputs.enum(
+                "index_name",
+                index_selector.values(),
+                required=True,
+                label="Index name",
+                description="The index to drop",
+                view=index_selector,
+            )
+        else:
+            prop = inputs.str(
+                "index_name",
+                label="This dataset has no non-default indexes",
+                view=types.Warning(),
+            )
+            prop.invalid = True
+
+        return types.Property(inputs, view=types.View(label="Drop index"))
+
+    def execute(self, ctx):
+        ctx.dataset.drop_index(ctx.params["index_name"])
+
+
+class CreateSummaryField(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="create_summary_field",
+            label="Create summary field",
+            dynamic=True,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        _create_summary_field_inputs(ctx, inputs)
+
+        return types.Property(
+            inputs, view=types.View(label="Create summary field")
+        )
+
+    def execute(self, ctx):
+        path = ctx.params["path"]
+        field_name = ctx.params.get("field_name", None)
+        sidebar_group = ctx.params.get("sidebar_group", None)
+        include_counts = ctx.params.get("include_counts", False)
+        group_by = ctx.params.get("group_by", None)
+        read_only = ctx.params.get("read_only", True)
+        create_index = ctx.params.get("create_index", True)
+
+        if not sidebar_group:
+            sidebar_group = False
+
+        ctx.dataset.create_summary_field(
+            path,
+            field_name=field_name,
+            sidebar_group=sidebar_group,
+            include_counts=include_counts,
+            group_by=group_by,
+            read_only=read_only,
+            create_index=create_index,
+        )
+
+        ctx.trigger("reload_dataset")
+
+
+def _create_summary_field_inputs(ctx, inputs):
+    schema = ctx.dataset.get_field_schema(flat=True)
+
+    path_keys = list(schema.keys())
+    path_selector = types.AutocompleteView()
+    for key in path_keys:
+        path_selector.add_choice(key, label=key)
+
+    inputs.enum(
+        "path",
+        path_selector.values(),
+        label="Input field",
+        description="The input field to summarize",
+        view=path_selector,
+        required=True,
+    )
+
+    path = ctx.params.get("path", None)
+    if path is None or path not in path_keys:
+        return
+
+    field_name = ctx.params.get("field_name", None)
+    if field_name is None:
+        default_field_name = ctx.dataset._get_default_summary_field_name(path)
+    else:
+        default_field_name = field_name
+
+    field_name_prop = inputs.str(
+        "field_name",
+        required=False,
+        label="Summary field",
+        description="The sample field in which to store the summary data",
+        default=default_field_name,
+    )
+
+    if field_name and field_name in path_keys:
+        field_name_prop.invalid = True
+        field_name_prop.error_message = f"Field '{field_name}' already exists"
+        inputs.str(
+            "error",
+            label="Error",
+            view=types.Error(
+                label="Field already exists",
+                description=f"Field '{field_name}' already exists",
+            ),
+        )
+        return
+
+    if ctx.dataset.app_config.sidebar_groups is not None:
+        sidebar_group_selector = types.AutocompleteView()
+        for group in ctx.dataset.app_config.sidebar_groups:
+            sidebar_group_selector.add_choice(group.name, label=group.name)
+    else:
+        sidebar_group_selector = None
+
+    inputs.str(
+        "sidebar_group",
+        default="summaries",
+        required=False,
+        label="Sidebar group",
+        description=(
+            "The name of an "
+            "[App sidebar group](https://docs.voxel51.com/user_guide/app.html#sidebar-groups) "
+            "to which to add the summary field"
+        ),
+        view=sidebar_group_selector,
+    )
+
+    field = schema.get(path, None)
+    if isinstance(field, (fo.StringField, fo.BooleanField)):
+        field_type = "categorical"
+    elif isinstance(
+        field,
+        (fo.FloatField, fo.IntField, fo.DateField, fo.DateTimeField),
+    ):
+        field_type = "numeric"
+    else:
+        field_type = None
+
+    if field_type == "categorical":
+        inputs.bool(
+            "include_counts",
+            label="Include counts",
+            description=(
+                "Whether to include per-value counts when summarizing the "
+                "categorical field"
+            ),
+            default=False,
+        )
+    elif field_type == "numeric":
+        group_prefix = path.rsplit(".", 1)[0] + "."
+        group_by_keys = sorted(p for p in schema if p.startswith(group_prefix))
+        group_by_selector = types.AutocompleteView()
+        for group in group_by_keys:
+            group_by_selector.add_choice(group.name, label=group.name)
+
+        inputs.enum(
+            "group_by",
+            group_by_selector.values(),
+            default=None,
+            required=False,
+            label="Group by",
+            description=(
+                "An optional attribute to group by when to generate "
+                "per-attribute `[min, max]` ranges"
+            ),
+            view=group_by_selector,
+        )
+
+    inputs.bool(
+        "read_only",
+        default=True,
+        required=False,
+        label="Read-only",
+        description="Whether to mark the summary field as read-only",
+    )
+
+    inputs.bool(
+        "create_index",
+        default=True,
+        required=False,
+        label="Create index",
+        description=(
+            "Whether to create database index(es) for the summary field"
+        ),
+    )
+
+
+class UpdateSummaryField(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="update_summary_field",
+            label="Update summary field",
+            dynamic=True,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        _update_summary_field_inputs(ctx, inputs)
+
+        return types.Property(
+            inputs, view=types.View(label="Update summary field")
+        )
+
+    def execute(self, ctx):
+        ctx.dataset.update_summary_field(ctx.params["field_name"])
+        ctx.trigger("reload_dataset")
+
+
+def _update_summary_field_inputs(ctx, inputs):
+    summary_fields = ctx.dataset.list_summary_fields()
+
+    if not summary_fields:
+        prop = inputs.str(
+            "field_name",
+            label="This dataset does not have summary fields",
+            view=types.Warning(),
+        )
+        prop.invalid = True
+        return
+
+    field_selector = types.AutocompleteView()
+    for key in summary_fields:
+        field_selector.add_choice(key, label=key)
+
+    inputs.enum(
+        "field_name",
+        field_selector.values(),
+        required=True,
+        label="Summary field",
+        description="The summary field to delete",
+        view=field_selector,
+    )
+
+    field_name = ctx.params.get("field_name", None)
+    if field_name not in summary_fields:
+        return
+
+    update_fields = ctx.dataset.check_summary_fields()
+    if field_name not in update_fields:
+        prop = inputs.str(
+            "check_field",
+            label=(f"Summary field '{field_name}' is already " "up-to-date"),
+            view=types.Warning(),
+        )
+        prop.invalid = True
+
+
+class DeleteSummaryField(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="delete_summary_field",
+            label="Delete summary field",
+            dynamic=True,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        summary_fields = ctx.dataset.list_summary_fields()
+
+        if summary_fields:
+            field_selector = types.AutocompleteView()
+            for key in summary_fields:
+                field_selector.add_choice(key, label=key)
+
+            inputs.enum(
+                "field_name",
+                field_selector.values(),
+                required=True,
+                label="Summary field",
+                description="The summary field to delete",
+                view=field_selector,
+            )
+        else:
+            prop = inputs.str(
+                "field_name",
+                label="This dataset does not have summary fields",
+                view=types.Warning(),
+            )
+            prop.invalid = True
+
+        return types.Property(
+            inputs, view=types.View(label="Delete summary field")
+        )
+
+    def execute(self, ctx):
+        ctx.dataset.delete_summary_field(ctx.params["field_name"])
+        ctx.trigger("reload_dataset")
+
+
+class AddGroupSlice(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="add_group_slice",
+            label="Add group slice",
+            dynamic=True,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        if ctx.dataset.media_type != fom.GROUP:
+            prop = inputs.str(
+                "msg",
+                label="This dataset does not contain groups",
+                view=types.Warning(),
+            )
+            prop.invalid = True
+        else:
+            name_prop = inputs.str(
+                "name",
+                default=None,
+                required=True,
+                label="Group slice",
+                description="A name for the new group slice",
+            )
+
+            name = ctx.params.get("name", None)
+            if name in ctx.dataset.group_media_types:
+                name_prop.invalid = True
+                name_prop.error_message = (
+                    f"Group slice '{name}' already exists"
+                )
+
+            media_type_selector = types.AutocompleteView()
+            media_types = fom.MEDIA_TYPES
+            for key in media_types:
+                media_type_selector.add_choice(key, label=key)
+
+            inputs.enum(
+                "media_type",
+                media_type_selector.values(),
+                default=None,
+                required=True,
+                label="Media type",
+                description="The media type of the slice",
+                view=media_type_selector,
+            )
+
+        return types.Property(inputs, view=types.View(label="Add group slice"))
+
+    def execute(self, ctx):
+        ctx.dataset.add_group_slice(
+            ctx.params["name"], ctx.params["media_type"]
+        )
+        ctx.trigger("reload_dataset")
+
+
+class RenameGroupSlice(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="rename_group_slice",
+            label="Rename group slice",
+            dynamic=True,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        if ctx.dataset.media_type != fom.GROUP:
+            prop = inputs.str(
+                "msg",
+                label="This dataset does not contain groups",
+                view=types.Warning(),
+            )
+            prop.invalid = True
+        else:
+            slice_selector = types.AutocompleteView()
+            group_slices = ctx.dataset.group_slices
+            for key in group_slices:
+                slice_selector.add_choice(key, label=key)
+
+            inputs.enum(
+                "name",
+                slice_selector.values(),
+                default=None,
+                required=True,
+                label="Group slice",
+                description="The group slice to rename",
+                view=slice_selector,
+            )
+
+            new_name_prop = inputs.str(
+                "new_name",
+                default=None,
+                required=True,
+                label="New group slice name",
+                description="A new name for the group slice",
+            )
+
+            new_name = ctx.params.get("new_name", None)
+            if new_name in group_slices:
+                new_name_prop.invalid = True
+                new_name_prop.error_message = (
+                    f"Group slice '{new_name}' already exists"
+                )
+
+        return types.Property(
+            inputs, view=types.View(label="Rename group slice")
+        )
+
+    def execute(self, ctx):
+        ctx.dataset.rename_group_slice(
+            ctx.params["name"], ctx.params["new_name"]
+        )
+        ctx.trigger("reload_dataset")
+
+
+class DeleteGroupSlice(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="delete_group_slice",
+            label="Delete group slice",
+            dynamic=True,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        if ctx.dataset.media_type != fom.GROUP:
+            prop = inputs.str(
+                "msg",
+                label="This dataset does not contain groups",
+                view=types.Warning(),
+            )
+            prop.invalid = True
+        else:
+            slice_selector = types.AutocompleteView()
+            group_slices = ctx.dataset.group_slices
+            for key in group_slices:
+                slice_selector.add_choice(key, label=key)
+
+            inputs.enum(
+                "name",
+                slice_selector.values(),
+                default=None,
+                required=True,
+                label="Group slice",
+                description="The group slice to delete",
+                view=slice_selector,
+            )
+
+        return types.Property(
+            inputs, view=types.View(label="Delete group slice")
+        )
+
+    def execute(self, ctx):
+        ctx.dataset.delete_group_slice(ctx.params["name"])
+        ctx.trigger("reload_dataset")
+
+
+class ListSavedViews(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="list_saved_views",
+            label="List saved views",
+            unlisted=True,
+        )
+
+    def execute(self, ctx):
+        return {"views": ctx.dataset.list_saved_views(info=True)}
+
+
+class LoadSavedView(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="load_saved_view",
+            label="Load saved view",
+            dynamic=True,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        saved_views = ctx.dataset.list_saved_views()
+
+        if saved_views:
+            saved_view_selector = types.AutocompleteView()
+            for key in saved_views:
+                saved_view_selector.add_choice(key, label=key)
+
+            inputs.enum(
+                "name",
+                saved_view_selector.values(),
+                default=None,
+                required=True,
+                label="Saved view",
+                description="The saved view to load",
+                view=saved_view_selector,
+            )
+        else:
+            prop = inputs.str(
+                "msg",
+                label="This dataset has no saved views",
+                view=types.Warning(),
+            )
+            prop.invalid = True
+
+        return types.Property(inputs, view=types.View(label="Load saved view"))
+
+    def execute(self, ctx):
+        ctx.ops.set_view(name=ctx.params["name"])
+
+
+class SaveView(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="save_view",
+            label="Save view",
+            dynamic=True,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        saved_views = ctx.dataset.list_saved_views()
+        saved_view_selector = types.AutocompleteView()
+        for key in saved_views:
+            saved_view_selector.add_choice(key, label=key)
+
+        inputs.str(
+            "name",
+            required=True,
+            label="Name",
+            description="A new or existing name for the view",
+            view=saved_view_selector,
+        )
+
+        inputs.str(
+            "description",
+            default=None,
+            required=False,
+            label="Description",
+            description="An optional description for the view",
+        )
+
+        inputs.str(
+            "color",
+            default=None,
+            required=False,
+            label="Color",
+            description=(
+                "An optional RGB color string like `#FF6D04` for the view"
+            ),
+        )
+
+        name = ctx.params.get("name", None)
+
+        if name in saved_views:
+            inputs.view(
+                "overwrite",
+                types.Notice(
+                    label=f"This will overwrite existing saved view '{name}'"
+                ),
+            )
+
+        return types.Property(inputs, view=types.View(label="Save view"))
+
+    def execute(self, ctx):
+        name = ctx.params.get("name", None)
+        description = ctx.params.get("description", None)
+        color = ctx.params.get("color", None)
+
+        ctx.dataset.save_view(
+            name,
+            ctx.view,
+            description=description,
+            color=color,
+            overwrite=True,
+        )
+
+
+class EditSavedViewInfo(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="edit_saved_view_info",
+            label="Edit saved view info",
+            dynamic=True,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        _edit_saved_view_info_inputs(ctx, inputs)
+
+        return types.Property(
+            inputs, view=types.View(label="Edit saved view info")
+        )
+
+    def execute(self, ctx):
+        name = ctx.params.get("name", None)
+        new_name = ctx.params.get("new_name", None)
+        description = ctx.params.get("description", None)
+        color = ctx.params.get("color", None)
+
+        info = dict(name=new_name, description=description, color=color)
+        ctx.dataset.update_saved_view_info(name, info)
+
+
+def _edit_saved_view_info_inputs(ctx, inputs):
+    saved_views = ctx.dataset.list_saved_views()
+
+    if not saved_views:
+        prop = inputs.str(
+            "msg",
+            label="This dataset has no saved views",
+            view=types.Warning(),
+        )
+        prop.invalid = True
+        return
+
+    saved_view_selector = types.AutocompleteView()
+    for key in saved_views:
+        saved_view_selector.add_choice(key, label=key)
+
+    inputs.enum(
+        "name",
+        saved_view_selector.values(),
+        default=ctx.view.name,
+        required=True,
+        label="Saved view",
+        description="The saved view to edit",
+        view=saved_view_selector,
+    )
+
+    name = ctx.params.get("name", None)
+    if name is None or name not in saved_views:
+        return
+
+    info = ctx.dataset.get_saved_view_info(name)
+
+    new_name_prop = inputs.str(
+        "new_name",
+        default=info.get("name"),
+        required=False,
+        label="New name",
+        description="A new name for the saved view",
+    )
+
+    new_name = ctx.params.get("new_name", None)
+    if new_name != name and new_name in saved_views:
+        new_name_prop.invalid = True
+        new_name_prop.error_message = (
+            f"Saved view with name '{new_name}' already exists"
+        )
+
+    inputs.str(
+        "description",
+        default=info.get("description"),
+        required=False,
+        label="Description",
+        description="An optional description for the saved view",
+    )
+
+    inputs.str(
+        "color",
+        default=info.get("color"),
+        required=False,
+        label="Color",
+        description=(
+            "An optional RGB color string like `#FF6D04` for the saved view"
+        ),
+    )
+
+
+class DeleteSavedView(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="delete_saved_view",
+            label="Delete saved view",
+            dynamic=True,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        saved_views = ctx.dataset.list_saved_views()
+
+        if saved_views:
+            saved_view_selector = types.AutocompleteView()
+            for key in saved_views:
+                saved_view_selector.add_choice(key, label=key)
+
+            inputs.enum(
+                "name",
+                saved_view_selector.values(),
+                default=None,
+                required=True,
+                label="Saved view",
+                description="The saved view to delete",
+                view=saved_view_selector,
+            )
+        else:
+            prop = inputs.str(
+                "msg",
+                label="This dataset has no saved views",
+                view=types.Warning(),
+            )
+            prop.invalid = True
+
+        return types.Property(
+            inputs, view=types.View(label="Delete saved view")
+        )
+
+    def execute(self, ctx):
+        ctx.dataset.delete_saved_view(ctx.params["name"])
+
+
+class ListWorkspaces(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="list_workspaces",
+            label="List workspaces",
+            unlisted=True,
+        )
+
+    def execute(self, ctx):
+        return {"workspaces": ctx.dataset.list_workspaces(info=True)}
+
+
+class LoadWorkspace(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="load_workspace",
+            label="Load workspace",
+            dynamic=True,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        workspaces = ctx.dataset.list_workspaces()
+
+        if workspaces:
+            workspace_selector = types.AutocompleteView()
+            for key in workspaces:
+                workspace_selector.add_choice(key, label=key)
+
+            inputs.enum(
+                "name",
+                workspace_selector.values(),
+                default=None,
+                required=True,
+                label="Workspace",
+                description="The workspace to load",
+                view=workspace_selector,
+            )
+        else:
+            prop = inputs.str(
+                "msg",
+                label="This dataset has no saved workspaces",
+                view=types.Warning(),
+            )
+            prop.invalid = True
+
+        return types.Property(inputs, view=types.View(label="Load workspace"))
+
+    def execute(self, ctx):
+        ctx.ops.set_spaces(name=ctx.params["name"])
+
+
+class SaveWorkspace(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="save_workspace",
+            label="Save workspace",
+            dynamic=True,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        workspaces = ctx.dataset.list_workspaces()
+        workspace_selector = types.AutocompleteView()
+        for key in workspaces:
+            workspace_selector.add_choice(key, label=key)
+
+        inputs.str(
+            "name",
+            required=True,
+            label="Name",
+            description="A name for the saved workspace",
+            view=workspace_selector,
+        )
+
+        inputs.str(
+            "description",
+            default=None,
+            required=False,
+            label="Description",
+            description="An optional description for the workspace",
+        )
+
+        inputs.str(
+            "color",
+            default=None,
+            required=False,
+            label="Color",
+            description=(
+                "An optional RGB color string like `#FF6D04` for the workspace"
+            ),
+        )
+
+        # @todo infer this automatically from current App spaces
+        spaces_prop = inputs.str(
+            "spaces",
+            default=None,
+            required=True,
+            label="Spaces",
+            description=(
+                "JSON description of the workspace to save: "
+                "`print(session.spaces.to_json(True))`"
+            ),
+            view=types.CodeView(),
+        )
+
+        spaces = ctx.params.get("spaces", None)
+        if spaces is not None:
+            try:
+                fo.Space.from_json(spaces)
+            except:
+                spaces_prop.invalid = True
+                spaces_prop.error_message = "Invalid workspace definition"
+
+        name = ctx.params.get("name", None)
+
+        if name in workspaces:
+            inputs.view(
+                "overwrite",
+                types.Notice(
+                    label=f"This will overwrite existing workspace '{name}'"
+                ),
+            )
+
+        return types.Property(inputs, view=types.View(label="Save workspace"))
+
+    def execute(self, ctx):
+        name = ctx.params.get("name", None)
+        description = ctx.params.get("description", None)
+        color = ctx.params.get("color", None)
+        spaces = ctx.params.get("spaces", None)
+
+        if isinstance(spaces, dict):
+            spaces = fo.Space.from_dict(spaces)
+        else:
+            spaces = fo.Space.from_json(spaces)
+
+        ctx.dataset.save_workspace(
+            name,
+            spaces,
+            description=description,
+            color=color,
+            overwrite=True,
+        )
+
+
+class EditWorkspaceInfo(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="edit_workspace_info",
+            label="Edit workspace info",
+            dynamic=True,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        _edit_workspace_info_inputs(ctx, inputs)
+
+        return types.Property(
+            inputs, view=types.View(label="Edit workspace info")
+        )
+
+    def execute(self, ctx):
+        name = ctx.params.get("name", None)
+        new_name = ctx.params.get("new_name", None)
+        description = ctx.params.get("description", None)
+        color = ctx.params.get("color", None)
+
+        info = dict(name=new_name, description=description, color=color)
+        ctx.dataset.update_workspace_info(name, info)
+
+
+def _edit_workspace_info_inputs(ctx, inputs):
+    workspaces = ctx.dataset.list_workspaces()
+
+    if not workspaces:
+        prop = inputs.str(
+            "msg",
+            label="This dataset has no saved workspaces",
+            view=types.Warning(),
+        )
+        prop.invalid = True
+        return
+
+    workspace_selector = types.AutocompleteView()
+    for key in workspaces:
+        workspace_selector.add_choice(key, label=key)
+
+    # @todo default to current workspace name, if one is currently open
+    inputs.enum(
+        "name",
+        workspace_selector.values(),
+        required=True,
+        label="Workspace",
+        description="The workspace to edit",
+        view=workspace_selector,
+    )
+
+    name = ctx.params.get("name", None)
+    if name is None or name not in workspaces:
+        return
+
+    info = ctx.dataset.get_workspace_info(name)
+
+    new_name_prop = inputs.str(
+        "new_name",
+        default=info.get("name"),
+        required=False,
+        label="New name",
+        description="A new name for the workspace",
+    )
+
+    new_name = ctx.params.get("new_name", None)
+    if new_name != name and new_name in workspaces:
+        new_name_prop.invalid = True
+        new_name_prop.error_message = (
+            f"Workspace with name '{new_name}' already exists"
+        )
+
+    inputs.str(
+        "description",
+        default=info.get("description"),
+        required=False,
+        label="Description",
+        description="An optional description for the workspace",
+    )
+
+    inputs.str(
+        "color",
+        default=info.get("color"),
+        required=False,
+        label="Color",
+        description=(
+            "An optional RGB color string like `#FF6D04` for the workspace"
+        ),
+    )
+
+
+class DeleteWorkspace(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="delete_workspace",
+            label="Delete workspace",
+            dynamic=True,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        workspaces = ctx.dataset.list_workspaces()
+
+        if workspaces:
+            workspace_selector = types.AutocompleteView()
+            for key in workspaces:
+                workspace_selector.add_choice(key, label=key)
+
+            inputs.enum(
+                "name",
+                workspace_selector.values(),
+                default=None,
+                required=True,
+                label="Workspace",
+                description="The workspace to delete",
+                view=workspace_selector,
+            )
+        else:
+            prop = inputs.str(
+                "msg",
+                label="This dataset has no saved workspaces",
+                view=types.Warning(),
+            )
+            prop.invalid = True
+
+        return types.Property(
+            inputs, view=types.View(label="Delete workspace")
+        )
+
+    def execute(self, ctx):
+        ctx.dataset.delete_workspace(ctx.params["name"])
 
 
 class ListFiles(foo.Operator):
@@ -419,105 +2152,85 @@ def list_files(dirpath):
     return dirs + files
 
 
-class ListWorkspaces(foo.Operator):
-    @property
-    def config(self):
-        return foo.OperatorConfig(
-            name="list_workspaces", label="List Workspaces", unlisted=True
-        )
+def _get_target_view(ctx, target):
+    if target == "SELECTED_LABELS":
+        return ctx.view.select_labels(labels=ctx.selected_labels)
 
-    def execute(self, ctx):
-        return {"workspaces": ctx.dataset.list_workspaces(info=True)}
+    if target == "SELECTED_SAMPLES":
+        return ctx.view.select(ctx.selected)
 
+    if target == "DATASET":
+        return ctx.dataset
 
-class LoadWorkspace(foo.Operator):
-    @property
-    def config(self):
-        return foo.OperatorConfig(
-            name="load_workspace", label="Load Workspace"
-        )
-
-    def resolve_input(self, ctx):
-        inputs = types.Object()
-        inputs.str("name", label="Workspace Name", required=True)
-        return types.Property(inputs)
-
-    def execute(self, ctx):
-        name = ctx.params.get("name", None)
-        ctx.ops.set_spaces(name=name)
-        return {}
+    return ctx.view
 
 
-class SaveWorkspace(foo.Operator):
-    @property
-    def config(self):
-        return foo.OperatorConfig(
-            name="save_workspace", label="Save Workspace"
-        )
+def _get_non_default_sample_fields(dataset):
+    schema = dataset.get_field_schema(flat=True)
 
-    def resolve_input(self, ctx):
-        inputs = types.Object()
-        inputs.str("name", label="Workspace Name", required=True)
-        inputs.str("description", label="Description")
-        inputs.str("color", label="Color")
-        inputs.obj("spaces", label="Spaces")
-        inputs.bool("edit", label="Edit")
-        if ctx.params.get("edit", False):
-            inputs.str(
-                "current_name", label="Current Workspace Name", required=True
-            )
-        return types.Property(inputs)
+    roots = {
+        path.rsplit(".", 1)[0] if "." in path else None
+        for path in schema.keys()
+    }
 
-    def execute(self, ctx):
-        name = ctx.params.get("name", None)
-        description = ctx.params.get("description", None)
-        color = ctx.params.get("color", None)
-        spaces_dict = ctx.params.get("spaces", None)
-        spaces = fo.Space.from_dict(spaces_dict)
-        edit = ctx.params.get("edit", False)
-        current_name = ctx.params.get("current_name", None)
-        if edit:
-            ctx.dataset.update_workspace_info(
-                current_name,
-                info=dict(name=name, color=color, description=description),
-            )
-        else:
-            ctx.dataset.save_workspace(
-                name, spaces, description=description, color=color
-            )
-        return {}
+    default_fields = set()
+    for root in roots:
+        default_fields.update(dataset._get_default_sample_fields(path=root))
+
+    for path in default_fields:
+        schema.pop(path, None)
+
+    return schema
 
 
-class DeleteWorkspace(foo.Operator):
-    @property
-    def config(self):
-        return foo.OperatorConfig(
-            name="delete_workspace", label="Delete Workspace"
-        )
+def _get_non_default_frame_fields(dataset):
+    schema = dataset.get_frame_field_schema(flat=True)
 
-    def resolve_input(self, ctx):
-        inputs = types.Object()
-        inputs.str("name", label="Workspace Name", required=True)
-        return types.Property(inputs)
+    roots = {
+        path.rsplit(".", 1)[0] if "." in path else None
+        for path in schema.keys()
+    }
 
-    def execute(self, ctx):
-        name = ctx.params.get("name", None)
-        ctx.dataset.delete_workspace(name)
-        return {}
+    default_fields = set()
+    for root in roots:
+        default_fields.update(dataset._get_default_frame_fields(path=root))
+
+    for path in default_fields:
+        schema.pop(path, None)
+
+    return schema
 
 
 BUILTIN_OPERATORS = [
+    EditFieldInfo(_builtin=True),
     CloneSelectedSamples(_builtin=True),
     CloneSampleField(_builtin=True),
+    CloneFrameField(_builtin=True),
     RenameSampleField(_builtin=True),
+    RenameFrameField(_builtin=True),
     ClearSampleField(_builtin=True),
+    ClearFrameField(_builtin=True),
     DeleteSelectedSamples(_builtin=True),
     DeleteSelectedLabels(_builtin=True),
     DeleteSampleField(_builtin=True),
-    PrintStdout(_builtin=True),
-    ListFiles(_builtin=True),
+    DeleteFrameField(_builtin=True),
+    CreateIndex(_builtin=True),
+    DropIndex(_builtin=True),
+    CreateSummaryField(_builtin=True),
+    UpdateSummaryField(_builtin=True),
+    DeleteSummaryField(_builtin=True),
+    AddGroupSlice(_builtin=True),
+    RenameGroupSlice(_builtin=True),
+    DeleteGroupSlice(_builtin=True),
+    ListSavedViews(_builtin=True),
+    LoadSavedView(_builtin=True),
+    SaveView(_builtin=True),
+    EditSavedViewInfo(_builtin=True),
+    DeleteSavedView(_builtin=True),
     ListWorkspaces(_builtin=True),
     LoadWorkspace(_builtin=True),
     SaveWorkspace(_builtin=True),
+    EditWorkspaceInfo(_builtin=True),
     DeleteWorkspace(_builtin=True),
+    ListFiles(_builtin=True),
 ]

--- a/fiftyone/operators/builtin.py
+++ b/fiftyone/operators/builtin.py
@@ -590,7 +590,7 @@ def _rename_frame_field_inputs(ctx, inputs):
             label="Error",
             view=types.Error(
                 label="Frame field already exists",
-                description=f"Frrame field '{new_field_name}' already exists",
+                description=f"Frame field '{new_field_name}' already exists",
             ),
         )
 

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -5634,6 +5634,18 @@ class DatasetDeletionTests(unittest.TestCase):
         self.assertTrue(last_modified_at4b < last_modified_at5b)
         self.assertEqual(last_modified_at4c, last_modified_at5c)
 
+        last_modified_at6b = dataset._get_last_modified_at()
+        last_modified_at6c = dataset._get_last_modified_at(frames=True)
+
+        self.assertEqual(last_modified_at6b, last_modified_at5b)
+        self.assertEqual(last_modified_at6c, last_modified_at5c)
+
+        last_modified_at7b = dataset.view()._get_last_modified_at()
+        last_modified_at7c = dataset.view()._get_last_modified_at(frames=True)
+
+        self.assertEqual(last_modified_at7b, last_modified_at5b)
+        self.assertEqual(last_modified_at7c, last_modified_at5c)
+
 
 class DynamicFieldTests(unittest.TestCase):
     @drop_datasets


### PR DESCRIPTION
## Change log

Added the following new builtin operators:
- `edit_field_info`
- `clone_frame_field`
- `rename_frame_field`
- `clear_frame_field`
- `delete_frame_field`
- `create_index`
- `drop_index`
- `create_summary_field`
- `update_summary_field`
- `delete_summary_field`
- `add_group_slice`
- `rename_group_slice`
- `delete_group_slice`
- `load_saved_view`
- `save_view`
- `edit_saved_view_info`
- `delete_saved_view`
- `edit_workspace_info`
- `sync_last_modified_at`

Enhancements to existing builtin operators
- Intelligent handling of read-only fields
- Intelligent handling of default fields
- Enhanced many fields' descriptions

Other updates
- Improved the robustness of the v1.0.0 migration (eg handle case where an existing dataset has an incompatible `created_at` or `last_modified_at` field)
- Optimized `max(last_modified_at)` computations via a new `_get_last_modified_at()` method
- Ensured that `last_modified_at` times are exactly in-sync when creating/updating saved views

## Tested by

Manual tests with the `quickstart`, `quickstart-video`, and `quickstart-groups` datasets.
