### PR TITLE
fix an issue where backtick can't be when editing evaluation note

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -1,5 +1,5 @@
 import { Dialog } from "@fiftyone/components";
-import { view } from "@fiftyone/state";
+import { editingFieldAtom, view } from "@fiftyone/state";
 import {
   ArrowBack,
   ArrowDropDown,
@@ -41,7 +41,7 @@ import {
   useTheme,
 } from "@mui/material";
 import React, { useEffect, useMemo, useState } from "react";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useSetRecoilState } from "recoil";
 import EvaluationNotes from "./EvaluationNotes";
 import EvaluationPlot from "./EvaluationPlot";
 import Status from "./Status";
@@ -133,6 +133,7 @@ export default function Evaluation(props: EvaluationProps) {
 
   const triggerEvent = useTriggerEvent();
   const activeFilter = useActiveFilter(evaluation, compareEvaluation);
+  const setEditingField = useSetRecoilState(editingFieldAtom);
 
   const closeNoteDialog = () => {
     setEditNoteState((note) => ({ ...note, open: false }));
@@ -1295,6 +1296,12 @@ export default function Evaluation(props: EvaluationProps) {
             </Typography>
           </Stack>
           <TextField
+            onFocus={() => {
+              setEditingField(true);
+            }}
+            onBlur={() => {
+              setEditingField(false);
+            }}
             multiline
             rows={10}
             defaultValue={evaluationNotes}

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -849,6 +849,7 @@ export function useOperatorBrowser() {
   const choices = useRecoilValue(operatorBrowserChoices);
   const promptForInput = usePromptOperatorInput();
   const isOperatorPaletteOpened = useRecoilValue(operatorPaletteOpened);
+  const editingField = useRecoilValue(fos.editingFieldAtom);
 
   const selectedValue = useMemo(() => {
     return selected ?? defaultSelected;
@@ -911,7 +912,8 @@ export function useOperatorBrowser() {
     (e) => {
       if (e.key !== "`" && !isVisible) return;
       if (e.key === "`" && isOperatorPaletteOpened) return;
-      if (BROWSER_CONTROL_KEYS.includes(e.key)) e.preventDefault();
+      if (BROWSER_CONTROL_KEYS.includes(e.key) && !editingField)
+        e.preventDefault();
       switch (e.key) {
         case "ArrowDown":
           selectNext();
@@ -920,7 +922,7 @@ export function useOperatorBrowser() {
           selectPrevious();
           break;
         case "`":
-          if (isOperatorPaletteOpened) break;
+          if (isOperatorPaletteOpened || editingField) break;
           if (isVisible) {
             close();
           } else {

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -385,3 +385,8 @@ export const escapeKeyHandlerIdsAtom = atom<Set<string>>({
   key: "escapeKeyHandlerIdsAtom",
   default: new Set(),
 });
+
+export const editingFieldAtom = atom<boolean>({
+  key: "editingFieldAtom",
+  default: false,
+});


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes an issue where you cannot type backtick (`) when adding or editing evaluation note.

## How is this patch tested? If it is not, please explain why.

Using add/edit evaluation note modal

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixes an issue where you cannot type backtick (`) when adding or editing evaluation note.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced state management for editing fields, enhancing user interaction.
	- Added event handlers for improved editing experience in the Evaluation component.
	- Implemented a new atom to track editing state across the application.

- **Bug Fixes**
	- Improved keyboard event handling to prevent unintended closures in the operator browser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->