### PR TITLE
Add button for range within groups when query performance is enabled

### DIFF
--- a/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
@@ -7,6 +7,7 @@ import RangeSlider from "./RangeSlider";
 import { Button } from "@mui/material";
 import { useTheme } from "@fiftyone/components";
 import * as state from "./state";
+import * as schemaAtoms from "@fiftyone/state/src/recoil/schema";
 
 const Container = styled.div`
   margin: 3px;
@@ -41,7 +42,8 @@ type Props = {
 
 const NumericFieldFilter = ({ color, modal, named = true, path }: Props) => {
   const name = path.split(".").slice(-1)[0];
-  const isGroup = path.includes(".");
+  const fieldType = useRecoilValue(schemaAtoms.filterFields(path));
+  const isGroup = fieldType.length > 1;
   const theme = useTheme();
   const [showRange, setShowRange] = React.useState(!isGroup);
   const field = fos.useAssertedRecoilValue(fos.field(path));

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
@@ -6,6 +6,7 @@ import FieldLabelAndInfo from "../../FieldLabelAndInfo";
 import RangeSlider from "./RangeSlider";
 import { Button } from "@mui/material";
 import { useTheme } from "@fiftyone/components";
+import * as state from "./state";
 
 const Container = styled.div`
   margin: 3px;
@@ -45,6 +46,11 @@ const NumericFieldFilter = ({ color, modal, named = true, path }: Props) => {
   const [showRange, setShowRange] = React.useState(!isGroup);
   const field = fos.useAssertedRecoilValue(fos.field(path));
   const queryPerformance = useRecoilValue(fos.queryPerformance);
+  const hasBounds = useRecoilValue(state.hasBounds({ path, modal }));
+
+  if (!queryPerformance && named && !hasBounds) {
+    return null;
+  }
 
   const handleShowRange = () => {
     setShowRange(true);

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
@@ -6,6 +6,8 @@ import FieldLabelAndInfo from "../../FieldLabelAndInfo";
 import Boxes from "./Boxes";
 import RangeSlider from "./RangeSlider";
 import * as state from "./state";
+import { Button, Typography } from "@mui/material";
+import { useTheme } from "@fiftyone/components";
 
 const Container = styled.div`
   margin: 3px;
@@ -15,6 +17,18 @@ const Container = styled.div`
 const Header = styled.div`
   display: flex;
   justify-content: space-between;
+`;
+
+const Box = styled.div`
+  display: flex;
+  justify-content: space-between;
+  column-gap: 1rem;
+  background: ${({ theme }) => theme.background.level2};
+  border: 1px solid var(--fo-palette-divider);
+  border-radius: 2px;
+  color: ${({ theme }) => theme.text.secondary};
+  margin-top: 0.25rem;
+  padding: 0.25rem 0.5rem;
 `;
 
 type Props = {
@@ -28,16 +42,17 @@ type Props = {
 
 const NumericFieldFilter = ({ color, modal, named = true, path }: Props) => {
   const name = path.split(".").slice(-1)[0];
+  const isGroup = path.includes(".");
+  const theme = useTheme();
+  const [showRange, setShowRange] = React.useState(!isGroup);
   const field = fos.useAssertedRecoilValue(fos.field(path));
-  const hasBounds = useRecoilValue(state.hasBounds({ path, modal }));
-  const indexed = useRecoilValue(fos.pathHasIndexes(path));
   const queryPerformance = useRecoilValue(fos.queryPerformance);
 
-  if (!queryPerformance && named && !hasBounds) {
-    return null;
-  }
+  const handleShowRange = () => {
+    setShowRange(true);
+  };
 
-  const boxes = queryPerformance && !indexed;
+  const showButton = isGroup && queryPerformance && !showRange;
 
   return (
     <Container onClick={(e) => e.stopPropagation()}>
@@ -53,8 +68,24 @@ const NumericFieldFilter = ({ color, modal, named = true, path }: Props) => {
           )}
         />
       )}
-      {boxes ? (
-        <Boxes path={path} />
+      {showButton ? (
+        <Box>
+          <Button
+            onClick={handleShowRange}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: "100%",
+              padding: "10px",
+              color: theme.text.secondary,
+              borderRadius: "8px",
+              border: "1px solid " + theme.secondary.main,
+            }}
+          >
+            Filter by {name}
+          </Button>
+        </Box>
       ) : (
         <RangeSlider color={color} modal={modal} path={path} />
       )}

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
@@ -3,10 +3,8 @@ import React from "react";
 import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 import FieldLabelAndInfo from "../../FieldLabelAndInfo";
-import Boxes from "./Boxes";
 import RangeSlider from "./RangeSlider";
-import * as state from "./state";
-import { Button, Typography } from "@mui/material";
+import { Button } from "@mui/material";
 import { useTheme } from "@fiftyone/components";
 
 const Container = styled.div`

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/RangeSlider.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/RangeSlider.tsx
@@ -65,7 +65,7 @@ const RangeSlider = ({
       {defaultRange && <Nonfinites modal={modal} path={path} />}
       <FilterOption color={color} modal={modal} path={path} />
       <Reset color={color} modal={modal} path={path} />
-      {!hasBounds && <Boxes path={path} />}
+      {!hasBounds && "No results"}
     </Container>
   );
 };

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/RangeSlider.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/RangeSlider.tsx
@@ -8,6 +8,7 @@ import FilterOption from "./FilterOption";
 import Nonfinites from "./Nonfinites";
 import Reset from "./Reset";
 import * as state from "./state";
+import Boxes from "./Boxes";
 
 const Container = styled.div`
   background: ${({ theme }) => theme.background.level2};
@@ -64,7 +65,7 @@ const RangeSlider = ({
       {defaultRange && <Nonfinites modal={modal} path={path} />}
       <FilterOption color={color} modal={modal} path={path} />
       <Reset color={color} modal={modal} path={path} />
-      {!hasBounds && "No results"}
+      {!hasBounds && <Boxes path={path} />}
     </Container>
   );
 };

--- a/app/packages/state/src/recoil/pathFilters/numeric.ts
+++ b/app/packages/state/src/recoil/pathFilters/numeric.ts
@@ -6,6 +6,7 @@ import * as filterAtoms from "../filters";
 import * as pathData from "../pathData";
 import type { Range } from "../utils";
 import { isFilterDefault } from "./utils";
+import { pathHasIndexes, queryPerformance } from "../queryPerformance";
 
 export interface NumericFilter {
   range: Range;
@@ -146,6 +147,10 @@ export const boundsAtom = selectorFamily<
   get:
     (params) =>
     ({ get }) => {
+      if (get(queryPerformance)) {
+        return get(pathData.lightningBounds(params.path));
+      }
+
       const bounds = get(pathData.bounds({ ...params, extended: false }));
       return bounds ? bounds : [null, null];
     },

--- a/app/packages/state/src/recoil/pathFilters/numeric.ts
+++ b/app/packages/state/src/recoil/pathFilters/numeric.ts
@@ -4,7 +4,6 @@ import * as fos from "../atoms";
 import * as visibilityAtoms from "../attributeVisibility";
 import * as filterAtoms from "../filters";
 import * as pathData from "../pathData";
-import { pathHasIndexes, queryPerformance } from "../queryPerformance";
 import type { Range } from "../utils";
 import { isFilterDefault } from "./utils";
 
@@ -147,14 +146,7 @@ export const boundsAtom = selectorFamily<
   get:
     (params) =>
     ({ get }) => {
-      if (get(queryPerformance)) {
-        return get(pathHasIndexes(params.path))
-          ? get(pathData.lightningBounds(params.path))
-          : [null, null];
-      }
-
       const bounds = get(pathData.bounds({ ...params, extended: false }));
-
       return bounds ? bounds : [null, null];
     },
 });


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add button for range within groups when query performance is enabled

## How is this patch tested? If it is not, please explain why.

![2024-11-05 09 45 55](https://github.com/user-attachments/assets/0c853d50-d765-4252-9781-aea0fb6e955f)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

If query performance is enabled and you open a group that has a range within it you'll need to press a button to show that range filter. This saves app performance because we don't have to calculate the bounds anytime a user opens a group even if they don't intend to use that range filter within the group.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a more interactive filtering mechanism with a new button in the NumericFieldFilter component.
	- Enhanced user interface in the RangeSlider by replacing the "No results" text with a visual component.

- **Bug Fixes**
	- Streamlined logic for bounds retrieval, ensuring a more consistent filtering experience.

- **Refactor**
	- Simplified internal state management and rendering logic in both NumericFieldFilter and RangeSlider components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->