### PR TITLE
debounce update sample to address DataCloneError

### DIFF
--- a/app/packages/looker/src/lookers/abstract.ts
+++ b/app/packages/looker/src/lookers/abstract.ts
@@ -48,13 +48,13 @@ import { AsyncLabelsRenderingManager } from "../worker/async-labels-rendering-ma
 import { LookerUtils } from "./shared";
 import { retrieveTransferables } from "./utils";
 
-const UPDATING_SAMPLES_IDS = new Set();
-
 const LABEL_LISTS_PATH = new Set(withPath(LABELS_PATH, LABEL_LISTS));
 const LABEL_LIST_KEY = Object.fromEntries(
   Object.entries(LABEL_LISTS_MAP).map(([k, v]) => [withPath(LABELS_PATH, k), v])
 );
 const LABELS_SET = new Set(LABELS);
+
+const UPDATE_SAMPLE_DEBOUNCE_MS = 100;
 
 /**
  * worker pool for processing labels
@@ -95,6 +95,7 @@ export abstract class AbstractLooker<
   private readonly ctx: CanvasRenderingContext2D;
   private previousState?: Readonly<State>;
   private readonly rootEvents: Events<State>;
+  private isSampleUpdating: boolean = false;
 
   protected readonly abortController: AbortController;
   protected currentOverlays: Overlay<State>[];
@@ -531,40 +532,29 @@ export abstract class AbstractLooker<
 
   abstract updateOptions(options: Partial<State["options"]>): void;
 
-  updateSample(sample: Sample) {
-    // todo: sometimes instance in spotlight?.updateItems() is defined but has no ref to sample
-    // this crashes the app. this is a bug and should be fixed
-    if (!this.sample) {
-      return;
-    }
-
-    const id = sample.id ?? sample._id;
-    const updateTimeoutMs = 10000;
-
-    if (UPDATING_SAMPLES_IDS.has(id)) {
-      UPDATING_SAMPLES_IDS.delete(id);
-      this.cleanOverlays(true);
-
-      // to prevent deadlock, we'll remove the id from the set after a timeout
-      const timeoutId = setTimeout(() => {
-        UPDATING_SAMPLES_IDS.delete(id);
-      }, updateTimeoutMs);
-
-      queueMicrotask(() => {
-        try {
-          this.updateSample(sample);
-          clearTimeout(timeoutId);
-        } catch (e) {
-          UPDATING_SAMPLES_IDS.delete(id);
-          this.updater({ error: e });
+  private updateSampleDebounced = (() => {
+    let timeoutId: ReturnType<typeof setTimeout>;
+    return (sample: Sample) => {
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => {
+        // todo: sometimes instance in spotlight?.updateItems() is defined but has no ref to sample
+        // this crashes the app. this is a bug and should be fixed
+        if (!this.sample) {
+          return;
         }
-      });
-      return;
-    }
 
-    UPDATING_SAMPLES_IDS.add(id);
+        if (this.isSampleUpdating) {
+          return;
+        }
 
-    this.loadSample(sample, retrieveTransferables(this.sampleOverlays));
+        this.isSampleUpdating = true;
+        this.loadSample(sample, retrieveTransferables(this.sampleOverlays));
+      }, UPDATE_SAMPLE_DEBOUNCE_MS);
+    };
+  })();
+
+  updateSample(sample: Sample) {
+    this.updateSampleDebounced(sample);
   }
 
   refreshSample(renderLabels: string[] | null = null) {
@@ -806,7 +796,7 @@ export abstract class AbstractLooker<
         });
         labelsWorker.removeEventListener("message", listener);
 
-        UPDATING_SAMPLES_IDS.delete(sample.id ?? sample._id);
+        this.isSampleUpdating = false;
       }
     };
 

--- a/app/packages/looker/src/lookers/abstract.ts
+++ b/app/packages/looker/src/lookers/abstract.ts
@@ -548,7 +548,11 @@ export abstract class AbstractLooker<
         }
 
         this.isSampleUpdating = true;
-        this.loadSample(sample, retrieveTransferables(this.sampleOverlays));
+        try {
+          this.loadSample(sample, retrieveTransferables(this.sampleOverlays));
+        } catch (error) {
+          this.isSampleUpdating = false;
+        }
       }, UPDATE_SAMPLE_DEBOUNCE_MS);
     };
   })();

--- a/app/packages/looker/src/worker/index.ts
+++ b/app/packages/looker/src/worker/index.ts
@@ -342,6 +342,18 @@ const processSample = async ({
   schema,
   activePaths,
 }: ProcessSample) => {
+  if (!sample) {
+    // edge case where looker hasn't been associated with a sample yet
+    // but `updateSample` was called anyway, say, due to user switching colors
+    // as soon as the app loads but before grid is ready
+    postMessage({
+      method: "processSample",
+      uuid,
+      error: "sample not attached",
+    });
+    return;
+  }
+
   mapId(sample);
 
   const imageBitmapPromises: Promise<ImageBitmap[]>[] = [];


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Removes global `UPDATING_SAMPLES_ID` in favor of local `isSampleUpdating`.
- Debounces `updateSample` (100ms)

## How is this patch tested? If it is not, please explain why.

Locally.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the sample update process by introducing a debounced mechanism to prevent overlapping actions, resulting in smoother and more stable handling of sample data.
	- Improved error handling in the sample processing function to prevent runtime errors when a sample is not attached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->