### PR TITLE
V1.3.2 main to develop

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -3,8 +3,27 @@ FiftyOne Release Notes
 
 .. default-role:: code
 
-FiftyOne Enterprise 2.6.1
--------------------------
+FiftyOne Teams 2.6.2
+--------------------
+*Released March 12, 2025*
+
+Includes all updates from :ref:`FiftyOne 1.3.2 <release-notes-v1.3.2>`
+
+.. _release-notes-v1.3.2:
+
+FiftyOne 1.3.2
+--------------
+*Released March 12, 2025*
+
+SDK
+
+- Fixed a bug
+  `#5486 <https://github.com/voxel51/fiftyone/issues/5486>`_
+  that caused model evaluation to fail in certain cases
+  `#5472 <https://github.com/voxel51/fiftyone/pull/5472>`_
+
+FiftyOne Teams 2.6.1
+--------------------
 *Released February 28, 2025*
 
 Includes all updates from :ref:`FiftyOne 1.3.1 <release-notes-v1.3.1>`, plus:


### PR DESCRIPTION
## What changes are proposed in this pull request?

post v1.3.2 merge main back into develop 

mostly bringing reflog up to date; also includes the new release notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Introduced updated release notes with new details for FiftyOne Teams 2.6.2 (March 12, 2025) and FiftyOne 1.3.2 (March 12, 2025).
  - The previous release note for FiftyOne Teams 2.6.1 remains unchanged with its February 28, 2025 release date.
- **Bug Fixes**
  - Documented a fix addressing model evaluation failures in the FiftyOne 1.3.2 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->