### PR TITLE
Fix size estimates

### DIFF
--- a/app/packages/utilities/src/size-bytes-estimate.test.ts
+++ b/app/packages/utilities/src/size-bytes-estimate.test.ts
@@ -32,7 +32,7 @@ describe("sizeBytesEstimate tests", () => {
     expect(sizeBytesEstimate("chars")).toBe(10);
   });
 
-  test("non-objects return 0", () => {
-    expect(sizeBytesEstimate(() => null)).toBe(0);
+  test("non-objects return non-zero", () => {
+    expect(sizeBytesEstimate(() => null)).toBe(1);
   });
 });

--- a/app/packages/utilities/src/size-bytes-estimate.ts
+++ b/app/packages/utilities/src/size-bytes-estimate.ts
@@ -64,5 +64,6 @@ const sizer = (object: SizerTypes) => {
 };
 
 export default function sizeBytesEstimate(object: SizeTypes) {
-  return sizer(object);
+  // return value > 0;
+  return Math.max(sizer(object), 1);
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Size estimates for LRU cache must be > 0

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video")

# Playback works as expected
session = fo.launch_app(dataset)

# Playback doesn't work
session.view = dataset.select_fields()
``` 

## How is this patch tested? If it is not, please explain why.

Unit test

## Release Notes

* Fixed video playback for videos without labels

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `sizeBytesEstimate` function to ensure it returns a minimum value of 1 for non-object inputs, enhancing the function's reliability.
  
- **Bug Fixes**
	- Adjusted test cases to reflect the new expected behavior for non-object inputs, ensuring accurate validation of the function's output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->