### PR TITLE
Always disable query performance for modal aggregations

### DIFF
--- a/app/packages/core/src/components/Actions/utils.test.ts
+++ b/app/packages/core/src/components/Actions/utils.test.ts
@@ -1,20 +1,19 @@
 import { describe, expect, it, vi } from "vitest";
+import * as utils from "../../../src/components/Actions/utils";
 
 vi.mock("recoil");
 vi.mock("recoil-relay");
-import * as utils from "../../../src/components/Actions/utils";
 
 import {
-  setMockAtoms,
-  TestSelector,
   TestSelectorFamily,
+  setMockAtoms,
 } from "../../../../../__mocks__/recoil";
 
 describe("Resolves tag counts", () => {
   it("resolves all", () => {
     setMockAtoms({
-      labelTagCounts: (params) => ({ one: 1, two: 1 }),
-      sampleTagCounts: (params) => ({ one: 1, two: 1 }),
+      labelTagCounts: (params) => ({ one: 1, two: 1, three: 1 }),
+      sampleTagCounts: (params) => ({ one: 1, two: 1, three: 1 }),
       tagStatistics: (modal) => ({
         count: 2,
         items: 1,
@@ -25,11 +24,21 @@ describe("Resolves tag counts", () => {
     const samples = <TestSelectorFamily<typeof utils.tagStats>>(
       (<unknown>utils.tagStats({ modal: false, labels: false }))
     );
-    expect(samples()).toStrictEqual({ one: 1, two: 1 });
+    expect(samples()).toStrictEqual({ one: 1, two: 1, three: 0 });
 
     const labels = <TestSelectorFamily<typeof utils.tagStats>>(
       (<unknown>utils.tagStats({ modal: false, labels: true }))
     );
-    expect(labels()).toStrictEqual({ one: 1, two: 1 });
+    expect(labels()).toStrictEqual({ one: 1, two: 1, three: 0 });
+
+    const samplesModal = <TestSelectorFamily<typeof utils.tagStats>>(
+      (<unknown>utils.tagStats({ modal: true, labels: false }))
+    );
+    expect(samplesModal()).toStrictEqual({ one: 1, two: 1 });
+
+    const labelsModal = <TestSelectorFamily<typeof utils.tagStats>>(
+      (<unknown>utils.tagStats({ modal: true, labels: true }))
+    );
+    expect(labelsModal()).toStrictEqual({ one: 1, two: 1 });
   });
 });

--- a/app/packages/core/src/components/Actions/utils.tsx
+++ b/app/packages/core/src/components/Actions/utils.tsx
@@ -132,7 +132,20 @@ export const tagStats = selectorFamily<
   get:
     ({ modal, labels }) =>
     ({ get }) => {
-      return get(tagStatistics({ modal, labels })).tags;
+      const data = modal
+        ? []
+        : Object.keys(
+            get(
+              labels
+                ? fos.labelTagCounts({ modal: false, extended: false })
+                : fos.sampleTagCounts({ modal: false, extended: false })
+            )
+          ).map((t) => [t, 0]);
+
+      return {
+        ...Object.fromEntries(data),
+        ...get(tagStatistics({ modal, labels })).tags,
+      };
     },
 });
 

--- a/app/packages/state/src/recoil/aggregations.ts
+++ b/app/packages/state/src/recoil/aggregations.ts
@@ -36,9 +36,11 @@ export const aggregationQuery = graphQLSelectorFamily<
   {
     customView?: any;
     extended: boolean;
+    isQueryPerformance?: boolean;
     modal: boolean;
     mixed?: boolean;
     paths: string[];
+
     root?: boolean;
   },
   Aggregation[]
@@ -52,9 +54,11 @@ export const aggregationQuery = graphQLSelectorFamily<
     ({
       customView = undefined,
       extended,
+      isQueryPerformance = undefined,
       mixed = false,
       modal,
       paths,
+
       root = false,
     }) =>
     ({ get }) => {
@@ -70,6 +74,7 @@ export const aggregationQuery = graphQLSelectorFamily<
       }
 
       mixed = mixed || get(groupStatistics(modal)) === "group";
+
       const aggForm = {
         index: get(refresher),
         dataset,
@@ -86,7 +91,10 @@ export const aggregationQuery = graphQLSelectorFamily<
         slices: mixed ? get(groupSlices) : get(currentSlices(modal)),
         slice: get(groupSlice),
         view: customView ? customView : !root ? get(viewAtoms.view) : [],
-        queryPerformance: get(queryPerformance) && !modal,
+        queryPerformance:
+          isQueryPerformance === undefined
+            ? get(queryPerformance) && !modal
+            : isQueryPerformance,
       };
 
       return {
@@ -100,7 +108,7 @@ export const aggregations = selectorFamily({
   get:
     (params: {
       extended: boolean;
-      lightning?: boolean;
+      isQueryPerformance?: boolean;
       modal: boolean;
       paths: string[];
       mixed?: boolean;
@@ -126,7 +134,7 @@ export const aggregation = selectorFamily({
       ...params
     }: {
       extended: boolean;
-      lightning?: boolean;
+      isQueryPerformance?: boolean;
       mixed?: boolean;
       modal: boolean;
       path: string;

--- a/app/packages/state/src/recoil/aggregations.ts
+++ b/app/packages/state/src/recoil/aggregations.ts
@@ -86,7 +86,7 @@ export const aggregationQuery = graphQLSelectorFamily<
         slices: mixed ? get(groupSlices) : get(currentSlices(modal)),
         slice: get(groupSlice),
         view: customView ? customView : !root ? get(viewAtoms.view) : [],
-        queryPerformance: get(queryPerformance),
+        queryPerformance: get(queryPerformance) && !modal,
       };
 
       return {

--- a/app/packages/state/src/recoil/pathData/tags.ts
+++ b/app/packages/state/src/recoil/pathData/tags.ts
@@ -15,6 +15,7 @@ export const labelTagCounts = selectorFamily<
         get(
           aggregation({
             extended,
+            isQueryPerformance: false,
             modal,
             path: `${path}.tags`,
             mixed: get(groupStatistics(modal)) === "group",
@@ -56,6 +57,7 @@ export const sampleTagCounts = selectorFamily<
       const data = get(
         aggregation({
           ...params,
+          isQueryPerformance: false,
           path: "tags",
           mixed: get(groupStatistics(params.modal)) === "group",
         })


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes opening the modal introduced by #5538. Also removes optimized tagging from the grid to ensure all possible tag values are presented when a sample selection is present.

## How is this patch tested? If it is not, please explain why.

Updated selector test

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced tag analytics now provide more detailed tag metrics for improved data insights.
	- Refined configuration for data aggregation optimizes performance and responsiveness in various contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->