### PR TITLE
fix teams install command

### DIFF
--- a/docs/source/teams/installation.rst
+++ b/docs/source/teams/installation.rst
@@ -46,7 +46,7 @@ private PyPI server as shown below:
 
 .. code-block:: shell
 
-    pip install --index-url https://{$TOKEN}@pypi.fiftyone.ai fiftyone
+    pip install --index-url https://${TOKEN}@pypi.fiftyone.ai fiftyone
 
 .. note::
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Well... that's been broken for a while and definitely doesn't work...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated installation instructions for the FiftyOne Teams Python SDK to clarify the process and configuration.
	- Changed environment variable syntax for consistency.
	- Expanded guidance on using Poetry, including private source setup and credential configuration.
	- Added detailed instructions for configuring cloud credentials for AWS, Google Cloud Storage, Microsoft Azure, and MinIO.
	- Introduced a new section on managing cloud credentials through the Teams UI, including bucket-specific credentials management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->