### PR TITLE
panel meta fixes

### DIFF
--- a/app/packages/spaces/src/components/AddPanelButton.tsx
+++ b/app/packages/spaces/src/components/AddPanelButton.tsx
@@ -112,7 +112,7 @@ export default function AddPanelButton({ node, spaceId }: AddPanelButtonProps) {
 
 function PanelCategories({ children }) {
   return (
-    <Grid container gap={1} sx={{ p: 2 }}>
+    <Grid container gap={1} sx={{ p: 1 }}>
       {children}
     </Grid>
   );

--- a/app/packages/spaces/src/components/AddPanelItem.tsx
+++ b/app/packages/spaces/src/components/AddPanelItem.tsx
@@ -19,6 +19,9 @@ export default function AddPanelItem({
   const theme = useTheme();
   const trackEvent = useTrackEvent();
   const { spaces } = useSpaces(spaceId);
+  if (showBeta) {
+    showNew = false;
+  }
   return (
     <Stack
       direction="row"
@@ -57,7 +60,7 @@ export default function AddPanelItem({
           style={{
             color: theme.custom.primarySoft,
             fontSize: "11px",
-            marginLeft: "6px",
+            marginLeft: "5px",
           }}
         >
           NEW
@@ -68,7 +71,7 @@ export default function AddPanelItem({
           style={{
             color: theme.custom.primarySoft,
             fontSize: "11px",
-            marginLeft: "6px",
+            marginLeft: "5px",
           }}
         >
           BETA


### PR DESCRIPTION
<img width="273" alt="image" src="https://github.com/user-attachments/assets/777180d6-e769-4665-80db-12fbc8ab15d5">

Improved padding / margin for panel metadata. Also fixed issue where NEW and BETA would show at the same time.