### PR TITLE
Fixes an issue where splitting the panel space wrongly triggers on_unload

### DIFF
--- a/app/packages/operators/src/CustomPanel.tsx
+++ b/app/packages/operators/src/CustomPanel.tsx
@@ -14,12 +14,14 @@ import { useActivePanelEventsCount } from "./hooks";
 import { Property } from "./types";
 import { CustomPanelProps, useCustomPanelHooks } from "./useCustomPanelHooks";
 import { useTrackEvent } from "@fiftyone/analytics";
+import usePanelEvent from "./usePanelEvent";
 
 export function CustomPanel(props: CustomPanelProps) {
   const { panelId, dimensions, panelName, panelLabel, isModalPanel } = props;
   const { height, width } = dimensions?.bounds || {};
   const { count } = useActivePanelEventsCount(panelId);
   const [_, setLoading] = usePanelLoading(panelId);
+  const triggerPanelEvent = usePanelEvent();
 
   const {
     handlePanelStateChange,
@@ -36,6 +38,7 @@ export function CustomPanel(props: CustomPanelProps) {
     setPanelCloseEffect(() => {
       clearUseKeyStores(panelId);
       trackEvent("close_panel", { panel: panelName });
+      triggerPanelEvent(panelId, { operator: props.onUnLoad });
     });
   }, []);
 

--- a/app/packages/operators/src/useCustomPanelHooks.ts
+++ b/app/packages/operators/src/useCustomPanelHooks.ts
@@ -165,14 +165,6 @@ export function useCustomPanelHooks(props: CustomPanelProps): CustomPanelHooks {
     triggerPanelEvent,
   ]);
 
-  useEffect(() => {
-    return () => {
-      if (props.onUnLoad) {
-        triggerPanelEvent(panelId, { operator: props.onUnLoad });
-      }
-    };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
   const handlePanelStateChangeOpDebounced = useMemo(() => {
     return debounce(
       (state, onChange, panelId) => {


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Testing DQ panel shows when splitting the panel's space using [][], the on_unload hook is called
- moving the on_unload trigger to `PanelCloseEffect` function fixes the issue


https://github.com/user-attachments/assets/eb5ae41c-b95c-4c5b-b28a-a29882ea931c



## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced event handling in the Custom Panel for unload actions.
  
- **Bug Fixes**
  - Removed cleanup effect for the `onUnLoad` prop, streamlining lifecycle interactions.

- **Refactor**
  - Updated state management logic for the Custom Panel.
  - Introduced conditional checks for event triggers based on schema changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->