### PR TITLE
use category as xaxis type for per-class perf charts

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -1143,6 +1143,9 @@ export default function Evaluation(props: EvaluationProps) {
                       }
                       loadView("class", { x: points[0]?.x });
                     }}
+                    layout={{
+                      xaxis: { type: "category" },
+                    }}
                   />
                 )}
                 {classMode === "table" && (


### PR DESCRIPTION
## What changes are proposed in this pull request?

use category as xaxis type for per-class perf charts to avoid binning by plotly.js

## How is this patch tested? If it is not, please explain why.

Using the model evaluation panel with numerical class labels

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

use category as xaxis type for per-class perf charts

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced chart visuals by configuring the evaluation plots to interpret x-axis values as categorical, providing clearer, more intuitive displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->