### PR TITLE
fix carousel lookers rendering as imavid in ordered dynamic groups

### DIFF
--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/carousel/DynamicGroupsFlashlightWrapper.tsx
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/carousel/DynamicGroupsFlashlightWrapper.tsx
@@ -59,7 +59,7 @@ export const DynamicGroupsFlashlightWrapper = React.memo(() => {
   );
 
   const createLooker = fos.useCreateLooker(
-    false,
+    true,
     true,
     {
       ...opts,

--- a/app/packages/core/src/components/Modal/Group/GroupCarousel.tsx
+++ b/app/packages/core/src/components/Modal/Group/GroupCarousel.tsx
@@ -72,7 +72,7 @@ const Column: React.FC = () => {
   );
 
   const createLooker = fos.useCreateLooker(
-    false,
+    true,
     true,
     {
       ...opts,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Roughly speaking, the flow we use to decide whether to render image vs imavid looker is shown below:
```
useCreateLooker(isModal) -> shouldRenderImavid(isModal) -> image vs imavid looker
```
Notice how `shouldRenderImavid` itself is parametrized by the modal setting - this was introduced in #4676. For the flow to work correctly, `useCreateLooker` needs the appropriate prop. It was erroneously set to `false` in `DynamicGroupsFlashlightWrapper` and `GroupCarousel::Column`, causing lookers to be rendered as Imavid when grid's "render frames as video" setting was enabled. This PR fixes the issue by passing `isModal = true` for both cases.

## How is this patch tested? If it is not, please explain why.

Existing E2E

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Description: Fixes an issue with image rendering in the carousel when grid’s render-frames-as-video setting is enabled.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced functionality of the Dynamic Groups Flashlight and Group Carousel components.
	- Improved highlight logic based on the current sample's state.
	- Updated flashlight behavior to respond to changes in the selected media field.

- **Bug Fixes**
	- Resolved issues with the lifecycle management of the flashlight instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->