### PR TITLE
Coinciding filter results for QP sidebar

### DIFF
--- a/app/packages/core/src/components/Filters/StringFilter/state.ts
+++ b/app/packages/core/src/components/Filters/StringFilter/state.ts
@@ -68,12 +68,17 @@ export const stringSearchResults = selectorFamily<
       };
 
       if (!modal && get(fos.queryPerformance)) {
+        const filters = Object.fromEntries(
+          Object.entries(get(fos.filters) || {}).filter(([p]) => p !== path)
+        );
+
         return {
           values: get(
             fos.lightningStringResults({
               path,
               search,
               exclude: [...selected.filter((s) => s !== null)] as string[],
+              filters,
             })
           )?.map((value) => ({ value, count: null })),
         };

--- a/app/packages/core/src/components/Filters/StringFilter/useSelected.ts
+++ b/app/packages/core/src/components/Filters/StringFilter/useSelected.ts
@@ -29,12 +29,13 @@ export default function (
   const shown =
     (!modal && queryPerformance) ||
     (resultsLoadable.state !== "loading" && (length >= CHECKBOX_LIMIT || id));
+  const isFrameField = useRecoilValue(fos.isFrameField(path));
 
   return {
     results,
 
     useSearch:
-      path === "_label_tags" && queryPerformance && !modal
+      path === "_label_tags" && queryPerformance && !isFrameField && !modal
         ? undefined
         : useSearch,
     showSearch: Boolean(shown) && !boolean,

--- a/app/packages/relay/src/queries/__generated__/lightningQuery.graphql.ts
+++ b/app/packages/relay/src/queries/__generated__/lightningQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<19f0c37a7189c44264fe0a982eca857b>>
+ * @generated SignedSource<<e18d763b5048c83b0ba06ace4b52f593>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,6 +15,7 @@ export type LightningInput = {
 };
 export type LightningPathInput = {
   exclude?: ReadonlyArray<string> | null;
+  filters?: object | null;
   first?: number | null;
   path: string;
   search?: string | null;

--- a/app/packages/state/src/recoil/filters.ts
+++ b/app/packages/state/src/recoil/filters.ts
@@ -10,7 +10,7 @@ import { indexedPaths } from "./queryPerformance";
 import { expandPath, fields } from "./schema";
 import { hiddenLabelIds } from "./selectors";
 import { sidebarExpandedStore } from "./sidebarExpanded";
-import { State } from "./types";
+import type { State } from "./types";
 
 export const modalFilters = sessionAtom({
   key: "modalFilters",

--- a/app/packages/state/src/recoil/pathData/lightningString.ts
+++ b/app/packages/state/src/recoil/pathData/lightningString.ts
@@ -1,9 +1,15 @@
+import type { SerializableParam } from "recoil";
 import { selectorFamily } from "recoil";
 import { lightningQuery } from "../queryPerformance";
 
 export const lightningStringResults = selectorFamily<
   string[],
-  { path: string; search?: string; exclude?: string[] }
+  {
+    path: string;
+    search?: string;
+    exclude?: string[];
+    filters: SerializableParam;
+  }
 >({
   key: "lightningStringResults",
   get:

--- a/app/packages/state/src/recoil/types.ts
+++ b/app/packages/state/src/recoil/types.ts
@@ -155,20 +155,6 @@ export namespace State {
     info: { [key: string]: string };
   }
 
-  /**
-   * @hidden
-   */
-  export interface CategoricalFilter<T> {
-    values: T[];
-    isMatching: boolean;
-    exclude: boolean;
-  }
-
-  /**
-   * @hidden
-   */
-  export type Filter = CategoricalFilter<string>;
-
   export interface SortBySimilarityParameters {
     brainKey: string;
     distField?: string;
@@ -178,8 +164,13 @@ export namespace State {
     queryIds?: string[];
   }
 
+  type FilterValues = string | boolean | number | null | undefined;
+
+  export interface Filter {
+    [key: string]: FilterValues | Array<FilterValues>;
+  }
+
   export interface Filters {
-    _label_tags?: CategoricalFilter<string>;
     [key: string]: Filter;
   }
 

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -455,6 +455,7 @@ input LightningPathInput {
   exclude: [String!] = null
   first: Int = 200
   search: String = null
+  filters: BSON = null
 }
 
 interface LightningResult {

--- a/fiftyone/server/lightning.py
+++ b/fiftyone/server/lightning.py
@@ -22,7 +22,9 @@ import fiftyone.core.fields as fof
 
 import fiftyone.server.constants as foc
 from fiftyone.server.data import Info
+from fiftyone.server.scalars import BSON
 from fiftyone.server.utils import meets_type
+from fiftyone.server.view import get_view
 
 
 _TWENTY_FOUR = 24
@@ -37,6 +39,7 @@ class LightningPathInput:
     )
     first: t.Optional[int] = foc.LIST_LIMIT
     search: t.Optional[str] = None
+    filters: t.Optional[BSON] = None
 
 
 @gql.input
@@ -135,7 +138,7 @@ async def lightning_resolver(
         for collection, sublist in zip(collections, queries)
         for item in sublist
     ]
-    result = await _do_async_pooled_queries(flattened)
+    result = await _do_async_pooled_queries(dataset, flattened)
 
     results = []
     offset = 0
@@ -154,6 +157,7 @@ class DistinctQuery:
     is_object_id_field: bool
     exclude: t.Optional[t.List[str]] = None
     search: t.Optional[str] = None
+    filters: t.Optional[BSON] = None
 
 
 def _resolve_lightning_path_queries(
@@ -258,6 +262,7 @@ def _resolve_lightning_path_queries(
         d["has_list"] = _has_list(dataset, field_path, is_frame_field)
         d["is_object_id_field"] = True
         d["path"] = field_path
+        d["filters"] = path.filters
         return (
             collection,
             [DistinctQuery(**d)],
@@ -273,6 +278,7 @@ def _resolve_lightning_path_queries(
         d["has_list"] = _has_list(dataset, field_path, is_frame_field)
         d["is_object_id_field"] = False
         d["path"] = field_path
+        d["filters"] = path.filters
         return (
             collection,
             [DistinctQuery(**d)],
@@ -283,24 +289,29 @@ def _resolve_lightning_path_queries(
 
 
 async def _do_async_pooled_queries(
+    dataset: fo.Dataset,
     queries: t.List[
         t.Tuple[AsyncIOMotorCollection, t.Union[DistinctQuery, t.List[t.Dict]]]
-    ]
+    ],
 ):
     return await asyncio.gather(
-        *[_do_async_query(collection, query) for collection, query in queries]
+        *[
+            _do_async_query(dataset, collection, query)
+            for collection, query in queries
+        ]
     )
 
 
 async def _do_async_query(
+    dataset: fo.Dataset,
     collection: AsyncIOMotorCollection,
     query: t.Union[DistinctQuery, t.List[t.Dict]],
 ):
     if isinstance(query, DistinctQuery):
-        if query.has_list:
+        if query.has_list and not query.filters:
             return await _do_distinct_query(collection, query)
 
-        return await _do_distinct_pipeline(collection, query)
+        return await _do_distinct_pipeline(dataset, collection, query)
 
     return [i async for i in collection.aggregate(query)]
 
@@ -336,9 +347,28 @@ async def _do_distinct_query(
 
 
 async def _do_distinct_pipeline(
-    collection: AsyncIOMotorCollection, query: DistinctQuery
+    dataset: fo.Dataset,
+    collection: AsyncIOMotorCollection,
+    query: DistinctQuery,
 ):
-    pipeline = [{"$sort": {query.path: 1}}]
+    pipeline = []
+    if query.filters:
+        pipeline += get_view(dataset, filters=query.filters)._pipeline()
+
+    pipeline += [{"$sort": {query.path: 1}}]
+
+    if query.search:
+        if query.is_object_id_field:
+            add = (_TWENTY_FOUR - len(query.search)) * "0"
+            value = {"$gte": ObjectId(f"{query.search}{add}")}
+        else:
+            value = Regex(f"^{query.search}")
+        pipeline.append({"$match": {query.path: value}})
+
+    pipeline += _match_arrays(dataset, query.path, False) + _unwind(
+        dataset, query.path, False
+    )
+
     if query.search:
         if query.is_object_id_field:
             add = (_TWENTY_FOUR - len(query.search)) * "0"


### PR DESCRIPTION
## What changes are proposed in this pull request?

https://github.com/user-attachments/assets/6395a19d-0ce0-483f-a8ce-fe92e2836640

## How is this patch tested? If it is not, please explain why.

Manual

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced filtering capabilities in Lightning queries with the addition of a `filters` parameter.
	- Updated input type for `LightningPathInput` to include optional filtering criteria.

- **Improvements**
	- Refined logic for handling search results and filtering in the application, allowing for more precise data retrieval based on user-defined criteria.

- **Bug Fixes**
	- Improved error handling and control flow in various selector and query functions to ensure robust performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->