### PR TITLE
Fix: quickstart3d load due to dict changed size during iteration

### DIFF
--- a/fiftyone/core/odm/utils.py
+++ b/fiftyone/core/odm/utils.py
@@ -658,7 +658,8 @@ class DocumentRegistry(object):
             pass
 
         # Then full module list
-        for module in sys.modules.values():
+        all_modules = sys.modules.copy().values()
+        for module in all_modules:
             try:
                 cls = self._get_cls(module, name)
                 self._cache[name] = cls

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -17,7 +17,6 @@ plotly==5.17.0
 pprintpp==0.4.0
 psutil>=5.7.0
 pymongo>=3.12,<4.9
-pydantic==2.6.4
 pytz==2022.1
 PyYAML==6.0.1
 regex==2022.8.17


### PR DESCRIPTION
This ended up being a bizarre series of events that led to this bug now of all times, since the code in question is years old.
If you're not satisfied with just the fix without knowing why, like I wasn't, follow along here. Otherwise the fix is quite simple, go there!

Alright here we go ...
1. 9/1/2022 - brimoor [introduced](https://github.com/voxel51/fiftyone/pull/2051) `DocumentRegistry` which allows custom embedded document classes to reside anywhere that is found within `sys.modules`. It does something like this:
```python
for module in sys.modules.values():
  try:
    return getattr(module, name)
  except AttributeError:
    pass
```
2. 1/10/2024 sash introduced [pydantic](https://github.com/voxel51/fiftyone/pull/3985) as part of 3D support. This was an oversight because we had used pydantic previously in the branch but decided to remove it - apparently leaving it in `requirements/common.txt`.
3. Did you know you can [override `__getattr__()` for a _module_](https://peps.python.org/pep-0562/)?? Well I did not. But that's what [pydantic v2](https://github.com/pydantic/pydantic/blob/main/pydantic/_migration.py#L249-L308) is doing to make a warning about accessing deprecated, removed, or relocated attributes.
4. In this function, it imports stuff! Specifically, `_internal._validators`.
5. Loading quickstart-3d requires a `DocumentRegistry` lookup of `OrthographicProjectionMetadata` at some point. `pydantic.errors` is in `sys.modules` at this point in time. So when we call `getattr(pydantic.errors, name)` it routes to the pydantic custom getter and imports a new package, thus changing the size of `sys.modules` while we're iterating! `RuntimeError: dictionary changed size during iteration`
6. Why are we importing `pydantic` anyway when we don't use it? [strawberry-graphql imports `pydantic` in its `experimental` submodule](https://github.com/strawberry-graphql/strawberry/blob/main/strawberry/experimental/__init__.py), but only if it can. So if you have pydantic in your environment, it'll pull it in.
7. Why did this issue with quickstart-3d start happening very recently?? My best guess is when we [bumped about a hundred versions of strawberry-graphql](https://github.com/voxel51/fiftyone/pull/4842) last month, some imports were shuffled around causing `sys.modules` content to be different.

FIN

## What changes are proposed in this pull request?

1. Remove `pydantic` from local build requirements
2. Make a copy of `sys.modules` first before traversing it. Avoids the "changed while iterating" thing.

## How is this patch tested? If it is not, please explain why.

```python
import fiftyone as fo

# I had to do this in order to reproduce the issue. I have NO idea why. Others could reproduce reliably without this.
fo.config.dataset_zoo_dir = "~/fiftyone2"

ds = fo.zoo.load_zoo_dataset("quickstart-3d")
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixed RuntimeError when loading quickstart-3d dataset

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
