### PR TITLE
disallow DOS set_queued in remote mode

### DIFF
--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -331,6 +331,10 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
                 }
             }
         elif run_state == ExecutionRunState.QUEUED:
+            if self.is_remote:
+                raise PermissionError(
+                    "Cannot set queued run_state in remote context"
+                )
             update = {
                 "$set": {
                     "run_state": run_state,

--- a/tests/unittests/operators/delegated_tests.py
+++ b/tests/unittests/operators/delegated_tests.py
@@ -1344,15 +1344,41 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self, mock_is_remote_service, mock_get_operator, mock_operator_exists
     ):
         db = delegated_operation.MongoDelegatedOperationRepo()
+        self.assertTrue(db.is_remote)
         dos = DelegatedOperationService(repo=db)
         ctx = ExecutionContext()
         ctx.request_params = {"foo": "bar"}
+
+        #####
         doc = dos.queue_operation(
             operator="@voxelfiftyone/operator/foo",
             label=mock_get_operator.return_value.name,
             delegation_target="test_target",
             context=ctx.serialize(),
         )
+        #####
+
         self.docs_to_delete.append(doc)
-        self.assertTrue(db.is_remote)
         self.assertEqual(doc.run_state, ExecutionRunState.SCHEDULED)
+
+    @patch.object(
+        delegated_operation,
+        "is_remote_service",
+        return_value=True,
+    )
+    def test_set_queue_remote_service(
+        self,
+        mock_is_remote_service,
+        mock_get_operator,
+        mock_operator_exists,
+    ):
+        mock_is_remote_service.return_value = True
+        db = delegated_operation.MongoDelegatedOperationRepo()
+        self.assertTrue(db.is_remote)
+        dos = DelegatedOperationService(repo=db)
+
+        op_id = bson.ObjectId()
+
+        #####
+        self.assertRaises(PermissionError, dos.set_queued, op_id)
+        #####


### PR DESCRIPTION
## What changes are proposed in this pull request?

disallow DOS set_queued in remote mode

## How is this patch tested? If it is not, please explain why.

added unit test
tested manually in Teams context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling for remote operations by preventing attempts to queue operations in unauthorized remote contexts. This update provides clearer feedback when such state changes are attempted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->