### PR TITLE
Pass custom label schema attribute keys to annotation backends

### DIFF
--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -955,11 +955,12 @@ def _format_attributes(backend, attributes):
         if not attr:
             attr = backend.recommend_attr_tool(name, None)
 
-        attr_type = attr.get("type", None)
-        values = attr.get("values", None)
-        default = attr.get("default", None)
-        mutable = attr.get("mutable", None)
-        read_only = attr.get("read_only", None)
+        _attr = attr.copy()
+        attr_type = _attr.get("type", None)
+        values = _attr.get("values", None)
+        default = _attr.get("default", None)
+        mutable = _attr.get("mutable", None)
+        read_only = _attr.get("read_only", None)
 
         if attr_type is None:
             raise ValueError(
@@ -978,7 +979,7 @@ def _format_attributes(backend, attributes):
                 )
             )
 
-        _attr = {"type": attr_type}
+        _attr["type"] = attr_type
 
         # Parse `values` property
         if values is not None:

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -955,12 +955,12 @@ def _format_attributes(backend, attributes):
         if not attr:
             attr = backend.recommend_attr_tool(name, None)
 
-        _attr = attr.copy()
-        attr_type = _attr.get("type", None)
-        values = _attr.get("values", None)
-        default = _attr.get("default", None)
-        mutable = _attr.get("mutable", None)
-        read_only = _attr.get("read_only", None)
+        _attr = deepcopy(attr)
+        attr_type = _attr.pop("type", None)
+        values = _attr.pop("values", None)
+        default = _attr.pop("default", None)
+        mutable = _attr.pop("mutable", None)
+        read_only = _attr.pop("read_only", None)
 
         if attr_type is None:
             raise ValueError(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Previously, the keys of attribute properties in an annotation label schema were filtered to only include a preconfigured set of values. For example, if you were to pass in this label schema:
```
{
  "gt": {
    "type": "detections", 
    "classes": [
      {
        "classes": ["c1"], 
        "attributes": {"a1": {"type": "select", "values": ["v1", "v2"], "otherattrf": "yes"}
  }
}
```
It would only pass along the "type" and "values" properties and remove the "otherattrf". This means that if a new annotation backend has custom attribute properties, there is no way to define those in the label schema.

## How is this patch tested? If it is not, please explain why.

The cvat, labelbox, and labelstudio tests were rerun and passed.

Printing the label schema from inside of an annotation backend now shows the custom attributes.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Annotation label schema attributes now support custom attributes for annotation backends.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the handling of attribute data to ensure original definitions remain unchanged, enhancing overall stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->