### PR TITLE
fix bug where custom defined colorscale wasn't being applied in heatmap tooltip

### DIFF
--- a/app/packages/looker/src/overlays/heatmap.ts
+++ b/app/packages/looker/src/overlays/heatmap.ts
@@ -178,7 +178,21 @@ export default class HeatmapOverlay<State extends BaseState>
         stop,
         state.options.coloring.scale.length
       );
-      return index < 0 ? 0 : get32BitColor(state.options.coloring.scale[index]);
+
+      if (index < 0) {
+        return 0;
+      }
+
+      // first check if we have a predefined colorscale for this field
+      const fieldSetting = state.options.colorscale.fields?.find(
+        (x) => x.path === this.field
+      );
+
+      if (fieldSetting?.rgb?.length) {
+        return get32BitColor(fieldSetting.rgb[index]);
+      }
+
+      return get32BitColor(state.options.coloring.scale[index]);
     }
 
     const color = getColor(

--- a/app/packages/looker/src/state.ts
+++ b/app/packages/looker/src/state.ts
@@ -33,7 +33,7 @@ export type ColorscaleInput = {
   path?: string;
   name?: string;
   list?: [];
-  rgb?: [RGB[]];
+  rgb?: RGB[];
 };
 
 export type Colorscale = {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Heatmap's `getColor` method should first read values from overridden per-field colorscale before global settings.

## How is this patch tested? If it is not, please explain why.

Local.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The heatmap overlay now delivers enhanced visualization by leveraging field-specific color scales for more accurate and visually appealing color mapping.
  
- **Refactor**
  - The color configuration format has been streamlined to simplify settings and improve consistency across visualizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->