### PR TITLE
Looker cache "frozen" fixes

### DIFF
--- a/app/packages/core/src/components/Grid/useRenderer.ts
+++ b/app/packages/core/src/components/Grid/useRenderer.ts
@@ -58,14 +58,12 @@ export default function ({
         throw new Error("bad data");
       }
 
-      const looker: fos.Lookers =
-        cache.getFrozen(key) ??
-        createLooker.current?.(
-          { ...result, symbol: id },
-          {
-            fontSize: getFontSize(),
-          }
-        );
+      const looker: fos.Lookers = createLooker.current?.(
+        { ...result, symbol: id },
+        {
+          fontSize: getFontSize(),
+        }
+      );
 
       looker.addEventListener("selectthumbnail", ({ detail }) =>
         selectSample.current?.(detail)
@@ -74,9 +72,9 @@ export default function ({
         cache.isShown(key) &&
           spotlight.sizeChange(key, looker.getSizeBytesEstimate());
       });
+
       cache.set(key, looker);
       looker.attach(element, dimensions);
-
       return cache.sizeOf(key);
     },
     [cache, createLooker, getFontSize, selectSample, store]

--- a/app/packages/looker/src/cache.test.ts
+++ b/app/packages/looker/src/cache.test.ts
@@ -1,4 +1,3 @@
-import { act } from "@testing-library/react-hooks";
 import { describe, expect, it } from "vitest";
 import { createCache } from "./cache";
 
@@ -14,38 +13,71 @@ describe("useLookerCache", () => {
       maxHiddenItems: 2,
       maxHiddenItemsSizeBytes: 2,
     });
+    expect(cache.frozen.size).toBe(0);
     expect(cache.hidden.size).toBe(0);
+    expect(cache.hidden.calculatedSize).toBe(0);
     expect(cache.pending.size).toBe(0);
     expect(cache.shown.size).toBe(0);
-    expect(cache.hidden.calculatedSize).toBe(0);
 
-    act(() => {
-      const looker = new Looker();
-      cache.set("one", looker);
-    });
-
+    cache.set("one", new Looker());
+    expect(cache.isShown("one")).toBe(true);
+    expect(cache.frozen.size).toBe(0);
     expect(cache.hidden.size).toBe(0);
+    expect(cache.hidden.calculatedSize).toBe(0);
     expect(cache.pending.size).toBe(0);
     expect(cache.shown.size).toBe(1);
-    expect(cache.hidden.calculatedSize).toBe(0);
 
     cache.hide("one");
-
+    expect(cache.isShown("one")).toBe(false);
+    expect(cache.frozen.size).toBe(0);
     expect(cache.hidden.size).toBe(0);
+    expect(cache.hidden.calculatedSize).toBe(0);
     expect(cache.pending.size).toBe(1);
     expect(cache.shown.size).toBe(0);
-    expect(cache.hidden.calculatedSize).toBe(0);
 
-    const looker = cache.get("one");
-    if (!looker) {
-      throw new Error("looker is missing");
-    }
-
+    const looker = cache.get("one")!;
+    looker.loaded = true;
     looker.dispatchEvent(new Event("load"));
-
+    expect(cache.isShown("one")).toBe(false);
+    expect(cache.frozen.size).toBe(0);
     expect(cache.hidden.size).toBe(1);
+    expect(cache.hidden.calculatedSize).toBe(1);
     expect(cache.pending.size).toBe(0);
     expect(cache.shown.size).toBe(0);
+
+    cache.freeze();
+    expect(cache.isShown("one")).toBe(false);
+    expect(cache.frozen.size).toBe(0);
+    expect(cache.hidden.size).toBe(1);
     expect(cache.hidden.calculatedSize).toBe(1);
+    expect(cache.pending.size).toBe(0);
+    expect(cache.shown.size).toBe(0);
+
+    cache.show("one");
+    expect(cache.isShown("one")).toBe(true);
+    cache.freeze();
+    expect(cache.isShown("one")).toBe(false);
+    expect(cache.frozen.size).toBe(1);
+    expect(cache.hidden.size).toBe(0);
+    expect(cache.hidden.calculatedSize).toBe(0);
+    expect(cache.pending.size).toBe(0);
+    expect(cache.shown.size).toBe(0);
+
+    cache.set("one", looker);
+    expect(cache.isShown("one")).toBe(true);
+    expect(cache.frozen.size).toBe(0);
+    expect(cache.hidden.size).toBe(0);
+    expect(cache.hidden.calculatedSize).toBe(0);
+    expect(cache.pending.size).toBe(0);
+    expect(cache.shown.size).toBe(1);
+
+    cache.freeze();
+    cache.unfreeze();
+    expect(cache.isShown("one")).toBe(false);
+    expect(cache.frozen.size).toBe(0);
+    expect(cache.hidden.size).toBe(1);
+    expect(cache.hidden.calculatedSize).toBe(1);
+    expect(cache.pending.size).toBe(0);
+    expect(cache.shown.size).toBe(0);
   });
 });

--- a/app/packages/spotlight/src/index.ts
+++ b/app/packages/spotlight/src/index.ts
@@ -326,6 +326,10 @@ export default class Spotlight<K, V> extends EventTarget {
     measure: Measure<K, V>;
     zooming?: boolean;
   }) {
+    if (this.#aborter.signal.aborted) {
+      return;
+    }
+
     if (go && offset !== false) {
       this.#forward.top = this.#pivot + this.#config.offset;
       this.#backward.top = this.#config.offset;
@@ -469,7 +473,7 @@ export default class Spotlight<K, V> extends EventTarget {
       }
     );
 
-    if (this.#loaded) {
+    if (this.#loaded && !this.#aborter.signal.aborted) {
       this.dispatchEvent(new Load(this.#config.key));
     }
   }


### PR DESCRIPTION
## What changes are proposed in this pull request?

The "frozen" intermediary looker cache state is important when creating a new `Spotlight` (layout). Previously shown instances are frozen during this transition, which marks them as neither shown, hidden, nor pending. Pending is a not yet loaded yet hidden instance

Fixes state transitions for these frozen instances. See recording for an issue currently on `develop` related to these transitions


https://github.com/user-attachments/assets/f404dfcf-dc23-4d4f-8e52-e400db7b729b

## How is this patch tested? If it is not, please explain why.

Unit tests

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined rendering and state management for a more consistent and reliable display.
- **Bug Fixes**
	- Enhanced cancellation handling to prevent unintended actions during aborted operations.

These improvements contribute to a smoother and more stable user experience without altering any public features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->