### PR TITLE
fix save workspace built-in operator

### DIFF
--- a/fiftyone/operators/builtin.py
+++ b/fiftyone/operators/builtin.py
@@ -1940,8 +1940,9 @@ class SaveWorkspace(foo.Operator):
         )
 
         # @todo infer this automatically from current App spaces
-        spaces_prop = inputs.str(
+        spaces_prop = inputs.oneof(
             "spaces",
+            [types.String(), types.Object()],
             default=None,
             required=True,
             label="Spaces",
@@ -1955,7 +1956,7 @@ class SaveWorkspace(foo.Operator):
         spaces = ctx.params.get("spaces", None)
         if spaces is not None:
             try:
-                fo.Space.from_json(spaces)
+                _parse_spaces(spaces)
             except:
                 spaces_prop.invalid = True
                 spaces_prop.error_message = "Invalid workspace definition"
@@ -1978,10 +1979,7 @@ class SaveWorkspace(foo.Operator):
         color = ctx.params.get("color", None)
         spaces = ctx.params.get("spaces", None)
 
-        if isinstance(spaces, dict):
-            spaces = fo.Space.from_dict(spaces)
-        else:
-            spaces = fo.Space.from_json(spaces)
+        spaces = _parse_spaces(spaces)
 
         ctx.dataset.save_workspace(
             name,
@@ -2292,6 +2290,12 @@ def _get_non_default_frame_fields(dataset):
         schema.pop(path, None)
 
     return schema
+
+
+def _parse_spaces(spaces):
+    if isinstance(spaces, dict):
+        return fo.Space.from_dict(spaces)
+    return fo.Space.from_json(spaces)
 
 
 BUILTIN_OPERATORS = [


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix save workspace built-in operator adding support for `spaces` param to be `dict` instead of just JSON string

## How is this patch tested? If it is not, please explain why.

Using save workspace modal in the app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced workspace management with improved input handling for workspace definitions.
	- Added a new method for standardized parsing of workspace formats (dictionary or JSON).
- **Bug Fixes**
	- Improved error handling for invalid workspace definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->