### PR TITLE
Retain browser setting for modal dynamic groups

### DIFF
--- a/app/packages/state/src/hooks/useSetModalState.ts
+++ b/app/packages/state/src/hooks/useSetModalState.ts
@@ -2,7 +2,6 @@ import type { CallbackInterface, RecoilState } from "recoil";
 
 import { useRelayEnvironment } from "react-relay";
 import { useRecoilCallback } from "recoil";
-import { dynamicGroupsViewMode } from "../recoil";
 import * as atoms from "../recoil/atoms";
 import * as filterAtoms from "../recoil/filters";
 import * as groupAtoms from "../recoil/groups";
@@ -44,8 +43,6 @@ export default () => {
             selectors.appConfigOption({ key, modal: false }),
           ];
         }),
-
-        [dynamicGroupsViewMode(true), dynamicGroupsViewMode(false)],
 
         [atoms.cropToContent(true), atoms.cropToContent(false)],
         [atoms.sortFilterResults(true), atoms.sortFilterResults(false)],

--- a/app/packages/state/src/recoil/options.ts
+++ b/app/packages/state/src/recoil/options.ts
@@ -4,7 +4,7 @@ import {
   mediaFieldsFragment,
   mediaFieldsFragment$key,
 } from "@fiftyone/relay";
-import { atomFamily, selector, selectorFamily } from "recoil";
+import { atomFamily, DefaultValue, selector, selectorFamily } from "recoil";
 import { getBrowserStorageEffectForKey } from "./customEffects";
 import { datasetSampleCount } from "./dataset";
 import { fieldPaths } from "./schema";
@@ -55,15 +55,39 @@ export const selectedMediaField = selectorFamily<string, boolean>({
       set(selectedMediaFieldAtomFamily(modal), value),
 });
 
-export const dynamicGroupsViewMode = atomFamily<
-  "carousel" | "pagination" | "video",
+export const dynamicGroupsViewModeStore = atomFamily<
+  "carousel" | "pagination" | "video" | null,
   boolean
 >({
-  key: "dynamicGroupsViewMode",
-  default: "pagination",
+  key: "dynamicGroupsViewModeStore",
+  default: null,
   effects: (modal) => [
     getBrowserStorageEffectForKey(`dynamicGroupsViewMode-${modal}`),
   ],
+});
+
+export const dynamicGroupsViewMode = selectorFamily({
+  key: "dynamicGroupsViewModeStore",
+  get:
+    (modal: boolean) =>
+    ({ get }) => {
+      const value = get(dynamicGroupsViewModeStore(modal));
+
+      if (!value) {
+        return modal ? get(dynamicGroupsViewModeStore(false)) : "pagination";
+      }
+
+      return value;
+    },
+  set:
+    (modal: boolean) =>
+    ({ reset, set }, newValue) => {
+      const instance = dynamicGroupsViewModeStore(modal);
+
+      newValue instanceof DefaultValue
+        ? reset(instance)
+        : set(instance, newValue);
+    },
 });
 
 export const isLargeVideo = selector<boolean>({

--- a/app/packages/state/src/recoil/options.ts
+++ b/app/packages/state/src/recoil/options.ts
@@ -4,7 +4,7 @@ import {
   mediaFieldsFragment,
   mediaFieldsFragment$key,
 } from "@fiftyone/relay";
-import { atomFamily, DefaultValue, selector, selectorFamily } from "recoil";
+import { DefaultValue, atomFamily, selector, selectorFamily } from "recoil";
 import { getBrowserStorageEffectForKey } from "./customEffects";
 import { datasetSampleCount } from "./dataset";
 import { fieldPaths } from "./schema";
@@ -74,7 +74,9 @@ export const dynamicGroupsViewMode = selectorFamily({
       const value = get(dynamicGroupsViewModeStore(modal));
 
       if (!value) {
-        return modal ? get(dynamicGroupsViewModeStore(false)) : "pagination";
+        return modal
+          ? get(dynamicGroupsViewModeStore(false)) ?? "pagination"
+          : "pagination";
       }
 
       return value;

--- a/app/packages/state/src/recoil/options.ts
+++ b/app/packages/state/src/recoil/options.ts
@@ -67,7 +67,7 @@ export const dynamicGroupsViewModeStore = atomFamily<
 });
 
 export const dynamicGroupsViewMode = selectorFamily({
-  key: "dynamicGroupsViewModeStore",
+  key: "dynamicGroupsViewMode",
   get:
     (modal: boolean) =>
     ({ get }) => {


### PR DESCRIPTION
Retain browser setting for dynamic groups mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new selector for managing dynamic group view modes, allowing for more flexible state handling.
	- Updated the dynamic group view mode atom to support null values, enhancing configuration options.

- **Bug Fixes**
	- Removed outdated references to dynamic group view modes, streamlining modal state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->