### PR TITLE
Model evaluation subsets backend

### DIFF
--- a/fiftyone/utils/eval/__init__.py
+++ b/fiftyone/utils/eval/__init__.py
@@ -7,6 +7,7 @@ Evaluation utilities.
 """
 import types
 
+from .base import get_subset_view
 from .classification import (
     evaluate_classifications,
     ClassificationEvaluationConfig,

--- a/fiftyone/utils/eval/base.py
+++ b/fiftyone/utils/eval/base.py
@@ -15,6 +15,7 @@ import numpy as np
 import sklearn.metrics as skm
 from tabulate import tabulate
 
+import fiftyone.core.collections as foc
 import fiftyone.core.evaluation as foe
 import fiftyone.core.fields as fof
 import fiftyone.core.plots as fop
@@ -538,8 +539,13 @@ class BaseClassificationResults(BaseEvaluationResults):
                 results.print_report(classes=classes)
 
         Args:
-            subset_def: a dict or list of dicts defining the subset. See above
-                for examples and see :func:`get_subset_view` for full syntax
+            subset_def: the subset definition, which can be:
+
+                -   a dict or list of dicts defining the subset. See above
+                    for examples and see :func:`get_subset_view` for full
+                    syntax
+                -   a :class:`fiftyone.core.view.DatasetView` defining the
+                    subset
 
         Returns:
             self
@@ -551,7 +557,10 @@ class BaseClassificationResults(BaseEvaluationResults):
             )
 
         gt_field = self.config.gt_field
-        subset_view = get_subset_view(self.samples, gt_field, subset_def)
+        if isinstance(subset_def, foc.SampleCollection):
+            subset_view = subset_def
+        else:
+            subset_view = get_subset_view(self.samples, gt_field, subset_def)
 
         self._samples_orig = self.samples
         self._ytrue_orig = self.ytrue

--- a/plugins/panels/model_evaluation/__init__.py
+++ b/plugins/panels/model_evaluation/__init__.py
@@ -15,10 +15,11 @@ import numpy as np
 
 from fiftyone import ViewField as F
 import fiftyone.core.fields as fof
+from fiftyone.core.plots.plotly import _to_log_colorscale
 from fiftyone.operators.categories import Categories
 from fiftyone.operators.panel import Panel, PanelConfig
-from fiftyone.core.plots.plotly import _to_log_colorscale
 import fiftyone.operators.types as types
+import fiftyone.utils.eval as foue
 
 
 STORE_NAME = "model_evaluation_panel_builtin"
@@ -577,6 +578,24 @@ class EvaluationPanel(Panel):
         y = view_options.get("y", None)
         field = view_options.get("field", None)
         missing = ctx.panel.get_state("missing", "(none)")
+
+        # Restrict to subset, if applicable
+        subset_name = view_state.get("subset_name", None)
+        if subset_name is not None:
+            subsets = ctx.panel.get_state("subsets")
+            subset_def = subsets.get(subset_name, None)
+
+            if isinstance(subset_def, tuple):
+                # Subset field
+                field, value = subset_def
+                eval_view = foue.get_subset_view(
+                    eval_view, gt_field, field=field, value=value
+                )
+            elif subset_def is not None:
+                # Subset expression
+                eval_view = foue.get_subset_view(
+                    eval_view, gt_field, expr=subset_def
+                )
 
         view = None
         if info.config.type == "classification":

--- a/plugins/panels/model_evaluation/__init__.py
+++ b/plugins/panels/model_evaluation/__init__.py
@@ -584,18 +584,7 @@ class EvaluationPanel(Panel):
         if subset_name is not None:
             subsets = ctx.panel.get_state("subsets")
             subset_def = subsets.get(subset_name, None)
-
-            if isinstance(subset_def, tuple):
-                # Subset field
-                field, value = subset_def
-                eval_view = foue.get_subset_view(
-                    eval_view, gt_field, field=field, value=value
-                )
-            elif subset_def is not None:
-                # Subset expression
-                eval_view = foue.get_subset_view(
-                    eval_view, gt_field, expr=subset_def
-                )
+            eval_view = foue.get_subset_view(eval_view, gt_field, subset_def)
 
         view = None
         if info.config.type == "classification":


### PR DESCRIPTION
## Change log

Adds support for computing metrics for subsets of a full set of evaluation results via a new `use_subset()` method.

## Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.random as four
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart")
four.random_split(dataset, {"sunny": 0.7, "cloudy": 0.2, "rainy": 0.1})

results = dataset.evaluate_detections(
    "predictions",
    gt_field="ground_truth",
    eval_key="eval",
)

counts = dataset.count_values("ground_truth.detections.label")
classes = sorted(counts, key=counts.get, reverse=True)[:5]

dataset.save_view("take100", dataset.take(100))

# Full results
results.print_report(classes=classes)

# Sunny samples
subset_def = dict(type="field", field="tags", value="sunny")
with results.use_subset(subset_def):
    results.print_report(classes=classes)

# Small objects
bbox_area = F("bounding_box")[2] * F("bounding_box")[3]
small_objects = bbox_area <= 0.05
subset_def = dict(type="attribute", expr=small_objects)
with results.use_subset(subset_def):
    results.print_report(classes=classes)

# Saved view
subset_def = dict(type="view", view="take100")
with results.use_subset(subset_def):
    results.print_report(classes=classes)

# Sunny samples + small objects
subset_def = [
    dict(type="field", field="tags", value="sunny"),
    dict(type="attribute", expr=small_objects),
]
with results.use_subset(subset_def):
    results.print_report(classes=classes)

# Random view + common samples
subset_def = [
    dict(type="view", view="take100"),
    dict(type="field", expr=F("uniqueness") < 0.25),
]
with results.use_subset(subset_def):
    results.print_report(classes=classes)
```

Full results:

```
              precision    recall  f1-score   support

      person       0.52      0.94      0.67       716
        kite       0.59      0.88      0.71       140
         car       0.18      0.80      0.29        61
        bird       0.65      0.78      0.71       110
      carrot       0.09      0.74      0.16        47

   micro avg       0.42      0.90      0.57      1074
   macro avg       0.41      0.83      0.51      1074
weighted avg       0.51      0.90      0.64      1074
```

Sunny samples:

```
              precision    recall  f1-score   support

      person       1.00      0.93      0.96       495
        kite       1.00      0.90      0.95        62
         car       1.00      0.69      0.81        35
        bird       1.00      0.78      0.88       104
      carrot       1.00      0.69      0.82        36

   micro avg       1.00      0.88      0.94       732
   macro avg       1.00      0.80      0.88       732
weighted avg       1.00      0.88      0.94       732
```

Small objects:

```
              precision    recall  f1-score   support

      person       1.00      0.87      0.93       324
        kite       1.00      0.76      0.87        72
         car       1.00      0.79      0.88        56
        bird       1.00      0.52      0.69        46
      carrot       1.00      0.75      0.86        40

   micro avg       1.00      0.81      0.89       538
   macro avg       1.00      0.74      0.84       538
weighted avg       1.00      0.81      0.89       538
```

Saved view:

```
              precision    recall  f1-score   support

      person       1.00      0.94      0.97       292
        kite       1.00      0.93      0.97        15
         car       1.00      0.87      0.93        15
        bird       1.00      0.35      0.52        23
      carrot       1.00      0.67      0.80         9

   micro avg       1.00      0.89      0.94       354
   macro avg       1.00      0.75      0.84       354
weighted avg       1.00      0.89      0.93       354
```

Sunny samples + small objects:

```
              precision    recall  f1-score   support

      person       1.00      0.85      0.92       227
        kite       1.00      0.87      0.93        45
         car       1.00      0.66      0.79        32
        bird       1.00      0.48      0.65        42
      carrot       1.00      0.71      0.83        31

   micro avg       1.00      0.79      0.88       377
   macro avg       1.00      0.71      0.82       377
weighted avg       1.00      0.79      0.87       377
```

Random view + common samples:

```
              precision    recall  f1-score   support

      person       1.00      0.93      0.97       107
        kite       1.00      0.93      0.97        15
         car       1.00      0.89      0.94         9
        bird       1.00      0.26      0.42        19
      carrot       0.00      0.00      0.00         0

   micro avg       1.00      0.85      0.92       150
   macro avg       0.80      0.60      0.66       150
weighted avg       1.00      0.85      0.90       150
```

## Example subsets

```py
subsets = {
    "sunny": dict(type="field", field="tags", value="sunny"),
    "cloudy": dict(type="field", field="tags", value="cloudy"),
    "rainy": dict(type="field", field="tags", value="rainy"),
}
```

```py
bbox_area = F("bounding_box")[2] * F("bounding_box")[3]
subsets = {
    "Small objects": dict(type="attribute", expr=bbox_area <= 0.05),
    "Medium objects": dict(type="attribute", expr=(0.05 <= bbox_area) & (bbox_area <= 0.5)),
    "Large objects": dict(type="attribute", expr=bbox_area > 0.5),
}
```

```py
bbox_area = F("bounding_box")[2] * F("bounding_box")[3]
subsets = {
    "Sunny small objects": [
        dict(type="field", field="tags", value="sunny"),
        dict(type="attribute", expr=0.05 <= bbox_area),
    ],
    "Rainy large objects": [
        dict(type="field", field="tags", value="rainy"),
        dict(type="attribute", expr=bbox_area > 0.1),
    ]
}
```

```py
subsets = {
    "Sunny unique objects": [
        dict(type="field", field="tags", value="sunny"),
        dict(type="field", expr=F("uniqueness") > 0.75),
    ],
    "Rainy common objects": [
        dict(type="field", field="tags", value="rainy"),
        dict(type="field", expr=F("uniqueness") < 0.25),
    ]
}
```

## Generating subset preview graph

`counts` is a dict that maps subset names to counts of ground truth labels that exist in each subset:

```py
counts = {}
for name, subset_def in subsets.items():
    with results.use_subset(subset_def):
        counts[name] = len(results.ytrue_ids)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced evaluation workflows by introducing dynamic subset management. Users can now filter, apply, and clear subsets of evaluation results for a more focused analysis.
  - Updated the evaluation panel to support saving, comparing, and visualizing evaluation subsets with improved parameter validation, providing a smoother review experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->