### PR TITLE
Tweak panel table action spacing

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/ActionsMenu.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ActionsMenu.tsx
@@ -95,7 +95,11 @@ function Action(props: ActionPropsType) {
         variant={variant}
         startIcon={Icon}
         onClick={handleClick}
-        sx={{ color: resolvedColor, padding: size === "small" ? 0 : undefined }}
+        sx={{
+          color: resolvedColor,
+          padding: size === "small" ? 0 : undefined,
+          minWidth: size === "small" ? 40 : undefined,
+        }}
       >
         {label}
       </Button>

--- a/app/packages/core/src/plugins/SchemaIO/components/TableView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TableView.tsx
@@ -141,7 +141,7 @@ export default function TableView(props: ViewPropsType) {
                 {hasRowActions && (
                   <TableCell
                     {...getComponentProps(props, "tableHeadCell", {
-                      sx: { ...headingCellBaseStyles, textAlign: "left" },
+                      sx: { ...headingCellBaseStyles, textAlign: "center" },
                     })}
                     width={`${max_inline_actions * 5}%`}
                     onClick={() => {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Tweak table spacing to align items better

## How is this patch tested? If it is not, please explain why.

![Screenshot 2024-11-18 at 10 19 49 PM](https://github.com/user-attachments/assets/f6c41405-6ff5-47fe-ba52-99c71a9c4266)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced button styling in the Actions Menu for improved appearance on smaller sizes.
	- Improved text alignment for the actions header in the Table View, now centered for better visual presentation.
	- Refined event handling for row actions in the Table View, ensuring correct action invocation.

- **Bug Fixes**
	- Adjusted handling of onClick events for clarity and reliability in the Table View.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->