### PR TITLE
[CVAT integration] Use pixelwise masks, not polygons, for instance segmentation #4483

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -1598,10 +1598,7 @@ class HasCVATBinMask:
                 mask[counter : counter + val] = 1
             counter += val
 
-        return mask.reshape(mask_width, mask_height)
-        # mask = np.zeros(mask_width * mask_height, dtype=np.uint8)
-        # mask[np.add.accumulate(rle)[::2]] = 1
-        # return mask.reshape(mask_width, mask_height)
+        return mask.reshape(mask_height, mask_width)
 
     @staticmethod
     def mask_to_cvat_rle(binary_mask: np.ndarray) -> np.array:
@@ -7119,7 +7116,7 @@ class CVATShape(CVATLabel):
             round(ybr - ytl) + 1,
         )  # We need to add 1 because cvat uses - 1
         mask = HasCVATBinMask.rle_to_binary_image_mask(
-            rel, mask_width=mask_h, mask_height=mask_w
+            rel, mask_height=mask_h, mask_width=mask_w
         )
         bbox = [
             xtl / frame_width,


### PR DESCRIPTION
The following items are still pending:

- [x] Code to upload fiftyone to CVAT pixel mask
- [x] Unit test for uploading to CVAT
- [x] Unit test for converting CVAT shapes back into the FiftyOne format
- [x] Implementation for converting CVAT shapes back into FiftyOne format

@ehofesmann  
1. Sorry, I'm not sure how I should go about testing CVAT components with API request ?
2. I'm also unsure how to incorporate the download from CVAT to Fiftyone. I attempted to use load_annotation_results, but it didn't seem to trigger this particular part of the code. Could you advise on how to proceed?https://github.com/voxel51/fiftyone/blob/77f664c6da47ce05abb36326237fc10aef5fe999/fiftyone/utils/cvat.py#L5908

## What changes are proposed in this pull request?

Propose following the issue #4483, to make it possible to export fiftyone mask to CVAT as pixel mask.

## How is this patch tested? If it is not, please explain why.

For now, simple upload test with rectangle. I seek guidance regarding how it should be properly tested. **For now this pull request is only a draft.**

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

Yes, 
> ```python
> dataset.annotate(anno_key, label_field='detections', label_type='instances')
> ```
The data should now be uploaded in pixel format instead of polygons. This change is good because CVAT does not support polygons with holes, which could create bottlenecks in certain use cases.

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new class for converting between run-length encoded masks and binary image masks.
	- Added methods to facilitate the conversion of masks for better integration with the FiftyOne framework.
	- Enhanced shape conversion capabilities to support instance detection with masks.
- **Bug Fixes**
	- Updated the export process to properly handle new mask types during annotation uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->