### PR TITLE
Better exception handling reserved attribute

### DIFF
--- a/fiftyone/core/odm/__init__.py
+++ b/fiftyone/core/odm/__init__.py
@@ -64,7 +64,7 @@ from .embedded_document import (
     BaseEmbeddedDocument,
     DynamicEmbeddedDocument,
     EmbeddedDocument,
-    FiftyoneDocumentException,
+    FiftyOneDynamicDocumentException,
 )
 from .frame import (
     DatasetFrameDocument,

--- a/fiftyone/core/odm/__init__.py
+++ b/fiftyone/core/odm/__init__.py
@@ -63,8 +63,8 @@ from .document import (
 from .embedded_document import (
     BaseEmbeddedDocument,
     DynamicEmbeddedDocument,
+    DynamicEmbeddedDocumentException,
     EmbeddedDocument,
-    FiftyOneDynamicDocumentException,
 )
 from .frame import (
     DatasetFrameDocument,

--- a/fiftyone/core/odm/__init__.py
+++ b/fiftyone/core/odm/__init__.py
@@ -64,6 +64,7 @@ from .embedded_document import (
     BaseEmbeddedDocument,
     DynamicEmbeddedDocument,
     EmbeddedDocument,
+    FiftyoneDocumentException,
 )
 from .frame import (
     DatasetFrameDocument,

--- a/fiftyone/core/odm/embedded_document.py
+++ b/fiftyone/core/odm/embedded_document.py
@@ -10,6 +10,11 @@ import mongoengine
 from .document import DynamicMixin, MongoEngineBaseDocument
 
 
+class FiftyoneDocumentException(Exception):
+    """Exception raised when an error occurs in a document operation."""
+    pass
+
+
 class BaseEmbeddedDocument(MongoEngineBaseDocument):
     """Base class for documents that are embedded within other documents and
     therefore are not stored in their own collection in the database.
@@ -40,11 +45,18 @@ class DynamicEmbeddedDocument(
     database.
 
     Dynamic documents can have arbitrary fields added to them.
+
+    Raises FiftyoneDocumentException if a kwarg attribute is reserved.
     """
 
     meta = {"abstract": True, "allow_inheritance": True}
 
     def __init__(self, *args, **kwargs):
+        for key, value in kwargs.items():
+            # Check if the key exists and is a property
+            if hasattr(self.__class__, key) and isinstance(getattr(self.__class__, key), property):
+               raise FiftyoneDocumentException(f"Attribute {key} already exists for {self.__class__.__name__}")
+
         super().__init__(*args, **kwargs)
         self.validate()
 

--- a/fiftyone/core/odm/embedded_document.py
+++ b/fiftyone/core/odm/embedded_document.py
@@ -74,7 +74,7 @@ class DynamicEmbeddedDocument(
                     and isinstance(getattr(self.__class__, key), property)
                 ):
                     raise FiftyOneDynamicDocumentException(
-                        f"Attribute {key} already exists for {self.__class__.__name__}"
+                        f"Invalid attribute name '{key}'. '{key}' is a reserved keyword for {self.__class__.__name__} objects"
                     )
             # If the error is not due to a reserved attribute, raise the original error
             raise e

--- a/fiftyone/core/odm/embedded_document.py
+++ b/fiftyone/core/odm/embedded_document.py
@@ -53,6 +53,10 @@ class DynamicEmbeddedDocument(
 
     def __init__(self, *args, **kwargs):
         for key, value in kwargs.items():
+            # Skip MongoDB internal fields
+            if key.startswith('_'):
+                continue
+
             # Check if the key exists and is a property
             if hasattr(self.__class__, key) and isinstance(getattr(self.__class__, key), property):
                raise FiftyoneDocumentException(f"Attribute {key} already exists for {self.__class__.__name__}")

--- a/tests/unittests/documents.py
+++ b/tests/unittests/documents.py
@@ -9,6 +9,7 @@ To run the unit tests, use the following command:
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+# pylint: disable=no-member
 
 import unittest
 from mongoengine import EmbeddedDocument
@@ -56,7 +57,7 @@ class TestDetection(unittest.TestCase):
         self.valid_detection = {
             "label": "car",
             "bounding_box": [0.1, 0.1, 0.2, 0.2],
-            "confidence": 0.95
+            "confidence": 0.95,
         }
 
     def test_valid_detection_creation(self):
@@ -73,7 +74,8 @@ class TestDetection(unittest.TestCase):
             fo.Detection(has_mask=True)
 
         self.assertTrue(
-            "Attribute has_mask already exists" in str(context.exception))
+            "Invalid attribute name 'has_mask'" in str(context.exception)
+        )
 
     def test_multiple_reserved_attributes(self):
         """Test that attempting to set multiple reserved properties raises FiftyoneDocumentException."""
@@ -81,11 +83,11 @@ class TestDetection(unittest.TestCase):
             fo.Detection(
                 has_mask=True,
                 bounding_box=[0.1, 0.1, 0.2, 0.2],
-                is_ground_truth=False  # Assuming this is another property
+                is_ground_truth=False,  # Assuming this is another property
             )
 
         # Should fail on the first reserved property it encounters
-        self.assertTrue("already exists" in str(context.exception))
+        self.assertTrue("Invalid attribute name" in str(context.exception))
 
     def test_dynamic_attribute_allowed(self):
         """Test that setting a new, non-reserved attribute is allowed."""

--- a/tests/unittests/documents.py
+++ b/tests/unittests/documents.py
@@ -99,3 +99,29 @@ class TestDetection(unittest.TestCase):
 
         self.assertEqual(detection.custom_field, "test")
         self.assertEqual(detection.another_custom_field, 123)
+
+    def test_detection_setattr(self):
+        """Test setting attributes on Detection instances."""
+
+        detection = fo.Detection()
+
+        # Test case 1: Setting a normal attribute (should succeed)
+        detection.custom_field = "value"
+        assert detection.custom_field == "value"
+
+        # Test case 2: Setting reserved properties (should raise exception)
+        with self.assertRaises(FiftyOneDynamicDocumentException) as context:
+            detection.has_mask = "new_label"
+
+    def test_extract_attribute_from_error(self):
+        # Test property setter pattern
+        error_msg1 = "property 'name' of 'MyDoc' object has no setter"
+        assert fo.Detection._extract_attribute_from_error(error_msg1) == "name"
+
+        # Test can't set attribute pattern
+        error_msg2 = "can't set attribute 'age'"
+        assert fo.Detection._extract_attribute_from_error(error_msg2) == "age"
+
+        # Test no match
+        error_msg3 = "some other error"
+        assert fo.Detection._extract_attribute_from_error(error_msg3) is None

--- a/tests/unittests/documents.py
+++ b/tests/unittests/documents.py
@@ -15,7 +15,7 @@ from mongoengine import EmbeddedDocument
 from mongoengine.errors import ValidationError
 from fiftyone.core.fields import EmbeddedDocumentListField
 from fiftyone.core.odm.dataset import SampleFieldDocument
-from fiftyone.core.odm import FiftyoneDocumentException
+from fiftyone.core.odm import FiftyOneDynamicDocumentException
 import fiftyone as fo
 
 
@@ -69,7 +69,7 @@ class TestDetection(unittest.TestCase):
     def test_reserved_attribute_raises_exception(self):
         """Test that attempting to set a reserved property raises FiftyoneDocumentException."""
         # has_mask is a known property of Detection
-        with self.assertRaises(FiftyoneDocumentException) as context:
+        with self.assertRaises(FiftyOneDynamicDocumentException) as context:
             fo.Detection(has_mask=True)
 
         self.assertTrue(
@@ -77,7 +77,7 @@ class TestDetection(unittest.TestCase):
 
     def test_multiple_reserved_attributes(self):
         """Test that attempting to set multiple reserved properties raises FiftyoneDocumentException."""
-        with self.assertRaises(FiftyoneDocumentException) as context:
+        with self.assertRaises(FiftyOneDynamicDocumentException) as context:
             fo.Detection(
                 has_mask=True,
                 bounding_box=[0.1, 0.1, 0.2, 0.2],


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently, when initializing FiftyOne objects like Detection with reserved attribute names (e.g., has_mask), the code fails with a confusing AttributeError indicating that a property has no setter. This error message isn't user-friendly and doesn't clearly explain that these are reserved attributes that shouldn't be set during initialization.

1) Modified the `DynamicEmbeddedDocument.__init__` to proactively check for reserved attributes (implemented as properties) before calling the parent class initializer. If a reserved attribute is detected, it raises a clear FiftyoneDocumentException with a descriptive message.

2) Added comprehensive unit tests to verify this behavior using the Detection class as a test case.

## How is this patch tested? If it is not, please explain why.

* Local testing (✅ )
* Unit test (✅ )

Example:
```
In [1]: import fiftyone as fo

In [2]: fo.Detection(has_mask="none")
---------------------------------------------------------------------------
FiftyoneDocumentException                 Traceback (most recent call last)
Cell In[2], line 1
----> 1 fo.Detection(has_mask="none")

File ~/workspace/fiftyone/fiftyone/core/odm/embedded_document.py:58, in DynamicEmbeddedDocument.__init__(self, *args, **kwargs)
     55 for key, value in kwargs.items():
     56     # Check if the key exists and is a property
     57     if hasattr(self.__class__, key) and isinstance(getattr(self.__class__, key), property):
---> 58        raise FiftyoneDocumentException(f"Attribute {key} already exists for {self.__class__.__name__}")
     60 super().__init__(*args, **kwargs)
     61 self.validate()

FiftyoneDocumentException: Attribute has_mask already exists for Detection
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new exception class `DynamicEmbeddedDocumentException` for improved error handling related to dynamic document operations.
	- Enhanced document initialization with stricter validation for reserved attributes.

- **Tests**
	- Added a new test class for validating the behavior of the `Detection` class.
	- Verified exception handling for reserved attributes during object initialization and attribute setting.
	- Ensured correct extraction of attribute names from exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->