### PR TITLE
remove erroneous base url extraction

### DIFF
--- a/app/packages/looker/src/worker/disk-overlay-decoder.ts
+++ b/app/packages/looker/src/worker/disk-overlay-decoder.ts
@@ -97,19 +97,11 @@ export const decodeOverlayOnDisk = async (
 
   // convert absolute file path to a URL that we can "fetch" from
   const overlayImageUrl = getSampleSrc(source || label[overlayPathField]);
-  const urlTokens = overlayImageUrl.split("?");
-
-  let baseUrl = overlayImageUrl;
-
-  // remove query params if not local URL
-  if (!urlTokens.at(1)?.startsWith("filepath=") && !source) {
-    baseUrl = overlayImageUrl.split("?")[0];
-  }
 
   let overlayImageBlob: Blob;
   try {
     const overlayImageFetchResponse = await enqueueFetch({
-      url: baseUrl,
+      url: overlayImageUrl,
       options: { priority: "low" },
     });
     overlayImageBlob = await overlayImageFetchResponse.blob();


### PR DESCRIPTION
## What changes are proposed in this pull request?

Modifying overlay image URL was leading to bugs in some cases. This modification was vestigial and added no value (instead, causes bugs). This PR fixes that.

## How is this patch tested? If it is not, please explain why.

Locally and with teams.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified error handling for overlay image fetching and decoding processes.
	- Improved URL handling for fetching overlay images by removing unnecessary modifications.

- **Chores**
	- Minor adjustments to variable declarations and removal of redundant code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->