### PR TITLE
Fix model zoo docs build

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,1 @@
-/source/user_guide/model_zoo/models.rst
+/source/model_zoo/models.rst

--- a/docs/scripts/make_model_zoo_docs.py
+++ b/docs/scripts/make_model_zoo_docs.py
@@ -423,7 +423,7 @@ def main():
     # Write docs page
 
     docs_dir = "/".join(os.path.realpath(__file__).split("/")[:-2])
-    outpath = os.path.join(docs_dir, "source/user_guide/model_zoo/models.rst")
+    outpath = os.path.join(docs_dir, "source/model_zoo/models.rst")
 
     print("Writing '%s'" % outpath)
     etau.write_file("\n".join(content), outpath)

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -452,7 +452,7 @@
             "base_name": "med-sam-2-video-torch",
             "base_filename": "med-sam-2_pretrain.pth",
             "version": null,
-            "description": "Fine-tuned SAM2-hiera-tiny model from paper: Medical SAM 2 - Segment Medical Images as Video via Segment Anything Model 2 <https://arxiv.org/abs/2408.00874>`_",
+            "description": "Fine-tuned SAM2-hiera-tiny model from `Medical SAM 2 - Segment Medical Images as Video via Segment Anything Model 2 <https://arxiv.org/abs/2408.00874>`_",
             "source": "https://github.com/MedicineToken/Medical-SAM2",
             "size_bytes": 155906050,
             "manager": {


### PR DESCRIPTION
We recently migrated `/user_guide/model_zoo` to `/model_zoo` in the docs, but we missed a couple places in the docs build. This is now fixed!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the file path for ignored documentation in `.gitignore`.
	- Changed the output path for generated model zoo documentation in the documentation script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->