### PR TITLE
chore(docs): Fix deprecation notice

### DIFF
--- a/docs/source/deprecation.rst
+++ b/docs/source/deprecation.rst
@@ -42,5 +42,5 @@ MongoDB 4.4
 
 `MongoDB 4.4 <https://www.mongodb.com/legal/support-policy/lifecycles>`_
 transitioned to `end-of-life` effective February of 2024. FiftyOne 
-releases after March 1, 2024 might no longer be compatible with
+releases after March 1, 2025 might no longer be compatible with
 MongoDB 4.4 and older.


### PR DESCRIPTION
## What changes are proposed in this pull request?

The mongoDB 4.4 deprecation notice was merged in previously. However, the year was wrong. It was 2024 and should be 2025.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the deprecation notice to extend MongoDB 4.4 support until after March 1, 2025, providing clearer compatibility guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->