### PR TITLE
remove itsdangerous pin

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,6 +1,6 @@
 aiofiles==0.7.0
 argcomplete==1.11.0
-boto3==1.17.36
+boto3==1.36.2
 cachetools==5.2.0
 dacite==1.6.0
 Deprecated==1.2.11

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,7 +1,7 @@
 google-api-python-client>=1.6.5
 google-cloud-storage>=1.36
 httplib2<=0.15
-ipywidgets>=7.5,<8
+ipywidgets>=7.5
 notebook>=5.3
 pydicom>=2.2.0
 shapely>=1.7.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,4 @@
 open3d>=0.16.0
-itsdangerous==2.0.1
 werkzeug>=2.0.3
 pydicom<3
 pytest==7.3.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,5 @@
 open3d<0.19.0
+itsdangerous==2.0.1
 werkzeug>=2.0.3
 pydicom<3
 pytest==7.3.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
-open3d>=0.16.0
+open3d==0.18.0
 itsdangerous==2.0.1
 werkzeug>=2.0.3
 pydicom<3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,5 @@
 awscli==1.37.2
-open3d>0.16.0
+open3d>=0.16.0
 werkzeug>=2.0.3
 pydicom<3
 pytest==7.3.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
-open3d==0.18.0
+open3d>=0.16,<0.19
 itsdangerous==2.0.1
 werkzeug>=2.0.3
 pydicom<3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
-open3d<0.19.0
+open3d~=0.18.0
 itsdangerous==2.0.1
 werkzeug>=2.0.3
 pydicom<3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
-open3d>=0.16.0
+open3d<0.19.0
 werkzeug>=2.0.3
 pydicom<3
 pytest==7.3.1
@@ -8,4 +8,3 @@ pytest-asyncio
 shapely
 tensorflow==2.17.0
 twine>=3
-urllib3==1.26.20

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,4 @@
+boto3==1.17.36
 open3d>0.16.0
 itsdangerous==2.1.2
 werkzeug>=2.0.3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
-boto3==1.17.36
+awscli==1.37.2
 open3d>0.16.0
 itsdangerous==2.1.2
 werkzeug>=2.0.3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
-open3d>=0.16,<0.19
+open3d>=0.16.0
 itsdangerous==2.0.1
 werkzeug>=2.0.3
 pydicom<3
@@ -9,3 +9,4 @@ pytest-asyncio
 shapely
 tensorflow==2.17.0
 twine>=3
+urllib3==1.26.20

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,5 @@
 awscli==1.37.2
 open3d>0.16.0
-itsdangerous==2.1.2
 werkzeug>=2.0.3
 pydicom<3
 pytest==7.3.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,5 @@
-open3d~=0.18.0
-itsdangerous==2.0.1
+open3d>0.16.0
+itsdangerous==2.1.2
 werkzeug>=2.0.3
 pydicom<3
 pytest==7.3.1


### PR DESCRIPTION
open3d 0.19.0 has updated flask dependencies that breaks build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Added a new package dependency: `awscli==1.37.2`.
	- Updated version of `boto3` to `1.36.2`.
	- Removed version constraint for `itsdangerous`.
	- Adjusted formatting for `twine` version constraint for consistency.
	- Updated version constraint for `ipywidgets` to allow versions 7.5 and above.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->