### PR TITLE
Fix docs download links

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -124,7 +124,7 @@ nbsphinx_prolog = """
             </a>
         </td>
         <td>
-            <a target="_blank" href="https://gitcdn.link/cdn/voxel51/fiftyone/%s/docs/source/{{ env.doc2path(env.docname, base=None) }}" download>
+            <a target="_blank" href="https://raw.githubusercontent.com/voxel51/fiftyone/%s/docs/source/{{ env.doc2path(env.docname, base=None) }}" download>
                 <img src="../_static/images/icons/cloud-icon-256px.png"> &nbsp; Download notebook
             </a>
         </td>


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes download links in documentation
<img width="1470" alt="Screenshot 2024-11-19 at 2 03 49 PM" src="https://github.com/user-attachments/assets/82782faa-df1f-4fbf-af31-5ab76678a23f">


As an example, the old format was
* https://gitcdn.link/cdn/voxel51/fiftyone/v1.0.2/docs/source/recipes/image_deduplication.ipynb

Updated to
* https://raw.githubusercontent.com/voxel51/fiftyone/v1.0.2/docs/source/recipes/image_deduplication.ipynb


### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the hyperlink for downloading notebooks in the documentation to improve accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->