### PR TITLE
remove reload_on_navigation panel option

### DIFF
--- a/app/packages/operators/src/Panel/register.tsx
+++ b/app/packages/operators/src/Panel/register.tsx
@@ -23,7 +23,6 @@ export default function registerPanel(ctx: ExecutionContext) {
     panelOptions: {
       allowDuplicates: ctx.params.allow_duplicates,
       helpMarkdown: ctx.params.help_markdown,
-      reloadOnNavigation: ctx.params.reload_on_navigation,
       surfaces: ctx.params.surfaces,
     },
   });

--- a/app/packages/plugins/src/index.ts
+++ b/app/packages/plugins/src/index.ts
@@ -325,12 +325,6 @@ type PanelOptions = {
    * Content displayed on the right side of the label in the panel title bar.
    */
   TabIndicator?: React.ComponentType;
-
-  /**
-   * If true, the plugin will be remounted when the user navigates to a different sample or group.
-   * This is only applicable to plugins that are in a modal.
-   */
-  reloadOnNavigation?: boolean;
 };
 
 type PluginComponentProps<T> = T & {

--- a/app/packages/spaces/src/components/Panel.tsx
+++ b/app/packages/spaces/src/components/Panel.tsx
@@ -1,7 +1,7 @@
 import { CenteredStack, scrollable } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
 import React, { useEffect } from "react";
-import { useRecoilValue, useSetRecoilState } from "recoil";
+import { useSetRecoilState } from "recoil";
 import { PANEL_LOADING_TIMEOUT } from "../constants";
 import { PanelContext } from "../contexts";
 import { useReactivePanel } from "../hooks";
@@ -19,8 +19,6 @@ function Panel(props: PanelProps) {
   const pending = fos.useTimeout(PANEL_LOADING_TIMEOUT);
   const setPanelIdToScope = useSetRecoilState(panelIdToScopeAtom);
   const scope = isModalPanel ? "modal" : "grid";
-
-  const thisModalUniqueId = useRecoilValue(fos.currentModalUniqueId);
 
   useEffect(() => {
     setPanelIdToScope((ids) => ({ ...ids, [node.id]: scope }));
@@ -42,9 +40,7 @@ function Panel(props: PanelProps) {
     );
   }
 
-  const { component: Component, panelOptions } = panel;
-
-  const shouldKeyComponent = isModalPanel && panelOptions?.reloadOnNavigation;
+  const { component: Component } = panel;
 
   return (
     <StyledPanel
@@ -55,11 +51,7 @@ function Panel(props: PanelProps) {
       ref={dimensions.ref}
     >
       <PanelContext.Provider value={{ node, scope }}>
-        <Component
-          key={shouldKeyComponent ? thisModalUniqueId : panelName}
-          panelNode={node}
-          dimensions={dimensions}
-        />
+        <Component panelNode={node} dimensions={dimensions} />
       </PanelContext.Provider>
     </StyledPanel>
   );

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -305,7 +305,6 @@ class Operations(object):
         light_icon=None,
         dark_icon=None,
         surfaces="grid",
-        reload_on_navigation=False,
         on_load=None,
         on_unload=None,
         on_change=None,
@@ -333,10 +332,7 @@ class Operations(object):
                 is in dark mode
             surfaces ('grid'): surfaces in which to show the panel. Must be
                 one of 'grid', 'modal', or 'grid modal'
-            reload_on_navigation (False): whether to reload the panel when the
-                user navigates to a new page. This is only applicable to panels
-                that are not shown in a modal
-            on_load (None): an operator to invoke when the panel is loaded
+           on_load (None): an operator to invoke when the panel is loaded
             on_unload (None): an operator to invoke when the panel is unloaded
             on_change (None): an operator to invoke when the panel state
                 changes
@@ -367,7 +363,6 @@ class Operations(object):
             "light_icon": light_icon,
             "dark_icon": dark_icon,
             "surfaces": surfaces,
-            "reload_on_navigation": reload_on_navigation,
             "on_load": on_load,
             "on_unload": on_unload,
             "on_change": on_change,

--- a/fiftyone/operators/panel.py
+++ b/fiftyone/operators/panel.py
@@ -28,9 +28,6 @@ class PanelConfig(OperatorConfig):
             in dark mode
         allow_multiple (False): whether to allow multiple instances of the
             panel to be opened
-        reload_on_navigation (False): whether to reload the panel when the
-            user navigates to a new page. This is only applicable to panels
-            that are not shown in a modal
         surfaces ("grid"): the surfaces on which the panel can be displayed
         help_markdown (None): a markdown string to display in the panel's help
             tooltip
@@ -46,7 +43,6 @@ class PanelConfig(OperatorConfig):
         dark_icon=None,
         allow_multiple=False,
         surfaces: PANEL_SURFACE = "grid",
-        reload_on_navigation=False,
         **kwargs
     ):
         super().__init__(name)
@@ -59,7 +55,6 @@ class PanelConfig(OperatorConfig):
         self.allow_multiple = allow_multiple
         self.unlisted = True
         self.on_startup = True
-        self.reload_on_navigation = reload_on_navigation
         self.surfaces = surfaces
         self.kwargs = kwargs  # unused, placeholder for future extensibility
 
@@ -74,7 +69,6 @@ class PanelConfig(OperatorConfig):
             "allow_multiple": self.allow_multiple,
             "on_startup": self.on_startup,
             "unlisted": self.unlisted,
-            "reload_on_navigation": self.reload_on_navigation,
             "surfaces": self.surfaces,
         }
 
@@ -114,7 +108,6 @@ class Panel(Operator):
             "dark_icon": self.config.dark_icon,
             "light_icon": self.config.light_icon,
             "surfaces": self.config.surfaces,
-            "reload_on_navigation": self.config.reload_on_navigation,
         }
         methods = ["on_load", "on_unload", "on_change"]
         ctx_change_events = [


### PR DESCRIPTION
Panel component subscribing to `fos.modalUniqueId` has negative performance consequences on the app, most importantly the sample modal plugin. This PR removes that.

## Motivation

Keying the panel component by "modal unique ID", which is a concatenation of sample and group id, leads to a slippery slope where the contract is not well-defined. This behavior was added to support `shouldReloadOnNavigation` panel option for modal panels, but what is "navigation" anyway? This gets tricky in dynamic groups of groups, for instance. Also, `key=foo` is a bad react pattern.

Removing this panel option also incentivizes the plugin author to write better code where they control the scope and maintain strict ownership of the resources they create / subscribe to, and their lifecycles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `reloadOnNavigation` property for future plugin functionality (commented out).
  
- **Bug Fixes**
	- Removed the `reloadOnNavigation` option from various components and methods, streamlining the panel registration and rendering process.
  
- **Refactor**
	- Simplified the `Panel` component by eliminating unnecessary state dependencies and rendering logic.
  
- **Documentation**
	- Updated documentation to reflect the removal of the `reload_on_navigation` parameter in relevant classes and methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->