### PR TITLE
Improve search results for multikey indexes in group datasets

### DIFF
--- a/fiftyone/server/lightning.py
+++ b/fiftyone/server/lightning.py
@@ -328,7 +328,7 @@ async def _do_async_query(
 ):
     if isinstance(query, DistinctQuery):
         if query.has_list:
-            return await _do_distinct_query(collection, query, filter)
+            return await _do_distinct_query(collection, query)
 
         return await _do_distinct_pipeline(dataset, collection, query, filter)
 
@@ -343,14 +343,13 @@ async def _do_async_query(
 async def _do_distinct_query(
     collection: AsyncIOMotorCollection,
     query: DistinctQuery,
-    filter: t.Optional[t.Mapping[str, str]],
 ):
     match = None
     if query.search:
         match = query.search
 
     try:
-        result = await collection.distinct(query.path, filter)
+        result = await collection.distinct(query.path)
     except:
         # too many results
         return None

--- a/tests/unittests/lightning_tests.py
+++ b/tests/unittests/lightning_tests.py
@@ -1132,7 +1132,7 @@ class TestGroupDatasetLightningQueries(unittest.IsolatedAsyncioTestCase):
                 },
                 {
                     "path": "classifications.classifications.label",
-                    "values": ["one"],
+                    "values": ["one", "two"],
                 },
                 {"path": "numeric", "min": 1.0, "max": 1.0},
                 {"path": "string", "values": ["one"]},
@@ -1164,7 +1164,7 @@ class TestGroupDatasetLightningQueries(unittest.IsolatedAsyncioTestCase):
                 },
                 {
                     "path": "classifications.classifications.label",
-                    "values": ["two"],
+                    "values": ["one", "two"],
                 },
                 {"path": "numeric", "min": 2.0, "max": 2.0},
                 {"path": "string", "values": ["two"]},


### PR DESCRIPTION
## What changes are proposed in this pull request?

Including a filter for a distinct call prevents a distinct scan, so omit the group slice

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Simplified distinct query processing, which may return broader result sets without specific filters.

- **Bug Fixes**
	- Adjusted expected output in unit tests to reflect changes in query results, ensuring accuracy in test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->