### PR TITLE
heatmap targets memory optimization

### DIFF
--- a/app/packages/looker/src/worker/canvas-decoder.ts
+++ b/app/packages/looker/src/worker/canvas-decoder.ts
@@ -1,9 +1,16 @@
+import { HEATMAP } from "@fiftyone/utilities";
 import { OverlayMask } from "../numpy";
 
-const offScreenCanvas = new OffscreenCanvas(1, 1);
-const offScreenCanvasCtx = offScreenCanvas.getContext("2d", {
-  willReadFrequently: true,
-})!;
+const canvasAndCtx = (() => {
+  if ("OffscreenCanvas" in self) {
+    const offScreenCanvas = new OffscreenCanvas(1, 1);
+    const offScreenCanvasCtx = offScreenCanvas.getContext("2d", {
+      willReadFrequently: true,
+    })!;
+
+    return { canvas: offScreenCanvas, ctx: offScreenCanvasCtx };
+  }
+})();
 
 const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
 /**
@@ -34,7 +41,33 @@ const getPngcolorType = async (blob: Blob): Promise<number | undefined> => {
   return colorType;
 };
 
-export const decodeWithCanvas = async (blob: Blob) => {
+/**
+ * Sets the buffer in place to grayscale by removing the G, B, and A channels.
+ *
+ * This is meant for images that are packed like the following, since the other channels are storing redundant data:
+ *
+ * X, X, X, 255, Y, Y, Y, 255, Z, Z, Z, 255, ...
+ */
+export const recastBufferToMonoChannel = (
+  uint8Array: Uint8ClampedArray,
+  width: number,
+  height: number,
+  stride: number
+) => {
+  const totalPixels = width * height;
+
+  let read = 0;
+  let write = 0;
+
+  while (write < totalPixels) {
+    uint8Array[write++] = uint8Array[read];
+    read += stride;
+  }
+
+  return uint8Array.slice(0, totalPixels).buffer;
+};
+
+export const decodeWithCanvas = async (blob: Blob, cls: string) => {
   let channels: number = 4;
 
   if (blob.type === "image/png") {
@@ -58,6 +91,8 @@ export const decodeWithCanvas = async (blob: Blob) => {
   const imageBitmap = await createImageBitmap(blob);
   const { width, height } = imageBitmap;
 
+  const { canvas: offScreenCanvas, ctx: offScreenCanvasCtx } = canvasAndCtx!;
+
   offScreenCanvas.width = width;
   offScreenCanvas.height = height;
 
@@ -67,26 +102,27 @@ export const decodeWithCanvas = async (blob: Blob) => {
 
   const imageData = offScreenCanvasCtx.getImageData(0, 0, width, height);
 
+  let targetsBuffer = imageData.data.buffer;
+
   if (channels === 1) {
-    // get rid of the G, B, and A channels, new buffer will be 1/4 the size
-    const rawBuffer = imageData.data;
-    const totalPixels = width * height;
+    // recasting because we know from png header that it's grayscale,
+    // but when we decoded using canvas, it's RGBA
+    targetsBuffer = recastBufferToMonoChannel(imageData.data, width, height, 4);
+  }
 
-    let read = 0;
-    let write = 0;
-
-    while (write < totalPixels) {
-      rawBuffer[write++] = rawBuffer[read];
-      // skip "G,B,A"
-      read += 4;
-    }
-
-    const grayScaleData = rawBuffer.slice(0, totalPixels);
-    rawBuffer.set(grayScaleData);
+  if (cls === HEATMAP && channels > 1) {
+    // recast to mono channel because we don't need the other channels
+    targetsBuffer = recastBufferToMonoChannel(
+      imageData.data,
+      width,
+      height,
+      channels
+    );
+    channels = 1;
   }
 
   return {
-    buffer: imageData.data.buffer,
+    buffer: targetsBuffer,
     channels,
     arrayType: "Uint8ClampedArray",
     shape: [height, width],

--- a/app/packages/looker/src/worker/disk-overlay-decoder.ts
+++ b/app/packages/looker/src/worker/disk-overlay-decoder.ts
@@ -1,9 +1,14 @@
 import { getSampleSrc } from "@fiftyone/state/src/recoil/utils";
-import { DETECTION, DETECTIONS } from "@fiftyone/utilities";
+import {
+  DETECTION,
+  DETECTIONS,
+  HEATMAP,
+  SEGMENTATION,
+} from "@fiftyone/utilities";
 import { Coloring, CustomizeColor } from "..";
 import { OverlayMask } from "../numpy";
 import { Colorscale } from "../state";
-import { decodeWithCanvas } from "./canvas-decoder";
+import { decodeWithCanvas, recastBufferToMonoChannel } from "./canvas-decoder";
 import { enqueueFetch } from "./pooled-fetch";
 import { getOverlayFieldFromCls } from "./shared";
 
@@ -114,7 +119,7 @@ export const decodeOverlayOnDisk = async (
   let overlayMask: OverlayMask;
 
   try {
-    overlayMask = await decodeWithCanvas(overlayImageBlob);
+    overlayMask = await decodeWithCanvas(overlayImageBlob, cls);
   } catch (e) {
     console.error(e);
     return;


### PR DESCRIPTION
## What changes are proposed in this pull request?

When png or jpg heatmaps are decoded, in addition to the overlay image buffer (later converted into GPU optimized [ImageBitmap](https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap)), we also store targets buffers for the tooltip. This targets buffer need not be w x h x 4, and can be of shape w x h.

This optimization should significantly reduce the memory footprint of the app when dealing with heatmaps.

## How is this patch tested? If it is not, please explain why.

Unit testing, local testing.

```python
import fiftyone as fo
import fiftyone.zoo as foz
import numpy as np
import cv2
import tempfile

d = foz.load_zoo_dataset("quickstart")
d.name = "quickstart-heatmaps"
d.persistent = True

def expand_dataset(dataset, target_num_samples):
    num_doubles = int(np.ceil(np.log2(target_num_samples / len(dataset))))
    with fo.ProgressBar(start_msg="Expanding dataset") as pb:
        for i in pb(list(range(1, num_doubles + 1))):
            if i == num_doubles:
                tmp = dataset[:(target_num_samples - len(dataset))].clone()
            else:
                tmp = dataset.clone()

            dataset.add_collection(tmp, new_ids=True)
            tmp.delete()

expand_dataset(d, len(d)*3)

def generate_random_fo_heatmap(size):
    heatmap = np.random.rand(size, size)
    heatmap = cv2.resize(heatmap, (size, size))
    heatmap = (heatmap * 255).astype(np.uint8)
    return heatmap

def write_heatmap_to_temp(heatmap, is_jpg=False):
    suffix = ".jpg" if is_jpg else ".png"
    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as f:
        if is_jpg:
            cv2.imwrite(f.name, heatmap, [int(cv2.IMWRITE_JPEG_QUALITY), 1])
        else:
            cv2.imwrite(f.name, heatmap)
    return f.name

try:
    d.delete_sample_field("heatmap")
except:
    pass

heatmap = generate_random_fo_heatmap(1080)

for s in d:
    heatmap_path = write_heatmap_to_temp(heatmap, is_jpg=True)
    s["heatmap"] = fo.Heatmap(map_path=heatmap_path)
    s.save()
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?


-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced canvas decoding with support for different image types
  - Added ability to recast image buffers to mono channel
  - Improved handling of overlay images for various label types (heatmap, segmentation, detection)

- **Bug Fixes**
  - Refined canvas and context creation process
  - Improved image data processing for different color formats

- **Tests**
  - Added comprehensive test cases for new buffer recasting functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->