### PR TITLE
Add select/exclude field stages to Query Performance

### DIFF
--- a/app/packages/state/src/recoil/queryPerformance.test.ts
+++ b/app/packages/state/src/recoil/queryPerformance.test.ts
@@ -40,6 +40,12 @@ describe("tests query performance selectors", () => {
     setMockAtoms({
       _view__setter: [
         {
+          _cls: "fiftyone.core.stages.ExcludeFields",
+        },
+        {
+          _cls: "fiftyone.core.stages.SelectFields",
+        },
+        {
           _cls: "fiftyone.core.stages.SelectGroupSlices",
         },
       ],

--- a/app/packages/state/src/recoil/queryPerformance.ts
+++ b/app/packages/state/src/recoil/queryPerformance.ts
@@ -19,8 +19,14 @@ import { datasetId, datasetName } from "./selectors";
 import { State } from "./types";
 import { view } from "./view";
 
+const EXCLUDE_FIELDS = "fiftyone.core.stages.ExcludedFields";
+const SELECT_FIELDS = "fiftyone.core.stages.SelectFields";
 const SELECT_GROUP_SLICES = "fiftyone.core.stages.SelectGroupSlices";
-const VALID_QP_STAGES = new Set([SELECT_GROUP_SLICES]);
+const VALID_QP_STAGES = new Set([
+  EXCLUDE_FIELDS,
+  SELECT_FIELDS,
+  SELECT_GROUP_SLICES,
+]);
 
 export const lightningQuery = graphQLSelectorFamily<
   foq.lightningQuery$variables,
@@ -199,11 +205,8 @@ export const isQueryPerformantView = selector({
       return true;
     }
 
-    if (stages.length === 1) {
-      return VALID_QP_STAGES.has(stages[0]._cls);
-    }
-
-    return false;
+    const stageClasses = [...new Set(stages.map(({ _cls }) => _cls))];
+    return stageClasses.every((cls) => VALID_QP_STAGES.has(cls));
   },
 });
 

--- a/app/packages/state/src/recoil/queryPerformance.ts
+++ b/app/packages/state/src/recoil/queryPerformance.ts
@@ -19,7 +19,7 @@ import { datasetId, datasetName } from "./selectors";
 import { State } from "./types";
 import { view } from "./view";
 
-const EXCLUDE_FIELDS = "fiftyone.core.stages.ExcludedFields";
+const EXCLUDE_FIELDS = "fiftyone.core.stages.ExcludeFields";
 const SELECT_FIELDS = "fiftyone.core.stages.SelectFields";
 const SELECT_GROUP_SLICES = "fiftyone.core.stages.SelectGroupSlices";
 const VALID_QP_STAGES = new Set([


### PR DESCRIPTION
## What changes are proposed in this pull request?

Selecting and excluding fields should not affect QP support

## How is this patch tested? If it is not, please explain why.

Recoil test

## Release Notes

* Added  Query Performance support for `ExcludeFields` and `SelectFields` views

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced query performance evaluation now supports multiple valid configurations, providing greater flexibility in assessing query optimization.
- **Tests**
	- Updated test scenarios include additional mock data to verify the improved performance validation logic under a broader range of configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->