### PR TITLE
Selection id bottleneck

### DIFF
--- a/app/packages/embeddings/src/useExtendedStageEffect.tsx
+++ b/app/packages/embeddings/src/useExtendedStageEffect.tsx
@@ -5,6 +5,7 @@ import { usePanelStatePartial } from "@fiftyone/spaces";
 import { fetchExtendedStage } from "./fetch";
 import { atoms as selectionAtoms } from "./usePlotSelection";
 import { usePointsField } from "./useBrainResult";
+import { shouldResolveSelection } from "./utils";
 
 export default function useExtendedStageEffect() {
   const datasetName = useRecoilValue(fos.datasetName);
@@ -23,11 +24,17 @@ export default function useExtendedStageEffect() {
 
   useEffect(() => {
     if (loadedPlot && Array.isArray(selection)) {
+      const shouldIncludeSelection = shouldResolveSelection(
+        view,
+        null,
+        loadedPlot.patches_field,
+        pointsField
+      );
       fetchExtendedStage({
         datasetName,
         view,
         patchesField: loadedPlot.patches_field,
-        selection,
+        selection: shouldIncludeSelection ? selection : null,
         slices,
         lassoPoints,
         pointsField,

--- a/app/packages/embeddings/src/useSelectionEffect.tsx
+++ b/app/packages/embeddings/src/useSelectionEffect.tsx
@@ -5,6 +5,7 @@ import { usePanelStatePartial } from "@fiftyone/spaces";
 import { useBrainResult } from "./useBrainResult";
 import { fetchUpdatedSelection } from "./fetch";
 import { usePlotSelection } from "./usePlotSelection";
+import { shouldResolveSelection } from "./utils";
 
 export function useSelectionEffect() {
   const { setPlotSelection } = usePlotSelection();
@@ -22,23 +23,40 @@ export function useSelectionEffect() {
   useEffect(() => {
     if (loadedPlot) {
       const resolvedExtended = selection ? extended : null;
-      fetchUpdatedSelection({
-        datasetName,
-        brainKey,
-        view,
-        filters,
-        extended: resolvedExtended,
-        extendedSelection: selection,
-        slices,
-      }).then((res) => {
-        let resolved = null;
-        if (res.selected) {
-          resolved = res.selected;
-        } else if (selectedSamples && selectedSamples.size) {
-          resolved = Array.from(selectedSamples);
-        }
-        setPlotSelection(resolved);
-      });
+      if (
+        shouldResolveSelection(
+          view,
+          filters,
+          loadedPlot?.patches_field,
+          loadedPlot?.points_field
+        )
+      ) {
+        fetchUpdatedSelection({
+          datasetName,
+          brainKey,
+          view,
+          filters,
+          extended: resolvedExtended,
+          extendedSelection: selection,
+          slices,
+        }).then((res) => {
+          let resolved = null;
+          if (res.selected) {
+            resolved = res.selected;
+          } else if (selectedSamples && selectedSamples.size) {
+            resolved = Array.from(selectedSamples);
+          }
+          setPlotSelection(resolved);
+        });
+      }
     }
-  }, [datasetName, brainKey, view, filters, selection, selectedSamples]);
+  }, [
+    datasetName,
+    brainKey,
+    view,
+    filters,
+    selection,
+    selectedSamples,
+    loadedPlot?.patches_field,
+  ]);
 }

--- a/app/packages/embeddings/src/useViewChangeEffect.tsx
+++ b/app/packages/embeddings/src/useViewChangeEffect.tsx
@@ -74,6 +74,7 @@ export function useViewChangeEffect() {
         setLoadingPlotError(null);
         setLoadedPlot(res);
         setPointsField(res.points_field);
+        setPatchesField(res.patches_field);
       })
       .finally(() => setLoadingPlot(false));
   }, [datasetName, brainKey, labelField, view, colorSeed, slices, filters]);

--- a/app/packages/embeddings/src/useViewChangeEffect.tsx
+++ b/app/packages/embeddings/src/useViewChangeEffect.tsx
@@ -74,7 +74,6 @@ export function useViewChangeEffect() {
         setLoadingPlotError(null);
         setLoadedPlot(res);
         setPointsField(res.points_field);
-        setPatchesField(res.patches_field);
       })
       .finally(() => setLoadingPlot(false));
   }, [datasetName, brainKey, labelField, view, colorSeed, slices, filters]);

--- a/app/packages/embeddings/src/utils.test.ts
+++ b/app/packages/embeddings/src/utils.test.ts
@@ -1,0 +1,52 @@
+import { shouldResolveSelection } from "./utils";
+import { it, expect, describe } from "vitest";
+
+describe("shouldResolveSelection", () => {
+  it("returns false when canUseSpatialSelection is true and filters are empty", () => {
+    const view = [];
+    const filters = {};
+    const patchesField = undefined;
+    const pointsField = "point";
+
+    const result = shouldResolveSelection(
+      view,
+      filters,
+      patchesField,
+      pointsField
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("returns true when canUseSpatialSelection is true and filters are not empty", () => {
+    const view = [];
+    const filters = { someFilter: true };
+    const patchesField = undefined;
+    const pointsField = "point";
+
+    const result = shouldResolveSelection(
+      view,
+      filters,
+      patchesField,
+      pointsField
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it("returns true when canUseSpatialSelection is false", () => {
+    const view = [];
+    const filters = {};
+    const patchesField = "ground_truth";
+    const pointsField = undefined;
+
+    const result = shouldResolveSelection(
+      view,
+      filters,
+      patchesField,
+      pointsField
+    );
+
+    expect(result).toBe(true);
+  });
+});

--- a/app/packages/embeddings/src/utils.ts
+++ b/app/packages/embeddings/src/utils.ts
@@ -1,8 +1,18 @@
+export type ViewStage = {
+  _cls: string;
+};
+
+export type Filters = {
+  [key: string]: {};
+} | null;
+
+const PATCHES_VIEW_STAGE = "fiftyone.core.stages.PatchesView";
+
 export function shouldResolveSelection(
-  view,
-  filters,
-  patchesField,
-  pointsField
+  view: ViewStage[],
+  filters: Filters,
+  patchesField?: string,
+  pointsField?: string
 ) {
   const samplesType = isPatchesView(view) ? "patches" : "samples";
   const plotType = patchesField ? "patches" : "samples";
@@ -10,16 +20,16 @@ export function shouldResolveSelection(
   return !canUseSpatialSelection || hasFilters(filters);
 }
 
-export function isPatchesView(view) {
+export function isPatchesView(view: ViewStage[]) {
   for (const stage of view) {
-    if (stage?._cls === "fiftyone.core.stages.ToPatches") {
+    if (stage?._cls === PATCHES_VIEW_STAGE) {
       return true;
     }
   }
   return false;
 }
 
-export function hasFilters(filters) {
+export function hasFilters(filters: Filters) {
   if (!filters) return false;
   return Object.keys(filters).length > 0;
 }

--- a/app/packages/embeddings/src/utils.ts
+++ b/app/packages/embeddings/src/utils.ts
@@ -1,0 +1,25 @@
+export function shouldResolveSelection(
+  view,
+  filters,
+  patchesField,
+  pointsField
+) {
+  const samplesType = isPatchesView(view) ? "patches" : "samples";
+  const plotType = patchesField ? "patches" : "samples";
+  const canUseSpatialSelection = pointsField && samplesType === plotType;
+  return !canUseSpatialSelection || hasFilters(filters);
+}
+
+export function isPatchesView(view) {
+  for (const stage of view) {
+    if (stage?._cls === "fiftyone.core.stages.ToPatches") {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function hasFilters(filters) {
+  if (!filters) return false;
+  return Object.keys(filters).length > 0;
+}


### PR DESCRIPTION
Dynamically determines if the embeddings plot should resolve highlighted plot points based on:

 - `points_field` - the points_field must be defined, meaning this view has a corresponding spatial index
 - `filters` - filters must not be provided, since those selected IDs must be resolved by the API
 - appropriate combination of patches|sample plot and grid sources - since only a flat collection can be spatially queried without resolved selected IDs

This way, when server-side id resolution is not required, the ids are never sent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Refined selection handling to ensure that content updates and data fetching now adapt to active filters and view settings, resulting in more accurate and consistent displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->