### PR TITLE
Hide sidebar sorting option for Query Performance

### DIFF
--- a/app/packages/core/src/components/Actions/Options.tsx
+++ b/app/packages/core/src/components/Actions/Options.tsx
@@ -14,6 +14,11 @@ const SortFilterResults = ({ modal }) => {
   const [{ count, asc }, setSortFilterResults] = useRecoilState(
     fos.sortFilterResults(modal)
   );
+  const queryPerformance = useRecoilValue(fos.queryPerformance);
+  if (queryPerformance) {
+    // sidebar sorting is not configurable
+    return null;
+  }
 
   return (
     <>


### PR DESCRIPTION
## What changes are proposed in this pull request?

Resolves #5530

## Release Notes

* Remove incorrectly shown sidebar sorting option when :ref:`Query Performance <app-optimizing-query-performance>` is enabled

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The results view now conditionally hides sorting options when performance conditions are met, streamlining the interface during heavy query operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->