### PR TITLE
use setup-ffmpeg with retries so that tests don't fail non-deterministically

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-  
+
 jobs:
   modified-files:
     runs-on: ubuntu-latest
@@ -38,6 +38,7 @@ jobs:
               - 'tests/**'
               - 'requirements.txt'
               - 'setup.py'
+              - '.github/workflows/test.yml'
 
   build:
     needs: modified-files
@@ -90,5 +91,5 @@ jobs:
       - run: sh -c ${{
           (needs.build.result == 'success' || needs.build.result == 'skipped') &&
           (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&
-          (needs.test.result == 'success' || needs.test.result == 'skipped') && 
+          (needs.test.result == 'success' || needs.test.result == 'skipped') &&
           (needs.e2e.result == 'success' || needs.e2e.result == 'skipped') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,8 +71,15 @@ jobs:
         run: |
           python tests/utils/setup_config.py
           python tests/utils/github_actions_flags.py
-      - name: FFmpeg
-        uses: FedericoCarboni/setup-ffmpeg@v3
+
+      # - name: Setup FFmpeg (with retries)
+      #   uses: FedericoCarboni/setup-ffmpeg@v3
+
+      # Use this until https://github.com/federicocarboni/setup-ffmpeg/pull/23
+      # is merged or the maintainer addresses the root issue.
+      - name: Setup FFmpeg (with retries)
+        uses: afoley587/setup-ffmpeg@main
+
       # Important: use pytest_wrapper.py instead of pytest directly to ensure
       # that services shut down cleanly and do not conflict with steps later in
       # this workflow


### PR DESCRIPTION
@afoley587 set it up for e2e workflow in #5258. This PR makes it available for Python test workflows, too. Without this, unit tests non-deterministically fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced our automation workflows to more accurately detect configuration updates that impact testing.
  - Improved the setup process for our multimedia processing tool by adding a robust retry mechanism, increasing reliability.
  - Applied minor formatting adjustments to streamline workflow logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->