### PR TITLE
Make v1.0.0 migration robust to in-progress terminations

### DIFF
--- a/fiftyone/migrations/revisions/v1_0_0.py
+++ b/fiftyone/migrations/revisions/v1_0_0.py
@@ -36,8 +36,6 @@ def up(db, dataset_name):
             added_last_modified_at_frames,
         ) = _up_fields(dataset_name, frame_fields)
 
-    db.datasets.replace_one(match_d, dataset_dict)
-
     # Populate `Sample.created_at` values
     sample_collection_name = dataset_dict.get("sample_collection_name", None)
     if sample_collection_name:
@@ -61,6 +59,8 @@ def up(db, dataset_name):
             added_last_modified_at_frames,
             now,
         )
+
+    db.datasets.replace_one(match_d, dataset_dict)
 
 
 def down(db, dataset_name):


### PR DESCRIPTION
The v1.0.0 migration contains two parts:
1. **FAST**: [Updating the dataset's doc](https://github.com/voxel51/fiftyone/blob/cb040edc14e14faad76bac00f5d95b2b5fcfffee/fiftyone/migrations/revisions/v1_0_0.py#L39)
2. **SLOWER**: [Populating values for new fields](https://github.com/voxel51/fiftyone/blob/cb040edc14e14faad76bac00f5d95b2b5fcfffee/fiftyone/migrations/revisions/v1_0_0.py#L160)

Previously, if a v1.0.0 migration was initiated but was killed before completion, datasets would wind up in a state where their dataset doc was updated and their version was bumped to v1.0.0 but their `created_at` and `last_modified_at` fields may not have all been populated.

With this change, if a v1.0.0 migration is terminated before completion, it will be automatically reattempted each time the dataset is loaded until the full migration completes.

## Patch for existing migrations

`patch_migrations_if_necessary()` will patch any datasets whose version has been bumped to 1.0.0 but don't yet have their `created_at` and `last_modified_at` values populated:

```py
import fiftyone as fo
from datetime import datetime
from packaging.version import Version as V

def patch_migrations_if_necessary():
    for info in fo.list_datasets(info=True):
        if V(info["version"]) >= V("1.0.0"):
            patch_migration_if_necessary(info["name"])

def patch_migration_if_necessary(name):
    dataset = fo.load_dataset(name)
    if dataset._get_last_modified_at() is not None:
        return

    print(f"Patching migration for dataset '{name}'")
    pipeline = [{"$set": {"created_at": {"$toDate": "$_id"}, "last_modified_at": datetime.now()}}]
    dataset._sample_collection.update_many({}, pipeline)
    if dataset._has_frame_fields():
        dataset._frame_collection.update_many({}, pipeline)
```

```py
patch_migrations_if_necessary()
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Adjusted the sequence of operations in the dataset migration process to ensure proper population of sample creation dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->