### PR TITLE
Exponenetial backoff to timeout

### DIFF
--- a/fiftyone/core/map/process.py
+++ b/fiftyone/core/map/process.py
@@ -135,17 +135,13 @@ class ProcessMapper(fomm.LocalMapper[T]):
             max_timeout = 5.0
             backoff_factor = 2
             current_timeout = initial_timeout
-            consecutive_timeouts = 0
-            max_consecutive_timeouts = 5
 
             while True:
                 try:
                     sample_id, err, result = queue.get(timeout=current_timeout)
                     # Reset backoff on successful get
                     current_timeout = initial_timeout
-                    consecutive_timeouts = 0
                 except Empty:
-                    consecutive_timeouts += 1
                     # Apply exponential backoff, but cap at max_timeout
                     current_timeout = min(
                         current_timeout * backoff_factor, max_timeout
@@ -153,9 +149,8 @@ class ProcessMapper(fomm.LocalMapper[T]):
 
                     # Reset backoff if we've hit too many consecutive timeouts
                     # This prevents getting stuck with very long timeouts
-                    if consecutive_timeouts >= max_consecutive_timeouts:
+                    if current_timeout == max_timeout:
                         current_timeout = initial_timeout
-                        consecutive_timeouts = 0
 
                     # Check if done after applying backoff
                     if batch_count.value >= num_batches:

--- a/fiftyone/core/map/process.py
+++ b/fiftyone/core/map/process.py
@@ -129,10 +129,35 @@ class ProcessMapper(fomm.LocalMapper[T]):
             )
 
             sample_errors: List[Tuple[bson.ObjectId, Exception, None]] = []
+
+            # Initialize backoff parameters
+            initial_timeout = 0.1
+            max_timeout = 5.0
+            backoff_factor = 2
+            current_timeout = initial_timeout
+            consecutive_timeouts = 0
+            max_consecutive_timeouts = 5
+
             while True:
                 try:
-                    sample_id, err, result = queue.get(timeout=0.01)
+                    sample_id, err, result = queue.get(timeout=current_timeout)
+                    # Reset backoff on successful get
+                    current_timeout = initial_timeout
+                    consecutive_timeouts = 0
                 except Empty:
+                    consecutive_timeouts += 1
+                    # Apply exponential backoff, but cap at max_timeout
+                    current_timeout = min(
+                        current_timeout * backoff_factor, max_timeout
+                    )
+
+                    # Reset backoff if we've hit too many consecutive timeouts
+                    # This prevents getting stuck with very long timeouts
+                    if consecutive_timeouts >= max_consecutive_timeouts:
+                        current_timeout = initial_timeout
+                        consecutive_timeouts = 0
+
+                    # Check if done after applying backoff
                     if batch_count.value >= num_batches:
                         break
                 else:

--- a/fiftyone/core/map/threading.py
+++ b/fiftyone/core/map/threading.py
@@ -144,10 +144,29 @@ class ThreadMapper(fomm.LocalMapper[T]):
                 q: ResultQueue[R], evts: List[threading.Event]
             ) -> Iterator[R]:
                 sample_errors: List[Tuple[bson.ObjectId, Exception, None]] = []
+
+                # Initialize backoff parameters
+                initial_timeout = 0.1
+                max_timeout = 5.0
+                backoff_factor = 2
+                current_timeout = initial_timeout
+
                 while True:
                     try:
-                        sample_id, err, result = q.get(timeout=0.1)
+                        sample_id, err, result = q.get(timeout=current_timeout)
+                        # Reset backoff on successful get
+                        current_timeout = initial_timeout
                     except queue.Empty:
+                        # Apply exponential backoff, but cap at max_timeout
+                        current_timeout = min(
+                            current_timeout * backoff_factor, max_timeout
+                        )
+
+                        # Reset backoff if we've hit too many consecutive timeouts
+                        # This prevents getting stuck with very long timeouts
+                        if current_timeout == max_timeout:
+                            current_timeout = initial_timeout
+
                         if not (evts := [e for e in evts if not e.is_set()]):
                             break
                     else:


### PR DESCRIPTION
## What changes are proposed in this pull request?

When there are multiple workers there could be many empty queue events. Adding exponential backoff helps to reduce these events and allow queue processing to be more efficient.

## How is this patch tested? If it is not, please explain why.

Benchmarking number with evaluate_detections:
```
=== Performance Summary ===

Sorted by execution time:
            configuration shard_method  num_workers backend  use_backoff    duration
   id_16w_process_backoff           id           16 process         True  483.764559
id_16w_process_no_backoff           id           16 process        False  494.329092
    id_8w_process_backoff           id            8 process         True  612.277136
 id_8w_process_no_backoff           id            8 process        False  623.627703
 id_4w_process_no_backoff           id            4 process        False 1093.151622
    id_4w_process_backoff           id            4 process         True 1113.857271
    id_2w_process_backoff           id            2 process         True 2074.191641
 id_2w_process_no_backoff           id            2 process        False 2088.305372
 id_1w_process_no_backoff           id            1 process        False 4037.498311
                 baseline         none            0    none        False 4063.030877

Average duration by shard method:
shard_method
id      1402.333634
none    4063.030877
Name: duration, dtype: float64

Average duration by number of workers:
num_workers
0     4063.030877
1     4037.498311
2     2081.248507
4     1103.504447
8      617.952420
16     489.046826
Name: duration, dtype: float64

Average duration by backend:
backend
none       4063.030877
process    1402.333634
Name: duration, dtype: float64
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
