### PR TITLE
fix circular import in operators/spaces

### DIFF
--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -1,5 +1,7 @@
 import { AnalyticsInfo, usingAnalytics } from "@fiftyone/analytics";
-import { SpaceNode, spaceNodeFromJSON, SpaceNodeJSON } from "@fiftyone/spaces";
+import SpaceNode from "@fiftyone/spaces/src/SpaceNode";
+import { SpaceNodeJSON } from "@fiftyone/spaces/src/types";
+import { spaceNodeFromJSON } from "@fiftyone/spaces/src/utils";
 import { getFetchFunction, isNullish, ServerError } from "@fiftyone/utilities";
 import { CallbackInterface } from "recoil";
 import { QueueItemStatus } from "./constants";


### PR DESCRIPTION
Temp fix for a circular import build time bug in webpack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated import paths for `SpaceNode`, `SpaceNodeJSON`, and `spaceNodeFromJSON` to improve code organization.
	- Revised `RawContext` type to align with the new structure of `spaces` using `SpaceNodeJSON`. 

These changes enhance the maintainability of the codebase while ensuring existing functionality remains unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->