### PR TITLE
Adds readonly property to PillBadge and Modal button

### DIFF
--- a/app/packages/components/src/components/ModalBase/ModalBase.tsx
+++ b/app/packages/components/src/components/ModalBase/ModalBase.tsx
@@ -44,6 +44,7 @@ interface ModalBaseProps {
 }
 
 interface ModalButtonView {
+  disabled?: boolean;
   variant: string;
   label: string;
   icon?: string;
@@ -102,6 +103,7 @@ const ModalBase: React.FC<ModalBaseProps> = ({
   const modalButtonView: ModalButtonView = {
     variant: props?.variant || "outlined",
     label: props?.label || "",
+    disabled: props?.disabled,
     componentsProps: {
       button: {
         sx: {

--- a/app/packages/components/src/components/ModalBase/ModalBase.tsx
+++ b/app/packages/components/src/components/ModalBase/ModalBase.tsx
@@ -177,12 +177,12 @@ const ModalBase: React.FC<ModalBaseProps> = ({
     ) {
       setPrimaryButtonView({
         ...primaryButtonView,
-        disabled: primaryButtonView?.disabled || true,
+        disabled: true,
       });
     } else {
       setPrimaryButtonView({
         ...primaryButtonView,
-        disabled: primaryButtonView?.disabled || false,
+        disabled: false,
       });
     }
   }, [primaryButtonView.params]);

--- a/app/packages/components/src/components/PillBadge/PillBadge.tsx
+++ b/app/packages/components/src/components/PillBadge/PillBadge.tsx
@@ -10,12 +10,14 @@ const PillBadge = ({
   variant = "filled",
   showIcon = true,
   operator,
+  readOnly = false,
 }: {
   text: string | string[] | [string, string][];
   color?: string;
   variant?: "filled" | "outlined";
   showIcon?: boolean;
   operator?: () => void;
+  readOnly?: boolean;
 }) => {
   const getInitialChipSelection = (
     text: string | string[] | [string, string][]
@@ -90,6 +92,7 @@ const PillBadge = ({
       ) : (
         <FormControl fullWidth>
           <Chip
+            disabled={readOnly}
             icon={
               showIcon ? (
                 <CircleIcon color={"inherit"} sx={{ fontSize: 10 }} />

--- a/app/packages/components/src/components/PillBadge/PillBadge.tsx
+++ b/app/packages/components/src/components/PillBadge/PillBadge.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import CircleIcon from "@mui/icons-material/Circle";
-import { Chip, FormControl, MenuItem, Select } from "@mui/material";
+import { Chip, FormControl, MenuItem, Select, Tooltip } from "@mui/material";
 import { usePanelEvent } from "@fiftyone/operators";
 import { usePanelId } from "@fiftyone/spaces";
 
@@ -11,7 +11,7 @@ const PillBadge = ({
   showIcon = true,
   operator,
   readOnly = false,
-  title = "",
+  tooltipTitle = "",
 }: {
   text: string | string[] | [string, string][];
   color?: string;
@@ -19,7 +19,7 @@ const PillBadge = ({
   showIcon?: boolean;
   operator?: () => void;
   readOnly?: boolean;
-  title?: string;
+  tooltipTitle?: string;
 }) => {
   const getInitialChipSelection = (
     text: string | string[] | [string, string][]
@@ -72,95 +72,15 @@ const PillBadge = ({
 
   return (
     <span>
-      {typeof text === "string" ? (
-        <Chip
-          title={title || readOnly ? "Read-only mode" : ""}
-          icon={
-            showIcon ? (
-              <CircleIcon color={"inherit"} sx={{ fontSize: 10 }} />
-            ) : undefined
-          }
-          label={text}
-          sx={{
-            ...chipStyle,
-            "& .MuiChip-icon": {
-              marginRight: "-7px",
-            },
-            "& .MuiChip-label": {
-              marginBottom: "1px",
-            },
-          }}
-          variant={variant as "filled" | "outlined" | undefined}
-        />
-      ) : (
-        <FormControl fullWidth>
+      <Tooltip title={tooltipTitle}>
+        {typeof text === "string" ? (
           <Chip
-            disabled={readOnly}
-            title={title || readOnly ? "Read-only mode" : ""}
             icon={
               showIcon ? (
                 <CircleIcon color={"inherit"} sx={{ fontSize: 10 }} />
               ) : undefined
             }
-            label={
-              Array.isArray(text) &&
-              text.length > 0 &&
-              Array.isArray(text[0]) ? (
-                <Select
-                  disabled={readOnly}
-                  value={chipSelection}
-                  variant={"standard"}
-                  disableUnderline={true}
-                  onChange={(event) => {
-                    const selectedText = text.find(
-                      (t) => t[0] === event.target.value
-                    );
-                    setChipSelection(event.target.value);
-                    setChipColor(selectedText?.[1] ?? "default");
-                    if (operator) {
-                      handleClick(panelId, {
-                        params: { value: event.target.value },
-                        operator,
-                      });
-                    }
-                  }}
-                  sx={{
-                    color: "inherit",
-                  }}
-                >
-                  {text.map((t, index) => (
-                    <MenuItem key={index} value={t[0]}>
-                      {t[0]}
-                    </MenuItem>
-                  ))}
-                </Select>
-              ) : (
-                <Select
-                  disabled={readOnly}
-                  value={chipSelection}
-                  variant={"standard"}
-                  disableUnderline={true}
-                  onChange={(event) => {
-                    setChipSelection(event.target.value);
-                    if (operator) {
-                      handleClick(panelId, {
-                        params: { value: event.target.value },
-                        operator,
-                      });
-                    }
-                  }}
-                  sx={{
-                    color: "inherit",
-                  }}
-                >
-                  {text.map((t, index) => (
-                    <MenuItem key={index} value={t}>
-                      {t}
-                    </MenuItem>
-                  ))}
-                </Select>
-              )
-            }
+            label={text}
             sx={{
               ...chipStyle,
               "& .MuiChip-icon": {
@@ -169,14 +89,94 @@ const PillBadge = ({
               "& .MuiChip-label": {
                 marginBottom: "1px",
               },
-              "& .MuiInput-input:focus": {
-                backgroundColor: "inherit",
-              },
             }}
             variant={variant as "filled" | "outlined" | undefined}
-          ></Chip>
-        </FormControl>
-      )}
+          />
+        ) : (
+          <FormControl fullWidth>
+            <Chip
+              disabled={readOnly}
+              icon={
+                showIcon ? (
+                  <CircleIcon color={"inherit"} sx={{ fontSize: 10 }} />
+                ) : undefined
+              }
+              label={
+                Array.isArray(text) &&
+                text.length > 0 &&
+                Array.isArray(text[0]) ? (
+                  <Select
+                    disabled={readOnly}
+                    value={chipSelection}
+                    variant={"standard"}
+                    disableUnderline={true}
+                    onChange={(event) => {
+                      const selectedText = text.find(
+                        (t) => t[0] === event.target.value
+                      );
+                      setChipSelection(event.target.value);
+                      setChipColor(selectedText?.[1] ?? "default");
+                      if (operator) {
+                        handleClick(panelId, {
+                          params: { value: event.target.value },
+                          operator,
+                        });
+                      }
+                    }}
+                    sx={{
+                      color: "inherit",
+                    }}
+                  >
+                    {text.map((t, index) => (
+                      <MenuItem key={index} value={t[0]}>
+                        {t[0]}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                ) : (
+                  <Select
+                    disabled={readOnly}
+                    value={chipSelection}
+                    variant={"standard"}
+                    disableUnderline={true}
+                    onChange={(event) => {
+                      setChipSelection(event.target.value);
+                      if (operator) {
+                        handleClick(panelId, {
+                          params: { value: event.target.value },
+                          operator,
+                        });
+                      }
+                    }}
+                    sx={{
+                      color: "inherit",
+                    }}
+                  >
+                    {text.map((t, index) => (
+                      <MenuItem key={index} value={t}>
+                        {t}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                )
+              }
+              sx={{
+                ...chipStyle,
+                "& .MuiChip-icon": {
+                  marginRight: "-7px",
+                },
+                "& .MuiChip-label": {
+                  marginBottom: "1px",
+                },
+                "& .MuiInput-input:focus": {
+                  backgroundColor: "inherit",
+                },
+              }}
+              variant={variant as "filled" | "outlined" | undefined}
+            ></Chip>
+          </FormControl>
+        )}
+      </Tooltip>
     </span>
   );
 };

--- a/app/packages/components/src/components/PillBadge/PillBadge.tsx
+++ b/app/packages/components/src/components/PillBadge/PillBadge.tsx
@@ -103,6 +103,7 @@ const PillBadge = ({
               text.length > 0 &&
               Array.isArray(text[0]) ? (
                 <Select
+                  disabled={readOnly}
                   value={chipSelection}
                   variant={"standard"}
                   disableUnderline={true}
@@ -131,6 +132,7 @@ const PillBadge = ({
                 </Select>
               ) : (
                 <Select
+                  disabled={readOnly}
                   value={chipSelection}
                   variant={"standard"}
                   disableUnderline={true}

--- a/app/packages/components/src/components/PillBadge/PillBadge.tsx
+++ b/app/packages/components/src/components/PillBadge/PillBadge.tsx
@@ -11,6 +11,7 @@ const PillBadge = ({
   showIcon = true,
   operator,
   readOnly = false,
+  title = "",
 }: {
   text: string | string[] | [string, string][];
   color?: string;
@@ -18,6 +19,7 @@ const PillBadge = ({
   showIcon?: boolean;
   operator?: () => void;
   readOnly?: boolean;
+  title?: string;
 }) => {
   const getInitialChipSelection = (
     text: string | string[] | [string, string][]
@@ -72,6 +74,7 @@ const PillBadge = ({
     <span>
       {typeof text === "string" ? (
         <Chip
+          title={title || readOnly ? "Read-only mode" : ""}
           icon={
             showIcon ? (
               <CircleIcon color={"inherit"} sx={{ fontSize: 10 }} />
@@ -93,6 +96,7 @@ const PillBadge = ({
         <FormControl fullWidth>
           <Chip
             disabled={readOnly}
+            title={title || readOnly ? "Read-only mode" : ""}
             icon={
               showIcon ? (
                 <CircleIcon color={"inherit"} sx={{ fontSize: 10 }} />

--- a/app/packages/core/src/plugins/SchemaIO/components/DropdownView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DropdownView.tsx
@@ -1,4 +1,4 @@
-import { IconButton, MenuItem, Select } from "@mui/material";
+import { IconButton, MenuItem, Select, Tooltip } from "@mui/material";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useKey } from "../hooks";
 import { getComponentProps, getFieldSx } from "../utils";
@@ -34,6 +34,7 @@ export default function DropdownView(props: ViewPropsType) {
     variant,
     icon,
     addOnClickToMenuItems = false,
+    tooltipTitle = "",
   } = view;
   const [IconComponent, setIconComponent] =
     useState<React.ComponentType<any> | null>(null);
@@ -156,61 +157,64 @@ export default function DropdownView(props: ViewPropsType) {
 
   return (
     <FieldWrapper {...props} hideHeader={compact}>
-      <Select
-        key={key}
-        disabled={readOnly}
-        autoFocus={autoFocus(props)}
-        defaultValue={computedDefaultValue}
-        size="small"
-        fullWidth={!icon}
-        displayEmpty
-        title={compact ? description : undefined}
-        renderValue={(value) => {
-          if (icon) {
-            return renderIcon();
-          }
-          const unselected = value?.length === 0;
-          setSelected(!unselected);
-          if (unselected) {
-            if (compact) {
-              return placeholder || label;
+      <Tooltip title={tooltipTitle}>
+        <Select
+          key={key}
+          disabled={readOnly}
+          autoFocus={autoFocus(props)}
+          defaultValue={computedDefaultValue}
+          size="small"
+          fullWidth={!icon}
+          displayEmpty
+          title={compact ? description : undefined}
+          renderValue={(value) => {
+            if (icon) {
+              return renderIcon();
             }
-            return placeholder;
-          }
-          if (multiple) {
-            return value.map((item) => choiceLabels[item] || item).join(", ");
-          }
-          return choiceLabels[value] || value;
-        }}
-        onChange={(e) => {
-          const value = e.target.value;
-          handleOnChange(value);
-        }}
-        multiple={multiple}
-        {...selectProps}
-        MenuProps={{
-          ...MenuProps,
-          sx: {
-            zIndex: (theme) => theme.zIndex.operatorPalette + 1,
-            ...(MenuProps?.sx || {}),
-          },
-        }}
-      >
-        {choices.map(({ value, ...choice }) => (
-          <MenuItem
-            key={value}
-            value={value}
-            onClick={() => {
-              if (addOnClickToMenuItems) {
-                handleOnChange(value);
+            const unselected = value?.length === 0;
+            setSelected(!unselected);
+            if (unselected) {
+              if (compact) {
+                return placeholder || label;
               }
-            }}
-            {...getComponentProps(props, "optionContainer")}
-          >
-            <ChoiceMenuItemBody {...choice} {...props} />
-          </MenuItem>
-        ))}
-      </Select>
+              return placeholder;
+            }
+            if (multiple) {
+              return value.map((item) => choiceLabels[item] || item).join(", ");
+            }
+            return choiceLabels[value] || value;
+          }}
+          onChange={(e) => {
+            const value = e.target.value;
+            handleOnChange(value);
+          }}
+          multiple={multiple}
+          {...selectProps}
+          MenuProps={{
+            ...MenuProps,
+            sx: {
+              zIndex: (theme) => theme.zIndex.operatorPalette + 1,
+              ...(MenuProps?.sx || {}),
+            },
+          }}
+        >
+          {choices.map(({ value, ...choice }) => (
+            <MenuItem
+              disabled={readOnly}
+              key={value}
+              value={value}
+              onClick={() => {
+                if (addOnClickToMenuItems) {
+                  handleOnChange(value);
+                }
+              }}
+              {...getComponentProps(props, "optionContainer")}
+            >
+              <ChoiceMenuItemBody {...choice} {...props} />
+            </MenuItem>
+          ))}
+        </Select>
+      </Tooltip>
     </FieldWrapper>
   );
 }

--- a/app/packages/core/src/plugins/SchemaIO/components/ImageView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ImageView.tsx
@@ -16,7 +16,7 @@ export default function ImageView(props) {
     operator,
     prompt = false,
     params,
-    cursor = true,
+    cursor = false,
   } = schema?.view || {};
   const imageURI = data ?? schema?.default;
 

--- a/app/packages/core/src/plugins/SchemaIO/components/PillBadgeView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/PillBadgeView.tsx
@@ -1,15 +1,17 @@
 import { Box } from "@mui/material";
 import { getComponentProps } from "../utils";
 import PillBadge from "@fiftyone/components/src/components/PillBadge/PillBadge";
+import { ViewPropsType } from "../utils/types";
 
-export default function PillBadgeView(props) {
+export default function PillBadgeView(props: ViewPropsType) {
   const { schema } = props;
   const { view = {}, onChange } = schema;
-  const { text, color, variant, showIcon } = view;
+  const { text, color, variant, showIcon, read_only: readOnly } = view;
 
   return (
     <Box {...getComponentProps(props, "container")}>
       <PillBadge
+        readOnly={readOnly}
         text={text}
         color={color}
         variant={variant}


### PR DESCRIPTION
## What changes are proposed in this pull request?

- adds a readonly property to PillBadge and ModalView - needed for enforcing permissioning in teams
- adds an optional tooltipTitle property so we can show things like "you don't have sufficient permissions." in teams context. @imanjra lmk if there is a better way and I'll followup with improvements.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `disabled` property to the `ModalButtonView` for enhanced button control.
	- Added `readOnly` and `tooltipTitle` properties to the `PillBadge` component, allowing it to render in a non-interactive state and provide additional context.
	- Updated the `PillBadgeView` to reflect the new `readOnly` prop for better schema integration.
	- Added a `tooltipTitle` property to the `DropdownView` for enhanced user guidance.

- **Improvements**
	- Enhanced button interactivity based on tagging functionality.
	- Improved usability of the `PillBadge` component by restricting user input when in read-only mode.
	- Adjusted the default cursor style in the `ImageView` component to provide clearer user interaction feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->