### PR TITLE
Fix search for string fields

### DIFF
--- a/fiftyone/server/lightning.py
+++ b/fiftyone/server/lightning.py
@@ -438,7 +438,7 @@ def _add_search(query: DistinctQuery):
             # search is not valid
             value = {"$lt": ObjectId("0" * _TWENTY_FOUR)}
     else:
-        value = Regex(f"^{search}")
+        value = Regex(f"^{query.search}")
     return {"$match": {query.path: value}}
 
 

--- a/tests/unittests/server_lightning_tests.py
+++ b/tests/unittests/server_lightning_tests.py
@@ -1053,6 +1053,47 @@ class TestStringLightningQueries(unittest.IsolatedAsyncioTestCase):
             ],
         )
 
+        # test search
+        result = await _execute(
+            query, dataset, fo.StringField, keys, search="lower"
+        )
+        self.assertListEqual(
+            result.data["lightning"],
+            [
+                {"path": "classification.none", "values": []},
+                {"path": "classification.str", "values": ["lower"]},
+                {"path": "classification.str_list", "values": ["lower"]},
+                {"path": "detections.detections.none", "values": []},
+                {"path": "detections.detections.str", "values": ["lower"]},
+                {
+                    "path": "detections.detections.str_list",
+                    "values": ["lower"],
+                },
+                {"path": "frames.classification.none", "values": []},
+                {"path": "frames.classification.str", "values": ["lower"]},
+                {
+                    "path": "frames.classification.str_list",
+                    "values": ["lower"],
+                },
+                {"path": "frames.detections.detections.none", "values": []},
+                {
+                    "path": "frames.detections.detections.str",
+                    "values": ["lower"],
+                },
+                {
+                    "path": "frames.detections.detections.str_list",
+                    "values": ["lower"],
+                },
+                {"path": "frames.none", "values": []},
+                {"path": "frames.str", "values": ["lower"]},
+                {"path": "frames.str_list", "values": ["lower"]},
+                {"path": "metadata.encoding_str", "values": []},
+                {"path": "none", "values": []},
+                {"path": "str", "values": ["lower"]},
+                {"path": "str_list", "values": ["lower"]},
+            ],
+        )
+
 
 class TestGroupDatasetLightningQueries(unittest.IsolatedAsyncioTestCase):
     @drop_async_dataset


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes sidebar searches for string fields. This is a regression currently in release/v1.4.1 due to https://github.com/voxel51/fiftyone/pull/5415. It does not exist in 1.3.1

## How is this patch tested? If it is not, please explain why.

Server test

## Release Notes

Not applicable

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue with search functionality to ensure user queries return accurate results.

- **Tests**
  - Added enhanced tests to verify that search operations for string fields filter results correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->