### PR TITLE
Add show, hide, and toggle sidebar operators

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -17,7 +17,12 @@ import { LOAD_WORKSPACE_OPERATOR } from "@fiftyone/spaces/src/components/Workspa
 import { toSlug } from "@fiftyone/utilities";
 import copyToClipboard from "copy-to-clipboard";
 import { cloneDeep, merge, set as setValue } from "lodash";
-import { useRecoilCallback, useSetRecoilState } from "recoil";
+import {
+  useRecoilCallback,
+  useRecoilState,
+  useRecoilValue,
+  useSetRecoilState,
+} from "recoil";
 import { useOperatorExecutor } from ".";
 import useRefetchableSavedViews from "../../core/src/hooks/useRefetchableSavedViews";
 import registerPanel from "./Panel/register";
@@ -1409,6 +1414,66 @@ class CloseSample extends Operator {
   }
 }
 
+class ShowSidebar extends Operator {
+  _builtIn = true;
+  get config(): OperatorConfig {
+    return new OperatorConfig({
+      name: "show_sidebar",
+      label: "Show sidebar",
+    });
+  }
+  useHooks(): object {
+    const modal = useRecoilValue(fos.modal);
+    const [visible, setVisible] = useRecoilState(fos.sidebarVisible(!!modal));
+    return {
+      show: () => setVisible(true),
+    };
+  }
+  async execute({ hooks }: ExecutionContext) {
+    hooks.show();
+  }
+}
+
+class HideSidebar extends Operator {
+  _builtIn = true;
+  get config(): OperatorConfig {
+    return new OperatorConfig({
+      name: "hide_sidebar",
+      label: "Hide sidebar",
+    });
+  }
+  useHooks(): object {
+    const modal = useRecoilValue(fos.modal);
+    const [visible, setVisible] = useRecoilState(fos.sidebarVisible(!!modal));
+    return {
+      hide: () => setVisible(false),
+    };
+  }
+  async execute({ hooks }: ExecutionContext) {
+    hooks.hide();
+  }
+}
+
+class ToggleSidebar extends Operator {
+  _builtIn = true;
+  get config(): OperatorConfig {
+    return new OperatorConfig({
+      name: "toggle_sidebar",
+      label: "Toggle sidebar",
+    });
+  }
+  useHooks(): object {
+    const modal = useRecoilValue(fos.modal);
+    const [visible, setVisible] = useRecoilState(fos.sidebarVisible(!!modal));
+    return {
+      toggle: () => setVisible(!visible),
+    };
+  }
+  async execute({ hooks }: ExecutionContext) {
+    hooks.toggle();
+  }
+}
+
 export function registerBuiltInOperators() {
   try {
     _registerBuiltInOperator(CopyViewAsJSON);
@@ -1462,6 +1527,9 @@ export function registerBuiltInOperators() {
     _registerBuiltInOperator(EnableQueryPerformance);
     _registerBuiltInOperator(OpenSample);
     _registerBuiltInOperator(CloseSample);
+    _registerBuiltInOperator(ShowSidebar);
+    _registerBuiltInOperator(HideSidebar);
+    _registerBuiltInOperator(ToggleSidebar);
   } catch (e) {
     console.error("Error registering built-in operators");
     console.error(e);

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -680,6 +680,18 @@ class Operations(object):
         """Closes the App's sample modal."""
         return self._ctx.trigger("close_sample")
 
+    def show_sidebar(self):
+        """Show the App's sidebar."""
+        return self._ctx.trigger("show_sidebar")
+
+    def hide_sidebar(self):
+        """Hide the App's sidebar."""
+        return self._ctx.trigger("hide_sidebar")
+
+    def toggle_sidebar(self):
+        """Toggle the visibility of the App's sidebar."""
+        return self._ctx.trigger("toggle_sidebar")
+
 
 def _serialize_view(view):
     return json.loads(json_util.dumps(view._serialize()))


### PR DESCRIPTION
```js
// js
import {executeOperator} from "@fiftyone/operators"

executeOperator("show_sidebar"); // show
executeOperator("hide_sidebar"); // hide
executeOperator("toggle_sidebar"); // toggle
```

```python
# python
ctx.ops.show_sidebar() # show
ctx.ops.hide_sidebar() # hide
ctx.ops.toggle_sidebar() # toggle
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to show, hide, and toggle the sidebar within the application.
	- Enhanced user interface for a more interactive experience by managing sidebar visibility.

- **Bug Fixes**
	- Improved state management for sidebar visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->