### PR TITLE
Adds index usage info to `get_index_information(include_stats=True)`

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -9506,8 +9506,8 @@ class SampleCollection(object):
         details on the structure of this dictionary.
 
         Args:
-            include_stats (False): whether to include the size and build status
-                of each index
+            include_stats (False): whether to include the size, usage, and
+                build status of each index
 
         Returns:
             a dict mapping index names to info dicts
@@ -9527,6 +9527,13 @@ class SampleCollection(object):
             for key in cs.get("indexBuilds", []):
                 if key in sample_info:
                     sample_info[key]["in_progress"] = True
+
+            for d in self._dataset._sample_collection.aggregate(
+                [{"$indexStats": {}}]
+            ):
+                key = d["name"]
+                if key in sample_info:
+                    sample_info[key]["accesses"] = d["accesses"]
 
         for key, info in sample_info.items():
             if len(info["key"]) == 1:
@@ -9549,6 +9556,13 @@ class SampleCollection(object):
                 for key in cs.get("indexBuilds", []):
                     if key in frame_info:
                         frame_info[key]["in_progress"] = True
+
+                for d in self._dataset._frame_collection.aggregate(
+                    [{"$indexStats": {}}]
+                ):
+                    key = d["name"]
+                    if key in frame_info:
+                        frame_info[key]["accesses"] = d["accesses"]
 
             for key, info in frame_info.items():
                 if len(info["key"]) == 1:

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1202,21 +1202,13 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         return stats
 
     def _sample_collstats(self):
-        conn = foo.get_db_conn()
-        return conn.command(
-            "collstats",
-            self._sample_collection_name,
-        )
+        return _get_collstats(self._sample_collection)
 
     def _frame_collstats(self):
         if self._frame_collection_name is None:
             return None
 
-        conn = foo.get_db_conn()
-        return conn.command(
-            "collstats",
-            self._frame_collection_name,
-        )
+        return _get_collstats(self._frame_collection)
 
     def first(self):
         """Returns the first sample in the dataset.
@@ -7770,15 +7762,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             self._frame_collection_name, write_concern=write_concern
         )
 
-    @property
-    def _frame_indexes(self):
-        frame_collection = self._frame_collection
-        if frame_collection is None:
-            return None
-
-        index_info = frame_collection.index_information()
-        return [k["key"][0][0] for k in index_info.values()]
-
     def _apply_sample_field_schema(self, schema):
         for field_name, field_or_str in schema.items():
             kwargs = foo.get_field_kwargs(field_or_str)
@@ -9102,6 +9085,14 @@ def _get_single_index_map(coll):
         for k, v in coll.index_information().items()
         if len(v["key"]) == 1
     }
+
+
+def _get_collstats(coll):
+    pipeline = [
+        {"$collStats": {"storageStats": {}}},
+        {"$replaceRoot": {"newRoot": "$storageStats"}},
+    ]
+    return next(coll.aggregate(pipeline))
 
 
 def _add_collection_with_new_ids(

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -671,7 +671,7 @@ class DatasetTests(unittest.TestCase):
             dataset.create_index("non_existent_field")
 
     @drop_datasets
-    def test_index_sizes(self):
+    def test_index_stats(self):
         gt = fo.Detections(detections=[fo.Detection(label="foo")])
         sample = fo.Sample(filepath="video.mp4", gt=gt)
         sample.frames[1] = fo.Frame(gt=gt)
@@ -700,7 +700,9 @@ class DatasetTests(unittest.TestCase):
         self.assertSetEqual(set(dataset.list_indexes()), indexes)
         self.assertSetEqual(set(info.keys()), indexes)
         for d in info.values():
-            self.assertTrue(d.get("size") is not None)
+            self.assertTrue(d["size"] is not None)
+            self.assertTrue("ops" in d["accesses"])
+            self.assertTrue("since" in d["accesses"])
 
     @drop_datasets
     def test_index_in_progress(self):


### PR DESCRIPTION
## Change log

- Adds index usage info to `get_index_information(include_stats=True)`
- Replaces `collstats()` calls with the `$collStats` aggregation, as the former has been [deprecated since MongoDB v6.2](https://www.mongodb.com/docs/manual/reference/command/collStats)
- Removes the unused `Dataset._frame_indexes` property

## Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

dataset.create_index([("id", 1), ("uniqueness", 1)])

# Use the indexes
_ = dataset[dataset.first().id]
_ = dataset[dataset.first().filepath]
_ = dataset._max("created_at")
_ = dataset._max("last_modified_at")
_ = len(dataset.select(dataset.take(10)).sort_by("uniqueness", create_index=False))

fo.pprint(dataset.get_index_information(include_stats=True))
```

```
{
    'id': {
        'v': 2,
        'key': [('_id', 1)],
        'size': 4096,
        'accesses': {
            'ops': 1,
            'since': datetime.datetime(2024, 12, 27, 2, 19, 24, 610000),
        },
    },
    'filepath': {
        'v': 2,
        'key': [('filepath', 1)],
        'size': 4096,
        'accesses': {
            'ops': 1,
            'since': datetime.datetime(2024, 12, 27, 2, 19, 24, 652000),
        },
    },
    'created_at': {
        'v': 2,
        'key': [('created_at', 1)],
        'size': 4096,
        'accesses': {
            'ops': 1,
            'since': datetime.datetime(2024, 12, 27, 2, 19, 24, 696000),
        },
    },
    'last_modified_at': {
        'v': 2,
        'key': [('last_modified_at', 1)],
        'size': 4096,
        'accesses': {
            'ops': 1,
            'since': datetime.datetime(2024, 12, 27, 2, 19, 24, 738000),
        },
    },
    '_id_1_uniqueness_1': {
        'v': 2,
        'key': [('_id', 1), ('uniqueness', 1)],
        'size': 24576,
        'accesses': {
            'ops': 1,
            'since': datetime.datetime(2024, 12, 27, 2, 19, 28, 896000),
        },
    },
}
```

## `collstats` -> `$collStats` migration

```py
import fiftyone as fo
import fiftyone.core.odm as foo

dataset = fo.Dataset()

db = foo.get_db_conn()
cs1 = db.command("collstats", dataset._sample_collection_name)
cs2 = dataset._sample_collstats()

assert cs1["storageSize"] == cs2["storageSize"]
assert cs1["size"] == cs2["size"]
assert cs1["count"] == cs2["count"]
assert cs1["indexBuilds"] == cs2["indexBuilds"]
assert cs1["indexSizes"] == cs2["indexSizes"]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced index information retrieval with detailed statistics including size, usage, and build status.
	- Introduced a new method for collecting structured collection statistics using an aggregation framework.

- **Bug Fixes**
	- Improved assertions in unit tests to validate additional index statistics.

- **Refactor**
	- Updated method calls to streamline collection statistics retrieval.
	- Renamed test method for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->