### PR TITLE
No wait summary field index creation

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1694,6 +1694,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         group_by=None,
         read_only=True,
         create_index=True,
+        wait=True,
     ):
         """Populates a sample-level field that records the unique values or
         numeric ranges that appear in the specified field on each sample in
@@ -1756,6 +1757,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             read_only (True): whether to mark the summary field as read-only
             create_index (True): whether to create database index(es) for the
                 summary field
+            wait (True): whether to wait for index creation to complete before
+                returning
 
         Returns:
             the summary field name
@@ -1898,7 +1901,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         if create_index:
             for _field_name in index_fields:
-                self.create_index(_field_name)
+                self.create_index(_field_name, wait=wait)
 
         field = self.get_field(field_name)
         field.info[_SUMMARY_FIELD_KEY]["last_modified_at"] = field.created_at


### PR DESCRIPTION
## What changes are proposed in this pull request?

Added a param (`wait`) to pass to index creation for summary fields

## How is this patch tested? If it is not, please explain why.

* Local testing

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
