### PR TITLE
add guards for missing location/dimensions while rendering 3d bounding boxes

### DIFF
--- a/app/packages/looker-3d/src/labels/index.tsx
+++ b/app/packages/looker-3d/src/labels/index.tsx
@@ -135,7 +135,11 @@ export const ThreeDLabels = ({ sampleMap }: ThreeDLabelsProps) => {
     const newPolylineOverlays = [];
 
     for (const overlay of rawOverlays) {
-      if (overlay._cls === "Detection") {
+      if (
+        overlay._cls === "Detection" &&
+        overlay.dimensions &&
+        overlay.location
+      ) {
         newCuboidOverlays.push(
           <Cuboid
             key={`cuboid-${overlay.id ?? overlay._id}-${overlay.sampleId}`}

--- a/app/packages/looker/src/overlays/detection.ts
+++ b/app/packages/looker/src/overlays/detection.ts
@@ -88,7 +88,7 @@ export default class DetectionOverlay<
     this.label.mask && this.drawMask(ctx, state);
     !state.config.thumbnail && this.drawLabelText(ctx, state);
 
-    if (this.is3D) {
+    if (this.is3D && this.label.dimensions && this.label.location) {
       this.fillRectFor3d(ctx, state, this.getColor(state));
     } else {
       this.strokeRect(ctx, state, this.getColor(state));

--- a/app/packages/looker/src/worker/threed-label-processor.ts
+++ b/app/packages/looker/src/worker/threed-label-processor.ts
@@ -47,6 +47,10 @@ const getInferredParamsForUndefinedProjection = (
 
     if (cls === DETECTIONS) {
       for (const detection of label.detections as DetectionLabel[]) {
+        if (!detection.location || !detection.dimensions) {
+          continue;
+        }
+
         const [x, y] = detection.location;
         const [lx, ly] = detection.dimensions;
 
@@ -55,7 +59,7 @@ const getInferredParamsForUndefinedProjection = (
         minY = Math.min(minY, y - ly / 2);
         maxY = Math.max(maxY, y + ly / 2);
       }
-    } else if (cls === "Detection") {
+    } else if (cls === "Detection" && label.location && label.dimensions) {
       const [x, y] = label.location as DetectionLabel["location"];
       const [lx, ly] = label.dimensions as DetectionLabel["dimensions"];
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Although it's a violation of the contract if a 3D labels doesn't have `location` and `dimensions` property, the app shouldn't crash if that's the case. This PR adds resilience against that behavior.

## How is this patch tested? If it is not, please explain why.

Locally.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
