### PR TITLE
fix cancel button of class performance config modal

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -1350,7 +1350,7 @@ export default function Evaluation(props: EvaluationProps) {
               variant="outlined"
               color="secondary"
               sx={{ width: "100%" }}
-              onClick={closeConfusionMatrixConfigDialog}
+              onClick={closeClassPerformanceConfigDialog}
             >
               Cancel
             </Button>


### PR DESCRIPTION
## What changes are proposed in this pull request?

fix cancel button of class performance config modal

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced dialog handling for class performance and confusion matrix configurations.
	- Updated dialog components for editing notes and configurations to improve user interaction.

- **Improvements**
	- Refined state management for dialog components to ensure accurate configuration application.
	- Enhanced type safety with the addition of `EvaluationProps` for better clarity in component properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->