### PR TITLE
Lightning mode refactor and disable/enable qp mode toggle 

### DIFF
--- a/app/packages/core/src/components/Actions/Options.tsx
+++ b/app/packages/core/src/components/Actions/Options.tsx
@@ -216,7 +216,7 @@ const DynamicGroupsViewMode = ({ modal }: { modal: boolean }) => {
   );
 };
 
-const Lightning = () => {
+const QueryPerformance = () => {
   const [threshold, setThreshold] = useRecoilState(fos.lightningThreshold);
   const config = useRecoilValue(fos.lightningThresholdConfig);
   const reset = useResetRecoilState(fos.lightningThreshold);
@@ -239,7 +239,7 @@ const Lightning = () => {
         svgStyles={{ height: "1rem", marginTop: 7.5 }}
       />
       <TabOption
-        active={threshold === null ? "disable" : "enable"}
+        active={(threshold === null) || (!fos.enableQueryPerformance) || (!fos.defaultQueryPerformance) ? "disable" : "enable"}
         options={["disable", "enable"].map((value) => ({
           text: value,
           title: value,
@@ -372,7 +372,7 @@ const Options = ({ modal, anchorRef }: OptionsProps) => {
       {isGroup && !isDynamicGroup && <GroupStatistics modal={modal} />}
       <MediaFields modal={modal} />
       <Patches modal={modal} />
-      {!view?.length && <Lightning />}
+      {!view?.length && <QueryPerformance />}
       {!modal && <SidebarMode />}
       <SortFilterResults modal={modal} />
     </Popout>

--- a/app/packages/core/src/components/Actions/Options.tsx
+++ b/app/packages/core/src/components/Actions/Options.tsx
@@ -222,8 +222,9 @@ const QueryPerformance = () => {
   const reset = useResetRecoilState(fos.lightningThreshold);
   const count = useRecoilValue(fos.datasetSampleCount);
   const theme = useTheme();
+  const enableQpMode = useRecoilValue(fos.enableQueryPerformanceConfig) && useRecoilValue(fos.defaultQueryPerformanceConfig);
 
-  return (
+  if (enableQpMode) return (
     <>
       <ActionOption
         id="qd-mode"
@@ -239,7 +240,7 @@ const QueryPerformance = () => {
         svgStyles={{ height: "1rem", marginTop: 7.5 }}
       />
       <TabOption
-        active={(threshold === null) || (!fos.enableQueryPerformance) || (!fos.defaultQueryPerformance) ? "disable" : "enable"}
+        active={(threshold === null) ? "disable" : "enable"}
         options={["disable", "enable"].map((value) => ({
           text: value,
           title: value,

--- a/app/packages/core/src/components/Actions/Options.tsx
+++ b/app/packages/core/src/components/Actions/Options.tsx
@@ -227,7 +227,7 @@ const QueryPerformance = () => {
   if (enableQpMode) return (
     <>
       <ActionOption
-        id="qd-mode"
+        id="qp-mode"
         text="Query Performance mode"
         href={QP_MODE}
         title={"More on Query Performance mode"}
@@ -244,7 +244,7 @@ const QueryPerformance = () => {
         options={["disable", "enable"].map((value) => ({
           text: value,
           title: value,
-          dataCy: `qd-mode-${value}`,
+          dataCy: `qp-mode-${value}`,
           onClick: () =>
             setThreshold(value === "disable" ? null : config ?? count),
         }))}

--- a/app/packages/core/src/components/Actions/Options.tsx
+++ b/app/packages/core/src/components/Actions/Options.tsx
@@ -222,7 +222,9 @@ const QueryPerformance = () => {
   const reset = useResetRecoilState(fos.lightningThreshold);
   const count = useRecoilValue(fos.datasetSampleCount);
   const theme = useTheme();
-  const enableQpMode = useRecoilValue(fos.enableQueryPerformanceConfig) && useRecoilValue(fos.defaultQueryPerformanceConfig);
+  const enableQueryPerformanceConfig = useRecoilValue(fos.enableQueryPerformanceConfig);
+  const defaultQueryPerformanceConfig = useRecoilValue(fos.defaultQueryPerformanceConfig);
+  const enableQpMode = enableQueryPerformanceConfig && defaultQueryPerformanceConfig;
 
   if (enableQpMode) return (
     <>

--- a/app/packages/core/src/components/Actions/Options.tsx
+++ b/app/packages/core/src/components/Actions/Options.tsx
@@ -17,7 +17,7 @@ import {
   useResetRecoilState,
   useSetRecoilState,
 } from "recoil";
-import { LIGHTNING_MODE, SIDEBAR_MODE } from "../../utils/links";
+import { QP_MODE, SIDEBAR_MODE } from "../../utils/links";
 import Checkbox from "../Common/Checkbox";
 import RadioGroup from "../Common/RadioGroup";
 import { Button } from "../utils";
@@ -226,9 +226,9 @@ const Lightning = () => {
   return (
     <>
       <ActionOption
-        id="lightning-mode"
+        id="qd-mode"
         text="Query Performance mode"
-        href={LIGHTNING_MODE}
+        href={QP_MODE}
         title={"More on Query Performance mode"}
         style={{
           background: "unset",
@@ -243,7 +243,7 @@ const Lightning = () => {
         options={["disable", "enable"].map((value) => ({
           text: value,
           title: value,
-          dataCy: `lightning-mode-${value}`,
+          dataCy: `qd-mode-${value}`,
           onClick: () =>
             setThreshold(value === "disable" ? null : config ?? count),
         }))}

--- a/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
+++ b/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
@@ -20,7 +20,7 @@ import {
 } from "recoil";
 import styled from "styled-components";
 import { ExternalLink } from "../../utils/generic";
-import { LIGHTNING_MODE } from "../../utils/links";
+import { QP_MODE } from "../../utils/links";
 import { activeColorEntry } from "../ColorModal/state";
 
 const selectedFieldInfo = atom<string | null>({
@@ -345,7 +345,7 @@ const Lightning: React.FunctionComponent<LightningProp> = ({ color, path }) => {
             <ContentValue>
               <ExternalLink
                 style={{ color: theme.text.primary }}
-                href={LIGHTNING_MODE}
+                href={QP_MODE}
               >
                 Lightning indexed
               </ExternalLink>

--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/Arrow.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/Arrow.tsx
@@ -7,7 +7,7 @@ import { RecoilState, useRecoilState } from "recoil";
 import { useTheme } from "styled-components";
 import {
   FRAME_FILTERING_DISABLED,
-  LIGHTNING_MODE,
+  QP_MODE,
 } from "../../../../utils/links";
 import DisabledReason from "./DisabledReason";
 
@@ -60,7 +60,7 @@ export default ({
   if (unindexed && !unlocked) {
     return (
       <Tooltip
-        text={<DisabledReason text={"add an index"} href={LIGHTNING_MODE} />}
+        text={<DisabledReason text={"add an index"} href={QP_MODE} />}
         placement="top-center"
       >
         {arrow}

--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/Tune.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/Tune.tsx
@@ -3,7 +3,7 @@ import { Tune } from "@mui/icons-material";
 import React from "react";
 import type { RecoilState } from "recoil";
 import { useSetRecoilState } from "recoil";
-import { LIGHTNING_MODE } from "../../../../utils/links";
+import { QP_MODE } from "../../../../utils/links";
 import DisabledReason from "./DisabledReason";
 
 export default ({
@@ -54,7 +54,7 @@ export default ({
   if (disabled) {
     return (
       <Tooltip
-        text={<DisabledReason href={LIGHTNING_MODE} text={"add an index"} />}
+        text={<DisabledReason href={QP_MODE} text={"add an index"} />}
         placement="top-center"
       >
         {children}

--- a/app/packages/core/src/utils/links.ts
+++ b/app/packages/core/src/utils/links.ts
@@ -13,7 +13,7 @@ export const FIELD_METADATA =
 export const FRAME_FILTERING_DISABLED =
   "https://docs.voxel51.com/user_guide/using_datasets.html#disable-frame-filtering";
 
-export const LIGHTNING_MODE =
+export const QP_MODE =
   "https://docs.voxel51.com/user_guide/app.html#lightning-mode";
 
 export const NAME_COLORSCALE = "https://plotly.com/python/colorscales/";

--- a/app/packages/state/src/recoil/lightning.ts
+++ b/app/packages/state/src/recoil/lightning.ts
@@ -200,6 +200,16 @@ export const lightningThresholdConfig = selector({
   get: ({ get }) => get(config).lightningThreshold,
 });
 
+export const enableQueryPerformanceConfig = selector({
+    key: "enableQueryPerformanceConfig",
+    get: ({ get }) => get(config).enableQueryPerformance,
+});
+
+export const defaultQueryPerformanceConfig = selector({
+    key: "defaultQueryPerformanceConfig",
+    get: ({ get }) => get(config).defaultQueryPerformance,
+});
+
 const lightningThresholdAtom = atomFamily<string, string>({
   key: "lightningThresholdAtom",
   default: undefined,

--- a/e2e-pw/src/oss/poms/action-row/display-options.ts
+++ b/e2e-pw/src/oss/poms/action-row/display-options.ts
@@ -13,7 +13,7 @@ export class DisplayOptionsPom {
   }
 
   async setLightningMode(mode: LightningMode) {
-    const selector = this.page.getByTestId(`lightning-mode-${mode}`);
+    const selector = this.page.getByTestId(`qp-mode-${mode}`);
     return selector.click();
   }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Refactored lightning mode to rename as query performance mode and allowed enabling/disabling qp mode toggle through deployment vars 

## How is this patch tested? If it is not, please explain why.

* Manual test (✅ )
* Loom video: https://www.loom.com/share/9b5acd7984e74b2aa7a68a194b8fb37d?sid=d0fdcfe6-2426-4a0c-9439-6a4488af906f

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new selectors for query performance configuration.

- **Improvements**
	- Renamed and restructured components related to performance modes for clarity and consistency.
	- Updated tooltip texts and links to reflect the new query performance mode.
	- Enhanced rendering logic to ensure correct display of performance-related information.

- **Documentation**
	- Updated component exports and type definitions for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->