### PR TITLE
Fix sample pages invalidation

### DIFF
--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -52,7 +52,7 @@ function Grid() {
   });
 
   const { page, store } = useSpotlightPager({
-    clearRecords: pageReset,
+    clearRecords: reset,
     pageSelector: pageParameters,
     records,
     zoomSelector: gridCrop,

--- a/app/packages/core/src/components/Grid/useLookerCache.ts
+++ b/app/packages/core/src/components/Grid/useLookerCache.ts
@@ -15,12 +15,6 @@ export default function useLookerCache({
   onSet?: (key: string) => void;
   reset: string;
 }) {
-  useEffect(() => {
-    const listener = () => cache.empty();
-    document.addEventListener("visibilitychange", listener);
-    return () => document.removeEventListener("visibilitychange", listener);
-  }, []);
-
   const cache = useMemoOne(() => {
     /** CLEAR CACHE WHEN reset CHANGES */
     reset;
@@ -36,6 +30,12 @@ export default function useLookerCache({
 
   // delete cache during cleanup
   useEffect(() => () => cache.delete(), [cache]);
+
+  useEffect(() => {
+    const listener = () => cache.empty();
+    document.addEventListener("visibilitychange", listener);
+    return () => document.removeEventListener("visibilitychange", listener);
+  }, [cache]);
 
   return cache;
 }

--- a/app/packages/core/src/components/Grid/useSpotlightPager.ts
+++ b/app/packages/core/src/components/Grid/useSpotlightPager.ts
@@ -3,14 +3,10 @@ import * as foq from "@fiftyone/relay";
 import type { ID, Response } from "@fiftyone/spotlight";
 import * as fos from "@fiftyone/state";
 import type { Schema } from "@fiftyone/utilities";
-import { useEffect, useMemo, useRef } from "react";
+import { useMemo, useRef } from "react";
 import { useErrorHandler } from "react-error-boundary";
 import type { VariablesOf } from "react-relay";
-import {
-  commitLocalUpdate,
-  fetchQuery,
-  useRelayEnvironment,
-} from "react-relay";
+import { fetchQuery, useRelayEnvironment } from "react-relay";
 import type { RecoilValueReadOnly } from "recoil";
 import { useRecoilCallback, useRecoilValue } from "recoil";
 import type { Subscription } from "relay-runtime";
@@ -69,6 +65,12 @@ const useSpotlightPager = ({
 
   const keys = useRef(new Set<string>());
 
+  const pages = useMemo(() => {
+    /** Track already request pages */
+    clearRecords;
+    return new Set();
+  }, [clearRecords]);
+
   const page = useRecoilCallback(
     ({ snapshot }) => {
       return async (pageNumber: number) => {
@@ -77,6 +79,14 @@ const useSpotlightPager = ({
         const schema = await snapshot.getPromise(
           fos.fieldSchema({ space: fos.State.SPACE.SAMPLE })
         );
+
+        // if a page has not been requested by this callback, require a network
+        // request
+        const fetchPolicy = pages.has(pageNumber)
+          ? "store-or-network"
+          : "network-only";
+        pages.add(pageNumber);
+
         return new Promise<Response<number, fos.Sample>>((resolve) => {
           subscription = fetchQuery<foq.paginateSamplesQuery>(
             environment,
@@ -84,7 +94,7 @@ const useSpotlightPager = ({
             variables,
             {
               networkCacheConfig: { metadata: {} },
-              fetchPolicy: "store-or-network",
+              fetchPolicy,
             }
           ).subscribe({
             next: (data) => {
@@ -114,30 +124,6 @@ const useSpotlightPager = ({
     },
     [environment, handleError, pager, store, zoom]
   );
-
-  const refresher = useRecoilValue(fos.refresher);
-
-  useEffect(() => {
-    clearRecords;
-    refresher;
-    const clear = () => {
-      commitLocalUpdate(fos.getCurrentEnvironment(), (store) => {
-        for (const id of keys.current) {
-          store.get(id)?.invalidateRecord();
-        }
-      });
-      keys.current.clear();
-    };
-
-    const unsubscribe = foq.subscribe(
-      ({ event }) => event === "fieldVisibility" && clear()
-    );
-
-    return () => {
-      clear();
-      unsubscribe();
-    };
-  }, [clearRecords, refresher]);
 
   return { page, records, store };
 };


### PR DESCRIPTION
## What changes are proposed in this pull request?

With grid caching now in place, it is apparent that the sample data request through relay is lacking. It seem that invalidating a record means future requests are not cached in the store.

Instead, we can force network requests when reloading samples from the server is necessary by toggling the `fetchPolicy`

### Before


https://github.com/user-attachments/assets/a2193407-def8-40e1-880d-9ec2f22b4873



### After

https://github.com/user-attachments/assets/40fe89be-f526-4fee-9d8c-d645d5f098ad




## How is this patch tested? If it is not, please explain why.

Existing grid tagging spec

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined record management in grid components to ensure a more consistent pagination experience.
  - Enhanced cache refresh functionality that responds to document visibility changes for up-to-date content.
  - Improved data fetching for paginated content by dynamically adjusting retrieval based on previously accessed pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->