### PR TITLE
Fix multi config test

### DIFF
--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -461,14 +461,14 @@ class ConfigTests(unittest.TestCase):
             # Add some duplicate documents
             db.config.insert_one(
                 {
-                    "_id": ObjectId.from_datetime(datetime(2022, 1, 1)),
+                    "_id": new_config_ids[0],
                     "version": "0.14.4",
                     "type": "fiftyone",
                 }
             )
             db.config.insert_one(
                 {
-                    "_id": ObjectId.from_datetime(datetime(2023, 1, 1)),
+                    "_id": new_config_ids[1],
                     "version": "0.1.4",
                     "type": "fiftyone",
                 }

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -445,6 +445,7 @@ class MigrationTests(unittest.TestCase):
 class ConfigTests(unittest.TestCase):
     def test_multiple_config_cleanup(self):
         # Note this is not a unit test and running this modifies the fiftyone config collection
+
         db = foo.get_db_conn()
         orig_config = foo.get_db_config()
 
@@ -453,38 +454,40 @@ class ConfigTests(unittest.TestCase):
             ObjectId.from_datetime(datetime(2022, 1, 1)),
             ObjectId.from_datetime(datetime(2023, 1, 1)),
         ]
+        try:
+            # Ensure that the fake configs are not already in the database due to failed cleanup
+            db.config.delete_many({"_id": {"$in": new_config_ids}})
 
-        # Ensure that the fake configs are not already in the database due to failed cleanup
-        db.config.delete_many({"_id": {"$in": new_config_ids}})
+            # Add some duplicate documents
+            db.config.insert_one(
+                {
+                    "_id": ObjectId.from_datetime(datetime(2022, 1, 1)),
+                    "version": "0.14.4",
+                    "type": "fiftyone",
+                }
+            )
+            db.config.insert_one(
+                {
+                    "_id": ObjectId.from_datetime(datetime(2023, 1, 1)),
+                    "version": "0.1.4",
+                    "type": "fiftyone",
+                }
+            )
 
-        # Add some duplicate documents
-        db.config.insert_one(
-            {
-                "_id": ObjectId.from_datetime(datetime(2022, 1, 1)),
-                "version": "0.14.4",
-                "type": "fiftyone",
-            }
-        )
-        db.config.insert_one(
-            {
-                "_id": ObjectId.from_datetime(datetime(2023, 1, 1)),
-                "version": "0.1.4",
-                "type": "fiftyone",
-            }
-        )
+            config = foo.get_db_config()
 
-        config = foo.get_db_config()
+            if fo.config.database_admin:
+                # Ensure that duplicate documents are automatically cleaned up if run by database admin
+                self.assertEqual(len(list(db.config.aggregate([]))), 1)
+            else:
+                # Otherwise, the duplicates are not cleaned up
+                self.assertEqual(len(list(db.config.aggregate([]))), 3)
 
-        if fo.config.database_admin:
-            # Ensure that duplicate documents are automatically cleaned up if run by database admin
-            self.assertEqual(len(list(db.config.aggregate([]))), 1)
-        else:
-            # Otherwise, the duplicates are not cleaned up
-            self.assertEqual(len(list(db.config.aggregate([]))), 3)
-        self.assertEqual(config, orig_config)
-
-        # Clean up the fake configs
-        db.config.delete_many({"_id": {"$in": new_config_ids}})
+            # Regardless, the config should be the same
+            self.assertEqual(config, orig_config)
+        finally:
+            # Clean up the fake configs
+            db.config.delete_many({"_id": {"$in": new_config_ids}})
 
 
 class TestLoadDataset(unittest.TestCase):


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Test fails if database admin set to false, leading to extra configs and failures upon rerun due to duplicate key error

## How is this patch tested? If it is not, please explain why.

- Tests pass with FIFTYONE_DATABASE_ADMIN = false

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Enhanced configuration cleanup test with conditional logic for database admin privileges
	- Added clarifying comment to explain test behavior
	- Implemented cleanup step for test configurations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->