### PR TITLE
fix tooltip and make label render status hidden field

### DIFF
--- a/app/packages/core/src/components/Grid/useUpdates.ts
+++ b/app/packages/core/src/components/Grid/useUpdates.ts
@@ -23,7 +23,7 @@ const handleNewOverlays = (entry: fos.Lookers, newFields: string[]) => {
     if (overlay.label) {
       // "pending" means we're marking this label for rendering or
       // painting, even if it's interrupted, say by unchecking sidebar
-      overlay.label.renderStatus = RENDER_STATUS_PAINTING;
+      overlay.label._renderStatus = RENDER_STATUS_PAINTING;
     }
   }
 
@@ -38,7 +38,7 @@ const handleChangedOverlays = (entry: fos.Lookers) => {
       continue;
     }
 
-    if (overlay?.label?.renderStatus !== RENDER_STATUS_PAINTING) {
+    if (overlay?.label?._renderStatus !== RENDER_STATUS_PAINTING) {
       continue;
     }
 

--- a/app/packages/looker/src/overlays/base.ts
+++ b/app/packages/looker/src/overlays/base.ts
@@ -20,7 +20,7 @@ export interface BaseLabel {
   frame_number?: number;
   tags: string[];
   index?: number;
-  renderStatus?: DenseLabelRenderStatus;
+  _renderStatus?: DenseLabelRenderStatus;
 }
 
 export interface PointInfo<Label extends BaseLabel = BaseLabel> {

--- a/app/packages/looker/src/overlays/detection.ts
+++ b/app/packages/looker/src/overlays/detection.ts
@@ -45,7 +45,7 @@ export default class DetectionOverlay<
   }
 
   containsPoint(state: Readonly<State>): CONTAINS {
-    if ((this.label.mask || this.label.mask_path) && this.label.mask?.data) {
+    if ((this.label.mask || this.label.mask_path) && !this.label.mask?.data) {
       return CONTAINS.NONE;
     }
 
@@ -113,6 +113,7 @@ export default class DetectionOverlay<
   }
 
   getPointInfo(state: Readonly<State>): PointInfo<DetectionLabel> {
+    console.log(">>>getPointInfo", this.label);
     return {
       color: this.getColor(state),
       field: this.field,

--- a/app/packages/looker/src/overlays/detection.ts
+++ b/app/packages/looker/src/overlays/detection.ts
@@ -65,18 +65,18 @@ export default class DetectionOverlay<
   }
 
   draw(ctx: CanvasRenderingContext2D, state: Readonly<State>): void {
-    // renderstatus is guaranteed to be undefined when there is no mask_path
+    // _renderStatus is guaranteed to be undefined when there is no mask_path
     // so if render status is not null, means there's a mask
     // we want to couple rendering of mask with bbox
     // so we return if render status is truthy and there's no mask
     // meaning mask is being processed
-    if (this.label.renderStatus && !this.label.mask) {
+    if (this.label._renderStatus && !this.label.mask) {
       return;
     }
 
     if (
       this.label.mask?.bitmap?.width &&
-      this.label.renderStatus === RENDER_STATUS_PAINTED
+      this.label._renderStatus === RENDER_STATUS_PAINTED
     ) {
       this.drawMask(ctx, state);
     }
@@ -113,7 +113,6 @@ export default class DetectionOverlay<
   }
 
   getPointInfo(state: Readonly<State>): PointInfo<DetectionLabel> {
-    console.log(">>>getPointInfo", this.label);
     return {
       color: this.getColor(state),
       field: this.field,

--- a/app/packages/looker/src/worker/deserializer.ts
+++ b/app/packages/looker/src/worker/deserializer.ts
@@ -26,7 +26,7 @@ export const DeserializerFactory = {
         image: new ArrayBuffer(width * height * 4),
       };
       buffers.push(data.buffer);
-      label.renderStatus = RENDER_STATUS_DECODED;
+      label._renderStatus = RENDER_STATUS_DECODED;
     }
   },
   Detections: (labels, buffers) => {
@@ -37,10 +37,10 @@ export const DeserializerFactory = {
 
     const allLabelsDecoded =
       list.length > 0 &&
-      list.every((label) => label.renderStatus === RENDER_STATUS_DECODED);
+      list.every((label) => label._renderStatus === RENDER_STATUS_DECODED);
 
     if (allLabelsDecoded) {
-      labels.renderStatus = RENDER_STATUS_DECODED;
+      labels._renderStatus = RENDER_STATUS_DECODED;
     }
   },
   Heatmap: (label, buffers) => {
@@ -56,7 +56,7 @@ export const DeserializerFactory = {
       };
 
       buffers.push(data.buffer);
-      label.renderStatus = RENDER_STATUS_DECODED;
+      label._renderStatus = RENDER_STATUS_DECODED;
     }
   },
   Segmentation: (label, buffers) => {
@@ -72,7 +72,7 @@ export const DeserializerFactory = {
       };
 
       buffers.push(data.buffer);
-      label.renderStatus = RENDER_STATUS_DECODED;
+      label._renderStatus = RENDER_STATUS_DECODED;
     }
   },
 };

--- a/app/packages/looker/src/worker/disk-overlay-decoder.ts
+++ b/app/packages/looker/src/worker/disk-overlay-decoder.ts
@@ -142,7 +142,7 @@ export const decodeOverlayOnDisk = async (
     image: new ArrayBuffer(overlayWidth * overlayHeight * 4),
   } as IntermediateMask;
 
-  label.renderStatus = RENDER_STATUS_DECODED;
+  label._renderStatus = RENDER_STATUS_DECODED;
 
   // no need to transfer image's buffer
   //since we'll be constructing ImageBitmap and transfering that

--- a/app/packages/looker/src/worker/index.ts
+++ b/app/packages/looker/src/worker/index.ts
@@ -67,12 +67,12 @@ const shouldProcessLabel = ({
 }) => {
   // check if it has a valid render status, in which case it takes precendence over activePaths
   // it means this label was processed before and we should re-render it
-  const currentLabelRenderStatus = label?.renderStatus;
+  const currentLabel_renderStatus = label?._renderStatus;
 
   if (
-    currentLabelRenderStatus === RENDER_STATUS_PAINTED ||
-    currentLabelRenderStatus === RENDER_STATUS_DECODED ||
-    currentLabelRenderStatus === RENDER_STATUS_PENDING
+    currentLabel_renderStatus === RENDER_STATUS_PAINTED ||
+    currentLabel_renderStatus === RENDER_STATUS_DECODED ||
+    currentLabel_renderStatus === RENDER_STATUS_PENDING
   ) {
     return true;
   }
@@ -153,7 +153,7 @@ const processLabels = async (
           }
         } else {
           // we'll process this label asynchronously later
-          label.renderStatus = null;
+          label._renderStatus = null;
         }
       }
 
@@ -250,7 +250,7 @@ const processLabels = async (
     }
 
     for (const label of labels) {
-      if (label?.renderStatus !== "painted") {
+      if (label?._renderStatus !== "painted") {
         continue;
       }
 

--- a/app/packages/looker/src/worker/painter.ts
+++ b/app/packages/looker/src/worker/painter.ts
@@ -30,7 +30,7 @@ export const PainterFactory = (requestColor) => ({
     if (!label?.mask) {
       return;
     }
-    label.renderStatus = RENDER_STATUS_PAINTING;
+    label._renderStatus = RENDER_STATUS_PAINTING;
 
     const setting = customizeColorSetting?.find((s) => s.path === field);
     let color;
@@ -144,7 +144,7 @@ export const PainterFactory = (requestColor) => ({
       }
     }
 
-    label.renderStatus = RENDER_STATUS_PAINTED;
+    label._renderStatus = RENDER_STATUS_PAINTED;
   },
   Detections: async (
     field,
@@ -159,7 +159,7 @@ export const PainterFactory = (requestColor) => ({
       return;
     }
 
-    labels.renderStatus = RENDER_STATUS_PAINTING;
+    labels._renderStatus = RENDER_STATUS_PAINTING;
 
     const promises = labels.detections.map((label) =>
       PainterFactory(requestColor).Detection(
@@ -175,7 +175,7 @@ export const PainterFactory = (requestColor) => ({
 
     await Promise.all(promises);
 
-    labels.renderStatus = RENDER_STATUS_PAINTED;
+    labels._renderStatus = RENDER_STATUS_PAINTED;
   },
   Heatmap: async (
     field,
@@ -253,7 +253,7 @@ export const PainterFactory = (requestColor) => ({
       overlay[i] = r;
     }
 
-    label.renderStatus = RENDER_STATUS_PAINTED;
+    label._renderStatus = RENDER_STATUS_PAINTED;
   },
   Segmentation: async (
     field,
@@ -267,7 +267,7 @@ export const PainterFactory = (requestColor) => ({
     if (!label?.mask) {
       return;
     }
-    label.renderStatus = RENDER_STATUS_PAINTING;
+    label._renderStatus = RENDER_STATUS_PAINTING;
 
     // the actual overlay that'll be painted, byte-length of width * height * 4 (RGBA channels)
     const overlay = new Uint32Array(label.mask.image);
@@ -401,7 +401,7 @@ export const PainterFactory = (requestColor) => ({
       }
     }
 
-    label.renderStatus = RENDER_STATUS_PAINTED;
+    label._renderStatus = RENDER_STATUS_PAINTED;
   },
 });
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Fix detection tooltip `containsPoint()` logic
- Prepend `_` in `renderStatus` so that it's not shown to the user. This is an internal implementation detail.

## How is this patch tested? If it is not, please explain why.

- https://github.com/voxel51/dataset-forge/blob/main/masks-correctness.py

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?


-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.
### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the internal handling of overlay and label rendering states for enhanced visual consistency.
- **Bug Fix**
  - Revised the evaluation logic for overlay interactions to ensure accurate mask detection and more reliable rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->