### PR TITLE
fix import timeouts on increasing datasets by precomputing batch size

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -3392,10 +3392,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             if sample.media_type == fom.VIDEO:
                 sample.frames.save()
 
-        if batcher is not None and batcher.manual_backpressure:
-            # @todo can we infer content size from insert_many() above?
-            batcher.apply_backpressure(dicts)
-
         return [str(d["_id"]) for d in dicts]
 
     def _upsert_samples(
@@ -3458,10 +3454,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
             if sample.media_type == fom.VIDEO:
                 sample.frames.save()
-
-        if batcher is not None and batcher.manual_backpressure:
-            # @todo can we infer content size from bulk_write() above?
-            batcher.apply_backpressure(dicts)
 
     def _make_dict(
         self,

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -809,9 +809,6 @@ def insert_documents(docs, coll, ordered=False, progress=None, num_docs=None):
                 batch = list(batch)
                 coll.insert_many(batch, ordered=ordered)
                 ids.extend(b["_id"] for b in batch)
-                if batcher.manual_backpressure:
-                    # @todo can we infer content size from insert_many() above?
-                    batcher.apply_backpressure(batch)
 
     except BulkWriteError as bwe:
         msg = bwe.details["writeErrors"][0]["errmsg"]
@@ -838,11 +835,6 @@ def bulk_write(ops, coll, ordered=False, progress=False):
             for batch in batcher:
                 batch = list(batch)
                 coll.bulk_write(batch, ordered=ordered)
-                if batcher.manual_backpressure:
-                    # @todo can we infer content size from bulk_write() above?
-                    # @todo do we need a more accurate measure of size here?
-                    content_size = sum(len(str(b)) for b in batch)
-                    batcher.apply_backpressure(content_size)
 
     except BulkWriteError as bwe:
         msg = bwe.details["writeErrors"][0]["errmsg"]

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1552,6 +1552,117 @@ class StaticBatcher(Batcher):
         return self.batch_size
 
 
+class ContentSizeBatcher(Batcher):
+    """Class for iterating over the elements of an iterable with a dynamic
+    batch size to achieve a desired content size.
+
+    The batch sizes emitted when iterating over this object are dynamically
+    scaled such that the total content size of the batch is as close as
+    possible to a specified target size.
+
+    This batcher does not require backpressure feedback because it calculates
+    the total size of the iterable object before batching.
+
+    This class is often used in conjunction with a :class:`ProgressBar` to keep
+    the user appraised on the status of a long-running task.
+
+    Example usage::
+
+        import fiftyone.core.utils as fou
+
+        elements = range(int(1e7))
+
+        batcher = fou.ContentSizeBatcher(
+            elements,
+            target_size=2**20,
+            progress=True
+        )
+
+        with batcher:
+            for batch in batcher:
+                print("batch size: %d" % len(batch))
+
+    Args:
+        iterable: an iterable to batch over. If ``None``, the result of
+            ``next()`` will be a batch size instead of a batch, and is an
+            infinite iterator.
+        target_size (1048576): the target batch bson content size, in bytes
+        min_batch_size (1): the minimum allowed batch size
+        max_batch_size (None): an optional maximum allowed batch size
+        return_views (False): whether to return each batch as a
+            :class:`fiftyone.core.view.DatasetView`. Only applicable when the
+            iterable is a :class:`fiftyone.core.collections.SampleCollection`
+        progress (False): whether to render a progress bar tracking the
+            consumption of the batches (True/False), use the default value
+            ``fiftyone.config.show_progress_bars`` (None), or a progress
+            callback function to invoke instead
+        total (None): the length of ``iterable``. Only applicable when
+            ``progress=True``. If not provided, it is computed via
+            ``len(iterable)``, if possible
+    """
+
+    def __init__(
+        self,
+        iterable,
+        target_size=2**20,
+        min_batch_size=1,
+        max_batch_size=None,
+        return_views=False,
+        progress=False,
+        total=None,
+    ):
+        iterable, iterable_copy = itertools.tee(iterable)
+        super().__init__(
+            iterable, return_views=return_views, progress=progress, total=total
+        )
+        self.batch_sizes = self._compute_batch_sizes(
+            target_size, min_batch_size, max_batch_size, iterable_copy
+        )
+        self.curr_batch = 0
+
+    def _compute_batch_sizes(
+        self, target_size, min_batch_size, max_batch_size, iterable
+    ):
+        batch_sizes = []
+        curr_batch_size = 0
+        curr_batch_content_size = 0
+
+        for obj in iterable:
+            try:
+                curr_batch_content_size += len(
+                    json_util.dumps(self._make_dict(obj))
+                )
+            except Exception:
+                curr_batch_content_size += len(str(obj))
+            curr_batch_size += 1
+            if curr_batch_size >= min_batch_size and (
+                curr_batch_content_size >= target_size
+                or curr_batch_size == max_batch_size
+            ):
+                batch_sizes.append(curr_batch_size)
+                curr_batch_size = 0
+                curr_batch_content_size = 0
+
+        if curr_batch_size:
+            batch_sizes.append(curr_batch_size)
+
+        return batch_sizes
+
+    def _make_dict(self, obj):
+        return (
+            obj.to_mongo_dict(include_id=True)
+            if hasattr(obj, "to_mongo_dict")
+            else obj
+        )
+
+    def _compute_batch_size(self):
+        size = 1
+        if self.curr_batch < len(self.batch_sizes):
+            size = self.batch_sizes[self.curr_batch]
+        self.curr_batch += 1
+        return size
+
+
 def get_default_batcher(iterable, progress=False, total=None):
     """Returns a :class:`Batcher` over ``iterable`` using defaults from your
     FiftyOne config.
@@ -1588,11 +1699,9 @@ def get_default_batcher(iterable, progress=False, total=None):
         )
     elif default_batcher == "size":
         target_content_size = fo.config.batcher_target_size_bytes
-        return ContentSizeDynamicBatcher(
-            iterable,
+        return ContentSizeBatcher(
+            iterable=iterable,
             target_size=target_content_size,
-            init_batch_size=1,
-            max_batch_beta=8.0,
             max_batch_size=100000,
             progress=progress,
             total=total,


### PR DESCRIPTION
## What changes are proposed in this pull request?

When importing a dataset that changes greatly in size between samples with the content size dynamic batcher we were seeing timeouts from mongo because based on the previous batch of samples we would predict future batch sizes which wasn't scaling up fast enough. Since most situations we have the content sizes before doing any writes to the database we can precompute these values and create batch sizes upfront.

## How is this patch tested? If it is not, please explain why.

- Set default batcher to "size"
- Downloaded the zip in the jira ticket above
- Ran the following command:
```
import fiftyone as fo

dns = '/Users/camronstaley/Downloads/Dr_Wright_Drives_Beta.zip'
ds=fo.Dataset.from_archive(dns,dataset_type=fo.types.FiftyOneDataset)
```

Output:
```
(TEAMS) (3.10.14) ➜  scripts python import_archive.py
/Users/camronstaley/Workplace/envs/TEAMS/lib/python3.10/site-packages/paramiko/pkey.py:100: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.
  "cipher": algorithms.TripleDES,
/Users/camronstaley/Workplace/envs/TEAMS/lib/python3.10/site-packages/paramiko/transport.py:259: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.
  "class": algorithms.TripleDES,
Assuming '/Users/camronstaley/Downloads/Dr_Wright_Drives_Beta' contains the extracted contents of '/Users/camronstaley/Downloads/Dr_Wright_Drives_Beta.zip'
Importing samples...
 100% |███████████████████████████████████████████████████████████████████████████████████████████| 3/3 [154.1ms elapsed, 0s remaining, 19.5 samples/s] 
Importing frames...
 100% |█████████████████████████████████████████████
```

batch sizes created:
```
[3670, 3666, 3663, 3653, 3653, 3670, 3666, 3663, 3653, 3653, 1968, 50, 50, 50, 50, 50, 50, 52, 50, 50, 50, 50, 50, 50, 50, 69, 50, 50, 86, 56, 51, 51, 51, 51, 53, 51, 64, 94, 56, 51, 50, 50, 50, 51, 50, 51, 50, 50, 50, 50, 50, 50, 50, 113, 63, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 65, 51, 51, 51, 51, 96, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 53, 57, 51, 51, 2203, 3031, 3023, 3022, 3022, 1015]
```

batch sizes created before these changes:
```
batch content size: 1048992
length of batch: 3666                                                                                                                                  
batch content size: 1050321
length of batch: 3660                                                                                                                                  
batch content size: 1050664
length of batch: 3653                                                                                                                                  
batch content size: 1048607
length of batch: 3653                                                                                                                                  
batch content size: 45736747
length of batch: 457
```
Above is just a small chunk of the batch sizes but the idea is that it ramped from 0 - 3600ish which maintained the 1 mb target size until it reached the 3rd video which was way more densely populated with labels. This resulted in the batch size being 45736747 and often times it timed out.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x ] No. You can skip the rest of this section.
-   [] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced new methods for managing dataset samples, including adding images and videos, and saving/loading dataset views.
  - Added a new `ContentSizeBatcher` for improved batch processing based on content size.

- **Enhancements**
  - Enhanced sample management with improved validation and dynamic schema expansion.
  - Streamlined error handling for clearer messages and better edge case management.

- **Bug Fixes**
  - Updated tests to ensure coverage for the new batching functionality while maintaining existing test integrity. 

- **Documentation**
  - Updated method documentation to reflect new functionalities and parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->