### PR TITLE
don't throw in spotlight.destroy()

### DIFF
--- a/app/packages/components/src/components/AdaptiveMenu/index.tsx
+++ b/app/packages/components/src/components/AdaptiveMenu/index.tsx
@@ -53,8 +53,10 @@ export default function AdaptiveMenu(props: AdaptiveMenuPropsType) {
     if (!containerElem) return;
     hideOverflowingNodes(containerElem, (_: number, lastVisibleItemId) => {
       const lastVisibleItem = itemsById[lastVisibleItemId];
-      const computedHidden = items.length - lastVisibleItem.index - 1;
-      setHidden(computedHidden);
+      if (lastVisibleItem?.index) {
+        const computedHidden = items.length - lastVisibleItem.index - 1;
+        setHidden(computedHidden);
+      }
     });
   }
 

--- a/app/packages/spotlight/src/index.ts
+++ b/app/packages/spotlight/src/index.ts
@@ -104,7 +104,8 @@ export default class Spotlight<K, V> extends EventTarget {
 
   destroy(): void {
     if (!this.attached) {
-      throw new Error("spotlight is not attached");
+      console.error("spotlight is not attached");
+      return;
     }
 
     this.#backward?.remove();


### PR DESCRIPTION
## What changes are proposed in this pull request?

Throwing here crashes the app. `console.error()-ing` recreates the grid.

## How is this patch tested? If it is not, please explain why.

smoke testing

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved logic for handling hidden items in the Adaptive Menu component.
	- Enhanced drag-and-drop functionality with priority checks for item movement.

- **Bug Fixes**
	- Updated error handling in the Spotlight class to log errors instead of throwing exceptions when the spotlight is not attached.

These changes enhance user experience by ensuring smoother interactions and better error management within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->