### PR TITLE
allow passing title to ButtonView when disabled

### DIFF
--- a/app/packages/components/src/components/ModalBase/ModalBase.tsx
+++ b/app/packages/components/src/components/ModalBase/ModalBase.tsx
@@ -49,6 +49,7 @@ interface ModalButtonView {
   label: string;
   icon?: string;
   iconPosition?: string;
+  title?: string;
   componentsProps: any;
 }
 
@@ -104,6 +105,7 @@ const ModalBase: React.FC<ModalBaseProps> = ({
     variant: props?.variant || "outlined",
     label: props?.label || "",
     disabled: props?.disabled,
+    title: props?.title,
     componentsProps: {
       button: {
         sx: {

--- a/app/packages/core/src/plugins/SchemaIO/components/ButtonView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ButtonView.tsx
@@ -38,10 +38,7 @@ export default function ButtonView(props: ViewPropsType) {
 
   return (
     <Box {...getComponentProps(props, "container")}>
-      <TooltipProvider
-        title={disabled ? "" : title}
-        {...getComponentProps(props, "tooltip")}
-      >
+      <TooltipProvider title={title} {...getComponentProps(props, "tooltip")}>
         <Button
           disabled={disabled}
           variant={variant}


### PR DESCRIPTION
## What changes are proposed in this pull request?

- realized there is a TitleProvider with a title property but it was only rendering when not disabled. if we allow it to have a title regardless of disabled or not, we can pass teams specific title for permissioning


https://github.com/user-attachments/assets/87091721-0b91-43e8-83fc-7afae14e5cab



## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `title` property for button views in modals, enhancing configuration flexibility.
	- Improved tooltip behavior to consistently display titles regardless of button state.

- **Bug Fixes**
	- Adjusted button click behavior to ensure actions are only triggered when appropriate, enhancing user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->