### PR TITLE
fix FIFTYONE_ENABLE_ORCHESTRATOR_REGISTRATION warning behavior

### DIFF
--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -327,7 +327,7 @@ const useOperatorPromptSubmitOptions = (
   const showWarning =
     executionOptions.orchestratorRegistrationEnabled &&
     !hasAvailableOrchestators &&
-    !allowImmediateExecution;
+    !executionOptions.allowImmediateExecution;
   const warningMessage =
     "There are no available orchestrators to schedule this operation. Please contact your administrator to add an orchestrator.";
 

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -326,7 +326,8 @@ const useOperatorPromptSubmitOptions = (
   if (selectedOption) selectedOption.selected = true;
   const showWarning =
     executionOptions.orchestratorRegistrationEnabled &&
-    !hasAvailableOrchestators;
+    !hasAvailableOrchestators &&
+    !allowImmediateExecution;
   const warningMessage =
     "There are no available orchestrators to schedule this operation. Please contact your administrator to add an orchestrator.";
 
@@ -947,7 +948,9 @@ export function useOperatorExecutor(uri, handlers: any = {}) {
         handlers.onSuccess?.(result);
         callback?.(result);
         if (result.error) {
-          const isAbortError = result.error.name === "AbortError" || result.error instanceof DOMException;
+          const isAbortError =
+            result.error.name === "AbortError" ||
+            result.error instanceof DOMException;
           if (!isAbortError) {
             notify({
               msg: result.errorMessage || `Operation failed: ${uri}`,


### PR DESCRIPTION
when this env var is set, it doesn't care that the op is not delegated to throw the error.

## What changes are proposed in this pull request?

Cases:
- allow immediate: "execute"
  - orch reg: previously warns ⚠️    <------------------------- fix here
  - no orch reg: 👍🏼 
- allow delegated
  - orchs
    - orch reg: Schedule on orch1, schedule on orch2 ...
    - no orch reg: ⚠️ deployment misconfiguration 🤷🏼‍♂️ 
  - no orchs
    - orch reg: Correctly warns
    - no orch reg: "Schedule"
- allow both
  - orchs
    - orch reg: Execute, schedule on orch1, schedule on orch2 ...
    - no orch reg: ⚠️ deployment misconfiguration 🤷🏼‍♂️ 
  - no orchs
    - orch reg: previously warns ⚠️    <------------------------- fix here
    - no orch reg: "Execute, Schedule"
- allow nothing: 🤷🏼‍♂️ 

The conditional soup is kind of a jumble here but from all the cases listed out above, all we need to do is require that allowImmediate is false in order to show the warning message. If it's true we know we'll at least have the "Execute" button and so should be able to run it. If there are registered orchs they should show up in the dropdown.

## How is this patch tested? If it is not, please explain why.

set env var, see that I can execute any non-delegated operator. Delegated ops still gets the error correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved user notifications for operator execution options based on available orchestrators.
  
- **Bug Fixes**
	- Enhanced error handling for abort errors, improving clarity and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->