### PR TITLE
Scheduler/default scheduled

### DIFF
--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -3102,7 +3102,7 @@ def _launch_delegated_local():
         print("Delegated operation service running")
         print("\nTo exit, press ctrl + c")
         while True:
-            dos.execute_scheduled_operations(limit=1, log=True)
+            dos.execute_queued_operations(limit=1, log=True)
             time.sleep(0.5)
     except KeyboardInterrupt:
         pass

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -7,7 +7,6 @@ Definition of the `fiftyone` command-line interface (CLI).
 """
 
 import argparse
-import warnings
 from collections import defaultdict
 from datetime import datetime
 import json
@@ -19,8 +18,6 @@ import textwrap
 
 import argcomplete
 from bson import ObjectId
-import humanize
-import pytz
 from tabulate import tabulate
 import webbrowser
 
@@ -3105,7 +3102,7 @@ def _launch_delegated_local():
         print("Delegated operation service running")
         print("\nTo exit, press ctrl + c")
         while True:
-            dos.execute_queued_operations(limit=1, log=True)
+            dos.execute_scheduled_operations(limit=1, log=True)
             time.sleep(0.5)
     except KeyboardInterrupt:
         pass

--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -15,6 +15,7 @@ from bson import ObjectId
 from pymongo import IndexModel
 from pymongo.collection import Collection
 
+from fiftyone.internal.util import is_remote_service
 from fiftyone.factory import DelegatedOperationPagingParams
 from fiftyone.factory.repos import DelegatedOperationDocument
 from fiftyone.operators.executor import (
@@ -134,7 +135,7 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
         self._collection = (
             collection if collection is not None else self._get_collection()
         )
-
+        self.is_remote = is_remote_service()
         self._create_indexes()
 
     def _get_collection(self) -> Collection:
@@ -170,7 +171,7 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             self._collection.create_indexes(indices_to_create)
 
     def queue_operation(self, **kwargs: Any) -> DelegatedOperationDocument:
-        op = DelegatedOperationDocument()
+        op = DelegatedOperationDocument(is_remote=self.is_remote)
         for prop in self.required_props:
             if prop not in kwargs:
                 raise ValueError("Missing required property '%s'" % prop)

--- a/fiftyone/factory/repos/delegated_operation_doc.py
+++ b/fiftyone/factory/repos/delegated_operation_doc.py
@@ -39,7 +39,7 @@ class DelegatedOperationDocument(object):
             ExecutionRunState.SCHEDULED
             if is_remote
             else ExecutionRunState.QUEUED
-        )  # if running locally use SCHEDULED otherwise QUEUED
+        )  # if running locally use QUEUED otherwise SCHEDULED
         self.run_link = None
         self.queued_at = datetime.utcnow() if not is_remote else None
         self.updated_at = datetime.utcnow()

--- a/fiftyone/factory/repos/delegated_operation_doc.py
+++ b/fiftyone/factory/repos/delegated_operation_doc.py
@@ -41,7 +41,7 @@ class DelegatedOperationDocument(object):
             else ExecutionRunState.SCHEDULED
         )  # if running locally use SCHEDULED otherwise QUEUED
         self.run_link = None
-        self.queued_at = datetime.utcnow() if not is_remote_service() else None
+        self.queued_at = datetime.utcnow() if is_remote_service() else None
         self.updated_at = datetime.utcnow()
         self.status = None
         self.dataset_id = None
@@ -49,7 +49,9 @@ class DelegatedOperationDocument(object):
         self.pinned = False
         self.completed_at = None
         self.failed_at = None
-        self.scheduled_at = datetime.utcnow() if is_remote_service() else None
+        self.scheduled_at = (
+            datetime.utcnow() if not is_remote_service() else None
+        )
         self.result = None
         self.id = None
         self._doc = None

--- a/fiftyone/factory/repos/delegated_operation_doc.py
+++ b/fiftyone/factory/repos/delegated_operation_doc.py
@@ -41,7 +41,9 @@ class DelegatedOperationDocument(object):
             else ExecutionRunState.SCHEDULED
         )  # if running locally use SCHEDULED otherwises QUEUED
         self.run_link = None
-        self.queued_at = datetime.utcnow()
+        self.queued_at = (
+            datetime.utcnow() if not is_internal_service() else None
+        )
         self.updated_at = datetime.utcnow()
         self.status = None
         self.dataset_id = None
@@ -49,7 +51,9 @@ class DelegatedOperationDocument(object):
         self.pinned = False
         self.completed_at = None
         self.failed_at = None
-        self.scheduled_at = None
+        self.scheduled_at = (
+            datetime.utcnow() if is_internal_service() else None
+        )
         self.result = None
         self.id = None
         self._doc = None

--- a/fiftyone/factory/repos/delegated_operation_doc.py
+++ b/fiftyone/factory/repos/delegated_operation_doc.py
@@ -8,7 +8,7 @@ FiftyOne delegated operation repository document.
 
 import logging
 from datetime import datetime
-from fiftyone.internal.util import is_internal_service
+from fiftyone.internal.util import is_remote_service
 
 from fiftyone.operators.executor import (
     ExecutionContext,
@@ -37,13 +37,11 @@ class DelegatedOperationDocument(object):
         )
         self.run_state = (
             ExecutionRunState.QUEUED
-            if is_internal_service()
+            if is_remote_service()
             else ExecutionRunState.SCHEDULED
-        )  # if running locally use SCHEDULED otherwises QUEUED
+        )  # if running locally use SCHEDULED otherwise QUEUED
         self.run_link = None
-        self.queued_at = (
-            datetime.utcnow() if not is_internal_service() else None
-        )
+        self.queued_at = datetime.utcnow() if not is_remote_service() else None
         self.updated_at = datetime.utcnow()
         self.status = None
         self.dataset_id = None
@@ -51,9 +49,7 @@ class DelegatedOperationDocument(object):
         self.pinned = False
         self.completed_at = None
         self.failed_at = None
-        self.scheduled_at = (
-            datetime.utcnow() if is_internal_service() else None
-        )
+        self.scheduled_at = datetime.utcnow() if is_remote_service() else None
         self.result = None
         self.id = None
         self._doc = None

--- a/fiftyone/factory/repos/delegated_operation_doc.py
+++ b/fiftyone/factory/repos/delegated_operation_doc.py
@@ -8,6 +8,7 @@ FiftyOne delegated operation repository document.
 
 import logging
 from datetime import datetime
+from fiftyone.internal.util import is_internal_service
 
 from fiftyone.operators.executor import (
     ExecutionContext,
@@ -36,7 +37,9 @@ class DelegatedOperationDocument(object):
         )
         self.run_state = (
             ExecutionRunState.QUEUED
-        )  # default to queued state on create
+            if is_internal_service()
+            else ExecutionRunState.SCHEDULED
+        )  # if running locally use SCHEDULED otherwises QUEUED
         self.run_link = None
         self.queued_at = datetime.utcnow()
         self.updated_at = datetime.utcnow()

--- a/fiftyone/factory/repos/delegated_operation_doc.py
+++ b/fiftyone/factory/repos/delegated_operation_doc.py
@@ -8,7 +8,6 @@ FiftyOne delegated operation repository document.
 
 import logging
 from datetime import datetime
-from fiftyone.internal.util import is_remote_service
 
 from fiftyone.operators.executor import (
     ExecutionContext,
@@ -26,6 +25,7 @@ class DelegatedOperationDocument(object):
         operator: str = None,
         delegation_target: str = None,
         context: dict = None,
+        is_remote: bool = False,
     ):
         self.operator = operator
         self.label = None
@@ -36,12 +36,12 @@ class DelegatedOperationDocument(object):
             else context
         )
         self.run_state = (
-            ExecutionRunState.QUEUED
-            if is_remote_service()
-            else ExecutionRunState.SCHEDULED
+            ExecutionRunState.SCHEDULED
+            if is_remote
+            else ExecutionRunState.QUEUED
         )  # if running locally use SCHEDULED otherwise QUEUED
         self.run_link = None
-        self.queued_at = datetime.utcnow() if is_remote_service() else None
+        self.queued_at = datetime.utcnow() if not is_remote else None
         self.updated_at = datetime.utcnow()
         self.status = None
         self.dataset_id = None
@@ -49,9 +49,7 @@ class DelegatedOperationDocument(object):
         self.pinned = False
         self.completed_at = None
         self.failed_at = None
-        self.scheduled_at = (
-            datetime.utcnow() if not is_remote_service() else None
-        )
+        self.scheduled_at = datetime.utcnow() if is_remote else None
         self.result = None
         self.id = None
         self._doc = None

--- a/fiftyone/internal/__init__.py
+++ b/fiftyone/internal/__init__.py
@@ -7,4 +7,4 @@ Internal classes and utilities.
 """
 
 from .secrets import *
-from .util import is_internal_service, has_encryption_key
+from .util import is_remote_service

--- a/fiftyone/internal/__init__.py
+++ b/fiftyone/internal/__init__.py
@@ -7,3 +7,4 @@ Internal classes and utilities.
 """
 
 from .secrets import *
+from .util import is_internal_service, has_encryption_key

--- a/fiftyone/internal/util.py
+++ b/fiftyone/internal/util.py
@@ -16,22 +16,13 @@ def is_remote_service():
     return has_encryption_key() and has_api_key()
 
 
-def is_internal_service():
-    """Whether the SDK is running in an internal service context.
-
-    Returns:
-        True/False
-    """
-    return False
-
-
 def has_encryption_key():
     """Whether the current environment has an encryption key.
 
     Returns:
         True/False
     """
-    return is_internal_service()
+    return False
 
 
 def has_api_key():

--- a/fiftyone/internal/util.py
+++ b/fiftyone/internal/util.py
@@ -1,0 +1,25 @@
+"""
+FiftyOne internal utilities.
+
+| Copyright 2017-2024, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+
+def is_internal_service():
+    """Whether the SDK is running in an internal service context.
+
+    Returns:
+        True/False
+    """
+    return False
+
+
+def has_encryption_key():
+    """Whether the current environment has an encryption key.
+
+    Returns:
+        True/False
+    """
+    return False

--- a/fiftyone/internal/util.py
+++ b/fiftyone/internal/util.py
@@ -7,6 +7,15 @@ FiftyOne internal utilities.
 """
 
 
+def is_remote_service():
+    """Whether the SDK is running in a remote service context.
+
+    Returns:
+        True/False
+    """
+    return has_encryption_key() and has_api_key()
+
+
 def is_internal_service():
     """Whether the SDK is running in an internal service context.
 
@@ -18,6 +27,15 @@ def is_internal_service():
 
 def has_encryption_key():
     """Whether the current environment has an encryption key.
+
+    Returns:
+        True/False
+    """
+    return is_internal_service()
+
+
+def has_api_key():
+    """Whether the current environment has an API key.
 
     Returns:
         True/False

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -381,7 +381,7 @@ class DelegatedOperationService(object):
             **kwargs,
         )
 
-    def execute_queued_operations(
+    def execute_scheduled_operations(
         self,
         operator=None,
         delegation_target=None,
@@ -390,7 +390,7 @@ class DelegatedOperationService(object):
         log=False,
         **kwargs,
     ):
-        """Executes queued delegated operations matching the given criteria.
+        """Executes scheduled delegated operations matching the given criteria.
 
         Args:
             operator (None): the optional name of the operator to execute all
@@ -410,18 +410,17 @@ class DelegatedOperationService(object):
         else:
             paging = None
 
-        queued_ops = self.list_operations(
+        scheduled_ops = self.list_operations(
             operator=operator,
             dataset_name=dataset_name,
             delegation_target=delegation_target,
-            run_state=ExecutionRunState.QUEUED,
+            run_state=ExecutionRunState.SCHEDULED,
             paging=paging,
             **kwargs,
         )
 
-        for op in queued_ops:
-            results.append(self.execute_operation(operation=op, log=log))
-        return results
+        for op in scheduled_ops:
+            self.execute_operation(operation=op, log=log)
 
     def count(self, filters=None, search=None):
         """Counts the delegated operations matching the given criteria.

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -381,7 +381,7 @@ class DelegatedOperationService(object):
             **kwargs,
         )
 
-    def execute_scheduled_operations(
+    def execute_queued_operations(
         self,
         operator=None,
         delegation_target=None,
@@ -390,7 +390,7 @@ class DelegatedOperationService(object):
         log=False,
         **kwargs,
     ):
-        """Executes scheduled delegated operations matching the given criteria.
+        """Executes queued delegated operations matching the given criteria.
 
         Args:
             operator (None): the optional name of the operator to execute all
@@ -410,16 +410,16 @@ class DelegatedOperationService(object):
         else:
             paging = None
 
-        scheduled_ops = self.list_operations(
+        queued_ops = self.list_operations(
             operator=operator,
             dataset_name=dataset_name,
             delegation_target=delegation_target,
-            run_state=ExecutionRunState.SCHEDULED,
+            run_state=ExecutionRunState.QUEUED,
             paging=paging,
             **kwargs,
         )
 
-        for op in scheduled_ops:
+        for op in queued_ops:
             self.execute_operation(operation=op, log=log)
 
     def count(self, filters=None, search=None):

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -420,7 +420,8 @@ class DelegatedOperationService(object):
         )
 
         for op in queued_ops:
-            self.execute_operation(operation=op, log=log)
+            results.append(self.execute_operation(operation=op, log=log))
+        return results
 
     def count(self, filters=None, search=None):
         """Counts the delegated operations matching the given criteria.

--- a/tests/unittests/operators/delegated_tests.py
+++ b/tests/unittests/operators/delegated_tests.py
@@ -469,7 +469,12 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.docs_to_delete.append(doc)
         self.assertEqual(doc.run_state, ExecutionRunState.QUEUED)
 
-        self.svc.execute_queued_operations(delegation_target="test_target")
+        results = self.svc.execute_queued_operations(
+            delegation_target="test_target"
+        )
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0].error)
+        self.assertDictEqual(results[0].result, MockOperator.result)
 
         doc = self.svc.get(doc_id=doc.id)
         self.assertEqual(doc.run_state, ExecutionRunState.COMPLETED)
@@ -497,7 +502,12 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.docs_to_delete.append(doc)
         self.assertEqual(doc.run_state, ExecutionRunState.QUEUED)
 
-        self.svc.execute_queued_operations(delegation_target="test_target")
+        results = self.svc.execute_queued_operations(
+            delegation_target="test_target"
+        )
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0].error)
+        self.assertDictEqual(results[0].result, MockOperator.result)
 
         doc = self.svc.get(doc_id=doc.id)
         self.assertEqual(doc.run_state, ExecutionRunState.COMPLETED)
@@ -565,7 +575,11 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.docs_to_delete.append(doc)
         self.assertEqual(doc.run_state, ExecutionRunState.QUEUED)
 
-        self.svc.execute_queued_operations(delegation_target="test_target")
+        results = self.svc.execute_queued_operations(
+            delegation_target="test_target"
+        )
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0].error)
 
         doc = self.svc.get(doc_id=doc.id)
         self.assertEqual(doc.run_state, ExecutionRunState.COMPLETED)
@@ -668,7 +682,12 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.docs_to_delete.append(doc)
         self.assertEqual(doc.run_state, ExecutionRunState.QUEUED)
 
-        self.svc.execute_queued_operations(delegation_target="test_target")
+        results = self.svc.execute_queued_operations(
+            delegation_target="test_target"
+        )
+        self.assertEqual(len(results), 1)
+        self.assertIsNotNone(results[0].error)
+        self.assertIsNone(results[0].result)
 
         doc = self.svc.get(doc_id=doc.id)
         self.assertEqual(doc.run_state, ExecutionRunState.FAILED)
@@ -705,7 +724,12 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.docs_to_delete.append(doc)
         self.assertEqual(doc.run_state, ExecutionRunState.QUEUED)
 
-        self.svc.execute_queued_operations(delegation_target="test_target")
+        results = self.svc.execute_queued_operations(
+            delegation_target="test_target"
+        )
+        self.assertEqual(len(results), 1)
+        self.assertIsNotNone(results[0].error)
+        self.assertIsNone(results[0].result)
 
         doc = self.svc.get(doc_id=doc.id)
         self.assertEqual(doc.run_state, ExecutionRunState.FAILED)
@@ -724,7 +748,12 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.assertIsNone(rerun_doc.completed_at)
         self.assertIsNone(rerun_doc.result)
 
-        self.svc.execute_queued_operations(delegation_target="test_target")
+        results = self.svc.execute_queued_operations(
+            delegation_target="test_target"
+        )
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0].error)
+        self.assertDictEqual(results[0].result, MockOperator.result)
 
         doc = self.svc.get(doc_id=rerun_doc.id)
         self.assertEqual(doc.run_state, ExecutionRunState.COMPLETED)
@@ -756,7 +785,13 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.assertEqual(doc.run_state, ExecutionRunState.QUEUED)
 
         # Execute once with original dataset name
-        self.svc.execute_queued_operations(delegation_target="test_target")
+        results = self.svc.execute_queued_operations(
+            delegation_target="test_target"
+        )
+        self.assertEqual(len(results), 1)
+        self.assertIsNotNone(results[0].error)
+        self.assertIsNone(results[0].result)
+
         doc = self.svc.get(doc_id=doc.id)
         self.assertEqual(doc.run_state, ExecutionRunState.FAILED)
 
@@ -782,7 +817,12 @@ class DelegatedOperationServiceTests(unittest.TestCase):
             self.assertIsNone(rerun_doc.completed_at)
             self.assertIsNone(rerun_doc.result)
 
-            self.svc.execute_queued_operations(delegation_target="test_target")
+            results = self.svc.execute_queued_operations(
+                delegation_target="test_target"
+            )
+            self.assertEqual(len(results), 1)
+            self.assertIsNone(results[0].error)
+            self.assertDictEqual(results[0].result, MockOperator.result)
 
             doc = self.svc.get(doc_id=rerun_doc.id)
             self.assertEqual(doc.run_state, ExecutionRunState.COMPLETED)
@@ -848,7 +888,13 @@ class DelegatedOperationServiceTests(unittest.TestCase):
 
         # Execute queued operation after saving the new dataset name
         try:
-            self.svc.execute_queued_operations(delegation_target="test_target")
+            results = self.svc.execute_queued_operations(
+                delegation_target="test_target"
+            )
+            self.assertEqual(len(results), 1)
+            self.assertIsNone(results[0].error)
+            self.assertDictEqual(results[0].result, MockOperator.result)
+
             doc = self.svc.get(doc_id=doc.id)
             self.assertEqual(doc.run_state, ExecutionRunState.COMPLETED)
         except:

--- a/tests/unittests/operators/delegated_tests.py
+++ b/tests/unittests/operators/delegated_tests.py
@@ -249,6 +249,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
 
         # get all the existing counts of scheduled operations
         initial_queued = len(self.svc.get_queued_operations())
+        initial_queued = len(self.svc.get_queued_operations())
         initial_running = len(self.svc.get_running_operations())
         initial_scheduled = len(self.svc.get_scheduled_operations())
         initial_dataset_scheduled = len(
@@ -292,8 +293,8 @@ class DelegatedOperationServiceTests(unittest.TestCase):
             self.docs_to_delete.append(doc)
             static_docs.append(doc.id)
 
-        scheduled = self.svc.get_scheduled_operations()
-        self.assertEqual(len(scheduled), 20 + initial_scheduled)
+        queued = self.svc.get_queued_operations()
+        self.assertEqual(len(queued), initial_queued)
 
         scheduled = self.svc.get_scheduled_operations(
             dataset_name=dataset_name

--- a/tests/unittests/operators/delegated_tests.py
+++ b/tests/unittests/operators/delegated_tests.py
@@ -293,20 +293,30 @@ class DelegatedOperationServiceTests(unittest.TestCase):
             static_docs.append(doc.id)
 
         queued = self.svc.get_queued_operations()
-        self.assertEqual(len(queued), 20 + initial_queued)
+        # dynamic + static docs should be queued
+        self.assertEqual(
+            len(queued), len(dynamic_docs) + len(static_docs) + initial_queued
+        )
 
         queued = self.svc.get_queued_operations(dataset_name=dataset_name)
-        self.assertEqual(len(queued), 10 + initial_dataset_queued)
+        # dataset_name corresponds to dynamic docs
+        self.assertEqual(
+            len(queued), len(dynamic_docs) + initial_dataset_queued
+        )
 
         queued = self.svc.get_queued_operations(operator=operator)
-        self.assertEqual(len(queued), 10 + initial_operator_queued)
+        # operator corresponds to dynamic docs
+        self.assertEqual(
+            len(queued), len(dynamic_docs) + initial_operator_queued
+        )
 
         # test set_running behavior
         for doc_id in dynamic_docs:
             self.svc.set_running(doc_id)
 
         queued = self.svc.get_queued_operations()
-        self.assertEqual(len(queued), 10 + initial_queued)
+        # static docs should be `queued`
+        self.assertEqual(len(queued), len(static_docs) + initial_queued)
 
         running = self.svc.get_running_operations()
         # dynamic docs should be `running`
@@ -316,8 +326,9 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         for doc_id in dynamic_docs:
             self.svc.set_scheduled(doc_id)
 
-        scheduled = self.svc.get_scheduled_operations()
-        self.assertEqual(len(scheduled), 10 + initial_scheduled)
+        queued = self.svc.get_queued_operations()
+        # static docs should be `queued`
+        self.assertEqual(len(queued), len(static_docs) + initial_queued)
 
         scheduled = self.svc.get_scheduled_operations()
         # dynamic docs should be `scheduled`

--- a/tests/unittests/operators/delegated_tests.py
+++ b/tests/unittests/operators/delegated_tests.py
@@ -28,9 +28,7 @@ from fiftyone.operators.executor import (
     ExecutionResult,
     ExecutionRunState,
 )
-from fiftyone.factory.repos.delegated_operation import (
-    MongoDelegatedOperationRepo,
-)
+from fiftyone.factory.repos import delegated_operation
 from fiftyone.operators.operator import Operator, OperatorConfig
 
 
@@ -1338,14 +1336,14 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.assertEqual(doc.run_state, ExecutionRunState.COMPLETED)
 
     @patch.object(
-        MongoDelegatedOperationRepo,
+        delegated_operation,
         "is_remote_service",
         return_value=True,
     )
     def test_queue_op_remote_service(
         self, mock_is_remote_service, mock_get_operator, mock_operator_exists
     ):
-        db = MongoDelegatedOperationRepo()
+        db = delegated_operation.MongoDelegatedOperationRepo()
         dos = DelegatedOperationService(repo=db)
         ctx = ExecutionContext()
         ctx.request_params = {"foo": "bar"}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Changing default state of delegated operations to now be "Scheduled" when running locally and not in a service environment. Pointed cli execution of delegated operations to point to Scheduled.

## How is this patch tested? If it is not, please explain why.

Launched FO locally and created a delegated operation through the UI which output the following item into mongo:
![Screenshot 2024-10-01 at 2 00 04 PM](https://github.com/user-attachments/assets/4304f7ec-a6ac-4556-91ca-21082714aacf)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

When running delegated operations locally they will start in the "Scheduled" state. If running these using the cli, then continue to use your commands as normal you'll just see the items are added to the collection as "Scheduled".

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced command-line interface (CLI) with several new commands for managing models, datasets, and plugins.
  - Introduced remote service detection and improved search capabilities within operations.

- **Bug Fixes**
  - Improved handling of operation failure states and refined state update logic.

- **Documentation**
  - Updated CLI documentation to include detailed examples and descriptions for the new commands.

- **Tests**
  - Updated unit tests to focus on the state of operation documents after execution, removing redundant assertions related to execution results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->