### PR TITLE
Segmentation annotations default flow modifications

### DIFF
--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -865,7 +865,6 @@ def _get_mask_targets(
     Returns:
         A tuple containing the mask targets dictionary {1: "label1", 2: "label2", ...} and a list of class names ["label1", "label2", ...]
     """
-    breakpoint()
     # We have defined mask targets for this field
     if "mask_targets" in label_info:
         mask_targets = label_info["mask_targets"]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Require users to specify a `mask_targets` argument for new segmentations annotations, otherwise fall back onto the dataset's defaults specified in `dataset.mask_targets` or `dataset.default_mask_targets`.

## How is this patch tested? If it is not, please explain why.

Manual testing of annotation flow with a test CVAT instance.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

When requesting semantic segmentations annotations, users must specify `mask_targets` for fields that do not yet exist.  If no targets are specified, the targets will be pulled from `dataset.mask_targets` or `dataset.default_mask_targets` if either exist.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced annotation functionality requiring mask targets for new segmentation fields.
	- Improved error handling for empty samples during annotation.

- **Bug Fixes**
	- Refined logic for determining mask targets, ensuring proper retrieval from existing samples or defaults.

- **Documentation**
	- Added detailed docstrings for better clarity on function parameters and return values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->