### PR TITLE
Add Model Evaluation panel callbacks for segmentation tasks

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -1783,11 +1783,8 @@ type SummaryRow = {
 
 function formatCustomMetricRows(evaluationMetrics, comparisonMetrics) {
   const results = [] as SummaryRow[];
-  const customMetrics = _.get(
-    evaluationMetrics,
-    "custom_metrics",
-    {}
-  ) as CustomMetrics;
+  const customMetrics = (_.get(evaluationMetrics, "custom_metrics", null) ||
+    {}) as CustomMetrics;
   for (const [operatorUri, customMetric] of Object.entries(customMetrics)) {
     const compareValue = _.get(
       comparisonMetrics,

--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -1621,6 +1621,68 @@ def is_rgb_target(target):
     )
 
 
+def hex_to_int(hex_str):
+    """Converts a hex string like `"#ff6d04"` to a hex integer.
+
+    Args:
+        hex_str: a hex string
+
+    Returns:
+        an integer
+    """
+    r = int(hex_str[1:3], 16)
+    g = int(hex_str[3:5], 16)
+    b = int(hex_str[5:7], 16)
+    return (r << 16) + (g << 8) + b
+
+
+def int_to_hex(value):
+    """Converts an RRGGBB integer value to hex string like `"#ff6d04"`.
+
+    Args:
+        value: an integer value
+
+    Returns:
+        a hex string
+    """
+    r = (value >> 16) & 255
+    g = (value >> 8) & 255
+    b = value & 255
+    return "#%02x%02x%02x" % (r, g, b)
+
+
+def rgb_array_to_int(mask):
+    """Converts an RGB mask array to a 2D hex integer mask array.
+
+    Args:
+        mask: an RGB mask array
+
+    Returns:
+        a 2D integer mask array
+    """
+    return (
+        np.left_shift(mask[:, :, 0], 16, dtype=int)
+        + np.left_shift(mask[:, :, 1], 8, dtype=int)
+        + mask[:, :, 2]
+    )
+
+
+def int_array_to_rgb(mask):
+    """Converts a 2D hex integer mask array to an RGB mask array.
+
+    Args:
+        mask: a 2D integer mask array
+
+    Returns:
+        an RGB mask array
+    """
+    return np.stack(
+        [(mask >> 16) & 255, (mask >> 8) & 255, mask & 255],
+        axis=2,
+        dtype=np.uint8,
+    )
+
+
 class EmbeddedDocumentField(mongoengine.fields.EmbeddedDocumentField, Field):
     """A field that stores instances of a given type of
     :class:`fiftyone.core.odm.BaseEmbeddedDocument` object.

--- a/fiftyone/server/utils.py
+++ b/fiftyone/server/utils.py
@@ -49,6 +49,21 @@ def load_and_cache_dataset(name):
     return dataset
 
 
+def cache_dataset(dataset):
+    """Caches the given dataset.
+
+    This method ensures that subsequent calls to
+    :func:`fiftyone.core.dataset.load_dataset` in async calls will return this
+    dataset singleton.
+
+    See :meth:`load_and_cache_dataset` for additional details.
+
+    Args:
+        dataset: a :class:`fiftyone.core.dataset.Dataset`
+    """
+    _cache[dataset.name] = dataset
+
+
 def change_sample_tags(sample_collection, changes):
     """Applies the changes to tags to all samples of the collection, if
     necessary.

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -369,7 +369,7 @@ class SimpleEvaluation(SegmentationEvaluation):
         if mask_targets is not None:
             if fof.is_rgb_mask_targets(mask_targets):
                 mask_targets = {
-                    _hex_to_int(k): v for k, v in mask_targets.items()
+                    fof.hex_to_int(k): v for k, v in mask_targets.items()
                 }
 
             values, classes = zip(*sorted(mask_targets.items()))
@@ -385,8 +385,9 @@ class SimpleEvaluation(SegmentationEvaluation):
 
         nc = len(values)
         confusion_matrix = np.zeros((nc, nc), dtype=int)
-        ypred_ids = {}
-        ytrue_ids = {}
+        weights_dict = {}
+        ytrue_ids_dict = {}
+        ypred_ids_dict = {}
 
         bandwidth = self.config.bandwidth
         average = self.config.average
@@ -428,16 +429,19 @@ class SimpleEvaluation(SegmentationEvaluation):
                     bandwidth=bandwidth,
                 )
                 sample_conf_mat += image_conf_mat
-                non_zero_indexes = np.nonzero(sample_conf_mat)
-                for index in zip(*non_zero_indexes):
-                    if index not in ypred_ids:
-                        ypred_ids[index] = [pred_seg.id]
-                    else:
-                        ypred_ids[index].append(pred_seg.id)
-                    if index not in ytrue_ids:
-                        ytrue_ids[index] = [gt_seg.id]
-                    else:
-                        ytrue_ids[index].append(gt_seg.id)
+
+                for index in zip(*np.nonzero(image_conf_mat)):
+                    if index not in weights_dict:
+                        weights_dict[index] = []
+                    weights_dict[index].append(int(image_conf_mat[index]))
+
+                    if index not in ytrue_ids_dict:
+                        ytrue_ids_dict[index] = []
+                    ytrue_ids_dict[index].append(gt_seg.id)
+
+                    if index not in ypred_ids_dict:
+                        ypred_ids_dict[index] = []
+                    ypred_ids_dict[index].append(pred_seg.id)
 
                 if processing_frames and save:
                     facc, fpre, frec = _compute_accuracy_precision_recall(
@@ -472,8 +476,9 @@ class SimpleEvaluation(SegmentationEvaluation):
             eval_key,
             confusion_matrix,
             classes,
-            ypred_ids=ypred_ids,
-            ytrue_ids=ytrue_ids,
+            weights_dict=weights_dict,
+            ytrue_ids_dict=ytrue_ids_dict,
+            ypred_ids_dict=ypred_ids_dict,
             missing=missing,
             backend=self,
         )
@@ -488,6 +493,11 @@ class SegmentationResults(BaseClassificationResults):
         eval_key: the evaluation key
         pixel_confusion_matrix: a pixel value confusion matrix
         classes: a list of class labels corresponding to the confusion matrix
+        weights_dict (None): a dict mapping ``(i, j)`` tuples to pixel counts
+        ytrue_ids_dict (None): a dict mapping ``(i, j)`` tuples to lists of
+            ground truth IDs
+        ypred_ids_dict (None): a dict mapping ``(i, j)`` tuples to lists of
+            predicted label IDs
         missing (None): a missing (background) class
         custom_metrics (None): an optional dict of custom metrics
         backend (None): a :class:`SegmentationEvaluation` backend
@@ -500,15 +510,27 @@ class SegmentationResults(BaseClassificationResults):
         eval_key,
         pixel_confusion_matrix,
         classes,
-        ypred_ids=None,
-        ytrue_ids=None,
+        weights_dict=None,
+        ytrue_ids_dict=None,
+        ypred_ids_dict=None,
         missing=None,
         custom_metrics=None,
         backend=None,
     ):
         pixel_confusion_matrix = np.asarray(pixel_confusion_matrix)
-        ytrue, ypred, weights, ytrue_ids, ypred_ids = self._parse_confusion_matrix(
-            pixel_confusion_matrix, classes, ypred_ids, ytrue_ids
+
+        (
+            ytrue,
+            ypred,
+            weights,
+            ytrue_ids,
+            ypred_ids,
+        ) = self._parse_confusion_matrix(
+            pixel_confusion_matrix,
+            classes,
+            weights_dict=weights_dict,
+            ytrue_ids_dict=ytrue_ids_dict,
+            ypred_ids_dict=ypred_ids_dict,
         )
 
         super().__init__(
@@ -527,12 +549,18 @@ class SegmentationResults(BaseClassificationResults):
         )
 
         self.pixel_confusion_matrix = pixel_confusion_matrix
+        self.weights_dict = weights_dict
+        self.ytrue_ids_dict = ytrue_ids_dict
+        self.ypred_ids_dict = ypred_ids_dict
 
     def attributes(self):
         return [
             "cls",
             "pixel_confusion_matrix",
             "classes",
+            "weights_dict",
+            "ytrue_ids_dict",
+            "ypred_ids_dict",
             "missing",
             "custom_metrics",
         ]
@@ -553,40 +581,66 @@ class SegmentationResults(BaseClassificationResults):
             eval_key,
             d["pixel_confusion_matrix"],
             d["classes"],
+            weights_dict=_parse_index_dict(d.get("weights_dict", None)),
+            ytrue_ids_dict=_parse_index_dict(d.get("ytrue_ids_dict", None)),
+            ypred_ids_dict=_parse_index_dict(d.get("ypred_ids_dict", None)),
             missing=d.get("missing", None),
             custom_metrics=d.get("custom_metrics", None),
             **kwargs,
         )
 
     @staticmethod
-    def _parse_confusion_matrix(confusion_matrix, classes, ytrue_ids_dict, ypred_ids_dict):
+    def _parse_confusion_matrix(
+        confusion_matrix,
+        classes,
+        weights_dict=None,
+        ytrue_ids_dict=None,
+        ypred_ids_dict=None,
+    ):
+        have_ids = ytrue_ids_dict is not None and ypred_ids_dict is not None
+
         ytrue = []
         ypred = []
         weights = []
-        ytrue_ids = None
-        ypred_ids = None
-        if ytrue_ids_dict is not None and ypred_ids_dict is not None:
+        if have_ids:
             ytrue_ids = []
             ypred_ids = []
+        else:
+            ytrue_ids = None
+            ypred_ids = None
+
         nrows, ncols = confusion_matrix.shape
         for i in range(nrows):
             for j in range(ncols):
-                index = (i, j)
                 cij = confusion_matrix[i, j]
                 if cij > 0:
-                    if ytrue_ids_dict is not None and ypred_ids_dict is not None:
-                        ytrue_ids+= ytrue_ids_dict[index]
-                        ypred_ids+= ypred_ids_dict[index]
-                        ytrue_multiplier = len(ytrue_ids_dict[index])
+                    if have_ids:
+                        index = (i, j)
+                        classi = classes[i]
+                        classj = classes[j]
+                        for weight, ytrue_id, ypred_id in zip(
+                            weights_dict[index],
+                            ytrue_ids_dict[index],
+                            ypred_ids_dict[index],
+                        ):
+                            ytrue.append(classi)
+                            ypred.append(classj)
+                            weights.append(weight)
+                            ytrue_ids.append(ytrue_id)
+                            ypred_ids.append(ypred_id)
                     else:
-                        ytrue_multiplier = 1
-                    for p in range(ytrue_multiplier):
                         ytrue.append(classes[i])
                         ypred.append(classes[j])
-                        weights.append(cij/ytrue_multiplier)
-                    #Note: The weights aren't equally divided by the different ytrue_ids, but it works out for the confusion matrix calculations.
-                    
+                        weights.append(cij)
+
         return ytrue, ypred, weights, ytrue_ids, ypred_ids
+
+
+def _parse_index_dict(d):
+    import ast
+
+    return {ast.literal_eval(k): v for k, v in d.items()}
+
 
 def _parse_config(pred_field, gt_field, method, **kwargs):
     if method is None:
@@ -630,10 +684,10 @@ def _compute_pixel_confusion_matrix(
     pred_mask, gt_mask, values, bandwidth=None
 ):
     if pred_mask.ndim == 3:
-        pred_mask = _rgb_array_to_int(pred_mask)
+        pred_mask = fof.rgb_array_to_int(pred_mask)
 
     if gt_mask.ndim == 3:
-        gt_mask = _rgb_array_to_int(gt_mask)
+        gt_mask = fof.rgb_array_to_int(gt_mask)
 
     if pred_mask.shape != gt_mask.shape:
         msg = (
@@ -706,37 +760,15 @@ def _get_mask_values(samples, pred_field, gt_field, progress=None):
                     mask = seg.get_mask()
                     if mask.ndim == 3:
                         is_rgb = True
-                        mask = _rgb_array_to_int(mask)
+                        mask = fof.rgb_array_to_int(mask)
 
                     values.update(mask.ravel())
 
     values = sorted(values)
 
     if is_rgb:
-        classes = [_int_to_hex(v) for v in values]
+        classes = [fof.int_to_hex(v) for v in values]
     else:
         classes = [str(v) for v in values]
 
     return values, classes
-
-
-def _rgb_array_to_int(mask):
-    return (
-        np.left_shift(mask[:, :, 0], 16, dtype=int)
-        + np.left_shift(mask[:, :, 1], 8, dtype=int)
-        + mask[:, :, 2]
-    )
-
-
-def _hex_to_int(hex_str):
-    r = int(hex_str[1:3], 16)
-    g = int(hex_str[3:5], 16)
-    b = int(hex_str[5:7], 16)
-    return (r << 16) + (g << 8) + b
-
-
-def _int_to_hex(value):
-    r = (value >> 16) & 255
-    g = (value >> 8) & 255
-    b = value & 255
-    return "#%02x%02x%02x" % (r, g, b)

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -466,7 +466,7 @@ class SimpleEvaluation(SegmentationEvaluation):
         else:
             missing = None
 
-        res = SegmentationResults(
+        return SegmentationResults(
             samples,
             self.config,
             eval_key,
@@ -477,7 +477,6 @@ class SimpleEvaluation(SegmentationEvaluation):
             missing=missing,
             backend=self,
         )
-        return res
 
 
 class SegmentationResults(BaseClassificationResults):

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -385,6 +385,8 @@ class SimpleEvaluation(SegmentationEvaluation):
 
         nc = len(values)
         confusion_matrix = np.zeros((nc, nc), dtype=int)
+        ypred_ids = {}
+        ytrue_ids = {}
 
         bandwidth = self.config.bandwidth
         average = self.config.average
@@ -426,6 +428,16 @@ class SimpleEvaluation(SegmentationEvaluation):
                     bandwidth=bandwidth,
                 )
                 sample_conf_mat += image_conf_mat
+                non_zero_indexes = np.nonzero(sample_conf_mat)
+                for index in zip(*non_zero_indexes):
+                    if index not in ypred_ids:
+                        ypred_ids[index] = [pred_seg.id]
+                    else:
+                        ypred_ids[index].append(pred_seg.id)
+                    if index not in ytrue_ids:
+                        ytrue_ids[index] = [gt_seg.id]
+                    else:
+                        ytrue_ids[index].append(gt_seg.id)
 
                 if processing_frames and save:
                     facc, fpre, frec = _compute_accuracy_precision_recall(
@@ -454,15 +466,18 @@ class SimpleEvaluation(SegmentationEvaluation):
         else:
             missing = None
 
-        return SegmentationResults(
+        res = SegmentationResults(
             samples,
             self.config,
             eval_key,
             confusion_matrix,
             classes,
+            ypred_ids=ypred_ids,
+            ytrue_ids=ytrue_ids,
             missing=missing,
             backend=self,
         )
+        return res
 
 
 class SegmentationResults(BaseClassificationResults):
@@ -486,13 +501,15 @@ class SegmentationResults(BaseClassificationResults):
         eval_key,
         pixel_confusion_matrix,
         classes,
+        ypred_ids=None,
+        ytrue_ids=None,
         missing=None,
         custom_metrics=None,
         backend=None,
     ):
         pixel_confusion_matrix = np.asarray(pixel_confusion_matrix)
-        ytrue, ypred, weights = self._parse_confusion_matrix(
-            pixel_confusion_matrix, classes
+        ytrue, ypred, weights, ytrue_ids, ypred_ids = self._parse_confusion_matrix(
+            pixel_confusion_matrix, classes, ypred_ids, ytrue_ids
         )
 
         super().__init__(
@@ -502,6 +519,8 @@ class SegmentationResults(BaseClassificationResults):
             ytrue,
             ypred,
             weights=weights,
+            ytrue_ids=ytrue_ids,
+            ypred_ids=ypred_ids,
             classes=classes,
             missing=missing,
             custom_metrics=custom_metrics,
@@ -541,21 +560,34 @@ class SegmentationResults(BaseClassificationResults):
         )
 
     @staticmethod
-    def _parse_confusion_matrix(confusion_matrix, classes):
+    def _parse_confusion_matrix(confusion_matrix, classes, ytrue_ids_dict, ypred_ids_dict):
         ytrue = []
         ypred = []
         weights = []
+        ytrue_ids = None
+        ypred_ids = None
+        if ytrue_ids_dict is not None and ypred_ids_dict is not None:
+            ytrue_ids = []
+            ypred_ids = []
         nrows, ncols = confusion_matrix.shape
         for i in range(nrows):
             for j in range(ncols):
+                index = (i, j)
                 cij = confusion_matrix[i, j]
                 if cij > 0:
-                    ytrue.append(classes[i])
-                    ypred.append(classes[j])
-                    weights.append(cij)
-
-        return ytrue, ypred, weights
-
+                    if ytrue_ids_dict is not None and ypred_ids_dict is not None:
+                        ytrue_ids+= ytrue_ids_dict[index]
+                        ypred_ids+= ypred_ids_dict[index]
+                        ytrue_multiplier = len(ytrue_ids_dict[index])
+                    else:
+                        ytrue_multiplier = 1
+                    for p in range(ytrue_multiplier):
+                        ytrue.append(classes[i])
+                        ypred.append(classes[j])
+                        weights.append(cij/ytrue_multiplier)
+                    #Note: The weights aren't equally divided by the different ytrue_ids, but it works out for the confusion matrix calculations.
+                    
+        return ytrue, ypred, weights, ytrue_ids, ypred_ids
 
 def _parse_config(pred_field, gt_field, method, **kwargs):
     if method is None:


### PR DESCRIPTION
## Change log

- Adds class/confusion matrix callbacks when evaluating segmentations

## TODO

- [x] Benchmark performance of using label IDs to implement `load_view()`
- [x] Investigate alternatives that don't require calling `load_evaluation_results()`? [cf this comment](https://github.com/voxel51/fiftyone/pull/5331#discussion_r1900245655)
- [ ] Figure out a way to show TP/FP/FN data in the ME panel?
- [ ] Figure out a way to support TP/FP/FN filtering in the App sidebar? 

## Example usage

```py
import random

import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.core.fields as fof
import fiftyone.utils.labels as foul

dataset = foz.load_zoo_dataset("quickstart", max_samples=10, shuffle=True)

model = foz.load_zoo_model("deeplabv3-resnet101-coco-torch")
dataset.apply_model(model, "resnet101")

model = foz.load_zoo_model("deeplabv3-resnet50-coco-torch")
dataset.apply_model(model, "resnet50")

CLASSES = (
    "background,aeroplane,bicycle,bird,boat,bottle,bus,car,cat,chair,cow," +
    "diningtable,dog,horse,motorbike,person,pottedplant,sheep,sofa,train," +
    "tvmonitor"
)
classes = CLASSES.split(",")
mask_targets = {idx: label for idx, label in enumerate(classes)}

rgb_mask_targets = {
    fof.int_to_hex(random.getrandbits(64)): label
    for label in CLASSES.split(",")
}

_mask_targets = {v: k for k, v in mask_targets.items()}
_rgb_mask_targets = {v: k for k, v in rgb_mask_targets.items()}
targets_map = {_mask_targets[c]: _rgb_mask_targets[c] for c in classes}

dataset.clone_sample_field("resnet101", "resnet101_rgb")
foul.transform_segmentations(
    dataset,
    "resnet101_rgb",
    targets_map,
)

dataset.clone_sample_field("resnet50", "resnet50_rgb")
foul.transform_segmentations(
    dataset,
    "resnet50_rgb",
    targets_map,
)

dataset.mask_targets["resnet101"] = mask_targets
dataset.mask_targets["resnet50"] = mask_targets
dataset.mask_targets["resnet101_rgb"] = rgb_mask_targets
dataset.mask_targets["resnet50_rgb"] = rgb_mask_targets
dataset.save()

# Evaluation with int mask targets
dataset.evaluate_segmentations(
    "resnet50",
    gt_field="resnet101",
    eval_key="eval",
)

# Evaluation with RGB mask targets
dataset.evaluate_segmentations(
    "resnet50_rgb",
    gt_field="resnet101_rgb",
    eval_key="eval_rgb",
    mask_targets=dataset.mask_targets["resnet50_rgb"],
)

sesssion = fo.launch_app(dataset)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added color conversion utilities for hex and integer representations
  - Enhanced segmentation evaluation with custom metrics support
  - Introduced dataset caching mechanism
  - Improved model evaluation panel functionality

- **Improvements**
  - Refined handling of segmentation results
  - Added more robust error handling for custom metrics
  - Streamlined segmentation evaluation processes

- **Technical Enhancements**
  - Updated utility functions for more flexible data processing
  - Improved compatibility between different evaluation components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->