### PR TITLE
Update docs footer to 2025

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -175,7 +175,7 @@ endblock %} {% block custom_footer %}
 
     <div class="footer__copyright">
       <ul class="list-inline">
-        <li>&copy; 2024 Voxel51 Inc.</li>
+        <li>&copy; 2025 Voxel51 Inc.</li>
         <li>
           <a href="{{link_privacypolicy}}">Privacy Policy</a>
         </li>


### PR DESCRIPTION
## What changes are proposed in this pull request?

Documentation footer 2025 update

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated copyright year in the footer from 2024 to 2025

<!-- end of auto-generated comment: release notes by coderabbit.ai -->