### PR TITLE
Summary field and index improvements

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1673,6 +1673,18 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             self.get_field_schema(flat=True, info_keys=_SUMMARY_FIELD_KEY)
         )
 
+    def _get_summarized_fields_map(self):
+        schema = self.get_field_schema(flat=True, info_keys=_SUMMARY_FIELD_KEY)
+
+        summarized_fields = {}
+        for path, field in schema.items():
+            summary_info = field.info[_SUMMARY_FIELD_KEY]
+            source_path = summary_info.get("path", None)
+            if source_path is not None:
+                summarized_fields[source_path] = path
+
+        return summarized_fields
+
     def create_summary_field(
         self,
         path,
@@ -1750,13 +1762,25 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         """
         _field = self.get_field(path)
 
-        if isinstance(_field, (fof.StringField, fof.BooleanField)):
+        is_list_field = isinstance(_field, fof.ListField)
+        if is_list_field:
+            _field = _field.field
+
+        if isinstance(
+            _field,
+            (fof.StringField, fof.BooleanField, fof.ObjectIdField),
+        ):
             field_type = "categorical"
         elif isinstance(
             _field,
             (fof.FloatField, fof.IntField, fof.DateField, fof.DateTimeField),
         ):
             field_type = "numeric"
+        elif is_list_field:
+            raise ValueError(
+                f"Cannot generate a summary for list field '{path}' with "
+                f"element type {type(_field)}"
+            )
         elif _field is not None:
             raise ValueError(
                 f"Cannot generate a summary for field '{path}' of "
@@ -1889,8 +1913,17 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         return field_name
 
     def _get_default_summary_field_name(self, path):
-        _path, is_frame_field, list_fields, _, _ = self._parse_field_name(path)
+        (
+            _path,
+            is_frame_field,
+            list_fields,
+            _,
+            id_to_str,
+        ) = self._parse_field_name(path)
+
         _chunks = _path.split(".")
+        if id_to_str:
+            _chunks = [c[1:] if c.startswith("_") else c for c in _chunks]
 
         chunks = []
         if is_frame_field:
@@ -1907,7 +1940,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if found_list:
             chunks.append(_chunks[-1])
 
-        return "_".join(chunks)
+        field_name = "_".join(chunks)
+
+        if field_name == path:
+            field_name += "_summary"
+
+        return field_name
 
     def _populate_summary_field(self, field_name, summary_info):
         path = summary_info["path"]

--- a/fiftyone/operators/builtin.py
+++ b/fiftyone/operators/builtin.py
@@ -1158,7 +1158,7 @@ class CreateSummaryField(foo.Operator):
 
     def execute(self, ctx):
         path = ctx.params["path"]
-        field_name = ctx.params.get("field_name", None)
+        _, field_name = _get_dynamic(ctx.params, "field_name", path, None)
         sidebar_group = ctx.params.get("sidebar_group", None)
         include_counts = ctx.params.get("include_counts", False)
         group_by = ctx.params.get("group_by", None)
@@ -1182,6 +1182,12 @@ class CreateSummaryField(foo.Operator):
         )
 
         ctx.trigger("reload_dataset")
+
+
+def _get_dynamic(params, key, ref_path, default=None):
+    dynamic_key = key + "|" + ref_path.replace(".", "_")
+    value = params.get(dynamic_key, default)
+    return dynamic_key, value
 
 
 def _create_summary_field_inputs(ctx, inputs):
@@ -1240,14 +1246,14 @@ def _create_summary_field_inputs(ctx, inputs):
     if path is None or path not in path_keys:
         return
 
-    field_name = ctx.params.get("field_name", None)
+    prop_name, field_name = _get_dynamic(ctx.params, "field_name", path, None)
     if field_name is None:
         default_field_name = ctx.dataset._get_default_summary_field_name(path)
     else:
         default_field_name = field_name
 
-    field_name_prop = inputs.str(
-        "field_name",
+    prop = inputs.str(
+        prop_name,
         required=False,
         label="Summary field",
         description="The sample field in which to store the summary data",
@@ -1255,8 +1261,8 @@ def _create_summary_field_inputs(ctx, inputs):
     )
 
     if field_name and field_name in schema:
-        field_name_prop.invalid = True
-        field_name_prop.error_message = f"Field '{field_name}' already exists"
+        prop.invalid = True
+        prop.error_message = f"Field '{field_name}' already exists"
         inputs.str(
             "error",
             label="Error",


### PR DESCRIPTION
## Change log

- Added support for generating summary fields for `ObjectIdField` and `ListField` 
- Improved default summary field name logic to prevent name clashes with existing fields
- Only show valid + unindexed fields in `create_index` operator
- Fixed a bug with frame-level default indexes in the builtin `drop_index` operator

## Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video")

# None of these were previously possible, now they are
dataset.create_summary_field("tags")
dataset.create_summary_field("id")
dataset.create_summary_field("frames.detections.detections.id")
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced summary field creation with improved validation for field types, including support for `ObjectIdField`.
	- Asynchronous index creation with the addition of a `wait` parameter.

- **Bug Fixes**
	- Improved error handling and user feedback for invalid input when creating or renaming fields.

- **Refactor**
	- Simplified input resolution methods and sorting logic for better clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->