### PR TITLE
Update docs with addition of FIFTYONE_CVAT_EMAIL

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -211,12 +211,13 @@ which can be done in a variety of ways.
 
 The recommended way to configure your CVAT login credentials is to store them
 in the `FIFTYONE_CVAT_USERNAME` and `FIFTYONE_CVAT_PASSWORD` environment
-variables. These are automatically accessed by FiftyOne whenever a connection
+variables. Optionally, you can also set the `FIFTYONE_CVAT_EMAIL` environment variable. These are automatically accessed by FiftyOne whenever a connection
 to CVAT is made.
 
 .. code-block:: shell
 
     export FIFTYONE_CVAT_USERNAME=...
+    export FIFTYONE_CVAT_EMAIL=...
     export FIFTYONE_CVAT_PASSWORD=...
 
 **FiftyOne annotation config**

--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -251,6 +251,7 @@ plugin's `fiftyone.yml` looks like this:
     secrets:
       - FIFTYONE_CVAT_URL
       - FIFTYONE_CVAT_USERNAME
+      - FIFTYONE_CVAT_EMAIL
       - FIFTYONE_CVAT_PASSWORD
       - FIFTYONE_LABELBOX_URL
       - FIFTYONE_LABELBOX_API_KEY
@@ -1527,6 +1528,7 @@ plugin declares the following secrets:
    secrets:
      - FIFTYONE_CVAT_URL
      - FIFTYONE_CVAT_USERNAME
+     - FIFTYONE_CVAT_EMAIL
      - FIFTYONE_CVAT_PASSWORD
      - FIFTYONE_LABELBOX_URL
      - FIFTYONE_LABELBOX_API_KEY
@@ -1543,6 +1545,7 @@ plugin, you would set:
 
     FIFTYONE_CVAT_URL=...
     FIFTYONE_CVAT_USERNAME=...
+    FIFTYONE_CVAT_EMAIL=...
     FIFTYONE_CVAT_PASSWORD=...
 
 At runtime, the plugin's :ref:`execution context <operator-execution-context>`
@@ -1555,6 +1558,7 @@ plugin. Operators can access these secrets via the `ctx.secrets` dict:
    def execute(self, ctx):
       url = ctx.secrets["FIFTYONE_CVAT_URL"]
       username = ctx.secrets["FIFTYONE_CVAT_USERNAME"]
+      email = ctx.secrets["FIFTYONE_CVAT_EMAIL"]
       password = ctx.secrets["FIFTYONE_CVAT_PASSWORD"]
 
 .. _operator-outputs:
@@ -2500,6 +2504,7 @@ plugin. Panels can access these secrets via the `ctx.secrets` dict:
     def on_load(self, ctx):
         url = ctx.secrets["FIFTYONE_CVAT_URL"]
         username = ctx.secrets["FIFTYONE_CVAT_USERNAME"]
+        email = ctx.secrets["FIFTYONE_CVAT_EMAIL"]
         password = ctx.secrets["FIFTYONE_CVAT_PASSWORD"]
 
 .. _panel-common-patterns:

--- a/docs/source/plugins/using_plugins.rst
+++ b/docs/source/plugins/using_plugins.rst
@@ -295,6 +295,7 @@ available metadata about a plugin:
     server_path             /plugins/fiftyone-plugins/plugins/annotation
     secrets                 FIFTYONE_CVAT_URL
                             FIFTYONE_CVAT_USERNAME
+                            FIFTYONE_CVAT_EMAIL
                             FIFTYONE_CVAT_PASSWORD
                             FIFTYONE_LABELBOX_URL
                             FIFTYONE_LABELBOX_API_KEY
@@ -468,6 +469,7 @@ plugin declares the following secrets:
     secrets:
       - FIFTYONE_CVAT_URL
       - FIFTYONE_CVAT_USERNAME
+      - FIFTYONE_CVAT_EMAIL
       - FIFTYONE_CVAT_PASSWORD
       - FIFTYONE_LABELBOX_URL
       - FIFTYONE_LABELBOX_API_KEY
@@ -490,6 +492,7 @@ plugin, you would set:
 
     FIFTYONE_CVAT_URL=...
     FIFTYONE_CVAT_USERNAME=...
+    FIFTYONE_CVAT_EMAIL=...
     FIFTYONE_CVAT_PASSWORD=...
 
 At runtime, the plugin's execution context will automatically be hydrated with
@@ -502,6 +505,7 @@ secrets via the `ctx.secrets` dict:
     def execute(self, ctx):
         url = ctx.secrets["FIFTYONE_CVAT_URL"]
         username = ctx.secrets["FIFTYONE_CVAT_USERNAME"]
+        email = ctx.secrets["FIFTYONE_CVAT_EMAIL"]
         password = ctx.secrets["FIFTYONE_CVAT_PASSWORD"]
 
 .. _using-panels:

--- a/docs/source/teams/secrets.rst
+++ b/docs/source/teams/secrets.rst
@@ -66,6 +66,7 @@ plugin declares the following secrets:
     secrets:
       - FIFTYONE_CVAT_URL
       - FIFTYONE_CVAT_USERNAME
+      - FIFTYONE_CVAT_EMAIL
       - FIFTYONE_CVAT_PASSWORD
       - FIFTYONE_LABELBOX_URL
       - FIFTYONE_LABELBOX_API_KEY
@@ -82,6 +83,7 @@ secrets via the ``ctx.secrets`` dict:
     def execute(self, ctx):
         url = ctx.secrets["FIFTYONE_CVAT_URL"]
         username = ctx.secrets["FIFTYONE_CVAT_USERNAME"]
+        email = ctx.secrets["FIFTYONE_CVAT_EMAIL"]
         password = ctx.secrets["FIFTYONE_CVAT_PASSWORD"]
 
 The ``ctx.secrets`` dict will also be automatically populated with the

--- a/docs/source/user_guide/annotation.rst
+++ b/docs/source/user_guide/annotation.rst
@@ -357,12 +357,13 @@ settings that you declare in this way will be passed as keyword arguments to
 methods like
 :meth:`annotate() <fiftyone.core.collections.SampleCollection.annotate>`
 whenever the corresponding backend is in use. For example, you can configure
-the URL, username, and password of your CVAT server as follows:
+the URL, username, email, and password of your CVAT server as follows:
 
 .. code-block:: shell
 
     export FIFTYONE_CVAT_URL=http://localhost:8080
     export FIFTYONE_CVAT_USERNAME=...
+    export FIFTYONE_CVAT_EMAIL=...
     export FIFTYONE_CVAT_PASSWORD=...
 
 The `FIFTYONE_ANNOTATION_BACKENDS` environment variable can be set to a


### PR DESCRIPTION
Functionality of using `FIFTYONE_CVAT_EMAIL` for auth has been added recently but I think the documentation update was missing. This PR updates the docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for a new environment variable, `FIFTYONE_CVAT_EMAIL`, for enhanced user authentication with the CVAT server.
	- Updated documentation for the `annotate()` method to clarify parameter usage and configuration options.

- **Documentation**
	- Expanded sections on plugin development and usage to include details about the new email secret and best practices for managing plugin secrets.
	- Improved clarity and structure of the annotation API documentation to enhance user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->