### PR TITLE
Bug fixes for Query Performance Toast

### DIFF
--- a/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
@@ -48,7 +48,9 @@ const NumericFieldFilter = ({ color, modal, named = true, path }: Props) => {
   const [showRange, setShowRange] = React.useState(!isGroup);
   const field = fos.useAssertedRecoilValue(fos.field(path));
   const queryPerformance = useRecoilValue(fos.queryPerformance);
-  const hasBounds = useRecoilValue(state.hasBounds({ path, modal }));
+  const hasBounds = useRecoilValue(
+    state.hasBounds({ path, modal, shouldCalculate: !queryPerformance })
+  );
 
   if (!queryPerformance && named && !hasBounds) {
     return null;

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
@@ -89,6 +89,7 @@ const NumericFieldFilter = ({ color, modal, named = true, path }: Props) => {
               color: theme.text.secondary,
               borderRadius: "8px",
               border: "1px solid " + theme.secondary.main,
+              height: "30px",
             }}
           >
             Filter by {name}

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/state.ts
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/state.ts
@@ -7,9 +7,12 @@ export const FLOAT_NONFINITES: Nonfinite[] = ["inf", "ninf", "nan"];
 export const hasBounds = selectorFamily({
   key: "hasBounds",
   get:
-    (params: { path: string; modal: boolean }) =>
+    (params: { path: string; modal: boolean; shouldCalculate: boolean }) =>
     ({ get }) => {
-      return Boolean(get(boundsAtom(params))?.every((b) => b !== null));
+      const shouldCalculate = params.shouldCalculate ?? true;
+      return shouldCalculate
+        ? Boolean(get(boundsAtom(params))?.every((b) => b !== null))
+        : Boolean(false);
     },
 });
 

--- a/app/packages/core/src/components/QueryPerformanceToast.tsx
+++ b/app/packages/core/src/components/QueryPerformanceToast.tsx
@@ -8,7 +8,7 @@ import { createPortal } from "react-dom";
 import { atom, useRecoilState } from "recoil";
 import { useTheme } from "@fiftyone/components";
 
-const SHOWN_FOR = 5000;
+const SHOWN_FOR = 10000;
 
 const hideQueryPerformanceToast = atom({
   key: "hideQueryPerformanceToast",
@@ -16,6 +16,7 @@ const hideQueryPerformanceToast = atom({
   effects: [
     getBrowserStorageEffectForKey("hideQueryPerformanceToast", {
       valueClass: "boolean",
+      sessionStorage: true,
     }),
   ],
 });

--- a/app/packages/core/src/components/QueryPerformanceToast.tsx
+++ b/app/packages/core/src/components/QueryPerformanceToast.tsx
@@ -51,8 +51,6 @@ const QueryPerformanceToast = ({
     return () => window.removeEventListener("queryperformance", listen);
   }, []);
 
-  console.log("attempting to render ", path);
-
   if (!element) {
     throw new Error("no query performance element");
   }

--- a/app/packages/core/src/components/QueryPerformanceToast.tsx
+++ b/app/packages/core/src/components/QueryPerformanceToast.tsx
@@ -51,6 +51,8 @@ const QueryPerformanceToast = ({
     return () => window.removeEventListener("queryperformance", listen);
   }, []);
 
+  console.log("attempting to render ", path);
+
   if (!element) {
     throw new Error("no query performance element");
   }

--- a/app/packages/core/src/components/QueryPerformanceToast.tsx
+++ b/app/packages/core/src/components/QueryPerformanceToast.tsx
@@ -38,8 +38,7 @@ const QueryPerformanceToast = ({
   const element = document.getElementById("queryPerformance");
   const theme = useTheme();
   const frameFields = useRecoilValue(atoms.frameFields);
-  console.log(frameFields);
-  console.log(path);
+
   useEffect(() => {
     const listen = (event) => {
       onDispatch(event);
@@ -67,7 +66,7 @@ const QueryPerformanceToast = ({
         horizontal: "center",
         backgroundColor: theme.custom.toastBackgroundColor,
       }}
-      primary={(setOpen) => {
+      primary={() => {
         return (
           <Button
             variant="contained"
@@ -78,7 +77,7 @@ const QueryPerformanceToast = ({
                   path.includes(`frames.${frame.path}`)
                 )
               );
-              setOpen(false);
+              setShown(false);
             }}
             sx={{
               marginLeft: "auto",
@@ -91,7 +90,7 @@ const QueryPerformanceToast = ({
           </Button>
         );
       }}
-      secondary={(setOpen) => {
+      secondary={() => {
         return (
           <div>
             <Button
@@ -101,7 +100,7 @@ const QueryPerformanceToast = ({
               size="small"
               onClick={() => {
                 setDisabled(true);
-                setOpen(false);
+                setShown(false);
               }}
               style={{ marginLeft: "auto", color: theme.text.secondary }} // Right align the button
             >

--- a/app/packages/core/src/components/QueryPerformanceToast.tsx
+++ b/app/packages/core/src/components/QueryPerformanceToast.tsx
@@ -8,6 +8,7 @@ import { createPortal } from "react-dom";
 import { atom, useRecoilState, useRecoilValue } from "recoil";
 import { useTheme } from "@fiftyone/components";
 import * as atoms from "@fiftyone/state/src/recoil/atoms";
+import * as fos from "@fiftyone/state";
 
 const SHOWN_FOR = 10000;
 
@@ -33,6 +34,7 @@ const QueryPerformanceToast = ({
   text = "View Documentation",
 }) => {
   const [path, setPath] = useState("");
+  const indexed = useRecoilValue(fos.pathHasIndexes(path));
   const [shown, setShown] = useState(false);
   const [disabled, setDisabled] = useRecoilState(hideQueryPerformanceToast);
   const element = document.getElementById("queryPerformance");
@@ -54,6 +56,11 @@ const QueryPerformanceToast = ({
   }
 
   if (!shown || disabled) {
+    return null;
+  }
+
+  // don't show the toast if the path is already indexed
+  if (path && indexed) {
     return null;
   }
 

--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/FilterablePathEntries.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/FilterablePathEntries.tsx
@@ -1,29 +1,8 @@
 import { pathColor } from "@fiftyone/state";
-import React, { useEffect } from "react";
+import React from "react";
 import { useRecoilValue } from "recoil";
 import FilterItem from "./FilterItem";
 import useFilterData from "./useFilterData";
-
-const TIMEOUT = 0;
-
-class QueryPerformanceToast extends Event {
-  path?: string;
-  constructor(path?: string) {
-    super("queryperformance");
-    this.path = path;
-  }
-}
-
-const QueryPerformanceDispatcher = ({ path }: { path: string }) => {
-  useEffect(() => {
-    const timeout = setTimeout(() => {
-      window.dispatchEvent(new QueryPerformanceToast(path));
-    }, TIMEOUT);
-
-    return () => clearTimeout(timeout);
-  }, [path]);
-  return null;
-};
 
 const FilterablePathEntries = ({
   modal,

--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/FilterablePathEntries.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/FilterablePathEntries.tsx
@@ -1,11 +1,9 @@
-import * as fos from "@fiftyone/state";
-import { count, pathColor } from "@fiftyone/state";
-import React, { Suspense, useEffect } from "react";
+import { pathColor } from "@fiftyone/state";
+import React, { useEffect } from "react";
 import { useRecoilValue } from "recoil";
 import FilterItem from "./FilterItem";
 import useFilterData from "./useFilterData";
 
-const LABEL_TAGS = "_label_tags";
 const TIMEOUT = 0;
 
 class QueryPerformanceToast extends Event {
@@ -27,25 +25,6 @@ const QueryPerformanceDispatcher = ({ path }: { path: string }) => {
   return null;
 };
 
-const QueryPerformanceSubscriber = ({ path }: { path: string }) => {
-  useRecoilValue(count({ extended: false, modal: false, path }));
-  return null;
-};
-
-const QueryPerformance = ({ path }: { path: string }) => {
-  const queryPerformance = useRecoilValue(fos.queryPerformance);
-
-  if (!queryPerformance || path === LABEL_TAGS || !path) {
-    return null;
-  }
-
-  return (
-    <Suspense fallback={<QueryPerformanceDispatcher path={path} />}>
-      <QueryPerformanceSubscriber path={path} />
-    </Suspense>
-  );
-};
-
 const FilterablePathEntries = ({
   modal,
   path,
@@ -61,12 +40,9 @@ const FilterablePathEntries = ({
 
   return (
     <>
-      {!modal && <QueryPerformance path={path} />}
-      <>
-        {data.map(({ color: _, ...props }) => (
-          <FilterItem key={props.path} color={color} {...events} {...props} />
-        ))}
-      </>
+      {data.map(({ color: _, ...props }) => (
+        <FilterItem key={props.path} color={color} {...events} {...props} />
+      ))}
     </>
   );
 };

--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/FilterablePathEntries.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/FilterablePathEntries.tsx
@@ -6,7 +6,7 @@ import FilterItem from "./FilterItem";
 import useFilterData from "./useFilterData";
 
 const LABEL_TAGS = "_label_tags";
-const TIMEOUT = 5000;
+const TIMEOUT = 0;
 
 class QueryPerformanceToast extends Event {
   path?: string;
@@ -35,7 +35,7 @@ const QueryPerformanceSubscriber = ({ path }: { path: string }) => {
 const QueryPerformance = ({ path }: { path: string }) => {
   const queryPerformance = useRecoilValue(fos.queryPerformance);
 
-  if (queryPerformance || path === LABEL_TAGS || !path) {
+  if (!queryPerformance || path === LABEL_TAGS || !path) {
     return null;
   }
 

--- a/app/packages/core/src/utils/links.ts
+++ b/app/packages/core/src/utils/links.ts
@@ -16,6 +16,9 @@ export const FRAME_FILTERING_DISABLED =
 export const QP_MODE =
   "https://docs.voxel51.com/user_guide/app.html#query-performance";
 
+export const QP_MODE_SUMMARY =
+  "https://docs.voxel51.com/user_guide/using_datasets.html#summary-fields";
+
 export const NAME_COLORSCALE = "https://plotly.com/python/colorscales/";
 
 export const OBJECT_PATCHES =

--- a/app/packages/utilities/src/fetch.ts
+++ b/app/packages/utilities/src/fetch.ts
@@ -22,6 +22,16 @@ export interface FetchFunction {
   ): Promise<R>;
 }
 
+class QueryPerformanceToast extends Event {
+  path?: string;
+  constructor(path?: string) {
+    super("queryperformance");
+    this.path = path;
+  }
+}
+
+const TIMEOUT = 5000;
+
 export const getFetchFunction = () => {
   return fetchFunctionSingleton;
 };
@@ -122,6 +132,14 @@ export const setFetchFunction = (
         })
       : fetch;
 
+    let timeoutId = undefined;
+    const filterPath = getFirstFilterPath(body);
+    if (filterPath) {
+      timeoutId = setTimeout(() => {
+        window.dispatchEvent(new QueryPerformanceToast(filterPath));
+      }, TIMEOUT);
+    }
+
     const response = await fetchCall(url, {
       method: method,
       cache: "no-cache",
@@ -129,8 +147,12 @@ export const setFetchFunction = (
       mode: "cors",
       body: body ? JSON.stringify(body) : null,
       signal: controller.signal,
-      referrerPolicy: 'same-origin',
+      referrerPolicy: "same-origin",
     });
+
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
 
     if (response.status >= 400) {
       const errorMetadata = {
@@ -272,7 +294,7 @@ export const getEventSource = (
       method: "POST",
       signal,
       body: JSON.stringify(body),
-      referrerPolicy: 'same-origin',
+      referrerPolicy: "same-origin",
       async onopen(response) {
         if (response.ok) {
           events.onopen && events.onopen();
@@ -407,4 +429,19 @@ const pollingEventSource = (
         2000
       );
     });
+};
+
+const getFirstFilterPath = (requestBody: any) => {
+  if (requestBody && requestBody.query) {
+    if (requestBody.query.includes("paginateSamplesQuery")) {
+      const pathsArray = requestBody?.variables?.filters;
+      const paths = pathsArray ? Object.keys(pathsArray) : [];
+      return paths.length > 0 ? paths[0] : undefined;
+    }
+    if (requestBody.query.includes("lightningQuery")) {
+      const paths = requestBody?.variables?.input?.paths;
+      return paths && paths.length > 0 ? paths[0].path : undefined;
+    }
+  }
+  return undefined;
 };


### PR DESCRIPTION
## What changes are proposed in this pull request?

Done:
- Change dismiss to be saved in session storage
- Change button size to match field sizes
- Make toasts show up everytime there's an event not just the first time
- When toast is on a frame filter field we will point users to the [summary page](https://docs.voxel51.com/user_guide/using_datasets.html#summary-fields)
- Updated toast time shown to 10 seconds 
- Don't show toast if field is already indexed
- Fire queryperformance event whenever one of the two calls are slower than 5 seconds:
    -    [lightningModeQuery](https://github.com/voxel51/fiftyone/blob/d83ee2d21402a94c699be5c4d0fe6cee7c8cd2ed/app/packages/state/src/recoil/queryPerformance.ts#L21)
    - [paginateSamplesQuery](https://github.com/voxel51/fiftyone/blob/c940dd82c1e22b58a1d7142d7da356711f8074ec/app/packages/core/src/components/Grid/useSpotlightPager.ts#L82)

## How is this patch tested? If it is not, please explain why.

Changed TIMEOUT to 0 so the toast is always triggered and then added a console log statement to QPToast to show that the path is set accordingly.

![2024-11-05 23 14 53](https://github.com/user-attachments/assets/f4b95132-549d-470c-b0e4-d7fad2fa2ebc)


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced `NumericFieldFilter` component to conditionally calculate bounds based on query performance.
	- Extended display duration of the `QueryPerformanceToast` from 5 to 10 seconds.
	- Introduced a new link for summary fields in the user guide.

- **Bug Fixes**
	- Improved interaction logic in the `QueryPerformanceToast` for better user experience.

- **Refactor**
	- Removed deprecated `QueryPerformance` components and related event handling from the `FilterablePathEntries` component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->