### PR TITLE
chore(ci): AS-326 Conditional GitHub Actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,13 +10,43 @@ on:
       - release/v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
+  modified-files:
+    runs-on: ubuntu-latest
+    outputs:
+      app-changes: ${{ steps.filter.outputs.app }}
+      e2e-changes: ${{ steps.filter.outputs.e2e-pw }}
+      fiftyone-changes: ${{ steps.filter.outputs.fiftyone }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            app:
+              - 'app/**'
+            e2e-pw:
+              - 'e2e-pw/**'
+            fiftyone:
+              - 'fiftyone/**'
+              - 'package/**'
+              - 'requirements/**'
+              - 'tests/**'
+              - 'requirements.txt'
+              - 'setup.py'
+
   build:
+    needs: modified-files
+    if: ${{ needs.modified-files.outputs.app-changes == 'true' || needs.modified-files.outputs.fiftyone-changes == 'true' }}
     uses: ./.github/workflows/build.yml
 
   e2e:
+    needs: modified-files
+    if: ${{ needs.modified-files.outputs.app-changes == 'true' || needs.modified-files.outputs.e2e-changes == 'true' || needs.modified-files.outputs.fiftyone-changes == 'true' }}
     uses: ./.github/workflows/e2e.yml
 
   lint:
+    needs: modified-files
+    if: ${{ needs.modified-files.outputs.app-changes == 'true' || needs.modified-files.outputs.fiftyone-changes == 'true' }}
     uses: ./.github/workflows/lint-app.yml
 
   teams:
@@ -43,6 +73,8 @@ jobs:
           wait_workflow: true
 
   test:
+    needs: modified-files
+    if: ${{ needs.modified-files.outputs.app-changes == 'true' || needs.modified-files.outputs.fiftyone-changes == 'true' }}
     uses: ./.github/workflows/test.yml
 
   all-tests:
@@ -51,6 +83,7 @@ jobs:
     if: always()
     steps:
       - run: sh -c ${{
-          needs.build.result == 'success' &&
-          needs.lint.result == 'success' &&
-          needs.test.result == 'success' }}
+          (needs.build.result == 'success' || needs.build.result == 'skipped') &&
+          (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&
+          (needs.test.result == 'success' || needs.test.result == 'skipped') && 
+          (needs.e2e.result == 'success' || needs.e2e.result == 'skipped') }}


### PR DESCRIPTION
## What changes are proposed in this pull request?

This aims to create conditional workflow steps to say things like:

* only docs are changing, don't run python tests
* only an e2e playwright change is happening, no need for x tests
* a python or js code changed, we should re-run everything to be safe.

The goal is to speed up build times and save money on github actions

## How is this patch tested? If it is not, please explain why.

* [Docs Only Changes](https://github.com/voxel51/fiftyone/actions/runs/11822906578) - This didn't trigger anything. Which is expected.
* [`setup.py` Changes](https://github.com/voxel51/fiftyone/actions/runs/11822940087) - This triggered everything. Which is expected.


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
