### PR TITLE
Bugfix for map samples progress bar

### DIFF
--- a/fiftyone/core/map/process.py
+++ b/fiftyone/core/map/process.py
@@ -234,7 +234,7 @@ def _map_batch(args: Tuple[int, int, fomb.SampleBatch]):
 
         pb = None
         if process_progress:
-            desc = f"Batch {i + 1:0{len(str(num_batches))}}/{num_batches}"
+            desc = f"Batch {i:0{len(str(num_batches))}}/{num_batches}"
             pb = tqdm(sample_iter, total=batch.total, desc=desc, position=i)
 
         while not process_cancel_event.is_set() and (

--- a/fiftyone/core/map/process.py
+++ b/fiftyone/core/map/process.py
@@ -232,11 +232,10 @@ def _map_batch(args: Tuple[int, int, fomb.SampleBatch]):
 
         sample_iter = sample_collection.iter_samples(autosave=process_save)
 
+        pb = None
         if process_progress:
             desc = f"Batch {i + 1:0{len(str(num_batches))}}/{num_batches}"
-            sample_iter = tqdm(
-                sample_iter, total=batch.total, desc=desc, position=i
-            )
+            pb = tqdm(sample_iter, total=batch.total, desc=desc, position=i)
 
         while not process_cancel_event.is_set() and (
             sample := next(sample_iter, None)
@@ -261,6 +260,8 @@ def _map_batch(args: Tuple[int, int, fomb.SampleBatch]):
                 if process_sample_count is not None:
                     with process_sample_count.get_lock():
                         process_sample_count.value += 1
+                if pb is not None:
+                    pb.update()
     finally:
         if process_batch_count is not None:
             with process_batch_count.get_lock():


### PR DESCRIPTION
## What changes are proposed in this pull request?

Running tqdm with multiple progress bars in `project/map-samples` has an error because the returned class `tqdm_asyncio` is not an iterator. Running the progress bar update manually fixes this issue. There is also a small bug fix for batch index.

## How is this patch tested? If it is not, please explain why.

* Tested manually

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced configuration options now permit setting a default number of processing workers.
  - Introduced flexible sample batching strategies to efficiently split and manage sample collections.
  - Added multiple parallel processing backends—including multiprocessing and threading—to boost mapping performance and improve error handling.
  - New utilities streamline the process of mapping and updating samples.

- **Tests**
  - Comprehensive new tests validate the improved batching and mapping functionalities for enhanced reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->