### PR TITLE
Document CVAT cloud storage id kwarg

### DIFF
--- a/docs/source/enterprise/cloud_media.rst
+++ b/docs/source/enterprise/cloud_media.rst
@@ -736,6 +736,23 @@ than the default behavior of uploading copies of the media to the CVAT server.
 First, follow
 `these instructions <https://opencv.github.io/cvat/docs/manual/basics/attach-cloud-storage/>`_
 to attach a cloud storage bucket to CVAT. Then, simply provide the
+`cloud_storage_id` parameter to
+:meth:`annotate() <fiftyone.core.collections.SampleCollection.annotate>` to
+specify the integer ID of the cloud storage configured in CVAT:
+
+.. code-block:: python
+    :linenos:
+
+    anno_key = "cloud_annotations"
+
+    results = dataset.annotate(
+        anno_key,
+        label_field="ground_truth",
+        cloud_storage_id=51,
+    )
+
+Alternatively, if you have configured a CVAT cloud manifest file
+then, simply provide the
 `cloud_manifest` parameter to
 :meth:`annotate() <fiftyone.core.collections.SampleCollection.annotate>` to
 specify the URL of the manifest file in your cloud bucket:
@@ -751,7 +768,7 @@ specify the URL of the manifest file in your cloud bucket:
         cloud_manifest="s3://voxel51/manifest.jsonl",
     )
 
-Alternatively, if your cloud manifest has the default name `manifest.jsonl`
+If your cloud manifest has the default name `manifest.jsonl`
 and exists in the root of the bucket containing the data in the sample
 collection being annotated, then you can simply pass `cloud_manifest=True`:
 
@@ -766,7 +783,7 @@ collection being annotated, then you can simply pass `cloud_manifest=True`:
 
 .. note::
 
-    The cloud manifest file must contain all media files in the sample
+    The cloud storage must contain all media files in the sample
     collection being annotated.
 
 .. _enterprise-annotating-cloud-media-v7:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds documentation for a new teams-only CVAT argument for interacting with cloud media

(Drafted until teams feature is merged)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced Grid controls with refined zoom, autosizing, and memory management.
  - Updated Embeddings interactions now support improved lasso selection.

- **Improvements**
  - Sidebar links and Query Performance icons have been updated to direct users to clearer, more informative documentation.
  - Snackbar notifications now distinctly present errors and actionable links, providing better feedback.

- **Documentation**
  - Command-line interface and enterprise docs are updated with new options, including glob pattern filtering, cloud storage integration, and spatial indexing guidelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->