### PR TITLE
Merging main after #5242

### DIFF
--- a/docs/generate_docs.bash
+++ b/docs/generate_docs.bash
@@ -102,7 +102,7 @@ echo "Generating API docs"
 sphinx-apidoc --force --no-toc --separate --follow-links \
     --templatedir=docs/templates/apidoc \
     -o docs/source/api fiftyone \
-        fiftyone/brain/internal \
+        fiftyone/brain/internal/models \
         fiftyone/server \
         fiftyone/service \
         fiftyone/management \

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -36,7 +36,7 @@ What's New
 
 - Added a :ref:`Model Evaluation panel <app-model-evaluation-panel>` for
   visually and interactively evaluating models in the FiftyOne App
-- Introduced :ref:`Query Performance <app-optimize-query-performance>` in the
+- Introduced :ref:`Query Performance <app-optimizing-query-performance>` in the
   App, which automatically nudges you to create the necessary indexes to
   greatly optimize queries on large datasets
 - Added a :ref:`leaky splits method <brain-leaky-splits>` for automatically
@@ -169,7 +169,7 @@ Core
 
 App
 
-- Added a new :ref:`TimelineView <fiftyone.operators.types.TimelineView>` for
+- Added a new :class:`TimelineView <fiftyone.operators.types.TimelineView>` for
   building custom animations
   `#4965 <https://github.com/voxel51/fiftyone/pull/4965>`_
 - Fixed overlay z-index and overflow for panels
@@ -480,7 +480,7 @@ What's New
   that allows users to build custom no-code dashboards that display statistics
   of interest about the current dataset (and beyond)
 - Added `Segment Anything 2 <https://ai.meta.com/sam2>`_ to the
-  :ref:`model zoo <segment-anything-2-hiera-small-video-torch>`!
+  :ref:`model zoo <model-zoo-segment-anything-2-hiera-small-video-torch>`!
   `#4671 <https://github.com/voxel51/fiftyone/pull/4671>`_
 - Added an :ref:`Elasticsearch integration <elasticsearch-integration>` for
   native text and image searches on FiftyOne datasets!

--- a/docs/source/teams/query_performance.rst
+++ b/docs/source/teams/query_performance.rst
@@ -106,7 +106,7 @@ field's filter widget and performing queries on it will be noticably faster.
     before creating multiple indexes simultaneously.
 
 You can also create and manage custom indexes
-:ref:`via the SDK <app-optimize-query-performance>`.
+:ref:`via the SDK <app-optimizing-query-performance>`.
 
 .. _query-performance-summary:
 

--- a/docs/source/user_guide/app.rst
+++ b/docs/source/user_guide/app.rst
@@ -395,9 +395,9 @@ only those samples and/or labels that match the filter.
    :alt: app-filters
    :align: center
 
-.. _app-optimize-query-performance:
+.. _app-optimizing-query-performance:
 
-Optimizing query performance
+Optimizing Query Performance
 ----------------------------
 
 The App's sidebar is optimized to leverage database indexes whenever possible.
@@ -491,8 +491,8 @@ perform initial filters on:
     :ref:`App config <configuring-fiftyone-app>`.
 
 For :ref:`grouped datasets <groups>`, you should create two indexes for each
-field you wish to filter by in query performance mode: the field itself and a
-compound index that includes the group slice name:
+field you wish to filter by: the field itself and a compound index that
+includes the group slice name:
 
 .. code-block:: python
     :linenos:
@@ -542,27 +542,27 @@ field:
 
     Numeric field filters are not supported by wildcard indexes.
 
-.. _app-disasbling-query-performance:
+.. _app-disabling-query-performance:
 
-Disabling query performance
+Disabling Query Performance
 ---------------------------
 
-Query performance is enabled by default for all datasets. This is generally the
-recommended setting for all large datasets to ensure that queries are
-performant.
+:ref:`Query Performance <app-optimizing-query-performance>` is enabled by
+default for all datasets. This is generally the recommended setting for all
+large datasets to ensure that queries are performant.
 
-However, in certain circumstances you may prefer to disable query performance,
+However, in certain circumstances you may prefer to disable Query Performance,
 which enables the App's sidebar to show additional information such as
 label/value counts that are useful but more expensive to compute.
 
-You can disable query performance for a particular dataset for its lifetime
+You can disable Query Performance for a particular dataset for its lifetime
 (in your current browser) via the gear icon in the Samples panel's actions row:
 
 .. image:: /images/app/app-query-performance-disabled.gif
     :alt: app-query-performance-disabled
     :align: center
 
-You can also disable query performance by default for all datasets by setting
+You can also disable Query Performance by default for all datasets by setting
 `default_query_performance=False` in your
 :ref:`App config <configuring-fiftyone-app>`.
 


### PR DESCRIPTION
I am perplexed why the diff from https://github.com/voxel51/fiftyone/pull/5239 still appears in this PR, but it seems fine...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced built-in compute capacity for Teams deployments.
  - Added the Data Lens for exploring and importing samples from external data sources.
  - Implemented the Data Quality Panel for automatic dataset quality scanning.
  - Launched the Query Performance Panel for optimizing queries on large datasets.
  - Enabled embedding visualizations and model evaluations from respective panels.
  - Added SMTP server configuration for sending user invitations.

- **Bug Fixes**
  - Minor corrections in release notes for version 1.1.0 for consistency.

- **Documentation**
  - Enhanced organization and clarity in the documentation for Query Performance and the FiftyOne App. 
  - Added new content for the Model Evaluation panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->