### PR TITLE
Revert on change PR 5348

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/OperatorExecutionButtonView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/OperatorExecutionButtonView.tsx
@@ -11,7 +11,6 @@ import TooltipProvider from "./TooltipProvider";
 import { OperatorExecutionOption } from "@fiftyone/operators/src/state";
 import {
   ExecutionCallback,
-  ExecutionCancelCallback,
   ExecutionErrorCallback,
 } from "@fiftyone/operators/src/types-internal";
 import { OperatorResult } from "@fiftyone/operators/src/operators";
@@ -31,8 +30,6 @@ export default function OperatorExecutionButtonView(props: ViewPropsType) {
     on_error,
     on_success,
     on_option_selected,
-    on_cancel,
-    prompt,
   } = view;
   const panelId = usePanelId();
   const variant = getVariant(props);
@@ -78,13 +75,6 @@ export default function OperatorExecutionButtonView(props: ViewPropsType) {
       });
     }
   };
-  const handleOnCancel: ExecutionCancelCallback = () => {
-    if (on_cancel) {
-      triggerEvent(panelId, {
-        operator: on_cancel,
-      });
-    }
-  };
   const handleOnOptionSelected = (option: OperatorExecutionOption) => {
     if (on_option_selected) {
       triggerEvent(panelId, {
@@ -96,13 +86,6 @@ export default function OperatorExecutionButtonView(props: ViewPropsType) {
     }
   };
 
-  const iconProps = prompt
-    ? {}
-    : {
-        startIcon: icon_position === "left" ? Icon : undefined,
-        endIcon: icon_position === "right" ? Icon : undefined,
-      };
-
   return (
     <Box {...getComponentProps(props, "container")}>
       <TooltipProvider title={title} {...getComponentProps(props, "tooltip")}>
@@ -111,12 +94,11 @@ export default function OperatorExecutionButtonView(props: ViewPropsType) {
           onSuccess={handleOnSuccess}
           onError={handleOnError}
           onOptionSelected={handleOnOptionSelected}
-          prompt={prompt}
-          onCancel={handleOnCancel}
           executionParams={computedParams}
           variant={variant}
           disabled={disabled}
-          {...iconProps}
+          startIcon={icon_position === "left" ? Icon : undefined}
+          endIcon={icon_position === "right" ? Icon : undefined}
           title={description}
           {...getComponentProps(props, "button", getButtonProps(props))}
         >

--- a/app/packages/core/src/plugins/SchemaIO/components/TooltipProvider.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TooltipProvider.tsx
@@ -6,7 +6,7 @@ export default function TooltipProvider(props: TooltipProps) {
   if (!title) return children;
   return (
     <Tooltip title={title} {...tooltipProps}>
-      <Box component="span">{children}</Box>
+      <Box>{children}</Box>
     </Tooltip>
   );
 }

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -1037,7 +1037,6 @@ class PromptUserForOperation extends Operator {
     inputs.obj("params", { label: "Params" });
     inputs.str("on_success", { label: "On success" });
     inputs.str("on_error", { label: "On error" });
-    inputs.str("on_cancel", { label: "On cancel" });
     inputs.bool("skip_prompt", { label: "Skip prompt", default: false });
     return new types.Property(inputs);
   }
@@ -1046,8 +1045,7 @@ class PromptUserForOperation extends Operator {
     return { triggerEvent };
   }
   async execute(ctx: ExecutionContext): Promise<void> {
-    const { params, operator_uri, on_success, on_error, on_cancel } =
-      ctx.params;
+    const { params, operator_uri, on_success, on_error } = ctx.params;
     const { triggerEvent } = ctx.hooks;
     const panelId = ctx.getCurrentPanelId();
     const shouldPrompt = !ctx.params.skip_prompt;
@@ -1056,14 +1054,6 @@ class PromptUserForOperation extends Operator {
       operator: operator_uri,
       params,
       prompt: shouldPrompt,
-      onCancel: () => {
-        if (on_cancel) {
-          triggerEvent(panelId, {
-            operator: on_cancel,
-            params: { operator_uri },
-          });
-        }
-      },
       callback: (result: OperatorResult, opts: { ctx: ExecutionContext }) => {
         const ctx = opts.ctx;
         if (result.error) {

--- a/app/packages/operators/src/components/OperatorExecutionButton/index.tsx
+++ b/app/packages/operators/src/components/OperatorExecutionButton/index.tsx
@@ -1,18 +1,17 @@
-import TooltipProvider from "@fiftyone/core/src/plugins/SchemaIO/components/TooltipProvider";
 import { Button } from "@mui/material";
+import { OperatorExecutionTrigger } from "../OperatorExecutionTrigger";
 import React, { useCallback, useMemo } from "react";
+import {
+  ExecutionCallback,
+  ExecutionErrorCallback,
+  OperatorExecutorOptions,
+} from "../../types-internal";
 import {
   OperatorExecutionOption,
   useOperatorExecutionOptions,
   useOperatorExecutor,
   usePromptOperatorInput,
 } from "../../state";
-import {
-  ExecutionCallback,
-  ExecutionErrorCallback,
-  OperatorExecutorOptions,
-} from "../../types-internal";
-import { OperatorExecutionTrigger } from "../OperatorExecutionTrigger";
 
 /**
  * Button which acts as a trigger for opening an `OperatorExecutionMenu`.
@@ -85,31 +84,10 @@ export const OperatorExecutionButton = ({
     [executorOptions, operator, executionParams]
   );
 
-  const { executionOptions, warningMessage, showWarning, isLoading } =
-    useOperatorExecutionOptions({
-      operatorUri,
-      onExecute,
-    });
-
-  if (isLoading) return null;
-
-  if (disabled) {
-    return (
-      <Button disabled {...props} variant={props.variant}>
-        {children}
-      </Button>
-    );
-  }
-
-  if (showWarning) {
-    return (
-      <TooltipProvider title={warningMessage}>
-        <Button disabled={true} variant={props.variant}>
-          {children}
-        </Button>
-      </TooltipProvider>
-    );
-  }
+  const { executionOptions } = useOperatorExecutionOptions({
+    operatorUri,
+    onExecute,
+  });
 
   if (prompt) {
     return (
@@ -129,7 +107,6 @@ export const OperatorExecutionButton = ({
       prompt={prompt}
       executionParams={executionParams}
       onOptionSelected={onOptionSelected}
-      executionOptions={executionOptions}
       disabled={disabled}
     >
       <Button disabled={disabled} {...props}>

--- a/app/packages/operators/src/components/OperatorExecutionButton/index.tsx
+++ b/app/packages/operators/src/components/OperatorExecutionButton/index.tsx
@@ -1,17 +1,11 @@
 import { Button } from "@mui/material";
 import { OperatorExecutionTrigger } from "../OperatorExecutionTrigger";
-import React, { useCallback, useMemo } from "react";
+import React from "react";
 import {
   ExecutionCallback,
   ExecutionErrorCallback,
-  OperatorExecutorOptions,
 } from "../../types-internal";
-import {
-  OperatorExecutionOption,
-  useOperatorExecutionOptions,
-  useOperatorExecutor,
-  usePromptOperatorInput,
-} from "../../state";
+import { OperatorExecutionOption } from "../../state";
 
 /**
  * Button which acts as a trigger for opening an `OperatorExecutionMenu`.
@@ -22,89 +16,33 @@ import {
  * @param executionParams Parameters to provide to the operator's execute call
  * @param onOptionSelected Callback for execution option selection
  * @param disabled If true, disables the button and context menu
- * @param executorOptions Operator executor options
  */
 export const OperatorExecutionButton = ({
   operatorUri,
   onSuccess,
   onError,
   onClick,
-  onCancel,
   executionParams,
   onOptionSelected,
-  prompt,
   disabled,
   children,
-  executorOptions,
   ...props
 }: {
   operatorUri: string;
   onSuccess?: ExecutionCallback;
   onError?: ExecutionErrorCallback;
   onClick?: () => void;
-  onCancel?: () => void;
-  prompt?: boolean;
   executionParams?: object;
   onOptionSelected?: (option: OperatorExecutionOption) => void;
   disabled?: boolean;
   children: React.ReactNode;
-  executorOptions?: OperatorExecutorOptions;
 }) => {
-  // Pass onSuccess and onError through to the operator executor.
-  // These will be invoked on operator completion.
-  const operatorHandlers = useMemo(() => {
-    return { onSuccess, onError };
-  }, [onSuccess, onError]);
-  const operator = useOperatorExecutor(operatorUri, operatorHandlers);
-  const promptForOperator = usePromptOperatorInput();
-
-  // This callback will be invoked when an execution target option is clicked
-  const onExecute = useCallback(
-    (options?: OperatorExecutorOptions) => {
-      const resolvedOptions = {
-        ...executorOptions,
-        ...options,
-      };
-
-      if (prompt) {
-        promptForOperator(operatorUri, executionParams, {
-          callback: (result, opts) => {
-            if (result?.error) {
-              onError?.(result, opts);
-            } else {
-              onSuccess?.(result, opts);
-            }
-          },
-          onCancel,
-        });
-      } else {
-        return operator.execute(executionParams ?? {}, resolvedOptions);
-      }
-    },
-    [executorOptions, operator, executionParams]
-  );
-
-  const { executionOptions } = useOperatorExecutionOptions({
-    operatorUri,
-    onExecute,
-  });
-
-  if (prompt) {
-    return (
-      <Button disabled={disabled} {...props} onClick={onExecute}>
-        {children}
-      </Button>
-    );
-  }
-
   return (
     <OperatorExecutionTrigger
       operatorUri={operatorUri}
       onClick={onClick}
       onSuccess={onSuccess}
       onError={onError}
-      onCancel={onCancel}
-      prompt={prompt}
       executionParams={executionParams}
       onOptionSelected={onOptionSelected}
       disabled={disabled}

--- a/app/packages/operators/src/components/OperatorExecutionTrigger/index.tsx
+++ b/app/packages/operators/src/components/OperatorExecutionTrigger/index.tsx
@@ -46,6 +46,7 @@ export const OperatorExecutionTrigger = ({
   onClick?: () => void;
   onSuccess?: ExecutionCallback;
   onError?: ExecutionErrorCallback;
+  onCancel?: () => void;
   prompt?: boolean;
   executionParams?: object;
   executorOptions?: OperatorExecutorOptions;

--- a/app/packages/operators/src/components/OperatorExecutionTrigger/index.tsx
+++ b/app/packages/operators/src/components/OperatorExecutionTrigger/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { Box, Button } from "@mui/material";
+import { Box } from "@mui/material";
 import { OperatorExecutionMenu } from "../OperatorExecutionMenu";
 import {
   ExecutionCallback,
@@ -10,7 +10,6 @@ import {
   OperatorExecutionOption,
   useOperatorExecutionOptions,
   useOperatorExecutor,
-  usePromptOperatorInput,
 } from "../../state";
 
 /**
@@ -39,8 +38,12 @@ import {
  * @param disabled If true, context menu will never open
  */
 export const OperatorExecutionTrigger = ({
+  operatorUri,
   onClick,
-  executionOptions,
+  onSuccess,
+  onError,
+  executionParams,
+  executorOptions,
   onOptionSelected,
   disabled,
   children,
@@ -51,17 +54,39 @@ export const OperatorExecutionTrigger = ({
   onClick?: () => void;
   onSuccess?: ExecutionCallback;
   onError?: ExecutionErrorCallback;
-  onCancel?: () => void;
-  prompt?: boolean;
   executionParams?: object;
   executorOptions?: OperatorExecutorOptions;
-  executionOptions?: OperatorExecutionOption[];
   onOptionSelected?: (option: OperatorExecutionOption) => void;
   disabled?: boolean;
 }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   // Anchor to use for context menu
   const containerRef = useRef(null);
+
+  // Pass onSuccess and onError through to the operator executor.
+  // These will be invoked on operator completion.
+  const operatorHandlers = useMemo(() => {
+    return { onSuccess, onError };
+  }, [onSuccess, onError]);
+  const operator = useOperatorExecutor(operatorUri, operatorHandlers);
+
+  // This callback will be invoked when an execution target option is clicked
+  const onExecute = useCallback(
+    (options?: OperatorExecutorOptions) => {
+      const resolvedOptions = {
+        ...executorOptions,
+        ...options,
+      };
+
+      return operator.execute(executionParams ?? {}, resolvedOptions);
+    },
+    [executorOptions, operator, executionParams]
+  );
+
+  const { executionOptions } = useOperatorExecutionOptions({
+    operatorUri,
+    onExecute,
+  });
 
   // Click handler controls the state of the context menu.
   const clickHandler = useCallback(() => {

--- a/app/packages/operators/src/components/OperatorExecutionTrigger/index.tsx
+++ b/app/packages/operators/src/components/OperatorExecutionTrigger/index.tsx
@@ -1,12 +1,17 @@
-import React, { useCallback, useRef, useState } from "react";
-import { Box } from "@mui/material";
+import React, { useCallback, useMemo, useRef, useState } from "react";
+import { Box, Button } from "@mui/material";
 import { OperatorExecutionMenu } from "../OperatorExecutionMenu";
 import {
   ExecutionCallback,
   ExecutionErrorCallback,
   OperatorExecutorOptions,
 } from "../../types-internal";
-import { OperatorExecutionOption } from "../../state";
+import {
+  OperatorExecutionOption,
+  useOperatorExecutionOptions,
+  useOperatorExecutor,
+  usePromptOperatorInput,
+} from "../../state";
 
 /**
  * Component which acts as a trigger for opening an `OperatorExecutionMenu`.

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -579,11 +579,6 @@ export const useOperatorPrompt = () => {
     },
     [operator, promptingOperator, cachedResolvedInput]
   );
-  const onCancel = promptingOperator.options?.onCancel;
-  const cancel = () => {
-    if (onCancel) onCancel();
-    close();
-  };
   const close = () => {
     setPromptingOperator(null);
     setInputFields(null);
@@ -661,7 +656,7 @@ export const useOperatorPrompt = () => {
     isExecuting,
     hasResultOrError,
     close,
-    cancel,
+    cancel: close,
     validationErrors,
     validate,
     validateThrottled,

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -422,10 +422,6 @@ export const useOperatorExecutionOptions = ({
   onExecute: (opts: OperatorExecutorOptions) => void;
 }): {
   executionOptions: OperatorExecutionOption[];
-  hasOptions: boolean;
-  warningMessage: React.ReactNode;
-  showWarning: boolean;
-  isLoading: boolean;
 } => {
   const ctx = useExecutionContext(operatorUri);
   const { isRemote } = getLocalOrRemoteOperator(operatorUri);
@@ -438,10 +434,6 @@ export const useOperatorExecutionOptions = ({
 
   return {
     executionOptions: submitOptions.options,
-    hasOptions: submitOptions.hasOptions,
-    warningMessage: submitOptions.warningMessage,
-    showWarning: submitOptions.showWarning,
-    isLoading: execDetails.isLoading,
   };
 };
 

--- a/app/packages/operators/src/types-internal.ts
+++ b/app/packages/operators/src/types-internal.ts
@@ -9,7 +9,6 @@ export type ExecutionErrorCallback = (
   error: OperatorResult,
   options: ExecutionCallbackOptions
 ) => void;
-export type ExecutionCancelCallback = () => void;
 
 export type OperatorExecutorOptions = {
   delegationTarget?: string;

--- a/app/packages/operators/src/usePanelEvent.ts
+++ b/app/packages/operators/src/usePanelEvent.ts
@@ -11,7 +11,6 @@ type HandlerOptions = {
   prompt?: boolean;
   panelId: string;
   callback?: ExecutionCallback;
-  onCancel?: () => void;
   currentPanelState?: any; // most current panel state
 };
 
@@ -21,7 +20,7 @@ export default function usePanelEvent() {
   const { increment, decrement } = useActivePanelEventsCount("");
   return usePanelStateByIdCallback((panelId, panelState, args) => {
     const options = args[0] as HandlerOptions;
-    const { params, operator, prompt, currentPanelState, onCancel } = options;
+    const { params, operator, prompt, currentPanelState } = options;
 
     if (!operator) {
       notify({
@@ -50,10 +49,7 @@ export default function usePanelEvent() {
     };
 
     if (prompt) {
-      promptForOperator(operator, actualParams, {
-        callback: eventCallback,
-        onCancel,
-      });
+      promptForOperator(operator, actualParams, { callback: eventCallback });
     } else {
       increment(panelId);
       executeOperator(operator, actualParams, { callback: eventCallback });

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -744,7 +744,6 @@ class ExecutionContext(object):
         params=None,
         on_success=None,
         on_error=None,
-        on_cancel=None,
         skip_prompt=False,
     ):
         """Prompts the user to execute the operator with the given URI.
@@ -755,7 +754,6 @@ class ExecutionContext(object):
             on_success (None): a callback to invoke if the user successfully
                 executes the operator
             on_error (None): a callback to invoke if the execution fails
-            on_cancel (None): a callback to invoke if the user cancels the prompt
             skip_prompt (False): whether to skip the prompt
 
         Returns:
@@ -771,7 +769,6 @@ class ExecutionContext(object):
                     "params": params,
                     "on_success": on_success,
                     "on_error": on_error,
-                    "on_cancel": on_cancel,
                     "skip_prompt": skip_prompt,
                 }
             ),


### PR DESCRIPTION
Reverts the [recent on_change PR](https://github.com/voxel51/fiftyone/pull/5348/commits)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Refactor**
	- Removed cancel functionality across multiple components and hooks
	- Simplified operator execution and prompt handling
	- Streamlined component props and state management

- **Removed Features**
	- Eliminated `on_cancel` callback and related cancellation logic
	- Removed additional execution option tracking and warning messages

The changes focus on reducing complexity in operator execution and prompt interactions, removing unnecessary cancellation mechanisms while maintaining core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->