### PR TITLE
fix issue with disabled schedule exec option

### DIFF
--- a/app/packages/operators/src/ExecutionOptionItem.tsx
+++ b/app/packages/operators/src/ExecutionOptionItem.tsx
@@ -1,0 +1,22 @@
+import { useTheme } from "@fiftyone/components";
+
+export default function ExecutionOptionItem({ label, tag, disabled }) {
+  const theme = useTheme();
+  const tagEl = tag ? (
+    <span
+      style={{
+        fontSize: "11px",
+        color: disabled ? theme.text.secondary : theme.custom.primarySoft,
+        marginLeft: "5px",
+      }}
+    >
+      {tag}
+    </span>
+  ) : null;
+  return (
+    <div style={{ display: "flex", alignItems: "center" }}>
+      {label}
+      {tagEl}
+    </div>
+  );
+}

--- a/app/packages/operators/src/SplitButton.tsx
+++ b/app/packages/operators/src/SplitButton.tsx
@@ -15,7 +15,7 @@ import {
 } from "@mui/material";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import { onEnter } from "./utils";
-import { useTheme } from "@fiftyone/components";
+import ExecutionOptionItem from "./ExecutionOptionItem";
 
 const ButtonStylesOverrides: ButtonProps["sx"] = {
   color: (theme) => theme.palette.text.secondary,
@@ -63,6 +63,7 @@ export default function SplitButton({
   };
 
   const handleSelect = (option) => {
+    if (!option.onSelect) return;
     option.onSelect();
     setOpen(false);
   };
@@ -142,7 +143,7 @@ export default function SplitButton({
                                 : theme.palette.text.disabled,
                           }}
                           primary={
-                            <PrimaryWithTag
+                            <ExecutionOptionItem
                               label={option.choiceLabel || option.label}
                               tag={option.tag}
                               disabled={option.disabled || !option.onClick}
@@ -169,26 +170,5 @@ export default function SplitButton({
         </Popper>
       )}
     </React.Fragment>
-  );
-}
-
-function PrimaryWithTag({ label, tag, disabled }) {
-  const theme = useTheme();
-  const tagEl = tag ? (
-    <span
-      style={{
-        fontSize: "11px",
-        color: disabled ? theme.text.secondary : theme.custom.primarySoft,
-        marginLeft: "5px",
-      }}
-    >
-      {tag}
-    </span>
-  ) : null;
-  return (
-    <div style={{ display: "flex", alignItems: "center" }}>
-      {label}
-      {tagEl}
-    </div>
   );
 }

--- a/app/packages/operators/src/components/OperatorExecutionMenu/index.tsx
+++ b/app/packages/operators/src/components/OperatorExecutionMenu/index.tsx
@@ -1,6 +1,6 @@
 import { Menu, MenuItem, Stack, Typography } from "@mui/material";
-import React from "react";
 import { OperatorExecutionOption } from "../../state";
+import ExecutionOptionItem from "../../ExecutionOptionItem";
 
 /**
  * Component which provides a context menu for executing an operator using a
@@ -28,24 +28,42 @@ export const OperatorExecutionMenu = ({
   return (
     <Menu anchorEl={anchor} open={open} onClose={onClose}>
       {executionOptions.map((target) => (
-        <MenuItem
+        <Item
           key={target.id}
-          onClick={() => {
-            onClose?.();
-            onOptionClick?.(target);
-            target.onClick();
-          }}
-        >
-          <Stack direction="column" spacing={1}>
-            <Typography fontWeight="bold">
-              {target.choiceLabel ?? target.label}
-            </Typography>
-            <Typography color="secondary">{target.description}</Typography>
-          </Stack>
-        </MenuItem>
+          target={target}
+          disabled={target.isDisabledSchedule || !target.onClick}
+          onClose={onClose}
+          onOptionClick={onOptionClick}
+        />
       ))}
     </Menu>
   );
 };
 
 export default OperatorExecutionMenu;
+
+function Item({ target, disabled, onClose, onOptionClick }) {
+  return (
+    <MenuItem
+      key={target.id}
+      onClick={() => {
+        if (disabled) return;
+        onClose?.();
+        onOptionClick?.(target);
+        target.onClick();
+      }}
+      sx={{ cursor: disabled ? "default" : "pointer" }}
+    >
+      <Stack direction="column" spacing={1}>
+        <Typography fontWeight="bold">
+          <ExecutionOptionItem
+            label={target.choiceLabel ?? target.label}
+            tag={target.tag}
+            disabled={disabled}
+          />
+        </Typography>
+        <Typography color="secondary">{target.description}</Typography>
+      </Stack>
+    </MenuItem>
+  );
+}

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -246,6 +246,7 @@ export type OperatorExecutionOption = {
   default?: boolean;
   selected?: boolean;
   onSelect?: () => void;
+  isDisabledSchedule?: boolean;
 };
 
 const useOperatorPromptSubmitOptions = (
@@ -346,6 +347,7 @@ const useOperatorPromptSubmitOptions = (
       id: "disabled-schedule",
       description: markdownDesc,
       isDelegated: true,
+      isDisabledSchedule: true,
     });
   }
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/289466aa-5539-436d-aad6-8600d27c2f68

This fixes an issue where the schedule option in the `OperatorExecutionButtonView` was click-able when it should be disabled. It also normalizes the display of the Execution Options in both the modal SplitButton and the OperatorExecutionButton.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the `ExecutionOptionItem` component for improved rendering of execution options.
	- Added a new `Item` component to streamline the `OperatorExecutionMenu` functionality.
	- Enhanced operator execution options with an `isDisabledSchedule` property to indicate scheduling availability.

- **Bug Fixes**
	- Improved error handling in the `handleSelect` function to prevent issues with undefined actions.

- **Refactor**
	- Removed the `PrimaryWithTag` function to simplify the `SplitButton` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->