### PR TITLE
forward credentials in three-js loaders selectively

### DIFF
--- a/app/packages/looker-3d/src/fo3d/Background.tsx
+++ b/app/packages/looker-3d/src/fo3d/Background.tsx
@@ -1,5 +1,5 @@
 import { getSampleSrc } from "@fiftyone/state";
-import { useLoader, useThree } from "@react-three/fiber";
+import { useThree } from "@react-three/fiber";
 import { useEffect, useMemo } from "react";
 import {
   Color,
@@ -7,6 +7,7 @@ import {
   CubeTextureLoader,
   TextureLoader,
 } from "three";
+import { useFoLoader } from "../hooks/use-fo-loaders";
 import type { FoSceneBackground } from "../utils";
 
 interface Fo3dBackgroundProps {
@@ -24,7 +25,7 @@ const CubeBackground = ({
   // images are assumed to correspond to px, nx, py, ny, pz, and nz
   const imageUrls = useMemo(() => cube.map(getSampleSrc), [cube]);
   // @ts-ignore - types are wrong for CubeTextureLoader
-  const [cubeMap]: [CubeTexture] = useLoader(CubeTextureLoader, [imageUrls]);
+  const [cubeMap]: [CubeTexture] = useFoLoader(CubeTextureLoader, [imageUrls]);
 
   useEffect(() => {
     if (cubeMap) {
@@ -49,7 +50,7 @@ const ImageBackground = ({
 }) => {
   const { scene } = useThree();
   const imageUrl = useMemo(() => getSampleSrc(image), [image]);
-  const texture = useLoader(TextureLoader, imageUrl);
+  const texture = useFoLoader(TextureLoader, imageUrl);
 
   useEffect(() => {
     scene.background = texture;

--- a/app/packages/looker-3d/src/fo3d/mesh/Fbx.tsx
+++ b/app/packages/looker-3d/src/fo3d/mesh/Fbx.tsx
@@ -9,6 +9,7 @@ import { useMeshMaterialControls } from "../../hooks/use-mesh-material-controls"
 import { usePercolateMaterial } from "../../hooks/use-set-scene-transparency";
 import { useFo3dContext } from "../context";
 import { getBasePathForTextures, getResolvedUrlForFo3dAsset } from "../utils";
+import { useFoLoader } from "../../hooks/use-fo-loaders";
 
 export const Fbx = ({
   name,
@@ -41,7 +42,7 @@ export const Fbx = ({
 
   const { material } = useMeshMaterialControls(name, defaultMaterial, true);
 
-  const fbx = useLoader(FBXLoader, fbxUrl, (loader) => {
+  const fbx = useFoLoader(FBXLoader, fbxUrl, (loader) => {
     loader.setResourcePath(resourcePath);
   });
 

--- a/app/packages/looker-3d/src/fo3d/mesh/Obj.tsx
+++ b/app/packages/looker-3d/src/fo3d/mesh/Obj.tsx
@@ -14,6 +14,7 @@ import { useMeshMaterialControls } from "../../hooks/use-mesh-material-controls"
 import { getColorFromPoolBasedOnHash } from "../../utils";
 import { useFo3dContext } from "../context";
 import { getBasePathForTextures, getResolvedUrlForFo3dAsset } from "../utils";
+import { useFoLoader } from "../../hooks/use-fo-loaders";
 
 const ObjMeshDefaultMaterial = ({
   name,
@@ -35,7 +36,7 @@ const ObjMeshDefaultMaterial = ({
     [objPath, preTransformedObjPath, fo3dRoot]
   );
 
-  const mesh = useLoader(OBJLoader, objUrl);
+  const mesh = useFoLoader(OBJLoader, objUrl);
 
   const { material } = useMeshMaterialControls(name, obj.defaultMaterial);
 
@@ -94,12 +95,12 @@ const ObjMeshWithCustomMaterial = ({
     [fo3dRoot, mtlUrl]
   );
 
-  const materials = useLoader(MTLLoader, mtlUrl, (loader) => {
+  const materials = useFoLoader(MTLLoader, mtlUrl, (loader) => {
     if (resourcePath) {
       loader.setResourcePath(resourcePath);
     }
   });
-  const mesh = useLoader(OBJLoader, objUrl, (loader) => {
+  const mesh = useFoLoader(OBJLoader, objUrl, (loader) => {
     if (mtlUrl) {
       materials.preload();
       loader.setMaterials(materials);

--- a/app/packages/looker-3d/src/fo3d/mesh/Ply.tsx
+++ b/app/packages/looker-3d/src/fo3d/mesh/Ply.tsx
@@ -19,6 +19,7 @@ import { useMeshMaterialControls } from "../../hooks/use-mesh-material-controls"
 import { useFo3dContext } from "../context";
 import { usePcdMaterial } from "../point-cloud/use-pcd-material";
 import { getBasePathForTextures, getResolvedUrlForFo3dAsset } from "../utils";
+import { useFoLoader } from "../../hooks/use-fo-loaders";
 
 interface PlyProps {
   name: string;
@@ -150,7 +151,7 @@ export const Ply = ({
     [fo3dRoot, plyUrl]
   );
 
-  const geometry = useLoader(PLYLoader, plyUrl, (loader) => {
+  const geometry = useFoLoader(PLYLoader, plyUrl, (loader) => {
     loader.resourcePath = resourcePath;
   });
 

--- a/app/packages/looker-3d/src/fo3d/mesh/Stl.tsx
+++ b/app/packages/looker-3d/src/fo3d/mesh/Stl.tsx
@@ -7,6 +7,7 @@ import type { StlAsset } from "../../hooks";
 import { useMeshMaterialControls } from "../../hooks/use-mesh-material-controls";
 import { useFo3dContext } from "../context";
 import { getResolvedUrlForFo3dAsset } from "../utils";
+import { useFoLoader } from "../../hooks/use-fo-loaders";
 
 /**
  *  Renders a single STL mesh.
@@ -38,7 +39,7 @@ export const Stl = ({
     [stlPath, preTransformedStlPath, fo3dRoot]
   );
 
-  const points = useLoader(STLLoader, stlUrl);
+  const points = useFoLoader(STLLoader, stlUrl);
   const [mesh, setMesh] = useState(null);
 
   const { material } = useMeshMaterialControls(name, defaultMaterial);

--- a/app/packages/looker-3d/src/fo3d/point-cloud/Pcd.tsx
+++ b/app/packages/looker-3d/src/fo3d/point-cloud/Pcd.tsx
@@ -7,6 +7,7 @@ import type { PcdAsset } from "../../hooks";
 import { useFo3dContext } from "../context";
 import { getResolvedUrlForFo3dAsset } from "../utils";
 import { usePcdMaterial } from "./use-pcd-material";
+import { useFoLoader } from "../../hooks/use-fo-loaders";
 
 export const Pcd = ({
   name,
@@ -32,7 +33,7 @@ export const Pcd = ({
     [pcdPath, preTransformedPcdPath, fo3dRoot]
   );
 
-  const points_ = useLoader(PCDLoader, pcdUrl);
+  const points_ = useFoLoader(PCDLoader, pcdUrl);
 
   // todo: hack until https://github.com/pmndrs/react-three-fiber/issues/245 is fixed
   const points = useMemo(() => points_.clone(false), [points_]);

--- a/app/packages/looker-3d/src/hooks/use-fo-loaders.ts
+++ b/app/packages/looker-3d/src/hooks/use-fo-loaders.ts
@@ -1,0 +1,20 @@
+import { useLoader } from "@react-three/fiber";
+
+/**
+ * Decorates useLoader() to support credentials forwarding
+ */
+export const useFoLoader = (
+  loader: Parameters<typeof useLoader>[0],
+  urls: Parameters<typeof useLoader>[1],
+  loaderFunction?: Parameters<typeof useLoader>[2]
+) => {
+  return useLoader(loader, urls, (loader) => {
+    if (sessionStorage.getItem("customCredentialsAudience")?.length) {
+      loader.setWithCredentials(true);
+    }
+
+    if (loaderFunction) {
+      loaderFunction(loader);
+    }
+  });
+};

--- a/app/packages/looker-3d/src/renderables/pcd/index.tsx
+++ b/app/packages/looker-3d/src/renderables/pcd/index.tsx
@@ -17,6 +17,7 @@ import {
   ShadeByHeight,
   ShadeByIntensity,
 } from "./shaders";
+import { useFoLoader } from "../../hooks/use-fo-loaders";
 
 type PointCloudMeshArgs = {
   upVector: THREE.Vector3;
@@ -48,7 +49,7 @@ export const PointCloudMesh = ({
   rotation,
   onLoad,
 }: PointCloudMeshArgs) => {
-  const points = useLoader(PCDLoader, src);
+  const points = useFoLoader(PCDLoader, src);
 
   const [colorMinMax, setColorMinMax] = useState<ColorMinMax>({
     min: 0,


### PR DESCRIPTION
Make three.js loaders forward credentials in special cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an enhanced asset loading system across 3D visual components that now supports credentials forwarding. This update improves the reliability and consistency in loading textures, models, and point cloud data.

- **Refactor**
	- Consolidated the asset loading approach by replacing the previous loader with the new mechanism, streamlining the code and optimizing the overall fetch process for 3D assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->