### PR TITLE
Prevent video time from getting assigned NaN when frame rate is undefined

### DIFF
--- a/app/packages/looker/src/elements/util.ts
+++ b/app/packages/looker/src/elements/util.ts
@@ -105,7 +105,8 @@ export const getClampedTime = (
 };
 
 export const getTime = (frameNumber: number, frameRate: number): number => {
-  return (frameNumber - 1 + 0.01) / frameRate;
+  const time = (frameNumber - 1 + 0.01) / frameRate;
+  return isFinite(time) ? time : 0.0;
 };
 
 export const getFrameString = (


### PR DESCRIPTION
## What changes are proposed in this pull request?

Prevent video time from getting assigned NaN when frame rate is undefined. This currently causes a crash during playback; with this change, playback will be disabled if the frame rate is undefined, but will not crash.

## How is this patch tested? If it is not, please explain why.

local app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the time calculation function to prevent non-finite values from being returned, enhancing application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->