### PR TITLE
Require HTTP polling for GitHub Codespaces context

### DIFF
--- a/fiftyone/core/context.py
+++ b/fiftyone/core/context.py
@@ -5,6 +5,7 @@ Context utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import json
 import os
 import typing as t
@@ -140,6 +141,18 @@ def _get_context():
     return _context
 
 
+def _requires_http_polling():
+    ### SSE is unreliable in GitHub Codespaces
+    if os.environ.get("CODESPACES", None) == "true":
+        return True
+
+    # SSE does not work in Colab
+    if _get_context() == _COLAB:
+        return True
+
+    return False
+
+
 def get_url(
     address: str,
     port: int,
@@ -153,7 +166,6 @@ def get_url(
         from google.colab.output import eval_js
 
         _url = eval_js(f"google.colab.kernel.proxyPort({port})")
-        kwargs["polling"] = "true"
     elif _context == _DATABRICKS:
         _url = _get_databricks_proxy_url(port)
         kwargs["proxy"] = _get_databricks_proxy(port)
@@ -166,7 +178,7 @@ def get_url(
     else:
         _url = f"http://{address}:{port}/"
 
-    if "proxy" in kwargs:
+    if "proxy" in kwargs or _requires_http_polling():
         kwargs["polling"] = "true"
 
     params = "&".join([f"{k}={v}" for k, v in kwargs.items()])

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -8,10 +8,8 @@ Session class for interacting with the FiftyOne App.
 
 from collections import defaultdict
 from functools import wraps
-from importlib import metadata
 import logging
 import os
-from packaging.requirements import Requirement
 import time
 import typing as t
 from uuid import uuid4
@@ -34,7 +32,6 @@ from fiftyone.core.config import AppConfig
 import fiftyone.core.context as focx
 import fiftyone.core.plots as fop
 import fiftyone.core.service as fos
-import fiftyone.core.sample as fosa
 from fiftyone.core.state import build_color_scheme, StateDescription
 import fiftyone.core.utils as fou
 import fiftyone.core.view as fov


### PR DESCRIPTION
## What changes are proposed in this pull request?

SSE has been shown to be an unreliable `/events `connection in GitHub Codespaces. This change adds the `polling=true` URL search parameter to a `Session.url` value automatically for a reliable HTTP polling connection in Codespaces. The `CODESPACES=true` env var indicates a Codespaces context.

Minor cleanup since Colab also requires HTTP polling.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved context-aware HTTP polling mechanism
	- Added optional `view_name` parameter for session initialization

- **Refactor**
	- Updated logic for determining HTTP polling requirements
	- Reorganized import statements

The changes enhance the application's adaptability in various computing environments, particularly for Codespaces and Google Colab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->