### PR TITLE
Add Datepicker to Sidebar

### DIFF
--- a/app/packages/components/src/components/DatePicker/DatePicker.tsx
+++ b/app/packages/components/src/components/DatePicker/DatePicker.tsx
@@ -38,6 +38,7 @@ const BasicDatePicker: React.FC<DatePickerProps> = ({
           minDate={minDate}
           maxDate={maxDate}
           format={format}
+          slotProps={{ popper: { placement: "right-end" } }}
         />
       ) : (
         <DatePicker
@@ -49,6 +50,7 @@ const BasicDatePicker: React.FC<DatePickerProps> = ({
           minDate={minDate}
           maxDate={maxDate}
           format={format}
+          slotProps={{ popper: { placement: "right-end" } }}
         />
       )}
     </LocalizationProvider>

--- a/app/packages/components/src/components/DatePicker/DatePicker.tsx
+++ b/app/packages/components/src/components/DatePicker/DatePicker.tsx
@@ -1,39 +1,58 @@
 import React from "react";
-import dayjs from 'dayjs';
-import { atom, useRecoilState } from "recoil";
-import TextField from '@mui/material/TextField';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-
+import dayjs from "dayjs";
+import {
+  LocalizationProvider,
+  DatePicker,
+  DateTimePicker,
+} from "@mui/x-date-pickers";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 
 interface DatePickerProps {
   label: string;
+  isDateTime: boolean;
+  value: dayjs.Dayjs | null;
+  onChange: (newValue: dayjs.Dayjs | null) => void;
+  minDate?: dayjs.Dayjs;
+  maxDate?: dayjs.Dayjs;
 }
 
-const dateValue = atom({
-  key: "dateValue",
-  default: dayjs('2024-01-01'),
-});
+const format = "YYYY-M-D HH:mm:ss";
 
 const BasicDatePicker: React.FC<DatePickerProps> = ({
   label,
+  isDateTime,
+  value,
+  onChange,
+  minDate,
+  maxDate,
 }) => {
-  const [value, setValue] = useRecoilState(dateValue);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DatePicker
-        label={label}
-        value={value}
-        onChange={(newValue) => {
-          setValue(newValue);
-        }}
-        renderInput={(params) => <TextField {...params} />}
-      />
+      {isDateTime ? (
+        <DateTimePicker
+          label={label}
+          value={value}
+          onChange={(newValue) => {
+            onChange(newValue);
+          }}
+          minDate={minDate}
+          maxDate={maxDate}
+          format={format}
+        />
+      ) : (
+        <DatePicker
+          label={label}
+          value={value}
+          onChange={(newValue) => {
+            onChange(newValue);
+          }}
+          minDate={minDate}
+          maxDate={maxDate}
+          format={format}
+        />
+      )}
     </LocalizationProvider>
   );
-}
+};
 
 export default BasicDatePicker;
-

--- a/app/packages/core/src/components/Filters/DateFieldFilter/Boxes.tsx
+++ b/app/packages/core/src/components/Filters/DateFieldFilter/Boxes.tsx
@@ -15,8 +15,9 @@ dayjs.extend(timezone);
 
 const Container = styled.div`
   display: flex;
+  flex-direction: column;
   justify-content: space-between;
-  column-gap: 1rem;
+  row-gap: 1rem;
   background: ${({ theme }) => theme.background.level2};
   border: 1px solid var(--fo-palette-divider);
   border-radius: 2px;

--- a/app/packages/core/src/components/Filters/DateFieldFilter/Boxes.tsx
+++ b/app/packages/core/src/components/Filters/DateFieldFilter/Boxes.tsx
@@ -19,7 +19,7 @@ const Container = styled.div`
   column-gap: 1rem;
   background: ${({ theme }) => theme.background.level2};
   border: 1px solid var(--fo-palette-divider);
-  border-radius: 2px;s
+  border-radius: 2px;
   color: ${({ theme }) => theme.text.secondary};
   margin-top: 0.25rem;
   padding: 0.25rem 0.5rem;

--- a/app/packages/core/src/components/Filters/DateFieldFilter/Boxes.tsx
+++ b/app/packages/core/src/components/Filters/DateFieldFilter/Boxes.tsx
@@ -1,0 +1,104 @@
+import { pathColor } from "@fiftyone/state";
+import React from "react";
+import type { RecoilState } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
+import styled from "styled-components";
+import { DatePicker } from "@fiftyone/components";
+import * as fou from "@fiftyone/utilities";
+import * as fos from "@fiftyone/state";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const Container = styled.div`
+  display: flex;
+  justify-content: space-between;
+  column-gap: 1rem;
+  background: ${({ theme }) => theme.background.level2};
+  border: 1px solid var(--fo-palette-divider);
+  border-radius: 2px;s
+  color: ${({ theme }) => theme.text.secondary};
+  margin-top: 0.25rem;
+  padding: 0.25rem 0.5rem;
+`;
+
+const Box = ({
+  rangeAtom,
+  boundsAtom,
+  color,
+  label,
+  isDateTime,
+  isMin,
+}: {
+  rangeAtom: RecoilState<fos.Range>;
+  boundsAtom: RecoilState<fos.Range>;
+  color: string;
+  label: string;
+  isDateTime: boolean;
+  isMin: boolean;
+}) => {
+  const [range, setRange] = useRecoilState(rangeAtom);
+  const [bounds] = useRecoilState(boundsAtom);
+  const timeZone = useRecoilValue(fos.timeZone);
+  console.log(timeZone);
+  const index = isMin ? 0 : 1;
+  console.log(dayjs(range[0]).tz(timeZone));
+  return (
+    <DatePicker
+      color={color}
+      label={label}
+      value={dayjs(range[index]).tz(timeZone)}
+      minDate={dayjs(isMin ? bounds[0] : range[0]).tz(timeZone)}
+      maxDate={dayjs(isMin ? range[1] : bounds[1]).tz(timeZone)}
+      onChange={(v) => {
+        if (dayjs.isDayjs(v) && v.isValid()) {
+          console.log(v);
+          const newRange = [...range];
+          newRange[index] = v?.valueOf();
+          setRange(newRange as fos.Range);
+        }
+      }}
+      isDateTime={isDateTime}
+    />
+  );
+};
+
+const Boxes = ({ path, modal }: { path: string; modal: boolean }) => {
+  const color = useRecoilValue(pathColor(path));
+  const ftype = useRecoilValue(fos.fieldType({ path }));
+  const isDateTime = ftype === fou.DATE_TIME_FIELD;
+  const range = fos.rangeAtom({
+    modal,
+    path,
+    withBounds: true,
+  });
+  const bounds = fos.boundsAtom({
+    path,
+    modal,
+  });
+  return (
+    <Container>
+      <Box
+        rangeAtom={range}
+        boundsAtom={bounds}
+        color={color}
+        label={"Start"}
+        isDateTime={isDateTime}
+        isMin={true}
+      />
+      <Box
+        rangeAtom={range}
+        boundsAtom={bounds}
+        color={color}
+        label={"End"}
+        isDateTime={isDateTime}
+        isMin={false}
+      />
+    </Container>
+  );
+};
+
+export default Boxes;

--- a/app/packages/core/src/components/Filters/DateFieldFilter/DateFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/DateFieldFilter/DateFieldFilter.tsx
@@ -1,0 +1,57 @@
+import * as fos from "@fiftyone/state";
+import React from "react";
+import { useRecoilValue } from "recoil";
+import styled from "styled-components";
+import FieldLabelAndInfo from "../../FieldLabelAndInfo";
+import * as state from "./state";
+import Boxes from "./Boxes";
+
+const Container = styled.div`
+  margin: 3px;
+  font-weight: bold;
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+type Props = {
+  color: string;
+  modal: boolean;
+  named?: boolean;
+  onFocus?: () => void;
+  onBlur?: () => void;
+  path: string;
+};
+
+const DateFieldFilter = ({ color, modal, named = true, path }: Props) => {
+  const name = path.split(".").slice(-1)[0];
+  const field = fos.useAssertedRecoilValue(fos.field(path));
+  const hasBounds = useRecoilValue(state.hasBounds({ path, modal }));
+  const queryPerformance = useRecoilValue(fos.queryPerformance);
+
+  if (!queryPerformance && named && !hasBounds) {
+    return null;
+  }
+
+  return (
+    <Container onClick={(e) => e.stopPropagation()}>
+      {named && name && (
+        <FieldLabelAndInfo
+          nested
+          field={field}
+          color={color}
+          template={({ label, hoverTarget }) => (
+            <Header>
+              <span ref={hoverTarget}>{label}</span>
+            </Header>
+          )}
+        />
+      )}
+      <Boxes path={path} modal={modal} />
+    </Container>
+  );
+};
+
+export default DateFieldFilter;

--- a/app/packages/core/src/components/Filters/DateFieldFilter/index.ts
+++ b/app/packages/core/src/components/Filters/DateFieldFilter/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DateFieldFilter";

--- a/app/packages/core/src/components/Filters/DateFieldFilter/state.ts
+++ b/app/packages/core/src/components/Filters/DateFieldFilter/state.ts
@@ -1,0 +1,46 @@
+import type { Nonfinite } from "@fiftyone/state";
+import { boundsAtom, nonfiniteAtom, rangeAtom } from "@fiftyone/state";
+import { selectorFamily } from "recoil";
+
+export const FLOAT_NONFINITES: Nonfinite[] = ["inf", "ninf", "nan"];
+
+export const hasBounds = selectorFamily({
+  key: "hasBounds",
+  get:
+    (params: { path: string; modal: boolean }) =>
+    ({ get }) => {
+      return Boolean(get(boundsAtom(params))?.every((b) => b !== null));
+    },
+});
+
+export const hasDefaultRange = selectorFamily({
+  key: "hasBounds",
+  get:
+    (params: { modal: boolean; path: string }) =>
+    ({ get }) => {
+      return Boolean(get(rangeAtom(params))?.every((r) => r === null));
+    },
+});
+
+export const hasNonfinites = selectorFamily({
+  key: "hasNonfinites",
+  get:
+    (params: { path: string; modal: boolean }) =>
+    ({ get }) => {
+      return FLOAT_NONFINITES.every((key) =>
+        get(nonfiniteAtom({ key, ...params }))
+      );
+    },
+});
+
+export const oneBound = selectorFamily({
+  key: "oneBound",
+  get:
+    (params: { path: string; modal: boolean }) =>
+    ({ get }) => {
+      return get(hasBounds(params)) &&
+        get(boundsAtom(params))[0] === get(boundsAtom(params))[1]
+        ? get(boundsAtom(params))[0]
+        : null;
+    },
+});

--- a/app/packages/core/src/components/Filters/index.tsx
+++ b/app/packages/core/src/components/Filters/index.tsx
@@ -1,4 +1,5 @@
 export { default as BooleanFieldFilter } from "./BooleanFieldFilter";
 export { default as LabelFieldFilter } from "./LabelTagsFilter";
 export { default as NumericFieldFilter } from "./NumericFieldFilter";
+export { default as DateFieldFilter } from "./DateFieldFilter";
 export { default as StringFieldFilter } from "./StringFieldFilter";

--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/FilterItem.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/FilterItem.tsx
@@ -14,8 +14,8 @@ interface FilterItem {
 
 export const FILTERS = {
   [fou.BOOLEAN_FIELD]: filters.BooleanFieldFilter,
-  [fou.DATE_FIELD]: filters.NumericFieldFilter,
-  [fou.DATE_TIME_FIELD]: filters.NumericFieldFilter,
+  [fou.DATE_FIELD]: filters.DateFieldFilter,
+  [fou.DATE_TIME_FIELD]: filters.DateFieldFilter,
   [fou.FLOAT_FIELD]: filters.NumericFieldFilter,
   [fou.FRAME_NUMBER_FIELD]: filters.NumericFieldFilter,
   [fou.FRAME_SUPPORT_FIELD]: filters.NumericFieldFilter,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add Datepicker to Sidebar

## How is this patch tested? If it is not, please explain why.

WORK IN PROGRESS TESTING NEED TO CHECK ALL EDGE CASES INCLUDING BUT NOT LIMITED TO:

- Different app timezones
- Larger date ranges
- Multiple dates at the same time
- A group of dates (is this even possible idk??)


![2024-11-04 17 42 15](https://github.com/user-attachments/assets/618b7b57-63fb-4e7c-adbf-10ec572a6931)


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Date and DateTime are no longer sliders but are instead a popup date picker.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a flexible `BasicDatePicker` component with enhanced configuration options, including date-time selection and range limits.
	- Added a new `DateFieldFilter` component for improved date filtering capabilities.
	- Implemented a `Boxes` component for managing date range selections visually.

- **Bug Fixes**
	- Updated filtering logic to correctly utilize the `DateFieldFilter` for date-related fields instead of numeric filters.

- **Chores**
	- Simplified import paths for the `DateFieldFilter` component for easier access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->