### PR TITLE
Fix exporting frame segmentations

### DIFF
--- a/fiftyone/utils/labels.py
+++ b/fiftyone/utils/labels.py
@@ -5,6 +5,7 @@ Label utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import eta.core.utils as etau
 
 import fiftyone.core.labels as fol
@@ -190,8 +191,15 @@ def export_segmentations(
         (fol.Segmentation, fol.Detection, fol.Detections, fol.Heatmap),
     )
 
-    samples = sample_collection.select_fields(in_field)
-    in_field, processing_frames = samples._handle_frame_field(in_field)
+    select_fields = [in_field]
+    in_field, processing_frames = sample_collection._handle_frame_field(
+        in_field
+    )
+    if processing_frames:
+        # filepath required for filename generation
+        select_fields.append("frames.filepath")
+
+    samples = sample_collection.select_fields(select_fields)
 
     if overwrite:
         etau.delete_dir(output_dir)


### PR DESCRIPTION
## What changes are proposed in this pull request?

For frames segmentation fields, when exporting masks to disks, frame filepaths are required.

A cleaner alternative to this may be to make `frames.filepath` a default field.

Current error:

```python
AttributeError                            Traceback (most recent call last)
Cell In[78], line 1
----> 1 foul.export_segmentations(
      2     dataset,
      3     "frames.heatmap",
      4     output_dir="/Users/ben/data/heatmaps",
      5 )

File ~/code/fiftyone/fiftyone/utils/labels.py:236, in export_segmentations(sample_collection, in_field, output_dir, rel_dir, update, overwrite, progress)
    233 elif isinstance(label, fol.Heatmap):
    234     if label.map is not None:
    235         outpath = filename_maker.get_output_path(
--> 236             image.filepath, output_ext=".png"
    237         )
    238         label.export_map(outpath, update=update)

File ~/code/fiftyone/fiftyone/core/document.py:44, in _Document.__getattr__(self, name)
     43 def __getattr__(self, name):
---> 44     return self.get_field(name)

File ~/code/fiftyone/fiftyone/core/document.py:756, in DocumentView.get_field(self, field_name)
    754 sf = self._selected_fields
    755 if sf is not None and field_name.split(".", 1)[0] not in sf:
--> 756     raise AttributeError(
    757         "Field '%s' was not selected on this %s"
    758         % (field_name, self.__class__.__name__)
    759     )
    761 return super().get_field(field_name)

AttributeError: Field 'filepath' was not selected on this FrameView
``` 

## Tests

### `export_segmentations()`

```python
import numpy as np
import fiftyone as fo
import fiftyone.utils.labels as foul
import fiftyone.zoo as foz

def drift(z):
    znew = ((z + 0.3 * np.random.randn() + 1) % 2) - 1
    return 0.9 * z + 0.1 * znew

def dancing_normal(h, w, n):
    x, y = np.meshgrid(np.linspace(-1, 1, w), np.linspace(-1, 1, h))
    x0, y0 = 0, 0

    maps = []
    for _ in range(n):
        x0, y0 = drift(x0), drift(y0)
        heatmap = np.exp(-np.sqrt((x - x0) ** 2 + (y - y0) ** 2))  # float heatmap
        # heatmap = np.round(255 * heatmap).astype(np.uint8)  # integer heatmap
        maps.append(heatmap)

    return maps

dataset = foz.load_zoo_dataset("quickstart-video", max_samples=1).select_fields().clone()
dataset.compute_metadata()

sample = dataset.first()

height = sample.metadata.frame_height // 16
width = sample.metadata.frame_width // 16
num_frames = len(sample.frames)
heatmaps = dancing_normal(height, width, num_frames)

for frame, heatmap in zip(sample.frames.values(), heatmaps):
    frame["heatmap"] = fo.Heatmap(map=heatmap)

sample.save()

# Export frame segmentations WITHOUT frame filepaths
foul.export_segmentations(
    dataset,
    "frames.heatmap",
    output_dir="/tmp/heatmaps1",
)

foul.import_segmentations(dataset, "frames.heatmap")
dataset.to_frames(sample_frames=True, output_dir="/tmp/frames")

# Export frame segmentations WITH frame filepaths
foul.export_segmentations(
    dataset,
    "frames.heatmap",
    output_dir="/tmp/heatmaps2",
    rel_dir="/tmp/frames",
)
``` 

### `objects_to_segmentations()`, `transform_segmentations()`, and `segmentations_to_detections()`

Note: this only verifies that image datasets continue to work. Video dataset support validation is via eyes on code 😅 

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.labels as foul

dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    label_types="segmentations",
    classes=["cat", "dog"],
    label_field="instances",
    max_samples=10,
    only_matching=True,
)

mask_targets = {"#ff6d04": "person", "#499cef": "cat", "#6d04ff": "dog"}

foul.objects_to_segmentations(
    dataset,
    "instances",
    "segmentations",
    mask_targets=mask_targets,
    output_dir="/tmp/segmentations1",
)

targets_map = {"#ff6d04": 1, "#499cef": 2, "#6d04ff": 3}

foul.transform_segmentations(
    dataset,
    "segmentations",
    targets_map,
    output_dir="/tmp/segmentations2",
)

mask_targets = {1: "person", 2: "cat", 3: "dog"}

foul.segmentations_to_detections(
    dataset,
    "segmentations",
    "instances2",
    mask_targets=mask_targets,
    output_dir="/tmp/segmentations3",
)
```
