### PR TITLE
Query performance operators

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -1313,6 +1313,42 @@ export class SetGroupSlice extends Operator {
   }
 }
 
+export class DisableQueryPerformance extends Operator {
+  _builtIn = true;
+  get config(): OperatorConfig {
+    return new OperatorConfig({
+      name: "disable_query_performance",
+      label: "Disable query performance",
+    });
+  }
+
+  useHooks() {
+    const { disable } = fos.useQueryPerformance();
+    return { disable };
+  }
+  async execute({ hooks }: ExecutionContext) {
+    hooks.disable();
+  }
+}
+
+export class EnableQueryPerformance extends Operator {
+  _builtIn = true;
+  get config(): OperatorConfig {
+    return new OperatorConfig({
+      name: "enable_query_performance",
+      label: "Enable query performance",
+    });
+  }
+
+  useHooks() {
+    const { enable } = fos.useQueryPerformance();
+    return { enable };
+  }
+  async execute({ hooks }: ExecutionContext) {
+    hooks.enable();
+  }
+}
+
 export function registerBuiltInOperators() {
   try {
     _registerBuiltInOperator(CopyViewAsJSON);
@@ -1362,6 +1398,8 @@ export function registerBuiltInOperators() {
     _registerBuiltInOperator(SetGroupSlice);
     _registerBuiltInOperator(SetPlayheadState);
     _registerBuiltInOperator(SetFrameNumber);
+    _registerBuiltInOperator(DisableQueryPerformance);
+    _registerBuiltInOperator(EnableQueryPerformance);
   } catch (e) {
     console.error("Error registering built-in operators");
     console.error(e);

--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -137,10 +137,10 @@ export class ExecutionContext {
   public get groupSlice(): any {
     return this._currentContext.groupSlice;
   }
-
   public get queryPerformance(): boolean {
     return Boolean(this._currentContext.queryPerformance);
   }
+
   getCurrentPanelId(): string | null {
     return this.params.panel_id || this.currentPanel?.id || null;
   }
@@ -711,6 +711,7 @@ export async function executeOperatorWithContext(
           view: currentContext.view,
           view_name: currentContext.viewName,
           group_slice: currentContext.groupSlice,
+          query_performance: currentContext.queryPerformance,
         }
       );
       result = serverResult.result;

--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -1,5 +1,5 @@
 import { AnalyticsInfo, usingAnalytics } from "@fiftyone/analytics";
-import { getFetchFunction, isNullish, ServerError } from "@fiftyone/utilities";
+import { ServerError, getFetchFunction, isNullish } from "@fiftyone/utilities";
 import { CallbackInterface } from "recoil";
 import { QueueItemStatus } from "./constants";
 import * as types from "./types";
@@ -91,6 +91,7 @@ export type RawContext = {
     scope: string;
   };
   groupSlice: string;
+  queryPerformance?: boolean;
 };
 
 export class ExecutionContext {
@@ -135,6 +136,10 @@ export class ExecutionContext {
   }
   public get groupSlice(): any {
     return this._currentContext.groupSlice;
+  }
+
+  public get queryPerformance(): boolean {
+    return Boolean(this._currentContext.queryPerformance);
   }
   getCurrentPanelId(): string | null {
     return this.params.panel_id || this.currentPanel?.id || null;

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -94,6 +94,7 @@ const globalContextSelector = selector({
     const viewName = get(fos.viewName);
     const extendedSelection = get(fos.extendedSelection);
     const groupSlice = get(fos.groupSlice);
+    const queryPerformance = typeof get(fos.lightningThreshold) === "number";
 
     return {
       datasetName,
@@ -105,6 +106,7 @@ const globalContextSelector = selector({
       viewName,
       extendedSelection,
       groupSlice,
+      queryPerformance,
     };
   },
 });
@@ -145,6 +147,7 @@ const useExecutionContext = (operatorName, hooks = {}) => {
     viewName,
     extendedSelection,
     groupSlice,
+    queryPerformance,
   } = curCtx;
   const [analyticsInfo] = useAnalyticsInfo();
   const ctx = useMemo(() => {
@@ -162,6 +165,7 @@ const useExecutionContext = (operatorName, hooks = {}) => {
         extendedSelection,
         analyticsInfo,
         groupSlice,
+        queryPerformance,
       },
       hooks
     );

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -181,6 +181,7 @@ const useExecutionContext = (operatorName, hooks = {}) => {
     viewName,
     currentSample,
     groupSlice,
+    queryPerformance,
   ]);
 
   return ctx;

--- a/app/packages/state/src/hooks/index.ts
+++ b/app/packages/state/src/hooks/index.ts
@@ -24,6 +24,7 @@ export { default as useLookerStore } from "./useLookerStore";
 export { default as useNotification } from "./useNotification";
 export * from "./useOnSelectLabel";
 export { default as usePanel } from "./usePanel";
+export { default as useQueryPerformance } from "./useQueryPerformance";
 export { default as useRefresh } from "./useRefresh";
 export { default as useReset } from "./useReset";
 export { default as useResetExtendedSelection } from "./useResetExtendedSelection";

--- a/app/packages/state/src/hooks/useQueryPerformance.ts
+++ b/app/packages/state/src/hooks/useQueryPerformance.ts
@@ -1,0 +1,41 @@
+import { useMemo } from "react";
+import { useRecoilCallback } from "recoil";
+import {
+  datasetSampleCount,
+  lightningThreshold,
+  lightningThresholdConfig,
+} from "../recoil";
+
+export default function () {
+  const disable = useRecoilCallback(
+    ({ set }) =>
+      () => {
+        set(lightningThreshold, null);
+      },
+    []
+  );
+
+  const enable = useRecoilCallback(
+    ({ set, snapshot }) =>
+      async (threshold?: number) => {
+        let setting = threshold;
+
+        if (setting === undefined) {
+          setting =
+            (await snapshot.getPromise(lightningThresholdConfig)) ??
+            (await snapshot.getPromise(datasetSampleCount));
+        }
+
+        set(lightningThreshold, setting);
+      },
+    []
+  );
+
+  return useMemo(
+    () => ({
+      disable,
+      enable,
+    }),
+    [disable, enable]
+  );
+}

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -713,6 +713,11 @@ class ExecutionContext(object):
         """The current group slice of the view (if any)."""
         return self.request_params.get("group_slice", None)
 
+    @property
+    def query_performance(self):
+        """Whether query performance is enabled."""
+        return self.request_params.get("query_performance", None)
+
     def prompt(
         self,
         operator_uri,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds `enable_query_performance` and `disable_query_performance` operators

https://github.com/user-attachments/assets/249f6449-3a19-4461-ac46-6d862443e6ca

## How is this patch tested? If it is not, please explain why.

todo

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new operators to enable and disable query performance.
	- Added a custom hook for managing query performance thresholds.
	- Enhanced execution context to include query performance metrics.

- **Bug Fixes**
	- Improved validation logic for operator prompts to ensure accurate input handling.

- **Documentation**
	- Updated exports to include the new `useQueryPerformance` hook.

- **Refactor**
	- Enhanced context management for operator execution and performance tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->