### PR TITLE
add log path field to DO

### DIFF
--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -44,6 +44,7 @@ class DelegatedOperationRepo(object):
         run_state: ExecutionRunState,
         result: ExecutionResult = None,
         run_link: str = None,
+        log_path: str = None,
         progress: ExecutionProgress = None,
         required_state: ExecutionRunState = None,
     ) -> DelegatedOperationDocument:
@@ -121,7 +122,9 @@ class DelegatedOperationRepo(object):
         self, _id: ObjectId, log_upload_error: str
     ) -> DelegatedOperationDocument:
         """Sets the log upload error for the delegated operation."""
-        raise NotImplementedError("subclass must implement set_log_upload_error()")
+        raise NotImplementedError(
+            "subclass must implement set_log_upload_error()"
+        )
 
     def get(self, _id: ObjectId) -> DelegatedOperationDocument:
         """Get an operation by id."""
@@ -268,6 +271,7 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
         run_state: ExecutionRunState,
         result: ExecutionResult = None,
         run_link: str = None,
+        log_path: str = None,
         progress: ExecutionProgress = None,
         required_state: ExecutionRunState = None,
     ) -> DelegatedOperationDocument:
@@ -337,6 +341,9 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
 
         if run_link is not None:
             update["$set"]["run_link"] = run_link
+
+        if log_path is not None:
+            update["$set"]["log_path"] = log_path
 
         if update is None:
             raise ValueError("Invalid run_state: {}".format(run_state))

--- a/fiftyone/factory/repos/delegated_operation_doc.py
+++ b/fiftyone/factory/repos/delegated_operation_doc.py
@@ -57,6 +57,7 @@ class DelegatedOperationDocument(object):
         self._doc = None
         self.metadata = None
         self.log_upload_error = None
+        self.log_path = None
 
     def from_pymongo(self, doc: dict):
         # required fields
@@ -74,6 +75,7 @@ class DelegatedOperationDocument(object):
         self.dataset_id = doc.get("dataset_id", None)
         self.run_link = doc.get("run_link", None)
         self.log_upload_error = doc.get("log_upload_error", None)
+        self.log_path = doc.get("log_path", None)
         self.metadata = doc.get("metadata", None)
         self.label = doc.get("label", None)
         self.updated_at = doc.get("updated_at", None)

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -84,6 +84,7 @@ class DelegatedOperationService(object):
         doc_id,
         progress=None,
         run_link=None,
+        log_path=None,
         required_state=None,
     ):
         """Sets the given delegated operation to running state.
@@ -95,6 +96,7 @@ class DelegatedOperationService(object):
                 operation
             run_link (None): an optional link to orchestrator-specific
                 information about the operation
+            log_path (None): an optional path to the log file for the operation
             required_state (None): an optional
                 :class:`fiftyone.operators.executor.ExecutionRunState` required
                 state of the operation. If provided, the update will only be
@@ -108,6 +110,7 @@ class DelegatedOperationService(object):
             _id=doc_id,
             run_state=ExecutionRunState.RUNNING,
             run_link=run_link,
+            log_path=log_path,
             progress=progress,
             required_state=required_state,
         )
@@ -157,6 +160,7 @@ class DelegatedOperationService(object):
         result=None,
         progress=None,
         run_link=None,
+        log_path=None,
         required_state=None,
     ):
         """Sets the given delegated operation to completed state.
@@ -171,6 +175,7 @@ class DelegatedOperationService(object):
                 operation
             run_link (None): an optional link to orchestrator-specific
                 information about the operation
+            log_path (None): an optional path to the log file for the operation
             required_state (None): an optional
                 :class:`fiftyone.operators.executor.ExecutionRunState` required
                 state of the operation. If provided, the update will only be
@@ -187,6 +192,7 @@ class DelegatedOperationService(object):
             result=result,
             progress=progress,
             run_link=run_link,
+            log_path=log_path,
             required_state=required_state,
         )
 
@@ -196,6 +202,7 @@ class DelegatedOperationService(object):
         result=None,
         progress=None,
         run_link=None,
+        log_path=None,
         required_state=None,
     ):
         """Sets the given delegated operation to failed state.
@@ -210,6 +217,7 @@ class DelegatedOperationService(object):
                 operation
             run_link (None): an optional link to orchestrator-specific
                 information about the operation
+            log_path (None): an optional path to the log file for the operation
             required_state (None): an optional
                 :class:`fiftyone.operators.executor.ExecutionRunState` required
                 state of the operation. If provided, the update will only be
@@ -224,6 +232,7 @@ class DelegatedOperationService(object):
             run_state=ExecutionRunState.FAILED,
             result=result,
             run_link=run_link,
+            log_path=log_path,
             progress=progress,
             required_state=required_state,
         )
@@ -263,7 +272,9 @@ class DelegatedOperationService(object):
         Returns:
             a :class:`fiftyone.factory.repos.DelegatedOperationDocument`
         """
-        return self._repo.set_log_upload_error(_id=doc_id, log_upload_error=log_upload_error)
+        return self._repo.set_log_upload_error(
+            _id=doc_id, log_upload_error=log_upload_error
+        )
 
     def delete_operation(self, doc_id):
         """Deletes the given delegated operation.
@@ -447,7 +458,9 @@ class DelegatedOperationService(object):
         """
         return self._repo.count(filters=filters, search=search)
 
-    def execute_operation(self, operation, log=False, run_link=None):
+    def execute_operation(
+        self, operation, log=False, run_link=None, log_path=None
+    ):
         """Executes the given delegated operation.
 
         Args:
@@ -457,6 +470,7 @@ class DelegatedOperationService(object):
                 delegated operations
             run_link (None): an optional link to orchestrator-specific
                 information about the operation
+            log_path (None): an optional path to the log file for the operation
         """
         result = None
         try:
@@ -464,6 +478,7 @@ class DelegatedOperationService(object):
                 self.set_running(
                     doc_id=operation.id,
                     run_link=run_link,
+                    log_path=log_path,
                     required_state=ExecutionRunState.QUEUED,
                 )
                 is not None


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adding a log_path field for DOs for executors that don't use airflow or have a prebuilt UI a path to a cloud bucket can be provided here for allowing users to download logs in the UI.

## How is this patch tested? If it is not, please explain why.

n/a

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
