### PR TITLE
Adding confidence to SAM predictions from box prompts

### DIFF
--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -271,14 +271,19 @@ class SegmentAnythingModel(fout.TorchSamplesMixin, fout.TorchImageModel):
                 device=sam_predictor.device,
             )
 
-            masks, _, _ = sam_predictor.predict_torch(
+            masks, scores, _ = sam_predictor.predict_torch(
                 point_coords=None,
                 point_labels=None,
                 boxes=transformed_boxes,
                 multimask_output=False,
             )
             outputs.append(
-                {"boxes": input_boxes, "labels": labels, "masks": masks}
+                {
+                    "boxes": input_boxes,
+                    "labels": labels,
+                    "masks": masks,
+                    "scores": scores,
+                }
             )
 
         return outputs

--- a/fiftyone/utils/sam2.py
+++ b/fiftyone/utils/sam2.py
@@ -201,7 +201,7 @@ class SegmentAnything2ImageModel(fosam.SegmentAnythingModel):
                 device=sam2_predictor.device,
             )
 
-            masks, _, _ = sam2_predictor.predict(
+            masks, scores, _ = sam2_predictor.predict(
                 point_coords=None,
                 point_labels=None,
                 box=sam_boxes[None, :],
@@ -214,6 +214,9 @@ class SegmentAnything2ImageModel(fosam.SegmentAnythingModel):
                     "boxes": input_boxes,
                     "labels": labels,
                     "masks": torch.tensor(masks, device=sam2_predictor.device),
+                    "scores": torch.tensor(
+                        scores, device=sam2_predictor.device
+                    ),
                 }
             )
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Added confidence scores to SAM predictions that are generate from bounding box prompts

## How is this patch tested? If it is not, please explain why.

Tested manually by applying model on a dataset and confirming that confidence scores are saved on the predictions.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other: SAM utils changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced prediction outputs for the segmentation models to include confidence scores alongside existing data (boxes, labels, masks).
	- Improved consistency in output formats across different model methods.

- **Bug Fixes**
	- Updated method signatures to ensure accurate return values for both segmentation models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->