### PR TITLE
refactor(workflows): replace `secrets.TEAMS_GITHUB_PAT`  with fine grained org secret `RO_FOT_FG_PAT`.

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: voxel51/fiftyone-teams
           path: fiftyone-teams
-          token: ${{ secrets.TEAMS_GITHUB_PAT }}
+          token: ${{ secrets.RO_FOT_FG_PAT }}
           ref: main
       - name: Set up Python 3.9
         uses: actions/setup-python@v5


### PR DESCRIPTION
## What changes are proposed in this pull request?

Aloha is improving our use of Personal Access Tokens by moving them towards GitHub Organization secrets.  These will be easier to manage (and update) when they expire).


The only reference of `TEAMS_GITHUB_PAT` is in `.github/workflows/build-docs.yml`. This workflow appears to only need read access to `voxel51/fiftyone-teams`, so use a fine grained PAT with only that permission.

## How is this patch tested? If it is not, please explain why.

Will be tested in the action run https://github.com/voxel51/fiftyone/actions/runs/11960057931/job/33343225189

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow configuration for building documentation to support additional branch patterns.
	- Refined environment setup for build and publish jobs, enhancing workflow flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->