### PR TITLE
use better heuristics for buffering in timeline

### DIFF
--- a/app/packages/core/src/components/Modal/ImaVidLooker.tsx
+++ b/app/packages/core/src/components/Modal/ImaVidLooker.tsx
@@ -1,6 +1,7 @@
 import { useTheme } from "@fiftyone/components";
 import { ImaVidLooker } from "@fiftyone/looker";
 import { FoTimelineConfig, useCreateTimeline } from "@fiftyone/playback";
+import { PLAYHEAD_STATE_PAUSED } from "@fiftyone/playback/src/lib/constants";
 import { useDefaultTimelineNameImperative } from "@fiftyone/playback/src/lib/use-default-timeline-name";
 import { Timeline } from "@fiftyone/playback/src/views/Timeline";
 import * as fos from "@fiftyone/state";
@@ -183,7 +184,10 @@ export const ImaVidLookerReact = React.memo(
               if (storeBufferManager.containsRange(unprocessedBufferRange)) {
                 // todo: change playhead state in setFrameNumberAtom and not here
                 // if done here, store ref to last playhead status
-                setPlayHeadState({ name: timelineName, state: "paused" });
+                setPlayHeadState({
+                  name: timelineName,
+                  state: PLAYHEAD_STATE_PAUSED,
+                });
                 resolve();
                 window.removeEventListener(
                   "fetchMore",

--- a/app/packages/core/src/components/Modal/ImaVidLooker.tsx
+++ b/app/packages/core/src/components/Modal/ImaVidLooker.tsx
@@ -1,20 +1,18 @@
 import { useTheme } from "@fiftyone/components";
 import { ImaVidLooker } from "@fiftyone/looker";
-import {
-  FoTimelineConfig,
-  useCreateTimeline,
-  useTimeline,
-} from "@fiftyone/playback";
+import type { FoTimelineConfig } from "@fiftyone/playback";
 import {
   PLAYHEAD_STATE_BUFFERING,
   PLAYHEAD_STATE_PAUSED,
   PLAYHEAD_STATE_PLAYING,
-} from "@fiftyone/playback/src/lib/constants";
-import { useDefaultTimelineNameImperative } from "@fiftyone/playback/src/lib/use-default-timeline-name";
+  useCreateTimeline,
+  useDefaultTimelineNameImperative,
+  useTimeline,
+} from "@fiftyone/playback";
 import { Timeline } from "@fiftyone/playback/src/views/Timeline";
 import * as fos from "@fiftyone/state";
 import { useEventHandler, useOnSelectLabel } from "@fiftyone/state";
-import { BufferRange } from "@fiftyone/utilities";
+import type { BufferRange } from "@fiftyone/utilities";
 import React, {
   useCallback,
   useEffect,

--- a/app/packages/playback/eslint.config.mjs
+++ b/app/packages/playback/eslint.config.mjs
@@ -16,4 +16,14 @@ export default [
     },
     rules: hooksPlugin.configs.recommended.rules,
   },
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+      "react/display-name": "off",
+    },
+  },
 ];

--- a/app/packages/playback/index.ts
+++ b/app/packages/playback/index.ts
@@ -1,3 +1,4 @@
+export * from "./src/lib/constants";
 export * from "./src/lib/state";
 export * from "./src/lib/use-create-timeline";
 export * from "./src/lib/use-default-timeline-name";

--- a/app/packages/playback/src/lib/constants.ts
+++ b/app/packages/playback/src/lib/constants.ts
@@ -7,3 +7,16 @@ export const GLOBAL_TIMELINE_ID = "fo-timeline-global";
 export const LOAD_RANGE_SIZE = 250;
 export const ATOM_FAMILY_CONFIGS_LRU_CACHE_SIZE = 100;
 export const SEEK_BAR_DEBOUNCE = 10;
+
+export const PLAYHEAD_STATE_PLAYING = "playing";
+export const PLAYHEAD_STATE_PAUSED = "paused";
+export const PLAYHEAD_STATE_BUFFERING = "buffering";
+export const PLAYHEAD_STATE_WAITING_TO_PLAY = "waitingToPlay";
+export const PLAYHEAD_STATE_WAITING_TO_PAUSE = "waitingToPause";
+
+export type PlayheadState =
+  | typeof PLAYHEAD_STATE_PLAYING
+  | typeof PLAYHEAD_STATE_PAUSED
+  | typeof PLAYHEAD_STATE_BUFFERING
+  | typeof PLAYHEAD_STATE_WAITING_TO_PLAY
+  | typeof PLAYHEAD_STATE_WAITING_TO_PAUSE;

--- a/app/packages/playback/src/lib/constants.ts
+++ b/app/packages/playback/src/lib/constants.ts
@@ -4,7 +4,7 @@ export const DEFAULT_SPEED = 1;
 export const DEFAULT_TARGET_FRAME_RATE = 30;
 export const DEFAULT_USE_TIME_INDICATOR = false;
 export const GLOBAL_TIMELINE_ID = "fo-timeline-global";
-export const LOAD_RANGE_SIZE = 250;
+export const MIN_LOAD_RANGE_SIZE = 350;
 export const ATOM_FAMILY_CONFIGS_LRU_CACHE_SIZE = 100;
 export const SEEK_BAR_DEBOUNCE = 10;
 

--- a/app/packages/playback/src/lib/state.test.ts
+++ b/app/packages/playback/src/lib/state.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vitest } from "vitest";
+import { getLoadRangeForFrameNumber } from "./state";
+
+vitest.mock("./constants", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./constants")>();
+  return {
+    ...actual,
+    MIN_LOAD_RANGE_SIZE: 5,
+    DEFAULT_TARGET_FRAME_RATE: 30,
+  };
+});
+
+describe("getLoadRangeForFrameNumber", () => {
+  it("returns correct range for a middle frame with default speed/targetFrameRate", () => {
+    const config = {
+      totalFrames: 100,
+      targetFrameRate: 30,
+      speed: 1,
+    };
+    // behindBuffer = 5
+    // baseAdaptiveBuffer = 5 * 1 * (30/30) = 5
+    // totalFramesFactor = ceil(100 * 0.02) = 2
+    // adaptiveAheadBuffer = max(5, ceil(5 + 2)) = 7
+    // => range = [50 - 5, 50 + 7] = [45, 57]
+    expect(getLoadRangeForFrameNumber(50, config)).toEqual([45, 57]);
+  });
+
+  it("returns correct range when near the beginning of the timeline", () => {
+    const config = {
+      totalFrames: 100,
+      targetFrameRate: 30,
+      speed: 1,
+    };
+    // frameNumber = 3:
+    // behindBuffer = 5 → initial min = 3 - 5 = -2
+    // adaptiveAheadBuffer = 7 (as above) → initial max = 3 + 7 = 10
+    // Since min < 1, extra = 1 - (-2) = 3, so final range = [1, 10 + 3] = [1, 13]
+    expect(getLoadRangeForFrameNumber(3, config)).toEqual([1, 13]);
+  });
+
+  it("returns correct range when near the end of the timeline", () => {
+    const config = {
+      totalFrames: 100,
+      targetFrameRate: 30,
+      speed: 1,
+    };
+    // frameNumber = 98:
+    // behindBuffer = 5 → initial min = 98 - 5 = 93
+    // adaptiveAheadBuffer = 7 → initial max = 98 + 7 = 105
+    // max > totalFrames, extra = 105 - 100 = 5, so adjust min = max(1, 93 - 5) = 88 and max = 100.
+    expect(getLoadRangeForFrameNumber(98, config)).toEqual([88, 100]);
+  });
+
+  it("returns correct range for custom speed and targetFrameRate", () => {
+    const config = {
+      totalFrames: 200,
+      targetFrameRate: 60,
+      speed: 2,
+    };
+    // frameNumber = 50:
+    // behindBuffer = 5 → min = 50 - 5 = 45
+    // baseAdaptiveBuffer = 5 * 2 * (60/30) = 20
+    // totalFramesFactor = ceil(200 * 0.02) = 4
+    // adaptiveAheadBuffer = max(5, ceil(20 + 4)) = 24
+    // => max = 50 + 24 = 74, range = [45, 74]
+    expect(getLoadRangeForFrameNumber(50, config)).toEqual([45, 74]);
+  });
+
+  it("returns full timeline range when timeline is very short", () => {
+    const config = {
+      totalFrames: 10,
+      targetFrameRate: 30,
+      speed: 1,
+    };
+    // frameNumber = 8:
+    // behindBuffer = 5 → min = 8 - 5 = 3
+    // baseAdaptiveBuffer = 5
+    // totalFramesFactor = ceil(10 * 0.02) = ceil(0.2) = 1
+    // adaptiveAheadBuffer = max(5, ceil(5 + 1)) = 6
+    // initial max = 8 + 6 = 14, then extra = 14 - 10 = 4, so final range = [max(1, 3 - 4), 10] = [1, 10]
+    expect(getLoadRangeForFrameNumber(8, config)).toEqual([1, 10]);
+  });
+
+  it("defaults speed and targetFrameRate when undefined", () => {
+    const config = {
+      totalFrames: 100,
+    };
+    // with defaults, the calculation is as in the first test.
+    expect(getLoadRangeForFrameNumber(50, config)).toEqual([45, 57]);
+  });
+
+  it("returns correct range when frameNumber is at the very start", () => {
+    const config = {
+      totalFrames: 100,
+      targetFrameRate: 30,
+      speed: 1,
+    };
+    // frameNumber = 1:
+    // behindBuffer = 5 → initial min = 1 - 5 = -4
+    // adaptiveAheadBuffer = 7 → initial max = 1 + 7 = 8
+    // min < 1, extra = 1 - (-4) = 5, adjust range to [1, 8 + 5] = [1, 13]
+    expect(getLoadRangeForFrameNumber(1, config)).toEqual([1, 13]);
+  });
+
+  it("returns correct range when frameNumber is at the very end", () => {
+    const config = {
+      totalFrames: 100,
+      targetFrameRate: 30,
+      speed: 1,
+    };
+    // frameNumber = 100:
+    // behindBuffer = 5 → min = 100 - 5 = 95
+    // adaptiveAheadBuffer = 7 → initial max = 100 + 7 = 107, then extra = 107 - 100 = 7,
+    // adjust min = max(1, 95 - 7) = 88, and set max = 100.
+    expect(getLoadRangeForFrameNumber(100, config)).toEqual([88, 100]);
+  });
+});

--- a/app/packages/playback/src/lib/use-create-timeline.ts
+++ b/app/packages/playback/src/lib/use-create-timeline.ts
@@ -15,7 +15,13 @@ import {
   setFrameNumberAtom,
   updatePlayheadStateAtom,
 } from "../lib/state";
-import { DEFAULT_FRAME_NUMBER } from "./constants";
+import {
+  DEFAULT_FRAME_NUMBER,
+  PLAYHEAD_STATE_BUFFERING,
+  PLAYHEAD_STATE_PAUSED,
+  PLAYHEAD_STATE_PLAYING,
+  PLAYHEAD_STATE_WAITING_TO_PAUSE,
+} from "./constants";
 import { useDefaultTimelineNameImperative } from "./use-default-timeline-name";
 import { getTimelineSetFrameNumberEventName } from "./utils";
 
@@ -102,11 +108,11 @@ export const useCreateTimeline = (
       return;
     }
 
-    if (playHeadState === "playing") {
+    if (playHeadState === PLAYHEAD_STATE_PLAYING) {
       startAnimation();
     }
 
-    if (playHeadState === "paused") {
+    if (playHeadState === PLAYHEAD_STATE_PAUSED) {
       cancelAnimation();
     }
 
@@ -221,8 +227,8 @@ export const useCreateTimeline = (
   const animate = useCallback(
     (newTime: DOMHighResTimeStamp) => {
       if (
-        playHeadStateRef.current === "paused" ||
-        playHeadStateRef.current === "waitingToPause"
+        playHeadStateRef.current === PLAYHEAD_STATE_PAUSED ||
+        playHeadStateRef.current === PLAYHEAD_STATE_WAITING_TO_PAUSE
       ) {
         cancelAnimation();
       }
@@ -304,7 +310,10 @@ export const useCreateTimeline = (
   );
 
   const startAnimation = useCallback(() => {
-    if (playHeadState === "paused" || playHeadState === "waitingToPause") {
+    if (
+      playHeadState === PLAYHEAD_STATE_PAUSED ||
+      playHeadState === PLAYHEAD_STATE_WAITING_TO_PAUSE
+    ) {
       cancelAnimation();
     }
 
@@ -368,11 +377,11 @@ export const useCreateTimeline = (
       const key = e.key.toLowerCase();
 
       if (key === " ") {
-        if (playHeadState === "buffering") {
+        if (playHeadState === PLAYHEAD_STATE_BUFFERING) {
           return;
         }
 
-        if (playHeadState === "paused") {
+        if (playHeadState === PLAYHEAD_STATE_PAUSED) {
           play();
         } else {
           pause();

--- a/app/packages/playback/src/lib/use-timeline.ts
+++ b/app/packages/playback/src/lib/use-timeline.ts
@@ -7,7 +7,6 @@ import {
   getFrameNumberAtom,
   getPlayheadStateAtom,
   getTimelineConfigAtom,
-  PlayheadState,
   SequenceTimelineSubscription,
   setFrameNumberAtom,
   TimelineName,
@@ -15,6 +14,7 @@ import {
   updateTimelineConfigAtom,
 } from "../lib/state";
 import { useDefaultTimelineNameImperative } from "./use-default-timeline-name";
+import { PlayheadState } from "./constants";
 
 /**
  * This hook provides access to the timeline with the given name.
@@ -97,6 +97,15 @@ export const useTimeline = (name?: TimelineName) => {
     );
   }, [timelineName]);
 
+  const getPlayHeadState = useAtomCallback(
+    useCallback(
+      (get) => {
+        return get(getPlayheadStateAtom(timelineName));
+      },
+      [timelineName]
+    )
+  );
+
   const setPlayHeadState = useCallback(
     (newState: PlayheadState) => {
       setPlayheadStateWrapper({ name: timelineName, state: newState });
@@ -132,6 +141,10 @@ export const useTimeline = (name?: TimelineName) => {
      * use the `useFrameNumber` hook.
      */
     getFrameNumber,
+    /**
+     * Imperative way to get the current playhead state of the timeline.
+     */
+    getPlayHeadState,
     /**
      * Dispatch a play event to the timeline.
      */

--- a/app/packages/playback/src/views/PlaybackElements.tsx
+++ b/app/packages/playback/src/views/PlaybackElements.tsx
@@ -3,7 +3,12 @@ import videoStyles from "@fiftyone/looker/src/elements/video.module.css";
 import { BufferRange, Buffers } from "@fiftyone/utilities";
 import React from "react";
 import styled from "styled-components";
-import { PlayheadState, TimelineName } from "../lib/state";
+import {
+  PLAYHEAD_STATE_PAUSED,
+  PLAYHEAD_STATE_PLAYING,
+  PlayheadState,
+} from "../lib/constants";
+import { TimelineName } from "../lib/state";
 import { convertFrameNumberToPercentage } from "../lib/use-timeline-viz-utils";
 import { getGradientStringForSeekbar } from "../lib/utils";
 import BufferingIcon from "./svgs/buffering.svg?react";
@@ -30,7 +35,7 @@ interface StatusIndicatorProps {
 export const Playhead = React.forwardRef<
   HTMLDivElement,
   PlayheadProps & React.HTMLProps<HTMLDivElement>
->(({ status, timelineName, play, pause, ...props }, ref) => {
+>(({ status, play, pause, ...props }, ref) => {
   const { className, ...otherProps } = props;
 
   return (
@@ -40,9 +45,10 @@ export const Playhead = React.forwardRef<
       className={`${className ?? ""} ${controlsStyles.lookerClickable}`}
       data-playhead-state={status}
     >
-      {status === "playing" && <PauseIcon onClick={pause} />}
-      {status === "paused" && <PlayIcon onClick={play} />}
-      {status !== "playing" && status !== "paused" && <BufferingIcon />}
+      {status === PLAYHEAD_STATE_PLAYING && <PauseIcon onClick={pause} />}
+      {status === PLAYHEAD_STATE_PAUSED && <PlayIcon onClick={play} />}
+      {status !== PLAYHEAD_STATE_PLAYING &&
+        status !== PLAYHEAD_STATE_PAUSED && <BufferingIcon />}
     </TimelineElementContainer>
   );
 });
@@ -53,6 +59,7 @@ export const Seekbar = React.forwardRef<
     loaded: Buffers;
     loading: BufferRange;
     debounce?: number;
+    style: React.CSSProperties;
     totalFrames: number;
     value: number;
     onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -68,7 +75,6 @@ export const Seekbar = React.forwardRef<
     onChange,
     onSeekStart,
     onSeekEnd,
-    debounce,
     style,
     className,
     ...otherProps
@@ -133,6 +139,7 @@ export const SeekbarThumb = React.forwardRef<
   React.HTMLProps<HTMLDivElement> & {
     shouldDisplayThumb: boolean;
     value: number;
+    style: React.CSSProperties;
   }
 >(({ shouldDisplayThumb, value, style, ...props }, ref) => {
   const progress = React.useMemo(() => Math.max(0, value - 0.5), [value]);
@@ -157,7 +164,10 @@ export const SeekbarThumb = React.forwardRef<
 
 export const Speed = React.forwardRef<
   HTMLDivElement,
-  SpeedProps & React.HTMLProps<HTMLDivElement>
+  SpeedProps &
+    React.HTMLProps<HTMLDivElement> & {
+      style: React.CSSProperties;
+    }
 >(({ speed, setSpeed, ...props }, ref) => {
   const { style, className, ...otherProps } = props;
 
@@ -220,6 +230,7 @@ export const StatusIndicator = React.forwardRef<
 
   return (
     <div
+      ref={ref}
       {...otherProps}
       className={`${className ?? ""} ${controlsStyles.lookerTime}`}
     >

--- a/app/packages/playback/src/views/PlaybackElements.tsx
+++ b/app/packages/playback/src/views/PlaybackElements.tsx
@@ -59,7 +59,7 @@ export const Seekbar = React.forwardRef<
     loaded: Buffers;
     loading: BufferRange;
     debounce?: number;
-    style: React.CSSProperties;
+    style?: React.CSSProperties;
     totalFrames: number;
     value: number;
     onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -139,7 +139,7 @@ export const SeekbarThumb = React.forwardRef<
   React.HTMLProps<HTMLDivElement> & {
     shouldDisplayThumb: boolean;
     value: number;
-    style: React.CSSProperties;
+    style?: React.CSSProperties;
   }
 >(({ shouldDisplayThumb, value, style, ...props }, ref) => {
   const progress = React.useMemo(() => Math.max(0, value - 0.5), [value]);
@@ -166,7 +166,7 @@ export const Speed = React.forwardRef<
   HTMLDivElement,
   SpeedProps &
     React.HTMLProps<HTMLDivElement> & {
-      style: React.CSSProperties;
+      style?: React.CSSProperties;
     }
 >(({ speed, setSpeed, ...props }, ref) => {
   const { style, className, ...otherProps } = props;

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
         "**/__generated__",
         "**/.yarn/**",
         "**/.storybook/**",
+        "node_modules",
       ],
     },
   },


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Uses total frames, frame rate, and speed as factors to determine look ahead range
- Instead of running `loadRange()` when we're stuck, do it preemptively
- Don't pause imavid unnecessarily
- Use constants for playhead status

Gif below shows imavid player on a "scene" with 10,000 500x500 frames. Note that frame numbers seem to be jumping ahead, but this is an artifact of gif sampling.


code: https://github.com/voxel51/dataset-forge/pull/2/files

![2025-02-24 15 21 30](https://github.com/user-attachments/assets/8f201524-7f37-433a-9448-34684025a729)


## How is this patch tested? If it is not, please explain why.

- Unit tests for look ahead range calculator
- Local smoke testing

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced playback experience with improved state management that accurately displays buffering, paused, and playing statuses.
  - Introduced flexible customization options for playback controls, including seekbar and speed indicators.
  - Adaptive load range calculations now provide smoother and more responsive media playback.

- **Bug Fixes**
  - Corrected play state transitions to ensure a more reliable and seamless playback experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->