### PR TITLE
Removed registry._EXTRA_OPERATORS

### DIFF
--- a/fiftyone/operators/registry.py
+++ b/fiftyone/operators/registry.py
@@ -68,9 +68,6 @@ def operator_exists(operator_uri, enabled=True):
     return registry.operator_exists(operator_uri)
 
 
-_EXTRA_OPERATORS = []
-
-
 class OperatorRegistry(object):
     """Operator registry.
 
@@ -94,7 +91,6 @@ class OperatorRegistry(object):
             a list of :class:`fiftyone.operators.Operator` instances
         """
         operators = []
-        operators.extend(_EXTRA_OPERATORS)
         for pctx in self.plugin_contexts:
             operators.extend(pctx.instances)
 

--- a/tests/unittests/operators/executor_tests.py
+++ b/tests/unittests/operators/executor_tests.py
@@ -1,16 +1,13 @@
 import pytest
-from unittest.mock import MagicMock, patch
-from starlette.exceptions import HTTPException
+from unittest.mock import patch
 
 import fiftyone.operators.types as types
 from fiftyone.operators.operator import Operator
 from fiftyone.operators.executor import (
     execute_or_delegate_operator,
     ExecutionResult,
-    ExecutionContext,
 )
 from fiftyone.operators import OperatorConfig
-import fiftyone.operators.registry as registry
 
 
 ECHO_URI = "@voxel51/operators/echo"
@@ -30,12 +27,11 @@ class EchoOperator(Operator):
         return {"message": ctx.params.get("message", None)}
 
 
-# Force registration of the operator for testing
-registry._EXTRA_OPERATORS.append(EchoOperator(_builtin=True))
-
-
 @pytest.mark.asyncio
-async def test_execute_or_delegate_operator():
+@patch("fiftyone.operators.registry.OperatorRegistry.list_operators")
+async def test_execute_or_delegate_operator(list_operators):
+    list_operators.return_value = [EchoOperator(_builtin=True)]
+
     request_params = {
         "dataset_name": "test_dataset",
         "operator_uri": ECHO_URI,

--- a/tests/unittests/operators/registry_tests.py
+++ b/tests/unittests/operators/registry_tests.py
@@ -1,0 +1,51 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from fiftyone.operators.registry import OperatorRegistry
+from fiftyone.operators import Panel
+
+
+class TestOperatorRegistry(unittest.TestCase):
+    @patch('fiftyone.plugins.context.build_plugin_contexts')
+    def setUp(self, mock_build_plugin_contexts):
+        # Mocking plugin contexts and operators
+        self.mock_contexts = [
+            MagicMock(instances=[
+                MagicMock(_builtin=True, spec=Panel),
+                MagicMock(_builtin=False, spec=object),
+            ]),
+            MagicMock(instances=[
+                MagicMock(_builtin=True, spec=object),
+                MagicMock(_builtin=False, spec=Panel),
+            ]),
+        ]
+        mock_build_plugin_contexts.return_value = self.mock_contexts
+
+        self.registry = OperatorRegistry()
+
+    def test_list_all_operators(self):
+        operators = self.registry.list_operators()
+        self.assertEqual(len(operators), 4)
+
+    def test_list_builtin_operators(self):
+        operators = self.registry.list_operators(builtin=True)
+        self.assertTrue(all(op._builtin for op in operators))
+        self.assertEqual(len(operators), 2)
+
+    def test_list_non_builtin_operators(self):
+        operators = self.registry.list_operators(builtin=False)
+        self.assertTrue(all(not op._builtin for op in operators))
+        self.assertEqual(len(operators), 2)
+
+    def test_list_panel_type_operators(self):
+        operators = self.registry.list_operators(type="panel")
+        self.assertTrue(all(isinstance(op, Panel) for op in operators))
+        self.assertEqual(len(operators), 2)
+
+    def test_list_operator_type_operators(self):
+        operators = self.registry.list_operators(type="operator")
+        self.assertTrue(all(not isinstance(op, Panel) for op in operators))
+        self.assertEqual(len(operators), 2)
+
+    def test_list_invalid_type_raises_error(self):
+        with self.assertRaises(ValueError):
+            self.registry.list_operators(type="invalid")

--- a/tests/unittests/operators/registry_tests.py
+++ b/tests/unittests/operators/registry_tests.py
@@ -47,5 +47,14 @@ class TestOperatorRegistry(unittest.TestCase):
         self.assertEqual(len(operators), 2)
 
     def test_list_invalid_type_raises_error(self):
-        with self.assertRaises(ValueError):
-            self.registry.list_operators(type="invalid")
+        for operator_type in ["invalid", "", 1]:
+            with self.assertRaises(ValueError):
+                self.registry.list_operators(type=operator_type)
+
+    def test_list_operators_empty_contexts(self):
+        with patch(
+                'fiftyone.plugins.context.build_plugin_contexts') as mock_build:
+            mock_build.return_value = []
+            registry = OperatorRegistry()
+            operators = registry.list_operators()
+            self.assertEqual(len(operators), 0)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Used patching so we don't have to inject operators for testing

## How is this patch tested? If it is not, please explain why.

* Ran unit test locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Removed `_EXTRA_OPERATORS` variable from the operator registry.

- **Tests**
	- Modified test function to use mocked `list_operators` method.
	- Introduced a new test suite for the `OperatorRegistry` class, validating various scenarios for operator listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->