### PR TITLE
fix typo in virtual environment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ brew install python@3.9
 brew install protobuf
 ```
 
-#### 4. Create and activate a virtual nvironment
+#### 4. Create and activate a virtual environment
 
 ```shell
 python3 -m venv fiftyone_env


### PR DESCRIPTION
Corrected "virtual nvironment" to "virtual environment" in the macOS prerequisites section.

## What changes are proposed in this pull request?

This PR fixes a minor typo ("virtual nvironment" → "virtual environment") in the macOS installation prerequisites documentation.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.  
- [x] Yes, minor documentation improvement.

Fixes a typo to improve clarity for users following installation instructions.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes  
- [ ] Build: Build and test infrastructure changes  
- [ ] Core: Core `fiftyone` Python library changes  
- [x] Documentation: FiftyOne documentation changes  
- [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typo in the project documentation to enhance clarity and professionalism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->