### PR TITLE
fit limit for confusion matrix in model eval

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -1679,7 +1679,7 @@ function getMatrix(matrices, config, maskTargets, compareMaskTargets?) {
     return compareMaskTargets?.[c] || maskTargets?.[c] || c;
   });
   const noneIndex = originalClasses.indexOf(NONE_CLASS);
-  if (parsedLimit < originalClasses.length) {
+  if (parsedLimit < originalClasses.length && noneIndex > -1) {
     labels.push(
       compareMaskTargets?.[NONE_CLASS] ||
         maskTargets?.[NONE_CLASS] ||


### PR DESCRIPTION
## What changes are proposed in this pull request?

fit limit for confusion matrix in model eval when there are no missing counts

## How is this patch tested? If it is not, please explain why.

Using model evaluation panel

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

See above

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of classification labels in the evaluation matrix
	- Enhanced logic for including special class labels in data processing

The changes refine the matrix generation process to more accurately manage class representations during evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->