### PR TITLE
Add support for cell tooltip in TableView

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/TableView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TableView.tsx
@@ -41,7 +41,6 @@ export default function TableView(props: ViewPropsType) {
     getTableData(props);
   const dataMissing = rows.length === 0;
   const hasRowActions = row_actions.length > 0;
-  const hasTooltips = tooltips.length > 0;
   const panelId = usePanelId();
   const handleClick = usePanelEvent();
   const theme = useTheme();

--- a/app/packages/core/src/plugins/SchemaIO/components/TableView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TableView.tsx
@@ -34,11 +34,13 @@ export default function TableView(props: ViewPropsType) {
     size = "small",
     variant = "filled",
     max_inline_actions = 1,
+    tooltips = []
   } = view;
   const { rows, selectedCells, selectedRows, selectedColumns } =
     getTableData(props);
   const dataMissing = rows.length === 0;
   const hasRowActions = row_actions.length > 0;
+  const hasTooltips = tooltips.length > 0;
   const panelId = usePanelId();
   const handleClick = usePanelEvent();
   const theme = useTheme();

--- a/app/packages/core/src/plugins/SchemaIO/components/TableView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TableView.tsx
@@ -10,6 +10,7 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  Tooltip,
   useTheme,
 } from "@mui/material";
 import { isPlainObject } from "lodash";
@@ -65,6 +66,14 @@ export default function TableView(props: ViewPropsType) {
     return computedRowActions;
   }, []);
 
+  const getTooltips = useCallback((tooltipList) => {
+    const tooltipDict = {};
+    for (const { value, row, column } of tooltipList) {
+      tooltipDict[`${row},${column}`] = value; // Create a key from row and column
+    }
+    return tooltipDict;
+  }, []);
+
   const handleCellClick = useCallback(
     (row, column) => {
       if (on_click_cell) {
@@ -95,6 +104,7 @@ export default function TableView(props: ViewPropsType) {
     color: theme.palette.text.secondary,
   };
   const filled = variant === "filled";
+  const tooltipMap = getTooltips(tooltips);
 
   return (
     <Box {...getComponentProps(props, "container")}>
@@ -172,13 +182,14 @@ export default function TableView(props: ViewPropsType) {
                         selectedCells.has(coordinate) ||
                         isRowSelected ||
                         selectedColumns.has(columnIndex);
-                      return (
+                      
+                      const tooltip = tooltipMap[coordinate]; // Check if there's a tooltip for the cell
+
+                      const cell = (
                         <TableCell
                           key={key}
                           sx={{
-                            background: isSelected
-                              ? selectedCellColor
-                              : "unset",
+                            background: isSelected ? selectedCellColor : "unset",
                           }}
                           onClick={() => {
                             handleCellClick(rowIndex, columnIndex);
@@ -188,7 +199,16 @@ export default function TableView(props: ViewPropsType) {
                           {formatCellValue(item[key], props)}
                         </TableCell>
                       );
+
+                      return tooltip ? (
+                        <Tooltip key={key} title={tooltip} arrow>
+                          {cell}
+                        </Tooltip>
+                      ) : (
+                        cell
+                      );
                     })}
+
                     {hasRowActions && (
                       <TableCell
                         align="right"

--- a/app/packages/core/src/plugins/SchemaIO/components/TableView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TableView.tsx
@@ -195,17 +195,17 @@ export default function TableView(props: ViewPropsType) {
                           }}
                           {...getComponentProps(props, "tableBodyCell")}
                         >
-                          {formatCellValue(item[key], props)}
+                          {tooltip ? (
+                            <Tooltip title={tooltip} arrow>
+                              <span>{formatCellValue(item[key], props)}</span> {/* Wrap content with Tooltip */}
+                            </Tooltip>
+                          ) : (
+                            formatCellValue(item[key], props) // No Tooltip for cells without tooltips
+                          )}
                         </TableCell>
                       );
-
-                      return tooltip ? (
-                        <Tooltip key={key} title={tooltip} arrow>
-                          {cell}
-                        </Tooltip>
-                      ) : (
-                        cell
-                      );
+                      
+                      return cell;
                     })}
 
                     {hasRowActions && (

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -1866,6 +1866,11 @@ class TableView(View):
         )
         self.row_actions.append(row_action)
         return row_action
+    
+    def add_tooltip(self, row, column, value, **kwargs):
+        tooltip = View(row=row, column=column, value=value, **kwargs)
+        self.tooltips.append(tooltip)
+        return tooltip
 
     def clone(self):
         clone = super().clone()

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -1837,6 +1837,25 @@ class Action(View):
 
     def to_json(self):
         return {**super().to_json()}
+    
+class Tooltip(View):
+    """A tooltip (currently supported only in a :class:`TableView`).
+
+    Args:
+        value: the value of the tooltip
+        row: the row of the tooltip
+        column: the column of the tooltip
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def clone(self):
+        clone = Tooltip(**self._kwargs)
+        return clone
+
+    def to_json(self):
+        return {**super().to_json()}
 
 
 class TableView(View):
@@ -1868,7 +1887,7 @@ class TableView(View):
         return row_action
     
     def add_tooltip(self, row, column, value, **kwargs):
-        tooltip = View(row=row, column=column, value=value, **kwargs)
+        tooltip = Tooltip(row=row, column=column, value=value, **kwargs)
         self.tooltips.append(tooltip)
         return tooltip
 

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -1870,6 +1870,7 @@ class TableView(View):
         super().__init__(**kwargs)
         self.columns = kwargs.get("columns", [])
         self.row_actions = kwargs.get("row_actions", [])
+        self.tooltips = kwargs.get("tooltips", [])
 
     def keys(self):
         return [column.key for column in self.columns]
@@ -1895,6 +1896,7 @@ class TableView(View):
         clone = super().clone()
         clone.columns = [column.clone() for column in self.columns]
         clone.row_actions = [action.clone() for action in self.row_actions]
+        clone.tooltips = [tooltip.clone() for tooltip in self.tooltips]
         return clone
 
     def to_json(self):
@@ -1902,6 +1904,7 @@ class TableView(View):
             **super().to_json(),
             "columns": [column.to_json() for column in self.columns],
             "row_actions": [action.to_json() for action in self.row_actions],
+            "tooltips": [tooltip.to_json() for tooltip in self.tooltips],
         }
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Added support for cell tooltip in TableView

## How is this patch tested? If it is not, please explain why.

* Tested locally

![image](https://github.com/user-attachments/assets/59d4b201-b981-45d1-be3b-b92a471ae3fd)

(the current panel is a local version for testing, not the RC version, so a few details might be a bit off)

Example usage: 
```
for row in range(len(all_indices), len(all_indices) + len(summary_fields)):
    table.add_tooltip(row, 1, "Summary field size not available")
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced tooltips for table cells, providing additional context when hovering over data.
	- Added functionality to manage and serialize tooltips within the `TableView` component.
- **Bug Fixes**
	- Minor adjustments made for code clarity and organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->