### PR TITLE
Small bug fix for Numerical Field in Summary Field Operator

### DIFF
--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -1773,6 +1773,12 @@ in the App.
 Panels can be defined in either Python or JS, and FiftyOne comes with a
 number of :ref:`builtin panels <plugins-design-panels>` for common tasks.
 
+Depending on the ``surfaces`` panel config, panels can be scoped to either
+the grid or the modal, and can be opened from the "+" menu - available both
+in the grid and the modal. Whereas grid panels unlock extensibility in the
+macro level of datasets, modal panels unlock extensibility in the micro level
+of samples.
+
 Panels, like :ref:`operators <developing-operators>`, can make use of the
 :mod:`fiftyone.operators.types` module and the
 :js:mod:`@fiftyone/operators <@fiftyone/operators>` package, which define a
@@ -1829,6 +1835,15 @@ subsequent sections.
 
                 # Whether to allow multiple instances of the panel to be opened
                 allow_multiple=False,
+
+                # Whether the panel should be made available in the grid, or
+                # the modal, or both (default = grid only)
+                surfaces="grid modal"
+
+                # Markdown-formatted text that describes the panel. This is
+                # rendererd in a tooltip when the help icon in the panel
+                # title is hovered over
+                help_markdown="A description of the panel",
             )
 
         def render(self, ctx):

--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -1774,10 +1774,11 @@ Panels can be defined in either Python or JS, and FiftyOne comes with a
 number of :ref:`builtin panels <plugins-design-panels>` for common tasks.
 
 Depending on the ``surfaces`` panel config, panels can be scoped to either
-the grid or the modal, and can be opened from the "+" menu - available both
-in the grid and the modal. Whereas grid panels unlock extensibility in the
-macro level of datasets, modal panels unlock extensibility in the micro level
-of samples.
+the grid or the modal. You can open these panels from the "+" menu, which
+is available in both the grid and modal views. Whereas grid panels enable
+extensibility at the macro level, allowing you to work with entire datasets,
+modal panels provide extensibility at the micro level, focusing on individual
+samples and scenarios.
 
 Panels, like :ref:`operators <developing-operators>`, can make use of the
 :mod:`fiftyone.operators.types` module and the

--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -1837,9 +1837,10 @@ subsequent sections.
                 # Whether to allow multiple instances of the panel to be opened
                 allow_multiple=False,
 
-                # Whether the panel should be made available in the grid, or
-                # the modal, or both (default = grid only)
-                surfaces="grid modal"
+                # Whether the panel should be available in the grid view
+                # modal view, or both
+                # Possible values: "grid", "modal", "grid modal"       
+                surfaces="grid modal" # default = "grid"
 
                 # Markdown-formatted text that describes the panel. This is
                 # rendererd in a tooltip when the help icon in the panel

--- a/fiftyone/operators/builtin.py
+++ b/fiftyone/operators/builtin.py
@@ -1255,7 +1255,7 @@ def _create_summary_field_inputs(ctx, inputs):
         group_by_keys = sorted(p for p in schema if p.startswith(group_prefix))
         group_by_selector = types.AutocompleteView()
         for group in group_by_keys:
-            group_by_selector.add_choice(group.name, label=group.name)
+            group_by_selector.add_choice(group, label=group)
 
         inputs.enum(
             "group_by",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently, when the field is numerical (such as the frame's confidence), the summary field operator errored out. This small bug fix rectifies that error.

![image](https://github.com/user-attachments/assets/058f79cf-e977-402b-abd4-170a679b22d5)

## How is this patch tested? If it is not, please explain why.

* Manual test (✅ )

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the autocomplete view in the group selection to display the group itself instead of its name, enhancing clarity for users.
  
- **Bug Fixes**
	- Improved the representation of choices in the `group_by_selector` for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->