### PR TITLE
Tweak dropdownview to allow to display icon only

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/DropdownView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DropdownView.tsx
@@ -1,3 +1,4 @@
+import MoreVertIcon from "@mui/icons-material/MoreVert";
 import SettingsIcon from "@mui/icons-material/Settings";
 import { MenuItem, Select } from "@mui/material";
 import React, { useState } from "react";
@@ -25,7 +26,7 @@ export default function DropdownView(props: ViewPropsType) {
     description,
     color,
     variant,
-    useIconOnly = false,
+    icon,
   } = view;
   const [key, setUserChanged] = useKey(path, schema, data, true);
   const [selected, setSelected] = useState(false);
@@ -84,8 +85,11 @@ export default function DropdownView(props: ViewPropsType) {
         displayEmpty
         title={compact ? description : undefined}
         renderValue={(value) => {
-          if (useIconOnly) {
+          if (icon === "SettingsIcon") {
             return <SettingsIcon />;
+          }
+          if (icon === "MoreVertIcon") {
+            return <MoreVertIcon />;
           }
           const unselected = value?.length === 0;
           setSelected(!unselected);

--- a/app/packages/core/src/plugins/SchemaIO/components/DropdownView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DropdownView.tsx
@@ -1,3 +1,4 @@
+import SettingsIcon from "@mui/icons-material/Settings";
 import { MenuItem, Select } from "@mui/material";
 import React, { useState } from "react";
 import { useKey } from "../hooks";
@@ -24,6 +25,7 @@ export default function DropdownView(props: ViewPropsType) {
     description,
     color,
     variant,
+    useIconOnly = false,
   } = view;
   const [key, setUserChanged] = useKey(path, schema, data, true);
   const [selected, setSelected] = useState(false);
@@ -82,6 +84,9 @@ export default function DropdownView(props: ViewPropsType) {
         displayEmpty
         title={compact ? description : undefined}
         renderValue={(value) => {
+          if (useIconOnly) {
+            return <SettingsIcon />;
+          }
           const unselected = value?.length === 0;
           setSelected(!unselected);
           if (unselected) {

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -2364,6 +2364,8 @@ class MenuView(GridView):
         ``"top-center"``, ``"top-right"``, ``"bottom-left"``, `"bottom-center"``, or
         ``"bottom-right"``. Overlay is useful when you want to display a floating menu on top of
         another content (for example, menu for full-panel-width plot)
+        icon (None): when set, the icon button will be displayed as the menu trigger,
+        instead of the selected value. Can be "SettingsIcon" or "MoreVertIcon"
     Returns:
         a :class:`Object`
     """

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -406,6 +406,9 @@ class Object(BaseType):
             ``"top-center"``, ``"top-right"``, ``"bottom-left"``, `"bottom-center"``, or
             ``"bottom-right"``. Overlay is useful when you want to display a floating menu on top of
             another content (for example, menu for full-panel-width plot)
+            icon (None): when set, the icon will be displayed as the menu button instead of the label.
+            Can be "SettingsIcon", "MoreVertIcon".
+
         Returns:
             a :class:`Object`
         """


### PR DESCRIPTION
## What changes are proposed in this pull request?

allow to pass down `icon` ("SettingsIcon" and "MoreVertIcon" at the moment) to menu, to make the dropdown view an action icon button menu.

## How is this patch tested? If it is not, please explain why.


https://github.com/user-attachments/assets/b82a66a5-29ff-4843-a62b-3b91d727b238




(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced the DropdownView component to support dynamic icons, allowing users to display icons alongside or instead of text in dropdown menus.
	- Introduced a new `icon` parameter in the MenuView class, enabling customization of the menu trigger with icons like SettingsIcon and MoreVertIcon.
	- Improved performance of the DropdownView with optimized rendering logic and style management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->