### PR TITLE
add fallback schema for onChange in DynamicIO

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
@@ -36,7 +36,12 @@ export default function DynamicIO(props: ViewPropsType) {
       if (isComposite) {
         computedAncestors[currentPath] = computedSchema;
       }
-      onChange(path, value, schema ?? subSchema, computedAncestors);
+      onChange(
+        path,
+        value,
+        schema ?? subSchema ?? computedSchema,
+        computedAncestors
+      );
     };
   }, [onChange, computedSchema, props.path]);
 

--- a/app/packages/core/src/plugins/SchemaIO/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/index.tsx
@@ -20,13 +20,13 @@ export function SchemaIOComponent(props) {
 
   const onIOChange = useCallback(
     (path, value, schema, ancestors) => {
-      value = coerceValue(value, schema);
+      const computedValue = coerceValue(value, schema);
       const currentState = stateRef.current;
       const updatedState = cloneDeep(currentState);
-      set(updatedState, path, cloneDeep(value));
+      set(updatedState, path, cloneDeep(computedValue));
       stateRef.current = updatedState;
       if (onPathChange) {
-        onPathChange(path, value, schema, updatedState);
+        onPathChange(path, computedValue, schema, updatedState);
       }
       if (onChange) {
         onChange(updatedState);


### PR DESCRIPTION
## What changes are proposed in this pull request?

add fallback schema for onChange in DynamicIO

Proposing as an alternative solution to https://github.com/voxel51/fiftyone/pull/5384

## How is this patch tested? If it is not, please explain why.

Using python panels

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Improvements**
  - Enhanced value handling in SchemaIO components
  - Improved fallback mechanism for schema-based data processing

- **Bug Fixes**
  - Refined value coercion logic to ensure more consistent data management
  - Added additional schema fallback support to prevent potential undefined scenarios

The updates focus on improving data processing and state management within the SchemaIO plugin, providing more robust handling of dynamic input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->