### PR TITLE
docs: AS-385 notes for mongo 8

### DIFF
--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -208,6 +208,12 @@ option to ``pip install``:
   can use :ref:`database admin privileges <database-migrations>` to control
   which clients are allowed to upgrade your FiftyOne deployment.
 
+.. note::
+
+  If you are a FiftyOne 1.2.0 or lower user with an Ubuntu 24 operating system, 
+  you will need to 
+  :ref:`upgrade your mongodb binaries <mongodb-7-to-8>`.
+
 .. _downgrading-fiftyone:
 
 Downgrading FiftyOne

--- a/docs/source/getting_started/upgrading-mongodb.rst
+++ b/docs/source/getting_started/upgrading-mongodb.rst
@@ -76,3 +76,6 @@ Upgrading Mongodb 7 to Mongodb 8
             setFeatureCompatibilityVersion: "8.0", 
             confirm: true 
         })
+
+        // Verify the upgrade
+        db.adminCommand({ getParameter: 1, featureCompatibilityVersion: 1 })

--- a/docs/source/getting_started/upgrading-mongodb.rst
+++ b/docs/source/getting_started/upgrading-mongodb.rst
@@ -78,4 +78,7 @@ Upgrading Mongodb 7 to Mongodb 8
         })
 
         // Verify the upgrade
-        db.adminCommand({ getParameter: 1, featureCompatibilityVersion: 1 })
+        db.adminCommand({ 
+            getParameter: 1, 
+            featureCompatibilityVersion: 1 
+        })

--- a/docs/source/getting_started/upgrading-mongodb.rst
+++ b/docs/source/getting_started/upgrading-mongodb.rst
@@ -1,0 +1,74 @@
+
+Upgrading MongoDB Binaries
+==========================
+
+Voxel51 advises performing database backups of your mongodb
+data directory whenever performing a database upgrade.
+
+.. note::
+
+    The following steps apply to FiftyOne users who utilize
+    the pre-packaged Fiftyone MongoDB instance. If you utilize
+    a :ref:`custom/shared MongoDB database <configuring-mongodb-connection>`,
+    follow the upgrade path advised by your database provider.
+    
+.. _mongodb-7-to-8:
+
+Upgrading Mongodb 7 to Mongodb 8
+------------------------------------
+
+1. Stop the Fiftyone session and exit the python interpreter. 
+   Ensure that the mongo process has been shut down.
+
+    **Mac/Linux users:**
+
+    .. code-block:: shell
+
+        ps -ef | egrep "fiftyone.*mongod"
+
+    **Windows users:**
+
+    .. code-block:: shell
+    
+        Get-Process | \
+            Where-Object { \
+                $_.Name -like "*fiftyone*" \
+                -and $_.Name -like "*mongod*" \
+            }
+
+2. Upgrade Fiftyone to 1.3.0+ and Fiftyone-db to 1.2.0+
+
+3. Relaunch Fiftyone
+
+4. `Install mongosh <https://www.mongodb.com/docs/mongodb-shell/install/>`_
+
+5. Find the MongoDB URI using your operating systems network libraries
+
+    **Mac/Linux users:**
+
+    .. code-block:: shell
+
+        sudo lsof -iTCP -sTCP:LISTEN -P -n | egrep "mongod"
+
+    **Windows users:**
+
+    .. code-block:: shell
+    
+        Get-NetTCPConnection | \
+            Where-Object { $_.State -eq 'Listen' } | \
+            Select-String -Pattern "mongod"
+
+6. Connect to mongodb using mongosh
+
+    .. code-block:: shell
+
+        mongosh "$URI_FROM_ABOVE"
+
+7. Run the following command:
+
+    .. code-block:: javascript
+    
+        db.adminCommand({ 
+            setFeatureCompatibilityVersion: "8.0", 
+            confirm: true 
+        })

--- a/docs/source/getting_started/upgrading-mongodb.rst
+++ b/docs/source/getting_started/upgrading-mongodb.rst
@@ -38,6 +38,10 @@ Upgrading Mongodb 7 to Mongodb 8
 
 2. Upgrade Fiftyone to 1.3.0+ and Fiftyone-db to 1.2.0+
 
+    .. code-block:: shell
+
+        pip install --upgrade fiftyone fiftyone[db]
+
 3. Relaunch Fiftyone
 
 4. `Install mongosh <https://www.mongodb.com/docs/mongodb-shell/install/>`_

--- a/docs/source/getting_started/upgrading-mongodb.rst
+++ b/docs/source/getting_started/upgrading-mongodb.rst
@@ -11,7 +11,7 @@ data directory whenever performing a database upgrade.
     the pre-packaged Fiftyone MongoDB instance. If you utilize
     a :ref:`custom/shared MongoDB database <configuring-mongodb-connection>`,
     follow the upgrade path advised by your database provider.
-    
+
 .. _mongodb-7-to-8:
 
 Upgrading Mongodb 7 to Mongodb 8


### PR DESCRIPTION
## What changes are proposed in this pull request?

[This PR](https://github.com/voxel51/fiftyone/pull/5269) allowed fiftyone to natively spawn a mongodb instance on ubuntu 24. Prior to that, a hack had to be used to [set the openssl version](https://github.com/voxel51/fiftyone/issues/2900). 
This PR aims to document the migration from a mongodb 7 instance to a mongodb 8 instance.

## How is this patch tested? If it is not, please explain why.

```shell
bash docs/generate-docs.sh
```

Leads to:

![Screenshot 2025-01-10 at 3 56 53 PM](https://github.com/user-attachments/assets/414f2ff3-6c6d-497f-8d83-194b18cfd735)

and

![Screenshot 2025-01-10 at 3 58 15 PM](https://github.com/user-attachments/assets/a71d68da-33ba-4ad9-9b05-1cadd937952d)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

The installed mongodb binary packaged with `fiftyone[db]` was upgraded fro Mongodb 7.0.4 to Mongodb 8.0.4 in order to comply with Mongodb's version matrix. Users who previously installed Fiftyone on ubuntu 24 should follow the migration guide in the documentation.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added installation guidance for FiftyOne users on Ubuntu 24 with version 1.2.0 or lower, including a note on upgrading MongoDB binaries.
  - Introduced a new section on upgrading MongoDB binaries, emphasizing the importance of database backups.
  - Provided detailed step-by-step instructions for upgrading from MongoDB version 7 to version 8, tailored for both Mac/Linux and Windows users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->