### PR TITLE
Fix `session.wait()`

### DIFF
--- a/fiftyone/server/events/dispatch.py
+++ b/fiftyone/server/events/dispatch.py
@@ -40,11 +40,14 @@ async def dispatch_event(
     Args:
         subscription: the calling subscription id
         event: the event
+
+    Returns:
+        the dispatched event
     """
     state = get_state()
     if isinstance(event, CaptureNotebookCell) and focx.is_databricks_context():
         add_screenshot(event)
-        return
+        return event
 
     if isinstance(event, SelectLabels):
         state.selected_labels = event.labels
@@ -81,3 +84,5 @@ async def dispatch_event(
             continue
 
         listener.queue.put_nowait((datetime.now(), event))
+
+    return event

--- a/fiftyone/server/events/listener.py
+++ b/fiftyone/server/events/listener.py
@@ -62,7 +62,7 @@ async def add_event_listener(
         while True:
             disconnected = await request.is_disconnected()
             if disconnected:
-                await _disconnect(
+                await disconnect(
                     data.is_app,
                     data.request_listeners,
                 )
@@ -90,18 +90,29 @@ async def add_event_listener(
             await asyncio.sleep(0.2)
 
     except asyncio.CancelledError as e:
-        await _disconnect(data.is_app, data.request_listeners)
+        await disconnect(data.is_app, data.request_listeners)
         raise e
 
 
-async def _disconnect(
+async def disconnect(
     is_app: bool, listeners: t.Set[t.Tuple[str, Listener]]
 ) -> None:
+    """Disconnect a listener
+
+    Args:
+        is_app: whether is an app listener
+        listeners: events the listener has subscribed to
+
+    Returns:
+        A closed session event or None
+    """
     for event_name, listener in listeners:
         get_listeners()[event_name].remove(listener)
 
     if is_app:
         decrement_app_count()
 
-        if get_app_count() and focx._get_context() == focx._NONE:
-            await dispatch_event(None, CloseSession())
+        if not get_app_count() and focx._get_context() == focx._NONE:
+            return await dispatch_event(None, CloseSession())
+
+    return None

--- a/tests/unittests/server_events_tests.py
+++ b/tests/unittests/server_events_tests.py
@@ -10,9 +10,12 @@ import unittest
 
 import fiftyone as fo
 import fiftyone.core.state as fos
+
 import fiftyone.core.session.events as fose
-import fiftyone.server.events.initialize as fosi
+
 import fiftyone.server.events.dispatch as fosd
+import fiftyone.server.events.listener as fosl
+import fiftyone.server.events.initialize as fosi
 import fiftyone.server.events.state as foss
 
 from decorators import drop_datasets
@@ -95,3 +98,11 @@ class TestServerEvents(unittest.IsolatedAsyncioTestCase):
         state = fos.StateDescription()
         await fosd.dispatch_event(None, fose.StateUpdate(state))
         self.assertEqual(state, foss.get_state())
+
+
+class TestListenerDisconnect(unittest.IsolatedAsyncioTestCase):
+    async def test_listener_disconnect(self):
+        foss.increment_app_count()
+        self.assertIsInstance(
+            await fosl.disconnect(True, set()), fose.CloseSession
+        )


### PR DESCRIPTION
## What changes are proposed in this pull request?

Session closing was incorrectly occurring only when there _were_ App connections still present

## How is this patch tested? If it is not, please explain why.

Server test

Manually confirmed with `fiftyone app launch --wait 1` and then closing the opened App window

## Release Notes

* Fixed `session.wait()` after closing all App windows

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced event dispatching with return statements to provide more visibility into event processing

- **Bug Fixes**
  - Updated event listener disconnection logic to ensure consistent behavior during session closure

- **Tests**
  - Added new unit test for listener disconnection functionality
  - Improved test coverage for server events

- **Refactor**
  - Renamed internal disconnect function for improved clarity
  - Updated method signatures to support new event handling approach

<!-- end of auto-generated comment: release notes by coderabbit.ai -->