### PR TITLE
Better heatmap range handling

### DIFF
--- a/app/packages/looker/src/worker/painter.test.ts
+++ b/app/packages/looker/src/worker/painter.test.ts
@@ -63,3 +63,13 @@ describe("filter resolves correctly", () => {
     ).toBeUndefined();
   });
 });
+
+describe("heatmap utils", () => {
+  it("clamps for heatmaps", async () => {
+    // A value below a heatmap range returns -1
+    expect(painter.clampedIndex(1, 2, 3, 4)).toBe(-1);
+
+    // A value above a heatmap range return the max
+    expect(painter.clampedIndex(4, 2, 3, 4)).toBe(3);
+  });
+});

--- a/app/packages/looker/src/worker/painter.ts
+++ b/app/packages/looker/src/worker/painter.ts
@@ -215,10 +215,11 @@ export const PainterFactory = (requestColor) => ({
 
           r = get32BitColor(color, Math.min(max, Math.abs(value)) / max);
         } else {
-          const scoped = Math.min(Math.max(value, start), stop);
-          const index = Math.round(
-            (Math.max(scoped - start, 0) / (stop - start)) * (scale.length - 1)
-          );
+          const index = clampedIndex(value, start, stop, scale.length);
+          if (value < 0) {
+            // values less than range start are background
+            continue;
+          }
           r = get32BitColor(scale[index]);
         }
 
@@ -391,4 +392,19 @@ const convertMaskColorsToObject = (array: MaskColorInput[]) => {
     result[item.intTarget.toString()] = item.color;
   });
   return result;
+};
+
+export const clampedIndex = (
+  value: number,
+  start: number,
+  stop: number,
+  length: number
+) => {
+  if (value < start) {
+    return -1;
+  }
+  const clamped = Math.min(Math.max(value, start), stop);
+  return Math.round(
+    (Math.max(clamped - start, 0) / (stop - start)) * (length - 1)
+  );
 };

--- a/app/packages/looker/src/worker/painter.ts
+++ b/app/packages/looker/src/worker/painter.ts
@@ -206,25 +206,28 @@ export const PainterFactory = (requestColor) => ({
       }
 
       // 0 is background image
-      if (value !== 0) {
-        let r;
-        if (coloring.by === COLOR_BY.FIELD) {
-          color =
-            fieldSetting?.fieldColor ??
-            (await requestColor(coloring.pool, coloring.seed, field));
+      if (value === 0) {
+        continue;
+      }
+      let r: number;
+      if (coloring.by === COLOR_BY.FIELD) {
+        color =
+          fieldSetting?.fieldColor ??
+          (await requestColor(coloring.pool, coloring.seed, field));
 
-          r = get32BitColor(color, Math.min(max, Math.abs(value)) / max);
-        } else {
-          const index = clampedIndex(value, start, stop, scale.length);
-          if (value < 0) {
-            // values less than range start are background
-            continue;
-          }
-          r = get32BitColor(scale[index]);
+        r = get32BitColor(color, Math.min(max, Math.abs(value)) / max);
+      } else {
+        const index = clampedIndex(value, start, stop, scale.length);
+
+        if (index < 0) {
+          // values less than range start are background
+          continue;
         }
 
-        overlay[i] = r;
+        r = get32BitColor(scale[index]);
       }
+
+      overlay[i] = r;
     }
   },
   Segmentation: async (
@@ -388,9 +391,9 @@ export const convertToHex = (color: string) =>
 const convertMaskColorsToObject = (array: MaskColorInput[]) => {
   const result = {};
   if (!array) return {};
-  array.forEach((item) => {
+  for (const item of array) {
     result[item.intTarget.toString()] = item.color;
-  });
+  }
   return result;
 };
 
@@ -403,7 +406,7 @@ export const clampedIndex = (
   if (value < start) {
     return -1;
   }
-  const clamped = Math.min(Math.max(value, start), stop);
+  const clamped = Math.min(value, stop);
   return Math.round(
     (Math.max(clamped - start, 0) / (stop - start)) * (length - 1)
   );

--- a/app/packages/looker/src/worker/painter.ts
+++ b/app/packages/looker/src/worker/painter.ts
@@ -215,8 +215,9 @@ export const PainterFactory = (requestColor) => ({
 
           r = get32BitColor(color, Math.min(max, Math.abs(value)) / max);
         } else {
+          const scoped = Math.min(Math.max(value, start), stop);
           const index = Math.round(
-            (Math.max(value - start, 0) / (stop - start)) * (scale.length - 1)
+            (Math.max(scoped - start, 0) / (stop - start)) * (scale.length - 1)
           );
           r = get32BitColor(scale[index]);
         }


### PR DESCRIPTION
## What changes are proposed in this pull request?

When heatmap values are above the `range`, consider them the `max` range value. When they are below the `range`, consider them like a `0` with no coloring (background)

```python
import fiftyone as fo
from fiftyone.core.state import build_color_scheme
import fiftyone.zoo as foz


color_scheme = build_color_scheme()
color_scheme.default_colorscale = {
    "name": None,
    "list": [
        {"color": "rgb(48, 18, 59)", "value": 0.0},
        {"color": "rgb(69, 90, 205)", "value": 0.003},
        {"color": "rgb(62, 155, 254)", "value": 0.008},
        {"color": "rgb(25, 214, 204)", "value": 0.0181},
        {"color": "rgb(70, 248, 132)", "value": 0.0473},
        {"color": "rgb(163, 253, 60)", "value": 0.0994},
        {"color": "rgb(225, 221, 55)", "value": 0.1825},
        {"color": "rgb(254, 165, 49)", "value": 0.3049},
        {"color": "rgb(240, 91, 18)", "value": 0.4756},
        {"color": "rgb(196, 37, 3)", "value": 0.741},
        {"color": "rgb(122, 4, 3)", "value": 1.0},
    ],
}


dataset = foz.load_zoo_dataset("quickstart", max_samples=1)
dataset.app_config.color_scheme = color_scheme
dataset.save()

sample = dataset.first()
sample["heatmap_over"] = fo.Heatmap(
    map_path="/path/to/heatmap.png",
    range=[38768.0, 39864.0],
)
sample["heatmap_under"] = fo.Heatmap(
    map_path="/path/to/heatmap.png",
    range=[30768.0, 31864.0],
)
sample.save()
``` 

https://github.com/user-attachments/assets/f1ece81a-4df8-4a53-8fe8-76a866b502d6

![66d21819553de2e89ff93430](https://github.com/user-attachments/assets/783c1c93-1b4d-4f5b-9457-6fe41fd0b27e)

## How is this patch tested? If it is not, please explain why.

Unit test

## Release Notes

* Fixed heatmap rendering for values outside of the `range` attribute 

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved color indexing logic for heatmap rendering.
	- Introduced a new `clampedIndex` function to handle index calculations.
- **Bug Fixes**
	- Enhanced robustness of color retrieval in heatmaps, ensuring valid colors are returned even for out-of-bounds values.
- **Tests**
	- Added a new test suite for verifying the behavior of the `clampedIndex` function. 
- **Refactor**
	- Streamlined control flow in the `Heatmap` method and refined color assignment logic in the `Segmentation` method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->