### PR TITLE
python panel state stability enhancements

### DIFF
--- a/app/packages/core/src/components/MainSpace/MainSpace.tsx
+++ b/app/packages/core/src/components/MainSpace/MainSpace.tsx
@@ -1,5 +1,11 @@
-import { SpacesRoot, usePanelsState, useSpaces } from "@fiftyone/spaces";
-import { constants, useSessionSpaces } from "@fiftyone/state";
+import {
+  SpaceNodeJSON,
+  SpacesRoot,
+  SpaceTree,
+  usePanelsState,
+  useSpaces,
+} from "@fiftyone/spaces";
+import { constants, useSessionSpaces, useUnboundState } from "@fiftyone/state";
 import { isEqual, size } from "lodash";
 import React, { useEffect, useRef } from "react";
 
@@ -13,29 +19,45 @@ function MainSpace() {
     sessionSpaces
   );
   const [panelsState, setPanelsState] = usePanelsState();
-  const oldSpaces = useRef(spaces);
+  const oldSpaces = useRef<SpaceTree | SpaceNodeJSON>(spaces);
   const oldPanelsState = useRef(panelsState);
   const isMounted = useRef(false);
+  const unboundState = useUnboundState({
+    spaces,
+    sessionSpaces,
+    panelsState,
+    sessionPanelsState,
+    updateSpaces,
+    setPanelsState,
+    setSessionSpaces,
+  });
 
   useEffect(() => clearSpaces, [clearSpaces]);
 
+  // Update local spaces layout to latest session spaces layout
   useEffect(() => {
+    const { spaces, updateSpaces } = unboundState;
     if (!spaces.equals(sessionSpaces)) {
       updateSpaces(sessionSpaces);
     }
   }, [sessionSpaces]);
 
+  // Update local panels state to latest session panels state
   useEffect(() => {
+    const { panelsState, setPanelsState } = unboundState;
     if (size(sessionPanelsState) && !isEqual(sessionPanelsState, panelsState)) {
       setPanelsState(sessionPanelsState);
     }
   }, [sessionPanelsState]);
 
+  // Update session spaces layout and panels state to latest local spaces layout and panels state
   useEffect(() => {
     if (!isMounted.current) {
       isMounted.current = true;
       return;
     }
+    const { sessionSpaces, sessionPanelsState, setSessionSpaces } =
+      unboundState;
     const serializedSpaces = spaces.toJSON();
     const spacesUpdated =
       !spaces.equals(sessionSpaces) && !spaces.equals(oldSpaces.current);
@@ -47,14 +69,7 @@ function MainSpace() {
     }
     oldSpaces.current = serializedSpaces;
     oldPanelsState.current = panelsState;
-  }, [
-    oldSpaces,
-    panelsState,
-    sessionSpaces,
-    sessionPanelsState,
-    setSessionSpaces,
-    spaces,
-  ]);
+  }, [oldSpaces, panelsState, spaces]);
 
   return <SpacesRoot id={FIFTYONE_GRID_SPACES_ID} />;
 }

--- a/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
@@ -1,18 +1,17 @@
 import { PluginComponentType, useActivePlugins } from "@fiftyone/plugins";
+import { useUnboundState } from "@fiftyone/state";
 import { isNullish } from "@fiftyone/utilities";
 import { get, isEqual, set } from "lodash";
-import { useEffect, useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 import { isPathUserChanged } from "../hooks";
 import {
   getComponent,
   getErrorsForView,
   isCompositeView,
-  isEditableView,
   isInitialized,
 } from "../utils";
 import { AncestorsType, SchemaType, ViewPropsType } from "../utils/types";
 import ContainerizedComponent from "./ContainerizedComponent";
-import { useUnboundState } from "@fiftyone/state";
 
 export default function DynamicIO(props: ViewPropsType) {
   const { schema, onChange } = props;
@@ -73,32 +72,41 @@ function useStateInitializer(props: ViewPropsType) {
   const computedSchema = getComputedSchema(props);
   const { default: defaultValue } = computedSchema;
   const shouldInitialize = useMemo(() => {
-    return !isCompositeView(computedSchema) && isEditableView(computedSchema);
+    return !isCompositeView(computedSchema);
   }, [computedSchema]);
   const basicData = useMemo(() => {
     if (shouldInitialize) {
       return data;
     }
   }, [shouldInitialize, data]);
-  const unboundState = useUnboundState({ computedSchema, props });
+  const unboundState = useUnboundState({
+    computedSchema,
+    props,
+    data,
+    shouldInitialize,
+    onChange,
+  });
 
   useEffect(() => {
-    const { computedSchema, props } = unboundState;
-    const { data, path, root_id } = props || {};
+    const { computedSchema, props, shouldInitialize, onChange } = unboundState;
+    const { data, path, root_id, otherProps = {} } = props || {};
+    const { updatableDefaultValue = true } = otherProps;
+    const updateToDefault = updatableDefaultValue ? true : isNullish(data);
     if (
       shouldInitialize &&
-      !isEqual(data, defaultValue) &&
-      !isPathUserChanged(path, root_id) &&
+      updateToDefault &&
       !isNullish(defaultValue) &&
-      !isInitialized(props)
+      !isPathUserChanged(path, root_id) &&
+      !isInitialized(props) &&
+      !isEqual(data, defaultValue)
     ) {
       onChange(path, defaultValue, computedSchema);
     }
-  }, [defaultValue, onChange, unboundState]);
+  }, [defaultValue]);
 
   useEffect(() => {
     if (basicData) {
-      const { computedSchema, props } = unboundState;
+      const { computedSchema, props, onChange } = unboundState;
       const { data, path } = props || {};
       if (
         !isEqual(data, basicData) &&
@@ -108,7 +116,7 @@ function useStateInitializer(props: ViewPropsType) {
         onChange(path, basicData, computedSchema);
       }
     }
-  }, [basicData, onChange, unboundState]);
+  }, [basicData]);
 }
 
 function schemaWithInheritedDefault(

--- a/app/packages/core/src/plugins/SchemaIO/components/TreeSelectionView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TreeSelectionView.tsx
@@ -275,7 +275,7 @@ export default function TreeSelectionView(props: ViewPropsType) {
         return updatedState;
       });
     }
-  }, [data, unboundState]);
+  }, [data]);
 
   // CheckboxView: Represents a single checkbox (either parent or child)
   function CheckboxView({

--- a/app/packages/operators/src/useCustomPanelHooks.ts
+++ b/app/packages/operators/src/useCustomPanelHooks.ts
@@ -78,7 +78,7 @@ export function useCustomPanelHooks(props: CustomPanelProps): CustomPanelHooks {
     return panelStateLocal?.loaded;
   }, [panelStateLocal?.loaded]);
   const triggerPanelEvent = usePanelEvent();
-  const lazyState = useUnboundState({ panelState });
+  const unboundState = useUnboundState({ panelState });
 
   const onLoad = useCallback(() => {
     if (props.onLoad && !isLoaded) {
@@ -203,7 +203,7 @@ export function useCustomPanelHooks(props: CustomPanelProps): CustomPanelHooks {
   const handlePanelStatePathChange = useMemo(() => {
     return (path, value, schema, state) => {
       if (schema?.onChange) {
-        const { panelState } = lazyState;
+        const { panelState } = unboundState;
         const currentPanelState = merge({}, panelState?.state, state);
         triggerPanelEvent(panelId, {
           operator: schema.onChange,
@@ -212,7 +212,7 @@ export function useCustomPanelHooks(props: CustomPanelProps): CustomPanelHooks {
         });
       }
     };
-  }, [panelId, triggerPanelEvent, lazyState]);
+  }, [panelId, triggerPanelEvent]);
 
   const handlePanelStatePathChangeDebounced = useMemo(() => {
     return memoizedDebounce(

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -324,6 +324,7 @@ class Operations(object):
         on_change_query_performance=None,
         allow_duplicates=False,
         priority=None,
+        reset_state=False,
         _builtin=False,
     ):
         """Registers a panel with the given name and lifecycle callbacks.
@@ -371,6 +372,8 @@ class Operations(object):
                 the panel to the opened
             priority (None): the priority of the panel, used for sort order
             _builtin (False): whether the panel is a builtin panel
+            reset_state (False): whether to reset the state of the panel prior to on load
+
         """
         params = {
             "panel_name": name,
@@ -398,6 +401,7 @@ class Operations(object):
             "on_change_query_performance": on_change_query_performance,
             "allow_duplicates": allow_duplicates,
             "priority": priority,
+            "reset_state": reset_state,
             "_builtin": _builtin,
         }
         return self._ctx.trigger("register_panel", params=params)

--- a/fiftyone/operators/panel.py
+++ b/fiftyone/operators/panel.py
@@ -33,6 +33,7 @@ class PanelConfig(OperatorConfig):
             tooltip
         category (Category): the category id of the panel
         priority (None): the priority of the panel for sorting in the UI
+        reset_state (False): whether to reset the state of the panel prior to on load
     """
 
     def __init__(
@@ -49,6 +50,7 @@ class PanelConfig(OperatorConfig):
         allow_multiple=False,
         surfaces: PANEL_SURFACE = "grid",
         priority=None,
+        reset_state=False,
         **kwargs
     ):
         super().__init__(name)
@@ -66,6 +68,7 @@ class PanelConfig(OperatorConfig):
         self.beta = beta
         self.is_new = is_new
         self.priority = priority
+        self.reset_state = reset_state
         self.kwargs = kwargs  # unused, placeholder for future extensibility
 
     def to_json(self):
@@ -84,6 +87,7 @@ class PanelConfig(OperatorConfig):
             "unlisted": self.unlisted,
             "surfaces": self.surfaces,
             "priority": self.priority,
+            "reset_state": self.reset_state,
         }
 
 
@@ -126,6 +130,7 @@ class Panel(Operator):
             "beta": self.config.beta,
             "is_new": self.config.is_new,
             "priority": self.config.priority,
+            "reset_state": self.config.reset_state,
             "_builtin": self._builtin,
         }
         methods = ["on_load", "on_unload", "on_change"]


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added a `reset_state` option for panels, allowing more granular control over panel state management.
	- Introduced a new hook, `useUnboundState`, to enhance state management in the `MainSpace` component.

- **Improvements**
	- Improved type safety for space and panel state handling.
	- Streamlined state initialization logic in dynamic components.
	- Enhanced control flow and error handling in custom panels.

- **Technical Updates**
	- Updated method signatures in panel and operator registration to support new state reset functionality.

These changes provide more robust and configurable state management for panels and components in the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->