### PR TITLE
add support for atomic state transitions

### DIFF
--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -301,6 +301,14 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
                     "updated_at": datetime.utcnow(),
                 }
             }
+        elif run_state == ExecutionRunState.QUEUED:
+            update = {
+                "$set": {
+                    "run_state": run_state,
+                    "queued_at": datetime.utcnow(),
+                    "updated_at": datetime.utcnow(),
+                }
+            }
 
         if run_link is not None:
             update["$set"]["run_link"] = run_link

--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -44,7 +44,7 @@ class DelegatedOperationRepo(object):
         result: ExecutionResult = None,
         run_link: str = None,
         progress: ExecutionProgress = None,
-        required_state: ExecutionResult = None,
+        required_state: ExecutionRunState = None,
     ) -> DelegatedOperationDocument:
         """Update the run state of an operation."""
         raise NotImplementedError("subclass must implement update_run_state()")

--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -330,7 +330,11 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             return_document=pymongo.ReturnDocument.AFTER,
         )
 
-        return DelegatedOperationDocument().from_pymongo(doc) if doc is not None else None
+        return (
+            DelegatedOperationDocument().from_pymongo(doc)
+            if doc is not None
+            else None
+        )
 
     def update_progress(
         self,

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -80,7 +80,13 @@ class DelegatedOperationService(object):
         """
         return self._repo.update_progress(_id=doc_id, progress=progress)
 
-    def set_running(self, doc_id, progress=None, run_link=None, required_state: ExecutionRunState = None):
+    def set_running(
+        self,
+        doc_id,
+        progress=None,
+        run_link=None,
+        required_state=None,
+    ):
         """Sets the given delegated operation to running state.
 
         Args:
@@ -90,11 +96,14 @@ class DelegatedOperationService(object):
                 operation
             run_link (None): an optional link to orchestrator-specific
                 information about the operation
-            required_state (ExecutionRunState): an optional required state of the operation. If provided, the
-                update will only be performed if the referenced operation matches this state.
+            required_state (None): an optional
+                :class:`fiftyone.operators.executor.ExecutionRunState` required
+                state of the operation. If provided, the update will only be
+                performed if the referenced operation matches this state.
 
         Returns:
-            a :class:`fiftyone.factory.repos.DelegatedOperationDocument`
+            a :class:`fiftyone.factory.repos.DelegatedOperationDocument` if the
+                update was performed, else ``None``.
         """
         return self._repo.update_run_state(
             _id=doc_id,
@@ -104,32 +113,43 @@ class DelegatedOperationService(object):
             required_state=required_state,
         )
 
-    def set_scheduled(self, doc_id, required_state: ExecutionRunState = None):
+    def set_scheduled(self, doc_id, required_state=None):
         """Sets the given delegated operation to scheduled state.
         Args:
             doc_id: the ID of the delegated operation
-            required_state (ExecutionRunState): an optional required state of the operation. If provided, the
-                update will only be performed if the referenced operation matches this state.
+            required_state (None): an optional
+                :class:`fiftyone.operators.executor.ExecutionRunState` required
+                state of the operation. If provided, the update will only be
+                performed if the referenced operation matches this state.
+
         Returns:
-            a :class:`fiftyone.factory.repos.DelegatedOperationDocument`
+            a :class:`fiftyone.factory.repos.DelegatedOperationDocument` if the
+                update was performed, else ``None``.
         """
         return self._repo.update_run_state(
-            _id=doc_id, run_state=ExecutionRunState.SCHEDULED, required_state=required_state
+            _id=doc_id,
+            run_state=ExecutionRunState.SCHEDULED,
+            required_state=required_state,
         )
 
-    def set_queued(self, doc_id, required_state: ExecutionRunState = None):
+    def set_queued(self, doc_id, required_state=None):
         """Sets the given delegated operation to queued state.
 
         Args:
             doc_id: the ID of the delegated operation
-            required_state (ExecutionRunState): an optional required state of the operation. If provided, the
-                update will only be performed if the referenced operation matches this state.
+            required_state (None): an optional
+                :class:`fiftyone.operators.executor.ExecutionRunState` required
+                state of the operation. If provided, the update will only be
+                performed if the referenced operation matches this state.
 
         Returns:
-            a :class:`fiftyone.factory.repos.DelegatedOperationDocument`
+            a :class:`fiftyone.factory.repos.DelegatedOperationDocument` if the
+                update was performed, else ``None``.
         """
         return self._repo.update_run_state(
-            _id=doc_id, run_state=ExecutionRunState.QUEUED, required_state=required_state
+            _id=doc_id,
+            run_state=ExecutionRunState.QUEUED,
+            required_state=required_state,
         )
 
     def set_completed(
@@ -138,7 +158,7 @@ class DelegatedOperationService(object):
         result=None,
         progress=None,
         run_link=None,
-        required_state: ExecutionRunState = None,
+        required_state=None,
     ):
         """Sets the given delegated operation to completed state.
 
@@ -152,11 +172,14 @@ class DelegatedOperationService(object):
                 operation
             run_link (None): an optional link to orchestrator-specific
                 information about the operation
-            required_state (ExecutionRunState): an optional required state of the operation. If provided, the
-                update will only be performed if the referenced operation matches this state.
+            required_state (None): an optional
+                :class:`fiftyone.operators.executor.ExecutionRunState` required
+                state of the operation. If provided, the update will only be
+                performed if the referenced operation matches this state.
 
         Returns:
-            a :class:`fiftyone.factory.repos.DelegatedOperationDocument`
+            a :class:`fiftyone.factory.repos.DelegatedOperationDocument` if the
+                update was performed, else ``None``.
         """
 
         return self._repo.update_run_state(
@@ -174,7 +197,7 @@ class DelegatedOperationService(object):
         result=None,
         progress=None,
         run_link=None,
-        required_state: ExecutionRunState = None,
+        required_state=None,
     ):
         """Sets the given delegated operation to failed state.
 
@@ -188,11 +211,14 @@ class DelegatedOperationService(object):
                 operation
             run_link (None): an optional link to orchestrator-specific
                 information about the operation
-            required_state (ExecutionRunState): an optional required state of the operation. If provided, the
-                update will only be performed if the referenced operation matches this state.
+            required_state (None): an optional
+                :class:`fiftyone.operators.executor.ExecutionRunState` required
+                state of the operation. If provided, the update will only be
+                performed if the referenced operation matches this state.
 
         Returns:
-            a :class:`fiftyone.factory.repos.DelegatedOperationDocument`
+            a :class:`fiftyone.factory.repos.DelegatedOperationDocument` if the
+                update was performed, else ``None``.
         """
         return self._repo.update_run_state(
             _id=doc_id,

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -117,6 +117,21 @@ class DelegatedOperationService(object):
             _id=doc_id, run_state=ExecutionRunState.SCHEDULED, required_state=required_state
         )
 
+    def set_queued(self, doc_id, required_state: ExecutionRunState = None):
+        """Sets the given delegated operation to queued state.
+
+        Args:
+            doc_id: the ID of the delegated operation
+            required_state (ExecutionRunState): an optional required state of the operation. If provided, the
+                update will only be performed if the referenced operation matches this state.
+
+        Returns:
+            a :class:`fiftyone.factory.repos.DelegatedOperationDocument`
+        """
+        return self._repo.update_run_state(
+            _id=doc_id, run_state=ExecutionRunState.QUEUED, required_state=required_state
+        )
+
     def set_completed(
         self,
         doc_id,

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -80,7 +80,7 @@ class DelegatedOperationService(object):
         """
         return self._repo.update_progress(_id=doc_id, progress=progress)
 
-    def set_running(self, doc_id, progress=None, run_link=None):
+    def set_running(self, doc_id, progress=None, run_link=None, required_state: ExecutionRunState = None):
         """Sets the given delegated operation to running state.
 
         Args:
@@ -90,6 +90,8 @@ class DelegatedOperationService(object):
                 operation
             run_link (None): an optional link to orchestrator-specific
                 information about the operation
+            required_state (ExecutionRunState): an optional required state of the operation. If provided, the
+                update will only be performed if the referenced operation matches this state.
 
         Returns:
             a :class:`fiftyone.factory.repos.DelegatedOperationDocument`
@@ -99,17 +101,20 @@ class DelegatedOperationService(object):
             run_state=ExecutionRunState.RUNNING,
             run_link=run_link,
             progress=progress,
+            required_state=required_state,
         )
 
-    def set_scheduled(self, doc_id):
+    def set_scheduled(self, doc_id, required_state: ExecutionRunState = None):
         """Sets the given delegated operation to scheduled state.
         Args:
             doc_id: the ID of the delegated operation
+            required_state (ExecutionRunState): an optional required state of the operation. If provided, the
+                update will only be performed if the referenced operation matches this state.
         Returns:
             a :class:`fiftyone.factory.repos.DelegatedOperationDocument`
         """
         return self._repo.update_run_state(
-            _id=doc_id, run_state=ExecutionRunState.SCHEDULED
+            _id=doc_id, run_state=ExecutionRunState.SCHEDULED, required_state=required_state
         )
 
     def set_completed(
@@ -118,6 +123,7 @@ class DelegatedOperationService(object):
         result=None,
         progress=None,
         run_link=None,
+        required_state: ExecutionRunState = None,
     ):
         """Sets the given delegated operation to completed state.
 
@@ -131,6 +137,8 @@ class DelegatedOperationService(object):
                 operation
             run_link (None): an optional link to orchestrator-specific
                 information about the operation
+            required_state (ExecutionRunState): an optional required state of the operation. If provided, the
+                update will only be performed if the referenced operation matches this state.
 
         Returns:
             a :class:`fiftyone.factory.repos.DelegatedOperationDocument`
@@ -142,6 +150,7 @@ class DelegatedOperationService(object):
             result=result,
             progress=progress,
             run_link=run_link,
+            required_state=required_state,
         )
 
     def set_failed(
@@ -150,6 +159,7 @@ class DelegatedOperationService(object):
         result=None,
         progress=None,
         run_link=None,
+        required_state: ExecutionRunState = None,
     ):
         """Sets the given delegated operation to failed state.
 
@@ -163,6 +173,8 @@ class DelegatedOperationService(object):
                 operation
             run_link (None): an optional link to orchestrator-specific
                 information about the operation
+            required_state (ExecutionRunState): an optional required state of the operation. If provided, the
+                update will only be performed if the referenced operation matches this state.
 
         Returns:
             a :class:`fiftyone.factory.repos.DelegatedOperationDocument`
@@ -173,6 +185,7 @@ class DelegatedOperationService(object):
             result=result,
             run_link=run_link,
             progress=progress,
+            required_state=required_state,
         )
 
     def set_pinned(self, doc_id, pinned=True):

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -445,7 +445,24 @@ class DelegatedOperationService(object):
                 information about the operation
         """
         try:
-            self.set_running(doc_id=operation.id, run_link=run_link)
+            succeeded = (
+                self.set_running(
+                    doc_id=operation.id,
+                    run_link=run_link,
+                    required_state=ExecutionRunState.QUEUED,
+                )
+                is not None
+            )
+            if not succeeded:
+                if log:
+                    logger.debug(
+                        "Not executing operation %s (%s) which is "
+                        "no longer in QUEUED state, or doesn't exist.",
+                        operation.id,
+                        operation.operator,
+                    )
+                return
+
             if log:
                 logger.info(
                     "\nRunning operation %s (%s)",

--- a/tests/unittests/delegated_operators_tests.py
+++ b/tests/unittests/delegated_operators_tests.py
@@ -242,7 +242,8 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         operator = "@voxelfiftyone/operator/foo"
         operator2 = "@voxelfiftyone/operator/bar"
 
-        docs_to_run = []
+        dynamic_docs = []
+        static_docs = []
 
         # get all the existing counts of queued operations
         initial_queued = len(self.svc.get_queued_operations())
@@ -271,7 +272,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
             )
             self.docs_to_delete.append(doc)
             # pylint: disable=no-member
-            docs_to_run.append(doc.id)
+            dynamic_docs.append(doc.id)
 
         for i in range(10):
             doc = self.svc.queue_operation(
@@ -287,33 +288,101 @@ class DelegatedOperationServiceTests(unittest.TestCase):
                 ),
             )
             self.docs_to_delete.append(doc)
+            static_docs.append(doc.id)
 
         queued = self.svc.get_queued_operations()
-        self.assertEqual(len(queued), 20 + initial_queued)
+        # dynamic + static docs should be queued
+        self.assertEqual(len(queued), len(dynamic_docs) + len(static_docs) + initial_queued)
 
         queued = self.svc.get_queued_operations(dataset_name=dataset_name)
-        self.assertEqual(len(queued), 10 + initial_dataset_queued)
+        # dataset_name corresponds to dynamic docs
+        self.assertEqual(len(queued), len(dynamic_docs) + initial_dataset_queued)
 
         queued = self.svc.get_queued_operations(operator=operator)
-        self.assertEqual(len(queued), 10 + initial_operator_queued)
+        # operator corresponds to dynamic docs
+        self.assertEqual(len(queued), len(dynamic_docs) + initial_operator_queued)
 
-        for doc in docs_to_run:
-            self.svc.set_running(doc)
+        # test set_running behavior
+        for doc_id in dynamic_docs:
+            self.svc.set_running(doc_id)
 
         queued = self.svc.get_queued_operations()
-        self.assertEqual(len(queued), 10 + initial_queued)
+        # static docs should be `queued`
+        self.assertEqual(len(queued), len(static_docs) + initial_queued)
 
         running = self.svc.get_running_operations()
-        self.assertEqual(len(running), 10 + initial_running)
+        # dynamic docs should be `running`
+        self.assertEqual(len(running), len(dynamic_docs) + initial_running)
 
-        for doc in docs_to_run:
-            self.svc.set_scheduled(doc)
+        # test set_scheduled behavior
+        for doc_id in dynamic_docs:
+            self.svc.set_scheduled(doc_id)
 
         queued = self.svc.get_queued_operations()
-        self.assertEqual(len(queued), 10 + initial_queued)
+        # static docs should be `queued`
+        self.assertEqual(len(queued), len(static_docs) + initial_queued)
 
         scheduled = self.svc.get_scheduled_operations()
-        self.assertEqual(len(scheduled), 10 + initial_scheduled)
+        # dynamic docs should be `scheduled`
+        self.assertEqual(len(scheduled), len(dynamic_docs) + initial_scheduled)
+
+        # test set_queued(id) behavior
+        for doc_id in dynamic_docs:
+            self.svc.set_queued(doc_id)
+
+        queued = self.svc.get_queued_operations()
+        # dynamic + static docs should be `queued`
+        self.assertEqual(len(queued), len(dynamic_docs) + len(static_docs) + initial_queued)
+
+        # test set_queued(id, current_state=...) behavior
+        # set_queued(id, current_state=...) should only transition elements matching `current_state`
+
+        subset_size = 4
+        non_subset_size = len(dynamic_docs) - subset_size
+        # transition a subset of docs to `scheduled`
+        for doc_id in dynamic_docs[:subset_size]:
+            self.svc.set_scheduled(doc_id)
+        # transition the other dynamic docs to `running` (just not `scheduled` or `queued`)
+        for doc_id in dynamic_docs[subset_size:]:
+            self.svc.set_running(doc_id)
+
+        scheduled = self.svc.get_scheduled_operations()
+        # subset should be `scheduled`
+        self.assertEqual(len(scheduled), subset_size + initial_scheduled)
+
+        running = self.svc.get_running_operations()
+        # non-subset should be `running`
+        self.assertEqual(len(running), non_subset_size + initial_running)
+
+        queued = self.svc.get_queued_operations()
+        # static docs should be `queued`
+        self.assertEqual(len(queued), len(static_docs) + initial_queued)
+
+        return_values = []
+        for doc_id in dynamic_docs:
+            # attempt to transition from scheduled to queued
+            return_values.append(
+                self.svc.set_queued(doc_id, required_state=ExecutionRunState.SCHEDULED)
+            )
+
+        # set_queued should return the updated doc if a transition occurred
+        for result in return_values[:subset_size]:
+            self.assertIsNotNone(result)
+        # set_queued should return `None` if no transition occurred
+        for result in return_values[subset_size:]:
+            self.assertIsNone(result)
+
+        queued = self.svc.get_queued_operations()
+        # subset + static docs should be `queued`
+        self.assertEqual(len(queued), subset_size + len(static_docs) + initial_queued)
+
+        scheduled = self.svc.get_scheduled_operations()
+        # only initial docs should still be `scheduled`
+        self.assertEqual(len(scheduled), initial_scheduled)
+
+        running = self.svc.get_running_operations()
+        # non-subset should still be `running`
+        self.assertEqual(len(running), non_subset_size + initial_running)
 
         dataset.delete()
         dataset2.delete()

--- a/tests/unittests/delegated_operators_tests.py
+++ b/tests/unittests/delegated_operators_tests.py
@@ -292,15 +292,21 @@ class DelegatedOperationServiceTests(unittest.TestCase):
 
         queued = self.svc.get_queued_operations()
         # dynamic + static docs should be queued
-        self.assertEqual(len(queued), len(dynamic_docs) + len(static_docs) + initial_queued)
+        self.assertEqual(
+            len(queued), len(dynamic_docs) + len(static_docs) + initial_queued
+        )
 
         queued = self.svc.get_queued_operations(dataset_name=dataset_name)
         # dataset_name corresponds to dynamic docs
-        self.assertEqual(len(queued), len(dynamic_docs) + initial_dataset_queued)
+        self.assertEqual(
+            len(queued), len(dynamic_docs) + initial_dataset_queued
+        )
 
         queued = self.svc.get_queued_operations(operator=operator)
         # operator corresponds to dynamic docs
-        self.assertEqual(len(queued), len(dynamic_docs) + initial_operator_queued)
+        self.assertEqual(
+            len(queued), len(dynamic_docs) + initial_operator_queued
+        )
 
         # test set_running behavior
         for doc_id in dynamic_docs:
@@ -332,7 +338,9 @@ class DelegatedOperationServiceTests(unittest.TestCase):
 
         queued = self.svc.get_queued_operations()
         # dynamic + static docs should be `queued`
-        self.assertEqual(len(queued), len(dynamic_docs) + len(static_docs) + initial_queued)
+        self.assertEqual(
+            len(queued), len(dynamic_docs) + len(static_docs) + initial_queued
+        )
 
         # test set_queued(id, current_state=...) behavior
         # set_queued(id, current_state=...) should only transition elements matching `current_state`
@@ -362,7 +370,9 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         for doc_id in dynamic_docs:
             # attempt to transition from scheduled to queued
             return_values.append(
-                self.svc.set_queued(doc_id, required_state=ExecutionRunState.SCHEDULED)
+                self.svc.set_queued(
+                    doc_id, required_state=ExecutionRunState.SCHEDULED
+                )
             )
 
         # set_queued should return the updated doc if a transition occurred
@@ -374,7 +384,9 @@ class DelegatedOperationServiceTests(unittest.TestCase):
 
         queued = self.svc.get_queued_operations()
         # subset + static docs should be `queued`
-        self.assertEqual(len(queued), subset_size + len(static_docs) + initial_queued)
+        self.assertEqual(
+            len(queued), subset_size + len(static_docs) + initial_queued
+        )
 
         scheduled = self.svc.get_scheduled_operations()
         # only initial docs should still be `scheduled`
@@ -605,6 +617,29 @@ class DelegatedOperationServiceTests(unittest.TestCase):
             },
         )
 
+    def test_queued_state_required_to_execute(
+        self, mock_get_operator, mock_operator_exists
+    ):
+        mock_inputs = MockInputs()
+        operator = mock.MagicMock()
+        mock_get_operator.return_value = operator
+        doc = self.svc.queue_operation(
+            operator="@voxelfiftyone/operator/foo",
+            delegation_target="test_target",
+            context=ExecutionContext(request_params={"foo": "bar"}),
+            metadata={"inputs_schema": mock_inputs.to_json()},
+        )
+
+        # Set it to running separately - execution not allowed now because
+        #   it's running elsewhere.
+        self.svc.set_running(doc.id)
+
+        self.svc.execute_operation(doc)
+        operator.execute.assert_not_called()
+
+        doc = self.svc.get(doc_id=doc.id)
+        self.assertEqual(doc.run_state, ExecutionRunState.RUNNING)
+
     @patch(
         "fiftyone.core.odm.utils.load_dataset",
     )
@@ -622,7 +657,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         doc = self.svc.queue_operation(
             operator="@voxelfiftyone/operator/foo",
             label=mock_get_operator.return_value.name,
-            delegation_target=f"test_target",
+            delegation_target="test_target",
             context=ctx.serialize(),
         )
 
@@ -659,7 +694,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         doc = self.svc.queue_operation(
             operator="@voxelfiftyone/operator/foo",
             label=get_op_mock.return_value.name,
-            delegation_target=f"test_target",
+            delegation_target="test_target",
             context=ctx.serialize(),
         )
 
@@ -709,7 +744,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         doc = self.svc.queue_operation(
             operator="@voxelfiftyone/operator/foo",
             label=get_op_mock.return_value.name,
-            delegation_target=f"test_target",
+            delegation_target="test_target",
             context=ctx.serialize(),
         )
 
@@ -774,7 +809,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         doc = self.svc.queue_operation(
             operator="@voxelfiftyone/operator/foo",
             label=get_op_mock.return_value.name,
-            delegation_target=f"test_target",
+            delegation_target="test_target",
             context=ctx.serialize(),
         )
 
@@ -956,7 +991,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         doc = self.svc.queue_operation(
             operator="@voxelfiftyone/operator/foo",
             label=mock_get_operator.return_value.name,
-            delegation_target=f"test_target",
+            delegation_target="test_target",
             context=ctx.serialize(),
         )
 
@@ -1187,7 +1222,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         doc = self.svc.queue_operation(
             operator="@voxelfiftyone/operator/foo",
             label=mock_get_operator.return_value.name,
-            delegation_target=f"test_target",
+            delegation_target="test_target",
             context=ctx.serialize(),
         )
         self.assertEqual(doc.label, mock_get_operator.return_value.name)
@@ -1217,7 +1252,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         doc = self.svc.queue_operation(
             operator="@voxelfiftyone/operator/foo",
             label=mock_get_operator.return_value.name,
-            delegation_target=f"test_target",
+            delegation_target="test_target",
             context=ctx.serialize(),
         )
         self.assertEqual(doc.label, mock_get_operator.return_value.name)


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds a new `set_queued` method to the `DelegatedOperationService` which provides a mechanism for transitioning operators to the `queued` run state. 

In addition, this updates the existing `update_run_state` to include an optional `required_state` field to provide a means to control state transitions. This new field allows actors to perform a state transition _only if the operator matches the `required_state`_. This enables concurrency-safe state transitions where multiple actors may attempt to transition the same DO. With this new parameter, only the first attempted transition will succeed; subsequent attempts will fail due to a `required_state` mismatch.

**Important note!!** `update_run_state` can now return `None` if no matching records are found; this is consistent with the behavior of the underlying `find_one_and_update` call and can be used to determine whether a state transition occurred.

## How is this patch tested? If it is not, please explain why.

Unit tests

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `set_queued` method for managing operation states.
	- Enhanced state transition control with a new `required_state` parameter across multiple methods.

- **Bug Fixes**
	- Improved robustness of state updates by ensuring transitions only occur if the current state matches the specified `required_state`.

- **Tests**
	- Expanded unit tests to include checks for the new `set_queued` method and refined assertions for operation state transitions, ensuring accurate tracking of operation statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->