### PR TITLE
sample update / overlay recoloring performance optimization

### DIFF
--- a/app/packages/looker/src/lookers/abstract.ts
+++ b/app/packages/looker/src/lookers/abstract.ts
@@ -515,7 +515,7 @@ export abstract class AbstractLooker<
   abstract updateOptions(options: Partial<State["options"]>): void;
 
   updateSample(sample: Sample) {
-    // collect any mask targets array buffer that overalys might have
+    // collect any mask targets array buffer that overlays might have
     // we'll transfer that to the worker instead of copying it
     const arrayBuffers: ArrayBuffer[] = [];
 

--- a/app/packages/looker/src/lookers/abstract.ts
+++ b/app/packages/looker/src/lookers/abstract.ts
@@ -547,9 +547,10 @@ export abstract class AbstractLooker<
         } else {
           arrayBuffers.push(buffer);
         }
-      } else {
+      } else if (buffer.byteLength) {
         // hope we don't run into this edge case (old browser)
-        // if we do, we'll just copy the buffer
+        // sometimes detached buffers have bytelength > 0
+        // if we run into this case, we'll just attempt to transfer the buffer
         // might get a DataCloneError if user is switching colors too fast
         arrayBuffers.push(buffer);
       }

--- a/app/packages/looker/src/lookers/abstract.ts
+++ b/app/packages/looker/src/lookers/abstract.ts
@@ -520,10 +520,6 @@ export abstract class AbstractLooker<
     const arrayBuffers: ArrayBuffer[] = [];
 
     for (const overlay of this.pluckedOverlays ?? []) {
-      // we paint overlays again, so cleanup the old ones
-      // this helps prevent memory leaks from, for instance, dangling ImageBitmaps
-      overlay.cleanup();
-
       let overlayData: LabelMask = null;
 
       if ("mask" in overlay.label) {
@@ -739,6 +735,12 @@ export abstract class AbstractLooker<
     );
   }
 
+  protected cleanOverlays() {
+    for (const overlay of this.sampleOverlays ?? []) {
+      overlay.cleanup();
+    }
+  }
+
   private loadSample(sample: Sample, transfer: Transferable[] = []) {
     const messageUUID = uuid();
 
@@ -746,6 +748,9 @@ export abstract class AbstractLooker<
 
     const listener = ({ data: { sample, coloring, uuid } }) => {
       if (uuid === messageUUID) {
+        // we paint overlays again, so cleanup the old ones
+        // this helps prevent memory leaks from, for instance, dangling ImageBitmaps
+        this.cleanOverlays();
         this.sample = sample;
         this.state.options.coloring = coloring;
         this.loadOverlays(sample);

--- a/app/packages/looker/src/overlays/base.ts
+++ b/app/packages/looker/src/overlays/base.ts
@@ -42,6 +42,7 @@ export interface SelectData {
 
 export type LabelMask = {
   bitmap?: ImageBitmap;
+  closedBitmapDims?: { width: number; height: number };
   data?: OverlayMask;
 };
 
@@ -67,6 +68,7 @@ export interface Overlay<State extends Partial<BaseState>> {
   draw(ctx: CanvasRenderingContext2D, state: State): void;
   isShown(state: Readonly<State>): boolean;
   field?: string;
+  label?: BaseLabel;
   containsPoint(state: Readonly<State>): CONTAINS;
   getMouseDistance(state: Readonly<State>): number;
   getPointInfo(state: Readonly<State>): any;
@@ -82,7 +84,7 @@ export abstract class CoordinateOverlay<
 > implements Overlay<State>
 {
   readonly field: string;
-  protected label: Label;
+  readonly label: Label;
 
   constructor(field: string, label: Label) {
     this.field = field;

--- a/app/packages/looker/src/overlays/base.ts
+++ b/app/packages/looker/src/overlays/base.ts
@@ -42,7 +42,6 @@ export interface SelectData {
 
 export type LabelMask = {
   bitmap?: ImageBitmap;
-  closedBitmapDims?: { width: number; height: number };
   data?: OverlayMask;
 };
 

--- a/app/packages/looker/src/overlays/detection.ts
+++ b/app/packages/looker/src/overlays/detection.ts
@@ -263,7 +263,6 @@ export default class DetectionOverlay<
 
   public cleanup(): void {
     this.label.mask?.bitmap?.close();
-    this.label.mask.bitmap = null;
   }
 }
 

--- a/app/packages/looker/src/overlays/detection.ts
+++ b/app/packages/looker/src/overlays/detection.ts
@@ -263,8 +263,14 @@ export default class DetectionOverlay<
 
   public cleanup(): void {
     if (this.label.mask?.bitmap) {
+      // store height and width in bitmap object since it might be used again
+      const height = this.label.mask.bitmap.height;
+      const width = this.label.mask.bitmap.width;
+
       this.label.mask?.bitmap.close();
       this.label.mask.bitmap = null;
+
+      this.label.mask.closedBitmapDims = { width, height };
     }
   }
 }

--- a/app/packages/looker/src/overlays/detection.ts
+++ b/app/packages/looker/src/overlays/detection.ts
@@ -262,16 +262,8 @@ export default class DetectionOverlay<
   }
 
   public cleanup(): void {
-    if (this.label.mask?.bitmap) {
-      // store height and width in bitmap object since it might be used again
-      const height = this.label.mask.bitmap.height;
-      const width = this.label.mask.bitmap.width;
-
-      this.label.mask?.bitmap.close();
-      this.label.mask.bitmap = null;
-
-      this.label.mask.closedBitmapDims = { width, height };
-    }
+    this.label.mask?.bitmap?.close();
+    this.label.mask.bitmap = null;
   }
 }
 

--- a/app/packages/looker/src/overlays/heatmap.ts
+++ b/app/packages/looker/src/overlays/heatmap.ts
@@ -207,16 +207,8 @@ export default class HeatmapOverlay<State extends BaseState>
   }
 
   public cleanup(): void {
-    if (this.label.map?.bitmap) {
-      // store height and width in bitmap object since it might be used again
-      const height = this.label.map.bitmap.height;
-      const width = this.label.map.bitmap.width;
-
-      this.label.map?.bitmap.close();
-      this.label.map.bitmap = null;
-
-      this.label.map.closedBitmapDims = { width, height };
-    }
+    this.label.map?.bitmap?.close();
+    this.label.map.bitmap = null;
   }
 }
 

--- a/app/packages/looker/src/overlays/heatmap.ts
+++ b/app/packages/looker/src/overlays/heatmap.ts
@@ -208,7 +208,6 @@ export default class HeatmapOverlay<State extends BaseState>
 
   public cleanup(): void {
     this.label.map?.bitmap?.close();
-    this.label.map.bitmap = null;
   }
 }
 

--- a/app/packages/looker/src/overlays/heatmap.ts
+++ b/app/packages/looker/src/overlays/heatmap.ts
@@ -39,7 +39,7 @@ export default class HeatmapOverlay<State extends BaseState>
   implements Overlay<State>
 {
   readonly field: string;
-  private label: HeatmapLabel;
+  readonly label: HeatmapLabel;
   private targets?: TypedArray;
   private readonly range: [number, number];
 
@@ -208,7 +208,14 @@ export default class HeatmapOverlay<State extends BaseState>
 
   public cleanup(): void {
     if (this.label.map?.bitmap) {
+      // store height and width in bitmap object since it might be used again
+      const height = this.label.map.bitmap.height;
+      const width = this.label.map.bitmap.width;
+
       this.label.map?.bitmap.close();
+      this.label.map.bitmap = null;
+
+      this.label.map.closedBitmapDims = { width, height };
     }
   }
 }

--- a/app/packages/looker/src/overlays/segmentation.ts
+++ b/app/packages/looker/src/overlays/segmentation.ts
@@ -263,7 +263,6 @@ export default class SegmentationOverlay<State extends BaseState>
 
   public cleanup(): void {
     this.label.mask?.bitmap?.close();
-    this.label.mask.bitmap = null;
   }
 }
 

--- a/app/packages/looker/src/overlays/segmentation.ts
+++ b/app/packages/looker/src/overlays/segmentation.ts
@@ -262,16 +262,8 @@ export default class SegmentationOverlay<State extends BaseState>
   }
 
   public cleanup(): void {
-    if (this.label.mask?.bitmap) {
-      // store height and width in bitmap object since it might be used again
-      const height = this.label.mask.bitmap.height;
-      const width = this.label.mask.bitmap.width;
-
-      this.label.mask?.bitmap.close();
-      this.label.mask.bitmap = null;
-
-      this.label.mask.closedBitmapDims = { width, height };
-    }
+    this.label.mask?.bitmap?.close();
+    this.label.mask.bitmap = null;
   }
 }
 

--- a/app/packages/looker/src/overlays/segmentation.ts
+++ b/app/packages/looker/src/overlays/segmentation.ts
@@ -30,7 +30,7 @@ export default class SegmentationOverlay<State extends BaseState>
   implements Overlay<State>
 {
   readonly field: string;
-  private label: SegmentationLabel;
+  readonly label: SegmentationLabel;
   private targets?: TypedArray;
 
   private isRgbMaskTargets = false;
@@ -263,7 +263,14 @@ export default class SegmentationOverlay<State extends BaseState>
 
   public cleanup(): void {
     if (this.label.mask?.bitmap) {
+      // store height and width in bitmap object since it might be used again
+      const height = this.label.mask.bitmap.height;
+      const width = this.label.mask.bitmap.width;
+
       this.label.mask?.bitmap.close();
+      this.label.mask.bitmap = null;
+
+      this.label.mask.closedBitmapDims = { width, height };
     }
   }
 }

--- a/app/packages/looker/src/worker/disk-overlay-decoder.ts
+++ b/app/packages/looker/src/worker/disk-overlay-decoder.ts
@@ -56,11 +56,16 @@ export const decodeOverlayOnDisk = async (
     // it's possible we're just re-coloring, in which case re-init mask image and set bitmap to null
     if (
       label[overlayField] &&
-      label[overlayField].closedBitmapDims &&
+      label[overlayField].bitmap &&
       !label[overlayField].image
     ) {
-      const height = label[overlayField].closedBitmapDims.height;
-      const width = label[overlayField].closedBitmapDims.width;
+      const height = label[overlayField].bitmap.height;
+      const width = label[overlayField].bitmap.width;
+
+      // close the copied bitmap
+      label[overlayField].bitmap.close();
+      label[overlayField].bitmap = null;
+
       label[overlayField].image = new ArrayBuffer(height * width * 4);
       label[overlayField].bitmap.close();
       label[overlayField].bitmap = null;

--- a/app/packages/looker/src/worker/disk-overlay-decoder.ts
+++ b/app/packages/looker/src/worker/disk-overlay-decoder.ts
@@ -56,11 +56,11 @@ export const decodeOverlayOnDisk = async (
     // it's possible we're just re-coloring, in which case re-init mask image and set bitmap to null
     if (
       label[overlayField] &&
-      label[overlayField].bitmap &&
+      label[overlayField].closedBitmapDims &&
       !label[overlayField].image
     ) {
-      const height = label[overlayField].bitmap.height;
-      const width = label[overlayField].bitmap.width;
+      const height = label[overlayField].closedBitmapDims.height;
+      const width = label[overlayField].closedBitmapDims.width;
       label[overlayField].image = new ArrayBuffer(height * width * 4);
       label[overlayField].bitmap.close();
       label[overlayField].bitmap = null;

--- a/app/packages/looker/src/worker/index.ts
+++ b/app/packages/looker/src/worker/index.ts
@@ -327,6 +327,10 @@ const processSample = async ({
   labelTagColors,
   schema,
 }: ProcessSample) => {
+  if (!sample) {
+    return;
+  }
+
   mapId(sample);
 
   const imageBitmapPromises: Promise<ImageBitmap[]>[] = [];

--- a/app/packages/looker/src/worker/index.ts
+++ b/app/packages/looker/src/worker/index.ts
@@ -327,10 +327,6 @@ const processSample = async ({
   labelTagColors,
   schema,
 }: ProcessSample) => {
-  if (!sample) {
-    return;
-  }
-
   mapId(sample);
 
   const imageBitmapPromises: Promise<ImageBitmap[]>[] = [];


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR makes sample update / overlay recoloring faster, by:
1) cleaning up existing label bitmaps to prevent memory leaks during sample update, and 
2) transferring ownership of targets array buffer to the worker (realloc) during sample update to avoid expensive copying operation

![2024-12-09 18 53 11](https://github.com/user-attachments/assets/079eb35c-9e3a-4b81-90de-c4e551f676a9)

## How is this patch tested? If it is not, please explain why.

Locally. I used the following code snippet:

```python
import fiftyone as fo
import fiftyone.zoo as foz
import numpy as np
from PIL import Image
import tempfile

UINT8_MAX = 2**8 - 1
UINT16_MAX = 2**16 - 1

def get_mask(height, width, dtype=np.uint8):
    if dtype == np.uint8:
        return np.random.binomial(1, 0.7, size=(height, width)).astype(np.uint8) * 255
    elif dtype == np.uint16:
        return np.random.binomial(1, 0.7, size=(height, width)).astype(np.uint16) * 65535
    else:
        raise Exception("dtype not supported")

def get_mask_path_from_mask(mask):
    img = Image.fromarray(mask)
    mask_path = tempfile.mktemp(".png")
    img.save(mask_path)
    return mask_path

try:
    fo.delete_dataset("detection_mask_path")
except:
    pass

dataset = foz.load_zoo_dataset("quickstart", dataset_name="detection_mask_path", persistent=True)

samples = dataset.take(len(dataset))
# multiply dataset n fold
for _ in range(3):
    dataset.add_samples(samples.clone())

mask = get_mask(256, 256)
for sample in dataset:
    mask_path = get_mask_path_from_mask(mask)
    gt_detections = sample.ground_truth.detections
    for detection in gt_detections:
        detection["mask"] = None
        detection["mask_path"] = mask_path
    pr_detections = sample.predictions.detections
    for detection in pr_detections:
        detection["mask"] = None
        detection["mask_path"] = mask_path
    sample.save()
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?


-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new properties for overlays, enhancing flexibility and usability.
	- Added a method for cleaning up overlays to prevent memory leaks.

- **Improvements**
	- Enhanced bitmap resource management in overlay handling.
	- Simplified cleanup methods across multiple overlay classes for better efficiency.

- **Bug Fixes**
	- Improved error handling during bitmap operations to ensure smoother performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->