### PR TITLE
refactor: remove pydantic from execution_store

### DIFF
--- a/fiftyone/factory/repos/execution_store.py
+++ b/fiftyone/factory/repos/execution_store.py
@@ -24,10 +24,8 @@ class ExecutionStoreRepo:
 
     def create_store(self, store_name, permissions=None) -> StoreDocument:
         """Creates a store in the execution store."""
-        store_doc = StoreDocument(
-            store_name=store_name, permissions=permissions
-        )
-        self._collection.insert_one(store_doc.dict())
+        store_doc = StoreDocument(store_name=store_name, value=permissions)
+        self._collection.insert_one(store_doc.to_mongo_dict())
         return store_doc
 
     def list_stores(self) -> list[str]:
@@ -40,14 +38,21 @@ class ExecutionStoreRepo:
         now = datetime.datetime.now()
         expiration = KeyDocument.get_expiration(ttl)
         key_doc = KeyDocument(
-            store_name=store_name, key=key, value=value, updated_at=now
+            store_name=store_name,
+            key=key,
+            value=value,
+            updated_at=now,
+            expires_at=expiration,
         )
 
         # Prepare the update operations
         update_fields = {
-            "$set": key_doc.dict(
-                exclude={"created_at", "expires_at", "store_name", "key"}
-            ),
+            "$set": {
+                k: v
+                for k, v in key_doc.to_mongo_dict().items()
+                if k
+                not in {"_id", "created_at", "expires_at", "store_name", "key"}
+            },
             "$setOnInsert": {
                 "store_name": store_name,
                 "key": key,

--- a/fiftyone/operators/store/models.py
+++ b/fiftyone/operators/store/models.py
@@ -1,21 +1,19 @@
-"""
-Store and key models for the execution store.
-"""
-
-from pydantic import BaseModel, Field
+from dataclasses import dataclass, field, asdict
 from typing import Optional, Dict, Any
 import datetime
 
 
-class KeyDocument(BaseModel):
+@dataclass
+class KeyDocument:
     """Model representing a key in the store."""
 
     store_name: str
     key: str
     value: Any
-    created_at: datetime.datetime = Field(
+    created_at: datetime.datetime = field(
         default_factory=datetime.datetime.now
     )
+    _id: Optional[Any] = None
     updated_at: Optional[datetime.datetime] = None
     expires_at: Optional[datetime.datetime] = None
 
@@ -24,10 +22,17 @@ class KeyDocument(BaseModel):
         """Gets the expiration date for a key with the given TTL."""
         if ttl is None:
             return None
-
         return datetime.datetime.now() + datetime.timedelta(seconds=ttl)
 
+    def to_mongo_dict(self, exclude_id: bool = True) -> Dict[str, Any]:
+        """Serializes the document to a MongoDB dictionary."""
+        data = asdict(self)
+        if exclude_id:
+            data.pop("_id", None)
+        return data
 
+
+@dataclass
 class StoreDocument(KeyDocument):
     """Model representing a Store."""
 

--- a/fiftyone/operators/store/store.py
+++ b/fiftyone/operators/store/store.py
@@ -7,7 +7,6 @@ FiftyOne execution store.
 """
 
 import logging
-from fiftyone.factory.repo_factory import RepositoryFactory
 from fiftyone.operators.store.service import ExecutionStoreService
 from typing import Any, Optional
 


### PR DESCRIPTION
Removes pydantic from execution store implementation. Uses dataclasses instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced document creation and update handling with improved field management.
	- Introduced a new serialization method for `KeyDocument` to convert instances into MongoDB-compatible dictionaries.

- **Bug Fixes**
	- Corrected method parameters for better consistency in document handling.

- **Refactor**
	- Transitioned `KeyDocument` from a Pydantic model to a simpler dataclass structure.
	- Removed unused import from the `ExecutionStore` class, streamlining the code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->