### PR TITLE
fix state scope missing in some panel hooks

### DIFF
--- a/app/packages/spaces/src/state.ts
+++ b/app/packages/spaces/src/state.ts
@@ -59,14 +59,18 @@ export const panelStateSelector = selectorFamily({
     (params: PanelStateParameter) =>
     ({ get }) => {
       const { panelId, local, scope } = params;
-      const stateAtom = getStateAtom(local, scope);
+      const fallbackScope = get(panelIdToScopeAtom)[panelId];
+      const computedScope = scope ?? fallbackScope;
+      const stateAtom = getStateAtom(local, computedScope);
       return get(stateAtom).get(panelId);
     },
   set:
     (params: PanelStateParameter) =>
     ({ get, set }, newValue) => {
       const { panelId, local, scope } = params;
-      const stateAtom = getStateAtom(local, scope);
+      const fallbackScope = get(panelIdToScopeAtom)[panelId];
+      const computedScope = scope ?? fallbackScope;
+      const stateAtom = getStateAtom(local, computedScope);
       const newState = new Map(get(stateAtom));
       newState.set(panelId, newValue);
       set(stateAtom, newState);
@@ -125,7 +129,7 @@ export const savedWorkspacesAtom = atom({
   },
 });
 
-export const panelIdToScopeAtom = atom({
+export const panelIdToScopeAtom = atom<PanelIdToScopeType>({
   key: "panelIdToScopeAtom",
   default: {},
 });
@@ -134,3 +138,7 @@ function getStateAtom(local?: boolean, scope?: string) {
   const nonGridScope = scope !== "grid";
   return local || nonGridScope ? panelsLocalStateAtom : panelsStateAtom;
 }
+
+type PanelIdToScopeType = {
+  [panelId: string]: string;
+};


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes state being lost due to missing scope in some spaces hook

## How is this patch tested? If it is not, please explain why.

Using the Dashboard paenl

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved state management for panels by dynamically determining the scope based on panel ID.
  
- **Bug Fixes**
	- Enhanced type safety and clarity for panel ID to scope mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->