### PR TITLE
fix delete saved workspace

### DIFF
--- a/app/packages/spaces/src/components/Workspaces/WorkspaceEditor.tsx
+++ b/app/packages/spaces/src/components/Workspaces/WorkspaceEditor.tsx
@@ -107,7 +107,7 @@ export default function WorkspaceEditor() {
                 setStatus("deleting");
                 executeOperator(
                   DELETE_WORKSPACE_OPERATOR,
-                  { name },
+                  { names: [name] },
                   {
                     callback: (result) => {
                       if (!result.error) {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix delete saved workspace action broken due to operator schema change

## How is this patch tested? If it is not, please explain why.

Using delete saved workspace in the app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fix delete saved workspace flow in the app

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the workspace deletion process to support handling multiple workspaces, paving the way for future batch deletion capabilities while maintaining a consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->