### PR TITLE
fix slow compute metadata on PNGs due to getexif on png

### DIFF
--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -459,8 +459,8 @@ def get_image_info(f):
     img = Image.open(f)
 
     # Flip the dimensions if image metadata requires us to. PIL.Image doesn't
-    #   handle by default.
-    if _image_has_flipped_dimensions(img):
+    #   handle by default. Image flipping only efficiently supported on JPEG.
+    if img.format == "JPEG" and _image_has_flipped_dimensions(img):
         width, height = img.height, img.width
     else:
         width, height = img.width, img.height
@@ -555,13 +555,12 @@ def _do_compute_metadata(args):
 def _compute_sample_metadata(
     filepath, media_type, skip_failures=False, cache=None
 ):
-    if not skip_failures:
-        return _get_metadata(filepath, media_type, cache=cache)
-
     try:
         return _get_metadata(filepath, media_type, cache=cache)
     except:
-        return None
+        if skip_failures:
+            return None
+        raise
 
 
 def _get_metadata(filepath, media_type, cache=None):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Running compute metadata on PNGs was being reported as unusually slow especially on larger images. These changes should give a decent speedup, but makes it so "flipped" PNGs will no longer be treated as such on the backend.

The reason for the slow down was that getexif will stream through the entire file if called on a PNG. We found that this method doesn't actually work for most other filetypes and only really efficiently works on JPEGS so we are restricting it to that use case.

## How is this patch tested? If it is not, please explain why.

Uploaded some large PNG's and JPG's to gcloud and then tested how long it took to get metadata:

```
import time
import fiftyone as fo


img_url = "some-url"
start_time = time.time()
metadata = fo.ImageMetadata.build_for(img_url)
end_time = time.time()

print(f"Time taken: {end_time - start_time} seconds")
```

Before changes:

```
Time taken with 812kb PNG: 0.4665961265563965 seconds
Time taken with 331kb JPG: 0.2698838710784912 seconds
Time taken with 3mb PNG: 0.6951353549957275 seconds
Time taken with 3mb JPG: 0.31340694427490234 seconds
```


After changes:

```
Time taken with 812kb PNG: 0.43336963653564453 seconds
Time taken with 331kb JPG: 0.2811110019683838 seconds
Time taken with 3mb PNG: 0.47894811630249023 seconds
Time taken with 3mb JPG: 0.3149549961090088 seconds
```

As you can see JPG sees very little difference in time take while PNG sees a pretty drastic change especially when the file size is larger or internet connection is worse due to it streaming the entire file instead of the first X bytes.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted image processing so that dimension corrections are applied only when needed for specific image formats.
	- Enhanced error handling to provide clearer feedback during metadata processing, ensuring that exceptions are managed appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->