### PR TITLE
Fix download context

### DIFF
--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -64,6 +64,7 @@ class DatasetView(foc.SampleCollection):
         "__media_type",
         "__group_slice",
         "__name",
+        "_download_context",
         "_make_sample_fcn",
         "_make_frame_fcn",
     )


### PR DESCRIPTION
## What changes are proposed in this pull request?

fix `TypeError: descriptor '_download_context' for 'SampleCollection' objects doesn't apply to a 'DatasetView' object`
repro:

```
model = foz.load_zoo_model("clip-vit-base32-torch")
q= q=fo.load_dataset('quickstart')
q.compute_embeddings(model, embeddings_field="clip-embeds")
```

## How is this patch tested? If it is not, please explain why.

tested locally 

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced management of download contexts in the dataset view.
  
- **Chores**
	- Updated the version constraint for the `fiftyone-brain` dependency to allow for new features and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->