### PR TITLE
Fix points_field attr reference when using older fiftyone.brain versions

### DIFF
--- a/fiftyone/server/routes/embeddings.py
+++ b/fiftyone/server/routes/embeddings.py
@@ -76,7 +76,11 @@ class OnPlotLoad(HTTPEndpoint):
 
         patches_field = results.config.patches_field
         is_patches_plot = patches_field is not None
-        points_field = results.config.points_field
+        points_field = (
+            results.config.points_field
+            if hasattr(results.config, "points_field")
+            else None
+        )
 
         # Determines which points from `results` are in `view`, which are the
         # only points we want to display in the embeddings plot


### PR DESCRIPTION
This prevents the following error when `fiftyone` is using a version of `fiftyone.brain` that does not include the new `config.points_field` attribute.

> points_field = results.config.points_field\nAttributeError: 'UMAPVisualizationConfig' object has no attribute 'points_field'\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced system robustness by adding a conditional check to ensure certain configuration settings are present before use, thereby preventing potential runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->