### PR TITLE
fix video regression + e2e

### DIFF
--- a/app/packages/looker/src/lookers/abstract.ts
+++ b/app/packages/looker/src/lookers/abstract.ts
@@ -397,12 +397,12 @@ export abstract class AbstractLooker<
     const argsWithSignal: AddEventListenerOptions =
       typeof optionsOrUseCapture === "boolean"
         ? {
-            signal: this.abortController.signal,
+            signal: this.abortController?.signal,
             capture: optionsOrUseCapture,
           }
         : {
             ...(optionsOrUseCapture ?? {}),
-            signal: this.abortController.signal,
+            signal: this.abortController?.signal,
           };
     this.eventTarget.addEventListener(eventType, handler, argsWithSignal);
   }

--- a/app/packages/looker/src/lookers/imavid/ima-vid-frame-samples.ts
+++ b/app/packages/looker/src/lookers/imavid/ima-vid-frame-samples.ts
@@ -88,7 +88,7 @@ export class ImaVidFrameSamples {
           sample.image = image;
           resolve(sampleId);
         },
-        { signal: this.abortController.signal }
+        { signal: this.abortController?.signal }
       );
 
       image.addEventListener(
@@ -105,7 +105,7 @@ export class ImaVidFrameSamples {
           // setting src should trigger the load event
           image.src = BASE64_BLACK_IMAGE;
         },
-        { signal: this.abortController.signal }
+        { signal: this.abortController?.signal }
       );
 
       image.src = source;

--- a/app/packages/looker/src/util.ts
+++ b/app/packages/looker/src/util.ts
@@ -462,7 +462,7 @@ export const createWorker = (
     (error) => {
       dispatchEvent("error", error);
     },
-    { signal: abortController.signal }
+    { signal: abortController?.signal }
   );
 
   worker.addEventListener(
@@ -475,7 +475,7 @@ export const createWorker = (
         dispatchEvent("error", new ErrorEvent("error", { error }));
       }
     },
-    { signal: abortController.signal }
+    { signal: abortController?.signal }
   );
 
   worker.postMessage({
@@ -496,7 +496,7 @@ export const createWorker = (
 
       listeners[method].forEach((callback) => callback(worker, args));
     },
-    { signal: abortController.signal }
+    { signal: abortController?.signal }
   );
   return worker;
 };

--- a/e2e-pw/src/oss/specs/regression-tests/group-video/default-video-slice-group.spec.ts
+++ b/e2e-pw/src/oss/specs/regression-tests/group-video/default-video-slice-group.spec.ts
@@ -71,7 +71,7 @@ test.describe("default video slice group", () => {
   });
 
   test.beforeEach(async ({ page, fiftyoneLoader }) => {
-    fiftyoneLoader.waitUntilGridVisible(page, datasetName);
+    await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
   });
 
   test("video as default slice renders", async ({ grid, modal }) => {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes a regression caused by the case when abort controller is undefined. Also fixes one of the e2e specs where an `await` was missing in a promise causing flakiness.

## How is this patch tested? If it is not, please explain why.

E2E

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling for event listeners by implementing optional chaining for `abortController`.
	- Improved robustness in image fetching processes related to frame samples.

- **Tests**
	- Updated test synchronization to ensure grid visibility before proceeding with assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->