### PR TITLE
additional panel meta (is_new, beta, category)

### DIFF
--- a/app/packages/components/src/components/ThemeProvider/index.tsx
+++ b/app/packages/components/src/components/ThemeProvider/index.tsx
@@ -95,6 +95,7 @@ let theme = extendMuiTheme({
           shadowDark: "hsl(200, 0%, 70%)",
           lightning: "hsl(25, 100%, 51%)",
           toastBackgroundColor: "#FFFFFF",
+          primarySoft: "hsl(25, 100%, 51%)",
         },
         voxel: {
           500: "#FF6D04",
@@ -177,6 +178,7 @@ let theme = extendMuiTheme({
           shadowDark: "hsl(200, 0%, 0%)",
           lightning: "#f5b700",
           toastBackgroundColor: "#333",
+          primarySoft: "hsl(25, 100%, 80%)",
         },
         voxel: {
           500: "#FF6D04",

--- a/app/packages/core/src/plugins/histograms.tsx
+++ b/app/packages/core/src/plugins/histograms.tsx
@@ -1,6 +1,10 @@
 import { Loading, Selector } from "@fiftyone/components";
 import { OperatorPlacements, types } from "@fiftyone/operators";
-import { PluginComponentType, registerComponent } from "@fiftyone/plugins";
+import {
+  Categories,
+  PluginComponentType,
+  registerComponent,
+} from "@fiftyone/plugins";
 import { usePanelTitle } from "@fiftyone/spaces";
 import { datasetName, distributionPaths, field } from "@fiftyone/state";
 import { BarChart } from "@mui/icons-material";
@@ -108,5 +112,6 @@ registerComponent({
   Icon: BarChart,
   panelOptions: {
     priority: BUILT_IN_PANEL_PRIORITY_CONST,
+    category: Categories.Curate,
   },
 });

--- a/app/packages/embeddings/src/EmptyEmbeddings.tsx
+++ b/app/packages/embeddings/src/EmptyEmbeddings.tsx
@@ -37,7 +37,11 @@ export default function EmptyEmbeddings() {
         <Grid container direction="column" alignItems="center" spacing={2}>
           <Grid item>
             <WorkspacesIcon
-              sx={{ fontSize: 64, color: "#ffba85", marginBottom: 2 }}
+              sx={{
+                fontSize: 64,
+                color: theme.custom.primarySoft,
+                marginBottom: 2,
+              }}
             />
           </Grid>
           <Grid item>

--- a/app/packages/embeddings/src/index.ts
+++ b/app/packages/embeddings/src/index.ts
@@ -1,4 +1,8 @@
-import { PluginComponentType, registerComponent } from "@fiftyone/plugins";
+import {
+  Categories,
+  PluginComponentType,
+  registerComponent,
+} from "@fiftyone/plugins";
 import WorkspacesIcon from "@mui/icons-material/Workspaces";
 import Embeddings from "./Embeddings";
 import EmbeddingsTabIndicator from "./EmbeddingsTabIndicator";
@@ -14,5 +18,6 @@ registerComponent({
   panelOptions: {
     TabIndicator: EmbeddingsTabIndicator,
     priority: BUILT_IN_PANEL_PRIORITY_CONST,
+    category: Categories.Curate,
   },
 });

--- a/app/packages/operators/src/Panel/register.tsx
+++ b/app/packages/operators/src/Panel/register.tsx
@@ -28,6 +28,7 @@ export default function registerPanel(ctx: ExecutionContext) {
       beta: ctx.params.beta,
       category: ctx.params.category,
       isNew: ctx.params.is_new,
+      priority: ctx.params.priority,
     },
   });
 }

--- a/app/packages/operators/src/Panel/register.tsx
+++ b/app/packages/operators/src/Panel/register.tsx
@@ -25,6 +25,9 @@ export default function registerPanel(ctx: ExecutionContext) {
       helpMarkdown: ctx.params.help_markdown,
       reloadOnNavigation: ctx.params.reload_on_navigation,
       surfaces: ctx.params.surfaces,
+      beta: ctx.params.beta,
+      category: ctx.params.category,
+      isNew: ctx.params.is_new,
     },
   });
 }

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -997,6 +997,10 @@ class RegisterPanel extends Operator {
     inputs.str("panel_name", { label: "Panel name", required: true });
     inputs.str("panel_label", { label: "Panel label", required: true });
     inputs.str("icon", { label: "Icon" });
+    inputs.str("help_markdown", { label: "Help markdown" });
+    inputs.str("category", { label: "Category" });
+    inputs.bool("beta", { label: "Beta", default: false });
+    inputs.bool("is_new", { label: "NEW", default: false });
     inputs.str("dark_icon", { label: "Icon for dark mode" });
     inputs.str("light_icon", { label: "Icon for light mode" });
     inputs.str("on_load", { label: "On load operator" });

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -1010,6 +1010,7 @@ class RegisterPanel extends Operator {
       label: "Allow duplicates",
       default: false,
     });
+    inputs.int("priority", { label: "Priority" });
     return new types.Property(inputs);
   }
   async execute(ctx: ExecutionContext): Promise<void> {

--- a/app/packages/plugins/src/index.ts
+++ b/app/packages/plugins/src/index.ts
@@ -320,7 +320,6 @@ export function getCategoryLabel(category: CategoryID): string {
 }
 
 export function getCategoryForPanel(panel: PluginComponentRegistration) {
-  console.log(panel);
   return panel.panelOptions?.category || "custom";
 }
 

--- a/app/packages/plugins/src/index.ts
+++ b/app/packages/plugins/src/index.ts
@@ -319,6 +319,11 @@ export function getCategoryLabel(category: CategoryID): string {
   }
 }
 
+export function getCategoryForPanel(panel: PluginComponentRegistration) {
+  console.log(panel);
+  return panel.panelOptions?.category || "custom";
+}
+
 type Category = {
   id: CategoryID;
   label: string;

--- a/app/packages/plugins/src/index.ts
+++ b/app/packages/plugins/src/index.ts
@@ -297,6 +297,33 @@ export enum PluginComponentType {
    */
 }
 
+type CategoryID = "import" | "curate" | "analyze" | "custom";
+
+export enum Categories {
+  Import = "import",
+  Curate = "curate",
+  Analyze = "analyze",
+  Custom = "custom",
+}
+
+export function getCategoryLabel(category: CategoryID): string {
+  switch (category) {
+    case "import":
+      return "Import";
+    case "curate":
+      return "Curate";
+    case "analyze":
+      return "Analyze";
+    case "custom":
+      return "Custom";
+  }
+}
+
+type Category = {
+  id: CategoryID;
+  label: string;
+};
+
 type PluginActivator = (props: any) => boolean;
 
 type PanelOptions = {
@@ -331,6 +358,21 @@ type PanelOptions = {
    * This is only applicable to plugins that are in a modal.
    */
   reloadOnNavigation?: boolean;
+
+  /**
+   * The category of the plugin
+   */
+  category: CategoryID;
+
+  /**
+   * Whether the plugin is in beta
+   */
+  beta: boolean;
+
+  /**
+   * Whether the plugin is new
+   */
+  isNew: boolean;
 };
 
 type PluginComponentProps<T> = T & {

--- a/app/packages/spaces/src/components/AddPanelButton.tsx
+++ b/app/packages/spaces/src/components/AddPanelButton.tsx
@@ -1,6 +1,7 @@
 import { IconButton, Popout, scrollable, useTheme } from "@fiftyone/components";
 import {
   Categories,
+  getCategoryForPanel,
   getCategoryLabel,
   PluginComponentRegistration,
 } from "@fiftyone/plugins";
@@ -48,7 +49,7 @@ export default function AddPanelButton({ node, spaceId }: AddPanelButtonProps) {
     .sort(panelsCompareFn);
 
   const categorizedPanels = availablePanels.reduce((acc, panel) => {
-    const category = panel.panelOptions?.category || Categories.Custom;
+    const category = getCategoryForPanel(panel);
     if (!acc[category]) {
       acc[category] = {
         label: getCategoryLabel(category),
@@ -97,6 +98,7 @@ export default function AddPanelButton({ node, spaceId }: AddPanelButtonProps) {
                     spaceId={spaceId}
                     showBeta={panel.panelOptions?.beta}
                     showNew={panel.panelOptions?.isNew}
+                    onClick={() => setOpen(false)}
                   />
                 ))}
               </PanelCategory>

--- a/app/packages/spaces/src/components/AddPanelButton.tsx
+++ b/app/packages/spaces/src/components/AddPanelButton.tsx
@@ -1,5 +1,9 @@
-import { IconButton, Popout, scrollable } from "@fiftyone/components";
-import { PluginComponentRegistration } from "@fiftyone/plugins";
+import { IconButton, Popout, scrollable, useTheme } from "@fiftyone/components";
+import {
+  Categories,
+  getCategoryLabel,
+  PluginComponentRegistration,
+} from "@fiftyone/plugins";
 import * as fos from "@fiftyone/state";
 import { Add } from "@mui/icons-material";
 import { useCallback, useMemo, useRef, useState } from "react";
@@ -9,6 +13,7 @@ import { AddPanelButtonProps } from "../types";
 import { panelsCompareFn } from "../utils/sort";
 import AddPanelItem from "./AddPanelItem";
 import { AddPanelButtonContainer } from "./StyledElements";
+import { Typography, Grid } from "@mui/material";
 
 export default function AddPanelButton({ node, spaceId }: AddPanelButtonProps) {
   const [open, setOpen] = useState(false);
@@ -26,9 +31,7 @@ export default function AddPanelButton({ node, spaceId }: AddPanelButtonProps) {
   const panels = usePanels(panelsPredicate);
   const spaceNodes = useSpaceNodes(spaceId);
   const nodeTypes = useMemo(() => {
-    return spaceNodes.map((node) => {
-      return node.type;
-    });
+    return spaceNodes.map((node) => node.type);
   }, [spaceNodes]);
   const popoutRef = useRef();
   fos.useOutsideClick(popoutRef, () => {
@@ -44,14 +47,28 @@ export default function AddPanelButton({ node, spaceId }: AddPanelButtonProps) {
     })
     .sort(panelsCompareFn);
 
+  const categorizedPanels = availablePanels.reduce((acc, panel) => {
+    const category = panel.panelOptions?.category || Categories.Custom;
+    if (!acc[category]) {
+      acc[category] = {
+        label: getCategoryLabel(category),
+        panels: [],
+      };
+    }
+    acc[category].panels.push(panel);
+    return acc;
+  }, {});
+
   if (availablePanels.length === 0) return null;
+
+  const sortedCategories = ["import", "curate", "analyze", "custom"]
+    .map((cat) => categorizedPanels[cat])
+    .filter((c) => c);
 
   return (
     <AddPanelButtonContainer ref={popoutRef}>
       <IconButton
-        onClick={() => {
-          setOpen(!open);
-        }}
+        onClick={() => setOpen(!open)}
         title="New panel"
         data-cy="new-panel-btn"
       >
@@ -68,17 +85,48 @@ export default function AddPanelButton({ node, spaceId }: AddPanelButtonProps) {
           }}
           popoutProps={{ className: scrollable }}
         >
-          {availablePanels.map((panel) => (
-            <AddPanelItem
-              key={panel.name}
-              spaceId={spaceId}
-              {...panel}
-              node={node}
-              onClick={() => setOpen(!open)}
-            />
-          ))}
+          <PanelCategories>
+            {sortedCategories.map(({ label, panels }) => (
+              <PanelCategory key={label} label={label}>
+                {panels.map((panel) => (
+                  <AddPanelItem
+                    key={panel.name}
+                    node={node}
+                    name={panel.name}
+                    label={panel.label}
+                    spaceId={spaceId}
+                    showBeta={panel.panelOptions?.beta}
+                    showNew={panel.panelOptions?.isNew}
+                  />
+                ))}
+              </PanelCategory>
+            ))}
+          </PanelCategories>
         </Popout>
       )}
     </AddPanelButtonContainer>
+  );
+}
+
+function PanelCategories({ children }) {
+  return (
+    <Grid container gap={1} sx={{ p: 2 }}>
+      {children}
+    </Grid>
+  );
+}
+
+function PanelCategory({ label, children }) {
+  const theme = useTheme();
+  return (
+    <Grid item>
+      <Typography
+        variant="subtitle2"
+        sx={{ padding: "0 8px", color: theme.text.secondary }}
+      >
+        {label || "no category"}
+      </Typography>
+      {children}
+    </Grid>
   );
 }

--- a/app/packages/spaces/src/components/AddPanelItem.tsx
+++ b/app/packages/spaces/src/components/AddPanelItem.tsx
@@ -5,6 +5,7 @@ import { useSpaces } from "../hooks";
 import SpaceNode from "../SpaceNode";
 import { AddPanelItemProps } from "../types";
 import PanelIcon from "./PanelIcon";
+import { useTheme } from "@fiftyone/components";
 
 export default function AddPanelItem({
   node,
@@ -12,7 +13,10 @@ export default function AddPanelItem({
   label,
   onClick,
   spaceId,
+  showBeta,
+  showNew,
 }: AddPanelItemProps) {
+  const theme = useTheme();
   const trackEvent = useTrackEvent();
   const { spaces } = useSpaces(spaceId);
   return (
@@ -48,6 +52,28 @@ export default function AddPanelItem({
       >
         {label || (name as string)}
       </Typography>
+      {showNew && (
+        <span
+          style={{
+            color: theme.primary.main,
+            fontSize: "10px",
+            marginLeft: "8px",
+          }}
+        >
+          NEW
+        </span>
+      )}
+      {showBeta && (
+        <span
+          style={{
+            color: theme.primary.main,
+            fontSize: "10px",
+            marginLeft: "8px",
+          }}
+        >
+          BETA
+        </span>
+      )}
     </Stack>
   );
 }

--- a/app/packages/spaces/src/components/AddPanelItem.tsx
+++ b/app/packages/spaces/src/components/AddPanelItem.tsx
@@ -56,8 +56,8 @@ export default function AddPanelItem({
         <span
           style={{
             color: theme.primary.main,
-            fontSize: "10px",
-            marginLeft: "8px",
+            fontSize: "11px",
+            marginLeft: "6px",
           }}
         >
           NEW
@@ -67,8 +67,8 @@ export default function AddPanelItem({
         <span
           style={{
             color: theme.primary.main,
-            fontSize: "10px",
-            marginLeft: "8px",
+            fontSize: "11px",
+            marginLeft: "6px",
           }}
         >
           BETA

--- a/app/packages/spaces/src/components/AddPanelItem.tsx
+++ b/app/packages/spaces/src/components/AddPanelItem.tsx
@@ -55,7 +55,7 @@ export default function AddPanelItem({
       {showNew && (
         <span
           style={{
-            color: theme.primary.main,
+            color: theme.custom.primarySoft,
             fontSize: "11px",
             marginLeft: "6px",
           }}
@@ -66,7 +66,7 @@ export default function AddPanelItem({
       {showBeta && (
         <span
           style={{
-            color: theme.primary.main,
+            color: theme.custom.primarySoft,
             fontSize: "11px",
             marginLeft: "6px",
           }}

--- a/app/packages/spaces/src/components/PanelIcon.tsx
+++ b/app/packages/spaces/src/components/PanelIcon.tsx
@@ -2,6 +2,7 @@ import ExtensionIcon from "@mui/icons-material/Extension";
 import { usePanel } from "../hooks";
 import { PanelIconProps } from "../types";
 import { warnPanelNotFound } from "../utils";
+import { Box } from "@mui/material";
 
 export default function PanelIcon(props: PanelIconProps) {
   const { name } = props;
@@ -10,12 +11,13 @@ export default function PanelIcon(props: PanelIconProps) {
   const { Icon } = panel;
   const PanelTabIcon = Icon || ExtensionIcon;
   return (
-    <PanelTabIcon
-      style={{
-        width: "1rem",
-        height: "1rem",
-        marginRight: "0.5rem",
-      }}
-    />
+    <Box sx={{ mr: "0.75rem", width: "1rem", height: "1.5rem" }}>
+      <PanelTabIcon
+        style={{
+          width: "1rem",
+          height: "1rem",
+        }}
+      />
+    </Box>
   );
 }

--- a/app/packages/spaces/src/components/PanelTab.tsx
+++ b/app/packages/spaces/src/components/PanelTab.tsx
@@ -1,7 +1,7 @@
 import { HelpTooltip, IconButton } from "@fiftyone/components";
 import { useTimeout } from "@fiftyone/state";
 import { Close } from "@mui/icons-material";
-import { CircularProgress, Skeleton, Typography } from "@mui/material";
+import { CircularProgress, Grid, Skeleton, Typography } from "@mui/material";
 import { useCallback } from "react";
 import { PANEL_LOADING_TIMEOUT } from "../constants";
 import {
@@ -55,6 +55,10 @@ export default function PanelTab({ node, active, spaceId }: PanelTabProps) {
       {panel && loading && <CircularProgress size={14} sx={{ mr: 0.85 }} />}
       {panel && !loading && <PanelIcon name={panelName as string} />}
       {panel && <Typography>{title || panel.label || panel.name}</Typography>}
+      <PanelTabMeta
+        showBeta={panel?.panelOptions?.beta}
+        showNew={panel?.panelOptions?.isNew}
+      />
       {panel && TabIndicator && (
         <TabIndicatorContainer>
           <TabIndicator />
@@ -83,5 +87,28 @@ export default function PanelTab({ node, active, spaceId }: PanelTabProps) {
         </IconButton>
       )}
     </StyledTab>
+  );
+}
+
+function PanelTabMeta({ showBeta, showNew }) {
+  return (
+    <Grid container gap={1} sx={{ width: "auto", ml: "6px" }}>
+      {showNew && (
+        <Grid
+          item
+          style={{ color: "var(--fo-palette-primary-main)", fontSize: 11 }}
+        >
+          NEW
+        </Grid>
+      )}
+      {showBeta && (
+        <Grid
+          item
+          style={{ color: "var(--fo-palette-primary-main)", fontSize: 11 }}
+        >
+          BETA
+        </Grid>
+      )}
+    </Grid>
   );
 }

--- a/app/packages/spaces/src/components/PanelTab.tsx
+++ b/app/packages/spaces/src/components/PanelTab.tsx
@@ -96,7 +96,10 @@ function PanelTabMeta({ showBeta, showNew }) {
       {showNew && (
         <Grid
           item
-          style={{ color: "var(--fo-palette-primary-main)", fontSize: 11 }}
+          style={{
+            color: "var(--fo-palette-custom-primarySoft)",
+            fontSize: 11,
+          }}
         >
           NEW
         </Grid>
@@ -104,7 +107,10 @@ function PanelTabMeta({ showBeta, showNew }) {
       {showBeta && (
         <Grid
           item
-          style={{ color: "var(--fo-palette-primary-main)", fontSize: 11 }}
+          style={{
+            color: "var(--fo-palette-custom-primarySoft)",
+            fontSize: 11,
+          }}
         >
           BETA
         </Grid>

--- a/app/packages/spaces/src/types.ts
+++ b/app/packages/spaces/src/types.ts
@@ -14,6 +14,8 @@ export type AddPanelItemProps = {
   Icon?: React.ComponentType;
   onClick?: () => void;
   spaceId: string;
+  showBeta?: boolean;
+  showNew?: boolean;
 };
 
 export type PanelIconProps = {

--- a/fiftyone/operators/__init__.py
+++ b/fiftyone/operators/__init__.py
@@ -17,8 +17,9 @@ from .executor import (
     ExecutionContext,
     ExecutionOptions,
 )
-from .utils import ProgressHandler
+from .utils import ProgressHandler, is_new
 from .panel import Panel, PanelConfig
+from .categories import Categories
 
 # This enables Sphinx refs to directly use paths imported here
 __all__ = [k for k, v in globals().items() if not k.startswith("_")]

--- a/fiftyone/operators/categories.py
+++ b/fiftyone/operators/categories.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class Categories(Enum):
+    IMPORT = "import"
+    CURATE = "curate"
+    ANALYZE = "analyze"
+    CUSTOM = "custom"

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -323,6 +323,7 @@ class Operations(object):
         on_change_extended_selection=None,
         on_change_group_slice=None,
         allow_duplicates=False,
+        priority=None,
     ):
         """Registers a panel with the given name and lifecycle callbacks.
 
@@ -368,6 +369,7 @@ class Operations(object):
                 slice changes
             allow_duplicates (False): whether to allow multiple instances of
                 the panel to the opened
+            priority (None): the priority of the panel, used for sort order
         """
         params = {
             "panel_name": name,
@@ -394,6 +396,7 @@ class Operations(object):
             "on_change_extended_selection": on_change_extended_selection,
             "on_change_group_slice": on_change_group_slice,
             "allow_duplicates": allow_duplicates,
+            "priority": priority,
         }
         return self._ctx.trigger("register_panel", params=params)
 

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -9,6 +9,7 @@ FiftyOne operator execution.
 import json
 
 from bson import json_util
+from .categories import Categories
 
 
 class Operations(object):
@@ -301,6 +302,9 @@ class Operations(object):
         name,
         label,
         help_markdown=None,
+        category=Categories.CUSTOM,
+        beta=False,
+        is_new=False,
         icon=None,
         light_icon=None,
         dark_icon=None,
@@ -337,6 +341,9 @@ class Operations(object):
             reload_on_navigation (False): whether to reload the panel when the
                 user navigates to a new page. This is only applicable to panels
                 that are not shown in a modal
+            beta (False): whether the panel is in beta
+            is_new (False): whether the panel is new
+            category (Categories.CUSTOM): the category of the panel
             on_load (None): an operator to invoke when the panel is loaded
             on_unload (None): an operator to invoke when the panel is unloaded
             on_change (None): an operator to invoke when the panel state
@@ -366,6 +373,9 @@ class Operations(object):
             "panel_name": name,
             "panel_label": label,
             "help_markdown": help_markdown,
+            "category": category.value if category is not None else None,
+            "beta": beta,
+            "is_new": is_new,
             "icon": icon,
             "light_icon": light_icon,
             "dark_icon": dark_icon,

--- a/fiftyone/operators/panel.py
+++ b/fiftyone/operators/panel.py
@@ -35,6 +35,7 @@ class PanelConfig(OperatorConfig):
         help_markdown (None): a markdown string to display in the panel's help
             tooltip
         category (Category): the category id of the panel
+        priority (None): the priority of the panel for sorting in the UI
     """
 
     def __init__(
@@ -51,6 +52,7 @@ class PanelConfig(OperatorConfig):
         allow_multiple=False,
         surfaces: PANEL_SURFACE = "grid",
         reload_on_navigation=False,
+        priority=None,
         **kwargs
     ):
         super().__init__(name)
@@ -68,6 +70,7 @@ class PanelConfig(OperatorConfig):
         self.category = category
         self.beta = beta
         self.is_new = is_new
+        self.priority = priority
         self.kwargs = kwargs  # unused, placeholder for future extensibility
 
     def to_json(self):
@@ -86,6 +89,7 @@ class PanelConfig(OperatorConfig):
             "unlisted": self.unlisted,
             "reload_on_navigation": self.reload_on_navigation,
             "surfaces": self.surfaces,
+            "priority": self.priority,
         }
 
 
@@ -128,6 +132,7 @@ class Panel(Operator):
             "category": self.config.category,
             "beta": self.config.beta,
             "is_new": self.config.is_new,
+            "priority": self.config.priority,
         }
         methods = ["on_load", "on_unload", "on_change"]
         ctx_change_events = [

--- a/fiftyone/operators/panel.py
+++ b/fiftyone/operators/panel.py
@@ -34,6 +34,7 @@ class PanelConfig(OperatorConfig):
         surfaces ("grid"): the surfaces on which the panel can be displayed
         help_markdown (None): a markdown string to display in the panel's help
             tooltip
+        category (Category): the category id of the panel
     """
 
     def __init__(
@@ -41,6 +42,9 @@ class PanelConfig(OperatorConfig):
         name,
         label,
         help_markdown=None,
+        beta=False,
+        is_new=False,
+        category=None,
         icon=None,
         light_icon=None,
         dark_icon=None,
@@ -61,6 +65,9 @@ class PanelConfig(OperatorConfig):
         self.on_startup = True
         self.reload_on_navigation = reload_on_navigation
         self.surfaces = surfaces
+        self.category = category
+        self.beta = beta
+        self.is_new = is_new
         self.kwargs = kwargs  # unused, placeholder for future extensibility
 
     def to_json(self):
@@ -68,6 +75,9 @@ class PanelConfig(OperatorConfig):
             "name": self.name,
             "label": self.label,
             "help_markdown": self.help_markdown,
+            "category": str(self.category) if self.category else None,
+            "beta": self.beta,
+            "is_new": self.is_new,
             "icon": self.icon,
             "light_icon": self.light_icon,
             "dark_icon": self.dark_icon,
@@ -115,6 +125,9 @@ class Panel(Operator):
             "light_icon": self.config.light_icon,
             "surfaces": self.config.surfaces,
             "reload_on_navigation": self.config.reload_on_navigation,
+            "category": self.config.category,
+            "beta": self.config.beta,
+            "is_new": self.config.is_new,
         }
         methods = ["on_load", "on_unload", "on_change"]
         ctx_change_events = [

--- a/fiftyone/operators/utils.py
+++ b/fiftyone/operators/utils.py
@@ -6,6 +6,7 @@ FiftyOne operator utilities.
 |
 """
 
+from datetime import datetime
 import logging
 from .operator import Operator
 
@@ -66,3 +67,40 @@ def is_method_overridden(base_class, sub_class_instance, method_name):
     base_method = getattr(base_class, method_name, None)
     sub_method = getattr(type(sub_class_instance), method_name, None)
     return base_method != sub_method
+
+
+from datetime import datetime, timedelta
+
+
+def is_new(release_date, days=30):
+    """
+    Determines if a feature is considered "new" based on its release date.
+
+    A feature is considered new if its release date is within the specified number of days.
+
+    Args:
+        release_date (str or datetime): The release date of the feature.
+            - If a string, it should be in the format "%Y-%m-%d" (e.g., "2024-11-09").
+            - If a datetime object, it will be used directly without conversion.
+        days (int, optional): The number of days within which the feature is considered new.
+            Defaults to 30.
+
+    Returns:
+        bool: True if the release date is within the specified number of days, False otherwise.
+
+    Examples:
+        >>> is_new("2024-11-09")  # Using a string date and default days
+        True  # if today's date is within 30 days after 2024-11-09
+
+        >>> is_new(datetime(2024, 11, 9), days=15)  # Using a datetime object with 15-day threshold
+        True  # if today's date is within 15 days after November 9, 2024
+
+        >>> is_new("2024-10-01", days=45)
+        False  # if today's date is more than 45 days after October 1, 2024
+    """
+    if isinstance(release_date, str):
+        release_date = datetime.strptime(release_date, "%Y-%m-%d")
+    elif not isinstance(release_date, datetime):
+        raise ValueError("release_date must be a string or datetime object")
+
+    return (datetime.now() - release_date).days <= days


### PR DESCRIPTION
Here's an example using all of the new settings in python and JS:

```python
class CounterExample(foo.Panel):
    @property
    def config(self):
        return foo.PanelConfig(
            name="example_counter",
            label="Examples: Counter",
            category=foo.Categories.ANALYZE, # new
            is_new=foo.is_new("2024-11-01"), # new
            beta=True # new,
            priority=52000 # new
        )
```

```typescript
registerComponent({
  name: "Embeddings",
  label: "Embeddings",
  component: Embeddings,
  type: PluginComponentType.Panel,
  activator: () => true,
  Icon: WorkspacesIcon,
  panelOptions: {
    TabIndicator: EmbeddingsTabIndicator,
    priority: BUILT_IN_PANEL_PRIORITY_CONST,
    category: Categories.Curate, // new
    isNew: true, // new
    beta: true, // new
    priority: 51001 // existing
  },
});
```

New information is displayed only in the `AddPanel*` component.

<img width="303" alt="image" src="https://github.com/user-attachments/assets/696835bb-9cbc-4ec4-8a5a-94c19a19d74f">
<img width="457" alt="image" src="https://github.com/user-attachments/assets/1d5f9bd8-499a-41d1-bcf1-a32043b0d894">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a categorization system for panels, allowing users to easily identify and organize panels by their respective categories.
	- Added visual indicators for "NEW" and "BETA" features in the UI, enhancing user awareness of recent additions and experimental features.

- **Improvements**
	- Enhanced the `AddPanelButton` and `AddPanelItem` components for better usability and organization.
	- Improved panel registration capabilities with new metadata options, including priority and categorization.

- **Bug Fixes**
	- Minor adjustments to ensure consistent behavior across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->