### PR TITLE
Do not collapse valid list field filters

### DIFF
--- a/app/packages/state/src/recoil/sidebar.test.ts
+++ b/app/packages/state/src/recoil/sidebar.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("recoil");
 vi.mock("recoil-relay");
 
-import { Field } from "@fiftyone/utilities";
-import { setMockAtoms, TestSelector } from "../../../../__mocks__/recoil";
+import { DICT_FIELD, Field, STRING_FIELD } from "@fiftyone/utilities";
+import { TestSelector, setMockAtoms } from "../../../../__mocks__/recoil";
 import * as sidebar from "./sidebar";
 
 const mockFields = {
@@ -564,5 +564,25 @@ describe("hiddenNoneGroups selector", () => {
     });
 
     expect(testHiddenNoneGroups()).toStrictEqual(present);
+  });
+});
+
+describe("collapsedPaths resolution", () => {
+  it("does not add valid list fields (i.e. with a primitive subfield)", () => {
+    setMockAtoms({
+      field: (path) =>
+        path === "dict_list"
+          ? { subfield: DICT_FIELD }
+          : { subfield: STRING_FIELD },
+      fieldPaths: ({ ftype }) =>
+        ftype === DICT_FIELD ? [] : ["dict_list", "string_list"],
+      fields: () => [],
+    });
+
+    const collapsed = <TestSelector<typeof sidebar.collapsedPaths>>(
+      (<unknown>sidebar.collapsedPaths)
+    );
+
+    expect(collapsed()).toStrictEqual(new Set(["dict_list"]));
   });
 });


### PR DESCRIPTION
## What changes are proposed in this pull request?

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
dataset.create_summary_field("ground_truth.detections.label")

# SUMMARIES group is expanded, currently it is collapsed by default
session = fo.launch_app(dataset)
``` 
<img width="1470" alt="Screenshot 2024-12-16 at 10 47 08 AM" src="https://github.com/user-attachments/assets/20203b7e-c7d0-42fb-855c-9b80e49cae44" />

## How is this patch tested? If it is not, please explain why.

Selector test

## Release Notes

* Fixed default summary fields group expansion in the sidebar

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `collapsedPaths` selector to manage sidebar functionality.
  - Added support for new field types in sidebar management.

- **Bug Fixes**
  - Enhanced logic for visibility of groups based on their expanded state.

- **Documentation**
  - Improved comments and clarity in the sidebar management logic. 

- **Tests**
  - Expanded test coverage for sidebar functionality, including a new test suite for `collapsedPaths`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->