### PR TITLE
Handle shadowed plugins

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -1239,14 +1239,14 @@ List plugins that are installed locally.
 
 .. code-block:: text
 
-    fiftyone plugins info [-h] NAME
+    fiftyone plugins info [-h] NAME_OR_DIR
 
 **Arguments**
 
 .. code-block:: text
 
     positional arguments:
-      NAME        the plugin name
+      NAME_OR_DIR  the plugin name or directory
 
     optional arguments:
       -h, --help  show this help message and exit
@@ -1257,6 +1257,9 @@ List plugins that are installed locally.
 
     # Prints information about a plugin
     fiftyone plugins info <name>
+
+    # Prints information about a plugin in a given directory
+    fiftyone plugins info <dir>
 
 .. _cli-fiftyone-plugins-download:
 

--- a/fiftyone/plugins/definitions.py
+++ b/fiftyone/plugins/definitions.py
@@ -22,13 +22,16 @@ class PluginDefinition(object):
     Args:
         directory: the directory containing the plugin
         metadata: a plugin metadata dict
+        shadow_paths (None): a list of plugin directories that this plugin
+            shadows
     """
 
     _REQUIRED_METADATA_KEYS = ["name"]
 
-    def __init__(self, directory, metadata):
+    def __init__(self, directory, metadata, shadow_paths=None):
         self._directory = directory
         self._metadata = metadata
+        self._shadow_paths = shadow_paths
         self._validate()
 
     @property
@@ -45,6 +48,11 @@ class PluginDefinition(object):
     def builtin(self):
         """Whether the plugin is a builtin plugin."""
         return self.directory.startswith(fpc.BUILTIN_PLUGINS_DIR)
+
+    @property
+    def shadow_paths(self):
+        """A list of plugin directories that this plugin shadows."""
+        return self._shadow_paths
 
     @property
     def author(self):
@@ -194,6 +202,7 @@ class PluginDefinition(object):
         """
         return {
             "name": self.name,
+            "builtin": self.builtin,
             "author": self.author,
             "version": self.version,
             "url": self.url,
@@ -211,15 +220,17 @@ class PluginDefinition(object):
             "has_js": self.has_js,
             "server_path": self.server_path,
             "secrets": self.secrets,
-            "builtin": self.builtin,
+            "shadow_paths": self.shadow_paths,
         }
 
     @classmethod
-    def from_disk(cls, metadata_path):
+    def from_disk(cls, metadata_path, shadow_paths=None):
         """Creates a :class:`PluginDefinition` for the given metadata file.
 
         Args:
             metadata_path: the path to a plugin ``.yaml`` file
+            shadow_paths (None): a list of plugin directories that this plugin
+                shadows
 
         Returns:
             a :class:`PluginDefinition`
@@ -228,7 +239,7 @@ class PluginDefinition(object):
         with open(metadata_path, "r") as f:
             metadata = yaml.safe_load(f)
 
-        return cls(dirpath, metadata)
+        return cls(dirpath, metadata, shadow_paths=shadow_paths)
 
     def _validate(self):
         missing = [

--- a/tests/unittests/plugins/core_tests.py
+++ b/tests/unittests/plugins/core_tests.py
@@ -150,8 +150,9 @@ def test_find_plugin_error_duplicate_name(mocker, fiftyone_plugins_dir):
         pd = {k: plugin_name + "-" + k for k in _REQUIRED_YML_KEYS}
         f.write(yaml.dump(pd))
 
-    with pytest.raises(ValueError):
-        _ = fop.find_plugin("test-plugin1-name")
+    # Should NOT raise errors
+    _ = fop.find_plugin("test-plugin1-name")
+    _ = fop.get_plugin("test-plugin1-name")
 
 
 def test_github_repository_parse_url():

--- a/tests/unittests/plugins/core_tests.py
+++ b/tests/unittests/plugins/core_tests.py
@@ -140,7 +140,7 @@ def mock_plugin_package_name(plugin_name, plugin_path):
     return fop.core.PluginPackage(plugin_name, plugin_path)
 
 
-def test_find_plugin_error_duplicate_name(mocker, fiftyone_plugins_dir):
+def test_duplicate_plugins(mocker, fiftyone_plugins_dir):
     mocker.patch("fiftyone.config.plugins_dir", fiftyone_plugins_dir)
 
     plugin_name = "test-plugin1"
@@ -150,7 +150,15 @@ def test_find_plugin_error_duplicate_name(mocker, fiftyone_plugins_dir):
         pd = {k: plugin_name + "-" + k for k in _REQUIRED_YML_KEYS}
         f.write(yaml.dump(pd))
 
+    plugin_names = [p.name for p in fop.list_plugins()]
+    assert plugin_names.count("test-plugin1-name") == 1
+
+    plugin_names = [p.name for p in fop.list_plugins(shadowed="all")]
+    assert plugin_names.count("test-plugin1-name") == 2
+
     # Should NOT raise errors
+    fop.disable_plugin("test-plugin1-name")
+    fop.enable_plugin("test-plugin1-name")
     _ = fop.find_plugin("test-plugin1-name")
     _ = fop.get_plugin("test-plugin1-name")
 


### PR DESCRIPTION
## Change log

- Updates the plugins API to gracefully ignore plugins that are "shadowed" by other plugins of the same name
- Ensures that `download_plugin(..., overwrite=True)` and `create_plugin(..., overwrite=True)` cannot overwrite builtin plugins

## Example usage

```shell
PLUGINS_DIR="$(fiftyone config plugins_dir)"

# (if necessary) remove source install of `fiftyone-plugins`
unlink "$PLUGINS_DIR/fiftyone-plugins"

# Install a plugin
fiftyone plugins download \
    https://github.com/voxel51/fiftyone-plugins \
    --plugin-names @voxel51/dashboard

# Duplicate the plugin
ORIG_DIR="$PLUGINS_DIR/@voxel51/dashboard"
DUP_DIR="$PLUGINS_DIR/also_dashboard"
cp -R $ORIG_DIR $DUP_DIR

# See how duplicate plugins are handled
fiftyone plugins list
"""
plugin                            version    enabled    builtin    shadowed    directory
--------------------------------  ---------  ---------  ---------  ----------  ------------------------------------------------------
@voxel51/operators                1.0.0      ✓          ✓                      /Users/Brian/dev/fiftyone/plugins/operators
@voxel51/panels                   1.0.0      ✓          ✓                      /Users/Brian/dev/fiftyone/plugins/panels
@voxel51/dashboard                1.0.1      ✓                                 /Users/Brian/fiftyone/__plugins__/@voxel51/dashboard
@voxel51/dashboard                1.0.1                            ✓           /Users/Brian/fiftyone/__plugins__/also_dashboard
"""

# Verify that the App works
# EG launch the Dashboard panel
fiftyone app launch

# Only affects the "active" plugin
# "Shadowed" plugin remains disabled
fiftyone plugins disable @voxel51/dashboard
fiftyone plugins list

# Only affects the "active" plugin
# "Shadowed" plugin remains disabled
fiftyone plugins enable @voxel51/dashboard
fiftyone plugins list

# Shows the "active" plugin
# The `shadow_paths` row indicates that this plugin is shadowing `also_dashboard`
fiftyone plugins info @voxel51/dashboard

# Show info about a "shadowed" plugin
fiftyone plugins info $DUP_DIR

# Delete a shadowed plugin
rm -rf $DUP_DIR

# The `shadowed` column is only shown if there are actually shadowed plugins
fiftyone plugins list
"""
plugin                            version    enabled    builtin    directory
--------------------------------  ---------  ---------  ---------  ------------------------------------------------------
@voxel51/operators                1.0.0      ✓          ✓          /Users/Brian/dev/fiftyone/plugins/operators
@voxel51/panels                   1.0.0      ✓          ✓          /Users/Brian/dev/fiftyone/plugins/panels
@voxel51/dashboard                1.0.1      ✓                     /Users/Brian/fiftyone/__plugins__/@voxel51/dashboard
"""

# Cleanup
fiftyone plugins delete @voxel51/dashboard

# (if necessary)
cd /path/to/fiftyone-plugins
ln -s "$(pwd)" "$(fiftyone config plugins_dir)/fiftyone-plugins"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced plugin management with support for shadowed plugins.
  - Expanded `fiftyone plugins info` command to accept plugin name or directory path.

- **Documentation**
  - Updated CLI documentation to clarify plugin information retrieval.
  - Improved command usage examples for plugin-related commands.

- **Improvements**
  - Added more comprehensive plugin listing capabilities, including shadowed plugins.
  - Enhanced plugin detection and management logic.
  - Improved error handling and logging for plugin operations.

These updates provide more flexibility and clarity in managing FiftyOne plugins, making it easier to discover and interact with plugin resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->