### PR TITLE
bugfix

### DIFF
--- a/fiftyone/utils/clip/zoo.py
+++ b/fiftyone/utils/clip/zoo.py
@@ -187,7 +187,7 @@ class TorchCLIPModel(fout.TorchImageModel, fom.PromptMixin):
         frame_size = (width, height)
 
         if self._using_gpu:
-            imgs = imgs.cuda()
+            imgs = imgs.to(torch.device(self.device))
 
         text_features = self._get_text_features()
         image_features = self._model.encode_image(imgs)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Change CLIP zoo model to send images for embedding to the same gpu it is on.

## How is this patch tested? If it is not, please explain why.

I ran the model with images on a gpu that's not 'cuda:0' and it ran.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other - fiftyone.zoo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Minor updates and maintenance performed to improve overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->