### PR TITLE
fix overlay z-index and overflow for panels

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/ContainerizedComponent.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ContainerizedComponent.tsx
@@ -7,6 +7,7 @@ import {
   overlayToSx,
 } from "../utils";
 import { ViewPropsType } from "../utils/types";
+import { has } from "lodash";
 
 export default function ContainerizedComponent(props: ContainerizedComponent) {
   const { schema, children } = props;
@@ -22,7 +23,11 @@ export default function ContainerizedComponent(props: ContainerizedComponent) {
   }
 
   if (isCompositeView(schema)) {
+    const hasOverlay = !!schema?.view?.overlay;
     const sxForOverlay = overlayToSx[schema?.view?.overlay] || {};
+    if (hasOverlay) {
+      sxForOverlay.zIndex = 999;
+    }
     return (
       <Box sx={{ position: "relative", ...sxForOverlay }}>
         {containerizedChildren}

--- a/app/packages/core/src/plugins/SchemaIO/components/GridView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/GridView.tsx
@@ -2,7 +2,7 @@ import { Box, BoxProps } from "@mui/material";
 import React from "react";
 import { HeaderView } from ".";
 import {
-  getAdjustedLayoutWidth,
+  getAdjustedLayoutDimensions,
   getComponentProps,
   getGridSx,
   getPath,
@@ -21,12 +21,13 @@ export default function GridView(props: ViewPropsType) {
   const propertiesAsArray = Object.entries(properties).map(([id, property]) => {
     return { id, ...property };
   });
-  const height = props?.layout?.height as number;
   const parsedGap = parseGap(gap);
-  const width = getAdjustedLayoutWidth(
-    props?.layout?.width,
-    parsedGap
-  ) as number;
+  const { height, width } = getAdjustedLayoutDimensions({
+    height: props?.layout?.height,
+    width: props?.layout?.width,
+    gap: parsedGap,
+    orientation,
+  });
 
   const baseGridProps: BoxProps = {
     sx: { gap: parsedGap, ...getGridSx(view) },

--- a/app/packages/core/src/plugins/SchemaIO/utils/layout.ts
+++ b/app/packages/core/src/plugins/SchemaIO/utils/layout.ts
@@ -179,11 +179,30 @@ export function parseGap(gap: number | string) {
   return 0;
 }
 
-export function getAdjustedLayoutWidth(layoutWidth?: number, gap?: number) {
-  if (typeof gap === "number" && typeof layoutWidth === "number") {
-    return layoutWidth - gap * 8;
+export function getAdjustedLayoutDimension(value?: number, gap?: number) {
+  if (typeof gap === "number" && typeof value === "number") {
+    return value - gap * 8;
   }
-  return layoutWidth;
+  return value;
+}
+
+export function getAdjustedLayoutDimensions({
+  height,
+  width,
+  gap,
+  orientation,
+}: {
+  height?: number;
+  width?: number;
+  gap?: number;
+  orientation?: string;
+}) {
+  const adjustedHeight = getAdjustedLayoutDimension(height, gap);
+  const adjustedWidth = getAdjustedLayoutDimension(width, gap);
+  if (orientation === "horizontal") {
+    return { height, width: adjustedWidth };
+  }
+  return { height: adjustedHeight, width };
 }
 
 type PaddingSxType = {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Menu overlays are not visible due to z-index clash.

## How is this patch tested? If it is not, please explain why.

Tested in the new 1d animated plot panel.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced overlay handling in the component for improved rendering of composite views.
	- Introduced a new function to streamline layout dimension calculations, consolidating width and height adjustments.

- **Bug Fixes**
	- Corrected overlay styling application based on the presence of an overlay in the schema's view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->