### PR TITLE
fix: add image tag for unlabeled sample in cvat

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -949,14 +949,8 @@ class CVATImageDatasetExporter(
     def export_sample(self, image_or_path, labels, metadata=None):
         out_image_path, uuid = self._media_exporter.export(image_or_path)
 
-        if labels is None:
-            return  # unlabeled
-
         if not isinstance(labels, dict):
             labels = {"labels": labels}
-
-        if all(v is None for v in labels.values()):
-            return  # unlabeled
 
         if metadata is None:
             metadata = fomt.ImageMetadata.build_for(image_or_path)


### PR DESCRIPTION
## What changes are proposed in this pull request?

The official CVAT format **does** contains `<image>` tag for unlabeled image, and **does not** for deleted images.

For many CV tasks, "unlabeled" images is indeed required, e.g. the background image of detection task, the negative samples of attribution task.

## How is this patch tested? If it is not, please explain why.

Test with a multilabel classification dataset, where so image does not belong to any required categories.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
