### PR TITLE
embeddings cta polish

### DIFF
--- a/app/packages/embeddings/src/ComputeVisualizationButton.tsx
+++ b/app/packages/embeddings/src/ComputeVisualizationButton.tsx
@@ -1,13 +1,26 @@
 import { Button } from "@mui/material";
-import { usePanelEvent } from "@fiftyone/operators";
-import { usePanelId } from "@fiftyone/spaces";
 import AddIcon from "@mui/icons-material/Add";
 import { useTheme } from "@fiftyone/components";
 
-export default function ComputeVisualizationButton({ uri }) {
-  const triggerEvent = usePanelEvent();
+export default function ComputeVisualizationButton({ variant, onClick }) {
   const theme = useTheme();
-  const panelId = usePanelId();
+
+  if (variant === "box") {
+    return (
+      <Button
+        variant="outlined"
+        sx={{
+          borderColor: theme.primary.main,
+          color: theme.primary.main,
+        }}
+        startIcon={<AddIcon />}
+        onClick={onClick}
+      >
+        Compute Visualization
+      </Button>
+    );
+  }
+
   return (
     <Button
       variant="contained"
@@ -16,13 +29,7 @@ export default function ComputeVisualizationButton({ uri }) {
         color: theme.text.primary,
       }}
       startIcon={<AddIcon />}
-      onClick={() => {
-        triggerEvent(panelId, {
-          params: { delegate: true },
-          operator: uri,
-          prompt: true,
-        });
-      }}
+      onClick={onClick}
     >
       Compute Visualization
     </Button>

--- a/app/packages/embeddings/src/Embeddings.tsx
+++ b/app/packages/embeddings/src/Embeddings.tsx
@@ -9,6 +9,7 @@ import {
   OpenWith,
   Warning,
   CenterFocusWeak,
+  Add,
 } from "@mui/icons-material";
 import { useBrainResultsSelector } from "./useBrainResult";
 import { useLabelSelector } from "./useLabelSelector";
@@ -25,6 +26,7 @@ import { useResetPlotZoom } from "./useResetPlotZoom";
 import { OperatorPlacements, types } from "@fiftyone/operators";
 import ComputeVisualizationButton from "./ComputeVisualizationButton";
 import EmptyEmbeddings from "./EmptyEmbeddings";
+import useComputeVisualization from "./useComputeVisualization";
 
 const Value: React.FC<{ value: string; className: string }> = ({ value }) => {
   return <>{value}</>;
@@ -50,6 +52,7 @@ export default function Embeddings({ containerHeight, dimensions }) {
   const embeddingsDocumentationLink = useExternalLink(
     "https://docs.voxel51.com"
   );
+  const computeViz = useComputeVisualization();
 
   useEffect(() => {
     setPanelCloseEffect(() => {
@@ -88,6 +91,14 @@ export default function Embeddings({ containerHeight, dimensions }) {
                 resultsPlacement="bottom-start"
                 containerStyle={selectorStyle}
               />
+            )}
+            {computeViz.isAvailable && (
+              <PlotOption
+                to={() => computeViz.prompt()}
+                title={"Compute visualization"}
+              >
+                <Add />
+              </PlotOption>
             )}
             {!plotSelection.selectionIsExternal && (
               <PlotOption
@@ -139,7 +150,6 @@ export default function Embeddings({ containerHeight, dimensions }) {
                 </PlotOption>
               </Fragment>
             )}
-            <ComputeVisualizationButton />
             <OperatorPlacements place={types.Places.EMBEDDINGS_ACTIONS} />
           </div>
         </Selectors>

--- a/app/packages/embeddings/src/EmptyEmbeddings.tsx
+++ b/app/packages/embeddings/src/EmptyEmbeddings.tsx
@@ -3,28 +3,13 @@ import { useTheme } from "@fiftyone/components";
 import WorkspacesIcon from "@mui/icons-material/Workspaces";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import ComputeVisualizationButton from "./ComputeVisualizationButton";
-import { useMemo } from "react";
-import { listLocalAndRemoteOperators } from "@fiftyone/operators/src/operators";
-
-const useFirstExistingUri = (uris: string[]) => {
-  const availableOperators = useMemo(() => listLocalAndRemoteOperators(), []);
-  return useMemo(() => {
-    const existingUri = uris.find((uri) =>
-      availableOperators.allOperators.some((op) => op.uri === uri)
-    );
-    const exists = Boolean(existingUri);
-    return { firstExistingUri: existingUri, exists };
-  }, [availableOperators, uris]);
-};
+import useComputeVisualization from "./useComputeVisualization";
 
 export default function EmptyEmbeddings() {
   const theme = useTheme();
   const secondaryBodyColor = theme.text.secondary;
-  let { firstExistingUri: computeVisUri, exists: hasComputeVisualization } =
-    useFirstExistingUri([
-      "@voxel51/brain/compute_visualization",
-      "@voxel51/operators/compute_visualization",
-    ]);
+  const computeViz = useComputeVisualization();
+  const hasComputeVisualization = computeViz.isAvailable;
 
   return (
     <Box
@@ -68,7 +53,9 @@ export default function EmptyEmbeddings() {
           </Grid>
           <Grid item />
           {!hasComputeVisualization && <OSSContent />}
-          {hasComputeVisualization && <ComputeVisContent uri={computeVisUri} />}
+          {hasComputeVisualization && (
+            <ComputeVisContent computeViz={computeViz} />
+          )}
         </Grid>
       </Box>
       {hasComputeVisualization && (
@@ -120,13 +107,13 @@ function OSSContent() {
   );
 }
 
-function ComputeVisContent({ uri }) {
+function ComputeVisContent({ computeViz }) {
   const theme = useTheme();
   const secondaryBodyColor = theme.text.secondary;
   return (
     <>
       <Grid item>
-        <ComputeVisualizationButton uri={uri} />
+        <ComputeVisualizationButton onClick={() => computeViz.prompt()} />
       </Grid>
     </>
   );

--- a/app/packages/embeddings/src/useComputeVisualization.ts
+++ b/app/packages/embeddings/src/useComputeVisualization.ts
@@ -1,0 +1,39 @@
+import { useCallback, useMemo } from "react";
+import { listLocalAndRemoteOperators } from "@fiftyone/operators/src/operators";
+import { usePanelEvent } from "@fiftyone/operators";
+import { usePanelId } from "@fiftyone/spaces";
+
+const useFirstExistingUri = (uris: string[]) => {
+  const availableOperators = useMemo(() => listLocalAndRemoteOperators(), []);
+  return useMemo(() => {
+    const existingUri = uris.find((uri) =>
+      availableOperators.allOperators.some((op) => op.uri === uri)
+    );
+    const exists = Boolean(existingUri);
+    return { firstExistingUri: existingUri, exists };
+  }, [availableOperators, uris]);
+};
+
+export default function useComputeVisualization() {
+  let { firstExistingUri: computeVisUri, exists: hasComputeVisualization } =
+    useFirstExistingUri([
+      "@voxel51/brain/compute_visualization",
+      "@voxel51/operators/compute_visualization",
+    ]);
+
+  const panelId = usePanelId();
+  const triggerEvent = usePanelEvent();
+
+  const prompt = useCallback(() => {
+    triggerEvent(panelId, {
+      params: { delegate: true },
+      operator: computeVisUri,
+      prompt: true,
+    });
+  }, [panelId, triggerEvent, computeVisUri]);
+
+  return {
+    isAvailable: hasComputeVisualization,
+    prompt,
+  };
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Refactors embeddings CTA logic into hook. Fixes issue where compute visualization button was displayed imporperly. Cleans up style of compute viz button in menu (see below).

<img width="539" alt="image" src="https://github.com/user-attachments/assets/7e9599fc-e522-4de9-9d30-6253791255dc">


## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `ComputeVisualizationButton` with improved styling and functionality based on the `variant` prop.
  - Added a new visualization option in the `Embeddings` component that prompts users to compute a visualization.
  - Launched a custom hook, `useComputeVisualization`, to manage compute visualization operations.

- **Bug Fixes**
  - Streamlined the logic in the `EmptyEmbeddings` component for better handling of compute visualization availability.

- **Refactor**
  - Removed dependencies on previous URI management and panel events to simplify component interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->