### PR TITLE
increase zIndex of modal sidebar to fix resize bug

### DIFF
--- a/app/packages/core/src/components/Sidebar/Sidebar.tsx
+++ b/app/packages/core/src/components/Sidebar/Sidebar.tsx
@@ -11,6 +11,7 @@ import SchemaSettings from "../Schema/SchemaSettings";
 import { Filter } from "./Entries";
 import style from "./Sidebar.module.css";
 import ViewSelection from "./ViewSelection";
+import { useTheme as useMUITheme } from "@mui/material";
 
 const MARGIN = 3;
 
@@ -693,6 +694,7 @@ const InteractiveSidebar = ({
     () => new ResizeObserver(placeItems)
   );
   const theme = useTheme();
+  const muiTheme = useMUITheme();
 
   return shown ? (
     <Resizable
@@ -705,7 +707,10 @@ const InteractiveSidebar = ({
         setWidth(width + delta);
       }}
       onResizeReset={resetWidth}
-      style={{ borderTopRightRadius: 8 }}
+      style={{
+        borderTopRightRadius: 8,
+        zIndex: modal ? muiTheme.zIndex.tooltip + 1 : undefined,
+      }}
     >
       <SchemaSettings />
       {!modal && (


### PR DESCRIPTION
## What changes are proposed in this pull request?

increase zIndex of modal sidebar to fix resize bug

## How is this patch tested? If it is not, please explain why.

By resizing the sidebar in modal

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced theme-based styling for the `Resizable` component in the `InteractiveSidebar`, enhancing its visual integration with Material-UI.

- **Bug Fixes**
	- Improved the `zIndex` handling for the `Resizable` component when a modal is active, ensuring proper layering in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->