### PR TITLE
Fix sample count not showing in grid and qp mode padding

### DIFF
--- a/app/packages/core/src/components/Sidebar/Entries/EntryCounts.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/EntryCounts.tsx
@@ -44,7 +44,8 @@ export const PathEntryCounts = ({ modal, path }: PathEntryCountsProps) => {
   const queryPerformance = useRecoilValue(fos.queryPerformance);
   const shown = useRecoilValue(showEntryCounts({ modal, path }));
 
-  return (!queryPerformance || hasFilters) && shown ? (
+  // empty path means we are showing grid sample count which is always allowed
+  return (!queryPerformance || hasFilters || path === "") && shown ? (
     <SuspenseEntryCounts
       countAtom={queryPerformance ? undefined : getAtom(false)}
       subcountAtom={getAtom(true)}

--- a/app/packages/core/src/components/Sidebar/Entries/FilterEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterEntry.tsx
@@ -90,7 +90,7 @@ const Filter = () => {
         )}
       </Box>
 
-      <Box display="flex" alignItems="center">
+      <Box display="flex" alignItems="center" gap="4px">
         {isFieldVisibilityActive && (
           <Tooltip text="Clear field selection" placement="bottom-center">
             <Box


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix sample count not showing in grid and qp mode padding

## How is this patch tested? If it is not, please explain why.

![2024-11-11 13 40 55](https://github.com/user-attachments/assets/8a58029d-077e-4238-8a2d-0c588ce3eaf7)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `PathEntryCounts` component to display grid sample counts even when the path is empty.
	- Improved layout of the `Filter` component by adding spacing between visibility controls.

- **Bug Fixes**
	- Adjusted rendering conditions to ensure proper display of entry counts based on the current state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->