### PR TITLE
List hf hub datasets

### DIFF
--- a/fiftyone/utils/huggingface.py
+++ b/fiftyone/utils/huggingface.py
@@ -67,22 +67,30 @@ logger = logging.getLogger(__name__)
 def list_hub_datasets():
     """Lists all FiftyOne datasets available on the Hugging Face Hub.
 
-    This function prints instructions for loading datasets and displays a list of
-    all datasets published by Voxel51 on the Hugging Face Hub.
+
+
+    Examples::
+
+        from fiftyone.utils.huggingface import load_from_hub
+        
+        # Return an iterable of all datasets in Voxel51 org
+        org_datasets = list_hub_datasets()
+        
+        # Print names of datasets
+        for dataset in org_datasets:
+            dataset_name = dataset.id
+            print(dataset_name)
+
+        # If a dataset looks interesting, you can load any of the following datasets as follows
+        dataset = load_from_hub("Voxel51/dataset-name")
+
+    Returns:
+        generator: A generator of dataset objects from the Hugging Face Hub API 
+             containing metadata about each dataset published by Voxel51
     """
-    from huggingface_hub import list_datasets
-    
-    print('You can load any of the following datasets as follows:\n')
-    print('from fiftyone.utils.huggingface import load_from_hub')
-    print('dataset = load_from_hub("Voxel51/dataset-name")\n')
-    print('Datasets on the Hugging Face Hub:\n')
-    
-    # List all datasets for Voxel51
-    org_datasets = list_datasets(author="Voxel51")
-    
-    for dataset in org_datasets:
-        dataset_name = dataset.id.split('Voxel51/')[-1]
-        print(dataset_name)
+
+
+    return hfh.list_datasets(author="Voxel51")
 
 
 def push_to_hub(

--- a/fiftyone/utils/huggingface.py
+++ b/fiftyone/utils/huggingface.py
@@ -31,7 +31,6 @@ from fiftyone.core.sample import Sample
 import fiftyone.core.utils as fou
 import fiftyone.types as fot
 
-from huggingface_hub import list_datasets
 
 hfh = fou.lazy_import(
     "huggingface_hub",
@@ -71,6 +70,7 @@ def list_hub_datasets():
     This function prints instructions for loading datasets and displays a list of
     all datasets published by Voxel51 on the Hugging Face Hub.
     """
+    from huggingface_hub import list_datasets
     
     print('You can load any of the following datasets as follows:\n')
     print('from fiftyone.utils.huggingface import load_from_hub')

--- a/fiftyone/utils/huggingface.py
+++ b/fiftyone/utils/huggingface.py
@@ -31,6 +31,8 @@ from fiftyone.core.sample import Sample
 import fiftyone.core.utils as fou
 import fiftyone.types as fot
 
+from huggingface_hub import list_datasets
+
 hfh = fou.lazy_import(
     "huggingface_hub",
     callback=lambda: fou.ensure_package("huggingface_hub>=0.20.0"),
@@ -62,6 +64,25 @@ SUPPORTED_DTYPES = (
 )
 
 logger = logging.getLogger(__name__)
+
+def list_hub_datasets():
+    """Lists all FiftyOne datasets available on the Hugging Face Hub.
+
+    This function prints instructions for loading datasets and displays a list of
+    all datasets published by Voxel51 on the Hugging Face Hub.
+    """
+    
+    print('You can load any of the following datasets as follows:\n')
+    print('from fiftyone.utils.huggingface import load_from_hub')
+    print('dataset = load_from_hub("Voxel51/dataset-name")\n')
+    print('Datasets on the Hugging Face Hub:\n')
+    
+    # List all datasets for Voxel51
+    org_datasets = list_datasets(author="Voxel51")
+    
+    for dataset in org_datasets:
+        dataset_name = dataset.id.split('Voxel51/')[-1]
+        print(dataset_name)
 
 
 def push_to_hub(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Added proper documentation and improved implementation of the `list_hub_datasets()` function in `fiftyone/utils/huggingface.py`. The changes include:
- Added comprehensive docstring explaining function purpose and usage
- Improved code readability with clear comments


## How is this patch tested? If it is not, please explain why.

The changes can be tested by:
1. Running the function directly:
```python
from fiftyone.utils.huggingface import list_hub_datasets
list_hub_datasets()
```

2. Checking the docstring help:
```python
help(list_hub_datasets)
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. You can now easily list the datasets we have on our HF org

Added documentation and improved implementation of `list_hub_datasets()` function, making it easier for users to discover and load FiftyOne datasets from the Hugging Face Hub.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [x] Other: utils/huggingface.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new function to list all FiftyOne datasets available on the Hugging Face Hub, enhancing user access to discoverable datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->