### PR TITLE
`beam.map()`

### DIFF
--- a/fiftyone/utils/beam.py
+++ b/fiftyone/utils/beam.py
@@ -9,15 +9,17 @@ import itertools
 import logging
 import os
 
+from bson import ObjectId
 import numpy as np
 
 import fiftyone.core.dataset as fod
 import fiftyone.core.utils as fou
 import fiftyone.core.view as fov
+import fiftyone.operators.store as foos
 
 os.environ["GRPC_VERBOSITY"] = "NONE"
 fou.ensure_import("apache_beam")
-tqdm = fou.lazy_import("tqdm")
+tqdm = fou.lazy_import("tqdm.auto")
 
 import apache_beam as beam
 from apache_beam.options.pipeline_options import PipelineOptions
@@ -346,6 +348,8 @@ def beam_export(
 def beam_map(
     sample_collection,
     map_fcn,
+    reduce_fcn=None,
+    save=None,
     shard_size=None,
     shard_method="id",
     num_workers=None,
@@ -353,16 +357,28 @@ def beam_map(
     progress=False,
     verbose=False,
 ):
-    """Applies the given function to each sample in the given collection via
-     `Apache Beam <https://beam.apache.org>`_ and saves any sample edits.
+    """Applies the given function to each sample in the collection via
+     `Apache Beam <https://beam.apache.org>`_.
 
-    This function is a parallelized alternative to
+    When only a ``map_fcn`` is provided, this function is a parallelized
+    version of
     :meth:`iter_samples(autosave=True) <fiftyone.core.collections.SampleCollection.iter_samples>`
-    that effectively performs the following operation in parallel::
+    that effectively performs the following operation with the outer loop
+    in parallel::
 
-        for batch_view in fou.iter_batches(sample_collection, num_shards):
+        for batch_view in fou.iter_batches(sample_collection, shard_size):
             for sample in batch_view.iter_samples(autosave=True):
                 map_fcn(sample)
+
+    When a ``reduce_fcn`` is provided, this function effectively performs the
+    following operation with the outer loop in parallel::
+
+        values = {}
+        for batch_view in fou.iter_batches(sample_collection, shard_size):
+            for sample in batch_view.iter_samples(autosave=save):
+                values[sample.id] = map_fcn(sample)
+
+        output = reduce_fcn(sample_collection, values)
 
     Example::
 
@@ -373,15 +389,40 @@ def beam_map(
         dataset = foz.load_zoo_dataset("cifar10", split="train")
         view = dataset.select_fields("ground_truth")
 
-        def map_fcn(sample):
-            sample["gt_label"] = sample.ground_truth.label.upper()
+        #
+        # Example 1: map
+        #
 
-        foub.beam_map(view, map_fcn, num_workers=8, progress=True)
+        def map_fcn(sample):
+            sample.ground_truth.label = sample.ground_truth.label.upper()
+
+        foub.beam_map(view, map_fcn, progress=True)
+
+        print(dataset.count_values("ground_truth.label"))
+
+        #
+        # Example 2: map-reduce
+        #
+
+        def map_fcn(sample):
+            return sample.ground_truth.label.lower()
+
+        def reduce_fcn(sample_collection, values):
+            from collections import Counter
+            return dict(Counter(values.values()))
+
+        counts = foub.beam_map(view, map_fcn, reduce_fcn=reduce_fcn, progress=True)
+        print(counts)
 
     Args:
         sample_collection: a
             :class:`fiftyone.core.collections.SampleCollection`
         map_fcn: a function to apply to each sample
+        reduce_fcn (None): an optional reduce function to apply to the map
+            outputs. See the docstring above for usage information
+        save (None): whether to save any sample edits applied by ``map_fcn``.
+            By default this is True when no ``reduce_fcn`` is provided and
+            False when a ``reduce_fcn`` is provided
         shard_size (None): an optional number of samples to distribute to each
             worker at a time. By default, samples are evenly distributed to
             workers with one shard per worker
@@ -397,6 +438,9 @@ def beam_map(
             ``num_workers`` workers
         progress (False): whether to render progress bar(s) for each worker
         verbose (False): whether to log the Beam pipeline's messages
+
+    Returns:
+        the output of ``reduce_fcn``, or None
     """
     if shard_method == "slice":
         n = len(sample_collection)
@@ -418,7 +462,7 @@ def beam_map(
 
     if shard_method == "slice":
         # Slice batches
-        slices = list(zip(edges[:-1], edges[1:]), 1)
+        slices = list(zip(edges[:-1], edges[1:]))
     else:
         # ID batches
         slices = [ids[i:j] for i, j in zip(edges[:-1], edges[1:])]
@@ -439,13 +483,29 @@ def beam_map(
         dataset_name = sample_collection.name
         view_stages = None
 
+    if save is None:
+        save = reduce_fcn is None
+
     map_batch = MapBatch(
         dataset_name,
         map_fcn,
         view_stages=view_stages,
-        save=True,
+        save=save,
+        return_outputs=reduce_fcn is not None,
         progress=progress,
     )
+
+    if reduce_fcn is not None:
+        result_key = f"beam_map_{str(ObjectId())}"
+        reduce_fn = ReduceFn(
+            dataset_name,
+            reduce_fcn,
+            view_stages=view_stages,
+            result_key=result_key,
+        )
+    else:
+        result_key = None
+        reduce_fn = None
 
     if options is None:
         options = PipelineOptions(
@@ -458,13 +518,19 @@ def beam_map(
     level = logger.level if verbose else logging.CRITICAL
     with fou.SetAttributes(logger, level=level):
         with beam.Pipeline(options=options) as pipeline:
-            _ = (
+            pcoll = (
                 pipeline
                 | "InitMap" >> beam.Create(batches)
                 | "MapBatches" >> beam.ParDo(map_batch)
             )
 
+            if reduce_fn is not None:
+                _ = pcoll | "ReduceFn" >> beam.CombineGlobally(reduce_fn)
+
     sample_collection.reload()
+
+    if result_key is not None:
+        return _get_key(sample_collection, result_key)
 
 
 class ImportBatch(beam.DoFn):
@@ -652,14 +718,15 @@ class MapBatch(beam.DoFn):
         map_fcn,
         view_stages=None,
         save=False,
+        return_outputs=True,
         progress=False,
     ):
         self.dataset_name = dataset_name
         self.map_fcn = map_fcn
         self.view_stages = view_stages
         self.save = save
+        self.return_outputs = return_outputs
         self.progress = progress
-
         self._sample_collection = None
 
     def setup(self):
@@ -697,11 +764,80 @@ class MapBatch(beam.DoFn):
             desc = f"Batch {i + 1:0{len(str(num_batches))}}/{num_batches}"
             with tqdm.tqdm(total=total, desc=desc, position=i) as pbar:
                 for sample in batch_view.iter_samples(autosave=self.save):
-                    self.map_fcn(sample)
-                    pbar.update(1)
+                    result = self.map_fcn(sample)
+                    if self.return_outputs and result is not None:
+                        yield sample.id, result
+
+                    pbar.update()
         else:
             for sample in batch_view.iter_samples(autosave=self.save):
-                self.map_fcn(sample)
+                result = self.map_fcn(sample)
+                if self.return_outputs and result is not None:
+                    yield sample.id, result
+
+
+class ReduceFn(beam.CombineFn):
+    def __init__(
+        self,
+        dataset_name,
+        reduce_fcn,
+        view_stages=None,
+        result_key=None,
+    ):
+        self.dataset_name = dataset_name
+        self.reduce_fcn = reduce_fcn
+        self.view_stages = view_stages
+        self.result_key = result_key
+
+        self._sample_collection = None
+
+    def setup(self):
+        import fiftyone as fo
+        import fiftyone.core.view as fov
+
+        dataset = fo.load_dataset(self.dataset_name)
+
+        if self.view_stages:
+            sample_collection = fov.DatasetView._build(
+                dataset, self.view_stages
+            )
+        else:
+            sample_collection = dataset
+
+        self._sample_collection = sample_collection
+
+    def create_accumulator(self):
+        return {}
+
+    def add_input(self, accumulator, input):
+        sample_id, value = input
+        accumulator[sample_id] = value
+        return accumulator
+
+    def merge_accumulators(self, accumulators):
+        accumulator = {}
+        for a in accumulators:
+            accumulator.update(a)
+        return accumulator
+
+    def extract_output(self, accumulator):
+        output = self.reduce_fcn(self._sample_collection, accumulator)
+        if output is None or self.result_key is None:
+            return
+
+        _set_key(self._sample_collection, self.result_key, output)
+
+
+def _set_key(sample_collection, key, value, ttl=60):
+    dataset_id = sample_collection._root_dataset._doc.id
+    store = foos.ExecutionStore.create("beam", dataset_id=dataset_id)
+    store.set(key, value, ttl=ttl)
+
+
+def _get_key(sample_collection, key):
+    dataset_id = sample_collection._root_dataset._doc.id
+    store = foos.ExecutionStore.create("beam", dataset_id=dataset_id)
+    return store.get(key)
 
 
 def _pop_first(x):

--- a/fiftyone/utils/beam.py
+++ b/fiftyone/utils/beam.py
@@ -5,12 +5,14 @@
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import inspect
 import itertools
 import logging
 import os
 
 from bson import ObjectId
 import numpy as np
+from tqdm.auto import tqdm
 
 import fiftyone.core.dataset as fod
 import fiftyone.core.utils as fou
@@ -19,7 +21,6 @@ import fiftyone.operators.store as foos
 
 os.environ["GRPC_VERBOSITY"] = "NONE"
 fou.ensure_import("apache_beam")
-tqdm = fou.lazy_import("tqdm.auto")
 
 import apache_beam as beam
 from apache_beam.options.pipeline_options import PipelineOptions
@@ -349,6 +350,7 @@ def beam_map(
     sample_collection,
     map_fcn,
     reduce_fcn=None,
+    reduce_cls=None,
     save=None,
     shard_size=None,
     shard_method="id",
@@ -360,25 +362,38 @@ def beam_map(
     """Applies the given function to each sample in the collection via
      `Apache Beam <https://beam.apache.org>`_.
 
-    When only a ``map_fcn`` is provided, this function is a parallelized
-    version of
-    :meth:`iter_samples(autosave=True) <fiftyone.core.collections.SampleCollection.iter_samples>`
-    that effectively performs the following operation with the outer loop
-    in parallel::
+    When only a ``map_fcn`` is provided, this function effectively performs
+    the following map operation with the outer loop in parallel::
 
-        for batch_view in fou.iter_batches(sample_collection, shard_size):
+        for batch_view in fou.iter_slices(sample_collection, shard_size):
             for sample in batch_view.iter_samples(autosave=True):
                 map_fcn(sample)
 
-    When a ``reduce_fcn`` is provided, this function effectively performs the
-    following operation with the outer loop in parallel::
+    When a ``reduce_fcn`` function is provided, this function effectively
+    performs the following map-reduce operation with the outer loop in
+    parallel::
 
-        values = {}
-        for batch_view in fou.iter_batches(sample_collection, shard_size):
+        outputs = {}
+
+        for batch_view in fou.iter_slices(sample_collection, shard_size):
             for sample in batch_view.iter_samples(autosave=save):
-                values[sample.id] = map_fcn(sample)
+                outputs[sample.id] = map_fcn(sample)
 
-        output = reduce_fcn(sample_collection, values)
+        output = reduce_fcn(sample_collection, outputs)
+
+    When a ``reduce_fcn`` class is provided, this function effectively performs
+    the following map-reduce operation with the outer loop in parallel:
+
+        reducer = reduce_fcn(...)
+
+        for batch_view in fou.iter_slices(sample_collection, shard_size):
+            for sample in batch_view.iter_samples(autosave=True):
+                sample_output = sample.map_fcn(sample)
+
+                # Outputs are fed to reducer.add_input()
+                yield sample.id, sample_output
+
+        output = reducer.extract_output(...)
 
     Example::
 
@@ -401,11 +416,11 @@ def beam_map(
         print(dataset.count_values("ground_truth.label"))
 
         #
-        # Example 2: map-reduce
+        # Example 2: map-reduce with reduce function
         #
 
         def map_fcn(sample):
-            return sample.ground_truth.label.lower()
+            return sample.ground_truth.label.upper()
 
         def reduce_fcn(sample_collection, values):
             from collections import Counter
@@ -414,15 +429,47 @@ def beam_map(
         counts = foub.beam_map(view, map_fcn, reduce_fcn=reduce_fcn, progress=True)
         print(counts)
 
+        #
+        # Example 3: map-reduce with reduce class
+        #
+
+        def map_fcn(sample):
+            return sample.ground_truth.label.upper()
+
+        class ReduceFcn(foub.ReduceFcn):
+            def create_accumulator(self):
+                from collections import Counter
+                return Counter()
+
+            def add_input(self, accumulator, input):
+                sample_id, value = input
+                accumulator[value] += 1
+                return accumulator
+
+            def merge_accumulators(self, accumulators):
+                from collections import Counter
+                accumulator = Counter()
+                for a in accumulators:
+                    accumulator.update(a)
+                return accumulator
+
+            def extract_output(self, accumulator):
+                counts = dict(accumulator)
+                self._store_output(counts)
+
+        counts = foub.beam_map(view, map_fcn, reduce_fcn=ReduceFcn, progress=True)
+        print(counts)
+
     Args:
         sample_collection: a
             :class:`fiftyone.core.collections.SampleCollection`
         map_fcn: a function to apply to each sample
-        reduce_fcn (None): an optional reduce function to apply to the map
-            outputs. See the docstring above for usage information
+        reduce_fcn (None): an optional function or
+            :class:`fiftyone.utils.beam.ReduceFcn` to reduce the map outputs.
+            See above for usage information
         save (None): whether to save any sample edits applied by ``map_fcn``.
             By default this is True when no ``reduce_fcn`` is provided and
-            False when a ``reduce_fcn`` is provided
+            False otherwise
         shard_size (None): an optional number of samples to distribute to each
             worker at a time. By default, samples are evenly distributed to
             workers with one shard per worker
@@ -440,7 +487,7 @@ def beam_map(
         verbose (False): whether to log the Beam pipeline's messages
 
     Returns:
-        the output of ``reduce_fcn``, or None
+        the output of ``reduce_fcn`` if provided, else None
     """
     if shard_method == "slice":
         n = len(sample_collection)
@@ -450,6 +497,17 @@ def beam_map(
 
     if num_workers is None:
         num_workers = fou.recommend_process_pool_workers()
+
+    # Must cap size of select(ids) stages
+    if shard_method == "id":
+        max_shard_size = fou.recommend_batch_size_for_value(
+            ObjectId(), max_size=100000
+        )
+
+        if shard_size is not None:
+            shard_size = min(shard_size, max_shard_size)
+        elif n > num_workers * max_shard_size:
+            shard_size = max_shard_size
 
     if shard_size is not None:
         # Fixed size shards
@@ -497,9 +555,15 @@ def beam_map(
 
     if reduce_fcn is not None:
         result_key = f"beam_map_{str(ObjectId())}"
-        reduce_fn = ReduceFn(
+
+        if inspect.isclass(reduce_fcn):
+            reduce_cls = reduce_fcn
+        else:
+            reduce_cls = ReduceFcn
+
+        reduce_fn = reduce_cls(
             dataset_name,
-            reduce_fcn,
+            reduce_fcn=reduce_fcn,
             view_stages=view_stages,
             result_key=result_key,
         )
@@ -525,7 +589,7 @@ def beam_map(
             )
 
             if reduce_fn is not None:
-                _ = pcoll | "ReduceFn" >> beam.CombineGlobally(reduce_fn)
+                _ = pcoll | "ReduceFcn" >> beam.CombineGlobally(reduce_fn)
 
     sample_collection.reload()
 
@@ -762,7 +826,7 @@ class MapBatch(beam.DoFn):
 
         if self.progress:
             desc = f"Batch {i + 1:0{len(str(num_batches))}}/{num_batches}"
-            with tqdm.tqdm(total=total, desc=desc, position=i) as pbar:
+            with tqdm(total=total, desc=desc, position=i) as pbar:
                 for sample in batch_view.iter_samples(autosave=self.save):
                     result = self.map_fcn(sample)
                     if self.return_outputs and result is not None:
@@ -776,11 +840,11 @@ class MapBatch(beam.DoFn):
                     yield sample.id, result
 
 
-class ReduceFn(beam.CombineFn):
+class ReduceFcn(beam.CombineFn):
     def __init__(
         self,
         dataset_name,
-        reduce_fcn,
+        reduce_fcn=None,
         view_stages=None,
         result_key=None,
     ):
@@ -821,8 +885,17 @@ class ReduceFn(beam.CombineFn):
         return accumulator
 
     def extract_output(self, accumulator):
+        if self.reduce_fcn is None:
+            return
+
         output = self.reduce_fcn(self._sample_collection, accumulator)
-        if output is None or self.result_key is None:
+        if output is None:
+            return
+
+        self._store_output(output)
+
+    def _store_output(self, output):
+        if self.result_key is None:
             return
 
         _set_key(self._sample_collection, self.result_key, output)


### PR DESCRIPTION
## Change log

Adds a `beam_map()` method that leverages Apache Beam to apply a `map_fcn` to each sample in a `sample_collection` in parallel, optionally saving any sample edits and/or applying a `reduce_fcn` or `aggregate_fcn` to the outputs.

## Example 1: map-save

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.beam as foub

dataset = foz.load_zoo_dataset("cifar10", split="train")
view = dataset.select_fields("ground_truth")

def map_fcn(sample):
    sample.ground_truth.label = sample.ground_truth.label.upper()

foub.beam_map(view, map_fcn, save=True, progress=True)

print(dataset.count_values("ground_truth.label"))
```

```
Batch 02/16: 100%|█████████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 811.38it/s]
Batch 13/16: 100%|█████████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 806.92it/s]
Batch 12/16: 100%|█████████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 795.11it/s]
Batch 06/16: 100%|█████████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 806.14it/s]
Batch 14/16: 100%|█████████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 790.75it/s]
Batch 03/16: 100%|█████████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 788.72it/s]
Batch 01/16: 100%|█████████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 789.38it/s]
Batch 11/16: 100%|█████████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 794.18it/s]
Batch 04/16: 100%|█████████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 789.54it/s]
Batch 07/16: 100%|█████████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 785.78it/s]
Batch 10/16: 100%|█████████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 796.16it/s]
Batch 15/16: 100%|█████████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 783.64it/s]
Batch 16/16: 100%|█████████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 783.61it/s]
Batch 09/16: 100%|█████████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 790.07it/s]
Batch 05/16: 100%|█████████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 1008.09it/s]
Batch 08/16: 100%|█████████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 1009.33it/s]
{'TRUCK': 5000, 'AIRPLANE': 5000, 'AUTOMOBILE': 5000, 'SHIP': 5000, 'FROG': 5000, 'BIRD': 5000, 'CAT': 5000, 'DEER': 5000, 'HORSE': 5000, 'DOG': 5000}
```

Same operation with `iter_samples(autosave=True)`:

```py
for sample in view.iter_samples(autosave=True, progress=True):
    map_fcn(sample)
```

```
 100% |██████████████████████████████████████████████████████████████████| 50000/50000 [27.6s elapsed, 0s remaining, 1.6K samples/s]      
```

## Example 2: map-reduce

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.beam as foub

dataset = foz.load_zoo_dataset("cifar10", split="train")
view = dataset.select_fields("ground_truth")

def map_fcn(sample):
    return sample.ground_truth.label.lower()

class ReduceFcn(foub.ReduceFcn):
    def create_accumulator(self):
        from collections import Counter
        return Counter()

    def add_input(self, accumulator, input):
        sample_id, value = input
        accumulator[value] += 1
        return accumulator

    def merge_accumulators(self, accumulators):
        from collections import Counter
        accumulator = Counter()
        for a in accumulators:
            accumulator.update(a)
        return accumulator

    def extract_output(self, accumulator):
        counts = dict(accumulator)
        self._store_output(counts)

counts = foub.beam_map(view, map_fcn, reduce_fcn=ReduceFcn, progress=True)
print(counts)
```

## Example 3: map-aggregate

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.beam as foub

dataset = foz.load_zoo_dataset("cifar10", split="train")
view = dataset.select_fields("ground_truth")

def map_fcn(sample):
    return sample.ground_truth.label.lower()

def aggregate_fcn(sample_collection, values):
    from collections import Counter
    return dict(Counter(values.values()))

counts = foub.beam_map(view, map_fcn, aggregate_fcn=aggregate_fcn, progress=True)
print(counts)
```
