### PR TITLE
fix mime type error

### DIFF
--- a/app/packages/looker/src/processOverlays.test.ts
+++ b/app/packages/looker/src/processOverlays.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import HeatmapOverlay from "./overlays/heatmap";
+import SegmentationOverlay from "./overlays/segmentation";
+import { filter } from "./processOverlays";
+
+const EMPTY = {
+  id: "",
+  tags: [],
+};
+
+describe("test overlay processing", () => {
+  it("filters heatmap without a map", () => {
+    expect(filter(new HeatmapOverlay("test", EMPTY), {})).toBe(true);
+  });
+
+  it("filters segmentations without a mask", () => {
+    expect(filter(new SegmentationOverlay("test", EMPTY), {})).toBe(true);
+  });
+});

--- a/app/packages/looker/src/processOverlays.ts
+++ b/app/packages/looker/src/processOverlays.ts
@@ -2,11 +2,12 @@
  * Copyright 2017-2025, Voxel51, Inc.
  */
 
-import { CONTAINS, Overlay } from "./overlays/base";
+import type { Overlay } from "./overlays/base";
+import { CONTAINS } from "./overlays/base";
 import { ClassificationsOverlay } from "./overlays/classifications";
 import HeatmapOverlay from "./overlays/heatmap";
 import SegmentationOverlay from "./overlays/segmentation";
-import { BaseState } from "./state";
+import type { BaseState } from "./state";
 import { rotate } from "./util";
 
 const processOverlays = <State extends BaseState>(
@@ -30,25 +31,17 @@ const processOverlays = <State extends BaseState>(
       continue;
     }
 
-    if (!(overlay.field && overlay.field in bins)) continue;
-
-    // todo: find a better approach / place for this.
-    // for instance, this won't work in detection overlay, where
-    // we might want the bounding boxes but masks might not have been loaded
-    if (overlay instanceof SegmentationOverlay && !overlay.label.mask) {
-      continue;
-    }
-
-    if (overlay instanceof HeatmapOverlay && !overlay.label.map) {
-      continue;
-    }
-
     if (!overlay.isShown(state)) continue;
+
+    if (filter(overlay, bins)) continue;
 
     bins[overlay.field].push(overlay);
   }
 
-  let ordered = activePaths.reduce((acc, cur) => [...acc, ...bins[cur]], []);
+  let ordered = activePaths.reduce((acc, cur) => {
+    acc.push(...bins[cur]);
+    return acc;
+  }, []);
 
   if (classifications && !state.config.thumbnail) {
     ordered = [classifications, ...ordered];
@@ -87,6 +80,28 @@ const processOverlays = <State extends BaseState>(
   }
 
   return [[...contained, ...outside], newRotate];
+};
+
+export const filter = <State extends BaseState>(
+  overlay: Overlay<State>,
+  bins: {
+    [k: string]: Overlay<State>[];
+  }
+) => {
+  if (!(overlay.field && overlay.field in bins)) return true;
+
+  // todo: find a better approach / place for this.
+  // for instance, this won't work in detection overlay, where
+  // we might want the bounding boxes but masks might not have been loaded
+  if (overlay instanceof HeatmapOverlay && !overlay.label.map) {
+    return true;
+  }
+
+  if (overlay instanceof SegmentationOverlay && !overlay.label.mask) {
+    return true;
+  }
+
+  return false;
 };
 
 export default processOverlays;

--- a/app/packages/looker/src/processOverlays.ts
+++ b/app/packages/looker/src/processOverlays.ts
@@ -35,19 +35,11 @@ const processOverlays = <State extends BaseState>(
     // todo: find a better approach / place for this.
     // for instance, this won't work in detection overlay, where
     // we might want the bounding boxes but masks might not have been loaded
-    if (
-      overlay instanceof SegmentationOverlay &&
-      overlay.label.mask_path &&
-      !overlay.label.mask
-    ) {
+    if (overlay instanceof SegmentationOverlay && !overlay.label.mask) {
       continue;
     }
 
-    if (
-      overlay instanceof HeatmapOverlay &&
-      overlay.label.map_path &&
-      !overlay.label.map
-    ) {
+    if (overlay instanceof HeatmapOverlay && !overlay.label.map) {
       continue;
     }
 

--- a/app/packages/looker/src/worker/canvas-decoder.ts
+++ b/app/packages/looker/src/worker/canvas-decoder.ts
@@ -73,6 +73,7 @@ export const decodeWithCanvas = async (blob: Blob, cls: string) => {
   let channels: number = 4;
 
   if (blob.type !== "image/jpg" && blob.type !== "image/jpeg") {
+    // note that the following function doesn't rely on MIME type and instead reads the file header
     const colorType = await getMaybePngcolorType(blob);
     if (colorType !== undefined) {
       // according to PNG specs:

--- a/app/packages/looker/src/worker/canvas-decoder.ts
+++ b/app/packages/looker/src/worker/canvas-decoder.ts
@@ -15,9 +15,11 @@ const canvasAndCtx = (() => {
 const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
 /**
  * Reads the PNG's image header chunk to determine the color type.
- * Returns the color type if PNG, otherwise undefined.
+ * Returns the color type if valid PNG, otherwise undefined.
  */
-const getPngcolorType = async (blob: Blob): Promise<number | undefined> => {
+const getMaybePngcolorType = async (
+  blob: Blob
+): Promise<number | undefined> => {
   // https://www.w3.org/TR/2003/REC-PNG-20031110/#11IHDR
 
   // PNG signature is 8 bytes
@@ -70,8 +72,8 @@ export const recastBufferToMonoChannel = (
 export const decodeWithCanvas = async (blob: Blob, cls: string) => {
   let channels: number = 4;
 
-  if (blob.type === "image/png") {
-    const colorType = await getPngcolorType(blob);
+  if (blob.type !== "image/jpg" && blob.type !== "image/jpeg") {
+    const colorType = await getMaybePngcolorType(blob);
     if (colorType !== undefined) {
       // according to PNG specs:
       // 0: Grayscale          => 1 channel


### PR DESCRIPTION
## What changes are proposed in this pull request?

Sometimes mime type is missing and we get just `binary/octet-stream` for masks. The app should be resilient against that.

Note: unit tests for masks decoding are added in #5413 

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fix masks loading bug

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Improved image processing flexibility in canvas decoding
  - Enhanced overlay processing with more robust filtering

- **Bug Fixes**
  - Refined image type handling in canvas decoding

- **Dependency Updates**
  - Upgraded boto3 to version 1.36.2
  - Updated ipywidgets version constraints
  - Added awscli 1.37.2 to test requirements

- **Chores**
  - Removed specific version constraint for itsdangerous package
  - Refactored overlay and image processing logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->