### PR TITLE
add global loading indicator in the grid for selective rendering

### DIFF
--- a/app/packages/app/src/useSyncLabelsRenderingStatus.tsx
+++ b/app/packages/app/src/useSyncLabelsRenderingStatus.tsx
@@ -1,0 +1,35 @@
+import { usePanelLoading } from "@fiftyone/spaces";
+import {
+  jotaiStore,
+  numConcurrentRenderingLabels,
+} from "@fiftyone/state/src/jotai";
+import { useEffect } from "react";
+
+/**
+ * Hook to sync the rendering status of labels with the panel loading status.
+ */
+export const useSyncLabelsRenderingStatus = () => {
+  const [_, setIsPanelUpdating] = usePanelLoading();
+
+  useEffect(() => {
+    let animationId: ReturnType<typeof requestAnimationFrame>;
+
+    const sync = () => {
+      animationId = requestAnimationFrame(sync);
+
+      const count = jotaiStore.get(numConcurrentRenderingLabels);
+
+      if (count > 0) {
+        setIsPanelUpdating(true);
+      } else {
+        setIsPanelUpdating(false);
+      }
+    };
+
+    animationId = requestAnimationFrame(sync);
+
+    return () => {
+      cancelAnimationFrame(animationId);
+    };
+  }, [setIsPanelUpdating]);
+};

--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -12,7 +12,7 @@ import React, {
 } from "react";
 import { useRecoilCallback, useRecoilValue } from "recoil";
 import { v4 as uuid } from "uuid";
-import { useSyncLabelsRenderingStatus } from "../../../../app/src/useSyncLabelsRenderingStatus";
+import { useSyncLabelsRenderingStatus } from "../../hooks";
 import { QP_WAIT, QueryPerformanceToastEvent } from "../QueryPerformanceToast";
 import { gridActivePathsLUT } from "../Sidebar/useDetectNewActiveLabelFields";
 import { gridCrop, gridSpacing, pageParameters } from "./recoil";

--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -12,6 +12,7 @@ import React, {
 } from "react";
 import { useRecoilCallback, useRecoilValue } from "recoil";
 import { v4 as uuid } from "uuid";
+import { useSyncLabelsRenderingStatus } from "../../../../app/src/useSyncLabelsRenderingStatus";
 import { QP_WAIT, QueryPerformanceToastEvent } from "../QueryPerformanceToast";
 import { gridActivePathsLUT } from "../Sidebar/useDetectNewActiveLabelFields";
 import { gridCrop, gridSpacing, pageParameters } from "./recoil";
@@ -32,6 +33,8 @@ function Grid() {
   const { lookerStore, pageReset, reset } = useRefreshers();
   const [resizing, setResizing] = useState(false);
   const threshold = useThreshold();
+
+  useSyncLabelsRenderingStatus();
 
   const records = useRecords(pageReset);
   const { page, store } = useSpotlightPager({

--- a/app/packages/core/src/hooks/index.ts
+++ b/app/packages/core/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { default as useRefetchableSavedViews } from "./useRefetchableSavedViews";
+export * from "./useSyncLabelsRenderingStatus";

--- a/app/packages/core/src/hooks/useSyncLabelsRenderingStatus.tsx
+++ b/app/packages/core/src/hooks/useSyncLabelsRenderingStatus.tsx
@@ -12,24 +12,13 @@ export const useSyncLabelsRenderingStatus = () => {
   const [_, setIsPanelUpdating] = usePanelLoading();
 
   useEffect(() => {
-    let animationId: ReturnType<typeof requestAnimationFrame>;
-
-    const sync = () => {
-      animationId = requestAnimationFrame(sync);
-
+    const unsub = jotaiStore.sub(numConcurrentRenderingLabels, () => {
       const count = jotaiStore.get(numConcurrentRenderingLabels);
-
-      if (count > 0) {
-        setIsPanelUpdating(true);
-      } else {
-        setIsPanelUpdating(false);
-      }
-    };
-
-    animationId = requestAnimationFrame(sync);
+      setIsPanelUpdating(count > 0);
+    });
 
     return () => {
-      cancelAnimationFrame(animationId);
+      unsub();
     };
   }, [setIsPanelUpdating]);
 };

--- a/app/packages/looker/src/lookers/abstract.ts
+++ b/app/packages/looker/src/lookers/abstract.ts
@@ -114,7 +114,7 @@ export abstract class AbstractLooker<
   sampleOverlays: Overlay<State>[];
   pluckedOverlays: Overlay<State>[];
 
-  protected asyncLabelsRenderingManager: AsyncLabelsRenderingManager;
+  public asyncLabelsRenderingManager: AsyncLabelsRenderingManager;
 
   constructor(
     sample: S,

--- a/app/packages/looker/src/worker/async-labels-rendering-manager.ts
+++ b/app/packages/looker/src/worker/async-labels-rendering-manager.ts
@@ -109,6 +109,7 @@ const assignJobToFreeWorker = (job: AsyncLabelsRenderingJob) => {
     job.reject(new Error(error.message));
     processingSamples.delete(job.sample);
     freeWorkers.push(worker);
+    updateRenderingCount(-1);
     processQueue();
   };
 
@@ -162,9 +163,9 @@ const assignJobToFreeWorker = (job: AsyncLabelsRenderingJob) => {
   );
   const transfer = retrieveTransferables(filteredOverlays);
 
-  updateRenderingCount(1);
-
   worker.postMessage(workerArgs, transfer);
+
+  updateRenderingCount(1);
 };
 
 export class AsyncLabelsRenderingManager {

--- a/app/packages/state/src/jotai/index.ts
+++ b/app/packages/state/src/jotai/index.ts
@@ -1,1 +1,8 @@
+import { atom } from "jotai";
+
+/**
+ * Number of concurrently rendering labels.
+ */
+export const numConcurrentRenderingLabels = atom(0);
+
 export * from "./jotai-store";


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR builds up on #5356 by adding a global loading indicator (a spinner) in grid panel title to show rendering status for asynchronous rendering of dense labels.

Note: This only works for the grid, although it can be extended to the modal easily, too. It makes sense to implement it for the modal in a separate PR.

![loading-indicator_small](https://github.com/user-attachments/assets/781fef55-0ca3-46b6-82bc-8c7b276beded)


## How is this patch tested? If it is not, please explain why.

- Smoke tested locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced label rendering feedback across the interface. Users will now experience more responsive panel loading and smoother updates when viewing grids and related components.
  - Improved background processing for label updates, ensuring that visual elements remain current and interactions are more fluid.
  - New functionality to track the number of concurrently rendering labels, improving overall performance and responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->