### PR TITLE
externalize @fiftyone/plugins

### DIFF
--- a/app/packages/plugins/src/externalize.ts
+++ b/app/packages/plugins/src/externalize.ts
@@ -3,6 +3,7 @@ import * as foo from "@fiftyone/operators";
 import * as fos from "@fiftyone/state";
 import * as fou from "@fiftyone/utilities";
 import * as fosp from "@fiftyone/spaces";
+import * as fop from "@fiftyone/plugins";
 import * as mui from "@mui/material";
 import React from "react";
 import ReactDOM from "react-dom";
@@ -19,6 +20,7 @@ declare global {
     __fou__: typeof fou;
     __foo__: typeof foo;
     __fosp__: typeof fosp;
+    __fop__: typeof fop;
     __mui__: typeof mui;
     __styled__: typeof styled;
   }
@@ -36,5 +38,6 @@ if (typeof window !== "undefined") {
   window.__foo__ = foo;
   window.__fosp__ = fosp;
   window.__mui__ = mui;
+  window.__fop__ = fop;
   window.__styled__ = styled;
 }


### PR DESCRIPTION
This makes it so that fiftyone plugins can be referenced by JS panels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Integrated the `@fiftyone/plugins` module into the global scope for enhanced accessibility across the application.
	- Added a new property `__fop__` to the global `Window` interface for seamless usage of the `fiftyone/plugins` module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->