### PR TITLE
Add PillBadgeView to Python Panels

### DIFF
--- a/app/packages/components/src/components/PillBadge/PillBadge.tsx
+++ b/app/packages/components/src/components/PillBadge/PillBadge.tsx
@@ -4,7 +4,7 @@ import { Chip, FormControl, MenuItem, Select } from "@mui/material";
 
 const PillBadge = ({
   text,
-  color,
+  color = "default",
   variant = "filled",
   showIcon = true,
 }: {
@@ -22,6 +22,9 @@ const PillBadge = ({
         : text[0]
       : ""
   );
+  const [chipColor, setChipColor] = useState(
+    typeof text === "string" ? color : Array.isArray(text) ? text[0][1] : color
+  );
   const COLORS: { [key: string]: string } = {
     default: "#999999",
     primary: "#FFB682",
@@ -32,7 +35,7 @@ const PillBadge = ({
   };
 
   const chipStyle: { [key: string]: string | number } = {
-    color: COLORS[color || "default"],
+    color: COLORS[chipColor || "default"],
     fontWeight: 500,
     paddingLeft: 1,
   };
@@ -72,13 +75,15 @@ const PillBadge = ({
                   value={chipSelection}
                   variant={"standard"}
                   disableUnderline={true}
-                  onChange={(event) =>
-                    setChipSelection(event.target.value as string)
-                  }
+                  onChange={(event) => {
+                    const selectedText = text.find(
+                      (t) => t[0] === event.target.value
+                    );
+                    setChipSelection(event.target.value);
+                    setChipColor(selectedText?.[1] ?? "default");
+                  }}
                   sx={{
-                    color: COLORS[color || "default"],
-                    boxShadow: "none",
-                    textShadow: "none",
+                    color: "inherit",
                   }}
                 >
                   {text.map((t, index) => (
@@ -96,9 +101,7 @@ const PillBadge = ({
                     setChipSelection(event.target.value as string)
                   }
                   sx={{
-                    color: COLORS[color || "default"],
-                    boxShadow: "none",
-                    textShadow: "none",
+                    color: "inherit",
                   }}
                 >
                   {text.map((t, index) => (
@@ -116,6 +119,9 @@ const PillBadge = ({
               },
               "& .MuiChip-label": {
                 marginBottom: "1px",
+              },
+              "& .MuiInput-input:focus": {
+                backgroundColor: "inherit",
               },
             }}
             variant={variant as "filled" | "outlined" | undefined}

--- a/app/packages/components/src/components/PillBadge/PillBadge.tsx
+++ b/app/packages/components/src/components/PillBadge/PillBadge.tsx
@@ -23,8 +23,15 @@ const PillBadge = ({
       : ""
   );
   const [chipColor, setChipColor] = useState(
-    typeof text === "string" ? color : Array.isArray(text) ? text[0][1] : color
+    typeof text === "string"
+      ? color
+      : Array.isArray(text)
+      ? Array.isArray(text[0])
+        ? text[0][1]
+        : color || "default"
+      : "default"
   );
+
   const COLORS: { [key: string]: string } = {
     default: "#999999",
     primary: "#FFB682",
@@ -35,7 +42,7 @@ const PillBadge = ({
   };
 
   const chipStyle: { [key: string]: string | number } = {
-    color: COLORS[chipColor || "default"],
+    color: COLORS[chipColor || "default"] || COLORS.default,
     fontWeight: 500,
     paddingLeft: 1,
   };
@@ -97,9 +104,7 @@ const PillBadge = ({
                   value={chipSelection}
                   variant={"standard"}
                   disableUnderline={true}
-                  onChange={(event) =>
-                    setChipSelection(event.target.value as string)
-                  }
+                  onChange={(event) => setChipSelection(event.target.value)}
                   sx={{
                     color: "inherit",
                   }}

--- a/app/packages/components/src/components/PillBadge/PillBadge.tsx
+++ b/app/packages/components/src/components/PillBadge/PillBadge.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { Badge, Chip } from "@mui/material";
+import CircleIcon from "@mui/icons-material/Circle";
+import { Chip } from "@mui/material";
 
 const PillBadge = ({
   text,
@@ -11,20 +12,32 @@ const PillBadge = ({
   variant?: "filled" | "outlined";
 }) => {
   const COLORS: { [key: string]: string } = {
-    default: "#777777",
+    default: "#999999",
     primary: "#FFB682",
     error: "error",
     warning: "warning",
     info: "info",
     success: "#8BC18D",
   };
+
+  const chipStyle: { [key: string]: string | number } = {
+    color: COLORS[color || "default"],
+    fontWeight: 500,
+    paddingLeft: 1,
+  };
+
   return (
     <span>
       {typeof text === "string" ? (
         <Chip
-          icon={<Badge />}
+          icon={<CircleIcon color={"inherit"} sx={{ fontSize: 10 }} />}
           label={text}
-          sx={{ color: COLORS[color || "default"], fontWeight: 500 }}
+          sx={{
+            ...chipStyle,
+            "& .MuiChip-label": {
+              marginBottom: "2px",
+            },
+          }}
           variant={variant as "filled" | "outlined" | undefined}
         />
       ) : (

--- a/app/packages/components/src/components/PillBadge/PillBadge.tsx
+++ b/app/packages/components/src/components/PillBadge/PillBadge.tsx
@@ -1,26 +1,16 @@
 import React from "react";
 import { Badge, Chip } from "@mui/material";
 
-const PillBadge = ({
-  text,
-  style,
-}: {
-  text: string;
-  color?: string;
-  style?: React.CSSProperties;
-}) => {
-  COLORS = {
-    default: "grey",
-    success: "green",
-    warning: "orange",
-    error: "red",
+const PillBadge = ({ text, color }: { text: string; color?: string }) => {
+  const COLORS: { [key: string]: string } = {
+    default: "#777777",
+    primary: "#FFB682",
+    error: "error",
+    warning: "warning",
+    info: "info",
+    success: "#8BC18D",
   };
-  return (
-    <span style={style ?? {}}>
-      <Chip icon={<Badge />} label={text} variant={} />
-      {text}
-    </span>
-  );
+  return <Chip icon={<Badge />} label={text} variant={} />;
 };
 
 export default PillBadge;

--- a/app/packages/components/src/components/PillBadge/PillBadge.tsx
+++ b/app/packages/components/src/components/PillBadge/PillBadge.tsx
@@ -4,11 +4,11 @@ import { Badge, Chip } from "@mui/material";
 const PillBadge = ({
   text,
   color,
-  variant,
+  variant = "filled",
 }: {
-  text: string;
+  text: string | string[];
   color?: string;
-  variant?: string;
+  variant?: "filled" | "outlined";
 }) => {
   const COLORS: { [key: string]: string } = {
     default: "#777777",
@@ -18,7 +18,20 @@ const PillBadge = ({
     info: "info",
     success: "#8BC18D",
   };
-  return <Chip label={text} />;
+  return (
+    <span>
+      {typeof text === "string" ? (
+        <Chip
+          icon={<Badge />}
+          label={text}
+          sx={{ color: COLORS[color || "default"], fontWeight: 500 }}
+          variant={variant as "filled" | "outlined" | undefined}
+        />
+      ) : (
+        <Chip />
+      )}
+    </span>
+  );
 };
 
 export default PillBadge;

--- a/app/packages/components/src/components/PillBadge/PillBadge.tsx
+++ b/app/packages/components/src/components/PillBadge/PillBadge.tsx
@@ -86,7 +86,7 @@ const PillBadge = ({
               ) : undefined
             }
             label={
-              Array.isArray(text) && Array.isArray(text[0]) ? (
+              Array.isArray(text) && text.length > 0 && Array.isArray(text[0]) ? (
                 <Select
                   value={chipSelection}
                   variant={"standard"}

--- a/app/packages/components/src/components/PillBadge/PillBadge.tsx
+++ b/app/packages/components/src/components/PillBadge/PillBadge.tsx
@@ -1,16 +1,25 @@
-import React from "react";
+import React, { useState } from "react";
 import CircleIcon from "@mui/icons-material/Circle";
-import { Chip } from "@mui/material";
+import { Chip, FormControl, MenuItem, Select } from "@mui/material";
 
 const PillBadge = ({
   text,
   color,
   variant = "filled",
 }: {
-  text: string | string[];
+  text: string | string[] | [string, string][];
   color?: string;
   variant?: "filled" | "outlined";
 }) => {
+  const [chipSelection, setChipSelection] = useState(
+    typeof text === "string"
+      ? text
+      : Array.isArray(text)
+      ? Array.isArray(text[0])
+        ? text[0][0]
+        : text[0]
+      : ""
+  );
   const COLORS: { [key: string]: string } = {
     default: "#999999",
     primary: "#FFB682",
@@ -34,14 +43,74 @@ const PillBadge = ({
           label={text}
           sx={{
             ...chipStyle,
+            "& .MuiChip-icon": {
+              marginRight: "-7px",
+            },
             "& .MuiChip-label": {
-              marginBottom: "2px",
+              marginBottom: "1px",
             },
           }}
           variant={variant as "filled" | "outlined" | undefined}
         />
       ) : (
-        <Chip />
+        <FormControl fullWidth>
+          <Chip
+            icon={<CircleIcon color={"inherit"} sx={{ fontSize: 10 }} />}
+            label={
+              Array.isArray(text) && Array.isArray(text[0]) ? (
+                <Select
+                  value={chipSelection}
+                  variant={"standard"}
+                  disableUnderline={true}
+                  onChange={(event) =>
+                    setChipSelection(event.target.value as string)
+                  }
+                  sx={{
+                    color: COLORS[color || "default"],
+                    boxShadow: "none",
+                    textShadow: "none",
+                  }}
+                >
+                  {text.map((t, index) => (
+                    <MenuItem key={index} value={t[0]}>
+                      {t[0]}
+                    </MenuItem>
+                  ))}
+                </Select>
+              ) : (
+                <Select
+                  value={chipSelection}
+                  variant={"standard"}
+                  disableUnderline={true}
+                  onChange={(event) =>
+                    setChipSelection(event.target.value as string)
+                  }
+                  sx={{
+                    color: COLORS[color || "default"],
+                    boxShadow: "none",
+                    textShadow: "none",
+                  }}
+                >
+                  {text.map((t, index) => (
+                    <MenuItem key={index} value={t}>
+                      {t}
+                    </MenuItem>
+                  ))}
+                </Select>
+              )
+            }
+            sx={{
+              ...chipStyle,
+              "& .MuiChip-icon": {
+                marginRight: "-7px",
+              },
+              "& .MuiChip-label": {
+                marginBottom: "1px",
+              },
+            }}
+            variant={variant as "filled" | "outlined" | undefined}
+          ></Chip>
+        </FormControl>
       )}
     </span>
   );

--- a/app/packages/components/src/components/PillBadge/PillBadge.tsx
+++ b/app/packages/components/src/components/PillBadge/PillBadge.tsx
@@ -6,10 +6,12 @@ const PillBadge = ({
   text,
   color,
   variant = "filled",
+  showIcon = true,
 }: {
   text: string | string[] | [string, string][];
   color?: string;
   variant?: "filled" | "outlined";
+  showIcon?: boolean;
 }) => {
   const [chipSelection, setChipSelection] = useState(
     typeof text === "string"
@@ -39,7 +41,11 @@ const PillBadge = ({
     <span>
       {typeof text === "string" ? (
         <Chip
-          icon={<CircleIcon color={"inherit"} sx={{ fontSize: 10 }} />}
+          icon={
+            showIcon ? (
+              <CircleIcon color={"inherit"} sx={{ fontSize: 10 }} />
+            ) : undefined
+          }
           label={text}
           sx={{
             ...chipStyle,
@@ -55,7 +61,11 @@ const PillBadge = ({
       ) : (
         <FormControl fullWidth>
           <Chip
-            icon={<CircleIcon color={"inherit"} sx={{ fontSize: 10 }} />}
+            icon={
+              showIcon ? (
+                <CircleIcon color={"inherit"} sx={{ fontSize: 10 }} />
+              ) : undefined
+            }
             label={
               Array.isArray(text) && Array.isArray(text[0]) ? (
                 <Select

--- a/app/packages/components/src/components/PillBadge/PillBadge.tsx
+++ b/app/packages/components/src/components/PillBadge/PillBadge.tsx
@@ -1,7 +1,15 @@
 import React from "react";
 import { Badge, Chip } from "@mui/material";
 
-const PillBadge = ({ text, color }: { text: string; color?: string }) => {
+const PillBadge = ({
+  text,
+  color,
+  variant,
+}: {
+  text: string;
+  color?: string;
+  variant?: string;
+}) => {
   const COLORS: { [key: string]: string } = {
     default: "#777777",
     primary: "#FFB682",
@@ -10,7 +18,7 @@ const PillBadge = ({ text, color }: { text: string; color?: string }) => {
     info: "info",
     success: "#8BC18D",
   };
-  return <Chip icon={<Badge />} label={text} variant={} />;
+  return <Chip label={text} />;
 };
 
 export default PillBadge;

--- a/app/packages/components/src/components/PillBadge/PillBadge.tsx
+++ b/app/packages/components/src/components/PillBadge/PillBadge.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Badge, Chip } from "@mui/material";
+
+const PillBadge = ({
+  text,
+  style,
+}: {
+  text: string;
+  color?: string;
+  style?: React.CSSProperties;
+}) => {
+  COLORS = {
+    default: "grey",
+    success: "green",
+    warning: "orange",
+    error: "red",
+  };
+  return (
+    <span style={style ?? {}}>
+      <Chip icon={<Badge />} label={text} variant={} />
+      {text}
+    </span>
+  );
+};
+
+export default PillBadge;

--- a/app/packages/components/src/components/PillBadge/PillBadge.tsx
+++ b/app/packages/components/src/components/PillBadge/PillBadge.tsx
@@ -13,24 +13,33 @@ const PillBadge = ({
   variant?: "filled" | "outlined";
   showIcon?: boolean;
 }) => {
+  const getInitialChipSelection = (
+    text: string | string[] | [string, string][]
+  ) => {
+    if (typeof text === "string") return text;
+    if (Array.isArray(text)) {
+      if (Array.isArray(text[0])) return text[0][0];
+      return text[0];
+    }
+    return "";
+  };
+
+  const getInitialChipColor = (
+    text: string | string[] | [string, string][],
+    color?: string
+  ) => {
+    if (typeof text === "string") return color;
+    if (Array.isArray(text)) {
+      if (Array.isArray(text[0])) return text[0][1];
+      return color || "default";
+    }
+    return "default";
+  };
+
   const [chipSelection, setChipSelection] = useState(
-    typeof text === "string"
-      ? text
-      : Array.isArray(text)
-      ? Array.isArray(text[0])
-        ? text[0][0]
-        : text[0]
-      : ""
+    getInitialChipSelection(text)
   );
-  const [chipColor, setChipColor] = useState(
-    typeof text === "string"
-      ? color
-      : Array.isArray(text)
-      ? Array.isArray(text[0])
-        ? text[0][1]
-        : color || "default"
-      : "default"
-  );
+  const [chipColor, setChipColor] = useState(getInitialChipColor(text, color));
 
   const COLORS: { [key: string]: string } = {
     default: "#999999",

--- a/app/packages/components/src/components/PillBadge/index.ts
+++ b/app/packages/components/src/components/PillBadge/index.ts
@@ -1,0 +1,1 @@
+export { default as PillBadge } from "./PillBadge";

--- a/app/packages/core/src/components/Modal/use-looker.ts
+++ b/app/packages/core/src/components/Modal/use-looker.ts
@@ -56,7 +56,7 @@ function useLooker<L extends fos.Lookers>({
     colorScheme;
     /** end refreshers */
 
-    !initialRef.current && looker.updateSample(sample);
+    !initialRef.current && looker.updateSample(sample.sample);
   }, [colorScheme, looker, sample]);
 
   useEffect(() => {

--- a/app/packages/core/src/plugins/SchemaIO/components/PillBadgeView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/PillBadgeView.tsx
@@ -6,10 +6,16 @@ import PillBadge from "@fiftyone/components/src/components/PillBadge/PillBadge";
 export default function PillBadgeView(props) {
   const { schema } = props;
   const { view = {} } = schema;
+  const { text, color, variant } = view;
 
   return (
     <Box {...getComponentProps(props, "container")}>
-      <PillBadge text={"..."} {...getComponentProps(props, "pillBadge")} />
+      <PillBadge
+        text={text}
+        color={color}
+        variant={variant}
+        {...getComponentProps(props, "pillBadge")}
+      />
     </Box>
   );
 }

--- a/app/packages/core/src/plugins/SchemaIO/components/PillBadgeView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/PillBadgeView.tsx
@@ -6,7 +6,7 @@ import PillBadge from "@fiftyone/components/src/components/PillBadge/PillBadge";
 export default function PillBadgeView(props) {
   const { schema } = props;
   const { view = {} } = schema;
-  const { text, color, variant } = view;
+  const { text, color, variant, showIcon } = view;
 
   return (
     <Box {...getComponentProps(props, "container")}>
@@ -14,6 +14,7 @@ export default function PillBadgeView(props) {
         text={text}
         color={color}
         variant={variant}
+        showIcon={showIcon}
         {...getComponentProps(props, "pillBadge")}
       />
     </Box>

--- a/app/packages/core/src/plugins/SchemaIO/components/PillBadgeView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/PillBadgeView.tsx
@@ -1,0 +1,15 @@
+import { Box } from "@mui/material";
+import React from "react";
+import { getComponentProps } from "../utils";
+import PillBadge from "@fiftyone/components/src/components/PillBadge/PillBadge";
+
+export default function PillBadgeView(props) {
+  const { schema } = props;
+  const { view = {} } = schema;
+
+  return (
+    <Box {...getComponentProps(props, "container")}>
+      <PillBadge text={"..."} {...getComponentProps(props, "pillBadge")} />
+    </Box>
+  );
+}

--- a/app/packages/core/src/plugins/SchemaIO/components/index.ts
+++ b/app/packages/core/src/plugins/SchemaIO/components/index.ts
@@ -49,3 +49,4 @@ export { default as TextFieldView } from "./TextFieldView";
 export { default as TupleView } from "./TupleView";
 export { default as UnsupportedView } from "./UnsupportedView";
 export { default as FrameLoaderView } from "./FrameLoaderView";
+export { default as PillBadgeView } from "./PillBadgeView";

--- a/e2e-pw/src/oss/specs/sidebar/frame-filtering.spec.ts
+++ b/e2e-pw/src/oss/specs/sidebar/frame-filtering.spec.ts
@@ -33,7 +33,7 @@ test.describe("frame filtering", () => {
       for name, disable in datasets:
         dataset = foz.load_zoo_dataset("quickstart-video", dataset_name=name, max_samples=1)
         dataset.app_config.disable_frame_filtering = disable
-        dataset.persist = True
+        dataset.persistent = True
         dataset.save()
       `
     );

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -1479,7 +1479,7 @@ class PillBadgeView(ReadOnlyView):
     """Displays a pill shaped badge.
 
     Args:
-        text ("Reviewed" | ["Reviewed", "Not Reviewed"]): a label or set of label options for the pill badge
+        text ("Reviewed" | ["Reviewed", "Not Reviewed"] | [["Not Started", "primary"], ["Reviewed", "success"], ["In Review", "warning"]): a label or set of label options with or without a color for the pill badge
         color ("primary"): the color of the pill
         variant ("outlined"): the variant of the pill
     """

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -1482,6 +1482,7 @@ class PillBadgeView(ReadOnlyView):
         text ("Reviewed" | ["Reviewed", "Not Reviewed"] | [["Not Started", "primary"], ["Reviewed", "success"], ["In Review", "warning"]): a label or set of label options with or without a color for the pill badge
         color ("primary"): the color of the pill
         variant ("outlined"): the variant of the pill
+        show_icon (False | True): whether to display indicator icon
     """
 
     def __init__(self, **kwargs):

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -1475,6 +1475,19 @@ class LoadingView(ReadOnlyView):
         super().__init__(**kwargs)
 
 
+class PillBadgeView(ReadOnlyView):
+    """Displays a pill shaped badge.
+
+    Args:
+        text ("Reviewed"): a label for the pill badge
+        color ("primary"): the color of the pill
+        variant ("outlined"): the variant of the pill
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
 class PlotlyView(View):
     """Displays a Plotly chart.
 

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -1479,7 +1479,7 @@ class PillBadgeView(ReadOnlyView):
     """Displays a pill shaped badge.
 
     Args:
-        text ("Reviewed"): a label for the pill badge
+        text ("Reviewed" | ["Reviewed", "Not Reviewed"]): a label or set of label options for the pill badge
         color ("primary"): the color of the pill
         variant ("outlined"): the variant of the pill
     """

--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -271,14 +271,19 @@ class SegmentAnythingModel(fout.TorchSamplesMixin, fout.TorchImageModel):
                 device=sam_predictor.device,
             )
 
-            masks, _, _ = sam_predictor.predict_torch(
+            masks, scores, _ = sam_predictor.predict_torch(
                 point_coords=None,
                 point_labels=None,
                 boxes=transformed_boxes,
                 multimask_output=False,
             )
             outputs.append(
-                {"boxes": input_boxes, "labels": labels, "masks": masks}
+                {
+                    "boxes": input_boxes,
+                    "labels": labels,
+                    "masks": masks,
+                    "scores": scores,
+                }
             )
 
         return outputs

--- a/fiftyone/utils/sam2.py
+++ b/fiftyone/utils/sam2.py
@@ -201,7 +201,7 @@ class SegmentAnything2ImageModel(fosam.SegmentAnythingModel):
                 device=sam2_predictor.device,
             )
 
-            masks, _, _ = sam2_predictor.predict(
+            masks, scores, _ = sam2_predictor.predict(
                 point_coords=None,
                 point_labels=None,
                 box=sam_boxes[None, :],
@@ -214,6 +214,9 @@ class SegmentAnything2ImageModel(fosam.SegmentAnythingModel):
                     "boxes": input_boxes,
                     "labels": labels,
                     "masks": torch.tensor(masks, device=sam2_predictor.device),
+                    "scores": torch.tensor(
+                        scores, device=sam2_predictor.device
+                    ),
                 }
             )
 


### PR DESCRIPTION
Adds a `PillBadgeView` to Python Panels which is a MuiChip component capable of rendering itself as a dropdown menu of options, color-coded or not (if desired). The indicator icon is also optional and can be enabled or removed with a `showIcon` flag



https://github.com/user-attachments/assets/a5ecf162-1ec9-4afb-9356-7a123467fd13

<img width="1461" alt="Screenshot 2024-10-10 at 12 38 22 AM" src="https://github.com/user-attachments/assets/c37f1122-be02-4cc8-a1bb-8200e22dce33">

https://github.com/user-attachments/assets/4acdf1d3-a4e2-4eea-9d55-1b0db4e55b87



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the `PillBadge` component for displaying customizable pill-shaped badges.
	- Added the `PillBadgeView` component to render `PillBadge` within a structured layout.
  
- **Bug Fixes**
	- Updated the persistence property in tests for correct dataset configuration.

- **Documentation**
	- Exported new components for easier access in other modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->