### PR TITLE
Support 3D object detection annotation on pcd files with CVAT

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -399,7 +399,7 @@ The following parameters are supported by all annotation backends:
     `fiftyone.annotation_config.backends.keys()` and the default is
     `fiftyone.annotation_config.default_backend`
 -   **media_field** (*"filepath"*): the sample field containing the path to the
-    source media to upload
+    source media to upload (required for 3D annotation)
 -   **launch_editor** (*False*): whether to launch the annotation backend's
     editor after uploading the samples
 
@@ -2235,6 +2235,56 @@ argument is not currently supported.
        cleanup=True,
    )
    dataset.delete_annotation_run(anno_key)
+
+.. _cvat-3d:
+
+Annotating 3D data
+------------------
+
+CVAT supports annotating 3D detections on pointcloud data. For the most part,
+annotating 3D data is similar to annotating 2D data using this integration.
+
+The primary difference is the format that is used to store these 3D scenes in
+FiftyOne (:ref:`fo3d format <3d-datasets>`) vs in CVAT
+(`see supported formats here <https://docs.cvat.ai/docs/manual/basics/create_an_annotation_task/#data-formats-for-a-3d-task>`_).
+The simplest format supported by CVAT is a single .pcd file. However, you can
+also provide contextual images along with the .pcd following one of the
+supported formats in the link above.
+
+
+.. note::
+
+    Due to this, there is a manual preprocessing step required before annotating 3D
+    datasets. You are expected to extract and structure your 3D scenes in a CVAT
+    compatible format, then populate a new field on your FiftyOne dataset with the
+    filepaths pointing to these 3D scenes. When you go to annotate your 3D dataset,
+    you are then required to provide the `media_field` keyword argument.
+
+See this example that shows how to annotate the pcd slice of the
+`quickstart-groups` zoo dataset:
+
+.. code:: python
+    :linenos:
+
+    import fiftyone.zoo as foz
+
+    dataset = foz.load_zoo_dataset("quickstart-groups")
+    view = dataset.select_group_slices("pcd")
+
+    # Populate a field on the dataset that points to the data to upload to CVAT
+    # This data can be as simple as a filepath to a .pcd file
+    # or it could be a structured zip archive including reference images along with the pcd
+    view.set_values("pcd_filepath", [f.replace(".fo3d", ".pcd") for f in view.values("filepath")])
+
+    results = view[1:2].annotate("test", label_field="ground_truth", media_field="pcd_filepath", launch_editor=True)
+
+    # Annotate the cuboids in CVAT
+
+    view.load_annotations("test")
+
+    # View the newly loaded/edited cuboids in FiftyOne
+    session = fo.launch_app(dataset)
+
 
 .. _cvat-annotating-videos:
 

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -4406,6 +4406,15 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         has_ignored_attributes = False
         save_config = False
 
+        is_3d = samples.media_type == fom.THREE_D
+        media_field = config.media_field
+        if is_3d and media_field == "filepath":
+            raise ValueError(
+                "The `media_field` argument is required when annotating 3D "
+                "datasets. See the documentation for more details: "
+                "https://docs.voxel51.com/integrations/cvat.html#annotating-3d-data"
+            )
+
         # When using an existing project, we cannot support multiple label
         # fields of the same type, since it would not be clear which field
         # labels should be downloaded into


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds support for 3d pointcloud annotation, specifically of 3D detections/cuboids, through the integration with CVAT.

3D annotation in CVAT is limited to 3d detections on a single .pcd file (with the option of adding up to 12 reference images). There are multiple directory structures that it supports for this: https://docs.cvat.ai/docs/manual/basics/create_an_annotation_task/#data-formats-for-a-3d-task

Given that 3d datasets in FiftyOne require media to be stored in .fo3d files, annotating them requires an additional step which is on the user to structure the data as needed by cvat, and store the references to that data in an alternate media field on the dataset.
Once that setup is complete, you can send 3d detections with pointcloud data and load them just as you would for 2d labels. See the test for an example.

An example of this has been added to the CVAT integration docs as well.
![image](https://github.com/user-attachments/assets/15257f55-5287-4efa-b912-4cb520f46cfc)


## How is this patch tested? If it is not, please explain why.

```python
import fiftyone.zoo as foz
import os

dataset = foz.load_zoo_dataset("quickstart-groups")
view = dataset.select_group_slices("pcd")

# Populate a field on the dataset that points to the data to upload to CVAT
# This data can be as simple as a filepath to a .pcd, or to a zip archive structured like any of these examples: https://docs.cvat.ai/docs/manual/basics/create_an_annotation_task/#data-formats-for-a-3d-task
view.set_values("pcd_filepath", [f.replace(".fo3d", ".pcd") for f in view.values("filepath")])

results = view[1:2].annotate("test", label_field="ground_truth", media_field="pcd_filepath", launch_editor=True)

# Annotate the cuboids in cvat

view.load_annotations("test")

# View the newly loaded/edited cuboids in FiftyOne
session = fo.launch_app(dataset)
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Adds support for annotation of 3D cuboids in pointcloud data through the CVAT integration.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for 3D data annotations, allowing point cloud (.pcd) files to be used alongside images and videos.
  - Enhanced the annotation process by requiring explicit specification for 3D data to ensure correct handling.
  - Introduced a new command-line argument for filtering operators based on a glob pattern in the `fiftyone operators list` command.
  - Added functionality for annotating cloud-backed datasets with a new `cloud_storage_id` parameter in the `annotate()` method.

- **Documentation**
  - Introduced a new section outlining the 3D annotation workflow, detailing preprocessing steps and providing a practical example for setting up 3D datasets.
  - Updated documentation to clarify the use of the `cloud_storage_id` parameter and improved overall clarity in various sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->