### PR TITLE
Handle tree paths in GitHub identifiers

### DIFF
--- a/fiftyone/plugins/utils.py
+++ b/fiftyone/plugins/utils.py
@@ -79,6 +79,12 @@ def find_plugins(gh_repo, path=None, info=False):
         plugins = fopu.find_plugins("https://github.com/voxel51/fiftyone-plugins")
         print(plugins)
 
+        # Search a specific tree root
+        plugins = fopu.find_plugins(
+            "https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/annotation"
+        )
+        print(plugins)
+
         # Search a specific branch + subdirectory
         plugins = fopu.find_plugins(
             "https://github.com/voxel51/fiftyone-plugins/tree/main",
@@ -87,16 +93,19 @@ def find_plugins(gh_repo, path=None, info=False):
         print(plugins)
 
     Args:
-        gh_repo: the GitHub repository or identifier, which can be:
+        gh_repo: the GitHub repository, identifier, or tree path, which can be:
 
             -   a GitHub repo URL like ``https://github.com/<user>/<repo>``
             -   a GitHub ref like
                 ``https://github.com/<user>/<repo>/tree/<branch>`` or
                 ``https://github.com/<user>/<repo>/commit/<commit>``
             -   a GitHub ref string like ``<user>/<repo>[/<ref>]``
+            -   a GitHub tree path like
+                ``https://github.com/<user>/<repo>/tree/<branch>/<path>``
 
         path (None): an optional subdirectory of the repository to which to
-            restrict the search
+            restrict the search. If ``gh_repo`` also contains a ``<path>``, it
+            is prepended to this value
         info (False): whether to retrieve full plugin info for each plugin
             (True) or just return paths to the fiftyone YAML files (False)
 
@@ -104,7 +113,13 @@ def find_plugins(gh_repo, path=None, info=False):
         a list of paths to fiftyone YAML files or plugin info dicts
     """
     root = path
-    repo = GitHubRepository(gh_repo)
+    repo = GitHubRepository(gh_repo, safe=True)
+
+    if repo.safe_path is not None:
+        if path is not None:
+            root = repo.safe_path + "/" + path
+        else:
+            root = repo.safe_path
 
     paths = []
     for d in repo.list_repo_contents(recursive=True):

--- a/fiftyone/utils/github.py
+++ b/fiftyone/utils/github.py
@@ -34,9 +34,13 @@ class GitHubRepository(object):
                 ``https://github.com/<user>/<repo>/tree/<branch>`` or
                 ``https://github.com/<user>/<repo>/commit/<commit>``
             -   a GitHub ref string like ``<user>/<repo>[/<ref>]``
+        safe (False): whether to allow ``repo`` to contain a tree path like
+            ``https://github.com/<user>/<repo>/tree/<branch>/<path>``. If
+            ``safe=True`` and a ``<path>`` is found, it is extracted and stored
+            in the :meth:`safe_path` property
     """
 
-    def __init__(self, repo):
+    def __init__(self, repo, safe=False):
         if etaw.is_url(repo):
             params = self.parse_url(repo)
         else:
@@ -45,7 +49,40 @@ class GitHubRepository(object):
         self._user = params.get("user")
         self._repo = params.get("repo")
         self._ref = params.get("ref", None)
+        self._safe_path = None
         self._session = None
+
+        if safe:
+            self._handle_safe_path()
+
+    def _handle_safe_path(self):
+        if self._ref is None or "/" not in self._ref:
+            return
+
+        api_root = f"https://api.github.com/repos/{self.user}/{self.repo}"
+
+        # Unfortunately, branch/tag names may contain slashes, so the only way
+        # to disambiguate <ref>/<path> is to query the API to see what exists
+        chunks = self._ref.split("/")
+        for i in range(len(chunks), 0, -1):
+            ref = "/".join(chunks[:i])
+            urls = [
+                f"{api_root}/git/ref/heads/{ref}",  # branch
+                f"{api_root}/git/ref/tags/{ref}",  # tag
+            ]
+            if "/" not in ref:
+                urls.append(f"{api_root}/commits/{ref}")  # commit
+
+            for url in urls:
+                try:
+                    _ = self._get(url)
+                    if ref != self._ref:
+                        self._ref = ref
+                        self._safe_path = "/".join(chunks[i:])
+
+                    return
+                except:
+                    pass
 
     @property
     def user(self):
@@ -62,9 +99,10 @@ class GitHubRepository(object):
         """The ref (e.g. branch, tag, commit hash), if any."""
         return self._ref
 
-    @ref.setter
-    def ref(self, ref):
-        self._ref = ref
+    @property
+    def safe_path(self):
+        """The path that was extracted from the provided ref, if any."""
+        return self._safe_path
 
     @property
     def identifier(self):
@@ -183,24 +221,28 @@ class GitHubRepository(object):
 
     def _make_session(self):
         session = requests.Session()
-        token = os.environ.get("GITHUB_TOKEN", None)
+        token = self._get_token()
         if token:
             logger.debug("Using GitHub token as authorization")
             session.headers.update({"Authorization": "token " + token})
 
         return session
 
+    def _get_token(self):
+        return os.environ.get("GITHUB_TOKEN", None)
+
     def _get(self, url, json=True):
         try:
             resp = self._get_session().get(url)
             resp.raise_for_status()
         except requests.exceptions.HTTPError as e:
-            if e.response.status_code in (403, 404):
+            if e.response.status_code in (403, 404) and not self._get_token():
                 raise requests.exceptions.HTTPError(
                     (
-                        "You can interact with private repositories and avoid "
-                        "rate limit errors by providing a personal access "
-                        "token via the 'GITHUB_TOKEN' environment variable"
+                        f"{e}.\n\nDid you know? You can interact with private "
+                        "repositories and avoid rate limit errors by "
+                        "providing a personal access token via the "
+                        "'GITHUB_TOKEN' environment variable"
                     ),
                     response=e.response,
                 )


### PR DESCRIPTION
## Change log

The [@voxel51/plugins/install_plugin](https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/plugins) operator stopped working as a side effect of https://github.com/voxel51/fiftyone/pull/4614 because the operator tried to issue a command like this:

```py
import fiftyone.plugins as fop

url = "https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/dashboard"
fop.download_plugin(url, plugin_names=["@voxel51/dashboard"])
```

where the `url` is pulled [directly from here](https://github.com/voxel51/fiftyone-plugins/blob/d458e19bf9141bb8cd68c0d382cda98fbb2e1169/plugins/dashboard/fiftyone.yml#L6).

When the operator was initially written, the above `download_plugin()` syntax worked, but only because the `GitHubRepository` class would automatically strip `main/plugins/dashboard` down to `main`. However, that was causing our plugins API to not support branches/tags that contain `/` (what https://github.com/voxel51/fiftyone/pull/4614 solved).

This PR brings us back to the best of both worlds: `GitHubRepository(repo)` now supports `repo` strings of the form `<ref>[/<path>]`, where both `<ref>` and `<path>` may contain `/`.

With this patch, the [@voxel51/plugins/install_plugin](https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/plugins) operator works again.

And, as an added bonus, the `download_plugin()` method now supports scoping downloads by subdirectory!

```py
fop.download_plugin("https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/dashboard")
```

Previously the only way to install a subset of plugins from a repository was to specify them by name via the `plugin_names=` kwarg.

## Example usages

### Search for plugins in a specific tree root

```py
import fiftyone.plugins.utils as fopu

plugins = fopu.find_plugins("https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/annotation")
assert len(plugins) == 1
```

### Download plugin from a specific tree root

```py
import fiftyone.plugins as fop

fop.download_plugin("https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/dashboard")
```

### New `GitHubRepository(..., safe=True)` syntax

This new syntax is what enables the other syntaxes to work under the hood:

```py
import fiftyone.utils.github as foug

url = "https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/dashboard"

repo = foug.GitHubRepository(url)
assert repo.ref == "main/plugins/dashboard"
assert repo.safe_path == None

repo = foug.GitHubRepository(url, safe=True)
assert repo.ref == "main"
assert repo.safe_path == "plugins/dashboard"

url = "https://github.com/voxel51/fiftyone-plugins/tree/f5e1d93233caace681b427d7e13677cbcfe58a06/plugins/dashboard"

repo = foug.GitHubRepository(url, safe=True)
assert repo.ref == "f5e1d93233caace681b427d7e13677cbcfe58a06"
assert repo.safe_path == "plugins/dashboard"
```
