### PR TITLE
Query performance tooltip

### DIFF
--- a/app/packages/core/src/components/Sidebar/Entries/FilterEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterEntry.tsx
@@ -11,7 +11,7 @@ import {
   useSetRecoilState,
 } from "recoil";
 import styled from "styled-components";
-import { LightningBolt } from "./FilterablePathEntry/Icon";
+import QueryPerformanceIcon from "./QueryPerformanceIcon";
 import { FilterInputDiv } from "./utils";
 
 const Text = styled.div`
@@ -131,7 +131,7 @@ const Filter = () => {
             </Box>
           </Tooltip>
         )}
-        {queryPerformance && <LightningBolt style={{ color: "#f5b700" }} />}
+        {queryPerformance && <QueryPerformanceIcon />}
         <Tooltip
           text="Change field visibility"
           placement="bottom-center"

--- a/app/packages/core/src/components/Sidebar/Entries/QueryPerformanceIcon.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/QueryPerformanceIcon.tsx
@@ -1,0 +1,104 @@
+import { getBrowserStorageEffectForKey } from "@fiftyone/state";
+import React from "react";
+import { atom, useRecoilState } from "recoil";
+import { LightningBolt } from "./FilterablePathEntry/Icon";
+import { Tooltip, Button, Box } from "@mui/material";
+import { useTheme } from "@fiftyone/components";
+import styled from "styled-components";
+import { QP_MODE } from "@fiftyone/core";
+
+const SectionTitle = styled.div`
+  font-size: 1rem;
+  line-height: 2.25rem;
+  color: ${({ theme }) => theme.text.primary};
+`;
+
+const Text = styled.p`
+  font-size: 1rem;
+  line-height: 1.25rem;
+  margin: 0;
+  padding: 0;
+  margin-bottom: 0.5rem;
+  max-width: 215px;
+  color: ${({ theme }) => theme.text.secondary};
+
+  & > a {
+    color: ${({ theme }) => theme.primary.plainColor};
+  }
+`;
+
+const showExpandedTooltip = atom({
+  key: "showExpandedQueryPerformanceTooltip",
+  default: true,
+  effects: [
+    getBrowserStorageEffectForKey("showExpandedQueryPerformanceTooltip", {
+      valueClass: "boolean",
+    }),
+  ],
+});
+
+const QueryPerformanceIcon = () => {
+  const theme = useTheme();
+  const [showExpanded, setShowExpanded] = useRecoilState(showExpandedTooltip);
+  return (
+    <Tooltip
+      title={
+        <div>
+          {showExpanded ? (
+            <Box>
+              <SectionTitle>Query Performance is Enabled</SectionTitle>
+              <Text>
+                Some fields are indexed for better query performance. You can
+                create or manage indexes from here.
+              </Text>
+              <Box display="flex" alignItems="center">
+                <Button
+                  variant="contained"
+                  sx={{
+                    marginLeft: "auto",
+                    backgroundColor: theme.primary.main,
+                    color: theme.text.primary,
+                    boxShadow: 0,
+                  }}
+                  onClick={() => {
+                    window.open(QP_MODE, "_blank")?.focus();
+                  }}
+                >
+                  View Documentation
+                </Button>
+                <Button
+                  onClick={() => {
+                    setShowExpanded(false);
+                  }}
+                  variant="text"
+                  color="secondary"
+                  style={{ marginLeft: "auto", color: theme.text.secondary }}
+                >
+                  Got it
+                </Button>
+              </Box>
+            </Box>
+          ) : (
+            <SectionTitle>Query Performance is Enabled</SectionTitle>
+          )}
+        </div>
+      }
+      placement="bottom"
+      arrow={true}
+      componentsProps={{
+        tooltip: {
+          sx: {
+            bgcolor: theme.custom.toastBackgroundColor,
+            "& .MuiTooltip-arrow": {
+              color: theme.custom.toastBackgroundColor,
+            },
+          },
+        },
+      }}
+    >
+      <LightningBolt style={{ color: "#f5b700" }} />
+    </Tooltip>
+  );
+};
+
+export default QueryPerformanceIcon;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add tooltip for query performance mode icon

## How is this patch tested? If it is not, please explain why.

![2024-11-08 11 51 16](https://github.com/user-attachments/assets/f458fac2-d7d7-4429-9f2d-de58ecd4e78b)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

When in query performance mode if you hover the lightning bolt you'll be given a dismissable tooltip which gives context to query performance mode.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `QueryPerformanceIcon` component that provides a tooltip displaying query performance information.
	- Updated the `Filter` component to use the new `QueryPerformanceIcon` instead of the previous icon.

- **Bug Fixes**
	- Ensured that the tooltip functionality remains intact with updated visual representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->