### PR TITLE
Add rich thumbnails to README key feature videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,34 +423,34 @@ for more information.
     Easily explore images, videos, and associated labels in a powerful visual
     interface.
 
-https://github.com/user-attachments/assets/e6815108-aa4c-4021-a188-c93b3b75cc73
+https://github.com/user-attachments/assets/9dc2db88-967d-43fa-bda0-85e4d5ab6a7a
 
 -   **[Explore Embeddings:](https://docs.voxel51.com/user_guide/app.html#embeddings-panel)**
     Select points of interest and view the corresponding samples/labels.
 
-https://github.com/user-attachments/assets/261e2098-aace-4e5c-babb-d044d83a9a13
+https://github.com/user-attachments/assets/246faeb7-dcab-4e01-9357-e50f6b106da7
 
 -   **[Analyze and Improve Models:](https://docs.voxel51.com/user_guide/evaluation.html)**
     Evaluate model performance, identify failure modes, and fine-tune your
     models.
 
-https://github.com/user-attachments/assets/ef6ff28f-8f3e-4a0d-b172-07227559fa91
+https://github.com/user-attachments/assets/8c32d6c4-51e7-4fea-9a3c-2ffd9690f5d6
 
 -   **[Advanced Data Curation:](https://docs.voxel51.com/brain.html)** Quickly
     find and fix data issues, annotation errors, and edge cases.
 
-https://github.com/user-attachments/assets/95f65ffc-b3b0-428a-9d59-64d425e1fe74
+https://github.com/user-attachments/assets/24fa1960-c2dd-46ae-ae5f-d58b3b84cfe4
 
 -   **[Rich Integrations:](https://docs.voxel51.com/integrations/index.html)**
     Works with popular deep learning libraries like PyTorch, Hugging Face,
     Ultralytics, and more.
 
-https://github.com/user-attachments/assets/2e7e4046-5ec0-43b0-99c5-6cacd4743ed6
+https://github.com/user-attachments/assets/de5f25e1-a967-4362-9e04-616449e745e5
 
 -   **[Open and Extensible:](https://docs.voxel51.com/plugins/index.html)**
     Customize and extend FiftyOne to fit your specific needs.
 
-https://github.com/user-attachments/assets/7aa906c9-aab3-45c7-bd66-f388cac343e0
+https://github.com/user-attachments/assets/c7ed496d-0cf7-45d6-9853-e349f1abd6f8
 
 <div id='additional-resources'>
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds social-style thumbnails to the videos under the Key Features section of README.

## How is this patch tested? If it is not, please explain why.

n/a

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated resource links in the documentation to ensure access to the current URLs for exploring complex datasets, embeddings, model analysis, data curation, integrations, and extensible features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->