### PR TITLE
Fix lightning numeric bounds

### DIFF
--- a/fiftyone/server/lightning.py
+++ b/fiftyone/server/lightning.py
@@ -466,7 +466,7 @@ def _match_arrays(dataset: fo.Dataset, path: str, is_frame_field: bool):
 def _parse_result(data):
     if data and data[0]:
         value = data[0]
-        if value.get("value") is not None:
+        if value.get("value", None) is not None:
             return value["value"]
 
         return value.get("_id", None)

--- a/tests/unittests/lightning_tests.py
+++ b/tests/unittests/lightning_tests.py
@@ -488,13 +488,13 @@ class TestFloatLightningQueries(unittest.IsolatedAsyncioTestCase):
             dataset,
             dict(
                 float=-1.0,
-                float_list=[-1.0],
+                float_list=[0.0, -1.0],
                 inf=-1.0,
-                inf_list=[-1.0],
+                inf_list=[0.0, -1.0],
                 nan=-1.0,
-                nan_list=[-1.0],
+                nan_list=[0.0, -1.0],
                 ninf=-1.0,
-                ninf_list=[-1.0],
+                ninf_list=[0.0, -1.0],
             ),
             dict(
                 float=0.0,
@@ -508,13 +508,13 @@ class TestFloatLightningQueries(unittest.IsolatedAsyncioTestCase):
             ),
             dict(
                 float=1.0,
-                float_list=[1.0],
+                float_list=[0.0, 1.0],
                 inf=1.0,
                 inf_list=[1.0],
                 nan=1.0,
-                nan_list=[1.0],
+                nan_list=[0.0, 1.0],
                 ninf=1.0,
-                ninf_list=[1.0],
+                ninf_list=[0.0, 1.0],
             ),
         )
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes bounds computations for embedded lists

## How is this patch tested? If it is not, please explain why.

Updated floats tests

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced data aggregation and result parsing for improved robustness.
  - Updated path construction for unwinding nested fields in datasets.

- **Tests**
  - Updated test data for float-related fields to include additional values, improving coverage of edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->