### PR TITLE
CVAT: Upload detection rotation attribute

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -6441,12 +6441,14 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 xbr = float(round((x + w) * width))
                 ybr = float(round((y + h) * height))
                 bbox = [xtl, ytl, xbr, ybr]
+                rotation = det["rotation"] if "rotation" in det else 0.0 or 0.0
 
                 curr_shapes.append(
                     {
                         "type": "rectangle",
                         "occluded": is_occluded,
                         "points": bbox,
+                        "rotation": rotation,
                         "label_id": class_name,
                         "group": group_id,
                         "frame": frame_id,

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -6441,21 +6441,22 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 xbr = float(round((x + w) * width))
                 ybr = float(round((y + h) * height))
                 bbox = [xtl, ytl, xbr, ybr]
-                rotation = det["rotation"] if "rotation" in det else 0.0 or 0.0
 
-                curr_shapes.append(
-                    {
-                        "type": "rectangle",
-                        "occluded": is_occluded,
-                        "points": bbox,
-                        "rotation": rotation,
-                        "label_id": class_name,
-                        "group": group_id,
-                        "frame": frame_id,
-                        "source": "manual",
-                        "attributes": attributes,
-                    }
-                )
+                shape = {
+                    "type": "rectangle",
+                    "occluded": is_occluded,
+                    "points": bbox,
+                    "label_id": class_name,
+                    "group": group_id,
+                    "frame": frame_id,
+                    "source": "manual",
+                    "attributes": attributes,
+                }
+
+                if det.has_attribute("rotation"):
+                    shape["rotation"] = det["rotation"] or 0.0
+
+                curr_shapes.append(shape)
             elif label_type in ("instance", "instances"):
                 if not det.has_mask:
                     continue
@@ -6471,19 +6472,18 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     rle = HasCVATBinaryMask._mask_to_cvat_rle(det.mask)
                     rle.extend([xtl, ytl, xbr - 1, ybr - 1])
 
-                    curr_shapes.append(
-                        {
-                            "type": "mask",
-                            "occluded": is_occluded,
-                            "z_order": 0,
-                            "points": rle,
-                            "label_id": class_name,
-                            "group": group_id,
-                            "frame": frame_id,
-                            "source": "manual",
-                            "attributes": deepcopy(attributes),
-                        }
-                    )
+                    shape = {
+                        "type": "mask",
+                        "occluded": is_occluded,
+                        "z_order": 0,
+                        "points": rle,
+                        "label_id": class_name,
+                        "group": group_id,
+                        "frame": frame_id,
+                        "source": "manual",
+                        "attributes": deepcopy(attributes),
+                    }
+                    curr_shapes.append(shape)
                 else:
                     polygon = det.to_polyline()
                     for points in polygon.points:
@@ -6497,19 +6497,18 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                             itertools.chain.from_iterable(abs_points)
                         )
 
-                        curr_shapes.append(
-                            {
-                                "type": "polygon",
-                                "occluded": is_occluded,
-                                "z_order": 0,
-                                "points": flattened_points,
-                                "label_id": class_name,
-                                "group": group_id,
-                                "frame": frame_id,
-                                "source": "manual",
-                                "attributes": deepcopy(attributes),
-                            }
-                        )
+                        shape = {
+                            "type": "polygon",
+                            "occluded": is_occluded,
+                            "z_order": 0,
+                            "points": flattened_points,
+                            "label_id": class_name,
+                            "group": group_id,
+                            "frame": frame_id,
+                            "source": "manual",
+                            "attributes": deepcopy(attributes),
+                        }
+                        curr_shapes.append(shape)
 
             if not curr_shapes:
                 continue


### PR DESCRIPTION
## What changes are proposed in this pull request?

CVAT allows for annotating rotated bounding boxes. If a "rotation" attribute exists on a Detection in FiftyOne, then it should be uploaded to CVAT in a way to set the rotation of bounding boxes to that angle.

## How is this patch tested? If it is not, please explain why.


```python
import fiftyone.zoo as foz
dataset = foz.load_zoo_dataset("quickstart")
sample = dataset.first()
sample.ground_truth.detections[0].rotation = 10.5
sample.ground_truth.detections[1].rotation = 70.0
sample.ground_truth.detections[2].rotation = 170.1
sample.save()

results = dataset[:1].annotate("test", label_field="ground_truth", launch_editor=True)
# See the rotation of the uploaded labels
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Updated the CVAT integration to support setting the rotation of bounding boxes uploaded to new tasks in CVAT from FiftyOne based on the `rotation` attribute of the detections in FiftyOne.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the annotation system to support rotated bounding boxes, ensuring object detections accurately reflect object orientation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->