### PR TITLE
fix hover background for panel in add panel popover

### DIFF
--- a/app/packages/spaces/src/components/AddPanelButton.tsx
+++ b/app/packages/spaces/src/components/AddPanelButton.tsx
@@ -121,7 +121,7 @@ function PanelCategories({ children }) {
 function PanelCategory({ label, children }) {
   const theme = useTheme();
   return (
-    <Grid item>
+    <Grid item sx={{ width: "100%" }}>
       <Typography
         variant="subtitle2"
         sx={{ padding: "0 8px", color: theme.text.secondary }}

--- a/app/packages/spaces/src/components/AddPanelItem.tsx
+++ b/app/packages/spaces/src/components/AddPanelItem.tsx
@@ -42,6 +42,7 @@ export default function AddPanelItem({
         cursor: "pointer",
         padding: "4px 8px",
         alignItems: "center",
+        width: "100%",
         "&:hover": { background: "var(--fo-palette-background-body)" },
       }}
     >


### PR DESCRIPTION
## What changes are proposed in this pull request?

fix hover background for panel in add panel popover to consistent with for all items

## How is this patch tested? If it is not, please explain why.

Using the app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

fix hover background for panel in add panel popover to consistent with for all items

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated layout styles for the `AddPanelButton` and `AddPanelItem` components to ensure they occupy the full width of their containers.
	- Modified display behavior for the "NEW" label based on the state of the "BETA" label.

- **Bug Fixes**
	- Improved layout consistency by adjusting width properties in relevant components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->