### PR TITLE
labels rendering performance improvement: create ImageBitmaps in worker

### DIFF
--- a/app/packages/looker/src/lookers/abstract.ts
+++ b/app/packages/looker/src/lookers/abstract.ts
@@ -293,6 +293,11 @@ export abstract class AbstractLooker<
           return;
         }
 
+        if (this.state.destroyed && this.sampleOverlays) {
+          // close all current overlays
+          this.pluckedOverlays.forEach((overlay) => overlay.cleanup?.());
+        }
+
         if (
           !this.state.windowBBox ||
           this.state.destroyed ||

--- a/app/packages/looker/src/lookers/frame-reader.ts
+++ b/app/packages/looker/src/lookers/frame-reader.ts
@@ -52,7 +52,15 @@ interface AcquireReaderOptions {
 export const { acquireReader, clearReader } = (() => {
   const createCache = (removeFrame: RemoveFrame) => {
     return new LRUCache<number, Frame>({
-      dispose: (_, key) => removeFrame(key),
+      dispose: (frame, key) => {
+        const overlays = frame.overlays;
+
+        for (let i = 0; i < overlays.length; i++) {
+          overlays[i].cleanup?.();
+        }
+
+        removeFrame(key);
+      },
       max: MAX_FRAME_STREAM_SIZE,
       maxSize: MAX_FRAME_STREAM_SIZE_BYTES,
       noDisposeOnSet: true,

--- a/app/packages/looker/src/overlays/base.ts
+++ b/app/packages/looker/src/overlays/base.ts
@@ -3,6 +3,7 @@
  */
 
 import { getCls, sizeBytesEstimate } from "@fiftyone/utilities";
+import { OverlayMask } from "../numpy";
 import type { BaseState, Coordinates, NONFINITE } from "../state";
 import { getLabelColor, shouldShowLabelTag } from "./util";
 
@@ -41,6 +42,7 @@ export interface SelectData {
 
 export type LabelMask = {
   bitmap?: ImageBitmap;
+  data?: OverlayMask;
 };
 
 export interface RegularLabel extends BaseLabel {

--- a/app/packages/looker/src/overlays/base.ts
+++ b/app/packages/looker/src/overlays/base.ts
@@ -73,6 +73,7 @@ export interface Overlay<State extends Partial<BaseState>> {
   getPoints(state: Readonly<State>): Coordinates[];
   getSelectData(state: Readonly<State>): SelectData;
   getSizeBytes(): number;
+  cleanup?(): void;
 }
 
 export abstract class CoordinateOverlay<

--- a/app/packages/looker/src/overlays/base.ts
+++ b/app/packages/looker/src/overlays/base.ts
@@ -39,6 +39,10 @@ export interface SelectData {
   frameNumber?: number;
 }
 
+export type LabelMask = {
+  bitmap?: ImageBitmap;
+};
+
 export interface RegularLabel extends BaseLabel {
   _id?: string;
   label?: string;

--- a/app/packages/looker/src/overlays/detection.ts
+++ b/app/packages/looker/src/overlays/detection.ts
@@ -264,7 +264,7 @@ export default class DetectionOverlay<
   public cleanup(): void {
     if (this.label.mask?.bitmap) {
       this.label.mask?.bitmap.close();
-      console.log(">>>cleanup");
+      this.label.mask.bitmap = null;
     }
   }
 }

--- a/app/packages/looker/src/overlays/detection.ts
+++ b/app/packages/looker/src/overlays/detection.ts
@@ -4,7 +4,6 @@
 import { NONFINITES } from "@fiftyone/utilities";
 
 import { INFO_COLOR } from "../constants";
-import { OverlayMask } from "../numpy";
 import { BaseState, BoundingBox, Coordinates, NONFINITE } from "../state";
 import { distanceFromLineSegment } from "../util";
 import { CONTAINS, CoordinateOverlay, PointInfo, RegularLabel } from "./base";

--- a/app/packages/looker/src/overlays/detection.ts
+++ b/app/packages/looker/src/overlays/detection.ts
@@ -6,13 +6,17 @@ import { NONFINITES } from "@fiftyone/utilities";
 import { INFO_COLOR } from "../constants";
 import { BaseState, BoundingBox, Coordinates, NONFINITE } from "../state";
 import { distanceFromLineSegment } from "../util";
-import { CONTAINS, CoordinateOverlay, PointInfo, RegularLabel } from "./base";
+import {
+  CONTAINS,
+  CoordinateOverlay,
+  LabelMask,
+  PointInfo,
+  RegularLabel,
+} from "./base";
 import { t } from "./util";
 
 export interface DetectionLabel extends RegularLabel {
-  mask?: {
-    bitmap?: ImageBitmap;
-  };
+  mask?: LabelMask;
   bounding_box: BoundingBox;
 
   // valid for 3D bounding boxes

--- a/app/packages/looker/src/overlays/detection.ts
+++ b/app/packages/looker/src/overlays/detection.ts
@@ -12,8 +12,7 @@ import { t } from "./util";
 
 export interface DetectionLabel extends RegularLabel {
   mask?: {
-    data: OverlayMask;
-    image: ArrayBuffer;
+    bitmap?: ImageBitmap;
   };
   bounding_box: BoundingBox;
 

--- a/app/packages/looker/src/overlays/detection.ts
+++ b/app/packages/looker/src/overlays/detection.ts
@@ -31,7 +31,6 @@ export default class DetectionOverlay<
 > extends CoordinateOverlay<State, DetectionLabel> {
   private is3D: boolean;
   private labelBoundingBox: BoundingBox;
-  private imageBitmap: ImageBitmap | null = null;
 
   constructor(field, label) {
     super(field, label);
@@ -260,6 +259,13 @@ export default class DetectionOverlay<
     const ow = state.strokeWidth / state.canvasBBox[2];
     const oh = state.strokeWidth / state.canvasBBox[3];
     return [(bx - ow) * w, (by - oh) * h, (bw + ow * 2) * w, (bh + oh * 2) * h];
+  }
+
+  public cleanup(): void {
+    if (this.label.mask?.bitmap) {
+      this.label.mask?.bitmap.close();
+      console.log(">>>cleanup");
+    }
   }
 }
 

--- a/app/packages/looker/src/overlays/heatmap.ts
+++ b/app/packages/looker/src/overlays/heatmap.ts
@@ -77,7 +77,7 @@ export default class HeatmapOverlay<State extends BaseState>
   }
 
   draw(ctx: CanvasRenderingContext2D, state: Readonly<State>): void {
-    if (this.label.map.bitmap) {
+    if (this.label.map?.bitmap) {
       const [tlx, tly] = t(state, 0, 0);
       const [brx, bry] = t(state, 1, 1);
       const tmp = ctx.globalAlpha;

--- a/app/packages/looker/src/overlays/heatmap.ts
+++ b/app/packages/looker/src/overlays/heatmap.ts
@@ -15,6 +15,7 @@ import { clampedIndex } from "../worker/painter";
 import {
   BaseLabel,
   CONTAINS,
+  LabelMask,
   Overlay,
   PointInfo,
   SelectData,
@@ -22,12 +23,8 @@ import {
 } from "./base";
 import { strokeCanvasRect, t } from "./util";
 
-interface HeatMap {
-  bitmap?: ImageBitmap;
-}
-
 interface HeatmapLabel extends BaseLabel {
-  map?: HeatMap;
+  map?: LabelMask;
   range?: [number, number];
 }
 

--- a/app/packages/looker/src/overlays/heatmap.ts
+++ b/app/packages/looker/src/overlays/heatmap.ts
@@ -78,21 +78,10 @@ export default class HeatmapOverlay<State extends BaseState>
 
   draw(ctx: CanvasRenderingContext2D, state: Readonly<State>): void {
     if (this.label.map.bitmap) {
-      // const maskCtx = this.canvas.getContext("2d");
-      // maskCtx.imageSmoothingEnabled = false;
-      // maskCtx.clearRect(
-      //   0,
-      //   0,
-      //   this.label.map.data.shape[1],
-      //   this.label.map.data.shape[0]
-      // );
-      // maskCtx.putImageData(this.imageData, 0, 0);
-
       const [tlx, tly] = t(state, 0, 0);
       const [brx, bry] = t(state, 1, 1);
       const tmp = ctx.globalAlpha;
       ctx.globalAlpha = state.options.alpha;
-      // ctx.drawImage(this.canvas, tlx, tly, brx - tlx, bry - tly);
       ctx.drawImage(this.label.map.bitmap, tlx, tly, brx - tlx, bry - tly);
       ctx.globalAlpha = tmp;
     }

--- a/app/packages/looker/src/overlays/heatmap.ts
+++ b/app/packages/looker/src/overlays/heatmap.ts
@@ -205,6 +205,12 @@ export default class HeatmapOverlay<State extends BaseState>
   getSizeBytes(): number {
     return sizeBytesEstimate(this.label);
   }
+
+  public cleanup(): void {
+    if (this.label.map?.bitmap) {
+      this.label.map?.bitmap.close();
+    }
+  }
 }
 
 export const getHeatmapPoints = (labels: HeatmapLabel[]): Coordinates[] => {

--- a/app/packages/looker/src/overlays/heatmap.ts
+++ b/app/packages/looker/src/overlays/heatmap.ts
@@ -6,6 +6,7 @@ import {
   getColor,
   getRGBA,
   getRGBAColor,
+  sizeBytesEstimate,
 } from "@fiftyone/utilities";
 import { ARRAY_TYPES, TypedArray } from "../numpy";
 import { BaseState, Coordinates } from "../state";
@@ -233,6 +234,10 @@ export default class HeatmapOverlay<State extends BaseState>
     }
 
     return this.targets[index];
+  }
+
+  getSizeBytes(): number {
+    return sizeBytesEstimate(this.label);
   }
 }
 

--- a/app/packages/looker/src/overlays/heatmap.ts
+++ b/app/packages/looker/src/overlays/heatmap.ts
@@ -42,8 +42,6 @@ export default class HeatmapOverlay<State extends BaseState>
   private label: HeatmapLabel;
   private targets?: TypedArray;
   private readonly range: [number, number];
-  private canvas: HTMLCanvasElement;
-  private imageData: ImageData;
 
   constructor(field: string, label: HeatmapLabel) {
     this.field = field;
@@ -65,25 +63,6 @@ export default class HeatmapOverlay<State extends BaseState>
     if (!width || !height) {
       return;
     }
-
-    this.canvas = document.createElement("canvas");
-    this.canvas.width = width;
-    this.canvas.height = height;
-
-    this.imageData = new ImageData(
-      new Uint8ClampedArray(this.label.map.image),
-      width,
-      height
-    );
-    const maskCtx = this.canvas.getContext("2d");
-    maskCtx.imageSmoothingEnabled = false;
-    maskCtx.clearRect(
-      0,
-      0,
-      this.label.map.data.shape[1],
-      this.label.map.data.shape[0]
-    );
-    maskCtx.putImageData(this.imageData, 0, 0);
   }
 
   containsPoint(state: Readonly<State>): CONTAINS {
@@ -98,22 +77,23 @@ export default class HeatmapOverlay<State extends BaseState>
   }
 
   draw(ctx: CanvasRenderingContext2D, state: Readonly<State>): void {
-    if (this.imageData) {
-      const maskCtx = this.canvas.getContext("2d");
-      maskCtx.imageSmoothingEnabled = false;
-      maskCtx.clearRect(
-        0,
-        0,
-        this.label.map.data.shape[1],
-        this.label.map.data.shape[0]
-      );
-      maskCtx.putImageData(this.imageData, 0, 0);
+    if (this.label.map.bitmap) {
+      // const maskCtx = this.canvas.getContext("2d");
+      // maskCtx.imageSmoothingEnabled = false;
+      // maskCtx.clearRect(
+      //   0,
+      //   0,
+      //   this.label.map.data.shape[1],
+      //   this.label.map.data.shape[0]
+      // );
+      // maskCtx.putImageData(this.imageData, 0, 0);
 
       const [tlx, tly] = t(state, 0, 0);
       const [brx, bry] = t(state, 1, 1);
       const tmp = ctx.globalAlpha;
       ctx.globalAlpha = state.options.alpha;
-      ctx.drawImage(this.canvas, tlx, tly, brx - tlx, bry - tly);
+      // ctx.drawImage(this.canvas, tlx, tly, brx - tlx, bry - tly);
+      ctx.drawImage(this.label.map.bitmap, tlx, tly, brx - tlx, bry - tly);
       ctx.globalAlpha = tmp;
     }
 

--- a/app/packages/looker/src/overlays/heatmap.ts
+++ b/app/packages/looker/src/overlays/heatmap.ts
@@ -7,7 +7,7 @@ import {
   getRGBA,
   getRGBAColor,
 } from "@fiftyone/utilities";
-import { ARRAY_TYPES, OverlayMask, TypedArray } from "../numpy";
+import { ARRAY_TYPES, TypedArray } from "../numpy";
 import { BaseState, Coordinates } from "../state";
 import { isFloatArray } from "../util";
 import { clampedIndex } from "../worker/painter";
@@ -22,8 +22,7 @@ import {
 import { strokeCanvasRect, t } from "./util";
 
 interface HeatMap {
-  data: OverlayMask;
-  image: ArrayBuffer;
+  bitmap?: ImageBitmap;
 }
 
 interface HeatmapLabel extends BaseLabel {

--- a/app/packages/looker/src/overlays/segmentation.ts
+++ b/app/packages/looker/src/overlays/segmentation.ts
@@ -32,8 +32,6 @@ export default class SegmentationOverlay<State extends BaseState>
   readonly field: string;
   private label: SegmentationLabel;
   private targets?: TypedArray;
-  private canvas: HTMLCanvasElement;
-  private imageData: ImageData;
 
   private isRgbMaskTargets = false;
 
@@ -51,6 +49,7 @@ export default class SegmentationOverlay<State extends BaseState>
     if (!this.label.mask) {
       return;
     }
+
     const [height, width] = this.label.mask.data.shape;
 
     if (!height || !width) {
@@ -60,25 +59,6 @@ export default class SegmentationOverlay<State extends BaseState>
     this.targets = new ARRAY_TYPES[this.label.mask.data.arrayType](
       this.label.mask.data.buffer
     );
-
-    this.canvas = document.createElement("canvas");
-    this.canvas.width = width;
-    this.canvas.height = height;
-
-    this.imageData = new ImageData(
-      new Uint8ClampedArray(this.label.mask.image),
-      width,
-      height
-    );
-    const maskCtx = this.canvas.getContext("2d");
-    maskCtx.imageSmoothingEnabled = false;
-    maskCtx.clearRect(
-      0,
-      0,
-      this.label.mask.data.shape[1],
-      this.label.mask.data.shape[0]
-    );
-    maskCtx.putImageData(this.imageData, 0, 0);
   }
 
   containsPoint(state: Readonly<State>): CONTAINS {
@@ -97,12 +77,12 @@ export default class SegmentationOverlay<State extends BaseState>
       return;
     }
 
-    if (this.imageData) {
+    if (this.label.mask?.bitmap) {
       const [tlx, tly] = t(state, 0, 0);
       const [brx, bry] = t(state, 1, 1);
       const tmp = ctx.globalAlpha;
       ctx.globalAlpha = state.options.alpha;
-      ctx.drawImage(this.canvas, tlx, tly, brx - tlx, bry - tly);
+      ctx.drawImage(this.label.mask.bitmap, tlx, tly, brx - tlx, bry - tly);
       ctx.globalAlpha = tmp;
     }
 

--- a/app/packages/looker/src/overlays/segmentation.ts
+++ b/app/packages/looker/src/overlays/segmentation.ts
@@ -2,7 +2,7 @@
  * Copyright 2017-2024, Voxel51, Inc.
  */
 
-import { getColor } from "@fiftyone/utilities";
+import { getColor, sizeBytesEstimate } from "@fiftyone/utilities";
 import { ARRAY_TYPES, TypedArray } from "../numpy";
 import { BaseState, Coordinates, MaskTargets } from "../state";
 import {
@@ -276,6 +276,10 @@ export default class SegmentationOverlay<State extends BaseState>
       return null;
     }
     return this.targets[index];
+  }
+
+  getSizeBytes(): number {
+    return sizeBytesEstimate(this.label);
   }
 }
 

--- a/app/packages/looker/src/overlays/segmentation.ts
+++ b/app/packages/looker/src/overlays/segmentation.ts
@@ -3,7 +3,7 @@
  */
 
 import { getColor } from "@fiftyone/utilities";
-import { ARRAY_TYPES, OverlayMask, TypedArray } from "../numpy";
+import { ARRAY_TYPES, TypedArray } from "../numpy";
 import { BaseState, Coordinates, MaskTargets } from "../state";
 import {
   BaseLabel,
@@ -17,8 +17,7 @@ import { isRgbMaskTargets, strokeCanvasRect, t } from "./util";
 
 interface SegmentationLabel extends BaseLabel {
   mask?: {
-    data: OverlayMask;
-    image: ArrayBuffer;
+    bitmap?: ImageBitmap;
   };
 }
 

--- a/app/packages/looker/src/overlays/segmentation.ts
+++ b/app/packages/looker/src/overlays/segmentation.ts
@@ -260,6 +260,12 @@ export default class SegmentationOverlay<State extends BaseState>
   getSizeBytes(): number {
     return sizeBytesEstimate(this.label);
   }
+
+  public cleanup(): void {
+    if (this.label.mask?.bitmap) {
+      this.label.mask?.bitmap.close();
+    }
+  }
 }
 
 export const getSegmentationPoints = (

--- a/app/packages/looker/src/overlays/segmentation.ts
+++ b/app/packages/looker/src/overlays/segmentation.ts
@@ -8,6 +8,7 @@ import { BaseState, Coordinates, MaskTargets } from "../state";
 import {
   BaseLabel,
   CONTAINS,
+  LabelMask,
   Overlay,
   PointInfo,
   SelectData,
@@ -16,9 +17,7 @@ import {
 import { isRgbMaskTargets, strokeCanvasRect, t } from "./util";
 
 interface SegmentationLabel extends BaseLabel {
-  mask?: {
-    bitmap?: ImageBitmap;
-  };
+  mask?: LabelMask;
 }
 
 interface SegmentationInfo extends BaseLabel {

--- a/app/packages/looker/src/worker/decorated-fetch.test.ts
+++ b/app/packages/looker/src/worker/decorated-fetch.test.ts
@@ -15,7 +15,7 @@ describe("fetchWithLinearBackoff", () => {
 
     expect(response).toBe(mockResponse);
     expect(global.fetch).toHaveBeenCalledTimes(1);
-    expect(global.fetch).toHaveBeenCalledWith("http://fiftyone.ai");
+    expect(global.fetch).toHaveBeenCalledWith("http://fiftyone.ai", {});
   });
 
   it("should retry when fetch fails and eventually succeed", async () => {
@@ -35,7 +35,7 @@ describe("fetchWithLinearBackoff", () => {
     global.fetch = vi.fn().mockRejectedValue(new Error("Network Error"));
 
     await expect(
-      fetchWithLinearBackoff("http://fiftyone.ai", 3, 10)
+      fetchWithLinearBackoff("http://fiftyone.ai", {}, 3, 10)
     ).rejects.toThrowError(new RegExp("Max retries for fetch reached"));
 
     expect(global.fetch).toHaveBeenCalledTimes(3);
@@ -46,7 +46,7 @@ describe("fetchWithLinearBackoff", () => {
     global.fetch = vi.fn().mockResolvedValue(mockResponse);
 
     await expect(
-      fetchWithLinearBackoff("http://fiftyone.ai", 5, 10)
+      fetchWithLinearBackoff("http://fiftyone.ai", {}, 5, 10)
     ).rejects.toThrow("HTTP error: 500");
 
     expect(global.fetch).toHaveBeenCalledTimes(5);
@@ -57,7 +57,7 @@ describe("fetchWithLinearBackoff", () => {
     global.fetch = vi.fn().mockResolvedValue(mockResponse);
 
     await expect(
-      fetchWithLinearBackoff("http://fiftyone.ai", 5, 10)
+      fetchWithLinearBackoff("http://fiftyone.ai", {}, 5, 10)
     ).rejects.toThrow("Non-retryable HTTP error: 404");
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
@@ -73,7 +73,12 @@ describe("fetchWithLinearBackoff", () => {
 
     vi.useFakeTimers();
 
-    const fetchPromise = fetchWithLinearBackoff("http://fiftyone.ai", 5, 10);
+    const fetchPromise = fetchWithLinearBackoff(
+      "http://fiftyone.ai",
+      {},
+      5,
+      10
+    );
 
     // advance timers to simulate delays
     // after first delay

--- a/app/packages/looker/src/worker/decorated-fetch.test.ts
+++ b/app/packages/looker/src/worker/decorated-fetch.test.ts
@@ -35,7 +35,14 @@ describe("fetchWithLinearBackoff", () => {
     global.fetch = vi.fn().mockRejectedValue(new Error("Network Error"));
 
     await expect(
-      fetchWithLinearBackoff("http://fiftyone.ai", {}, 3, 10)
+      fetchWithLinearBackoff(
+        "http://fiftyone.ai",
+        {},
+        {
+          retries: 3,
+          delay: 10,
+        }
+      )
     ).rejects.toThrowError(new RegExp("Max retries for fetch reached"));
 
     expect(global.fetch).toHaveBeenCalledTimes(3);
@@ -46,7 +53,14 @@ describe("fetchWithLinearBackoff", () => {
     global.fetch = vi.fn().mockResolvedValue(mockResponse);
 
     await expect(
-      fetchWithLinearBackoff("http://fiftyone.ai", {}, 5, 10)
+      fetchWithLinearBackoff(
+        "http://fiftyone.ai",
+        {},
+        {
+          retries: 5,
+          delay: 10,
+        }
+      )
     ).rejects.toThrow("HTTP error: 500");
 
     expect(global.fetch).toHaveBeenCalledTimes(5);
@@ -57,7 +71,14 @@ describe("fetchWithLinearBackoff", () => {
     global.fetch = vi.fn().mockResolvedValue(mockResponse);
 
     await expect(
-      fetchWithLinearBackoff("http://fiftyone.ai", {}, 5, 10)
+      fetchWithLinearBackoff(
+        "http://fiftyone.ai",
+        {},
+        {
+          retries: 5,
+          delay: 10,
+        }
+      )
     ).rejects.toThrow("Non-retryable HTTP error: 404");
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
@@ -76,8 +97,7 @@ describe("fetchWithLinearBackoff", () => {
     const fetchPromise = fetchWithLinearBackoff(
       "http://fiftyone.ai",
       {},
-      5,
-      10
+      { retries: 5, delay: 10 }
     );
 
     // advance timers to simulate delays

--- a/app/packages/looker/src/worker/decorated-fetch.ts
+++ b/app/packages/looker/src/worker/decorated-fetch.ts
@@ -12,12 +12,13 @@ class NonRetryableError extends Error {
 
 export const fetchWithLinearBackoff = async (
   url: string,
+  opts: RequestInit = {},
   retries = DEFAULT_MAX_RETRIES,
   delay = DEFAULT_BASE_DELAY
 ) => {
   for (let i = 0; i < retries; i++) {
     try {
-      const response = await fetch(url);
+      const response = await fetch(url, opts);
       if (response.ok) {
         return response;
       } else {

--- a/app/packages/looker/src/worker/deserializer.ts
+++ b/app/packages/looker/src/worker/deserializer.ts
@@ -14,7 +14,7 @@ const extractSerializedMask = (
 };
 
 export const DeserializerFactory = {
-  Detection: (label, buffers) => {
+  Detection: (label) => {
     const serializedMask = extractSerializedMask(label, "mask");
 
     if (serializedMask) {
@@ -24,17 +24,15 @@ export const DeserializerFactory = {
         data,
         image: new ArrayBuffer(width * height * 4),
       };
-      buffers.push(data.buffer);
-      buffers.push(label.mask.image);
     }
   },
-  Detections: (labels, buffers) => {
+  Detections: (labels) => {
     const list = labels?.detections || [];
     for (const label of list) {
-      DeserializerFactory.Detection(label, buffers);
+      DeserializerFactory.Detection(label);
     }
   },
-  Heatmap: (label, buffers) => {
+  Heatmap: (label) => {
     const serializedMask = extractSerializedMask(label, "map");
 
     if (serializedMask) {
@@ -45,12 +43,9 @@ export const DeserializerFactory = {
         data,
         image: new ArrayBuffer(width * height * 4),
       };
-
-      buffers.push(data.buffer);
-      buffers.push(label.map.image);
     }
   },
-  Segmentation: (label, buffers) => {
+  Segmentation: (label) => {
     const serializedMask = extractSerializedMask(label, "mask");
 
     if (serializedMask) {
@@ -61,9 +56,6 @@ export const DeserializerFactory = {
         data,
         image: new ArrayBuffer(width * height * 4),
       };
-
-      buffers.push(data.buffer);
-      buffers.push(label.mask.image);
     }
   },
 };

--- a/app/packages/looker/src/worker/deserializer.ts
+++ b/app/packages/looker/src/worker/deserializer.ts
@@ -14,7 +14,7 @@ const extractSerializedMask = (
 };
 
 export const DeserializerFactory = {
-  Detection: (label) => {
+  Detection: (label, buffers) => {
     const serializedMask = extractSerializedMask(label, "mask");
 
     if (serializedMask) {
@@ -24,15 +24,16 @@ export const DeserializerFactory = {
         data,
         image: new ArrayBuffer(width * height * 4),
       };
+      buffers.push(data.buffer);
     }
   },
-  Detections: (labels) => {
+  Detections: (labels, buffers) => {
     const list = labels?.detections || [];
     for (const label of list) {
-      DeserializerFactory.Detection(label);
+      DeserializerFactory.Detection(label, buffers);
     }
   },
-  Heatmap: (label) => {
+  Heatmap: (label, buffers) => {
     const serializedMask = extractSerializedMask(label, "map");
 
     if (serializedMask) {
@@ -43,9 +44,11 @@ export const DeserializerFactory = {
         data,
         image: new ArrayBuffer(width * height * 4),
       };
+
+      buffers.push(data.buffer);
     }
   },
-  Segmentation: (label) => {
+  Segmentation: (label, buffers) => {
     const serializedMask = extractSerializedMask(label, "mask");
 
     if (serializedMask) {
@@ -56,6 +59,8 @@ export const DeserializerFactory = {
         data,
         image: new ArrayBuffer(width * height * 4),
       };
+
+      buffers.push(data.buffer);
     }
   },
 };

--- a/app/packages/looker/src/worker/disk-overlay-decoder.test.ts
+++ b/app/packages/looker/src/worker/disk-overlay-decoder.test.ts
@@ -1,0 +1,216 @@
+import { getSampleSrc } from "@fiftyone/state";
+import { DETECTIONS, HEATMAP } from "@fiftyone/utilities";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Coloring, CustomizeColor } from "..";
+import { LabelMask } from "../overlays/base";
+import type { Colorscale } from "../state";
+import { decodeWithCanvas } from "./canvas-decoder";
+import { fetchWithLinearBackoff } from "./decorated-fetch";
+import { decodeOverlayOnDisk, IntermediateMask } from "./disk-overlay-decoder";
+
+vi.mock("@fiftyone/state", () => ({
+  getSampleSrc: vi.fn(),
+}));
+
+vi.mock("@fiftyone/utilities", () => ({
+  DETECTION: "Detection",
+  DETECTIONS: "Detections",
+  HEATMAP: "Heatmap",
+}));
+
+vi.mock("./canvas-decoder", () => ({
+  decodeWithCanvas: vi.fn(),
+}));
+
+vi.mock("./decorated-fetch", () => ({
+  fetchWithLinearBackoff: vi.fn(),
+}));
+
+const COLORING = {} as Coloring;
+const COLOR_SCALE = {} as Colorscale;
+const CUSTOMIZE_COLOR_SETTING: CustomizeColor[] = [];
+const SOURCES = {};
+
+type MaskUnion = (IntermediateMask & LabelMask) | null;
+
+describe("decodeOverlayOnDisk", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return early if label already has overlay field (not on disk)", async () => {
+    const field = "testField";
+    const label = { mask: {}, mask_path: "shouldBeIgnored" };
+    const cls = "Segmentation";
+    const maskPathDecodingPromises: Promise<void>[] = [];
+
+    await decodeOverlayOnDisk(
+      field,
+      label,
+      COLORING,
+      CUSTOMIZE_COLOR_SETTING,
+      COLOR_SCALE,
+      SOURCES,
+      cls,
+      maskPathDecodingPromises
+    );
+
+    expect(label.mask).toBeDefined();
+    expect(fetchWithLinearBackoff).not.toHaveBeenCalled();
+  });
+
+  it("should fetch and decode overlay when label has overlay path field", async () => {
+    const field = "testField";
+    const label = { mask_path: "/path/to/mask", mask: null as MaskUnion };
+    const cls = "Segmentation";
+    const maskPathDecodingPromises: Promise<void>[] = [];
+
+    const sampleSrcUrl = "http://example.com/path/to/mask";
+    const mockBlob = new Blob(["mock data"], { type: "image/png" });
+    const overlayMask = { shape: [100, 200] };
+
+    vi.mocked(getSampleSrc).mockReturnValue(sampleSrcUrl);
+    vi.mocked(fetchWithLinearBackoff).mockResolvedValue({
+      blob: () => Promise.resolve(mockBlob),
+    } as Response);
+    vi.mocked(decodeWithCanvas).mockResolvedValue(overlayMask);
+
+    await decodeOverlayOnDisk(
+      field,
+      label,
+      COLORING,
+      CUSTOMIZE_COLOR_SETTING,
+      COLOR_SCALE,
+      SOURCES,
+      cls,
+      maskPathDecodingPromises
+    );
+
+    expect(getSampleSrc).toHaveBeenCalledWith("/path/to/mask");
+    expect(fetchWithLinearBackoff).toHaveBeenCalledWith(sampleSrcUrl);
+    expect(decodeWithCanvas).toHaveBeenCalledWith(mockBlob);
+    expect(label.mask).toBeDefined();
+    expect(label.mask.data).toBe(overlayMask);
+    expect(label.mask.image).toBeInstanceOf(ArrayBuffer);
+    expect(label.mask.image.byteLength).toBe(100 * 200 * 4);
+  });
+
+  it("should handle HEATMAP class", async () => {
+    const field = "testField";
+    const label = { map_path: "/path/to/map", map: null as MaskUnion };
+    const cls = HEATMAP;
+    const maskPathDecodingPromises: Promise<void>[] = [];
+
+    const sampleSrcUrl = "http://example.com/path/to/map";
+    const mockBlob = new Blob(["mock data"], { type: "image/png" });
+    const overlayMask = { shape: [100, 200] };
+
+    vi.mocked(getSampleSrc).mockReturnValue(sampleSrcUrl);
+    vi.mocked(fetchWithLinearBackoff).mockResolvedValue({
+      blob: () => Promise.resolve(mockBlob),
+    } as Response);
+    vi.mocked(decodeWithCanvas).mockResolvedValue(overlayMask);
+
+    await decodeOverlayOnDisk(
+      field,
+      label,
+      COLORING,
+      CUSTOMIZE_COLOR_SETTING,
+      COLOR_SCALE,
+      SOURCES,
+      cls,
+      maskPathDecodingPromises
+    );
+
+    expect(getSampleSrc).toHaveBeenCalledWith("/path/to/map");
+    expect(fetchWithLinearBackoff).toHaveBeenCalledWith(sampleSrcUrl);
+    expect(decodeWithCanvas).toHaveBeenCalledWith(mockBlob);
+    expect(label.map).toBeDefined();
+    expect(label.map.data).toBe(overlayMask);
+    expect(label.map.image).toBeInstanceOf(ArrayBuffer);
+    expect(label.map.image.byteLength).toBe(100 * 200 * 4);
+  });
+
+  it("should handle DETECTIONS class and process detections recursively", async () => {
+    const field = "testField";
+    const label = {
+      detections: [
+        { mask_path: "/path/to/mask1", mask: null as MaskUnion },
+        { mask_path: "/path/to/mask2", mask: null as MaskUnion },
+      ],
+    };
+    const cls = DETECTIONS;
+    const maskPathDecodingPromises: Promise<void>[] = [];
+
+    const sampleSrcUrl1 = "http://example.com/path/to/mask1";
+    const sampleSrcUrl2 = "http://example.com/path/to/mask2";
+    const mockBlob1 = new Blob(["mock data 1"], { type: "image/png" });
+    const mockBlob2 = new Blob(["mock data 2"], { type: "image/png" });
+    const overlayMask1 = { shape: [50, 50] };
+    const overlayMask2 = { shape: [60, 60] };
+
+    vi.mocked(getSampleSrc)
+      .mockReturnValueOnce(sampleSrcUrl1)
+      .mockReturnValueOnce(sampleSrcUrl2);
+    vi.mocked(fetchWithLinearBackoff)
+      .mockResolvedValueOnce({
+        blob: () => Promise.resolve(mockBlob1),
+      } as Response)
+      .mockResolvedValueOnce({
+        blob: () => Promise.resolve(mockBlob2),
+      } as Response);
+    vi.mocked(decodeWithCanvas)
+      .mockResolvedValueOnce(overlayMask1)
+      .mockResolvedValueOnce(overlayMask2);
+
+    await decodeOverlayOnDisk(
+      field,
+      label,
+      COLORING,
+      CUSTOMIZE_COLOR_SETTING,
+      COLOR_SCALE,
+      SOURCES,
+      cls,
+      maskPathDecodingPromises
+    );
+
+    await Promise.all(maskPathDecodingPromises);
+
+    expect(getSampleSrc).toHaveBeenNthCalledWith(1, "/path/to/mask1");
+    expect(getSampleSrc).toHaveBeenNthCalledWith(2, "/path/to/mask2");
+    expect(label.detections[0].mask).toBeDefined();
+    expect(label.detections[0].mask.data).toBe(overlayMask1);
+    expect(label.detections[1].mask).toBeDefined();
+    expect(label.detections[1].mask.data).toBe(overlayMask2);
+  });
+
+  it("should return early if fetch (with retry) fails", async () => {
+    const field = "testField";
+    const label = { mask_path: "/path/to/mask", mask: null as MaskUnion };
+    const cls = "Segmentation";
+    const maskPathDecodingPromises: Promise<void>[] = [];
+
+    const sampleSrcUrl = "http://example.com/path/to/mask";
+
+    vi.mocked(getSampleSrc).mockReturnValue(sampleSrcUrl);
+    vi.mocked(fetchWithLinearBackoff).mockRejectedValue(
+      new Error("Fetch failed")
+    );
+
+    await decodeOverlayOnDisk(
+      field,
+      label,
+      COLORING,
+      CUSTOMIZE_COLOR_SETTING,
+      COLOR_SCALE,
+      SOURCES,
+      cls,
+      maskPathDecodingPromises
+    );
+
+    expect(getSampleSrc).toHaveBeenCalledWith("/path/to/mask");
+    expect(fetchWithLinearBackoff).toHaveBeenCalledWith(sampleSrcUrl);
+    expect(decodeWithCanvas).not.toHaveBeenCalled();
+    expect(label.mask).toBeNull();
+  });
+});

--- a/app/packages/looker/src/worker/disk-overlay-decoder.ts
+++ b/app/packages/looker/src/worker/disk-overlay-decoder.ts
@@ -24,7 +24,8 @@ export const decodeOverlayOnDisk = async (
   colorscale: Colorscale,
   sources: { [path: string]: string },
   cls: string,
-  maskPathDecodingPromises: Promise<void>[] = []
+  maskPathDecodingPromises: Promise<void>[] = [],
+  maskTargetsBuffers: ArrayBuffer[] = []
 ) => {
   // handle all list types here
   if (cls === DETECTIONS) {
@@ -88,4 +89,8 @@ export const decodeOverlayOnDisk = async (
     data: overlayMask,
     image: new ArrayBuffer(overlayWidth * overlayHeight * 4),
   } as IntermediateMask;
+
+  // no need to transfer image's buffer
+  //since we'll be constructing ImageBitmap and transfering that
+  maskTargetsBuffers.push(overlayMask.buffer);
 };

--- a/app/packages/looker/src/worker/disk-overlay-decoder.ts
+++ b/app/packages/looker/src/worker/disk-overlay-decoder.ts
@@ -53,6 +53,14 @@ export const decodeOverlayOnDisk = async (
   const overlayField = overlayFields.canonical;
 
   if (Boolean(label[overlayField]) || !Object.hasOwn(label, overlayPathField)) {
+    // it's possible we're just re-coloring, in which case re-init mask image and set bitmap to null
+    if (!label[overlayField].image && label[overlayField].bitmap) {
+      const height = label[overlayField].bitmap.height;
+      const width = label[overlayField].bitmap.width;
+      label[overlayField].image = new ArrayBuffer(height * width * 4);
+      label[overlayField].bitmap.close();
+      label[overlayField].bitmap = null;
+    }
     // nothing to be done
     return;
   }

--- a/app/packages/looker/src/worker/disk-overlay-decoder.ts
+++ b/app/packages/looker/src/worker/disk-overlay-decoder.ts
@@ -1,4 +1,4 @@
-import { getSampleSrc } from "@fiftyone/state";
+import { getSampleSrc } from "@fiftyone/state/src/recoil/utils";
 import { DETECTION, DETECTIONS, HEATMAP } from "@fiftyone/utilities";
 import { Coloring, CustomizeColor } from "..";
 import { OverlayMask } from "../numpy";

--- a/app/packages/looker/src/worker/disk-overlay-decoder.ts
+++ b/app/packages/looker/src/worker/disk-overlay-decoder.ts
@@ -1,9 +1,15 @@
 import { getSampleSrc } from "@fiftyone/state";
 import { DETECTION, DETECTIONS, HEATMAP } from "@fiftyone/utilities";
 import { Coloring, CustomizeColor } from "..";
+import { OverlayMask } from "../numpy";
 import { Colorscale } from "../state";
 import { decodeWithCanvas } from "./canvas-decoder";
 import { fetchWithLinearBackoff } from "./decorated-fetch";
+
+export type IntermediateMask = {
+  data: OverlayMask;
+  image: ArrayBuffer;
+};
 
 /**
  * Some label types (example: segmentation, heatmap) can have their overlay data stored on-disk,
@@ -42,10 +48,7 @@ export const decodeOverlayOnDisk = async (
   const overlayPathField = cls === HEATMAP ? "map_path" : "mask_path";
   const overlayField = overlayPathField === "map_path" ? "map" : "mask";
 
-  if (
-    Object.hasOwn(label, overlayField) ||
-    !Object.hasOwn(label, overlayPathField)
-  ) {
+  if (Boolean(label[overlayField]) || !Object.hasOwn(label, overlayPathField)) {
     // nothing to be done
     return;
   }
@@ -83,5 +86,5 @@ export const decodeOverlayOnDisk = async (
   label[overlayField] = {
     data: overlayMask,
     image: new ArrayBuffer(overlayWidth * overlayHeight * 4),
-  };
+  } as IntermediateMask;
 };

--- a/app/packages/looker/src/worker/disk-overlay-decoder.ts
+++ b/app/packages/looker/src/worker/disk-overlay-decoder.ts
@@ -1,0 +1,87 @@
+import { getSampleSrc } from "@fiftyone/state";
+import { DETECTION, DETECTIONS, HEATMAP } from "@fiftyone/utilities";
+import { Coloring, CustomizeColor } from "..";
+import { Colorscale } from "../state";
+import { decodeWithCanvas } from "./canvas-decoder";
+import { fetchWithLinearBackoff } from "./decorated-fetch";
+
+/**
+ * Some label types (example: segmentation, heatmap) can have their overlay data stored on-disk,
+ * we want to impute the relevant mask property of these labels from what's stored in the disk
+ */
+export const decodeOverlayOnDisk = async (
+  field: string,
+  label: Record<string, any>,
+  coloring: Coloring,
+  customizeColorSetting: CustomizeColor[],
+  colorscale: Colorscale,
+  sources: { [path: string]: string },
+  cls: string,
+  maskPathDecodingPromises: Promise<void>[] = []
+) => {
+  // handle all list types here
+  if (cls === DETECTIONS) {
+    const promises: Promise<void>[] = [];
+    for (const detection of label.detections) {
+      promises.push(
+        decodeOverlayOnDisk(
+          field,
+          detection,
+          coloring,
+          customizeColorSetting,
+          colorscale,
+          {},
+          DETECTION
+        )
+      );
+    }
+    maskPathDecodingPromises.push(...promises);
+  }
+
+  // overlay path is in `map_path` property for heatmap, or else, it's in `mask_path` property (for segmentation or detection)
+  const overlayPathField = cls === HEATMAP ? "map_path" : "mask_path";
+  const overlayField = overlayPathField === "map_path" ? "map" : "mask";
+
+  if (
+    Object.hasOwn(label, overlayField) ||
+    !Object.hasOwn(label, overlayPathField)
+  ) {
+    // nothing to be done
+    return;
+  }
+
+  // convert absolute file path to a URL that we can "fetch" from
+  const overlayImageUrl = getSampleSrc(
+    sources[`${field}.${overlayPathField}`] || label[overlayPathField]
+  );
+  const urlTokens = overlayImageUrl.split("?");
+
+  let baseUrl = overlayImageUrl;
+
+  // remove query params if not local URL
+  if (!urlTokens.at(1)?.startsWith("filepath=")) {
+    baseUrl = overlayImageUrl.split("?")[0];
+  }
+
+  let overlayImageBlob: Blob;
+  try {
+    const overlayImageFetchResponse = await fetchWithLinearBackoff(baseUrl);
+    overlayImageBlob = await overlayImageFetchResponse.blob();
+  } catch (e) {
+    console.error(e);
+    // skip decoding if fetch fails altogether
+    return;
+  }
+
+  const overlayMask = await decodeWithCanvas(overlayImageBlob);
+  const [overlayHeight, overlayWidth] = overlayMask.shape;
+
+  // set the `mask` property for this label
+  // we need to do this because we need raw image pixel data
+  // to iterate through and paint it with the color
+  // defined by the user for this particular label
+  label[overlayField] = {
+    data: overlayMask,
+    image: new ArrayBuffer(overlayWidth * overlayHeight * 4),
+  };
+};

--- a/app/packages/looker/src/worker/disk-overlay-decoder.ts
+++ b/app/packages/looker/src/worker/disk-overlay-decoder.ts
@@ -39,7 +39,9 @@ export const decodeOverlayOnDisk = async (
           customizeColorSetting,
           colorscale,
           {},
-          DETECTION
+          DETECTION,
+          maskPathDecodingPromises,
+          maskTargetsBuffers
         )
       );
     }

--- a/app/packages/looker/src/worker/disk-overlay-decoder.ts
+++ b/app/packages/looker/src/worker/disk-overlay-decoder.ts
@@ -1,10 +1,11 @@
 import { getSampleSrc } from "@fiftyone/state/src/recoil/utils";
-import { DETECTION, DETECTIONS, HEATMAP } from "@fiftyone/utilities";
+import { DETECTION, DETECTIONS } from "@fiftyone/utilities";
 import { Coloring, CustomizeColor } from "..";
 import { OverlayMask } from "../numpy";
 import { Colorscale } from "../state";
 import { decodeWithCanvas } from "./canvas-decoder";
 import { fetchWithLinearBackoff } from "./decorated-fetch";
+import { getOverlayFieldFromCls } from "./shared";
 
 export type IntermediateMask = {
   data: OverlayMask;
@@ -44,9 +45,9 @@ export const decodeOverlayOnDisk = async (
     maskPathDecodingPromises.push(...promises);
   }
 
-  // overlay path is in `map_path` property for heatmap, or else, it's in `mask_path` property (for segmentation or detection)
-  const overlayPathField = cls === HEATMAP ? "map_path" : "mask_path";
-  const overlayField = overlayPathField === "map_path" ? "map" : "mask";
+  const overlayFields = getOverlayFieldFromCls(cls);
+  const overlayPathField = overlayFields.disk;
+  const overlayField = overlayFields.canonical;
 
   if (Boolean(label[overlayField]) || !Object.hasOwn(label, overlayPathField)) {
     // nothing to be done

--- a/app/packages/looker/src/worker/disk-overlay-decoder.ts
+++ b/app/packages/looker/src/worker/disk-overlay-decoder.ts
@@ -83,7 +83,15 @@ export const decodeOverlayOnDisk = async (
     return;
   }
 
-  const overlayMask = await decodeWithCanvas(overlayImageBlob);
+  let overlayMask: OverlayMask;
+
+  try {
+    overlayMask = await decodeWithCanvas(overlayImageBlob);
+  } catch (e) {
+    console.error(e);
+    return;
+  }
+
   const [overlayHeight, overlayWidth] = overlayMask.shape;
 
   // set the `mask` property for this label

--- a/app/packages/looker/src/worker/disk-overlay-decoder.ts
+++ b/app/packages/looker/src/worker/disk-overlay-decoder.ts
@@ -4,7 +4,7 @@ import { Coloring, CustomizeColor } from "..";
 import { OverlayMask } from "../numpy";
 import { Colorscale } from "../state";
 import { decodeWithCanvas } from "./canvas-decoder";
-import { fetchWithLinearBackoff } from "./decorated-fetch";
+import { enqueueFetch } from "./pooled-fetch";
 import { getOverlayFieldFromCls } from "./shared";
 
 export type IntermediateMask = {
@@ -70,7 +70,10 @@ export const decodeOverlayOnDisk = async (
 
   let overlayImageBlob: Blob;
   try {
-    const overlayImageFetchResponse = await fetchWithLinearBackoff(baseUrl);
+    const overlayImageFetchResponse = await enqueueFetch({
+      url: baseUrl,
+      options: { priority: "low" },
+    });
     overlayImageBlob = await overlayImageFetchResponse.blob();
   } catch (e) {
     console.error(e);

--- a/app/packages/looker/src/worker/disk-overlay-decoder.ts
+++ b/app/packages/looker/src/worker/disk-overlay-decoder.ts
@@ -54,7 +54,11 @@ export const decodeOverlayOnDisk = async (
 
   if (Boolean(label[overlayField]) || !Object.hasOwn(label, overlayPathField)) {
     // it's possible we're just re-coloring, in which case re-init mask image and set bitmap to null
-    if (!label[overlayField].image && label[overlayField].bitmap) {
+    if (
+      label[overlayField] &&
+      label[overlayField].bitmap &&
+      !label[overlayField].image
+    ) {
       const height = label[overlayField].bitmap.height;
       const width = label[overlayField].bitmap.width;
       label[overlayField].image = new ArrayBuffer(height * width * 4);

--- a/app/packages/looker/src/worker/index.ts
+++ b/app/packages/looker/src/worker/index.ts
@@ -188,8 +188,6 @@ const processLabels = async (
   await Promise.allSettled(maskPathDecodingPromises);
 
   // overlay painting loop
-  if (sample.id.endsWith("50a4")) console.log(">>>Painting overlays for hen");
-
   for (const field in sample) {
     let labels = sample[field];
 
@@ -208,7 +206,6 @@ const processLabels = async (
         continue;
       }
       if (painterFactory[cls]) {
-        if (sample.id.endsWith("50a4")) debugger;
         painterPromises.push(
           painterFactory[cls](
             prefix ? prefix + field : field,

--- a/app/packages/looker/src/worker/index.ts
+++ b/app/packages/looker/src/worker/index.ts
@@ -330,27 +330,23 @@ const processSample = async ({
     maskTargetsBuffers.push(...moreMaskTargetsBuffers);
   }
 
-  // todo: address frames
-  // if (sample.frames && sample.frames.length) {
-  //   bufferPromises = [
-  //     ...bufferPromises,
-  //     ...sample.frames
-  //       .map((frame) =>
-  //         processLabels(
-  //           frame,
-  //           coloring,
-  //           "frames.",
-  //           sources,
-  //           customizeColorSetting,
-  //           colorscale,
-  //           labelTagColors,
-  //           selectedLabelTags,
-  //           schema
-  //         )
-  //       )
-  //       .flat(),
-  //   ];
-  // }
+  if (sample.frames && sample.frames.length) {
+    for (const frame of sample.frames) {
+      const [moreBitmapPromises, moreMaskTargetsBuffers] = await processLabels(
+        frame,
+        coloring,
+        "frames.",
+        sources,
+        customizeColorSetting,
+        colorscale,
+        labelTagColors,
+        selectedLabelTags,
+        schema
+      );
+      imageBitmapPromises.push(...moreBitmapPromises);
+      maskTargetsBuffers.push(...moreMaskTargetsBuffers);
+    }
+  }
 
   Promise.all(imageBitmapPromises).then((bitmaps) => {
     postMessage(

--- a/app/packages/looker/src/worker/index.ts
+++ b/app/packages/looker/src/worker/index.ts
@@ -188,6 +188,8 @@ const processLabels = async (
   await Promise.allSettled(maskPathDecodingPromises);
 
   // overlay painting loop
+  if (sample.id.endsWith("50a4")) console.log(">>>Painting overlays for hen");
+
   for (const field in sample) {
     let labels = sample[field];
 
@@ -206,6 +208,7 @@ const processLabels = async (
         continue;
       }
       if (painterFactory[cls]) {
+        if (sample.id.endsWith("50a4")) debugger;
         painterPromises.push(
           painterFactory[cls](
             prefix ? prefix + field : field,

--- a/app/packages/looker/src/worker/index.ts
+++ b/app/packages/looker/src/worker/index.ts
@@ -94,15 +94,14 @@ const painterFactory = PainterFactory(requestColor);
 const ALL_VALID_LABELS = new Set(VALID_LABEL_TYPES);
 
 /**
- * 1. Start deserializing on-disk masks. Accumulate promises.
+ * This function processes labels in a recursive manner. It follows the following steps:
+ * 1. Deserialize masks. Accumulate promises.
  * 2. Await mask path decoding to finish.
  * 3. Start painting overlays. Accumulate promises.
  * 4. Await overlay painting to finish.
  * 5. Start bitmap generation. Accumulate promises.
  * 6. Await bitmap generation to finish.
- * 7. Transfer bitmaps back to the main thread.
- *
- * Note that on-disk masks support async deserialization, which means they are more performant.
+ * 7. Transfer bitmaps and mask targets array buffers back to the main thread.
  */
 const processLabels = async (
   sample: ProcessSample["sample"],

--- a/app/packages/looker/src/worker/index.ts
+++ b/app/packages/looker/src/worker/index.ts
@@ -2,14 +2,12 @@
  * Copyright 2017-2024, Voxel51, Inc.
  */
 
-import { getSampleSrc } from "@fiftyone/state/src/recoil/utils";
 import {
   DENSE_LABELS,
   DETECTION,
   DETECTIONS,
   DYNAMIC_EMBEDDED_DOCUMENT,
   EMBEDDED_DOCUMENT,
-  HEATMAP,
   LABEL_LIST,
   Schema,
   Stage,
@@ -29,9 +27,8 @@ import {
   LabelTagColor,
   Sample,
 } from "../state";
-import { decodeWithCanvas } from "./canvas-decoder";
-import { fetchWithLinearBackoff } from "./decorated-fetch";
 import { DeserializerFactory } from "./deserializer";
+import { decodeOverlayOnDisk } from "./disk-overlay-decoder";
 import { PainterFactory } from "./painter";
 import { mapId } from "./shared";
 import { process3DLabels } from "./threed-label-processor";
@@ -97,87 +94,6 @@ const painterFactory = PainterFactory(requestColor);
 const ALL_VALID_LABELS = new Set(VALID_LABEL_TYPES);
 
 /**
- * Some label types (example: segmentation, heatmap) can have their overlay data stored on-disk,
- * we want to impute the relevant mask property of these labels from what's stored in the disk
- */
-const imputeOverlayFromPath = async (
-  field: string,
-  label: Record<string, any>,
-  coloring: Coloring,
-  customizeColorSetting: CustomizeColor[],
-  colorscale: Colorscale,
-  sources: { [path: string]: string },
-  cls: string,
-  maskPathDecodingPromises: Promise<void>[] = []
-) => {
-  // handle all list types here
-  if (cls === DETECTIONS) {
-    const promises: Promise<void>[] = [];
-    for (const detection of label.detections) {
-      promises.push(
-        imputeOverlayFromPath(
-          field,
-          detection,
-          coloring,
-          customizeColorSetting,
-          colorscale,
-          {},
-          DETECTION
-        )
-      );
-    }
-    maskPathDecodingPromises.push(...promises);
-  }
-
-  // overlay path is in `map_path` property for heatmap, or else, it's in `mask_path` property (for segmentation or detection)
-  const overlayPathField = cls === HEATMAP ? "map_path" : "mask_path";
-  const overlayField = overlayPathField === "map_path" ? "map" : "mask";
-
-  if (
-    Object.hasOwn(label, overlayField) ||
-    !Object.hasOwn(label, overlayPathField)
-  ) {
-    // nothing to be done
-    return;
-  }
-
-  // convert absolute file path to a URL that we can "fetch" from
-  const overlayImageUrl = getSampleSrc(
-    sources[`${field}.${overlayPathField}`] || label[overlayPathField]
-  );
-  const urlTokens = overlayImageUrl.split("?");
-
-  let baseUrl = overlayImageUrl;
-
-  // remove query params if not local URL
-  if (!urlTokens.at(1)?.startsWith("filepath=")) {
-    baseUrl = overlayImageUrl.split("?")[0];
-  }
-
-  let overlayImageBlob: Blob;
-  try {
-    const overlayImageFetchResponse = await fetchWithLinearBackoff(baseUrl);
-    overlayImageBlob = await overlayImageFetchResponse.blob();
-  } catch (e) {
-    console.error(e);
-    // skip decoding if fetch fails altogether
-    return;
-  }
-
-  const overlayMask = await decodeWithCanvas(overlayImageBlob);
-  const [overlayHeight, overlayWidth] = overlayMask.shape;
-
-  // set the `mask` property for this label
-  // we need to do this because we need raw image pixel data
-  // to iterate through and paint it with the color
-  // defined by the user for this particular label
-  label[overlayField] = {
-    data: overlayMask,
-    image: new ArrayBuffer(overlayWidth * overlayHeight * 4),
-  };
-};
-
-/**
  * 1. Start deserializing on-disk masks. Accumulate promises.
  * 2. Await mask path decoding to finish.
  * 3. Start painting overlays. Accumulate promises.
@@ -218,7 +134,7 @@ const processLabels = async (
 
       if (DENSE_LABELS.has(cls)) {
         maskPathDecodingPromises.push(
-          imputeOverlayFromPath(
+          decodeOverlayOnDisk(
             `${prefix || ""}${field}`,
             label,
             coloring,

--- a/app/packages/looker/src/worker/index.ts
+++ b/app/packages/looker/src/worker/index.ts
@@ -247,6 +247,11 @@ const collectBitmapPromises = (label, cls, bitmapPromises) => {
   if (label[overlayField]) {
     const [height, width] = label[overlayField].data.shape;
 
+    if (!height || !width) {
+      label[overlayField].image = null;
+      return;
+    }
+
     const imageData = new ImageData(
       new Uint8ClampedArray(label[overlayField].image),
       width,

--- a/app/packages/looker/src/worker/pooled-fetch.test.ts
+++ b/app/packages/looker/src/worker/pooled-fetch.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, Mock, vi } from "vitest";
+import { enqueueFetch } from "./pooled-fetch";
+
+const MAX_CONCURRENT_REQUESTS = 100;
+
+// helper function to create a deferred promise
+function createDeferredPromise<T>() {
+  let resolve: (value: T | PromiseLike<T>) => void;
+  let reject: (reason?: any) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve: resolve!, reject: reject! };
+}
+
+describe("enqueueFetch", () => {
+  let mockedFetch: Mock;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockedFetch = vi.fn();
+    global.fetch = mockedFetch;
+  });
+
+  it("should return response when fetch succeeds", async () => {
+    const mockResponse = new Response("OK", { status: 200 });
+    mockedFetch.mockResolvedValue(mockResponse);
+
+    const response = await enqueueFetch({ url: "https://fiftyone.ai" });
+    expect(response).toBe(mockResponse);
+  });
+
+  it("should process multiple requests in order", async () => {
+    const mockResponse1 = new Response("First", { status: 200 });
+    const mockResponse2 = new Response("Second", { status: 200 });
+
+    const deferred1 = createDeferredPromise<Response>();
+    const deferred2 = createDeferredPromise<Response>();
+
+    mockedFetch
+      .mockImplementationOnce(() => deferred1.promise)
+      .mockImplementationOnce(() => deferred2.promise);
+
+    const promise1 = enqueueFetch({ url: "https://fiftyone.ai/1" });
+    const promise2 = enqueueFetch({ url: "https://fiftyone.ai/2" });
+
+    deferred1.resolve(mockResponse1);
+
+    const response1 = await promise1;
+    expect(response1).toBe(mockResponse1);
+
+    deferred2.resolve(mockResponse2);
+
+    const response2 = await promise2;
+    expect(response2).toBe(mockResponse2);
+  });
+
+  it("should not exceed MAX_CONCURRENT_REQUESTS", async () => {
+    const numRequests = MAX_CONCURRENT_REQUESTS + 50;
+    const deferredPromises = [];
+
+    for (let i = 0; i < numRequests; i++) {
+      const deferred = createDeferredPromise<Response>();
+      deferredPromises.push(deferred);
+      mockedFetch.mockImplementationOnce(() => deferred.promise);
+      enqueueFetch({ url: `https://fiftyone.ai/${i}` });
+    }
+
+    // at this point, fetch should have been called MAX_CONCURRENT_REQUESTS times
+    expect(mockedFetch).toHaveBeenCalledTimes(MAX_CONCURRENT_REQUESTS);
+
+    // resolve all deferred promises
+    deferredPromises.forEach((deferred, index) => {
+      deferred.resolve(new Response(`Response ${index}`, { status: 200 }));
+    });
+
+    // wait for all promises to resolve
+    await Promise.all(deferredPromises.map((dp) => dp.promise));
+
+    // all requests should have been processed
+    expect(mockedFetch).toHaveBeenCalledTimes(numRequests);
+  });
+
+  it("should reject immediately on non-retryable error", async () => {
+    const mockResponse = new Response("Not Found", { status: 404 });
+    mockedFetch.mockResolvedValue(mockResponse);
+
+    await expect(enqueueFetch({ url: "https://fiftyone.ai" })).rejects.toThrow(
+      "Non-retryable HTTP error: 404"
+    );
+  });
+
+  it("should retry on retryable errors up to MAX_RETRIES times", async () => {
+    const MAX_RETRIES = 3;
+    mockedFetch.mockRejectedValue(new Error("Network Error"));
+
+    await expect(
+      enqueueFetch({
+        url: "https://fiftyone.ai",
+        retryOptions: {
+          retries: MAX_RETRIES,
+          delay: 50,
+        },
+      })
+    ).rejects.toThrow("Max retries for fetch reached");
+
+    expect(mockedFetch).toHaveBeenCalledTimes(MAX_RETRIES);
+  });
+});

--- a/app/packages/looker/src/worker/pooled-fetch.ts
+++ b/app/packages/looker/src/worker/pooled-fetch.ts
@@ -1,10 +1,19 @@
 import { fetchWithLinearBackoff } from "./decorated-fetch";
 
+interface QueueItem {
+  request: {
+    url: string;
+    options?: RequestInit;
+  };
+  resolve: (value: Response | PromiseLike<Response>) => void;
+  reject: (reason?: any) => void;
+}
+
 // note: arbitrary number that seems to work well
 const MAX_CONCURRENT_REQUESTS = 100;
 
 let activeRequests = 0;
-const requestQueue = [];
+const requestQueue: QueueItem[] = [];
 
 export const enqueueFetch = (request: {
   url: string;
@@ -33,6 +42,5 @@ const processFetchQueue = () => {
     .catch((error) => {
       activeRequests--;
       reject(error);
-      processFetchQueue();
     });
 };

--- a/app/packages/looker/src/worker/pooled-fetch.ts
+++ b/app/packages/looker/src/worker/pooled-fetch.ts
@@ -1,0 +1,38 @@
+import { fetchWithLinearBackoff } from "./decorated-fetch";
+
+// note: arbitrary number that seems to work well
+const MAX_CONCURRENT_REQUESTS = 100;
+
+let activeRequests = 0;
+const requestQueue = [];
+
+export const enqueueFetch = (request: {
+  url: string;
+  options?: RequestInit;
+}): Promise<Response> => {
+  return new Promise((resolve, reject) => {
+    requestQueue.push({ request, resolve, reject });
+    processFetchQueue();
+  });
+};
+
+const processFetchQueue = () => {
+  if (activeRequests >= MAX_CONCURRENT_REQUESTS || requestQueue.length === 0) {
+    return;
+  }
+
+  const { request, resolve, reject } = requestQueue.shift();
+  activeRequests++;
+
+  fetchWithLinearBackoff(request.url, request.options)
+    .then((response) => {
+      activeRequests--;
+      resolve(response);
+      processFetchQueue();
+    })
+    .catch((error) => {
+      activeRequests--;
+      reject(error);
+      processFetchQueue();
+    });
+};

--- a/app/packages/looker/src/worker/shared.ts
+++ b/app/packages/looker/src/worker/shared.ts
@@ -1,3 +1,5 @@
+import { HEATMAP } from "@fiftyone/utilities";
+
 /**
  * Map the _id field to id
  */
@@ -7,4 +9,13 @@ export const mapId = (obj) => {
     delete obj._id;
   }
   return obj;
+};
+
+export const getOverlayFieldFromCls = (cls: string) => {
+  switch (cls) {
+    case HEATMAP:
+      return { canonical: "map", disk: "map_path" };
+    default:
+      return { canonical: "mask", disk: "mask_path" };
+  }
 };


### PR DESCRIPTION
## What changes are proposed in this pull request?

_Continues efforts in #5156 to improve FiftyOne's overlays rendering performance._


Instead of transferring raw 32 bit image array buffers from worker to the main thread, we create [ImageBitmap](https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap) in the worker and transfer that instead.

Also adds a pooled fetch executor to make sure worker threads don't inundate the browser with unbounded number of fetch requests.

### BEFORE
#### Worker
- Deserialize masks from database or disk
- Create a 32 bit image buffer and paint it
- Transfer the array buffer to main thread

#### Main thread
##### Overlay constructor
- Create an ephemeral canvas in overlay constructor
- Create new [ImageData](https://developer.mozilla.org/en-US/docs/Web/API/ImageData) from image buffer 
- Paint the `ImageData` to the ephemeral canvas

##### `drawMask`
- Paint ephemeral canvas to main canvas

### NOW
#### Worker
- Deserialize masks from database or disk
- Create a 32 bit image buffer and paint it
- Create [ImageBitmap](https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap)s asynchronously and transfer to main thread
- Garbage collect 32 bit image buffer from above

#### Main thread
##### Overlay constructor
- Nothing

##### `drawMask`
- Paint `ImageBitmap` from worker to main canvas




## How is this patch tested? If it is not, please explain why.

Locally. Todo: more rigorous performance testing 

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?


-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function for decoding overlay data from disk, enhancing the handling of various label types.
	- Added support for concurrent fetch requests with a queue system to manage load efficiently.
	- Enhanced error handling and processing logic for overlay images and bitmaps.
	- Added new methods to estimate the size of labels in bytes and clean up bitmap resources.
	- Implemented a new function to retrieve overlay fields based on class type.

- **Bug Fixes**
	- Improved error handling in overlay fetching and decoding processes.

- **Documentation**
	- Updated tests for the `fetchWithLinearBackoff` function to ensure consistent usage of options.

- **Refactor**
	- Streamlined the handling of masks and overlays across various classes, simplifying the structure and improving efficiency.
	- Refactored the `processLabels` and `processSample` functions to accommodate new processing logic.
	- Enhanced resource management in the `dispose` function for better cleanup of overlays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->