### PR TITLE
Add support for patching samples with serialized values

### DIFF
--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -17,6 +17,7 @@ from pymongo import InsertOne, UpdateOne
 
 import eta.core.serial as etas
 
+import fiftyone.core.fields as fof
 import fiftyone.core.utils as fou
 
 from .database import ensure_connection
@@ -352,6 +353,12 @@ class MongoEngineBaseDocument(SerializableDocument):
 
         if len(chunks) > 1:
             doc = self.get_field(chunks[0])
+
+            # handle sytnax: sample["field.0.attr"] = value
+            if isinstance(doc, (mongoengine.base.BaseList, fof.ListField)):
+                chunks = chunks[1].split(".", 1)
+                doc = doc[int(chunks[0])]
+
             return doc.set_field(chunks[1], value, create=create)
 
         if not create and not self.has_field(field_name):

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -11,6 +11,7 @@ from datetime import datetime
 import itertools
 
 from bson import ObjectId
+import mongoengine
 from pymongo import UpdateOne
 
 import fiftyone.core.fields as fof
@@ -141,6 +142,12 @@ class DatasetMixin(object):
 
         if len(chunks) > 1:
             doc = self.get_field(chunks[0])
+
+            # handle sytnax: sample["field.0.attr"] = value
+            if isinstance(doc, (mongoengine.base.BaseList, fof.ListField)):
+                chunks = chunks[1].split(".", 1)
+                doc = doc[int(chunks[0])]
+
             return doc.set_field(chunks[1], value, create=create)
 
         if not self.has_field(field_name):

--- a/fiftyone/core/odm/utils.py
+++ b/fiftyone/core/odm/utils.py
@@ -115,6 +115,9 @@ def deserialize_value(value):
         # Serialized array in non-extended format
         return fou.deserialize_numpy_array(value)
 
+    if isinstance(value, list):
+        return [deserialize_value(v) for v in value]
+
     return value
 
 


### PR DESCRIPTION
## Change log

- Adds support for list values to `foo.deserialize_value()`
- Adds support for setting nested list attributes directly via `Sample.__setitem__`

```py
# Existing object-oriented syntax
sample.ground_truth.detections[0].label = "cat"

# New deep-set syntax
sample["ground_truth.detections.0.label"] = "cat"
```

## Motivation

Suppose you want to edit a sample in one process but then serialize the edits and apply the patches in another process.

As shown below, this is now fully-supported via a natural syntax, including nested list/embedded document updates:

```py
import fiftyone as fo
import fiftyone.core.odm as foo

sample = fo.Sample(
    filepath="image.jpg", 
    metadata=fo.ImageMetadata(),
    ground_truth=fo.Detections(detections=[fo.Detection()]),
    predictions=fo.Detections(),
)

dataset = fo.Dataset()
dataset.add_sample(sample)

# Perform some complex sample edits 
d = fo.Detection()
sample.filepath = "IMAGE.JPG"
sample.metadata.size_bytes = 51
sample.ground_truth.detections[0].label = "CAT"
sample.predictions.detections.append(d)

# Serialize edits
ops, _ = sample._save(deferred=True)
id = ops[0]._filter["_id"]
edits = ops[0]._doc["$set"]
edits.pop("last_modified_at")
```

```py
fo.pprint(edits)
```

```
{
    'filepath': 'IMAGE.JPG',
    'metadata.size_bytes': 51,
    'ground_truth.detections.0.label': 'CAT',
    'predictions.detections': [
        SON([('_id', ObjectId('67d3a5bcf7ec00b13ee88651')), ('_cls', 'Detection'), ('attributes', {}), ('tags', []), ('bounding_box', [])]),
    ],
}
```

```py
# Simulate a new process
dataset.reload()

# Here's the punch line: this syntax is super clean!
def patch_sample(dataset, id, edits):
    sample = dataset[id]
    for path, value in edits.items():
        sample[path] = foo.deserialize_value(value)
    sample.save()

# Apply edits
patch_sample(dataset, id, edits)

# Verify that edits were applied correctly
sample = dataset[id]
sample.reload()
assert sample.filepath == "IMAGE.JPG"
assert sample.metadata.size_bytes == 51
assert sample.ground_truth.detections[0].label == "CAT"
assert sample.predictions.detections[0] == d
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced handling of complex, nested data structures by improving support for list-type fields, ensuring more seamless data updates.
- **Tests**
  - Expanded test coverage for sample updates, confirming that modifications to various fields are processed reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->