### PR TITLE
Add open modal operator

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -1361,12 +1361,12 @@ export class EnableQueryPerformance extends Operator {
   }
 }
 
-class SetExpanded extends Operator {
+class OpenSample extends Operator {
   _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
-      name: "set_expanded",
-      label: "Set expanded",
+      name: "open_sample",
+      label: "Open Sample",
       unlisted: true,
     });
   }
@@ -1385,8 +1385,27 @@ class SetExpanded extends Operator {
   async execute({ hooks, params }: ExecutionContext) {
     hooks.setExpanded({
       id: params.id,
-      groupId: params.group_id,
+      group_id: params.group_id,
     });
+  }
+}
+
+class CloseSample extends Operator {
+  _builtIn = true;
+  get config(): OperatorConfig {
+    return new OperatorConfig({
+      name: "close_sample",
+      label: "Close Sample",
+      unlisted: true,
+    });
+  }
+  useHooks(): object {
+    return {
+      close: fos.useClearModal(),
+    };
+  }
+  async execute({ hooks, params }: ExecutionContext) {
+    hooks.close();
   }
 }
 
@@ -1441,7 +1460,8 @@ export function registerBuiltInOperators() {
     _registerBuiltInOperator(SetFrameNumber);
     _registerBuiltInOperator(DisableQueryPerformance);
     _registerBuiltInOperator(EnableQueryPerformance);
-    _registerBuiltInOperator(SetExpanded);
+    _registerBuiltInOperator(OpenSample);
+    _registerBuiltInOperator(CloseSample);
   } catch (e) {
     console.error("Error registering built-in operators");
     console.error(e);

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -1361,6 +1361,35 @@ export class EnableQueryPerformance extends Operator {
   }
 }
 
+class SetExpanded extends Operator {
+  _builtIn = true;
+  get config(): OperatorConfig {
+    return new OperatorConfig({
+      name: "set_expanded",
+      label: "Set expanded",
+      unlisted: true,
+    });
+  }
+  async resolveInput(): Promise<types.Property> {
+    const inputs = new types.Object();
+    inputs.str("id", { label: "Sample ID" });
+    inputs.str("group_id", { label: "Group ID" });
+
+    return new types.Property(inputs);
+  }
+  useHooks(): object {
+    return {
+      setExpanded: fos.useSetExpandedSample(),
+    };
+  }
+  async execute({ hooks, params }: ExecutionContext) {
+    hooks.setExpanded({
+      id: params.id,
+      groupId: params.group_id,
+    });
+  }
+}
+
 export function registerBuiltInOperators() {
   try {
     _registerBuiltInOperator(CopyViewAsJSON);
@@ -1412,6 +1441,7 @@ export function registerBuiltInOperators() {
     _registerBuiltInOperator(SetFrameNumber);
     _registerBuiltInOperator(DisableQueryPerformance);
     _registerBuiltInOperator(EnableQueryPerformance);
+    _registerBuiltInOperator(SetExpanded);
   } catch (e) {
     console.error("Error registering built-in operators");
     console.error(e);

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -665,15 +665,20 @@ class Operations(object):
         """
         return self._ctx.trigger("set_group_slice", {"slice": slice})
 
-    def set_expanded(self, id=None, group_id=None):
+    def open_sample(self, id=None, group_id=None):
         """Open a modal for the specified sample or group in the App.
 
         Args:
             id (None): the ID of the sample or group to view in the modal
+            group_id (None): the ID of the group to view in the modal
         """
         return self._ctx.trigger(
-            "set_expanded", {"id": id, "group_id": group_id}
+            "open_sample", {"id": id, "group_id": group_id}
         )
+
+    def close_sample(self):
+        """Close the modal for the sample or group in the App."""
+        return self._ctx.trigger("close_sample")
 
 
 def _serialize_view(view):

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -665,6 +665,16 @@ class Operations(object):
         """
         return self._ctx.trigger("set_group_slice", {"slice": slice})
 
+    def set_expanded(self, id=None, group_id=None):
+        """Open a modal for the specified sample or group in the App.
+
+        Args:
+            id (None): the ID of the sample or group to view in the modal
+        """
+        return self._ctx.trigger(
+            "set_expanded", {"id": id, "group_id": group_id}
+        )
+
 
 def _serialize_view(view):
     return json.loads(json_util.dumps(view._serialize()))

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -666,18 +666,18 @@ class Operations(object):
         return self._ctx.trigger("set_group_slice", {"slice": slice})
 
     def open_sample(self, id=None, group_id=None):
-        """Open a modal for the specified sample or group in the App.
+        """Opens the specified sample or group in the App's sample modal.
 
         Args:
-            id (None): the ID of the sample or group to view in the modal
-            group_id (None): the ID of the group to view in the modal
+            id (None): a sample ID to open in the modal
+            group_id (None): a group ID to open in the modal
         """
         return self._ctx.trigger(
             "open_sample", {"id": id, "group_id": group_id}
         )
 
     def close_sample(self):
-        """Close the modal for the sample or group in the App."""
+        """Closes the App's sample modal."""
         return self._ctx.trigger("close_sample")
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced two new operators, `OpenSample` and `CloseSample`, for managing the state of samples in the application.
  - Added methods to open and close modals for specified samples or groups.

- **Bug Fixes**
  - None reported.

- **Documentation**
  - None reported.

- **Refactor**
  - None reported.

- **Style**
  - None reported.

- **Tests**
  - None reported.

- **Chores**
  - None reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->