### PR TITLE
Allow for compatibility within the 1.x major version

### DIFF
--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -42,7 +42,7 @@ RESOURCES_DIR = os.path.join(FIFTYONE_DIR, "resources")
 # This setting may be ``None`` if this client has no compatibility with other
 # versions
 #
-COMPATIBLE_VERSIONS = ">=0.19,<1.5"
+COMPATIBLE_VERSIONS = ">=0.19,<2"
 
 # Package metadata
 _META = metadata("fiftyone")


### PR DESCRIPTION
## What changes are proposed in this pull request?

Relax the compatibility range so that, moving forward, an older SDK can attempt to access a newer-versioned database or dataset.

## How is this patch tested? If it is not, please explain why.

Will test as part of the release.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Relax SDK <=> DB compatibility to allow connection when both are within the same major version.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Expanded the version compatibility range, allowing support for a broader set of upcoming software versions and enhancing integration flexibility for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->