### PR TITLE
Fix confidence handling for keypoint evaluation

### DIFF
--- a/fiftyone/utils/eval/coco.py
+++ b/fiftyone/utils/eval/coco.py
@@ -13,6 +13,7 @@ import numpy as np
 
 import eta.core.utils as etau
 
+import fiftyone.core.labels as fol
 import fiftyone.core.plots as fop
 import fiftyone.utils.iou as foui
 
@@ -552,6 +553,11 @@ def _coco_evaluation_setup(
             label = obj.label if classwise else "all"
             cats[label]["preds"].append(obj)
 
+    if isinstance(preds, fol.Keypoints):
+        sort_key = lambda p: np.nanmean(p.confidence) if p.confidence else -1
+    else:
+        sort_key = lambda p: p.confidence or -1
+
     # Compute IoUs within each category
     pred_ious = {}
     for objects in cats.values():
@@ -559,7 +565,7 @@ def _coco_evaluation_setup(
         preds = objects["preds"]
 
         # Highest confidence predictions first
-        preds = sorted(preds, key=lambda p: p.confidence or -1, reverse=True)
+        preds = sorted(preds, key=sort_key, reverse=True)
 
         if max_preds is not None:
             preds = preds[:max_preds]
@@ -587,6 +593,13 @@ def _compute_matches(
 
         # Match each prediction to the highest available IoU ground truth
         for pred in objects["preds"]:
+            if isinstance(pred, fol.Keypoint):
+                pred_conf = (
+                    np.nanmean(pred.confidence) if pred.confidence else None
+                )
+            else:
+                pred_conf = pred.confidence
+
             if pred.id in pred_ious:
                 best_match = None
                 best_match_iou = iou_thresh
@@ -638,7 +651,7 @@ def _compute_matches(
                             gt.label,
                             pred.label,
                             best_match_iou,
-                            pred.confidence,
+                            pred_conf,
                             gt.id,
                             pred.id,
                             iscrowd(gt),
@@ -651,7 +664,7 @@ def _compute_matches(
                             None,
                             pred.label,
                             None,
-                            pred.confidence,
+                            pred_conf,
                             None,
                             pred.id,
                             None,
@@ -665,7 +678,7 @@ def _compute_matches(
                         None,
                         pred.label,
                         None,
-                        pred.confidence,
+                        pred_conf,
                         None,
                         pred.id,
                         None,

--- a/fiftyone/utils/eval/openimages.py
+++ b/fiftyone/utils/eval/openimages.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 
 import numpy as np
 
+import fiftyone.core.labels as fol
 import fiftyone.core.plots as fop
 import fiftyone.utils.iou as foui
 
@@ -545,6 +546,11 @@ def _open_images_evaluation_setup(
                 if config.expand_pred_hierarchy and label != "all":
                     _expand_detection_hierarchy(cats, obj, config, "preds")
 
+    if isinstance(preds, fol.Keypoints):
+        sort_key = lambda p: np.nanmean(p.confidence) if p.confidence else -1
+    else:
+        sort_key = lambda p: p.confidence or -1
+
     # Compute IoUs within each category
     pred_ious = {}
     for objects in cats.values():
@@ -552,7 +558,7 @@ def _open_images_evaluation_setup(
         preds = objects["preds"]
 
         # Highest confidence predictions first
-        preds = sorted(preds, key=lambda p: p.confidence or -1, reverse=True)
+        preds = sorted(preds, key=sort_key, reverse=True)
 
         if max_preds is not None:
             preds = preds[:max_preds]
@@ -583,6 +589,13 @@ def _compute_matches(
 
         # Match each prediction to the highest available IoU ground truth
         for pred in objects["preds"]:
+            if isinstance(pred, fol.Keypoint):
+                pred_conf = (
+                    np.nanmean(pred.confidence) if pred.confidence else None
+                )
+            else:
+                pred_conf = pred.confidence
+
             if pred.id in pred_ious:
                 best_match = None
                 best_match_iou = iou_thresh
@@ -667,7 +680,7 @@ def _compute_matches(
                                 gt.label,
                                 pred.label,
                                 best_match_iou,
-                                pred.confidence,
+                                pred_conf,
                                 gt.id,
                                 pred.id,
                             )
@@ -679,7 +692,7 @@ def _compute_matches(
                             None,
                             pred.label,
                             None,
-                            pred.confidence,
+                            pred_conf,
                             None,
                             pred.id,
                         )
@@ -687,7 +700,7 @@ def _compute_matches(
             elif pred.label == cat:
                 pred[eval_key] = "fp"
                 matches.append(
-                    (None, pred.label, None, pred.confidence, None, pred.id)
+                    (None, pred.label, None, pred_conf, None, pred.id)
                 )
 
         # Leftover GTs are false negatives


### PR DESCRIPTION
## Change log

- Fixes a bug where `evaluate_detections()` would fail when applied to `Keypoints` fields
    - The reason was that `confidence` is a list, not a scalar, for keypoints

## Example usage

```py
import numpy as np

import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    label_types="detections",
    classes=["person"],
    max_samples=10,
    only_matching=True,
)

model = foz.load_zoo_model("keypoint-rcnn-resnet50-fpn-coco-torch")
dataset.default_skeleton = model.skeleton

dataset.apply_model(model, label_field="gt")

dataset.clone_sample_field("gt_keypoints", "pred_keypoints")

for sample in dataset.iter_samples(autosave=True):
    for keypoint in sample.pred_keypoints.keypoints:
        points = np.array(keypoint.points)
        points += 0.02 * np.random.randn(*points.shape)
        keypoint.points = points.tolist()

# Previously failed; now successfully completes!
results = dataset.evaluate_detections(
    "pred_keypoints",
    gt_field="gt_keypoints",
    eval_key="eval",
)

results.print_report()

# Open Model Evaluation panel and verify that everything loads correctly
session = fo.launch_app(dataset)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced support for keypoint-based object detection evaluations
  - Improved confidence calculation for keypoint predictions

- **Bug Fixes**
  - Fixed handling of confidence values for different prediction types
  - Resolved potential issues with NaN confidence values during evaluation

- **Improvements**
  - Updated sorting and matching logic for keypoint predictions
  - More robust evaluation process for object detection metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->