### PR TITLE
Add FrameNumberField  support for lightning queries

### DIFF
--- a/fiftyone/server/lightning.py
+++ b/fiftyone/server/lightning.py
@@ -97,7 +97,6 @@ INT_CLS = {
     fof.DateField: DateLightningResult,
     fof.DateTimeField: DateTimeLightningResult,
     fof.FrameNumberField: IntLightningResult,
-    fof.FrameSupportField: IntLightningResult,
     fof.IntField: IntLightningResult,
 }
 

--- a/fiftyone/server/lightning.py
+++ b/fiftyone/server/lightning.py
@@ -96,6 +96,8 @@ class StringLightningResult(LightningResult):
 INT_CLS = {
     fof.DateField: DateLightningResult,
     fof.DateTimeField: DateTimeLightningResult,
+    fof.FrameNumberField: IntLightningResult,
+    fof.FrameSupportField: IntLightningResult,
     fof.IntField: IntLightningResult,
 }
 

--- a/tests/unittests/lightning_tests.py
+++ b/tests/unittests/lightning_tests.py
@@ -282,6 +282,98 @@ class TestDatetimeLightningQueries(unittest.IsolatedAsyncioTestCase):
         )
 
 
+class TestIntLightningQueries(unittest.IsolatedAsyncioTestCase):
+    @drop_async_dataset
+    async def test_ints(self, dataset: fo.Dataset):
+        dataset.add_sample_field("frame_numbers", fo.FrameNumberField)
+        dataset.add_sample_field("frame_supports", fo.FrameSupportField)
+        dataset.add_sample_field("ints", fo.IntField)
+        keys = _add_samples(
+            dataset,
+            dict(ints=1, frame_numbers=1, frame_supports=[1, 1]),
+            dict(ints=2, frame_numbers=2, frame_supports=[2, 2]),
+        )
+
+        query = """
+            query Query($input: LightningInput!) {
+                lightning(input: $input) {
+                    ... on IntLightningResult {
+                        max
+                        min
+                        path
+                    }
+                }
+            }
+        """
+
+        result = await _execute(
+            query,
+            dataset,
+            (fo.FrameNumberField, fo.FrameSupportField, fo.IntField),
+            keys,
+        )
+
+        self.assertListEqual(
+            result.data["lightning"],
+            [
+                {
+                    "max": 2.0,
+                    "min": 1.0,
+                    "path": "classification.frame_numbers",
+                },
+                {
+                    "max": 2.0,
+                    "min": 1.0,
+                    "path": "classification.frame_supports",
+                },
+                {"max": 2.0, "min": 1.0, "path": "classification.ints"},
+                {
+                    "max": 2.0,
+                    "min": 1.0,
+                    "path": "detections.detections.frame_numbers",
+                },
+                {
+                    "max": 2.0,
+                    "min": 1.0,
+                    "path": "detections.detections.frame_supports",
+                },
+                {"max": 2.0, "min": 1.0, "path": "detections.detections.ints"},
+                {"max": 2.0, "min": 1.0, "path": "frame_numbers"},
+                {"max": 2.0, "min": 1.0, "path": "frame_supports"},
+                {
+                    "max": 2.0,
+                    "min": 1.0,
+                    "path": "frames.classification.frame_numbers",
+                },
+                {
+                    "max": 2.0,
+                    "min": 1.0,
+                    "path": "frames.classification.frame_supports",
+                },
+                {"max": 2.0, "min": 1.0, "path": "frames.classification.ints"},
+                {
+                    "max": 2.0,
+                    "min": 1.0,
+                    "path": "frames.detections.detections.frame_numbers",
+                },
+                {
+                    "max": 2.0,
+                    "min": 1.0,
+                    "path": "frames.detections.detections.frame_supports",
+                },
+                {
+                    "max": 2.0,
+                    "min": 1.0,
+                    "path": "frames.detections.detections.ints",
+                },
+                {"max": 2.0, "min": 1.0, "path": "frames.frame_numbers"},
+                {"max": 2.0, "min": 1.0, "path": "frames.frame_supports"},
+                {"max": 2.0, "min": 1.0, "path": "frames.ints"},
+                {"max": 2.0, "min": 1.0, "path": "ints"},
+            ],
+        )
+
+
 class TestFloatLightningQueries(unittest.IsolatedAsyncioTestCase):
     @drop_async_dataset
     async def test_floats(self, dataset: fo.Dataset):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds missing FrameNumberField support for lightning queries. With QP enabled, the below field will error when expanding it in the sidebar

```python
import fiftyone as fo
import fiftyone.zoo as foz 

dataset = foz.load_zoo_dataset("quickstart")
dataset.add_sample_field("frame_number", fo.FrameNumberField)
``` 

## How is this patch tested? If it is not, please explain why.

Unit tests

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for handling frame number fields in lightning queries, allowing structured responses similar to integer fields.

- **Tests**
	- Added a new test class to validate integer-related queries in the Lightning API, enhancing test coverage for integer fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->