### PR TITLE
Fix modal sidebar regressions

### DIFF
--- a/app/packages/core/src/components/Sidebar/Entries/EntryCounts.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/EntryCounts.tsx
@@ -41,7 +41,7 @@ export const PathEntryCounts = ({ modal, path }: PathEntryCountsProps) => {
     [modal, path]
   );
   const hasFilters = useRecoilValue(fos.fieldIsFiltered({ modal, path }));
-  const queryPerformance = useRecoilValue(fos.queryPerformance);
+  const queryPerformance = useRecoilValue(fos.queryPerformance) && !modal;
   const shown = useRecoilValue(showEntryCounts({ modal, path }));
 
   // empty path means we are showing grid sample count which is always allowed

--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/Icon.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/Icon.tsx
@@ -40,7 +40,7 @@ const Lightning = ({
 };
 
 const IconWrapper = ({ modal, path }: { modal: boolean; path: string }) => {
-  const disabled = useRecoilValue(fos.isDisabledFilterPath(path));
+  const disabled = useRecoilValue(fos.isDisabledFilterPath(path)) && !modal;
   const expandedPath = useRecoilValue(fos.expandPath(path));
   const frameFilteringDisabled =
     useRecoilValue(fos.isDisabledFrameFilterPath(path)) && !modal;

--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/useTitleTemplate.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/useTitleTemplate.tsx
@@ -97,7 +97,7 @@ const useTitleTemplate = ({
             <Hidden path={path} />
           </Suspense>
         )}
-        {!disabled && isFilterMode && (
+        {(modal || !disabled) && isFilterMode && (
           <PathEntryCounts key="count" modal={modal} path={expandedPath} />
         )}
         {!disabled && <Icon modal={modal} path={path} />}

--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/useTitleTemplate.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/useTitleTemplate.tsx
@@ -78,7 +78,7 @@ const useTitleTemplate = ({
   path: string;
 }) => {
   return function useTitleTemplate({ hoverHandlers, hoverTarget, container }) {
-    const disabled = useRecoilValue(fos.isDisabledFilterPath(path));
+    const enabled = useRecoilValue(fos.isDisabledFilterPath(path)) || modal;
     const isFilterMode = useRecoilValue(fos.isSidebarFilterMode);
     const expandedPath = useRecoilValue(fos.expandPath(path));
 
@@ -97,10 +97,10 @@ const useTitleTemplate = ({
             <Hidden path={path} />
           </Suspense>
         )}
-        {(modal || !disabled) && isFilterMode && (
+        {enabled && isFilterMode && (
           <PathEntryCounts key="count" modal={modal} path={expandedPath} />
         )}
-        {!disabled && <Icon modal={modal} path={path} />}
+        {enabled && <Icon modal={modal} path={path} />}
       </NameAndCountContainer>
     );
   };

--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/useTitleTemplate.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/useTitleTemplate.tsx
@@ -78,7 +78,7 @@ const useTitleTemplate = ({
   path: string;
 }) => {
   return function useTitleTemplate({ hoverHandlers, hoverTarget, container }) {
-    const enabled = useRecoilValue(fos.isDisabledFilterPath(path)) || modal;
+    const enabled = !useRecoilValue(fos.isDisabledCheckboxPath(path));
     const isFilterMode = useRecoilValue(fos.isSidebarFilterMode);
     const expandedPath = useRecoilValue(fos.expandPath(path));
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Contains two changes, which I both are the desired behavior (I believe)

* Show counts and subcounts for label filters in the modal even when QP is enabled
* Allow modal frame label filtering when `FIFTYONE_APP_DISABLED_FRAME_FILTERING` is enabled

<img width="1470" alt="Screenshot 2024-11-14 at 4 46 03 PM" src="https://github.com/user-attachments/assets/62fd72bb-04f0-4a24-9f30-fcba4578eb38">

https://github.com/user-attachments/assets/f9cc7438-6205-41b7-a8d1-8ef17c598f9a


### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced sidebar component logic to improve rendering behavior based on modal state.
- **Bug Fixes**
	- Resolved issues with the disabled state of icons in the sidebar, ensuring accurate control flow.
- **Refactor**
	- Updated variable naming for clarity in the rendering conditions of components related to sidebar entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->