### PR TITLE
Don't require pipeline updates when setting output schema

### DIFF
--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -177,15 +177,15 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
                 raise ValueError("Missing required property '%s'" % prop)
             setattr(op, prop, kwargs.get(prop))
 
-        # also set the delegation target (not required)
         delegation_target = kwargs.get("delegation_target", None)
         if delegation_target:
             setattr(op, "delegation_target", delegation_target)
 
-        # also set the metadata (not required)
         metadata = kwargs.get("metadata", None)
         if metadata:
             setattr(op, "metadata", metadata)
+        else:
+            setattr(op, "metadata", {})
 
         context = None
         if isinstance(op.context, dict):
@@ -262,8 +262,6 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             else None
         )
 
-        needs_pipeline_update = False
-
         if run_state == ExecutionRunState.COMPLETED:
             update = {
                 "$set": {
@@ -278,7 +276,6 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
                 update["$set"]["metadata.outputs_schema"] = (
                     outputs_schema or {}
                 )
-                needs_pipeline_update = True
 
         elif run_state == ExecutionRunState.FAILED:
             update = {
@@ -327,12 +324,6 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
         collection_filter = {"_id": _id}
         if required_state is not None:
             collection_filter["run_state"] = required_state
-
-        # Using pipeline update instead of a single update doc fixes a case
-        #   where `metadata` is null and so accessing the dotted field
-        #   `metadata.output_schema` creates the document instead of erroring.
-        if needs_pipeline_update:
-            update = [update]
 
         doc = self._collection.find_one_and_update(
             filter=collection_filter,

--- a/tests/unittests/operators/delegated_tests.py
+++ b/tests/unittests/operators/delegated_tests.py
@@ -212,7 +212,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.assertIsNotNone(doc.queued_at)
         self.assertEqual(doc.label, "Mock Operator")
         self.assertEqual(doc.run_state, ExecutionRunState.QUEUED)
-        self.assertIsNone(doc.metadata)
+        self.assertEqual(doc.metadata, {})
 
         doc2_metadata = {"inputs_schema": {}}
         doc2 = self.svc.queue_operation(
@@ -227,7 +227,6 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.assertIsNotNone(doc2.queued_at)
         self.assertEqual(doc2.label, "@voxelfiftyone/operator/foo")
         self.assertEqual(doc2.run_state, ExecutionRunState.QUEUED)
-        self.assertIsNotNone(doc2.metadata)
         self.assertEqual(doc2.metadata, doc2_metadata)
 
     def test_list_operations(self, mock_get_operator, mock_operator_exists):
@@ -484,35 +483,6 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.assertEqual(doc.status.progress, 0.5)
         self.assertEqual(doc.status.label, "halfway there")
         self.assertIsNotNone(doc.status.updated_at)
-
-    def test_output_schema_null_metadata(
-        self, mock_get_operator, mock_operator_exists
-    ):
-        mock_outputs = MockOutputs()
-        doc = self.svc.queue_operation(
-            operator="@voxelfiftyone/operator/foo",
-            delegation_target="test_target",
-            context=ExecutionContext(request_params={"foo": "bar"}),
-        )
-
-        # Set metadata to null instead of being unset, to test that corner case
-        self.svc._repo._collection.find_one_and_update(
-            {"_id": bson.ObjectId(doc.id)}, {"$set": {"metadata": None}}
-        )
-
-        self.svc.set_completed(
-            doc.id,
-            result=ExecutionResult(outputs_schema=mock_outputs.to_json()),
-        )
-
-        doc = self.svc.get(doc_id=doc.id)
-        self.assertEqual(doc.run_state, ExecutionRunState.COMPLETED)
-        self.assertEqual(
-            doc.metadata,
-            {
-                "outputs_schema": mock_outputs.to_json(),
-            },
-        )
 
     @patch(
         "fiftyone.core.odm.utils.load_dataset",


### PR DESCRIPTION
On `develop`, running a delegated operation with an output schema like [this one](https://github.com/voxel51/fiftyone-plugins/blob/d589a19fd7f996517d8d84b20d5d5a23c5c33cc6/plugins/brain/__init__.py#L90-L93) would fail on MongoDB <5 with the following error:

```
pymongo.errors.OperationFailure: Invalid $set :: caused by :: an empty object is not a valid value. Found empty object at path metadata.outputs_schema.type.properties, full error: {'ok': 0.0, 'errmsg': 'Invalid $set :: caused by :: an empty object is not a valid value. Found empty object at path metadata.outputs_schema.type.properties', 'code': 40180, 'codeName': 'Location40180'}
```

The reason was because [line 337](https://github.com/voxel51/fiftyone/blob/6a5b17f74ac5ddff753eead60a9772aee9506afb/fiftyone/factory/repos/delegated_operation.py#L337) was attempting an update aggregation like this:

```
[
    {
        '$set': {
            'run_state': 'completed',
            'completed_at': datetime.datetime(2024, 11, 22, 21, 16, 17, 69660),
            'updated_at': datetime.datetime(2024, 11, 22, 21, 16, 17, 69663),
            'result': {
                'result': None,
                'executor': None,
                'error': None,
                'error_message': None,
                'delegated': False,
                'validation_ctx': None,
            },
            'metadata.outputs_schema': {
                'type': {'name': 'Object', 'properties': {}},
                'default': None,
                'required': False,
                'choices': None,
                'invalid': False,
                'error_message': '',
                'on_change': None,
                'view': {
                    'name': 'View',
                    'label': 'Request complete',
                    'description': None,
                    'caption': None,
                    'space': None,
                    'placeholder': None,
                    'read_only': None,
                    'component': None,
                    'componentsProps': None,
                    'container': None,
                },
            },
        },
    },
]
```

and sadly this part:

```
'type': {'name': 'Object', 'properties': {}},
```

is [not supported on MongoDB < 5](https://www.mongodb.com/community/forums/t/mongoservererror-invalid-set-caused-by-an-empty-object-is-not-a-valid-value/148344).

The solution is to ensure that the `metadata` key always exists. Then we don't need the `needs_pipeline_update` flag! 🎉 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of metadata in queued operations, ensuring it defaults to an empty dictionary.
	- Streamlined logic for updating run states, simplifying the process without altering core functionality.

- **Bug Fixes**
	- Improved error handling in the queue operation method for better dataset ID resolution.

- **Tests**
	- Updated unit tests to reflect changes in metadata handling, ensuring consistency in expectations.
	- Removed outdated tests related to null metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->