### PR TITLE
Fix recall sweep computation.

### DIFF
--- a/fiftyone/utils/eval/coco.py
+++ b/fiftyone/utils/eval/coco.py
@@ -830,6 +830,8 @@ def _compute_pr_curves(samples, config, classes=None, progress=None):
             thresholds[idx][c_idx] = t
             if rec.size != 0:
                 recall_sweep[idx][c_idx] = rec[-1]
+            else:
+                recall_sweep[idx][c_idx] = 0               
 
     return precision, recall, thresholds, iou_threshs, classes, recall_sweep
 

--- a/fiftyone/utils/eval/coco.py
+++ b/fiftyone/utils/eval/coco.py
@@ -828,7 +828,8 @@ def _compute_pr_curves(samples, config, classes=None, progress=None):
 
             precision[idx][c_idx] = q
             thresholds[idx][c_idx] = t
-            recall_sweep[idx][c_idx] = rec[-1]
+            if rec.size != 0:
+                recall_sweep[idx][c_idx] = rec[-1]
 
     return precision, recall, thresholds, iou_threshs, classes, recall_sweep
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Check for recall array emptiness before assigning to recall_sweep variable.

## How is this patch tested? If it is not, please explain why.

Tested `_compute_pr_curves()` locally with generated input args.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fix exception on _compute_pr_curves when recall value does not exist.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the reliability of evaluation processing by adding a safeguard that prevents errors when encountering empty data arrays. This improvement ensures that evaluations run smoothly even in scenarios with missing recall values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->