### PR TITLE
Fix sidebar indexes

### DIFF
--- a/app/packages/core/src/components/Filters/NumericFieldFilter/Box.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/Box.tsx
@@ -14,12 +14,13 @@ const BoxDiv = styled.div`
 export default function Box({
   children,
   text,
-}: React.PropsWithChildren<{ text?: string }>) {
+  height = 30,
+}: React.PropsWithChildren<{ text?: string; height?: number }>) {
   const value = text === "Loading" ? <LoadingDots text="Loading" /> : text;
   return (
     <BoxDiv
       style={{
-        height: 71,
+        height: height,
         display: "flex",
         justifyContent: "center",
         flexDirection: "column",

--- a/fiftyone/server/indexes.py
+++ b/fiftyone/server/indexes.py
@@ -5,6 +5,7 @@ FiftyOne Server indexes.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from enum import Enum
 import typing as t
 
@@ -58,6 +59,9 @@ def from_dict(d: t.Dict[str, t.Dict[str, t.Any]]):
 def _from_dict(d: t.Dict[str, t.Dict[str, t.Any]]):
     indexes: t.List[Index] = []
     for name, index in d.items():
+        if index.get("in_progress", False):
+            continue
+
         key = [_index_key_from_dict(*field) for field in index["key"]]
         if None in key:
             continue

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -697,5 +697,5 @@ def _assign_estimated_counts(dataset: Dataset, fo_dataset: fo.Dataset):
 
 def _assign_lightning_info(dataset: Dataset, fo_dataset: fo.Dataset):
     dataset.sample_indexes, dataset.frame_indexes = indexes_from_dict(
-        fo_dataset.get_index_information()
+        fo_dataset.get_index_information(include_stats=True)
     )


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Fix sizing of sidebar range fields
- Make it so qp indexes on the sidebar take into consideration if index creation is in progress

## How is this patch tested? If it is not, please explain why.


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The `Box` component now supports a dynamic `height` property, enhancing layout flexibility.
	- Improved index processing logic to skip "in_progress" indexes, ensuring only completed indexes are processed.
	- Enhanced retrieval of index information by including additional statistical data.

- **Bug Fixes**
	- Adjusted the `_assign_lightning_info` function to improve index information retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->