### PR TITLE
chore: update Dockerfile to handle multiple python versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,12 +31,23 @@ ARG PYTHON_VERSION=3.11
 FROM python:${PYTHON_VERSION} AS builder
 ARG PIP_INDEX_URL=https://pypi.org/simple
 
+# default: use local wheel
+#
 COPY dist dist
 
 RUN pip --no-cache-dir install -q -U pip setuptools wheel \
     && pip wheel --wheel-dir=/wheels \
         dist/*.whl \
         ipython
+
+# server: use published pypi package
+#
+# ARG FO_VERSION
+# ENV FO_VERSION=${FO_VERSION}
+# RUN pip --no-cache-dir install -q -U pip setuptools wheel \
+#     && pip wheel --wheel-dir=/wheels \
+#         fiftyone==${FO_VERSION} \
+#         ipython
 
 #
 # Other packages you might want to add to the list above:
@@ -87,16 +98,17 @@ RUN --mount=type=cache,from=builder,target=/builder,ro \
     /builder/wheels/*
 
 #
-# Default, interactive, behavior
+# default: interactive, behavior
 #
-
 CMD [ "ipython" ]
 
-# Use this if want the default behavior to launch the App instead
+# server: Launch the App
+#
 # EXPOSE 5151
 # CMD [ \
 #     "python", \
-#     ".fiftyone-venv/lib/python3.11/site-packages/fiftyone/server/main.py", \
+#     "-m", \
+#     "fiftyone.server.main", \
 #     "--port", \
 #     "5151" \
 #     ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # Copyright 2017-2025, Voxel51, Inc.
 # voxel51.com
 #
-# Dockerfile for building a FiftyOne image atop a Python 3.11 base image
+# Dockerfile for building a FiftyOne image atop a Python base image as defined
+#  by the PYTHON_VERSION build-arg
 #
 # ARGs::
 #


### PR DESCRIPTION
## What changes are proposed in this pull request?

A long time ago, in a galaxy pretty close to this one, we made some hard-coded decisions that weren't great, but got us where we needed to be that day.  This change goes back and makes things a little cleaner and easier to automate.

Today's original goal was to change:
```
-# CMD [ \
-#     "python", \
-#     ".fiftyone-venv/lib/python3.11/site-packages/fiftyone/server/main.py", \
-#     "--port", \
-#     "5151" \
-#     ]
```
to 
```
+CMD [ \
+    "python", \
+    "-m", \
+    "fiftyone.server.main", \
+    "--port", \
+    "5151" \
+    ]
```
So the server would run regardless of the python version...  things have, sorta gotten out of hand...

## How is this patch tested? If it is not, please explain why.

### Test OSS Default Builds (Interactive, source)
```
❯ export RELEASE_VERSION=1.4.0.dev1
❯ make docker
❯ docker run -p 5151:5151 -it local/fiftyone fiftyone --version
FiftyOne v1.4.0.dev1, Voxel51, Inc.
❯ docker run -p 5151:5151 -it local/fiftyone
Python 3.11.11 (main, Feb  4 2025, 04:55:09) [GCC 12.2.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.32.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import fiftyone as fo

In [2]:
```

### Test server build from source artifact
```
❯ docker build -t local/fiftyone:${RELEASE_VERSION}-server --target server .
❯ docker run -p 5151:5151 -it local/fiftyone:${RELEASE_VERSION}-server fiftyone --version
FiftyOne v1.4.0.dev1, Voxel51, Inc.
❯ docker run -p 5151:5151 -it local/fiftyone:${RELEASE_VERSION}-server
[2025-02-20 00:47:14 +0000] [1] [INFO] Running on http://0.0.0.0:5151 (CTRL + C to quit)
```

### Test interactive build from released artifact
```
❯ docker build -t local/fiftyone:1.3.0-interactive --build-arg BUILD_TYPE=released --build-arg FO_VERSION=1.3.0 .
❯ docker run -it --rm local/fiftyone:1.3.0-interactive fiftyone --version
FiftyOne v1.3.0, Voxel51, Inc.
❯ docker run -it --rm -p 5151:5151 local/fiftyone:1.3.0-interactive
Python 3.11.11 (main, Feb  4 2025, 04:55:09) [GCC 12.2.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.32.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]:
```

### Test server build from released artifact
```
❯ docker build -t local/fiftyone:1.3.0-server --build-arg BUILD_TYPE=released --build-arg FO_VERSION=1.3.0 --target server .
❯ docker run -it --rm local/fiftyone:1.3.0-server fiftyone --version
FiftyOne v1.3.0, Voxel51, Inc.
❯ docker run -it --rm local/fiftyone:1.3.0-server
[2025-02-20 00:53:24 +0000] [1] [INFO] Running on http://0.0.0.0:5151 (CTRL + C to quit)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced flexible container build configurations, allowing selection between development and production setups.
  - Enhanced startup commands to ensure smoother server and interactive session launches.

- **Chores**
  - Streamlined and clarified build instructions to improve overall image construction and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->