### PR TITLE
New loading panels

### DIFF
--- a/app/packages/operators/src/CustomPanel.tsx
+++ b/app/packages/operators/src/CustomPanel.tsx
@@ -15,6 +15,7 @@ import { Property } from "./types";
 import { CustomPanelProps, useCustomPanelHooks } from "./useCustomPanelHooks";
 import { useTrackEvent } from "@fiftyone/analytics";
 import usePanelEvent from "./usePanelEvent";
+import LoadingSpinner from "@fiftyone/components/src/components/Loading/LoadingSpinner";
 
 export function CustomPanel(props: CustomPanelProps) {
   const { panelId, dimensions, panelName, panelLabel, isModalPanel } = props;
@@ -23,14 +24,14 @@ export function CustomPanel(props: CustomPanelProps) {
   const [_, setLoading] = usePanelLoading(panelId);
   const triggerPanelEvent = usePanelEvent();
 
-  const {
+  let {
     handlePanelStateChange,
     handlePanelStatePathChange,
     panelSchema,
     data,
     onLoadError,
   } = useCustomPanelHooks(props);
-  const pending = fos.useTimeout(PANEL_LOAD_TIMEOUT);
+  let pending = fos.useTimeout(PANEL_LOAD_TIMEOUT);
   const setPanelCloseEffect = useSetPanelCloseEffect();
   const trackEvent = useTrackEvent();
 
@@ -48,6 +49,10 @@ export function CustomPanel(props: CustomPanelProps) {
     setLoading(count > 0);
   }, [setLoading, count]);
 
+  // remove this
+  panelSchema = null;
+  pending = false;
+
   if (pending && !panelSchema && !onLoadError) {
     return <PanelSkeleton />;
   }
@@ -55,15 +60,17 @@ export function CustomPanel(props: CustomPanelProps) {
   if (!panelSchema)
     return (
       <CenteredStack spacing={1}>
-        <Typography variant="h4">{panelLabel || "Operator Panel"}</Typography>
-        <Typography color="text.secondary">
-          Operator panel &quot;
-          <Typography component="span">{panelName}</Typography>&quot; is not
-          configured yet.
-        </Typography>
-        <Typography component="pre" color="text.tertiary">
-          {panelId}
-        </Typography>
+        {!onLoadError && (
+          <>
+            <Typography variant="h4">
+              <LoadingSpinner />
+              Still loading...
+            </Typography>
+            <Typography color="text.secondary">
+              This panel is taking longer than expected to load.
+            </Typography>
+          </>
+        )}
         {onLoadError && (
           <Box maxWidth="95%">
             <CodeBlock text={onLoadError} />

--- a/app/packages/operators/src/CustomPanel.tsx
+++ b/app/packages/operators/src/CustomPanel.tsx
@@ -16,6 +16,13 @@ import { CustomPanelProps, useCustomPanelHooks } from "./useCustomPanelHooks";
 import { useTrackEvent } from "@fiftyone/analytics";
 import usePanelEvent from "./usePanelEvent";
 import LoadingSpinner from "@fiftyone/components/src/components/Loading/LoadingSpinner";
+import { styled } from "@mui/system";
+
+const SpinnerContainer = styled(Box)`
+  display: flex;
+  justify-content: center;
+  margin-bottom: 2rem;
+`;
 
 export function CustomPanel(props: CustomPanelProps) {
   const { panelId, dimensions, panelName, panelLabel, isModalPanel } = props;
@@ -49,10 +56,6 @@ export function CustomPanel(props: CustomPanelProps) {
     setLoading(count > 0);
   }, [setLoading, count]);
 
-  // remove this
-  panelSchema = null;
-  pending = false;
-
   if (pending && !panelSchema && !onLoadError) {
     return <PanelSkeleton />;
   }
@@ -62,12 +65,18 @@ export function CustomPanel(props: CustomPanelProps) {
       <CenteredStack spacing={1}>
         {!onLoadError && (
           <>
-            <Typography variant="h4">
+            <SpinnerContainer>
               <LoadingSpinner />
-              Still loading...
-            </Typography>
-            <Typography color="text.secondary">
+            </SpinnerContainer>
+            <Typography variant="h5">Still loading...</Typography>
+            <Typography
+              variant="body1"
+              color="text.secondary"
+              style={{ textAlign: "center" }}
+            >
               This panel is taking longer than expected to load.
+              <br />
+              You can continue to work with other panels while this loads.
             </Typography>
           </>
         )}

--- a/app/packages/operators/src/constants.ts
+++ b/app/packages/operators/src/constants.ts
@@ -7,7 +7,7 @@ export enum OPERATOR_PROMPT_AREAS {
   DRAWER_LEFT = "operator_prompt_area_drawer_left",
   DRAWER_RIGHT = "operator_prompt_area_drawer_right",
 }
-export const PANEL_LOAD_TIMEOUT = 60000;
+export const PANEL_LOAD_TIMEOUT = 10000;
 export enum QueueItemStatus {
   Pending,
   Executing,

--- a/app/packages/operators/src/constants.ts
+++ b/app/packages/operators/src/constants.ts
@@ -7,7 +7,7 @@ export enum OPERATOR_PROMPT_AREAS {
   DRAWER_LEFT = "operator_prompt_area_drawer_left",
   DRAWER_RIGHT = "operator_prompt_area_drawer_right",
 }
-export const PANEL_LOAD_TIMEOUT = 5000;
+export const PANEL_LOAD_TIMEOUT = 60000;
 export enum QueueItemStatus {
   Pending,
   Executing,


### PR DESCRIPTION
Reworks python panel loading slightly. Shows a new and less confusing message when a panel takes longer than `PANEL_LOAD_TIMEOUT=10s`.

<img width="2554" alt="image" src="https://github.com/user-attachments/assets/74e72174-1336-4aeb-9fd9-fee072ca8923" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced panel loading experience with a dynamic message and visual spinner to indicate progress, allowing users to continue interacting with other panels while waiting.

- **Chores**
  - Increased the waiting period for panel loading to improve overall responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->