### PR TITLE
fix qp null exception when setting state

### DIFF
--- a/app/packages/app/src/routing/RouterContext.ts
+++ b/app/packages/app/src/routing/RouterContext.ts
@@ -223,7 +223,7 @@ const makeGetEntryResource = <T extends OperationType>() => {
     hard: boolean;
     handleError?: (error: unknown) => void;
   }): Resource<Entry<T>> => {
-    if (isReusable(location)) {
+    if (!hard && isReusable(location)) {
       // throw the current resource (page) if it can be reused
       throw currentResource;
     }

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -524,13 +524,15 @@ export const useOperatorPrompt = () => {
     ({ get, set }) =>
       (fieldName, value) => {
         const state = get(promptingOperatorState);
-        set(promptingOperatorState, {
-          ...state,
-          params: {
-            ...state.params,
-            [fieldName]: value,
-          },
-        });
+        if (state) {
+          set(promptingOperatorState, {
+            ...state,
+            params: {
+              ...state?.params,
+              [fieldName]: value,
+            },
+          });
+        }
       }
   );
   const execute = useCallback(


### PR DESCRIPTION
## What changes are proposed in this pull request?

If the toast triggers the QP operator for creating an index and it defaults to summary, switching to index and then creating the index would throw a null state exception although the panel would close and create the index. These changes stop that from happening.

## How is this patch tested? If it is not, please explain why.

Before:
![2024-11-21 10 24 54](https://github.com/user-attachments/assets/f774733d-28cb-46f3-9b4b-083085d9aed3)

After:
![2024-11-21 10 17 36](https://github.com/user-attachments/assets/e9ee154b-4c1e-4856-a1e0-1f7a78b4a4b8)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved state management by adding checks to prevent updates when the state is null or undefined, enhancing overall app stability.
  
- **Refactor**
	- Updated code formatting for better clarity and consistency without affecting functionality.
  
- **Enhancements**
	- Refined resource management logic in routing to improve how resources are reused based on the `hard` flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->