### PR TITLE
Use estimated document count when possible for `count()` operations

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -7726,6 +7726,20 @@ class SampleCollection(object):
         Returns:
             the count
         """
+
+        # Optimization: use estimated document count when possible
+        if (
+            isinstance(self, fod.Dataset)
+            and expr is None
+            and (
+                field_or_expr is None
+                or (field_or_expr == "frames" and self._has_frame_fields())
+            )
+        ):
+            frames = field_or_expr == "frames"
+            # pylint: disable=no-member
+            return self._estimated_count(frames=frames)
+
         make = lambda field_or_expr: foa.Count(
             field_or_expr, expr=expr, safe=safe
         )

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -360,6 +360,15 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     def __len__(self):
         return self.count()
 
+    def _estimated_count(self, frames=False):
+        if frames:
+            if self._frame_collection is None:
+                return None
+
+            return self._frame_collection.estimated_document_count()
+
+        return self._sample_collection.estimated_document_count()
+
     def __getitem__(self, id_filepath_slice):
         if isinstance(id_filepath_slice, numbers.Integral):
             raise ValueError(


### PR DESCRIPTION
## Change log

Use estimated document counts for `dataset.count()` and `dataset.count("frames")`.

## Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video")

# These all now use estimated document counts
_ = dataset.summary()
_ = len(dataset)
_ = dataset.count()
_ = dataset.count("frames")

dataset = foz.load_zoo_dataset("quickstart-groups")

# And so do these
view = dataset.select_group_slices(_allow_mixed=True)
_ = view.summary()
_ = len(view)
_ = view.count()
```

## Discussion

When are estimated document counts not exact? See
https://www.mongodb.com/docs/manual/reference/method/db.collection.estimatedDocumentCount/#behavior

For context, aside from cases where a user is directly calling `count()`, there are a couple key operations that call `count()` internally:

1. `len(dataset)` calls `dataset.count()`
2. `print(dataset)` calls `dataset.summary()` which calls `dataset.count()`

In my opinion, 2 is a clear case where it makes sense to use estimated document counts. It's more important for `print(dataset)` to be fast than it is for the count to be accurate in every possible case.

1 is a bit dubious though. On one hand, it's reasonable to assume that there are cases where you want to know *exactly* how many samples are in a dataset. On the other hand, there are times, especially in interactive shells, where you don't need precision, you just want to know, well, *roughly* how big the dataset is (ya know, an *estimate*).

My current opinion is that it is probably okay for `len(dataset)` to be an estimate. After all, datasets may have samples added/deleted at any time. So there's really no guarantee how long an "exact" document count will remain exact. And therefore it you're writing code that relies on `len(dataset)` being exact for a long period of time, then you're probably asking for trouble.

An alternative strategy would be to make this optimization *optional*, eg by introducing a syntax like this:

```py
# Allow estimated document counts, if possible
dataset_or_view.count(..., allow_estimates=True)
```

We could then make sure that `print(dataset)` uses the optimization, while making the default `dataset.count(..., allow_estimates=False)` so that `len(dataset)` is exact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Optimization**
	- Enhanced document counting method with estimated count functionality.
	- Added performance-improving checks for sample and frame collections.
	- Introduced a new method to determine full dataset collection status.

- **New Features**
	- Added a method to quickly obtain an estimated count of samples or frames in the dataset.
	- Enhanced modal components to ensure correct re-rendering based on selected media fields.
	- Improved operator execution handling by simplifying the interaction model and removing unused props.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->