### PR TITLE
fix zoom to crop in 3d

### DIFF
--- a/app/packages/looker-3d/src/fo3d/MediaTypeFo3d.tsx
+++ b/app/packages/looker-3d/src/fo3d/MediaTypeFo3d.tsx
@@ -388,7 +388,7 @@ export const MediaTypeFo3dComponent = () => {
         return;
       }
 
-      const labelBoundingBoxes = [];
+      const labelBoundingBoxes: THREE.Box3[] = [];
 
       for (const selectedLabel of currentSelectedLabels) {
         const field = selectedLabel.field;
@@ -441,17 +441,23 @@ export const MediaTypeFo3dComponent = () => {
         labelBoundingBoxes.push(thisLabelBoundingBox);
       }
 
-      const unionBoundingBox = labelBoundingBoxes[0].clone();
+      const unionBoundingBox: THREE.Box3 = labelBoundingBoxes[0];
 
       for (let i = 1; i < labelBoundingBoxes.length; i++) {
         unionBoundingBox.union(labelBoundingBoxes[i]);
       }
 
-      const unionBoundingBoxCenter = unionBoundingBox.getCenter(
-        new THREE.Vector3()
-      );
-      const unionBoundingBoxSize = unionBoundingBox.getSize(
-        new THREE.Vector3()
+      // center = (min + max) / 2
+      let unionBoundingBoxCenter = new Vector3();
+      unionBoundingBoxCenter = unionBoundingBoxCenter
+        .addVectors(unionBoundingBox.min, unionBoundingBox.max)
+        .multiplyScalar(0.5);
+
+      // size = max - min
+      let unionBoundingBoxSize = new Vector3();
+      unionBoundingBoxSize = unionBoundingBoxSize.subVectors(
+        unionBoundingBox.max,
+        unionBoundingBox.min
       );
 
       const maxSize = Math.max(

--- a/app/packages/looker-3d/src/fo3d/MediaTypeFo3d.tsx
+++ b/app/packages/looker-3d/src/fo3d/MediaTypeFo3d.tsx
@@ -441,7 +441,7 @@ export const MediaTypeFo3dComponent = () => {
         labelBoundingBoxes.push(thisLabelBoundingBox);
       }
 
-      const unionBoundingBox: THREE.Box3 = labelBoundingBoxes[0];
+      const unionBoundingBox: THREE.Box3 = labelBoundingBoxes[0].clone();
 
       for (let i = 1; i < labelBoundingBoxes.length; i++) {
         unionBoundingBox.union(labelBoundingBoxes[i]);


### PR DESCRIPTION
## What changes are proposed in this pull request?

three js' bounding box's `.getSize()` and `.getCenter()` are not working as expected. They both return zero. Reason to be investigated. I replaced those APIs with custom code and it's working again.

![2024-12-05 14 15 26](https://github.com/user-attachments/assets/9ae5be18-1322-4aac-98cc-97e54772fcac)


## How is this patch tested? If it is not, please explain why.

locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?


-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced type safety and clarity in the 3D media component.
	- Improved calculations for camera positioning based on bounding boxes.

- **Bug Fixes**
	- Minor adjustments to camera controls and event listeners for better functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->