### PR TITLE
fix execute not working for JS operators

### DIFF
--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -183,7 +183,10 @@ function useExecutionOptions(operatorURI, ctx, isRemote) {
 
   const fetch = useCallback(
     debounce(async (ctxOverride = null) => {
-      if (!isRemote) return;
+      if (!isRemote) {
+        setExecutionOptions({ allowImmediateExecution: true });
+        return;
+      }
       if (!ctxOverride) setIsLoading(true); // only show loading if loading the first time
       const options = await resolveExecutionOptions(
         operatorURI,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix JS operator execute

## How is this patch tested? If it is not, please explain why.

Using a JS operator

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of execution options for local executions, allowing for immediate execution when not using remote settings.

- **Bug Fixes**
	- Ensured that execution options state is updated correctly even when exiting early from the function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->