### PR TITLE
mark newly added plugin config options as optional

### DIFF
--- a/app/packages/plugins/src/index.ts
+++ b/app/packages/plugins/src/index.ts
@@ -323,7 +323,7 @@ export function getCategoryLabel(category: CategoryID): string {
       return "Curate";
     case "analyze":
       return "Analyze";
-    case "custom":
+    default:
       return "Custom";
   }
 }
@@ -332,16 +332,13 @@ export function getCategoryForPanel(panel: PluginComponentRegistration) {
   return panel.panelOptions?.category || "custom";
 }
 
-type Category = {
-  id: CategoryID;
-  label: string;
-};
-
 type PluginActivator = (props: any) => boolean;
 
 type PanelOptions = {
   /**
-   * Whether to allow multiple instances of the plugin
+   * Whether to allow multiple instances of the plugin.
+   *
+   * Defaults to `false`.
    */
   allowDuplicates?: boolean;
 
@@ -352,7 +349,7 @@ type PanelOptions = {
   priority?: number;
 
   /**
-   * Markdown help text for the plugin
+   * Markdown help text for the plugin.
    */
   helpMarkdown?: string;
 
@@ -367,19 +364,27 @@ type PanelOptions = {
   TabIndicator?: React.ComponentType;
 
   /**
-   * The category of the plugin
+   * The category of the plugin.
+   *
+   * Defaults to `custom`.
    */
-  category: CategoryID;
+  category?: CategoryID;
 
   /**
-   * Whether the plugin is in beta
+   * Whether the plugin is in beta.
+   * This is used to highlight beta plugins.
+   *
+   * Defaults to `false`.
    */
-  beta: boolean;
+  beta?: boolean;
 
   /**
-   * Whether the plugin is new
+   * Whether the plugin is new.
+   * This is used to highlight new plugins.
+   *
+   * Defaults to `false`.
    */
-  isNew: boolean;
+  isNew?: boolean;
 };
 
 type PluginComponentProps<T> = T & {

--- a/app/packages/spaces/src/components/AddPanelButton.tsx
+++ b/app/packages/spaces/src/components/AddPanelButton.tsx
@@ -89,15 +89,15 @@ export default function AddPanelButton({ node, spaceId }: AddPanelButtonProps) {
           <PanelCategories>
             {sortedCategories.map(({ label, panels }) => (
               <PanelCategory key={label} label={label}>
-                {panels.map((panel) => (
+                {panels.map((panel: PluginComponentRegistration) => (
                   <AddPanelItem
                     key={panel.name}
                     node={node}
                     name={panel.name}
                     label={panel.label}
                     spaceId={spaceId}
-                    showBeta={panel.panelOptions?.beta}
-                    showNew={panel.panelOptions?.isNew}
+                    showBeta={panel.panelOptions?.beta ?? false}
+                    showNew={panel.panelOptions?.isNew ?? false}
                     onClick={() => setOpen(false)}
                   />
                 ))}

--- a/app/packages/spaces/src/components/PanelTab.tsx
+++ b/app/packages/spaces/src/components/PanelTab.tsx
@@ -56,8 +56,8 @@ export default function PanelTab({ node, active, spaceId }: PanelTabProps) {
       {panel && !loading && <PanelIcon name={panelName as string} />}
       {panel && <Typography>{title || panel.label || panel.name}</Typography>}
       <PanelTabMeta
-        showBeta={panel?.panelOptions?.beta}
-        showNew={panel?.panelOptions?.isNew}
+        showBeta={panel?.panelOptions?.beta ?? false}
+        showNew={panel?.panelOptions?.isNew ?? false}
       />
       {panel && TabIndicator && (
         <TabIndicatorContainer>
@@ -90,7 +90,13 @@ export default function PanelTab({ node, active, spaceId }: PanelTabProps) {
   );
 }
 
-function PanelTabMeta({ showBeta, showNew }) {
+function PanelTabMeta({
+  showBeta,
+  showNew,
+}: {
+  showBeta: boolean;
+  showNew: boolean;
+}) {
   return (
     <Grid container gap={1} sx={{ width: "auto", ml: "6px" }}>
       {showNew && (


### PR DESCRIPTION
## What changes are proposed in this pull request?

#5038 introduced some new plugin config options that are currently marked as required. They can be marked optional.


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in plugin registration with optional properties for `PanelOptions`.
	- Improved handling of category labels to default to "Custom" for unmatched categories.

- **Bug Fixes**
	- Updated handling of optional properties (`showBeta`, `showNew`) in components to ensure default values are applied, enhancing robustness.

- **Refactor**
	- Improved type safety in components by explicitly defining types for parameters and props.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->