### PR TITLE
debounce modal navigation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,7 +47,7 @@ jobs:
 
   all-tests:
     runs-on: ubuntu-latest
-    needs: [build, lint, test]
+    needs: [build, lint, test, e2e]
     if: always()
     steps:
       - run: sh -c ${{

--- a/app/packages/app/src/components/AnalyticsConsent.tsx
+++ b/app/packages/app/src/components/AnalyticsConsent.tsx
@@ -85,17 +85,23 @@ export default function AnalyticsConsent({
             Help us improve FiftyOne
           </Typography>
           <Typography marginBottom={1}>
-            We use cookies to understand how FiftyOne is used and improve the product.
-            You can help us by enabling anonymous analytics.
+            We use cookies to understand how FiftyOne is used and improve the
+            product. You can help us by enabling anonymous analytics.
           </Typography>
           <Grid container gap={2} justifyContent="end" direction="row">
             <Grid item alignContent="center">
-              <Link style={{ cursor: "pointer" }} onClick={handleDisable}>
+              <Link
+                style={{ cursor: "pointer" }}
+                onClick={handleDisable}
+                data-cy="btn-disable-cookies"
+              >
                 Disable
               </Link>
             </Grid>
             <Grid item>
-              <Button variant="contained" onClick={handleEnable}>Enable</Button>
+              <Button variant="contained" onClick={handleEnable}>
+                Enable
+              </Button>
             </Grid>
           </Grid>
         </Grid>

--- a/app/packages/core/src/components/Modal/ModalNavigation.tsx
+++ b/app/packages/core/src/components/Modal/ModalNavigation.tsx
@@ -68,13 +68,15 @@ const ModalNavigation = ({ onNavigate }: { onNavigate: () => void }) => {
 
   modalRef.current = modal;
 
+  // important: make sure all dependencies of the navigators are referentially stable,
+  // or else the debouncing mechanism won't work
   const nextNavigator = useMemo(
     () =>
       createDebouncedNavigator({
         isNavigationIllegalWhen: () => modalRef.current?.hasNext === false,
         navigateFn: (offset) => navigation?.next(offset).then(setModal),
         onNavigationStart: onNavigate,
-        debounceTime: 200,
+        debounceTime: 150,
       }),
     [navigation, onNavigate, setModal]
   );
@@ -85,7 +87,7 @@ const ModalNavigation = ({ onNavigate }: { onNavigate: () => void }) => {
         isNavigationIllegalWhen: () => modalRef.current?.hasPrevious === false,
         navigateFn: (offset) => navigation?.previous(offset).then(setModal),
         onNavigationStart: onNavigate,
-        debounceTime: 200,
+        debounceTime: 150,
       }),
     [navigation, onNavigate, setModal]
   );

--- a/app/packages/core/src/components/Modal/ModalNavigation.tsx
+++ b/app/packages/core/src/components/Modal/ModalNavigation.tsx
@@ -3,7 +3,7 @@ import {
   LookerArrowRightIcon,
 } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
-import React, { useCallback, useRef } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import { useRecoilValue, useRecoilValueLoadable } from "recoil";
 import styled from "styled-components";
 
@@ -63,17 +63,92 @@ const ModalNavigation = ({ onNavigate }: { onNavigate: () => void }) => {
   const modal = useRecoilValue(fos.modalSelector);
   const navigation = useRecoilValue(fos.modalNavigation);
 
-  const navigateNext = useCallback(async () => {
-    onNavigate();
-    const result = await navigation?.next();
-    setModal(result);
+  const nextTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const accumulatedNextOffsetRef = useRef(0);
+
+  const previousTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const accumulatedPreviousOffsetRef = useRef(0);
+
+  const modalRef = useRef(modal);
+
+  modalRef.current = modal;
+
+  const navigateNext = useCallback(() => {
+    if (!modalRef.current?.hasNext) {
+      return;
+    }
+
+    if (!nextTimeoutRef.current) {
+      // First click: navigate immediately
+      onNavigate();
+      navigation?.next(1).then(setModal);
+      accumulatedNextOffsetRef.current = 0;
+      console.log(">!>Immediate next execution");
+    } else {
+      // Subsequent clicks: accumulate offset
+      accumulatedNextOffsetRef.current += 1;
+      console.log(">!>Debouncing next");
+    }
+
+    // Reset debounce timer
+    if (nextTimeoutRef.current) {
+      clearTimeout(nextTimeoutRef.current);
+    }
+
+    nextTimeoutRef.current = setTimeout(() => {
+      if (accumulatedNextOffsetRef.current > 0) {
+        onNavigate();
+        navigation?.next(accumulatedNextOffsetRef.current).then(setModal);
+        accumulatedNextOffsetRef.current = 0;
+      }
+      nextTimeoutRef.current = null;
+    }, 200);
   }, [navigation, onNavigate, setModal]);
 
-  const navigatePrevious = useCallback(async () => {
-    onNavigate();
-    const result = await navigation?.previous();
-    setModal(result);
-  }, [onNavigate, navigation, setModal]);
+  const navigatePrevious = useCallback(() => {
+    if (!modalRef.current?.hasPrevious) {
+      return;
+    }
+
+    if (!previousTimeoutRef.current) {
+      // First click: navigate immediately
+      onNavigate();
+      navigation?.previous(1).then(setModal);
+      accumulatedPreviousOffsetRef.current = 0;
+      console.log(">!>Immediate previous execution");
+    } else {
+      // Subsequent clicks: accumulate offset
+      accumulatedPreviousOffsetRef.current += 1;
+      console.log(">!>Debouncing previous");
+    }
+
+    // Reset debounce timer
+    if (previousTimeoutRef.current) {
+      clearTimeout(previousTimeoutRef.current);
+    }
+
+    previousTimeoutRef.current = setTimeout(() => {
+      if (accumulatedPreviousOffsetRef.current > 0) {
+        onNavigate();
+        navigation
+          ?.previous(accumulatedPreviousOffsetRef.current)
+          .then(setModal);
+        accumulatedPreviousOffsetRef.current = 0;
+      }
+      previousTimeoutRef.current = null;
+    }, 200);
+  }, [navigation, onNavigate, setModal]);
+
+  useEffect(() => {
+    return () => {
+      if (nextTimeoutRef.current) {
+        clearTimeout(nextTimeoutRef.current);
+      }
+      if (previousTimeoutRef.current) {
+        clearTimeout(previousTimeoutRef.current);
+      }
+    };
+  }, []);
 
   const keyboardHandler = useCallback(
     (e: KeyboardEvent) => {
@@ -122,6 +197,10 @@ const ModalNavigation = ({ onNavigate }: { onNavigate: () => void }) => {
           onClick={navigateNext}
         >
           <LookerArrowRightIcon data-cy="nav-right-button" />
+          <div>oi</div>
+          {accumulatedNextOffsetRef.current > 0 && (
+            <div>{accumulatedNextOffsetRef.current}</div>
+          )}
         </Arrow>
       )}
     </>

--- a/app/packages/core/src/components/Modal/debouncedNavigator.test.ts
+++ b/app/packages/core/src/components/Modal/debouncedNavigator.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createDebouncedNavigator } from "./debouncedNavigator";
+
+describe("createDebouncedNavigator", () => {
+  let navigateFn: ReturnType<typeof vi.fn>;
+  let onNavigationStart: ReturnType<typeof vi.fn>;
+  let isNavigationIllegalWhen: ReturnType<typeof vi.fn>;
+  let debouncedNavigator: ReturnType<typeof createDebouncedNavigator>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    navigateFn = vi.fn();
+    onNavigationStart = vi.fn();
+    isNavigationIllegalWhen = vi.fn().mockReturnValue(false);
+    debouncedNavigator = createDebouncedNavigator({
+      isNavigationIllegalWhen,
+      navigateFn,
+      onNavigationStart,
+      debounceTime: 100,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("should navigate immediately on the first call", () => {
+    debouncedNavigator.navigate();
+
+    expect(isNavigationIllegalWhen).toHaveBeenCalled();
+    expect(onNavigationStart).toHaveBeenCalledTimes(1);
+    expect(navigateFn).toHaveBeenCalledWith(1);
+  });
+
+  it("should debounce subsequent calls and accumulate offset", () => {
+    // immediate call
+    debouncedNavigator.navigate();
+    // accumulated
+    debouncedNavigator.navigate();
+    // accumulated
+    debouncedNavigator.navigate();
+
+    // only the first call
+    expect(onNavigationStart).toHaveBeenCalledTimes(1);
+
+    // advance time less than debounceTime
+    vi.advanceTimersByTime(50);
+    // another accumulated call
+    debouncedNavigator.navigate();
+
+    // advance time to trigger debounce after the last navigate
+    // need to advance full debounceTime after last call
+    vi.advanceTimersByTime(100);
+
+    // first immediate call + after debounce
+    expect(onNavigationStart).toHaveBeenCalledTimes(2);
+    // immediate call
+    expect(navigateFn).toHaveBeenCalledWith(1);
+    // accumulated calls
+    expect(navigateFn).toHaveBeenCalledWith(3);
+  });
+
+  it("should reset after debounce period", () => {
+    // immediate call
+    debouncedNavigator.navigate();
+    // accumulated
+    debouncedNavigator.navigate();
+
+    vi.advanceTimersByTime(100);
+
+    // next navigate call should be immediate again
+    debouncedNavigator.navigate();
+
+    expect(onNavigationStart).toHaveBeenCalledTimes(3);
+    expect(navigateFn).toHaveBeenNthCalledWith(1, 1);
+    // accumulated offset
+    expect(navigateFn).toHaveBeenNthCalledWith(2, 1);
+    expect(navigateFn).toHaveBeenNthCalledWith(3, 1);
+  });
+
+  it("should not navigate when isNavigationIllegalWhen returns true", () => {
+    isNavigationIllegalWhen.mockReturnValueOnce(true);
+
+    debouncedNavigator.navigate();
+
+    expect(isNavigationIllegalWhen).toHaveBeenCalled();
+    expect(onNavigationStart).not.toHaveBeenCalled();
+    expect(navigateFn).not.toHaveBeenCalled();
+  });
+
+  it("should cancel pending navigation when cleanup is called", () => {
+    // immediate call
+    debouncedNavigator.navigate();
+    // accumulated
+    debouncedNavigator.navigate();
+    debouncedNavigator.cleanup();
+
+    vi.advanceTimersByTime(200);
+
+    // only the immediate call
+    expect(onNavigationStart).toHaveBeenCalledTimes(1);
+    expect(navigateFn).toHaveBeenCalledTimes(1);
+    expect(navigateFn).toHaveBeenCalledWith(1);
+  });
+
+  it("should clear timeout when isNavigationIllegalWhen returns true during debounce", () => {
+    // immediate call
+    debouncedNavigator.navigate();
+    // accumulated
+    debouncedNavigator.navigate();
+
+    isNavigationIllegalWhen.mockReturnValue(true);
+    // should not accumulate further
+    debouncedNavigator.navigate();
+
+    vi.advanceTimersByTime(100);
+
+    // only the initial navigation
+    expect(onNavigationStart).toHaveBeenCalledTimes(1); //
+    // only immediate call
+    expect(navigateFn).toHaveBeenCalledTimes(1);
+    expect(navigateFn).toHaveBeenCalledWith(1);
+
+    // reset mock to allow navigation
+    isNavigationIllegalWhen.mockReturnValue(false);
+
+    // should navigate immediately
+    debouncedNavigator.navigate();
+
+    expect(onNavigationStart).toHaveBeenCalledTimes(2);
+    expect(navigateFn).toHaveBeenCalledTimes(2);
+    expect(navigateFn).toHaveBeenCalledWith(1);
+  });
+
+  it("should handle multiple sequences correctly", () => {
+    // first sequence
+    // immediate
+    debouncedNavigator.navigate();
+    // accumulated
+    debouncedNavigator.navigate();
+    debouncedNavigator.navigate();
+
+    vi.advanceTimersByTime(100);
+
+    expect(onNavigationStart).toHaveBeenCalledTimes(2);
+    expect(navigateFn).toHaveBeenNthCalledWith(1, 1);
+    expect(navigateFn).toHaveBeenNthCalledWith(2, 2);
+
+    // second sequence
+    // immediate call
+    debouncedNavigator.navigate();
+    // accumulated
+    debouncedNavigator.navigate();
+
+    vi.advanceTimersByTime(100);
+
+    expect(onNavigationStart).toHaveBeenCalledTimes(4);
+    expect(navigateFn).toHaveBeenNthCalledWith(3, 1);
+    expect(navigateFn).toHaveBeenNthCalledWith(4, 1);
+  });
+
+  it("should reset accumulatedOffset when isNavigationIllegalWhen returns true", () => {
+    // immediate call
+    debouncedNavigator.navigate();
+    // accumulated
+    debouncedNavigator.navigate();
+
+    isNavigationIllegalWhen.mockReturnValueOnce(true);
+
+    // should not accumulate further
+    debouncedNavigator.navigate();
+
+    vi.advanceTimersByTime(100);
+
+    // only the immediate call
+    expect(onNavigationStart).toHaveBeenCalledTimes(1);
+    expect(navigateFn).toHaveBeenCalledTimes(1);
+    expect(navigateFn).toHaveBeenCalledWith(1);
+  });
+});

--- a/app/packages/core/src/components/Modal/debouncedNavigator.ts
+++ b/app/packages/core/src/components/Modal/debouncedNavigator.ts
@@ -1,6 +1,6 @@
 interface DebouncedNavigatorOptions {
   isNavigationIllegalWhen: () => boolean;
-  navigateFn: (offset: number) => Promise<void> | void;
+  navigateFn: (offset: number) => Promise<void>;
   onNavigationStart: () => void;
   debounceTime?: number;
 }

--- a/app/packages/core/src/components/Modal/debouncedNavigator.ts
+++ b/app/packages/core/src/components/Modal/debouncedNavigator.ts
@@ -1,0 +1,70 @@
+interface DebouncedNavigatorOptions {
+  isNavigationIllegalWhen: () => boolean;
+  navigateFn: (offset: number) => Promise<void> | void;
+  onNavigationStart: () => void;
+  debounceTime?: number;
+}
+
+export function createDebouncedNavigator({
+  isNavigationIllegalWhen,
+  navigateFn,
+  onNavigationStart,
+  debounceTime = 100,
+}: DebouncedNavigatorOptions) {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  let accumulatedOffset = 0;
+  let isFirstCall = true;
+
+  const cleanup = () => {
+    if (timeout) {
+      clearTimeout(timeout);
+      timeout = null;
+    }
+    accumulatedOffset = 0;
+    isFirstCall = true;
+  };
+
+  const navigate = () => {
+    if (isNavigationIllegalWhen()) {
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = null;
+      }
+      // Reset state variables
+      isFirstCall = true;
+      accumulatedOffset = 0;
+      return;
+    }
+
+    if (isFirstCall) {
+      // first invocation: navigate immediately
+      onNavigationStart();
+      navigateFn(1);
+      accumulatedOffset = 0;
+      isFirstCall = false;
+    } else {
+      // subsequently, accumulate offset
+      accumulatedOffset += 1;
+    }
+
+    // reset debounce timer
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+
+    timeout = setTimeout(() => {
+      if (accumulatedOffset > 0) {
+        onNavigationStart();
+        navigateFn(accumulatedOffset);
+        accumulatedOffset = 0;
+      }
+      timeout = null;
+      isFirstCall = true;
+    }, debounceTime);
+  };
+
+  return {
+    navigate,
+    cleanup,
+  };
+}

--- a/app/packages/core/src/components/Modal/hooks.ts
+++ b/app/packages/core/src/components/Modal/hooks.ts
@@ -1,16 +1,25 @@
 import * as fos from "@fiftyone/state";
 import { useHelpPanel, useJSONPanel } from "@fiftyone/state";
-import { useCallback, useContext } from "react";
+import { useCallback, useContext, useRef } from "react";
 import { useRecoilCallback } from "recoil";
 import { modalContext } from "./modal-context";
 
 export const useLookerHelpers = () => {
   const jsonPanel = useJSONPanel();
   const helpPanel = useHelpPanel();
+
+  // todo: jsonPanel and helpPanel are not referentially stable
+  // so use refs here
+  const jsonPanelRef = useRef(jsonPanel);
+  const helpPanelRef = useRef(helpPanel);
+
+  jsonPanelRef.current = jsonPanel;
+  helpPanelRef.current = helpPanel;
+
   const onNavigate = useCallback(() => {
-    jsonPanel.close();
-    helpPanel.close();
-  }, [helpPanel, jsonPanel]);
+    jsonPanelRef.current?.close();
+    helpPanelRef.current?.close();
+  }, []);
 
   return {
     jsonPanel,

--- a/app/packages/core/src/components/Modal/hooks.ts
+++ b/app/packages/core/src/components/Modal/hooks.ts
@@ -10,8 +10,8 @@ export const useLookerHelpers = () => {
 
   // todo: jsonPanel and helpPanel are not referentially stable
   // so use refs here
-  const jsonPanelRef = useRef(jsonPanel);
-  const helpPanelRef = useRef(helpPanel);
+  const jsonPanelRef = useRef<typeof jsonPanel>(jsonPanel);
+  const helpPanelRef = useRef<typeof helpPanel>(helpPanel);
 
   jsonPanelRef.current = jsonPanel;
   helpPanelRef.current = helpPanel;

--- a/app/packages/state/src/hooks/useExpandSample.ts
+++ b/app/packages/state/src/hooks/useExpandSample.ts
@@ -8,6 +8,7 @@ import * as atoms from "../recoil/atoms";
 import * as groupAtoms from "../recoil/groups";
 import useSetExpandedSample from "./useSetExpandedSample";
 import useSetModalState from "./useSetModalState";
+import { useCallback } from "react";
 
 export type Sample = Exclude<
   Exclude<
@@ -22,6 +23,7 @@ export type Sample = Exclude<
 export default (store: WeakMap<ID, { index: number; sample: Sample }>) => {
   const setExpandedSample = useSetExpandedSample();
   const setModalState = useSetModalState();
+
   return useRecoilCallback(
     ({ snapshot, set }) =>
       async ({
@@ -64,20 +66,20 @@ export default (store: WeakMap<ID, { index: number; sample: Sample }>) => {
           return { id: id.description, groupId };
         };
 
-        const next = async () => {
-          const result = await iter(cursor.next(1));
+        const next = async (skip: number) => {
+          const result = await iter(cursor.next(skip));
           return {
-            hasNext: Boolean(await cursor.next(1, true)),
+            hasNext: Boolean(await cursor.next(skip, true)),
             hasPrevious: true,
             ...result,
           };
         };
 
-        const previous = async () => {
-          const result = await iter(cursor.next(-1));
+        const previous = async (skip: number) => {
+          const result = await iter(cursor.next(-1 * skip));
           return {
             hasNext: true,
-            hasPrevious: Boolean(await cursor.next(-1, true)),
+            hasPrevious: Boolean(await cursor.next(-1 * skip, true)),
             ...result,
           };
         };

--- a/app/packages/state/src/hooks/useExpandSample.ts
+++ b/app/packages/state/src/hooks/useExpandSample.ts
@@ -8,7 +8,6 @@ import * as atoms from "../recoil/atoms";
 import * as groupAtoms from "../recoil/groups";
 import useSetExpandedSample from "./useSetExpandedSample";
 import useSetModalState from "./useSetModalState";
-import { useCallback } from "react";
 
 export type Sample = Exclude<
   Exclude<
@@ -66,20 +65,20 @@ export default (store: WeakMap<ID, { index: number; sample: Sample }>) => {
           return { id: id.description, groupId };
         };
 
-        const next = async (skip: number) => {
-          const result = await iter(cursor.next(skip));
+        const next = async (offset?: number) => {
+          const result = await iter(cursor.next(offset ?? 1));
           return {
-            hasNext: Boolean(await cursor.next(skip, true)),
+            hasNext: Boolean(await cursor.next(offset ?? 1, true)),
             hasPrevious: true,
             ...result,
           };
         };
 
-        const previous = async (skip: number) => {
-          const result = await iter(cursor.next(-1 * skip));
+        const previous = async (offset: number) => {
+          const result = await iter(cursor.next(-1 * (offset ?? 1)));
           return {
             hasNext: true,
-            hasPrevious: Boolean(await cursor.next(-1 * skip, true)),
+            hasPrevious: Boolean(await cursor.next(-1 * (offset ?? 1), true)),
             ...result,
           };
         };

--- a/app/packages/state/src/hooks/useExpandSample.ts
+++ b/app/packages/state/src/hooks/useExpandSample.ts
@@ -65,20 +65,26 @@ export default (store: WeakMap<ID, { index: number; sample: Sample }>) => {
           return { id: id.description, groupId };
         };
 
-        const next = async (offset?: number) => {
-          const result = await iter(cursor.next(offset ?? 1));
+        const next = async (offset: number = 1) => {
+          const nextId = await cursor.next(offset);
+          const nextCheckId = await cursor.next(offset, true);
+
+          const result = await iter(Promise.resolve(nextId));
           return {
-            hasNext: Boolean(await cursor.next(offset ?? 1, true)),
+            hasNext: Boolean(nextCheckId),
             hasPrevious: true,
             ...result,
           };
         };
 
         const previous = async (offset: number) => {
-          const result = await iter(cursor.next(-1 * (offset ?? 1)));
+          const prevId = await cursor.next(-1 * offset);
+          const prevCheckId = await cursor.next(-1 * offset, true);
+
+          const result = await iter(Promise.resolve(prevId));
           return {
             hasNext: true,
-            hasPrevious: Boolean(await cursor.next(-1 * (offset ?? 1), true)),
+            hasPrevious: Boolean(prevCheckId),
             ...result,
           };
         };

--- a/app/packages/state/src/recoil/modal.ts
+++ b/app/packages/state/src/recoil/modal.ts
@@ -119,8 +119,8 @@ export const isModalActive = selector<boolean>({
 });
 
 export type ModalNavigation = {
-  next: () => Promise<ModalSelector>;
-  previous: () => Promise<ModalSelector>;
+  next: (offset?: number) => Promise<ModalSelector>;
+  previous: (offset?: number) => Promise<ModalSelector>;
 };
 
 export const modalNavigation = atom<ModalNavigation>({

--- a/e2e-pw/src/oss/constants/index.ts
+++ b/e2e-pw/src/oss/constants/index.ts
@@ -2,6 +2,7 @@ import { Duration } from "src/oss/utils";
 
 // time to wait for fiftyone app to load
 export const DEFAULT_APP_LOAD_TIMEOUT = Duration.Minutes(2);
+export const POPUP_DISMISS_TIMEOUT = Duration.Seconds(5);
 
 export const DEFAULT_APP_PORT = 8787;
 export const DEFAULT_APP_HOSTNAME = "0.0.0.0";

--- a/e2e-pw/src/oss/fixtures/loader.ts
+++ b/e2e-pw/src/oss/fixtures/loader.ts
@@ -8,6 +8,7 @@ import {
 import { PythonRunner } from "src/shared/python-runner/python-runner";
 import kill from "tree-kill";
 import waitOn from "wait-on";
+import { POPUP_DISMISS_TIMEOUT } from "../constants";
 import { Duration } from "../utils";
 
 type WebServerProcessConfig = {
@@ -188,5 +189,22 @@ export class OssLoader extends AbstractFiftyoneLoader {
       {},
       { timeout: Duration.Seconds(10) }
     );
+
+    // close all pop-ups (cookies, new feature annoucement, etc.)
+    try {
+      await page
+        .getByTestId("btn-dismiss-query-performance-toast")
+        .click({ timeout: POPUP_DISMISS_TIMEOUT });
+    } catch {
+      console.log("No query performance toast to dismiss");
+    }
+
+    try {
+      await page
+        .getByTestId("btn-disable-cookies")
+        .click({ timeout: POPUP_DISMISS_TIMEOUT });
+    } catch {
+      console.log("No cookies button to disable");
+    }
   }
 }

--- a/e2e-pw/src/oss/poms/selector.ts
+++ b/e2e-pw/src/oss/poms/selector.ts
@@ -60,7 +60,5 @@ class SelectorAsserter {
         )
       ).toBeVisible();
     }
-
-    await this.selectorPom.closeResults();
   }
 }

--- a/e2e-pw/src/oss/specs/plugins/histograms.spec.ts
+++ b/e2e-pw/src/oss/specs/plugins/histograms.spec.ts
@@ -75,15 +75,13 @@ test("histograms panel", async ({ histogram, panel }) => {
     "str",
     "tags",
   ]);
-  await expect(await histogram.locator).toHaveScreenshot("bool-histogram.png", {
+  await expect(histogram.locator).toHaveScreenshot("bool-histogram.png", {
     animations: "allow",
   });
+  await histogram.selector.closeResults();
 
   await histogram.selectField("float");
-  await expect(await histogram.locator).toHaveScreenshot(
-    "float-histogram.png",
-    {
-      animations: "allow",
-    }
-  );
+  await expect(histogram.locator).toHaveScreenshot("float-histogram.png", {
+    animations: "allow",
+  });
 });

--- a/e2e-pw/src/oss/specs/regression-tests/media-field.spec.ts
+++ b/e2e-pw/src/oss/specs/regression-tests/media-field.spec.ts
@@ -64,13 +64,8 @@ test.beforeAll(async ({ fiftyoneLoader }) => {
   dataset.save()`);
 });
 
-test("grid media field", async ({ eventUtils, fiftyoneLoader, grid, page }) => {
+test("grid media field", async ({ fiftyoneLoader, grid, page }) => {
   await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
-  const wait = eventUtils.getEventReceivedPromiseForPredicate(
-    "canvas-loaded",
-    ({ detail }) => detail.sampleFilepath === "/tmp/empty.png"
-  );
-  await wait;
   await expect(grid.getNthLooker(0)).toHaveScreenshot("grid-media-field.png");
 });
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR allows modal navigation to be debounced. The first navigation command is immediately executed, whereas subsequent commands are accumulated and executed later. This should reduce the number of network requests incurred when users navigate really fast, and also improve perceived sample navigation speed.

## How is this patch tested? If it is not, please explain why.

Unit tests. Local smoke tests. All existing E2E green.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced navigation in modals with debounced navigation actions.
	- Introduced a timeout for dismissing pop-ups.

- **Improvements**
	- Improved readability of consent text in the AnalyticsConsent component.
	- Pagination functionality now supports customizable offsets for navigating samples.

- **Bug Fixes**
	- Adjusted control flow to prevent automatic closing of results in the SelectorAsserter class.

- **Tests**
	- Added unit tests for debounced navigation functionality.
	- Updated test specifications for histogram panel to improve efficiency.
	- Simplified test structure for media field tests and marked one as skipped due to an unresolved issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->