### PR TITLE
add set_group_slice operator

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -1225,6 +1225,29 @@ export class ApplyPanelStatePath extends Operator {
   }
 }
 
+export class SetGroupSlice extends Operator {
+  get config(): OperatorConfig {
+    return new OperatorConfig({
+      name: "set_group_slice",
+      label: "Set group slice",
+      // unlisted: true,
+    });
+  }
+  useHooks() {
+    const setSlice = fos.useSetGroupSlice();
+    return { setSlice };
+  }
+  async resolveInput(): Promise<types.Property> {
+    const inputs = new types.Object();
+    inputs.str("slice", { label: "Group slice", required: true });
+    return new types.Property(inputs);
+  }
+  async execute(ctx: ExecutionContext): Promise<void> {
+    const { slice } = ctx.params;
+    ctx.hooks.setSlice(slice);
+  }
+}
+
 export function registerBuiltInOperators() {
   try {
     _registerBuiltInOperator(CopyViewAsJSON);
@@ -1271,6 +1294,7 @@ export function registerBuiltInOperators() {
     _registerBuiltInOperator(TrackEvent);
     _registerBuiltInOperator(SetPanelTitle);
     _registerBuiltInOperator(ApplyPanelStatePath);
+    _registerBuiltInOperator(SetGroupSlice);
   } catch (e) {
     console.error("Error registering built-in operators");
     console.error(e);

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -573,7 +573,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if slice_name is None:
             slice_name = self._doc.default_group_slice
 
-        if slice_name not in self._doc.group_media_types:
+        if (
+            slice_name is not None
+            and slice_name not in self._doc.group_media_types
+        ):
             raise ValueError("Dataset has no group slice '%s'" % slice_name)
 
         self._group_slice = slice_name

--- a/fiftyone/operators/builtin.py
+++ b/fiftyone/operators/builtin.py
@@ -1518,7 +1518,8 @@ class RenameGroupSlice(foo.Operator):
         new_name = ctx.params["new_name"]
 
         ctx.dataset.rename_group_slice(name, new_name)
-        ctx.trigger("reload_dataset")
+        ctx.ops.set_group_slice(new_name)
+        ctx.ops.reload_dataset()
 
 
 class DeleteGroupSlice(foo.Operator):
@@ -1564,7 +1565,17 @@ class DeleteGroupSlice(foo.Operator):
         name = ctx.params["name"]
 
         ctx.dataset.delete_group_slice(name)
-        ctx.trigger("reload_dataset")
+        group_slices = ctx.dataset.group_slices
+        selected_group_slice = next(
+            (
+                group_slice
+                for group_slice in group_slices
+                if group_slice != name
+            ),
+            None,
+        )
+        ctx.ops.set_group_slice(selected_group_slice)
+        ctx.ops.reload_dataset()
 
 
 class ListSavedViews(foo.Operator):

--- a/fiftyone/operators/builtin.py
+++ b/fiftyone/operators/builtin.py
@@ -1518,7 +1518,11 @@ class RenameGroupSlice(foo.Operator):
         new_name = ctx.params["new_name"]
 
         ctx.dataset.rename_group_slice(name, new_name)
-        ctx.ops.set_group_slice(new_name)
+
+        # @todo ideally we would only set this if the group slice we renamed is
+        # currently loaded in the App
+        ctx.ops.set_group_slice(ctx.dataset.default_group_slice)
+
         ctx.ops.reload_dataset()
 
 
@@ -1565,16 +1569,11 @@ class DeleteGroupSlice(foo.Operator):
         name = ctx.params["name"]
 
         ctx.dataset.delete_group_slice(name)
-        group_slices = ctx.dataset.group_slices
-        selected_group_slice = next(
-            (
-                group_slice
-                for group_slice in group_slices
-                if group_slice != name
-            ),
-            None,
-        )
-        ctx.ops.set_group_slice(selected_group_slice)
+
+        # @todo ideally we would only set this if the group slice we deleted is
+        # currently loaded in the App
+        ctx.ops.set_group_slice(ctx.dataset.default_group_slice)
+
         ctx.ops.reload_dataset()
 
 

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -630,10 +630,10 @@ class Operations(object):
         )
 
     def set_group_slice(self, slice):
-        """Set the group slices in the App.
+        """Set the active group slice in the App.
 
         Args:
-            slice: the group slice to set
+            slice: the group slice to activate
         """
         return self._ctx.trigger("set_group_slice", {"slice": slice})
 

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -629,6 +629,14 @@ class Operations(object):
             "set_panel_title", params={"id": id, "title": title}
         )
 
+    def set_group_slice(self, slice):
+        """Set the group slices in the App.
+
+        Args:
+            slice: the group slice to set
+        """
+        return self._ctx.trigger("set_group_slice", {"slice": slice})
+
 
 def _serialize_view(view):
     return json.loads(json_util.dumps(view._serialize()))


### PR DESCRIPTION
## What changes are proposed in this pull request?

add set_group_slice operator and use it in delete/rename group operation

## How is this patch tested? If it is not, please explain why.

Using delete/rename group operator

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new operator, **Set Group Slice**, allowing users to set group slices more effectively.
	- Added a method to set group slices within the application context.

- **Improvements**
	- Updated the **Rename Group Slice** and **Delete Group Slice** operations for more efficient dataset state management after renaming and deleting group slices.
	- Enhanced error handling in the **group_slice** method to prevent unnecessary errors when the slice name is not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->