### PR TITLE
enhancement for empty values for list and str types

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/index.tsx
@@ -3,6 +3,7 @@ import { cloneDeep, get, set } from "lodash";
 import React, { useCallback, useEffect, useRef } from "react";
 import DynamicIO from "./components/DynamicIO";
 import { clearUseKeyStores, SchemaIOContext } from "./hooks";
+import { coerceValue } from "./utils";
 
 export function SchemaIOComponent(props) {
   const { onChange, onPathChange, id, shouldClearUseKeyStores } = props;
@@ -20,7 +21,7 @@ export function SchemaIOComponent(props) {
 
   const onIOChange = useCallback(
     (path, value, schema, ancestors) => {
-      const computedValue = coerceValue(value, schema);
+      const computedValue = coerceValue(path, value, schema);
       const currentState = stateRef.current;
       const updatedState = cloneDeep(currentState);
       set(updatedState, path, cloneDeep(computedValue));
@@ -62,17 +63,6 @@ export function SchemaIOComponent(props) {
       />
     </SchemaIOContext.Provider>
   );
-}
-
-function coerceValue(value, schema) {
-  // coerce the value to None if it is an empty string or empty array
-  if (schema.type === "array" && Array.isArray(value) && value.length === 0) {
-    return null;
-  }
-  if (schema.type === "string" && value === "") {
-    return null;
-  }
-  return value;
 }
 
 registerComponent({


### PR DESCRIPTION
## What changes are proposed in this pull request?

This reverts *some* of the null coercion changes from https://github.com/voxel51/fiftyone/pull/5375. Namely:
- for string fields: empty `""` values are *NOT* coerced to `None` if the default value of the field is `""`
- for list fields: empty `[]` values are *NOT* coerced to `None` if the default value of the field is `[]`

## How is this patch tested? If it is not, please explain why.

Using various operators with list/str type

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced logic for value coercion based on user interaction and schema definitions.
  - Added new functions to determine when values should be coerced, improving data handling.

- **Refactor**
  - Adjusted how input values are processed and stored, ensuring more predictable handling of data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->