### PR TITLE
Revert "Merge pull request #5348 from voxel51/prompt-on-cancel"

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/OperatorExecutionButtonView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/OperatorExecutionButtonView.tsx
@@ -11,7 +11,6 @@ import TooltipProvider from "./TooltipProvider";
 import { OperatorExecutionOption } from "@fiftyone/operators/src/state";
 import {
   ExecutionCallback,
-  ExecutionCancelCallback,
   ExecutionErrorCallback,
 } from "@fiftyone/operators/src/types-internal";
 import { OperatorResult } from "@fiftyone/operators/src/operators";
@@ -31,8 +30,6 @@ export default function OperatorExecutionButtonView(props: ViewPropsType) {
     on_error,
     on_success,
     on_option_selected,
-    on_cancel,
-    prompt,
   } = view;
   const panelId = usePanelId();
   const variant = getVariant(props);
@@ -78,13 +75,6 @@ export default function OperatorExecutionButtonView(props: ViewPropsType) {
       });
     }
   };
-  const handleOnCancel: ExecutionCancelCallback = () => {
-    if (on_cancel) {
-      triggerEvent(panelId, {
-        operator: on_cancel,
-      });
-    }
-  };
   const handleOnOptionSelected = (option: OperatorExecutionOption) => {
     if (on_option_selected) {
       triggerEvent(panelId, {
@@ -96,13 +86,6 @@ export default function OperatorExecutionButtonView(props: ViewPropsType) {
     }
   };
 
-  const iconProps = prompt
-    ? {}
-    : {
-        startIcon: icon_position === "left" ? Icon : undefined,
-        endIcon: icon_position === "right" ? Icon : undefined,
-      };
-
   return (
     <Box {...getComponentProps(props, "container")}>
       <TooltipProvider title={title} {...getComponentProps(props, "tooltip")}>
@@ -111,12 +94,11 @@ export default function OperatorExecutionButtonView(props: ViewPropsType) {
           onSuccess={handleOnSuccess}
           onError={handleOnError}
           onOptionSelected={handleOnOptionSelected}
-          prompt={prompt}
-          onCancel={handleOnCancel}
           executionParams={computedParams}
           variant={variant}
           disabled={disabled}
-          {...iconProps}
+          startIcon={icon_position === "left" ? Icon : undefined}
+          endIcon={icon_position === "right" ? Icon : undefined}
           title={description}
           {...getComponentProps(props, "button", getButtonProps(props))}
         >

--- a/app/packages/core/src/plugins/SchemaIO/components/TooltipProvider.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TooltipProvider.tsx
@@ -6,7 +6,7 @@ export default function TooltipProvider(props: TooltipProps) {
   if (!title) return children;
   return (
     <Tooltip title={title} {...tooltipProps}>
-      <Box component="span">{children}</Box>
+      <Box>{children}</Box>
     </Tooltip>
   );
 }

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -1037,7 +1037,6 @@ class PromptUserForOperation extends Operator {
     inputs.obj("params", { label: "Params" });
     inputs.str("on_success", { label: "On success" });
     inputs.str("on_error", { label: "On error" });
-    inputs.str("on_cancel", { label: "On cancel" });
     inputs.bool("skip_prompt", { label: "Skip prompt", default: false });
     return new types.Property(inputs);
   }
@@ -1046,8 +1045,7 @@ class PromptUserForOperation extends Operator {
     return { triggerEvent };
   }
   async execute(ctx: ExecutionContext): Promise<void> {
-    const { params, operator_uri, on_success, on_error, on_cancel } =
-      ctx.params;
+    const { params, operator_uri, on_success, on_error } = ctx.params;
     const { triggerEvent } = ctx.hooks;
     const panelId = ctx.getCurrentPanelId();
     const shouldPrompt = !ctx.params.skip_prompt;
@@ -1056,14 +1054,6 @@ class PromptUserForOperation extends Operator {
       operator: operator_uri,
       params,
       prompt: shouldPrompt,
-      onCancel: () => {
-        if (on_cancel) {
-          triggerEvent(panelId, {
-            operator: on_cancel,
-            params: { operator_uri },
-          });
-        }
-      },
       callback: (result: OperatorResult, opts: { ctx: ExecutionContext }) => {
         const ctx = opts.ctx;
         if (result.error) {

--- a/app/packages/operators/src/components/OperatorExecutionButton/index.tsx
+++ b/app/packages/operators/src/components/OperatorExecutionButton/index.tsx
@@ -1,18 +1,11 @@
-import TooltipProvider from "@fiftyone/core/src/plugins/SchemaIO/components/TooltipProvider";
 import { Button } from "@mui/material";
-import React, { useCallback, useMemo } from "react";
-import {
-  OperatorExecutionOption,
-  useOperatorExecutionOptions,
-  useOperatorExecutor,
-  usePromptOperatorInput,
-} from "../../state";
+import { OperatorExecutionTrigger } from "../OperatorExecutionTrigger";
+import React from "react";
 import {
   ExecutionCallback,
   ExecutionErrorCallback,
-  OperatorExecutorOptions,
 } from "../../types-internal";
-import { OperatorExecutionTrigger } from "../OperatorExecutionTrigger";
+import { OperatorExecutionOption } from "../../state";
 
 /**
  * Button which acts as a trigger for opening an `OperatorExecutionMenu`.
@@ -23,33 +16,26 @@ import { OperatorExecutionTrigger } from "../OperatorExecutionTrigger";
  * @param executionParams Parameters to provide to the operator's execute call
  * @param onOptionSelected Callback for execution option selection
  * @param disabled If true, disables the button and context menu
- * @param executorOptions Operator executor options
  */
 export const OperatorExecutionButton = ({
   operatorUri,
   onSuccess,
   onError,
   onClick,
-  onCancel,
   executionParams,
   onOptionSelected,
-  prompt,
   disabled,
   children,
-  executorOptions,
   ...props
 }: {
   operatorUri: string;
   onSuccess?: ExecutionCallback;
   onError?: ExecutionErrorCallback;
   onClick?: () => void;
-  onCancel?: () => void;
-  prompt?: boolean;
   executionParams?: object;
   onOptionSelected?: (option: OperatorExecutionOption) => void;
   disabled?: boolean;
   children: React.ReactNode;
-  executorOptions?: OperatorExecutorOptions;
 }) => {
   // Pass onSuccess and onError through to the operator executor.
   // These will be invoked on operator completion.
@@ -125,11 +111,8 @@ export const OperatorExecutionButton = ({
       onClick={onClick}
       onSuccess={onSuccess}
       onError={onError}
-      onCancel={onCancel}
-      prompt={prompt}
       executionParams={executionParams}
       onOptionSelected={onOptionSelected}
-      executionOptions={executionOptions}
       disabled={disabled}
     >
       <Button disabled={disabled} {...props}>

--- a/app/packages/operators/src/components/OperatorExecutionTrigger/index.tsx
+++ b/app/packages/operators/src/components/OperatorExecutionTrigger/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import { Box } from "@mui/material";
 import { OperatorExecutionMenu } from "../OperatorExecutionMenu";
 import {
@@ -6,7 +6,11 @@ import {
   ExecutionErrorCallback,
   OperatorExecutorOptions,
 } from "../../types-internal";
-import { OperatorExecutionOption } from "../../state";
+import {
+  OperatorExecutionOption,
+  useOperatorExecutionOptions,
+  useOperatorExecutor,
+} from "../../state";
 
 /**
  * Component which acts as a trigger for opening an `OperatorExecutionMenu`.
@@ -34,8 +38,12 @@ import { OperatorExecutionOption } from "../../state";
  * @param disabled If true, context menu will never open
  */
 export const OperatorExecutionTrigger = ({
+  operatorUri,
   onClick,
-  executionOptions,
+  onSuccess,
+  onError,
+  executionParams,
+  executorOptions,
   onOptionSelected,
   disabled,
   children,
@@ -46,16 +54,39 @@ export const OperatorExecutionTrigger = ({
   onClick?: () => void;
   onSuccess?: ExecutionCallback;
   onError?: ExecutionErrorCallback;
-  prompt?: boolean;
   executionParams?: object;
   executorOptions?: OperatorExecutorOptions;
-  executionOptions?: OperatorExecutionOption[];
   onOptionSelected?: (option: OperatorExecutionOption) => void;
   disabled?: boolean;
 }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   // Anchor to use for context menu
   const containerRef = useRef(null);
+
+  // Pass onSuccess and onError through to the operator executor.
+  // These will be invoked on operator completion.
+  const operatorHandlers = useMemo(() => {
+    return { onSuccess, onError };
+  }, [onSuccess, onError]);
+  const operator = useOperatorExecutor(operatorUri, operatorHandlers);
+
+  // This callback will be invoked when an execution target option is clicked
+  const onExecute = useCallback(
+    (options?: OperatorExecutorOptions) => {
+      const resolvedOptions = {
+        ...executorOptions,
+        ...options,
+      };
+
+      return operator.execute(executionParams ?? {}, resolvedOptions);
+    },
+    [executorOptions, operator, executionParams]
+  );
+
+  const { executionOptions } = useOperatorExecutionOptions({
+    operatorUri,
+    onExecute,
+  });
 
   // Click handler controls the state of the context menu.
   const clickHandler = useCallback(() => {

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -422,10 +422,6 @@ export const useOperatorExecutionOptions = ({
   onExecute: (opts: OperatorExecutorOptions) => void;
 }): {
   executionOptions: OperatorExecutionOption[];
-  hasOptions: boolean;
-  warningMessage: React.ReactNode;
-  showWarning: boolean;
-  isLoading: boolean;
 } => {
   const ctx = useExecutionContext(operatorUri);
   const { isRemote } = getLocalOrRemoteOperator(operatorUri);
@@ -438,10 +434,6 @@ export const useOperatorExecutionOptions = ({
 
   return {
     executionOptions: submitOptions.options,
-    hasOptions: submitOptions.hasOptions,
-    warningMessage: submitOptions.warningMessage,
-    showWarning: submitOptions.showWarning,
-    isLoading: execDetails.isLoading,
   };
 };
 
@@ -587,11 +579,6 @@ export const useOperatorPrompt = () => {
     },
     [operator, promptingOperator, cachedResolvedInput]
   );
-  const onCancel = promptingOperator.options?.onCancel;
-  const cancel = () => {
-    if (onCancel) onCancel();
-    close();
-  };
   const close = () => {
     setPromptingOperator(null);
     setInputFields(null);
@@ -669,7 +656,7 @@ export const useOperatorPrompt = () => {
     isExecuting,
     hasResultOrError,
     close,
-    cancel,
+    cancel: close,
     validationErrors,
     validate,
     validateThrottled,

--- a/app/packages/operators/src/types-internal.ts
+++ b/app/packages/operators/src/types-internal.ts
@@ -9,7 +9,6 @@ export type ExecutionErrorCallback = (
   error: OperatorResult,
   options: ExecutionCallbackOptions
 ) => void;
-export type ExecutionCancelCallback = () => void;
 
 export type OperatorExecutorOptions = {
   delegationTarget?: string;

--- a/app/packages/operators/src/usePanelEvent.ts
+++ b/app/packages/operators/src/usePanelEvent.ts
@@ -11,7 +11,6 @@ type HandlerOptions = {
   prompt?: boolean;
   panelId: string;
   callback?: ExecutionCallback;
-  onCancel?: () => void;
   currentPanelState?: any; // most current panel state
 };
 
@@ -21,7 +20,7 @@ export default function usePanelEvent() {
   const { increment, decrement } = useActivePanelEventsCount("");
   return usePanelStateByIdCallback((panelId, panelState, args) => {
     const options = args[0] as HandlerOptions;
-    const { params, operator, prompt, currentPanelState, onCancel } = options;
+    const { params, operator, prompt, currentPanelState } = options;
 
     if (!operator) {
       notify({
@@ -50,10 +49,7 @@ export default function usePanelEvent() {
     };
 
     if (prompt) {
-      promptForOperator(operator, actualParams, {
-        callback: eventCallback,
-        onCancel,
-      });
+      promptForOperator(operator, actualParams, { callback: eventCallback });
     } else {
       increment(panelId);
       executeOperator(operator, actualParams, { callback: eventCallback });

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -744,7 +744,6 @@ class ExecutionContext(object):
         params=None,
         on_success=None,
         on_error=None,
-        on_cancel=None,
         skip_prompt=False,
     ):
         """Prompts the user to execute the operator with the given URI.
@@ -755,7 +754,6 @@ class ExecutionContext(object):
             on_success (None): a callback to invoke if the user successfully
                 executes the operator
             on_error (None): a callback to invoke if the execution fails
-            on_cancel (None): a callback to invoke if the user cancels the prompt
             skip_prompt (False): whether to skip the prompt
 
         Returns:
@@ -771,7 +769,6 @@ class ExecutionContext(object):
                     "params": params,
                     "on_success": on_success,
                     "on_error": on_error,
-                    "on_cancel": on_cancel,
                     "skip_prompt": skip_prompt,
                 }
             ),


### PR DESCRIPTION
This reverts commit c5d3bf5715f1f5fa1049ff381f2a3508dd31df26, reversing changes made to 55709fbe72ca648bd1927ae3e9001359851b9dfd.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed cancellation handling across multiple components and files
	- Simplified operator execution and prompt workflows
	- Streamlined component props and hook return types

- **Changes**
	- Eliminated `onCancel` functionality from operator execution
	- Reduced complexity in execution options and state management
	- Removed unused type declarations and callback parameters

The changes focus on simplifying the operator execution process by removing cancellation-related code and reducing unnecessary complexity in the implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->