### PR TITLE
Gracefully handle empty datasets when computing embeddings

### DIFF
--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -988,6 +988,9 @@ def _compute_image_embeddings_single(
     if errors:
         return embeddings  # may contain None, must return as list
 
+    if not embeddings:
+        return np.empty((0, 0), dtype=float)
+
     return np.stack(embeddings)
 
 
@@ -1034,6 +1037,9 @@ def _compute_image_embeddings_batch(
 
     if errors:
         return embeddings  # may contain None, must return as list
+
+    if not embeddings:
+        return np.empty((0, 0), dtype=float)
 
     return np.stack(embeddings)
 
@@ -1096,6 +1102,9 @@ def _compute_image_embeddings_data_loader(
 
     if errors:
         return embeddings  # may contain None, must return as list
+
+    if not embeddings:
+        return np.empty((0, 0), dtype=float)
 
     return np.stack(embeddings)
 
@@ -1276,6 +1285,9 @@ def _compute_video_embeddings(
 
     if errors:
         return embeddings  # may contain None, must return as list
+
+    if not embeddings:
+        return np.empty((0, 0), dtype=float)
 
     return np.stack(embeddings)
 
@@ -1572,6 +1584,9 @@ def _embed_patches_single(model, img, detections, force_square, alpha):
         )
         embedding = model.embed(patch)
         embeddings.append(embedding)
+
+    if not embeddings:
+        return None
 
     return np.stack(embeddings)
 


### PR DESCRIPTION
```py
import fiftyone as fo
import fiftyone.zoo as foz

# An empty dataset
dataset = fo.Dataset()
dataset.media_type = "image"

model = foz.load_zoo_model("clip-vit-base32-torch")

# Raises an error on `develop`, now returns an empty array
embeddings = dataset.compute_embeddings(model)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced embedding computation methods to ensure consistent return types, now returning an empty array when no embeddings are generated.
	- Improved error handling for embedding processes, allowing for continued processing when certain samples fail.

- **Bug Fixes**
	- Refined checks in embedding methods to prevent potential issues when no embeddings are produced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->