### PR TITLE
Limit frames lookup pipeline for grid

### DIFF
--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -5,6 +5,7 @@ Dataset views.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import defaultdict, OrderedDict
 import contextlib
 from copy import copy, deepcopy
@@ -1544,6 +1545,7 @@ class DatasetView(foc.SampleCollection):
         media_type=None,
         attach_frames=False,
         detach_frames=False,
+        limit_frames=None,
         frames_only=False,
         support=None,
         group_slice=None,
@@ -1644,12 +1646,16 @@ class DatasetView(foc.SampleCollection):
             # Two lookups are required; manually do the **last** one and rely
             # on dataset._pipeline() to do the first one
             attach_frames = True
-            _pipeline = self._dataset._attach_frames_pipeline(support=support)
+            _pipeline = self._dataset._attach_frames_pipeline(
+                limit=limit_frames, support=support
+            )
             _pipelines.insert(_attach_frames_idx, _pipeline)
         elif _found_select_group_slice and _attach_frames_idx is not None:
             # Must manually attach frames after the group selection
             attach_frames = None  # special syntax: frames already attached
-            _pipeline = self._dataset._attach_frames_pipeline(support=support)
+            _pipeline = self._dataset._attach_frames_pipeline(
+                limit=limit_frames, support=support
+            )
             _pipelines.insert(_attach_frames_idx, _pipeline)
         elif _attach_frames_idx0 is not None or _attach_frames_idx is not None:
             # Exactly one lookup is required; rely on dataset._pipeline() to
@@ -1706,6 +1712,7 @@ class DatasetView(foc.SampleCollection):
             media_type=media_type,
             attach_frames=attach_frames,
             detach_frames=detach_frames,
+            limit_frames=limit_frames,
             frames_only=frames_only,
             support=support,
             group_slice=group_slice,

--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -113,15 +113,12 @@ async def paginate_samples(
     pipeline = view._pipeline(
         attach_frames=has_frames,
         detach_frames=False,
+        limit_frames=1,
         manual_group_select=sample_filter
         and sample_filter.group
         and (sample_filter.group.id and not sample_filter.group.slices),
         support=support,
     )
-
-    # Only return the first frame of each video sample for the grid thumbnail
-    if has_frames:
-        pipeline.append({"$addFields": {"frames": {"$slice": ["$frames", 1]}}})
 
     samples = await foo.aggregate(
         foo.get_async_db_conn()[view._dataset._sample_collection_name],


### PR DESCRIPTION
## What changes are proposed in this pull request?

Limit the lookup pipeline for frames in grid samples request to one, as only the first frame is needed

## How is this patch tested? If it is not, please explain why.

Todo

## Release Notes

Todo

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
