### PR TITLE
Add on_cancel callback for operator prompt

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/OperatorExecutionButtonView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/OperatorExecutionButtonView.tsx
@@ -11,6 +11,7 @@ import TooltipProvider from "./TooltipProvider";
 import { OperatorExecutionOption } from "@fiftyone/operators/src/state";
 import {
   ExecutionCallback,
+  ExecutionCancelCallback,
   ExecutionErrorCallback,
 } from "@fiftyone/operators/src/types-internal";
 import { OperatorResult } from "@fiftyone/operators/src/operators";
@@ -30,6 +31,8 @@ export default function OperatorExecutionButtonView(props: ViewPropsType) {
     on_error,
     on_success,
     on_option_selected,
+    on_cancel,
+    prompt,
   } = view;
   const panelId = usePanelId();
   const variant = getVariant(props);
@@ -75,6 +78,13 @@ export default function OperatorExecutionButtonView(props: ViewPropsType) {
       });
     }
   };
+  const handleOnCancel: ExecutionCancelCallback = () => {
+    if (on_cancel) {
+      triggerEvent(panelId, {
+        operator: on_cancel,
+      });
+    }
+  };
   const handleOnOptionSelected = (option: OperatorExecutionOption) => {
     if (on_option_selected) {
       triggerEvent(panelId, {
@@ -86,6 +96,13 @@ export default function OperatorExecutionButtonView(props: ViewPropsType) {
     }
   };
 
+  const iconProps = prompt
+    ? {}
+    : {
+        startIcon: icon_position === "left" ? Icon : undefined,
+        endIcon: icon_position === "right" ? Icon : undefined,
+      };
+
   return (
     <Box {...getComponentProps(props, "container")}>
       <TooltipProvider title={title} {...getComponentProps(props, "tooltip")}>
@@ -94,11 +111,12 @@ export default function OperatorExecutionButtonView(props: ViewPropsType) {
           onSuccess={handleOnSuccess}
           onError={handleOnError}
           onOptionSelected={handleOnOptionSelected}
+          prompt={prompt}
+          onCancel={handleOnCancel}
           executionParams={computedParams}
           variant={variant}
           disabled={disabled}
-          startIcon={icon_position === "left" ? Icon : undefined}
-          endIcon={icon_position === "right" ? Icon : undefined}
+          {...iconProps}
           title={description}
           {...getComponentProps(props, "button", getButtonProps(props))}
         >

--- a/app/packages/core/src/plugins/SchemaIO/components/TooltipProvider.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TooltipProvider.tsx
@@ -6,7 +6,7 @@ export default function TooltipProvider(props: TooltipProps) {
   if (!title) return children;
   return (
     <Tooltip title={title} {...tooltipProps}>
-      <Box>{children}</Box>
+      <Box component="span">{children}</Box>
     </Tooltip>
   );
 }

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -1037,6 +1037,7 @@ class PromptUserForOperation extends Operator {
     inputs.obj("params", { label: "Params" });
     inputs.str("on_success", { label: "On success" });
     inputs.str("on_error", { label: "On error" });
+    inputs.str("on_cancel", { label: "On cancel" });
     inputs.bool("skip_prompt", { label: "Skip prompt", default: false });
     return new types.Property(inputs);
   }
@@ -1045,7 +1046,8 @@ class PromptUserForOperation extends Operator {
     return { triggerEvent };
   }
   async execute(ctx: ExecutionContext): Promise<void> {
-    const { params, operator_uri, on_success, on_error } = ctx.params;
+    const { params, operator_uri, on_success, on_error, on_cancel } =
+      ctx.params;
     const { triggerEvent } = ctx.hooks;
     const panelId = ctx.getCurrentPanelId();
     const shouldPrompt = !ctx.params.skip_prompt;
@@ -1054,6 +1056,14 @@ class PromptUserForOperation extends Operator {
       operator: operator_uri,
       params,
       prompt: shouldPrompt,
+      onCancel: () => {
+        if (on_cancel) {
+          triggerEvent(panelId, {
+            operator: on_cancel,
+            params: { operator_uri },
+          });
+        }
+      },
       callback: (result: OperatorResult, opts: { ctx: ExecutionContext }) => {
         const ctx = opts.ctx;
         if (result.error) {

--- a/app/packages/operators/src/components/OperatorExecutionButton/index.tsx
+++ b/app/packages/operators/src/components/OperatorExecutionButton/index.tsx
@@ -1,11 +1,17 @@
 import { Button } from "@mui/material";
 import { OperatorExecutionTrigger } from "../OperatorExecutionTrigger";
-import React from "react";
+import React, { useCallback, useMemo } from "react";
 import {
   ExecutionCallback,
   ExecutionErrorCallback,
+  OperatorExecutorOptions,
 } from "../../types-internal";
-import { OperatorExecutionOption } from "../../state";
+import {
+  OperatorExecutionOption,
+  useOperatorExecutionOptions,
+  useOperatorExecutor,
+  usePromptOperatorInput,
+} from "../../state";
 
 /**
  * Button which acts as a trigger for opening an `OperatorExecutionMenu`.
@@ -16,33 +22,89 @@ import { OperatorExecutionOption } from "../../state";
  * @param executionParams Parameters to provide to the operator's execute call
  * @param onOptionSelected Callback for execution option selection
  * @param disabled If true, disables the button and context menu
+ * @param executorOptions Operator executor options
  */
 export const OperatorExecutionButton = ({
   operatorUri,
   onSuccess,
   onError,
   onClick,
+  onCancel,
   executionParams,
   onOptionSelected,
+  prompt,
   disabled,
   children,
+  executorOptions,
   ...props
 }: {
   operatorUri: string;
   onSuccess?: ExecutionCallback;
   onError?: ExecutionErrorCallback;
   onClick?: () => void;
+  onCancel?: () => void;
+  prompt?: boolean;
   executionParams?: object;
   onOptionSelected?: (option: OperatorExecutionOption) => void;
   disabled?: boolean;
   children: React.ReactNode;
+  executorOptions?: OperatorExecutorOptions;
 }) => {
+  // Pass onSuccess and onError through to the operator executor.
+  // These will be invoked on operator completion.
+  const operatorHandlers = useMemo(() => {
+    return { onSuccess, onError };
+  }, [onSuccess, onError]);
+  const operator = useOperatorExecutor(operatorUri, operatorHandlers);
+  const promptForOperator = usePromptOperatorInput();
+
+  // This callback will be invoked when an execution target option is clicked
+  const onExecute = useCallback(
+    (options?: OperatorExecutorOptions) => {
+      const resolvedOptions = {
+        ...executorOptions,
+        ...options,
+      };
+
+      if (prompt) {
+        promptForOperator(operatorUri, executionParams, {
+          callback: (result, opts) => {
+            if (result?.error) {
+              onError?.(result, opts);
+            } else {
+              onSuccess?.(result, opts);
+            }
+          },
+          onCancel,
+        });
+      } else {
+        return operator.execute(executionParams ?? {}, resolvedOptions);
+      }
+    },
+    [executorOptions, operator, executionParams]
+  );
+
+  const { executionOptions } = useOperatorExecutionOptions({
+    operatorUri,
+    onExecute,
+  });
+
+  if (prompt) {
+    return (
+      <Button disabled={disabled} {...props} onClick={onExecute}>
+        {children}
+      </Button>
+    );
+  }
+
   return (
     <OperatorExecutionTrigger
       operatorUri={operatorUri}
       onClick={onClick}
       onSuccess={onSuccess}
       onError={onError}
+      onCancel={onCancel}
+      prompt={prompt}
       executionParams={executionParams}
       onOptionSelected={onOptionSelected}
       disabled={disabled}

--- a/app/packages/operators/src/components/OperatorExecutionButton/index.tsx
+++ b/app/packages/operators/src/components/OperatorExecutionButton/index.tsx
@@ -1,17 +1,18 @@
+import TooltipProvider from "@fiftyone/core/src/plugins/SchemaIO/components/TooltipProvider";
 import { Button } from "@mui/material";
-import { OperatorExecutionTrigger } from "../OperatorExecutionTrigger";
 import React, { useCallback, useMemo } from "react";
-import {
-  ExecutionCallback,
-  ExecutionErrorCallback,
-  OperatorExecutorOptions,
-} from "../../types-internal";
 import {
   OperatorExecutionOption,
   useOperatorExecutionOptions,
   useOperatorExecutor,
   usePromptOperatorInput,
 } from "../../state";
+import {
+  ExecutionCallback,
+  ExecutionErrorCallback,
+  OperatorExecutorOptions,
+} from "../../types-internal";
+import { OperatorExecutionTrigger } from "../OperatorExecutionTrigger";
 
 /**
  * Button which acts as a trigger for opening an `OperatorExecutionMenu`.
@@ -84,10 +85,23 @@ export const OperatorExecutionButton = ({
     [executorOptions, operator, executionParams]
   );
 
-  const { executionOptions } = useOperatorExecutionOptions({
-    operatorUri,
-    onExecute,
-  });
+  const { executionOptions, warningMessage, showWarning, isLoading } =
+    useOperatorExecutionOptions({
+      operatorUri,
+      onExecute,
+    });
+
+  if (isLoading) return null;
+
+  if (showWarning) {
+    return (
+      <TooltipProvider title={warningMessage}>
+        <Button disabled={true} variant={props.variant}>
+          {children}
+        </Button>
+      </TooltipProvider>
+    );
+  }
 
   if (prompt) {
     return (
@@ -107,6 +121,7 @@ export const OperatorExecutionButton = ({
       prompt={prompt}
       executionParams={executionParams}
       onOptionSelected={onOptionSelected}
+      executionOptions={executionOptions}
       disabled={disabled}
     >
       <Button disabled={disabled} {...props}>

--- a/app/packages/operators/src/components/OperatorExecutionTrigger/index.tsx
+++ b/app/packages/operators/src/components/OperatorExecutionTrigger/index.tsx
@@ -46,7 +46,6 @@ export const OperatorExecutionTrigger = ({
   onClick?: () => void;
   onSuccess?: ExecutionCallback;
   onError?: ExecutionErrorCallback;
-  onCancel?: () => void;
   prompt?: boolean;
   executionParams?: object;
   executorOptions?: OperatorExecutorOptions;

--- a/app/packages/operators/src/components/OperatorExecutionTrigger/index.tsx
+++ b/app/packages/operators/src/components/OperatorExecutionTrigger/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { Box } from "@mui/material";
+import { Box, Button } from "@mui/material";
 import { OperatorExecutionMenu } from "../OperatorExecutionMenu";
 import {
   ExecutionCallback,
@@ -10,6 +10,7 @@ import {
   OperatorExecutionOption,
   useOperatorExecutionOptions,
   useOperatorExecutor,
+  usePromptOperatorInput,
 } from "../../state";
 
 /**
@@ -38,12 +39,8 @@ import {
  * @param disabled If true, context menu will never open
  */
 export const OperatorExecutionTrigger = ({
-  operatorUri,
   onClick,
-  onSuccess,
-  onError,
-  executionParams,
-  executorOptions,
+  executionOptions,
   onOptionSelected,
   disabled,
   children,
@@ -54,39 +51,17 @@ export const OperatorExecutionTrigger = ({
   onClick?: () => void;
   onSuccess?: ExecutionCallback;
   onError?: ExecutionErrorCallback;
+  onCancel?: () => void;
+  prompt?: boolean;
   executionParams?: object;
   executorOptions?: OperatorExecutorOptions;
+  executionOptions?: OperatorExecutionOption[];
   onOptionSelected?: (option: OperatorExecutionOption) => void;
   disabled?: boolean;
 }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   // Anchor to use for context menu
   const containerRef = useRef(null);
-
-  // Pass onSuccess and onError through to the operator executor.
-  // These will be invoked on operator completion.
-  const operatorHandlers = useMemo(() => {
-    return { onSuccess, onError };
-  }, [onSuccess, onError]);
-  const operator = useOperatorExecutor(operatorUri, operatorHandlers);
-
-  // This callback will be invoked when an execution target option is clicked
-  const onExecute = useCallback(
-    (options?: OperatorExecutorOptions) => {
-      const resolvedOptions = {
-        ...executorOptions,
-        ...options,
-      };
-
-      return operator.execute(executionParams ?? {}, resolvedOptions);
-    },
-    [executorOptions, operator, executionParams]
-  );
-
-  const { executionOptions } = useOperatorExecutionOptions({
-    operatorUri,
-    onExecute,
-  });
 
   // Click handler controls the state of the context menu.
   const clickHandler = useCallback(() => {

--- a/app/packages/operators/src/components/OperatorExecutionTrigger/index.tsx
+++ b/app/packages/operators/src/components/OperatorExecutionTrigger/index.tsx
@@ -1,17 +1,12 @@
-import React, { useCallback, useMemo, useRef, useState } from "react";
-import { Box, Button } from "@mui/material";
+import React, { useCallback, useRef, useState } from "react";
+import { Box } from "@mui/material";
 import { OperatorExecutionMenu } from "../OperatorExecutionMenu";
 import {
   ExecutionCallback,
   ExecutionErrorCallback,
   OperatorExecutorOptions,
 } from "../../types-internal";
-import {
-  OperatorExecutionOption,
-  useOperatorExecutionOptions,
-  useOperatorExecutor,
-  usePromptOperatorInput,
-} from "../../state";
+import { OperatorExecutionOption } from "../../state";
 
 /**
  * Component which acts as a trigger for opening an `OperatorExecutionMenu`.

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -422,6 +422,10 @@ export const useOperatorExecutionOptions = ({
   onExecute: (opts: OperatorExecutorOptions) => void;
 }): {
   executionOptions: OperatorExecutionOption[];
+  hasOptions: boolean;
+  warningMessage: React.ReactNode;
+  showWarning: boolean;
+  isLoading: boolean;
 } => {
   const ctx = useExecutionContext(operatorUri);
   const { isRemote } = getLocalOrRemoteOperator(operatorUri);
@@ -434,6 +438,10 @@ export const useOperatorExecutionOptions = ({
 
   return {
     executionOptions: submitOptions.options,
+    hasOptions: submitOptions.hasOptions,
+    warningMessage: submitOptions.warningMessage,
+    showWarning: submitOptions.showWarning,
+    isLoading: execDetails.isLoading,
   };
 };
 

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -579,6 +579,11 @@ export const useOperatorPrompt = () => {
     },
     [operator, promptingOperator, cachedResolvedInput]
   );
+  const onCancel = promptingOperator.options?.onCancel;
+  const cancel = () => {
+    if (onCancel) onCancel();
+    close();
+  };
   const close = () => {
     setPromptingOperator(null);
     setInputFields(null);
@@ -656,7 +661,7 @@ export const useOperatorPrompt = () => {
     isExecuting,
     hasResultOrError,
     close,
-    cancel: close,
+    cancel,
     validationErrors,
     validate,
     validateThrottled,

--- a/app/packages/operators/src/types-internal.ts
+++ b/app/packages/operators/src/types-internal.ts
@@ -9,6 +9,7 @@ export type ExecutionErrorCallback = (
   error: OperatorResult,
   options: ExecutionCallbackOptions
 ) => void;
+export type ExecutionCancelCallback = () => void;
 
 export type OperatorExecutorOptions = {
   delegationTarget?: string;

--- a/app/packages/operators/src/usePanelEvent.ts
+++ b/app/packages/operators/src/usePanelEvent.ts
@@ -11,6 +11,7 @@ type HandlerOptions = {
   prompt?: boolean;
   panelId: string;
   callback?: ExecutionCallback;
+  onCancel?: () => void;
   currentPanelState?: any; // most current panel state
 };
 
@@ -20,7 +21,7 @@ export default function usePanelEvent() {
   const { increment, decrement } = useActivePanelEventsCount("");
   return usePanelStateByIdCallback((panelId, panelState, args) => {
     const options = args[0] as HandlerOptions;
-    const { params, operator, prompt, currentPanelState } = options;
+    const { params, operator, prompt, currentPanelState, onCancel } = options;
 
     if (!operator) {
       notify({
@@ -49,7 +50,10 @@ export default function usePanelEvent() {
     };
 
     if (prompt) {
-      promptForOperator(operator, actualParams, { callback: eventCallback });
+      promptForOperator(operator, actualParams, {
+        callback: eventCallback,
+        onCancel,
+      });
     } else {
       increment(panelId);
       executeOperator(operator, actualParams, { callback: eventCallback });

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -744,6 +744,7 @@ class ExecutionContext(object):
         params=None,
         on_success=None,
         on_error=None,
+        on_cancel=None,
         skip_prompt=False,
     ):
         """Prompts the user to execute the operator with the given URI.
@@ -754,6 +755,7 @@ class ExecutionContext(object):
             on_success (None): a callback to invoke if the user successfully
                 executes the operator
             on_error (None): a callback to invoke if the execution fails
+            on_cancel (None): a callback to invoke if the user cancels the prompt
             skip_prompt (False): whether to skip the prompt
 
         Returns:
@@ -769,6 +771,7 @@ class ExecutionContext(object):
                     "params": params,
                     "on_success": on_success,
                     "on_error": on_error,
+                    "on_cancel": on_cancel,
                     "skip_prompt": skip_prompt,
                 }
             ),


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds a new `on_cancel` callback when prompting for an operator. This will be called if a user cancels the operator prompt. NOTE: this behavior is not intended or available for immediately executing operators, such as when `skip_prompt=True` or the operator does not have input.

The example below is available as [a panel example here](https://github.com/voxel51/fiftyone-plugins/pull/194).

```python
class PromptExample(foo.Panel):
    def render(self, ctx):
        panel = types.Object()
        msg = ctx.panel.state.message
        result = f"message: {msg}" if msg else "..."
        panel.md(
            f"""
            ### Prompt Example

            This is an example of a prompt that can be used to gather user input.
                 
            {result}
        """
        )
        panel.btn("prompt", label="Prompt", on_click=self.on_click_prompt)
        return types.Property(
            panel,
            view=types.GridView(margin=5),
        )

    def on_success(self, ctx):
        ctx.panel.state.message = ctx.params.get("result", {}).get("message")
        ctx.ops.notify("Prompt was successful!")

    def on_cancel(self, ctx):
        ctx.ops.notify("Prompt was canceled", variant="warning")

    def on_click_prompt(self, ctx):
        ctx.prompt(
            "@voxel51/panel-examples/example_message",
            on_success=self.on_success,
            # NEW
            on_cancel=self.on_cancel,
        )
```

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Adds a new `on_cancel` event for `ctx.prompt()`.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Plugins
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added a new `on_cancel` parameter to prompt operations across multiple components.
	- Introduced enhanced cancellation handling for operator prompts.
	- Implemented a flexible mechanism to execute custom logic when a prompt is canceled.
	- Added new properties `onCancel` and `prompt` to relevant components for improved interaction.

- **Improvements**
	- Extended prompt functionality to support more robust user interaction scenarios.
	- Improved error handling and user experience during operation cancellations.
	- Streamlined component logic for better management of operator execution and menu interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->