### PR TITLE
fix: wrong check for has_mask

### DIFF
--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -1304,7 +1304,7 @@ class COCOObject(object):
             x, y, w, h = label.bounding_box
             bbox = [x * width, y * height, w * width, h * height]
 
-            if label.has_mask is not None:
+            if label.has_mask:
                 segmentation = _instance_to_coco_segmentation(
                     label, frame_size, iscrowd=iscrowd, tolerance=tolerance
                 )
@@ -2116,7 +2116,7 @@ def _coco_objects_to_detections(
         )
 
         if detection is not None and (
-            not load_segmentations or detection.has_mask is not None
+            not load_segmentations or detection.has_mask
         ):
             detections.append(detection)
 

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -6455,7 +6455,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     }
                 )
             elif label_type in ("instance", "instances"):
-                if det.has_mask is None:
+                if not det.has_mask:
                     continue
 
                 if self._server_version >= Version("2.3"):


### PR DESCRIPTION
## What changes are proposed in this pull request?

I was importing the `CrowdHuman` Dataset and export it to the `COCODetectionDataset` which take me more than 2 hours. 😨 So confused! So I profiled the exporting progress and found out that more than 90% of the time is spent on the `_instance_to_coco_segmentation` call, but the `CrowdHuman` doesn't have mask. The reason is that the `has_mask` property of the `Label` returns `bool` result, but the `coco.py` and `cvat.py` still checking it with `None`, which always result in `True`.

This modification change the exporting time from 2hrs+ to 2min in the CrowdHuman dataset.

## How is this patch tested? If it is not, please explain why.

I have test it on the `CrowdHuman` dataset, which is imported and export to `COCODetectionDataset`

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
