### PR TITLE
Bump to ETA v0.13.1

### DIFF
--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -973,19 +973,6 @@ class ProgressBar(etau.ProgressBar):
         self._progress = progress
         self._callback = callback
 
-    def __call__(self, iterable):
-        # Ensure that `len(iterable)` is not computed unnecessarily
-        no_len = self._quiet and self._total is None
-        if no_len:
-            self._total = -1
-
-        super().__call__(iterable)
-
-        if no_len:
-            self._total = None
-
-        return self
-
     def set_iteration(self, *args, **kwargs):
         super().set_iteration(*args, **kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ INSTALL_REQUIRES = [
     # internal packages
     "fiftyone-brain>=0.18.2,<0.19",
     "fiftyone-db>=0.4,<2.0",
-    "voxel51-eta>=0.13.0,<0.14",
+    "voxel51-eta>=0.13.1,<0.14",
 ]
 
 


### PR DESCRIPTION
This optimizes `dataset.first()` by ensuring that `len(dataset)` is not called unnecessarily.
