### PR TITLE
Fix #4890

### DIFF
--- a/app/packages/looker/src/elements/common/bubbles.test.ts
+++ b/app/packages/looker/src/elements/common/bubbles.test.ts
@@ -1,9 +1,11 @@
 import type { Schema } from "@fiftyone/utilities";
 import {
+  CLASSIFICATIONS,
   DYNAMIC_EMBEDDED_DOCUMENT_PATH,
   EMBEDDED_DOCUMENT_FIELD,
   LIST_FIELD,
   STRING_FIELD,
+  TEMPORAL_DETECTIONS,
 } from "@fiftyone/utilities";
 import { describe, expect, it } from "vitest";
 import { getBubbles, getField, unwind } from "./bubbles";
@@ -195,6 +197,38 @@ describe("text bubble tests", () => {
         }
       )
     ).toStrictEqual([field.fields.value, ["value"]]);
+
+    const classifications = {
+      ...FIELD_DATA,
+      dbField: "classes",
+      ftype: EMBEDDED_DOCUMENT_FIELD,
+      embeddedDocType: CLASSIFICATIONS,
+      fields: {},
+    };
+
+    expect(
+      getBubbles(
+        "classes",
+        { classes: { classifications: [{ label: "label" }] } },
+        { classes: classifications }
+      )
+    );
+
+    const temporalDetections = {
+      ...FIELD_DATA,
+      dbField: "temporal",
+      ftype: EMBEDDED_DOCUMENT_FIELD,
+      embeddedDocType: TEMPORAL_DETECTIONS,
+      fields: {},
+    };
+
+    expect(
+      getBubbles(
+        "temporal",
+        { temporal: { detections: [{ label: "label" }] } },
+        { temporal: temporalDetections }
+      )
+    );
   });
 
   it("getField gets field from a path keys", () => {

--- a/app/packages/looker/src/elements/common/bubbles.ts
+++ b/app/packages/looker/src/elements/common/bubbles.ts
@@ -54,14 +54,14 @@ export const getBubbles = (
     }
 
     if (field.embeddedDocType === withPath(LABELS_PATH, CLASSIFICATIONS)) {
-      out.values = out.values.flatMap(
+      out.values = unwind(field.dbField, out.values).flatMap(
         (value) => value.classifications || []
       ) as Sample[];
       break;
     }
 
     if (field.embeddedDocType === withPath(LABELS_PATH, TEMPORAL_DETECTIONS)) {
-      out.values = out.values.flatMap(
+      out.values = unwind(field.dbField, out.values).flatMap(
         (value) => value.detections || []
       ) as Sample[];
       break;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Resolves #4890

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video", max_samples=1)

sample = dataset.first()
sample["classes"] = fo.Classifications(classifications=[fo.Classification(label="class")])
sample["detections"] = fo.TemporalDetections(detections=[fo.TemporalDetection(label="detection")])
sample.save()

session = fo.launch_app(dataset)
``` 
<img width="1470" alt="Screenshot 2024-10-04 at 10 42 39 AM" src="https://github.com/user-attachments/assets/057b649c-cdb3-436c-8190-5ebf0fac7976">

## How is this patch tested? If it is not, please explain why.

Unit tests for the  `Classifications` and `TemporalDetections` special cases

## Release Notes

* Fixed |Classifications| and |TemporalDetections| grid rendering

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of classifications and temporal detections in bubble processing.
  
- **Bug Fixes**
	- Improved functionality of the `getBubbles` function to correctly process nested data structures. 

- **Tests**
	- Expanded test coverage for the `getBubbles` function with new scenarios for classifications and temporal detections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->