### PR TITLE
Update TableView with multi inline actions

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/ActionsMenu.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ActionsMenu.tsx
@@ -13,12 +13,12 @@ import {
 import React, { useCallback } from "react";
 import { getColorByCode } from "../utils";
 
-const DEFAULT_MAX_INLINE = 1;
+const DEFAULT_MAX_INLINE = 2;
 
 export default function ActionsMenu(props: ActionsPropsType) {
   const { actions, maxInline = DEFAULT_MAX_INLINE, size } = props;
 
-  if (actions.length === maxInline) {
+  if (actions.length <= maxInline) {
     return (
       <Stack direction="row" spacing={0.5} justifyContent="flex-end">
         {actions.map((action) => (

--- a/app/packages/core/src/plugins/SchemaIO/components/ActionsMenu.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ActionsMenu.tsx
@@ -13,7 +13,7 @@ import {
 import React, { useCallback } from "react";
 import { getColorByCode } from "../utils";
 
-const DEFAULT_MAX_INLINE = 2;
+export const DEFAULT_MAX_INLINE = 1;
 
 export default function ActionsMenu(props: ActionsPropsType) {
   const { actions, maxInline = DEFAULT_MAX_INLINE, size } = props;

--- a/app/packages/core/src/plugins/SchemaIO/components/ActionsMenu.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ActionsMenu.tsx
@@ -13,7 +13,7 @@ import {
 import React, { useCallback } from "react";
 import { getColorByCode } from "../utils";
 
-export const DEFAULT_MAX_INLINE = 1;
+const DEFAULT_MAX_INLINE = 1;
 
 export default function ActionsMenu(props: ActionsPropsType) {
   const { actions, maxInline = DEFAULT_MAX_INLINE, size } = props;

--- a/app/packages/core/src/plugins/SchemaIO/components/TableView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TableView.tsx
@@ -33,6 +33,7 @@ export default function TableView(props: ViewPropsType) {
     selected_color,
     size = "small",
     variant = "filled",
+    max_icons_inline = 1,
   } = view;
   const { rows, selectedCells, selectedRows, selectedColumns } =
     getTableData(props);
@@ -198,6 +199,7 @@ export default function TableView(props: ViewPropsType) {
                           <ActionsMenu
                             actions={getRowActions(rowIndex)}
                             size={size}
+                            maxInline={max_icons_inline}
                           />
                         )}
                       </TableCell>

--- a/app/packages/core/src/plugins/SchemaIO/components/TableView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TableView.tsx
@@ -33,7 +33,7 @@ export default function TableView(props: ViewPropsType) {
     selected_color,
     size = "small",
     variant = "filled",
-    max_icons_inline = 1,
+    max_inline_actions = 1,
   } = view;
   const { rows, selectedCells, selectedRows, selectedColumns } =
     getTableData(props);
@@ -199,7 +199,7 @@ export default function TableView(props: ViewPropsType) {
                           <ActionsMenu
                             actions={getRowActions(rowIndex)}
                             size={size}
-                            maxInline={max_icons_inline}
+                            maxInline={max_inline_actions}
                           />
                         )}
                       </TableCell>


### PR DESCRIPTION
## What changes are proposed in this pull request?

Update TableView with multiple inline actions

## How is this patch tested? If it is not, please explain why.

* Tested locally

Users can set the `max_icons_inline` arg from TableView:

```
table = types.TableView(
    on_click_row=self.on_click_row,
    max_icons_inline=2,
)
```

Result:

![image](https://github.com/user-attachments/assets/a5de6088-9d3c-4ea5-b09d-a51ba29338c5)


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Actions Menu to display up to two actions inline, improving visibility and accessibility.
	- Introduced a new property in the TableView component to customize the maximum number of actions displayed inline, allowing for better control over the layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->