### PR TITLE
Add utils for supporting rerun panel plugin

### DIFF
--- a/app/packages/state/src/utils.ts
+++ b/app/packages/state/src/utils.ts
@@ -18,7 +18,7 @@ import {
   RecordSource,
   Store,
 } from "relay-runtime";
-import { State } from "./recoil";
+import { ModalSample, State } from "./recoil";
 
 export const deferrer =
   (initialized: MutableRefObject<boolean>) =>
@@ -105,6 +105,7 @@ export const getStandardizedUrls = (
   urls:
     | readonly { readonly field: string; readonly url: string }[]
     | { [field: string]: string }
+    | ModalSample["urls"]
 ) => {
   if (!Array.isArray(urls)) {
     return urls;

--- a/app/packages/utilities/src/schema.test.ts
+++ b/app/packages/utilities/src/schema.test.ts
@@ -19,7 +19,7 @@ const SCHEMA: schema.Schema = {
       "fiftyone.core.odm.embedded_document.DynamicEmbeddedDocument",
     ftype: "fiftyone.core.fields.EmbeddedDocumentField",
     info: {},
-    name: "top",
+    name: "embedded",
     path: "embedded",
     subfield: null,
     fields: {
@@ -30,7 +30,7 @@ const SCHEMA: schema.Schema = {
         ftype: "fiftyone.core.fields.EmbeddedDocumentField",
         info: {},
         name: "field",
-        path: "field",
+        path: "embedded.field",
         subfield: null,
       },
     },
@@ -42,7 +42,7 @@ const SCHEMA: schema.Schema = {
       "fiftyone.core.odm.embedded_document.DynamicEmbeddedDocument",
     ftype: "fiftyone.core.fields.EmbeddedDocumentField",
     info: {},
-    name: "top",
+    name: "embeddedWithDbFields",
     path: "embeddedWithDbFields",
     subfield: null,
     fields: {
@@ -54,7 +54,7 @@ const SCHEMA: schema.Schema = {
         ftype: "fiftyone.core.fields.EmbeddedDocumentField",
         info: {},
         name: "sample_id",
-        path: "sample_id",
+        path: "embeddedWithDbFields.sample_id",
         subfield: null,
       },
     },
@@ -62,7 +62,7 @@ const SCHEMA: schema.Schema = {
 };
 
 describe("schema", () => {
-  describe("getCls ", () => {
+  describe("getCls", () => {
     it("should get top level cls", () => {
       expect(schema.getCls("top", SCHEMA)).toBe("TopLabel");
     });
@@ -79,7 +79,7 @@ describe("schema", () => {
     });
   });
 
-  describe("getFieldInfo ", () => {
+  describe("getFieldInfo", () => {
     it("should get top level field info", () => {
       expect(schema.getFieldInfo("top", SCHEMA)).toEqual({
         ...SCHEMA.top,
@@ -89,7 +89,7 @@ describe("schema", () => {
 
     it("should get embedded field info", () => {
       expect(schema.getFieldInfo("embedded.field", SCHEMA)).toEqual({
-        ...SCHEMA.embedded.fields.field,
+        ...SCHEMA.embedded.fields!.field,
         pathWithDbField: "",
       });
     });
@@ -107,6 +107,71 @@ describe("schema", () => {
         SCHEMA
       );
       expect(field?.pathWithDbField).toBe("embeddedWithDbFields._sample_id");
+    });
+  });
+
+  describe("getFieldsWithEmbeddedDocType", () => {
+    it("should get all fields with embeddedDocType at top level", () => {
+      expect(
+        schema.getFieldsWithEmbeddedDocType(
+          SCHEMA,
+          "fiftyone.core.labels.TopLabel"
+        )
+      ).toEqual([SCHEMA.top]);
+    });
+
+    it("should get all fields with embeddedDocType in nested fields", () => {
+      expect(
+        schema.getFieldsWithEmbeddedDocType(
+          SCHEMA,
+          "fiftyone.core.labels.EmbeddedLabel"
+        )
+      ).toEqual([
+        SCHEMA.embedded.fields!.field,
+        SCHEMA.embeddedWithDbFields.fields!.sample_id,
+      ]);
+    });
+
+    it("should return empty array if embeddedDocType does not exist", () => {
+      expect(
+        schema.getFieldsWithEmbeddedDocType(SCHEMA, "nonexistentDocType")
+      ).toEqual([]);
+    });
+
+    it("should return empty array for empty schema", () => {
+      expect(schema.getFieldsWithEmbeddedDocType({}, "anyDocType")).toEqual([]);
+    });
+  });
+
+  describe("doesSchemaContainEmbeddedDocType", () => {
+    it("should return true if embeddedDocType exists at top level", () => {
+      expect(
+        schema.doesSchemaContainEmbeddedDocType(
+          SCHEMA,
+          "fiftyone.core.labels.TopLabel"
+        )
+      ).toBe(true);
+    });
+
+    it("should return true if embeddedDocType exists in nested fields", () => {
+      expect(
+        schema.doesSchemaContainEmbeddedDocType(
+          SCHEMA,
+          "fiftyone.core.labels.EmbeddedLabel"
+        )
+      ).toBe(true);
+    });
+
+    it("should return false if embeddedDocType does not exist", () => {
+      expect(
+        schema.doesSchemaContainEmbeddedDocType(SCHEMA, "nonexistentDocType")
+      ).toBe(false);
+    });
+
+    it("should return false for empty schema", () => {
+      expect(schema.doesSchemaContainEmbeddedDocType({}, "anyDocType")).toBe(
+        false
+      );
     });
   });
 });

--- a/app/packages/utilities/src/schema.ts
+++ b/app/packages/utilities/src/schema.ts
@@ -51,3 +51,43 @@ export function getCls(fieldPath: string, schema: Schema): string | undefined {
 
   return field.embeddedDocType.split(".").slice(-1)[0];
 }
+
+export function getFieldsWithEmbeddedDocType(
+  schema: Schema,
+  embeddedDocType: string
+): Field[] {
+  const result: Field[] = [];
+
+  function recurse(schema: Schema) {
+    for (const field of Object.values(schema ?? {})) {
+      if (field.embeddedDocType === embeddedDocType) {
+        result.push(field);
+      }
+      if (field.fields) {
+        recurse(field.fields);
+      }
+    }
+  }
+
+  recurse(schema);
+  return result;
+}
+
+export function doesSchemaContainEmbeddedDocType(
+  schema: Schema,
+  embeddedDocType: string
+): boolean {
+  function recurse(schema: Schema): boolean {
+    return Object.values(schema ?? {}).some((field) => {
+      if (field.embeddedDocType === embeddedDocType) {
+        return true;
+      }
+      if (field.fields) {
+        return recurse(field.fields);
+      }
+      return false;
+    });
+  }
+
+  return recurse(schema);
+}

--- a/fiftyone/server/metadata.py
+++ b/fiftyone/server/metadata.py
@@ -24,6 +24,7 @@ import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
 from fiftyone.core.collections import SampleCollection
 from fiftyone.utils.utils3d import OrthographicProjectionMetadata
+from fiftyone.utils.rerun import RrdFile
 
 import fiftyone.core.media as fom
 
@@ -33,6 +34,7 @@ _ADDITIONAL_MEDIA_FIELDS = {
     fol.Heatmap: "map_path",
     fol.Segmentation: "mask_path",
     OrthographicProjectionMetadata: "filepath",
+    RrdFile: "filepath",
 }
 _FFPROBE_BINARY_PATH = shutil.which("ffprobe")
 

--- a/fiftyone/utils/rerun.py
+++ b/fiftyone/utils/rerun.py
@@ -1,0 +1,28 @@
+"""
+Utilities for working with `Rerun <https://rerun.io/>`_.
+
+| Copyright 2017-2024, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import fiftyone.core.fields as fof
+import fiftyone.core.labels as fol
+from fiftyone.core.odm import DynamicEmbeddedDocument
+
+
+class RrdFile(DynamicEmbeddedDocument, fol._HasMedia):
+    """Class for storing a rerun data (rrd) file and its associated metadata.
+
+    Args:
+        filepath (None): the path to the rrd file
+        version (0.18.2): the version of the rrd file. Since rrd files do not
+            yet guarantee backwards compatibility, this field is used to
+            determine how to parse the file and what rerun viewer to use.
+            If not provided, the default version is 0.18.2
+    """
+
+    _MEDIA_FIELD = "filepath"
+
+    filepath = fof.StringField()
+    version = fof.StringField(default="0.18.2")

--- a/fiftyone/utils/rerun.py
+++ b/fiftyone/utils/rerun.py
@@ -16,13 +16,10 @@ class RrdFile(DynamicEmbeddedDocument, fol._HasMedia):
 
     Args:
         filepath (None): the path to the rrd file
-        version (0.18.2): the version of the rrd file. Since rrd files do not
-            yet guarantee backwards compatibility, this field is used to
-            determine how to parse the file and what rerun viewer to use.
-            If not provided, the default version is 0.18.2
+        version (None): the version of the rrd file
     """
 
     _MEDIA_FIELD = "filepath"
 
     filepath = fof.StringField()
-    version = fof.StringField(default="0.18.2")
+    version = fof.StringField()


### PR DESCRIPTION
This PR introduces data model to support rerun panel plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new functions for enhanced schema handling: `getFieldsWithEmbeddedDocType` and `doesSchemaContainEmbeddedDocType`.
	- Added support for a new media type, `RrdFile`, allowing for better metadata management and retrieval of file paths.
	- New utilities for working with the Rerun data visualization tool, including the `RrdFile` class.

- **Bug Fixes**
	- Updated schema properties for improved clarity and accuracy.

- **Tests**
	- Expanded test coverage for new schema functionalities and embedded document types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->