### PR TITLE
Add ToastView to Python Panels

### DIFF
--- a/app/packages/components/src/components/Toast/Toast.tsx
+++ b/app/packages/components/src/components/Toast/Toast.tsx
@@ -2,12 +2,22 @@ import React from "react";
 import { atom, useRecoilState } from "recoil";
 import { Box, Snackbar, SnackbarContent } from "@mui/material";
 
-// Define types for the props
 interface ToastProps {
   message: React.ReactNode;
-  primary: (setOpen: React.Dispatch<React.SetStateAction<boolean>>) => React.ReactNode;
-  secondary: (setOpen: React.Dispatch<React.SetStateAction<boolean>>) => React.ReactNode;
-  duration?: number;         // Optional duration, with a default value
+  primary: (
+    setOpen: React.Dispatch<React.SetStateAction<boolean>>
+  ) => React.ReactNode;
+  secondary: (
+    setOpen: React.Dispatch<React.SetStateAction<boolean>>
+  ) => React.ReactNode;
+  duration?: number;
+  layout?: {
+    vertical?: "top" | "bottom";
+    horizontal?: "left" | "center" | "right";
+    height?: number | string;
+    backgroundColor?: string;
+    color?: string;
+  };
 }
 
 const toastStateAtom = atom({
@@ -15,41 +25,56 @@ const toastStateAtom = atom({
   default: true,
 });
 
-const Toast: React.FC<ToastProps> = ({message, primary, secondary, duration = 5000 }) => {
+const Toast: React.FC<ToastProps> = ({
+  message,
+  primary,
+  secondary,
+  duration = 5000,
+  layout = {},
+}) => {
+  const [open, setOpen] = useRecoilState(toastStateAtom);
 
-  const [open, setOpen] = useRecoilState(toastStateAtom); // State management for toast visibility
+  const handleClose = React.useCallback(
+    (event, reason) => {
+      if (reason === "clickaway") return;
+      setOpen(false);
+    },
+    [setOpen]
+  );
 
-  const handleClose = (event, reason) => {
-    if (reason === "clickaway") {
-      return;
-    }
-    setOpen(false);
-  };
-
-  const action = (
-    <div>
-      <Box display="flex" justifyContent="flex-end">
-        {primary(setOpen)} {/* Pass setOpen to primary button */}
-        {secondary(setOpen)} {/* Pass setOpen to secondary button */}
-      </Box>
-    </div>
+  const action = React.useMemo(
+    () => (
+      <div>
+        <Box display="flex" justifyContent="flex-end">
+          {primary(setOpen)}
+          {secondary(setOpen)}
+        </Box>
+      </div>
+    ),
+    [primary, secondary, setOpen]
   );
 
   return (
     <Snackbar
-      anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      anchorOrigin={{
+        vertical: layout.vertical ?? "bottom",
+        horizontal: layout.horizontal ?? "center",
+      }}
       open={open}
       onClose={handleClose}
       autoHideDuration={duration}
-      sx={{ height: 5 }}
+      sx={{ height: layout.height ?? 5 }}
     >
       <SnackbarContent
         message={message}
         action={action}
-        style={{ backgroundColor: "#333", color: "#fff" }}
+        style={{
+          backgroundColor: layout.backgroundColor ?? "#333",
+          color: layout.color ?? "#fff",
+        }}
       />
     </Snackbar>
   );
-}
+};
 
 export default Toast;

--- a/app/packages/components/src/components/Toast/Toast.tsx
+++ b/app/packages/components/src/components/Toast/Toast.tsx
@@ -4,17 +4,15 @@ import { Box, Snackbar, SnackbarContent } from "@mui/material";
 
 interface ToastProps {
   message: React.ReactNode;
-  primary: (
-    setOpen: React.Dispatch<React.SetStateAction<boolean>>
-  ) => React.ReactNode;
-  secondary: (
-    setOpen: React.Dispatch<React.SetStateAction<boolean>>
-  ) => React.ReactNode;
+  primary?: any;
+  secondary?: any;
   duration?: number;
   layout?: {
     vertical?: "top" | "bottom";
     horizontal?: "left" | "center" | "right";
     height?: number | string;
+    top?: number | string;
+    bottom?: number | string;
     backgroundColor?: string;
     color?: string;
   };
@@ -32,45 +30,65 @@ const Toast: React.FC<ToastProps> = ({
   duration = 5000,
   layout = {},
 }) => {
-  const [open, setOpen] = useRecoilState(toastStateAtom);
+  const snackbarStyle = {
+    height: layout?.height || 5,
+    ...(layout?.top && {
+      top: {
+        xs: layout.top,
+        sm: layout.top,
+        md: layout.top,
+        lg: layout.top,
+        xl: layout.top,
+      },
+    }),
+    ...(layout?.bottom && {
+      bottom: {
+        xs: layout.bottom,
+        sm: layout.bottom,
+        md: layout.bottom,
+        lg: layout.bottom,
+        xl: layout.bottom,
+      },
+    }),
+  };
 
-  const handleClose = React.useCallback(
-    (event, reason) => {
-      if (reason === "clickaway") return;
-      setOpen(false);
-    },
-    [setOpen]
-  );
+  const [open, setOpen] = useRecoilState(toastStateAtom); // State management for toast visibility
 
-  const action = React.useMemo(
-    () => (
-      <div>
-        <Box display="flex" justifyContent="flex-end">
-          {primary(setOpen)}
-          {secondary(setOpen)}
-        </Box>
-      </div>
-    ),
-    [primary, secondary, setOpen]
+  const handleClose = (event, reason) => {
+    if (reason === "clickaway") {
+      return;
+    }
+    setOpen(false);
+  };
+
+  const action = (
+    <div>
+      <Box display="flex" justifyContent="flex-end">
+        {/* note: Not implemented within Python Panels context */}
+        {primary && primary(setOpen)} {/* Pass setOpen to primary button */}
+        {secondary && secondary(setOpen)}{" "}
+        {/* Pass setOpen to secondary button */}
+      </Box>
+    </div>
   );
 
   return (
     <Snackbar
       anchorOrigin={{
-        vertical: layout.vertical ?? "bottom",
-        horizontal: layout.horizontal ?? "center",
+        vertical: "top",
+        horizontal: layout?.horizontal || "center",
       }}
       open={open}
       onClose={handleClose}
       autoHideDuration={duration}
-      sx={{ height: layout.height ?? 5 }}
+      sx={snackbarStyle}
     >
       <SnackbarContent
         message={message}
         action={action}
         style={{
-          backgroundColor: layout.backgroundColor ?? "#333",
-          color: layout.color ?? "#fff",
+          backgroundColor: layout?.backgroundColor || "#333",
+          color: layout?.color || "#fff",
         }}
       />
     </Snackbar>

--- a/app/packages/components/src/components/Toast/Toast.tsx
+++ b/app/packages/components/src/components/Toast/Toast.tsx
@@ -75,7 +75,7 @@ const Toast: React.FC<ToastProps> = ({
   return (
     <Snackbar
       anchorOrigin={{
-        vertical: "top",
+        vertical: layout?.vertical || "bottom",
         horizontal: layout?.horizontal || "center",
       }}
       open={open}

--- a/app/packages/components/src/components/Toast/Toast.tsx
+++ b/app/packages/components/src/components/Toast/Toast.tsx
@@ -15,6 +15,8 @@ interface ToastProps {
     bottom?: number | string;
     backgroundColor?: string;
     color?: string;
+    fontSize?: string;
+    textAlign?: string;
   };
 }
 
@@ -86,9 +88,12 @@ const Toast: React.FC<ToastProps> = ({
       <SnackbarContent
         message={message}
         action={action}
-        style={{
+        sx={{
           backgroundColor: layout?.backgroundColor || "#333",
           color: layout?.color || "#fff",
+          fontSize: layout?.fontSize || "14px",
+          display: "block",
+          textAlign: layout?.textAlign || "left",
         }}
       />
     </Snackbar>

--- a/app/packages/core/src/plugins/SchemaIO/components/ToastView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ToastView.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { Toast } from "@fiftyone/components";
+
+export default function ToastView(props) {
+  const { schema } = props;
+  const { view = {} } = schema;
+  const { message, primary, secondary, duration, layout } = view;
+
+  return (
+    <Toast
+      message={message}
+      primary={primary}
+      secondary={secondary}
+      duration={duration}
+      layout={layout}
+    />
+  );
+}

--- a/app/packages/core/src/plugins/SchemaIO/components/ToastView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ToastView.tsx
@@ -4,15 +4,7 @@ import { Toast } from "@fiftyone/components";
 export default function ToastView(props) {
   const { schema } = props;
   const { view = {} } = schema;
-  const { message, primary, secondary, duration, layout } = view;
+  const { message, duration, layout } = view;
 
-  return (
-    <Toast
-      message={message}
-      primary={primary}
-      secondary={secondary}
-      duration={duration}
-      layout={layout}
-    />
-  );
+  return <Toast message={message} duration={duration} layout={layout} />;
 }

--- a/app/packages/core/src/plugins/SchemaIO/components/index.ts
+++ b/app/packages/core/src/plugins/SchemaIO/components/index.ts
@@ -50,5 +50,6 @@ export { default as TabsView } from "./TabsView";
 export { default as TagsView } from "./TagsView";
 export { default as TextView } from "./TextView";
 export { default as TextFieldView } from "./TextFieldView";
+export { default as ToastView } from "./ToastView";
 export { default as TupleView } from "./TupleView";
 export { default as UnsupportedView } from "./UnsupportedView";

--- a/app/packages/operators/src/types.ts
+++ b/app/packages/operators/src/types.ts
@@ -1197,6 +1197,20 @@ export class ModalView extends Button {
 }
 
 /**
+ * Operator class for describing a ToastView {@link View} for an
+ * operator type.
+ */
+export class ToastView extends View {
+  constructor(options: ViewProps) {
+    super(options);
+    this.name = "ToastView";
+  }
+  static fromJSON(json) {
+    return new ToastView(json);
+  }
+}
+
+/**
  * Places where you can have your operator placement rendered.
  */
 export enum Places {
@@ -1267,6 +1281,7 @@ const VIEWS = {
   LazyFieldView,
   PillBadgeView,
   ModalView,
+  ToastView,
 };
 
 export function typeFromJSON({ name, ...rest }): ANY_TYPE {

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -1813,6 +1813,21 @@ class AlertView(View):
         return {**super().to_json(), "severity": self.severity}
 
 
+class ToastView(View):
+    """Displays a snackbar style toast element.
+
+    Args:
+        message: the message to display
+        primary (None): the primary button text
+        secondary (None): the secondary button text
+        duration (None): the duration to stay on screen in milliseconds
+        layout (None): the layout of the toast
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
 class CheckboxView(View):
     """Displays a checkbox.
 

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -1816,10 +1816,22 @@ class AlertView(View):
 class ToastView(View):
     """Displays a snackbar style toast element.
 
+    Examples::
+
+    schema = {
+            "message": "Test",
+            "duration": 30000,
+            "layout": {
+                "vertical": "top",
+                "horizontal": "center",
+                "top": "200px"
+            },
+        }
+        snackbar = types.ToastView(**schema)
+        panel.obj("toast", view=snackbar)
+
     Args:
         message: the message to display
-        primary (None): the primary button text
-        secondary (None): the secondary button text
         duration (None): the duration to stay on screen in milliseconds
         layout (None): the layout of the toast
     """

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -21,11 +21,9 @@ os.environ["FIFTYONE_SERVER"] = "1"
 
 import fiftyone as fo
 import fiftyone.constants as foc
-import fiftyone.zoo as foz
 
 from fiftyone.server.app import app
 from fiftyone.server.events import set_port
-
 
 DEBUG_LOGGING = fo.config.logging_level == "DEBUG"
 
@@ -49,8 +47,4 @@ if __name__ == "__main__":
     if args.clean_start:
         fo.delete_datasets("*")
 
-    dataset_directory = "."
-    dataset = foz.load_zoo_dataset("quickstart")
-
-
-asyncio.run(serve(app, config), debug=DEBUG_LOGGING)
+    asyncio.run(serve(app, config), debug=DEBUG_LOGGING)

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -21,9 +21,11 @@ os.environ["FIFTYONE_SERVER"] = "1"
 
 import fiftyone as fo
 import fiftyone.constants as foc
+import fiftyone.zoo as foz
 
 from fiftyone.server.app import app
 from fiftyone.server.events import set_port
+
 
 DEBUG_LOGGING = fo.config.logging_level == "DEBUG"
 
@@ -47,4 +49,8 @@ if __name__ == "__main__":
     if args.clean_start:
         fo.delete_datasets("*")
 
-    asyncio.run(serve(app, config), debug=DEBUG_LOGGING)
+    dataset_directory = "."
+    dataset = foz.load_zoo_dataset("quickstart")
+
+
+asyncio.run(serve(app, config), debug=DEBUG_LOGGING)


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Refactor @minhtuev 's `Toast` component to include ability to render `ToastView` in Python Panel context
- Added `ToastView` to Python Panel

https://github.com/user-attachments/assets/60368159-daec-4cc9-a922-1b0f79d577dc




## How is this patch tested? If it is not, please explain why.

Tested locally in Python Panel context

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a customizable `Toast` component with optional properties for layout and button functionalities.
	- Added a new `ToastView` component for displaying toast messages with customizable duration and layout.
	- Implemented a new `ToastView` class for enhanced integration within the application.

- **Bug Fixes**
	- Enhanced rendering logic to ensure buttons are only displayed when provided.

- **Documentation**
	- Updated exports to include the new `ToastView` component for easier access within the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->