### PR TITLE
Adding label IDs in Segmentation Evaluation results

### DIFF
--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -391,9 +391,9 @@ class SimpleEvaluation(SegmentationEvaluation):
                     bandwidth=bandwidth,
                 )
                 sample_conf_mat += image_conf_mat
-                non_zero_indexes = np.nonzero(sample_conf_mat)
+                non_zero_indexes = np.nonzero(image_conf_mat)
                 for index in zip(*non_zero_indexes):
-                    matches.append((classes[index[0]], classes[index[1]], sample_conf_mat[index[0], index[1]], gt_seg.id, pred_seg.id))
+                    matches.append((classes[index[0]], classes[index[1]], image_conf_mat[index[0], index[1]], gt_seg.id, pred_seg.id))
 
                 if processing_frames and save:
                     facc, fpre, frec = _compute_accuracy_precision_recall(

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -423,7 +423,8 @@ class SimpleEvaluation(SegmentationEvaluation):
             missing = classes[0] if values[0] in (0, "#000000") else None
         else:
             missing = None
-
+        if len(matches) == 0:
+            matches = None
         return SegmentationResults(
             samples,
             self.config,

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -390,11 +390,13 @@ class SimpleEvaluation(SegmentationEvaluation):
                     values,
                     bandwidth=bandwidth,
                 )
-                sample_conf_mat += image_conf_mat
+                
                 non_zero_indexes = np.nonzero(image_conf_mat)
                 for index in zip(*non_zero_indexes):
                     matches.append((classes[index[0]], classes[index[1]], image_conf_mat[index[0], index[1]], gt_seg.id, pred_seg.id))
 
+                sample_conf_mat += image_conf_mat
+                
                 if processing_frames and save:
                     facc, fpre, frec = _compute_accuracy_precision_recall(
                         image_conf_mat, values, average

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -509,7 +509,7 @@ class SegmentationResults(BaseEvaluationResults):
         )
 
     @staticmethod
-    def _parse_confusion_matrix(confusion_matrix, classes, ytrue_ids_dict, ypred_ids_dict):
+    def _parse_confusion_matrix(confusion_matrix, classes):
         ytrue = []
         ypred = []
         weights = []

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -430,7 +430,7 @@ class SimpleEvaluation(SegmentationEvaluation):
         else:
             missing = None
 
-        res = SegmentationResults(
+        return SegmentationResults(
             samples,
             self.config,
             eval_key,
@@ -441,7 +441,6 @@ class SimpleEvaluation(SegmentationEvaluation):
             missing=missing,
             backend=self,
         )
-        return res
 
 
 class SegmentationResults(BaseEvaluationResults):

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -423,15 +423,14 @@ class SimpleEvaluation(SegmentationEvaluation):
             missing = classes[0] if values[0] in (0, "#000000") else None
         else:
             missing = None
-        if len(matches) == 0:
-            matches = None
+            
         return SegmentationResults(
             samples,
             self.config,
             eval_key,
             confusion_matrix,
             classes,
-            matches=matches,
+            matches=None if len(matches) == 0 else matches,
             missing=missing,
             backend=self,
         )

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -8,6 +8,7 @@ Segmentation evaluation.
 from copy import deepcopy
 import logging
 import inspect
+import itertools
 import warnings
 
 import numpy as np
@@ -487,9 +488,6 @@ class SegmentationResults(BaseEvaluationResults):
 
         self.pixel_confusion_matrix = pixel_confusion_matrix
 
-    def attributes(self):
-        return ["cls", "pixel_confusion_matrix", "classes", "missing"]
-
     def dice_score(self):
         """Computes the Dice score across all samples in the evaluation.
 
@@ -500,12 +498,27 @@ class SegmentationResults(BaseEvaluationResults):
 
     @classmethod
     def _from_dict(cls, d, samples, config, eval_key, **kwargs):
+        ytrue = d["ytrue"]
+        ypred = d["ypred"]
+        weights = d["weights"]
+
+        ytrue_ids = d.get("ytrue_ids", None)
+        if ytrue_ids is None:
+            ytrue_ids = itertools.repeat(None)
+
+        ypred_ids = d.get("ypred_ids", None)
+        if ypred_ids is None:
+            ypred_ids = itertools.repeat(None)
+
+        matches = list(zip(ytrue, ypred, weights, ytrue_ids, ypred_ids))
+
         return cls(
             samples,
             config,
             eval_key,
             d["pixel_confusion_matrix"],
             d["classes"],
+            matches=matches,
             missing=d.get("missing", None),
             **kwargs,
         )

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -446,6 +446,7 @@ class SegmentationResults(BaseEvaluationResults):
         eval_key: the evaluation key
         pixel_confusion_matrix: a pixel value confusion matrix
         classes: a list of class labels corresponding to the confusion matrix
+        matches: a list of tuples containing (true_class, pred_class, weight, gt_id, pred_id)
         missing (None): a missing (background) class
         backend (None): a :class:`SegmentationEvaluation` backend
     """

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -466,7 +466,7 @@ class SegmentationResults(BaseEvaluationResults):
             ytrue, ypred, weights, ytrue_ids, ypred_ids = zip(*matches)
         else:
             ytrue, ypred, weights = self._parse_confusion_matrix(
-                pixel_confusion_matrix, classes, ypred_ids, ytrue_ids
+                pixel_confusion_matrix, classes
             )
 
         super().__init__(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adding Segmentation Ids in Segementation Evaluation results fixes the click through behavior when you attach plots to sessions in FiftyOne Notebooks.

## How is this patch tested? If it is not, please explain why.

Manually tested

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Adds in click-through capabilities for segmentation evaluation confusion matrices.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

Code to test- 
```import numpy as np

import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset('quickstart',max_samples=3)

# Generate some toy semantic segmentations
for idx, sample in enumerate(dataset.iter_samples(autosave=True)):
    mask = idx*np.ones((10,10),dtype=np.uint8)
    seg = fo.Segmentation(mask=mask)
    sample['segmentation'] = seg

    mask = (idx+1)*np.ones((10,10),dtype=np.uint8)
    seg = fo.Segmentation(mask=mask)
    sample['segmentation2'] = seg

res = dataset.evaluate_segmentations(
    "segmentation2",
    gt_field="segmentation",
    eval_key="eval_seg"
)

plot = res.plot_confusion_matrix()
plot.show()

session = fo.launch_app(dataset)
session.plots.attach(plot)

# Click on dark cells of confusion matrix. Expected clicking on eg (r,c) = (0,1) to select the first sample in the view.```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced segmentation evaluation with more detailed performance insights.
  - Added capability to track pixel-level classification matches across samples.

- **Improvements**
  - Expanded evaluation results to provide more granular information about segmentation performance.
  - Updated evaluation process to include detailed pixel-level match data in results reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->