### PR TITLE
better group slice support for operators

### DIFF
--- a/app/packages/operators/src/CustomPanel.tsx
+++ b/app/packages/operators/src/CustomPanel.tsx
@@ -114,6 +114,7 @@ export function defineCustomPanel({
   on_change_selected,
   on_change_selected_labels,
   on_change_extended_selection,
+  on_change_group_slice,
   panel_name,
   panel_label,
 }) {
@@ -130,6 +131,7 @@ export function defineCustomPanel({
       onChangeSelected={on_change_selected}
       onChangeSelectedLabels={on_change_selected_labels}
       onChangeExtendedSelection={on_change_extended_selection}
+      onChangeGroupSlice={on_change_group_slice}
       dimensions={dimensions}
       panelName={panel_name}
       panelLabel={panel_label}

--- a/app/packages/operators/src/hooks.ts
+++ b/app/packages/operators/src/hooks.ts
@@ -25,6 +25,7 @@ function useOperatorThrottledContextSetter() {
   const filters = useRecoilValue(fos.filters);
   const selectedSamples = useRecoilValue(fos.selectedSamples);
   const selectedLabels = useRecoilValue(fos.selectedLabels);
+  const groupSlice = useRecoilValue(fos.groupSlice);
   const currentSample = useCurrentSample();
   const setContext = useSetRecoilState(operatorThrottledContext);
   const setThrottledContext = useMemo(() => {
@@ -47,6 +48,7 @@ function useOperatorThrottledContextSetter() {
       selectedLabels,
       currentSample,
       viewName,
+      groupSlice,
     });
   }, [
     setThrottledContext,
@@ -58,6 +60,7 @@ function useOperatorThrottledContextSetter() {
     selectedLabels,
     currentSample,
     viewName,
+    groupSlice,
   ]);
 }
 

--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -90,6 +90,7 @@ export type RawContext = {
     selection: string[] | null;
     scope: string;
   };
+  groupSlice: string;
 };
 
 export class ExecutionContext {
@@ -131,6 +132,9 @@ export class ExecutionContext {
   }
   public get extendedSelection(): any {
     return this._currentContext.extendedSelection;
+  }
+  public get groupSlice(): any {
+    return this._currentContext.groupSlice;
   }
   getCurrentPanelId(): string | null {
     return this.params.panel_id || this.currentPanel?.id || null;
@@ -538,6 +542,7 @@ async function executeOperatorAsGenerator(
       selected_labels: formatSelectedLabels(currentContext.selectedLabels),
       view: currentContext.view,
       view_name: currentContext.viewName,
+      group_slice: currentContext.groupSlice,
     },
     "json-stream"
   );
@@ -700,6 +705,7 @@ export async function executeOperatorWithContext(
           selected_labels: formatSelectedLabels(currentContext.selectedLabels),
           view: currentContext.view,
           view_name: currentContext.viewName,
+          group_slice: currentContext.groupSlice,
         }
       );
       result = serverResult.result;
@@ -802,6 +808,7 @@ export async function resolveRemoteType(
       selected_labels: formatSelectedLabels(currentContext.selectedLabels),
       view: currentContext.view,
       view_name: currentContext.viewName,
+      group_slice: currentContext.groupSlice,
     }
   );
 
@@ -875,6 +882,7 @@ export async function resolveExecutionOptions(
       selected_labels: formatSelectedLabels(currentContext.selectedLabels),
       view: currentContext.view,
       view_name: currentContext.viewName,
+      group_slice: currentContext.groupSlice,
     }
   );
 
@@ -905,6 +913,7 @@ export async function fetchRemotePlacements(ctx: ExecutionContext) {
       selected_labels: formatSelectedLabels(currentContext.selectedLabels),
       current_sample: currentContext.currentSample,
       view_name: currentContext.viewName,
+      group_slice: currentContext.groupSlice,
     }
   );
   if (result && result.error) {

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -93,6 +93,7 @@ const globalContextSelector = selector({
     const selectedLabels = get(fos.selectedLabels);
     const viewName = get(fos.viewName);
     const extendedSelection = get(fos.extendedSelection);
+    const groupSlice = get(fos.groupSlice);
 
     return {
       datasetName,
@@ -103,6 +104,7 @@ const globalContextSelector = selector({
       selectedLabels,
       viewName,
       extendedSelection,
+      groupSlice,
     };
   },
 });
@@ -142,6 +144,7 @@ const useExecutionContext = (operatorName, hooks = {}) => {
     selectedLabels,
     viewName,
     extendedSelection,
+    groupSlice,
   } = curCtx;
   const [analyticsInfo] = useAnalyticsInfo();
   const ctx = useMemo(() => {
@@ -158,6 +161,7 @@ const useExecutionContext = (operatorName, hooks = {}) => {
         viewName,
         extendedSelection,
         analyticsInfo,
+        groupSlice,
       },
       hooks
     );
@@ -172,6 +176,7 @@ const useExecutionContext = (operatorName, hooks = {}) => {
     hooks,
     viewName,
     currentSample,
+    groupSlice,
   ]);
 
   return ctx;

--- a/app/packages/operators/src/useCustomPanelHooks.ts
+++ b/app/packages/operators/src/useCustomPanelHooks.ts
@@ -25,6 +25,7 @@ export interface CustomPanelProps {
   onChangeSelected?: string;
   onChangeSelectedLabels?: string;
   onChangeExtendedSelection?: string;
+  onChangeGroupSlice?: string;
   dimensions: DimensionsType | null;
   panelName?: string;
   panelLabel?: string;
@@ -128,6 +129,12 @@ export function useCustomPanelHooks(props: CustomPanelProps): CustomPanelHooks {
     panelId,
     ctx.selectedLabels,
     props.onChangeSelectedLabels
+  );
+  useCtxChangePanelEvent(
+    isLoaded,
+    panelId,
+    ctx.groupSlice,
+    props.onChangeGroupSlice
   );
 
   useEffect(() => {

--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -979,6 +979,7 @@ contains the following properties:
 -   `ctx.selected_labels` - the list of currently selected labels in the App,
     if any
 -   `ctx.extended_selection` - the extended selection of the view, if any
+-   `ctx.group_slice` - the active group slice in the App, if any
 -   `ctx.user_id` - the ID of the user that invoked the operator, if known
 -   `ctx.panel_id` - the ID of the panel that invoked the operator, if any
 -   `ctx.panel` - a :class:`PanelRef <fiftyone.operators.panel.PanelRef>`

--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -2047,6 +2047,19 @@ subsequent sections.
             }
             ctx.panel.set_state("event", "on_change_extended_selection")
             ctx.panel.set_data("event_data", event)
+        
+        def on_change_group_slice(self, ctx):
+            """Implement this method to set panel state/data when the current
+            group slice changes.
+
+            The current group slice will be available via ``ctx.group_slice``.
+            """
+            event = {
+                "data": ctx.group_slice,
+                "description": "the current group slice",
+            }
+            ctx.panel.set_state("event", "on_change_group_slice")
+            ctx.panel.set_data("event_data", event)
 
         #######################################################################
         # Custom events

--- a/fiftyone/operators/builtin.py
+++ b/fiftyone/operators/builtin.py
@@ -1518,9 +1518,8 @@ class RenameGroupSlice(foo.Operator):
         new_name = ctx.params["new_name"]
 
         ctx.dataset.rename_group_slice(name, new_name)
-
         if ctx.group_slice == name:
-            ctx.ops.set_group_slice(ctx.dataset.default_group_slice)
+            ctx.ops.set_group_slice(new_name)
 
         ctx.ops.reload_dataset()
 
@@ -1566,9 +1565,11 @@ class DeleteGroupSlice(foo.Operator):
 
     def execute(self, ctx):
         name = ctx.params["name"]
+
         ctx.dataset.delete_group_slice(name)
         if ctx.group_slice == name:
             ctx.ops.set_group_slice(ctx.dataset.default_group_slice)
+
         ctx.ops.reload_dataset()
 
 

--- a/fiftyone/operators/builtin.py
+++ b/fiftyone/operators/builtin.py
@@ -1519,9 +1519,8 @@ class RenameGroupSlice(foo.Operator):
 
         ctx.dataset.rename_group_slice(name, new_name)
 
-        # @todo ideally we would only set this if the group slice we renamed is
-        # currently loaded in the App
-        ctx.ops.set_group_slice(ctx.dataset.default_group_slice)
+        if ctx.group_slice == name:
+            ctx.ops.set_group_slice(ctx.dataset.default_group_slice)
 
         ctx.ops.reload_dataset()
 
@@ -1567,13 +1566,9 @@ class DeleteGroupSlice(foo.Operator):
 
     def execute(self, ctx):
         name = ctx.params["name"]
-
         ctx.dataset.delete_group_slice(name)
-
-        # @todo ideally we would only set this if the group slice we deleted is
-        # currently loaded in the App
-        ctx.ops.set_group_slice(ctx.dataset.default_group_slice)
-
+        if ctx.group_slice == name:
+            ctx.ops.set_group_slice(ctx.dataset.default_group_slice)
         ctx.ops.reload_dataset()
 
 

--- a/fiftyone/operators/builtin.py
+++ b/fiftyone/operators/builtin.py
@@ -1487,7 +1487,7 @@ class RenameGroupSlice(foo.Operator):
             inputs.enum(
                 "name",
                 slice_selector.values(),
-                default=None,
+                default=ctx.group_slice,
                 required=True,
                 label="Group slice",
                 description="The group slice to rename",
@@ -1552,7 +1552,7 @@ class DeleteGroupSlice(foo.Operator):
             inputs.enum(
                 "name",
                 slice_selector.values(),
-                default=None,
+                default=ctx.group_slice,
                 required=True,
                 label="Group slice",
                 description="The group slice to delete",

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -697,6 +697,11 @@ class ExecutionContext(object):
         """
         return self._ops
 
+    @property
+    def group_slice(self):
+        """The group slice of the view."""
+        return self.request_params.get("group_slice", None)
+
     def prompt(
         self,
         operator_uri,

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -316,6 +316,7 @@ class Operations(object):
         on_change_selected=None,
         on_change_selected_labels=None,
         on_change_extended_selection=None,
+        on_change_group_slice=None,
         allow_duplicates=False,
     ):
         """Registers a panel with the given name and lifecycle callbacks.
@@ -353,6 +354,7 @@ class Operations(object):
                 current selected labels changes
             on_change_extended_selection (None): an operator to invoke when the
                 current extended selection changes
+            on_change_group_slice (None): an operator to invoke when the group slice changes
             allow_duplicates (False): whether to allow multiple instances of
                 the panel to the opened
         """
@@ -375,6 +377,7 @@ class Operations(object):
             "on_change_selected": on_change_selected,
             "on_change_selected_labels": on_change_selected_labels,
             "on_change_extended_selection": on_change_extended_selection,
+            "on_change_group_slice": on_change_group_slice,
             "allow_duplicates": allow_duplicates,
         }
         return self._ctx.trigger("register_panel", params=params)

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -354,7 +354,8 @@ class Operations(object):
                 current selected labels changes
             on_change_extended_selection (None): an operator to invoke when the
                 current extended selection changes
-            on_change_group_slice (None): an operator to invoke when the group slice changes
+            on_change_group_slice (None): an operator to invoke when the group
+                slice changes
             allow_duplicates (False): whether to allow multiple instances of
                 the panel to the opened
         """

--- a/fiftyone/operators/panel.py
+++ b/fiftyone/operators/panel.py
@@ -125,6 +125,7 @@ class Panel(Operator):
             "on_change_selected",
             "on_change_selected_labels",
             "on_change_extended_selection",
+            "on_change_group_slice",
         ]
         for method in methods + ctx_change_events:
             if hasattr(self, method) and callable(getattr(self, method)):


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Add group slice in operator and python panel context and add associated events
- Fix group slice operator to only change slice when needed

## How is this patch tested? If it is not, please explain why.

Using an example operator and panel

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `on_change_group_slice` parameter to enhance group slice handling in the Custom Panel.
	- Added `groupSlice` to various contexts, improving the management of group slice data.
	- New event handler for `on_change_group_slice` to respond to group slice changes during startup.

- **Documentation**
	- Updated documentation to reflect the new `on_change_group_slice` parameter in relevant functions.

- **Bug Fixes**
	- Improved logic for setting group slice to ensure updates occur only when necessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->