### PR TITLE
[Docs] Treat delegated execution separately

### DIFF
--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -1142,10 +1142,10 @@ executed in the background while you continue to use the App.
 There are a variety of options available for configuring whether a given
 operation should be delegated or executed immediately.
 
-.. _operator-delegation-configuration:
+.. _operator-execution-options:
 
-Delegation configuration
-~~~~~~~~~~~~~~~~~~~~~~~~
+Execution options
+~~~~~~~~~~~~~~~~~
 
 You can provide the optional properties described below in the
 :ref:`operator's config <operator-config>` to specify the available execution
@@ -1183,12 +1183,12 @@ user to choose between the supported options if there are multiple:
 .. image:: /images/plugins/operators/operator-execute-button.png
     :align: center
 
-.. _operator-execution-options:
+.. _dynamic-execution-options:
 
-Execution options
-~~~~~~~~~~~~~~~~~
+Dynamic execution options
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Operators can implement
+Operators may also implement
 :meth:`resolve_execution_options() <fiftyone.operators.operator.Operator.resolve_execution_options>`
 to dynamically configure the available execution options based on the current
 execution context:
@@ -1238,14 +1238,9 @@ of the current view:
         # Force delegation for large views and immediate execution for small views
         return len(ctx.view) > 1000
 
-.. note::
-
-    If :meth:`resolve_delegation() <fiftyone.operators.operator.Operator.resolve_delegation>`
-    is not implemented or returns `None`, then the choice of execution mode is
-    deferred to
-    :meth:`resolve_execution_options() <fiftyone.operators.operator.Operator.resolve_execution_options>`
-    to specify the available execution options as described in the previous
-    section.
+If :meth:`resolve_delegation() <fiftyone.operators.operator.Operator.resolve_delegation>`
+is not implemented or returns `None`, then the choice of execution mode is
+deferred to the prior mechanisms described above.
 
 .. _operator-reporting-progress:
 

--- a/docs/source/plugins/using_plugins.rst
+++ b/docs/source/plugins/using_plugins.rst
@@ -669,6 +669,12 @@ operator does just that:
     :linenos:
 
     class ComputeMetadata(foo.Operator):
+        return foo.OperatorConfig(
+            ...
+            allow_immediate_execution=True,
+            allow_delegated_execution=True,
+        )
+
         def __call__(
             self,
             sample_collection,
@@ -686,12 +692,6 @@ operator does just that:
                 ctx,
                 params=params,
                 request_delegation=delegate,
-            )
-
-        def resolve_execution_options(self, ctx):
-            return foo.ExecutionOptions(
-                allow_delegated_execution=True,
-                allow_immediate_execution=True,
             )
 
 which means that it can be invoked like so:
@@ -767,8 +767,7 @@ Requesting delegation
 ~~~~~~~~~~~~~~~~~~~~~
 
 If an operation supports both immediate and
-:ref:`delegated execution <delegated-operations>` as specified either by its
-:ref:`configuration <operator-delegation-configuration>` or
+:ref:`delegated execution <delegated-operations>` as specified by its
 :ref:`execution options <operator-execution-options>`, you can request
 delegated execution by passing the `request_delegation=True` flag to
 :func:`execute_operator() <fiftyone.operators.execute_operator>`:

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -261,12 +261,13 @@ async def execute_or_delegate_operator(
             ctx.request_params["delegated"] = True
             metadata = {"inputs_schema": None, "outputs_schema": None}
 
-            try:
-                metadata["inputs_schema"] = inputs.to_json()
-            except Exception as e:
-                logger.warning(
-                    f"Failed to resolve inputs schema for the operation: {str(e)}"
-                )
+            if inputs is not None:
+                try:
+                    metadata["inputs_schema"] = inputs.to_json()
+                except Exception as e:
+                    logger.warning(
+                        f"Failed to resolve inputs schema for the operation: {str(e)}"
+                    )
 
             op = DelegatedOperationService().queue_operation(
                 operator=operator.uri,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Revised documentation for using plugins, clarifying the removal of the `delegate` parameter from the `compute_metadata` operator.
	- Enhanced explanations and examples for delegating function calls.
	- Improved overall structure and organization of the documentation for better usability.
	- Expanded content and new examples added for developing plugins, including a "Hello World" example.

- **Bug Fixes**
	- Updated error handling in the execution of delegated operations to prevent potential errors when `inputs` is `None`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->