### PR TITLE
listen to data change and cause re-render for input fields

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/SliderView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/SliderView.tsx
@@ -98,12 +98,12 @@ export default function SliderView(props: ViewPropsType) {
     ? schemaMultipleOf
     : (max - min) / 100;
 
-  // if external reset happens, update the key for inputs
+  // external data reset re-renders the inputs
   useEffect(() => {
-    if (isEqual(data, [min, max])) {
+    if (!isEqual(data, [min, max])) {
       return setFieldsRevision(fieldsRevision + 1);
     }
-  }, [key]);
+  }, [data]);
 
   const [unit, _] = useState<ValueFormat>(valueFormat);
 

--- a/app/packages/core/src/plugins/SchemaIO/components/SliderView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/SliderView.tsx
@@ -100,9 +100,7 @@ export default function SliderView(props: ViewPropsType) {
 
   // external data reset re-renders the inputs
   useEffect(() => {
-    if (!isEqual(data, [min, max])) {
-      return setFieldsRevision(fieldsRevision + 1);
-    }
+    return setFieldsRevision(fieldsRevision + 1);
   }, [data]);
 
   const [unit, _] = useState<ValueFormat>(valueFormat);


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

- [x] we are not using the useKey() hook to re-render the input fields. They need to get updated now when data changes. reset from a panel is an example of external calls setting input values


https://github.com/user-attachments/assets/4278936a-c7f4-4fb8-b660-f05448230107



## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved responsiveness of input fields in the SliderView component to external data changes.
  
- **Documentation**
	- Updated comments for better clarity regarding the handling of external data resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->