### PR TITLE
Add COCO-styled mAR to evaluate_detections 

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -415,6 +415,13 @@ export default function Evaluation(props: EvaluationProps) {
       hide: !isObjectDetection,
     },
     {
+      id: "mAR",
+      property: "mAR",
+      value: evaluationMetrics.mAR,
+      compareValue: compareEvaluationMetrics.mAR,
+      hide: !isObjectDetection,
+    },
+    {
       id: "tp",
       property: "True Positives",
       value: evaluationMetrics.tp,

--- a/docs/source/integrations/coco.rst
+++ b/docs/source/integrations/coco.rst
@@ -471,13 +471,14 @@ The example below demonstrates COCO-style detection evaluation on the
 mAP and PR curves
 ~~~~~~~~~~~~~~~~~
 
-You can compute mean average precision (mAP) and precision-recall (PR) curves
-for your predictions by passing the ``compute_mAP=True`` flag to
+You can compute mean average precision (mAP), mean average recall (mAR), and
+precision-recall (PR) curves for your predictions by passing the
+``compute_mAP=True`` flag to
 :meth:`evaluate_detections() <fiftyone.core.collections.SampleCollection.evaluate_detections>`:
 
 .. note::
 
-    All mAP calculations are performed according to the
+    All mAP and mAR calculations are performed according to the
     `COCO evaluation protocol <https://cocodataset.org/#detection-eval>`_.
 
 .. code-block:: python
@@ -489,7 +490,7 @@ for your predictions by passing the ``compute_mAP=True`` flag to
     dataset = foz.load_zoo_dataset("quickstart")
     print(dataset)
 
-    # Performs an IoU sweep so that mAP and PR curves can be computed
+    # Performs an IoU sweep so that mAP, mAR, and PR curves can be computed
     results = dataset.evaluate_detections(
         "predictions",
         gt_field="ground_truth",
@@ -499,6 +500,9 @@ for your predictions by passing the ``compute_mAP=True`` flag to
 
     print(results.mAP())
     # 0.3957
+
+    print(results.mAR())
+    # 0.5210
 
     plot = results.plot_pr_curves(classes=["person", "kite", "car"])
     plot.show()

--- a/docs/source/user_guide/evaluation.rst
+++ b/docs/source/user_guide/evaluation.rst
@@ -1041,16 +1041,17 @@ The example below demonstrates COCO-style detection evaluation on the
     The easiest way to analyze models in FiftyOne is via the
     :ref:`Model Evaluation panel <app-model-evaluation-panel>`!
 
-mAP and PR curves
+mAP, mAR and PR curves
 ~~~~~~~~~~~~~~~~~
 
-You can compute mean average precision (mAP) and precision-recall (PR) curves
-for your objects by passing the ``compute_mAP=True`` flag to
+You can compute mean average precision (mAP), mean average recall (mAR), and
+precision-recall (PR) curves for your predictions by passing the
+``compute_mAP=True`` flag to
 :meth:`evaluate_detections() <fiftyone.core.collections.SampleCollection.evaluate_detections>`:
 
 .. note::
 
-    All mAP calculations are performed according to the
+    All mAP and mAR calculations are performed according to the
     `COCO evaluation protocol <https://cocodataset.org/#detection-eval>`_.
 
 .. code-block:: python
@@ -1062,7 +1063,7 @@ for your objects by passing the ``compute_mAP=True`` flag to
     dataset = foz.load_zoo_dataset("quickstart")
     print(dataset)
 
-    # Performs an IoU sweep so that mAP and PR curves can be computed
+    # Performs an IoU sweep so that mAP, mAR, and PR curves can be computed
     results = dataset.evaluate_detections(
         "predictions",
         gt_field="ground_truth",
@@ -1071,6 +1072,9 @@ for your objects by passing the ``compute_mAP=True`` flag to
 
     print(results.mAP())
     # 0.3957
+
+    print(results.mAR())
+    # 0.5210
 
     plot = results.plot_pr_curves(classes=["person", "kite", "car"])
     plot.show()

--- a/docs/source/user_guide/evaluation.rst
+++ b/docs/source/user_guide/evaluation.rst
@@ -1042,7 +1042,7 @@ The example below demonstrates COCO-style detection evaluation on the
     :ref:`Model Evaluation panel <app-model-evaluation-panel>`!
 
 mAP, mAR and PR curves
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 You can compute mean average precision (mAP), mean average recall (mAR), and
 precision-recall (PR) curves for your predictions by passing the

--- a/fiftyone/operators/builtins/panels/model_evaluation/__init__.py
+++ b/fiftyone/operators/builtins/panels/model_evaluation/__init__.py
@@ -140,6 +140,12 @@ class EvaluationPanel(Panel):
         except Exception as e:
             return None
 
+    def get_mar(self, results):
+        try:
+            return results.mAR()
+        except Exception as e:
+            return None
+
     def set_status(self, ctx):
         if not self.can_edit_status(ctx):
             ctx.ops.notify(
@@ -355,6 +361,7 @@ class EvaluationPanel(Panel):
                 info, results
             )
             metrics["mAP"] = self.get_map(results)
+            metrics["mAR"] = self.get_mar(results)
             evaluation_data = {
                 "metrics": metrics,
                 "info": serialized_info,

--- a/fiftyone/utils/eval/coco.py
+++ b/fiftyone/utils/eval/coco.py
@@ -293,6 +293,7 @@ class COCODetectionResults(DetectionResults):
         self.precision = np.asarray(precision)
         self.recall = np.asarray(recall)
         self.iou_threshs = np.asarray(iou_threshs)
+        self.recall_sweep = recall_sweep
         self.thresholds = (
             np.asarray(thresholds) if thresholds is not None else None
         )
@@ -449,6 +450,7 @@ class COCODetectionResults(DetectionResults):
         precision = d["precision"]
         recall = d["recall"]
         iou_threshs = d["iou_threshs"]
+        recall_sweep = d.get("recall_sweep", None)
         thresholds = d.get("thresholds", None)
         return super()._from_dict(
             d,
@@ -458,6 +460,7 @@ class COCODetectionResults(DetectionResults):
             precision=precision,
             recall=recall,
             iou_threshs=iou_threshs,
+            recall_sweep=recall_sweep,
             thresholds=thresholds,
             **kwargs,
         )

--- a/fiftyone/utils/eval/coco.py
+++ b/fiftyone/utils/eval/coco.py
@@ -5,6 +5,7 @@ COCO-style detection evaluation.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 from collections import defaultdict
 
@@ -50,7 +51,7 @@ class COCOEvaluationConfig(DetectionEvaluationConfig):
         tolerance (None): a tolerance, in pixels, when generating approximate
             polylines for instance masks. Typical values are 1-3 pixels
         compute_mAP (False): whether to perform the necessary computations so
-            that mAP and PR curves can be generated
+            that mAP, mAR, and PR curves can be generated
         iou_threshs (None): a list of IoU thresholds to use when computing mAP
             and PR curves. Only applicable when ``compute_mAP`` is True
         max_preds (None): the maximum number of predicted objects to evaluate
@@ -255,7 +256,8 @@ class COCODetectionResults(DetectionResults):
         recall: an array of recall values
         iou_threshs: an array of IoU thresholds
         classes: the list of possible classes
-        recall_sweep (None): an array of recall values of shape ``num_iou x num_classes``
+        recall_sweep (None): an array of recall values of shape
+            ``num_iou x num_classes``
         thresholds (None): an optional array of decision thresholds of shape
             ``num_iou_threshs x num_classes x num_recall``
         missing (None): a missing label string. Any unmatched objects are

--- a/fiftyone/utils/eval/coco.py
+++ b/fiftyone/utils/eval/coco.py
@@ -795,7 +795,6 @@ def _compute_pr_curves(samples, config, classes=None, progress=None):
                 for ri, pi in enumerate(inds):
                     q[ri] = pre[pi]
                     t[ri] = confs[pi]
-
             except:
                 pass
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds COCO-styled mean average recall to `evaluate_detections()`.

## How is this patch tested? If it is not, please explain why.

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

results = dataset.evaluate_detections(
    "predictions",
    gt_field="ground_truth",
    eval_key="eval",
    compute_mAP=True,
)

print(results.mAR())

# Open Model Evaluation panel and see mAR in the table :)
session = fo.launch_app(dataset)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Introduced Mean Average Recall (mAR) metric in evaluation summaries.
    - Added functionality to visualize and interact with evaluation results in the app.
    - Enhanced COCO evaluation capabilities to compute mAR alongside mAP.

- **Documentation**
    - Expanded documentation on evaluation methods, including mAR and its integration with COCO-style evaluations.
    - Updated examples and explanations for clarity and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->