### PR TITLE
Fixes disabled color on buttonView when no colorCode is passed & refactor

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/ButtonView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ButtonView.tsx
@@ -107,17 +107,12 @@ function getButtonProps(props: ViewPropsType): ButtonProps {
   }
 
   if (disabled) {
-    const [bgColor, textColor] = getDisabledColors(color);
+    const [bgColor, textColor] = getDisabledColors();
     baseProps.sx["&.Mui-disabled"] = {
       backgroundColor: variant === "outlined" ? "inherit" : bgColor,
       color: textColor,
     };
-    if (variant === "square") {
-      baseProps.sx["&.Mui-disabled"].backgroundColor = (theme) =>
-        theme.palette.background.field;
-    }
-
-    if (variant === "outlined") {
+    if (["square", "outlined"].includes(variant)) {
       baseProps.sx["&.Mui-disabled"].backgroundColor = (theme) =>
         theme.palette.background.field;
     }

--- a/app/packages/core/src/plugins/SchemaIO/utils/style.ts
+++ b/app/packages/core/src/plugins/SchemaIO/utils/style.ts
@@ -8,15 +8,8 @@ export function getColorByCode(code: ColorType) {
   }
 }
 
-export function getDisabledColors(code: ColorType) {
-  if (code) {
-    if (["primary", "secondary", ...fiftyOneColorNames].includes(code))
-      return [
-        "var(--fo-palette-primary-main)",
-        "var(--fo-palette-text-primary)",
-      ];
-    return [code, "var(--fo-palette-text-primary)"];
-  }
+export function getDisabledColors() {
+  return ["var(--fo-palette-primary-main)", "var(--fo-palette-text-primary)"];
 }
 
 export function getFieldSx(options: FieldsetOptionsType) {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes disabled color on buttonView when no colorCode is passed & refactor

## How is this patch tested? If it is not, please explain why.

snippet below for testing

<img width="332" alt="Screen Shot 2024-10-16 at 9 29 52 AM" src="https://github.com/user-attachments/assets/53dbd9ef-af22-410c-9882-0137bd44d6ac">


```
import fiftyone.operators as foo
import fiftyone.operators.types as types


class Snippet(foo.Panel):
    @property
    def config(self):
        return foo.PanelConfig(name="Snippet", label="Snippet")

    def increment(self, ctx):
        ctx.panel.state.my_count += 1

    def render(self, ctx):
        panel = types.Object()

        # contained enabled
        panel.btn(
            "hello_btn",
            label="Mark as reviewed",
            icon="emoji_people",
            on_click=self.increment,
            variant="contained",
            color="primary",
            disabled=False,
            componentsProps={'button': {'sx': {'width': '200px', 'ml': '30%', 'mt': '10px'}}}
        )

        panel.btn(
            f"compute_button",
            label=f"Scanning Dataset",
            variant="contained",
            disabled=True,
            componentsProps={'button': {'sx': {'width': '200px', 'ml': '30%', 'mt': '10px'}}}
        )

        # contained disabled
        panel.btn(
            "hello_btn2",
            label="Mark as reviewed",
            icon="emoji_people",
            on_click=self.increment,
            variant="contained",
            color="primary",
            disabled=True,
            componentsProps={'button': {'sx': {'width': '200px', 'ml': '30%', 'mt': '10px'}}}
        )

        # contained enabled secondary
        panel.btn(
            "hello_btn3",
            label="Mark as reviewed",
            icon="emoji_people",
            on_click=self.increment,
            variant="contained",
            color="secondary",
            disabled=False,
            componentsProps={'button': {'sx': {'width': '200px', 'ml': '30%', 'mt': '10px'}}}
        )

        # contained disabled secondary
        panel.btn(
            "hello_btn4",
            label="Mark as reviewed",
            icon="emoji_people",
            on_click=self.increment,
            variant="contained",
            color="secondary",
            disabled=True,
            componentsProps={'button': {'sx': {'width': '200px', 'ml': '30%', 'mt': '10px'}}}
        )

        # square disabled
        panel.btn(
            "hello_btn5",
            label="Mark as reviewed",
            icon="emoji_people",
            on_click=self.increment,
            variant="square",
            color="primary",
            disabled=False,
            componentsProps={'button': {'sx': {'width': '200px', 'ml': '30%', 'mt': '10px'}}}
        )

        # square disabled
        panel.btn(
            "hello_btn6",
            label="Mark as reviewed",
            icon="emoji_people",
            on_click=self.increment,
            variant="square",
            color="primary",
            disabled=True,
            componentsProps={'button': {'sx': {'width': '200px', 'ml': '30%', 'mt': '10px'}}}
        )

        # round enabled
        panel.btn(
            "hello_btn7",
            label="Mark as reviewed",
            icon="emoji_people",
            on_click=self.increment,
            variant="round",
            color="primary",
            disabled=False,
            componentsProps={'button': {'sx': {'width': '200px', 'ml': '30%', 'mt': '10px'}}}
        )

        # round disabled
        panel.btn(
            "hello_btn8",
            label="Mark as reviewed",
            icon="emoji_people",
            on_click=self.increment,
            variant="round",
            color="primary",
            disabled=True,
            componentsProps={'button': {'sx': {'width': '200px', 'ml': '30%', 'mt': '10px'}}}
        )

        # outlined enabled
        panel.btn(
            "hello_btn9",
            label="Mark as reviewed",
            icon="emoji_people",
            on_click=self.increment,
            variant="outlined",
            color="primary",
            disabled=False,
            componentsProps={'button': {'sx': {'width': '200px', 'ml': '30%', 'mt': '10px'}}}
        )

        # outlined disabled
        panel.btn(
            "hello_btn10",
            label="Mark as reviewed",
            icon="emoji_people",
            on_click=self.increment,
            variant="outlined",
            color="primary",
            disabled=True,
            componentsProps={'button': {'sx': {'width': '200px', 'ml': '30%', 'mt': '10px'}}}
        )

        btn_view = types.ButtonView(
            label="Test",
            title="test",
            href="http://voxel51.com",
            params={"message": "Hello World"},
            # color="51",
            color="primary",
            variant="contained",
            disabled=False, # or disabled=False
            componentsProps={'button': {'sx': {'width': '200px', 'ml': '30%', 'mt': '10px'}}}
        )

        panel.view("btn", btn_view)

        btn_view_2 = types.ButtonView(
            label="Test",
            title="test",
            href="http://voxel51.com",
            params={"message": "Hello World"},
            # color="51",
            color="primary",
            variant="contained",
            disabled=True, # or disabled=False
            componentsProps={'button': {'sx': {'width': '200px', 'ml': '30%', 'mt': '10px'}}}
        )

        panel.view("btn_2", btn_view_2)

        return types.Property(panel)



def register(p):
    p.register(Snippet)

````

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of disabled button states for better visual feedback.
  
- **Bug Fixes**
	- Streamlined logic for determining disabled button colors, enhancing clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->