### PR TITLE
imavid: return 0 instead of NaN if total frames is 1 or 0

### DIFF
--- a/app/packages/playback/src/lib/use-timeline-viz-utils.ts
+++ b/app/packages/playback/src/lib/use-timeline-viz-utils.ts
@@ -52,5 +52,10 @@ export const convertFrameNumberToPercentage = (
   // offset by -1 since frame indexing is 1-based
   const numerator = frameNumber - 1;
   const denominator = totalFrames - 1;
+
+  if (denominator <= 0) {
+    return 0;
+  }
+
   return (numerator / denominator) * 100;
 };


### PR DESCRIPTION
minor bugfix to prevent cases where NaN might be returned as a result of division by zero

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of edge cases in timeline visualization calculations to prevent potential division by zero errors
	- Enhanced robustness of percentage conversion function when dealing with minimal frame counts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->