### PR TITLE
Update release-notes.rst for 1.3.2 / 2.6.2

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -3,6 +3,25 @@ FiftyOne Release Notes
 
 .. default-role:: code
 
+FiftyOne Teams 2.6.2
+--------------------
+*Released March 12, 2025*
+
+Includes all updates from :ref:`FiftyOne 1.3.2 <release-notes-v1.3.2>`
+
+.. _release-notes-v1.3.2:
+
+FiftyOne 1.3.2
+--------------
+*Released March 12, 2025*
+
+SDK
+
+- Fixed a bug 
+  `#5486 <https://github.com/voxel51/fiftyone/issues/5486>`_
+  that caused model evaluation to fail in certain cases
+  `#5472 <https://github.com/voxel51/fiftyone/pull/5472>`_
+
 FiftyOne Teams 2.6.1
 --------------------
 *Released February 28, 2025*


### PR DESCRIPTION
## What changes are proposed in this pull request?

Release notes for OSS 1.3.2 / Teams 2.6.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Introduced new release note sections for "FiftyOne Teams 2.6.2" and "FiftyOne 1.3.2", both released on March 12, 2025.
  - Maintained the previous release note for "FiftyOne Teams 2.6.1" from February 28, 2025.

- **Bug Fixes**
  - Addressed an issue that previously caused model evaluation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->