### PR TITLE
Add author/license to all zoo models/datasets

### DIFF
--- a/docs/scripts/make_model_zoo_docs.py
+++ b/docs/scripts/make_model_zoo_docs.py
@@ -55,6 +55,12 @@ _MODEL_TEMPLATE = """
 
 -   Model name: ``{{ name }}``
 -   Model source: {{ source }}
+{% if author %}
+-   Model author: {{ author }}
+{% endif %}
+{% if license %}
+-   Model license: {{ license }}
+{% endif %}
 {% if size %}
 -   Model size: {{ size }}
 {% endif %}
@@ -331,6 +337,8 @@ def _render_model_content(template, model_name):
         header_name=header_name,
         description=zoo_model.description,
         source=zoo_model.source,
+        author=zoo_model.author,
+        license=zoo_model.license,
         size=size_str,
         exposes_embeddings=exposes_embeddings,
         tags=tags_str,

--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -2265,7 +2265,7 @@ List datasets in the FiftyOne Dataset Zoo.
 
 .. code-block:: text
 
-    fiftyone zoo datasets list [-h] [-n] [-d] [-s SOURCE] [-t TAGS]
+    fiftyone zoo datasets list [-h] [-n] [-d] [-s SOURCE] [-t TAGS] [-l LICENSE]
 
 **Arguments**
 
@@ -2279,6 +2279,9 @@ List datasets in the FiftyOne Dataset Zoo.
       -s SOURCE, --source SOURCE
                             only show datasets available from the specified source
       -t TAGS, --tags TAGS  only show datasets with the specified tag or list,of,tags
+      -l LICENSE, --license LICENSE
+                            only show datasets with the specified license or
+                            any of the list,of,licenses
 
 **Examples**
 
@@ -2306,6 +2309,11 @@ List datasets in the FiftyOne Dataset Zoo.
 
     # List available datasets with the given tag
     fiftyone zoo datasets list --tags <tag>
+
+.. code-block:: shell
+
+    # List available datasets with the given license
+    fiftyone zoo datasets list --license <license>
 
 .. _cli-fiftyone-zoo-datasets-find:
 
@@ -2608,7 +2616,7 @@ List models in the FiftyOne Model Zoo.
 
 .. code-block:: text
 
-    fiftyone zoo models list [-h] [-n] [-d] [-t TAGS] [-s SOURCE]
+    fiftyone zoo models list [-h] [-n] [-d] [-t TAGS] [-s SOURCE] [-l LICENSE]
 
 **Arguments**
 
@@ -2622,6 +2630,9 @@ List models in the FiftyOne Model Zoo.
       -t TAGS, --tags TAGS  only show models with the specified tag or list,of,tags
       -s SOURCE, --source SOURCE
                             only show models available from the specified remote source
+      -l LICENSE, --license LICENSE
+                            only show models with the specified license or any
+                            of the list,of,licenses
 
 **Examples**
 
@@ -2649,6 +2660,11 @@ List models in the FiftyOne Model Zoo.
 
     # List available models from the given remote source
     fiftyone zoo models list --source <source>
+
+.. code-block:: shell
+
+    # List available models with the given license
+    fiftyone zoo models list --license <license>
 
 .. _cli-fiftyone-zoo-models-find:
 

--- a/docs/source/dataset_zoo/datasets.rst
+++ b/docs/source/dataset_zoo/datasets.rst
@@ -565,7 +565,7 @@ detection, and segmentation labels.
 
 -   Dataset name: ``bdd100k``
 -   Dataset source: https://bdd-data.berkeley.edu
--   Dataset license: https://bdd-data.berkeley.edu
+-   Dataset license: https://bdd-data.berkeley.edu/download.html
 -   Dataset size: 7.10 GB
 -   Tags: ``image, multilabel, automotive, manual``
 -   Supported splits: ``train, validation, test``

--- a/docs/source/dataset_zoo/datasets.rst
+++ b/docs/source/dataset_zoo/datasets.rst
@@ -130,6 +130,7 @@ version of the dataset.
 
 -   Dataset name: ``activitynet-100``
 -   Dataset source: http://activity-net.org/index.html
+-   Dataset license: CC-BY-4.0
 -   Dataset size: 223 GB
 -   Tags: ``video, classification, action-recognition, temporal-detection``
 -   Supported splits: ``train, validation, test``
@@ -339,6 +340,7 @@ version of the dataset.
 
 -   Dataset name: ``activitynet-200``
 -   Dataset source: http://activity-net.org/index.html
+-   Dataset license: CC-BY-4.0
 -   Dataset size: 500 GB
 -   Tags: ``video, classification, action-recognition, temporal-detection``
 -   Supported splits: ``train, validation, test``
@@ -563,6 +565,7 @@ detection, and segmentation labels.
 
 -   Dataset name: ``bdd100k``
 -   Dataset source: https://bdd-data.berkeley.edu
+-   Dataset license: https://doc.bdd100k.com/license.html
 -   Dataset size: 7.10 GB
 -   Tags: ``image, multilabel, automotive, manual``
 -   Supported splits: ``train, validation, test``
@@ -627,6 +630,7 @@ pixels. This version contains image-level labels only.
 
 -   Dataset name: ``caltech101``
 -   Dataset source: https://data.caltech.edu/records/mzrjq-6wc02
+-   Dataset license: CC-BY-4.0
 -   Dataset size: 138.60 MB
 -   Tags: ``image, classification``
 -   Supported splits: ``N/A``
@@ -679,6 +683,7 @@ Images are of variable sizes, with typical edge lengths of 80-800 pixels.
 
 -   Dataset name: ``caltech256``
 -   Dataset source: https://data.caltech.edu/records/nyy15-4j048
+-   Dataset license: CC-BY-4.0
 -   Dataset size: 1.16 GB
 -   Tags: ``image, classification``
 -   Supported splits: ``N/A``
@@ -864,6 +869,7 @@ The dataset is intended for:
 
 -   Dataset name: ``cityscapes``
 -   Dataset source: https://www.cityscapes-dataset.com
+-   Dataset license: https://www.cityscapes-dataset.com/license
 -   Dataset size: 11.80 GB
 -   Tags: ``image, multilabel, automotive, manual``
 -   Supported splits: ``train, validation, test``
@@ -940,6 +946,7 @@ version of the dataset.
 
 -   Dataset name: ``coco-2014``
 -   Dataset source: http://cocodataset.org/#home
+-   Dataset license: CC-BY-4.0
 -   Dataset size: 37.57 GB
 -   Tags: ``image, detection, segmentation``
 -   Supported splits: ``train, validation, test``
@@ -1176,6 +1183,7 @@ version of the dataset.
 
 -   Dataset name: ``coco-2017``
 -   Dataset source: http://cocodataset.org/#home
+-   Dataset license: CC-BY-4.0
 -   Dataset size: 25.20 GB
 -   Tags: ``image, detection, segmentation``
 -   Supported splits: ``train, validation, test``
@@ -1395,6 +1403,7 @@ There are 60,000 training images and 10,000 test images.
 
 -   Dataset name: ``fashion-mnist``
 -   Dataset source: https://github.com/zalandoresearch/fashion-mnist
+-   Dataset license: MIT
 -   Dataset size: 36.42 MB
 -   Tags: ``image, classification``
 -   Supported splits: ``train, test``
@@ -1537,6 +1546,7 @@ benchmarks, and more), see the recent journal:
 
 -   Dataset name: ``fiw``
 -   Dataset source: https://web.northeastern.edu/smilelab/fiw/
+-   Dataset license: https://fulab.sites.northeastern.edu/fiw-download
 -   Dataset size: 173.00 MB
 -   Tags: ``image, kinship, verification, classification, search-and-retrieval, facial-recognition``
 -   Supported splits: ``test, val, train``
@@ -1591,6 +1601,7 @@ clips distributed across 51 action classes.
 
 -   Dataset name: ``hmdb51``
 -   Dataset source: https://serre-lab.clps.brown.edu/resource/hmdb-a-large-human-motion-database
+-   Dataset license: CC-BY-4.0
 -   Dataset size: 2.16 GB
 -   Tags: ``video, action-recognition``
 -   Supported splits: ``train, test, other``
@@ -1676,6 +1687,7 @@ training and validation sets are provided.
 
 -   Dataset name: ``imagenet-2012``
 -   Dataset source: http://image-net.org
+-   Dataset license: https://image-net.org/download
 -   Dataset size: 144.02 GB
 -   Tags: ``image, classification, manual``
 -   Supported splits: ``train, validation``
@@ -1781,6 +1793,7 @@ These images are provided according to the terms below.
 
 -   Dataset name: ``imagenet-sample``
 -   Dataset source: http://image-net.org
+-   Dataset license: https://image-net.org/download
 -   Dataset size: 98.26 MB
 -   Tags: ``image, classification``
 -   Supported splits: ``N/A``
@@ -2533,6 +2546,7 @@ object development kit on the KITTI homepage.
 
 -   Dataset name: ``kitti``
 -   Dataset source: http://www.cvlibs.net/datasets/kitti
+-   Dataset license: CC-BY-NC-SA-3.0
 -   Dataset size: 12.57 GB
 -   Tags: ``image, detection``
 -   Supported splits: ``train, test``
@@ -2591,6 +2605,7 @@ object development kit on the KITTI homepage.
 
 -   Dataset name: ``kitti-multiview``
 -   Dataset source: http://www.cvlibs.net/datasets/kitti
+-   Dataset license: CC-BY-NC-SA-3.0
 -   Dataset size: 53.34 GB
 -   Tags: ``image, point-cloud, detection``
 -   Supported splits: ``train, test``
@@ -2691,6 +2706,7 @@ There are 60,000 training images and 10,000 test images.
 
 -   Dataset name: ``mnist``
 -   Dataset source: http://yann.lecun.com/exdb/mnist
+-   Dataset license: CC-BY-SA-3.0
 -   Dataset size: 21.00 MB
 -   Tags: ``image, classification``
 -   Supported splits: ``train, test``
@@ -2758,6 +2774,7 @@ and visual relationship tasks for the 600 boxable classes.
 
 -   Dataset name: ``open-images-v6``
 -   Dataset source: https://storage.googleapis.com/openimages/web/index.html
+-   Dataset license: CC-BY-2.0
 -   Dataset size: 561 GB
 -   Tags: ``image, detection, segmentation, classification``
 -   Supported splits: ``train, test, validation``
@@ -2997,6 +3014,7 @@ keypoints, and visual relationship tasks for the 600 boxable classes.
 
 -   Dataset name: ``open-images-v7``
 -   Dataset source: https://storage.googleapis.com/openimages/web/index.html
+-   Dataset license: CC-BY-2.0
 -   Dataset size: 561 GB
 -   Tags: ``image, detection, segmentation, classification, keypoint``
 -   Supported splits: ``train, test, validation``
@@ -3282,6 +3300,7 @@ from
 
 -   Dataset name: ``quickstart``
 -   Dataset size: 23.40 MB
+-   Dataset license: CC-BY-4.0
 -   Tags: ``image, quickstart``
 -   Supported splits: ``N/A``
 -   ZooDataset class:
@@ -3376,6 +3395,7 @@ generated by human annotators.
 
 -   Dataset name: ``quickstart-video``
 -   Dataset size: 35.20 MB
+-   Dataset license: CC-BY-4.0
 -   Tags: ``video, quickstart``
 -   Supported splits: ``N/A``
 -   ZooDataset class:
@@ -3429,6 +3449,7 @@ annotation data.
 
 -   Dataset name: ``quickstart-groups``
 -   Dataset size: 516.3 MB
+-   Dataset license: CC-BY-NC-SA-3.0
 -   Tags: ``image, point-cloud, quickstart``
 -   Supported splits: ``N/A``
 -   ZooDataset class:
@@ -3480,6 +3501,7 @@ Objects have been rescaled and recentered from the original dataset.
 
 -   Dataset name: ``quickstart-3d``
 -   Dataset size: 215.7 MB
+-   Dataset license: https://modelnet.cs.princeton.edu
 -   Tags: ``3d, point-cloud, mesh, quickstart``
 -   Supported splits: ``N/A``
 -   ZooDataset class:
@@ -3537,6 +3559,7 @@ by Sama.
 
 -   Dataset name: ``sama-coco``
 -   Dataset source: https://www.sama.com/sama-coco-dataset/
+-   Dataset license: CC-BY-4.0
 -   Dataset size: 25.67 GB
 -   Tags: ``image, detection, segmentation``
 -   Supported splits: ``train, validation, test``
@@ -3769,6 +3792,7 @@ viewpoint, etc.
 
 -   Dataset name: ``ucf101``
 -   Dataset source: https://www.crcv.ucf.edu/research/data-sets/ucf101
+-   Dataset license: CC0-1.0
 -   Dataset size: 6.48 GB
 -   Tags: ``video, action-recognition``
 -   Supported splits: ``train, test``

--- a/docs/source/dataset_zoo/datasets.rst
+++ b/docs/source/dataset_zoo/datasets.rst
@@ -565,7 +565,7 @@ detection, and segmentation labels.
 
 -   Dataset name: ``bdd100k``
 -   Dataset source: https://bdd-data.berkeley.edu
--   Dataset license: https://doc.bdd100k.com/license.html
+-   Dataset license: https://bdd-data.berkeley.edu
 -   Dataset size: 7.10 GB
 -   Tags: ``image, multilabel, automotive, manual``
 -   Supported splits: ``train, validation, test``

--- a/docs/source/dataset_zoo/datasets.rst
+++ b/docs/source/dataset_zoo/datasets.rst
@@ -558,14 +558,14 @@ detection, and segmentation labels.
                     test/
                     val/
 
-    You can register at https://bdd-data.berkeley.edu in order to get links
+    You can register at http://bdd-data.berkeley.edu in order to get links
     to download the data.
 
 **Details**
 
 -   Dataset name: ``bdd100k``
--   Dataset source: https://bdd-data.berkeley.edu
--   Dataset license: https://bdd-data.berkeley.edu/download.html
+-   Dataset source: http://bdd-data.berkeley.edu
+-   Dataset license: http://bdd-data.berkeley.edu/download.html
 -   Dataset size: 7.10 GB
 -   Tags: ``image, multilabel, automotive, manual``
 -   Supported splits: ``train, validation, test``

--- a/docs/source/model_zoo/api.rst
+++ b/docs/source/model_zoo/api.rst
@@ -120,6 +120,9 @@ Getting information about zoo models
         print("***** Model description *****")
         print(zoo_model.description)
 
+        print("\n***** License *****")
+        print(zoo_model.license)
+
         print("\n***** Tags *****")
         print(zoo_model.tags)
 
@@ -130,6 +133,9 @@ Getting information about zoo models
 
         ***** Model description *****
         Faster R-CNN model with ResNet-50 FPN backbone trained on COCO. Source: https://pytorch.org/docs/stable/torchvision/models.html
+
+        ***** License *****
+        BSD 3-Clause
 
         ***** Tags *****
         ['detection', 'coco', 'torch']
@@ -180,8 +186,13 @@ Getting information about zoo models
         {
             "base_name": "faster-rcnn-resnet50-fpn-coco-torch",
             "base_filename": "fasterrcnn_resnet50_fpn_coco-258fb6c6.pth",
+            "author": "Shaoqing Ren, et al.",
             "version": null,
-            "description": "Faster R-CNN model with ResNet-50 FPN backbone trained on COCO. Source: https://pytorch.org/docs/stable/torchvision/models.html",
+            "url": null,
+            "source": "https://pytorch.org/vision/main/models.html",
+            "license": "BSD 3-Clause",
+            "description": "Faster R-CNN model from `Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks <https://arxiv.org/abs/1506.01497>`_ with ResNet-50 FPN backbone trained on COCO",
+            "size_bytes": 167502836,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
                 "config": {
@@ -193,10 +204,11 @@ Getting information about zoo models
                 "config": {
                     "entrypoint_fcn": "torchvision.models.detection.faster_rcnn.fasterrcnn_resnet50_fpn",
                     "entrypoint_args": {
-                        "pretrained": true
+                        "weights": "FasterRCNN_ResNet50_FPN_Weights.DEFAULT"
                     },
                     "output_processor_cls": "fiftyone.utils.torch.DetectorOutputProcessor",
-                    "labels_path": "{{eta-resources}}/ms-coco-labels.txt"
+                    "labels_path": "{{eta-resources}}/ms-coco-labels.txt",
+                    "confidence_thresh": 0.3
                 }
             },
             "requirements": {
@@ -214,7 +226,9 @@ Getting information about zoo models
             "tags": [
                 "detection",
                 "coco",
-                "torch"
+                "torch",
+                "faster-rcnn",
+                "resnet"
             ],
             "date_added": "2020-12-11T13:45:51"
         }

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -5862,7 +5862,7 @@ Core
 - Added support for :ref:`importing <VideoClassificationDirectoryTree-import>`
   and :ref:`exporting <VideoClassificationDirectoryTree-export>` video
   classification datasets organized as directory trees on disk
-- Added `BDD100K <https://bdd-data.berkeley.edu>`_,
+- Added `BDD100K <http://bdd-data.berkeley.edu>`_,
   `HMDB51 <https://serre-lab.clps.brown.edu/resource/hmdb-a-large-human-motion-database>`_,
   and `UCF101 <https://www.crcv.ucf.edu/research/data-sets/ucf101>`_ to
   the :ref:`Dataset Zoo <dataset-zoo>`

--- a/docs/source/user_guide/dataset_creation/datasets.rst
+++ b/docs/source/user_guide/dataset_creation/datasets.rst
@@ -271,7 +271,7 @@ refer to the corresponding dataset format when reading the dataset from disk.
     |                                                                                       | <https://github.com/voxel51/eta/blob/develop/docs/image_labels_guide.md>`_.        |
     +---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
     | :ref:`BDDDataset <BDDDataset-import>`                                                 | A labeled dataset consisting of images and their associated multitask predictions  |
-    |                                                                                       | saved in `Berkeley DeepDrive (BDD) format <https://bdd-data.berkeley.edu>`_.       |
+    |                                                                                       | saved in `Berkeley DeepDrive (BDD) format <http://bdd-data.berkeley.edu>`_.        |
     +---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
     | :ref:`CSVDataset <CSVDataset-import>`                                                 | A labeled dataset consisting of images or videos and their associated field values |
     |                                                                                       | stored as columns of a CSV file.                                                   |
@@ -4120,7 +4120,7 @@ BDDDataset
 
 The :class:`fiftyone.types.BDDDataset` type represents a labeled dataset
 consisting of images and their associated multitask predictions saved in
-`Berkeley DeepDrive (BDD) format <https://bdd-data.berkeley.edu>`_.
+`Berkeley DeepDrive (BDD) format <http://bdd-data.berkeley.edu>`_.
 
 Datasets of this type are read in the following format:
 

--- a/docs/source/user_guide/export_datasets.rst
+++ b/docs/source/user_guide/export_datasets.rst
@@ -510,7 +510,7 @@ refer to the corresponding dataset format when writing the dataset to disk.
     |                                                                    | <https://github.com/voxel51/eta/blob/develop/docs/video_labels_guide.md>`_.        |
     +--------------------------------------------------------------------+------------------------------------------------------------------------------------+
     | :ref:`BDDDataset <BDDDataset-export>`                              | A labeled dataset consisting of images and their associated multitask predictions  |
-    |                                                                    | saved in `Berkeley DeepDrive (BDD) format <https://bdd-data.berkeley.edu>`_.       |
+    |                                                                    | saved in `Berkeley DeepDrive (BDD) format <http://bdd-data.berkeley.edu>`_.        |
     +--------------------------------------------------------------------+------------------------------------------------------------------------------------+
     | :ref:`CSVDataset <CSVDataset-export>`                              | A flexible CSV format that represents slice(s) of a dataset's values as columns of |
     |                                                                    | a CSV file.                                                                        |
@@ -3291,7 +3291,7 @@ BDDDataset
 
 The :class:`fiftyone.types.BDDDataset` type represents a labeled dataset
 consisting of images and their associated multitask predictions saved in
-`Berkeley DeepDrive (BDD) format <https://bdd-data.berkeley.edu>`_.
+`Berkeley DeepDrive (BDD) format <http://bdd-data.berkeley.edu>`_.
 
 Datasets of this type are exported in the following format:
 

--- a/fiftyone/types/dataset_types.py
+++ b/fiftyone/types/dataset_types.py
@@ -706,7 +706,7 @@ class FiftyOneVideoLabelsDataset(VideoLabelsDataset):
 class BDDDataset(ImageLabelsDataset):
     """A labeled dataset consisting of images and their associated multitask
     predictions saved in
-    `Berkeley DeepDrive (BDD) format <https://bdd-data.berkeley.edu>`_.
+    `Berkeley DeepDrive (BDD) format <http://bdd-data.berkeley.edu>`_.
 
     See :ref:`this page <BDDDataset-import>` for importing datasets of this
     type, and see :ref:`this page <BDDDataset-export>` for exporting datasets

--- a/fiftyone/utils/bdd.py
+++ b/fiftyone/utils/bdd.py
@@ -1,6 +1,6 @@
 """
 Utilities for working with datasets in
-`Berkeley DeepDrive (BDD) format <https://bdd-data.berkeley.edu>`_.
+`Berkeley DeepDrive (BDD) format <http://bdd-data.berkeley.edu>`_.
 
 | Copyright 2017-2025, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_

--- a/fiftyone/zoo/datasets/base.py
+++ b/fiftyone/zoo/datasets/base.py
@@ -437,7 +437,7 @@ class BDD100KDataset(FiftyOneDataset):
                     test/
                     val/
 
-    You can register at https://bdd-data.berkeley.edu in order to get links to
+    You can register at http://bdd-data.berkeley.edu in order to get links to
     download the data.
 
     Example usage::
@@ -460,7 +460,7 @@ class BDD100KDataset(FiftyOneDataset):
         7.10 GB
 
     Source
-        https://bdd-data.berkeley.edu
+        http://bdd-data.berkeley.edu
 
     Args:
         source_dir (None): the directory containing the manually downloaded
@@ -479,7 +479,7 @@ class BDD100KDataset(FiftyOneDataset):
 
     @property
     def license(self):
-        return "https://doc.bdd100k.com/license.html"
+        return "http://bdd-data.berkeley.edu/download.html"
 
     @property
     def tags(self):
@@ -3126,7 +3126,7 @@ class QuickstartGeoDataset(FiftyOneDataset):
 
     @property
     def license(self):
-        return "https://doc.bdd100k.com/license.html"
+        return "http://bdd-data.berkeley.edu/download.html"
 
     @property
     def tags(self):

--- a/fiftyone/zoo/datasets/base.py
+++ b/fiftyone/zoo/datasets/base.py
@@ -183,6 +183,10 @@ class ActivityNet100Dataset(FiftyOneDataset):
         return "activitynet-100"
 
     @property
+    def license(self):
+        return "CC-BY-4.0"
+
+    @property
     def tags(self):
         return (
             "video",
@@ -362,6 +366,10 @@ class ActivityNet200Dataset(FiftyOneDataset):
         return "activitynet-200"
 
     @property
+    def license(self):
+        return "CC-BY-4.0"
+
+    @property
     def tags(self):
         return (
             "video",
@@ -470,6 +478,10 @@ class BDD100KDataset(FiftyOneDataset):
         return "bdd100k"
 
     @property
+    def license(self):
+        return "https://doc.bdd100k.com/license.html"
+
+    @property
     def tags(self):
         return ("image", "multilabel", "automotive", "manual")
 
@@ -544,6 +556,10 @@ class Caltech101Dataset(FiftyOneDataset):
         return "caltech101"
 
     @property
+    def license(self):
+        return "CC-BY-4.0"
+
+    @property
     def tags(self):
         return ("image", "classification")
 
@@ -612,6 +628,10 @@ class Caltech256Dataset(FiftyOneDataset):
     @property
     def name(self):
         return "caltech256"
+
+    @property
+    def license(self):
+        return "CC-BY-4.0"
 
     @property
     def tags(self):
@@ -743,6 +763,10 @@ class CityscapesDataset(FiftyOneDataset):
     @property
     def name(self):
         return "cityscapes"
+
+    @property
+    def license(self):
+        return "https://www.cityscapes-dataset.com/license"
 
     @property
     def tags(self):
@@ -930,6 +954,10 @@ class COCO2014Dataset(FiftyOneDataset):
     @property
     def name(self):
         return "coco-2014"
+
+    @property
+    def license(self):
+        return "CC-BY-4.0"
 
     @property
     def tags(self):
@@ -1124,6 +1152,10 @@ class COCO2017Dataset(FiftyOneDataset):
     @property
     def name(self):
         return "coco-2017"
+
+    @property
+    def license(self):
+        return "CC-BY-4.0"
 
     @property
     def tags(self):
@@ -1321,6 +1353,10 @@ class SamaCOCODataset(FiftyOneDataset):
         return "sama-coco"
 
     @property
+    def license(self):
+        return "CC-BY-4.0"
+
+    @property
     def tags(self):
         return ("image", "detection", "segmentation")
 
@@ -1487,6 +1523,10 @@ class FIWDataset(FiftyOneDataset):
         return "fiw"
 
     @property
+    def license(self):
+        return "https://fulab.sites.northeastern.edu/fiw-download"
+
+    @property
     def tags(self):
         return (
             "image",
@@ -1550,6 +1590,10 @@ class HMDB51Dataset(FiftyOneDataset):
     @property
     def name(self):
         return "hmdb51"
+
+    @property
+    def license(self):
+        return "CC-BY-4.0"
 
     @property
     def tags(self):
@@ -1656,6 +1700,10 @@ class ImageNetSampleDataset(FiftyOneDataset):
     @property
     def name(self):
         return "imagenet-sample"
+
+    @property
+    def license(self):
+        return "https://image-net.org/download"
 
     @property
     def tags(self):
@@ -1801,6 +1849,10 @@ class Kinetics400Dataset(FiftyOneDataset):
     @property
     def name(self):
         return "kinetics-400"
+
+    @property
+    def license(self):
+        return None
 
     @property
     def tags(self):
@@ -1958,6 +2010,10 @@ class Kinetics600Dataset(FiftyOneDataset):
         return "kinetics-600"
 
     @property
+    def license(self):
+        return None
+
+    @property
     def tags(self):
         return (
             "video",
@@ -2105,6 +2161,10 @@ class Kinetics700Dataset(FiftyOneDataset):
     @property
     def name(self):
         return "kinetics-700"
+
+    @property
+    def license(self):
+        return None
 
     @property
     def tags(self):
@@ -2263,6 +2323,10 @@ class Kinetics7002020Dataset(FiftyOneDataset):
         return "kinetics-700-2020"
 
     @property
+    def license(self):
+        return None
+
+    @property
     def tags(self):
         return (
             "video",
@@ -2333,6 +2397,10 @@ class KITTIDataset(FiftyOneDataset):
         return "kitti"
 
     @property
+    def license(self):
+        return "CC-BY-NC-SA-3.0"
+
+    @property
     def tags(self):
         return ("image", "detection")
 
@@ -2395,6 +2463,10 @@ class KITTIMultiviewDataset(FiftyOneDataset):
     @property
     def name(self):
         return "kitti-multiview"
+
+    @property
+    def license(self):
+        return "CC-BY-NC-SA-3.0"
 
     @property
     def tags(self):
@@ -2467,6 +2539,10 @@ class LabeledFacesInTheWildDataset(FiftyOneDataset):
     @property
     def name(self):
         return "lfw"
+
+    @property
+    def license(self):
+        return None
 
     @property
     def tags(self):
@@ -2652,6 +2728,10 @@ class OpenImagesV6Dataset(FiftyOneDataset):
     @property
     def name(self):
         return "open-images-v6"
+
+    @property
+    def license(self):
+        return "CC-BY-2.0"
 
     @property
     def tags(self):
@@ -2845,6 +2925,10 @@ class OpenImagesV7Dataset(FiftyOneDataset):
         return "open-images-v7"
 
     @property
+    def license(self):
+        return "CC-BY-2.0"
+
+    @property
     def tags(self):
         return (
             "image",
@@ -2919,6 +3003,10 @@ class PlacesDataset(FiftyOneDataset):
         return "places"
 
     @property
+    def license(self):
+        return None
+
+    @property
     def tags(self):
         return ("image", "classification")
 
@@ -2978,6 +3066,10 @@ class QuickstartDataset(FiftyOneDataset):
         return "quickstart"
 
     @property
+    def license(self):
+        return "CC-BY-4.0"
+
+    @property
     def tags(self):
         return ("image", "quickstart")
 
@@ -3031,6 +3123,10 @@ class QuickstartGeoDataset(FiftyOneDataset):
     @property
     def name(self):
         return "quickstart-geo"
+
+    @property
+    def license(self):
+        return "https://doc.bdd100k.com/license.html"
 
     @property
     def tags(self):
@@ -3087,6 +3183,10 @@ class QuickstartVideoDataset(FiftyOneDataset):
         return "quickstart-video"
 
     @property
+    def license(self):
+        return "CC-BY-4.0"
+
+    @property
     def tags(self):
         return ("video", "quickstart")
 
@@ -3140,6 +3240,10 @@ class QuickstartGroupsDataset(FiftyOneDataset):
     @property
     def name(self):
         return "quickstart-groups"
+
+    @property
+    def license(self):
+        return "CC-BY-NC-SA-3.0"
 
     @property
     def tags(self):
@@ -3212,6 +3316,10 @@ class Quickstart3DDataset(FiftyOneDataset):
         return "quickstart-3d"
 
     @property
+    def license(self):
+        return "https://modelnet.cs.princeton.edu"
+
+    @property
     def tags(self):
         return ("3d", "point-cloud", "mesh", "quickstart")
 
@@ -3282,6 +3390,10 @@ class UCF101Dataset(FiftyOneDataset):
     @property
     def name(self):
         return "ucf101"
+
+    @property
+    def license(self):
+        return "CC0-1.0"
 
     @property
     def tags(self):

--- a/fiftyone/zoo/datasets/tf.py
+++ b/fiftyone/zoo/datasets/tf.py
@@ -64,6 +64,10 @@ class MNISTDataset(TFDSDataset):
         return "mnist"
 
     @property
+    def license(self):
+        return "CC-BY-SA-3.0"
+
+    @property
     def tags(self):
         return ("image", "classification")
 
@@ -119,6 +123,10 @@ class FashionMNISTDataset(TFDSDataset):
     @property
     def name(self):
         return "fashion-mnist"
+
+    @property
+    def license(self):
+        return "MIT"
 
     @property
     def tags(self):
@@ -179,6 +187,10 @@ class CIFAR10Dataset(TFDSDataset):
         return "cifar10"
 
     @property
+    def license(self):
+        return None
+
+    @property
     def tags(self):
         return ("image", "classification")
 
@@ -235,6 +247,10 @@ class CIFAR100Dataset(TFDSDataset):
     @property
     def name(self):
         return "cifar100"
+
+    @property
+    def license(self):
+        return None
 
     @property
     def tags(self):
@@ -329,6 +345,10 @@ class ImageNet2012Dataset(TFDSDataset):
         return "imagenet-2012"
 
     @property
+    def license(self):
+        return "https://image-net.org/download"
+
+    @property
     def tags(self):
         return ("image", "classification", "manual")
 
@@ -403,6 +423,10 @@ class VOC2007Dataset(TFDSDataset):
         return "voc-2007"
 
     @property
+    def license(self):
+        return None
+
+    @property
     def tags(self):
         return ("image", "detection")
 
@@ -465,6 +489,10 @@ class VOC2012Dataset(TFDSDataset):
     @property
     def name(self):
         return "voc-2012"
+
+    @property
+    def license(self):
+        return None
 
     @property
     def tags(self):

--- a/fiftyone/zoo/datasets/torch.py
+++ b/fiftyone/zoo/datasets/torch.py
@@ -68,6 +68,10 @@ class MNISTDataset(TorchVisionDataset):
         return "mnist"
 
     @property
+    def license(self):
+        return "CC-BY-SA-3.0"
+
+    @property
     def tags(self):
         return ("image", "classification")
 
@@ -119,6 +123,10 @@ class FashionMNISTDataset(TorchVisionDataset):
     @property
     def name(self):
         return "fashion-mnist"
+
+    @property
+    def license(self):
+        return "MIT"
 
     @property
     def tags(self):
@@ -173,6 +181,10 @@ class CIFAR10Dataset(TorchVisionDataset):
         return "cifar10"
 
     @property
+    def license(self):
+        return None
+
+    @property
     def tags(self):
         return ("image", "classification")
 
@@ -225,6 +237,10 @@ class CIFAR100Dataset(TorchVisionDataset):
     @property
     def name(self):
         return "cifar100"
+
+    @property
+    def license(self):
+        return None
 
     @property
     def tags(self):
@@ -315,6 +331,10 @@ class ImageNet2012Dataset(TorchVisionDataset):
         return "imagenet-2012"
 
     @property
+    def license(self):
+        return "https://image-net.org/download"
+
+    @property
     def tags(self):
         return ("image", "classification", "manual")
 
@@ -383,6 +403,10 @@ class VOC2007Dataset(TorchVisionDataset):
         return "voc-2007"
 
     @property
+    def license(self):
+        return None
+
+    @property
     def tags(self):
         return ("image", "detection")
 
@@ -445,6 +469,10 @@ class VOC2012Dataset(TorchVisionDataset):
     @property
     def name(self):
         return "voc-2012"
+
+    @property
+    def license(self):
+        return None
 
     @property
     def tags(self):

--- a/fiftyone/zoo/models/__init__.py
+++ b/fiftyone/zoo/models/__init__.py
@@ -32,7 +32,7 @@ _MODELS = weakref.WeakValueDictionary()
 logger = logging.getLogger(__name__)
 
 
-def list_zoo_models(tags=None, source=None):
+def list_zoo_models(tags=None, source=None, license=None):
     """Returns the list of available models in the FiftyOne Model Zoo.
 
     Also includes models from any remote sources that you've registered.
@@ -61,15 +61,18 @@ def list_zoo_models(tags=None, source=None):
             of tags
         source (None): only include models available via the given remote
             source
+        license (None): only include models that are distributed under the
+            specified license or any of the specified list of licenses. Run
+            ``fiftyone zoo models list`` to see the available licenses
 
     Returns:
         a list of model names
     """
-    models = _list_zoo_models(tags=tags, source=source)
+    models = _list_zoo_models(tags=tags, source=source, license=license)
     return sorted(model.name for model in models)
 
 
-def _list_zoo_models(tags=None, source=None):
+def _list_zoo_models(tags=None, source=None, license=None):
     manifest, remote_sources = _load_zoo_models_manifest()
 
     if source is not None:
@@ -84,6 +87,19 @@ def _list_zoo_models(tags=None, source=None):
             tags = set(tags)
 
         manifest = [model for model in manifest if tags.issubset(model.tags)]
+
+    if license is not None:
+        if etau.is_str(license):
+            licenses = {license}
+        else:
+            licenses = set(license)
+
+        manifest = [
+            model
+            for model in manifest
+            if model.license
+            and licenses.intersection(model.license.split(","))
+        ]
 
     return list(manifest)
 

--- a/fiftyone/zoo/models/manifest-tf.json
+++ b/fiftyone/zoo/models/manifest-tf.json
@@ -6,6 +6,8 @@
             "version": null,
             "description": "DeepLabv3+ semantic segmentation model from `Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation <https://arxiv.org/abs/1802.02611>`_ with Xception backbone trained on the Cityscapes dataset",
             "source": "https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md",
+            "author": "Liang-Chieh Chen, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 165712950,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -46,6 +48,8 @@
             "version": null,
             "description": "DeepLabv3+ semantic segmentation model from `Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation <https://arxiv.org/abs/1802.02611>`_ with MobileNetV2 backbone trained on the Cityscapes dataset",
             "source": "https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md",
+            "author": "Liang-Chieh Chen, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 8771639,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -86,6 +90,8 @@
             "version": null,
             "description": "EfficientDet-D0 model from `EfficientDet: Scalable and Efficient Object Detection <https://arxiv.org/abs/1911.09070>`_ trained on COCO",
             "source": "https://github.com/voxel51/automl/tree/master/efficientdet",
+            "author": "Mingxing Tan, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 40058880,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -125,6 +131,8 @@
             "version": null,
             "description": "EfficientDet-D1 model from `EfficientDet: Scalable and Efficient Object Detection <https://arxiv.org/abs/1911.09070>`_ trained on COCO",
             "source": "https://github.com/voxel51/automl/tree/master/efficientdet",
+            "author": "Mingxing Tan, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 64638976,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -164,6 +172,8 @@
             "version": null,
             "description": "EfficientDet-D2 model from `EfficientDet: Scalable and Efficient Object Detection <https://arxiv.org/abs/1911.09070>`_ trained on COCO",
             "source": "https://github.com/voxel51/automl/tree/master/efficientdet",
+            "author": "Mingxing Tan, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 77598720,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -203,6 +213,8 @@
             "version": null,
             "description": "EfficientDet-D3 model from `EfficientDet: Scalable and Efficient Object Detection <https://arxiv.org/abs/1911.09070>`_ trained on COCO",
             "source": "https://github.com/voxel51/automl/tree/master/efficientdet",
+            "author": "Mingxing Tan, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 111607808,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -242,6 +254,8 @@
             "version": null,
             "description": "EfficientDet-D4 model from `EfficientDet: Scalable and Efficient Object Detection <https://arxiv.org/abs/1911.09070>`_ trained on COCO",
             "source": "https://github.com/voxel51/automl/tree/master/efficientdet",
+            "author": "Mingxing Tan, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 183848960,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -281,6 +295,8 @@
             "version": null,
             "description": "EfficientDet-D5 model from `EfficientDet: Scalable and Efficient Object Detection <https://arxiv.org/abs/1911.09070>`_ trained on COCO",
             "source": "https://github.com/voxel51/automl/tree/master/efficientdet",
+            "author": "Mingxing Tan, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 289206272,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -320,6 +336,8 @@
             "version": null,
             "description": "EfficientDet-D6 model from `EfficientDet: Scalable and Efficient Object Detection <https://arxiv.org/abs/1911.09070>`_ trained on COCO",
             "source": "https://github.com/voxel51/automl/tree/master/efficientdet",
+            "author": "Mingxing Tan, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 436658176,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -359,6 +377,8 @@
             "version": null,
             "description": "Faster R-CNN model from `Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks <https://arxiv.org/abs/1506.01497>`_ atrous version with Inception backbone trained on COCO",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf1_detection_zoo.md",
+            "author": "Shaoqing Ren, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 245851264,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -404,6 +424,8 @@
             "version": null,
             "description": "Faster R-CNN model from `Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks <https://arxiv.org/abs/1506.01497>`_ atrous version with low-proposals and Inception backbone trained on COCO",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf1_detection_zoo.md",
+            "author": "Shaoqing Ren, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 245851253,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -449,6 +471,8 @@
             "version": null,
             "description": "Faster R-CNN model from `Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks <https://arxiv.org/abs/1506.01497>`_ with Inception v2 backbone trained on COCO",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf1_detection_zoo.md",
+            "author": "Shaoqing Ren, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 55542502,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -487,6 +511,8 @@
             "version": null,
             "description": "Faster R-CNN model from `Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks <https://arxiv.org/abs/1506.01497>`_ with NAS-net backbone trained on COCO",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf1_detection_zoo.md",
+            "author": "Shaoqing Ren, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 424621069,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -525,6 +551,8 @@
             "version": null,
             "description": "Faster R-CNN model from `Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks <https://arxiv.org/abs/1506.01497>`_ with low-proposals and NAS-net backbone trained on COCO",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf1_detection_zoo.md",
+            "author": "Shaoqing Ren, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 424548921,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -563,6 +591,8 @@
             "version": null,
             "description": "Faster R-CNN model from `Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks <https://arxiv.org/abs/1506.01497>`_ with ResNet-101 backbone trained on COCO",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf1_detection_zoo.md",
+            "author": "Shaoqing Ren, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 195464472,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -601,6 +631,8 @@
             "version": null,
             "description": "Faster R-CNN model from `Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks <https://arxiv.org/abs/1506.01497>`_ with low-proposals and ResNet-101 backbone trained on COCO",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf1_detection_zoo.md",
+            "author": "Shaoqing Ren, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 195464472,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -639,6 +671,8 @@
             "version": null,
             "description": "Faster R-CNN model from `Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks <https://arxiv.org/abs/1506.01497>`_ with ResNet-50 backbone trained on COCO",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf1_detection_zoo.md",
+            "author": "Shaoqing Ren, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 119089545,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -677,6 +711,8 @@
             "version": null,
             "description": "Faster R-CNN model from `Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks <https://arxiv.org/abs/1506.01497>`_ with low-proposals and ResNet-50 backbone trained on COCO",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf1_detection_zoo.md",
+            "author": "Shaoqing Ren, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 119089545,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -715,6 +751,8 @@
             "version": null,
             "description": "Inception v2 model from `Rethinking the Inception Architecture for Computer Vision <https://arxiv.org/abs/1512.00567>`_ trained on ImageNet",
             "source": "https://github.com/tensorflow/models/tree/archive/research/slim#pre-trained-models",
+            "author": "Christian Szegedy, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 224198038,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -761,6 +799,8 @@
             "version": null,
             "description": "Inception v4 model from `Inception-v4, Inception-ResNet and the Impact of Residual Connections on Learning <https://arxiv.org/abs/1602.07261>`_ trained on ImageNet",
             "source": "https://github.com/tensorflow/models/tree/archive/research/slim#pre-trained-models",
+            "author": "Christian Szegedy, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 171242881,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -806,6 +846,8 @@
             "version": null,
             "description": "Mask R-CNN model from `Mask R-CNN <https://arxiv.org/abs/1703.06870>`_ atrous version with Inception backbone trained on COCO",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf1_detection_zoo.md",
+            "author": "Kaiming He, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 266873310,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -851,6 +893,8 @@
             "version": null,
             "description": "Mask R-CNN model from `Mask R-CNN <https://arxiv.org/abs/1703.06870>`_ with Inception backbone trained on COCO",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf1_detection_zoo.md",
+            "author": "Kaiming He, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 67138064,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -889,6 +933,8 @@
             "version": null,
             "description": "Mask R-CNN model from `Mask R-CNN <https://arxiv.org/abs/1703.06870>`_ atrous version with ResNet-101 backbone trained on COCO",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf1_detection_zoo.md",
+            "author": "Kaiming He, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 221832819,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -927,6 +973,8 @@
             "version": null,
             "description": "Mask R-CNN model from `Mask R-CNN <https://arxiv.org/abs/1703.06870>`_ atrous version with ResNet-50 backbone trained on COCO",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf1_detection_zoo.md",
+            "author": "Kaiming He, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 145011833,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -964,6 +1012,9 @@
             "base_filename": "mobilenet-v2-imagenet.pb",
             "version": null,
             "description": "MobileNetV2 model from `MobileNetV2: Inverted Residuals and Linear Bottlenecks <https://arxiv.org/abs/1801.04381>`_ trained on ImageNet",
+            "source": "https://github.com/tensorflow/models/tree/archive/research/slim#pre-trained-models",
+            "author": "Mark Sandler, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 14297900,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1009,6 +1060,8 @@
             "version": null,
             "description": "ResNet-50 v1 model from `Deep Residual Learning for Image Recognition <https://arxiv.org/abs/1512.03385>`_ trained on ImageNet",
             "source": "https://github.com/tensorflow/models/tree/archive/research/slim#pre-trained-models",
+            "author": "Kaiming He, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 102591940,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1054,6 +1107,8 @@
             "version": null,
             "description": "ResNet-50 v2 model from `Deep Residual Learning for Image Recognition <https://arxiv.org/abs/1512.03385>`_ trained on ImageNet",
             "source": "https://github.com/tensorflow/models/tree/archive/research/slim#pre-trained-models",
+            "author": "Kaiming He, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 102614513,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1099,6 +1154,8 @@
             "version": null,
             "description": "R-FCN object detection model from `R-FCN: Object Detection via Region-based Fully Convolutional Networks <https://arxiv.org/abs/1605.06409>`_ with ResNet-101 backbone trained on COCO",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf1_detection_zoo.md",
+            "author": "Jifeng Dai, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 218274055,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1137,6 +1194,8 @@
             "version": null,
             "description": "Inception Single Shot Detector model from `SSD: Single Shot MultiBox Detector <https://arxiv.org/abs/1512.02325>`_ trained on COCO",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf1_detection_zoo.md",
+            "author": "Wei Liu, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 102241138,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1175,6 +1234,8 @@
             "version": null,
             "description": "Single Shot Detector model from `SSD: Single Shot MultiBox Detector <https://arxiv.org/abs/1512.02325>`_ with MobileNetV1 backbone trained on COCO",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf1_detection_zoo.md",
+            "author": "Wei Liu, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 29185289,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1213,6 +1274,8 @@
             "version": null,
             "description": "FPN Single Shot Detector model from `SSD: Single Shot MultiBox Detector <https://arxiv.org/abs/1512.02325>`_ with MobileNetV1 backbone trained on COCO",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf1_detection_zoo.md",
+            "author": "Wei Liu, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 51346898,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1251,6 +1314,8 @@
             "version": null,
             "description": "FPN Single Shot Detector model from `SSD: Single Shot MultiBox Detector <https://arxiv.org/abs/1512.02325>`_ with ResNet-50 backbone trained on COCO",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf1_detection_zoo.md",
+            "author": "Wei Liu, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 134294086,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1289,6 +1354,8 @@
             "version": null,
             "description": "VGG-16 model from `Very Deep Convolutional Networks for Large-Scale Image Recognition <https://arxiv.org/abs/1409.1556>`_ trained on ImageNet",
             "source": "https://gist.github.com/ksimonyan/211839e770f7b538e2d8#file-readme-md",
+            "author": "Karen Simonyan, et al.",
+            "license": "CC-BY-4.0",
             "size_bytes": 553436134,
             "manager": {
                 "config": {
@@ -1333,6 +1400,8 @@
             "version": null,
             "description": "YOLOv2 model from `YOLO9000: Better, Faster, Stronger <https://arxiv.org/abs/1612.08242>`_ trained on COCO",
             "source": "https://github.com/thtrieu/darkflow",
+            "author": "Joseph Redmon, et al.",
+            "license": "GPL-3.0",
             "size_bytes": 203934260,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1370,6 +1439,8 @@
             "version": null,
             "description": "CenterNet model from `Objects as Points <https://arxiv.org/abs/1904.07850>`_ with the Hourglass-104 backbone trained on COCO resized to 512x512",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "author": "Xingyi Zhou, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 1600851968,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1410,6 +1481,8 @@
             "version": null,
             "description": "CenterNet model from `Objects as Points <https://arxiv.org/abs/1904.07850>`_ with the Hourglass-104 backbone trained on COCO resized to 1024x1024",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "author": "Xingyi Zhou, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 1426460092,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1450,6 +1523,8 @@
             "version": null,
             "description": "CenterNet model from `Objects as Points <https://arxiv.org/abs/1904.07850>`_ with the ResNet-50-v1 backbone + FPN trained on COCO resized to 512x512",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "author": "Xingyi Zhou, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 204067969,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1490,6 +1565,8 @@
             "version": null,
             "description": "CenterNet model from `Objects as Points <https://arxiv.org/abs/1904.07850>`_ with the ResNet-101v1 backbone + FPN trained on COCO resized to 512x512",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "author": "Xingyi Zhou, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 345992335,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1530,6 +1607,8 @@
             "version": null,
             "description": "CenterNet model from `Objects as Points <https://arxiv.org/abs/1904.07850>`_ with the ResNet-50v2 backbone trained on COCO resized to 512x512",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "author": "Xingyi Zhou, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 237977273,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1570,6 +1649,8 @@
             "version": null,
             "description": "CenterNet model from `Objects as Points <https://arxiv.org/abs/1904.07850>`_ with the MobileNetV2 backbone trained on COCO resized to 512x512",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "author": "Xingyi Zhou, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 44016454,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1610,6 +1691,8 @@
             "version": null,
             "description": "EfficientDet-D0 model from `EfficientDet: Scalable and Efficient Object Detection <https://arxiv.org/abs/1911.09070>`_ trained on COCO resized to 512x512",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "author": "Mingxing Tan, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 30736482,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1650,6 +1733,8 @@
             "version": null,
             "description": "EfficientDet-D1 model from `EfficientDet: Scalable and Efficient Object Detection <https://arxiv.org/abs/1911.09070>`_ trained on COCO resized to 640x640",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "author": "Mingxing Tan, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 51839363,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1690,6 +1775,8 @@
             "version": null,
             "description": "EfficientDet-D2 model from `EfficientDet: Scalable and Efficient Object Detection <https://arxiv.org/abs/1911.09070>`_ trained on COCO resized to 768x768",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "author": "Mingxing Tan, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 62929273,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1730,6 +1817,8 @@
             "version": null,
             "description": "EfficientDet-D3 model from `EfficientDet: Scalable and Efficient Object Detection <https://arxiv.org/abs/1911.09070>`_ trained on COCO resized to 896x896",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "author": "Mingxing Tan, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 92858658,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1770,6 +1859,8 @@
             "version": null,
             "description": "EfficientDet-D4 model from `EfficientDet: Scalable and Efficient Object Detection <https://arxiv.org/abs/1911.09070>`_ trained on COCO resized to 1024x1024",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "author": "Mingxing Tan, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 158496448,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1810,6 +1901,8 @@
             "version": null,
             "description": "EfficientDet-D5 model from `EfficientDet: Scalable and Efficient Object Detection <https://arxiv.org/abs/1911.09070>`_ trained on COCO resized to 1280x1280",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "author": "Mingxing Tan, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 256286417,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1850,6 +1943,8 @@
             "version": null,
             "description": "EfficientDet-D6 model from `EfficientDet: Scalable and Efficient Object Detection <https://arxiv.org/abs/1911.09070>`_ trained on COCO resized to 1280x1280",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "author": "Mingxing Tan, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 393872877,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1890,6 +1985,8 @@
             "version": null,
             "description": "EfficientDet-D7 model from `EfficientDet: Scalable and Efficient Object Detection <https://arxiv.org/abs/1911.09070>`_ trained on COCO resized to 1536x1536",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "author": "Mingxing Tan, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 394474998,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1930,6 +2027,8 @@
             "version": null,
             "description": "MobileNetV2 model from `MobileNetV2: Inverted Residuals and Linear Bottlenecks <https://arxiv.org/pdf/1801.04381.pdf>`_ resized to 320x320",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "author": "Mark Sandler, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 46042990,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1970,6 +2069,8 @@
             "version": null,
             "description": "MobileNetV1 model from `MobileNetV2: Inverted Residuals and Linear Bottlenecks <https://arxiv.org/pdf/1801.04381.pdf>`_ resized to 640x640",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "author": "Mark Sandler, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 46042990,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -6,6 +6,8 @@
             "version": null,
             "description": "AlexNet model architecture from `One weird trick for parallelizing convolutional neural networks <https://arxiv.org/abs/1404.5997>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Alex Krizhevsky",
+            "license": "BSD 3-Clause",
             "size_bytes": 244418560,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -54,6 +56,8 @@
             "version": null,
             "description": "DeepLabV3 model from `Rethinking Atrous Convolution for Semantic Image Segmentation <https://arxiv.org/abs/1706.05587>`_ with ResNet-101 backbone trained on COCO",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Liang-Chieh Chen, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 244545539,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -93,6 +97,8 @@
             "version": null,
             "description": "Segment Anything Model (SAM) from `Segment Anything <https://arxiv.org/abs/2304.02643>`_ with ViT-B/16 backbone trained on SA-1B",
             "source": "https://segment-anything.com",
+            "author": "Alexander Kirillov, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 732512,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -126,6 +132,8 @@
             "version": null,
             "description": "Segment Anything Model (SAM) from `Segment Anything <https://arxiv.org/abs/2304.02643>`_ with ViT-H/16 backbone trained on SA-1B",
             "source": "https://segment-anything.com",
+            "author": "Alexander Kirillov, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 5008896,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -159,6 +167,8 @@
             "version": null,
             "description": "Segment Anything Model (SAM) from `Segment Anything <https://arxiv.org/abs/2304.02643>`_ with ViT-L/16 backbone trained on SA-1B",
             "source": "https://segment-anything.com",
+            "author": "Alexander Kirillov, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 2440480,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -192,6 +202,8 @@
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
             "source": "https://ai.meta.com/sam2/",
+            "author": "Nikhila Ravi, et al.",
+            "license": "Apache 2.0,BSD 3-Clause",
             "size_bytes": 155906050,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -225,6 +237,8 @@
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
             "source": "https://ai.meta.com/sam2/",
+            "author": "Nikhila Ravi, et al.",
+            "license": "Apache 2.0,BSD 3-Clause",
             "size_bytes": 155906050,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -258,6 +272,8 @@
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
             "source": "https://ai.meta.com/sam2/",
+            "author": "Nikhila Ravi, et al.",
+            "license": "Apache 2.0,BSD 3-Clause",
             "size_bytes": 155906050,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -291,6 +307,8 @@
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
             "source": "https://ai.meta.com/sam2/",
+            "author": "Nikhila Ravi, et al.",
+            "license": "Apache 2.0,BSD 3-Clause",
             "size_bytes": 155906050,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -324,6 +342,8 @@
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
             "source": "https://ai.meta.com/sam2/",
+            "author": "Nikhila Ravi, et al.",
+            "license": "Apache 2.0,BSD 3-Clause",
             "size_bytes": 155906050,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -356,6 +376,8 @@
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
             "source": "https://ai.meta.com/sam2/",
+            "author": "Nikhila Ravi, et al.",
+            "license": "Apache 2.0,BSD 3-Clause",
             "size_bytes": 155906050,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -389,6 +411,8 @@
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
             "source": "https://ai.meta.com/sam2/",
+            "author": "Nikhila Ravi, et al.",
+            "license": "Apache 2.0,BSD 3-Clause",
             "size_bytes": 155906050,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -422,6 +446,8 @@
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
             "source": "https://ai.meta.com/sam2/",
+            "author": "Nikhila Ravi, et al.",
+            "license": "Apache 2.0,BSD 3-Clause",
             "size_bytes": 155906050,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -455,6 +481,8 @@
             "version": null,
             "description": "Fine-tuned SAM2-hiera-tiny model from `Medical SAM 2 - Segment Medical Images as Video via Segment Anything Model 2 <https://arxiv.org/abs/2408.00874>`_",
             "source": "https://github.com/MedicineToken/Medical-SAM2",
+            "author": "Jiayuan Zhu, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 155906050,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -493,6 +521,8 @@
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
             "source": "https://ai.meta.com/sam2/",
+            "author": "Nikhila Ravi, et al.",
+            "license": "Apache 2.0,BSD 3-Clause",
             "size_bytes": 155906050,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -528,6 +558,8 @@
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
             "source": "https://ai.meta.com/sam2/",
+            "author": "Nikhila Ravi, et al.",
+            "license": "Apache 2.0,BSD 3-Clause",
             "size_bytes": 155906050,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -563,6 +595,8 @@
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
             "source": "https://ai.meta.com/sam2/",
+            "author": "Nikhila Ravi, et al.",
+            "license": "Apache 2.0,BSD 3-Clause",
             "size_bytes": 155906050,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -598,6 +632,8 @@
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
             "source": "https://ai.meta.com/sam2/",
+            "author": "Nikhila Ravi, et al.",
+            "license": "Apache 2.0,BSD 3-Clause",
             "size_bytes": 155906050,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -633,6 +669,8 @@
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
             "source": "https://ai.meta.com/sam2/",
+            "author": "Nikhila Ravi, et al.",
+            "license": "Apache 2.0,BSD 3-Clause",
             "size_bytes": 155906050,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -667,6 +705,8 @@
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
             "source": "https://ai.meta.com/sam2/",
+            "author": "Nikhila Ravi, et al.",
+            "license": "Apache 2.0,BSD 3-Clause",
             "size_bytes": 155906050,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -702,6 +742,8 @@
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
             "source": "https://ai.meta.com/sam2/",
+            "author": "Nikhila Ravi, et al.",
+            "license": "Apache 2.0,BSD 3-Clause",
             "size_bytes": 155906050,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -737,6 +779,8 @@
             "version": null,
             "description": "Segment Anything Model 2 (SAM2) from `SAM2: Segment Anything in Images and Videos <https://arxiv.org/abs/2408.00714>`_",
             "source": "https://ai.meta.com/sam2/",
+            "author": "Nikhila Ravi, et al.",
+            "license": "Apache 2.0,BSD 3-Clause",
             "size_bytes": 155906050,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -772,6 +816,8 @@
             "version": null,
             "description": "DeepLabV3 model from `Rethinking Atrous Convolution for Semantic Image Segmentation <https://arxiv.org/abs/1706.05587>`_ with ResNet-50 backbone trained on COCO",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Liang-Chieh Chen, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 168312152,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -811,6 +857,8 @@
             "version": null,
             "description": "Densenet-121 model from `Densely Connected Convolutional Networks <https://arxiv.org/pdf/1608.06993.pdf>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Gao Huang, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 32342954,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -859,6 +907,8 @@
             "version": null,
             "description": "Densenet-161 model from `Densely Connected Convolutional Networks <https://arxiv.org/pdf/1608.06993.pdf>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Gao Huang, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 115730790,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -907,6 +957,8 @@
             "version": null,
             "description": "Densenet-169 model from `Densely Connected Convolutional Networks <https://arxiv.org/pdf/1608.06993.pdf>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Gao Huang, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 57365526,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -955,6 +1007,8 @@
             "version": null,
             "description": "Densenet-201 model from `Densely Connected Convolutional Networks <https://arxiv.org/pdf/1608.06993.pdf>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Gao Huang, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 81131730,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1003,6 +1057,8 @@
             "version": null,
             "description": "Faster R-CNN model from `Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks <https://arxiv.org/abs/1506.01497>`_ with ResNet-50 FPN backbone trained on COCO",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Shaoqing Ren, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 167502836,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1040,6 +1096,8 @@
             "version": null,
             "description": "FCN model from `Fully Convolutional Networks for Semantic Segmentation <https://arxiv.org/abs/1411.4038>`_ with ResNet-101 backbone trained on COCO",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Jonathan Long, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 217800805,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1079,6 +1137,8 @@
             "version": null,
             "description": "FCN model from `Fully Convolutional Networks for Semantic Segmentation <https://arxiv.org/abs/1411.4038>`_ with ResNet-50 backbone trained on COCO",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Jonathan Long, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 141567418,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1118,6 +1178,8 @@
             "version": null,
             "description": "GoogLeNet (Inception v1) model from `Going Deeper with Convolutions <https://arxiv.org/abs/1409.4842>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Christian Szegedy, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 52147035,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1166,6 +1228,8 @@
             "version": null,
             "description": "Inception v3 model from `Rethinking the Inception Architecture for Computer Vision <https://arxiv.org/abs/1512.00567>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Christian Szegedy, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 108857766,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1213,6 +1277,8 @@
             "version": null,
             "description": "Keypoint R-CNN model from `Mask R-CNN <https://arxiv.org/abs/1703.06870>`_ with ResNet-50 FPN backbone trained on COCO",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Kaiming He, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 237034793,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1276,6 +1342,8 @@
             "version": null,
             "description": "Mask R-CNN model from `Mask R-CNN <https://arxiv.org/abs/1703.06870>`_ with ResNet-50 FPN backbone trained on COCO",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Kaiming He, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 178090079,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1312,6 +1380,8 @@
             "version": null,
             "description": "MNASNet model from from `MnasNet: Platform-Aware Neural Architecture Search for Mobile <https://arxiv.org/abs/1807.11626>`_ with depth multiplier of 0.5 trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Mingxing Tan, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 9008489,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1360,6 +1430,8 @@
             "version": null,
             "description": "MNASNet model from `MnasNet: Platform-Aware Neural Architecture Search for Mobile <https://arxiv.org/abs/1807.11626>`_ with depth multiplier of 1.0 trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Mingxing Tan, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 17736997,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1408,6 +1480,8 @@
             "version": null,
             "description": "MobileNetV2 model from `MobileNetV2: Inverted Residuals and Linear Bottlenecks <https://arxiv.org/abs/1801.04381>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Mark Sandler, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 14212972,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1456,6 +1530,8 @@
             "version": null,
             "description": "ResNet-101 model from `Deep Residual Learning for Image Recognition <https://arxiv.org/abs/1512.03385>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Kaiming He, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 178728960,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1504,6 +1580,8 @@
             "version": null,
             "description": "ResNet-152 model from `Deep Residual Learning for Image Recognition <https://arxiv.org/abs/1512.03385>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Kaiming He, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 241530880,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1552,6 +1630,8 @@
             "version": null,
             "description": "ResNet-18 model from `Deep Residual Learning for Image Recognition <https://arxiv.org/abs/1512.03385>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Kaiming He, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 46827520,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1600,6 +1680,8 @@
             "version": null,
             "description": "ResNet-34 model from `Deep Residual Learning for Image Recognition <https://arxiv.org/abs/1512.03385>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Kaiming He, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 87306240,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1648,6 +1730,8 @@
             "version": null,
             "description": "ResNet-50 model from `Deep Residual Learning for Image Recognition <https://arxiv.org/abs/1512.03385>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Kaiming He, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 102502400,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1696,6 +1780,8 @@
             "version": null,
             "description": "ResNeXt-101 32x8d model from `Aggregated Residual Transformations for Deep Neural Networks <https://arxiv.org/abs/1611.05431>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Saining Xie, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 356082095,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1744,6 +1830,8 @@
             "version": null,
             "description": "ResNeXt-50 32x4d model from `Aggregated Residual Transformations for Deep Neural Networks <https://arxiv.org/abs/1611.05431>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Saining Xie, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 100441675,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1792,6 +1880,8 @@
             "version": null,
             "description": "RetinaNet model from `Focal Loss for Dense Object Detection <https://arxiv.org/abs/1708.02002>`_ with ResNet-50 FPN backbone trained on COCO",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Tsung-Yi Lin, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 136595076,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1829,6 +1919,8 @@
             "version": null,
             "description": "ShuffleNetV2 model from `ShuffleNet V2: Practical Guidelines for Efficient CNN Architecture Design <https://arxiv.org/abs/1807.11164>`_ with 0.5x output channels trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Ningning Ma, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 5538128,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1877,6 +1969,8 @@
             "version": null,
             "description": "ShuffleNetV2 model from `ShuffleNet V2: Practical Guidelines for Efficient CNN Architecture Design <https://arxiv.org/abs/1807.11164>`_ with 1.0x output channels trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Ningning Ma, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 9218294,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1925,6 +2019,8 @@
             "version": null,
             "description": "SqueezeNet 1.1 model from `the official SqueezeNet repo <https://github.com/forresti/SqueezeNet/tree/master/SqueezeNet_v1.1>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Forrest Iandola",
+            "license": "BSD 2-Clause",
             "size_bytes": 4966400,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -1965,6 +2061,8 @@
             "version": null,
             "description": "SqueezeNet model from `SqueezeNet: AlexNet-level accuracy with 50x fewer parameters and <0.5MB model size <https://arxiv.org/abs/1602.07360>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Forrest Iandola",
+            "license": "BSD 2-Clause",
             "size_bytes": 5017600,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -2005,6 +2103,8 @@
             "version": null,
             "description": "VGG-11 model from `Very Deep Convolutional Networks for Large-Scale Image Recognition <https://arxiv.org/abs/1409.1556>`_ with batch normalization trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Karen Simonyan, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 531503671,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -2053,6 +2153,8 @@
             "version": null,
             "description": "VGG-11 model from `Very Deep Convolutional Networks for Large-Scale Image Recognition <https://arxiv.org/abs/1409.1556>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Karen Simonyan, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 531456000,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -2099,6 +2201,8 @@
             "version": null,
             "description": "VGG-13 model from `Very Deep Convolutional Networks for Large-Scale Image Recognition <https://arxiv.org/abs/1409.1556>`_ with batch normalization trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Karen Simonyan, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 532246301,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -2147,6 +2251,8 @@
             "version": null,
             "description": "VGG-13 model from `Very Deep Convolutional Networks for Large-Scale Image Recognition <https://arxiv.org/abs/1409.1556>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Karen Simonyan, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 532194478,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -2193,6 +2299,8 @@
             "version": null,
             "description": "VGG-16 model from `Very Deep Convolutional Networks for Large-Scale Image Recognition <https://arxiv.org/abs/1409.1556>`_ with batch normalization trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Karen Simonyan, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 553507836,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -2241,6 +2349,8 @@
             "version": null,
             "description": "VGG-16 model from `Very Deep Convolutional Networks for Large-Scale Image Recognition <https://arxiv.org/abs/1409.1556>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Karen Simonyan, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 553433881,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -2287,6 +2397,8 @@
             "version": null,
             "description": "VGG-19 model from `Very Deep Convolutional Networks for Large-Scale Image Recognition <https://arxiv.org/abs/1409.1556>`_ with batch normalization trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Karen Simonyan, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 574769405,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -2335,6 +2447,8 @@
             "version": null,
             "description": "VGG-19 model from `Very Deep Convolutional Networks for Large-Scale Image Recognition <https://arxiv.org/abs/1409.1556>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Karen Simonyan, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 574673361,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -2381,6 +2495,8 @@
             "version": null,
             "description": "Wide ResNet-101-2 model from `Wide Residual Networks <https://arxiv.org/abs/1605.07146>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Sergey Zagoruyko, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 254695146,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -2429,6 +2545,8 @@
             "version": null,
             "description": "Wide ResNet-50-2 model from `Wide Residual Networks <https://arxiv.org/abs/1605.07146>`_ trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
+            "author": "Sergey Zagoruyko, et al.",
+            "license": "BSD 3-Clause",
             "size_bytes": 138223492,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -2477,6 +2595,8 @@
             "version": null,
             "description": "OPEN CLIP text/image encoder from `Learning Transferable Visual Models From Natural Language Supervision <https://arxiv.org/abs/2103.00020>`_ trained on 400M text-image pairs",
             "source": "https://github.com/mlfoundations/open_clip",
+            "author": "Gabriel Ilharco, et al.",
+            "license": "MIT",
             "size_bytes": null,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.open_clip.TorchOpenClipModel",
@@ -2518,6 +2638,8 @@
             "version": null,
             "description": "Hugging Face Transformers model for image classification",
             "source": "https://huggingface.co/docs/transformers/tasks/image_classification",
+            "author": "Thomas Wolf, et al.",
+            "license": "Apache 2.0",
             "size_bytes": null,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForImageClassification",
@@ -2547,6 +2669,8 @@
             "version": null,
             "description": "Hugging Face Transformers model for object detection",
             "source": "https://huggingface.co/docs/transformers/tasks/object_detection",
+            "author": "Thomas Wolf, et al.",
+            "license": "Apache 2.0",
             "size_bytes": null,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForObjectDetection",
@@ -2576,6 +2700,8 @@
             "version": null,
             "description": "Hugging Face Transformers model for semantic segmentation",
             "source": "https://huggingface.co/docs/transformers/tasks/semantic_segmentation",
+            "author": "Thomas Wolf, et al.",
+            "license": "Apache 2.0",
             "size_bytes": null,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForSemanticSegmentation",
@@ -2599,6 +2725,8 @@
             "version": null,
             "description": "Hugging Face Transformers model for monocular depth estimation",
             "source": "https://huggingface.co/docs/transformers/tasks/monocular_depth_estimation",
+            "author": "Thomas Wolf, et al.",
+            "license": "Apache 2.0",
             "size_bytes": null,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForDepthEstimation",
@@ -2622,6 +2750,8 @@
             "version": null,
             "description": "Hugging Face Transformers model for zero-shot image classification",
             "source": "https://huggingface.co/docs/transformers/tasks/zero_shot_image_classification",
+            "author": "Thomas Wolf, et al.",
+            "license": "Apache 2.0",
             "size_bytes": null,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneZeroShotTransformerForImageClassification",
@@ -2652,6 +2782,8 @@
             "version": null,
             "description": "Hugging Face Transformers model for zero-shot object detection",
             "source": "https://huggingface.co/docs/transformers/tasks/zero_shot_object_detection",
+            "author": "Thomas Wolf, et al.",
+            "license": "Apache 2.0",
             "size_bytes": null,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneZeroShotTransformerForObjectDetection",
@@ -2682,6 +2814,8 @@
             "version": null,
             "description": "CLIP text/image encoder from `Learning Transferable Visual Models From Natural Language Supervision <https://arxiv.org/abs/2103.00020>`_ trained on 400M text-image pairs",
             "source": "https://github.com/openai/CLIP",
+            "author": "Alec Radford, et al.",
+            "license": "MIT",
             "size_bytes": 353976522,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -2728,6 +2862,8 @@
             "base_name": "dinov2-vits14-torch",
             "description": "DINOv2: Learning Robust Visual Features without Supervision. Model: ViT-S/14 distilled",
             "source": "https://github.com/facebookresearch/dinov2",
+            "author": "Maxime Oquab, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 88283115,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.torch.TorchImageModel",
@@ -2757,6 +2893,8 @@
             "base_name": "dinov2-vitb14-torch",
             "description": "DINOv2: Learning Robust Visual Features without Supervision. Model: ViT-B/14 distilled",
             "source": "https://github.com/facebookresearch/dinov2",
+            "author": "Maxime Oquab, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 346378731,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.torch.TorchImageModel",
@@ -2786,6 +2924,8 @@
             "base_name": "dinov2-vitl14-torch",
             "description": "DINOv2: Learning Robust Visual Features without Supervision. Model: ViT-L/14 distilled",
             "source": "https://github.com/facebookresearch/dinov2",
+            "author": "Maxime Oquab, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 1217586395,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.torch.TorchImageModel",
@@ -2815,6 +2955,8 @@
             "base_name": "dinov2-vitg14-torch",
             "description": "DINOv2: Learning Robust Visual Features without Supervision. Model: ViT-g/14",
             "source": "https://github.com/facebookresearch/dinov2",
+            "author": "Maxime Oquab, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 4546108579,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.torch.TorchImageModel",
@@ -2844,6 +2986,8 @@
             "base_name": "dinov2-vits14-reg-torch",
             "description": "DINOv2: Learning Robust Visual Features without Supervision. Model: ViT-S/14 distilled",
             "source": "https://github.com/facebookresearch/dinov2",
+            "author": "Maxime Oquab, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 88291785,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.torch.TorchImageModel",
@@ -2873,6 +3017,8 @@
             "base_name": "dinov2-vitb14-reg-torch",
             "description": "DINOv2: Learning Robust Visual Features without Supervision. Model: ViT-B/14 distilled",
             "source": "https://github.com/facebookresearch/dinov2",
+            "author": "Maxime Oquab, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 346393545,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.torch.TorchImageModel",
@@ -2902,6 +3048,8 @@
             "base_name": "dinov2-vitl14-reg-torch",
             "description": "DINOv2: Learning Robust Visual Features without Supervision. Model: ViT-L/14 distilled",
             "source": "https://github.com/facebookresearch/dinov2",
+            "author": "Maxime Oquab, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 1217607321,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.torch.TorchImageModel",
@@ -2931,6 +3079,8 @@
             "base_name": "dinov2-vitg14-reg-torch",
             "description": "DINOv2: Learning Robust Visual Features without Supervision. Model: ViT-g/14",
             "source": "https://github.com/facebookresearch/dinov2",
+            "author": "Maxime Oquab, et al.",
+            "license": "Apache 2.0",
             "size_bytes": 4546140349,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.torch.TorchImageModel",
@@ -2960,6 +3110,8 @@
             "base_name": "yolov5n-coco-torch",
             "description": "Ultralytics YOLOv5n model trained on COCO",
             "source": "https://pytorch.org/hub/ultralytics_yolov5",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 7936,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.torch.TorchImageModel",
@@ -2991,6 +3143,8 @@
             "base_name": "yolov5s-coco-torch",
             "description": "Ultralytics YOLOv5s model trained on COCO",
             "source": "https://pytorch.org/hub/ultralytics_yolov5",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 28928,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.torch.TorchImageModel",
@@ -3022,6 +3176,8 @@
             "base_name": "yolov5m-coco-torch",
             "description": "Ultralytics YOLOv5m model trained on COCO",
             "source": "https://pytorch.org/hub/ultralytics_yolov5",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 83872,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.torch.TorchImageModel",
@@ -3053,6 +3209,8 @@
             "base_name": "yolov5l-coco-torch",
             "description": "Ultralytics YOLOv5l model trained on COCO",
             "source": "https://pytorch.org/hub/ultralytics_yolov5",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 197504,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.torch.TorchImageModel",
@@ -3085,6 +3243,8 @@
             "base_filename": "yolov8n-coco.pt",
             "description": "Ultralytics YOLOv8n model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov8/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 6534387,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3117,6 +3277,8 @@
             "base_filename": "yolov8s-coco.pt",
             "description": "Ultralytics YOLOv8s model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov8/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 22573363,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3149,6 +3311,8 @@
             "base_filename": "yolov8m-coco.pt",
             "description": "Ultralytics YOLOv8m model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov8/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 52117635,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3181,6 +3345,8 @@
             "base_filename": "yolov8l-coco.pt",
             "description": "Ultralytics YOLOv8l model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov8/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 87769683,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3213,6 +3379,8 @@
             "base_filename": "yolov8x-coco.pt",
             "description": "Ultralytics YOLOv8x model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov8/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 136867539,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3245,6 +3413,8 @@
             "base_filename": "yolov8n-seg-coco.pt",
             "description": "Ultralytics YOLOv8n Segmentation model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov8/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 7054355,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3277,6 +3447,8 @@
             "base_filename": "yolov8s-seg-coco.pt",
             "description": "Ultralytics YOLOv8s Segmentation model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov8/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 23897299,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3309,6 +3481,8 @@
             "base_filename": "yolov8m-seg-coco.pt",
             "description": "Ultralytics YOLOv8m Segmentation model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov8/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 54899779,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3341,6 +3515,8 @@
             "base_filename": "yolov8l-seg-coco.pt",
             "description": "Ultralytics YOLOv8l Segmentation model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov8/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 92391859,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3373,6 +3549,8 @@
             "base_filename": "yolov8x-seg-coco.pt",
             "description": "Ultralytics YOLOv8x Segmentation model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov8/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 144076467,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3405,6 +3583,8 @@
             "base_filename": "yolov9c-coco.pt",
             "description": "YOLOv9-C model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov9/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 51802599,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3437,6 +3617,8 @@
             "base_filename": "yolov9e-coco.pt",
             "description": "YOLOv9-E model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov9/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 117530476,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3469,6 +3651,8 @@
             "base_filename": "yolov9c-seg-coco.pt",
             "description": "YOLOv9-C Segmentation model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov9/#__tabbed_1_2",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 112406113,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3501,6 +3685,8 @@
             "base_filename": "yolov9e-seg-coco.pt",
             "description": "YOLOv9-E Segmentation model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov9/#__tabbed_1_2",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 243481823,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3533,6 +3719,8 @@
             "base_filename": "yolov10n-coco.pt",
             "description": "YOLOv10-N model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov10/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 5860383,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3565,6 +3753,8 @@
             "base_filename": "yolov10s-coco.pt",
             "description": "YOLOv10-S model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov10/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 16623111,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3597,6 +3787,8 @@
             "base_filename": "yolov10m-coco.pt",
             "description": "YOLOv10-M model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov10/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 33643667,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3629,6 +3821,8 @@
             "base_filename": "yolov10l-coco.pt",
             "description": "YOLOv10-L model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov10/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 52425230,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3661,6 +3855,8 @@
             "base_filename": "yolov10x-coco.pt",
             "description": "YOLOv10-X model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov10/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 64395854,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3693,6 +3889,8 @@
             "base_filename": "yolo11n-coco.pt",
             "description": "YOLO11-N model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov11/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 5613764,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3725,6 +3923,8 @@
             "base_filename": "yolo11s-coco.pt",
             "description": "YOLO11-S model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov11/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 19313732,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3757,6 +3957,8 @@
             "base_filename": "yolo11m-coco.pt",
             "description": "YOLO11-M model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov11/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 40684120,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3789,6 +3991,8 @@
             "base_filename": "yolo11l-coco.pt",
             "description": "YOLO11-L model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov11/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 51387343,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3821,6 +4025,8 @@
             "base_filename": "yolo11x-coco.pt",
             "description": "YOLO11-X model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolov11/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 114636239,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3853,6 +4059,8 @@
             "base_filename": "yolo11n-seg-coco.pt",
             "description": "YOLO11-N Segmentation model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolo11/#__tabbed_1_2",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 6182636,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3885,6 +4093,8 @@
             "base_filename": "yolo11s-seg-coco.pt",
             "description": "YOLO11-S Segmentation model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolo11/#__tabbed_1_2",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 20669228,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3917,6 +4127,8 @@
             "base_filename": "yolo11m-seg-coco.pt",
             "description": "YOLO11-M Segmentation model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolo11/#__tabbed_1_2",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 45400152,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3949,6 +4161,8 @@
             "base_filename": "yolo11l-seg-coco.pt",
             "description": "YOLO11-L Segmentation model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolo11/#__tabbed_1_2",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 56096965,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -3981,6 +4195,8 @@
             "base_filename": "yolo11x-seg-coco.pt",
             "description": "YOLO11-X Segmentation model trained on COCO",
             "source": "https://docs.ultralytics.com/models/yolo11/#__tabbed_1_2",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 125090821,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -4013,6 +4229,8 @@
             "base_filename": "rtdetr-l-coco.pt",
             "description": "RT-DETR-l model trained on COCO",
             "source": "https://docs.ultralytics.com/models/rtdetr/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 66511432,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -4045,6 +4263,8 @@
             "base_filename": "rtdetr-x-coco.pt",
             "description": "RT-DETR-x model trained on COCO",
             "source": "https://docs.ultralytics.com/models/rtdetr/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 135755662,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -4077,6 +4297,8 @@
             "base_filename": "yolov8s-world.pt",
             "description": "YOLOv8s-World model",
             "source": "https://docs.ultralytics.com/models/yolo-world/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 27166882,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -4109,6 +4331,8 @@
             "base_filename": "yolov8m-world.pt",
             "description": "YOLOv8m-World model",
             "source": "https://docs.ultralytics.com/models/yolo-world/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 58607810,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -4141,6 +4365,8 @@
             "base_filename": "yolov8l-world.pt",
             "description": "YOLOv8l-World model",
             "source": "https://docs.ultralytics.com/models/yolo-world/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 95664610,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -4173,6 +4399,8 @@
             "base_filename": "yolov8x-world.pt",
             "description": "YOLOv8x-World model",
             "source": "https://docs.ultralytics.com/models/yolo-world/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 147959522,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -4205,6 +4433,8 @@
             "base_filename": "yolov8n-obb.pt",
             "description": "YOLOv8n Oriented Bounding Box model",
             "source": "https://docs.ultralytics.com/tasks/obb/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 6548034,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -4237,6 +4467,8 @@
             "base_filename": "yolov8s-obb.pt",
             "description": "YOLOv8s Oriented Bounding Box model",
             "source": "https://docs.ultralytics.com/tasks/obb/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 23245186,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -4269,6 +4501,8 @@
             "base_filename": "yolov8m-obb.pt",
             "description": "YOLOv8m Oriented Bounding Box model",
             "source": "https://docs.ultralytics.com/tasks/obb/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 53304682,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -4301,6 +4535,8 @@
             "base_filename": "yolov8l-obb.pt",
             "description": "YOLOv8l Oriented Bounding Box model",
             "source": "https://docs.ultralytics.com/tasks/obb/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 89504274,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -4333,6 +4569,8 @@
             "base_filename": "yolov8x-obb.pt",
             "description": "YOLOv8x Oriented Bounding Box model",
             "source": "https://docs.ultralytics.com/tasks/obb/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 139533138,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -4365,6 +4603,8 @@
             "base_filename": "yolov8n-oiv7.pt",
             "description": "Ultralytics YOLOv8n model trained on Open Images v7",
             "source": "https://docs.ultralytics.com/datasets/detect/open-images-v7",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 6534387,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -4397,6 +4637,8 @@
             "base_filename": "yolov8s-oiv7.pt",
             "description": "Ultralytics YOLOv8s model trained on Open Images v7",
             "source": "https://docs.ultralytics.com/datasets/detect/open-images-v7",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 22573363,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -4429,6 +4671,8 @@
             "base_filename": "yolov8m-oiv7.pt",
             "description": "Ultralytics YOLOv8m model trained Open Images v7",
             "source": "https://docs.ultralytics.com/datasets/detect/open-images-v7",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 52117635,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -4461,6 +4705,8 @@
             "base_filename": "yolov8l-oiv7.pt",
             "description": "Ultralytics YOLOv8l model trained Open Images v7",
             "source": "https://docs.ultralytics.com/datasets/detect/open-images-v7",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 87769683,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -4493,6 +4739,8 @@
             "base_filename": "yolov8x-oiv7.pt",
             "description": "Ultralytics YOLOv8x model trained Open Images v7",
             "source": "https://docs.ultralytics.com/datasets/detect/open-images-v7",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 136867539,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -4526,6 +4774,8 @@
             "version": null,
             "description": "YOLO-NAS is an open-source training library for advanced computer vision models. It specializes in accuracy and efficiency, supporting tasks like object detection",
             "source": "https://github.com/Deci-AI/super-gradients",
+            "author": "Shay Aharon, et al.",
+            "license": "Apache 2.0",
             "size_bytes": null,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.super_gradients.TorchYoloNasModel",
@@ -4551,6 +4801,8 @@
             "base_name": "yolov5x-coco-torch",
             "description": "Ultralytics YOLOv5x model trained on COCO",
             "source": "https://pytorch.org/hub/ultralytics_yolov5",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
             "size_bytes": 360496,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.torch.TorchImageModel",


### PR DESCRIPTION
## Change log

- Populates the `author` and `license` fields of all zoo models
- Adds a `license` property to all zoo datasets
- Adds support for filtering zoo models by license via `foz.list_zoo_models(..., license="MIT")`
- Adds support for filtering zoo datasets by license via `foz.list_zoo_datasets(..., license="CC-BY-4.0")`
- Adds a license column to the `fiftyone zoo models list` CLI command
- Adds a license column to the `fiftyone zoo datasets list` CLI command
- Adds author/license information to the model zoo docs
- Adds license information to the dataset zoo docs

## Example usage

```py
import fiftyone.zoo as foz

assert len(foz.list_zoo_models(license="MIT")) < len(foz.list_zoo_models())
assert len(foz.list_zoo_datasets(license="CC-BY-4.0")) < len(foz.list_zoo_datasets())
```

```
$ fiftyone zoo models list
name                                                         tags                                                            license                  remote    downloaded    model_path
-----------------------------------------------------------  --------------------------------------------------------------  -----------------------  --------  ------------  --------------------------------------------------------------------------------------------
alexnet-imagenet-torch                                       classification,embeddings,logits,imagenet,torch,alexnet         BSD 3-Clause                       ✓             /Users/Brian/fiftyone/__models__/alexnet-owt-4df8aa71.pth
centernet-hg104-1024-coco-tf2                                detection,coco,tf2,centernet                                    Apache 2.0                         ✓             /Users/Brian/fiftyone/__models__/centernet_hg104_1024x1024_coco17_tpu-32.tar.gz
centernet-hg104-512-coco-tf2                                 detection,coco,tf2,centernet                                    Apache 2.0                         ✓             /Users/Brian/fiftyone/__models__/centernet_hg104_512x512_coco17_tpu-8.tar.gz
centernet-mobilenet-v2-fpn-512-coco-tf2                      detection,coco,tf2,centernet,mobilenet                          Apache 2.0
centernet-resnet101-v1-fpn-512-coco-tf2                      detection,coco,tf2,centernet,resnet                             Apache 2.0                         ✓             /Users/Brian/fiftyone/__models__/centernet_resnet101_v1_fpn_512x512_coco17_tpu-8.tar.gz
centernet-resnet50-v1-fpn-512-coco-tf2                       detection,coco,tf2,centernet,resnet                             Apache 2.0                         ✓             /Users/Brian/fiftyone/__models__/centernet_resnet50_v1_fpn_512x512_coco17_tpu-8.tar.gz
centernet-resnet50-v2-512-coco-tf2                           detection,coco,tf2,centernet,resnet                             Apache 2.0                         ✓             /Users/Brian/fiftyone/__models__/centernet_resnet50_v2_512x512_coco17_tpu-8.tar.gz
classification-transformer-torch                             classification,logits,embeddings,torch,transformers             Apache 2.0                         ?             ?
clip-vit-base32-torch                                        classification,logits,embeddings,torch,clip,zero-shot           MIT                                ✓             /Users/Brian/fiftyone/__models__/CLIP-ViT-B-32.pt
...
```

```
$ fiftyone zoo datasets list
name                tags                                                                               license                                            split       downloaded    dataset_dir                                         base    torch (*)    tensorflow    remote
------------------  ---------------------------------------------------------------------------------  -------------------------------------------------  ----------  ------------  --------------------------------------------------  ------  -----------  ------------  --------
activitynet-100     video,temporal-detection,action-detection                                          CC-BY-4.0                                          test                                                                          ✓
activitynet-100     video,temporal-detection,action-detection                                          CC-BY-4.0                                          train                                                                         ✓
activitynet-100     video,temporal-detection,action-detection                                          CC-BY-4.0                                          validation                                                                    ✓
activitynet-200     video,temporal-detection,action-detection                                          CC-BY-4.0                                          test                                                                          ✓
activitynet-200     video,temporal-detection,action-detection                                          CC-BY-4.0                                          train                                                                         ✓
activitynet-200     video,temporal-detection,action-detection                                          CC-BY-4.0                                          validation  ✓             /Users/Brian/fiftyone/activitynet-200/validation    ✓
bdd100k             image,multilabel,automotive,manual                                                 https://doc.bdd100k.com/license.html               test        ✓             /Users/Brian/fiftyone/bdd100k/test                  ✓
bdd100k             image,multilabel,automotive,manual                                                 https://doc.bdd100k.com/license.html               train                                                                         ✓
bdd100k             image,multilabel,automotive,manual                                                 https://doc.bdd100k.com/license.html               validation  ✓             /Users/Brian/fiftyone/bdd100k/validation            ✓
caltech101          image,classification                                                               CC-BY-4.0                                                      ✓             /Users/Brian/fiftyone/caltech101                    ✓
caltech256          image,classification                                                               CC-BY-4.0                                                      ✓             /Users/Brian/fiftyone/caltech256                    ✓
cifar10             image,classification                                                                                                                  test        ✓             /Users/Brian/fiftyone/cifar10/test                          ✓            ✓
cifar10             image,classification                                                                                                                  train       ✓             /Users/Brian/fiftyone/cifar10/train                         ✓            ✓
cifar100            image,classification                                                                                                                  test        ✓             /Users/Brian/fiftyone/cifar100/test                         ✓            ✓
cifar100            image,classification                                                                                                                  train       ✓             /Users/Brian/fiftyone/cifar100/train
...
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added license filtering for datasets and models.
  - Enhanced documentation with licensing information for multiple datasets and models.
  - Introduced author and license details in model documentation.

- **Documentation**
  - Updated CLI commands to support license-based filtering.
  - Added license details for numerous datasets in the FiftyOne Dataset Zoo.
  - Improved model and dataset metadata with author and licensing information.
  - Corrected URLs for Berkeley DeepDrive (BDD) format documentation. 

- **Improvements**
  - Expanded dataset and model metadata to include more comprehensive information.
  - Enhanced search and filtering capabilities for datasets and models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->