### PR TITLE
Freeze psutil/tensorflow dep

### DIFF
--- a/requirements/github.txt
+++ b/requirements/github.txt
@@ -4,7 +4,7 @@
 numpy<2
 pydicom>=2.2.0
 shapely>=1.7.1
-tensorflow
+tensorflow==2.17.0
 tensorflow-datasets
 torch
 torchvision

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,5 +7,5 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 pytest-asyncio
 shapely
-tensorflow
+tensorflow==2.17.0
 twine>=3


### PR DESCRIPTION
## What changes are proposed in this pull request?

An attempt to try and freeze testing dependencies so testing images will successfully build

See the previous build error aiming to fix

<img width="1728" alt="Screenshot 2024-10-27 at 12 35 00 PM" src="https://github.com/user-attachments/assets/a1141660-5c2c-4868-b7f3-b774c704ab0e">


## How is this patch tested? If it is not, please explain why.

Through watching if tests build successfully

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the `tensorflow` package version to `2.17.0` in both the main and test requirements, ensuring compatibility and functionality improvements.
  
- **Chores**
	- Removed outdated dependencies `common.txt` and `test.txt` from the requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->