### PR TITLE
fix(ci): AS-359 Update Ubuntu24 Binaries For MongoDB

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-24.04-m
+          - ubuntu-latest-m
           - windows-latest
         python:
           - "3.9"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: workflow_call
 
 jobs:
   test-app:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest-m
+          - ubuntu-24.04-m
           - windows-latest
         python:
           - "3.9"

--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -124,8 +124,8 @@ LINUX_DOWNLOADS = {
             "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.4.tgz",
         },
         "24": {
-            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-7.0.4.tgz",
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.4.tgz",
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2404-8.0.4.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2404-8.0.4.tgz",
         },
     },
 }

--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -175,7 +175,7 @@ def _get_download():
 MONGODB_BINARIES = ["mongod"]
 
 
-VERSION = "1.1.7"
+VERSION = "1.2.0"
 
 
 def get_version():


### PR DESCRIPTION
## What changes are proposed in this pull request?

Ubuntu24 does not support mongo 7, we should use the supported mongo 8 binaries for Ubuntu24.

> **NOTE** 
> Before merging, revert the `runs-on` clauses for the `-m` runners

> **NOTE** 
> GitHub actions will hard swap `ubuntu-latest` to Ubuntu24 by January 17th ([Issue Here](https://github.com/actions/runner-images/issues/10636))
> We can either target this change for the next release branch or, if this becomes a problem on the release branch, we can change the `runs-on` attribute for the github actions to be `ubuntu-22.04` instead of `ubuntu-latest`.

## How is this patch tested? If it is not, please explain why.

```shell
docker run -it --rm ubuntu:24.04


apt-get update && apt-get install wget curl
wget "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2404-8.0.4.tgz"
tar -xvzf mongodb-linux-aarch64-ubuntu2404-8.0.4.tgz
cd mongodb-linux-aarch64-ubuntu2404-8.0.4/bin
./mongod --version
```

Testing via github actions on an `ubuntu-24` machine.
[Actions On Ubuntu24](https://github.com/voxel51/fiftyone/actions/runs/12317095939?pr=5269)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

This change updates the `fiftyone-db` mongo binaries from version 7 to version 8. The current binaries that are in `setup.py` for ubuntu 24 are actually ubuntu 22 binaries and, therefore, don't work as expected.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Updated testing workflow to use newer versions of Ubuntu for improved compatibility.
	- Enhanced download URLs for MongoDB binaries to support Ubuntu 24.04.
	- Incremented package version for MongoDB from 1.1.7 to 1.2.0.

- **Bug Fixes**
	- Ensured correct fetching of MongoDB binaries for both architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->