### PR TITLE
delete model evaluation from model eval panel

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/ActionMenu.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/ActionMenu.tsx
@@ -1,0 +1,72 @@
+import { DeleteOutline, MoreVert } from "@mui/icons-material";
+import {
+  Box,
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+} from "@mui/material";
+import React, { useState } from "react";
+import { useSetRecoilState } from "recoil";
+import { openModelEvalDialog, selectedModelEvaluation } from "./utils";
+
+type ActionMenuProps = {
+  evaluationName: string;
+};
+
+const ActionMenu: React.FC<ActionMenuProps> = (props) => {
+  const setOpenModelEvalDialog = useSetRecoilState(openModelEvalDialog);
+  const setEvaluation = useSetRecoilState(selectedModelEvaluation);
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const handleOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    event.preventDefault();
+    setAnchorEl(event.currentTarget);
+  };
+
+  return (
+    <Box>
+      <IconButton key={props.evaluationName} onClick={handleOpen}>
+        <MoreVert />
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={() => setAnchorEl(null)}
+      >
+        {/* <MenuItem
+        onClick={() => {
+          // Handle re-evaluate action
+          handleReEvaluate();
+          setAnchorEl(null);
+        }}
+      >
+        <ListItemIcon>
+          <Refresh fontSize="small" />
+        </ListItemIcon>
+        <ListItemText>Re-evaluate</ListItemText>
+      </MenuItem> */}
+        <MenuItem
+          onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+            event.stopPropagation();
+            event.preventDefault();
+            setEvaluation(props.evaluationName);
+            setOpenModelEvalDialog(true);
+            setAnchorEl(null);
+          }}
+        >
+          <ListItemIcon>
+            <DeleteOutline fontSize="small" color="error" />
+          </ListItemIcon>
+          <ListItemText
+            primary="Delete"
+            primaryTypographyProps={{ color: "error" }}
+          />
+        </MenuItem>
+      </Menu>
+    </Box>
+  );
+};
+
+export default ActionMenu;

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/ConfirmationDialog.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/ConfirmationDialog.tsx
@@ -25,7 +25,7 @@ const ConfirmationDialog = ({
     const evalId = evaluations.find(
       (evaluation) => evaluation.key === selectedEvaluation
     ).id;
-    handleDelete(evalId);
+    handleDelete(evalId, selectedEvaluation);
     setSelectedEvaluation(null);
     handleClose();
   };

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/ConfirmationDialog.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/ConfirmationDialog.tsx
@@ -1,0 +1,54 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from "@mui/material";
+import React from "react";
+import { useRecoilState } from "recoil";
+import { selectedModelEvaluation } from "./utils";
+
+const ConfirmationDialog = ({ open, handleClose }) => {
+  const dialogTitle = "Delete Model Evaluation";
+  const [selectedEvaluation, setSelectedEvaluation] = useRecoilState(
+    selectedModelEvaluation
+  );
+
+  const handleConfirm = () => {
+    // trigger delete evaluation operation here
+    console.log(`Deleting evaluation with id ${selectedEvaluation}`);
+    setSelectedEvaluation(null);
+    handleClose();
+  };
+  return (
+    <Dialog open={open} onClose={handleClose}>
+      <DialogTitle id="confirmation-dialog-title">{dialogTitle}</DialogTitle>
+      <DialogContent>
+        <DialogContentText id="confirmation-dialog-description">
+          {`Are you sure you want to delete the model evaluation `}
+          <strong>{selectedEvaluation}</strong>
+          {`? This action cannot be undone.`}
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions
+        sx={{ display: "flex", justifyContent: "space-between", width: "100%" }}
+      >
+        <Button onClick={handleClose} variant="outlined" sx={{ width: "50%" }}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleConfirm}
+          variant="contained"
+          autoFocus
+          sx={{ width: "50%" }}
+        >
+          Delete evaluation
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ConfirmationDialog;

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/ConfirmationDialog.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/ConfirmationDialog.tsx
@@ -10,18 +10,26 @@ import React from "react";
 import { useRecoilState } from "recoil";
 import { selectedModelEvaluation } from "./utils";
 
-const ConfirmationDialog = ({ open, handleClose }) => {
+const ConfirmationDialog = ({
+  open,
+  handleClose,
+  handleDelete,
+  evaluations,
+}) => {
   const dialogTitle = "Delete Model Evaluation";
   const [selectedEvaluation, setSelectedEvaluation] = useRecoilState(
     selectedModelEvaluation
   );
 
   const handleConfirm = () => {
-    // trigger delete evaluation operation here
-    console.log(`Deleting evaluation with id ${selectedEvaluation}`);
+    const evalId = evaluations.find(
+      (evaluation) => evaluation.key === selectedEvaluation
+    ).id;
+    handleDelete(evalId);
     setSelectedEvaluation(null);
     handleClose();
   };
+
   return (
     <Dialog open={open} onClose={handleClose}>
       <DialogTitle id="confirmation-dialog-title">{dialogTitle}</DialogTitle>

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -44,7 +44,7 @@ import {
 import get from "lodash/get";
 import React, { useEffect, useMemo, useState } from "react";
 import { useRecoilState, useSetRecoilState } from "recoil";
-import ActionMenu from "./actionMenu";
+import ActionMenu from "./ActionMenu";
 import Error from "./Error";
 import EvaluationIcon from "./EvaluationIcon";
 import EvaluationNotes from "./EvaluationNotes";

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -44,6 +44,7 @@ import {
 import get from "lodash/get";
 import React, { useEffect, useMemo, useState } from "react";
 import { useRecoilState, useSetRecoilState } from "recoil";
+import ActionMenu from "./actionMenu";
 import Error from "./Error";
 import EvaluationIcon from "./EvaluationIcon";
 import EvaluationNotes from "./EvaluationNotes";
@@ -577,6 +578,7 @@ export default function Evaluation(props: EvaluationProps) {
               <Info />
             </ToggleButton>
           </ToggleButtonGroup>
+          <ActionMenu evaluationName={evaluation.info.key} />
         </Stack>
       </Stack>
 

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Overview.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Overview.tsx
@@ -10,7 +10,7 @@ import {
   EvaluationCardProps,
   OverviewProps,
 } from "./Types";
-import ActionMenu from "./actionMenu";
+import ActionMenu from "./ActionMenu";
 
 export default function Overview(props: OverviewProps) {
   const {

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Overview.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Overview.tsx
@@ -2,6 +2,7 @@ import { EditableLabel, LoadingDots } from "@fiftyone/components";
 import { Card, CardActionArea, Chip, Stack, Typography } from "@mui/material";
 import React from "react";
 import Evaluate from "./Evaluate";
+import EvaluationIcon from "./EvaluationIcon";
 import EvaluationNotes from "./EvaluationNotes";
 import Status from "./Status";
 import {
@@ -9,7 +10,7 @@ import {
   EvaluationCardProps,
   OverviewProps,
 } from "./Types";
-import EvaluationIcon from "./EvaluationIcon";
+import ActionMenu from "./actionMenu";
 
 export default function Overview(props: OverviewProps) {
   const {
@@ -101,7 +102,7 @@ function EvaluationCard(props: EvaluationCardProps) {
     >
       <Card
         sx={{ p: 2, cursor: "pointer" }}
-        onClick={() => {
+        onClick={(event: React.MouseEvent<HTMLDivElement>) => {
           onSelect(eval_key, id);
         }}
       >
@@ -124,19 +125,26 @@ function EvaluationCard(props: EvaluationCardProps) {
               showEditIcon={hovering}
             />
           </Stack>
-          {pending && (
-            <Chip
-              variant="filled"
-              size="small"
-              label={
-                <LoadingDots
-                  text="Evaluating"
-                  style={{ fontSize: "1rem", paddingLeft: 6, color: "#999999" }}
-                />
-              }
-            />
-          )}
-          {status && <Status status={status} readOnly />}
+          <Stack direction="row" spacing={0.5} alignItems={"center"}>
+            {pending && (
+              <Chip
+                variant="filled"
+                size="small"
+                label={
+                  <LoadingDots
+                    text="Evaluating"
+                    style={{
+                      fontSize: "1rem",
+                      paddingLeft: 6,
+                      color: "#999999",
+                    }}
+                  />
+                }
+              />
+            )}
+            {status && <Status status={status} readOnly />}
+            <ActionMenu evaluationName={eval_key} />
+          </Stack>
         </Stack>
         {note && <EvaluationNotes notes={note} variant="overview" />}
       </Card>

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/index.tsx
@@ -95,23 +95,26 @@ export default function NativeModelEvaluationView(props) {
   );
 
   const onDelete = useCallback(
-    (eval_id: string) => {
-      console.log("delete_evaluation", delete_evaluation);
-      debugger;
-      triggerEvent(delete_evaluation, { eval_id }, false, (results) => {
-        console.log("evalId, evalKey", eval_id);
-        if (results?.error === null) {
-          const updatedEvaluations = evaluations.filter(
-            (evaluation) => evaluation.id !== eval_id
-          );
-          onChange("evaluations", updatedEvaluations);
-          if (page === "evaluation") {
-            // should return to overview page
-            onChange("view", { page: "overview" });
+    (eval_id: string, eval_key: string) => {
+      triggerEvent(
+        delete_evaluation,
+        { eval_id, eval_key },
+        false,
+        (results) => {
+          if (results?.error === null) {
+            const updatedEvaluations = evaluations.filter(
+              (evaluation) => evaluation.id !== eval_id
+            );
+            onChange("evaluations", updatedEvaluations);
             triggerEvent(on_change_view);
+            if (page === "evaluation") {
+              // should return to overview page
+              onChange("view", { page: "overview" });
+              triggerEvent(on_change_view);
+            }
           }
         }
-      });
+      );
     },
     [triggerEvent, delete_evaluation, evaluations, onChange]
   );

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/index.tsx
@@ -25,6 +25,7 @@ export default function NativeModelEvaluationView(props) {
     on_evaluate_model,
     load_evaluation,
     load_evaluation_view,
+    delete_evaluation,
     set_status,
     set_note,
     load_view,
@@ -94,6 +95,26 @@ export default function NativeModelEvaluationView(props) {
     setOpenDialog(false);
     setSelectedEvaluation(null);
   };
+
+  const onDelete = useCallback(
+    (evalId: string, evalKey: string) => {
+      triggerEvent(delete_evaluation, { evalId, evalKey }, false, (results) => {
+        console.log("evalId, evalKey", evalId, evalKey);
+        if (results?.error === null) {
+          const updatedEvaluations = evaluations.filter(
+            (evaluation) => evaluation.key !== evalKey
+          );
+          onChange("evaluations", updatedEvaluations);
+          if (page === "evaluation") {
+            // should return to overview page
+            onChange("view", { page: "overview" });
+            triggerEvent(on_change_view);
+          }
+        }
+      });
+    },
+    [triggerEvent, delete_evaluation, evaluations, onChange]
+  );
 
   return (
     <Box sx={{ height: "100%" }}>

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/index.tsx
@@ -2,7 +2,7 @@ import { PanelCTA } from "@fiftyone/components";
 import { constants } from "@fiftyone/utilities";
 import { Box } from "@mui/material";
 import React, { useCallback, useMemo } from "react";
-import { useRecoilState, useSetRecoilState } from "recoil";
+import { useRecoilState } from "recoil";
 import ConfirmationDialog from "./ConfirmationDialog";
 import Evaluate from "./Evaluate";
 import Evaluation from "./Evaluation";
@@ -18,18 +18,20 @@ const TRY_LINK = "http://voxel51.com/try-evaluation";
 export default function NativeModelEvaluationView(props) {
   const { data = {}, schema, onChange, layout } = props;
   const [openDialog, setOpenDialog] = useRecoilState(openModelEvalDialog);
-  const setSelectedEvaluation = useSetRecoilState(selectedModelEvaluation);
+  const [selectedEvaluation, setSelectedEvaluation] = useRecoilState(
+    selectedModelEvaluation
+  );
   const { view } = schema;
   const {
     on_change_view,
     on_evaluate_model,
     load_evaluation,
     load_evaluation_view,
-    delete_evaluation,
     set_status,
     set_note,
     load_view,
     rename_evaluation,
+    delete_evaluation,
   } = view;
   const {
     evaluations = [],
@@ -67,6 +69,7 @@ export default function NativeModelEvaluationView(props) {
       triggerEvent(on_evaluate_model);
     }
   }, [triggerEvent, on_evaluate_model]);
+
   const onRename = useCallback(
     (old_name: string, new_name: string) => {
       triggerEvent(
@@ -91,18 +94,15 @@ export default function NativeModelEvaluationView(props) {
     [triggerEvent, rename_evaluation, evaluations, onChange]
   );
 
-  const handleClose = () => {
-    setOpenDialog(false);
-    setSelectedEvaluation(null);
-  };
-
   const onDelete = useCallback(
-    (evalId: string, evalKey: string) => {
-      triggerEvent(delete_evaluation, { evalId, evalKey }, false, (results) => {
-        console.log("evalId, evalKey", evalId, evalKey);
+    (eval_id: string) => {
+      console.log("delete_evaluation", delete_evaluation);
+      debugger;
+      triggerEvent(delete_evaluation, { eval_id }, false, (results) => {
+        console.log("evalId, evalKey", eval_id);
         if (results?.error === null) {
           const updatedEvaluations = evaluations.filter(
-            (evaluation) => evaluation.key !== evalKey
+            (evaluation) => evaluation.id !== eval_id
           );
           onChange("evaluations", updatedEvaluations);
           if (page === "evaluation") {
@@ -115,6 +115,11 @@ export default function NativeModelEvaluationView(props) {
     },
     [triggerEvent, delete_evaluation, evaluations, onChange]
   );
+
+  const handleClose = () => {
+    setOpenDialog(false);
+    setSelectedEvaluation(null);
+  };
 
   return (
     <Box sx={{ height: "100%" }}>
@@ -187,7 +192,12 @@ export default function NativeModelEvaluationView(props) {
             onRename={onRename}
           />
         ))}
-      <ConfirmationDialog open={openDialog} handleClose={handleClose} />
+      <ConfirmationDialog
+        open={openDialog}
+        handleClose={handleClose}
+        evaluations={evaluations}
+        handleDelete={onDelete}
+      />
     </Box>
   );
 }

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/index.tsx
@@ -94,6 +94,8 @@ export default function NativeModelEvaluationView(props) {
     [triggerEvent, rename_evaluation, evaluations, onChange]
   );
 
+  const time = new Date().getTime();
+
   const onDelete = useCallback(
     (eval_id: string, eval_key: string) => {
       triggerEvent(
@@ -102,21 +104,26 @@ export default function NativeModelEvaluationView(props) {
         false,
         (results) => {
           if (results?.error === null) {
+            // update the current page display
             const updatedEvaluations = evaluations.filter(
               (evaluation) => evaluation.id !== eval_id
             );
             onChange("evaluations", updatedEvaluations);
-            triggerEvent(on_change_view);
+            onChange(
+              "view.key",
+              `${eval_id}_${updatedEvaluations.length}_${time}`
+            );
             if (page === "evaluation") {
               // should return to overview page
               onChange("view", { page: "overview" });
+              onChange("view.key", eval_id + "_deleted");
               triggerEvent(on_change_view);
             }
           }
         }
       );
     },
-    [triggerEvent, delete_evaluation, evaluations, onChange]
+    [triggerEvent, delete_evaluation, evaluations, onChange, time]
   );
 
   const handleClose = () => {

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/index.tsx
@@ -105,6 +105,8 @@ export default function NativeModelEvaluationView(props) {
         (results) => {
           if (results?.error === null) {
             // update the current page display
+            // if after deletion, there is no evaluation left,
+            // go to the create evaluation page
             const updatedEvaluations = evaluations.filter(
               (evaluation) => evaluation.id !== eval_id
             );

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/index.tsx
@@ -2,15 +2,23 @@ import { PanelCTA } from "@fiftyone/components";
 import { constants } from "@fiftyone/utilities";
 import { Box } from "@mui/material";
 import React, { useCallback, useMemo } from "react";
+import { useRecoilState, useSetRecoilState } from "recoil";
+import ConfirmationDialog from "./ConfirmationDialog";
 import Evaluate from "./Evaluate";
 import Evaluation from "./Evaluation";
 import Overview from "./Overview";
-import { useTriggerEvent } from "./utils";
+import {
+  openModelEvalDialog,
+  selectedModelEvaluation,
+  useTriggerEvent,
+} from "./utils";
 
 const TRY_LINK = "http://voxel51.com/try-evaluation";
 
 export default function NativeModelEvaluationView(props) {
   const { data = {}, schema, onChange, layout } = props;
+  const [openDialog, setOpenDialog] = useRecoilState(openModelEvalDialog);
+  const setSelectedEvaluation = useSetRecoilState(selectedModelEvaluation);
   const { view } = schema;
   const {
     on_change_view,
@@ -81,6 +89,11 @@ export default function NativeModelEvaluationView(props) {
     },
     [triggerEvent, rename_evaluation, evaluations, onChange]
   );
+
+  const handleClose = () => {
+    setOpenDialog(false);
+    setSelectedEvaluation(null);
+  };
 
   return (
     <Box sx={{ height: "100%" }}>
@@ -153,6 +166,7 @@ export default function NativeModelEvaluationView(props) {
             onRename={onRename}
           />
         ))}
+      <ConfirmationDialog open={openDialog} handleClose={handleClose} />
     </Box>
   );
 }

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/utils.ts
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/utils.ts
@@ -2,6 +2,7 @@ import { usePanelEvent } from "@fiftyone/operators";
 import { usePanelId } from "@fiftyone/spaces";
 import { capitalize } from "lodash";
 import { useCallback } from "react";
+import { atom } from "recoil";
 
 export function useTriggerEvent() {
   const panelId = usePanelId();
@@ -91,3 +92,20 @@ export function computeSortedCompareKeys(
       return a.key.localeCompare(b.key);
     });
 }
+
+/**
+ * Atom state to control the visibility of the delete evaluation dialog
+ */
+export const openModelEvalDialog = atom<boolean>({
+  key: "openModelEvalDialog",
+  default: false,
+});
+
+/**
+ * Atom state to store the currently selected model evaluation key to act on.
+ * Contains the name and id of the selected evaluation.
+ */
+export const selectedModelEvaluation = atom<string | null>({
+  key: "selectedEvalation",
+  default: null,
+});

--- a/plugins/panels/model_evaluation/__init__.py
+++ b/plugins/panels/model_evaluation/__init__.py
@@ -762,7 +762,7 @@ class EvaluationPanel(Panel):
                 set_note=self.set_note,
                 load_view=self.load_view,
                 rename_evaluation=self.rename_evaluation,
-                delete_evalution=self.delete_evaluation,
+                delete_evaluation=self.delete_evaluation,
             ),
         )
 

--- a/plugins/panels/model_evaluation/__init__.py
+++ b/plugins/panels/model_evaluation/__init__.py
@@ -111,31 +111,6 @@ class EvaluationPanel(Panel):
         ctx.panel.set_data("permissions", permissions)
         self.load_pending_evaluations(ctx)
 
-    def on_delete_evaluation(self, ctx):
-        if not self.can_delete_evaluation(ctx):
-            ctx.ops.notify(
-                "You do not have permission to delete evaluations",
-                variant="error",
-            )
-            return
-        current_eval_key = ctx.params.get("key", None)
-        print("going to delete", current_eval_key)
-        try:
-            ctx.dataset.on_delete_evaluation(current_eval_key)
-            view_state = ctx.panel.get_state("view") or {}
-            eval_id = view_state.get("id")
-            store = self.get_store(ctx)
-            store.delete_key(eval_id)
-            ctx.ops.notify(
-                "Evaluation deleted successfully!",
-                variant="success",
-            )
-        except Exception as e:
-            ctx.ops.notify(
-                f"Failed to delete evaluation successfully",
-                variant="error",
-            )
-
     def get_avg_confidence(self, per_class_metrics):
         count = 0
         total = 0
@@ -253,6 +228,29 @@ class EvaluationPanel(Panel):
         except Exception as e:
             ctx.ops.notify(
                 f"Failed to rename evaluation '{old_name}' to '{new_name}'",
+                variant="error",
+            )
+
+    def delete_evaluation(self, ctx):
+        if not self.can_delete_evaluation(ctx):
+            ctx.ops.notify(
+                "You do not have permission to delete evaluations",
+                variant="error",
+            )
+            return
+        eval_id = ctx.params.get("eval_id", None)
+
+        try:
+            ctx.dataset.delete_evaluation(eval_id)
+            store = self.get_store(ctx)
+            store.delete_key(eval_id)
+            ctx.ops.notify(
+                "Evaluation deleted successfully!",
+                variant="success",
+            )
+        except Exception as e:
+            ctx.ops.notify(
+                f"Failed to delete evaluation successfully",
                 variant="error",
             )
 
@@ -760,11 +758,11 @@ class EvaluationPanel(Panel):
                 on_evaluate_model=self.on_evaluate_model,
                 load_evaluation=self.load_evaluation,
                 load_evaluation_view=self.load_evaluation_view,
-                delete_evalution=self.on_delete_evaluation,
                 set_status=self.set_status,
                 set_note=self.set_note,
                 load_view=self.load_view,
                 rename_evaluation=self.rename_evaluation,
+                delete_evalution=self.delete_evaluation,
             ),
         )
 

--- a/plugins/panels/model_evaluation/__init__.py
+++ b/plugins/panels/model_evaluation/__init__.py
@@ -238,12 +238,16 @@ class EvaluationPanel(Panel):
                 variant="error",
             )
             return
+
+        # use eval_id to delete the execution store
         eval_id = ctx.params.get("eval_id", None)
+        # use eval_key to delete the evaluation from dataset
+        eval_key = ctx.params.get("eval_key", None)
 
         try:
-            ctx.dataset.delete_evaluation(eval_id)
+            ctx.dataset.delete_evaluation(eval_key)
             store = self.get_store(ctx)
-            store.delete_key(eval_id)
+            store.delete(eval_id)
             ctx.ops.notify(
                 "Evaluation deleted successfully!",
                 variant="success",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Support the ability to delete a model evaluation run and clean up execution store from the model eval panel

## How is this patch tested? If it is not, please explain why.


https://github.com/user-attachments/assets/f6e68d63-8de9-43d5-b569-c9982123c145




## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced an interactive menu in evaluation views that allows users to initiate deletion of model evaluations.
  - Added a confirmation dialog to verify deletion actions, ensuring that evaluations are only removed when intended.
  - Enhanced the evaluation management workflow with improved state handling for dialog visibility and selected evaluations.
  - Implemented permission checks for deleting evaluations to ensure proper user access control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->