### PR TITLE
Direct frame collection aggregations for expanded sample view

### DIFF
--- a/app/packages/app/src/index.tsx
+++ b/app/packages/app/src/index.tsx
@@ -1,7 +1,7 @@
 import { ErrorBoundary, ThemeProvider } from "@fiftyone/components";
 import { BeforeScreenshotContext, screenshotCallbacks } from "@fiftyone/state";
 import { SnackbarProvider } from "notistack";
-import type React from "react";
+import React from "react";
 import { createRoot } from "react-dom/client";
 import { RecoilRoot } from "recoil";
 import Network from "./Network";
@@ -13,6 +13,7 @@ const App: React.FC = () => {
 
   return <Network environment={environment} context={context} />;
 };
+
 
 createRoot(document.getElementById("root") as HTMLDivElement).render(
   <RecoilRoot>

--- a/app/packages/components/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/app/packages/components/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,3 +1,4 @@
+import { useTrackEvent } from "@fiftyone/analytics";
 import { useClearModal } from "@fiftyone/state";
 import {
   GraphQLError,
@@ -18,7 +19,6 @@ import { scrollable } from "../../scrollable.module.css";
 import CodeBlock from "../CodeBlock";
 import Loading from "../Loading";
 import style from "./ErrorBoundary.module.css";
-import { useTrackEvent } from "@fiftyone/analytics";
 
 type AppError = GraphQLError | NetworkError | NotFoundError | ServerError;
 
@@ -34,7 +34,8 @@ const Errors = (onReset?: () => void, disableReset?: boolean) => {
     const clearModal = useClearModal();
     useLayoutEffect(() => {
       clearModal();
-    }, []);
+      document.getElementById("modal")?.classList.remove("modalon");
+    }, [clearModal]);
 
     if (error instanceof NotFoundError) {
       return <Loading>{error.message}</Loading>;

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -10294,7 +10294,7 @@ class SampleCollection(object):
                 pipeline=pipeline,
                 attach_frames=aggregation._needs_frames(self),
                 group_slices=aggregation._needs_group_slices(self),
-                optimize_frames=optimize_frames,
+                optimize_frames=is_frames,
             )
 
         return compiled, pipelines, is_frame_collection

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -7484,6 +7484,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         detach_groups=False,
         groups_only=False,
         manual_group_select=False,
+        optimize_frames=False,
         post_pipeline=None,
     ):
         if media_type is None:
@@ -7520,6 +7521,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         if groups_only:
             detach_groups = False
+
+        if optimize_frames:
+            attach_frames = False
+            detach_frames = False
+            frames_only = False
 
         _pipeline = []
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -2404,7 +2404,7 @@ class FilterLabels(ViewStage):
         else:
             label_filter = self._filter
 
-        if is_frame_field:
+        if is_frame_field and not self._frames:
             if self._is_labels_list_field:
                 _make_filter_pipeline = _get_filter_frames_list_field_pipeline
             else:

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -2321,11 +2321,13 @@ class FilterLabels(ViewStage):
         filter,
         only_matches=True,
         trajectories=False,
+        _frames=False,
         _new_field=None,
         _validate=True,
     ):
         self._field = field
         self._filter = filter
+        self._frames = _frames
         self._only_matches = only_matches
         self._trajectories = trajectories
         self._new_field = _new_field or field
@@ -2448,9 +2450,8 @@ class FilterLabels(ViewStage):
 
         if self._is_frame_field:
             filter_field = self._field.split(".", 1)[1]  # remove `frames`
-            return _get_field_mongo_filter(
-                self._filter, prefix="$frame." + filter_field
-            )
+            prefix = filter_field if self._frames else "$frame." + filter_field
+            return _get_field_mongo_filter(self._filter, prefix=prefix)
 
         return _get_field_mongo_filter(self._filter, prefix=self._field)
 

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -5,6 +5,7 @@ Dataset views.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import defaultdict, OrderedDict
 import contextlib
 from copy import copy, deepcopy

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -1552,6 +1552,7 @@ class DatasetView(foc.SampleCollection):
         detach_groups=False,
         groups_only=False,
         manual_group_select=False,
+        optimize_frames=False,
         post_pipeline=None,
     ):
         _pipelines = []
@@ -1637,6 +1638,11 @@ class DatasetView(foc.SampleCollection):
         #######################################################################
         # Insert frame lookup pipeline(s) if needed
         #######################################################################
+
+        if optimize_frames:
+            _attach_frames_idx = None
+            _attach_frames_idx0 = None
+            _attach_frames_idx1 = None
 
         if _attach_frames_idx1 is not None and _attach_frames_idx is not None:
             _attach_frames_idx = _attach_frames_idx1
@@ -1936,6 +1942,7 @@ def make_optimized_select_view(
     ordered=False,
     groups=False,
     flatten=False,
+    optimize_frames=False,
 ):
     """Returns a view that selects the provided sample IDs that is optimized
     to reduce the document list as early as possible in the pipeline.
@@ -1981,7 +1988,10 @@ def make_optimized_select_view(
                 if type(stage) in fost._STAGES_THAT_SELECT_FIRST:
                     view = view._add_view_stage(stage, validate=False)
 
-        view = view.select(sample_ids, ordered=ordered)
+        if optimize_frames:
+            view = view.match({"_sample_id": ObjectId(sample_ids[0])})
+        else:
+            view = view.select(sample_ids, ordered=ordered)
 
     #
     # Selecting the samples of interest first can be significantly faster than

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -1720,6 +1720,7 @@ class DatasetView(foc.SampleCollection):
             detach_groups=detach_groups,
             groups_only=groups_only,
             manual_group_select=manual_group_select,
+            optimize_frames=optimize_frames,
             post_pipeline=post_pipeline,
         )
 

--- a/fiftyone/server/aggregations.py
+++ b/fiftyone/server/aggregations.py
@@ -124,6 +124,7 @@ async def aggregate_resolver(
     if form.mixed and "" in form.paths:
         slice_view = await _load_view(form, [form.slice])
 
+    optimize_frames = not True
     if form.sample_ids:
         view = fov.make_optimized_select_view(view, form.sample_ids)
 
@@ -149,13 +150,9 @@ async def aggregate_resolver(
     )
     counts = [len(a) for a in aggregations]
     flattened = [item for sublist in aggregations for item in sublist]
-
-    # TODO: stop aggregate resolver from being called for non-existent fields,
-    #  but fail silently for now by just returning empty results
-    try:
-        result = await view._async_aggregate(flattened)
-    except:
-        return []
+    result = await view._async_aggregate(
+        flattened, optimize_frames=optimize_frames
+    )
 
     results = []
     offset = 0

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -81,6 +81,7 @@ def get_view(
     sample_filter=None,
     reload=True,
     awaitable=False,
+    optimize_frames=False,
 ):
     """Gets the view defined by the given request parameters.
 
@@ -136,6 +137,7 @@ def get_view(
                 pagination_data=pagination_data,
                 extended_stages=extended_stages,
                 media_types=media_types,
+                optimize_frames=optimize_frames,
             )
 
         return view
@@ -152,6 +154,7 @@ def get_extended_view(
     extended_stages=None,
     pagination_data=False,
     media_types=None,
+    optimize_frames=False,
 ):
     """Create an extended view with the provided filters.
 
@@ -191,13 +194,23 @@ def get_extended_view(
         if label_tags:
             view = _match_label_tags(view, label_tags)
 
-        match_stage = _make_match_stage(view, filters)
+        match_stage = _make_match_stage(
+            view, filters, optimize_frames=optimize_frames
+        )
         stages = []
         if match_stage:
             stages = [match_stage]
 
-        stages.extend(_make_field_filter_stages(view, filters))
-        stages.extend(_make_label_filter_stages(view, filters))
+        stages.extend(
+            _make_field_filter_stages(
+                view, filters, optimize_frames=optimize_frames
+            )
+        )
+        stages.extend(
+            _make_label_filter_stages(
+                view, filters, optimize_frames=optimize_frames
+            )
+        )
 
         for stage in stages:
             view = view.add_stage(stage)
@@ -351,10 +364,10 @@ def _project_pagination_paths(
     )
 
 
-def _make_match_stage(view, filters):
+def _make_match_stage(view, filters, optimize_frames=False):
     queries = []
 
-    for path, parent_path, args in _iter_paths(view, filters):
+    for path, parent_path, args, is_frame_field in _iter_paths(view, filters):
         is_matching = args.get("isMatching", True)
         path_field = view.get_field(path)
 
@@ -370,15 +383,18 @@ def _make_match_stage(view, filters):
         if args.get("exclude") and not is_matching:
             continue
 
+        if is_frame_field and optimize_frames:
+            path = path[len("frames.") :]
+
         queries.append(_make_query(path, path_field, args))
 
     if queries:
         return fosg.Match({"$and": queries})
 
 
-def _make_field_filter_stages(view, filters):
+def _make_field_filter_stages(view, filters, optimize_frames=False):
     stages = []
-    for path, parent_path, args in _iter_paths(
+    for path, parent_path, args, is_frame_field in _iter_paths(
         view, filters, label_types=False
     ):
         if args.get("isMatching", False):
@@ -392,29 +408,32 @@ def _make_field_filter_stages(view, filters):
             continue
 
         set_field = parent_path
+        if is_frame_field and optimize_frames:
+            set_field = set_field[len("frames.") :]
 
         expr = _make_scalar_expression(F(path.split(".")[-1]), args, field)
 
         if expr is None:
             continue
 
-        expr = F(parent_path).filter(expr)
+        expr = F(set_field).filter(expr)
+
         stages.append(fosg.SetField(set_field, expr, _allow_missing=True))
 
     return stages
 
 
-def _make_label_filter_stages(
-    view,
-    filters,
-):
+def _make_label_filter_stages(view, filters, optimize_frames=False):
     stages = []
-    for path, label_path, args in _iter_paths(view, filters, label_types=True):
+    for path, label_path, args, is_frame_field in _iter_paths(
+        view, filters, label_types=True
+    ):
         if args.get("isMatching", False):
             continue
 
         field = view.get_field(path)
         label_field = view.get_field(label_path)
+
         if issubclass(
             label_field.document_type, (fol.Keypoint, fol.Keypoints)
         ) and isinstance(field, fof.ListField):
@@ -444,6 +463,7 @@ def _make_label_filter_stages(
                 label_path,
                 expr,
                 only_matches=not args.get("exclude", False),
+                _frames=is_frame_field and optimize_frames,
             )
         )
 
@@ -479,7 +499,7 @@ def _iter_paths(
             if label_types != _is_label:
                 continue
 
-        yield path, parent_path, filters[path]
+        yield path, parent_path, filters[path], view._is_frame_field(path)
 
 
 def _is_support(field):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Circumvents MongoDB lookup limitations by adding an `optimize_frames` pathway to `Aggregation` pipelines for large video samples in the modal sidebar

## How is this patch tested? If it is not, please explain why.

Todo

## Release Notes



### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
