### PR TITLE
Expand python testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
         exclude:
           - os: windows-latest
             python: "3.9"
@@ -43,6 +44,8 @@ jobs:
             python: "3.10"
           - os: windows-latest
             python: "3.11"
+          - os: windows-latest
+            python: "3.12"
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Add Python 3.12 testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced our continuous integration process to incorporate testing with Python 3.12 and 3.13. Adjustments have been made to ensure that tests run only on supported operating system configurations, improving overall stability and compatibility. These updates reinforce our commitment to quality assurance and reliable performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->