### PR TITLE
Ensure runs remain associated will full datasets

### DIFF
--- a/fiftyone/core/odm/runs.py
+++ b/fiftyone/core/odm/runs.py
@@ -29,5 +29,5 @@ class RunDocument(Document):
     version = StringField()
     timestamp = DateTimeField()
     config = DictField()
-    view_stages = ListField(StringField())
+    view_stages = ListField(StringField(), default=None)
     results = FileField()


### PR DESCRIPTION
Updates the `register_run()` and `load_run_view()` interface so that runs that are performed on full datasets will still reflect this fact when `load_run_view()` is called later.

The example below demonstrates a real world application of this. Previously, the last assertion would fail because `load_run_view()` would return `dataset.view()` rather than `dataset`. Now the fact that the index was generated on the full dataset is preserved forever! 🎉

```py
import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
index = fob.compute_similarity(dataset, brain_key="img_sim")

# This was true, and it still is
assert index.samples is dataset

dataset.clear_cache()
index = dataset.load_brain_results("img_sim")

# This was previously false, but now is true
assert index.samples is dataset
```
