### PR TITLE
Remove usage of deprecated matplotlib InsetPosition

### DIFF
--- a/fiftyone/core/plots/matplotlib.py
+++ b/fiftyone/core/plots/matplotlib.py
@@ -14,7 +14,6 @@ from matplotlib.widgets import Button, LassoSelector
 from matplotlib.path import Path
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
-from mpl_toolkits.axes_grid1.inset_locator import InsetPosition
 from mpl_toolkits.mplot3d import Axes3D  # pylint: disable=unused-import
 import sklearn.metrics.pairwise as skp
 import sklearn.metrics as skm
@@ -1166,8 +1165,7 @@ class InteractiveCollection(InteractiveMatplotlibPlot):
 
         self._buttons = []
         for i, (label, icon_img, callback) in enumerate(button_defs):
-            bax = self.ax.figure.add_axes([0, 0, 1, 1], label=label)
-            bax.set_axes_locator(InsetPosition(self.ax, _button_pos(i)))
+            bax = self.ax.inset_axes(_button_pos(i), label=label)
             button = Button(
                 bax, "", color=color, hovercolor=hovercolor, image=icon_img
             )


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/5304

## Tested by

In a Jupyter notebook, run the following:

```
%matplotlib notebook
```

```py
import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
results = fob.compute_visualization(dataset, brain_key="img_viz")
```

```py
plot = results.visualize(labels="uniqueness", backend="matplotlib")
plot.show()
```

```py
session = fo.launch_app(dataset)
session.plots.attach(plot)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the method for creating inset axes for buttons in the plot interface
	- Improved code readability by using a more direct approach to adding axes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->