### PR TITLE
[POC] add TTL cache support for plugins registry

### DIFF
--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -114,6 +114,18 @@ class FiftyOneConfig(EnvConfig):
             env_var="FIFTYONE_PLUGINS_CACHE_ENABLED",
             default=False,
         )
+        self.plugins_cache_ttl = self.parse_int(
+            d,
+            "plugins_cache_ttl",
+            env_var="FIFTYONE_PLUGINS_CACHE_TTL",
+            default=60,  # 60 seconds (1 minutes)
+        )
+        self.plugins_cache_strategy = self.parse_string(
+            d,
+            "plugins_cache_strategy",
+            env_var="FIFTYONE_PLUGINS_CACHE_STRATEGY",
+            default="fs",  # supported values: "fs", "ttl"
+        )
         self.operator_timeout = self.parse_int(
             d,
             "operator_timeout",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add a TTL cache strategy support for plugins registry

## How is this patch tested? If it is not, please explain why.

Using various operators and panels events

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
