### PR TITLE
prevent operator prompt exit when isExecuting

### DIFF
--- a/app/packages/operators/src/OperatorPalette.tsx
+++ b/app/packages/operators/src/OperatorPalette.tsx
@@ -25,6 +25,7 @@ export default function OperatorPalette(props: OperatorPaletteProps) {
     onCancel,
     onClose,
     onOutsideClick,
+    isExecuting,
     allowPropagation,
     submitOnControlEnter,
     title,
@@ -64,11 +65,32 @@ export default function OperatorPalette(props: OperatorPaletteProps) {
     };
   }, [paletteElem, keyDownHandler]);
 
+  const handleClose = (
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    reason: "escapeKeyDown" | "backdropClick"
+  ) => {
+    // Prevent closing if an action is in progress
+    if (isExecuting) return;
+
+    switch (reason) {
+      case "escapeKeyDown":
+      case "backdropClick":
+        if (onOutsideClick) {
+          onOutsideClick();
+        } else if (onClose) {
+          onClose();
+        }
+        break;
+      default:
+        onClose?.();
+    }
+  };
+
   return (
     <Dialog
       {...dialogProps}
       open
-      onClose={onClose || onOutsideClick}
+      onClose={handleClose}
       scroll={scroll}
       maxWidth={false}
       aria-labelledby=""
@@ -135,4 +157,5 @@ export type OperatorPaletteProps = PropsWithChildren & {
   warningTitle?: string;
   warningMessage?: string;
   dialogProps?: Omit<DialogProps, "open">;
+  isExecuting?: boolean;
 };


### PR DESCRIPTION
## What changes are proposed in this pull request?

When in executing, the user should not be able to exit or close the prompt modal

## How is this patch tested? If it is not, please explain why.

https://github.com/user-attachments/assets/5360e1d8-72b1-4fcc-979c-37a8115d5978



## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a mechanism to prevent dialog closure during active operations
- **Improvements**
	- Enhanced user interaction control in the Operator Palette component
	- Implemented safeguards to manage dialog closing behavior during ongoing actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->