### PR TITLE
Fix execute_operator() with delegation

### DIFF
--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -514,11 +514,12 @@ class DelegatedOperationService(object):
         result = await do_execute_operator(operator, ctx, exhaust=True)
 
         outputs_schema = None
-        request_params = {**context.request_params, "results": result}
         try:
-            outputs = await resolve_type_with_context(
-                request_params, "outputs"
-            )
+            # Resolve output types now
+            ctx.request_params["target"] = "outputs"
+            ctx.request_params["results"] = result
+
+            outputs = resolve_type_with_context(operator, ctx)
             if outputs is not None:
                 outputs_schema = outputs.to_json()
         except (AttributeError, Exception):

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -519,7 +519,7 @@ class DelegatedOperationService(object):
             ctx.request_params["target"] = "outputs"
             ctx.request_params["results"] = result
 
-            outputs = resolve_type_with_context(operator, ctx)
+            outputs = await resolve_type_with_context(operator, ctx)
             if outputs is not None:
                 outputs_schema = outputs.to_json()
         except (AttributeError, Exception):

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -54,7 +54,6 @@ class DelegatedOperationService(object):
                 - inputs_schema: the schema of the operator's inputs
                 - outputs_schema: the schema of the operator's outputs
 
-
         Returns:
             a :class:`fiftyone.factory.repos.DelegatedOperationDocument`
         """

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -383,13 +383,16 @@ async def resolve_type(registry, operator_uri, request_params):
 
 
 async def resolve_type_with_context(operator, context):
-    """Resolves the "inputs" or "outputs" schema of an operator with the given context.
+    """Resolves the "inputs" or "outputs" schema of an operator with the given
+    context.
+
     Args:
         operator: the :class:`fiftyone.operators.Operator`
         context: the :class:`ExecutionContext` of an operator
+
     Returns:
-        the schema of "inputs" or "outputs" :class:`fiftyone.operators.types.Property` of
-        an operator, or None
+        the "inputs" or "outputs" schema
+        :class:`fiftyone.operators.types.Property` of an operator, or None
     """
     try:
         return operator.resolve_type(

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -379,10 +379,10 @@ async def resolve_type(registry, operator_uri, request_params):
     )
     await ctx.resolve_secret_values(operator._plugin_secrets)
 
-    return resolve_type_with_context(operator, ctx)
+    return await resolve_type_with_context(operator, ctx)
 
 
-def resolve_type_with_context(operator, context):
+async def resolve_type_with_context(operator, context):
     """Resolves the "inputs" or "outputs" schema of an operator with the given context.
     Args:
         operator: the :class:`fiftyone.operators.Operator`

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -378,31 +378,25 @@ async def resolve_type(registry, operator_uri, request_params):
         required_secrets=operator._plugin_secrets,
     )
     await ctx.resolve_secret_values(operator._plugin_secrets)
+
+    return resolve_type_with_context(operator, ctx)
+
+
+def resolve_type_with_context(operator, context):
+    """Resolves the "inputs" or "outputs" schema of an operator with the given context.
+    Args:
+        operator: the :class:`fiftyone.operators.Operator`
+        context: the :class:`ExecutionContext` of an operator
+    Returns:
+        the schema of "inputs" or "outputs" :class:`fiftyone.operators.types.Property` of
+        an operator, or None
+    """
     try:
         return operator.resolve_type(
-            ctx, request_params.get("target", "inputs")
+            context, context.request_params.get("target", "inputs")
         )
     except Exception as e:
         return ExecutionResult(error=traceback.format_exc())
-
-
-async def resolve_type_with_context(request_params, target=None):
-    """Resolves the "inputs" or "outputs" schema of an operator with the given
-    context.
-
-    Args:
-        request_params: a dictionary of request parameters
-        target (None): the target schema ("inputs" or "outputs")
-
-    Returns:
-        the schema of "inputs" or "outputs"
-        :class:`fiftyone.operators.types.Property` of an operator, or None
-    """
-    computed_target = target or request_params.get("target", None)
-    computed_request_params = {**request_params, "target": computed_target}
-    operator_uri = request_params.get("operator_uri", None)
-    registry = OperatorRegistry()
-    return await resolve_type(registry, operator_uri, computed_request_params)
 
 
 async def resolve_execution_options(registry, operator_uri, request_params):


### PR DESCRIPTION
`resolve_type_with_context()` had morphed since introduction and was now recreating the Context even though we already have it. The bug was that when scheduled from the SDK, `operator_uri` is not a part of `request_params`. When scheduled from the UI, it is, plus a whole bunch of other attributes. Introduced sometime pre-v1.0

## What changes are proposed in this pull request?

Repurpose/refactor `resolve_type_with_context()` to be more what the name implies it's gonna do. Then make `resolve_type()` use that also.
If we reuse the `ExecutionContext` we already had (which was properly created), it is cleaner plus has a valid `operator_uri` which fixes this particular bug.

## How is this patch tested? If it is not, please explain why.

I tried to make some exposing tests but I was getting frustrated and I have limited hours before going out for a week. So ended up scrapping it.
We definitely need more testing in this area of the code.

Here's @brimoor's manual test that works now (no error on resolving output schema).

```python
import fiftyone as fo
import fiftyone.operators as foo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
compute_metadata = foo.get_operator("@voxel51/utils/compute_metadata")

# Schedule a delegated operation to (re)compute metadata
compute_metadata(dataset, overwrite=True, delegate=True)
```

```
$ fiftyone delegated launch
Running operation xyz (@voxel51/utils/compute_metadata)
Computing metadata...
 100% |██████████████████████████| 200/200 [50.6ms elapsed, 0s remaining, 4.0K samples/s] 

Operation xyz complete
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for output schema resolution, now logging warnings instead of raising exceptions.
	- Simplified type resolution process with improved error management.

- **Documentation**
	- Updated comments and docstrings for clarity on method functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->