### PR TITLE
Cherry Pick Open3d fix

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,6 +1,6 @@
 aiofiles==0.7.0
 argcomplete==1.11.0
-boto3==1.17.36
+boto3==1.36.2
 cachetools==5.2.0
 dacite==1.6.0
 Deprecated==1.2.11

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,7 +1,7 @@
 google-api-python-client>=1.6.5
 google-cloud-storage>=1.36
 httplib2<=0.15
-ipywidgets>=7.5,<8
+ipywidgets>=7.5
 notebook>=5.3
 pydicom>=2.2.0
 shapely>=1.7.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,5 @@
+awscli==1.37.2
 open3d>=0.16.0
-itsdangerous==2.0.1
 werkzeug>=2.0.3
 pydicom<3
 pytest==7.3.1


### PR DESCRIPTION
Cherry picks #5403 for `release/v1.3.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependencies**
	- Updated `boto3` package to version 1.36.2
	- Modified `ipywidgets` version constraint to allow newer versions
	- Added `awscli` package version 1.37.2 to test requirements
	- Removed `itsdangerous` package from test requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->