### PR TITLE
Improve performance for Selection tree component

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/TreeSelectionView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TreeSelectionView.tsx
@@ -39,12 +39,7 @@ export default function TreeSelectionView(props: ViewPropsType) {
   const { view = {} } = schema;
 
   if (data == undefined) {
-    const sampleIds = view?.data.flatMap(([parentId, children]) => {
-      return children.map((childId) =>
-        typeof childId === "string" ? childId : childId[0]
-      );
-    });
-    onChange(path, sampleIds);
+    onChange(path, []);
   }
 
   const structure = view?.data || [];
@@ -78,7 +73,7 @@ export default function TreeSelectionView(props: ViewPropsType) {
   const initialCollapsedState: CollapsedState = React.useMemo(() => {
     const state: CollapsedState = {};
     structure.forEach(([parentId]) => {
-      state[parentId] = false; // start as expanded
+      state[parentId] = true; // start as expanded
     });
     return state;
   }, [structure]);
@@ -87,7 +82,7 @@ export default function TreeSelectionView(props: ViewPropsType) {
     initialCollapsedState
   );
 
-  const [allCollapsed, setAllCollapsed] = React.useState(false);
+  const [allCollapsed, setAllCollapsed] = React.useState(true);
 
   const handleExpandCollapseAll = () => {
     setCollapsedState((prevState) => {
@@ -208,17 +203,6 @@ export default function TreeSelectionView(props: ViewPropsType) {
     const idx = structure.findIndex(([id]) => id === groupId);
     return idx === -1 ? 0 : idx + 1;
   };
-
-  // On init, all samples are selected by default
-  useEffect(() => {
-    const sampleIds = view?.data.flatMap(([parentId, children]) => {
-      return children.map((childId) =>
-        typeof childId === "string" ? childId : childId[0]
-      );
-    });
-    onChange(path, sampleIds);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   // this only runs when data and checkboxstate are different
   // meaning the user selected samples from the grid

--- a/app/packages/core/src/plugins/SchemaIO/components/TreeSelectionView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TreeSelectionView.tsx
@@ -73,7 +73,7 @@ export default function TreeSelectionView(props: ViewPropsType) {
   const initialCollapsedState: CollapsedState = React.useMemo(() => {
     const state: CollapsedState = {};
     structure.forEach(([parentId]) => {
-      state[parentId] = true; // start as expanded
+      state[parentId] = true; // start as folded
     });
     return state;
   }, [structure]);
@@ -92,7 +92,7 @@ export default function TreeSelectionView(props: ViewPropsType) {
       });
       return newState;
     });
-    setAllCollapsed(!allCollapsed); // Toggle the expand/collapse state
+    setAllCollapsed(!allCollapsed);
   };
 
   const handleCheckboxChange = (id: string, isChecked: boolean) => {
@@ -178,7 +178,7 @@ export default function TreeSelectionView(props: ViewPropsType) {
         const isSample =
           !structure.some(([parentId]) => parentId === key) &&
           key !== "selectAll";
-        return isSample && updatedState[key].checked; // Only checked samples
+        return isSample && updatedState[key].checked;
       });
 
       // We update the actual output value (ctx.params.value \ data) here.
@@ -188,7 +188,6 @@ export default function TreeSelectionView(props: ViewPropsType) {
     });
   };
 
-  // Function to handle expand/collapse toggle
   const handleToggleCollapse = (id: string) => {
     setCollapsedState((prevState) => ({
       ...prevState,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Previously, the python panel component would initialize with all children selected on render. This cause flashes and unstable performance issues when syncing the selected state among the grid, python panel state, and the selection tree component. 

This PR reverted the initial setting to not selected state. 

## How is this patch tested? If it is not, please explain why.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved handling of the selection state in the Tree Selection component when no data is provided.
	- Default state now initializes with all parent nodes collapsed for a cleaner user interface.

- **Bug Fixes**
	- Resolved issues with automatic sample selection on initialization, enhancing user control over selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->