### PR TITLE
remove cross origin anonymous

### DIFF
--- a/app/packages/looker/src/elements/image.ts
+++ b/app/packages/looker/src/elements/image.ts
@@ -54,7 +54,6 @@ export class ImageElement extends BaseElement<ImageState, HTMLImageElement> {
 
   createHTMLElement() {
     const element = new Image();
-    element.crossOrigin = "Anonymous";
     element.loading = "eager";
     return element;
   }

--- a/app/packages/looker/src/elements/imavid/index.ts
+++ b/app/packages/looker/src/elements/imavid/index.ts
@@ -158,7 +158,6 @@ export class ImaVidElement extends BaseElement<ImaVidState, HTMLImageElement> {
     );
 
     this.element = new Image();
-    this.element.crossOrigin = "Anonymous";
     this.element.loading = "eager";
 
     this.element.addEventListener("load", () => {

--- a/app/packages/looker/src/elements/three-d.ts
+++ b/app/packages/looker/src/elements/three-d.ts
@@ -71,7 +71,6 @@ export class ThreeDElement extends BaseElement<ThreeDState, HTMLImageElement> {
 
     this.element = new Image();
     this.element.loading = "eager";
-    this.element.crossOrigin = "Anonymous";
     if (this.isOpmAvailable) {
       this.element.setAttribute("src", src);
     } else {

--- a/app/packages/looker/src/elements/util.ts
+++ b/app/packages/looker/src/elements/util.ts
@@ -228,7 +228,6 @@ const makeAcquirer = (
 
       if (VIDEOS.length < maxVideos) {
         const video = document.createElement("video");
-        video.crossOrigin = "Anonymous";
         video.preload = "metadata";
         video.muted = true;
         video.loop = false;


### PR DESCRIPTION
## What changes are proposed in this pull request?

No need for cross origin to be anonymous when we are just painting to the canvas.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
	- Removed `crossOrigin` attribute configuration for image and video elements across multiple components
	- Potential impact on cross-origin resource loading behavior
	- No changes to core functionality of image and video handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->