### PR TITLE
Fix target view for clear sample/frame field operators

### DIFF
--- a/fiftyone/operators/builtin.py
+++ b/fiftyone/operators/builtin.py
@@ -622,8 +622,11 @@ class ClearSampleField(foo.Operator):
 
     def execute(self, ctx):
         field_name = ctx.params["field_name"]
+        target = ctx.params.get("target", None)
 
-        ctx.dataset.clear_sample_field(field_name)
+        target_view = _get_target_view(ctx, target)
+
+        target_view.clear_sample_field(field_name)
         ctx.trigger("reload_dataset")
 
 
@@ -713,8 +716,11 @@ class ClearFrameField(foo.Operator):
 
     def execute(self, ctx):
         field_name = ctx.params["field_name"]
+        target = ctx.params.get("target", None)
 
-        ctx.dataset.clear_frame_field(field_name)
+        target_view = _get_target_view(ctx, target)
+
+        target_view.clear_frame_field(field_name)
         ctx.trigger("reload_dataset")
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `ClearSampleField` and `ClearFrameField` operators to allow clearing fields in specific views or the entire dataset.
	- Users can now specify whether to clear fields for selected samples or the current view, improving flexibility.

- **Bug Fixes**
	- Resolved issues with input resolution to align with the new functionality for handling the `target` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->