### PR TITLE
add dataset link for estores

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -54,6 +54,7 @@ import fiftyone.core.storage as fost
 from fiftyone.core.singletons import DatasetSingleton
 import fiftyone.core.utils as fou
 import fiftyone.core.view as fov
+from fiftyone.operators.store import ExecutionStoreService
 
 fot = fou.lazy_import("fiftyone.core.stages")
 foud = fou.lazy_import("fiftyone.utils.data")
@@ -5182,9 +5183,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         # Update singleton
         self._instances.pop(self._doc.name, None)
-
         _delete_dataset_doc(self._doc)
         self._deleted = True
+
+        _cleanup_execution_store_for_dataset(self._doc.id)
 
     def add_dir(
         self,
@@ -10176,3 +10178,9 @@ def _extract_archive_if_necessary(archive_path, cleanup):
         )
 
     return dataset_dir
+
+
+def _cleanup_execution_store_for_dataset(dataset_id):
+    """Cleans up the execution store for the given dataset."""
+    svc = ExecutionStoreService(dataset_id=dataset_id)
+    svc.cleanup_for_dataset()

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -54,7 +54,6 @@ import fiftyone.core.storage as fost
 from fiftyone.core.singletons import DatasetSingleton
 import fiftyone.core.utils as fou
 import fiftyone.core.view as fov
-from fiftyone.operators.store import ExecutionStoreService
 
 fot = fou.lazy_import("fiftyone.core.stages")
 foud = fou.lazy_import("fiftyone.utils.data")
@@ -10182,5 +10181,7 @@ def _extract_archive_if_necessary(archive_path, cleanup):
 
 def _cleanup_execution_store_for_dataset(dataset_id):
     """Cleans up the execution store for the given dataset."""
+    from fiftyone.operators.store import ExecutionStoreService
+
     svc = ExecutionStoreService(dataset_id=dataset_id)
     svc.cleanup_for_dataset()

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -57,6 +57,7 @@ import fiftyone.core.view as fov
 
 fot = fou.lazy_import("fiftyone.core.stages")
 foud = fou.lazy_import("fiftyone.utils.data")
+foos = fou.lazy_import("fiftyone.operators.store")
 
 
 _SUMMARY_FIELD_KEY = "_summary_field"
@@ -5180,12 +5181,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             self._frame_collection.drop()
             fofr.Frame._reset_docs(self._frame_collection_name)
 
+        foos.cleanup_store_for_dataset(self._doc.id)
+
         # Update singleton
         self._instances.pop(self._doc.name, None)
         _delete_dataset_doc(self._doc)
         self._deleted = True
-
-        _cleanup_execution_store_for_dataset(self._doc.id)
 
     def add_dir(
         self,
@@ -10177,11 +10178,3 @@ def _extract_archive_if_necessary(archive_path, cleanup):
         )
 
     return dataset_dir
-
-
-def _cleanup_execution_store_for_dataset(dataset_id):
-    """Cleans up the execution store for the given dataset."""
-    from fiftyone.operators.store import ExecutionStoreService
-
-    svc = ExecutionStoreService(dataset_id=dataset_id)
-    svc.cleanup_for_dataset()

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -37,6 +37,7 @@ fob = fou.lazy_import("fiftyone.core.brain")
 fod = fou.lazy_import("fiftyone.core.dataset")
 foe = fou.lazy_import("fiftyone.core.evaluation")
 fors = fou.lazy_import("fiftyone.core.runs")
+foos = fou.lazy_import("fiftyone.operators.store")
 
 
 logger = logging.getLogger(__name__)
@@ -1125,6 +1126,16 @@ def delete_dataset(name, dry_run=False):
         _logger.info("Deleting %d run result(s)", len(result_ids))
         if not dry_run:
             _delete_run_results(conn, result_ids)
+
+    dataset_id = dataset_dict["_id"]
+    svc = foos.ExecutionStoreService(dataset_id=dataset_id)
+    num_docs = sum(
+        len(svc.list_keys(store_name)) for store_name in svc.list_stores()
+    )
+    if num_docs > 0:
+        _logger.info("Deleting %d store doc(s)", num_docs)
+        if not dry_run:
+            foos.cleanup_store_for_dataset(dataset_id)
 
 
 def delete_saved_view(dataset_name, view_name, dry_run=False):

--- a/fiftyone/factory/repo_factory.py
+++ b/fiftyone/factory/repo_factory.py
@@ -8,6 +8,7 @@ FiftyOne repository factory.
 
 from pymongo.database import Database
 
+from typing import Optional
 import fiftyone.core.odm as foo
 from fiftyone.factory.repos.delegated_operation import (
     DelegatedOperationRepo,
@@ -50,7 +51,9 @@ class RepositoryFactory(object):
         ]
 
     @staticmethod
-    def execution_store_repo() -> ExecutionStoreRepo:
+    def execution_store_repo(
+        dataset_id: Optional[str] = None,
+    ) -> ExecutionStoreRepo:
         """Factory method for execution store repository."""
         if (
             MongoExecutionStoreRepo.COLLECTION_NAME
@@ -59,7 +62,8 @@ class RepositoryFactory(object):
             RepositoryFactory.repos[
                 MongoExecutionStoreRepo.COLLECTION_NAME
             ] = MongoExecutionStoreRepo(
-                collection=_get_db()[MongoExecutionStoreRepo.COLLECTION_NAME]
+                collection=_get_db()[MongoExecutionStoreRepo.COLLECTION_NAME],
+                dataset_id=dataset_id,
             )
 
         return RepositoryFactory.repos[MongoExecutionStoreRepo.COLLECTION_NAME]

--- a/fiftyone/factory/repo_factory.py
+++ b/fiftyone/factory/repo_factory.py
@@ -8,7 +8,7 @@ FiftyOne repository factory.
 
 from pymongo.database import Database
 
-from bson import ObjectId
+import bson
 from typing import Optional
 import fiftyone.core.odm as foo
 from fiftyone.factory.repos.delegated_operation import (
@@ -53,7 +53,7 @@ class RepositoryFactory(object):
 
     @staticmethod
     def execution_store_repo(
-        dataset_id: Optional[str] = None,
+        dataset_id: Optional[bson.ObjectId] = None,
     ) -> ExecutionStoreRepo:
         """Factory method for execution store repository."""
         if (

--- a/fiftyone/factory/repo_factory.py
+++ b/fiftyone/factory/repo_factory.py
@@ -8,6 +8,7 @@ FiftyOne repository factory.
 
 from pymongo.database import Database
 
+from bson import ObjectId
 from typing import Optional
 import fiftyone.core.odm as foo
 from fiftyone.factory.repos.delegated_operation import (

--- a/fiftyone/factory/repos/execution_store.py
+++ b/fiftyone/factory/repos/execution_store.py
@@ -7,10 +7,12 @@ from pymongo.collection import Collection
 from fiftyone.operators.store.models import StoreDocument, KeyDocument
 
 
-def _where(store_name, key=None):
+def _where(store_name, key=None, dataset_id=None):
     query = {"store_name": store_name}
     if key is not None:
         query["key"] = key
+    if dataset_id is not None:
+        query["dataset_id"] = dataset_id
     return query
 
 
@@ -19,12 +21,17 @@ class ExecutionStoreRepo:
 
     COLLECTION_NAME = "execution_store"
 
-    def __init__(self, collection: Collection):
+    def __init__(self, collection: Collection, dataset_id: str = None):
         self._collection = collection
+        self._dataset_id = dataset_id
 
     def create_store(self, store_name, permissions=None) -> StoreDocument:
         """Creates a store in the execution store."""
-        store_doc = StoreDocument(store_name=store_name, value=permissions)
+        store_doc = StoreDocument(
+            store_name=store_name,
+            value=permissions,
+            dataset_id=self._dataset_id,
+        )
         self._collection.insert_one(store_doc.to_mongo_dict())
         return store_doc
 
@@ -43,6 +50,7 @@ class ExecutionStoreRepo:
             value=value,
             updated_at=now,
             expires_at=expiration,
+            dataset_id=self._dataset_id,
         )
 
         # Prepare the update operations
@@ -58,6 +66,7 @@ class ExecutionStoreRepo:
                 "key": key,
                 "created_at": now,
                 "expires_at": expiration if ttl else None,
+                "dataset_id": self._dataset_id,
             },
         }
 
@@ -75,7 +84,9 @@ class ExecutionStoreRepo:
 
     def get_key(self, store_name, key) -> KeyDocument:
         """Gets a key from the specified store."""
-        raw_key_doc = self._collection.find_one(_where(store_name, key))
+        raw_key_doc = self._collection.find_one(
+            _where(store_name, key, self._dataset_id)
+        )
         key_doc = KeyDocument(**raw_key_doc) if raw_key_doc else None
         return key_doc
 
@@ -94,20 +105,29 @@ class ExecutionStoreRepo:
 
     def delete_key(self, store_name, key) -> bool:
         """Deletes the document that matches the store name and key."""
-        result = self._collection.delete_one(_where(store_name, key))
+        result = self._collection.delete_one(
+            _where(store_name, key, self._dataset_id)
+        )
         return result.deleted_count > 0
 
     def delete_store(self, store_name) -> int:
         """Deletes the entire store."""
-        result = self._collection.delete_many(_where(store_name))
+        result = self._collection.delete_many(
+            _where(store_name, dataset_id=self._dataset_id)
+        )
+        return result.deleted_count
+
+    def cleanup_for_dataset(self) -> int:
+        """Deletes all keys for a specific dataset."""
+        result = self._collection.delete_many({"dataset_id": self._dataset_id})
         return result.deleted_count
 
 
 class MongoExecutionStoreRepo(ExecutionStoreRepo):
     """MongoDB implementation of execution store repository."""
 
-    def __init__(self, collection: Collection):
-        super().__init__(collection)
+    def __init__(self, collection: Collection, dataset_id: str = None):
+        super().__init__(collection, dataset_id)
         self._create_indexes()
 
     def _create_indexes(self):
@@ -115,17 +135,18 @@ class MongoExecutionStoreRepo(ExecutionStoreRepo):
         expires_at_name = "expires_at"
         store_name_name = "store_name"
         key_name = "key"
-        full_key_name = "store_name_and_key"
+        full_key_name = "unique_store_index"
+        dataset_id_name = "dataset_id"
         if expires_at_name not in indices:
             self._collection.create_index(
                 expires_at_name, name=expires_at_name, expireAfterSeconds=0
             )
         if full_key_name not in indices:
             self._collection.create_index(
-                [(store_name_name, 1), (key_name, 1)],
+                [(store_name_name, 1), (key_name, 1), (dataset_id_name, 1)],
                 name=full_key_name,
                 unique=True,
             )
-        for name in [store_name_name, key_name]:
+        for name in [store_name_name, key_name, dataset_id_name]:
             if name not in indices:
                 self._collection.create_index(name, name=name)

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -875,7 +875,6 @@ class ExecutionContext(object):
         else:
             self.log(f"Progress: {progress} - {label}")
 
-    # TODO resolve circular import so this can have a type
     def create_store(self, store_name):
         """Creates a new store with the specified name.
 
@@ -887,7 +886,8 @@ class ExecutionContext(object):
         """
         from fiftyone.operators.store import ExecutionStore
 
-        return ExecutionStore.create(store_name)
+        dataset_id = self.dataset._doc.id
+        return ExecutionStore.create(store_name, dataset_id)
 
     def serialize(self):
         """Serializes the execution context.

--- a/fiftyone/operators/store/__init__.py
+++ b/fiftyone/operators/store/__init__.py
@@ -5,14 +5,16 @@ FiftyOne execution store module.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import types
 
-from .service import ExecutionStoreService
+from .service import cleanup_store_for_dataset, ExecutionStoreService
 from .store import ExecutionStore
 from .models import StoreDocument, KeyDocument
 
+# This tells Sphinx to allow refs to imported objects in this module
+# https://stackoverflow.com/a/31594545/16823653
 __all__ = [
-    "ExecutionStoreService",
-    "StoreDocument",
-    "KeyDocument",
-    "ExecutionStore",
+    k
+    for k, v in globals().items()
+    if not k.startswith("_") and not isinstance(v, types.ModuleType)
 ]

--- a/fiftyone/operators/store/models.py
+++ b/fiftyone/operators/store/models.py
@@ -7,6 +7,7 @@ import datetime
 class KeyDocument:
     """Model representing a key in the store."""
 
+    dataset_id: Optional[str] = None
     store_name: str
     key: str
     value: Any

--- a/fiftyone/operators/store/models.py
+++ b/fiftyone/operators/store/models.py
@@ -1,3 +1,4 @@
+import bson
 from dataclasses import dataclass, field, asdict
 from typing import Optional, Dict, Any
 import datetime
@@ -7,7 +8,6 @@ import datetime
 class KeyDocument:
     """Model representing a key in the store."""
 
-    dataset_id: Optional[str] = None
     store_name: str
     key: str
     value: Any
@@ -17,6 +17,7 @@ class KeyDocument:
     _id: Optional[Any] = None
     updated_at: Optional[datetime.datetime] = None
     expires_at: Optional[datetime.datetime] = None
+    dataset_id: Optional[bson.ObjectId] = None
 
     @staticmethod
     def get_expiration(ttl: Optional[int]) -> Optional[datetime.datetime]:
@@ -30,6 +31,8 @@ class KeyDocument:
         data = asdict(self)
         if exclude_id:
             data.pop("_id", None)
+        if self.dataset_id is None:
+            data.pop("dataset_id", None)
         return data
 
 

--- a/fiftyone/operators/store/service.py
+++ b/fiftyone/operators/store/service.py
@@ -9,12 +9,25 @@ FiftyOne execution store service.
 import bson
 import logging
 from typing import Optional, List
+
 from fiftyone.operators.store.models import StoreDocument, KeyDocument
+
 
 logger = logging.getLogger(__name__)
 
 
-class ExecutionStoreService:
+def cleanup_store_for_dataset(dataset_id):
+    """Deletes all documents in the execution store associated with the given
+    dataset.
+
+    Args:
+        dataset_id: the dataset ID
+    """
+    svc = ExecutionStoreService(dataset_id=dataset_id)
+    svc.cleanup_for_dataset()
+
+
+class ExecutionStoreService(object):
     def __init__(
         self,
         repo: Optional["ExecutionStoreRepo"] = None,
@@ -23,8 +36,8 @@ class ExecutionStoreService:
         """Service for managing execution store operations.
 
         Args:
-            repo: Optional execution store repository instance
-            dataset_id: Optional bson.ObjectId of the dataset to scope operations to
+            repo (None): execution store repository instance
+            dataset_id (None): dataset ID to scope operations to
         """
         from fiftyone.factory.repo_factory import (
             RepositoryFactory,
@@ -139,5 +152,7 @@ class ExecutionStoreService:
         return self._repo.list_keys(store_name)
 
     def cleanup_for_dataset(self) -> None:
-        """Cleans up the execution store for the dataset specified during initialization."""
+        """Cleans up the execution store for the dataset specified during
+        initialization.
+        """
         self._repo.cleanup_for_dataset()

--- a/fiftyone/operators/store/service.py
+++ b/fiftyone/operators/store/service.py
@@ -132,3 +132,11 @@ class ExecutionStoreService:
             a list of keys in the store
         """
         return self._repo.list_keys(store_name)
+
+    def cleanup_for_dataset(self, dataset_id: str) -> None:
+        """Cleans up the execution store for the specified dataset.
+
+        Args:
+            dataset_id: the ID of the dataset
+        """
+        self._repo.cleanup_for_dataset(dataset_id=dataset_id)

--- a/fiftyone/operators/store/service.py
+++ b/fiftyone/operators/store/service.py
@@ -133,10 +133,10 @@ class ExecutionStoreService:
         """
         return self._repo.list_keys(store_name)
 
-    def cleanup_for_dataset(self, dataset_id: str) -> None:
+    def cleanup_for_dataset(self) -> None:
         """Cleans up the execution store for the specified dataset.
 
         Args:
             dataset_id: the ID of the dataset
         """
-        self._repo.cleanup_for_dataset(dataset_id=dataset_id)
+        self._repo.cleanup_for_dataset()

--- a/fiftyone/operators/store/service.py
+++ b/fiftyone/operators/store/service.py
@@ -16,14 +16,20 @@ logger = logging.getLogger(__name__)
 class ExecutionStoreService:
     """Service for managing execution store operations."""
 
-    def __init__(self, repo: Optional["ExecutionStoreRepo"] = None):
+    def __init__(
+        self,
+        repo: Optional["ExecutionStoreRepo"] = None,
+        dataset_id: Optional[str] = None,
+    ):
         from fiftyone.factory.repo_factory import (
             RepositoryFactory,
             ExecutionStoreRepo,
         )
 
         if repo is None:
-            repo = RepositoryFactory.execution_store_repo()
+            repo = RepositoryFactory.execution_store_repo(
+                dataset_id=dataset_id
+            )
 
         self._repo: ExecutionStoreRepo = repo
 

--- a/fiftyone/operators/store/service.py
+++ b/fiftyone/operators/store/service.py
@@ -6,6 +6,7 @@ FiftyOne execution store service.
 |
 """
 
+import bson
 import logging
 from typing import Optional, List
 from fiftyone.operators.store.models import StoreDocument, KeyDocument
@@ -14,13 +15,17 @@ logger = logging.getLogger(__name__)
 
 
 class ExecutionStoreService:
-    """Service for managing execution store operations."""
-
     def __init__(
         self,
         repo: Optional["ExecutionStoreRepo"] = None,
-        dataset_id: Optional[str] = None,
+        dataset_id: Optional[bson.ObjectId] = None,
     ):
+        """Service for managing execution store operations.
+
+        Args:
+            repo: Optional execution store repository instance
+            dataset_id: Optional bson.ObjectId of the dataset to scope operations to
+        """
         from fiftyone.factory.repo_factory import (
             RepositoryFactory,
             ExecutionStoreRepo,
@@ -134,9 +139,5 @@ class ExecutionStoreService:
         return self._repo.list_keys(store_name)
 
     def cleanup_for_dataset(self) -> None:
-        """Cleans up the execution store for the specified dataset.
-
-        Args:
-            dataset_id: the ID of the dataset
-        """
+        """Cleans up the execution store for the dataset specified during initialization."""
         self._repo.cleanup_for_dataset()

--- a/fiftyone/operators/store/store.py
+++ b/fiftyone/operators/store/store.py
@@ -6,6 +6,7 @@ FiftyOne execution store.
 |
 """
 
+import bson
 import logging
 from fiftyone.operators.store.service import ExecutionStoreService
 from typing import Any, Optional
@@ -16,7 +17,7 @@ logger = logging.getLogger(__name__)
 class ExecutionStore:
     @staticmethod
     def create(
-        store_name: str, dataset_id: Optional[str] = None
+        store_name: str, dataset_id: Optional[bson.ObjectId] = None
     ) -> "ExecutionStore":
         return ExecutionStore(
             store_name, ExecutionStoreService(dataset_id=dataset_id)

--- a/fiftyone/operators/store/store.py
+++ b/fiftyone/operators/store/store.py
@@ -15,8 +15,12 @@ logger = logging.getLogger(__name__)
 
 class ExecutionStore:
     @staticmethod
-    def create(store_name: str) -> "ExecutionStore":
-        return ExecutionStore(store_name, ExecutionStoreService())
+    def create(
+        store_name: str, dataset_id: Optional[str] = None
+    ) -> "ExecutionStore":
+        return ExecutionStore(
+            store_name, ExecutionStoreService(dataset_id=dataset_id)
+        )
 
     def __init__(self, store_name: str, store_service: ExecutionStoreService):
         """

--- a/fiftyone/operators/store/store.py
+++ b/fiftyone/operators/store/store.py
@@ -8,21 +8,15 @@ FiftyOne execution store.
 
 import bson
 import logging
-from fiftyone.operators.store.service import ExecutionStoreService
 from typing import Any, Optional
+
+from fiftyone.operators.store.service import ExecutionStoreService
+
 
 logger = logging.getLogger(__name__)
 
 
-class ExecutionStore:
-    @staticmethod
-    def create(
-        store_name: str, dataset_id: Optional[bson.ObjectId] = None
-    ) -> "ExecutionStore":
-        return ExecutionStore(
-            store_name, ExecutionStoreService(dataset_id=dataset_id)
-        )
-
+class ExecutionStore(object):
     def __init__(self, store_name: str, store_service: ExecutionStoreService):
         """
         Args:
@@ -32,11 +26,19 @@ class ExecutionStore:
         self.store_name: str = store_name
         self._store_service: ExecutionStoreService = store_service
 
+    @staticmethod
+    def create(
+        store_name: str, dataset_id: Optional[bson.ObjectId] = None
+    ) -> "ExecutionStore":
+        return ExecutionStore(
+            store_name, ExecutionStoreService(dataset_id=dataset_id)
+        )
+
     def list_all_stores(self) -> list[str]:
         """Lists all stores in the execution store.
 
         Returns:
-            list: A list of store names.
+            list: a list of store names
         """
         return self._store_service.list_stores()
 
@@ -44,10 +46,10 @@ class ExecutionStore:
         """Retrieves a value from the store by its key.
 
         Args:
-            key (str): The key to retrieve the value for.
+            key: the key to retrieve the value for
 
         Returns:
-            Optional[Any]: The value stored under the given key, or None if not found.
+            the value stored under the given key, or None if not found
         """
         key_doc = self._store_service.get_key(self.store_name, key)
         if key_doc is None:
@@ -58,9 +60,9 @@ class ExecutionStore:
         """Sets a value in the store with an optional TTL.
 
         Args:
-            key (str): The key to store the value under.
-            value (Any): The value to store.
-            ttl (Optional[int], optional): The time-to-live in seconds. Defaults to None.
+            key: the key to store the value under
+            value: the value to store
+            ttl (None): the time-to-live in seconds
         """
         self._store_service.set_key(self.store_name, key, value, ttl)
 
@@ -68,10 +70,10 @@ class ExecutionStore:
         """Deletes a key from the store.
 
         Args:
-            key (str): The key to delete.
+            key: the key to delete.
 
         Returns:
-            bool: True if the key was deleted, False otherwise.
+            True/False whether the key was deleted
         """
         return self._store_service.delete_key(self.store_name, key)
 
@@ -79,10 +81,10 @@ class ExecutionStore:
         """Checks if the store has a specific key.
 
         Args:
-            key (str): The key to check.
+            key: the key to check
 
         Returns:
-            bool: True if the key exists, False otherwise.
+            True/False whether the key exists
         """
         return self._store_service.has_key(self.store_name, key)
 
@@ -94,8 +96,8 @@ class ExecutionStore:
         """Updates the TTL for a specific key.
 
         Args:
-            key (str): The key to update the TTL for.
-            new_ttl (int): The new TTL in seconds.
+            key: the key to update the TTL for
+            new_ttl: the new TTL in seconds
         """
         self._store_service.update_ttl(self.store_name, key, new_ttl)
 
@@ -103,10 +105,10 @@ class ExecutionStore:
         """Retrieves the TTL for a specific key.
 
         Args:
-            key (str): The key to get the TTL for.
+            key: the key to get the TTL for
 
         Returns:
-            Optional[int]: The TTL in seconds, or None if the key does not have a TTL.
+            the TTL in seconds, or None if the key does not have a TTL
         """
         return self._store_service.get_ttl(self.store_name, key)
 
@@ -114,6 +116,6 @@ class ExecutionStore:
         """Lists all keys in the store.
 
         Returns:
-            list: A list of keys in the store.
+            a list of keys in the store
         """
         return self._store_service.list_keys(self.store_name)

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -28,6 +28,7 @@ import fiftyone.core.fields as fof
 import fiftyone.core.odm as foo
 import fiftyone.utils.data as foud
 from fiftyone import ViewField as F
+from fiftyone.operators.store import ExecutionStoreService
 
 from decorators import drop_datasets, skip_windows
 
@@ -138,8 +139,17 @@ class DatasetTests(unittest.TestCase):
         self.assertListEqual(list_datasets(), dataset_names)
 
         name = dataset_names.pop(0)
-        datasets[name].delete()
+        dataset = datasets[name]
+        dataset_id = dataset._doc.id
+        exec_store_svc = ExecutionStoreService(dataset_id=dataset_id)
+        store_name = "test_store"
+        exec_store_svc.set_key(store_name, "foo", "bar")
+        keys = exec_store_svc.list_keys(store_name)
+        self.assertEqual(keys, ["foo"])
+        dataset.delete()
         self.assertListEqual(list_datasets(), dataset_names)
+        keys = exec_store_svc.list_keys(store_name)
+        self.assertEqual(keys, [])
         with self.assertRaises(ValueError):
             len(datasets[name])
 

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -26,6 +26,7 @@ import eta.core.utils as etau
 import fiftyone as fo
 import fiftyone.core.fields as fof
 import fiftyone.core.odm as foo
+from fiftyone.operators.store import ExecutionStoreService
 import fiftyone.utils.data as foud
 from fiftyone import ViewField as F
 
@@ -123,8 +124,6 @@ class DatasetTests(unittest.TestCase):
 
     @drop_datasets
     def test_delete_dataset(self):
-        from fiftyone.operators.store import ExecutionStoreService
-
         IGNORED_DATASET_NAMES = fo.list_datasets()
 
         def list_datasets():
@@ -140,27 +139,35 @@ class DatasetTests(unittest.TestCase):
         self.assertListEqual(list_datasets(), dataset_names)
 
         name = dataset_names.pop(0)
+
         dataset = datasets[name]
         dataset_id = dataset._doc.id
-        exec_store_svc = ExecutionStoreService(dataset_id=dataset_id)
+        svc = ExecutionStoreService(dataset_id=dataset_id)
         store_name = "test_store"
-        exec_store_svc.set_key(store_name, "foo", "bar")
-        keys = exec_store_svc.list_keys(store_name)
-        self.assertEqual(keys, ["foo"])
+        svc.set_key(store_name, "foo", "bar")
+        keys = svc.list_keys(store_name)
+
+        self.assertListEqual(keys, ["foo"])
+
         dataset.delete()
+
         self.assertListEqual(list_datasets(), dataset_names)
-        keys = exec_store_svc.list_keys(store_name)
-        self.assertEqual(keys, [])
+        keys = svc.list_keys(store_name)
+
+        self.assertListEqual(keys, [])
         with self.assertRaises(ValueError):
-            len(datasets[name])
+            len(dataset)
 
         name = dataset_names.pop(0)
+
         fo.delete_dataset(name)
+
         self.assertListEqual(list_datasets(), dataset_names)
         with self.assertRaises(ValueError):
             len(datasets[name])
 
         new_dataset = fo.Dataset(name)
+
         self.assertEqual(len(new_dataset), 0)
 
     @drop_datasets

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -28,7 +28,6 @@ import fiftyone.core.fields as fof
 import fiftyone.core.odm as foo
 import fiftyone.utils.data as foud
 from fiftyone import ViewField as F
-from fiftyone.operators.store import ExecutionStoreService
 
 from decorators import drop_datasets, skip_windows
 
@@ -124,6 +123,8 @@ class DatasetTests(unittest.TestCase):
 
     @drop_datasets
     def test_delete_dataset(self):
+        from fiftyone.operators.store import ExecutionStoreService
+
         IGNORED_DATASET_NAMES = fo.list_datasets()
 
         def list_datasets():

--- a/tests/unittests/execution_store_tests.py
+++ b/tests/unittests/execution_store_tests.py
@@ -10,6 +10,7 @@ import time
 import unittest
 from unittest.mock import patch, MagicMock, ANY, Mock
 import datetime
+from bson import ObjectId
 
 from fiftyone.operators.store import ExecutionStoreService
 from fiftyone.operators.store.models import KeyDocument
@@ -223,3 +224,139 @@ class TestExecutionStoreIntegration(unittest.TestCase):
         self.mock_collection.delete_many.assert_called_with(
             {"store_name": "mock_store"}
         )
+
+
+class ExecutionStoreServiceDatasetIdTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mock_collection = MagicMock()
+        self.dataset_id = ObjectId()
+        self.store_repo = ExecutionStoreRepo(
+            self.mock_collection, dataset_id=self.dataset_id
+        )
+        self.store_service = ExecutionStoreService(self.store_repo)
+
+    def test_set_key_with_dataset_id(self):
+        self.store_service.set_key(
+            "widgets",
+            "widget_1",
+            {"name": "Widget One", "value": 100},
+            ttl=60000,
+        )
+        self.mock_collection.update_one.assert_called_once()
+        self.mock_collection.update_one.assert_called_with(
+            {
+                "store_name": "widgets",
+                "key": "widget_1",
+                "dataset_id": self.dataset_id,
+            },
+            {
+                "$set": {
+                    "value": {"name": "Widget One", "value": 100},
+                    "updated_at": IsDateTime(),
+                },
+                "$setOnInsert": {
+                    "store_name": "widgets",
+                    "key": "widget_1",
+                    "created_at": IsDateTime(),
+                    "expires_at": IsDateTime(),
+                    "dataset_id": self.dataset_id,
+                },
+            },
+            upsert=True,
+        )
+
+    def test_get_key_with_dataset_id(self):
+        self.mock_collection.find_one.return_value = {
+            "store_name": "widgets",
+            "key": "widget_1",
+            "value": {"name": "Widget One", "value": 100},
+            "created_at": time.time(),
+            "updated_at": time.time(),
+            "expires_at": time.time() + 60000,
+            "dataset_id": self.dataset_id,
+        }
+        self.store_service.get_key("widgets", "widget_1")
+        self.mock_collection.find_one.assert_called_once()
+        self.mock_collection.find_one.assert_called_with(
+            {
+                "store_name": "widgets",
+                "key": "widget_1",
+                "dataset_id": self.dataset_id,
+            }
+        )
+
+    def test_list_keys_with_dataset_id(self):
+        self.store_service.list_keys("widgets")
+        self.mock_collection.find.assert_called_once()
+        self.mock_collection.find.assert_called_with(
+            {"store_name": "widgets", "dataset_id": self.dataset_id},
+            {"key": 1},
+        )
+
+    def test_delete_key_with_dataset_id(self):
+        mock_result = MagicMock()
+        mock_result.deleted_count = 1  # Simulate a successful deletion
+        self.mock_collection.delete_one.return_value = mock_result
+
+        deleted = self.store_service.delete_key("widgets", "widget_1")
+        assert deleted
+
+        self.mock_collection.delete_one.assert_called_once()
+        self.mock_collection.delete_one.assert_called_with(
+            {
+                "store_name": "widgets",
+                "key": "widget_1",
+                "dataset_id": self.dataset_id,
+            }
+        )
+
+        def test_create_store_with_dataset_id(self):
+            self.store_service.create_store("widgets")
+            self.mock_collection.insert_one.assert_called_once()
+            self.mock_collection.insert_one.assert_called_with(
+                {
+                    "store_name": "widgets",
+                    "key": "__store__",  # Include this in your expected call
+                    "value": None,
+                    "dataset_id": self.dataset_id,
+                    "created_at": IsDateTime(),
+                    "updated_at": None,
+                    "expires_at": None,
+                }
+            )
+
+    def test_delete_store_with_dataset_id(self):
+        self.store_service.delete_store("widgets")
+        self.mock_collection.delete_many.assert_called_once()
+        self.mock_collection.delete_many.assert_called_with(
+            {"store_name": "widgets", "dataset_id": self.dataset_id}
+        )
+
+    def test_update_ttl_with_dataset_id(self):
+        ttl_seconds = 60000
+        expected_expiration = KeyDocument.get_expiration(ttl_seconds)
+        mock_result = MagicMock()
+        mock_result.modified_count = 1
+        self.mock_collection.update_one.return_value = mock_result
+
+        updated = self.store_service.update_ttl(
+            "widgets", "widget_1", ttl_seconds
+        )
+        assert updated
+
+        actual_call = self.mock_collection.update_one.call_args
+        actual_query, actual_update = actual_call[0]
+
+        assert actual_query == {
+            "store_name": "widgets",
+            "key": "widget_1",
+            "dataset_id": self.dataset_id,
+        }
+
+        actual_expires_at = actual_update["$set"]["expires_at"]
+        assert isinstance(actual_expires_at, datetime.datetime)
+
+        time_delta = actual_expires_at - expected_expiration
+        assert_delta_seconds_approx(
+            time_delta, 0
+        )  # Check that the time difference is within the allowed EPSILON


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced support for managing execution stores tied to specific datasets.
  - Added a cleanup function to remove execution data when datasets are deleted.
  - Enhanced the `ExecutionStore` and `ExecutionStoreService` to accept and utilize dataset IDs.

- **Bug Fixes**
  - Improved key management in execution stores during dataset deletions.

- **Tests**
  - Expanded unit tests to cover new dataset ID functionality in execution store operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->