### PR TITLE
Support on-disk instance segmentations in SDK

### DIFF
--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -2542,7 +2542,7 @@ Object detections stored in |Detections| may also have instance segmentation
 masks.
 
 These masks can be stored in one of two ways: either directly in the database
-via the :attr:`mask<fiftyone.core.labels.Detection.mask>` attribute, or on
+via the :attr:`mask <fiftyone.core.labels.Detection.mask>` attribute, or on
 disk referenced by the
 :attr:`mask_path <fiftyone.core.labels.Detection.mask_path>` attribute.
 
@@ -2605,8 +2605,10 @@ object's bounding box when visualizing in the App.
                 <Detection: {
                     'id': '5f8709282018186b6ef6682b',
                     'attributes': {},
+                    'tags': [],
                     'label': 'cat',
                     'bounding_box': [0.48, 0.513, 0.397, 0.288],
+                    'mask': None,
                     'mask_path': '/path/to/mask.png',
                     'confidence': 0.96,
                     'index': None,
@@ -2615,8 +2617,8 @@ object's bounding box when visualizing in the App.
         }>,
     }>
 
-Like all |Label| types, you can also add custom attributes to your detections
-by dynamically adding new fields to each |Detection| instance:
+Like all |Label| types, you can also add custom attributes to your instance
+segmentations by dynamically adding new fields to each |Detection| instance:
 
 .. code-block:: python
     :linenos:

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -10681,6 +10681,9 @@ class SampleCollection(object):
                 app_media_fields.discard("filepath")
 
         for field_name, field in schema.items():
+            while isinstance(field, fof.ListField):
+                field = field.field
+
             if field_name in app_media_fields:
                 media_fields[field_name] = None
             elif isinstance(field, fof.EmbeddedDocumentField) and issubclass(

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -10712,9 +10712,9 @@ class SampleCollection(object):
 
         return media_fields
 
-    def _resolve_media_field(self, media_field):
+    def _parse_media_field(self, media_field):
         if media_field in self._dataset.app_config.media_fields:
-            return media_field
+            return media_field, None
 
         _media_field, is_frame_field = self._handle_frame_field(media_field)
 
@@ -10730,7 +10730,13 @@ class SampleCollection(object):
                 if is_frame_field:
                     _resolved_field = self._FRAMES_PREFIX + _resolved_field
 
-                return _resolved_field
+                _list_fields = self._parse_field_name(
+                    _resolved_field, auto_unwind=False
+                )[-2]
+                if _list_fields:
+                    return _resolved_field, _list_fields[0]
+
+                return _resolved_field, None
 
         raise ValueError("'%s' is not a valid media field" % media_field)
 

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -409,7 +409,8 @@ class Detection(_HasAttributesDict, _HasID, _HasMedia, Label):
             its bounding box, which should be a 2D binary or 0/1 integer numpy
             array
         mask_path (None):  the absolute path to the instance segmentation image
-            on disk
+            on disk, which should be a single-channel PNG image where any
+            non-zero values represent the instance's extent
         confidence (None): a confidence in ``[0, 1]`` for the detection
         index (None): an index for the object
         attributes ({}): a dict mapping attribute names to :class:`Attribute`
@@ -532,8 +533,8 @@ class Detection(_HasAttributesDict, _HasID, _HasMedia, Label):
         """
         if not self.has_mask:
             raise ValueError(
-                "Only detections with their `mask` attributes populated can "
-                "be converted to segmentations"
+                "Only detections with their `mask` or `mask_path` attribute "
+                "populated can be converted to segmentations"
             )
 
         mask, target = _parse_segmentation_target(mask, frame_size, target)

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -1894,7 +1894,7 @@ class LegacyFiftyOneDatasetExporter(GenericSampleDatasetExporter):
             self._metadata["frame_fields"] = schema
 
         self._media_fields = sample_collection._get_media_fields(
-            include_filepath=False
+            blacklist="filepath",
         )
 
         info = dict(sample_collection.info)
@@ -2202,7 +2202,7 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
             _sample_collection = sample_collection
 
         self._media_fields = sample_collection._get_media_fields(
-            include_filepath=False
+            blacklist="filepath"
         )
 
         logger.info("Exporting samples...")

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -12,11 +12,13 @@ import os
 import warnings
 from collections import defaultdict
 
+from bson import json_util
+import pydash
+
 import eta.core.datasets as etad
 import eta.core.frameutils as etaf
 import eta.core.serial as etas
 import eta.core.utils as etau
-from bson import json_util
 
 import fiftyone as fo
 import fiftyone.core.collections as foc
@@ -2029,34 +2031,38 @@ class LegacyFiftyOneDatasetExporter(GenericSampleDatasetExporter):
 
     def _export_media_fields(self, sd):
         for field_name, key in self._media_fields.items():
-            value = sd.get(field_name, None)
-            if value is None:
-                continue
-
-            if key is not None:
-                self._export_media_field(value, field_name, key=key)
-            else:
-                self._export_media_field(sd, field_name)
+            self._export_media_field(sd, field_name, key=key)
 
     def _export_media_field(self, d, field_name, key=None):
-        if key is not None:
-            value = d.get(key, None)
-        else:
-            key = field_name
-            value = d.get(field_name, None)
-
+        value = pydash.get(d, field_name, None)
         if value is None:
             return
 
         media_exporter = self._get_media_field_exporter(field_name)
-        outpath, _ = media_exporter.export(value)
 
-        if self.abs_paths:
-            d[key] = outpath
-        else:
-            d[key] = fou.safe_relpath(
-                outpath, self.export_dir, default=outpath
-            )
+        if not isinstance(value, (list, tuple)):
+            value = [value]
+
+        for _d in value:
+            if key is not None:
+                _value = _d.get(key, None)
+            else:
+                _value = _d
+
+            if _value is None:
+                continue
+
+            outpath, _ = media_exporter.export(_value)
+
+            if not self.abs_paths:
+                outpath = fou.safe_relpath(
+                    outpath, self.export_dir, default=outpath
+                )
+
+            if key is not None:
+                _d[key] = outpath
+            else:
+                pydash.set_(d, field_name, outpath)
 
     def _get_media_field_exporter(self, field_name):
         media_exporter = self._media_field_exporters.get(field_name, None)
@@ -2333,33 +2339,43 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
 
     def _export_media_fields(self, sd):
         for field_name, key in self._media_fields.items():
-            value = sd.get(field_name, None)
-            if value is None:
-                continue
-
-            if key is not None:
-                self._export_media_field(value, field_name, key=key)
-            else:
-                self._export_media_field(sd, field_name)
+            self._export_media_field(sd, field_name, key=key)
 
     def _export_media_field(self, d, field_name, key=None):
-        if key is not None:
-            value = d.get(key, None)
-        else:
-            key = field_name
-            value = d.get(field_name, None)
-
+        value = pydash.get(d, field_name, None)
         if value is None:
             return
 
-        if self.export_media is not False:
-            # Store relative path
-            media_exporter = self._get_media_field_exporter(field_name)
-            _, uuid = media_exporter.export(value)
-            d[key] = os.path.join("fields", field_name, uuid)
-        elif self.rel_dir is not None:
-            # Remove `rel_dir` prefix from path
-            d[key] = fou.safe_relpath(value, self.rel_dir, default=value)
+        media_exporter = self._get_media_field_exporter(field_name)
+
+        if not isinstance(value, (list, tuple)):
+            value = [value]
+
+        for _d in value:
+            if key is not None:
+                _value = _d.get(key, None)
+            else:
+                _value = _d
+
+            if _value is None:
+                continue
+
+            if self.export_media is not False:
+                # Store relative path
+                _, uuid = media_exporter.export(_value)
+                outpath = os.path.join("fields", field_name, uuid)
+            elif self.rel_dir is not None:
+                # Remove `rel_dir` prefix from path
+                outpath = fou.safe_relpath(
+                    _value, self.rel_dir, default=_value
+                )
+            else:
+                continue
+
+            if key is not None:
+                _d[key] = outpath
+            else:
+                pydash.set_(d, field_name, outpath)
 
     def _get_media_field_exporter(self, field_name):
         media_exporter = self._media_field_exporters.get(field_name, None)

--- a/fiftyone/utils/labels.py
+++ b/fiftyone/utils/labels.py
@@ -155,8 +155,8 @@ def export_segmentations(
     overwrite=False,
     progress=None,
 ):
-    """Exports the segmentations (or heatmaps) stored as in-database arrays in
-    the specified field to images on disk.
+    """Exports the semantic segmentations, instance segmentations, or heatmaps
+    stored as in-database arrays in the specified field to images on disk.
 
     Any labels without in-memory arrays are skipped.
 
@@ -164,7 +164,9 @@ def export_segmentations(
         sample_collection: a
             :class:`fiftyone.core.collections.SampleCollection`
         in_field: the name of the
-            :class:`fiftyone.core.labels.Segmentation` or
+            :class:`fiftyone.core.labels.Segmentation`,
+            :class:`fiftyone.core.labels.Detection`,
+            :class:`fiftyone.core.labels.Detections`, or
             :class:`fiftyone.core.labels.Heatmap` field
         output_dir: the directory in which to write the images
         rel_dir (None): an optional relative directory to strip from each input
@@ -183,7 +185,9 @@ def export_segmentations(
     """
     fov.validate_non_grouped_collection(sample_collection)
     fov.validate_collection_label_fields(
-        sample_collection, in_field, (fol.Segmentation, fol.Heatmap)
+        sample_collection,
+        in_field,
+        (fol.Segmentation, fol.Detection, fol.Detections, fol.Heatmap),
     )
 
     samples = sample_collection.select_fields(in_field)
@@ -207,16 +211,31 @@ def export_segmentations(
             if label is None:
                 continue
 
-            outpath = filename_maker.get_output_path(
-                image.filepath, output_ext=".png"
-            )
-
-            if isinstance(label, fol.Heatmap):
-                if label.map is not None:
-                    label.export_map(outpath, update=update)
-            else:
+            if isinstance(label, fol.Segmentation):
                 if label.mask is not None:
+                    outpath = filename_maker.get_output_path(
+                        image.filepath, output_ext=".png"
+                    )
                     label.export_mask(outpath, update=update)
+            elif isinstance(label, fol.Detection):
+                if label.mask is not None:
+                    outpath = filename_maker.get_output_path(
+                        image.filepath, output_ext=".png"
+                    )
+                    label.export_mask(outpath, update=update)
+            elif isinstance(label, fol.Detections):
+                for detection in label.detections:
+                    if detection.mask is not None:
+                        outpath = filename_maker.get_output_path(
+                            image.filepath, output_ext=".png"
+                        )
+                        detection.export_mask(outpath, update=update)
+            elif isinstance(label, fol.Heatmap):
+                if label.map is not None:
+                    outpath = filename_maker.get_output_path(
+                        image.filepath, output_ext=".png"
+                    )
+                    label.export_map(outpath, update=update)
 
 
 def import_segmentations(
@@ -226,8 +245,8 @@ def import_segmentations(
     delete_images=False,
     progress=None,
 ):
-    """Imports the segmentations (or heatmaps) stored on disk in the specified
-    field to in-database arrays.
+    """Imports the semantic segmentations, instance segmentations, or heatmaps
+    stored on disk in the specified field to in-database arrays.
 
     Any labels without images on disk are skipped.
 
@@ -235,7 +254,9 @@ def import_segmentations(
         sample_collection: a
             :class:`fiftyone.core.collections.SampleCollection`
         in_field: the name of the
-            :class:`fiftyone.core.labels.Segmentation` or
+            :class:`fiftyone.core.labels.Segmentation`,
+            :class:`fiftyone.core.labels.Detection`,
+            :class:`fiftyone.core.labels.Detections`, or
             :class:`fiftyone.core.labels.Heatmap` field
         update (True): whether to delete the image paths from the labels
         delete_images (False): whether to delete any imported images from disk
@@ -245,7 +266,9 @@ def import_segmentations(
     """
     fov.validate_non_grouped_collection(sample_collection)
     fov.validate_collection_label_fields(
-        sample_collection, in_field, (fol.Segmentation, fol.Heatmap)
+        sample_collection,
+        in_field,
+        (fol.Segmentation, fol.Detection, fol.Detections, fol.Heatmap),
     )
 
     samples = sample_collection.select_fields(in_field)
@@ -262,16 +285,31 @@ def import_segmentations(
             if label is None:
                 continue
 
-            if isinstance(label, fol.Heatmap):
-                if label.map_path is not None:
-                    del_path = label.map_path if delete_images else None
-                    label.import_map(update=update)
-                    if del_path:
-                        etau.delete_file(del_path)
-            else:
+            if isinstance(label, fol.Segmentation):
                 if label.mask_path is not None:
                     del_path = label.mask_path if delete_images else None
                     label.import_mask(update=update)
+                    if del_path:
+                        etau.delete_file(del_path)
+            elif isinstance(label, fol.Detection):
+                if label.mask_path is not None:
+                    del_path = label.mask_path if delete_images else None
+                    label.import_mask(update=update)
+                    if del_path:
+                        etau.delete_file(del_path)
+            elif isinstance(label, fol.Detections):
+                for detection in label.detections:
+                    if detection.mask_path is not None:
+                        del_path = (
+                            detection.mask_path if delete_images else None
+                        )
+                        detection.import_mask(update=update)
+                        if del_path:
+                            etau.delete_file(del_path)
+            elif isinstance(label, fol.Heatmap):
+                if label.map_path is not None:
+                    del_path = label.map_path if delete_images else None
+                    label.import_map(update=update)
                     if del_path:
                         etau.delete_file(del_path)
 
@@ -389,6 +427,9 @@ def segmentations_to_detections(
     out_field,
     mask_targets=None,
     mask_types="stuff",
+    output_dir=None,
+    rel_dir=None,
+    overwrite=False,
     progress=None,
 ):
     """Converts the semantic segmentations masks in the specified field of the
@@ -423,6 +464,18 @@ def segmentations_to_detections(
             -   ``"thing"`` if all classes are thing classes
             -   a dict mapping pixel values (2D masks) or RGB hex strings (3D
                 masks) to ``"stuff"`` or ``"thing"`` for each class
+        output_dir (None): an optional output directory in which to write
+            instance segmentation images. If none is provided, the instance
+            segmentations are stored in the database
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier that is joined with
+            ``output_dir`` to generate an output path for each instance
+            segmentation image. This argument allows for populating nested
+            subdirectories in ``output_dir`` that match the shape of the input
+            paths. The path is converted to an absolute path (if necessary) via
+            :func:`fiftyone.core.storage.normalize_path`
+        overwrite (False): whether to delete ``output_dir`` prior to exporting
+            if it exists
         progress (None): whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
@@ -438,6 +491,14 @@ def segmentations_to_detections(
     in_field, processing_frames = samples._handle_frame_field(in_field)
     out_field, _ = samples._handle_frame_field(out_field)
 
+    if overwrite and output_dir is not None:
+        etau.delete_dir(output_dir)
+
+    if output_dir is not None:
+        filename_maker = fou.UniqueFilenameMaker(
+            output_dir=output_dir, rel_dir=rel_dir, idempotent=False
+        )
+
     for sample in samples.iter_samples(autosave=True, progress=progress):
         if processing_frames:
             images = sample.frames.values()
@@ -449,9 +510,17 @@ def segmentations_to_detections(
             if label is None:
                 continue
 
-            image[out_field] = label.to_detections(
+            detections = label.to_detections(
                 mask_targets=mask_targets, mask_types=mask_types
             )
+            if output_dir is not None:
+                for detection in detections.detections:
+                    mask_path = filename_maker.get_output_path(
+                        image.filepath, output_ext=".png"
+                    )
+                    detection.export_mask(mask_path, update=True)
+
+            image[out_field] = detections
 
 
 def instances_to_polylines(


### PR DESCRIPTION
```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.labels as foul

dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    label_types="segmentations",
    classes=["cat", "dog"],
    label_field="instances",
    max_samples=10,
    only_matching=True,
)

foul.export_segmentations(
    dataset,
    "instances",
    "/tmp/instances/masks",
)

assert dataset.count("instances.detections.mask") == 0
assert dataset.count("instances.detections.mask_path") > 0

dataset.export(
    export_dir="/tmp/instances/fod",
    dataset_type=fo.types.FiftyOneDataset,
    # export_media=False,
)

dataset2 = fo.Dataset.from_dir(
    dataset_dir="/tmp/instances/fod",
    dataset_type=fo.types.FiftyOneDataset,
)

assert dataset2.count("instances.detections.mask") == 0
assert dataset2.count("instances.detections.mask_path") > 0

foul.import_segmentations(dataset2, "instances")

assert dataset2.count("instances.detections.mask") > 0
assert dataset2.count("instances.detections.mask_path") == 0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced documentation for FiftyOne datasets, including new sections and clearer examples.
	- Improved functionality for dataset exporters and importers, supporting additional label types.
	- Added new test methods for validating instance segmentation functionality.

- **Bug Fixes**
	- Clarified requirements for segmentation processes and improved error handling in related methods.

- **Documentation**
	- Expanded and refined sections on instance segmentation, dataset deletion, and dynamic attributes for better user understanding.

- **Tests**
	- Introduced new unit tests for instance segmentation to ensure robust functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->