### PR TITLE
support media fields in ImaVid

### DIFF
--- a/app/packages/core/src/components/Modal/ImaVidLooker.tsx
+++ b/app/packages/core/src/components/Modal/ImaVidLooker.tsx
@@ -195,8 +195,7 @@ export const ImaVidLookerReact = React.memo(
 
           window.addEventListener(
             "fetchMore",
-            fetchMoreListener as EventListener,
-            { once: true }
+            fetchMoreListener as EventListener
           );
         });
       },

--- a/app/packages/core/src/components/Modal/ModalLooker.tsx
+++ b/app/packages/core/src/components/Modal/ModalLooker.tsx
@@ -65,8 +65,10 @@ export const ModalLooker = React.memo(
     );
     const video = useRecoilValue(fos.isVideoDataset);
 
+    const modalMediaField = useRecoilValue(fos.selectedMediaField(true));
+
     if (shouldRenderImavid) {
-      return <ImaVidLookerReact sample={sample} />;
+      return <ImaVidLookerReact sample={sample} key={modalMediaField} />;
     }
 
     if (video) {

--- a/app/packages/state/src/hooks/useCreateLooker.ts
+++ b/app/packages/state/src/hooks/useCreateLooker.ts
@@ -224,9 +224,10 @@ export default <T extends AbstractLooker<BaseState>>(
             .valueOrThrow();
 
           const thisSampleId = sample._id as string;
-          if (!ImaVidFramesControllerStore.has(thisSampleId)) {
+          const imavidPartitionKey = `${thisSampleId}-${mediaField}`;
+          if (!ImaVidFramesControllerStore.has(imavidPartitionKey)) {
             ImaVidFramesControllerStore.set(
-              thisSampleId,
+              imavidPartitionKey,
               new ImaVidFramesController({
                 environment,
                 firstFrameNumber,
@@ -240,7 +241,8 @@ export default <T extends AbstractLooker<BaseState>>(
 
           config = {
             ...config,
-            frameStoreController: ImaVidFramesControllerStore.get(thisSampleId),
+            frameStoreController:
+              ImaVidFramesControllerStore.get(imavidPartitionKey),
             frameRate: dynamicGroupsTargetFrameRateValue,
             firstFrameNumber: isModal
               ? snapshot

--- a/app/packages/state/src/hooks/useCreateLooker.ts
+++ b/app/packages/state/src/hooks/useCreateLooker.ts
@@ -151,7 +151,7 @@ export default <T extends AbstractLooker<BaseState>>(
           shouldHandleKeyEvents: isModal,
         };
 
-        let sampleMediaFilePath = urls[mediaField];
+        let sampleMediaFilePath = urls[mediaField] ?? urls.filepath;
         if (isNullish(sampleMediaFilePath) && options.mediaFallback === true) {
           sampleMediaFilePath = urls.filepath;
         }

--- a/app/packages/state/src/hooks/useCreateLooker.ts
+++ b/app/packages/state/src/hooks/useCreateLooker.ts
@@ -151,7 +151,7 @@ export default <T extends AbstractLooker<BaseState>>(
           shouldHandleKeyEvents: isModal,
         };
 
-        let sampleMediaFilePath = urls[mediaField] ?? urls.filepath;
+        let sampleMediaFilePath = urls[mediaField];
         if (isNullish(sampleMediaFilePath) && options.mediaFallback === true) {
           sampleMediaFilePath = urls.filepath;
         }

--- a/app/packages/state/src/recoil/dynamicGroups.ts
+++ b/app/packages/state/src/recoil/dynamicGroups.ts
@@ -15,7 +15,7 @@ import {
   modalGroupSlice,
 } from "./groups";
 import { modalLooker, modalSample } from "./modal";
-import { dynamicGroupsViewMode } from "./options";
+import { dynamicGroupsViewMode, selectedMediaField } from "./options";
 import { fieldPaths, fieldSchema } from "./schema";
 import { datasetName, parentMediaTypeSelector } from "./selectors";
 import { State } from "./types";
@@ -289,8 +289,9 @@ export const imaVidStoreKey = selectorFamily<
     ({ get }) => {
       const { groupBy, orderBy } = get(dynamicGroupParameters);
       const slice = get(currentSlice(modal)) ?? "UNSLICED";
+      const mediaField = get(selectedMediaField(modal));
 
-      return `$${groupBy}-${orderBy}-${groupByFieldValue}-${slice}`;
+      return `$${groupBy}-${orderBy}-${groupByFieldValue}-${slice}-${mediaField}`;
     },
 });
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

ImaVid currently has poor or no support of media fields. This PR fixes that.

## How is this patch tested? If it is not, please explain why.

e2e + local test directions forthcoming

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?


-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced media field selection and rendering in modal components.
  - Improved media file path handling and store management.

- **Bug Fixes**
  - Optimized event listener behavior for media frame fetching.

- **Refactor**
  - Updated key generation for media-related components.
  - Improved granularity of frame store controller management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->