### PR TITLE
chore(docs): Add deprecation notice for kubernetes 1.27 and older

### DIFF
--- a/docs/source/deprecation.rst
+++ b/docs/source/deprecation.rst
@@ -26,3 +26,12 @@ Python 3.8
 `Python 3.8 <https://devguide.python.org/versions/>`_
 transitions to `end-of-life` effective October of 2024. FiftyOne releases after
 September 30, 2024 will no longer support Python 3.8.
+
+Kubernetes 1.27
+---------------
+*Support ended November 1, 2024*
+
+`Kubernetes 1.27 <https://kubernetes.io/releases/>`_
+transitioned to `end-of-life` effective July of 2024. FiftyOne Teams 
+releases after October 31, 2024 might no longer be compatible with
+Kubernetes 1.27 and older.


### PR DESCRIPTION
## What changes are proposed in this pull request?

We are deprecating kubernetes versions older than 1.28 (1.27 and below). This adds a deprecation notice to [here](https://docs.voxel51.com/deprecation.html).

## How is this patch tested? If it is not, please explain why.

N/a as this is a docs-only PR.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

`Kubernetes 1.27 ` transitioned to `end-of-life` effective July of 2024. 
FiftyOne Teams releases after October 31, 2024 might no longer be compatible with Kubernetes 1.27 and older.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated deprecation notice for Kubernetes 1.27, indicating that support ended on November 1, 2024, and future releases may not be compatible. Existing notices for FiftyOne Desktop and Python 3.8 remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->