### PR TITLE
Bug fix for TableView tooltip

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/ActionsMenu.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ActionsMenu.tsx
@@ -114,8 +114,7 @@ function Action(props: ActionPropsType) {
 
   return tooltip ? (
     <Tooltip title={tooltip}>
-      <span>{content}</span>{" "}
-      {/* Use <span> to wrap the child to avoid DOM issues */}
+      <span>{content}</span>
     </Tooltip>
   ) : (
     content

--- a/app/packages/core/src/plugins/SchemaIO/components/TableView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TableView.tsx
@@ -183,7 +183,7 @@ export default function TableView(props: ViewPropsType) {
                         selectedColumns.has(columnIndex);
                       
                       const tooltip = tooltipMap[coordinate]; // Check if there's a tooltip for the cell
-
+                      const content = formatCellValue(item[key], props);
                       const cell = (
                         <TableCell
                           key={key}
@@ -197,11 +197,9 @@ export default function TableView(props: ViewPropsType) {
                         >
                           {tooltip ? (
                             <Tooltip title={tooltip} arrow>
-                              <span>{formatCellValue(item[key], props)}</span> {/* Wrap content with Tooltip */}
+                              <span> {content} </span>
                             </Tooltip>
-                          ) : (
-                            formatCellValue(item[key], props) // No Tooltip for cells without tooltips
-                          )}
+                          ) : (content)}
                         </TableCell>
                       );
                       


### PR DESCRIPTION
## What changes are proposed in this pull request?

In teams, Tooltip cannot handle multiple children at once and thus causing error

## How is this patch tested? If it is not, please explain why.

* Tested locally (Cam)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced readability of the `TableView` component by simplifying cell content rendering and tooltip management.
  
- **Refactor**
  - Removed unnecessary comments in the `ActionsMenu` component to streamline the code while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->