### PR TITLE
add label_count link

### DIFF
--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -2199,6 +2199,11 @@ The ``surfaces`` key defines the panel's scope:
     :ref:`modal view <app-sample-view>`, which allows you to build interactions
     that focus on individual samples and scenarios
 
+.. note::
+
+   For an example of a modal panel, refer to the
+   `label count panel <https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/label_count>`_.
+
 .. _panel-execution-context:
 
 Execution context


### PR DESCRIPTION
Add a link to the label count panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced guidelines for developing plugins, including expanded sections on panel and operator development.
	- Improved readability with clearer structure and best practices for plugin creation.
	- Added numerous examples and use cases, including a "Hello World" plugin.
	- Introduced new notes on important considerations for plugin management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->