### PR TITLE
[WIP] Add support for other media types

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -465,6 +465,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if media_type == self._doc.media_type:
             return
 
+        # @todo handle custom media types?
         if media_type not in fom.MEDIA_TYPES and media_type != fom.GROUP:
             raise ValueError(
                 "Invalid media_type '%s'. Supported values are %s"
@@ -2784,6 +2785,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 % (name, existing_media_type, media_type)
             )
 
+        # @todo handle custom media types?
         if media_type not in fom.MEDIA_TYPES:
             raise ValueError("Invalid media type '%s'" % media_type)
 

--- a/fiftyone/core/media.py
+++ b/fiftyone/core/media.py
@@ -5,15 +5,17 @@ Sample media utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import eta.core.image as etai
 import eta.core.video as etav
 
 
 # Valid media types
-VIDEO = "video"
 IMAGE = "image"
+VIDEO = "video"
 POINT_CLOUD = "point-cloud"
 THREE_D = "3d"
-MEDIA_TYPES = {IMAGE, VIDEO, POINT_CLOUD, THREE_D}
+OTHER = "other"
+MEDIA_TYPES = {IMAGE, VIDEO, POINT_CLOUD, THREE_D, OTHER}
 
 # Special media types
 GROUP = "group"
@@ -29,6 +31,9 @@ def get_media_type(filepath):
     Returns:
         the media type
     """
+    if etai.is_image_mime_type(filepath):
+        return IMAGE
+
     if etav.is_video_mime_type(filepath):
         return VIDEO
 
@@ -38,7 +43,7 @@ def get_media_type(filepath):
     if filepath.endswith(".fo3d"):
         return THREE_D
 
-    return IMAGE
+    return OTHER
 
 
 class MediaTypeError(TypeError):

--- a/fiftyone/core/odm/sample.py
+++ b/fiftyone/core/odm/sample.py
@@ -115,12 +115,22 @@ class NoDatasetSampleDocument(NoDatasetMixin, SerializableDocument):
     def __init__(self, **kwargs):
         filepath = fos.normalize_path(kwargs["filepath"])
 
+        # @todo support custom media types?
+        media_type = kwargs.pop("media_type", None)
+        if media_type is None:
+            media_type = fomm.get_media_type(filepath)
+        elif media_type not in fomm.MEDIA_TYPES:
+            raise ValueError(
+                "Invalid media_type '%s'. Supported values are %s"
+                % (media_type, fomm.MEDIA_TYPES)
+            )
+
         kwargs["id"] = kwargs.get("id", None)
         kwargs["filepath"] = filepath
         kwargs["created_at"] = None
         kwargs["last_modified_at"] = None
         kwargs["_rand"] = _generate_rand(filepath=filepath)
-        kwargs["_media_type"] = fomm.get_media_type(filepath)
+        kwargs["_media_type"] = media_type
         kwargs["_dataset_id"] = None
 
         self._data = OrderedDict()

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -451,8 +451,13 @@ class _SampleMixin(object):
         if field_name != "filepath":
             return
 
+        # @todo support custom media types?
         new_media_type = fomm.get_media_type(value)
-        if self.media_type != new_media_type:
+        if (
+            self.media_type != new_media_type
+            and new_media_type != fomm.OTHER
+            and self.media_type != fomm.OTHER
+        ):
             raise fomm.MediaTypeError(
                 "A sample's 'filepath' can be changed, but its media type "
                 "cannot; current '%s', new '%s'"

--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -59,6 +59,11 @@ class VideoSample(Sample):
     frame_rate: float
 
 
+@gql.type
+class OtherSample(Sample):
+    pass
+
+
 SampleItem = gql.union(
     "SampleItem",
     types=(ImageSample, PointCloudSample, ThreeDSample, VideoSample),
@@ -69,6 +74,7 @@ MEDIA_TYPES = {
     fom.POINT_CLOUD: PointCloudSample,
     fom.VIDEO: VideoSample,
     fom.THREE_D: ThreeDSample,
+    fom.OTHER: OtherSample,
 }
 
 

--- a/plugins/operators/__init__.py
+++ b/plugins/operators/__init__.py
@@ -1514,6 +1514,7 @@ class AddGroupSlice(foo.Operator):
                     f"Group slice '{name}' already exists"
                 )
 
+            # @todo support custom media types?
             media_type_selector = types.AutocompleteView()
             media_types = fom.MEDIA_TYPES
             for key in media_types:


### PR DESCRIPTION
## Change log

- Adds a new `media_type="other"` that is automatically used when encountering samples with unknown media type
- Adds support for explicitly setting media type via `fo.Sample(filepath=..., media_type=...)`
    - This could be useful, eg, when creating image datasets whose file extensions aren't automatically recognized as images via `fom.get_media_type()` 

## TODO

- Add App support for "other" media types (will need to discuss offline how to achieve this)
- Allow users to define custom media types? EG:

```py
import fiftyone as fo

dataset = fo.Dataset()

sample = fo.Sample(filepath="image.rrd", media_type="rerun")
print(sample.media_type)

dataset.add_sample(sample)
print(dataset.media_type)
```

## Example usage

Explicit `media_type="image"`:

```py
import fiftyone as fo

dataset = fo.Dataset()

sample = fo.Sample(filepath="image.ext", media_type="image")
print(sample.media_type)

dataset.add_sample(sample)
print(dataset.media_type)

dataset.export(
    export_dir="/tmp/fod",
    dataset_type=fo.types.FiftyOneDataset,
    export_media=False,
    overwrite=True,
)

dataset2 = fo.Dataset.from_dir(
    dataset_dir="/tmp/fod",
    dataset_type=fo.types.FiftyOneDataset,
)
print(dataset2.media_type)
print(dataset2.first().media_type)
```

Default `media_type="other"`:

```py
import fiftyone as fo

dataset = fo.Dataset()

sample = fo.Sample(filepath="image.ext")
print(sample.media_type)

dataset.add_sample(sample)
print(dataset.media_type)

dataset.export(
    export_dir="/tmp/fod",
    dataset_type=fo.types.FiftyOneDataset,
    export_media=False,
    overwrite=True,
)

dataset2 = fo.Dataset.from_dir(
    dataset_dir="/tmp/fod",
    dataset_type=fo.types.FiftyOneDataset,
)
print(dataset2.media_type)
print(dataset2.first().media_type)
```



