### PR TITLE
Persist current slice during group modal navigation

### DIFF
--- a/app/packages/state/src/hooks/useSetExpandedSample.ts
+++ b/app/packages/state/src/hooks/useSetExpandedSample.ts
@@ -27,9 +27,9 @@ export default () => {
             .filter(({ mediaType }) => !THREE_D.has(mediaType))
             .map(({ name }) => name)
             .sort()[0];
-        }
 
-        set(groupAtoms.modalGroupSlice, fallback);
+          set(groupAtoms.modalGroupSlice, fallback);
+        }
       },
     []
   );

--- a/e2e-pw/src/oss/specs/smoke-tests/quickstart-groups.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/quickstart-groups.spec.ts
@@ -92,6 +92,12 @@ test.describe("quickstart-groups", () => {
       expect(await modal.sidebar.getSampleFilepath(false)).toEqual(
         FIRST_SAMPLE_FILENAME
       );
+
+      await modal.navigateSlice("group", "right");
+      await modal.navigateNextSample();
+      expect(await modal.sidebar.getSidebarEntryText("group.name")).toEqual(
+        "right"
+      );
     });
 
     test("group media visibility toggle works", async ({ modal }) => {

--- a/e2e-pw/src/oss/specs/smoke-tests/quickstart-groups.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/quickstart-groups.spec.ts
@@ -93,7 +93,8 @@ test.describe("quickstart-groups", () => {
         FIRST_SAMPLE_FILENAME
       );
 
-      await modal.navigateSlice("group", "right");
+      await modal.sidebar.toggleSidebarGroup("GROUP");
+      await modal.navigateSlice("group.name", "right");
       await modal.navigateNextSample();
       expect(await modal.sidebar.getSidebarEntryText("group.name")).toEqual(
         "right"


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes active slice persistence in the group modal

https://github.com/user-attachments/assets/ebbbf9e4-28ae-43d1-b18b-32cc919c66f4


## How is this patch tested? If it is not, please explain why.

e2e assertion

## Release Notes

* Fixed active slice persistence during group modal navigation

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the "quickstart-groups" test suite to verify sidebar navigation functionality.
- **Bug Fixes**
	- Adjusted control flow in the sample expansion logic for improved functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->