### PR TITLE
Add referrerPolicy fetch.ts

### DIFF
--- a/app/packages/utilities/src/fetch.ts
+++ b/app/packages/utilities/src/fetch.ts
@@ -129,6 +129,7 @@ export const setFetchFunction = (
       mode: "cors",
       body: body ? JSON.stringify(body) : null,
       signal: controller.signal,
+      referrerPolicy: 'same-origin',
     });
 
     if (response.status >= 400) {
@@ -271,6 +272,7 @@ export const getEventSource = (
       method: "POST",
       signal,
       body: JSON.stringify(body),
+      referrerPolicy: 'same-origin',
       async onopen(response) {
         if (response.ok) {
           events.onopen && events.onopen();


### PR DESCRIPTION
Set referrerPolicy to 'same-origin' rather default `strict-origin-when-cross-origin` 

## What changes are proposed in this pull request?

Allow Fiftyone app running behind generic reverse proxy

## How is this patch tested? If it is not, please explain why.

Tested on our Fiftyone instance running behind Azure reverse proxy

## Release Notes

Fix #4539

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced fetch functionality with a new `referrerPolicy` option for improved privacy control.
  
- **Bug Fixes**
	- Improved error handling for fetch operations, providing more detailed error information for failed requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->