### PR TITLE
Remove potential for misspelling expected Dataset fields

### DIFF
--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -74,6 +74,16 @@ class ClipsView(fov.DatasetView):
             the clips in this view
     """
 
+    __slots__ = (
+        "_classification_field",
+        "_source_collection",
+        "_clips_stage",
+        "_clips_dataset",
+        "__stages",
+        "__media_type",
+        "__name",
+    )
+
     def __init__(
         self,
         source_collection,
@@ -447,6 +457,13 @@ class TrajectoriesView(ClipsView):
         clips_dataset: the :class:`fiftyone.core.dataset.Dataset` that serves
             the clips in this view
     """
+
+    __slots__ = (
+        "_num_trajectory_stages",
+        "__stages",
+        "__media_type",
+        "__name",
+    )
 
     def __init__(
         self,

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -217,6 +217,8 @@ class SampleCollection(object):
     :class:`fiftyone.core.dataset.Dataset`.
     """
 
+    __slots__ = ("__weakref__",)
+
     _FRAMES_PREFIX = "frames."
     _GROUPS_PREFIX = "groups."
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -296,6 +296,18 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             name
     """
 
+    __slots__ = (
+        "_doc",
+        "_sample_doc_cls",
+        "_frame_doc_cls",
+        "_group_slice",
+        "_annotation_cache",
+        "_brain_cache",
+        "_evaluation_cache",
+        "_run_cache",
+        "_deleted",
+    )
+
     def __init__(
         self,
         name=None,

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -86,6 +86,15 @@ class EvaluationPatchView(_PatchView):
 
 
 class _PatchesView(fov.DatasetView):
+    __slots__ = (
+        "_source_collection",
+        "_patches_stage",
+        "_patches_dataset",
+        "__stages",
+        "__media_type",
+        "__name",
+    )
+
     def __init__(
         self,
         source_collection,
@@ -445,6 +454,8 @@ class PatchesView(_PatchesView):
             the patches in this view
     """
 
+    __slots__ = ("_patches_field",)
+
     def __init__(
         self,
         source_collection,
@@ -500,6 +511,8 @@ class EvaluationPatchesView(_PatchesView):
         patches_dataset: the :class:`fiftyone.core.dataset.Dataset` that serves
             the patches in this view
     """
+
+    __slots__ = ("_gt_field", "_pred_field")
 
     def __init__(
         self,

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -82,6 +82,15 @@ class FramesView(fov.DatasetView):
             the frames in this view
     """
 
+    __slots__ = (
+        "_source_collection",
+        "_frames_stage",
+        "_frames_dataset",
+        "__stages",
+        "__media_type",
+        "__name",
+    )
+
     def __init__(
         self,
         source_collection,

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -559,13 +559,13 @@ class DatasetView(foc.SampleCollection):
                 yield sample
 
     def _make_sample(self, d):
-        if getattr(self, "_make_sample_fcn", None) is None:
+        if self._make_sample_fcn is None:
             self._make_sample_fcn = self._init_make_sample()
 
         return self._make_sample_fcn(d)
 
     def _make_frame(self, d):
-        if getattr(self, "_make_frame_fcn", None) is None:
+        if self._make_frame_fcn is None:
             self._make_frame_fcn = self._init_make_frame()
 
         return self._make_frame_fcn(d)
@@ -1407,9 +1407,8 @@ class DatasetView(foc.SampleCollection):
         for stage in self._stages:
             _view = _view.add_stage(stage)
 
-        for name in ("_make_sample_fcn", "_make_frame_fcn"):
-            if hasattr(self, name):
-                delattr(self, name)
+        self._make_sample_fcn = None
+        self._make_frame_fcn = None
 
     def to_dict(
         self,

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -79,9 +79,6 @@ class DatasetView(foc.SampleCollection):
         if _stages is None:
             _stages = []
 
-        self._make_sample_fcn = None
-        self._make_frame_fcn = None
-
         self.__dataset = dataset
         self.__stages = _stages
         self.__media_type = _media_type
@@ -559,13 +556,13 @@ class DatasetView(foc.SampleCollection):
                 yield sample
 
     def _make_sample(self, d):
-        if self._make_sample_fcn is None:
+        if getattr(self, "_make_sample_fcn", None) is None:
             self._make_sample_fcn = self._init_make_sample()
 
         return self._make_sample_fcn(d)
 
     def _make_frame(self, d):
-        if self._make_frame_fcn is None:
+        if getattr(self, "_make_frame_fcn", None) is None:
             self._make_frame_fcn = self._init_make_frame()
 
         return self._make_frame_fcn(d)
@@ -1407,8 +1404,9 @@ class DatasetView(foc.SampleCollection):
         for stage in self._stages:
             _view = _view.add_stage(stage)
 
-        self._make_sample_fcn = None
-        self._make_frame_fcn = None
+        for name in ("_make_sample_fcn", "_make_frame_fcn"):
+            if hasattr(self, name):
+                delattr(self, name)
 
     def to_dict(
         self,

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -58,6 +58,16 @@ class DatasetView(foc.SampleCollection):
             view
     """
 
+    __slots__ = (
+        "__dataset",
+        "__stages",
+        "__media_type",
+        "__group_slice",
+        "__name",
+        "_make_sample_fcn",
+        "_make_frame_fcn",
+    )
+
     def __init__(
         self,
         dataset,
@@ -68,6 +78,9 @@ class DatasetView(foc.SampleCollection):
     ):
         if _stages is None:
             _stages = []
+
+        self._make_sample_fcn = None
+        self._make_frame_fcn = None
 
         self.__dataset = dataset
         self.__stages = _stages

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -695,8 +695,10 @@ class DatasetTests(unittest.TestCase):
         frame_stats["indexBuilds"] = ["gt.detections.label_1"]
 
         with patch.object(
-            dataset, "_sample_collstats", return_value=sample_stats
-        ), patch.object(dataset, "_frame_collstats", return_value=frame_stats):
+            fo.Dataset, "_sample_collstats", return_value=sample_stats
+        ), patch.object(
+            fo.Dataset, "_frame_collstats", return_value=frame_stats
+        ):
             info = dataset.get_index_information(include_stats=True)
             for key in [
                 "gt.detections.label",

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -197,6 +197,14 @@ class DatasetTests(unittest.TestCase):
         self.assertTrue(last_loaded_at3 > last_loaded_at2)
 
     @drop_datasets
+    def test_set_unknown_attribute(self):
+        dataset_name = self.test_set_unknown_attribute.__name__
+
+        dataset = fo.Dataset(dataset_name)
+        self.assertRaises(AttributeError, setattr, dataset, "persistant", True)
+        self.assertRaises(AttributeError, setattr, dataset, "somethingelse", 5)
+
+    @drop_datasets
     def test_dataset_tags(self):
         dataset_name = self.test_dataset_tags.__name__
 

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -109,6 +109,15 @@ class DatasetViewTests(unittest.TestCase):
         )
 
     @drop_datasets
+    def test_set_unknown_attribute(self):
+        dataset_name = self.test_set_unknown_attribute.__name__
+
+        dataset = fo.Dataset(dataset_name)
+        view = dataset.view()
+        self.assertRaises(AttributeError, setattr, view, "persistant", True)
+        self.assertRaises(AttributeError, setattr, view, "somethingelse", 5)
+
+    @drop_datasets
     def test_view(self):
         dataset = fo.Dataset()
         dataset.add_sample_field(


### PR DESCRIPTION
Including 'persistent' and others.

This is merely a jumping off proposal. There may be some use case where users set previously-undefined variables on the dataset object and it makes sense, but I can't think of one. For `Sample` and similar objects, it is allowed and encouraged even via the `[]` syntax.

## What changes are proposed in this pull request?

give dataset and samplecollection __slots__ so you cant add arbitrary variables

## How is this patch tested? If it is not, please explain why.

```python
import fiftyone as fo

ds = fo.Dataset("hello-im-dan-and-or-kacey")
ds.persistant = True # error
ds.persistent = True # no error
```
Result error
```
AttributeError: 'Dataset' object has no attribute 'persistant'
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced memory optimization for `DatasetView` through `__slots__` declaration.
	- Added initialization of `_make_sample_fcn` and `_make_frame_fcn` attributes.

- **Improvements**
	- Enhanced test coverage with a new test for handling unknown attributes in `DatasetView`, ensuring robust error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->