### PR TITLE
Cleanup builtin plugins interface

### DIFF
--- a/docs/generate_docs.bash
+++ b/docs/generate_docs.bash
@@ -103,10 +103,16 @@ sphinx-apidoc --force --no-toc --separate --follow-links \
     --templatedir=docs/templates/apidoc \
     -o docs/source/api fiftyone \
         fiftyone/brain/internal/models \
+        fiftyone/constants \
+        fiftyone/internal \
         fiftyone/server \
         fiftyone/service \
         fiftyone/management \
         fiftyone/api
+
+sphinx-apidoc --force --no-toc --separate --follow-links \
+    --templatedir=docs/templates/apidoc \
+    -o docs/source/plugins/api plugins
 
 # Remove symlink
 unlink fiftyone/brain

--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -830,19 +830,19 @@ Tools for working with FiftyOne operators and panels.
 
     available commands:
       {list,info}
-        list       List operators and panels that you've installed locally.
-        info       Prints information about operators and panels that you've installed locally.
+        list       List operators and panels that are installed locally.
+        info       Prints information about operators and panels that are installed locally.
 
 .. _cli-fiftyone-operators-list:
 
 List operators
 ~~~~~~~~~~~~~~
 
-List operators and panels that you've installed locally.
+List operators and panels that are installed locally.
 
 .. code-block:: text
 
-    fiftyone operators list [-h] [-e] [-d] [-o] [-p] [-n]
+    fiftyone operators list [-h] [-e] [-d] [-b] [-c] [-o] [-p] [-n]
 
 **Arguments**
 
@@ -852,6 +852,8 @@ List operators and panels that you've installed locally.
       -h, --help            show this help message and exit
       -e, --enabled         only show enabled operators and panels
       -d, --disabled        only show disabled operators and panels
+      -b, --builtins-only   only show builtin operators and panels
+      -c, --no-builtins     only show non-builtin operators and panels
       -o, --operators-only  only show operators
       -p, --panels-only     only show panels
       -n, --names-only      only show names
@@ -875,7 +877,12 @@ List operators and panels that you've installed locally.
 
 .. code-block:: shell
 
-    # Only list panels
+    # List non-builtin operators and panels
+    fiftyone operators list --no-builtins
+
+.. code-block:: shell
+
+    # List panels
     fiftyone operators list --panels-only
 
 .. _cli-fiftyone-operators-info:
@@ -883,7 +890,7 @@ List operators and panels that you've installed locally.
 Operator info
 ~~~~~~~~~~~~~
 
-Prints information about operators and panels that you've installed locally.
+Prints information about operators and panels that are installed locally.
 
 .. code-block:: text
 
@@ -1169,8 +1176,8 @@ Tools for working with FiftyOne plugins.
 
     available commands:
       {list,info,download,requirements,create,enable,disable,delete}
-        list                List plugins that you've downloaded or created locally.
-        info                Prints information about plugins that you've downloaded or created
+        list                List plugins that are installed locally.
+        info                Prints information about plugins that are installed locally.
         download            Download plugins from the web.
         requirements        Handles package requirements for plugins.
         create              Creates or initializes a plugin.
@@ -1183,21 +1190,23 @@ Tools for working with FiftyOne plugins.
 List plugins
 ~~~~~~~~~~~~
 
-List plugins that you've downloaded or created locally.
+List plugins that are installed locally.
 
 .. code-block:: text
 
-    fiftyone plugins list [-h] [-e] [-d] [-n]
+    fiftyone plugins list [-h] [-e] [-d] [-b] [-c] [-n]
 
 **Arguments**
 
 .. code-block:: text
 
     optional arguments:
-      -h, --help        show this help message and exit
-      -e, --enabled     only show enabled plugins
-      -d, --disabled    only show disabled plugins
-      -n, --names-only  only show plugin names
+      -h, --help           show this help message and exit
+      -e, --enabled        only show enabled plugins
+      -d, --disabled       only show disabled plugins
+      -b, --builtins-only  only show builtin plugins
+      -c, --no-builtins    only show non-builtin plugins
+      -n, --names-only     only show plugin names
 
 **Examples**
 
@@ -1216,12 +1225,17 @@ List plugins that you've downloaded or created locally.
     # List disabled plugins
     fiftyone plugins list --disabled
 
+.. code-block:: shell
+
+    # List non-builtin plugins
+    fiftyone plugins list --no-builtins
+
 .. _cli-fiftyone-plugins-info:
 
 Plugin info
 ~~~~~~~~~~~
 
-List plugins that you've downloaded or created locally.
+List plugins that are installed locally.
 
 .. code-block:: text
 

--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -85,8 +85,7 @@ more complex workflows such as requesting annotation of samples from a
 configurable backend. Operators can even be composed of other operators or be
 used to add functionality to custom panels.
 
-FiftyOne comes with a number of builtin
-:mod:`Python <fiftyone.operators.builtin.operations>` and
+FiftyOne comes with a number of builtin :mod:`Python <plugins.operators>` and
 `JavaScript <https://github.com/voxel51/fiftyone/blob/develop/app/packages/operators/src/built-in-operators.ts>`_
 operators for common tasks that are intended for either user-facing or internal
 plugin use.
@@ -676,7 +675,7 @@ outputs. They can be :ref:`executed <using-operators>` by users in the App or
 triggered internally by other operators.
 
 Operators can be defined in either Python or JS, and FiftyOne comes with a
-number of builtin :mod:`Python <fiftyone.operators.builtin>` and
+number of builtin :mod:`Python <plugins.operators>` and
 `JS <https://github.com/voxel51/fiftyone/blob/develop/app/packages/operators/src/built-in-operators.ts>`_
 operators for common tasks.
 
@@ -1405,11 +1404,10 @@ method via :meth:`ctx.ops <fiftyone.operators.operations.Operations>` and
 :meth:`ctx.trigger <fiftyone.operators.executor.ExecutionContext.trigger>`.
 
 The :meth:`ctx.ops <fiftyone.operators.operations.Operations>` property of an
-execution context exposes all builtin
-:mod:`Python <fiftyone.operators.builtin>` and
+execution context exposes all builtin :mod:`Python <plugins.operators>` and
 `JavaScript <https://github.com/voxel51/fiftyone/blob/develop/app/packages/operators/src/built-in-operators.ts>`_
-in a conveniently documented functional interface. For example, many operations
-involve updating the current state of the App:
+operators in a conveniently documented functional interface. For example, many
+operations involve updating the current state of the App:
 
 .. code-block:: python
     :linenos:

--- a/docs/source/plugins/index.rst
+++ b/docs/source/plugins/index.rst
@@ -128,4 +128,5 @@ App? Just open the :ref:`Embeddings panel <app-embeddings-panel>`:
    Overview <self>
    Using plugins <using_plugins>
    Developing plugins <developing_plugins>
+   API reference <api/plugins>
    TypeScript API reference <ts-api>

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -163,13 +163,13 @@ SDK
 - Improved support for creating summary fields and indexes
   `#5091 <https://github.com/voxel51/fiftyone/pull/5091>`_
 - Added support for creating compound indexes when using the builtin
-  :class:`create_index <fiftyone.operators.builtin.CreateIndex>` operator that
+  :class:`create_index <plugins.operators.CreateIndex>` operator that
   optimize sidebar queries for group datasets
   `#5174 <https://github.com/voxel51/fiftyone/pull/5174>`_
 - The builtin
-  :class:`clear_sample_field <fiftyone.operators.builtin.ClearSampleField>`
+  :class:`clear_sample_field <plugins.operators.ClearSampleField>`
   and
-  :class:`clear_frame_field <fiftyone.operators.builtin.ClearFrameField>`
+  :class:`clear_frame_field <plugins.operators.ClearFrameField>`
   operators now support clearing fields of views, in addition to full datasets
   `#5122 <https://github.com/voxel51/fiftyone/pull/5122>`_
 - Fixed a bug that prevented users with `pydantic` installed from loading the

--- a/docs/source/user_guide/evaluation.rst
+++ b/docs/source/user_guide/evaluation.rst
@@ -13,7 +13,7 @@ When you evaluate a model in FiftyOne, you get access to the standard aggregate
 metrics such as classification reports, confusion matrices, and PR curves
 for your model. In addition, FiftyOne can also record fine-grained statistics
 like accuracy and false positive counts at the sample-level, which you can
-:ref:`interactively explore <model-evaluation-panel>` in the App to diagnose
+:ref:`interactively explore <app-model-evaluation-panel>` in the App to diagnose
 the strengths and weaknesses of your models on individual data samples.
 
 Sample-level analysis often leads to critical insights that will help you

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2905,7 +2905,7 @@ class OperatorsCommand(Command):
 
 
 class OperatorsListCommand(Command):
-    """List operators and panels that you've installed locally.
+    """List operators and panels that are installed locally.
 
     Examples::
 
@@ -2918,7 +2918,10 @@ class OperatorsListCommand(Command):
         # List disabled operators and panels
         fiftyone operators list --disabled
 
-        # Only list panels
+        # List non-builtin operators and panels
+        fiftyone operators list --no-builtins
+
+        # List panels
         fiftyone operators list --panels-only
     """
 
@@ -2939,11 +2942,25 @@ class OperatorsListCommand(Command):
             help="only show disabled operators and panels",
         )
         parser.add_argument(
+            "-b",
+            "--builtins-only",
+            action="store_true",
+            default=None,
+            help="only show builtin operators and panels",
+        )
+        parser.add_argument(
+            "-c",
+            "--no-builtins",
+            action="store_true",
+            default=None,
+            help="only show non-builtin operators and panels",
+        )
+        parser.add_argument(
             "-o",
             "--operators-only",
             action="store_true",
             default=None,
-            help="only show operators",
+            help="only show non-panel operators",
         )
         parser.add_argument(
             "-p",
@@ -2968,6 +2985,13 @@ class OperatorsListCommand(Command):
         else:
             enabled = "all"
 
+        if args.builtins_only:
+            builtin = True
+        elif args.no_builtins:
+            builtin = False
+        else:
+            builtin = "all"
+
         if args.operators_only:
             type = "operator"
         elif args.panels_only:
@@ -2975,11 +2999,11 @@ class OperatorsListCommand(Command):
         else:
             type = None
 
-        _print_operators_list(enabled, type, args.names_only)
+        _print_operators_list(enabled, builtin, type, args.names_only)
 
 
-def _print_operators_list(enabled, type, names_only):
-    operators = foo.list_operators(enabled=enabled, type=type)
+def _print_operators_list(enabled, builtin, type, names_only):
+    operators = foo.list_operators(enabled=enabled, builtin=builtin, type=type)
 
     if names_only:
         operators_map = defaultdict(list)
@@ -3016,7 +3040,7 @@ def _print_operators_list(enabled, type, names_only):
 
 
 class OperatorsInfoCommand(Command):
-    """Prints info about operators and panels that you've installed locally.
+    """Prints info about operators and panels that are installed locally.
 
     Examples::
 
@@ -3498,7 +3522,7 @@ class PluginsCommand(Command):
 
 
 class PluginsListCommand(Command):
-    """List plugins that you've installed locally.
+    """List plugins that are installed locally.
 
     Examples::
 
@@ -3510,6 +3534,9 @@ class PluginsListCommand(Command):
 
         # List disabled plugins
         fiftyone plugins list --disabled
+
+        # List non-builtin plugins
+        fiftyone plugins list --no-builtins
     """
 
     @staticmethod
@@ -3529,6 +3556,20 @@ class PluginsListCommand(Command):
             help="only show disabled plugins",
         )
         parser.add_argument(
+            "-b",
+            "--builtins-only",
+            action="store_true",
+            default=None,
+            help="only show builtin plugins",
+        )
+        parser.add_argument(
+            "-c",
+            "--no-builtins",
+            action="store_true",
+            default=None,
+            help="only show non-builtin plugins",
+        )
+        parser.add_argument(
             "-n",
             "--names-only",
             action="store_true",
@@ -3544,11 +3585,18 @@ class PluginsListCommand(Command):
         else:
             enabled = "all"
 
-        _print_plugins_list(enabled, args.names_only)
+        if args.builtins_only:
+            builtin = True
+        elif args.no_builtins:
+            builtin = False
+        else:
+            builtin = "all"
+
+        _print_plugins_list(enabled, builtin, args.names_only)
 
 
-def _print_plugins_list(enabled, names_only):
-    plugin_defintions = fop.list_plugins(enabled=enabled)
+def _print_plugins_list(enabled, builtin, names_only):
+    plugin_defintions = fop.list_plugins(enabled=enabled, builtin=builtin)
 
     if names_only:
         for pd in plugin_defintions:
@@ -3558,14 +3606,15 @@ def _print_plugins_list(enabled, names_only):
 
     enabled_plugins = set(fop.list_enabled_plugins())
 
-    headers = ["plugin", "version", "enabled", "directory"]
+    headers = ["plugin", "version", "enabled", "builtin", "directory"]
     rows = []
     for pd in plugin_defintions:
         rows.append(
             {
                 "plugin": pd.name,
                 "version": pd.version or "",
-                "enabled": pd.name in enabled_plugins,
+                "enabled": pd.builtin or pd.name in enabled_plugins,
+                "builtin": pd.builtin,
                 "directory": pd.directory,
             }
         )
@@ -3577,7 +3626,7 @@ def _print_plugins_list(enabled, names_only):
 
 
 class PluginsInfoCommand(Command):
-    """Prints info about plugins that you've installed locally.
+    """Prints info about plugins that are installed locally.
 
     Examples::
 

--- a/fiftyone/operators/registry.py
+++ b/fiftyone/operators/registry.py
@@ -38,7 +38,7 @@ def list_operators(enabled=True, builtin="all", type=None):
     Args:
         enabled (True): whether to include only enabled operators (True) or
             only disabled operators (False) or all operators ("all")
-        builtin (None): whether to include only builtin operators (True) or
+        builtin ("all"): whether to include only builtin operators (True) or
             only non-builtin operators (False) or all operators ("all")
         type (None): whether to include only ``"panel"`` or ``"operator"`` type
             operators

--- a/fiftyone/operators/registry.py
+++ b/fiftyone/operators/registry.py
@@ -32,25 +32,25 @@ def get_operator(operator_uri, enabled=True):
     return operator
 
 
-def list_operators(enabled=True, type=None, builtins_only=False):
+def list_operators(enabled=True, builtin="all", type=None):
     """Returns all available operators.
 
     Args:
         enabled (True): whether to include only enabled operators (True) or
             only disabled operators (False) or all operators ("all")
+        builtin (None): whether to include only builtin operators (True) or
+            only non-builtin operators (False) or all operators ("all")
         type (None): whether to include only ``"panel"`` or ``"operator"`` type
             operators
-        builtins_only (False): whether to include only builtin operators
 
     Returns:
         a list of :class:`fiftyone.operators.Operator` instances
     """
+    if builtin == "all":
+        builtin = None
+
     registry = OperatorRegistry(enabled=enabled)
-    return registry.list_operators(
-        include_builtin=enabled != False,
-        type=type,
-        builtins_only=builtins_only,
-    )
+    return registry.list_operators(builtin=builtin, type=type)
 
 
 def operator_exists(operator_uri, enabled=True):
@@ -81,16 +81,14 @@ class OperatorRegistry(object):
     def __init__(self, enabled=True):
         self.plugin_contexts = fopc.build_plugin_contexts(enabled=enabled)
 
-    def list_operators(
-        self, include_builtin=True, type=None, builtins_only=False
-    ):
+    def list_operators(self, builtin=None, type=None):
         """Lists the available FiftyOne operators.
 
         Args:
-            include_builtin (True): whether to include builtin operators
+            builtin (None): whether to include only builtin operators (True) or
+                only non-builtin operators (False)
             type (None): whether to include only ``"panel"`` or ``"operator"``
                 type operators
-            builtins_only (False): whether to include only builtin operators
 
         Returns:
             a list of :class:`fiftyone.operators.Operator` instances
@@ -100,11 +98,10 @@ class OperatorRegistry(object):
         for pctx in self.plugin_contexts:
             operators.extend(pctx.instances)
 
-        if not include_builtin:
-            operators = [op for op in operators if op._builtin is False]
-
-        if builtins_only:
+        if builtin is True:
             operators = [op for op in operators if op._builtin is True]
+        elif builtin is False:
+            operators = [op for op in operators if op._builtin is False]
 
         if type == "panel":
             operators = [op for op in operators if isinstance(op, Panel)]
@@ -138,7 +135,7 @@ class OperatorRegistry(object):
         Returns:
             True/False
         """
-        for operator in self.list_operators(include_builtin=True):
+        for operator in self.list_operators():
             if operator_uri == operator.uri:
                 return True
 

--- a/fiftyone/operators/server.py
+++ b/fiftyone/operators/server.py
@@ -27,8 +27,8 @@ from .operator import Operator
 
 
 def get_operators(registry: PermissionedOperatorRegistry):
-    operators = registry.list_operators(include_builtin=True, type="operator")
-    panels = registry.list_operators(include_builtin=True, type="panel")
+    operators = registry.list_operators(type="operator")
+    panels = registry.list_operators(type="panel")
     return operators + panels
 
 

--- a/fiftyone/plugins/constants.py
+++ b/fiftyone/plugins/constants.py
@@ -7,6 +7,6 @@ FiftyOne plugins constants.
 """
 import os
 
-BUILTIN_PLUGINS_DIR = os.path.join(
-    os.path.dirname(__file__), "..", "..", "plugins"
+BUILTIN_PLUGINS_DIR = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "plugins")
 )

--- a/fiftyone/plugins/context.py
+++ b/fiftyone/plugins/context.py
@@ -35,7 +35,7 @@ def build_plugin_contexts(enabled=True):
         a list of :class:`PluginContext` instances
     """
     plugin_contexts = []
-    for pd in fop.list_plugins(enabled=enabled, include_builtin=True):
+    for pd in fop.list_plugins(enabled=enabled, builtin="all"):
         pctx = PluginContext(pd)
         pctx.register_all()
         plugin_contexts.append(pctx)
@@ -63,7 +63,9 @@ class PluginContext(object):
 
     @property
     def secrets(self):
-        """List of keys for required secrets as specified in the plugin definition."""
+        """List of keys for required secrets as specified in the plugin
+        definition.
+        """
         return self.plugin_definition.secrets
 
     def has_errors(self):
@@ -96,7 +98,8 @@ class PluginContext(object):
             Any errors are logged rather than being raised.
 
         Args:
-            cls: an :class:`fiftyone.operators.operator.Operator` or :class:`fiftyone.operators.panel.Panel` class
+            cls: an :class:`fiftyone.operators.operator.Operator` or
+                :class:`fiftyone.operators.panel.Panel` class
         """
         try:
             instance = cls(_builtin=self.plugin_definition.builtin)

--- a/fiftyone/plugins/core.py
+++ b/fiftyone/plugins/core.py
@@ -49,13 +49,14 @@ class PluginPackage:
         return f"Plugin(name={self.name}, path={self.path})"
 
 
-def list_plugins(enabled=True, include_builtin=False):
+def list_plugins(enabled=True, builtin=False):
     """Returns the definitions of available plugins.
 
     Args:
         enabled (True): whether to include only enabled plugins (True) or only
             disabled plugins (False) or all plugins ("all")
-        include_builtin (False): whether to include built-in plugins
+        builtin (False): whether to include only builtin plugins (True) or only
+            non-builtin plugins (False) or all plugins ("all")
 
     Returns:
         a list of :class:`PluginDefinition` instances
@@ -63,8 +64,11 @@ def list_plugins(enabled=True, include_builtin=False):
     if enabled == "all":
         enabled = None
 
+    if builtin == "all":
+        builtin = None
+
     plugins = []
-    for p in _list_plugins(enabled=enabled, include_builtin=include_builtin):
+    for p in _list_plugins(enabled=enabled, builtin=builtin):
         try:
             plugins.append(_load_plugin_definition(p))
         except:
@@ -73,21 +77,47 @@ def list_plugins(enabled=True, include_builtin=False):
     return plugins
 
 
-def enable_plugin(plugin_name):
+def enable_plugin(plugin_name, _allow_missing=False):
     """Enables the given plugin.
 
     Args:
         plugin_name: the plugin name
     """
+    try:
+        plugin = get_plugin(plugin_name)
+    except ValueError:
+        if not _allow_missing:
+            raise
+
+        plugin = None
+
+    if plugin is not None and plugin.builtin:
+        raise ValueError(
+            f"Cannot change enablement of builtin plugin '{plugin_name}'"
+        )
+
     _update_plugin_settings(plugin_name, enabled=True)
 
 
-def disable_plugin(plugin_name):
+def disable_plugin(plugin_name, _allow_missing=False):
     """Disables the given plugin.
 
     Args:
         plugin_name: the plugin name
     """
+    try:
+        plugin = get_plugin(plugin_name)
+    except ValueError:
+        if not _allow_missing:
+            raise
+
+        plugin = None
+
+    if plugin is not None and plugin.builtin:
+        raise ValueError(
+            f"Cannot change enablement of builtin plugin '{plugin_name}'"
+        )
+
     _update_plugin_settings(plugin_name, enabled=False)
 
 
@@ -97,9 +127,12 @@ def delete_plugin(plugin_name):
     Args:
         plugin_name: the plugin name
     """
-    plugin = _get_plugin(plugin_name)
+    plugin = get_plugin(plugin_name)
+    if plugin.builtin:
+        raise ValueError(f"Cannot delete builtin plugin '{plugin_name}'")
+
     _update_plugin_settings(plugin_name, delete=True)
-    etau.delete_dir(plugin.path)
+    etau.delete_dir(plugin.directory)
 
 
 def list_downloaded_plugins():
@@ -108,7 +141,7 @@ def list_downloaded_plugins():
     Returns:
         a list of plugin names
     """
-    return _list_plugins_by_name()
+    return _list_plugins_by_name(builtin=False)
 
 
 def list_enabled_plugins():
@@ -117,7 +150,7 @@ def list_enabled_plugins():
     Returns:
         a list of plugin names
     """
-    return _list_plugins_by_name(enabled=True)
+    return _list_plugins_by_name(enabled=True, builtin=False)
 
 
 def list_disabled_plugins():
@@ -126,7 +159,7 @@ def list_disabled_plugins():
     Returns:
         a list of plugin names
     """
-    return _list_plugins_by_name(enabled=False)
+    return _list_plugins_by_name(enabled=False, builtin=False)
 
 
 def get_plugin(name):
@@ -507,18 +540,19 @@ def _parse_plugin_metadata(metadata_path):
     return PluginPackage(plugin_name, plugin_path)
 
 
-def _list_plugins(enabled=None, include_builtin=False):
+def _list_plugins(enabled=None, builtin=None):
+    plugin_paths = []
+
+    if builtin in (True, None):
+        plugin_paths.extend(
+            _iter_plugin_metadata_files(constants.BUILTIN_PLUGINS_DIR)
+        )
+
+    if builtin in (False, None):
+        plugin_paths.extend(_iter_plugin_metadata_files())
+
     plugins = []
-    external_plugin_paths = list(_iter_plugin_metadata_files())
-    builtin_plugin_paths = list(
-        _iter_plugin_metadata_files(constants.BUILTIN_PLUGINS_DIR)
-    )
-    all_plugin_paths = (
-        (external_plugin_paths + builtin_plugin_paths)
-        if include_builtin
-        else external_plugin_paths
-    )
-    for metadata_path in all_plugin_paths:
+    for metadata_path in plugin_paths:
         try:
             plugin = _parse_plugin_metadata(metadata_path)
             plugins.append(plugin)
@@ -537,8 +571,12 @@ def _list_plugins(enabled=None, include_builtin=False):
     return plugins
 
 
-def _list_plugins_by_name(enabled=None, check_for_duplicates=True):
-    plugin_names = [p.name for p in _list_plugins(enabled=enabled)]
+def _list_plugins_by_name(
+    enabled=None, builtin=None, check_for_duplicates=True
+):
+    plugin_names = [
+        p.name for p in _list_plugins(enabled=enabled, builtin=builtin)
+    ]
 
     if check_for_duplicates:
         dups = [n for n, c in Counter(plugin_names).items() if c > 1]
@@ -583,9 +621,9 @@ def _iter_plugin_metadata_files(root_dir=None, strict=False):
                 break
 
 
-def _get_plugin(name, enabled=None, check_for_duplicates=True):
+def _get_plugin(name, enabled=None, builtin=None, check_for_duplicates=True):
     plugin = None
-    for _plugin in _list_plugins(enabled=enabled):
+    for _plugin in _list_plugins(enabled=enabled, builtin=builtin):
         if _plugin.name == name:
             if check_for_duplicates and plugin is not None:
                 raise ValueError(f"Multiple plugins found with name '{name}'")
@@ -651,9 +689,6 @@ def _recommend_label(name):
 
 
 def _update_plugin_settings(plugin_name, enabled=None, delete=False, **kwargs):
-    # This would ensure that the plugin actually exists
-    # _get_plugin(plugin_name)
-
     # Plugins are enabled by default, so if we can't read the App config or it
     # doesn't exist, don't do anything
     okay_missing = enabled in (True, None) and not kwargs
@@ -692,7 +727,7 @@ def _update_plugin_settings(plugin_name, enabled=None, delete=False, **kwargs):
         plugin_settings = plugins[plugin_name]
 
         if enabled in (True, None):
-            # Plugins are enabled by default, so just remove the entry altogether
+            # Plugins are enabled by default, so just remove entry altogether
             plugin_settings.pop("enabled", None)
             if not plugin_settings:
                 plugins.pop(plugin_name)

--- a/fiftyone/plugins/core.py
+++ b/fiftyone/plugins/core.py
@@ -26,7 +26,7 @@ import fiftyone.core.storage as fos
 import fiftyone.core.utils as fou
 from fiftyone.plugins.definitions import PluginDefinition
 from fiftyone.utils.github import GitHubRepository
-import fiftyone.plugins.constants as constants
+import fiftyone.plugins.constants as fpc
 
 PLUGIN_METADATA_FILENAMES = ("fiftyone.yml", "fiftyone.yaml")
 
@@ -545,7 +545,7 @@ def _list_plugins(enabled=None, builtin=None):
 
     if builtin in (True, None):
         plugin_paths.extend(
-            _iter_plugin_metadata_files(constants.BUILTIN_PLUGINS_DIR)
+            _iter_plugin_metadata_files(fpc.BUILTIN_PLUGINS_DIR)
         )
 
     if builtin in (False, None):

--- a/fiftyone/plugins/definitions.py
+++ b/fiftyone/plugins/definitions.py
@@ -13,7 +13,7 @@ import yaml
 import eta.core.serial as etas
 
 import fiftyone as fo
-import fiftyone.plugins.constants as constants
+import fiftyone.plugins.constants as fpc
 
 
 class PluginDefinition(object):
@@ -44,7 +44,7 @@ class PluginDefinition(object):
     @property
     def builtin(self):
         """Whether the plugin is a builtin plugin."""
-        return self.directory.startswith(constants.BUILTIN_PLUGINS_DIR)
+        return self.directory.startswith(fpc.BUILTIN_PLUGINS_DIR)
 
     @property
     def author(self):

--- a/plugins/operators/fiftyone.yml
+++ b/plugins/operators/fiftyone.yml
@@ -3,7 +3,7 @@ description: Core FiftyOne operators
 version: 1.0.0
 fiftyone:
   version: "*"
-url: https://github.com/voxel51/fiftyone/fiftyone/builtins/operators
+url: https://github.com/voxel51/fiftyone/plugins/operators
 operators:
   - edit_field_info
   - clone_selected_samples

--- a/plugins/panels/fiftyone.yml
+++ b/plugins/panels/fiftyone.yml
@@ -1,4 +1,4 @@
-name: "@voxel51/panel"
+name: "@voxel51/panels"
 description: Core FiftyOne panels
 version: 1.0.0
 fiftyone:

--- a/tests/unittests/plugins/core_tests.py
+++ b/tests/unittests/plugins/core_tests.py
@@ -50,19 +50,19 @@ def fiftyone_plugins_dir(tmp_path_factory):
     return fn
 
 
+def test_disable_plugin(app_config_path):
+    fop.disable_plugin("my-plugin", _allow_missing=True)
+    with open(app_config_path, "r") as f:
+        config = json.load(f)
+    assert config["plugins"]["my-plugin"]["enabled"] == False
+
+
 def test_enable_plugin(app_config_path):
-    fop.enable_plugin("my-plugin")
+    fop.enable_plugin("my-plugin", _allow_missing=True)
     with open(app_config_path, "r") as f:
         config = json.load(f)
 
     assert config["plugins"].get("my-plugin", {}).get("enabled", True) == True
-
-
-def test_disable_plugin(app_config_path):
-    fop.disable_plugin("my-plugin")
-    with open(app_config_path, "r") as f:
-        config = json.load(f)
-    assert config["plugins"]["my-plugin"]["enabled"] == False
 
 
 def test_delete_plugin_success(mocker, fiftyone_plugins_dir):


### PR DESCRIPTION
## Change log

Code
- ensure that `enable_plugin()`, `disable_plugin()` and `delete_plugin()` can't be run on builtin plugins
- consolidate `include_builtin` and `builtins_only` arguments into a single `builtin` argument, for consistency with the existing `enabled` argument

CLI
- include `builtin` column in `fiftyone plugins list` output
- include `--builtins-only` and `--no-builtins` filtering options for `fiftyone plugins|operators list`

Docs
- include plugins API reference in docs build
- fix various broken links for builtin operators in the docs

## Example usage

```shell
# Now includes `builtin` column
fiftyone plugins list

# New filtering options
fiftyone plugins list --builtins-only
fiftyone plugins list --no-builtins
fiftyone operators list --builtins-only
fiftyone operators list --no-builtins

# Not allowed
fiftyone plugins enable '@voxel51/operators'
fiftyone plugins disable '@voxel51/operators'
fiftyone plugins delete '@voxel51/operators'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Documentation**
	- Updated documentation for CLI commands related to operators and plugins
	- Added API reference section for plugins
	- Improved clarity of plugin and operator documentation
	- Updated user guide references for model evaluation

- **New Features**
	- Enhanced filtering for operators and plugins (builtin/non-builtin)
	- Added support for more flexible plugin management
	- Introduced example Databricks connector and Data Lens connector

- **Bug Fixes**
	- Improved path normalization for plugin directories
	- Refined error handling for built-in plugins
	- Fixed potential `StopIteration` errors during long-running operations

- **Chores**
	- Updated plugin and panel configuration files
	- Streamlined plugin listing and retrieval logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->