### PR TITLE
Embeddings legend mouse event fix

### DIFF
--- a/app/packages/embeddings/src/styled-components.tsx
+++ b/app/packages/embeddings/src/styled-components.tsx
@@ -19,9 +19,11 @@ export const Selectors = styled.div`
   > div {
     display: flex;
     column-gap: 1rem;
+    pointer-events: all;
   }
   justify-content: space-between;
   width: 100%;
+  pointer-events: none;
 `;
 
 export const PlotOption = styled(Link)`


### PR DESCRIPTION
Fixes an issue with the embeddings legend where mouse events are handled by the Selector div which overlaps the legend.

**Before**

https://github.com/user-attachments/assets/3023ee3f-317c-464d-b2b2-7da11d6ce360

**After**

https://github.com/user-attachments/assets/0d467ca2-8666-435c-a7fc-4223a91bfa46



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved pointer event handling in user interface components so that interactive elements (child components) now respond correctly to user interactions while their enclosing container remains non-interactive. This update enhances overall responsiveness and ensures a more intuitive experience when navigating and interacting with the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->