### PR TITLE
Remove deprecated fiftyone-desktop refs

### DIFF
--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -106,11 +106,3 @@ DATABASE_APPNAME = "fiftyone"
 
 # Server setup
 SERVER_DIR = os.path.join(FIFTYONE_DIR, "server")
-
-# App setup
-try:
-    from fiftyone.desktop import FIFTYONE_DESKTOP_APP_DIR
-except ImportError:
-    FIFTYONE_DESKTOP_APP_DIR = os.path.normpath(
-        os.path.join(FIFTYONE_DIR, "../app")
-    )

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -1125,7 +1125,7 @@ class Session(object):
             if wait < 0:
                 while True:
                     time.sleep(10)
-            elif self.remote:
+            else:
                 self._wait_closed = False
                 while not self._wait_closed:
                     time.sleep(wait)

--- a/fiftyone/utils/quickstart.py
+++ b/fiftyone/utils/quickstart.py
@@ -11,9 +11,7 @@ import fiftyone.core.session as fos
 import fiftyone.zoo.datasets as fozd
 
 
-def quickstart(
-    video=False, port=None, address=None, remote=False, desktop=None
-):
+def quickstart(video=False, port=None, address=None, remote=False):
     """Runs the FiftyOne quickstart.
 
     This method loads an interesting dataset from the Dataset Zoo, launches the
@@ -27,9 +25,6 @@ def quickstart(
             ``fiftyone.config.default_app_address`` is used
         remote (False): whether this is a remote session, and opening the App
             should not be attempted
-        desktop (None): whether to launch the App in the browser (False) or as
-            a desktop App (True). If None, ``fiftyone.config.desktop_app`` is
-            used. Not applicable to notebook contexts
 
     Returns:
         a tuple containing
@@ -39,30 +34,29 @@ def quickstart(
             the App that was launched
     """
     if video:
-        return _video_quickstart(port, address, remote, desktop)
+        return _video_quickstart(port, address, remote)
 
-    return _quickstart(port, address, remote, desktop)
+    return _quickstart(port, address, remote)
 
 
-def _quickstart(port, address, remote, desktop):
+def _quickstart(port, address, remote):
     print(_QUICKSTART_GUIDE)
     dataset = fozd.load_zoo_dataset("quickstart")
-    return _launch_app(dataset, port, address, remote, desktop)
+    return _launch_app(dataset, port, address, remote)
 
 
-def _video_quickstart(port, address, remote, desktop):
+def _video_quickstart(port, address, remote):
     print(_VIDEO_QUICKSTART_GUIDE)
     dataset = fozd.load_zoo_dataset("quickstart-video")
-    return _launch_app(dataset, port, address, remote, desktop)
+    return _launch_app(dataset, port, address, remote)
 
 
-def _launch_app(dataset, port, address, remote, desktop):
+def _launch_app(dataset, port, address, remote):
     session = fos.launch_app(
         dataset=dataset,
         port=port,
         address=address,
         remote=remote,
-        desktop=desktop,
     )
 
     return dataset, session


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/4880
Resolves https://github.com/voxel51/fiftyone/issues/4889

## Tested by

```
fiftyone quickstart
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Simplified the quickstart process by removing the desktop application option from the interface.
- **Bug Fixes**
	- Eliminated fallback logic for the `FIFTYONE_DESKTOP_APP_DIR`, streamlining the app setup process.
- **Improvements**
	- Enhanced session management by standardizing the waiting behavior across different session types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->