### PR TITLE
Show "missing" counts in confusion matrices

### DIFF
--- a/fiftyone/operators/builtins/panels/model_evaluation/__init__.py
+++ b/fiftyone/operators/builtins/panels/model_evaluation/__init__.py
@@ -248,7 +248,6 @@ class EvaluationPanel(Panel):
 
     def get_confusion_matrices(self, results):
         default_classes = results.classes.tolist()
-        other_label = "(other)"
         freq = Counter(results.ytrue)
         if results.missing in freq:
             freq.pop(results.missing)
@@ -257,27 +256,32 @@ class EvaluationPanel(Panel):
         mc_classes = sorted(freq, key=freq.get, reverse=True)
         lc_classes = sorted(freq, key=freq.get)
         default_matrix, _default_classes, _ = results._confusion_matrix(
-            other_label=other_label,
+            include_other=False,
+            include_missing=True,
             tabulate_ids=False,
         )
         az_matrix, _az_classes, _ = results._confusion_matrix(
             classes=az_classes,
-            other_label=other_label,
+            include_other=False,
+            include_missing=True,
             tabulate_ids=False,
         )
         za_matrix, _za_classes, _ = results._confusion_matrix(
             classes=za_classes,
-            other_label=other_label,
+            include_other=False,
+            include_missing=True,
             tabulate_ids=False,
         )
         mc_matrix, _mc_classes, _ = results._confusion_matrix(
             classes=mc_classes,
-            other_label=other_label,
+            include_other=False,
+            include_missing=True,
             tabulate_ids=False,
         )
         lc_matrix, _lc_classes, _ = results._confusion_matrix(
             classes=lc_classes,
-            other_label=other_label,
+            include_other=False,
+            include_missing=True,
             tabulate_ids=False,
         )
         default_colorscale = self.get_confusion_matrix_colorscale(

--- a/fiftyone/operators/builtins/panels/model_evaluation/__init__.py
+++ b/fiftyone/operators/builtins/panels/model_evaluation/__init__.py
@@ -247,7 +247,8 @@ class EvaluationPanel(Panel):
         return colorscale
 
     def get_confusion_matrices(self, results):
-        default_classes = results.classes
+        default_classes = results.classes.tolist()
+        other_label = "(other)"
         freq = Counter(results.ytrue)
         if results.missing in freq:
             freq.pop(results.missing)
@@ -255,11 +256,30 @@ class EvaluationPanel(Panel):
         za_classes = sorted(default_classes, reverse=True)
         mc_classes = sorted(freq, key=freq.get, reverse=True)
         lc_classes = sorted(freq, key=freq.get)
-        default_matrix = results.confusion_matrix()
-        az_matrix = results.confusion_matrix(classes=az_classes)
-        za_matrix = results.confusion_matrix(classes=za_classes)
-        mc_matrix = results.confusion_matrix(classes=mc_classes)
-        lc_matrix = results.confusion_matrix(classes=lc_classes)
+        default_matrix, _default_classes, _ = results._confusion_matrix(
+            other_label=other_label,
+            tabulate_ids=False,
+        )
+        az_matrix, _az_classes, _ = results._confusion_matrix(
+            classes=az_classes,
+            other_label=other_label,
+            tabulate_ids=False,
+        )
+        za_matrix, _za_classes, _ = results._confusion_matrix(
+            classes=za_classes,
+            other_label=other_label,
+            tabulate_ids=False,
+        )
+        mc_matrix, _mc_classes, _ = results._confusion_matrix(
+            classes=mc_classes,
+            other_label=other_label,
+            tabulate_ids=False,
+        )
+        lc_matrix, _lc_classes, _ = results._confusion_matrix(
+            classes=lc_classes,
+            other_label=other_label,
+            tabulate_ids=False,
+        )
         default_colorscale = self.get_confusion_matrix_colorscale(
             default_matrix
         )
@@ -268,11 +288,11 @@ class EvaluationPanel(Panel):
         mc_colorscale = self.get_confusion_matrix_colorscale(mc_matrix)
         lc_colorscale = self.get_confusion_matrix_colorscale(lc_matrix)
         return {
-            "default_classes": default_classes.tolist(),
-            "az_classes": az_classes,
-            "za_classes": za_classes,
-            "mc_classes": mc_classes,
-            "lc_classes": lc_classes,
+            "default_classes": _default_classes,
+            "az_classes": _az_classes,
+            "za_classes": _za_classes,
+            "mc_classes": _mc_classes,
+            "lc_classes": _lc_classes,
             "default_matrix": default_matrix.tolist(),
             "az_matrix": az_matrix.tolist(),
             "za_matrix": za_matrix.tolist(),


### PR DESCRIPTION
## Change log

When evaluating object detections, confusion matrices need the ability to show an additional row/column to capture “missing” values:
- "missing": false negative ground truth (no matched prediction)
- "missing": false positive predictions (no matched ground truth)

## TODO

- [x] Update `set_view()` callbacks to correctly handle "missing" cases
- [x] The panel currently throws an exception when I click on a "missing" row/col (bottom row or rightmost col)
- [x] The backend now includes the "missing" class as the **LAST** row/col of the confusion matrices (see the example code below). When the user requests `k=10` classes, we need to display 11 total rows/cols: the 10 rows/cols representing the classes they requested PLUS the last row/col so that we're showing the "missing" data. This means the frontend logic for applying the `limit=k` logic will need to select the first `k` rows plus the last row of the appropriate confusion matrix, rather than just the first `k` rows 

## Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

results = dataset.evaluate_detections(
    "predictions",
    gt_field="ground_truth",
    eval_key="eval",
    classwise=False,
)

session = fo.launch_app(dataset)
```

```py
from collections import Counter

freq = Counter(results.ytrue)
if results.missing in freq:
    freq.pop(results.missing)

results.missing
# '(none)'

classes = sorted(freq, key=freq.get, reverse=True)[:5]
# ['person', 'kite', 'bird', 'car', 'carrot']

cmat, labels, _ = results._confusion_matrix(
    classes=classes,
    include_other=False,
    include_missing=True,
    tabulate_ids=False,
)

"""
cmat
array([[665,   2,   1,   0,   0,  43],
       [  0, 123,   1,   0,   0,  15],
       [  3,   2,  84,   0,   0,  22],
       [  0,   0,   0,  45,   0,  12],
       [  0,   0,   0,   0,  34,  12],
       [472,  59,  23, 154, 344,   0]])

labels
['person', 'kite', 'bird', 'car', 'carrot', '(none)']
"""
```
