### PR TITLE
ID_LIKE fallback for fiftyone-db

### DIFF
--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -175,7 +175,7 @@ def _get_download():
 MONGODB_BINARIES = ["mongod"]
 
 
-VERSION = "1.1.6"
+VERSION = "1.1.7"
 
 
 def get_version():

--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -148,7 +148,11 @@ def _get_linux_download():
         # filter empty lines
         d = dict(line for line in reader if line)
 
-    for k, v in LINUX_DOWNLOADS[d["ID"].lower()].items():
+    key = d["ID"].lower()
+    if key not in LINUX_DOWNLOADS:
+        key = d["ID_LIKE"].lower()
+
+    for k, v in LINUX_DOWNLOADS[key].items():
         if d["VERSION_ID"].startswith(k):
             return v[MACHINE]
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

To support more Linux varieties, e.g. `Aurora` based on `Fedora`, fall back to the `ID_LIKE` entry in `/etc/os-release`

```
NAME="Aurora"
VERSION="40.20240930.0 (Kinoite)"
ID=aurora
ID_LIKE="fedora"
VERSION_ID=40
VERSION_CODENAME="Archaeopteryx"
PLATFORM_ID="platform:f40"
``` 

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved support for various Linux distributions during package installation.
- **Version Update**
	- Updated package version from 1.1.6 to 1.1.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->