### PR TITLE
Add `create_index` kwarg to geo stages

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -5277,6 +5277,7 @@ class SampleCollection(object):
         min_distance=None,
         max_distance=None,
         query=None,
+        create_index=True,
     ):
         """Sorts the samples in the collection by their proximity to a
         specified geolocation.
@@ -5359,6 +5360,8 @@ class SampleCollection(object):
             query (None): an optional dict defining a
                 `MongoDB read query <https://docs.mongodb.com/manual/tutorial/query-documents/#read-operations-query-argument>`_
                 that samples must match in order to be included in this view
+            create_index (True): whether to create the required spherical
+                index, if necessary
 
         Returns:
             a :class:`fiftyone.core.view.DatasetView`
@@ -5370,11 +5373,18 @@ class SampleCollection(object):
                 min_distance=min_distance,
                 max_distance=max_distance,
                 query=query,
+                create_index=create_index,
             )
         )
 
     @view_stage
-    def geo_within(self, boundary, location_field=None, strict=True):
+    def geo_within(
+        self,
+        boundary,
+        location_field=None,
+        strict=True,
+        create_index=True,
+    ):
         """Filters the samples in this collection to only include samples whose
         geolocation is within a specified boundary.
 
@@ -5420,13 +5430,18 @@ class SampleCollection(object):
             strict (True): whether a sample's location data must strictly fall
                 within boundary (True) in order to match, or whether any
                 intersection suffices (False)
+            create_index (True): whether to create the required spherical
+                index, if necessary
 
         Returns:
             a :class:`fiftyone.core.view.DatasetView`
         """
         return self._add_view_stage(
             fos.GeoWithin(
-                boundary, location_field=location_field, strict=strict
+                boundary,
+                location_field=location_field,
+                strict=strict,
+                create_index=create_index,
             )
         )
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -3017,14 +3017,20 @@ def _extract_filter_field(val):
 
 
 class _GeoStage(ViewStage):
-    def __init__(self, location_field):
+    def __init__(self, location_field=None, create_index=True):
         self._location_field = location_field
         self._location_key = None
+        self._create_index = create_index
 
     @property
     def location_field(self):
         """The location field."""
         return self._location_field
+
+    @property
+    def create_index(self):
+        """Whether to create the required spherical index, if necessary."""
+        return self._create_index
 
     def validate(self, sample_collection):
         if self._location_field is None:
@@ -3039,8 +3045,9 @@ class _GeoStage(ViewStage):
             # Assume the user directly specified the subfield to use
             self._location_key = self._location_field
 
-        # These operations require a spherical index
-        sample_collection.create_index([(self._location_key, "2dsphere")])
+        if self._create_index:
+            # These operations require a spherical index
+            sample_collection.create_index([(self._location_key, "2dsphere")])
 
 
 class GeoNear(_GeoStage):
@@ -3128,6 +3135,8 @@ class GeoNear(_GeoStage):
         query (None): an optional dict defining a
             `MongoDB read query <https://docs.mongodb.com/manual/tutorial/query-documents/#read-operations-query-argument>`_
             that samples must match in order to be included in this view
+        create_index (True): whether to create the required spherical index,
+            if necessary
     """
 
     def __init__(
@@ -3137,8 +3146,12 @@ class GeoNear(_GeoStage):
         min_distance=None,
         max_distance=None,
         query=None,
+        create_index=True,
     ):
-        super().__init__(location_field)
+        super().__init__(
+            location_field=location_field,
+            create_index=create_index,
+        )
         self._point = foug.parse_point(point)
         self._min_distance = min_distance
         self._max_distance = max_distance
@@ -3195,6 +3208,7 @@ class GeoNear(_GeoStage):
             ["min_distance", self._min_distance],
             ["max_distance", self._max_distance],
             ["query", self._query],
+            ["create_index", self._create_index],
         ]
 
     @classmethod
@@ -3224,6 +3238,12 @@ class GeoNear(_GeoStage):
                 "type": "NoneType|dict",
                 "placeholder": "",
                 "default": "None",
+            },
+            {
+                "name": "create_index",
+                "type": "bool",
+                "default": "True",
+                "placeholder": "create_index (default=True)",
             },
         ]
 
@@ -3275,10 +3295,20 @@ class GeoWithin(_GeoStage):
         strict (True): whether a sample's location data must strictly fall
             within boundary (True) in order to match, or whether any
             intersection suffices (False)
+
     """
 
-    def __init__(self, boundary, location_field=None, strict=True):
-        super().__init__(location_field)
+    def __init__(
+        self,
+        boundary,
+        location_field=None,
+        strict=True,
+        create_index=True,
+    ):
+        super().__init__(
+            location_field=location_field,
+            create_index=create_index,
+        )
         self._boundary = foug.parse_polygon(boundary)
         self._strict = strict
 
@@ -3307,6 +3337,7 @@ class GeoWithin(_GeoStage):
             ["boundary", self._boundary],
             ["location_field", self._location_field],
             ["strict", self._strict],
+            ["create_index", self._create_index],
         ]
 
     @classmethod
@@ -3324,6 +3355,12 @@ class GeoWithin(_GeoStage):
                 "type": "bool",
                 "default": "True",
                 "placeholder": "strict (default=True)",
+            },
+            {
+                "name": "create_index",
+                "type": "bool",
+                "default": "True",
+                "placeholder": "create_index (default=True)",
             },
         ]
 


### PR DESCRIPTION
Adds a `create_index` kwarg to `GeoNear` and `GeoWithin` stages, for consistency with the `SortBy` and `GroupBy` stages.

Note that, unlike sorting/grouping, the geo stages **require** the spherical index to exist in order to function. However, it feels appropriate to provide a `create_index=False` syntax to provide users a way to guarantee that nothing expensive like index creation will occur when creating/using a view.
