### PR TITLE
bugfix: Fixes toastview cannot render consecutively issue

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/ToastView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ToastView.tsx
@@ -1,10 +1,111 @@
-import React from "react";
-import { Toast } from "@fiftyone/components";
+import React, { useState } from "react";
+import { Box, Snackbar, SnackbarContent } from "@mui/material";
 
 export default function ToastView(props) {
   const { schema } = props;
   const { view = {} } = schema;
   const { message, duration, layout } = view;
 
-  return <Toast message={message} duration={duration} layout={layout} />;
+  return (
+    <Toast
+      message={message}
+      duration={duration}
+      layout={layout}
+      key={view.key ?? "toast"}
+    />
+  );
 }
+
+interface ToastProps {
+  message: React.ReactNode;
+  primary?: (setOpen: (open: boolean) => void) => React.ReactNode;
+  secondary?: (setOpen: (open: boolean) => void) => React.ReactNode;
+  duration?: number;
+  layout?: {
+    vertical?: "top" | "bottom";
+    horizontal?: "left" | "center" | "right";
+    height?: number | string;
+    top?: number | string;
+    bottom?: number | string;
+    backgroundColor?: string;
+    color?: string;
+    fontSize?: string;
+    textAlign?: string;
+  };
+  onHandleClose?: (
+    event: React.SyntheticEvent<any> | Event,
+    reason?: string
+  ) => void;
+}
+
+const Toast: React.FC<ToastProps> = ({
+  message,
+  primary,
+  secondary,
+  duration = 5000,
+  layout = {},
+  onHandleClose,
+}) => {
+  const [open, setOpen] = useState(true); // do not use a global recoil atom for this state
+
+  const handleClose = (
+    event: React.SyntheticEvent<any> | Event,
+    reason?: string
+  ) => {
+    if (reason === "clickaway") {
+      return;
+    }
+    setOpen(false);
+
+    if (onHandleClose) {
+      onHandleClose(event, reason);
+    }
+  };
+
+  const snackbarStyle = {
+    height: layout?.height || 5,
+    ...(layout?.top && { top: layout.top }),
+    ...(layout?.bottom && { bottom: layout.bottom }),
+  };
+
+  const action = (
+    <Box display="flex" justifyContent="flex-end">
+      {primary && primary(setOpen)} {/* Pass setOpen to primary button */}
+      {secondary && secondary(setOpen)} {/* Pass setOpen to secondary button */}
+    </Box>
+  );
+
+  return (
+    <Snackbar
+      anchorOrigin={{
+        vertical: layout?.vertical || "bottom",
+        horizontal: layout?.horizontal || "center",
+      }}
+      open={open}
+      onClose={handleClose}
+      autoHideDuration={duration}
+      sx={snackbarStyle}
+    >
+      <SnackbarContent
+        message={
+          <Box
+            display="flex"
+            alignItems="center"
+            justifyContent="space-between"
+            gap={4}
+          >
+            <Box>{message}</Box>
+            {action}
+          </Box>
+        }
+        sx={{
+          backgroundColor: layout?.backgroundColor || "#333",
+          color: layout?.color || "#fff",
+          fontSize: layout?.fontSize || "14px",
+          display: "block",
+          textAlign: layout?.textAlign || "left",
+        }}
+      />
+    </Snackbar>
+  );
+};


### PR DESCRIPTION
## What changes are proposed in this pull request?

As a python panel component, ToastView cannot use the existing Toast component which relies on the global recoil state to manage the Toaster state. Thus, this PR updates the ToastView to allow for consecutive Toast updates. 

## How is this patch tested? If it is not, please explain why.

https://github.com/user-attachments/assets/8578b809-66a2-48cd-bcea-cecc06d13c39


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a customizable `Toast` component for enhanced notification display.
	- Added support for primary and secondary action buttons in toast notifications.

- **Improvements**
	- Enhanced flexibility in toast notification layout and styling.
	- Implemented auto-hide functionality for toast notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->