### PR TITLE
fix modal not rendering properly in qp mode

### DIFF
--- a/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
@@ -61,7 +61,7 @@ const NumericFieldFilter = ({ color, modal, named = true, path }: Props) => {
     setShowRange(true);
   };
 
-  const showButton = isGroup && queryPerformance && !showRange;
+  const showButton = isGroup && queryPerformance && !showRange && !modal;
 
   return (
     <Container onClick={(e) => e.stopPropagation()}>

--- a/app/packages/core/src/components/Filters/StringFilter/Checkboxes.tsx
+++ b/app/packages/core/src/components/Filters/StringFilter/Checkboxes.tsx
@@ -105,7 +105,9 @@ const useValues = ({
   const boolean = useRecoilValue(isBooleanField(path));
 
   const hasCheckboxResults =
-    (!queryPerformance && counts.size <= CHECKBOX_LIMIT && !objectId) ||
+    ((!queryPerformance || modal) &&
+      counts.size <= CHECKBOX_LIMIT &&
+      !objectId) ||
     skeleton ||
     boolean;
 

--- a/app/packages/state/src/recoil/pathFilters/numeric.ts
+++ b/app/packages/state/src/recoil/pathFilters/numeric.ts
@@ -6,7 +6,7 @@ import * as filterAtoms from "../filters";
 import * as pathData from "../pathData";
 import type { Range } from "../utils";
 import { isFilterDefault } from "./utils";
-import { pathHasIndexes, queryPerformance } from "../queryPerformance";
+import { queryPerformance } from "../queryPerformance";
 
 export interface NumericFilter {
   range: Range;
@@ -147,7 +147,7 @@ export const boundsAtom = selectorFamily<
   get:
     (params) =>
     ({ get }) => {
-      if (get(queryPerformance)) {
+      if (get(queryPerformance) && !params.modal) {
         return get(pathData.lightningBounds(params.path));
       }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Modal was not rendering properly in qp mode (ranges were covered by the box and dropdown checkboxes were returning no results). These changes fix those.

## How is this patch tested? If it is not, please explain why.

Local dev

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced visibility logic for the range slider button in the NumericFieldFilter component, now contingent on modal state.
	- Updated conditions for displaying checkbox results in the Checkboxes component, allowing for broader visibility based on modal state.

- **Bug Fixes**
	- Adjusted logic in the boundsAtom selector to ensure bounds are fetched correctly based on modal parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->