### PR TITLE
Adding SAM 2.1 to the model zoo

### DIFF
--- a/docs/scripts/make_model_zoo_docs.py
+++ b/docs/scripts/make_model_zoo_docs.py
@@ -147,17 +147,6 @@ _MODEL_TEMPLATE = """
     dataset.apply_model(model, label_field="auto")
 
     session = fo.launch_app(dataset)
-{% elif 'segment-anything' in tags and 'video' in tags  and 'med-SAM' not in tags %}
-    model = foz.load_zoo_model("{{ name }}")
-
-    # Segment inside boxes and propagate to all frames
-    dataset.apply_model(
-        model,
-        label_field="segmentations",
-        prompt_field="frames.detections",  # can contain Detections or Keypoints
-    )
-
-    session = fo.launch_app(dataset)
 {% elif 'med-sam' in name %}
     model = foz.load_zoo_model("{{ name }}")
 
@@ -166,6 +155,17 @@ _MODEL_TEMPLATE = """
         model,
         label_field="pred_segmentations",
         prompt_field="frames.gt_detections",
+    )
+
+    session = fo.launch_app(dataset)
+{% elif 'segment-anything' in tags and 'video' in tags %}
+    model = foz.load_zoo_model("{{ name }}")
+
+    # Segment inside boxes and propagate to all frames
+    dataset.apply_model(
+        model,
+        label_field="segmentations",
+        prompt_field="frames.detections",  # can contain Detections or Keypoints
     )
 
     session = fo.launch_app(dataset)

--- a/docs/scripts/make_model_zoo_docs.py
+++ b/docs/scripts/make_model_zoo_docs.py
@@ -354,7 +354,7 @@ def _render_card_model_content(template, model_name):
 
     tags = ",".join(tags)
 
-    link = "models.html#%s" % zoo_model.name
+    link = "models.html#%s" % zoo_model.name.replace(".", "-")
 
     description = zoo_model.description
 

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -487,6 +487,285 @@
             "date_added": "2024-08-17 14:48:00"
         },
         {
+            "base_name": "segment-anything-2-1-hiera-tiny-image-torch",
+            "base_filename": "sam2.1_hiera_tiny_image.pt",
+            "version": null,
+            "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
+            "source": "https://ai.meta.com/sam2/",
+            "size_bytes": 155906050,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_tiny.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.sam2.SegmentAnything2ImageModel",
+                "config": {
+                    "entrypoint_fcn": "sam2.build_sam.build_sam2",
+                    "entrypoint_args": {
+                        "model_cfg": "configs/sam2.1/sam2.1_hiera_t.yaml"
+                    },
+                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segment-anything", "torch", "zero-shot"],
+            "date_added": "2024-08-05 14:38:20"
+        },
+        {
+            "base_name": "segment-anything-2-1-hiera-small-image-torch",
+            "base_filename": "sam2.1_hiera_small_image.pt",
+            "version": null,
+            "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
+            "source": "https://ai.meta.com/sam2/",
+            "size_bytes": 155906050,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_small.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.sam2.SegmentAnything2ImageModel",
+                "config": {
+                    "entrypoint_fcn": "sam2.build_sam.build_sam2",
+                    "entrypoint_args": {
+                        "model_cfg": "configs/sam2.1/sam2.1_hiera_s.yaml"
+                    },
+                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segment-anything", "torch", "zero-shot"],
+            "date_added": "2024-08-05 14:38:20"
+        },
+        {
+            "base_name": "segment-anything-2-1-hiera-base-plus-image-torch",
+            "base_filename": "sam2.1_hiera_base_plus_image.pt",
+            "version": null,
+            "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
+            "source": "https://ai.meta.com/sam2/",
+            "size_bytes": 155906050,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_base_plus.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.sam2.SegmentAnything2ImageModel",
+                "config": {
+                    "entrypoint_fcn": "sam2.build_sam.build_sam2",
+                    "entrypoint_args": {
+                        "model_cfg": "configs/sam2.1/sam2.1_hiera_b+.yaml"
+                    },
+                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segment-anything", "torch", "zero-shot"],
+            "date_added": "2024-08-05 14:38:20"
+        },
+        {
+            "base_name": "segment-anything-2-1-hiera-large-image-torch",
+            "base_filename": "sam2.1_hiera_large_image.pt",
+            "version": null,
+            "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
+            "source": "https://ai.meta.com/sam2/",
+            "size_bytes": 155906050,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_large.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.sam2.SegmentAnything2ImageModel",
+                "config": {
+                    "entrypoint_fcn": "sam2.build_sam.build_sam2",
+                    "entrypoint_args": {
+                        "model_cfg": "configs/sam2.1/sam2.1_hiera_l.yaml"
+                    },
+                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segment-anything", "torch", "zero-shot"],
+            "date_added": "2024-08-05 14:38:20"
+        },
+        {
+            "base_name": "segment-anything-2-1-hiera-tiny-video-torch",
+            "base_filename": "sam2.1_hiera_tiny_video.pt",
+            "version": null,
+            "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
+            "source": "https://ai.meta.com/sam2/",
+            "size_bytes": 155906050,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_tiny.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.sam2.SegmentAnything2VideoModel",
+                "config": {
+                    "entrypoint_fcn": "sam2.build_sam.build_sam2_video_predictor",
+                    "entrypoint_args": {
+                        "model_cfg": "configs/sam2.1/sam2.1_hiera_t.yaml"
+                    }
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segment-anything", "torch", "zero-shot", "video"],
+            "date_added": "2024-08-05 14:38:20"
+        },
+        {
+            "base_name": "segment-anything-2-1-hiera-small-video-torch",
+            "base_filename": "sam2.1_hiera_small_video.pt",
+            "version": null,
+            "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
+            "source": "https://ai.meta.com/sam2/",
+            "size_bytes": 155906050,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_small.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.sam2.SegmentAnything2VideoModel",
+                "config": {
+                    "entrypoint_fcn": "sam2.build_sam.build_sam2_video_predictor",
+                    "entrypoint_args": {
+                        "model_cfg": "configs/sam2.1/sam2.1_hiera_s.yaml"
+                    },
+                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segment-anything", "torch", "zero-shot", "video"],
+            "date_added": "2024-08-05 14:38:20"
+        },
+        {
+            "base_name": "segment-anything-2-1-hiera-base-plus-video-torch",
+            "base_filename": "sam2.1_hiera_base_plus_video.pt",
+            "version": null,
+            "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
+            "source": "https://ai.meta.com/sam2/",
+            "size_bytes": 155906050,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_base_plus.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.sam2.SegmentAnything2VideoModel",
+                "config": {
+                    "entrypoint_fcn": "sam2.build_sam.build_sam2_video_predictor",
+                    "entrypoint_args": {
+                        "model_cfg": "configs/sam2.1/sam2.1_hiera_b+.yaml"
+                    },
+                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segment-anything", "torch", "zero-shot", "video"],
+            "date_added": "2024-08-05 14:38:20"
+        },
+        {
+            "base_name": "segment-anything-2-1-hiera-large-video-torch",
+            "base_filename": "sam2.1_hiera_large_video.pt",
+            "version": null,
+            "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
+            "source": "https://ai.meta.com/sam2/",
+            "size_bytes": 155906050,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_large.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.sam2.SegmentAnything2VideoModel",
+                "config": {
+                    "entrypoint_fcn": "sam2.build_sam.build_sam2_video_predictor",
+                    "entrypoint_args": {
+                        "model_cfg": "configs/sam2.1/sam2.1_hiera_l.yaml"
+                    },
+                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segment-anything", "torch", "zero-shot", "video"],
+            "date_added": "2024-08-05 14:38:20"
+        },
+        {
             "base_name": "deeplabv3-resnet50-coco-torch",
             "base_filename": "deeplabv3_resnet50_coco-cd0a2569.pth",
             "version": null,

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -487,7 +487,7 @@
             "date_added": "2024-08-17 14:48:00"
         },
         {
-            "base_name": "segment-anything-2-1-hiera-tiny-image-torch",
+            "base_name": "segment-anything-2.1-hiera-tiny-image-torch",
             "base_filename": "sam2.1_hiera_tiny_image.pt",
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
@@ -522,7 +522,7 @@
             "date_added": "2024-08-05 14:38:20"
         },
         {
-            "base_name": "segment-anything-2-1-hiera-small-image-torch",
+            "base_name": "segment-anything-2.1-hiera-small-image-torch",
             "base_filename": "sam2.1_hiera_small_image.pt",
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
@@ -557,7 +557,7 @@
             "date_added": "2024-08-05 14:38:20"
         },
         {
-            "base_name": "segment-anything-2-1-hiera-base-plus-image-torch",
+            "base_name": "segment-anything-2.1-hiera-base-plus-image-torch",
             "base_filename": "sam2.1_hiera_base_plus_image.pt",
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
@@ -592,7 +592,7 @@
             "date_added": "2024-08-05 14:38:20"
         },
         {
-            "base_name": "segment-anything-2-1-hiera-large-image-torch",
+            "base_name": "segment-anything-2.1-hiera-large-image-torch",
             "base_filename": "sam2.1_hiera_large_image.pt",
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
@@ -627,7 +627,7 @@
             "date_added": "2024-08-05 14:38:20"
         },
         {
-            "base_name": "segment-anything-2-1-hiera-tiny-video-torch",
+            "base_name": "segment-anything-2.1-hiera-tiny-video-torch",
             "base_filename": "sam2.1_hiera_tiny_video.pt",
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
@@ -661,7 +661,7 @@
             "date_added": "2024-08-05 14:38:20"
         },
         {
-            "base_name": "segment-anything-2-1-hiera-small-video-torch",
+            "base_name": "segment-anything-2.1-hiera-small-video-torch",
             "base_filename": "sam2.1_hiera_small_video.pt",
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
@@ -696,7 +696,7 @@
             "date_added": "2024-08-05 14:38:20"
         },
         {
-            "base_name": "segment-anything-2-1-hiera-base-plus-video-torch",
+            "base_name": "segment-anything-2.1-hiera-base-plus-video-torch",
             "base_filename": "sam2.1_hiera_base_plus_video.pt",
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
@@ -731,7 +731,7 @@
             "date_added": "2024-08-05 14:38:20"
         },
         {
-            "base_name": "segment-anything-2-1-hiera-large-video-torch",
+            "base_name": "segment-anything-2.1-hiera-large-video-torch",
             "base_filename": "sam2.1_hiera_large_video.pt",
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)
This PR adds in checkpoints for SAM2.1 models into the FiftyOne Model zoo.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other: FiftyOne model zoo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved logic for handling model applications in documentation generation, enhancing specificity for 'med-sam' and 'segment-anything' models.
	- Updated label and prompt fields for dataset model applications based on model type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->