### PR TITLE
add ability to rename evaluation in model eval panel

### DIFF
--- a/app/packages/components/src/components/EditableLabel/index.tsx
+++ b/app/packages/components/src/components/EditableLabel/index.tsx
@@ -1,0 +1,104 @@
+import {
+  CancelOutlined,
+  Close,
+  EditOutlined,
+  SaveOutlined,
+} from "@mui/icons-material";
+import {
+  Box,
+  CircularProgress,
+  IconButton,
+  Stack,
+  TextField,
+  Typography,
+  TypographyProps,
+} from "@mui/material";
+import React, { useState } from "react";
+
+export default function EditableLabel(props: EditableLabelProps) {
+  const {
+    label,
+    onSave,
+    onCancel,
+    labelProps = {},
+    saving,
+    showEditIcon = true,
+  } = props;
+  const [mode, setMode] = useState<"view" | "edit">("view");
+  const [updatedLabel, setUpdatedLabel] = useState(label);
+
+  return (
+    <Stack direction="row" spacing={0.5} alignItems="center">
+      {mode === "view" && <Typography {...labelProps}>{label}</Typography>}
+      {mode === "edit" && (
+        <TextField
+          defaultValue={label}
+          size="small"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          onChange={(e) => setUpdatedLabel(e.target.value)}
+          InputProps={{
+            endAdornment: (
+              <Stack direction="row" alignItems="center">
+                {saving ? (
+                  <CircularProgress size={16} />
+                ) : (
+                  <>
+                    <IconButton
+                      size="small"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        setMode("view");
+                        onCancel();
+                      }}
+                    >
+                      <CancelOutlined sx={{ fontSize: 16 }} />
+                    </IconButton>
+                    <IconButton
+                      size="small"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        setMode("view");
+                        onSave(updatedLabel);
+                      }}
+                    >
+                      <SaveOutlined sx={{ fontSize: 16 }} />
+                    </IconButton>
+                  </>
+                )}
+              </Stack>
+            ),
+          }}
+          sx={{ backgroundColor: "#191919" }}
+        />
+      )}
+      {mode === "view" && (
+        <IconButton
+          size="small"
+          sx={{ opacity: showEditIcon ? 1 : 0, transition: "opacity 0.3s" }}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setMode("edit");
+          }}
+        >
+          <EditOutlined sx={{ fontSize: 16 }} />
+        </IconButton>
+      )}
+    </Stack>
+  );
+}
+
+type EditableLabelProps = {
+  label: string;
+  onSave: (newLabel: string) => void;
+  onCancel: () => void;
+  showEditIcon?: boolean;
+  labelProps?: TypographyProps;
+  saving?: boolean;
+  mode?: "view" | "edit";
+};

--- a/app/packages/components/src/components/index.ts
+++ b/app/packages/components/src/components/index.ts
@@ -40,5 +40,6 @@ export { default as ThemeProvider, useFont, useTheme } from "./ThemeProvider";
 export { default as Tooltip } from "./Tooltip";
 export { default as Toast } from "./Toast";
 export { default as PanelCTA } from "./PanelCTA";
+export { default as EditableLabel } from "./EditableLabel";
 
 export * from "./types";

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -1,4 +1,4 @@
-import { Dialog } from "@fiftyone/components";
+import { Dialog, EditableLabel } from "@fiftyone/components";
 import { editingFieldAtom, view } from "@fiftyone/state";
 import {
   ArrowBack,
@@ -70,6 +70,7 @@ export default function Evaluation(props: EvaluationProps) {
     setNoteEvent,
     notes = {},
     loadView,
+    onRename,
   } = props;
   const theme = useTheme();
   const [expanded, setExpanded] = React.useState("summary");
@@ -535,7 +536,12 @@ export default function Evaluation(props: EvaluationProps) {
             <ArrowBack />
           </IconButton>
           <EvaluationIcon type={evaluationType} method={evaluationMethod} />
-          <Typography>{name}</Typography>
+          <EditableLabel
+            label={name}
+            onSave={(newLabel) => {
+              onRename(name, newLabel);
+            }}
+          />
         </Stack>
         <Stack direction="row" spacing={2} sx={{ alignItems: "center" }}>
           <Status
@@ -1643,6 +1649,7 @@ type EvaluationProps = {
   setNoteEvent: string;
   notes: Record<string, string>;
   loadView: (type: string, params: any) => void;
+  onRename: (oldName: string, newName: string) => void;
 };
 
 function ColorSquare(props: { color: string }) {

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Overview.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Overview.tsx
@@ -1,4 +1,4 @@
-import { LoadingDots } from "@fiftyone/components";
+import { EditableLabel, LoadingDots } from "@fiftyone/components";
 import { Card, CardActionArea, Chip, Stack, Typography } from "@mui/material";
 import React from "react";
 import Evaluate from "./Evaluate";
@@ -20,6 +20,7 @@ export default function Overview(props: OverviewProps) {
     notes = {},
     permissions = {},
     pending_evaluations,
+    onRename,
   } = props;
   const count = evaluations.length;
 
@@ -52,6 +53,7 @@ export default function Overview(props: OverviewProps) {
             type={type}
             method={method}
             onSelect={onSelect}
+            onRename={onRename}
           />
         );
       })}
@@ -73,10 +75,30 @@ export default function Overview(props: OverviewProps) {
 }
 
 function EvaluationCard(props: EvaluationCardProps) {
-  const { pending, onSelect, eval_key, note, status, id, type, method } = props;
+  const {
+    pending,
+    onSelect,
+    eval_key,
+    note,
+    status,
+    id,
+    type,
+    method,
+    onRename,
+  } = props;
+  const [hovering, setHovering] = React.useState(false);
 
   return (
-    <CardActionArea key={eval_key} disabled={pending}>
+    <CardActionArea
+      key={eval_key}
+      disabled={pending}
+      onMouseEnter={() => {
+        setHovering(true);
+      }}
+      onMouseLeave={() => {
+        setHovering(false);
+      }}
+    >
       <Card
         sx={{ p: 2, cursor: "pointer" }}
         onClick={() => {
@@ -93,9 +115,14 @@ function EvaluationCard(props: EvaluationCardProps) {
               type={type as ConcreteEvaluationType}
               method={method}
             />
-            <Typography sx={{ fontSize: 16, fontWeight: 600 }}>
-              {eval_key}
-            </Typography>
+            <EditableLabel
+              label={eval_key}
+              labelProps={{ sx: { fontSize: 16, fontWeight: 600 } }}
+              onSave={(newName) => {
+                onRename(eval_key, newName);
+              }}
+              showEditIcon={hovering}
+            />
           </Stack>
           {pending && (
             <Chip

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Types.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Types.tsx
@@ -6,6 +6,7 @@ export type OverviewProps = {
   notes?: Record<string, string>;
   permissions?: Record<string, boolean>;
   pending_evaluations: PendingEvaluationType[];
+  onRename: (oldName: string, newName: string) => void;
 };
 
 export type EvaluationType = {
@@ -33,6 +34,7 @@ export type EvaluationCardProps = {
   onSelect: OverviewProps["onSelect"];
   pending?: boolean;
   status?: string;
+  onRename: OverviewProps["onRename"];
 };
 
 export type ConcreteEvaluationType =

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/index.tsx
@@ -20,6 +20,7 @@ export default function NativeModelEvaluationView(props) {
     set_status,
     set_note,
     load_view,
+    rename_evaluation,
   } = view;
   const {
     evaluations = [],
@@ -57,6 +58,29 @@ export default function NativeModelEvaluationView(props) {
       triggerEvent(on_evaluate_model);
     }
   }, [triggerEvent, on_evaluate_model]);
+  const onRename = useCallback(
+    (old_name: string, new_name: string) => {
+      triggerEvent(
+        rename_evaluation,
+        { old_name, new_name },
+        false,
+        (results) => {
+          if (results?.error === null) {
+            const updatedEvaluations = evaluations.map((evaluation) => {
+              if (evaluation.key === old_name) {
+                return { ...evaluation, key: new_name };
+              }
+            });
+            onChange("evaluations", updatedEvaluations);
+            if (page === "evaluation") {
+              onChange("view.key", new_name);
+            }
+          }
+        }
+      );
+    },
+    [triggerEvent, rename_evaluation, evaluations, onChange]
+  );
 
   return (
     <Box sx={{ height: "100%" }}>
@@ -84,6 +108,7 @@ export default function NativeModelEvaluationView(props) {
           loadView={(type, options) => {
             triggerEvent(load_view, { type, options });
           }}
+          onRename={onRename}
         />
       )}
       {page === "overview" &&
@@ -125,6 +150,7 @@ export default function NativeModelEvaluationView(props) {
             notes={notes}
             permissions={permissions}
             pending_evaluations={pending_evaluations}
+            onRename={onRename}
           />
         ))}
     </Box>

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/utils.ts
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/utils.ts
@@ -7,8 +7,13 @@ export function useTriggerEvent() {
   const handleEvent = usePanelEvent();
 
   const triggerEvent = useCallback(
-    (event: string, params?: any, prompt?: boolean) => {
-      handleEvent(panelId, { operator: event, params, prompt });
+    (event: string, params?: any, prompt?: boolean, callback?: any) => {
+      handleEvent(panelId, {
+        operator: event,
+        params,
+        prompt,
+        callback,
+      });
     },
     [handleEvent, panelId]
   );

--- a/plugins/panels/model_evaluation/__init__.py
+++ b/plugins/panels/model_evaluation/__init__.py
@@ -65,6 +65,7 @@ class EvaluationPanel(Panel):
             "can_evaluate": True,
             "can_edit_note": True,
             "can_edit_status": True,
+            "can_rename": True,
         }
 
     def can_evaluate(self, ctx):
@@ -75,6 +76,9 @@ class EvaluationPanel(Panel):
 
     def can_edit_status(self, ctx):
         return self.get_permissions(ctx).get("can_edit_status", False)
+
+    def can_rename(self, ctx):
+        return self.get_permissions(ctx).get("can_rename", False)
 
     def on_load(self, ctx):
         store = self.get_store(ctx)
@@ -194,6 +198,35 @@ class EvaluationPanel(Panel):
         store.set("notes", notes)
         ctx.panel.set_data("notes", notes)
         ctx.ops.notify(f"Note updated successfully!", variant="success")
+
+    def rename_evaluation(self, ctx):
+        if not self.can_rename(ctx):
+            ctx.ops.notify(
+                "You do not have permission to rename this evaluation",
+                variant="error",
+            )
+            return
+        old_name = ctx.params.get("old_name", None)
+        new_name = ctx.params.get("new_name", None)
+        try:
+            ctx.dataset.rename_evaluation(old_name, new_name)
+            view_state = ctx.panel.get_state("view") or {}
+            eval_id = view_state.get("id")
+            store = self.get_store(ctx)
+            evaluation_data = store.get(eval_id)
+            if evaluation_data:
+                evaluation_data["info"]["name"] = new_name
+                evaluation_data["info"]["key"] = new_name
+                store.set(eval_id, evaluation_data, ttl=CACHE_TTL)
+            ctx.ops.notify(
+                f"Renamed evaluation '{old_name}' to '{new_name}' successfully!",
+                variant="success",
+            )
+        except Exception as e:
+            ctx.ops.notify(
+                f"Failed to rename evaluation '{old_name}' to '{new_name}'",
+                variant="error",
+            )
 
     def load_evaluation_view(self, ctx):
         view_state = ctx.panel.get_state("view") or {}
@@ -702,6 +735,7 @@ class EvaluationPanel(Panel):
                 set_status=self.set_status,
                 set_note=self.set_note,
                 load_view=self.load_view,
+                rename_evaluation=self.rename_evaluation,
             ),
         )
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

add ability to rename evaluation in model eval panel

## How is this patch tested? If it is not, please explain why.

Using the model evaluation panel's new rename flow

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

add ability to rename evaluation in model eval panel

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an inline editable label that lets users switch between viewing and editing modes seamlessly.
	- Enabled direct renaming of evaluations from the interface, complete with visual status indicators and hover-triggered edit icons.
	- Added permission checks to ensure only authorized users can rename evaluations, enhancing security and user control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->