### PR TITLE
[WIP] Optimize `values()` calls

### DIFF
--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -2898,12 +2898,17 @@ class Values(Aggregation):
             context=context,
         )
 
-        self._field = self._manual_field or field
-        self._big_field = big_field
-        self._num_list_fields = len(list_fields)
+        # Optimization: call str() in memory rather than $toString in database
+        if id_to_str:
+            field = fof.ObjectIdField()
+            id_to_str = False
 
-        pipeline.extend(
-            _make_extract_values_pipeline(
+        # Optimization: use field inclusion syntax when possible
+        if self._expr is None and path == "_id":
+            big_field = path
+            _pipeline = [{"$project": {"_id": 1}}]
+        else:
+            _pipeline = _make_extract_values_pipeline(
                 path,
                 list_fields,
                 id_to_str,
@@ -2911,7 +2916,12 @@ class Values(Aggregation):
                 self._big_result,
                 big_field,
             )
-        )
+
+        self._field = self._manual_field or field
+        self._big_field = big_field
+        self._num_list_fields = len(list_fields)
+
+        pipeline.extend(_pipeline)
 
         return pipeline
 

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -2899,7 +2899,7 @@ class Values(Aggregation):
         )
 
         # Optimization: call str() in memory rather than $toString in database
-        if id_to_str:
+        if id_to_str and not self._raw:
             field = fof.ObjectIdField()
             id_to_str = False
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -10630,6 +10630,9 @@ class SampleCollection(object):
             if _group_slices:
                 group_slices.update(_group_slices)
 
+            # Optimization: some aggregations are allowed to change field name
+            big_field = getattr(aggregation, "_big_field", big_field)
+
             try:
                 assert len(_pipeline) == 1
                 project[big_field] = _pipeline[0]["$project"][big_field]

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -10642,6 +10642,9 @@ class SampleCollection(object):
                     "$project stage; found %s" % _pipeline
                 )
 
+        if "_id" not in project:
+            project["_id"] = False
+
         return self._pipeline(
             pipeline=[{"$project": project}],
             attach_frames=attach_frames,


### PR DESCRIPTION
## Change log

- Optimizes `values("id")` and `values("filepath")` pipelines by using field inclusion syntax where possible
- Optimizes all `values()` calls by omitting `_id` from return results where possible

## Context

Currently, `values("id")` executes the following pipeline:

```py
pipeline = [
    {
        "$project": {
            "value": {
                "$cond": {
                    "if": {"$gt": ["$_id", None]},
                    "then": {"$toString": "$_id"},
                    "else": None,
                },
            },
        },
    },
]
```

However, the conditional logic in that pipeline is not actually needed for *required* fields like `id` and `filepath`.

I wanted to see how much faster `values("id")` would be if the following pipeline were instead used:

```py
pipeline = [{"$project": {"_id": 1}}]
```

with the `str()` conversion instead happening in Python rather than in the database.

## Findings 

The benchmarking section below shows the following findings on a local database with a 500k sample dataset:
- The `{"$project": {"_id": 1}}` pipeline runs in 2.1 seconds compared to the original pipeline, which runs in 3.4 seconds

## What about index usage?

`values("id")` does not leverage the `_id` field index in either of the above pipelines by default. It uses a `COLLSCAN`. So, I also wanted to see how much faster/slower both pipelines are when they use an `IXSCAN`, which can be forced via `hint={"_id": 1}`.

Interestingly, adding `hint={"_id": 1}` makes both pipelines 0.4-0.6 seconds *slower* on my local machine, so I am *not* proposing to add `hint={"_id": 1}` anywhere at this time.

## Create large dataset

```py
import numpy as np

import fiftyone as fo
import fiftyone.zoo as foz

def expand_dataset(dataset, target_num_samples):
    num_doubles = int(np.ceil(np.log2(target_num_samples / len(dataset))))
    with fo.ProgressBar(start_msg="Expanding dataset") as pb:
        for i in pb(list(range(1, num_doubles + 1))):
            # Cloning avoids the halloween problem, which I observed if directly using `dataset` in-place of `tmp` here
            # https://www.mongodb.com/docs/manual/reference/operator/aggregation/merge/#output-to-the-same-collection-that-is-being-aggregated
            if i == num_doubles:
                tmp = dataset[:(target_num_samples - len(dataset))].clone()
            else:
                tmp = dataset.clone()

            dataset.add_collection(tmp, new_ids=True)
            tmp.delete()

dataset = foz.load_zoo_dataset(
    "cifar10",
    split="train",
    dataset_name="zzz",
    persistent=True,
)

expand_dataset(dataset, 500000)
```

## Test real usage

```py
import fiftyone as fo
import eta.core.utils as etau

dataset = fo.load_dataset("zzz")
dataset.clone_sample_field("id", "id2")
# dataset.create_index("id2")

# Uses optimized values() call
# Time elapsed: 2.7 seconds
with etau.Timer():
    _ = dataset.values("id")

# Using existing values() call
# Time elapsed: 3.8 seconds
with etau.Timer():
    _ = dataset.values("id2")
```

## Benchmarking

```py
import fiftyone as fo
import eta.core.utils as etau

dataset = fo.load_dataset("zzz")

# Current behavior: in-database string conversion
# Time elapsed: 2.8 seconds
with etau.Timer():
    pipeline = [
        {
            "$project": {
                "value": {
                    "$cond": {
                        "if": {"$gt": ["$_id", None]},
                        "then": {"$toString": "$_id"},
                        "else": None,
                    },
                },
            },
        },
    ]
    results = dataset._sample_collection.aggregate(pipeline)
    ids = [d["value"] for d in results]

# With field inclusion
# Time elapsed: 2.1 seconds
with etau.Timer():
    pipeline = [{"$project": {"_id": 1}}]
    results = dataset._sample_collection.aggregate(pipeline)
    ids = [d["_id"] for d in results]
    ids = [str(_id) for _id in ids]

# With field inclusion + index hint
# Time elapsed: 2.5 seconds
with etau.Timer():
    pipeline = [{"$project": {"_id": 1}}]
    results = dataset._sample_collection.aggregate(pipeline, hint={"_id": 1})
    ids = [d["_id"] for d in results]
    ids = [str(_id) for _id in ids]

# With field setting + hint
# Time elapsed: 3.4 seconds
with etau.Timer():
    pipeline = [{"$project": {"value": "$_id"}}]
    results = dataset._sample_collection.aggregate(pipeline, hint={"_id": 1})
    ids = [d["value"] for d in results]
    ids = [str(_id) for _id in ids]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved performance for retrieving "id" and "filepath" fields with optimized aggregation pipelines.
  - Option to return raw MongoDB aggregation pipelines for advanced use cases.

- **Bug Fixes**
  - Ensured the MongoDB document `_id` field is excluded from aggregation results when not needed.
  - Allowed batch aggregation pipelines to customize field names and exclude `_id` explicitly.

- **Tests**
  - Added tests to verify optimized pipeline generation and correct value types for "id", "_id", and "filepath" fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->