### PR TITLE
Bump brain version to v0.20.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ INSTALL_REQUIRES = [
     "universal-analytics-python3>=1.0.1,<2",
     "pydash",
     # internal packages
-    "fiftyone-brain>=0.19.0,<0.20",
+    "fiftyone-brain>=0.20.0,<0.21",
     "fiftyone-db>=0.4,<2.0",
     "voxel51-eta>=0.14.0,<0.15",
 ]


### PR DESCRIPTION
Bumping `fiftyone-brain` version in preparation for when https://github.com/voxel51/fiftyone-brain/pull/242 is released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Revised the version requirements of a key external dependency to ensure the software remains compatible with the most recent and stable releases. With this adjustment, users can expect improved integration and reduced potential for conflicts in future updates, contributing to a more reliable overall experience and ensuring optimal performance and user satisfaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->