### PR TITLE
Similarity race condition patch

### DIFF
--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -572,6 +572,7 @@ class TorchImageModel(
         if self.config.cudnn_benchmark is not None:
             torch.backends.cudnn.benchmark = self._benchmark_orig
             self._benchmark_orig = None
+
         if self._no_grad is not None:
             self._no_grad.__exit__(*args)
             self._no_grad = None

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -572,9 +572,9 @@ class TorchImageModel(
         if self.config.cudnn_benchmark is not None:
             torch.backends.cudnn.benchmark = self._benchmark_orig
             self._benchmark_orig = None
-
-        self._no_grad.__exit__(*args)
-        self._no_grad = None
+        if self._no_grad is not None:
+            self._no_grad.__exit__(*args)
+            self._no_grad = None
 
     @property
     def media_type(self):


### PR DESCRIPTION
## What changes are proposed in this pull request?



To reproduce (as of v2.1.3):

* Load the quickstart dataset and compute similarity with CLIP
* Create a view stage with Limit 200
* Sort by text similarity against dogs

This error gets raised by the App:

To catch this error, launch the path with:
```
python /path/to/your/install/of/fiftyone/server/main.py
```

```python
File "/home/eric/work/fiftyone/fiftyone-teams/fiftyone/utils/torch.py", line 580, in __exit__
    self._no_grad.__exit__(*args)
AttributeError: 'NoneType' object has no attribute '__exit__'
 ```


## How is this patch tested? If it is not, please explain why.

TBD

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixed a race condition when sorting by text similarity on a view in the App.

### What areas of FiftyOne does this PR affect?

-   [X] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
