### PR TITLE
remove overriding the grid sx

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/GridView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/GridView.tsx
@@ -39,10 +39,7 @@ export default function GridView(props: ViewPropsType) {
   };
 
   return (
-    <Box
-      {...getComponentProps(props, "container")}
-      sx={{ width: "100%", boxSizing: "border-box", padding: 1 }}
-    >
+    <Box {...getComponentProps(props, "container")}>
       <HeaderView {...props} divider nested />
       <Box {...getProps(props, "grid", baseGridProps)}>
         {propertiesAsArray.map((property) => {


### PR DESCRIPTION
## What changes are proposed in this pull request?

This causes regression in all GridViews - avoid overriding the spread props

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the `GridView` component by removing the `sx` prop from the outer `Box`, enhancing maintainability while preserving layout and rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->