### PR TITLE
fix e2e flakiness because of timeline API

### DIFF
--- a/e2e-pw/src/oss/poms/modal/imavid-controls.ts
+++ b/e2e-pw/src/oss/poms/modal/imavid-controls.ts
@@ -32,10 +32,22 @@ export class ModalImaAsVideoControlsPom {
     return timelineId;
   }
 
+  private async waitUntilBufferingIsFinished() {
+    await this.page.waitForFunction(
+      () =>
+        document
+          .querySelector("[data-cy=imavid-playhead]")
+          ?.getAttribute("data-playhead-state") !== "buffering"
+    );
+  }
+
   private async togglePlay() {
+    await this.waitUntilBufferingIsFinished();
+
     let currentPlayHeadStatus = await this.playPauseButton.getAttribute(
       "data-playhead-state"
     );
+
     const original = currentPlayHeadStatus;
 
     // keep pressing space until play head status changes


### PR DESCRIPTION
-  Block while buffering is being done before toggling play/pause button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved playback control by ensuring the play action only occurs after buffering is complete. 

- **Bug Fixes**
	- Enhanced reliability of the toggle play functionality by waiting for the buffering state to finish before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->