### PR TITLE
use required_state in DO.execute_operation, for atomicity

### DIFF
--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -445,7 +445,24 @@ class DelegatedOperationService(object):
                 information about the operation
         """
         try:
-            self.set_running(doc_id=operation.id, run_link=run_link)
+            succeeded = (
+                self.set_running(
+                    doc_id=operation.id,
+                    run_link=run_link,
+                    required_state=ExecutionRunState.QUEUED,
+                )
+                is not None
+            )
+            if not succeeded:
+                if log:
+                    logger.debug(
+                        "Not executing operation %s (%s) which is "
+                        "no longer in QUEUED state, or doesn't exist.",
+                        operation.id,
+                        operation.operator,
+                    )
+                return
+
             if log:
                 logger.info(
                     "\nRunning operation %s (%s)",

--- a/tests/unittests/delegated_operators_tests.py
+++ b/tests/unittests/delegated_operators_tests.py
@@ -625,7 +625,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         mock_get_operator.return_value = operator
         doc = self.svc.queue_operation(
             operator="@voxelfiftyone/operator/foo",
-            delegation_target=f"test_target",
+            delegation_target="test_target",
             context=ExecutionContext(request_params={"foo": "bar"}),
             metadata={"inputs_schema": mock_inputs.to_json()},
         )
@@ -657,7 +657,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         doc = self.svc.queue_operation(
             operator="@voxelfiftyone/operator/foo",
             label=mock_get_operator.return_value.name,
-            delegation_target=f"test_target",
+            delegation_target="test_target",
             context=ctx.serialize(),
         )
 
@@ -694,7 +694,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         doc = self.svc.queue_operation(
             operator="@voxelfiftyone/operator/foo",
             label=get_op_mock.return_value.name,
-            delegation_target=f"test_target",
+            delegation_target="test_target",
             context=ctx.serialize(),
         )
 
@@ -744,7 +744,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         doc = self.svc.queue_operation(
             operator="@voxelfiftyone/operator/foo",
             label=get_op_mock.return_value.name,
-            delegation_target=f"test_target",
+            delegation_target="test_target",
             context=ctx.serialize(),
         )
 
@@ -809,7 +809,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         doc = self.svc.queue_operation(
             operator="@voxelfiftyone/operator/foo",
             label=get_op_mock.return_value.name,
-            delegation_target=f"test_target",
+            delegation_target="test_target",
             context=ctx.serialize(),
         )
 
@@ -991,7 +991,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         doc = self.svc.queue_operation(
             operator="@voxelfiftyone/operator/foo",
             label=mock_get_operator.return_value.name,
-            delegation_target=f"test_target",
+            delegation_target="test_target",
             context=ctx.serialize(),
         )
 
@@ -1222,7 +1222,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         doc = self.svc.queue_operation(
             operator="@voxelfiftyone/operator/foo",
             label=mock_get_operator.return_value.name,
-            delegation_target=f"test_target",
+            delegation_target="test_target",
             context=ctx.serialize(),
         )
         self.assertEqual(doc.label, mock_get_operator.return_value.name)
@@ -1252,7 +1252,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         doc = self.svc.queue_operation(
             operator="@voxelfiftyone/operator/foo",
             label=mock_get_operator.return_value.name,
-            delegation_target=f"test_target",
+            delegation_target="test_target",
             context=ctx.serialize(),
         )
         self.assertEqual(doc.label, mock_get_operator.return_value.name)

--- a/tests/unittests/delegated_operators_tests.py
+++ b/tests/unittests/delegated_operators_tests.py
@@ -629,6 +629,9 @@ class DelegatedOperationServiceTests(unittest.TestCase):
             context=ExecutionContext(request_params={"foo": "bar"}),
             metadata={"inputs_schema": mock_inputs.to_json()},
         )
+
+        # Set it to running separately - execution not allowed now because
+        #   it's running elsewhere.
         self.svc.set_running(doc.id)
 
         self.svc.execute_operation(doc)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Use `required_state=QUEUED` in `dos.execute_operation()` to make sure it only gets run once.

## How is this patch tested? If it is not, please explain why.

Added new test

```python
dos = food.DelegatedOperationService()
doc = dos.queue_operation(...)
dos.set_running(doc.id)

# Returns immediately, does not log INFO that operator is executing
dos.execute_operation(doc, log=True) 
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced operation execution control to ensure operations are only executed when in the QUEUED state.
  
- **Bug Fixes**
	- Improved handling of operation states to prevent execution of operations not in the expected state.

- **Tests**
	- Added a test to ensure operations cannot be executed unless they are in the QUEUED state, enhancing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->