### PR TITLE
Fix builtin operators

### DIFF
--- a/fiftyone/plugins/definitions.py
+++ b/fiftyone/plugins/definitions.py
@@ -44,7 +44,7 @@ class PluginDefinition(object):
     @property
     def builtin(self):
         """Whether the plugin is a builtin plugin."""
-        self.directory.startswith(constants.BUILTIN_PLUGINS_DIR)
+        return self.directory.startswith(constants.BUILTIN_PLUGINS_DIR)
 
     @property
     def author(self):


### PR DESCRIPTION
## What changes are proposed in this pull request?

- fix builtin property

## How is this patch tested? If it is not, please explain why.

- tested locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the `builtin` property implementation in the `PluginDefinition` class to properly return a boolean value indicating whether a plugin is built-in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->