### PR TITLE
Remove extended selection from embeddings plot

### DIFF
--- a/app/packages/embeddings/src/EmbeddingsPlot.tsx
+++ b/app/packages/embeddings/src/EmbeddingsPlot.tsx
@@ -61,17 +61,30 @@ export function EmbeddingsPlot({
   if (error) {
     return <Loading>{error.message}</Loading>;
   }
+  const data = useMemo(
+    () =>
+      tracesToData(
+        traces,
+        style,
+        getColor,
+        resolvedSelection,
+        selectionStyle,
+        fieldColorscale,
+        setting
+      ),
+    [
+      traces,
+      style,
+      getColor,
+      resolvedSelection,
+      selectionStyle,
+      fieldColorscale,
+      setting,
+    ]
+  );
+
   if (labelSelectorLoading || isLoading || !traces)
     return <Loading>Pixelating...</Loading>;
-  const data = tracesToData(
-    traces,
-    style,
-    getColor,
-    resolvedSelection,
-    selectionStyle,
-    fieldColorscale,
-    setting
-  );
   const isCategorical = style === "categorical";
 
   return (
@@ -80,7 +93,7 @@ export function EmbeddingsPlot({
         <Plot
           data={data}
           style={{ zIndex: 1 }}
-          onSelected={(selected, foo) => {
+          onSelected={(selected) => {
             if (!selected || selected?.points?.length === 0) return;
 
             const result = {};

--- a/app/packages/embeddings/src/tracesToData.tsx
+++ b/app/packages/embeddings/src/tracesToData.tsx
@@ -17,6 +17,7 @@ export function tracesToData(
   colorscale,
   setting
 ) {
+  if (!traces) return null;
   const isCategorical = style === "categorical";
   const isContinuous = style === "continuous";
   const isUncolored = style === "uncolored";

--- a/app/packages/embeddings/src/useExtendedStageEffect.tsx
+++ b/app/packages/embeddings/src/useExtendedStageEffect.tsx
@@ -13,7 +13,13 @@ export default function useExtendedStageEffect() {
   const setOverrideStage = useSetRecoilState(
     fos.extendedSelectionOverrideStage
   );
-  const { selection } = useRecoilValue(fos.extendedSelection);
+  // const { selection } = useRecoilValue(fos.extendedSelection);
+  // const [plotSelection, setPlotSelection] = usePanelStatePartial(
+  //   "plotSelection",
+  //   [],
+  //   true
+  // );
+  const plotSelection = useRecoilValue(selectionAtoms.plotSelection);
   const getCurrentDataset = useRecoilCallback(({ snapshot }) => async () => {
     return snapshot.getPromise(fos.datasetName);
   });
@@ -22,12 +28,13 @@ export default function useExtendedStageEffect() {
   const [pointsField] = usePointsField();
 
   useEffect(() => {
-    if (loadedPlot && Array.isArray(selection)) {
+    if (pointsField && !hasLassoPoints(lassoPoints)) return;
+    if (loadedPlot && Array.isArray(plotSelection)) {
       fetchExtendedStage({
         datasetName,
         view,
         patchesField: loadedPlot.patches_field,
-        selection,
+        selection: lassoPoints ? null : plotSelection,
         slices,
         lassoPoints,
         pointsField,
@@ -43,8 +50,12 @@ export default function useExtendedStageEffect() {
     datasetName,
     loadedPlot?.patches_field,
     view,
-    selection,
+    plotSelection,
     pointsField,
     lassoPoints,
   ]);
+}
+
+function hasLassoPoints(lasooPoints) {
+  return lasooPoints.x.length > 0 && lasooPoints.y.length > 0;
 }

--- a/app/packages/embeddings/src/usePlot.tsx
+++ b/app/packages/embeddings/src/usePlot.tsx
@@ -13,7 +13,7 @@ export function usePlot({ clearSelection, setPlotSelection }) {
   );
 
   useViewChangeEffect();
-  useSelectionEffect();
+  // useSelectionEffect();
   useExtendedStageEffect();
 
   return {

--- a/app/packages/embeddings/src/usePlotSelection.tsx
+++ b/app/packages/embeddings/src/usePlotSelection.tsx
@@ -9,11 +9,16 @@ import { usePanelStatePartial } from "@fiftyone/spaces";
 import { useBrainResultInfo } from "./useBrainResultInfo";
 import { SELECTION_SCOPE } from "./constants";
 import { useResetExtendedSelection } from "@fiftyone/state";
+import { usePointsField } from "./useBrainResult";
 
 export const atoms = {
   lassoPoints: atom({
     key: "lassoPoints",
     default: { x: [], y: [] },
+  }),
+  plotSelection: atom({
+    key: "plotSelection",
+    default: [],
   }),
 };
 
@@ -27,11 +32,13 @@ export function usePlotSelection() {
   const [selectedSamples, setSelectedSamples] = useRecoilState(
     fos.selectedSamples
   );
-  const [plotSelection, setPlotSelection] = usePanelStatePartial(
-    "plotSelection",
-    [],
-    true
-  );
+  // const [plotSelection, setPlotSelection] = usePanelStatePartial(
+  //   "plotSelection",
+  //   [],
+  //   true
+  // );
+  const pointField = usePointsField();
+  const [plotSelection, setPlotSelection] = useRecoilState(atoms.plotSelection);
   const [lassoPoints, setLassoPoints] = useRecoilState(atoms.lassoPoints);
   const selectedPatchIds = useRecoilValue(fos.selectedPatchIds(patchesField));
   const selectedPatchSampleIds = useRecoilValue(fos.selectedPatchSamples);
@@ -39,13 +46,19 @@ export function usePlotSelection() {
     selectedResults,
     lassoPoints: { x: number[]; y: number[] }
   ) {
+    console.log("selectedResults", selectedResults);
     setSelectedSamples(new Set());
-    setExtendedSelection({
-      selection: selectedResults,
-      scope: SELECTION_SCOPE,
-    });
+    // No need to set the extended selection here, as it is already provided to ctx.view and others
+    // setExtendedSelection({
+    //   selection: selectedResults,
+    //   scope: SELECTION_SCOPE,
+    // });
+    // if (!pointField) {
+    // setPlotSelection(selectedResults);
+    // }
+
     if (lassoPoints) {
-      // TODO: this handleSelected is called without lassoPoints in some unkown cases
+      // TODO: this handleSelected is called without lassoPoints in some unknown cases
       setLassoPoints(lassoPoints);
     }
     if (selectedResults === null) {

--- a/app/packages/embeddings/src/useSelectionEffect.tsx
+++ b/app/packages/embeddings/src/useSelectionEffect.tsx
@@ -2,10 +2,13 @@ import { useEffect } from "react";
 import { useRecoilValue } from "recoil";
 import * as fos from "@fiftyone/state";
 import { usePanelStatePartial } from "@fiftyone/spaces";
-import { useBrainResult } from "./useBrainResult";
+import { useBrainResult, usePointsField } from "./useBrainResult";
 import { fetchUpdatedSelection } from "./fetch";
 import { usePlotSelection } from "./usePlotSelection";
 
+//
+// NOTE: this is no longer in use
+//
 export function useSelectionEffect() {
   const { setPlotSelection } = usePlotSelection();
   const datasetName = useRecoilValue(fos.datasetName);
@@ -17,6 +20,7 @@ export function useSelectionEffect() {
   const extended = useRecoilValue(fos.extendedStagesUnsorted);
   const { selection } = useRecoilValue(fos.extendedSelection);
   const slices = useRecoilValue(fos.currentSlices(false));
+  const pointsField = usePointsField();
 
   // updated the selection when the extended view updates
   useEffect(() => {

--- a/fiftyone/server/routes/embeddings.py
+++ b/fiftyone/server/routes/embeddings.py
@@ -153,6 +153,7 @@ class OnPlotLoad(HTTPEndpoint):
             "missing_count": missing_count,
             "patches_field": patches_field,
             "points_field": points_field,
+            "is_patches_view": is_patches_view,
         }
 
 
@@ -178,6 +179,10 @@ class EmbeddingsSelection(HTTPEndpoint):
 
         dataset = fosu.load_and_cache_dataset(dataset_name)
         results = dataset.load_brain_results(brain_key)
+        point_field = results.config.points_field
+
+        if point_field:
+            return {"selected": None}
 
         view = fosv.get_view(
             dataset_name,
@@ -245,8 +250,6 @@ class EmbeddingsExtendedStage(HTTPEndpoint):
         lasso_points = data.get("lassoPoints", None)
         points_field = data.get("pointsField", None)
 
-        print(points_field)
-
         view = fosv.get_view(
             dataset_name,
             stages=stages,
@@ -255,6 +258,8 @@ class EmbeddingsExtendedStage(HTTPEndpoint):
 
         is_patches_view = view._is_patches
         is_patches_plot = patches_field is not None
+
+        print(lasso_points)
 
         if (
             lasso_points is not None


### PR DESCRIPTION
This removes the extended selection usage from the embeddings panel.