### PR TITLE
fix false positives in toast

### DIFF
--- a/app/packages/components/src/components/Selector/Selector.tsx
+++ b/app/packages/components/src/components/Selector/Selector.tsx
@@ -44,7 +44,6 @@ function Selector<T>(props: SelectorProps<T>) {
     useSearch,
     component,
     toKey = (value) => String(value),
-
     inputStyle,
     inputClassName,
     containerStyle,

--- a/app/packages/components/src/components/Selector/Selector.tsx
+++ b/app/packages/components/src/components/Selector/Selector.tsx
@@ -32,6 +32,7 @@ export interface SelectorProps<T> {
   onMouseEnter?: React.MouseEventHandler;
   cy?: string;
   noResults?: string;
+  DuringSuspense?: (props: React.PropsWithChildren) => React.JSX.Element;
 }
 
 function Selector<T>(props: SelectorProps<T>) {
@@ -43,6 +44,7 @@ function Selector<T>(props: SelectorProps<T>) {
     useSearch,
     component,
     toKey = (value) => String(value),
+
     inputStyle,
     inputClassName,
     containerStyle,
@@ -52,6 +54,7 @@ function Selector<T>(props: SelectorProps<T>) {
     onMouseEnter,
     cy,
     noResults,
+    DuringSuspense = ({ children }) => <>{children}</>,
     ...otherProps
   } = props;
 
@@ -205,7 +208,9 @@ function Selector<T>(props: SelectorProps<T>) {
               >
                 <Suspense
                   fallback={
-                    <LoadingDots style={{ float: "right" }} text="Loading" />
+                    <DuringSuspense>
+                      <LoadingDots style={{ float: "right" }} text="Loading" />
+                    </DuringSuspense>
                   }
                 >
                   <SearchResults

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
@@ -89,7 +89,6 @@ const NumericFieldFilter = ({ color, modal, named = true, path }: Props) => {
 
 const Loading = ({ modal, path }: { modal: boolean; path: string }) => {
   useQueryPerformanceTimeout(modal, path);
-
   return <Box text="Loading" />;
 };
 

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import FieldLabelAndInfo from "../../FieldLabelAndInfo";
 import { LightningBolt } from "../../Sidebar/Entries/FilterablePathEntry/Icon";
 import { Button } from "../../utils";
+import useQueryPerformanceTimeout from "../use-query-performance-timeout";
 import Box from "./Box";
 import RangeSlider from "./RangeSlider";
 import useShow from "./use-show";
@@ -63,7 +64,7 @@ const NumericFieldFilter = ({ color, modal, named = true, path }: Props) => {
           )}
         />
       )}
-      <Suspense fallback={<Box text="Loading" />}>
+      <Suspense fallback={<Loading modal={modal} path={path} />}>
         {showLoadButton ? (
           <Box>
             <Button
@@ -84,6 +85,12 @@ const NumericFieldFilter = ({ color, modal, named = true, path }: Props) => {
       </Suspense>
     </Container>
   );
+};
+
+const Loading = ({ modal, path }: { modal: boolean; path: string }) => {
+  useQueryPerformanceTimeout(modal, path);
+
+  return <Box text="Loading" />;
 };
 
 export default NumericFieldFilter;

--- a/app/packages/core/src/components/Filters/StringFilter/StringFilter.tsx
+++ b/app/packages/core/src/components/Filters/StringFilter/StringFilter.tsx
@@ -150,7 +150,6 @@ const StringFilter = ({
 const withQueryPerformanceTimeout = (modal: boolean, path: string) => {
   return ({ children }: React.PropsWithChildren) => {
     useQueryPerformanceTimeout(modal, path);
-
     return <>{children}</>;
   };
 };

--- a/app/packages/core/src/components/Filters/StringFilter/StringFilter.tsx
+++ b/app/packages/core/src/components/Filters/StringFilter/StringFilter.tsx
@@ -7,6 +7,7 @@ import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 import FieldLabelAndInfo from "../../FieldLabelAndInfo";
 import { isInKeypointsField } from "../state";
+import useQueryPerformanceTimeout from "../use-query-performance-timeout";
 import Checkboxes from "./Checkboxes";
 import ResultComponent from "./Result";
 import useOnSelect from "./useOnSelect";
@@ -128,6 +129,7 @@ const StringFilter = ({
             containerStyle={{ borderBottomColor: color, zIndex: 1000 }}
             toKey={(value) => String(value.value)}
             id={path}
+            DuringSuspense={withQueryPerformanceTimeout(modal, path)}
           />
         )}
         <Checkboxes
@@ -143,6 +145,14 @@ const StringFilter = ({
       </StringFilterContainer>
     </NamedStringFilterContainer>
   );
+};
+
+const withQueryPerformanceTimeout = (modal: boolean, path: string) => {
+  return ({ children }: React.PropsWithChildren) => {
+    useQueryPerformanceTimeout(modal, path);
+
+    return <>{children}</>;
+  };
 };
 
 export default StringFilter;

--- a/app/packages/core/src/components/Filters/StringFilter/useOnSelect.ts
+++ b/app/packages/core/src/components/Filters/StringFilter/useOnSelect.ts
@@ -26,6 +26,7 @@ export default function (
         }
         selected.add(value);
         set(selectedAtom, [...selected].sort());
+
         return "";
       },
     [modal, path, selectedAtom]

--- a/app/packages/core/src/components/Filters/StringFilter/useSelected.ts
+++ b/app/packages/core/src/components/Filters/StringFilter/useSelected.ts
@@ -32,7 +32,6 @@ export default function (
 
   return {
     results,
-
     useSearch:
       path === "_label_tags" && queryPerformance && !modal
         ? undefined

--- a/app/packages/core/src/components/Filters/use-query-performance-timeout.ts
+++ b/app/packages/core/src/components/Filters/use-query-performance-timeout.ts
@@ -13,12 +13,6 @@ export default function useQueryPerformanceTimeout(
       return;
     }
 
-    /** TMP TESTING */
-    window.dispatchEvent(
-      new QueryPerformanceToastEvent(path, shouldOptimize.isFrameField)
-    );
-    /** TMP TESTING */
-
     const timeout = setTimeout(() => {
       window.dispatchEvent(
         new QueryPerformanceToastEvent(path, shouldOptimize.isFrameField)

--- a/app/packages/core/src/components/Filters/use-query-performance-timeout.ts
+++ b/app/packages/core/src/components/Filters/use-query-performance-timeout.ts
@@ -1,0 +1,32 @@
+import { pathCanBeOptimized } from "@fiftyone/state";
+import { useEffect } from "react";
+import { useRecoilValue } from "recoil";
+import { QP_WAIT, QueryPerformanceToastEvent } from "../QueryPerformanceToast";
+
+export default function useQueryPerformanceTimeout(
+  modal: boolean,
+  path: string
+) {
+  const shouldOptimize = useRecoilValue(pathCanBeOptimized(path));
+  useEffect(() => {
+    if (modal || !shouldOptimize) {
+      return;
+    }
+
+    /** TMP TESTING */
+    window.dispatchEvent(
+      new QueryPerformanceToastEvent(path, shouldOptimize.isFrameField)
+    );
+    /** TMP TESTING */
+
+    const timeout = setTimeout(() => {
+      window.dispatchEvent(
+        new QueryPerformanceToastEvent(path, shouldOptimize.isFrameField)
+      );
+    }, QP_WAIT);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [modal, path, shouldOptimize]);
+}

--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -12,6 +12,7 @@ import React, {
 } from "react";
 import { useRecoilValue } from "recoil";
 import { v4 as uuid } from "uuid";
+import { QP_WAIT, QueryPerformanceToastEvent } from "../QueryPerformanceToast";
 import { gridCrop, gridSpacing, pageParameters } from "./recoil";
 import useAt from "./useAt";
 import useEscape from "./useEscape";
@@ -121,7 +122,17 @@ function Grid() {
     }
 
     const element = document.getElementById(id);
+
+    const info = fos.getQueryPerformancePath();
+    const timeout = setTimeout(() => {
+      if (info) {
+        window.dispatchEvent(
+          new QueryPerformanceToastEvent(info.path, info.isFrameField)
+        );
+      }
+    }, QP_WAIT);
     const mount = () => {
+      clearTimeout(timeout);
       document.dispatchEvent(new CustomEvent("grid-mount"));
     };
 
@@ -130,6 +141,7 @@ function Grid() {
     spotlight.addEventListener("rowchange", set);
 
     return () => {
+      clearTimeout(timeout);
       freeVideos();
       spotlight.removeEventListener("load", mount);
       spotlight.removeEventListener("rowchange", set);

--- a/app/packages/core/src/components/QueryPerformanceToast.tsx
+++ b/app/packages/core/src/components/QueryPerformanceToast.tsx
@@ -10,7 +10,7 @@ import { atom, useRecoilState } from "recoil";
 
 const SHOWN_FOR = 10000;
 
-export const QP_WAIT = 5100;
+export const QP_WAIT = 5151;
 
 declare global {
   interface WindowEventMap

--- a/app/packages/core/src/components/QueryPerformanceToast.tsx
+++ b/app/packages/core/src/components/QueryPerformanceToast.tsx
@@ -7,7 +7,6 @@ import { Bolt } from "@mui/icons-material";
 import React, { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { atom, useRecoilState, useRecoilValue } from "recoil";
-import * as atoms from "@fiftyone/state/src/recoil/atoms";
 import * as fos from "@fiftyone/state";
 
 const SHOWN_FOR = 10000;
@@ -40,7 +39,7 @@ const QueryPerformanceToast = ({
   const element = document.getElementById("queryPerformance");
   const theme = useTheme();
   const trackEvent = useTrackEvent();
-  console.log(info);
+
   useEffect(() => {
     const listen = (event) => {
       onDispatch(event);

--- a/app/packages/state/src/hooks/useCreateLooker.ts
+++ b/app/packages/state/src/hooks/useCreateLooker.ts
@@ -125,7 +125,6 @@ export default <T extends AbstractLooker<BaseState>>(
         let config: ConstructorParameters<T>[1] = {
           enableTimeline,
           fieldSchema: {
-            ...fieldSchema,
             frames: {
               name: "frames",
               ftype: LIST_FIELD,
@@ -134,6 +133,7 @@ export default <T extends AbstractLooker<BaseState>>(
               fields: frameFieldSchema,
               dbField: null,
             },
+            ...fieldSchema,
           },
           sources: urls,
           frameNumber: create === FrameLooker ? frameNumber : undefined,

--- a/app/packages/state/src/recoil/selectors.ts
+++ b/app/packages/state/src/recoil/selectors.ts
@@ -584,7 +584,7 @@ export const hasSelectedSamples = selector<boolean>({
   },
 });
 
-const frameFieldsList = selector({
+export const frameFieldsList = selector({
   key: "frameFieldsList",
   get: ({ get }) => {
     const fields = get(atoms.frameFields);

--- a/app/packages/utilities/src/fetch.ts
+++ b/app/packages/utilities/src/fetch.ts
@@ -30,7 +30,7 @@ class QueryPerformanceToast extends Event {
   }
 }
 
-const TIMEOUT = 5000;
+const TIMEOUT = 5100;
 
 export const getFetchFunction = () => {
   return fetchFunctionSingleton;
@@ -132,14 +132,6 @@ export const setFetchFunction = (
         })
       : fetch;
 
-    let timeoutId = undefined;
-    const filterPath = getFirstFilterPath(body);
-    if (filterPath) {
-      timeoutId = setTimeout(() => {
-        window.dispatchEvent(new QueryPerformanceToast(filterPath));
-      }, TIMEOUT);
-    }
-
     const response = await fetchCall(url, {
       method: method,
       cache: "no-cache",
@@ -149,10 +141,6 @@ export const setFetchFunction = (
       signal: controller.signal,
       referrerPolicy: "same-origin",
     });
-
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-    }
 
     if (response.status >= 400) {
       const errorMetadata = {

--- a/app/packages/utilities/src/fetch.ts
+++ b/app/packages/utilities/src/fetch.ts
@@ -22,16 +22,6 @@ export interface FetchFunction {
   ): Promise<R>;
 }
 
-class QueryPerformanceToast extends Event {
-  path?: string;
-  constructor(path?: string) {
-    super("queryperformance");
-    this.path = path;
-  }
-}
-
-const TIMEOUT = 5100;
-
 export const getFetchFunction = () => {
   return fetchFunctionSingleton;
 };


### PR DESCRIPTION
## What changes are proposed in this pull request?

The toast was showing anytime a query was slow without guaranteeing the user can create an index. These changes fix that.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a customizable loading experience with the new `DuringSuspense` prop in the Selector component.
  - Added a new loading component for improved performance handling in the NumericFieldFilter.
  - Enhanced performance management in the StringFilter using a new higher-order component.

- **Bug Fixes**
  - Improved error handling in the useCreateLooker hook and refined media handling.

- **Refactor**
  - Streamlined state management and event handling in the QueryPerformanceToast component.
  - Simplified query performance and filter management logic in the filters and selectors.

- **Chores**
  - Removed outdated performance event handling from the fetch utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->