### PR TITLE
plugin component: nested group selections 

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/TreeSelectionView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TreeSelectionView.tsx
@@ -189,7 +189,7 @@ export default function TreeSelectionView(props: ViewPropsType) {
     structure: [string, (string | [string, string[]])[]][]
   ): number => {
     const idx = structure.findIndex(([id]) => id === groupId);
-    return idx === -1 ? 0 : idx;
+    return idx === -1 ? 0 : idx + 1;
   };
 
   // CheckboxView: Represents a single checkbox (either parent or child)

--- a/app/packages/core/src/plugins/SchemaIO/components/TreeSelectionView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TreeSelectionView.tsx
@@ -1,13 +1,304 @@
-import { Box, Grid } from "@mui/material";
-import React from "react";
-import { HeaderView } from ".";
-import { getComponentProps, getPath } from "../utils";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { Box, Checkbox, FormControlLabel, IconButton } from "@mui/material";
+import React, { useEffect } from "react";
+import { ViewPropsType } from "../utils/types";
 
-export default function TreeSelectionView(props) {
-  const { path, schema, data } = props;
-  const { view = {}, items } = schema;
+interface CheckedState {
+  [key: string]: {
+    checked: boolean;
+    indeterminate?: boolean;
+  };
+}
 
-  console.log("TreeSelectionView", schema.view.items);
+interface CollapsedState {
+  [key: string]: boolean; // true for collapsed, false for expanded
+}
 
-  return <Box {...getComponentProps(props, "container")}></Box>;
+interface CheckboxViewProps {
+  id: string;
+  label: string;
+  isChecked: boolean;
+  isIndeterminate: boolean;
+  onChange: (id: string, checked: boolean) => void;
+}
+
+interface TreeNodeProps {
+  nodeId: string;
+  childrenIds: (string | [string, string[]])[];
+  checkedState: CheckedState;
+  collapsedState: CollapsedState;
+  onChange: (id: string, checked: boolean) => void;
+  onToggleCollapse: (id: string) => void;
+}
+
+export default function TreeSelectionView(props: ViewPropsType) {
+  const { onChange, path, schema, data } = props;
+  const { view = {} } = schema;
+
+  if (data == undefined) {
+    const sampleIds = view?.data.flatMap(([parentId, children]) => {
+      return children.map((childId) =>
+        typeof childId === "string" ? childId : childId[0]
+      );
+    });
+    onChange(path, sampleIds);
+  }
+
+  const structure = view?.data || [];
+
+  const initialCheckedState: CheckedState = React.useMemo(() => {
+    const state: CheckedState = {
+      selectAll: { checked: true, indeterminate: false },
+    };
+    structure.forEach(([parentId, children]) => {
+      state[parentId] = { checked: true, indeterminate: false };
+      children.forEach((childId) => {
+        if (typeof childId === "string") {
+          state[childId] = { checked: true };
+        } else {
+          state[childId[0]] = { checked: true, indeterminate: false };
+          childId[1].forEach((nestedChildId) => {
+            state[nestedChildId] = { checked: true };
+          });
+        }
+      });
+    });
+    return state;
+  }, [structure]);
+
+  const [checkedState, setCheckedState] =
+    React.useState<CheckedState>(initialCheckedState);
+
+  // Initialize collapsed state for all parents
+  const initialCollapsedState: CollapsedState = React.useMemo(() => {
+    const state: CollapsedState = {};
+    structure.forEach(([parentId]) => {
+      state[parentId] = false; // start as expanded
+    });
+    return state;
+  }, [structure]);
+
+  const [collapsedState, setCollapsedState] = React.useState<CollapsedState>(
+    initialCollapsedState
+  );
+
+  const handleCheckboxChange = (id: string, isChecked: boolean) => {
+    setCheckedState((prevState) => {
+      const updatedState = {
+        ...prevState,
+        [id]: { ...prevState[id], checked: isChecked },
+      };
+
+      if (id === "selectAll") {
+        // Apply the checked/unchecked state to all items when 'selectAll' is toggled
+        Object.keys(updatedState).forEach((key) => {
+          updatedState[key] = { checked: isChecked, indeterminate: false };
+        });
+      } else {
+        // Update children if the selected ID is a parent
+        const parentEntry = structure.find(([parentId]) => parentId === id);
+        if (parentEntry) {
+          const [, children] = parentEntry;
+          children.forEach((childId) => {
+            if (typeof childId === "string") {
+              updatedState[childId] = { checked: isChecked };
+            } else {
+              const [nestedParentId, nestedChildren] = childId;
+              updatedState[nestedParentId] = {
+                checked: isChecked,
+                indeterminate: false,
+              };
+              nestedChildren.forEach((nestedChildId) => {
+                updatedState[nestedChildId] = { checked: isChecked };
+              });
+            }
+          });
+          updatedState[id].indeterminate = false;
+        }
+
+        // Recursive function to update the checked/indeterminate state of parent nodes
+        const updateParentState = (parentId) => {
+          const parentEntry = structure.find(
+            ([groupId]) => groupId === parentId
+          );
+          if (!parentEntry) return;
+
+          const [, children] = parentEntry;
+          const allChecked = children.every((childId) =>
+            typeof childId === "string"
+              ? updatedState[childId].checked
+              : updatedState[childId[0]].checked
+          );
+          const someChecked = children.some((childId) =>
+            typeof childId === "string"
+              ? updatedState[childId].checked
+              : updatedState[childId[0]].checked
+          );
+
+          updatedState[parentId] = {
+            checked: allChecked,
+            indeterminate: !allChecked && someChecked,
+          };
+        };
+
+        // Propagate state to parent groups
+        structure.forEach(([parentId]) => {
+          updateParentState(parentId);
+        });
+      }
+
+      // Update the selectAll checkbox status based on the final state of all nodes
+      const allGroupsSelected = structure.every(
+        ([parentId]) => updatedState[parentId].checked
+      );
+      const anySelected = structure.some(
+        ([parentId]) =>
+          updatedState[parentId].checked || updatedState[parentId].indeterminate
+      );
+
+      updatedState["selectAll"] = {
+        checked: allGroupsSelected,
+        indeterminate: anySelected && !allGroupsSelected,
+      };
+
+      const selectedSampleIds = Object.keys(updatedState).filter((key) => {
+        const isSample =
+          !structure.some(([parentId]) => parentId === key) &&
+          key !== "selectAll";
+        return isSample && updatedState[key].checked; // Only checked samples
+      });
+
+      // We update the actual output value (ctx.params.value \ data) here.
+      onChange(path, selectedSampleIds);
+
+      return updatedState;
+    });
+  };
+
+  // Function to handle expand/collapse toggle
+  const handleToggleCollapse = (id: string) => {
+    setCollapsedState((prevState) => ({
+      ...prevState,
+      [id]: !prevState[id],
+    }));
+  };
+
+  const getGroupIdx = (
+    groupId: string,
+    structure: [string, (string | [string, string[]])[]][]
+  ): number => {
+    const idx = structure.findIndex(([id]) => id === groupId);
+    return idx === -1 ? 0 : idx;
+  };
+
+  // CheckboxView: Represents a single checkbox (either parent or child)
+  function CheckboxView({
+    id,
+    label,
+    isChecked,
+    isIndeterminate,
+    onChange,
+  }: CheckboxViewProps) {
+    return (
+      <FormControlLabel
+        control={
+          <Checkbox
+            id={id}
+            checked={isChecked}
+            indeterminate={isIndeterminate}
+            onChange={(event) => onChange(id, event.target.checked)}
+          />
+        }
+        label={label}
+      />
+    );
+  }
+
+  // TreeNode: Recursive component to render each parent and its children
+  function TreeNode({
+    nodeId,
+    childrenIds,
+    checkedState,
+    collapsedState,
+    onChange,
+    onToggleCollapse,
+  }: TreeNodeProps) {
+    const isCollapsed = collapsedState[nodeId] || false;
+    const count = childrenIds.length;
+    const title = `Group ${getGroupIdx(nodeId, structure)}  • ${count} Samples`;
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", ml: 3 }}>
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+          {/* Render Parent Checkbox */}
+          <CheckboxView
+            id={nodeId}
+            label={title}
+            isChecked={checkedState[nodeId]?.checked || false}
+            isIndeterminate={checkedState[nodeId]?.indeterminate || false}
+            onChange={onChange}
+          />
+          {/* Expand/Collapse Button */}
+          <IconButton onClick={() => onToggleCollapse(nodeId)} size="small">
+            {isCollapsed ? <ChevronRightIcon /> : <ExpandMoreIcon />}
+          </IconButton>
+        </Box>
+
+        {/* Render Child Checkboxes if expanded */}
+        {!isCollapsed && (
+          <Box sx={{ display: "flex", flexDirection: "column", ml: 3 }}>
+            {childrenIds.map((childId) =>
+              typeof childId === "string" ? (
+                <CheckboxView
+                  key={childId}
+                  id={childId}
+                  label={childId}
+                  isChecked={checkedState[childId]?.checked || false}
+                  isIndeterminate={false}
+                  onChange={onChange}
+                />
+              ) : (
+                <TreeNode
+                  key={childId[0]}
+                  nodeId={childId[0]}
+                  childrenIds={childId[1]}
+                  checkedState={checkedState}
+                  collapsedState={collapsedState}
+                  onChange={onChange}
+                  onToggleCollapse={onToggleCollapse}
+                />
+              )
+            )}
+          </Box>
+        )}
+      </Box>
+    );
+  }
+
+  // render the full structure
+  return (
+    <div>
+      {/* Select All Checkbox */}
+      <CheckboxView
+        id="selectAll"
+        label="Select All"
+        isChecked={checkedState.selectAll.checked}
+        isIndeterminate={checkedState.selectAll.indeterminate || false}
+        onChange={handleCheckboxChange}
+      />
+
+      {/* Render Tree Structure */}
+      {structure.map(([parentId, children]) => (
+        <TreeNode
+          key={parentId}
+          nodeId={parentId}
+          childrenIds={children}
+          checkedState={checkedState}
+          collapsedState={collapsedState}
+          onChange={handleCheckboxChange}
+          onToggleCollapse={handleToggleCollapse}
+        />
+      ))}
+    </div>
+  );
 }

--- a/app/packages/core/src/plugins/SchemaIO/components/TreeSelectionView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TreeSelectionView.tsx
@@ -1,0 +1,13 @@
+import { Box, Grid } from "@mui/material";
+import React from "react";
+import { HeaderView } from ".";
+import { getComponentProps, getPath } from "../utils";
+
+export default function TreeSelectionView(props) {
+  const { path, schema, data } = props;
+  const { view = {}, items } = schema;
+
+  console.log("TreeSelectionView", schema.view.items);
+
+  return <Box {...getComponentProps(props, "container")}></Box>;
+}

--- a/app/packages/core/src/plugins/SchemaIO/components/index.ts
+++ b/app/packages/core/src/plugins/SchemaIO/components/index.ts
@@ -53,4 +53,5 @@ export { default as TextView } from "./TextView";
 export { default as TimelineView } from "./TimelineView";
 export { default as ToastView } from "./ToastView";
 export { default as TupleView } from "./TupleView";
+export { default as TreeSelectionView } from "./TreeSelectionView";
 export { default as UnsupportedView } from "./UnsupportedView";

--- a/app/packages/core/src/plugins/SchemaIO/utils/index.ts
+++ b/app/packages/core/src/plugins/SchemaIO/utils/index.ts
@@ -111,6 +111,7 @@ const NON_EDITABLE_VIEWS = [
   "ProgressView",
   "TableView",
   "TagsView",
+  "TreeSelectionView",
 ];
 
 export function isCompositeView(schema: SchemaType) {

--- a/app/packages/operators/src/types.ts
+++ b/app/packages/operators/src/types.ts
@@ -783,6 +783,28 @@ export class TupleView extends View {
 }
 
 /**
+ * Operator class for describing a tree node selection {@link View} for an
+ * operator type.
+ */
+export class TreeSelectionView extends View {
+  items: Array<View>;
+  constructor(options: ViewProps) {
+    super(options);
+    this.items = options.items as Array<View>;
+    console.log("tree selection view", this.items);
+    this.name = "TreeSelectionView";
+  }
+
+  static fromJSON(json) {
+    console.log("fromJson", json, json.items.map(viewFromJSON));
+    return new TreeSelectionView({
+      ...json,
+      items: json.items.map(viewFromJSON),
+    });
+  }
+}
+
+/**
  * Operator class for describing a code block {@link View} for an
  * operator type.
  */
@@ -1258,6 +1280,7 @@ const VIEWS = {
   OneOfView,
   ListView,
   TupleView,
+  TreeSelectionView,
   CodeView,
   ColorView,
   JSONView,

--- a/app/packages/operators/src/types.ts
+++ b/app/packages/operators/src/types.ts
@@ -790,16 +790,12 @@ export class TreeSelectionView extends View {
   items: Array<View>;
   constructor(options: ViewProps) {
     super(options);
-    this.items = options.items as Array<View>;
-    console.log("tree selection view", this.items);
     this.name = "TreeSelectionView";
   }
 
   static fromJSON(json) {
-    console.log("fromJson", json, json.items.map(viewFromJSON));
     return new TreeSelectionView({
       ...json,
-      items: json.items.map(viewFromJSON),
     });
   }
 }

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -622,11 +622,9 @@ class Object(BaseType):
         """
         tree_selection_view = TreeSelectionView(**kwargs)
         tree_type = Object(*items)
-        print("tree", items, tree_type)
         self.define_property(
             name, tree_type, view=tree_selection_view, **kwargs
         )
-        print("tree_type", tree_type)
         return tree_type
 
     def clone(self):
@@ -1437,14 +1435,12 @@ class TupleView(View):
 class TreeSelectionView(View):
     """Displays a tree structure of selection checkboxes of :class:`View` instances."""
 
-    def __init__(self, *itemsView, **options):
+    def __init__(self, **options):
         super().__init__(**options)
-        self.items = itemsView
 
     def to_json(self):
         return {
             **super().to_json(),
-            "items": [item.to_json() for item in self.items],
         }
 
 

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -610,6 +610,25 @@ class Object(BaseType):
         self.define_property(name, tuple_type, view=tuple_view, **kwargs)
         return tuple_type
 
+    def tree(self, name, *items, **kwargs):
+        """Defines a tree property on the object.
+
+        Args:
+            name: the name of the property
+            *items: the types of the items in the tree
+
+        Returns:
+            a :class:`Tree`
+        """
+        tree_selection_view = TreeSelectionView(**kwargs)
+        tree_type = Object(*items)
+        print("tree", items, tree_type)
+        self.define_property(
+            name, tree_type, view=tree_selection_view, **kwargs
+        )
+        print("tree_type", tree_type)
+        return tree_type
+
     def clone(self):
         """Clones the definition of the object.
 
@@ -879,6 +898,27 @@ class Tuple(BaseType):
     def to_json(self):
         return {
             **super().to_json(),
+            "items": [item.to_json() for item in self.items],
+        }
+
+
+class Tree(BaseType):
+    """Represents a tree selection type.
+    Examples::
+
+        import fiftyone.operators.types as types
+        inputs = types.Object()
+
+    Args:
+    *items: the tree structure of items
+    """
+
+    def __init__(self, *items):
+        self.items = items
+
+    def to_json(self):
+        return {
+            "name": self.__class__.__name__,
             "items": [item.to_json() for item in self.items],
         }
 
@@ -1382,6 +1422,20 @@ class ListView(View):
 
 class TupleView(View):
     """Displays a tuple of :class:`View` instances."""
+
+    def __init__(self, *itemsView, **options):
+        super().__init__(**options)
+        self.items = itemsView
+
+    def to_json(self):
+        return {
+            **super().to_json(),
+            "items": [item.to_json() for item in self.items],
+        }
+
+
+class TreeSelectionView(View):
+    """Displays a tree structure of selection checkboxes of :class:`View` instances."""
 
     def __init__(self, *itemsView, **options):
         super().__init__(**options)

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -1433,7 +1433,31 @@ class TupleView(View):
 
 
 class TreeSelectionView(View):
-    """Displays a tree structure of selection checkboxes of :class:`View` instances."""
+    """Displays a tree selection checkbox groups.
+
+    Examples::
+
+        import fiftyone.operators.types as types
+
+        structure = [
+            ["group_id_1", ["sample_id_1", "sample_id_2"]],
+            ["group_id_2", ["sample_id_3", "sample_id_4", "sample_id_5"], ["group_id_8", ["sample_id_6"]]],
+        ]
+
+        tree_view = types.TreeSelectionView(
+            data=structure # this data represents the basic group structure;
+        )
+
+        panel.view('exact_duplicate_selections', view=tree_view, on_change=self.toggle_select)
+
+        def toggle_select(self, ctx):
+            selected = ctx.params['value']
+            print('selected samples:', selected)
+
+    Args:
+        data (None): a list of lists representing the tree structure of groups and its children
+        on_change (None): the operator to execute when the tree selection changes
+    """
 
     def __init__(self, **options):
         super().__init__(**options)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add a new TreeSelectionView plugin component that renders controls in groups

- Users can select individual samples or groups or select all
- Groups can expand and collapse

## How is this patch tested? If it is not, please explain why.


https://github.com/user-attachments/assets/8b22eda3-8916-497a-8eca-b3b95b463067



## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `TreeSelectionView` component for rendering a tree structure with selectable items and expand/collapse functionality.
	- Added a new method to define tree properties in the `Object` class, enhancing hierarchical data representation.

- **Enhancements**
	- Updated the list of non-editable views to include `TreeSelectionView`, ensuring it is treated as non-editable in schemas.
	- Integrated `TreeSelectionView` into the existing type and view systems, making it a recognized view type.

- **Documentation**
	- Added export statements for the new `TreeSelectionView` component for easier import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->