### PR TITLE
fix colorscheme bug when switching datasets

### DIFF
--- a/app/packages/app/src/useSetters/onSetDataset.ts
+++ b/app/packages/app/src/useSetters/onSetDataset.ts
@@ -32,7 +32,7 @@ const onSetDataset: RegisteredSetter =
       sessionRef.current.sessionSpaces = GRID_SPACES_DEFAULT;
       sessionRef.current.fieldVisibilityStage = undefined;
       sessionRef.current.colorScheme = ensureColorScheme(
-        entry.data.dataset?.appConfig,
+        entry.data.dataset?.appConfig?.colorScheme,
         entry.data.config
       );
       sessionRef.current.sessionGroupSlice =

--- a/e2e-pw/src/oss/fixtures/loader.ts
+++ b/e2e-pw/src/oss/fixtures/loader.ts
@@ -42,6 +42,11 @@ export class OssLoader extends AbstractFiftyoneLoader {
     throw new Error("Method not implemented.");
   }
 
+  async selectDatasetFromSelector(page: Page, datasetName: string) {
+    await page.getByTestId("selector-dataset").click();
+    await page.getByTestId(`selector-result-${datasetName}`).click();
+  }
+
   async waitUntilGridVisible(
     page: Page,
     datasetName: string,

--- a/e2e-pw/src/oss/poms/color-modal/index.ts
+++ b/e2e-pw/src/oss/poms/color-modal/index.ts
@@ -1,12 +1,14 @@
-import { Locator, Page } from "src/oss/fixtures";
+import { Locator, Page, expect } from "src/oss/fixtures";
 
 export class ColorModalPom {
   readonly page: Page;
   readonly colorModal: Locator;
+  readonly assert: ColorModalAsserter;
 
   constructor(page: Page) {
     this.page = page;
     this.colorModal = page.locator("#colorModal");
+    this.assert = new ColorModalAsserter(this);
   }
 
   getFieldSelector(fieldName: string) {
@@ -124,5 +126,17 @@ export class ColorModalPom {
   async clearDefault() {
     const clearDefaultButton = this.page.getByTestId("button-Clear default");
     await clearDefaultButton.click();
+  }
+}
+
+class ColorModalAsserter {
+  constructor(private readonly colorModalPom: ColorModalPom) {}
+
+  async isColorByModeEqualTo(mode: "value" | "field" | "instance") {
+    await expect(
+      this.colorModalPom.colorModal
+        .getByTestId(`radio-button-${mode}`)
+        .getByRole("radio")
+    ).toBeChecked();
   }
 }

--- a/e2e-pw/src/oss/specs/color-scheme/color-scheme.spec.ts
+++ b/e2e-pw/src/oss/specs/color-scheme/color-scheme.spec.ts
@@ -30,7 +30,11 @@ const test = base.extend<{
   },
 });
 
-const datasetName = getUniqueDatasetNameWithPrefix("quickstart");
+const quickstartColorByField = getUniqueDatasetNameWithPrefix("quickstart");
+
+const dummyDatasetColorByInstance = getUniqueDatasetNameWithPrefix(
+  "dummy-color-by-instance"
+);
 
 test.afterAll(async ({ foWebServer }) => {
   await foWebServer.stopWebServer();
@@ -38,34 +42,46 @@ test.afterAll(async ({ foWebServer }) => {
 
 test.beforeAll(async ({ fiftyoneLoader, foWebServer }) => {
   await foWebServer.startWebServer();
-  await fiftyoneLoader.loadZooDataset("quickstart", datasetName, {
+  await fiftyoneLoader.loadZooDataset("quickstart", quickstartColorByField, {
     max_samples: 5,
   });
 
   await fiftyoneLoader.executePythonCode(`
       import fiftyone as fo
       import random
-      dataset = fo.load_dataset("${datasetName}")
+      quickstart_color_by_field = fo.load_dataset("${quickstartColorByField}")      
 
-      n = len(dataset)
+      n = len(quickstart_color_by_field)
       labels = ["foo", "bar", "spam", "eggs"]
       collaborators = ["alice", "bob", "charlie", "peter", "susan"]
 
       # Add label attributes of each primitive type
-      patches = dataset.to_patches("ground_truth")
+      patches = quickstart_color_by_field.to_patches("ground_truth")
       p = len(patches)
 
-      dataset.add_sample_field("ground_truth.detections.str_field", fo.StringField)
+      quickstart_color_by_field.add_sample_field("ground_truth.detections.str_field", fo.StringField)
       patches.set_values("ground_truth.str_field", [labels[index % 4] for index in range(p)])
-      `);
+
+      dummy_color_by_instance = fo.Dataset("${dummyDatasetColorByInstance}")
+      dummy_color_by_instance.persistent = True
+      dummy_color_by_instance.add_sample(
+        fo.Sample(
+          filepath="dummy.png",
+          ground_truth=fo.Detections(detections=[fo.Detection(label="foo")])
+        )
+      )
+      dummy_color_by_instance.app_config.color_scheme = fo.ColorScheme(color_by="instance", color_pool=["red", "green", "blue", "yellow", "purple", "orange", "brown", "pink", "gray", "black", "white"])
+      dummy_color_by_instance.save()
+    `);
 });
 
 test.describe.serial("color scheme basic functionality with quickstart", () => {
   test.beforeEach(async ({ page, fiftyoneLoader }) => {
-    await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
+    await fiftyoneLoader.waitUntilGridVisible(page, quickstartColorByField);
   });
 
   test("update color by value mode, use tag as colorByAttribute", async ({
+    fiftyoneLoader,
     gridActionsRow,
     colorModal,
     page,
@@ -104,5 +120,17 @@ test.describe.serial("color scheme basic functionality with quickstart", () => {
     expect(await tagBubble.getAttribute("style")).toContain(
       "rgb(154, 205, 50)"
     );
+
+    // switch dataset to dummy_color_by_instance, and verify that color_by mode is "instance"
+    // we're asserting that when dataset is switched, session color settings are reset to default from app config
+    await fiftyoneLoader.waitUntilGridVisible(
+      page,
+      dummyDatasetColorByInstance
+    );
+
+    // open color modal
+    await gridActionsRow.toggleColorSettings();
+    await colorModal.assert.isColorByModeEqualTo("instance");
+    await colorModal.closeColorModal();
   });
 });

--- a/e2e-pw/src/oss/specs/color-scheme/color-scheme.spec.ts
+++ b/e2e-pw/src/oss/specs/color-scheme/color-scheme.spec.ts
@@ -85,6 +85,7 @@ test.describe.serial("color scheme basic functionality with quickstart", () => {
     gridActionsRow,
     colorModal,
     page,
+    grid,
     eventUtils,
     sidebar,
   }) => {
@@ -114,7 +115,6 @@ test.describe.serial("color scheme basic functionality with quickstart", () => {
     const tagBubble = page.getByTestId("tag-validation").first();
 
     await gridRefreshedEventPromise;
-    await gridRefreshedEventPromise;
 
     // verify validation tag has yellow green as background color
     expect(await tagBubble.getAttribute("style")).toContain(
@@ -123,10 +123,12 @@ test.describe.serial("color scheme basic functionality with quickstart", () => {
 
     // switch dataset to dummy_color_by_instance, and verify that color_by mode is "instance"
     // we're asserting that when dataset is switched, session color settings are reset to default from app config
-    await fiftyoneLoader.waitUntilGridVisible(
+    const gridRefreshPromise = grid.getWaitForGridRefreshPromise();
+    await fiftyoneLoader.selectDatasetFromSelector(
       page,
       dummyDatasetColorByInstance
     );
+    await gridRefreshPromise;
 
     // open color modal
     await gridActionsRow.toggleColorSettings();

--- a/e2e-pw/src/shared/abstract-loader.ts
+++ b/e2e-pw/src/shared/abstract-loader.ts
@@ -48,6 +48,18 @@ export abstract class AbstractFiftyoneLoader {
   abstract executePythonCode(code: string): Promise<void>;
 
   /**
+   * Select a dataset from the dataset selector.
+   * This method doesn't result in a page reload.
+   *
+   * @param page Playwright page object.
+   * @param datasetName Name of the dataset to be selected.
+   */
+  abstract selectDatasetFromSelector(
+    page: Page,
+    datasetName: string
+  ): Promise<void>;
+
+  /**
    * Wait until the dataset is loaded into the view.
    *
    * @param page Playwright page object.


### PR DESCRIPTION
## What changes are proposed in this pull request?

The expectation is that color scheme resets to what is set in dataset app config, if specified, when switching datasets. It's currently broken right now and this PR fixes that.

## How is this patch tested? If it is not, please explain why.

Locally. Also updated the e2e spec to test it.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the dataset selection workflow for seamless transitions without page reload, providing users with a smoother experience.
  - Improved the application’s handling of color schemes, ensuring a consistent and reliable visual presentation when switching datasets.

- **Refactor**
  - Optimized internal processing to focus directly on color configuration, resulting in more accurate and dependable color updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->