### PR TITLE
Fix video tooltip

### DIFF
--- a/app/packages/core/src/components/ColorModal/ColorFooter.tsx
+++ b/app/packages/core/src/components/ColorModal/ColorFooter.tsx
@@ -3,7 +3,7 @@ import * as foq from "@fiftyone/relay";
 import * as fos from "@fiftyone/state";
 import React, { useEffect } from "react";
 import { useMutation } from "react-relay";
-import { useRecoilState, useRecoilValue } from "recoil";
+import { useRecoilValue } from "recoil";
 import { ButtonGroup, ModalActionButtonContainer } from "./ShareStyledDiv";
 import { activeColorEntry } from "./state";
 
@@ -14,8 +14,7 @@ const ColorFooter: React.FC = () => {
     ? canEditCustomColors.message
     : "Save to dataset app config";
   const setColorScheme = fos.useSetSessionColorScheme();
-  const [activeColorModalField, setActiveColorModalField] =
-    useRecoilState(activeColorEntry);
+  const activeColorModalField = useRecoilValue(activeColorEntry);
   const [setDatasetColorScheme] =
     useMutation<foq.setDatasetColorSchemeMutation>(foq.setDatasetColorScheme);
   const colorScheme = useRecoilValue(fos.colorScheme);
@@ -26,8 +25,8 @@ const ColorFooter: React.FC = () => {
   const subscription = useRecoilValue(fos.stateSubscription);
 
   useEffect(
-    () => foq.subscribe(() => setActiveColorModalField(null)),
-    [setActiveColorModalField]
+    () => foq.subscribe((_, { set }) => set(activeColorEntry, null)),
+    []
   );
 
   if (!activeColorModalField) return null;

--- a/app/packages/core/src/components/Modal/ModalLooker.tsx
+++ b/app/packages/core/src/components/Modal/ModalLooker.tsx
@@ -1,11 +1,10 @@
 import { useTheme } from "@fiftyone/components";
 import type { ImageLooker } from "@fiftyone/looker";
 import * as fos from "@fiftyone/state";
-import React, { useEffect, useMemo } from "react";
-import { useRecoilCallback, useRecoilValue, useSetRecoilState } from "recoil";
+import React, { useMemo } from "react";
+import { useRecoilCallback, useRecoilValue } from "recoil";
 import { ImaVidLookerReact } from "./ImaVidLooker";
 import { VideoLookerReact } from "./VideoLooker";
-import { useModalContext } from "./hooks";
 import useLooker from "./use-looker";
 
 export const useShowOverlays = () => {
@@ -28,21 +27,8 @@ interface LookerProps {
 }
 
 const ModalLookerNoTimeline = React.memo((props: LookerProps) => {
-  const { id, looker, ref } = useLooker<ImageLooker>(props);
+  const { id, ref } = useLooker<ImageLooker>(props);
   const theme = useTheme();
-  const setModalLooker = useSetRecoilState(fos.modalLooker);
-
-  const { setActiveLookerRef } = useModalContext();
-
-  useEffect(() => {
-    setModalLooker(looker);
-  }, [looker, setModalLooker]);
-
-  useEffect(() => {
-    if (looker) {
-      setActiveLookerRef(looker as fos.Lookers);
-    }
-  }, [looker, setActiveLookerRef]);
 
   return (
     <div

--- a/app/packages/core/src/components/Modal/use-looker.ts
+++ b/app/packages/core/src/components/Modal/use-looker.ts
@@ -1,10 +1,10 @@
 import * as fos from "@fiftyone/state";
 import React, { useEffect, useRef, useState } from "react";
 import { useErrorHandler } from "react-error-boundary";
-import { useRecoilValue } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import { v4 as uuid } from "uuid";
 import { useClearSelectedLabels, useShowOverlays } from "./ModalLooker";
-import { useLookerOptionsUpdate } from "./hooks";
+import { useLookerOptionsUpdate, useModalContext } from "./hooks";
 import useKeyEvents from "./use-key-events";
 import { shortcutToHelpItems } from "./utils";
 
@@ -102,6 +102,20 @@ function useLooker<L extends fos.Lookers>({
   );
 
   useKeyEvents(initialRef, sample.sample._id, looker);
+
+  const setModalLooker = useSetRecoilState(fos.modalLooker);
+
+  const { setActiveLookerRef } = useModalContext();
+
+  useEffect(() => {
+    setModalLooker(looker);
+  }, [looker, setModalLooker]);
+
+  useEffect(() => {
+    if (looker) {
+      setActiveLookerRef(looker as fos.Lookers);
+    }
+  }, [looker, setActiveLookerRef]);
 
   return { id, looker, ref, sample, updateLookerOptions };
 }

--- a/app/packages/looker/src/lookers/video.ts
+++ b/app/packages/looker/src/lookers/video.ts
@@ -15,6 +15,7 @@ import {
   FrameSample,
   LabelData,
   StateUpdate,
+  VideoConfig,
   VideoSample,
   VideoState,
 } from "../state";
@@ -318,7 +319,7 @@ export class VideoLooker extends AbstractLooker<VideoState, VideoSample> {
         ...this.getDefaultOptions(),
         ...options,
       },
-      buffers: [[firstFrame, firstFrame]] as Buffers,
+      buffers: this.initialBuffers(config),
       seekBarHovering: false,
       SHORTCUTS: VIDEO_SHORTCUTS,
       hasPoster: false,
@@ -328,8 +329,8 @@ export class VideoLooker extends AbstractLooker<VideoState, VideoSample> {
   }
 
   hasDefaultZoom(state: VideoState, overlays: Overlay<VideoState>[]): boolean {
-    let pan = [0, 0];
-    let scale = 1;
+    const pan = [0, 0];
+    const scale = 1;
 
     return (
       scale === state.scale &&
@@ -404,8 +405,6 @@ export class VideoLooker extends AbstractLooker<VideoState, VideoSample> {
     ) {
       lookerWithReader?.pause();
       lookerWithReader = this;
-      this.frames = new Map();
-      this.state.buffers = [[1, 1]];
       this.setReader();
     } else if (lookerWithReader !== this && frameCount) {
       this.state.buffering && this.dispatchEvent("buffering", false);
@@ -554,6 +553,9 @@ export class VideoLooker extends AbstractLooker<VideoState, VideoSample> {
       lookerWithReader?.pause();
       lookerWithReader = null;
     }
+
+    this.frames = new Map();
+    this.state.buffers = this.initialBuffers(this.state.config);
     super.updateSample(sample);
   }
 
@@ -566,6 +568,11 @@ export class VideoLooker extends AbstractLooker<VideoState, VideoSample> {
       this.frames.has(frameNumber) &&
       this.frames.get(frameNumber)?.deref() !== undefined
     );
+  }
+
+  private initialBuffers(config: VideoConfig) {
+    const firstFrame = config.support ? config.support[0] : 1;
+    return [[firstFrame, firstFrame]] as Buffers;
   }
 }
 

--- a/app/packages/looker/src/lookers/video.ts
+++ b/app/packages/looker/src/lookers/video.ts
@@ -402,10 +402,11 @@ export class VideoLooker extends AbstractLooker<VideoState, VideoSample> {
       lookerWithReader !== this &&
       frameCount !== null
     ) {
-      lookerWithReader && lookerWithReader.pause();
-      this.setReader();
+      lookerWithReader?.pause();
       lookerWithReader = this;
+      this.frames = new Map();
       this.state.buffers = [[1, 1]];
+      this.setReader();
     } else if (lookerWithReader !== this && frameCount) {
       this.state.buffering && this.dispatchEvent("buffering", false);
       this.state.playing = false;
@@ -549,10 +550,11 @@ export class VideoLooker extends AbstractLooker<VideoState, VideoSample> {
   }
 
   updateSample(sample: VideoSample) {
-    this.state.buffers = [[1, 1]];
-    this.frames.clear();
+    if (lookerWithReader === this) {
+      lookerWithReader?.pause();
+      lookerWithReader = null;
+    }
     super.updateSample(sample);
-    this.setReader();
   }
 
   getVideo() {

--- a/app/packages/looker/src/state.ts
+++ b/app/packages/looker/src/state.ts
@@ -341,6 +341,7 @@ export interface ImageState extends BaseState {
 }
 
 export interface VideoState extends BaseState {
+  buffers: Buffers;
   config: VideoConfig;
   options: VideoOptions;
   seeking: boolean;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds the tooltip back to the modal video looker. Also fixes changing the color scheme for video lookers. See recording for current issue

https://github.com/user-attachments/assets/21daa6c0-6c1b-474e-8f7d-702fad93b507


### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced state management for the modal looker, improving integration with the modal context.
  - Improved video frame management and playback functionality.
  - Added support for tracking multiple buffer ranges in video playback.

- **Bug Fixes**
  - Simplified the `ModalLookerNoTimeline` component, removing unused imports and unnecessary state management.
  - Streamlined state management in the `ColorFooter` component.

- **Documentation**
  - Updated import statements for clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->