### PR TITLE
cleanup DO tests and fix divergence

### DIFF
--- a/tests/unittests/operators/delegated_tests.py
+++ b/tests/unittests/operators/delegated_tests.py
@@ -161,10 +161,6 @@ class MockProgressiveOperatorWithOutputs(MockGeneratorOperator):
 
 
 @patch(
-    "fiftyone.operators.registry.OperatorRegistry.operator_exists",
-    return_value=True,
-)
-@patch(
     "fiftyone.operators.registry.OperatorRegistry.get_operator",
     return_value=MockOperator(),
 )
@@ -172,11 +168,22 @@ class DelegatedOperationServiceTests(unittest.TestCase):
     _should_fail = False
 
     def setUp(self):
+        self.mock_is_remote_service = patch.object(
+            delegated_operation,
+            "is_remote_service",
+            return_value=False,
+        ).start()
+
+        self.mock_operator_exists = patch(
+            "fiftyone.operators.registry.OperatorRegistry.operator_exists",
+            return_value=True,
+        ).start()
         self.docs_to_delete = []
         self.svc = DelegatedOperationService()
 
     def tearDown(self):
         self.delete_test_data()
+        patch.stopall()
 
     def delete_test_data(self):
         with patch.object(
@@ -193,9 +200,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
     @patch(
         "fiftyone.core.odm.utils.load_dataset",
     )
-    def test_delegate_operation(
-        self, mock_load_dataset, mock_get_operator, mock_operator_exists
-    ):
+    def test_delegate_operation(self, mock_load_dataset, mock_get_operator):
         dataset_id = ObjectId()
         dataset_name = f"test_dataset_{dataset_id}"
         mock_load_dataset.return_value.name = dataset_name
@@ -229,7 +234,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.assertEqual(doc2.run_state, ExecutionRunState.QUEUED)
         self.assertEqual(doc2.metadata, doc2_metadata)
 
-    def test_list_operations(self, mock_get_operator, mock_operator_exists):
+    def test_list_operations(self, mock_get_operator):
         dataset_name = f"test_dataset_{ObjectId()}"
         dataset = Dataset(dataset_name, _create=True, persistent=True)
         dataset.save()
@@ -405,9 +410,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
     @patch(
         "fiftyone.core.odm.utils.load_dataset",
     )
-    def test_set_run_states(
-        self, mock_load_dataset, mock_get_operator, mock_operator_exists
-    ):
+    def test_set_run_states(self, mock_load_dataset, mock_get_operator):
         mock_inputs = MockInputs()
         mock_load_dataset.return_value = MockDataset()
         mock_get_operator.return_value = MockOperatorWithIO()
@@ -453,9 +456,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
     @patch(
         "fiftyone.core.odm.utils.load_dataset",
     )
-    def test_sets_progress(
-        self, mock_load_dataset, mock_get_operator, mock_operator_exists
-    ):
+    def test_sets_progress(self, mock_load_dataset, mock_get_operator):
         mock_load_dataset.return_value = MockDataset()
         mock_get_operator.return_value = MockOperator(sets_progress=True)
 
@@ -487,9 +488,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
     @patch(
         "fiftyone.core.odm.utils.load_dataset",
     )
-    def test_full_run_success(
-        self, mock_load_dataset, mock_get_operator, mock_operator_exists
-    ):
+    def test_full_run_success(self, mock_load_dataset, mock_get_operator):
         mock_load_dataset.return_value = MockDataset()
         doc = self.svc.queue_operation(
             operator="@voxelfiftyone/operator/foo",
@@ -524,9 +523,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
     @patch(
         "fiftyone.core.odm.utils.load_dataset",
     )
-    def test_generator_run_success(
-        self, mock_load_dataset, mock_get_operator, mock_operator_exists
-    ):
+    def test_generator_run_success(self, mock_load_dataset, mock_get_operator):
         mock_load_dataset.return_value = MockDataset()
         mock_get_operator.return_value = MockGeneratorOperator()
 
@@ -560,7 +557,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         "fiftyone.core.odm.utils.load_dataset",
     )
     def test_generator_sets_progress(
-        self, mock_load_dataset, mock_get_operator, mock_operator_exists
+        self, mock_load_dataset, mock_get_operator
     ):
         mock_load_dataset.return_value = MockDataset()
         mock_get_operator.return_value = MockGeneratorOperator(
@@ -592,9 +589,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
     @patch(
         "fiftyone.core.odm.utils.load_dataset",
     )
-    def test_updates_progress(
-        self, mock_load_dataset, mock_get_operator, mock_operator_exists
-    ):
+    def test_updates_progress(self, mock_load_dataset, mock_get_operator):
         mock_inputs = MockInputs()
         mock_outputs = MockOutputs()
         mock_get_operator.return_value = MockProgressiveOperatorWithOutputs()
@@ -636,9 +631,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
             },
         )
 
-    def test_queued_state_required_to_execute(
-        self, mock_get_operator, mock_operator_exists
-    ):
+    def test_queued_state_required_to_execute(self, mock_get_operator):
         mock_inputs = MockInputs()
         operator = mock.MagicMock()
         mock_get_operator.return_value = operator
@@ -662,9 +655,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
     @patch(
         "fiftyone.core.odm.utils.load_dataset",
     )
-    def test_full_run_fail(
-        self, mock_load_dataset, mock_get_operator, mock_operator_exists
-    ):
+    def test_full_run_fail(self, mock_load_dataset, mock_get_operator):
         dataset_id = ObjectId()
         dataset_name = f"test_dataset_{dataset_id}"
         mock_load_dataset.return_value.name = dataset_name
@@ -703,9 +694,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
     @patch(
         "fiftyone.core.odm.utils.load_dataset",
     )
-    def test_rerun_failed(
-        self, mock_load_dataset, get_op_mock, op_exists_mock
-    ):
+    def test_rerun_failed(self, mock_load_dataset, get_op_mock):
         dataset_id = ObjectId()
         dataset_name = f"test_dataset_{dataset_id}"
         mock_load_dataset.return_value.name = dataset_name
@@ -759,7 +748,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         doc = self.svc.get(doc_id=rerun_doc.id)
         self.assertEqual(doc.run_state, ExecutionRunState.COMPLETED)
 
-    def test_rerun_with_renamed_dataset(self, get_op_mock, op_exists_mock):
+    def test_rerun_with_renamed_dataset(self, get_op_mock):
         # setup
         uid = str(ObjectId())
         dataset_name = f"test_dataset_{uid}"
@@ -839,7 +828,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         "fiftyone.core.odm.utils.load_dataset",
     )
     def test_execute_with_already_processing_op(
-        self, mock_load_dataset, mock_get_operator, mock_operator_exists
+        self, mock_load_dataset, mock_get_operator
     ):
         mock_load_dataset.return_value = MockDataset()
         doc = self.svc.queue_operation(
@@ -857,7 +846,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.assertEqual(changed_doc.status, doc.status)
         self.assertIsNone(result)
 
-    def test_execute_with_renamed_dataset(self, get_op_mock, op_exists_mock):
+    def test_execute_with_renamed_dataset(self, get_op_mock):
         # setup
         uid = str(ObjectId())
         dataset_name = f"test_dataset_{uid}"
@@ -905,7 +894,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         finally:
             dataset.delete()
 
-    def test_paging_sorting(self, mock_get_operator, mock_operator_exists):
+    def test_paging_sorting(self, mock_get_operator):
         dataset_name = f"test_dataset_{ObjectId()}"
         dataset = Dataset(dataset_name, _create=True, persistent=True)
         dataset.save()
@@ -1075,9 +1064,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
     @patch(
         "fiftyone.core.odm.utils.load_dataset",
     )
-    def test_deletes_by_dataset_id(
-        self, mock_load_dataset, mock_get_operator, mock_operator_exists
-    ):
+    def test_deletes_by_dataset_id(self, mock_load_dataset, mock_get_operator):
         dataset_id = ObjectId()
         dataset_name = f"test_dataset_{dataset_id}"
         mock_load_dataset.return_value.name = dataset_name
@@ -1130,9 +1117,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
     @patch(
         "fiftyone.core.odm.utils.load_dataset",
     )
-    def test_search(
-        self, mock_load_dataset, mock_get_operator, mock_operator_exists
-    ):
+    def test_search(self, mock_load_dataset, mock_get_operator):
         dataset_id = ObjectId()
         dataset_name = f"test_dataset_{dataset_id}"
         mock_load_dataset.return_value.name = dataset_name
@@ -1231,9 +1216,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
     @patch(
         "fiftyone.core.odm.utils.load_dataset",
     )
-    def test_count(
-        self, mock_load_dataset, mock_get_operator, mock_operator_exists
-    ):
+    def test_count(self, mock_load_dataset, mock_get_operator):
         dataset_id = ObjectId()
         dataset_name = f"test_dataset_{dataset_id}"
         mock_load_dataset.return_value.name = dataset_name
@@ -1282,9 +1265,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
     @patch(
         "fiftyone.core.odm.utils.load_dataset",
     )
-    def test_rename_operation(
-        self, mock_load_dataset, mock_get_operator, mock_operator_exists
-    ):
+    def test_rename_operation(self, mock_load_dataset, mock_get_operator):
         dataset_id = ObjectId()
         dataset_name = f"test_dataset_{dataset_id}"
         mock_load_dataset.return_value.name = dataset_name
@@ -1313,7 +1294,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
     )
     @pytest.mark.asyncio
     async def test_set_completed_in_async_context(
-        self, mock_load_dataset, mock_get_operator, mock_operator_exists
+        self, mock_load_dataset, mock_get_operator
     ):
         dataset_id = ObjectId()
         dataset_name = f"test_dataset_{dataset_id}"
@@ -1335,14 +1316,8 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         doc = self.svc.set_completed(doc_id=doc.id)
         self.assertEqual(doc.run_state, ExecutionRunState.COMPLETED)
 
-    @patch.object(
-        delegated_operation,
-        "is_remote_service",
-        return_value=True,
-    )
-    def test_queue_op_remote_service(
-        self, mock_is_remote_service, mock_get_operator, mock_operator_exists
-    ):
+    def test_queue_op_remote_service(self, mock_get_operator):
+        self.mock_is_remote_service.return_value = True
         db = delegated_operation.MongoDelegatedOperationRepo()
         self.assertTrue(db.is_remote)
         dos = DelegatedOperationService(repo=db)
@@ -1361,18 +1336,8 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.docs_to_delete.append(doc)
         self.assertEqual(doc.run_state, ExecutionRunState.SCHEDULED)
 
-    @patch.object(
-        delegated_operation,
-        "is_remote_service",
-        return_value=True,
-    )
-    def test_set_queue_remote_service(
-        self,
-        mock_is_remote_service,
-        mock_get_operator,
-        mock_operator_exists,
-    ):
-        mock_is_remote_service.return_value = True
+    def test_set_queue_remote_service(self, mock_get_operator):
+        self.mock_is_remote_service.return_value = True
         db = delegated_operation.MongoDelegatedOperationRepo()
         self.assertTrue(db.is_remote)
         dos = DelegatedOperationService(repo=db)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Some divergence in teams was causing merge conflicts this should clean that up and also removes the need for all the duplicate "mock_some_object_that_isn't_actually_used" stuff.

## How is this patch tested? If it is not, please explain why.

tests still pass

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Simplified unit tests by removing redundant configurations to improve clarity.
  - Enhanced test reliability by refining setup and cleanup processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->