### PR TITLE
Ensure socket closes

### DIFF
--- a/fiftyone/service/ipc.py
+++ b/fiftyone/service/ipc.py
@@ -109,7 +109,7 @@ def send_request(port, message):
     Returns:
         response (any type)
     """
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.connect(("localhost", port))
-    pickle.dump(message, s.makefile("wb"))
-    return pickle.load(s.makefile("rb"))
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.connect(("localhost", port))
+        pickle.dump(message, s.makefile("wb"))
+        return pickle.load(s.makefile("rb"))

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,6 @@
 open3d>=0.16.0
 itsdangerous==2.0.1
-werkzeug==3.0.3
+werkzeug==2.0.3
 pydicom<3
 pytest==7.3.1
 pytest-cov==4.0.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,6 @@
-open3d==0.16.0
+open3d>=0.16.0
 itsdangerous==2.0.1
-werkzeug==2.0.3
+werkzeug>=2.0.3
 pydicom<3
 pytest==7.3.1
 pytest-cov==4.0.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
-open3d>=0.16.0,<0.18.0
+open3d==0.16.1
 itsdangerous==2.0.1
 werkzeug==2.0.3
 pydicom<3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
-open3d>=0.16.0
+open3d>=0.16.0,<0.18.0
 itsdangerous==2.0.1
 werkzeug==2.0.3
 pydicom<3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
-open3d==0.16.1
+open3d==0.16.0
 itsdangerous==2.0.1
 werkzeug==2.0.3
 pydicom<3


### PR DESCRIPTION
## What changes are proposed in this pull request?

- call send_request using a context manager to ensure the socket always closes
- currently, terminating the server results in a ResourceWarning: 
 
```
Object allocated at (most recent call last):
  File "../fiftyone/service/ipc.py", lineno 112
    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/subprocess.py:1070: ResourceWarning: subprocess 19806 is still running
```

## How is this patch tested? If it is not, please explain why.

- add unit test and passes

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced inter-process communication (IPC) testing with a new test case for socket closure on exceptions.

- **Bug Fixes**
	- Improved resource management by ensuring sockets are automatically closed after use.

- **Chores**
	- Updated the version constraints for the `open3d` package in the testing requirements.
	- Updated the version of the `werkzeug` package in the testing requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->