### PR TITLE
Add timeline ops

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -1215,7 +1215,11 @@ export class SetPanelTitle extends Operator {
 type SetPlayheadStateHooks = {
   setPlayheadState: (state: fop.PlayheadState, timeline_name?: string) => void;
 };
-type SetPlayheadStateParams = { state: any; timeline_name?: string };
+type SetPlayheadStateParams = {
+  state: fop.PlayheadState;
+  timeline_name?: string;
+};
+
 export class SetPlayheadState extends Operator {
   get config(): OperatorConfig {
     return new OperatorConfig({

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -12,6 +12,7 @@ import * as types from "./types";
 
 import { useTrackEvent } from "@fiftyone/analytics";
 import { setPathUserUnchanged } from "@fiftyone/core/src/plugins/SchemaIO/hooks";
+import * as fop from "@fiftyone/playback";
 import { LOAD_WORKSPACE_OPERATOR } from "@fiftyone/spaces/src/components/Workspaces/constants";
 import { toSlug } from "@fiftyone/utilities";
 import copyToClipboard from "copy-to-clipboard";
@@ -31,8 +32,6 @@ import {
 } from "./operators";
 import { useShowOperatorIO } from "./state";
 import usePanelEvent from "./usePanelEvent";
-import { useAtomValue } from "jotai";
-import * as fop from "@fiftyone/playback";
 
 //
 // BUILT-IN OPERATORS

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -1224,8 +1224,14 @@ export class SetPlayheadState extends Operator {
       unlisted: true,
     });
   }
-  useHooks(): SetPlayheadStateHooks {
-    const timeline = fop.useTimeline();
+  async resolveInput(): Promise<types.Property> {
+    const inputs = new types.Object();
+    inputs.enum("state", ["playing", "paused"], { label: "State" });
+    inputs.str("timeline_name", { label: "Timeline name" });
+    return new types.Property(inputs);
+  }
+  useHooks(ctx: ExecutionContext): SetPlayheadStateHooks {
+    const timeline = fop.useTimeline(ctx.params.timeline_name);
     return {
       setPlayheadState: (state: fop.PlayheadState) => {
         timeline.setPlayHeadState(state);
@@ -1235,7 +1241,7 @@ export class SetPlayheadState extends Operator {
   async execute({ hooks, params }: ExecutionContext): Promise<void> {
     const { setPlayheadState } = hooks as SetPlayheadStateHooks;
     const { state, timeline_name } = params as SetPlayheadStateParams;
-    setPlayheadState(state, timeline_name);
+    setPlayheadState(state);
   }
 }
 

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -1213,7 +1213,7 @@ export class SetPanelTitle extends Operator {
 }
 
 type SetPlayheadStateHooks = {
-  setPlayheadState: ReturnType<typeof fop.useUpdatePlayheadState>;
+  setPlayheadState: (state: fop.PlayheadState, timeline_name?: string) => void;
 };
 type SetPlayheadStateParams = { state: any; timeline_name?: string };
 export class SetPlayheadState extends Operator {

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -1240,7 +1240,7 @@ export class SetPlayheadState extends Operator {
   }
   async execute({ hooks, params }: ExecutionContext): Promise<void> {
     const { setPlayheadState } = hooks as SetPlayheadStateHooks;
-    const { state, timeline_name } = params as SetPlayheadStateParams;
+    const { state } = params as SetPlayheadStateParams;
     setPlayheadState(state);
   }
 }
@@ -1256,7 +1256,11 @@ class SetFrameNumber extends Operator {
   async resolveInput(): Promise<types.Property> {
     const inputs = new types.Object();
     inputs.str("timeline_name", { label: "Timeline name" });
-    inputs.int("frame_number", { label: "Frame number", required: true });
+    inputs.int("frame_number", {
+      label: "Frame number",
+      required: true,
+      min: 0,
+    });
     return new types.Property(inputs);
   }
   async execute(ctx: ExecutionContext): Promise<void> {


### PR DESCRIPTION
Adds the following operators:

 - SetFrameNumber
 - SetPlayheadState


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `SetPlayheadState` class for setting the playhead state in timelines.
	- Added `SetFrameNumber` class to specify and set a frame number in timelines.
	- Both classes are now available as built-in operators within the application, enhancing timeline control capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->