### PR TITLE
add do log file size

### DIFF
--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -126,6 +126,12 @@ class DelegatedOperationRepo(object):
             "subclass must implement set_log_upload_error()"
         )
 
+    def set_log_size(
+        self, _id: ObjectId, log_size: int
+    ) -> DelegatedOperationDocument:
+        """Sets the log size for the delegated operation."""
+        raise NotImplementedError("subclass must implement set_log_size()")
+
     def get(self, _id: ObjectId) -> DelegatedOperationDocument:
         """Get an operation by id."""
         raise NotImplementedError("subclass must implement get()")
@@ -261,6 +267,16 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
         doc = self._collection.find_one_and_update(
             filter={"_id": _id},
             update={"$set": {"log_upload_error": log_upload_error}},
+            return_document=pymongo.ReturnDocument.AFTER,
+        )
+        return DelegatedOperationDocument().from_pymongo(doc)
+
+    def set_log_size(
+        self, _id: ObjectId, log_size: int
+    ) -> DelegatedOperationDocument:
+        doc = self._collection.find_one_and_update(
+            filter={"_id": _id},
+            update={"$set": {"log_size": log_size}},
             return_document=pymongo.ReturnDocument.AFTER,
         )
         return DelegatedOperationDocument().from_pymongo(doc)

--- a/fiftyone/factory/repos/delegated_operation_doc.py
+++ b/fiftyone/factory/repos/delegated_operation_doc.py
@@ -57,6 +57,7 @@ class DelegatedOperationDocument(object):
         self._doc = None
         self.metadata = None
         self.log_upload_error = None
+        self.log_size = None
         self.log_path = None
 
     def from_pymongo(self, doc: dict):
@@ -75,6 +76,7 @@ class DelegatedOperationDocument(object):
         self.dataset_id = doc.get("dataset_id", None)
         self.run_link = doc.get("run_link", None)
         self.log_upload_error = doc.get("log_upload_error", None)
+        self.log_size = doc.get("log_size", None)
         self.log_path = doc.get("log_path", None)
         self.metadata = doc.get("metadata", None)
         self.label = doc.get("label", None)

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -276,6 +276,18 @@ class DelegatedOperationService(object):
             _id=doc_id, log_upload_error=log_upload_error
         )
 
+    def set_log_size(self, doc_id, log_size):
+        """Sets the log size for the given delegated operation.
+
+        Args:
+            doc_id: the ID of the delegated operation
+            log size: the size of the log file for the given delegated operation.
+
+        Returns:
+            a :class:`fiftyone.factory.repos.DelegatedOperationDocument`
+        """
+        return self._repo.set_log_size(_id=doc_id, log_size=log_size)
+
     def delete_operation(self, doc_id):
         """Deletes the given delegated operation.
 


### PR DESCRIPTION

## What changes are proposed in this pull request?

Adding a log size field to DOs so that we can optionally provide a log size on upload to be returned by the backend if present. If the log size isn't present in the backend we will attempt to fetch it from the cloud storage location (less efficient but still works in cases where X customer has a custom log file but isn't storing that size in mongo like we are).

## How is this patch tested? If it is not, please explain why.

Ran executor locally and then tested that log file sizes were reflected / stored in mongodb:

<img width="740" alt="Screenshot 2025-02-27 at 9 50 49 PM" src="https://github.com/user-attachments/assets/dc129550-a89b-4a02-9c37-b98db279e89d" />

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
