### PR TITLE
Bump fot-brain

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ INSTALL_REQUIRES = [
     "universal-analytics-python3>=1.0.1,<2",
     "pydash",
     # internal packages
-    "fiftyone-brain>=0.17.0,<0.18",
+    "fiftyone-brain>=0.18.0,<0.19",
     "fiftyone-db>=0.4,<2.0",
     "voxel51-eta>=0.13.0,<0.14",
 ]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Bumps the fiftyone-brain version from `0.17.0,0.18` to `0.18.0,0.19`.

## How is this patch tested? If it is not, please explain why.

Tested via GitHub actions.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other - dependencies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version constraint for the `fiftyone-brain` dependency to allow for newer versions, improving compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->