### PR TITLE
Fix cached looker font sizes

### DIFF
--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -72,7 +72,13 @@ function Grid() {
       get: (next) => page(next),
       render: (id, element, dimensions, zooming) => {
         if (lookerStore.has(id.description)) {
-          lookerStore.get(id.description)?.attach(element, dimensions);
+          const looker = lookerStore.get(id.description);
+          if (!zooming)
+            looker?.updateOptions({
+              fontSize: getFontSize(),
+            });
+          looker?.attach(element, dimensions);
+
           return;
         }
 

--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -72,12 +72,9 @@ function Grid() {
       get: (next) => page(next),
       render: (id, element, dimensions, zooming) => {
         if (lookerStore.has(id.description)) {
-          const looker = lookerStore.get(id.description);
-          if (!zooming)
-            looker?.updateOptions({
-              fontSize: getFontSize(),
-            });
-          looker?.attach(element, dimensions);
+          lookerStore
+            .get(id.description)
+            ?.attach(element, dimensions, getFontSize());
 
           return;
         }

--- a/app/packages/core/src/components/ImageContainerHeader.tsx
+++ b/app/packages/core/src/components/ImageContainerHeader.tsx
@@ -3,7 +3,7 @@ import * as fos from "@fiftyone/state";
 import { isGroup as isGroupAtom } from "@fiftyone/state";
 import { Apps, ImageAspectRatio } from "@mui/icons-material";
 import Color from "color";
-import { Suspense, useMemo } from "react";
+import React, { Suspense, useMemo } from "react";
 import {
   constSelector,
   useRecoilCallback,

--- a/app/packages/looker/src/lookers/abstract.ts
+++ b/app/packages/looker/src/lookers/abstract.ts
@@ -469,13 +469,18 @@ export abstract class AbstractLooker<
   /**
    * Attaches the instance to the provided HTMLElement and adds event listeners
    */
-  attach(element: HTMLElement | string, dimensions?: Dimensions): void {
+  attach(
+    element: HTMLElement | string,
+    dimensions?: Dimensions,
+    fontSize?: number
+  ): void {
     if (typeof element === "string") {
       element = document.getElementById(element);
     }
 
     if (element === this.lookerElement.element.parentElement) {
-      this.state.disabled && this.updater({ disabled: false });
+      this.state.disabled &&
+        this.updater({ disabled: false, options: { fontSize } });
       return;
     }
 
@@ -491,6 +496,7 @@ export abstract class AbstractLooker<
     this.updater({
       windowBBox: dimensions ? [0, 0, ...dimensions] : getElementBBox(element),
       disabled: false,
+      options: { fontSize },
     });
     element.appendChild(this.lookerElement.element);
     !dimensions && this.resizeObserver.observe(element);


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes cached looker font size when resizing the grid

### Before
https://github.com/user-attachments/assets/bb27c924-059d-4ee6-b60a-afc9250ca74c

### After
https://github.com/user-attachments/assets/db1d8ea6-4689-4eec-8567-be7db128ee67

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `Grid` component with improved error handling and font size management for `looker` instances.
	- Updated `attach` method to accept an optional font size parameter for better rendering control.

- **Bug Fixes**
	- Refined error messages for better clarity regarding data integrity issues.
	- Improved cleanup functions to prevent memory leaks related to event listeners.

- **Style**
	- Changed import statement for React in `ImageContainerHeader` to a named import without affecting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->