### PR TITLE
[Docs] Leaky splits

### DIFF
--- a/docs/source/brain.rst
+++ b/docs/source/brain.rst
@@ -1872,7 +1872,7 @@ can give you an insight into the source of the leaks in your dataset.
 **What to expect**: Leakiness find leaks by embedding samples with a powerful
 model and finding very close samples in different splits in this space. Large,
 powerful models that were *not* trained on a dataset can provide insight into
-visiual and semantic similarity between images, without creating further leaks
+visual and semantic similarity between images, without creating further leaks
 in the process.
 
 **Similarity**: At its core, the leaky-splits module is a wrapper for the brain's

--- a/docs/source/brain.rst
+++ b/docs/source/brain.rst
@@ -1778,7 +1778,7 @@ can have consequences when evaluating a model. It can often be easy to
 overestimate model capability due to this issue. FiftyOne Brain offers a way
 of identifying such cases in dataset splits.
 
-The leaks of a |Dataset| can be computed directly without the need
+The leaks of a |Dataset| or |DatasetView| can be computed directly without the need
 for the predictions of a pre-trained model via the
 :meth:`compute_leaky_splits() <fiftyone.brain.compute_leaky_splits>`
 method:

--- a/docs/source/brain.rst
+++ b/docs/source/brain.rst
@@ -1815,9 +1815,8 @@ cleaning the dataset with
 :meth:`no_leaks_view() <fiftyone.brain.internal.core.leaky_splits.LeakySplitsIndex.no_leaks_view>`
 or tagging them for the future with
 :meth:`tag_leaks() <fiftyone.brain.internal.core.leaky_splits.LeakySplitsIndex.tag_leaks>`.
-Besides this, a view with all leaks is returned. This is not only visually
-appealing and fun to look at, but can also give you an insight into the
-source of the leaks in your dataset.
+Besides this, a view with all leaks is returned. Visualization of this view
+can give you an insight into the source of the leaks in your dataset.
 
 **What to expect**: Leakyness find leaks by embedding samples with a powerful
 model and finding very close samples in different splits in this space. Large,

--- a/docs/source/brain.rst
+++ b/docs/source/brain.rst
@@ -1776,7 +1776,7 @@ Despite our best efforts, duplicates and other forms of non-IID samples
 show up in our data. When these samples end up in different splits, this
 can have consequences when evaluating a model. It can often be easy to
 overestimate model capability due to this issue. The FiftyOne Brain offers a way
-of identifying such cases in dataset splits.
+to identify such cases in dataset splits.
 
 The leaks of a |Dataset| or |DatasetView| can be computed directly without the need
 for the predictions of a pre-trained model via the

--- a/docs/source/brain.rst
+++ b/docs/source/brain.rst
@@ -1811,10 +1811,13 @@ of tags, a field, or views.
 
 **Output**: An index that will allow you to look through your leaks and
 provides some useful actions once they are discovered such as automatically
-cleaning the dataset with `view_without_leaks` or tagging them for the future
-with `tag_leaks`. Besides this, a view with all leaks is returned. This is
-not only visually appealing and fun to look at, but can also give you an
-insight into the source of the leaks in your dataset.
+cleaning the dataset with
+:meth:`no_leaks_view() <fiftyone.brain.internal.core.leaky_splits.LeakySplitsIndex.no_leaks_view>`
+or tagging them for the future with
+:meth:`tag_leaks() <fiftyone.brain.internal.core.leaky_splits.LeakySplitsIndex.tag_leaks>`.
+Besides this, a view with all leaks is returned. This is not only visually
+appealing and fun to look at, but can also give you an insight into the
+source of the leaks in your dataset.
 
 **What to expect**: Leakyness find leaks by embedding samples with a powerful
 model and finding very close samples in different splits in this space. Large,

--- a/docs/source/brain.rst
+++ b/docs/source/brain.rst
@@ -76,7 +76,7 @@ workflow:
 
 * :ref:`Leaky Splits <brain-image-leaky-splits>`:
   Often when sourcing data en masse, duplicates and near duplicates can slip
-  through the cracks. The FiftyOne Brain offers a *leaky-splits check* that
+  through the cracks. The FiftyOne Brain offers a *leaky-splits analysis* that
   can be used to find potential leaks between dataset splits. These splits can
   be misleading when evaluating a model, giving an overly optimistic measure
   for the quality of training. 
@@ -1775,7 +1775,7 @@ ____________
 Despite our best efforts, duplicates and other forms of non-IID samples
 show up in our data. When these samples end up in different splits, this
 can have consequences when evaluating a model. It can often be easy to
-overestimate model capability due to this issue. FiftyOne Brain offers a way
+overestimate model capability due to this issue. The FiftyOne Brain offers a way
 of identifying such cases in dataset splits.
 
 The leaks of a |Dataset| or |DatasetView| can be computed directly without the need

--- a/docs/source/brain.rst
+++ b/docs/source/brain.rst
@@ -1818,7 +1818,7 @@ or tagging them for the future with
 Besides this, a view with all leaks is returned. Visualization of this view
 can give you an insight into the source of the leaks in your dataset.
 
-**What to expect**: Leakyness find leaks by embedding samples with a powerful
+**What to expect**: Leakiness find leaks by embedding samples with a powerful
 model and finding very close samples in different splits in this space. Large,
 powerful models that were *not* trained on a dataset can provide insight into
 visiual and semantic similarity between images, without creating further leaks

--- a/docs/source/brain.rst
+++ b/docs/source/brain.rst
@@ -1840,7 +1840,7 @@ handle the rest.
 
 **Thresholds**: The leaky-splits module uses a threshold to decide what samples
 are 'too close' and mark them as potential leaks. This threshold can be changed
-either by passing a value to the `threshold` argument of the `compute_leaky_splits`
+either by passing a value to the `threshold` argument of the `compute_leaky_splits()`
 method, or by using the
 :meth:`set_threshold() <fiftyone.brain.internal.core.leaky_splits.SimilarityIndex.set_threshold>`
 method. The best value for your use-case may vary depending on your dataset, as well


### PR DESCRIPTION
## What changes are proposed in this pull request?

Added docs for new leaky-splits module

## How is this patch tested? If it is not, please explain why.

Built docs and checked that they looked generally sane.

## Release Notes

New brain method for detecting leaky splits! Try it out by importing `from fiftyone.brain import compute_leaky_splits`.
Documentation can be found in the brain docs.

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

see https://github.com/voxel51/fiftyone-brain/pull/203

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new documentation section on "Leaky Splits" for identifying potential data leaks between dataset splits.
	- Included a visual representation of the leaky splits analysis.

- **Documentation**
	- Updated existing documentation to include details on the `compute_leaky_splits()` method, input requirements, expected outputs, and leak detection mechanisms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->