### PR TITLE
Fix session's selected labels

### DIFF
--- a/tests/unittests/session_events_tests.py
+++ b/tests/unittests/session_events_tests.py
@@ -1,5 +1,5 @@
 """
-FiftyOne session-related unit tests.
+FiftyOne session events-related unit tests.
 
 | Copyright 2017-2025, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
@@ -11,7 +11,6 @@ import unittest
 
 from dacite import from_dict
 
-import fiftyone as fo
 from fiftyone.core.state import StateDescription
 from fiftyone.core.session.session import _on_select_labels
 from fiftyone.core.session.events import SelectLabels

--- a/tests/unittests/session_tests.py
+++ b/tests/unittests/session_tests.py
@@ -1,0 +1,49 @@
+"""
+FiftyOne session-related unit tests.
+
+| Copyright 2017-2025, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from dataclasses import asdict
+import unittest
+
+from dacite import from_dict
+
+import fiftyone as fo
+from fiftyone.core.state import StateDescription
+from fiftyone.core.session.session import _on_select_labels
+from fiftyone.core.session.events import SelectLabels
+
+from decorators import drop_datasets
+
+
+class SessionTests(unittest.TestCase):
+    @drop_datasets
+    def test_select_labels(self):
+        state = StateDescription()
+        event = from_dict(
+            SelectLabels,
+            dict(
+                labels=[
+                    {
+                        "label_id": "0" * 24,
+                        "field": "ground_truth",
+                        "sample_id": "0" * 24,
+                        "frame_number": None,
+                    }
+                ]
+            ),
+        )
+
+        _on_select_labels(state, event)
+        self.assertListEqual(
+            state.selected_labels, [asdict(data) for data in event.labels]
+        )
+
+        _on_select_labels(
+            state,
+            SelectLabels([]),
+        )
+        self.assertListEqual(state.selected_labels, [])


### PR DESCRIPTION
## What changes are proposed in this pull request?

Resolves the below for the `Session` class
```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
session = fo.launch_app(dataset)

# Select some label(s) in the App...

# Problem 1
assert isinstance(session.selected_labels[0], dict)

# Problem 2
# currently raises an error, but shouldn't
session.tag_selected_labels("test")

# Problem 3
# currently raises an error when labels are selected, but shouldn't
session.refresh()
``` 

## How is this patch tested? If it is not, please explain why.

Initial session test

## Release Notes

* Fixed :attr:`Session.selected_labels <fiftyone.core.session.Session.selected_labels>` events

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the handling of label selections to ensure a consistent and robust session state when selecting labels.
- **Tests**
  - Added new tests that verify the correctness of label selection functionality, including handling scenarios with and without selected labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->