### PR TITLE
Admins can choose to disable toasts by default

### DIFF
--- a/app/packages/core/src/components/Actions/Options.tsx
+++ b/app/packages/core/src/components/Actions/Options.tsx
@@ -174,7 +174,9 @@ const DynamicGroupsViewMode = ({ modal }: { modal: boolean }) => {
 const QueryPerformance = () => {
   const theme = useTheme();
   const [enabled, setEnabled] = useRecoilState(fos.queryPerformance);
-  if (!useRecoilValue(fos.enableQueryPerformanceConfig)) {
+
+  // Admins can choose to disable all QP features (toast + toggle) or disable toasts for each dataset
+  if (!useRecoilValue(fos.enableQueryPerformanceConfig) || !useRecoilValue(fos.defaultQueryPerformanceConfig)) {
     return null;
   }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Admins can choose to configure vars to disable toasts by default

## How is this patch tested? If it is not, please explain why.

* Manual testing

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
