### PR TITLE
do not use operator executor for disabled buttons

### DIFF
--- a/app/packages/operators/src/components/OperatorExecutionButton/index.tsx
+++ b/app/packages/operators/src/components/OperatorExecutionButton/index.tsx
@@ -93,6 +93,14 @@ export const OperatorExecutionButton = ({
 
   if (isLoading) return null;
 
+  if (disabled) {
+    return (
+      <Button disabled {...props} variant={props.variant}>
+        {children}
+      </Button>
+    );
+  }
+
   if (showWarning) {
     return (
       <TooltipProvider title={warningMessage}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the `OperatorExecutionButton` to directly render a disabled state when the button is inactive, improving user experience by simplifying the button's behavior.

- **Bug Fixes**
	- Resolved issues with rendering logic when the button is disabled, ensuring consistent behavior across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->