### PR TITLE
[Proposal] rename ctx.create_store to ctx.store

### DIFF
--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -875,8 +875,9 @@ class ExecutionContext(object):
         else:
             self.log(f"Progress: {progress} - {label}")
 
-    def create_store(self, store_name):
-        """Creates a new store with the specified name.
+    def store(self, store_name):
+        """
+        Create (if not previously created) and use a store with the specified name.
 
         Args:
             store_name: the name of the store


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add `ctx.store` and deprecate `cts.create_store`

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `store` method for enhanced store management, allowing for scoped store names based on operator URI.
	- Retained the original `create_store` method as deprecated, guiding users to transition to the new method.
  
- **Bug Fixes**
	- Added logging to the `set_progress` method to improve error handling when progress is set without a defined function.

- **Documentation**
	- Updated the `store` method's documentation to reflect its new functionality and usage.
	- Revised the documentation for the deprecated `create_store` method to provide transition guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->