### PR TITLE
Add set_log_upload_error for DOs

### DIFF
--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -117,11 +117,11 @@ class DelegatedOperationRepo(object):
         """Sets the label for the delegated operation."""
         raise NotImplementedError("subclass must implement set_label()")
 
-    def set_log_status(
-        self, _id: ObjectId, log_status: str
+    def set_log_upload_error(
+        self, _id: ObjectId, log_upload_error: str
     ) -> DelegatedOperationDocument:
-        """Sets the log status for the delegated operation."""
-        raise NotImplementedError("subclass must implement set_log_status()")
+        """Sets the log upload error for the delegated operation."""
+        raise NotImplementedError("subclass must implement set_log_upload_error()")
 
     def get(self, _id: ObjectId) -> DelegatedOperationDocument:
         """Get an operation by id."""
@@ -252,12 +252,12 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
         )
         return DelegatedOperationDocument().from_pymongo(doc)
 
-    def set_log_status(
-        self, _id: ObjectId, log_status: str
+    def set_log_upload_error(
+        self, _id: ObjectId, log_upload_error: str
     ) -> DelegatedOperationDocument:
         doc = self._collection.find_one_and_update(
             filter={"_id": _id},
-            update={"$set": {"log_status": log_status}},
+            update={"$set": {"log_upload_error": log_upload_error}},
             return_document=pymongo.ReturnDocument.AFTER,
         )
         return DelegatedOperationDocument().from_pymongo(doc)

--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -117,6 +117,12 @@ class DelegatedOperationRepo(object):
         """Sets the label for the delegated operation."""
         raise NotImplementedError("subclass must implement set_label()")
 
+    def set_log_status(
+        self, _id: ObjectId, log_status: str
+    ) -> DelegatedOperationDocument:
+        """Sets the log status for the delegated operation."""
+        raise NotImplementedError("subclass must implement set_log_status()")
+
     def get(self, _id: ObjectId) -> DelegatedOperationDocument:
         """Get an operation by id."""
         raise NotImplementedError("subclass must implement get()")
@@ -164,6 +170,13 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             indices_to_create.append(
                 IndexModel(
                     [("run_state", pymongo.ASCENDING)], name="run_state_1"
+                )
+            )
+
+        if "dataset_id_1" not in index_names:
+            indices_to_create.append(
+                IndexModel(
+                    [("dataset_id", pymongo.ASCENDING)], name="dataset_id_1"
                 )
             )
 
@@ -235,6 +248,16 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
         doc = self._collection.find_one_and_update(
             filter={"_id": _id},
             update={"$set": {"label": label}},
+            return_document=pymongo.ReturnDocument.AFTER,
+        )
+        return DelegatedOperationDocument().from_pymongo(doc)
+
+    def set_log_status(
+        self, _id: ObjectId, log_status: str
+    ) -> DelegatedOperationDocument:
+        doc = self._collection.find_one_and_update(
+            filter={"_id": _id},
+            update={"$set": {"log_status": log_status}},
             return_document=pymongo.ReturnDocument.AFTER,
         )
         return DelegatedOperationDocument().from_pymongo(doc)

--- a/fiftyone/factory/repos/delegated_operation_doc.py
+++ b/fiftyone/factory/repos/delegated_operation_doc.py
@@ -56,6 +56,7 @@ class DelegatedOperationDocument(object):
         self.id = None
         self._doc = None
         self.metadata = None
+        self.log_status = None
 
     def from_pymongo(self, doc: dict):
         # required fields
@@ -72,6 +73,7 @@ class DelegatedOperationDocument(object):
         self.pinned = doc.get("pinned", None)
         self.dataset_id = doc.get("dataset_id", None)
         self.run_link = doc.get("run_link", None)
+        self.log_status = doc.get("log_status", None)
         self.metadata = doc.get("metadata", None)
         self.label = doc.get("label", None)
         self.updated_at = doc.get("updated_at", None)

--- a/fiftyone/factory/repos/delegated_operation_doc.py
+++ b/fiftyone/factory/repos/delegated_operation_doc.py
@@ -56,7 +56,7 @@ class DelegatedOperationDocument(object):
         self.id = None
         self._doc = None
         self.metadata = None
-        self.log_status = None
+        self.log_upload_error = None
 
     def from_pymongo(self, doc: dict):
         # required fields
@@ -73,7 +73,7 @@ class DelegatedOperationDocument(object):
         self.pinned = doc.get("pinned", None)
         self.dataset_id = doc.get("dataset_id", None)
         self.run_link = doc.get("run_link", None)
-        self.log_status = doc.get("log_status", None)
+        self.log_upload_error = doc.get("log_upload_error", None)
         self.metadata = doc.get("metadata", None)
         self.label = doc.get("label", None)
         self.updated_at = doc.get("updated_at", None)

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -252,17 +252,18 @@ class DelegatedOperationService(object):
         """
         return self._repo.set_label(_id=doc_id, label=label)
 
-    def set_log_status(self, doc_id, log_status):
-        """Sets the log status for the given delegated operation.
+    def set_log_upload_error(self, doc_id, log_upload_error):
+        """Sets the log upload error for the given delegated operation.
 
         Args:
             doc_id: the ID of the delegated operation
-            log status: the status of the logs to set
+            log upload error: the error message if we failed to upload
+            logs for the given delegated operation.
 
         Returns:
             a :class:`fiftyone.factory.repos.DelegatedOperationDocument`
         """
-        return self._repo.set_log_status(_id=doc_id, log_status=log_status)
+        return self._repo.set_log_upload_error(_id=doc_id, log_upload_error=log_upload_error)
 
     def delete_operation(self, doc_id):
         """Deletes the given delegated operation.

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -252,6 +252,18 @@ class DelegatedOperationService(object):
         """
         return self._repo.set_label(_id=doc_id, label=label)
 
+    def set_log_status(self, doc_id, log_status):
+        """Sets the log status for the given delegated operation.
+
+        Args:
+            doc_id: the ID of the delegated operation
+            log status: the status of the logs to set
+
+        Returns:
+            a :class:`fiftyone.factory.repos.DelegatedOperationDocument`
+        """
+        return self._repo.set_log_status(_id=doc_id, log_status=log_status)
+
     def delete_operation(self, doc_id):
         """Deletes the given delegated operation.
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adding set_log_upload_error for DOs so that we can update that field when needed for use in delegated operations. This field will be populated if we fail to flush logs to the user provided log location after a DO finishes execution.

Also, adding an index on dataset_id so we can filter without needing to do a scan making this collection scale better as DOs get used more overtime.

## How is this patch tested? If it is not, please explain why.

script:

```
from fiftyone.operators.delegated import DelegatedOperationService

do = DelegatedOperationService()
dos = do.get_running_operations()
do.set_log_upload_error(dos[0].id, log_upload_error="test")
```

Result:

```
{
  "_id": {
    "$oid": "671142e671e8dc3ec03dafbe"
  },
  "operator": "@voxelfiftyone/operator/foo",
  "label": "@voxelfiftyone/operator/foo",
  "delegation_target": "test_target",
  "context": {
    "request_params": {
      "foo": "bar"
    },
    "params": {},
    "executor": null,
    "user": null
  },
  "run_state": "running",
  "run_link": null,
  "queued_at": {
    "$date": "2024-10-17T17:01:26.650Z"
  },
  "updated_at": {
    "$date": "2024-10-17T17:01:26.650Z"
  },
  "status": null,
  "dataset_id": null,
  "started_at": {
    "$date": "2024-10-17T17:01:26.650Z"
  },
  "pinned": false,
  "completed_at": null,
  "failed_at": null,
  "scheduled_at": null,
  "result": null,
  "metadata": {
    "inputs_schema": {
      "inputs": {
        "type": "string"
      }
    }
  },
  "log_upload_error": "test"
}
```

Index created:

![Screenshot 2025-01-29 at 2 46 25 PM](https://github.com/user-attachments/assets/1f408ff2-817a-4c02-95a0-30084d613e6f)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added ability to set log upload errors for delegated operations.
  - Introduced new `log_upload_error` attribute to track log upload issues.

- **Performance Improvements**
  - Enhanced database indexing for more efficient queries on dataset operations.

- **Technical Enhancements**
  - Expanded delegated operation document model to support log upload error tracking.
  - Implemented repository method for updating log upload errors across different components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->