### PR TITLE
delegated operator fixes

### DIFF
--- a/tests/unittests/operators/delegated_tests.py
+++ b/tests/unittests/operators/delegated_tests.py
@@ -11,6 +11,7 @@ import unittest
 from unittest import mock
 from unittest.mock import patch
 
+import bson
 import pytest
 
 import fiftyone
@@ -483,6 +484,35 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.assertEqual(doc.status.progress, 0.5)
         self.assertEqual(doc.status.label, "halfway there")
         self.assertIsNotNone(doc.status.updated_at)
+
+    def test_output_schema_null_metadata(
+        self, mock_get_operator, mock_operator_exists
+    ):
+        mock_outputs = MockOutputs()
+        doc = self.svc.queue_operation(
+            operator="@voxelfiftyone/operator/foo",
+            delegation_target="test_target",
+            context=ExecutionContext(request_params={"foo": "bar"}),
+        )
+
+        # Set metadata to null instead of being unset, to test that corner case
+        self.svc._repo._collection.find_one_and_update(
+            {"_id": bson.ObjectId(doc.id)}, {"$set": {"metadata": None}}
+        )
+
+        self.svc.set_completed(
+            doc.id,
+            result=ExecutionResult(outputs_schema=mock_outputs.to_json()),
+        )
+
+        doc = self.svc.get(doc_id=doc.id)
+        self.assertEqual(doc.run_state, ExecutionRunState.COMPLETED)
+        self.assertEqual(
+            doc.metadata,
+            {
+                "outputs_schema": mock_outputs.to_json(),
+            },
+        )
 
     @patch(
         "fiftyone.core.odm.utils.load_dataset",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Addresses some weirdness introduced in https://github.com/voxel51/fiftyone/pull/4436.

1. I believe the `if` on line 272 should be indented to be under the `COMPLETED` case. Otherwise the if statement flow is goofy and should be reworked anyways.
2. Passing an array as the `update` param is unusual, though legal. I'm wondering what was intended with the addition of the `$ifNull`? As written, I don't think it does much because the `output_schema` is fixed.

## How is this patch tested? If it is not, please explain why.

test still passes

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced logic for updating operation states, ensuring correct handling of null metadata.
  
- **Bug Fixes**
	- Improved handling of `outputs_schema` to prevent unintended document creation.

- **Tests**
	- Added a test case to verify system behavior when metadata is null, ensuring robust updates to `outputs_schema`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->