### PR TITLE
Fix dynamic groups carousel bug

### DIFF
--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/carousel/DynamicGroupCarousel.tsx
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/carousel/DynamicGroupCarousel.tsx
@@ -23,7 +23,7 @@ export const DynamicGroupCarousel = React.memo(() => {
    * Problem = flashlight is not re-rendering when group by field changes.
    * Solution was to key it by groupByValue, but when the component
    * subscribes to the groupByFieldValue using useRecoilValue(fos.groupByFieldValue),
-   * while it solves the problem,it causes flashlight to behave weirdly.
+   * while it solves the problem, it causes flashlight to behave weirdly.
    * (try scrolling carousel and selecting samples, flashlight will reset to the front)
    *
    */
@@ -47,7 +47,6 @@ export const DynamicGroupCarousel = React.memo(() => {
     return () => window.clearInterval(intervalId);
   }, []);
 
-  console.log("Group by value is ", groupByValueRef.current);
   return (
     <Resizable
       size={{ height, width: "100%" }}

--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/carousel/DynamicGroupsFlashlightWrapper.tsx
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/carousel/DynamicGroupsFlashlightWrapper.tsx
@@ -3,7 +3,7 @@ import { Sample, freeVideos } from "@fiftyone/looker";
 import * as fos from "@fiftyone/state";
 import { selectedSamples } from "@fiftyone/state";
 import { get } from "lodash";
-import {
+import React, {
   useCallback,
   useEffect,
   useId,
@@ -46,7 +46,7 @@ const pageParams = selector({
   },
 });
 
-export const DynamicGroupsFlashlightWrapper = () => {
+export const DynamicGroupsFlashlightWrapper = React.memo(() => {
   const id = useId();
 
   const store = fos.useLookerStore();
@@ -175,4 +175,4 @@ export const DynamicGroupsFlashlightWrapper = () => {
       id={id}
     ></div>
   );
-};
+});


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes bug where carousel wasn't updating when navigating between samples

![carousel-small](https://github.com/user-attachments/assets/22ddb940-0773-490a-8bda-f7a26ec8360d)


## How is this patch tested? If it is not, please explain why.

Locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced performance of the `DynamicGroupCarousel` and `DynamicGroupsFlashlightWrapper` components through memoization.
  
- **Bug Fixes**
	- Improved re-rendering efficiency for `DynamicGroupsFlashlightWrapper` by preventing unnecessary updates.

These changes aim to provide a smoother user experience by optimizing component rendering and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->