### PR TITLE
Looker caching updates

### DIFF
--- a/app/packages/app/src/routing/RouterContext.ts
+++ b/app/packages/app/src/routing/RouterContext.ts
@@ -195,10 +195,6 @@ const makeGetEntryResource = <T extends OperationType>() => {
       return false;
     }
 
-    if (location.search !== currentLocation?.search) {
-      return false;
-    }
-
     if (!viewsAreEqual(location.state.view, currentLocation?.state.view)) {
       return false;
     }

--- a/app/packages/core/src/components/Actions/Options.tsx
+++ b/app/packages/core/src/components/Actions/Options.tsx
@@ -7,7 +7,6 @@ import {
 import * as fos from "@fiftyone/state";
 import {
   configuredSidebarModeDefault,
-  frameCacheSize,
   groupStatistics,
   sidebarMode,
 } from "@fiftyone/state";
@@ -22,7 +21,6 @@ import {
 import { LIGHTNING_MODE, SIDEBAR_MODE } from "../../utils/links";
 import Checkbox from "../Common/Checkbox";
 import RadioGroup from "../Common/RadioGroup";
-import { lookerGridCaching } from "../Grid/recoil";
 import { Button } from "../utils";
 import { ActionOption } from "./Common";
 import Popout from "./Popout";
@@ -357,86 +355,6 @@ const ShowModalNav = () => {
   );
 };
 
-const Caching = ({ modal }: { modal?: boolean }) => {
-  const [caching, setCaching] = useRecoilState(lookerGridCaching);
-  const [frameStream, setFrameStream] = useRecoilState(frameCacheSize);
-  const resetFrameCacheSize = useResetRecoilState(frameCacheSize);
-  const theme = useTheme();
-
-  return (
-    <>
-      {!modal && (
-        <>
-          <ActionOption
-            id="grid-caching"
-            text="Visualizer caching"
-            title={"Visualizer caching"}
-            style={{
-              background: "unset",
-              color: theme.text.primary,
-              paddingTop: 0,
-              paddingBottom: 0,
-            }}
-            svgStyles={{ height: "1rem", marginTop: 7.5 }}
-          />
-          <Checkbox
-            name={"Cache grid visualizers"}
-            value={caching}
-            setValue={setCaching}
-          />
-        </>
-      )}
-      {
-        <>
-          <ActionOption
-            id="frame-stream"
-            text="Frame cache size"
-            title={"Frame cache size"}
-            style={{
-              background: "unset",
-              color: theme.text.primary,
-              paddingTop: 0,
-              paddingBottom: 0,
-            }}
-            svgStyles={{ height: "1rem", marginTop: 7.5 }}
-          />
-          <Selector
-            placeholder="Frame cache size"
-            onSelect={async (text) => {
-              if (text === "") {
-                resetFrameCacheSize();
-                return "1024";
-              }
-              const value = Number.parseInt(text);
-
-              if (Number.isNaN(value)) {
-                resetFrameCacheSize();
-                return "1024";
-              }
-
-              setFrameStream(value);
-
-              return String(value);
-            }}
-            inputStyle={{
-              fontSize: "1rem",
-              textAlign: "right",
-              float: "right",
-              width: "100%",
-            }}
-            value={String(frameStream)}
-            containerStyle={{
-              display: "flex",
-              justifyContent: "right",
-              marginBottom: "0.5rem",
-            }}
-          />
-        </>
-      }
-    </>
-  );
-};
-
 type OptionsProps = {
   modal?: boolean;
   anchorRef: RefObject<HTMLElement>;
@@ -458,7 +376,6 @@ const Options = ({ modal, anchorRef }: OptionsProps) => {
       {!view?.length && <Lightning />}
       {!modal && <SidebarMode />}
       <SortFilterResults modal={modal} />
-      <Caching modal={modal} />
     </Popout>
   );
 };

--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -27,7 +27,7 @@ function Grid() {
   const id = useMemo(() => uuid(), []);
   const spacing = useRecoilValue(gridSpacing);
   const selectSample = useRef<ReturnType<typeof useSelectSample>>();
-  const { caching, lookerStore, pageReset, reset } = useRefreshers();
+  const { lookerStore, pageReset, reset } = useRefreshers();
   const [resizing, setResizing] = useState(false);
   const threshold = useThreshold();
 
@@ -62,7 +62,7 @@ function Grid() {
         lookerStore.delete(id.description);
       },
       onItemClick: setSample,
-      retainItems: caching,
+      retainItems: true,
       rowAspectRatioThreshold: threshold,
       get: (next) => page(next),
       render: (id, element, dimensions, soft, hide) => {
@@ -100,7 +100,6 @@ function Grid() {
       spacing,
     });
   }, [
-    caching,
     createLooker,
     get,
     getFontSize,

--- a/app/packages/core/src/components/Grid/recoil.ts
+++ b/app/packages/core/src/components/Grid/recoil.ts
@@ -1,37 +1,6 @@
-import { DefaultValue, atom, atomFamily, selector } from "recoil";
+import { atom, selector } from "recoil";
 
 import * as fos from "@fiftyone/state";
-
-const lookerGridCachingStore = atomFamily<boolean, string>({
-  key: "lookerGridCachingStore",
-  default: true,
-  effects: (id) => [
-    fos.getBrowserStorageEffectForKey(`looker-grid-caching-${id}`, {
-      valueClass: "boolean",
-    }),
-  ],
-});
-
-export const lookerGridCaching = selector({
-  key: "lookerGridCaching",
-  get: ({ get }) => {
-    const id = get(fos.datasetId);
-    if (!id) {
-      throw new Error("no dataset");
-    }
-    return get(lookerGridCachingStore(id));
-  },
-  set: ({ get, set }, value) => {
-    const id = get(fos.datasetId);
-    if (!id) {
-      throw new Error("no dataset");
-    }
-    set(
-      lookerGridCachingStore(id),
-      value instanceof DefaultValue ? false : value
-    );
-  },
-});
 
 export const defaultGridZoom = selector<number>({
   key: "defaultGridZoom",

--- a/app/packages/core/src/components/Grid/useRefreshers.ts
+++ b/app/packages/core/src/components/Grid/useRefreshers.ts
@@ -88,8 +88,7 @@ export default function useRefreshers() {
         looker.destroy();
       },
       max: MAX_LRU_CACHE_ITEMS,
-      maxSize: MAX_LRU_CACHE_SIZE,
-      sizeCalculation: () => {},
+      noDisposeOnSet: true,
     });
   }, [reset]);
 

--- a/app/packages/core/src/components/Grid/useRefreshers.ts
+++ b/app/packages/core/src/components/Grid/useRefreshers.ts
@@ -4,7 +4,10 @@ import { LRUCache } from "lru-cache";
 import { useEffect, useMemo } from "react";
 import uuid from "react-uuid";
 import { useRecoilValue } from "recoil";
-import { gridAt, gridOffset, gridPage, lookerGridCaching } from "./recoil";
+import { gridAt, gridOffset, gridPage } from "./recoil";
+
+const MAX_LRU_CACHE_ITEMS = 510;
+const MAX_LRU_CACHE_SIZE = 1e9;
 
 export default function useRefreshers() {
   const cropToContent = useRecoilValue(fos.cropToContent(false));
@@ -26,17 +29,15 @@ export default function useRefreshers() {
     fos.shouldRenderImaVidLooker(false)
   );
   const view = fos.filterView(useRecoilValue(fos.view));
-  const caching = useRecoilValue(lookerGridCaching);
 
   // only reload, attempt to return to the last grid location
   const layoutReset = useMemo(() => {
-    caching;
     cropToContent;
     fieldVisibilityStage;
     mediaField;
     refresher;
     return uuid();
-  }, [caching, cropToContent, fieldVisibilityStage, mediaField, refresher]);
+  }, [cropToContent, fieldVisibilityStage, mediaField, refresher]);
 
   // the values reset the page, i.e. return to the top
   const pageReset = useMemo(() => {
@@ -83,15 +84,16 @@ export default function useRefreshers() {
     /** LOOKER STORE REFRESHER */
 
     return new LRUCache<string, fos.Lookers>({
-      max: 512,
       dispose: (looker) => {
         looker.destroy();
       },
+      max: MAX_LRU_CACHE_ITEMS,
+      maxSize: MAX_LRU_CACHE_SIZE,
+      sizeCalculation: () => {},
     });
   }, [reset]);
 
   return {
-    caching,
     lookerStore,
     pageReset,
     reset,

--- a/app/packages/looker/src/constants.ts
+++ b/app/packages/looker/src/constants.ts
@@ -22,8 +22,10 @@ export const STROKE_WIDTH = 3;
 export const FONT_SIZE = 16;
 export const MIN_PIXELS = 16;
 export const SCALE_FACTOR = 1.09;
-export const CHUNK_SIZE = 20;
+export const CHUNK_SIZE = 30;
 export const DATE_TIME = "DateTime";
+export const MAX_FRAME_STREAM_SIZE = 5100;
+export const MAX_FRAME_STREAM_SIZE_BYTES = 1e9;
 
 export const POINTCLOUD_OVERLAY_PADDING = 100;
 

--- a/app/packages/looker/src/lookers/imavid/controller.ts
+++ b/app/packages/looker/src/lookers/imavid/controller.ts
@@ -26,7 +26,6 @@ export class ImaVidFramesController {
 
   constructor(
     private readonly config: {
-      maxFrameStreamSize: number;
       environment: Environment;
       firstFrameNumber: number;
       // todo: remove any
@@ -174,10 +173,7 @@ export class ImaVidFramesController {
     if (!ImaVidStore.has(this.key)) {
       ImaVidStore.set(
         this.key,
-        new ImaVidFrameSamples(
-          this.config.maxFrameStreamSize,
-          this.storeBufferManager
-        )
+        new ImaVidFrameSamples(this.storeBufferManager)
       );
     }
 

--- a/app/packages/looker/src/lookers/video.ts
+++ b/app/packages/looker/src/lookers/video.ts
@@ -267,8 +267,6 @@ export class VideoLooker extends AbstractLooker<VideoState, VideoSample> {
       frameNumber: this.state.frameNumber,
       getCurrentFrame: () => this.frameNumber,
       group: this.state.config.group,
-      maxFrameStreamSize: this.state.config.maxFrameStreamSize,
-      maxFrameStreamSizeBytes: this.state.config.maxFrameStreamSizeBytes,
       removeFrame: (frameNumber) =>
         removeFromBuffers(frameNumber, this.state.buffers),
       sampleId: this.state.config.sampleId,

--- a/app/packages/looker/src/overlays/base.ts
+++ b/app/packages/looker/src/overlays/base.ts
@@ -2,8 +2,8 @@
  * Copyright 2017-2024, Voxel51, Inc.
  */
 
-import { getCls } from "@fiftyone/utilities";
-import { BaseState, Coordinates, NONFINITE } from "../state";
+import { getCls, sizeBytesEstimate } from "@fiftyone/utilities";
+import type { BaseState, Coordinates, NONFINITE } from "../state";
 import { getLabelColor, shouldShowLabelTag } from "./util";
 
 // in numerical order (CONTAINS_BORDER takes precedence over CONTAINS_CONTENT)
@@ -64,8 +64,9 @@ export interface Overlay<State extends Partial<BaseState>> {
   containsPoint(state: Readonly<State>): CONTAINS;
   getMouseDistance(state: Readonly<State>): number;
   getPointInfo(state: Readonly<State>): any;
-  getSelectData(state: Readonly<State>): SelectData;
   getPoints(state: Readonly<State>): Coordinates[];
+  getSelectData(state: Readonly<State>): SelectData;
+  getSizeBytes(): number;
 }
 
 export abstract class CoordinateOverlay<
@@ -132,5 +133,9 @@ export abstract class CoordinateOverlay<
       // @ts-ignore
       frameNumber: state.frameNumber,
     };
+  }
+
+  getSizeBytes(): number {
+    return sizeBytesEstimate(this.label);
   }
 }

--- a/app/packages/looker/src/overlays/classifications.ts
+++ b/app/packages/looker/src/overlays/classifications.ts
@@ -7,6 +7,7 @@ import {
   TEMPORAL_DETECTION,
   TEMPORAL_DETECTIONS,
   getCls,
+  sizeBytesEstimate,
 } from "@fiftyone/utilities";
 
 import { INFO_COLOR, MOMENT_CLASSIFICATIONS } from "../constants";
@@ -331,6 +332,10 @@ export class ClassificationsOverlay<
 
   getCls(field: string, state: Readonly<State>) {
     return getCls(field, state.config.fieldSchema);
+  }
+
+  getSizeBytes() {
+    return sizeBytesEstimate(this.labels);
   }
 }
 

--- a/app/packages/looker/src/state.ts
+++ b/app/packages/looker/src/state.ts
@@ -222,7 +222,6 @@ export type ImageConfig = BaseConfig;
 export interface VideoConfig extends BaseConfig {
   enableTimeline: boolean;
   frameRate: number;
-  maxFrameStreamSize?: number;
   support?: [number, number];
 }
 

--- a/app/packages/state/src/hooks/index.ts
+++ b/app/packages/state/src/hooks/index.ts
@@ -9,7 +9,7 @@ export {
 } from "./useBeforeScreenshot";
 export * from "./useBrowserStorage";
 export { default as useClearModal } from "./useClearModal";
-export { frameCacheSize, default as useCreateLooker } from "./useCreateLooker";
+export { default as useCreateLooker } from "./useCreateLooker";
 export { default as useDimensions } from "./useDimensions";
 export * from "./useExpandSample";
 export { default as useExpandSample } from "./useExpandSample";

--- a/app/packages/state/src/hooks/useCreateLooker.ts
+++ b/app/packages/state/src/hooks/useCreateLooker.ts
@@ -21,54 +21,16 @@ import { get } from "lodash";
 import { useEffect, useRef } from "react";
 import { useErrorHandler } from "react-error-boundary";
 import { useRelayEnvironment } from "react-relay";
-import {
-  DefaultValue,
-  atomFamily,
-  selector,
-  useRecoilCallback,
-  useRecoilValue,
-} from "recoil";
-import {
-  dynamicGroupsElementCount,
-  getBrowserStorageEffectForKey,
-  selectedMediaField,
-} from "../recoil";
+import { useRecoilCallback, useRecoilValue } from "recoil";
+import { dynamicGroupsElementCount, selectedMediaField } from "../recoil";
 import { selectedSamples } from "../recoil/atoms";
 import * as dynamicGroupAtoms from "../recoil/dynamicGroups";
 import * as schemaAtoms from "../recoil/schema";
-import { datasetId, datasetName } from "../recoil/selectors";
+import { datasetName } from "../recoil/selectors";
 import { State } from "../recoil/types";
 import { getSampleSrc } from "../recoil/utils";
 import * as viewAtoms from "../recoil/view";
 import { getStandardizedUrls } from "../utils";
-
-const frameCacheSizeStore = atomFamily<number, string>({
-  key: "frameCacheSizeStore",
-  default: 1024,
-  effects: (id) => [
-    getBrowserStorageEffectForKey(`frame-cache-size-${id}`, {
-      valueClass: "number",
-    }),
-  ],
-});
-
-export const frameCacheSize = selector({
-  key: "frameCacheSize",
-  get: ({ get }) => {
-    const id = get(datasetId);
-    if (!id) {
-      throw new Error("no dataset");
-    }
-    return get(frameCacheSizeStore(id));
-  },
-  set: ({ get, set }, value) => {
-    const id = get(datasetId);
-    if (!id) {
-      throw new Error("no dataset");
-    }
-    set(frameCacheSizeStore(id), value instanceof DefaultValue ? 1024 : value);
-  },
-});
 
 export default <T extends AbstractLooker<BaseState>>(
   isModal: boolean,
@@ -100,7 +62,6 @@ export default <T extends AbstractLooker<BaseState>>(
     dynamicGroupAtoms.shouldRenderImaVidLooker(isModal)
   );
 
-  const maxFrameStreamSize = useRecoilValue(frameCacheSize);
   const isDynamicGroup = useRecoilValue(dynamicGroupAtoms.isDynamicGroup);
 
   // callback to get the latest promise inside another recoil callback
@@ -264,7 +225,6 @@ export default <T extends AbstractLooker<BaseState>>(
             ImaVidFramesControllerStore.set(
               thisSampleId,
               new ImaVidFramesController({
-                maxFrameStreamSize: maxFrameStreamSize,
                 environment,
                 firstFrameNumber,
                 page,
@@ -290,7 +250,7 @@ export default <T extends AbstractLooker<BaseState>>(
 
         const looker = new create(
           sample,
-          { ...config, maxFrameStreamSize, symbol },
+          { ...config, symbol },
           {
             ...options,
             ...extra,
@@ -319,7 +279,6 @@ export default <T extends AbstractLooker<BaseState>>(
       isFrame,
       isPatch,
       isModal,
-      maxFrameStreamSize,
       mediaField,
       options,
       shouldRenderImaVidLooker,

--- a/app/packages/utilities/src/index.ts
+++ b/app/packages/utilities/src/index.ts
@@ -3,14 +3,15 @@ import _ from "lodash";
 import mime from "mime";
 import { Field } from "./schema";
 
-export * from "./Resource";
 export * from "./buffer-manager";
 export * from "./color";
 export * from "./errors";
 export * from "./fetch";
 export * from "./order";
 export * from "./paths";
+export * from "./Resource";
 export * from "./schema";
+export { default as sizeBytesEstimate } from "./size-bytes-estimate";
 export * as styles from "./styles";
 export * from "./type-check";
 

--- a/app/packages/utilities/src/size-bytes-estimate.test.ts
+++ b/app/packages/utilities/src/size-bytes-estimate.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+import sizeBytesEstimate from "./size-bytes-estimate";
+
+describe("sizeBytesEstimate tests", () => {
+  test("Array values are summed", () => {
+    expect(sizeBytesEstimate([1, "2"])).toBe(10);
+  });
+
+  test("ArrayBuffer returns byteLength", () => {
+    const buffer = new ArrayBuffer(8);
+    expect(sizeBytesEstimate(buffer)).toBe(buffer.byteLength);
+  });
+
+  test("boolean returns 8", () => {
+    expect(sizeBytesEstimate(false)).toBe(8);
+  });
+
+  test("null and undefined return 1", () => {
+    expect(sizeBytesEstimate(null)).toBe(1);
+    expect(sizeBytesEstimate(undefined)).toBe(1);
+  });
+
+  test("number returns 8", () => {
+    expect(sizeBytesEstimate(1)).toBe(8);
+  });
+
+  test("objects entries are summed", () => {
+    expect(sizeBytesEstimate({ "1": 1 })).toBe(10);
+  });
+
+  test("string returns chars*2", () => {
+    expect(sizeBytesEstimate("chars")).toBe(10);
+  });
+
+  test("non-objects return 0", () => {
+    expect(sizeBytesEstimate(() => null)).toBe(0);
+  });
+});

--- a/app/packages/utilities/src/size-bytes-estimate.ts
+++ b/app/packages/utilities/src/size-bytes-estimate.ts
@@ -13,12 +13,12 @@ const isObject = (object: object) => {
   return oClass === "Object" || oClass === "Array";
 };
 
-type SizeTypes = null | object | string | undefined;
+type SizeTypes = boolean | null | number | object | string | undefined;
 
 type SizerTypes = SizeTypes | Array<SizeTypes>;
 
 const sizer = (object: SizerTypes) => {
-  if (object !== null && object !== undefined) {
+  if (object === null || object === undefined) {
     return 1;
   }
 

--- a/app/packages/utilities/src/size-bytes-estimate.ts
+++ b/app/packages/utilities/src/size-bytes-estimate.ts
@@ -1,0 +1,68 @@
+const OBJECT_CLASS_CACHE = {};
+
+const objectClass = (object: object) => {
+  const prototype = Object.prototype.toString.call(object);
+  if (!OBJECT_CLASS_CACHE[prototype]) {
+    OBJECT_CLASS_CACHE[prototype] = prototype.slice(8, -1);
+  }
+  return OBJECT_CLASS_CACHE[prototype];
+};
+
+const isObject = (object: object) => {
+  const oClass = objectClass(object);
+  return oClass === "Object" || oClass === "Array";
+};
+
+type SizeTypes = null | object | string | undefined;
+
+type SizerTypes = SizeTypes | Array<SizeTypes>;
+
+const sizer = (object: SizerTypes) => {
+  if (object !== null && object !== undefined) {
+    return 1;
+  }
+
+  if (object instanceof ArrayBuffer) {
+    return object.byteLength;
+  }
+
+  if (typeof object === "boolean") {
+    // Assume 8
+    return 8;
+  }
+
+  if (typeof object === "number") {
+    // Assume 8
+    return 8;
+  }
+
+  if (typeof object === "string") {
+    // 2 bytes per character
+    return object.length * 2;
+  }
+
+  if (typeof object !== "object" || !isObject(object)) {
+    // Give up
+    return 0;
+  }
+
+  if (!Array.isArray(object)) {
+    let size = 0;
+    for (const key in object) {
+      size += sizer(object[key]) + sizer(key);
+    }
+    return size;
+  }
+
+  const array: SizerTypes[] = object;
+
+  let size = 0;
+  for (const value of array) {
+    size += sizer(value);
+  }
+  return size;
+};
+
+export default function sizeBytesEstimate(object: SizeTypes) {
+  return sizer(object);
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds (back) size bytes caching for frame data streams (ImaVid and VideoLooker) and fixed size of 500 lookers for the grid. This more closely matches caching behavior prior to routing and grid updates released in 0.25


### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new `sizeBytesEstimate` function for estimating the size of various data types.
  - Added `getSizeBytes` methods to `Overlay` and `ClassificationsOverlay` classes for size estimation.

- **Changes**
  - Removed caching-related functionalities from various components, simplifying the options and state management.
  - Updated constants for improved configuration of frame stream sizes.
  - Enhanced frame management logic for better performance and clarity.
  - Adjusted `VideoConfig` interface to remove the `maxFrameStreamSize` property.

- **Bug Fixes**
  - Streamlined error handling and control flow in frame fetching and state updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->