### PR TITLE
bugfix: y-axis autorange reversed on all evaluation chart

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -1172,6 +1172,11 @@ export default function Evaluation(props: EvaluationProps) {
                       const firstPoint = points[0];
                       loadView("matrix", { x: firstPoint.x, y: firstPoint.y });
                     }}
+                    layout={{
+                      yaxis: {
+                        autorange: "reversed",
+                      },
+                    }}
                   />
                 </Stack>
                 {compareKey && (
@@ -1207,6 +1212,11 @@ export default function Evaluation(props: EvaluationProps) {
                             ].join(" <br>") + "<extra></extra>",
                         },
                       ]}
+                      layout={{
+                        yaxis: {
+                          autorange: "reversed",
+                        },
+                      }}
                     />
                   </Stack>
                 )}

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/EvaluationPlot.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/EvaluationPlot.tsx
@@ -1,4 +1,5 @@
 import { useTheme } from "@fiftyone/components";
+import { merge } from "lodash";
 import React, { useMemo } from "react";
 import Plot, { PlotParams } from "react-plotly.js";
 
@@ -44,6 +45,11 @@ export default function EvaluationPlot(props: EvaluationPlotProps) {
       },
     };
   }, [theme]);
+
+  const mergedLayout = useMemo(() => {
+    return merge({}, layoutDefaults, layout);
+  }, [layoutDefaults, layout]);
+
   const configDefaults: PlotConfig = useMemo(() => {
     return {
       displaylogo: false,
@@ -65,7 +71,7 @@ export default function EvaluationPlot(props: EvaluationPlotProps) {
   return (
     <Plot
       config={configDefaults}
-      layout={{ ...layoutDefaults, ...layout }}
+      layout={mergedLayout}
       style={{ height: "100%", width: "100%", zIndex: 1, ...style }}
       data={data}
       {...otherProps}

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/EvaluationPlot.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/EvaluationPlot.tsx
@@ -31,7 +31,6 @@ export default function EvaluationPlot(props: EvaluationPlotProps) {
         color: theme.text.secondary,
         gridcolor: theme.primary.softBorder,
         automargin: true, // Enable automatic margin adjustment
-        autorange: "reversed",
       },
       autosize: true,
       margin: { t: 20, l: 50, b: 50, r: 20, pad: 0 },


### PR DESCRIPTION
## What changes are proposed in this pull request?

fix the bug that evaluation chart y-axis all reversed. Only confusion matrices chart should revert, while others maintain the same.

## How is this patch tested? If it is not, please explain why.

![Screenshot 2024-11-26 at 9 56 35 AM](https://github.com/user-attachments/assets/fe11c326-7f41-4a2d-bd6d-de7216dad284)
![Screenshot 2024-11-26 at 9 56 30 AM](https://github.com/user-attachments/assets/c3be6695-9a93-42b4-a1e4-7cfa1d3e26fd)


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced visual representation of confusion matrices with improved layout configurations.
- **Bug Fixes**
	- Adjusted y-axis rendering for the evaluation confusion matrix to ensure correct alignment of true labels.
	- Updated y-axis behavior in the evaluation plot for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->