### PR TITLE
add db migration for 1.4.0

### DIFF
--- a/fiftyone/migrations/revisions/v1_4_0.py
+++ b/fiftyone/migrations/revisions/v1_4_0.py
@@ -10,7 +10,6 @@ and a cleaner implementation.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-from pymongo import UpdateOne
 
 
 def up(db, dataset_name):

--- a/fiftyone/migrations/revisions/v1_4_0.py
+++ b/fiftyone/migrations/revisions/v1_4_0.py
@@ -1,6 +1,8 @@
 """
 FiftyOne v1.4.0 revision.
 
+In previous versions we used the run_link field in delegated operations to store the path to the log file. This revision migrates the data from the run_link field to the new log_path field allowing for the use of both fields and a cleaner implementation.
+
 | Copyright 2017-2025, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |

--- a/fiftyone/migrations/revisions/v1_4_0.py
+++ b/fiftyone/migrations/revisions/v1_4_0.py
@@ -1,0 +1,53 @@
+"""
+FiftyOne v1.4.0 revision.
+
+| Copyright 2017-2025, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+
+def up(db, dataset_name):
+    delegated_ops = _get_ops(db, dataset_name)
+
+    for op in delegated_ops:
+        run_link = op.get("run_link")
+
+        if (
+            run_link
+            and isinstance(run_link, str)
+            and run_link.endswith(".log")
+        ):
+            db.delegated_ops.update_one(
+                {"_id": op["_id"]},
+                {"$set": {"log_path": run_link, "run_link": None}},
+            )
+
+
+def down(db, dataset_name):
+    delegated_ops = _get_ops(db, dataset_name)
+
+    for op in delegated_ops:
+        log_path = op.get("log_path")
+
+        if (
+            log_path
+            and isinstance(log_path, str)
+            and log_path.endswith(".log")
+        ):
+            db.delegated_ops.update_one(
+                {"_id": op["_id"]},
+                {"$set": {"log_path": None, "run_link": log_path}},
+            )
+
+
+def _get_ops(db, dataset_name):
+    dataset = db.datasets.find_one({"name": dataset_name})
+    if not dataset:
+        return []
+
+    dataset_id = dataset.get("_id")
+    if not dataset_id:
+        return []
+
+    return db.delegated_ops.find({"dataset_id": dataset_id})

--- a/fiftyone/migrations/revisions/v1_4_0.py
+++ b/fiftyone/migrations/revisions/v1_4_0.py
@@ -1,7 +1,10 @@
 """
 FiftyOne v1.4.0 revision.
 
-In previous versions we used the run_link field in delegated operations to store the path to the log file. This revision migrates the data from the run_link field to the new log_path field allowing for the use of both fields and a cleaner implementation.
+In previous versions we used the run_link field in delegated operations to
+store the path to the log file. This revision migrates the data from the 
+run_link field to the new log_path field allowing for the use of both fields 
+and a cleaner implementation.
 
 | Copyright 2017-2025, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_


### PR DESCRIPTION
## What changes are proposed in this pull request?

As part of the scheduler v2 changes we are refactoring delegated operations so that run_link is no longer being repurposed for storing the log path and instead we will use the log_path field. 1.4 expect these fields to be populated accordingly so we need to do this migration if users upgrade to the new version.

## How is this patch tested? If it is not, please explain why.

Running 

```
fiftyone migrate --all --version 1.4.0 
```

Caused all delegated ops with a run_link ending in .log to move to log_path and set run_link to null. Using the same command above for a lower version like 1.3.0 caused the opposite to happen.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Introduced a migration update to refine the management of logging information for dataset operations.
  - Adjusted log reference handling to ensure consistency, with a reversible process to restore previous settings if necessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->