### PR TITLE
fix infinite initialization of dynamic io fields

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/AutocompleteView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/AutocompleteView.tsx
@@ -25,7 +25,7 @@ export default function AutocompleteView(props) {
         disabled={readOnly}
         autoHighlight
         clearOnBlur={multiple}
-        defaultValue={getDefaultValue(data, choices)}
+        defaultValue={getDefaultValue(data, choices, multiple)}
         freeSolo={allowUserInput}
         size="small"
         onChange={(e, choice) => {
@@ -40,6 +40,9 @@ export default function AutocompleteView(props) {
             valuesOnly,
             multiple
           );
+          if (multiple && Array.isArray(changedValue) && !changedValue.length) {
+            onChange(path, null);
+          }
           onChange(path, changedValue);
           setUserChanged();
         }}
@@ -94,7 +97,13 @@ export default function AutocompleteView(props) {
 
 // TODO: move these functions to a utils file
 
-function getDefaultValue(defaultValue, choices = []) {
+function getDefaultValue(defaultValue, choices = [], multiple) {
+  if (multiple) {
+    if (Array.isArray(defaultValue)) {
+      return defaultValue;
+    }
+    return [];
+  }
   const choice = choices.find(({ value }) => value === defaultValue);
   return choice || defaultValue;
 }

--- a/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
@@ -1,7 +1,7 @@
 import { PluginComponentType, useActivePlugins } from "@fiftyone/plugins";
 import { isNullish } from "@fiftyone/utilities";
 import { get, isEqual, set } from "lodash";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { isPathUserChanged } from "../hooks";
 import {
   getComponent,
@@ -72,7 +72,9 @@ function useStateInitializer(props: ViewPropsType) {
   const { data, onChange } = props;
   const computedSchema = getComputedSchema(props);
   const { default: defaultValue } = computedSchema;
+  const hasInitialized = useRef(false);
   const shouldInitialize = useMemo(() => {
+    if (hasInitialized.current) return false;
     return !isCompositeView(computedSchema) && isEditableView(computedSchema);
   }, [computedSchema]);
   const basicData = useMemo(() => {
@@ -92,6 +94,7 @@ function useStateInitializer(props: ViewPropsType) {
       !isNullish(defaultValue) &&
       !isInitialized(props)
     ) {
+      hasInitialized.current = true;
       onChange(path, defaultValue, computedSchema);
     }
   }, [defaultValue, onChange, unboundState]);

--- a/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
@@ -1,6 +1,6 @@
 import { PluginComponentType, useActivePlugins } from "@fiftyone/plugins";
 import { isNullish } from "@fiftyone/utilities";
-import { get, isEqual, set } from "lodash";
+import { get, has, isEqual, set } from "lodash";
 import { useEffect, useMemo, useRef } from "react";
 import { isPathUserChanged } from "../hooks";
 import {
@@ -76,7 +76,7 @@ function useStateInitializer(props: ViewPropsType) {
   const shouldInitialize = useMemo(() => {
     if (hasInitialized.current) return false;
     return !isCompositeView(computedSchema) && isEditableView(computedSchema);
-  }, [computedSchema]);
+  }, [computedSchema, hasInitialized]);
   const basicData = useMemo(() => {
     if (shouldInitialize) {
       return data;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes an issue that shows up when using the following `fiftyone.operators.type`:

```
inputs = types.Object()
inputs.list(
    "things",
    types.String(),
    label="List of things"
    view=types.AutocompleteView(multiple=True),
)
```

See this [issue](https://github.com/voxel51/fiftyone-plugins/issues/208) for details.

## How is this patch tested? If it is not, please explain why.

Tested using the `edit_dataset_info` operator.

## Release Notes

Fixed an issue with list fields causing a "Maximum update depth exceeded" react error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the behavior of autocomplete inputs for multi-select, ensuring accurate default settings and improved handling when no selections are made.
  
- **Refactor**
	- Optimized the initialization flow in dynamic input components to ensure that setup occurs only once, enhancing overall stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->