### PR TITLE
Fix #5570 full schema merges

### DIFF
--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -1130,9 +1130,6 @@ class DatasetMixin(object):
                     )
                 )
 
-        if isinstance(field, fof.ObjectIdField) and field_name.startswith("_"):
-            field_name = field_name[1:]
-
         if field_name in doc._fields:
             existing_field = doc._fields[field_name]
 

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -3479,6 +3479,35 @@ class MultitaskImageDatasetTests(ImageDatasetTests):
             )
         )
 
+        # Test full schema merge
+
+        export_dir = self._new_dir()
+
+        sample1 = fo.Sample(filepath="video1.mp4")
+        sample1.frames[1] = fo.Frame()
+
+        dataset1 = fo.Dataset()
+        dataset1.add_sample(sample1)
+
+        sample2 = fo.Sample(filepath="video2.mp4")
+        sample2.frames[1] = fo.Frame()
+
+        dataset2 = fo.Dataset()
+        dataset2.add_sample(sample2)
+
+        dataset2.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.FiftyOneDataset,
+            export_media=False,
+        )
+
+        dataset1.add_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.FiftyOneDataset,
+        )
+
+        self.assertEqual(len(dataset1), 2)
+
     @skipwindows
     @drop_datasets
     def test_legacy_fiftyone_dataset(self):
@@ -3842,6 +3871,35 @@ class MultitaskImageDatasetTests(ImageDatasetTests):
                 m1 < m2 for m1, m2 in zip(last_modified_at1, last_modified_at2)
             )
         )
+
+        # Test full schema merge
+
+        export_dir = self._new_dir()
+
+        sample1 = fo.Sample(filepath="video1.mp4")
+        sample1.frames[1] = fo.Frame()
+
+        dataset1 = fo.Dataset()
+        dataset1.add_sample(sample1)
+
+        sample2 = fo.Sample(filepath="video2.mp4")
+        sample2.frames[1] = fo.Frame()
+
+        dataset2 = fo.Dataset()
+        dataset2.add_sample(sample2)
+
+        dataset2.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.LegacyFiftyOneDataset,
+            export_media=False,
+        )
+
+        dataset1.add_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.LegacyFiftyOneDataset,
+        )
+
+        self.assertEqual(len(dataset1), 2)
 
 
 class OpenLABELImageDatasetTests(ImageDatasetTests):


### PR DESCRIPTION
Resolves #5570

```py
import fiftyone as fo

sample1 = fo.Sample(filepath="video1.mp4")
sample1.frames[1] = fo.Frame()

dataset1 = fo.Dataset()
dataset1.add_sample(sample1)

sample2 = fo.Sample(filepath="video2.mp4")
sample2.frames[1] = fo.Frame()

dataset2 = fo.Dataset()
dataset2.add_sample(sample2)

dataset2.export(
    export_dir="/tmp/fod",
    dataset_type=fo.types.FiftyOneDataset,
    export_media=False,
    overwrite=True,
)

# Previously raised an error; now succeeds
_ = dataset1.add_dir(
    dataset_dir="/tmp/fod",
    dataset_type=fo.types.FiftyOneDataset,
)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted dataset merging to preserve original field names, ensuring consistent behavior.
- **Tests**
  - Added new test cases to verify successful dataset merging across both modern and legacy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->