### PR TITLE
hide compute_viz in OSS

### DIFF
--- a/app/packages/embeddings/src/useComputeVisualization.ts
+++ b/app/packages/embeddings/src/useComputeVisualization.ts
@@ -3,6 +3,8 @@ import { listLocalAndRemoteOperators } from "@fiftyone/operators/src/operators";
 import { usePanelEvent } from "@fiftyone/operators";
 import { usePanelId } from "@fiftyone/spaces";
 
+const IS_OSS = true; // false in fiftyone-teams
+
 const useFirstExistingUri = (uris: string[]) => {
   const availableOperators = useMemo(() => listLocalAndRemoteOperators(), []);
   return useMemo(() => {
@@ -33,7 +35,7 @@ export default function useComputeVisualization() {
   }, [panelId, triggerEvent, computeVisUri]);
 
   return {
-    isAvailable: hasComputeVisualization,
+    isAvailable: IS_OSS ? false : hasComputeVisualization,
     prompt,
   };
 }


### PR DESCRIPTION
Hides the compute_visualization button in the embeddings panel when run in OSS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new constant to differentiate behavior based on the environment, affecting the availability of the compute visualization feature.
- **Bug Fixes**
	- Adjusted the logic for the `isAvailable` property to ensure proper functionality in the OSS environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->