### PR TITLE
tweaks slider to show raw value by default + bug fix

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/SliderView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/SliderView.tsx
@@ -6,14 +6,14 @@ import { autoFocus, getComponentProps } from "../utils";
 import FieldWrapper from "./FieldWrapper";
 import { ViewPropsType } from "../utils/types";
 
-type ValueFormat = "flt" | "%";
+type ValueFormat = "" | "%";
 
 const valueLabelFormat = (
   value: number,
   min: number,
   max: number,
   valueFormat: ValueFormat,
-  valuePrecision = 0,
+  valuePrecision = 6,
   skipUnit = true
 ) => {
   const formattedValue =
@@ -64,8 +64,8 @@ export default function SliderView(props: ViewPropsType) {
 
   const {
     value_label_display: valueLabelDisplay = "on",
-    value_format: valueFormat = "%",
-    value_precision: valuePrecision = 2,
+    value_format: valueFormat = "",
+    value_precision: valuePrecision = 6,
     variant = null,
     label_position: labelPosition = "left",
     label = "Threshold",
@@ -73,6 +73,8 @@ export default function SliderView(props: ViewPropsType) {
     min: viewMin,
     max: viewMax,
   } = view;
+
+  const isDoubleSlider = Boolean(viewMin) && Boolean(viewMax);
 
   const multipleOf = viewMultipleOf;
   const [min, max] = [
@@ -131,15 +133,19 @@ export default function SliderView(props: ViewPropsType) {
         val = min + (max - min) * (finalValue / 100);
       }
 
-      let finalMin = isMin ? val : data?.[0] || min;
-      let finalMax = !isMin ? val : data?.[1] || max;
+      if (isDoubleSlider) {
+        let finalMin = isMin ? val : data?.[0] || min;
+        let finalMax = !isMin ? val : data?.[1] || max;
 
-      if (finalMax <= finalMin) {
-        finalMin = finalMax;
-        finalMax = finalMin;
+        if (finalMax <= finalMin) {
+          finalMin = finalMax;
+          finalMax = finalMin;
+        }
+        onChange(path, [finalMin, finalMax], schema);
+      } else {
+        // single slider
+        onChange(path, val, schema);
       }
-
-      onChange(path, [finalMin, finalMax], schema);
     }
   };
 
@@ -152,7 +158,6 @@ export default function SliderView(props: ViewPropsType) {
 
   const handleSliderCommit = (_, value: number | number[]) => {
     onChange(path, value, schema);
-    setUserChanged();
     setFieldsRevision(fieldsRevision + 1);
   };
 
@@ -192,18 +197,20 @@ export default function SliderView(props: ViewPropsType) {
           {variant === "withInputs" && (
             <Grid container justifyContent="space-between" pl={1}>
               <Grid item pl={labelPosition === "left" ? "100px" : "0"}>
-                <SliderInputField
-                  key={fieldsRevision}
-                  label={`Min ${unit === "flt" ? "" : unit}`}
-                  value={minText}
-                  onKeyDown={(e) => handleKeyDown(e, true)}
-                  UnitSelection={null}
-                />
+                {isDoubleSlider && (
+                  <SliderInputField
+                    key={fieldsRevision}
+                    label={`Min ${unit}`}
+                    value={minText}
+                    onKeyDown={(e) => handleKeyDown(e, true)}
+                    UnitSelection={null}
+                  />
+                )}
               </Grid>
               <Grid item>
                 <SliderInputField
                   key={fieldsRevision}
-                  label={`Max ${unit === "flt" ? "" : unit}`}
+                  label={`Max ${unit}`}
                   value={maxText}
                   onKeyDown={(e) => handleKeyDown(e, false)}
                   UnitSelection={null}


### PR DESCRIPTION
## What changes are proposed in this pull request?

- [x] default unit is raw value - not %
- [x] default precision is 6 (subject to tweaks after design review)
- [x] removes unnecessary `setUserChanged();`
- [x] ability to have a single slider with max


<img width="682" alt="Screen Shot 2024-11-04 at 4 10 27 PM" src="https://github.com/user-attachments/assets/fb111553-513e-4f1b-8c1a-e9075fcf40f2">

single slider example - just for testing

<img width="723" alt="Screen Shot 2024-11-04 at 4 41 50 PM" src="https://github.com/user-attachments/assets/d1512ef5-0958-4eba-8c45-223d28009231">


## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility of the slider component to support both single and double slider configurations.
	- Simplified rendering logic for the slider inputs and labels.

- **Improvements**
	- Updated default value formats and precision for better user experience with slider values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->