### PR TITLE
add modal context to panel and operator views & fix zIndex of ArrowNavView

### DIFF
--- a/app/packages/core/src/plugins/OperatorIO/index.tsx
+++ b/app/packages/core/src/plugins/OperatorIO/index.tsx
@@ -15,6 +15,7 @@ function OperatorIOComponent(props) {
     initialData,
     id,
     shouldClearUseKeyStores,
+    ...otherProps
   } = props;
   const ioSchema = operatorToIOSchema(schema, { isOutput: type === "output" });
 
@@ -29,6 +30,7 @@ function OperatorIOComponent(props) {
       errors={getErrorsByPath(errors)}
       initialData={initialData}
       layout={layout}
+      otherProps={otherProps}
     />
   );
 }

--- a/app/packages/core/src/plugins/SchemaIO/components/ArrowNavView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ArrowNavView.tsx
@@ -9,7 +9,7 @@ import React from "react";
 import { ViewPropsType } from "../utils/types";
 
 export default function ArrowNavView(props: ViewPropsType) {
-  const { schema } = props;
+  const { schema, otherProps } = props;
   const { view = {} } = schema;
   const {
     on_backward,
@@ -20,12 +20,16 @@ export default function ArrowNavView(props: ViewPropsType) {
   } = view;
   const panelId = usePanelId();
   const handleClick = usePanelEvent();
+  const backwardStyles = positionBasedStyleBackward[position] || {};
+  const forwardStyles = positionBasedStyleForward[position] || {};
+  const { isModalPanel } = otherProps;
+  const zIndex = isModalPanel ? 1501 : 1000;
 
   return (
     <>
       {backward && (
         <Arrow
-          style={positionBasedStyleBackward[position]}
+          style={{ ...backwardStyles, zIndex }}
           onClick={() => {
             if (on_backward) {
               handleClick(panelId, { operator: on_backward });
@@ -38,7 +42,7 @@ export default function ArrowNavView(props: ViewPropsType) {
       {forward && (
         <Arrow
           $isRight
-          style={positionBasedStyleForward[position]}
+          style={{ ...forwardStyles, zIndex }}
           onClick={() => {
             if (on_forward) {
               handleClick(panelId, { operator: on_forward });

--- a/app/packages/core/src/plugins/SchemaIO/utils/types.ts
+++ b/app/packages/core/src/plugins/SchemaIO/utils/types.ts
@@ -63,6 +63,7 @@ export type ViewPropsType<Schema extends SchemaType = SchemaType> = {
     ROWS: number;
   };
   autoFocused?: React.MutableRefObject<boolean>;
+  otherProps: { [key: string]: any };
 };
 
 export type CustomComponentsType = {

--- a/app/packages/operators/src/CustomPanel.tsx
+++ b/app/packages/operators/src/CustomPanel.tsx
@@ -16,7 +16,7 @@ import { CustomPanelProps, useCustomPanelHooks } from "./useCustomPanelHooks";
 import { useTrackEvent } from "@fiftyone/analytics";
 
 export function CustomPanel(props: CustomPanelProps) {
-  const { panelId, dimensions, panelName, panelLabel } = props;
+  const { panelId, dimensions, panelName, panelLabel, isModalPanel } = props;
   const { height, width } = dimensions?.bounds || {};
   const { count } = useActivePanelEventsCount(panelId);
   const [_, setLoading] = usePanelLoading(panelId);
@@ -89,6 +89,7 @@ export function CustomPanel(props: CustomPanelProps) {
             layout={{ height, width }}
             onPathChange={handlePanelStatePathChange}
             shouldClearUseKeyStores={false}
+            isModalPanel={isModalPanel}
           />
         </DimensionRefresher>
       </Box>
@@ -122,24 +123,28 @@ export function defineCustomPanel({
   panel_name,
   panel_label,
 }) {
-  return ({ panelNode, dimensions }) => (
-    <CustomPanel
-      panelId={panelNode?.id}
-      onLoad={on_load}
-      onUnLoad={on_unload}
-      onChange={on_change}
-      onChangeCtx={on_change_ctx}
-      onChangeView={on_change_view}
-      onChangeDataset={on_change_dataset}
-      onChangeCurrentSample={on_change_current_sample}
-      onChangeSelected={on_change_selected}
-      onChangeSelectedLabels={on_change_selected_labels}
-      onChangeExtendedSelection={on_change_extended_selection}
-      onChangeGroupSlice={on_change_group_slice}
-      onChangeSpaces={on_change_spaces}
-      dimensions={dimensions}
-      panelName={panel_name}
-      panelLabel={panel_label}
-    />
-  );
+  return (props) => {
+    const { dimensions, panelNode, isModalPanel } = props;
+    return (
+      <CustomPanel
+        panelId={panelNode?.id}
+        onLoad={on_load}
+        onUnLoad={on_unload}
+        onChange={on_change}
+        onChangeCtx={on_change_ctx}
+        onChangeView={on_change_view}
+        onChangeDataset={on_change_dataset}
+        onChangeCurrentSample={on_change_current_sample}
+        onChangeSelected={on_change_selected}
+        onChangeSelectedLabels={on_change_selected_labels}
+        onChangeExtendedSelection={on_change_extended_selection}
+        onChangeGroupSlice={on_change_group_slice}
+        onChangeSpaces={on_change_spaces}
+        dimensions={dimensions}
+        panelName={panel_name}
+        panelLabel={panel_label}
+        isModalPanel={isModalPanel}
+      />
+    );
+  };
 }

--- a/app/packages/operators/src/useCustomPanelHooks.ts
+++ b/app/packages/operators/src/useCustomPanelHooks.ts
@@ -31,6 +31,7 @@ export interface CustomPanelProps {
   dimensions: DimensionsType | null;
   panelName?: string;
   panelLabel?: string;
+  isModalPanel?: boolean;
 }
 
 export interface CustomPanelHooks {

--- a/app/packages/plugins/src/index.ts
+++ b/app/packages/plugins/src/index.ts
@@ -382,6 +382,7 @@ type PanelOptions = {
 type PluginComponentProps<T> = T & {
   panelNode?: unknown;
   dimensions?: unknown;
+  isModalPanel?: boolean;
 };
 
 /**

--- a/app/packages/spaces/src/components/Panel.tsx
+++ b/app/packages/spaces/src/components/Panel.tsx
@@ -59,6 +59,7 @@ function Panel(props: PanelProps) {
           key={shouldKeyComponent ? thisModalUniqueId : panelName}
           panelNode={node}
           dimensions={dimensions}
+          isModalPanel={isModalPanel}
         />
       </PanelContext.Provider>
     </StyledPanel>


### PR DESCRIPTION
## What changes are proposed in this pull request?

- add modal context to panel and operator views
  - Available in panel at `props.isModalPanel` 
  - Available in operator view at `props.otherProps.isModalPanel` 
- fix zIndex of ArrowNavView

## How is this patch tested? If it is not, please explain why.

Using ArrowNavView

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

See above

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
