### PR TITLE
always disable orchestrator registration

### DIFF
--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -1277,9 +1277,7 @@ class ExecutionOptions(object):
 
     @property
     def orchestrator_registration_enabled(self):
-        return bool(
-            os.environ.get("FIFTYONE_ENABLE_ORCHESTRATOR_REGISTRATION", False)
-        )
+        return False
 
     def update(self, available_orchestrators=None):
         self._available_orchestrators = available_orchestrators


### PR DESCRIPTION
Always disable orchestrator_registration in OSS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified the orchestrator registration logic to always return `False`, ensuring consistent behavior regardless of environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->