### PR TITLE
 Fix RGB mask targets when hex color codes are lowercase

### DIFF
--- a/app/packages/state/src/utils.test.ts
+++ b/app/packages/state/src/utils.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { convertTargets } from "./utils";
+
+describe("convertTargets", () => {
+  it("upper cases rgb hex targets", () => {
+    expect(
+      convertTargets([{ target: "#ffffff", value: "white" }])
+    ).toStrictEqual({ "#FFFFFF": { label: "white", intTarget: 1 } });
+  });
+});

--- a/app/packages/state/src/utils.ts
+++ b/app/packages/state/src/utils.ts
@@ -113,22 +113,22 @@ export const getStandardizedUrls = (
   return Object.fromEntries(urls.map(({ field, url }) => [field, url]));
 };
 
-const convertTargets = (
+export const convertTargets = (
   targets: {
     target: string;
     value: string;
   }[]
-) => {
+): { [key: string]: { label: string; intTarget: number } | string } => {
   return Object.fromEntries(
     (targets || []).map(({ target, value }, i) => {
-      if (!isNaN(Number(target))) {
+      if (!Number.isNaN(Number(target))) {
         // masks targets is for non-rgb masks
         return [target, value];
       }
 
       // convert into RGB mask representation
       // offset of 1 in intTarget because 0 has a special significance
-      return [target, { label: value, intTarget: i + 1 }];
+      return [target.toUpperCase(), { label: value, intTarget: i + 1 }];
     })
   );
 };


### PR DESCRIPTION
## What changes are proposed in this pull request?

RGB masks in looker expect an uppercase hex color

```python
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.labels as foul

dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    label_types="segmentations",
    classes=["person", "cat", "dog"],
    label_field="instances",
    max_samples=50,
    only_matching=True,
)

mask_targets = {"#ff6d04": "person", "#499cef": "cat", "#6d04ff": "dog"}
dataset.default_mask_targets = mask_targets

foul.objects_to_segmentations(
    dataset,
    "instances",
    "segmentations",
    mask_targets=mask_targets,
    output_dir="/tmp/segmentations",
)
``` 

## How is this patch tested? If it is not, please explain why.

Unit test

## Release Notes

* Fixed RGB mask targets when hex color codes are lowercase

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new test suite for the `convertTargets` function to ensure accurate color conversion.
  
- **Improvements**
	- Made the `convertTargets` function publicly accessible and defined its return type for clarity.
	- Enhanced functionality to convert RGB hex color targets to uppercase format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->