### PR TITLE
Add support for tooltip overwrite 

### DIFF
--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -1848,17 +1848,23 @@ class Tooltip(View):
         column: the column of the tooltip
     """
 
-    def __init__(self, row, column, **kwargs):
+    def __init__(self, row, column, value, **kwargs):
         super().__init__(**kwargs)
         self.row = row
         self.column = column
+        self.value = value
 
     def clone(self):
-        clone = Tooltip(self.row, self.column, **self._kwargs)
+        clone = Tooltip(self.row, self.column, self.value, **self._kwargs)
         return clone
 
     def to_json(self):
-        return {**super().to_json(), "row": self.row, "column": self.column}
+        return {
+            **super().to_json(),
+            "row": self.row,
+            "column": self.column,
+            "value": self.value,
+        }
 
 
 class TableView(View):

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -1906,11 +1906,17 @@ class TableView(View):
         self.row_actions.append(row_action)
         return row_action
 
-    def add_tooltip(self, row, column, value, **kwargs):
+    def add_tooltip(self, row, column, value, overwrite=True, **kwargs):
         if (row, column) in self._tooltip_map:
-            raise ValueError(
-                f"Tooltip for row '{row}' and column '{column}' already exists"
-            )
+            if overwrite:
+                tooltip = self._tooltip_map[(row, column)]
+                tooltip.value = value
+                tooltip.__dict__.update(kwargs)
+                return tooltip
+            else:
+                raise ValueError(
+                    f"Tooltip for row '{row}' and column '{column}' already exists"
+                )
 
         tooltip = Tooltip(row=row, column=column, value=value, **kwargs)
         self.tooltips.append(tooltip)

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -1912,12 +1912,12 @@ class TableView(View):
         self.row_actions.append(row_action)
         return row_action
 
-    def add_tooltip(self, row, column, value, overwrite=True, **kwargs):
+    def add_tooltip(self, row, column, value, overwrite=False, **kwargs):
         if (row, column) in self._tooltip_map:
             if overwrite:
                 tooltip = self._tooltip_map[(row, column)]
                 tooltip.value = value
-                tooltip.__dict__.update(kwargs)
+                tooltip._kwargs = kwargs
                 return tooltip
             else:
                 raise ValueError(

--- a/tests/unittests/operators/tableview_tests.py
+++ b/tests/unittests/operators/tableview_tests.py
@@ -43,10 +43,18 @@ class TableViewTests(unittest.TestCase):
         table.add_tooltip(1, 2, "Tooltip 2")
 
         with self.assertRaises(ValueError):
-            table.add_tooltip(1, 1, "Tooltip 3", overwrite=False)
+            table.add_tooltip(1, 1, "Tooltip 3")
 
-        table.add_tooltip(1, 1, "Tooltip 3")
+        table.add_tooltip(1, 1, "Tooltip 3", arg1=1, arg2=2, overwrite=True)
         self.assertEqual(
             set([tooltip.value for tooltip in table.tooltips]),
             {"Tooltip 2", "Tooltip 3"},
         )
+
+        tooltip = table._tooltip_map[(1, 1)]
+        self.assertEqual(tooltip.value, "Tooltip 3")
+        self.assertEqual(tooltip._kwargs, {"arg1": 1, "arg2": 2})
+
+        result = tooltip.to_json()
+        for key, value in {"value": "Tooltip 3", "arg1": 1, "arg2": 2}.items():
+            self.assertEqual(result[key], value)

--- a/tests/unittests/operators/tableview_tests.py
+++ b/tests/unittests/operators/tableview_tests.py
@@ -43,4 +43,7 @@ class TableViewTests(unittest.TestCase):
         table.add_tooltip(1, 2, "Tooltip 2")
 
         with self.assertRaises(ValueError):
-            table.add_tooltip(1, 1, "Tooltip 3")
+            table.add_tooltip(1, 1, "Tooltip 3", overwrite=False)
+
+        table.add_tooltip(1, 1, "Tooltip 3")
+

--- a/tests/unittests/operators/tableview_tests.py
+++ b/tests/unittests/operators/tableview_tests.py
@@ -46,4 +46,7 @@ class TableViewTests(unittest.TestCase):
             table.add_tooltip(1, 1, "Tooltip 3", overwrite=False)
 
         table.add_tooltip(1, 1, "Tooltip 3")
-
+        self.assertEqual(
+            set([tooltip.value for tooltip in table.tooltips]),
+            {"Tooltip 2", "Tooltip 3"},
+        )


### PR DESCRIPTION
## What changes are proposed in this pull request?

Allowed users to easily overwrite tooltips in TableView and updated tests

## How is this patch tested? If it is not, please explain why.

* Local testing

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a required `value` parameter for tooltips, enhancing tooltip functionality.
  - Updated `add_tooltip` method in TableView to include an `overwrite` parameter for managing existing tooltips.

- **Bug Fixes**
  - Improved error handling for tooltip management when attempting to overwrite existing tooltips.
  - Enhanced validation for tooltip updates, ensuring correct behavior based on the `overwrite` parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->