### PR TITLE
extend compatibility of array deserialization in lookers

### DIFF
--- a/app/packages/looker/src/overlays/segmentation.ts
+++ b/app/packages/looker/src/overlays/segmentation.ts
@@ -273,7 +273,7 @@ export default class SegmentationOverlay<State extends BaseState>
   private getTarget(state: Readonly<State>): number {
     const index = this.getIndex(state);
 
-    if (index < 0) {
+    if (index < 0 || !this.targets || index >= this.targets.length) {
       return null;
     }
     return this.targets[index];

--- a/app/packages/looker/src/worker/deserializer.ts
+++ b/app/packages/looker/src/worker/deserializer.ts
@@ -1,13 +1,21 @@
 import { deserialize } from "../numpy";
 
+const extractSerializedMask = (
+  label: object,
+  maskProp: string
+): string | undefined => {
+  if (typeof label?.[maskProp] === "string") {
+    return label[maskProp];
+  } else if (typeof label?.[maskProp]?.$binary?.base64 === "string") {
+    return label[maskProp].$binary.base64;
+  }
+
+  return undefined;
+};
+
 export const DeserializerFactory = {
   Detection: (label, buffers) => {
-    let serializedMask: string;
-    if (typeof label?.mask === "string") {
-      serializedMask = label.mask;
-    } else if (typeof label?.mask?.$binary?.base64 === "string") {
-      serializedMask = label.mask.$binary.base64;
-    }
+    const serializedMask = extractSerializedMask(label, "mask");
 
     if (serializedMask) {
       const data = deserialize(serializedMask);
@@ -27,12 +35,7 @@ export const DeserializerFactory = {
     }
   },
   Heatmap: (label, buffers) => {
-    let serializedMask: string;
-    if (typeof label?.map === "string") {
-      serializedMask = label.map;
-    } else if (typeof label?.map?.$binary?.base64 === "string") {
-      serializedMask = label.map.$binary.base64;
-    }
+    const serializedMask = extractSerializedMask(label, "map");
 
     if (serializedMask) {
       const data = deserialize(serializedMask);
@@ -48,12 +51,7 @@ export const DeserializerFactory = {
     }
   },
   Segmentation: (label, buffers) => {
-    let serializedMask: string;
-    if (typeof label?.mask === "string") {
-      serializedMask = label.mask;
-    } else if (typeof label?.mask?.$binary?.base64 === "string") {
-      serializedMask = label.mask.$binary.base64;
-    }
+    const serializedMask = extractSerializedMask(label, "mask");
 
     if (serializedMask) {
       const data = deserialize(serializedMask);

--- a/app/packages/looker/src/worker/deserializer.ts
+++ b/app/packages/looker/src/worker/deserializer.ts
@@ -2,8 +2,15 @@ import { deserialize } from "../numpy";
 
 export const DeserializerFactory = {
   Detection: (label, buffers) => {
+    let serializedMask: string;
     if (typeof label?.mask === "string") {
-      const data = deserialize(label.mask);
+      serializedMask = label.mask;
+    } else if (typeof label?.mask?.$binary?.base64 === "string") {
+      serializedMask = label.mask.$binary.base64;
+    }
+
+    if (serializedMask) {
+      const data = deserialize(serializedMask);
       const [height, width] = data.shape;
       label.mask = {
         data,
@@ -20,8 +27,15 @@ export const DeserializerFactory = {
     }
   },
   Heatmap: (label, buffers) => {
+    let serializedMask: string;
     if (typeof label?.map === "string") {
-      const data = deserialize(label.map);
+      serializedMask = label.map;
+    } else if (typeof label?.map?.$binary?.base64 === "string") {
+      serializedMask = label.map.$binary.base64;
+    }
+
+    if (serializedMask) {
+      const data = deserialize(serializedMask);
       const [height, width] = data.shape;
 
       label.map = {
@@ -34,8 +48,15 @@ export const DeserializerFactory = {
     }
   },
   Segmentation: (label, buffers) => {
+    let serializedMask: string;
     if (typeof label?.mask === "string") {
-      const data = deserialize(label.mask);
+      serializedMask = label.mask;
+    } else if (typeof label?.mask?.$binary?.base64 === "string") {
+      serializedMask = label.mask.$binary.base64;
+    }
+
+    if (serializedMask) {
+      const data = deserialize(serializedMask);
       const [height, width] = data.shape;
 
       label.mask = {


### PR DESCRIPTION
## What changes are proposed in this pull request?

* Extend array deserialization in lookers to include additional fields
* Fix bug where `this.targets` can be undefined in `Segmentation`, causing a crash

## How is this patch tested? If it is not, please explain why.

local app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved error handling in the Segmentation overlay for better target validation.
	- Enhanced deserialization process for masks and maps, accommodating various input formats.

- **Bug Fixes**
	- Fixed potential out-of-bounds access in the Segmentation overlay's target retrieval logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->