### PR TITLE
Fix App dataset color scheme assignment

### DIFF
--- a/app/packages/app/src/useSetters/onSetDataset.test.ts
+++ b/app/packages/app/src/useSetters/onSetDataset.test.ts
@@ -1,0 +1,12 @@
+import { SESSION_DEFAULT } from "@fiftyone/state";
+import { describe, expect, it } from "vitest";
+import { assignSession } from "./onSetDataset";
+
+describe("test session assignment for dataset transition", () => {
+  it("assigns color scheme settings", () => {
+    const session = { ...SESSION_DEFAULT };
+
+    assignSession(session, { colorScheme: { colorPool: ["#ffffff"] } });
+    expect(session.colorScheme.colorPool).toEqual(["#ffffff"]);
+  });
+});

--- a/app/packages/app/src/useSetters/onSetDataset.ts
+++ b/app/packages/app/src/useSetters/onSetDataset.ts
@@ -5,6 +5,8 @@ import {
 } from "@fiftyone/relay";
 import {
   GRID_SPACES_DEFAULT,
+  ResponseFrom,
+  Session,
   ensureColorScheme,
   stateSubscription,
 } from "@fiftyone/state";
@@ -27,17 +29,11 @@ const onSetDataset: RegisteredSetter =
       });
 
     const unsubscribe = subscribeBefore<DatasetPageQuery>((entry) => {
-      sessionRef.current.selectedLabels = [];
-      sessionRef.current.selectedSamples = new Set();
-      sessionRef.current.sessionSpaces = GRID_SPACES_DEFAULT;
-      sessionRef.current.fieldVisibilityStage = undefined;
-      sessionRef.current.colorScheme = ensureColorScheme(
-        entry.data.dataset?.appConfig,
-        entry.data.config
-      );
-      sessionRef.current.sessionGroupSlice =
-        entry.data.dataset?.defaultGroupSlice || undefined;
-
+      assignSession(sessionRef.current, {
+        colorScheme: entry.data.dataset?.appConfig?.colorScheme,
+        config: entry.data.config,
+        groupSlice: entry.data.dataset?.defaultGroupSlice,
+      });
       unsubscribe();
     });
 
@@ -59,5 +55,28 @@ const onSetDataset: RegisteredSetter =
       }
     );
   };
+
+export const assignSession = (
+  session: Session,
+  settings: {
+    colorScheme?: Partial<
+      NonNullable<
+        NonNullable<ResponseFrom<DatasetPageQuery>["dataset"]>["appConfig"]
+      >["colorScheme"]
+    >;
+    config?: ResponseFrom<DatasetPageQuery>["config"];
+    groupSlice?: null | string;
+  }
+) => {
+  session.selectedLabels = [];
+  session.selectedSamples = new Set();
+  session.sessionSpaces = GRID_SPACES_DEFAULT;
+  session.fieldVisibilityStage = undefined;
+  session.colorScheme = ensureColorScheme(
+    settings.colorScheme,
+    settings.config
+  );
+  session.sessionGroupSlice = settings?.groupSlice || undefined;
+};
 
 export default onSetDataset;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Minimal change to fix #5410 with a test

To reproduce

```python
import fiftyone as fo
import fiftyone.zoo as foz

color_scheme = fo.ColorScheme(
    color_by="field",
    opacity=0.7,
    color_pool=["#ffffff"],
    fields=[
        {
            "path": "ground_truth",
            "fieldColor": "#000000",
        }
    ],
)
dataset = foz.load_zoo_dataset("quickstart")

dataset.app_config.color_scheme = color_scheme
dataset.save()

session = fo.launch_app()
# navigate to "quickstart" in the App
``` 
Recording shows correct behavior

https://github.com/user-attachments/assets/313eb510-1e01-46e5-a574-6208b218ee28

## How is this patch tested? If it is not, please explain why.

Test case for `assignSession`

## Release Notes

* Fixed color scheme defaults when changing datasets in the App

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
