### PR TITLE
model evaluation panel permission ux tweaks

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluate.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluate.tsx
@@ -1,13 +1,25 @@
 import { MuiButton } from "@fiftyone/components";
 import { Add } from "@mui/icons-material";
+import { Box } from "@mui/material";
 import React from "react";
 
 export default function Evaluate(props: EvaluateProps) {
-  const { onEvaluate } = props;
+  const { onEvaluate, permissions } = props;
+  const canEvaluate = permissions.can_evaluate;
   return (
-    <MuiButton onClick={onEvaluate} startIcon={<Add />} variant="contained">
-      Evaluate Model
-    </MuiButton>
+    <Box
+      title={canEvaluate ? "" : "You do not have permission to evaluate model"}
+      sx={{ cursor: canEvaluate ? "pointer" : "not-allowed" }}
+    >
+      <MuiButton
+        onClick={onEvaluate}
+        startIcon={<Add />}
+        variant="contained"
+        disabled={!canEvaluate}
+      >
+        Evaluate Model
+      </MuiButton>
+    </Box>
   );
 }
 

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -611,20 +611,26 @@ export default function Evaluation(props: EvaluationProps) {
       <Card sx={{ p: 2 }}>
         <Stack direction="row" sx={{ justifyContent: "space-between" }}>
           <Typography color="secondary">Evaluation notes</Typography>
-          {can_edit_note && (
-            <Box>
-              <IconButton
-                size="small"
-                color="secondary"
-                sx={{ borderRadius: 16 }}
-                onClick={() => {
-                  setEditNoteState((note) => ({ ...note, open: true }));
-                }}
-              >
-                <EditNote />
-              </IconButton>
-            </Box>
-          )}
+          <Box
+            title={
+              can_edit_note
+                ? ""
+                : "You do not have permission to edit evaluation notes"
+            }
+            sx={{ cursor: can_edit_note ? "pointer" : "not-allowed" }}
+          >
+            <IconButton
+              size="small"
+              color="secondary"
+              sx={{ borderRadius: 16 }}
+              onClick={() => {
+                setEditNoteState((note) => ({ ...note, open: true }));
+              }}
+              disabled={!can_edit_note}
+            >
+              <EditNote />
+            </IconButton>
+          </Box>
         </Stack>
         <EvaluationNotes notes={evaluationNotes} variant="details" />
       </Card>

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Overview.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Overview.tsx
@@ -97,7 +97,7 @@ function EvaluationCard(props: EvaluationCardProps) {
               }
             />
           )}
-          {status && <Status status={status} />}
+          {status && <Status status={status} readOnly />}
         </Stack>
         {note && <EvaluationNotes notes={note} variant="overview" />}
       </Card>

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Status.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Status.tsx
@@ -4,10 +4,10 @@ import React from "react";
 import { useTriggerEvent } from "./utils";
 
 export default function Status(props: StatusProps) {
-  const { status, canEdit, setStatusEvent } = props;
+  const { status, canEdit, readOnly, setStatusEvent } = props;
   const triggerEvent = useTriggerEvent();
 
-  if (canEdit) {
+  if (!readOnly) {
     return (
       <Select
         sx={{
@@ -22,6 +22,12 @@ export default function Status(props: StatusProps) {
         onChange={(e) => {
           triggerEvent(setStatusEvent, { status: e.target.value });
         }}
+        title={
+          canEdit
+            ? ""
+            : "You do not have permission to update evaluation status"
+        }
+        disabled={!canEdit}
       >
         {STATUSES.map((status) => {
           const color = COLOR_BY_STATUS[status];
@@ -63,7 +69,8 @@ export default function Status(props: StatusProps) {
 type StatusProps = {
   status?: string;
   canEdit?: boolean;
-  setStatusEvent?: string;
+  readOnly?: boolean;
+  setStatusEvent: string;
 };
 
 const STATUS_LABELS = {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Disable actions with appropriate messages instead of hiding when permission is not sufficient to perform an action

## How is this patch tested? If it is not, please explain why.

Using model evaluation panel with several action disabled due to permission

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

See above

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced permission handling for evaluation actions in the Evaluate component.
  - Added tooltips and conditional disabling for evaluation notes editing based on user permissions.
  - Introduced a read-only mode for the Status component to prevent unauthorized edits.

- **Bug Fixes**
  - Refined user feedback for evaluation actions to prevent interactions when permissions are insufficient.

- **Style**
  - Minor adjustments to layout and styling for consistency with the application's design language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->