### PR TITLE
add skip_prompt

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -1027,6 +1027,7 @@ class PromptUserForOperation extends Operator {
     inputs.obj("params", { label: "Params" });
     inputs.str("on_success", { label: "On success" });
     inputs.str("on_error", { label: "On error" });
+    inputs.str("skip_prompt", { label: "Skip prompt", default: false });
     return new types.Property(inputs);
   }
   useHooks(ctx: ExecutionContext): {} {
@@ -1037,11 +1038,12 @@ class PromptUserForOperation extends Operator {
     const { params, operator_uri, on_success, on_error } = ctx.params;
     const { triggerEvent } = ctx.hooks;
     const panelId = ctx.getCurrentPanelId();
+    const shouldPrompt = !params.skip_prompt;
 
     triggerEvent(panelId, {
       operator: operator_uri,
       params,
-      prompt: true,
+      prompt: shouldPrompt,
       callback: (result: OperatorResult) => {
         if (result.error) {
           triggerEvent(panelId, {

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -1027,7 +1027,7 @@ class PromptUserForOperation extends Operator {
     inputs.obj("params", { label: "Params" });
     inputs.str("on_success", { label: "On success" });
     inputs.str("on_error", { label: "On error" });
-    inputs.str("skip_prompt", { label: "Skip prompt", default: false });
+    inputs.bool("skip_prompt", { label: "Skip prompt", default: false });
     return new types.Property(inputs);
   }
   useHooks(ctx: ExecutionContext): {} {
@@ -1038,7 +1038,7 @@ class PromptUserForOperation extends Operator {
     const { params, operator_uri, on_success, on_error } = ctx.params;
     const { triggerEvent } = ctx.hooks;
     const panelId = ctx.getCurrentPanelId();
-    const shouldPrompt = !params.skip_prompt;
+    const shouldPrompt = !ctx.params.skip_prompt;
 
     triggerEvent(panelId, {
       operator: operator_uri,
@@ -1046,15 +1046,19 @@ class PromptUserForOperation extends Operator {
       prompt: shouldPrompt,
       callback: (result: OperatorResult) => {
         if (result.error) {
-          triggerEvent(panelId, {
-            operator: on_error,
-            params: { error: result.error },
-          });
+          if (on_error) {
+            triggerEvent(panelId, {
+              operator: on_error,
+              params: { error: result.error },
+            });
+          }
         } else {
-          triggerEvent(panelId, {
-            operator: on_success,
-            params: { result: result.result },
-          });
+          if (on_success) {
+            triggerEvent(panelId, {
+              operator: on_success,
+              params: { result: result.result },
+            });
+          }
         }
       },
     });

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -769,6 +769,7 @@ class ExecutionContext(object):
                     "params": params,
                     "on_success": on_success,
                     "on_error": on_error,
+                    "skip_prompt": skip_prompt,
                 }
             ),
         )

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -744,6 +744,7 @@ class ExecutionContext(object):
         params=None,
         on_success=None,
         on_error=None,
+        skip_prompt=False,
     ):
         """Prompts the user to execute the operator with the given URI.
 
@@ -753,6 +754,7 @@ class ExecutionContext(object):
             on_success (None): a callback to invoke if the user successfully
                 executes the operator
             on_error (None): a callback to invoke if the execution fails
+            skip_prompt (False): whether to skip the prompt
 
         Returns:
             a :class:`fiftyone.operators.message.GeneratedMessage` containing


### PR DESCRIPTION
Allows disabling of prompt when using `ctx.prompt()`, which will execute the operator immediately given the params.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `skip_prompt` option for the `PromptUserForOperation` class, allowing users to bypass prompts during operation execution.
	- Added a `skip_prompt` parameter to the `prompt` method in the `ExecutionContext` class for enhanced control over user prompts.

- **Documentation**
	- Updated method signatures and documentation to reflect the new `skip_prompt` parameter, improving clarity on its usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->