### PR TITLE
Fixes treeSelection filtering of samples in group

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/TreeSelectionView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TreeSelectionView.tsx
@@ -177,7 +177,8 @@ export default function TreeSelectionView(props: ViewPropsType) {
       const selectedSampleIds = Object.keys(updatedState).filter((key) => {
         const isSample =
           !structure.some(([parentId]) => parentId === key) &&
-          key !== "selectAll";
+          key !== "selectAll" &&
+          !Object.keys(updatedState[key])?.includes("indeterminate");
         return isSample && updatedState[key].checked;
       });
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Adds a filter to TreeSelection to filter the group ids
- tested locally with @lanzhenw 

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
