### PR TITLE
Add YOLO11 Models to Zoo

### DIFF
--- a/docs/source/integrations/ultralytics.rst
+++ b/docs/source/integrations/ultralytics.rst
@@ -105,6 +105,13 @@ You can directly pass Ultralytics `YOLO` or `RTDETR` detection models to
     # model = YOLO("yolov10l.pt)
     # model = YOLO("yolov10x.pt)
 
+    # YOLOv11
+    # model = YOLO("yolo11n.pt)
+    # model = YOLO("yolo11s.pt)
+    # model = YOLO("yolo11m.pt)
+    # model = YOLO("yolo11l.pt)
+    # model = YOLO("yolo11x.pt)
+
     # RTDETR
     # model = YOLO("rtdetr-l.pt")
     # model = YOLO("rtdetr-x.pt")
@@ -140,6 +147,7 @@ You can also load any of these models directly from the
     # model_name = "yolov8m-coco-torch"
     # model_name = "yolov9e-coco-torch"
     # model_name = "yolov10s-coco-torch"
+    # model_name = "yolo11x-coco-torch"
     # model_name = "rtdetr-l-coco-torch"
 
     model = foz.load_zoo_model(

--- a/docs/source/integrations/ultralytics.rst
+++ b/docs/source/integrations/ultralytics.rst
@@ -190,6 +190,11 @@ You can directly pass Ultralytics YOLO segmentation models to
     # model = YOLO("yolov8l-seg.pt")
     # model = YOLO("yolov8x-seg.pt")
 
+    # model = YOLO("yolo11s-seg.pt")
+    # model = YOLO("yolo11m-seg.pt")
+    # model = YOLO("yolo11l-seg.pt")
+    # model = YOLO("yolo11x-seg.pt")
+
     dataset.apply_model(model, label_field="instances")
 
     session = fo.launch_app(dataset)
@@ -215,19 +220,27 @@ manually convert Ultralytics predictions into the desired
    :align: center
 
 
-You can also load YOLOv8 and YOLOv9 segmentation models from the
+You can also load YOLOv8, YOLOv9, and YOLO11 segmentation models from the
 :ref:`FiftyOne Model Zoo <model-zoo>`:
 
 .. code-block:: python
     :linenos:
 
-    model_name = "yolov9c-seg-coco-torch"
-    # model_name = "yolov9e-seg-coco-torch"
-    # model_name = "yolov8x-seg-coco-torch"
-    # model_name = "yolov8l-seg-coco-torch"
-    # model_name = "yolov8m-seg-coco-torch"
+    model_name = "yolov8n-seg-coco-torch"
     # model_name = "yolov8s-seg-coco-torch"
-    # model_name = "yolov8n-seg-coco-torch"
+    # model_name = "yolov8m-seg-coco-torch"
+    # model_name = "yolov8l-seg-coco-torch"
+    # model_name = "yolov8x-seg-coco-torch"
+
+    # model_name = "yolov9c-seg-coco-torch"
+    # model_name = "yolov9e-seg-coco-torch"
+
+    # model_name = "yolo11n-seg-coco-torch"
+    # model_name = "yolo11s-seg-coco-torch"
+    # model_name = "yolo11m-seg-coco-torch"
+    # model_name = "yolo11l-seg-coco-torch"
+    # model_name = "yolo11x-seg-coco-torch"
+    
 
     model = foz.load_zoo_model(model_name, label_field="yolo_seg")
 

--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -17,7 +17,6 @@ import fiftyone.core.labels as fol
 from fiftyone.core.models import Model
 import fiftyone.utils.torch as fout
 import fiftyone.core.utils as fou
-import fiftyone.zoo as foz
 import fiftyone.zoo.models as fozm
 
 ultralytics = fou.lazy_import("ultralytics")

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -3421,6 +3421,166 @@
             "date_added": "2024-10-05 19:22:51"
         },
         {
+            "base_name": "yolo11n-seg-coco-torch",
+            "base_filename": "yolo11n-seg-coco.pt",
+            "description": "YOLO11-N Segmentation model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/yolo11/#__tabbed_1_2",
+            "size_bytes": 6182636,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n-seg.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLOSegmentationModel",
+                "config": {}
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.3.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segmentation", "coco", "torch", "yolo"],
+            "date_added": "2024-10-05 19:22:51"
+        },
+        {
+            "base_name": "yolo11s-seg-coco-torch",
+            "base_filename": "yolo11s-seg-coco.pt",
+            "description": "YOLO11-S Segmentation model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/yolo11/#__tabbed_1_2",
+            "size_bytes": 20669228,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11s-seg.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLOSegmentationModel",
+                "config": {}
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.3.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segmentation", "coco", "torch", "yolo"],
+            "date_added": "2024-10-05 19:22:51"
+        },
+        {
+            "base_name": "yolo11m-seg-coco-torch",
+            "base_filename": "yolo11m-seg-coco.pt",
+            "description": "YOLO11-M Segmentation model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/yolo11/#__tabbed_1_2",
+            "size_bytes": 45400152,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11m-seg.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLOSegmentationModel",
+                "config": {}
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.3.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segmentation", "coco", "torch", "yolo"],
+            "date_added": "2024-10-05 19:22:51"
+        },
+        {
+            "base_name": "yolo11l-seg-coco-torch",
+            "base_filename": "yolo11l-seg-coco.pt",
+            "description": "YOLO11-L Segmentation model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/yolo11/#__tabbed_1_2",
+            "size_bytes": 56096965,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11l-seg.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLOSegmentationModel",
+                "config": {}
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.3.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segmentation", "coco", "torch", "yolo"],
+            "date_added": "2024-10-05 19:22:51"
+        },
+        {
+            "base_name": "yolo11x-seg-coco-torch",
+            "base_filename": "yolo11x-seg-coco.pt",
+            "description": "YOLO11-X Segmentation model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/yolo11/#__tabbed_1_2",
+            "size_bytes": 125090821,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11x-seg.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLOSegmentationModel",
+                "config": {}
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.3.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segmentation", "coco", "torch", "yolo"],
+            "date_added": "2024-10-05 19:22:51"
+        },
+        {
             "base_name": "rtdetr-l-coco-torch",
             "base_filename": "rtdetr-l-coco.pt",
             "description": "RT-DETR-l model trained on COCO",

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -3261,6 +3261,166 @@
             "date_added": "2024-07-01 19:22:51"
         },
         {
+            "base_name": "yolov11n-coco-torch",
+            "base_filename": "yolov11n-coco.pt",
+            "description": "YOLOv11-N model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/yolov11/",
+            "size_bytes": 5613764,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {}
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.3.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch", "yolo"],
+            "date_added": "2024-10-05 19:22:51"
+        },
+        {
+            "base_name": "yolov11s-coco-torch",
+            "base_filename": "yolov11s-coco.pt",
+            "description": "YOLOv11-S model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/yolov11/",
+            "size_bytes": 19313732,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11s.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {}
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.3.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch", "yolo"],
+            "date_added": "2024-10-05 19:22:51"
+        },
+        {
+            "base_name": "yolov11m-coco-torch",
+            "base_filename": "yolov11m-coco.pt",
+            "description": "YOLOv11-M model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/yolov11/",
+            "size_bytes": 40684120,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11m.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {}
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.3.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch", "yolo"],
+            "date_added": "2024-10-05 19:22:51"
+        },
+        {
+            "base_name": "yolov11l-coco-torch",
+            "base_filename": "yolov11l-coco.pt",
+            "description": "YOLOv11-L model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/yolov11/",
+            "size_bytes": 51387343,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11l.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {}
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.3.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch", "yolo"],
+            "date_added": "2024-10-05 19:22:51"
+        },
+        {
+            "base_name": "yolov11x-coco-torch",
+            "base_filename": "yolov11x-coco.pt",
+            "description": "YOLOv11-X model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/yolov11/",
+            "size_bytes": 114636239,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11x.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {}
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.3.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch", "yolo"],
+            "date_added": "2024-10-05 19:22:51"
+        },
+        {
             "base_name": "rtdetr-l-coco-torch",
             "base_filename": "rtdetr-l-coco.pt",
             "description": "RT-DETR-l model trained on COCO",

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -3261,9 +3261,9 @@
             "date_added": "2024-07-01 19:22:51"
         },
         {
-            "base_name": "yolov11n-coco-torch",
-            "base_filename": "yolov11n-coco.pt",
-            "description": "YOLOv11-N model trained on COCO",
+            "base_name": "yolo11n-coco-torch",
+            "base_filename": "yolo11n-coco.pt",
+            "description": "YOLO11-N model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov11/",
             "size_bytes": 5613764,
             "manager": {
@@ -3293,9 +3293,9 @@
             "date_added": "2024-10-05 19:22:51"
         },
         {
-            "base_name": "yolov11s-coco-torch",
-            "base_filename": "yolov11s-coco.pt",
-            "description": "YOLOv11-S model trained on COCO",
+            "base_name": "yolo11s-coco-torch",
+            "base_filename": "yolo11s-coco.pt",
+            "description": "YOLO11-S model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov11/",
             "size_bytes": 19313732,
             "manager": {
@@ -3325,9 +3325,9 @@
             "date_added": "2024-10-05 19:22:51"
         },
         {
-            "base_name": "yolov11m-coco-torch",
-            "base_filename": "yolov11m-coco.pt",
-            "description": "YOLOv11-M model trained on COCO",
+            "base_name": "yolo11m-coco-torch",
+            "base_filename": "yolo11m-coco.pt",
+            "description": "YOLO11-M model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov11/",
             "size_bytes": 40684120,
             "manager": {
@@ -3357,9 +3357,9 @@
             "date_added": "2024-10-05 19:22:51"
         },
         {
-            "base_name": "yolov11l-coco-torch",
-            "base_filename": "yolov11l-coco.pt",
-            "description": "YOLOv11-L model trained on COCO",
+            "base_name": "yolo11l-coco-torch",
+            "base_filename": "yolo11l-coco.pt",
+            "description": "YOLO11-L model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov11/",
             "size_bytes": 51387343,
             "manager": {
@@ -3389,9 +3389,9 @@
             "date_added": "2024-10-05 19:22:51"
         },
         {
-            "base_name": "yolov11x-coco-torch",
-            "base_filename": "yolov11x-coco.pt",
-            "description": "YOLOv11-X model trained on COCO",
+            "base_name": "yolo11x-coco-torch",
+            "base_filename": "yolo11x-coco.pt",
+            "description": "YOLO11-X model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov11/",
             "size_bytes": 114636239,
             "manager": {

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -3796,7 +3796,7 @@
                     "support": true
                 }
             },
-            "tags": ["classification", "torch", "yolo"],
+            "tags": ["detection", "torch", "yolo"],
             "date_added": "2024-01-06 08:51:14"
         },
         {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds YOLO11 detection and segmentation models to the zoo manifest and the integration docs. 

Note that unlike previous yolo models, which included a "v" in the name, they do away with that here. So instead of "yolov11n", it is "yolo11n". 

Only detection and segmentation models are explicitly added to the zoo because these are the only ones (not the OBB, classification, and pose) which have superior performance to yolov8.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?


-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

YOLO11 detection and segmentation models added to the model zoo, bringing significant inference speedups on TensorRT compared to previous yolo models

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded support for YOLOv11 models in the documentation, including object detection and instance segmentation examples.
	- Enhanced integration of various Ultralytics models into the FiftyOne framework, allowing for better processing and formatting of model outputs.

- **Documentation**
	- Updated documentation to include new commented code snippets for loading YOLOv11 models from the FiftyOne Model Zoo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->