### PR TITLE
Add support for listing operators with glob pattern via CLI

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -842,7 +842,7 @@ List operators and panels that are installed locally.
 
 .. code-block:: text
 
-    fiftyone operators list [-h] [-e] [-d] [-b] [-c] [-o] [-p] [-n]
+    fiftyone operators list [-h] [-g PATT] [-e] [-d] [-b] [-c] [-o] [-p] [-n]
 
 **Arguments**
 
@@ -850,6 +850,8 @@ List operators and panels that are installed locally.
 
     optional arguments:
       -h, --help            show this help message and exit
+      -g PATT, --glob-patt PATT
+                            only show operators whose URI matches the glob pattern
       -e, --enabled         only show enabled operators and panels
       -d, --disabled        only show disabled operators and panels
       -b, --builtins-only   only show builtin operators and panels
@@ -864,6 +866,11 @@ List operators and panels that are installed locally.
 
     # List all available operators and panels
     fiftyone operators list
+
+.. code-block:: shell
+
+    # List operators and panels whose URI matches the given glob pattern
+    fiftyone operators list --glob-patt '*/compute_*'
 
 .. code-block:: shell
 

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -9,8 +9,10 @@ Definition of the `fiftyone` command-line interface (CLI).
 import argparse
 from collections import defaultdict
 from datetime import datetime
+import fnmatch
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -2969,6 +2971,9 @@ class OperatorsListCommand(Command):
         # List all available operators and panels
         fiftyone operators list
 
+        # List operators and panels whose URI matches the given glob pattern
+        fiftyone operators list --glob-patt '*/compute_*'
+
         # List enabled operators and panels
         fiftyone operators list --enabled
 
@@ -2984,6 +2989,12 @@ class OperatorsListCommand(Command):
 
     @staticmethod
     def setup(parser):
+        parser.add_argument(
+            "-g",
+            "--glob-patt",
+            metavar="PATT",
+            help="only show operators whose URI matches the glob pattern",
+        )
         parser.add_argument(
             "-e",
             "--enabled",
@@ -3056,16 +3067,26 @@ class OperatorsListCommand(Command):
         else:
             type = None
 
-        _print_operators_list(enabled, builtin, type, args.names_only)
+        _print_operators_list(
+            enabled, builtin, type, args.glob_patt, args.names_only
+        )
 
 
-def _print_operators_list(enabled, builtin, type, names_only):
+def _print_operators_list(enabled, builtin, type, glob_patt, names_only):
+    if glob_patt is not None:
+        regex = re.compile(fnmatch.translate(glob_patt))
+    else:
+        regex = None
+
     operators = foo.list_operators(enabled=enabled, builtin=builtin, type=type)
 
     if names_only:
         operators_map = defaultdict(list)
-        for operator in operators:
-            operators_map[operator.plugin_name].append(operator)
+        for op in operators:
+            if regex is not None and not regex.match(op.uri):
+                continue
+
+            operators_map[op.plugin_name].append(op)
 
         for pname, ops in operators_map.items():
             print(pname)
@@ -3080,6 +3101,9 @@ def _print_operators_list(enabled, builtin, type, names_only):
 
     rows = []
     for op in operators:
+        if regex is not None and not regex.match(op.uri):
+            continue
+
         rows.append(
             {
                 "uri": op.uri,


### PR DESCRIPTION
```
$ fiftyone operators list --glob-patt '*compute*'
uri                                              enabled    builtin    panel    unlisted
-----------------------------------------------  ---------  ---------  -------  ----------
@voxel51/utils/compute_metadata                  ✓
@voxel51/brain/compute_visualization             ✓
@voxel51/brain/compute_similarity                ✓
@voxel51/brain/compute_uniqueness                ✓
@voxel51/brain/compute_mistakenness              ✓
@voxel51/brain/compute_hardness                  ✓
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional filter parameter to the operator listing command, enabling users to refine displayed operators using glob pattern matching.
  
- **Documentation**
  - Updated the help and examples to illustrate the new filtering option for improved clarity and ease of use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->