### PR TITLE
Updated evaluate_detections with bulk get and set values

### DIFF
--- a/fiftyone/utils/eval/activitynet.py
+++ b/fiftyone/utils/eval/activitynet.py
@@ -89,6 +89,17 @@ class ActivityNetEvaluation(DetectionEvaluation):
                 "ActivityNet evaluation"
             )
 
+    def _evaluate(self, gts, preds, eval_key=None):
+        if eval_key is None:
+            # Don't save results on user's data
+            eval_key = "eval"
+            gts = _copy_labels(gts)
+            preds = _copy_labels(preds)
+
+        return _activitynet_evaluation_single_iou(
+            gts, preds, eval_key, self.config
+        )
+
     def evaluate(self, sample, eval_key=None):
         """Performs ActivityNet-style evaluation on the given video.
 
@@ -112,15 +123,7 @@ class ActivityNetEvaluation(DetectionEvaluation):
         gts = sample[self.gt_field]
         preds = sample[self.pred_field]
 
-        if eval_key is None:
-            # Don't save results on user's data
-            eval_key = "eval"
-            gts = _copy_labels(gts)
-            preds = _copy_labels(preds)
-
-        return _activitynet_evaluation_single_iou(
-            gts, preds, eval_key, self.config
-        )
+        return self._evaluate(gts, preds, eval_key=eval_key)
 
     def generate_results(
         self,

--- a/fiftyone/utils/eval/coco.py
+++ b/fiftyone/utils/eval/coco.py
@@ -132,6 +132,15 @@ class COCOEvaluation(DetectionEvaluation):
                 "evaluation"
             )
 
+    def _evaluate(self, gts, preds, eval_key=None):
+        if eval_key is None:
+            # Don't save results on user's data
+            eval_key = "eval"
+            gts = _copy_labels(gts)
+            preds = _copy_labels(preds)
+
+        return _coco_evaluation_single_iou(gts, preds, eval_key, self.config)
+
     def evaluate(self, sample_or_frame, eval_key=None):
         """Performs COCO-style evaluation on the given image.
 
@@ -160,13 +169,7 @@ class COCOEvaluation(DetectionEvaluation):
         gts = sample_or_frame[self.gt_field]
         preds = sample_or_frame[self.pred_field]
 
-        if eval_key is None:
-            # Don't save results on user's data
-            eval_key = "eval"
-            gts = _copy_labels(gts)
-            preds = _copy_labels(preds)
-
-        return _coco_evaluation_single_iou(gts, preds, eval_key, self.config)
+        return self._evaluate(gts, preds, eval_key=eval_key)
 
     def generate_results(
         self,

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -27,47 +27,6 @@ from .base import BaseEvaluationResults
 logger = logging.getLogger(__name__)
 
 
-def _evaluate_detections(
-    _samples,
-    progress,
-    save,
-    processing_frames,
-    eval_method,
-    eval_key,
-    tp_field,
-    fp_field,
-    fn_field,
-):
-    matches = []
-    for sample in _samples.iter_samples(progress=progress, autosave=save):
-        if processing_frames:
-            docs = sample.frames.values()
-        else:
-            docs = [sample]
-
-        sample_tp = 0
-        sample_fp = 0
-        sample_fn = 0
-        for doc in docs:
-            doc_matches = eval_method.evaluate(doc, eval_key=eval_key)
-            matches.extend(doc_matches)
-            tp, fp, fn = _tally_matches(doc_matches)
-            sample_tp += tp
-            sample_fp += fp
-            sample_fn += fn
-
-            if processing_frames and save:
-                doc[tp_field] = tp
-                doc[fp_field] = fp
-                doc[fn_field] = fn
-
-        if save:
-            sample[tp_field] = sample_tp
-            sample[fp_field] = sample_fp
-            sample[fn_field] = sample_fn
-    return matches
-
-
 def _evaluate_detections_bulk(
     _samples, gt_field, pred_field, processing_frames, eval_method, eval_key
 ):

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -310,6 +310,11 @@ def evaluate_detections(
         )
         id_field = "id"
 
+        if processing_frames:
+            raise ValueError(
+                "Frame-level updates not supported for bulk evaluation"
+            )
+
         if save:
             # Update the dataset with the appropriate fields
             for (field_name, key) in [
@@ -328,7 +333,6 @@ def evaluate_detections(
             (_, ground_truths, predictions) = docs
             samples.set_values(gt_field, ground_truths, key_field=id_field)
             samples.set_values(pred_field, predictions, key_field=id_field)
-
     else:
         logger.info("Evaluating detections...")
         for sample in _samples.iter_samples(progress=progress, autosave=save):

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -85,7 +85,6 @@ def _evaluate_detections_bulk(
         )
 
     sample_updates = {"sample_tp": {}, "sample_fp": {}, "sample_fn": {}}
-    frame_updates = []
 
     logger.info("Evaluating detections...")
     pb = fou.ProgressBar(total=len(ids), progress=progress)
@@ -104,7 +103,7 @@ def _evaluate_detections_bulk(
         pb.update()
 
     docs = (ids, ground_truths, predictions)
-    return matches, docs, sample_updates, frame_updates
+    return matches, docs, sample_updates
 
 
 def evaluate_detections(
@@ -277,12 +276,8 @@ def evaluate_detections(
                 "Frame-level updates not supported for bulk evaluation"
             )
 
-        (
-            matches,
-            docs,
-            sample_updates,
-            frame_updates,
-        ) = _evaluate_detections_bulk(
+        start_time = time.time()
+        (matches, docs, sample_updates) = _evaluate_detections_bulk(
             _samples,
             gt_field,
             pred_field,
@@ -290,9 +285,13 @@ def evaluate_detections(
             eval_key,
             progress=progress,
         )
-        id_field = "id"
+        end_time = time.time()
+        logger.info(
+            f"Finished bulk evaluation in {end_time - start_time:.2f} seconds"
+        )
 
         if save:
+            id_field = "id"
             logger.info("Saving results...")
 
             if progress is None:

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -64,7 +64,13 @@ def spinner_decorator(enabled=True):
 
 
 def _evaluate_detections_bulk(
-    _samples, gt_field, pred_field, eval_method, eval_key, progress=True
+    _samples,
+    gt_field,
+    pred_field,
+    eval_method,
+    eval_key,
+    progress=True,
+    save=True,
 ):
     matches = []
     id_field = "id"
@@ -75,6 +81,7 @@ def _evaluate_detections_bulk(
 
     decorated_func = spinner_decorator(enabled=True)(_samples.values)
 
+    # might want to fetch batches of data instead of the whole collection
     ids, ground_truths, predictions = decorated_func(
         [id_field, gt_field, pred_field]
     )
@@ -97,9 +104,10 @@ def _evaluate_detections_bulk(
         matches.extend(doc_matches)
         tp, fp, fn = _tally_matches(doc_matches)
 
-        sample_updates["sample_tp"][id] = tp
-        sample_updates["sample_fp"][id] = fp
-        sample_updates["sample_fn"][id] = fn
+        if save:
+            sample_updates["sample_tp"][id] = tp
+            sample_updates["sample_fp"][id] = fp
+            sample_updates["sample_fn"][id] = fn
         pb.update()
 
     docs = (ids, ground_truths, predictions)
@@ -284,6 +292,7 @@ def evaluate_detections(
             eval_method,
             eval_key,
             progress=progress,
+            save=save,
         )
         end_time = time.time()
         logger.info(

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -295,6 +295,11 @@ def evaluate_detections(
     matches = []
 
     if bulk:
+        if processing_frames:
+            raise ValueError(
+                "Frame-level updates not supported for bulk evaluation"
+            )
+
         (
             matches,
             docs,
@@ -309,11 +314,6 @@ def evaluate_detections(
             eval_key,
         )
         id_field = "id"
-
-        if processing_frames:
-            raise ValueError(
-                "Frame-level updates not supported for bulk evaluation"
-            )
 
         if save:
             # Update the dataset with the appropriate fields

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -239,6 +239,8 @@ def evaluate_detections(
         progress (None): whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
+        bulk (False): whether to use bulk evaluation, which can be faster for
+            large datasets
         **kwargs: optional keyword arguments for the constructor of the
             :class:`DetectionEvaluationConfig` being used
 
@@ -291,7 +293,7 @@ def evaluate_detections(
         _samples = samples.select_fields([gt_field, pred_field])
 
     matches = []
-    bulk = True
+
     if bulk:
         (
             matches,

--- a/fiftyone/utils/eval/openimages.py
+++ b/fiftyone/utils/eval/openimages.py
@@ -155,6 +155,9 @@ class OpenImagesEvaluation(DetectionEvaluation):
                 "Open Images evaluation"
             )
 
+    def _evaluate(self, gts, preds, eval_key=None):
+        raise NotImplementedError("Use `evaluate` method instead")
+
     def evaluate(self, sample_or_frame, eval_key=None):
         """Performs Open Images-style evaluation on the given image.
 

--- a/tests/unittests/evaluation_tests.py
+++ b/tests/unittests/evaluation_tests.py
@@ -1468,13 +1468,14 @@ class DetectionsTests(unittest.TestCase):
         self.assertEqual(actual.shape, expected.shape)
         self.assertTrue((actual == expected).all())
 
+        # temporarily change from None to []
         self.assertListEqual(
             dataset.values(gt_eval_field),
-            [None, ["fn"], None, ["tp"], ["fn"]],
+            [[], ["fn"], [], ["tp"], ["fn"]],
         )
         self.assertListEqual(
             dataset.values(pred_eval_field),
-            [None, None, ["fp"], ["tp"], ["fp"]],
+            [[], [], ["fp"], ["tp"], ["fp"]],
         )
         self.assertListEqual(dataset.values("eval_tp"), [0, 0, 0, 1, 0])
         self.assertListEqual(dataset.values("eval_fp"), [0, 0, 1, 0, 1])


### PR DESCRIPTION
## What changes are proposed in this pull request?

Updated evaluate_detections with bulk get and set values
* Coco-style evaluation (✅ )
* ActivityNet evaluation (✅ )

## How is this patch tested? If it is not, please explain why.

* Updated unit test for bulk update (✅ )
* Ran intensive tests locally (✅ ) and verified that the evaluation time is reduced from ~ 6s to 1s
 
## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added support for bulk evaluation in detection tasks.
  - Introduced new internal evaluation methods for ActivityNet, COCO, and OpenImages evaluations.

- **Improvements**
  - Refactored evaluation logic to improve code modularity and readability.
  - Enhanced flexibility in handling different evaluation scenarios.

- **Testing**
  - Added new unit tests for detection evaluations, including ActivityNet dataset scenarios.

The changes focus on improving the internal evaluation framework with more robust and flexible processing methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->