### PR TITLE
update panel table content to be same size as header

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/TableView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TableView.tsx
@@ -194,6 +194,7 @@ export default function TableView(props: ViewPropsType) {
                             background: isSelected
                               ? selectedCellColor
                               : "unset",
+                            fontSize: "1rem",
                           }}
                           onClick={() => {
                             handleCellClick(rowIndex, columnIndex);
@@ -220,6 +221,7 @@ export default function TableView(props: ViewPropsType) {
                           background: isRowSelected
                             ? selectedCellColor
                             : "unset",
+                          fontSize: "1rem",
                         }}
                       >
                         {currentRowHasActions ? (


### PR DESCRIPTION
## What changes are proposed in this pull request?

Updated panel table content font size to be same as header

## How is this patch tested? If it is not, please explain why.

![image](https://github.com/user-attachments/assets/6ea1fd19-a56d-4646-8281-b9076af41ed8)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced visual consistency in the table by standardizing font size across all cells.
	- Improved click event handling for cells, rows, and columns to streamline user interactions.

- **Bug Fixes**
	- Adjusted logic for row actions to ensure only valid actions are processed based on the current row state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->