### PR TITLE
Bumping compatibility version

### DIFF
--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -42,7 +42,7 @@ RESOURCES_DIR = os.path.join(FIFTYONE_DIR, "resources")
 # This setting may be ``None`` if this client has no compatibility with other
 # versions
 #
-COMPATIBLE_VERSIONS = ">=0.19,<0.25"
+COMPATIBLE_VERSIONS = ">=0.19,<1.1"
 
 # Package metadata
 _META = metadata("fiftyone")


### PR DESCRIPTION
The compatibility version should have been bumped for the 1.0 release but was not 😢 

(this bug would only affect users who have manually set `fiftyone_database_admin=false`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded compatibility range for client versions, now supporting versions up to but not including 1.1.

- **Bug Fixes**
	- Resolved limitations by allowing support for a broader range of compatible versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->