### PR TITLE
Fix deleted datasets on App server

### DIFF
--- a/fiftyone/core/singletons.py
+++ b/fiftyone/core/singletons.py
@@ -5,6 +5,7 @@ FiftyOne singleton implementations.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import defaultdict
 import weakref
 
@@ -37,7 +38,9 @@ class DatasetSingleton(type):
             name = instance.name  # `__init__` may have changed `name`
         else:
             try:
-                instance._update_last_loaded_at()
+                instance._update_last_loaded_at(
+                    force=kwargs.get("force_load", False)
+                )
             except ValueError:
                 instance._deleted = True
                 return cls.__call__(

--- a/fiftyone/core/singletons.py
+++ b/fiftyone/core/singletons.py
@@ -39,7 +39,7 @@ class DatasetSingleton(type):
         else:
             try:
                 instance._update_last_loaded_at(
-                    force=kwargs.get("force_load", False)
+                    force=kwargs.get("_force_load", False)
                 )
             except ValueError:
                 instance._deleted = True

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -585,11 +585,7 @@ async def serialize_dataset(
         if not fod.dataset_exists(dataset_name):
             return None
 
-        dataset = fod.load_dataset(dataset_name)
-
-        if update_last_loaded_at:
-            dataset._update_last_loaded_at(force=True)
-
+        dataset = fo.Dataset(dataset_name, _create=False, force_load=True)
         dataset.reload()
         view_name = None
         try:

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -585,7 +585,7 @@ async def serialize_dataset(
         if not fod.dataset_exists(dataset_name):
             return None
 
-        dataset = fo.Dataset(dataset_name, _create=False, force_load=True)
+        dataset = fo.Dataset(dataset_name, _create=False, _force_load=True)
         dataset.reload()
         view_name = None
         try:


### PR DESCRIPTION
```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
session = fo.launch_app(dataset)

#.wait for App, then delete dataset and recreate
dataset.delete()
dataset = foz.load_zoo_dataset("quickstart")

# refresh browser page
``` 
<img width="1470" alt="Screenshot 2024-11-22 at 8 10 20 PM" src="https://github.com/user-attachments/assets/0ca093ad-5cef-49f8-abfb-7e1471b50832">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced dataset loading mechanism to ensure datasets are loaded correctly and efficiently.
	- Improved error handling for loading saved views, allowing for more robust dataset view creation.

- **Bug Fixes**
	- Adjusted error handling logic to better manage exceptions during dataset and view loading.

- **Refactor**
	- Updated method signatures for better control over dataset loading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->