### PR TITLE
set qp to false for e2e testing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest-m
     env:
       FIFTYONE_DO_NOT_TRACK: true
-      FIFTYONE_APP_ENABLE_QUERY_PERFORMANCE: false
+      FIFTYONE_APP_DEFAULT_QUERY_PERFORMANCE: false
       FIFTYONE_DATABASE_URI: mongodb://localhost:27017
       FIFTYONE_DATABASE_NAME: playwright
       ELECTRON_EXTRA_LAUNCH_ARGS: "--disable-gpu"

--- a/e2e-pw/.env.dev.template
+++ b/e2e-pw/.env.dev.template
@@ -3,5 +3,5 @@ export FIFTYONE_DATABASE_NAME=playwright
 export FIFTYONE_ROOT_DIR=/Users/johndoe/code/fiftyone
 export USE_DEV_BUILD=true
 export VENV_PATH=/Users/johndoe/fiftyone/venvs/oss
-
+export FIFTYONE_APP_DEFAULT_QUERY_PERFORMANCE=false
 export FIFTYONE_PLUGINS_DIR=$FIFTYONE_ROOT_DIR/e2e-pw/src/shared/assets/plugins


### PR DESCRIPTION
## What changes are proposed in this pull request?

e2e are failing because the sidebar is not as expected because we changed the default state of QP mode to be enabled. More tests will need to be added later but for now I am changing it to false by default so tests should resume passing.

## How is this patch tested? If it is not, please explain why.

in this pr / locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new environment variable `FIFTYONE_APP_DEFAULT_QUERY_PERFORMANCE` set to `false`, allowing for enhanced application performance configuration.
  
- **Bug Fixes**
	- Corrected the runner specification for end-to-end testing to ensure compatibility with the appropriate environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->