### PR TITLE
Fallback to mask targets when annotating existing segmentation fields

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -457,7 +457,11 @@ details:
     attributes are included for all fields that do not explicitly define their
     per-field attributes (in addition to any per-class attributes)
 -   **mask_targets** (*None*): a dict mapping pixel values to semantic label
-    strings. Only applicable when annotating semantic segmentations
+    strings. Only applicable when annotating semantic segmentations. All new
+    label fields must have mask targets provided via one of the supported
+    methods. For existing label fields, if mask targets are not provided by
+    this argument nor `label_schema`, any applicable mask targets stored on
+    your dataset will be used, if available
 -   **allow_additions** (*True*): whether to allow new labels to be added. Only
     applicable when editing existing label fields
 -   **allow_deletions** (*True*): whether to allow labels to be deleted. Only
@@ -678,8 +682,13 @@ FiftyOne can infer the appropriate values to use:
 
 -   **label_type**: if omitted, the |Label| type of the field will be used to
     infer the appropriate value for this parameter
--   **classes**: if omitted for a non-semantic segmentation field, the observed
-    labels on your dataset will be used to construct a classes list
+-   **classes**: if omitted, the observed labels on your dataset will be used
+    to construct a classes list
+-   **mask_targets**: if omitted for a semantic segmentation field, the mask
+    targets from the
+    :meth:`mask_targets <fiftyone.core.dataset.Dataset.mask_targets>` or
+    :meth:`default_mask_targets <fiftyone.core.dataset.Dataset.default_mask_targets>`
+    properties of your dataset will be used, if available
 
 .. _cvat-label-attributes:
 

--- a/docs/source/integrations/labelbox.rst
+++ b/docs/source/integrations/labelbox.rst
@@ -456,7 +456,11 @@ details:
     attributes are included for all fields that do not explicitly define their
     per-field attributes (in addition to any per-class attributes)
 -   **mask_targets** (*None*): a dict mapping pixel values to semantic label
-    strings. Only applicable when annotating semantic segmentations
+    strings. Only applicable when annotating semantic segmentations. All new
+    label fields must have mask targets provided via one of the supported
+    methods. For existing label fields, if mask targets are not provided by
+    this argument nor `label_schema`, any applicable mask targets stored on
+    your dataset will be used, if available
 -   **allow_additions** (*True*): whether to allow new labels to be added. Only
     applicable when editing existing label fields
 -   **allow_deletions** (*True*): whether to allow labels to be deleted. Only
@@ -625,8 +629,13 @@ FiftyOne can infer the appropriate values to use:
 
 -   **label_type**: if omitted, the |Label| type of the field will be used to
     infer the appropriate value for this parameter
--   **classes**: if omitted for a non-semantic segmentation field, the observed
-    labels on your dataset will be used to construct a classes list
+-   **classes**: if omitted, the observed labels on your dataset will be used
+    to construct a classes list
+-   **mask_targets**: if omitted for a semantic segmentation field, the mask
+    targets from the
+    :meth:`mask_targets <fiftyone.core.dataset.Dataset.mask_targets>` or
+    :meth:`default_mask_targets <fiftyone.core.dataset.Dataset.default_mask_targets>`
+    properties of your dataset will be used, if available
 
 .. note::
 

--- a/docs/source/integrations/labelstudio.rst
+++ b/docs/source/integrations/labelstudio.rst
@@ -444,7 +444,11 @@ more details:
     :meth:`Dataset.classes <fiftyone.core.dataset.Dataset.classes>` or
     :meth:`Dataset.default_classes <fiftyone.core.dataset.Dataset.default_classes>`
 -   **mask_targets** (*None*): a dict mapping pixel values to semantic label
-    strings. Only applicable when annotating semantic segmentations
+    strings. Only applicable when annotating semantic segmentations. All new
+    label fields must have mask targets provided via one of the supported
+    methods. For existing label fields, if mask targets are not provided by
+    this argument nor `label_schema`, any applicable mask targets stored on
+    your dataset will be used, if available
 
 |br|
 In addition, the following Label Studio-specific parameters from
@@ -519,11 +523,8 @@ FiftyOne can infer the appropriate values to use:
 
 -   **label_type**: if omitted, the |Label| type of the field will be used to
     infer the appropriate value for this parameter
--   **classes**: if omitted for a non-semantic segmentation field, the class
-    lists from the :meth:`classes <fiftyone.core.dataset.Dataset.classes>` or
-    :meth:`default_classes <fiftyone.core.dataset.Dataset.default_classes>`
-    properties of your dataset will be used, if available. Otherwise, the
-    observed labels on your dataset will be used to construct a classes list
+-   **classes**: if omitted, the observed labels on your dataset will be used
+    to construct a classes list
 -   **mask_targets**: if omitted for a semantic segmentation field, the mask
     targets from the
     :meth:`mask_targets <fiftyone.core.dataset.Dataset.mask_targets>` or

--- a/docs/source/user_guide/annotation.rst
+++ b/docs/source/user_guide/annotation.rst
@@ -510,7 +510,11 @@ more details:
     attributes are included for all fields that do not explicitly define their
     per-field attributes (in addition to any per-class attributes)
 -   **mask_targets** (*None*): a dict mapping pixel values to semantic label
-    strings. Only applicable when annotating semantic segmentations
+    strings. Only applicable when annotating semantic segmentations. All new
+    label fields must have mask targets provided via one of the supported
+    methods. For existing label fields, if mask targets are not provided by
+    this argument nor `label_schema`, any applicable mask targets stored on
+    your dataset will be used, if available
 -   **allow_additions** (*True*): whether to allow new labels to be added. Only
     applicable when editing existing label fields
 -   **allow_deletions** (*True*): whether to allow labels to be deleted. Only
@@ -669,8 +673,13 @@ FiftyOne can infer the appropriate values to use:
 
 -   **label_type**: if omitted, the |Label| type of the field will be used to
     infer the appropriate value for this parameter
--   **classes**: if omitted for a non-semantic segmentation field, the observed
-    labels on your dataset will be used to construct a classes list
+-   **classes**: if omitted, the observed labels on your dataset will be used
+    to construct a classes list
+-   **mask_targets**: if omitted for a semantic segmentation field, the mask
+    targets from the
+    :meth:`mask_targets <fiftyone.core.dataset.Dataset.mask_targets>` or
+    :meth:`default_mask_targets <fiftyone.core.dataset.Dataset.default_mask_targets>`
+    properties of your dataset will be used, if available
 
 .. _annotation-label-attributes:
 


### PR DESCRIPTION
Merging https://github.com/voxel51/fiftyone/pull/4990 plus some documentation updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Clarified handling of `mask_targets` and `classes` parameters in the annotation process across CVAT, Labelbox, and Label Studio integrations.
	- Enhanced explanations regarding the requirements for new and existing label fields in the FiftyOne annotation API.
	- Updated user guide to reflect changes in the `annotate()` method, improving clarity on parameter usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->