### PR TITLE
Modal tagging fixes

### DIFF
--- a/app/packages/core/src/components/Modal/use-looker.ts
+++ b/app/packages/core/src/components/Modal/use-looker.ts
@@ -29,14 +29,30 @@ function useLooker<L extends fos.Lookers>({
   );
   const selectedMediaField = useRecoilValue(fos.selectedMediaField(true));
   const colorScheme = useRecoilValue(fos.colorScheme);
+
+  // use a ref for sample data to prevent instance recreation
+  //
+  // sample updates via looker.updateSample(...) in ImaVidLookerReact,
+  // VideoLookerReact, and ModalLookerNoTimeline
+  const sampleRef = useRef(sample);
+  sampleRef.current = sample;
   const looker = React.useMemo(() => {
     /** start refreshers */
     reset;
     selectedMediaField;
     /** end refreshers */
 
-    return createLooker.current(sample);
-  }, [createLooker, reset, sample, selectedMediaField]) as L;
+    return createLooker.current(sampleRef.current);
+  }, [createLooker, reset, selectedMediaField]) as L;
+
+  useEffect(() => {
+    /** start refreshers */
+    colorScheme;
+    /** end refreshers */
+
+    !initialRef.current && looker.updateSample(sample.sample);
+  }, [colorScheme, looker, sample]);
+
   const handleError = useErrorHandler();
   const updateLookerOptions = useLookerOptionsUpdate();
 
@@ -50,14 +66,6 @@ function useLooker<L extends fos.Lookers>({
   useEffect(() => {
     !initialRef.current && looker.updateOptions(lookerOptions);
   }, [looker, lookerOptions]);
-
-  useEffect(() => {
-    /** start refreshers */
-    colorScheme;
-    /** end refreshers */
-
-    !initialRef.current && looker.updateSample(sample.sample);
-  }, [colorScheme, looker, sample]);
 
   useEffect(() => {
     initialRef.current = false;

--- a/app/packages/core/src/components/Modal/use-looker.ts
+++ b/app/packages/core/src/components/Modal/use-looker.ts
@@ -32,8 +32,7 @@ function useLooker<L extends fos.Lookers>({
 
   // use a ref for sample data to prevent instance recreation
   //
-  // sample updates via looker.updateSample(...) in ImaVidLookerReact,
-  // VideoLookerReact, and ModalLookerNoTimeline
+  // sample updates are handled via looker.updateSample(...)
   const sampleRef = useRef(sample);
   sampleRef.current = sample;
   const looker = React.useMemo(() => {

--- a/fiftyone/server/routes/tag.py
+++ b/fiftyone/server/routes/tag.py
@@ -19,7 +19,6 @@ from fiftyone.server.decorators import route
 from fiftyone.server.filters import GroupElementFilter, SampleFilter
 import fiftyone.server.tags as fost
 import fiftyone.server.utils as fosu
-import fiftyone.server.view as fosv
 
 
 class Tag(HTTPEndpoint):
@@ -96,7 +95,7 @@ class Tag(HTTPEndpoint):
         samples = []
         async for document in foo.aggregate(
             foo.get_async_db_conn()[view._dataset._sample_collection_name],
-            view._pipeline(attach_frames=is_video, detach_frames=is_video),
+            view._pipeline(attach_frames=is_video),
         ):
             samples.append(document)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes a regression that recreates looker instances after tagging. Recreating the instance means "resetting" all state for the user, e.g. resetting playback for video, or any zoom level

Also removes an incorrect `detach_frames` flag for the updated samples tagging response. Fixes a blank first frame issue after tagging (see "Before" recording)

### Before

https://github.com/user-attachments/assets/1b488606-ebf8-4955-8d31-dbbc65fe05aa

### After

https://github.com/user-attachments/assets/44bd49bf-8a70-45fb-8c9b-af553d708f96

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

* Fixed sample updates after tagging in the modal

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the modal interface by refining how sample data is updated and managed, ensuring smoother interactions and improved efficiency.
  - Streamlined video tagging by simplifying the pipeline configuration for frame processing, resulting in a more robust and consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->