### PR TITLE
add docs on panel surfaces

### DIFF
--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -1773,6 +1773,12 @@ in the App.
 Panels can be defined in either Python or JS, and FiftyOne comes with a
 number of :ref:`builtin panels <plugins-design-panels>` for common tasks.
 
+Depending on the ``surfaces`` panel config, panels can be scoped to either
+the grid or the modal, and can be opened from the "+" menu - available both
+in the grid and the modal. Whereas grid panels unlock extensibility in the
+macro level of datasets, modal panels unlock extensibility in the micro level
+of samples.
+
 Panels, like :ref:`operators <developing-operators>`, can make use of the
 :mod:`fiftyone.operators.types` module and the
 :js:mod:`@fiftyone/operators <@fiftyone/operators>` package, which define a
@@ -1829,6 +1835,15 @@ subsequent sections.
 
                 # Whether to allow multiple instances of the panel to be opened
                 allow_multiple=False,
+
+                # Whether the panel should be made available in the grid, or
+                # the modal, or both (default = grid only)
+                surfaces="grid modal"
+
+                # Markdown-formatted text that describes the panel. This is
+                # rendererd in a tooltip when the help icon in the panel
+                # title is hovered over
+                help_markdown="A description of the panel",
             )
 
         def render(self, ctx):

--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -1774,10 +1774,11 @@ Panels can be defined in either Python or JS, and FiftyOne comes with a
 number of :ref:`builtin panels <plugins-design-panels>` for common tasks.
 
 Depending on the ``surfaces`` panel config, panels can be scoped to either
-the grid or the modal, and can be opened from the "+" menu - available both
-in the grid and the modal. Whereas grid panels unlock extensibility in the
-macro level of datasets, modal panels unlock extensibility in the micro level
-of samples.
+the grid or the modal. You can open these panels from the "+" menu, which
+is available in both the grid and modal views. Whereas grid panels enable
+extensibility at the macro level, allowing you to work with entire datasets,
+modal panels provide extensibility at the micro level, focusing on individual
+samples and scenarios.
 
 Panels, like :ref:`operators <developing-operators>`, can make use of the
 :mod:`fiftyone.operators.types` module and the

--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -1837,9 +1837,10 @@ subsequent sections.
                 # Whether to allow multiple instances of the panel to be opened
                 allow_multiple=False,
 
-                # Whether the panel should be made available in the grid, or
-                # the modal, or both (default = grid only)
-                surfaces="grid modal"
+                # Whether the panel should be available in the grid view
+                # modal view, or both
+                # Possible values: "grid", "modal", "grid modal"       
+                surfaces="grid modal" # default = "grid"
 
                 # Markdown-formatted text that describes the panel. This is
                 # rendererd in a tooltip when the help icon in the panel


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced panel configuration allows panels to be scoped to grid or modal views.
	- New parameters `surfaces` and `help_markdown` added for improved usability and documentation.
  
These changes improve the flexibility and user experience when interacting with panels in the FiftyOne application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->