### PR TITLE
Fix incorrect `$geoWithin` injection in embeddings backend

### DIFF
--- a/app/packages/embeddings/src/utils.ts
+++ b/app/packages/embeddings/src/utils.ts
@@ -6,7 +6,7 @@ export type Filters = {
   [key: string]: {};
 } | null;
 
-const PATCHES_VIEW_STAGE = "fiftyone.core.stages.PatchesView";
+const PATCHES_VIEW_STAGE = "fiftyone.core.stages.ToPatches";
 
 export function shouldResolveSelection(
   view: ViewStage[],

--- a/fiftyone/server/routes/embeddings.py
+++ b/fiftyone/server/routes/embeddings.py
@@ -253,11 +253,12 @@ class EmbeddingsExtendedStage(HTTPEndpoint):
 
         is_patches_view = view._is_patches
         is_patches_plot = patches_field is not None
+        view_and_plot_source_are_equal = is_patches_view == is_patches_plot
 
         if (
             lasso_points is not None
             and points_field is not None
-            and (patches_field is None or is_patches_view)
+            and view_and_plot_source_are_equal
         ):
             # Lasso points via spatial index
             # Unfortunately we can't use $geoWithin to filter nested arrays.


### PR DESCRIPTION
Fixes an issue where the `$geoWithin` `fos.Mongo` stage was being added incorrectly. Now the embeddings backend will ensure that the plot source and the view source are the same before injecting the `$geoWithin` stage.

**You should never see this**

We should never see a `ToPatches` stage w/ a `Mongo` stage here (after clicking the bookmark).

<img width="729" alt="image" src="https://github.com/user-attachments/assets/bcb4d030-2a01-4ea6-b424-901a280b1d7e" />

We also ensure that this stage is never injected in the other combination: sample view and patches plot. The only way for the panel to handle this currently is by the old mechanism: `fos.MatchLabels`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Refined the internal logic for processing selections to improve consistency between view types and corresponding plot sources, ensuring smoother handling of selection actions.
	- Updated the constant used for identifying patches views to enhance clarity in logic comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->