### PR TITLE
Fix `open-clip-torch` model inference

### DIFF
--- a/fiftyone/utils/open_clip.py
+++ b/fiftyone/utils/open_clip.py
@@ -88,7 +88,7 @@ class TorchOpenClipModel(fout.TorchImageModel, fom.PromptMixin):
         (
             self._model,
             _,
-            self.preprocess,
+            self._preprocess,
         ) = open_clip.create_model_and_transforms(
             config.clip_model,
             pretrained=config.pretrained,
@@ -134,7 +134,7 @@ class TorchOpenClipModel(fout.TorchImageModel, fom.PromptMixin):
 
     def _predict_all(self, imgs):
         if self._preprocess:
-            imgs = [self._preprocess(img).unsqueeze(0) for img in imgs]
+            imgs = [self._preprocess(img) for img in imgs]
 
         if isinstance(imgs, (list, tuple)):
             imgs = torch.stack(imgs)

--- a/fiftyone/utils/open_clip.py
+++ b/fiftyone/utils/open_clip.py
@@ -57,6 +57,7 @@ class TorchOpenClipModel(fout.TorchImageModel, fom.PromptMixin):
     def __init__(self, config):
         super().__init__(config)
         self._text_features = None
+        self.preprocess = self._preprocess_aux
 
     @property
     def can_embed_prompts(self):
@@ -88,7 +89,7 @@ class TorchOpenClipModel(fout.TorchImageModel, fom.PromptMixin):
         (
             self._model,
             _,
-            self._preprocess,
+            self._preprocess_aux,
         ) = open_clip.create_model_and_transforms(
             config.clip_model,
             pretrained=config.pretrained,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix open clip zoo model.

See https://github.com/voxel51/fiftyone/pull/5026#issuecomment-2594278205 for details.

## How is this patch tested? If it is not, please explain why.

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("coco-2017", split="validation", max_samples=10, shuffle=True)
model = foz.load_zoo_model("open-clip-torch")

dataset.apply_model(model, label_field="predictions")
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated preprocessing method for OpenClip model.
	- Simplified image preprocessing during prediction.

These changes enhance the efficiency of the OpenClip model's image processing capabilities, leading to improved performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->