### PR TITLE
Fixes sort in model eval display option and enables "display options" in table view

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -1059,18 +1059,16 @@ export default function Evaluation(props: EvaluationProps) {
                         );
                       })}
                     </Select>
-                    {classMode === "chart" && (
-                      <IconButton
-                        onClick={() => {
-                          setClassPerformanceDialogConfig((state) => ({
-                            ...state,
-                            open: true,
-                          }));
-                        }}
-                      >
-                        <Settings />
-                      </IconButton>
-                    )}
+                    <IconButton
+                      onClick={() => {
+                        setClassPerformanceDialogConfig((state) => ({
+                          ...state,
+                          open: true,
+                        }));
+                      }}
+                    >
+                      <Settings />
+                    </IconButton>
                   </Stack>
                 </Stack>
                 {classMode === "chart" && (
@@ -1654,9 +1652,10 @@ function formatPerClassPerformance(perClassPerformance, barConfig) {
         return b.value - a.value;
       } else if (sortBy === "worst") {
         return a.value - b.value;
-      } else {
-        return b.property.localeCompare(a.property);
+      } else if (sortBy === "az") {
+        return a.property.localeCompare(b.property);
       }
+      return b.property.localeCompare(a.property);
     });
   }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Shows the cog settings for Display Options in table view as well as chart view.
- Sorting a-z and z-a both were showing z-a results. 

## How is this patch tested? If it is not, please explain why.

Uploading Screen Recording 2025-01-09 at 1.17.58 PM.mov…

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
