### PR TITLE
Clear extended selection for dataset changes

### DIFF
--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -237,14 +237,50 @@ export const similaritySorting = atom<boolean>({
   default: false,
 });
 
-export const extendedSelection = atom<{ selection: string[]; scope?: string }>({
-  key: "extendedSelection",
-  default: { selection: null },
-});
-export const extendedSelectionOverrideStage = atom<any>({
-  key: "extendedSelectionOverrideStage",
-  default: null,
-});
+export const extendedSelection = (() => {
+  let current = { selection: null };
+  return graphQLSyncFragmentAtom<
+    datasetFragment$key,
+    { selection: string[]; scope?: string }
+  >(
+    {
+      fragments: [datasetFragment],
+      keys: ["dataset"],
+      default: { selection: null },
+      read: (data, previous) => {
+        if (previous && data.id !== previous?.id) {
+          current = { selection: null };
+        }
+
+        return current;
+      },
+    },
+    {
+      key: "extendedSelection",
+    }
+  );
+})();
+
+export const extendedSelectionOverrideStage = (() => {
+  let current = null;
+  return graphQLSyncFragmentAtom<datasetFragment$key, any>(
+    {
+      fragments: [datasetFragment],
+      keys: ["dataset"],
+      default: { selection: null },
+      read: (data, previous) => {
+        if (previous && data.id !== previous?.id) {
+          current = null;
+        }
+
+        return current;
+      },
+    },
+    {
+      key: "extendedSelectionOverrideStage",
+    }
+  );
+})();
 
 export const similarityParameters = (() => {
   let update = false;

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -267,7 +267,7 @@ export const extendedSelectionOverrideStage = (() => {
     {
       fragments: [datasetFragment],
       keys: ["dataset"],
-      default: { selection: null },
+      default: null,
       read: (data, previous) => {
         if (previous && data.id !== previous?.id) {
           current = null;


### PR DESCRIPTION

Create and extended selection with the embeddings panel and then change datasets

```py
import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
fob.compute_visualization(dataset, brain_key="viz")
``` 
#### Before

https://github.com/user-attachments/assets/680745e4-f3ab-49fe-b405-62da1aebdc88

#### After
https://github.com/user-attachments/assets/4f80a53d-5777-48bc-8b5e-8973b78f0b11




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced state management for dataset interactions with more dynamic behavior.
	- Updated default values for selection-related functionalities.
	- Improved internal state handling for better responsiveness to changes.

- **Bug Fixes**
	- Improved responsiveness of state transitions in the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->