### PR TITLE
QP sidebar filters to active slice for group datasets

### DIFF
--- a/app/packages/relay/src/queries/__generated__/lightningQuery.graphql.ts
+++ b/app/packages/relay/src/queries/__generated__/lightningQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e18d763b5048c83b0ba06ace4b52f593>>
+ * @generated SignedSource<<b00c282e2f46c6801c4836c6006241a1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ConcreteRequest, Query } from 'relay-runtime';
 export type LightningInput = {
   dataset: string;
   paths: ReadonlyArray<LightningPathInput>;
+  slice?: string | null;
 };
 export type LightningPathInput = {
   exclude?: ReadonlyArray<string> | null;

--- a/app/packages/state/src/recoil/queryPerformance.ts
+++ b/app/packages/state/src/recoil/queryPerformance.ts
@@ -85,8 +85,6 @@ const indexesByPath = selector({
 
     const { sampleIndexes: samples, frameIndexes: frames } = get(indexes);
 
-    console.log(samples);
-
     const schema = gatherPaths(State.SPACE.SAMPLE);
     const frameSchema = gatherPaths(State.SPACE.FRAME).map((p) =>
       p.slice("frames.".length)

--- a/app/packages/state/src/recoil/queryPerformance.ts
+++ b/app/packages/state/src/recoil/queryPerformance.ts
@@ -11,7 +11,7 @@ import { graphQLSelectorFamily } from "recoil-relay";
 import type { ResponseFrom } from "../utils";
 import { config } from "./config";
 import { getBrowserStorageEffectForKey } from "./customEffects";
-import { groupSlice, groupStatistics } from "./groups";
+import { groupSlice } from "./groups";
 import { isLabelPath } from "./labels";
 import { RelayEnvironmentKey } from "./relay";
 import * as schemaAtoms from "./schema";
@@ -35,8 +35,7 @@ export const lightningQuery = graphQLSelectorFamily<
         input: {
           dataset: get(datasetName),
           paths,
-          slice:
-            get(groupStatistics(false)) === "group" ? null : get(groupSlice),
+          slice: get(groupSlice),
         },
       };
     },
@@ -85,6 +84,8 @@ const indexesByPath = selector({
       );
 
     const { sampleIndexes: samples, frameIndexes: frames } = get(indexes);
+
+    console.log(samples);
 
     const schema = gatherPaths(State.SPACE.SAMPLE);
     const frameSchema = gatherPaths(State.SPACE.FRAME).map((p) =>

--- a/app/packages/state/src/recoil/queryPerformance.ts
+++ b/app/packages/state/src/recoil/queryPerformance.ts
@@ -11,6 +11,7 @@ import { graphQLSelectorFamily } from "recoil-relay";
 import type { ResponseFrom } from "../utils";
 import { config } from "./config";
 import { getBrowserStorageEffectForKey } from "./customEffects";
+import { groupSlice, groupStatistics } from "./groups";
 import { isLabelPath } from "./labels";
 import { RelayEnvironmentKey } from "./relay";
 import * as schemaAtoms from "./schema";
@@ -34,6 +35,8 @@ export const lightningQuery = graphQLSelectorFamily<
         input: {
           dataset: get(datasetName),
           paths,
+          slice:
+            get(groupStatistics(false)) === "group" ? null : get(groupSlice),
         },
       };
     },

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -444,6 +444,7 @@ input LabelTagColorInput {
 input LightningInput {
   dataset: String!
   paths: [LightningPathInput!]!
+  slice: String = null
 }
 
 input LightningPathInput {

--- a/docs/source/user_guide/app.rst
+++ b/docs/source/user_guide/app.rst
@@ -489,8 +489,6 @@ perform initial filters on:
     # Note: it is faster to declare indexes before adding samples
     dataset.add_samples(...)
 
-    fo.app_config.default_query_performance = True
-
     session = fo.launch_app(dataset)
 
 .. note::
@@ -521,8 +519,6 @@ compound index that includes the group slice name:
     dataset.create_index("ground_truth.detections.label")
     dataset.create_index([("group.name", 1), ("ground_truth.detections.label", 1)])
 
-    fo.app_config.default_query_performance = True
-
     session = fo.launch_app(dataset)
 
 For datasets with a small number of fields, you can index all fields by adding
@@ -537,8 +533,6 @@ a single
 
     dataset = foz.load_zoo_dataset("quickstart")
     dataset.create_index("$**")
-
-    fo.app_config.default_query_performance = True
 
     session = fo.launch_app(dataset)
 

--- a/fiftyone/server/lightning.py
+++ b/fiftyone/server/lightning.py
@@ -9,7 +9,6 @@ FiftyOne Server lightning queries
 from bson import ObjectId
 from dataclasses import asdict, dataclass
 from datetime import date, datetime
-import math
 import typing as t
 
 import asyncio
@@ -46,6 +45,7 @@ class LightningPathInput:
 class LightningInput:
     dataset: str
     paths: t.List[LightningPathInput]
+    slice: t.Optional[str] = None
 
 
 @gql.interface
@@ -138,7 +138,13 @@ async def lightning_resolver(
         for collection, sublist in zip(collections, queries)
         for item in sublist
     ]
-    result = await _do_async_pooled_queries(dataset, flattened)
+
+    filter = (
+        {f"{dataset.group_field}.name": input.slice}
+        if dataset.group_field and input.slice
+        else None
+    )
+    result = await _do_async_pooled_queries(dataset, flattened, filter)
 
     results = []
     offset = 0
@@ -293,10 +299,11 @@ async def _do_async_pooled_queries(
     queries: t.List[
         t.Tuple[AsyncIOMotorCollection, t.Union[DistinctQuery, t.List[t.Dict]]]
     ],
+    filter: t.Optional[t.Mapping[str, str]],
 ):
     return await asyncio.gather(
         *[
-            _do_async_query(dataset, collection, query)
+            _do_async_query(dataset, collection, query, filter)
             for collection, query in queries
         ]
     )
@@ -306,25 +313,28 @@ async def _do_async_query(
     dataset: fo.Dataset,
     collection: AsyncIOMotorCollection,
     query: t.Union[DistinctQuery, t.List[t.Dict]],
+    filter: t.Optional[t.Mapping[str, str]],
 ):
     if isinstance(query, DistinctQuery):
         if query.has_list and not query.filters:
-            return await _do_distinct_query(collection, query)
+            return await _do_distinct_query(collection, query, filter)
 
-        return await _do_distinct_pipeline(dataset, collection, query)
+        return await _do_distinct_pipeline(dataset, collection, filter)
 
     return [i async for i in collection.aggregate(query)]
 
 
 async def _do_distinct_query(
-    collection: AsyncIOMotorCollection, query: DistinctQuery
+    collection: AsyncIOMotorCollection,
+    query: DistinctQuery,
+    filter: t.Optional[t.Mapping[str, str]],
 ):
     match = None
     if query.search:
         match = query.search
 
     try:
-        result = await collection.distinct(query.path)
+        result = await collection.distinct(query.path, filter)
     except:
         # too many results
         return None
@@ -350,12 +360,16 @@ async def _do_distinct_pipeline(
     dataset: fo.Dataset,
     collection: AsyncIOMotorCollection,
     query: DistinctQuery,
+    filter: t.Optional[t.Mapping[str, str]],
 ):
     pipeline = []
     if query.filters:
         pipeline += get_view(dataset, filters=query.filters)._pipeline()
 
-    pipeline += [{"$sort": {query.path: 1}}]
+    if filter:
+        pipeline.append({"$match": filter})
+
+    pipeline.append({"$sort": {query.path: 1}})
 
     if query.search:
         if query.is_object_id_field:


### PR DESCRIPTION
## What changes are proposed in this pull request?

```py
import fiftyone as fo

dataset = fo.Dataset("one-two-group")
group = fo.Group()
one = fo.Sample(
    classifications=fo.Classifications(
        classifications=[fo.Classification(label="one")]
    ),
    filepath="one.png",
    group=group.element("one"),
    numeric=1,
    string="one",
)
two = fo.Sample(
    classifications=fo.Classifications(
        classifications=[fo.Classification(label="two")]
    ),
    filepath="two.png",
    group=group.element("two"),
    numeric=2,
    string="two",
)
dataset.add_samples([one, two])
``` 

https://github.com/user-attachments/assets/23490901-c43e-47e3-bc1b-3cefa9f57acb

## How is this patch tested? If it is not, please explain why.

Lightning server tests

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new optional `slice` field in the `LightningInput` class for enhanced dataset querying.
  - Updated GraphQL schema with new input fields for improved flexibility in filtering and selection.

- **Bug Fixes**
  - Enhanced query performance logging to assist in monitoring sample indexes.

- **Documentation**
  - Comprehensive updates to the user guide, including clearer instructions on managing sessions, datasets, and views, as well as optimizing query performance.

- **Tests**
  - Added new tests for querying grouped datasets, improving overall test coverage and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->