### PR TITLE
Add custom metric to Summary in Model Evaluation panel

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -465,6 +465,12 @@ export default function Evaluation(props: EvaluationProps) {
           : false,
       hide: !showTpFpFn,
     },
+    {
+      id: "custom_metrics",
+      property: "Custom Metrics",
+      value: evaluationMetrics.custom_metrics,
+      compareValue: compareEvaluationMetrics.custom_metrics,
+    },
   ];
 
   const perClassPerformance = {};

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -1793,7 +1793,7 @@ function formatCustomMetricRows(evluationMetrics, comparisonMetrics) {
       `custom_metrics.${operatorName}.value`,
       null
     );
-    const hasComparisonValue = compareValue !== null;
+    const hasOneValue = customMetric.value !== null || compareValue !== null;
 
     results.push({
       id: operatorName,
@@ -1803,7 +1803,7 @@ function formatCustomMetricRows(evluationMetrics, comparisonMetrics) {
       lesserIsBetter: true, // TODO - this needs to be provided from the customMetrics object
       filterable: false,
       active: false,
-      hide: !hasComparisonValue,
+      hide: !hasOneValue,
     });
   }
   return results;

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -1763,6 +1763,7 @@ type PLOT_CONFIG_DIALOG_TYPE = PLOT_CONFIG_TYPE & {
 type CustomMetric = {
   label: string;
   value: any;
+  lower_is_better: boolean;
 };
 
 type CustomMetrics = {
@@ -1800,7 +1801,7 @@ function formatCustomMetricRows(evaluationMetrics, comparisonMetrics) {
       property: customMetric.label,
       value: customMetric.value,
       compareValue,
-      lesserIsBetter: true, // TODO - this needs to be provided from the customMetrics object
+      lesserIsBetter: customMetric.lower_is_better,
       filterable: false,
       active: false,
       hide: !hasOneValue,

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -471,13 +471,14 @@ export default function Evaluation(props: EvaluationProps) {
   ];
 
   for (const key in evaluationCustomMetrics) {
+    const cm_keys = Object.keys(evaluationCustomMetrics[key]);
     summaryRows.push({
       id: key,
-      property: evaluationCustomMetrics[key].label.toString(),
-      value: evaluationCustomMetrics[key].value,
-      compareValue: compareEvaluationCustomMetrics[key].value,
+      property: evaluationCustomMetrics[key][cm_keys[0]].toString(),
+      value: evaluationCustomMetrics[key][cm_keys[1]],
+      compareValue: compareEvaluationCustomMetrics[key][cm_keys[1]],
       lesserIsBetter: true,
-      filterable: true,
+      filterable: false,
       active: false,
       hide: false,
     });

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -1780,10 +1780,10 @@ type SummaryRow = {
   hide: boolean;
 };
 
-function formatCustomMetricRows(evluationMetrics, comparisonMetrics) {
+function formatCustomMetricRows(evaluationMetrics, comparisonMetrics) {
   const results = [] as SummaryRow[];
   const customMetrics = _.get(
-    evluationMetrics,
+    evaluationMetrics,
     "custom_metrics",
     {}
   ) as CustomMetrics;

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -196,6 +196,7 @@ export default function Evaluation(props: EvaluationProps) {
   const evaluationTimestamp = evaluationInfo.timestamp;
   const evaluationConfig = evaluationInfo.config;
   const evaluationMetrics = evaluation.metrics;
+  const evaluationCustomMetrics = evaluation.custom_metrics;
   const evaluationType = evaluationConfig.type;
   const evaluationMethod = evaluationConfig.method;
   const compareEvaluationInfo = compareEvaluation?.info || {};
@@ -203,6 +204,8 @@ export default function Evaluation(props: EvaluationProps) {
   const compareEvaluationTimestamp = compareEvaluationInfo?.timestamp;
   const compareEvaluationConfig = compareEvaluationInfo?.config || {};
   const compareEvaluationMetrics = compareEvaluation?.metrics || {};
+  const compareEvaluationCustomMetrics =
+    compareEvaluation?.custom_metrics || {};
   const compareEvaluationType = compareEvaluationConfig.type;
   const isObjectDetection = evaluationType === "detection";
   const isClassification = evaluationType === "classification";
@@ -465,13 +468,20 @@ export default function Evaluation(props: EvaluationProps) {
           : false,
       hide: !showTpFpFn,
     },
-    {
-      id: "custom_metrics",
-      property: "Custom Metrics",
-      value: evaluationMetrics.custom_metrics,
-      compareValue: compareEvaluationMetrics.custom_metrics,
-    },
   ];
+
+  for (const key in evaluationCustomMetrics) {
+    summaryRows.push({
+      id: key,
+      property: evaluationCustomMetrics[key].label.toString(),
+      value: evaluationCustomMetrics[key].value,
+      compareValue: compareEvaluationCustomMetrics[key].value,
+      lesserIsBetter: true,
+      filterable: true,
+      active: false,
+      hide: false,
+    });
+  }
 
   const perClassPerformance = {};
   for (const key in evaluation?.per_class_metrics) {

--- a/fiftyone/operators/builtins/panels/model_evaluation/__init__.py
+++ b/fiftyone/operators/builtins/panels/model_evaluation/__init__.py
@@ -368,11 +368,9 @@ class EvaluationPanel(Panel):
             )
             metrics["mAP"] = self.get_map(results)
             metrics["mAR"] = self.get_mar(results)
-            metrics["custom_metrics"] = json.dumps(
-                self.get_custom_metrics(results)
-            )
             evaluation_data = {
                 "metrics": metrics,
+                "custom_metrics": self.get_custom_metrics(results),
                 "info": serialized_info,
                 "confusion_matrices": self.get_confusion_matrices(results),
                 "per_class_metrics": per_class_metrics,

--- a/fiftyone/operators/builtins/panels/model_evaluation/__init__.py
+++ b/fiftyone/operators/builtins/panels/model_evaluation/__init__.py
@@ -7,7 +7,6 @@ Model evaluation panel.
 """
 
 from collections import defaultdict, Counter
-import json
 import os
 import traceback
 

--- a/fiftyone/operators/builtins/panels/model_evaluation/__init__.py
+++ b/fiftyone/operators/builtins/panels/model_evaluation/__init__.py
@@ -7,11 +7,11 @@ Model evaluation panel.
 """
 
 from collections import defaultdict, Counter
+import json
 import os
 import traceback
 
 import numpy as np
-import json
 from fiftyone import ViewField as F
 from fiftyone.operators.categories import Categories
 from fiftyone.operators.panel import Panel, PanelConfig
@@ -147,7 +147,10 @@ class EvaluationPanel(Panel):
             return None
 
     def get_custom_metrics(self, results):
-        return results.custom_metrics
+        custom_metrics = results.custom_metrics
+        if custom_metrics:
+            return custom_metrics
+        return {}
 
     def set_status(self, ctx):
         if not self.can_edit_status(ctx):

--- a/fiftyone/operators/builtins/panels/model_evaluation/__init__.py
+++ b/fiftyone/operators/builtins/panels/model_evaluation/__init__.py
@@ -147,20 +147,7 @@ class EvaluationPanel(Panel):
 
     def get_custom_metrics(self, results):
         try:
-            metrics = results.custom_metrics
-            metrics_config = results.custom_metrics_config
-            custom_metrics = {}
-            for config in metrics_config:
-                name = config["name"]
-                label = config["label"]
-                value = metrics[label]
-                lower_is_better = config["lower_is_better"]
-                custom_metrics[name] = {
-                    "label": label,
-                    "value": value,
-                    "lower_is_better": lower_is_better,
-                }
-            return custom_metrics
+            return results.custom_metrics
         except Exception:
             return None
 
@@ -380,7 +367,6 @@ class EvaluationPanel(Panel):
             )
             metrics["mAP"] = self.get_map(results)
             metrics["mAR"] = self.get_mar(results)
-            metrics["custom_metrics"] = self.get_custom_metrics(results)
             evaluation_data = {
                 "metrics": metrics,
                 "custom_metrics": self.get_custom_metrics(results),

--- a/fiftyone/operators/builtins/panels/model_evaluation/__init__.py
+++ b/fiftyone/operators/builtins/panels/model_evaluation/__init__.py
@@ -11,7 +11,7 @@ import os
 import traceback
 
 import numpy as np
-
+import json
 from fiftyone import ViewField as F
 from fiftyone.operators.categories import Categories
 from fiftyone.operators.panel import Panel, PanelConfig
@@ -145,6 +145,9 @@ class EvaluationPanel(Panel):
             return results.mAR()
         except Exception as e:
             return None
+
+    def get_custom_metrics(self, results):
+        return results.custom_metrics
 
     def set_status(self, ctx):
         if not self.can_edit_status(ctx):
@@ -362,6 +365,9 @@ class EvaluationPanel(Panel):
             )
             metrics["mAP"] = self.get_map(results)
             metrics["mAR"] = self.get_mar(results)
+            metrics["custom_metrics"] = json.dumps(
+                self.get_custom_metrics(results)
+            )
             evaluation_data = {
                 "metrics": metrics,
                 "info": serialized_info,

--- a/fiftyone/operators/builtins/panels/model_evaluation/__init__.py
+++ b/fiftyone/operators/builtins/panels/model_evaluation/__init__.py
@@ -146,10 +146,23 @@ class EvaluationPanel(Panel):
             return None
 
     def get_custom_metrics(self, results):
-        custom_metrics = results.custom_metrics
-        if custom_metrics:
+        try:
+            metrics = results.custom_metrics
+            metrics_config = results.custom_metrics_config
+            custom_metrics = {}
+            for config in metrics_config:
+                name = config["name"]
+                label = config["label"]
+                value = metrics[label]
+                lower_is_better = config["lower_is_better"]
+                custom_metrics[name] = {
+                    "label": label,
+                    "value": value,
+                    "lower_is_better": lower_is_better,
+                }
             return custom_metrics
-        return {}
+        except Exception:
+            return None
 
     def set_status(self, ctx):
         if not self.can_edit_status(ctx):
@@ -367,6 +380,7 @@ class EvaluationPanel(Panel):
             )
             metrics["mAP"] = self.get_map(results)
             metrics["mAR"] = self.get_mar(results)
+            metrics["custom_metrics"] = self.get_custom_metrics(results)
             evaluation_data = {
                 "metrics": metrics,
                 "custom_metrics": self.get_custom_metrics(results),

--- a/fiftyone/utils/eval/base.py
+++ b/fiftyone/utils/eval/base.py
@@ -59,10 +59,15 @@ class BaseEvaluationMethod(foe.EvaluationMethod):
                     samples, eval_key, results, **kwargs or {}
                 )
                 if value is not None:
-                    results.custom_metrics[operator.config.name] = {
+                    results.custom_metrics[operator.config.label] = value
+                    config = {
+                        "name": operator.config.name,
                         "label": operator.config.label,
-                        "value": value,
+                        "lower_is_better": operator.config.kwargs.get(
+                            "lower_is_better", True
+                        ),
                     }
+                    results.custom_metrics_config.append(config)
             except Exception as e:
                 logger.warning(
                     "Failed to compute metric '%s': Reason: %s",
@@ -184,16 +189,8 @@ class BaseClassificationResults(BaseEvaluationResults):
         self.classes = np.asarray(classes)
         self.missing = missing
         self.custom_metrics = custom_metrics
-
-    @property
-    def additional_metrics(self):
-        if not self.custom_metrics:
-            return None
-        metrics = {}
-        for d in self.custom_metrics.values():
-            label, value = list(d.values())
-            metrics[label] = value
-        return metrics
+        # Stores configs for custom metrics with a return value (used by the model evaluation panel).
+        self.custom_metrics_config = []
 
     def report(self, classes=None):
         """Generates a classification report for the results via

--- a/fiftyone/utils/eval/base.py
+++ b/fiftyone/utils/eval/base.py
@@ -60,15 +60,13 @@ class BaseEvaluationMethod(foe.EvaluationMethod):
                     if results.custom_metrics is None:
                         results.custom_metrics = {}
 
-                    results.custom_metrics[operator.config.label] = value
-                    config = {
-                        "name": operator.config.name,
+                    results.custom_metrics[operator.config.name] = {
+                        "value": value,
                         "label": operator.config.label,
                         "lower_is_better": operator.config.kwargs.get(
                             "lower_is_better", True
                         ),
                     }
-                    results.custom_metrics_config.append(config)
             except Exception as e:
                 logger.warning(
                     "Failed to compute metric '%s': Reason: %s",
@@ -190,8 +188,6 @@ class BaseClassificationResults(BaseEvaluationResults):
         self.classes = np.asarray(classes)
         self.missing = missing
         self.custom_metrics = custom_metrics
-        # Stores configs for custom metrics with a return value (used by the model evaluation panel).
-        self.custom_metrics_config = []
 
     def report(self, classes=None):
         """Generates a classification report for the results via
@@ -398,6 +394,14 @@ class BaseClassificationResults(BaseEvaluationResults):
             backend=backend,
             **kwargs,
         )
+
+    def custom_metrics_report(self):
+        """Generates a report for the custom metrics."""
+        if self.custom_metrics:
+            report = {}
+            for metric in self.custom_metrics.values():
+                report[metric["label"]] = metric["value"]
+            return report
 
     def _parse_classes(self, classes):
         if classes is not None:

--- a/fiftyone/utils/eval/base.py
+++ b/fiftyone/utils/eval/base.py
@@ -5,6 +5,7 @@ Base evaluation methods.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import itertools
 import logging
 
@@ -58,7 +59,10 @@ class BaseEvaluationMethod(foe.EvaluationMethod):
                     samples, eval_key, results, **kwargs or {}
                 )
                 if value is not None:
-                    results.custom_metrics[operator.config.label] = value
+                    results.custom_metrics[operator.config.name] = {
+                        "label": operator.config.label,
+                        "value": value,
+                    }
             except Exception as e:
                 logger.warning(
                     "Failed to compute metric '%s': Reason: %s",
@@ -180,6 +184,16 @@ class BaseClassificationResults(BaseEvaluationResults):
         self.classes = np.asarray(classes)
         self.missing = missing
         self.custom_metrics = custom_metrics
+
+    @property
+    def additional_metrics(self):
+        if not self.custom_metrics:
+            return None
+        metrics = {}
+        for d in self.custom_metrics.values():
+            label, value = list(d.values())
+            metrics[label] = value
+        return metrics
 
     def report(self, classes=None):
         """Generates a classification report for the results via

--- a/fiftyone/utils/eval/regression.py
+++ b/fiftyone/utils/eval/regression.py
@@ -5,6 +5,7 @@ Regression evaluation.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from copy import deepcopy
 import inspect
 import itertools
@@ -425,6 +426,8 @@ class RegressionResults(BaseEvaluationResults):
         self.ids = ids
         self.missing = missing
         self.custom_metrics = custom_metrics
+        # Stores configs for custom metrics with a return value (used by the model evaluation panel).
+        self.custom_metrics_config = []
 
     def metrics(self, weights=None):
         """Computes various popular regression metrics for the results.

--- a/fiftyone/utils/eval/regression.py
+++ b/fiftyone/utils/eval/regression.py
@@ -426,8 +426,6 @@ class RegressionResults(BaseEvaluationResults):
         self.ids = ids
         self.missing = missing
         self.custom_metrics = custom_metrics
-        # Stores configs for custom metrics with a return value (used by the model evaluation panel).
-        self.custom_metrics_config = []
 
     def metrics(self, weights=None):
         """Computes various popular regression metrics for the results.
@@ -492,6 +490,14 @@ class RegressionResults(BaseEvaluationResults):
         """
         metrics = self.metrics(weights=weights)
         _print_dict_as_table(metrics, digits)
+
+    def custom_metrics_report(self):
+        """Generates a report for the custom metrics."""
+        if self.custom_metrics:
+            report = {}
+            for metric in self.custom_metrics.values():
+                report[metric["label"]] = metric["value"]
+            return report
 
     def plot_results(
         self, labels=None, sizes=None, backend="plotly", **kwargs


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds `Custom Metrics` to Summary in Model Evaluation panel

## How is this patch tested? If it is not, please explain why.

![image](https://github.com/user-attachments/assets/806be69a-e225-4c7d-8405-87eadcb61e01)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
