### PR TITLE
Adding min() and max() aggregations

### DIFF
--- a/docs/source/user_guide/using_aggregations.rst
+++ b/docs/source/user_guide/using_aggregations.rst
@@ -376,6 +376,46 @@ compute the sum of the (non-``None``) values of a field in a collection:
     )
     # 0.34994137249820706
 
+.. _aggregations-min:
+
+Min values
+__________
+
+You can use the
+:meth:`min() <fiftyone.core.collections.SampleCollection.min>` aggregation to
+compute the minimum of the (non-``None``) values of a field in a collection:
+
+.. code-block:: python
+    :linenos:
+
+    import fiftyone.zoo as foz
+
+    dataset = foz.load_zoo_dataset("quickstart")
+
+    # Compute minimum confidence of detections in the `predictions` field
+    print(dataset.min("predictions.detections.confidence"))
+    # 0.05003104358911514
+
+.. _aggregations-max:
+
+Max values
+__________
+
+You can use the
+:meth:`max() <fiftyone.core.collections.SampleCollection.max>` aggregation to
+compute the maximum of the (non-``None``) values of a field in a collection:
+
+.. code-block:: python
+    :linenos:
+
+    import fiftyone.zoo as foz
+
+    dataset = foz.load_zoo_dataset("quickstart")
+
+    # Compute maximum confidence of detections in the `predictions` field
+    print(dataset.max("predictions.detections.confidence"))
+    # 0.9999035596847534
+
 .. _aggregations-mean:
 
 Mean values

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -21,6 +21,8 @@ from .core.aggregations import (
     Distinct,
     FacetAggregations,
     HistogramValues,
+    Min,
+    Max,
     Mean,
     Quantiles,
     Schema,

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -659,6 +659,20 @@ class SampleCollection(object):
         return self._get_extremum(path, -1)
 
     def _get_extremum(self, path, order):
+        #
+        # This method exists in addition to `min()` and `max()` aggregations
+        # for two reasons:
+        #
+        # 1. `$sort + $limit 1` is more efficient than `$group _id: None` when
+        #    the field is indexed
+        #
+        # 2. When `path` is a frame-level field, these methods are optimized to
+        #    directly aggregate on the frames collection, which is something
+        #    that the Aggregation classes do not yet support. In other words,
+        #    `dataset._max("frames.last_modified_at")` is currently more
+        #    performant than `dataset.max("frames.last_modified_at")`
+        #
+
         path, is_frame_field = self._handle_frame_field(path)
         path = self._handle_db_field(path, frames=is_frame_field)
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -646,55 +646,58 @@ class SampleCollection(object):
     def _sync_dataset_last_modified_at(self):
         dataset = self._root_dataset
         curr_lma = dataset.last_modified_at
-        lma = self._get_last_modified_at()
+        lma = self._max("last_modified_at")
 
         if lma is not None and (curr_lma is None or lma > curr_lma):
             dataset._doc.last_modified_at = lma
             dataset._doc.save(virtual=True)
 
-    def _get_last_modified_at(self, frames=False):
-        if frames and not self._contains_videos(any_slice=True):
+    def _min(self, path):
+        return self._get_extremum(path, 1)
+
+    def _max(self, path):
+        return self._get_extremum(path, -1)
+
+    def _get_extremum(self, path, order):
+        path, is_frame_field = self._handle_frame_field(path)
+        path = self._handle_db_field(path, frames=is_frame_field)
+
+        if is_frame_field and not self._contains_videos(any_slice=True):
             return
 
         if isinstance(self, fod.Dataset):
             # pylint:disable=no-member
             dataset = self
-            if frames:
+            if is_frame_field:
                 coll = dataset._frame_collection
             else:
                 coll = dataset._sample_collection
 
             pipeline = [
-                {"$sort": {"last_modified_at": -1}},
+                {"$sort": {path: order}},
                 {"$limit": 1},
-                {"$project": {"last_modified_at": True}},
+                {"$project": {path: True}},
             ]
 
             results = foo.aggregate(coll, pipeline)
         else:
             if self.media_type == fom.GROUP:
-                if frames:
+                if is_frame_field:
                     view = self.select_group_slices(media_type=fom.VIDEO)
                 else:
                     view = self.select_group_slices(_allow_mixed=True)
             else:
                 view = self
 
-            pipeline = [
-                {
-                    "$group": {
-                        "_id": None,
-                        "last_modified_at": {"$max": "$last_modified_at"},
-                    }
-                }
-            ]
+            op = "$min" if order > 0 else "$max"
+            pipeline = [{"$group": {"_id": None, path: {op: "$" + path}}}]
 
             results = view._aggregate(
-                frames_only=frames, post_pipeline=pipeline
+                frames_only=is_frame_field, post_pipeline=pipeline
             )
 
         try:
-            return next(iter(results))["last_modified_at"]
+            return next(iter(results))[path]
         except:
             return None
 
@@ -7521,11 +7524,13 @@ class SampleCollection(object):
 
         ``None``-valued fields are ignored.
 
-        This aggregation is typically applied to *numeric* field types (or
-        lists of such types):
+        This aggregation is typically applied to *numeric* or *date* field
+        types (or lists of such types):
 
         -   :class:`fiftyone.core.fields.IntField`
         -   :class:`fiftyone.core.fields.FloatField`
+        -   :class:`fiftyone.core.fields.DateField`
+        -   :class:`fiftyone.core.fields.DateTimeField`
 
         Examples::
 
@@ -7561,7 +7566,7 @@ class SampleCollection(object):
             print(bounds)  # (min, max)
 
             #
-            # Compute the a bounds of a numeric list field
+            # Compute the bounds of a numeric list field
             #
 
             bounds = dataset.bounds("numeric_list_field")
@@ -7997,6 +8002,174 @@ class SampleCollection(object):
         """
         make = lambda field_or_expr: foa.HistogramValues(
             field_or_expr, expr=expr, bins=bins, range=range, auto=auto
+        )
+        return self._make_and_aggregate(make, field_or_expr)
+
+    @aggregation
+    def min(self, field_or_expr, expr=None, safe=False):
+        """Computes the minimum of a numeric field of the collection.
+
+        ``None``-valued fields are ignored.
+
+        This aggregation is typically applied to *numeric* or *date* field
+        types (or lists of such types):
+
+        -   :class:`fiftyone.core.fields.IntField`
+        -   :class:`fiftyone.core.fields.FloatField`
+        -   :class:`fiftyone.core.fields.DateField`
+        -   :class:`fiftyone.core.fields.DateTimeField`
+
+        Examples::
+
+            import fiftyone as fo
+            from fiftyone import ViewField as F
+
+            dataset = fo.Dataset()
+            dataset.add_samples(
+                [
+                    fo.Sample(
+                        filepath="/path/to/image1.png",
+                        numeric_field=1.0,
+                        numeric_list_field=[1, 2, 3],
+                    ),
+                    fo.Sample(
+                        filepath="/path/to/image2.png",
+                        numeric_field=4.0,
+                        numeric_list_field=[1, 2],
+                    ),
+                    fo.Sample(
+                        filepath="/path/to/image3.png",
+                        numeric_field=None,
+                        numeric_list_field=None,
+                    ),
+                ]
+            )
+
+            #
+            # Compute the minimum of a numeric field
+            #
+
+            min = dataset.min("numeric_field")
+            print(min)  # the min
+
+            #
+            # Compute the minimum of a numeric list field
+            #
+
+            min = dataset.min("numeric_list_field")
+            print(min)  # the min
+
+            #
+            # Compute the minimum of a transformation of a numeric field
+            #
+
+            min = dataset.min(2 * (F("numeric_field") + 1))
+            print(min)  # the min
+
+        Args:
+            field_or_expr: a field name, ``embedded.field.name``,
+                :class:`fiftyone.core.expressions.ViewExpression`, or
+                `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+                defining the field or expression to aggregate. This can also
+                be a list or tuple of such arguments, in which case a tuple of
+                corresponding aggregation results (each receiving the same
+                additional keyword arguments, if any) will be returned
+            expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
+                `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+                to apply to ``field_or_expr`` (which must be a field) before
+                aggregating
+            safe (False): whether to ignore nan/inf values when dealing with
+                floating point values
+
+        Returns:
+            the minimum value
+        """
+        make = lambda field_or_expr: foa.Min(
+            field_or_expr, expr=expr, safe=safe
+        )
+        return self._make_and_aggregate(make, field_or_expr)
+
+    @aggregation
+    def max(self, field_or_expr, expr=None, safe=False):
+        """Computes the maximum of a numeric field of the collection.
+
+        ``None``-valued fields are ignored.
+
+        This aggregation is typically applied to *numeric* or *date* field
+        types (or lists of such types):
+
+        -   :class:`fiftyone.core.fields.IntField`
+        -   :class:`fiftyone.core.fields.FloatField`
+        -   :class:`fiftyone.core.fields.DateField`
+        -   :class:`fiftyone.core.fields.DateTimeField`
+
+        Examples::
+
+            import fiftyone as fo
+            from fiftyone import ViewField as F
+
+            dataset = fo.Dataset()
+            dataset.add_samples(
+                [
+                    fo.Sample(
+                        filepath="/path/to/image1.png",
+                        numeric_field=1.0,
+                        numeric_list_field=[1, 2, 3],
+                    ),
+                    fo.Sample(
+                        filepath="/path/to/image2.png",
+                        numeric_field=4.0,
+                        numeric_list_field=[1, 2],
+                    ),
+                    fo.Sample(
+                        filepath="/path/to/image3.png",
+                        numeric_field=None,
+                        numeric_list_field=None,
+                    ),
+                ]
+            )
+
+            #
+            # Compute the maximum of a numeric field
+            #
+
+            max = dataset.max("numeric_field")
+            print(max)  # the max
+
+            #
+            # Compute the maximum of a numeric list field
+            #
+
+            max = dataset.max("numeric_list_field")
+            print(max)  # the max
+
+            #
+            # Compute the maximum of a transformation of a numeric field
+            #
+
+            max = dataset.max(2 * (F("numeric_field") + 1))
+            print(max)  # the max
+
+        Args:
+            field_or_expr: a field name, ``embedded.field.name``,
+                :class:`fiftyone.core.expressions.ViewExpression`, or
+                `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+                defining the field or expression to aggregate. This can also
+                be a list or tuple of such arguments, in which case a tuple of
+                corresponding aggregation results (each receiving the same
+                additional keyword arguments, if any) will be returned
+            expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
+                `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+                to apply to ``field_or_expr`` (which must be a field) before
+                aggregating
+            safe (False): whether to ignore nan/inf values when dealing with
+                floating point values
+
+        Returns:
+            the maximum value
+        """
+        make = lambda field_or_expr: foa.Max(
+            field_or_expr, expr=expr, safe=safe
         )
         return self._make_and_aggregate(make, field_or_expr)
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2083,15 +2083,15 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 update_indexes.append(path)
             elif self._is_frame_field(source_path):
                 if frames_last_modified_at is None:
-                    frames_last_modified_at = self._get_last_modified_at(
-                        frames=True
+                    frames_last_modified_at = self._max(
+                        "frames.last_modified_at"
                     )
 
                 if frames_last_modified_at > last_modified_at:
                     update_indexes.append(path)
             else:
                 if samples_last_modified_at is None:
-                    samples_last_modified_at = self._get_last_modified_at()
+                    samples_last_modified_at = self._max("last_modified_at")
 
                 if samples_last_modified_at > last_modified_at:
                     update_indexes.append(path)

--- a/tests/unittests/aggregation_tests.py
+++ b/tests/unittests/aggregation_tests.py
@@ -234,6 +234,92 @@ class DatasetTests(unittest.TestCase):
         self.assertAlmostEqual(d.sum(2.0 * (F("numeric_field") + 1)), 10.0)
 
     @drop_datasets
+    def test_min(self):
+        d = fo.Dataset()
+        d.add_sample_field("numbers", fo.ListField, subfield=fo.IntField())
+        s = fo.Sample(filepath="image.jpeg")
+        s["number"] = 0
+        s["numbers"] = [0, 1]
+        d.add_sample(s)
+        self.assertEqual(d.min("number"), 0)
+        self.assertEqual(d.min("numbers"), 0)
+
+        d = fo.Dataset()
+        s = fo.Sample(filepath="video.mp4")
+        d.add_sample(s)
+        d.add_frame_field("numbers", fo.ListField, subfield=fo.IntField())
+        s[1]["number"] = 0
+        s[1]["numbers"] = [0, 1]
+        s.save()
+        self.assertEqual(d.min("frames.number"), 0)
+        self.assertEqual(d.min("frames.numbers"), 0)
+
+        d = fo.Dataset()
+        s = fo.Sample(filepath="image.jpeg")
+        s["detection"] = fo.Detection(label="label", confidence=1)
+        d.add_sample(s)
+        self.assertEqual(d.min("detection.confidence"), 1)
+
+        s["detections"] = fo.Detections(
+            detections=[
+                fo.Detection(label="label", confidence=1),
+                fo.Detection(label="label", confidence=0),
+            ]
+        )
+        s.save()
+        self.assertEqual(d.min("detections.detections.confidence"), 0)
+        self.assertEqual(d.min(1 + F("detections.detections.confidence")), 1)
+
+        d = fo.Dataset()
+        s = fo.Sample(filepath="video.mp4")
+        s[1]["detection"] = fo.Detection(label="label", confidence=1)
+        d.add_sample(s)
+        self.assertEqual(d.min("frames.detection.confidence"), 1)
+
+    @drop_datasets
+    def test_max(self):
+        d = fo.Dataset()
+        d.add_sample_field("numbers", fo.ListField, subfield=fo.IntField())
+        s = fo.Sample(filepath="image.jpeg")
+        s["number"] = 0
+        s["numbers"] = [0, 1]
+        d.add_sample(s)
+        self.assertEqual(d.max("number"), 0)
+        self.assertEqual(d.max("numbers"), 1)
+
+        d = fo.Dataset()
+        s = fo.Sample(filepath="video.mp4")
+        d.add_sample(s)
+        d.add_frame_field("numbers", fo.ListField, subfield=fo.IntField())
+        s[1]["number"] = 0
+        s[1]["numbers"] = [0, 1]
+        s.save()
+        self.assertEqual(d.max("frames.number"), 0)
+        self.assertEqual(d.max("frames.numbers"), 1)
+
+        d = fo.Dataset()
+        s = fo.Sample(filepath="image.jpeg")
+        s["detection"] = fo.Detection(label="label", confidence=1)
+        d.add_sample(s)
+        self.assertEqual(d.max("detection.confidence"), 1)
+
+        s["detections"] = fo.Detections(
+            detections=[
+                fo.Detection(label="label", confidence=1),
+                fo.Detection(label="label", confidence=0),
+            ]
+        )
+        s.save()
+        self.assertEqual(d.max("detections.detections.confidence"), 1)
+        self.assertEqual(d.max(1 + F("detections.detections.confidence")), 2)
+
+        d = fo.Dataset()
+        s = fo.Sample(filepath="video.mp4")
+        s[1]["detection"] = fo.Detection(label="label", confidence=1)
+        d.add_sample(s)
+        self.assertEqual(d.max("frames.detection.confidence"), 1)
+
+    @drop_datasets
     def test_mean(self):
         d = fo.Dataset()
         d.add_sample_field("numeric_field", fo.IntField)

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -5644,14 +5644,14 @@ class DatasetDeletionTests(unittest.TestCase):
         self.assertTrue(last_modified_at4b < last_modified_at5b)
         self.assertEqual(last_modified_at4c, last_modified_at5c)
 
-        last_modified_at6b = dataset._get_last_modified_at()
-        last_modified_at6c = dataset._get_last_modified_at(frames=True)
+        last_modified_at6b = dataset._max("last_modified_at")
+        last_modified_at6c = dataset._max("frames.last_modified_at")
 
         self.assertEqual(last_modified_at6b, last_modified_at5b)
         self.assertEqual(last_modified_at6c, last_modified_at5c)
 
-        last_modified_at7b = dataset.view()._get_last_modified_at()
-        last_modified_at7c = dataset.view()._get_last_modified_at(frames=True)
+        last_modified_at7b = dataset.view()._max("last_modified_at")
+        last_modified_at7c = dataset.view()._max("frames.last_modified_at")
 
         self.assertEqual(last_modified_at7b, last_modified_at5b)
         self.assertEqual(last_modified_at7c, last_modified_at5c)


### PR DESCRIPTION
Adds `min()` and `max()` aggregations.

These can be computed via `bounds()[0]` and `bounds()[1]` today, but it's nice to have dedicated methods because:
- These are more efficient when you don't need both extrema
- Yields more readable code when you want only a particular extremum

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new aggregation methods for computing minimum (`min()`) and maximum (`max()`) values in datasets.
	- Added new public entities, `Min` and `Max`, to enhance aggregation functionalities.
	- Updated documentation to include examples for the new aggregation methods.

- **Bug Fixes**
	- Improved handling of summary fields to ensure accurate updates based on dataset modifications.

- **Tests**
	- Added unit tests for the new `min` and `max` functionalities to validate their performance and correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->