### PR TITLE
fix "forwarding" typo in RemoteInstructions component

### DIFF
--- a/app/packages/app/src/components/Setup.tsx
+++ b/app/packages/app/src/components/Setup.tsx
@@ -79,7 +79,7 @@ session = fo.launch_app(dataset, port=${port})
 };
 
 const RemoteInstructions = () => {
-  const bashSnippet = `# Option 1: Configure port forwaring
+  const bashSnippet = `# Option 1: Configure port forwarding
 # Then open http://localhost:${port} in your web browser
 ssh -N -L ${port}:127.0.0.1:XXXX [<username>@]<hostname>
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

typo: forwaring -> forwarding

(you could probably setup a typo checker: https://github.com/crate-ci/typos)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
