### PR TITLE
add original params to prompt callbacks

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -1049,7 +1049,8 @@ class PromptUserForOperation extends Operator {
       operator: operator_uri,
       params,
       prompt: shouldPrompt,
-      callback: (result: OperatorResult) => {
+      callback: (result: OperatorResult, opts: { ctx: ExecutionContext }) => {
+        const ctx = opts.ctx;
         if (result.error) {
           if (on_error) {
             triggerEvent(panelId, {
@@ -1061,7 +1062,7 @@ class PromptUserForOperation extends Operator {
           if (on_success) {
             triggerEvent(panelId, {
               operator: on_success,
-              params: { result: result.result },
+              params: { result: result.result, original_params: ctx.params },
             });
           }
         }

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -954,8 +954,8 @@ export function useOperatorExecutor(uri, handlers: any = {}) {
         setResult(result.result);
         setError(result.error);
         setIsDelegated(result.delegated);
-        handlers.onSuccess?.(result);
-        callback?.(result);
+        handlers.onSuccess?.(result, { ctx });
+        callback?.(result, { ctx });
         if (result.error) {
           const isAbortError =
             result.error.name === "AbortError" ||
@@ -970,7 +970,7 @@ export function useOperatorExecutor(uri, handlers: any = {}) {
           }
         }
       } catch (e) {
-        callback?.(new OperatorResult(operator, null, ctx.executor, e, false));
+        callback?.(new OperatorResult(operator, null, ctx.executor, e, false), {ctx});
         const isAbortError =
           e.name === "AbortError" || e instanceof DOMException;
         const msg = e.message || "Failed to execute an operation";

--- a/app/packages/operators/src/types-internal.ts
+++ b/app/packages/operators/src/types-internal.ts
@@ -1,6 +1,7 @@
-import { OperatorResult } from "./operators";
+import { ExecutionContext, OperatorResult } from "./operators";
 
-export type ExecutionCallback = (result: OperatorResult) => void;
+export type ExecutionCallbackOptions = {ctx: ExecutionContext};
+export type ExecutionCallback = (result: OperatorResult, options: ExecutionCallbackOptions) => void;
 export type ExecutionErrorCallback = (error: Error) => void;
 
 export type OperatorExecutorOptions = {

--- a/app/packages/operators/src/usePanelEvent.ts
+++ b/app/packages/operators/src/usePanelEvent.ts
@@ -36,7 +36,7 @@ export default function usePanelEvent() {
       panel_state: currentPanelState ?? (panelState?.state || {}),
     };
 
-    const eventCallback = (result) => {
+    const eventCallback = (result, opts) => {
       decrement(panelId);
       const msg =
         result.errorMessage || result.error || "Failed to execute operation";
@@ -45,7 +45,7 @@ export default function usePanelEvent() {
         notify({ msg: computedMsg, variant: "error" });
         console.error(result?.error);
       }
-      options?.callback?.(result);
+      options?.callback?.(result, opts);
     };
 
     if (prompt) {


### PR DESCRIPTION
```python
# usage
def my_event(self, ctx):
  ctx.prompt(my_op, on_success=self.on_success)

def on_success(self, ctx):
  print(ctx.params.get("original_params", None))
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced success event handling by including original parameters for improved context.
	- Updated method signatures to provide additional contextual information during operation execution.
	- Improved `eventCallback` functionality to handle more contextual information through a new parameter.

- **Bug Fixes**
	- Adjusted invocation of success handlers to pass more comprehensive data, enhancing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->