### PR TITLE
Add detach to spotlight

### DIFF
--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -62,6 +62,10 @@ function Grid() {
         looker?.destroy();
         lookerStore.delete(id.description);
       },
+      detach: (id) => {
+        const looker = lookerStore.get(id.description);
+        looker?.destroy();
+      },
       onItemClick: setSample,
       retainItems: true,
       rowAspectRatioThreshold: threshold,

--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -64,7 +64,7 @@ function Grid() {
       },
       detach: (id) => {
         const looker = lookerStore.get(id.description);
-        looker?.destroy();
+        looker?.detach();
       },
       onItemClick: setSample,
       retainItems: true,

--- a/app/packages/spotlight/src/row.ts
+++ b/app/packages/spotlight/src/row.ts
@@ -120,7 +120,7 @@ export default class Row<K, V> {
   }
 
   destroy(destroyItems = false) {
-    destroyItems && this.#destroyItems();
+    this.#destroyItems(destroyItems);
     this.#aborter.abort();
   }
 
@@ -231,8 +231,8 @@ export default class Row<K, V> {
     return set.size === ONE ? this.#row[ZERO].item.aspectRatio : null;
   }
 
-  #destroyItems() {
-    const destroy = this.#config.destroy;
+  #destroyItems(destroyItems = false) {
+    const destroy = destroyItems ? this.#config.destroy : this.#config.detach;
     if (!destroy) {
       return;
     }

--- a/app/packages/spotlight/src/types.ts
+++ b/app/packages/spotlight/src/types.ts
@@ -58,6 +58,7 @@ export type Request<K, V> = (key: K) => Promise<{
 export interface SpotlightConfig<K, V> {
   at?: At;
   destroy?: (id: ID) => void;
+  detach?: (id: ID) => void;
   get: Get<K, V>;
   key: K;
   offset?: number;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Looker instances should be detached when a spotlight instance is destroyed

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `detach` method for the `Spotlight` instance to enhance looker management.
	- Added an optional `detach` method to the `SpotlightConfig` interface for configurable detachment behavior.

- **Bug Fixes**
	- Updated the `#destroyItems` method in the `Row` class to allow for more explicit handling of item destruction based on a new parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->