### PR TITLE
Bump brain version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ INSTALL_REQUIRES = [
     "universal-analytics-python3>=1.0.1,<2",
     "pydash",
     # internal packages
-    "fiftyone-brain>=0.20.0,<0.21",
+    "fiftyone-brain>=0.20.1,<0.21",
     "fiftyone-db>=0.4,<2.0",
     "voxel51-eta>=0.14.0,<0.15",
 ]


### PR DESCRIPTION
Would be nice to require `fiftyone-brain>=0.20.1` so that we can ensure `fiftyone==1.4.0` users won't encounter the small bug fixed in https://github.com/voxel51/fiftyone-brain/pull/246