### PR TITLE
bump brain version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ INSTALL_REQUIRES = [
     "universal-analytics-python3>=1.0.1,<2",
     "pydash",
     # internal packages
-    "fiftyone-brain>=0.18.0,<0.19",
+    "fiftyone-brain>=0.18.2,<0.19",
     "fiftyone-db>=0.4,<2.0",
     "voxel51-eta>=0.13.0,<0.14",
 ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the minimum required version of the `fiftyone-brain` dependency to 0.18.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->