### PR TITLE
Exection store interface cleanup

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -49,6 +49,7 @@ fov = fou.lazy_import("fiftyone.core.view")
 foua = fou.lazy_import("fiftyone.utils.annotations")
 foud = fou.lazy_import("fiftyone.utils.data")
 foue = fou.lazy_import("fiftyone.utils.eval")
+foos = fou.lazy_import("fiftyone.operators.store")
 
 
 logger = logging.getLogger(__name__)
@@ -10950,6 +10951,24 @@ class SampleCollection(object):
                 values_map[_id] = _val
 
         return [values_map.get(i, None) for i in ids]
+
+    def _has_stores(self):
+        dataset_id = self._root_dataset._doc.id
+        svc = foos.ExecutionStoreService(dataset_id=dataset_id)
+        return svc.count_stores() > 0
+
+    def _list_stores(self):
+        dataset_id = self._root_dataset._doc.id
+        svc = foos.ExecutionStoreService(dataset_id=dataset_id)
+        return svc.list_stores()
+
+    def _get_store(self, store_name):
+        dataset_id = self._root_dataset._doc.id
+        svc = foos.ExecutionStoreService(dataset_id=dataset_id)
+        if not svc.has_store(store_name):
+            raise ValueError(f"Dataset has no store '{store_name}'")
+
+        return foos.ExecutionStore(store_name, svc)
 
 
 def _iter_label_fields(sample_collection):

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -5181,7 +5181,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             self._frame_collection.drop()
             fofr.Frame._reset_docs(self._frame_collection_name)
 
-        foos.cleanup_store_for_dataset(self._doc.id)
+        svc = foos.ExecutionStoreService(dataset_id=self._doc.id)
+        svc.cleanup()
 
         # Update singleton
         self._instances.pop(self._doc.name, None)

--- a/fiftyone/core/odm/__init__.py
+++ b/fiftyone/core/odm/__init__.py
@@ -36,6 +36,7 @@ from .database import (
     drop_orphan_collections,
     drop_orphan_saved_views,
     drop_orphan_runs,
+    drop_orphan_stores,
     list_collections,
     get_collection_stats,
     stream_collection,

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -37,7 +37,6 @@ fob = fou.lazy_import("fiftyone.core.brain")
 fod = fou.lazy_import("fiftyone.core.dataset")
 foe = fou.lazy_import("fiftyone.core.evaluation")
 fors = fou.lazy_import("fiftyone.core.runs")
-foos = fou.lazy_import("fiftyone.operators.store")
 
 
 logger = logging.getLogger(__name__)
@@ -1157,12 +1156,14 @@ def delete_dataset(name, dry_run=False):
         if not dry_run:
             _delete_run_results(conn, result_ids)
 
-    svc = foos.ExecutionStoreService(dataset_id=dataset_dict["_id"])
-    num_stores = svc.count_stores()
+    _id = dataset_dict["_id"]
+    num_stores = conn.execution_store.count_documents(
+        {"dataset_id": _id, "key": "__store__"}
+    )
     if num_stores > 0:
         _logger.info("Deleting %d store(s)", num_stores)
         if not dry_run:
-            svc.cleanup()
+            conn.execution_store.delete_many({"dataset_id": _id})
 
 
 def delete_saved_view(dataset_name, view_name, dry_run=False):

--- a/fiftyone/factory/repo_factory.py
+++ b/fiftyone/factory/repo_factory.py
@@ -6,10 +6,11 @@ FiftyOne repository factory.
 |
 """
 
+from typing import Optional
+
+from bson import ObjectId
 from pymongo.database import Database
 
-import bson
-from typing import Optional
 import fiftyone.core.odm as foo
 from fiftyone.factory.repos.delegated_operation import (
     DelegatedOperationRepo,
@@ -19,6 +20,7 @@ from fiftyone.factory.repos.execution_store import (
     ExecutionStoreRepo,
     MongoExecutionStoreRepo,
 )
+
 
 _db: Database = None
 
@@ -53,9 +55,8 @@ class RepositoryFactory(object):
 
     @staticmethod
     def execution_store_repo(
-        dataset_id: Optional[bson.ObjectId] = None,
+        dataset_id: Optional[ObjectId] = None,
     ) -> ExecutionStoreRepo:
-        """Factory method for execution store repository."""
         if (
             MongoExecutionStoreRepo.COLLECTION_NAME
             not in RepositoryFactory.repos

--- a/fiftyone/factory/repos/execution_store.py
+++ b/fiftyone/factory/repos/execution_store.py
@@ -52,8 +52,7 @@ class ExecutionStoreRepo(object):
                 store_name=store_name,
                 key="__store__",
                 dataset_id=self._dataset_id,
-            ),
-            {},
+            )
         )
         return bool(result)
 

--- a/fiftyone/factory/repos/execution_store.py
+++ b/fiftyone/factory/repos/execution_store.py
@@ -34,11 +34,10 @@ class ExecutionStoreRepo(object):
         self._collection = collection
         self._dataset_id = dataset_id
 
-    def create_store(self, store_name, permissions=None) -> StoreDocument:
+    def create_store(self, store_name) -> StoreDocument:
         """Creates a store associated with the current context."""
         store_doc = StoreDocument(
             store_name=store_name,
-            value=permissions,
             dataset_id=self._dataset_id,
         )
         self._collection.insert_one(store_doc.to_mongo_dict())

--- a/fiftyone/factory/repos/execution_store.py
+++ b/fiftyone/factory/repos/execution_store.py
@@ -15,7 +15,18 @@ from fiftyone.operators.store.models import StoreDocument, KeyDocument
 
 
 class ExecutionStoreRepo(object):
-    """Base class for execution store repositories."""
+    """Base class for execution store repositories.
+
+    Each instance of this repository has a context:
+
+    -   If a ``dataset_id`` is provided, it operates on stores associated with
+        that dataset
+    -   If no ``dataset_id`` is provided, it operates on stores that are not
+        associated with a dataset
+
+    To operate on all stores across all contexts, use the ``XXX_global()``
+    methods that this class provides.
+    """
 
     COLLECTION_NAME = "execution_store"
 

--- a/fiftyone/factory/repos/execution_store.py
+++ b/fiftyone/factory/repos/execution_store.py
@@ -164,7 +164,11 @@ class ExecutionStoreRepo(object):
     def list_keys(self, store_name) -> list[str]:
         """Lists all keys in the specified store."""
         result = self._collection.find(
-            dict(store_name=store_name, dataset_id=self._dataset_id),
+            dict(
+                store_name=store_name,
+                key={"$ne": "__store__"},
+                dataset_id=self._dataset_id,
+            ),
             {"key": 1},
         )
         return [d["key"] for d in result]
@@ -172,7 +176,11 @@ class ExecutionStoreRepo(object):
     def count_keys(self, store_name) -> int:
         """Counts the keys in the specified store."""
         return self._collection.count_documents(
-            dict(store_name=store_name, dataset_id=self._dataset_id)
+            dict(
+                store_name=store_name,
+                key={"$ne": "__store__"},
+                dataset_id=self._dataset_id,
+            )
         )
 
     def cleanup(self) -> int:

--- a/fiftyone/operators/store/__init__.py
+++ b/fiftyone/operators/store/__init__.py
@@ -1,5 +1,5 @@
 """
-FiftyOne execution store module.
+Execution store.
 
 | Copyright 2017-2024, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
@@ -7,7 +7,7 @@ FiftyOne execution store module.
 """
 import types
 
-from .service import cleanup_store_for_dataset, ExecutionStoreService
+from .service import ExecutionStoreService
 from .store import ExecutionStore
 from .models import StoreDocument, KeyDocument
 

--- a/fiftyone/operators/store/models.py
+++ b/fiftyone/operators/store/models.py
@@ -1,7 +1,16 @@
-import bson
+"""
+Execution store models.
+
+| Copyright 2017-2024, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from datetime import datetime, timedelta
 from dataclasses import dataclass, field, asdict
-from typing import Optional, Dict, Any
-import datetime
+from typing import Optional, Any
+
+from bson import ObjectId
 
 
 @dataclass
@@ -11,22 +20,21 @@ class KeyDocument:
     store_name: str
     key: str
     value: Any
-    created_at: datetime.datetime = field(
-        default_factory=datetime.datetime.now
-    )
     _id: Optional[Any] = None
-    updated_at: Optional[datetime.datetime] = None
-    expires_at: Optional[datetime.datetime] = None
-    dataset_id: Optional[bson.ObjectId] = None
+    dataset_id: Optional[ObjectId] = None
+    created_at: datetime = field(default_factory=datetime.now)
+    updated_at: Optional[datetime] = None
+    expires_at: Optional[datetime] = None
 
     @staticmethod
-    def get_expiration(ttl: Optional[int]) -> Optional[datetime.datetime]:
+    def get_expiration(ttl: Optional[int]) -> Optional[datetime]:
         """Gets the expiration date for a key with the given TTL."""
         if ttl is None:
             return None
-        return datetime.datetime.now() + datetime.timedelta(seconds=ttl)
 
-    def to_mongo_dict(self, exclude_id: bool = True) -> Dict[str, Any]:
+        return datetime.now() + timedelta(seconds=ttl)
+
+    def to_mongo_dict(self, exclude_id: bool = True) -> dict[str, Any]:
         """Serializes the document to a MongoDB dictionary."""
         data = asdict(self)
         if exclude_id:
@@ -41,4 +49,4 @@ class StoreDocument(KeyDocument):
     """Model representing a Store."""
 
     key: str = "__store__"
-    value: Optional[Dict[str, Any]] = None
+    value: Optional[dict[str, Any]] = None

--- a/fiftyone/operators/store/models.py
+++ b/fiftyone/operators/store/models.py
@@ -22,7 +22,7 @@ class KeyDocument:
     value: Any
     _id: Optional[Any] = None
     dataset_id: Optional[ObjectId] = None
-    created_at: datetime = field(default_factory=datetime.now)
+    created_at: datetime = field(default_factory=datetime.utcnow)
     updated_at: Optional[datetime] = None
     expires_at: Optional[datetime] = None
 
@@ -32,7 +32,7 @@ class KeyDocument:
         if ttl is None:
             return None
 
-        return datetime.now() + timedelta(seconds=ttl)
+        return datetime.utcnow() + timedelta(seconds=ttl)
 
     def to_mongo_dict(self, exclude_id: bool = True) -> dict[str, Any]:
         """Serializes the document to a MongoDB dictionary."""

--- a/fiftyone/operators/store/service.py
+++ b/fiftyone/operators/store/service.py
@@ -13,17 +13,31 @@ from fiftyone.operators.store.models import StoreDocument, KeyDocument
 
 
 class ExecutionStoreService(object):
+    """Service for managing execution store operations.
+
+    Note that each instance of this service has a context:
+
+    -   If a ``dataset_id`` is provided (or a ``repo`` associated with one),
+        this instance operates on stores associated with that dataset
+    -   If no ``dataset_id`` is provided (or a ``repo`` is provided that is not
+        associated with one), this instance operates on stores that are not
+        associated with a dataset
+
+    To operate on all stores across all contexts, use the ``XXX_global()``
+    methods that this class provides.
+
+    Args:
+        repo (None): a
+            :class:`fiftyone.factory.repos.execution_store.ExecutionStoreRepo`
+        dataset_id (None): a dataset ID to scope operations to
+    """
+
     def __init__(
         self,
         repo: Optional["ExecutionStoreRepo"] = None,
         dataset_id: Optional[ObjectId] = None,
     ):
-        """Service for managing execution store operations.
 
-        Args:
-            repo (None): execution store repository instance
-            dataset_id (None): a dataset ID to scope operations to
-        """
         from fiftyone.factory.repo_factory import (
             RepositoryFactory,
             ExecutionStoreRepo,

--- a/fiftyone/operators/store/store.py
+++ b/fiftyone/operators/store/store.py
@@ -1,40 +1,40 @@
 """
-FiftyOne execution store.
+Execution store class.
 
 | Copyright 2017-2024, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
 
-import bson
-import logging
 from typing import Any, Optional
+
+from bson import ObjectId
 
 from fiftyone.operators.store.service import ExecutionStoreService
 
 
-logger = logging.getLogger(__name__)
-
-
 class ExecutionStore(object):
+    """Execution store.
+
+    Args:
+        store_name: the name of the store
+        store_service: an
+            :class:`fiftyone.operators.store.service.ExecutionStoreService`
+    """
+
     def __init__(self, store_name: str, store_service: ExecutionStoreService):
-        """
-        Args:
-            store_name (str): The name of the store.
-            store_service (ExecutionStoreService): The store service instance.
-        """
         self.store_name: str = store_name
         self._store_service: ExecutionStoreService = store_service
 
     @staticmethod
     def create(
-        store_name: str, dataset_id: Optional[bson.ObjectId] = None
+        store_name: str, dataset_id: Optional[ObjectId] = None
     ) -> "ExecutionStore":
         return ExecutionStore(
             store_name, ExecutionStoreService(dataset_id=dataset_id)
         )
 
-    def list_all_stores(self) -> list[str]:
+    def list_stores(self) -> list[str]:
         """Lists all stores in the execution store.
 
         Returns:
@@ -64,7 +64,7 @@ class ExecutionStore(object):
             value: the value to store
             ttl (None): the time-to-live in seconds
         """
-        self._store_service.set_key(self.store_name, key, value, ttl)
+        self._store_service.set_key(self.store_name, key, value, ttl=ttl)
 
     def delete(self, key: str) -> bool:
         """Deletes a key from the store.

--- a/fiftyone/operators/utils.py
+++ b/fiftyone/operators/utils.py
@@ -6,8 +6,9 @@ FiftyOne operator utilities.
 |
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
+
 from .operator import Operator
 
 
@@ -69,34 +70,36 @@ def is_method_overridden(base_class, sub_class_instance, method_name):
     return base_method != sub_method
 
 
-from datetime import datetime, timedelta
-
-
 def is_new(release_date, days=30):
     """
     Determines if a feature is considered "new" based on its release date.
 
-    A feature is considered new if its release date is within the specified number of days.
+    A feature is considered new if its release date is within the specified
+    number of days.
+
+    Examples::
+
+        is_new("2024-11-09")
+        # True if today's date is within 30 days after 2024-11-09
+
+        is_new(datetime(2024, 11, 9), days=15)
+        # True if today's date is within 15 days after November 9, 2024
+
+        is_new("2024-10-01", days=45)
+        # False if today's date is more than 45 days after October 1, 2024
 
     Args:
-        release_date (str or datetime): The release date of the feature.
-            - If a string, it should be in the format "%Y-%m-%d" (e.g., "2024-11-09").
-            - If a datetime object, it will be used directly without conversion.
-        days (int, optional): The number of days within which the feature is considered new.
-            Defaults to 30.
+        release_date: the release date of the feature, in one of the following
+            formats:
+
+            -   a string in the format ``"%Y-%m-%d"``, e.g., ``"2024-11-09"``
+            -   a datetime instance
+
+        days (30): the number of days for which the feature is considered new
 
     Returns:
-        bool: True if the release date is within the specified number of days, False otherwise.
-
-    Examples:
-        >>> is_new("2024-11-09")  # Using a string date and default days
-        True  # if today's date is within 30 days after 2024-11-09
-
-        >>> is_new(datetime(2024, 11, 9), days=15)  # Using a datetime object with 15-day threshold
-        True  # if today's date is within 15 days after November 9, 2024
-
-        >>> is_new("2024-10-01", days=45)
-        False  # if today's date is more than 45 days after October 1, 2024
+        True/False whether the release date is within the specified number of
+        days
     """
     if isinstance(release_date, str):
         release_date = datetime.strptime(release_date, "%Y-%m-%d")

--- a/tests/unittests/execution_store_tests.py
+++ b/tests/unittests/execution_store_tests.py
@@ -249,6 +249,22 @@ class TestExecutionStoreIntegration(unittest.TestCase):
             {"key": 1},
         )
 
+    def test_has_store(self):
+        self.mock_collection.find_one.return_value = {
+            "store_name": "mock_store",
+            "key": "__store__",
+        }
+        has_store = self.store_service.has_store("mock_store")
+        assert has_store
+        self.mock_collection.find_one.assert_called_once()
+        self.mock_collection.find_one.assert_called_with(
+            {
+                "store_name": "mock_store",
+                "key": "__store__",
+                "dataset_id": None,
+            }
+        )
+
     def test_delete(self):
         self.mock_collection.delete_one.return_value = Mock(deleted_count=1)
         deleted = self.store.delete("widget_1")

--- a/tests/unittests/execution_store_tests.py
+++ b/tests/unittests/execution_store_tests.py
@@ -59,7 +59,11 @@ class ExecutionStoreServiceIntegrationTests(unittest.TestCase):
         )
         self.mock_collection.update_one.assert_called_once()
         self.mock_collection.update_one.assert_called_with(
-            {"store_name": "widgets", "key": "widget_1"},
+            {
+                "store_name": "widgets",
+                "key": "widget_1",
+                "dataset_id": None,
+            },
             {
                 "$set": {
                     "value": {"name": "Widget One", "value": 100},
@@ -80,6 +84,7 @@ class ExecutionStoreServiceIntegrationTests(unittest.TestCase):
             "store_name": "widgets",
             "key": "widget_1",
             "value": {"name": "Widget One", "value": 100},
+            "dataset_id": None,
             "created_at": time.time(),
             "updated_at": time.time(),
             "expires_at": time.time() + 60000,
@@ -87,7 +92,11 @@ class ExecutionStoreServiceIntegrationTests(unittest.TestCase):
         self.store_service.get_key(store_name="widgets", key="widget_1")
         self.mock_collection.find_one.assert_called_once()
         self.mock_collection.find_one.assert_called_with(
-            {"store_name": "widgets", "key": "widget_1"}
+            {
+                "store_name": "widgets",
+                "key": "widget_1",
+                "dataset_id": None,
+            }
         )
 
     def test_create_store(self):
@@ -109,7 +118,11 @@ class ExecutionStoreServiceIntegrationTests(unittest.TestCase):
         self.store_repo.delete_key("widgets", "widget_1")
         self.mock_collection.delete_one.assert_called_once()
         self.mock_collection.delete_one.assert_called_with(
-            {"store_name": "widgets", "key": "widget_1"}
+            {
+                "store_name": "widgets",
+                "key": "widget_1",
+                "dataset_id": None,
+            }
         )
 
     def test_update_ttl(self):
@@ -129,7 +142,7 @@ class ExecutionStoreServiceIntegrationTests(unittest.TestCase):
         self.store_repo.delete_store("widgets")
         self.mock_collection.delete_many.assert_called_once()
         self.mock_collection.delete_many.assert_called_with(
-            {"store_name": "widgets"}
+            {"store_name": "widgets", "dataset_id": None}
         )
 
     def test_list_keys(self):
@@ -141,15 +154,22 @@ class ExecutionStoreServiceIntegrationTests(unittest.TestCase):
         assert keys == ["widget_1", "widget_2"]
         self.mock_collection.find.assert_called_once()
         self.mock_collection.find.assert_called_with(
-            {"store_name": "widgets"}, {"key": 1}
+            {"store_name": "widgets", "dataset_id": None},
+            {"key": 1},
         )
 
     def test_list_stores(self):
-        self.mock_collection.distinct.return_value = ["widgets", "gadgets"]
+        self.mock_collection.find.return_value = [
+            {"store_name": "widgets"},
+            {"store_name": "gadgets"},
+        ]
         stores = self.store_repo.list_stores()
         assert stores == ["widgets", "gadgets"]
-        self.mock_collection.distinct.assert_called_once()
-        self.mock_collection.distinct.assert_called_with("store_name")
+        self.mock_collection.find.assert_called_once()
+        self.mock_collection.find.assert_called_with(
+            {"key": "__store__", "dataset_id": None},
+            {"store_name": 1},
+        )
 
 
 class TestExecutionStoreIntegration(unittest.TestCase):
@@ -165,7 +185,11 @@ class TestExecutionStoreIntegration(unittest.TestCase):
         )
         self.mock_collection.update_one.assert_called_once()
         self.mock_collection.update_one.assert_called_with(
-            {"store_name": "mock_store", "key": "widget_1"},
+            {
+                "store_name": "mock_store",
+                "key": "widget_1",
+                "dataset_id": None,
+            },
             {
                 "$set": {
                     "updated_at": IsDateTime(),
@@ -186,6 +210,7 @@ class TestExecutionStoreIntegration(unittest.TestCase):
             "store_name": "mock_store",
             "key": "widget_1",
             "value": {"name": "Widget One", "value": 100},
+            "dataset_id": None,
             "created_at": time.time(),
             "updated_at": time.time(),
             "expires_at": time.time() + 60000,
@@ -194,7 +219,11 @@ class TestExecutionStoreIntegration(unittest.TestCase):
         assert value == {"name": "Widget One", "value": 100}
         self.mock_collection.find_one.assert_called_once()
         self.mock_collection.find_one.assert_called_with(
-            {"store_name": "mock_store", "key": "widget_1"}
+            {
+                "store_name": "mock_store",
+                "key": "widget_1",
+                "dataset_id": None,
+            }
         )
 
     def test_list_keys(self):
@@ -206,7 +235,8 @@ class TestExecutionStoreIntegration(unittest.TestCase):
         assert keys == ["widget_1", "widget_2"]
         self.mock_collection.find.assert_called_once()
         self.mock_collection.find.assert_called_with(
-            {"store_name": "mock_store"}, {"key": 1}
+            {"store_name": "mock_store", "dataset_id": None},
+            {"key": 1},
         )
 
     def test_delete(self):
@@ -215,14 +245,18 @@ class TestExecutionStoreIntegration(unittest.TestCase):
         assert deleted
         self.mock_collection.delete_one.assert_called_once()
         self.mock_collection.delete_one.assert_called_with(
-            {"store_name": "mock_store", "key": "widget_1"}
+            {
+                "store_name": "mock_store",
+                "key": "widget_1",
+                "dataset_id": None,
+            }
         )
 
     def test_clear(self):
         self.store.clear()
         self.mock_collection.delete_many.assert_called_once()
         self.mock_collection.delete_many.assert_called_with(
-            {"store_name": "mock_store"}
+            {"store_name": "mock_store", "dataset_id": None}
         )
 
 

--- a/tests/unittests/execution_store_tests.py
+++ b/tests/unittests/execution_store_tests.py
@@ -31,7 +31,7 @@ def assert_delta_seconds_approx(time_delta, seconds, epsilon=EPSILON):
     assert abs(time_delta.total_seconds() - seconds) < epsilon
 
 
-class TeskKeyDocument(unittest.TestCase):
+class TestKeyDocument(unittest.TestCase):
     def test_get_expiration(self):
         ttl = 1
         now = datetime.utcnow()


### PR DESCRIPTION
## Change log

- bug fix: must use `datetime.utcnow()` rather than `datetime.now()` to ensure TTL cleanup works as expected
- Updated the `ExecutionStoreRepo` interface so that all methods are restricted to the current dataset context (or the global datasetless context). Previously some methods were scoped to the current dataset while others were not, which could cause unexpected behavior. New `list_stores_global()` and `has_store_global()` methods are added that really do query across all contexts, if this is desired
- added a `foo.drop_orphan_stores()` utility
- added private `_has_store()`, `_list_stores()`, and `_get_store()` utils to the `SampleCollection` class for internal usage
- general linting of docstrings to be Sphinx-friendly

## Example usage

```py
import fiftyone as fo
import fiftyone.core.odm as foo
import fiftyone.operators.store as foos

d = fo.Dataset()

svc = foos.ExecutionStoreService(dataset_id=d._doc.id)
svc.create_store("test")
svc.set_key("test", "foo", {"spam": "eggs"})

print(d._has_stores())
print(d._list_stores())
store = d._get_store("test")
print(store.get("foo"))

foo.delete_dataset(d.name, dry_run=True)
foo.delete_dataset(d.name, dry_run=False)

foo.drop_orphan_stores(dry_run=True)
foo.drop_orphan_stores(dry_run=False)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added methods for managing execution stores, including checking for stores, listing stores, and fetching specific stores.
	- Introduced a function to remove orphaned execution stores associated with non-existent datasets.
	- Enhanced the `ExecutionStoreService` with new methods for store and key management.

- **Bug Fixes**
	- Updated internal logic for dataset deletion to improve cleanup processes.

- **Documentation**
	- Improved documentation clarity for several methods and functions throughout the codebase.

- **Tests**
	- Enhanced unit tests to ensure dataset ID handling in execution store operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->