### PR TITLE
add spaces context to operators

### DIFF
--- a/app/packages/operators/src/CustomPanel.tsx
+++ b/app/packages/operators/src/CustomPanel.tsx
@@ -115,6 +115,7 @@ export function defineCustomPanel({
   on_change_selected_labels,
   on_change_extended_selection,
   on_change_group_slice,
+  on_change_spaces,
   panel_name,
   panel_label,
 }) {
@@ -132,6 +133,7 @@ export function defineCustomPanel({
       onChangeSelectedLabels={on_change_selected_labels}
       onChangeExtendedSelection={on_change_extended_selection}
       onChangeGroupSlice={on_change_group_slice}
+      onChangeSpaces={on_change_spaces}
       dimensions={dimensions}
       panelName={panel_name}
       panelLabel={panel_label}

--- a/app/packages/operators/src/hooks.ts
+++ b/app/packages/operators/src/hooks.ts
@@ -28,6 +28,8 @@ function useOperatorThrottledContextSetter() {
   const groupSlice = useRecoilValue(fos.groupSlice);
   const currentSample = useCurrentSample();
   const setContext = useSetRecoilState(operatorThrottledContext);
+  const spaces = useRecoilValue(fos.sessionSpaces);
+  const workspaceName = spaces._name;
   const setThrottledContext = useMemo(() => {
     return debounce(
       (context) => {
@@ -49,6 +51,8 @@ function useOperatorThrottledContextSetter() {
       currentSample,
       viewName,
       groupSlice,
+      spaces,
+      workspaceName,
     });
   }, [
     setThrottledContext,
@@ -61,6 +65,8 @@ function useOperatorThrottledContextSetter() {
     currentSample,
     viewName,
     groupSlice,
+    spaces,
+    workspaceName,
   ]);
 }
 

--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -1,5 +1,6 @@
 import { AnalyticsInfo, usingAnalytics } from "@fiftyone/analytics";
-import { ServerError, getFetchFunction, isNullish } from "@fiftyone/utilities";
+import { SpaceNode, spaceNodeFromJSON, SpaceNodeJSON } from "@fiftyone/spaces";
+import { getFetchFunction, isNullish, ServerError } from "@fiftyone/utilities";
 import { CallbackInterface } from "recoil";
 import { QueueItemStatus } from "./constants";
 import * as types from "./types";
@@ -92,6 +93,8 @@ export type RawContext = {
   };
   groupSlice: string;
   queryPerformance?: boolean;
+  spaces: SpaceNodeJSON;
+  workspaceName: string;
 };
 
 export class ExecutionContext {
@@ -139,6 +142,12 @@ export class ExecutionContext {
   }
   public get queryPerformance(): boolean {
     return Boolean(this._currentContext.queryPerformance);
+  }
+  public get spaces(): SpaceNode {
+    return spaceNodeFromJSON(this._currentContext.spaces);
+  }
+  public get workspaceName(): string {
+    return this._currentContext.workspaceName;
   }
 
   getCurrentPanelId(): string | null {
@@ -548,6 +557,8 @@ async function executeOperatorAsGenerator(
       view: currentContext.view,
       view_name: currentContext.viewName,
       group_slice: currentContext.groupSlice,
+      spaces: currentContext.spaces,
+      workspace_name: currentContext.workspaceName,
     },
     "json-stream"
   );
@@ -712,6 +723,8 @@ export async function executeOperatorWithContext(
           view_name: currentContext.viewName,
           group_slice: currentContext.groupSlice,
           query_performance: currentContext.queryPerformance,
+          spaces: currentContext.spaces,
+          workspace_name: currentContext.workspaceName,
         }
       );
       result = serverResult.result;
@@ -815,6 +828,8 @@ export async function resolveRemoteType(
       view: currentContext.view,
       view_name: currentContext.viewName,
       group_slice: currentContext.groupSlice,
+      spaces: currentContext.spaces,
+      workspace_name: currentContext.workspaceName,
     }
   );
 
@@ -889,6 +904,8 @@ export async function resolveExecutionOptions(
       view: currentContext.view,
       view_name: currentContext.viewName,
       group_slice: currentContext.groupSlice,
+      spaces: currentContext.spaces,
+      workspace_name: currentContext.workspaceName,
     }
   );
 
@@ -920,6 +937,8 @@ export async function fetchRemotePlacements(ctx: ExecutionContext) {
       current_sample: currentContext.currentSample,
       view_name: currentContext.viewName,
       group_slice: currentContext.groupSlice,
+      spaces: currentContext.spaces,
+      workspace_name: currentContext.workspaceName,
     }
   );
   if (result && result.error) {

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -95,6 +95,8 @@ const globalContextSelector = selector({
     const extendedSelection = get(fos.extendedSelection);
     const groupSlice = get(fos.groupSlice);
     const queryPerformance = typeof get(fos.lightningThreshold) === "number";
+    const spaces = get(fos.sessionSpaces);
+    const workspaceName = spaces?._name;
 
     return {
       datasetName,
@@ -107,6 +109,8 @@ const globalContextSelector = selector({
       extendedSelection,
       groupSlice,
       queryPerformance,
+      spaces,
+      workspaceName,
     };
   },
 });
@@ -148,6 +152,8 @@ const useExecutionContext = (operatorName, hooks = {}) => {
     extendedSelection,
     groupSlice,
     queryPerformance,
+    spaces,
+    workspaceName,
   } = curCtx;
   const [analyticsInfo] = useAnalyticsInfo();
   const ctx = useMemo(() => {
@@ -166,6 +172,8 @@ const useExecutionContext = (operatorName, hooks = {}) => {
         analyticsInfo,
         groupSlice,
         queryPerformance,
+        spaces,
+        workspaceName,
       },
       hooks
     );
@@ -182,6 +190,8 @@ const useExecutionContext = (operatorName, hooks = {}) => {
     currentSample,
     groupSlice,
     queryPerformance,
+    spaces,
+    workspaceName,
   ]);
 
   return ctx;

--- a/app/packages/operators/src/useCustomPanelHooks.ts
+++ b/app/packages/operators/src/useCustomPanelHooks.ts
@@ -26,6 +26,8 @@ export interface CustomPanelProps {
   onChangeSelectedLabels?: string;
   onChangeExtendedSelection?: string;
   onChangeGroupSlice?: string;
+  onChangeSpaces?: string;
+  onChangeWorkspace?: string;
   dimensions: DimensionsType | null;
   panelName?: string;
   panelLabel?: string;
@@ -135,6 +137,13 @@ export function useCustomPanelHooks(props: CustomPanelProps): CustomPanelHooks {
     panelId,
     ctx.groupSlice,
     props.onChangeGroupSlice
+  );
+  useCtxChangePanelEvent(isLoaded, panelId, ctx.spaces, props.onChangeSpaces);
+  useCtxChangePanelEvent(
+    isLoaded,
+    panelId,
+    ctx.workspaceName,
+    props.onChangeWorkspace
   );
 
   useEffect(() => {

--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -1001,6 +1001,7 @@ contains the following properties:
     if any
 -   `ctx.results` - a dict containing the outputs of the `execute()` method, if
     it has been called
+-   `ctx.spaces` - The current workspace or the state of spaces in the app.
 -   `ctx.hooks` **(JS only)** - the return value of the operator's `useHooks()`
     method
 
@@ -2058,6 +2059,19 @@ subsequent sections.
                 "description": "the current group slice",
             }
             ctx.panel.set_state("event", "on_change_group_slice")
+            ctx.panel.set_data("event_data", event)
+
+        def on_change_spaces(self, ctx):
+            """Implement this method to set panel state/data when the current
+            state of spaces changes in the app.
+
+            The current state of spaces will be available via ``ctx.spaces``.
+            """
+            event = {
+                "data": ctx.spaces,
+                "description": "the current state of spaces",
+            }
+            ctx.panel.set_state("event", "on_change_spaces")
             ctx.panel.set_data("event_data", event)
 
         #######################################################################

--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -974,6 +974,7 @@ contains the following properties:
 -   `ctx.dataset_name`:  the name of the current dataset
 -   `ctx.dataset` - the current |Dataset| instance
 -   `ctx.view` - the current |DatasetView| instance
+-   `ctx.spaces` - the current :ref:`Spaces layout <app-spaces>` in the App
 -   `ctx.current_sample` - the ID of the active sample in the App modal, if any
 -   `ctx.selected` - the list of currently selected samples in the App, if any
 -   `ctx.selected_labels` - the list of currently selected labels in the App,
@@ -1001,7 +1002,6 @@ contains the following properties:
     if any
 -   `ctx.results` - a dict containing the outputs of the `execute()` method, if
     it has been called
--   `ctx.spaces` - The current workspace or the state of spaces in the app.
 -   `ctx.hooks` **(JS only)** - the return value of the operator's `useHooks()`
     method
 
@@ -1992,6 +1992,19 @@ subsequent sections.
             ctx.panel.set_state("event", "on_change_view")
             ctx.panel.set_data("event_data", event)
 
+        def on_change_spaces(self, ctx):
+            """Implement this method to set panel state/data when the current
+            spaces layout changes.
+
+            The current spaces layout will be available via ``ctx.spaces``.
+            """
+            event = {
+                "data": ctx.spaces,
+                "description": "the current spaces layout",
+            }
+            ctx.panel.set_state("event", "on_change_spaces")
+            ctx.panel.set_data("event_data", event)
+
         def on_change_current_sample(self, ctx):
             """Implement this method to set panel state/data when a new sample
             is loaded in the Sample modal.
@@ -2059,19 +2072,6 @@ subsequent sections.
                 "description": "the current group slice",
             }
             ctx.panel.set_state("event", "on_change_group_slice")
-            ctx.panel.set_data("event_data", event)
-
-        def on_change_spaces(self, ctx):
-            """Implement this method to set panel state/data when the current
-            state of spaces changes in the app.
-
-            The current state of spaces will be available via ``ctx.spaces``.
-            """
-            event = {
-                "data": ctx.spaces,
-                "description": "the current state of spaces",
-            }
-            ctx.panel.set_state("event", "on_change_spaces")
             ctx.panel.set_data("event_data", event)
 
         #######################################################################

--- a/fiftyone/operators/builtin.py
+++ b/fiftyone/operators/builtin.py
@@ -14,6 +14,7 @@ import fiftyone.core.media as fom
 import fiftyone.core.storage as fos
 import fiftyone.operators as foo
 import fiftyone.operators.types as types
+from fiftyone.core.odm.workspace import default_workspace_factory
 
 
 class EditFieldInfo(foo.Operator):
@@ -1957,10 +1958,11 @@ class SaveWorkspace(foo.Operator):
         color = ctx.params.get("color", None)
         spaces = ctx.params.get("spaces", None)
 
-        if spaces is None:
+        curr_spaces = spaces is None
+        if curr_spaces:
             spaces = ctx.spaces
         else:
-            spaces = _parse_spaces(spaces)
+            spaces = _parse_spaces(ctx, spaces)
 
         ctx.dataset.save_workspace(
             name,
@@ -1969,6 +1971,9 @@ class SaveWorkspace(foo.Operator):
             color=color,
             overwrite=True,
         )
+
+        if curr_spaces:
+            ctx.ops.set_spaces(name=name)
 
 
 class EditWorkspaceInfo(foo.Operator):
@@ -1995,8 +2000,13 @@ class EditWorkspaceInfo(foo.Operator):
         description = ctx.params.get("description", None)
         color = ctx.params.get("color", None)
 
+        curr_name = ctx.spaces.name
         info = dict(name=new_name, description=description, color=color)
+
         ctx.dataset.update_workspace_info(name, info)
+
+        if curr_name is not None and curr_name != new_name:
+            ctx.ops.set_spaces(name=new_name)
 
 
 def _edit_workspace_info_inputs(ctx, inputs):
@@ -2015,12 +2025,11 @@ def _edit_workspace_info_inputs(ctx, inputs):
     for key in workspaces:
         workspace_selector.add_choice(key, label=key)
 
-    current_workspace = ctx.spaces.name if ctx.spaces else None
     inputs.enum(
         "name",
         workspace_selector.values(),
+        default=ctx.spaces.name,
         required=True,
-        default=current_workspace,
         label="Workspace",
         description="The workspace to edit",
         view=workspace_selector,
@@ -2084,11 +2093,11 @@ class DeleteWorkspace(foo.Operator):
             workspace_selector = types.AutocompleteView()
             for key in workspaces:
                 workspace_selector.add_choice(key, label=key)
-            current_workspace = ctx.spaces.name if ctx.spaces else None
+
             inputs.enum(
                 "name",
                 workspace_selector.values(),
-                default=current_workspace,
+                default=ctx.spaces.name,
                 required=True,
                 label="Workspace",
                 description="The workspace to delete",
@@ -2109,7 +2118,11 @@ class DeleteWorkspace(foo.Operator):
     def execute(self, ctx):
         name = ctx.params["name"]
 
+        curr_spaces = name == ctx.spaces.name
         ctx.dataset.delete_workspace(name)
+
+        if curr_spaces:
+            ctx.ops.set_spaces(spaces=default_workspace_factory())
 
 
 class SyncLastModifiedAt(foo.Operator):
@@ -2274,10 +2287,11 @@ def _get_non_default_frame_fields(dataset):
     return schema
 
 
-def _parse_spaces(spaces):
-    if isinstance(spaces, dict):
-        return fo.Space.from_dict(spaces)
-    return fo.Space.from_json(spaces)
+def _parse_spaces(ctx, spaces):
+    if isinstance(spaces, str):
+        spaces = json.loads(spaces)
+
+    return fo.Space.from_dict(spaces)
 
 
 BUILTIN_OPERATORS = [

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -718,6 +718,18 @@ class ExecutionContext(object):
         """Whether query performance is enabled."""
         return self.request_params.get("query_performance", None)
 
+    @property
+    def spaces(self):
+        """The current workspace or the state of spaces in the app."""
+        workspace_name = self.request_params.get("workspace_name", None)
+        if workspace_name is not None:
+            return self.dataset.load_workspace(workspace_name)
+
+        spaces_dict = self.request_params.get("spaces", None)
+        if spaces_dict is None:
+            return None
+        return fo.Space.from_dict(spaces_dict)
+
     def prompt(
         self,
         operator_uri,

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -611,6 +611,19 @@ class ExecutionContext(object):
         return has_stages or has_filters or has_extended
 
     @property
+    def spaces(self):
+        """The current spaces layout in the FiftyOne App."""
+        workspace_name = self.request_params.get("workspace_name", None)
+        if workspace_name is not None:
+            return self.dataset.load_workspace(workspace_name)
+
+        spaces_dict = self.request_params.get("spaces", None)
+        if spaces_dict is not None:
+            return fo.Space.from_dict(spaces_dict)
+
+        return None
+
+    @property
     def selected(self):
         """The list of selected sample IDs (if any)."""
         return self.request_params.get("selected", [])
@@ -717,18 +730,6 @@ class ExecutionContext(object):
     def query_performance(self):
         """Whether query performance is enabled."""
         return self.request_params.get("query_performance", None)
-
-    @property
-    def spaces(self):
-        """The current workspace or the state of spaces in the app."""
-        workspace_name = self.request_params.get("workspace_name", None)
-        if workspace_name is not None:
-            return self.dataset.load_workspace(workspace_name)
-
-        spaces_dict = self.request_params.get("spaces", None)
-        if spaces_dict is None:
-            return None
-        return fo.Space.from_dict(spaces_dict)
 
     def prompt(
         self,

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -310,8 +310,9 @@ class Operations(object):
         on_unload=None,
         on_change=None,
         on_change_ctx=None,
-        on_change_view=None,
         on_change_dataset=None,
+        on_change_view=None,
+        on_change_spaces=None,
         on_change_current_sample=None,
         on_change_selected=None,
         on_change_selected_labels=None,
@@ -342,10 +343,12 @@ class Operations(object):
                 changes
             on_change_ctx (None): an operator to invoke when the panel
                 execution context changes
-            on_change_view (None): an operator to invoke when the current view
-                changes
             on_change_dataset (None): an operator to invoke when the current
                 dataset changes
+            on_change_view (None): an operator to invoke when the current view
+                changes
+            on_change_spaces (None): an operator to invoke when the current
+                spaces layout changes
             on_change_current_sample (None): an operator to invoke when the
                 current sample changes
             on_change_selected (None): an operator to invoke when the current
@@ -356,7 +359,6 @@ class Operations(object):
                 current extended selection changes
             on_change_group_slice (None): an operator to invoke when the group
                 slice changes
-            on_change_spaces (None): an operator to invoke when the current spaces changes
             allow_duplicates (False): whether to allow multiple instances of
                 the panel to the opened
         """
@@ -373,8 +375,9 @@ class Operations(object):
             "on_unload": on_unload,
             "on_change": on_change,
             "on_change_ctx": on_change_ctx,
-            "on_change_view": on_change_view,
             "on_change_dataset": on_change_dataset,
+            "on_change_view": on_change_view,
+            "on_change_spaces": on_change_spaces,
             "on_change_current_sample": on_change_current_sample,
             "on_change_selected": on_change_selected,
             "on_change_selected_labels": on_change_selected_labels,

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -356,6 +356,7 @@ class Operations(object):
                 current extended selection changes
             on_change_group_slice (None): an operator to invoke when the group
                 slice changes
+            on_change_spaces (None): an operator to invoke when the current spaces changes
             allow_duplicates (False): whether to allow multiple instances of
                 the panel to the opened
         """

--- a/fiftyone/operators/panel.py
+++ b/fiftyone/operators/panel.py
@@ -119,14 +119,14 @@ class Panel(Operator):
         methods = ["on_load", "on_unload", "on_change"]
         ctx_change_events = [
             "on_change_ctx",
-            "on_change_view",
             "on_change_dataset",
+            "on_change_view",
+            "on_change_spaces",
             "on_change_current_sample",
             "on_change_selected",
             "on_change_selected_labels",
             "on_change_extended_selection",
             "on_change_group_slice",
-            "on_change_spaces",
         ]
         for method in methods + ctx_change_events:
             if hasattr(self, method) and callable(getattr(self, method)):

--- a/fiftyone/operators/panel.py
+++ b/fiftyone/operators/panel.py
@@ -126,6 +126,7 @@ class Panel(Operator):
             "on_change_selected_labels",
             "on_change_extended_selection",
             "on_change_group_slice",
+            "on_change_spaces",
         ]
         for method in methods + ctx_change_events:
             if hasattr(self, method) and callable(getattr(self, method)):


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Add `spaces` to operator context
- Add panel events for spaces and workspace change

## How is this patch tested? If it is not, please explain why.

Using a test panel and operator

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

See above

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced `CustomPanel` to handle changes in spaces and workspace contexts.
	- Added new properties to the `ExecutionContext` for improved context management during operator execution.
	- Introduced optional parameters in the `register_panel` method to respond to changes in spaces and workspace.
	- Improved workspace management features with context-aware defaults for user inputs.
	- Expanded `Panel` class to handle additional context change events during startup.

- **Documentation**
	- Updated documentation for developing plugins to include new methods for managing spaces and workspace state changes.

These updates improve user interaction and flexibility within the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->