### PR TITLE
Remove deprecated methods for 1.0

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -4155,52 +4155,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 self._frame_collection_name, sample_ids=sample_ids
             )
 
-    @deprecated(reason="Use delete_samples() instead")
-    def remove_sample(self, sample_or_id):
-        """Removes the given sample from the dataset.
-
-        If reference to a sample exists in memory, the sample will be updated
-        such that ``sample.in_dataset`` is False.
-
-        .. warning::
-
-            This method is deprecated and will be removed in a future release.
-            Use the drop-in replacement :meth:`delete_samples` instead.
-
-        Args:
-            sample_or_id: the sample to remove. Can be any of the following:
-
-                -   a sample ID
-                -   a :class:`fiftyone.core.sample.Sample`
-                -   a :class:`fiftyone.core.sample.SampleView`
-        """
-        self.delete_samples(sample_or_id)
-
-    @deprecated(reason="Use delete_samples() instead")
-    def remove_samples(self, samples_or_ids):
-        """Removes the given samples from the dataset.
-
-        If reference to a sample exists in memory, the sample will be updated
-        such that ``sample.in_dataset`` is False.
-
-        .. warning::
-
-            This method is deprecated and will be removed in a future release.
-            Use the drop-in replacement :meth:`delete_samples` instead.
-
-        Args:
-            samples_or_ids: the samples to remove. Can be any of the following:
-
-                -   a sample ID
-                -   an iterable of sample IDs
-                -   a :class:`fiftyone.core.sample.Sample` or
-                    :class:`fiftyone.core.sample.SampleView`
-                -   an iterable of :class:`fiftyone.core.sample.Sample` or
-                    :class:`fiftyone.core.sample.SampleView` instances
-                -   a :class:`fiftyone.core.collections.SampleCollection`
-        """
-        self.delete_samples(samples_or_ids)
-
     def save(self):
         """Saves the dataset to the database.
 


### PR DESCRIPTION
We're going to 1.0 and it is time to remove the `@deprecated` methods, which have been marked as such for [over 3 years](https://github.com/voxel51/fiftyone/blame/12aec6e9bdc3d0249e00762babbbbc701441ddc4/fiftyone/core/dataset.py#L4158).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed deprecated methods for sample removal to streamline functionality.
	- Users are now encouraged to use the `delete_samples` method for managing dataset samples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->