### PR TITLE
fix load_evaluation bug with serialized_info

### DIFF
--- a/fiftyone/operators/builtins/panels/model_evaluation/__init__.py
+++ b/fiftyone/operators/builtins/panels/model_evaluation/__init__.py
@@ -308,13 +308,13 @@ class EvaluationPanel(Panel):
         if evaluation_data is None:
             info = ctx.dataset.get_evaluation_info(computed_eval_key)
             evaluation_type = info.config.type
+            serialized_info = info.serialize()
             if evaluation_type not in SUPPORTED_EVALUATION_TYPES:
                 ctx.panel.set_data(
                     f"evaluation_{computed_eval_key}_error",
                     {"error": "unsupported", "info": serialized_info},
                 )
                 return
-            serialized_info = info.serialize()
             gt_field = info.config.gt_field
             mask_targets = (
                 self.get_mask_targets(ctx.dataset, gt_field)


### PR DESCRIPTION
## What changes are proposed in this pull request?

fix load_evaluation bug with serialized_info

## How is this patch tested? If it is not, please explain why.

Using model evaluation panel 

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error reporting for unsupported evaluation types in the Evaluation Panel.

- **Chores**
	- Adjusted the order of operations in the load_evaluation method for better context in error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->