### PR TITLE
fix confusion matrix in model evaluation panel

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -1158,8 +1158,8 @@ export default function Evaluation(props: EvaluationProps) {
                         hovertemplate:
                           [
                             "<b>count: %{z:d}</b>",
-                            `ground_truth: %{y}`,
-                            `predictions: %{x}`,
+                            `${evaluation?.info?.config?.gt_field}: %{y}`,
+                            `${evaluation?.info?.config?.pred_field}: %{x}`,
                           ].join(" <br>") + "<extra></extra>",
                       },
                     ]}

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -1158,8 +1158,13 @@ export default function Evaluation(props: EvaluationProps) {
                         hovertemplate:
                           [
                             "<b>count: %{z:d}</b>",
-                            `${evaluation?.info?.config?.gt_field}: %{y}`,
-                            `${evaluation?.info?.config?.pred_field}: %{x}`,
+                            `${
+                              evaluation?.info?.config?.gt_field || "truth"
+                            }: %{y}`,
+                            `${
+                              evaluation?.info?.config?.pred_field ||
+                              "predicted"
+                            }: %{x}`,
                           ].join(" <br>") + "<extra></extra>",
                       },
                     ]}
@@ -1192,8 +1197,13 @@ export default function Evaluation(props: EvaluationProps) {
                           hovertemplate:
                             [
                               "<b>count: %{z:d}</b>",
-                              `ground_truth: %{y}`,
-                              `predictions: %{x}`,
+                              `${
+                                evaluation?.info?.config?.gt_field || "truth"
+                              }: %{y}`,
+                              `${
+                                evaluation?.info?.config?.pred_field ||
+                                "predicted"
+                              }: %{x}`,
                             ].join(" <br>") + "<extra></extra>",
                         },
                       ]}

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -1155,6 +1155,12 @@ export default function Evaluation(props: EvaluationProps) {
                         colorscale: confusionMatrixConfig.log
                           ? confusionMatrix?.colorscale || "viridis"
                           : "viridis",
+                        hovertemplate:
+                          [
+                            "<b>count: %{z:d}</b>",
+                            `ground_truth: %{y}`,
+                            `predictions: %{x}`,
+                          ].join(" <br>") + "<extra></extra>",
                       },
                     ]}
                     onClick={({ points }) => {
@@ -1183,6 +1189,12 @@ export default function Evaluation(props: EvaluationProps) {
                           colorscale: confusionMatrixConfig.log
                             ? compareConfusionMatrix?.colorscale || "viridis"
                             : "viridis",
+                          hovertemplate:
+                            [
+                              "<b>count: %{z:d}</b>",
+                              `ground_truth: %{y}`,
+                              `predictions: %{x}`,
+                            ].join(" <br>") + "<extra></extra>",
                         },
                       ]}
                     />

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -1532,8 +1532,8 @@ function getMatrix(matrices, config) {
   if (!matrices) return;
   const { sortBy = "az", limit } = config;
   const parsedLimit = typeof limit === "number" ? limit : undefined;
-  const classes = matrices[`${sortBy}_classes`].slice(parsedLimit);
-  const matrix = matrices[`${sortBy}_matrix`].slice(parsedLimit);
+  const classes = matrices[`${sortBy}_classes`].slice(0, parsedLimit);
+  const matrix = matrices[`${sortBy}_matrix`].slice(0, parsedLimit);
   const colorscale = matrices[`${sortBy}_colorscale`];
   return { labels: classes, matrix, colorscale };
 }

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/EvaluationPlot.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/EvaluationPlot.tsx
@@ -31,7 +31,6 @@ export default function EvaluationPlot(props: EvaluationPlotProps) {
         color: theme.text.secondary,
         gridcolor: theme.primary.softBorder,
         automargin: true, // Enable automatic margin adjustment
-        scaleanchor: "x",
       },
       autosize: true,
       margin: { t: 20, l: 50, b: 50, r: 20, pad: 0 },

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/EvaluationPlot.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/EvaluationPlot.tsx
@@ -31,6 +31,7 @@ export default function EvaluationPlot(props: EvaluationPlotProps) {
         color: theme.text.secondary,
         gridcolor: theme.primary.softBorder,
         automargin: true, // Enable automatic margin adjustment
+        autorange: "reversed",
       },
       autosize: true,
       margin: { t: 20, l: 50, b: 50, r: 20, pad: 0 },

--- a/fiftyone/core/plots/plotly.py
+++ b/fiftyone/core/plots/plotly.py
@@ -103,6 +103,8 @@ def plot_confusion_matrix(
             labels,
             colorscale=colorscale,
             title=title,
+            gt_field=gt_field,
+            pred_field=pred_field,
             **kwargs,
         )
 
@@ -121,16 +123,24 @@ def plot_confusion_matrix(
 
 
 def _plot_confusion_matrix_static(
-    confusion_matrix, labels, colorscale=None, title=None, **kwargs
+    confusion_matrix,
+    labels,
+    colorscale=None,
+    title=None,
+    gt_field=None,
+    pred_field=None,
+    **kwargs,
 ):
     confusion_matrix = np.asarray(confusion_matrix)
     num_rows, num_cols = confusion_matrix.shape
     zlim = [0, confusion_matrix.max()]
+    truth = gt_field or "truth"
+    predicted = pred_field or "predicted"
 
     hover_lines = [
         "<b>count: %{z:d}</b>",
-        "truth: %{y}",
-        "predicted: %{x}",
+        f"{truth}: %{{y}}",
+        f"{predicted}: %{{x}}",
     ]
     hovertemplate = "<br>".join(hover_lines) + "<extra></extra>"
 
@@ -164,8 +174,6 @@ def _plot_confusion_matrix_static(
             scaleanchor="x",
             scaleratio=1,
         ),
-        xaxis_title="Predicted label",
-        yaxis_title="True label",
         title=title,
     )
 
@@ -234,6 +242,8 @@ def _plot_confusion_matrix_interactive(
         xlabels=xlabels,
         ylabels=ylabels,
         zlim=zlim,
+        gt_field=gt_field,
+        pred_field=pred_field,
         colorscale=colorscale,
         link_type="labels",
         init_view=samples,
@@ -1959,6 +1969,10 @@ class InteractiveHeatmap(PlotlyInteractivePlot):
         zlim (None): a ``[zmin, zmax]`` limit to use for the colorbar
         values_title ("count"): the semantic meaning of the heatmap values.
             Used for tooltips
+        gt_field (None): the name of the ground truth field, if known. Used for
+            tooltips
+        pred_field (None): the name of the predictions field, if known. Used
+            for tooltips
         colorscale (None): a plotly colorscale to use
         grid_opacity (0.1): an opacity value for the grid points
         bg_opacity (0.25): an opacity value for background (unselected) cells
@@ -1974,6 +1988,8 @@ class InteractiveHeatmap(PlotlyInteractivePlot):
         ylabels=None,
         zlim=None,
         values_title="count",
+        gt_field=None,
+        pred_field=None,
         colorscale=None,
         grid_opacity=0.1,
         bg_opacity=0.25,
@@ -1991,6 +2007,8 @@ class InteractiveHeatmap(PlotlyInteractivePlot):
         self.ylabels = ylabels
         self.zlim = zlim
         self.values_title = values_title
+        self.gt_field = gt_field
+        self.pred_field = pred_field
         self.colorscale = colorscale
         self.grid_opacity = grid_opacity
         self.bg_opacity = bg_opacity
@@ -2185,11 +2203,13 @@ class InteractiveHeatmap(PlotlyInteractivePlot):
         xticks = np.arange(num_cols)
         yticks = np.arange(num_rows)
         X, Y = np.meshgrid(xticks, yticks)
+        truth = self.gt_field or "truth"
+        predicted = self.pred_field or "predicted"
 
         hover_lines = [
             "<b>%s: %%{z}</b>" % self.values_title,
-            "truth: %{y}",
-            "predicted: %{x}",
+            f"{truth}: %{{y}}",
+            f"{predicted}: %{{x}}",
         ]
         hovertemplate = "<br>".join(hover_lines) + "<extra></extra>"
 

--- a/fiftyone/utils/eval/base.py
+++ b/fiftyone/utils/eval/base.py
@@ -333,15 +333,17 @@ class BaseEvaluationResults(foe.EvaluationResults):
             # Omit `(other, other)`
             i = labels.index(other_label)
             cmat[i, i] = 0
-            ids[i, i] = []
+            if tabulate_ids:
+                ids[i, i] = []
 
             if added_missing:
                 # Omit `(other, missing)` and `(missing, other)`
                 j = labels.index(self.missing)
                 cmat[i, j] = 0
                 cmat[j, i] = 0
-                ids[i, j] = []
-                ids[j, i] = []
+                if tabulate_ids:
+                    ids[i, j] = []
+                    ids[j, i] = []
 
         rm_inds = []
 
@@ -357,7 +359,10 @@ class BaseEvaluationResults(foe.EvaluationResults):
 
         if rm_inds:
             cmat = np.delete(np.delete(cmat, rm_inds, axis=0), rm_inds, axis=1)
-            ids = np.delete(np.delete(ids, rm_inds, axis=0), rm_inds, axis=1)
+            if tabulate_ids:
+                ids = np.delete(
+                    np.delete(ids, rm_inds, axis=0), rm_inds, axis=1
+                )
             labels = [l for i, l in enumerate(labels) if i not in rm_inds]
 
         return cmat, labels, ids


### PR DESCRIPTION
## What changes are proposed in this pull request?

fix confusion matrix in model evaluation panel

## How is this patch tested? If it is not, please explain why.

Using model evaluation panel

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of confusion matrices and performance metrics in the evaluation component.
	- Added dynamic hover tooltips in confusion matrix plots to reflect ground truth and predicted fields.
	- Improved clarity of data displayed in confusion matrices with updated hover information.

- **Bug Fixes**
	- Fixed potential issues with undefined limits in matrix slicing.

- **Chores**
	- Minor adjustments to configuration options for displaying class performance and confusion matrices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->