### PR TITLE
Use estimated count on full dataset view

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -10619,7 +10619,6 @@ class SampleCollection(object):
         return _handle_id_fields(self, field_name)
 
     def _is_full_collection(self):
-        """Checks if the current instance represents a full collection."""
         if isinstance(self, fod.Dataset) and self.media_type != fom.GROUP:
             return True
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -10619,18 +10619,22 @@ class SampleCollection(object):
         return _handle_id_fields(self, field_name)
 
     def _is_full_collection(self):
+        """Checks if the current instance represents a full collection."""
         if isinstance(self, fod.Dataset) and self.media_type != fom.GROUP:
             return True
 
-        # pylint:disable=no-member
-        if (
-            isinstance(self, fov.DatasetView)
-            and self._dataset.media_type == fom.GROUP
-            and len(self._stages) == 1
-            and isinstance(self._stages[0], fos.SelectGroupSlices)
-            and self._pipeline() == []
-        ):
-            return True
+        if isinstance(self, fov.DatasetView):
+            if not self._pipeline() and self._dataset.media_type != fom.GROUP:
+                return True
+
+            # pylint:disable=no-member
+            if (
+                self._dataset.media_type == fom.GROUP
+                and len(self._stages) == 1
+                and isinstance(self._stages[0], fos.SelectGroupSlices)
+                and not self._pipeline()
+            ):
+                return True
 
         return False
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -10625,7 +10625,7 @@ class SampleCollection(object):
         if isinstance(self, fov.DatasetView):
             if not (
                 self._pipeline()
-                or isinstance(self, fov.ClipsView)
+                or self._is_clips
                 or self._dataset.media_type == fom.GROUP
             ):
                 return True

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -10623,10 +10623,14 @@ class SampleCollection(object):
             return True
 
         if isinstance(self, fov.DatasetView):
-            # pylint:disable=no-member
-            if not self._stages and self._dataset.media_type != fom.GROUP:
+            if not (
+                self._pipeline()
+                or isinstance(self, fov.ClipsView)
+                or self._dataset.media_type == fom.GROUP
+            ):
                 return True
 
+            # pylint:disable=no-member
             if (
                 self._dataset.media_type == fom.GROUP
                 and len(self._stages) == 1

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -10623,14 +10623,14 @@ class SampleCollection(object):
             return True
 
         if isinstance(self, fov.DatasetView):
+            # pylint:disable=no-member
             if not (
-                self._pipeline()
+                len(self._stages)
                 or self._is_clips
                 or self._dataset.media_type == fom.GROUP
             ):
                 return True
 
-            # pylint:disable=no-member
             if (
                 self._dataset.media_type == fom.GROUP
                 and len(self._stages) == 1

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -10623,10 +10623,10 @@ class SampleCollection(object):
             return True
 
         if isinstance(self, fov.DatasetView):
-            if not self._pipeline() and self._dataset.media_type != fom.GROUP:
+            # pylint:disable=no-member
+            if not self._stages and self._dataset.media_type != fom.GROUP:
                 return True
 
-            # pylint:disable=no-member
             if (
                 self._dataset.media_type == fom.GROUP
                 and len(self._stages) == 1

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -10624,10 +10624,10 @@ class SampleCollection(object):
 
         if isinstance(self, fov.DatasetView):
             # pylint:disable=no-member
-            if not (
-                len(self._stages)
-                or self._is_clips
-                or self._dataset.media_type == fom.GROUP
+            if (
+                not len(self._stages)
+                and not self._is_clips
+                and self._dataset.media_type != fom.GROUP
             ):
                 return True
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- use estimated count for full dataset view so dataset slices with negative starts can be optimized

## How is this patch tested? If it is not, please explain why.

- tested locally with 11M sample dataset

```
# With Changes
In [18]: %time v=ds[-2:]
CPU times: user 5.4 ms, sys: 886 µs, total: 6.29 ms
Wall time: 770 ms
```

```
# Without changes
In [19]: %time v=ds[-2:]
CPU times: user 3.63 s, sys: 496 ms, total: 4.12 s
Wall time: 16min 58s
```

```
In [20]: len(ds)
Out[20]: 11460588

```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Simplified logic for determining full collection status.
  - Streamlined condition checks to improve clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->