### PR TITLE
add exec button to py panels

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/OperatorExecutionButtonView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/OperatorExecutionButtonView.tsx
@@ -10,7 +10,7 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import TooltipProvider from "./TooltipProvider";
 
 export default function OperatorExecutionButtonView(props: ViewPropsType) {
-  const { schema, path, onClick } = props;
+  const { schema, path } = props;
   const { view = {} } = schema;
   const {
     description,
@@ -19,7 +19,6 @@ export default function OperatorExecutionButtonView(props: ViewPropsType) {
     label,
     operator,
     params = {},
-    prompt,
     title,
     disabled = false,
   } = view;
@@ -43,8 +42,6 @@ export default function OperatorExecutionButtonView(props: ViewPropsType) {
           operatorUri={operator}
           executionParams={computedParams}
           variant={variant}
-          onClick={(e) => onClick?.(e, computedParams, props)}
-          color="primary"
           disabled={disabled}
           startIcon={icon_position === "left" ? Icon : undefined}
           endIcon={icon_position === "right" ? Icon : undefined}
@@ -59,7 +56,8 @@ export default function OperatorExecutionButtonView(props: ViewPropsType) {
 }
 
 function getButtonProps(props: ViewPropsType): ButtonProps {
-  const { label, variant, color, disabled } = props.schema.view;
+  const { label, color, disabled } = props.schema.view;
+  const variant = getVariant(props);
   const baseProps: ButtonProps = getCommonProps(props);
   if (isNullish(label)) {
     baseProps.sx["& .MuiButton-startIcon"] = { mr: 0, ml: 0 };
@@ -86,9 +84,10 @@ function getButtonProps(props: ViewPropsType): ButtonProps {
     baseProps.sx.borderColor = borderColor;
     baseProps.sx.borderBottomColor = borderColor;
   }
-  if (isNullish(variant)) {
+  if (isNullish(variant) || variant === "contained") {
     baseProps.variant = "contained";
-    baseProps.color = "tertiary";
+    baseProps.color = "primary";
+    baseProps.sx.color = (theme) => theme.palette.text.primary;
     baseProps.sx["&:hover"] = {
       backgroundColor: (theme) => theme.palette.tertiary.hover,
     };

--- a/app/packages/operators/src/types.ts
+++ b/app/packages/operators/src/types.ts
@@ -1242,6 +1242,20 @@ export class ToastView extends View {
 }
 
 /**
+ * Operator class for rendering a execution button.
+ */
+
+class OperatorExecutionButtonView extends View {
+  constructor(options: ViewProps) {
+    super(options);
+    this.name = "OperatorExecutionButtonView";
+  }
+  static fromJSON(json) {
+    return new OperatorExecutionButtonView(json);
+  }
+}
+
+/**
  * Places where you can have your operator placement rendered.
  */
 export enum Places {

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -1370,6 +1370,43 @@ class Button(View):
         )
 
 
+class OperatorExecutionButtonView(Button):
+    """Represents an operator execution button in a :class:`View`.
+
+    Examples::
+
+        import fiftyone.operators.types as types
+
+        operatorButtonView = types.OperatorExecutionButtonView(
+            icon="expand_more",
+            operator="execute_custom_operator",
+            params={"key": "value"},
+            label="Execute",
+            description="Executes the specified operator",
+        )
+
+        inputs = types.Object()
+        inputs.view("operator_btn", operatorButtonView)
+
+    Args:
+        icon (str): an icon for the button. Defaults to "expand_more" if not provided.
+        label (str): a label for the button.
+        description (str): a description for the button.
+        title (str): a tooltip title for the button.
+        operator (str): the name of the operator to execute when the button is clicked.
+        params (dict): the parameters to pass to the operator.
+        prompt (str): a prompt for the operation.
+        disabled (bool): whether the button is disabled.
+    """
+
+    def __init__(self, **kwargs):
+        if "operator" not in kwargs or not isinstance(kwargs["operator"], str):
+            raise ValueError(
+                "The 'operator' parameter of type str is required."
+            )
+        super().__init__(**kwargs)
+
+
 class OneOfView(View):
     """Displays one of the given :class:`View` instances.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new button for executing operators within views.
	- Added multiple view classes for enhanced data representation, including `OneOfView`, `ListView`, `TupleView`, `TreeSelectionView`, `FrameLoaderView`, and `TimelineView`.
- **Improvements**
	- Streamlined button properties handling for better interactivity and color management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->