### PR TITLE
Add support for remote zoo model parameters

### DIFF
--- a/docs/scripts/make_model_zoo_docs.py
+++ b/docs/scripts/make_model_zoo_docs.py
@@ -203,6 +203,18 @@ _MODEL_TEMPLATE = """
 
     dataset.apply_model(model, label_field="predictions")
     session.refresh()
+{% elif 'zero-shot' in tags and 'yolo' in tags %}
+    #
+    # Make zero-shot predictions with custom classes
+    #
+
+    model = foz.load_zoo_model(
+        "{{ name }}",
+        classes=["person", "dog", "cat", "bird", "car", "tree", "chair"],
+    )
+
+    dataset.apply_model(model, label_field="predictions")
+    session.refresh()
 {% endif %}
 """
 

--- a/docs/source/dataset_zoo/remote.rst
+++ b/docs/source/dataset_zoo/remote.rst
@@ -14,6 +14,12 @@ download/preparation methods are hosted via GitHub repositories or public URLs.
     provide your GitHub personal access token by setting the ``GITHUB_TOKEN``
     environment variable.
 
+.. note::
+
+    Check out `voxel51/coco-2017 <https://github.com/voxel51/coco-2017>`_ and
+    `voxel51/caltech101 <https://github.com/voxel51/caltech101>`_ for examples
+    of remotely-sourced datasets.
+
 .. _dataset-zoo-remote-usage:
 
 Working with remotely-sourced datasets
@@ -440,8 +446,3 @@ When
 :meth:`load_zoo_dataset(name_or_url, ..., **kwargs) <fiftyone.zoo.datasets.load_zoo_dataset>`
 is called, any `kwargs` declared by ``download_and_prepare()`` and
 ``load_dataset()`` are passed through to them, respectively.
-
-.. note::
-
-    Check out `voxel51/coco-2017 <https://github.com/voxel51/coco-2017>`_ for
-    an example of a remotely-sourced dataset that supports partial downloads.

--- a/docs/source/model_zoo/remote.rst
+++ b/docs/source/model_zoo/remote.rst
@@ -216,7 +216,7 @@ A remote source of models is defined by a directory with the following contents:
         def load_model(model_name, model_path, **kwargs):
             pass
 
-        def get_parameters(model_name, ctx, inputs):
+        def resolve_input(model_name, ctx):
             pass
 
         def parse_parameters(model_name, ctx, params):
@@ -428,13 +428,13 @@ When
 :meth:`load_zoo_model(name_or_url, ..., **kwargs) <fiftyone.zoo.models.load_zoo_model>`
 is called, any `kwargs` are passed through to ``load_model(..., **kwargs)``.
 
-.. _model-zoo-remote-get-parameters:
+.. _model-zoo-remote-resolve-input:
 
-Get parameters
-~~~~~~~~~~~~~~
+Resolve input
+~~~~~~~~~~~~~
 
 If a remote source contains model(s) that support custom parameters, then the
-``__init__.py`` file can define a ``get_parameters()`` method with the
+``__init__.py`` file can define a ``resolve_input()`` method with the
 signature below that defines any necessary properties to collect the model's
 custom parameters from a user when the model is invoked
 :ref:`via an operator <using-operators>`:
@@ -442,7 +442,9 @@ custom parameters from a user when the model is invoked
 .. code-block:: python
     :linenos:
 
-    def get_parameters(model_name, ctx, inputs):
+    from fiftyone.operators import types
+
+    def resolve_input(model_name, ctx):
         """Defines any necessary properties to collect the model's custom
         parameters from a user during prompting.
 
@@ -450,8 +452,11 @@ custom parameters from a user when the model is invoked
             model_name: the name of the model, as declared by the ``base_name`` and
                 optional ``version`` fields of the manifest
             ctx: an :class:`fiftyone.operators.ExecutionContext`
-            inputs: a :class:`fiftyone.operators.types.Property`
+
+        Returns:
+            a :class:`fiftyone.operators.types.Property`, or None
         """
+        inputs = types.Object()
         inputs.list(
             "classes",
             types.String(),
@@ -463,6 +468,7 @@ custom parameters from a user when the model is invoked
             ),
             view=types.AutocompleteView(),
         )
+        return types.Property(inputs)
 
 .. note::
 

--- a/docs/source/user_guide/evaluation.rst
+++ b/docs/source/user_guide/evaluation.rst
@@ -2111,6 +2111,7 @@ Let's look at an example evaluation metric operator:
     :linenos:
 
     import fiftyone.operators as foo
+    from fiftyone.operators import types
 
     class ExampleMetric(foo.EvaluationMetric):
         @property
@@ -2141,10 +2142,14 @@ Let's look at an example evaluation metric operator:
                 unlisted=True,  # required
             )
 
-        def get_parameters(self, ctx, inputs):
-            """You can implement this method to collect user input for the
-            metric's parameters in the App.
+        def resolve_input(self, ctx, inputs):
+            """You can optionally implement this method to collect user input
+            for the metric's parameters in the App.
+
+            Returns:
+                a :class:`fiftyone.operators.types.Property`, or None
             """
+            inputs = types.Object()
             inputs.str(
                 "value",
                 label="Example value",
@@ -2152,6 +2157,7 @@ Let's look at an example evaluation metric operator:
                 default="foo",
                 required=True,
             )
+            return types.Property(inputs)
 
         def compute(self, samples, results, value="foo"):
             """All metric operators must implement this method. It defines the

--- a/fiftyone/operators/evaluation_metric.py
+++ b/fiftyone/operators/evaluation_metric.py
@@ -45,15 +45,17 @@ class EvaluationMetricConfig(OperatorConfig):
 class EvaluationMetric(Operator):
     """Base class for evaluation metric operators."""
 
-    def get_parameters(self, ctx, inputs):
+    def resolve_input(self, ctx):
         """Defines any necessary properties to collect this evaluation metric's
         parameters from a user during prompting.
 
         Args:
             ctx: an :class:`fiftyone.operators.ExecutionContext`
-            inputs: a :class:`fiftyone.operators.types.Property`
+
+        Returns:
+            a :class:`fiftyone.operators.types.Property`, or None
         """
-        pass
+        return None
 
     def parse_parameters(self, ctx, params):
         """Performs any necessary execution-time formatting to this evaluation

--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -371,7 +371,8 @@ class FiftyOneYOLOModelConfig(Config, fozm.HasZooModel):
         model (None): an ``ultralytics.YOLO`` model to use
         model_name (None): the name of an ``ultralytics.YOLO`` model to load
         model_path (None): the path to an ``ultralytics.YOLO`` model checkpoint
-        classes (None): an optional list of classes
+        classes (None): an optional list of classes to use for zero-shot
+            prediction
     """
 
     def __init__(self, d):

--- a/fiftyone/zoo/models/__init__.py
+++ b/fiftyone/zoo/models/__init__.py
@@ -302,7 +302,7 @@ def load_zoo_model(
     config_dict = deepcopy(model.default_deployment_config_dict)
 
     if isinstance(model, RemoteZooModel) and config_dict is None:
-        model = model._load_model(**kwargs)
+        model = model.load_model(**kwargs)
     else:
         model_path = model.get_path_in_dir(models_dir)
         model = fom.load_model(config_dict, model_path=model_path, **kwargs)
@@ -505,15 +505,15 @@ class RemoteZooModel(ZooModel):
     def _get_model_path(self):
         return self.get_path_in_dir(fo.config.model_zoo_dir)
 
-    def _load_model(self, **kwargs):
+    def load_model(self, **kwargs):
         model_path = self._get_model_path()
         return _load_remote_model(self.name, model_path, **kwargs)
 
-    def _get_parameters(self, ctx, inputs):
+    def resolve_input(self, ctx):
         model_path = self._get_model_path()
-        _get_remote_model_parameters(self.name, model_path, ctx, inputs)
+        return _resolve_remote_input(self.name, model_path, ctx)
 
-    def _parse_parameters(self, ctx, params):
+    def parse_parameters(self, ctx, params):
         model_path = self._get_model_path()
         _parse_remote_model_parameters(self.name, model_path, ctx, params)
 
@@ -551,20 +551,24 @@ def _load_remote_model(model_name, model_path, **kwargs):
     return module.load_model(model_name, model_path, **kwargs)
 
 
-def _get_remote_model_parameters(model_name, model_path, ctx, inputs):
+def _resolve_remote_input(model_name, model_path, ctx):
     model_dir = os.path.dirname(model_path)
 
     module = _import_zoo_module(model_dir)
-    if hasattr(module, "get_parameters"):
-        module.get_parameters(model_name, ctx, inputs)
+    if not hasattr(module, "resolve_input"):
+        return None
+
+    return module.resolve_input(model_name, ctx)
 
 
 def _parse_remote_model_parameters(model_name, model_path, ctx, params):
     model_dir = os.path.dirname(model_path)
 
     module = _import_zoo_module(model_dir)
-    if hasattr(module, "parse_parameters"):
-        module.parse_parameters(model_name, ctx, params)
+    if not hasattr(module, "parse_parameters"):
+        return
+
+    module.parse_parameters(model_name, ctx, params)
 
 
 def _import_zoo_module(model_dir):

--- a/fiftyone/zoo/models/__init__.py
+++ b/fiftyone/zoo/models/__init__.py
@@ -300,11 +300,11 @@ def load_zoo_model(
         model.ensure_requirements(error_level=error_level)
 
     config_dict = deepcopy(model.default_deployment_config_dict)
-    model_path = model.get_path_in_dir(models_dir)
 
     if isinstance(model, RemoteZooModel) and config_dict is None:
-        model = _load_remote_model(model.name, model_path, **kwargs)
+        model = model._load_model(**kwargs)
     else:
+        model_path = model.get_path_in_dir(models_dir)
         model = fom.load_model(config_dict, model_path=model_path, **kwargs)
 
     if cache and key is not None:
@@ -502,6 +502,21 @@ class RemoteZooModel(ZooModel):
             config = RemoteModelManagerConfig(dict(model_name=self.name))
             self.manager = RemoteModelManager(config)
 
+    def _get_model_path(self):
+        return self.get_path_in_dir(fo.config.model_zoo_dir)
+
+    def _load_model(self, **kwargs):
+        model_path = self._get_model_path()
+        return _load_remote_model(self.name, model_path, **kwargs)
+
+    def _get_parameters(self, ctx, inputs):
+        model_path = self._get_model_path()
+        _get_remote_model_parameters(self.name, model_path, ctx, inputs)
+
+    def _parse_parameters(self, ctx, params):
+        model_path = self._get_model_path()
+        _parse_remote_model_parameters(self.name, model_path, ctx, params)
+
 
 class RemoteModelManagerConfig(etam.ModelManagerConfig):
     def __init__(self, d):
@@ -534,6 +549,22 @@ def _load_remote_model(model_name, model_path, **kwargs):
         raise ValueError(f"Module {model_dir} has no 'load_model()' method")
 
     return module.load_model(model_name, model_path, **kwargs)
+
+
+def _get_remote_model_parameters(model_name, model_path, ctx, inputs):
+    model_dir = os.path.dirname(model_path)
+
+    module = _import_zoo_module(model_dir)
+    if hasattr(module, "get_parameters"):
+        module.get_parameters(model_name, ctx, inputs)
+
+
+def _parse_remote_model_parameters(model_name, model_path, ctx, params):
+    model_dir = os.path.dirname(model_path)
+
+    module = _import_zoo_module(model_dir)
+    if hasattr(module, "parse_parameters"):
+        module.parse_parameters(model_name, ctx, params)
 
 
 def _import_zoo_module(model_dir):


### PR DESCRIPTION
## Change log

- Adds `resolve_input()` and `parse_parameters()` methods to the remote zoo model interface. These methods allow remote zoo models to inject custom parameters into an operator's input form.

See https://github.com/voxel51/fiftyone-plugins/pull/201 for example usage.