### PR TITLE
chore(ci): AS-347 concurrency groups for prs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,6 +9,10 @@ on:
       - main
       - release/v[0-9]+.[0-9]+.[0-9]+
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+  
 jobs:
   modified-files:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What changes are proposed in this pull request?

We can add concurrency groups with `cancel-in-progress` to cancel pre-existing jobs.
It seems like a good idea to save money on workflows that might take a bit on PRs.

## How is this patch tested? If it is not, please explain why.

This change was tested with GH Actions

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a concurrency control mechanism in the GitHub Actions workflow to optimize execution by preventing overlapping runs.

- **Chores**
	- Updated workflow configuration to manage simultaneous executions and improve overall efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->