### PR TITLE
Include more brain modules in docs builds

### DIFF
--- a/docs/generate_docs.bash
+++ b/docs/generate_docs.bash
@@ -102,7 +102,7 @@ echo "Generating API docs"
 sphinx-apidoc --force --no-toc --separate --follow-links \
     --templatedir=docs/templates/apidoc \
     -o docs/source/api fiftyone \
-        fiftyone/brain/internal \
+        fiftyone/brain/internal/models \
         fiftyone/server \
         fiftyone/service \
         fiftyone/management \


### PR DESCRIPTION
There are currently some broken links on [this page](https://docs.voxel51.com/brain.html#brain-leaky-splits) because they link to modules like `fiftyone.brain.internal.XXX` that were previously omitted from the docs build.

Seeing that the Brain is now open source, we can happily include more modules in the docs builds and fix these links.