### PR TITLE
Reset to initial buffers in video looker

### DIFF
--- a/app/packages/looker/src/elements/video.ts
+++ b/app/packages/looker/src/elements/video.ts
@@ -65,17 +65,18 @@ export class LoaderBar extends BaseElement<VideoState> {
   }: Readonly<VideoState>) {
     const shown =
       !error && hovering && (waitingForVideo || buffering || waitingToStream);
+
+    if (shown === this.shown) {
+      return this.element;
+    }
+
     const start = lockedToSupport ? support[0] : 1;
     const end = lockedToSupport
       ? support[1]
       : getFrameNumber(duration, duration, frameRate);
-    if (shown === this.shown || start === end) {
-      return this.element;
-    }
 
     this.shown = shown;
-
-    if (this.shown) {
+    if (this.shown && start !== end) {
       this.element.style.display = "block";
     } else {
       this.element.style.display = "none";

--- a/app/packages/looker/src/lookers/video.ts
+++ b/app/packages/looker/src/lookers/video.ts
@@ -52,6 +52,7 @@ export class VideoLooker extends AbstractLooker<VideoState, VideoSample> {
     if (LOOKER_WITH_READER === this) {
       clearReader();
       LOOKER_WITH_READER = null;
+      this.state.buffers = this.initialBuffers(this.state.config);
     }
     super.detach();
   }
@@ -361,6 +362,7 @@ export class VideoLooker extends AbstractLooker<VideoState, VideoSample> {
     if (LOOKER_WITH_READER === this) {
       if (this.state.config.thumbnail && !this.state.hovering) {
         clearReader();
+        this.state.buffers = this.initialBuffers(this.state.config);
         LOOKER_WITH_READER = null;
       }
     }

--- a/e2e-pw/src/oss/specs/grid-tagging.spec.ts
+++ b/e2e-pw/src/oss/specs/grid-tagging.spec.ts
@@ -44,9 +44,10 @@ test("grid tagging", async ({ fiftyoneLoader, grid, page, sidebar }) => {
   await sidebar.clickFieldCheckbox("filepath");
   await sidebar.clickFieldCheckbox("tags");
   await grid.scrollBottom();
-  await expect(await grid.locator).toHaveScreenshot("grid-untagged.png", {
-    animations: "allow",
-  });
+  for (let i = 31; i <= 54; i++) {
+    const locator = grid.locator.getByText(`/tmp/${i}.png`);
+    await expect(locator).toBeVisible();
+  }
 
   await grid.run(async () => {
     await grid.actionsRow.toggleTagSamplesOrLabels();
@@ -54,7 +55,11 @@ test("grid tagging", async ({ fiftyoneLoader, grid, page, sidebar }) => {
     await grid.tagger.addNewTag("sample", "grid-test");
   });
 
-  await expect(await grid.locator).toHaveScreenshot("grid-tagged.png", {
-    animations: "allow",
-  });
+  for (let i = 31; i <= 54; i++) {
+    const locator = grid.locator.getByText(`/tmp/${i}.png`);
+    await expect(locator).toBeVisible();
+    await expect(
+      locator.locator("..").getByTestId("tag-tags-grid-test")
+    ).toBeVisible();
+  }
 });


### PR DESCRIPTION
## What changes are proposed in this pull request?


1. When releasing the frame reader, buffers should be reset. Currently, labels may flicker (see first recording)
2. Do not show loading bar for single frame videos (second recording)

https://github.com/user-attachments/assets/c03777f1-ca98-4bd8-a9a0-91c3677170c4

https://github.com/user-attachments/assets/adda2e69-5a92-4b54-b805-025a909e7402

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced rendering logic for video controls, improving responsiveness and clarity.
	- Updated play button appearance based on playback states.

- **Bug Fixes**
	- Improved management of video buffers during detachment and sample updates.

- **Tests**
	- Updated grid tagging tests to use visibility checks instead of screenshot comparisons for better accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->