### PR TITLE
decouple execution store logic from mongo

### DIFF
--- a/fiftyone/factory/repos/execution_store.py
+++ b/fiftyone/factory/repos/execution_store.py
@@ -1,44 +1,283 @@
 """
-Execution store repository.
+Execution store repository interface and implementations.
 
 | Copyright 2017-2025, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
 
+from abc import ABC, abstractmethod
 from datetime import datetime
+from typing import Any, Dict, List, Optional
 
 from bson import ObjectId
-from pymongo.collection import Collection
-from typing import Any, Dict
 
-from fiftyone.operators.store.models import StoreDocument, KeyDocument
+from fiftyone.operators.store.models import KeyDocument, StoreDocument
 
 
-class ExecutionStoreRepo(object):
-    """Base class for execution store repositories.
+class ExecutionStoreRepo(ABC):
+    """Abstract base class for execution store repositories.
 
-    Each instance of this repository has a context:
-
-    -   If a ``dataset_id`` is provided, it operates on stores associated with
-        that dataset
-    -   If no ``dataset_id`` is provided, it operates on stores that are not
-        associated with a dataset
+    Each instance operates in a context:
+    - If a `dataset_id` is provided, it operates on stores associated with that dataset.
+    - If no `dataset_id` is provided, it operates on stores not associated with any dataset.
 
     To operate on all stores across all contexts, use the ``XXX_global()``
     methods that this class provides.
     """
 
-    COLLECTION_NAME = "execution_store"
+    def __init__(self, dataset_id: Optional[ObjectId] = None):
+        """Initialize the execution store repository.
 
-    def __init__(self, collection: Collection, dataset_id: ObjectId = None):
-        self._collection = collection
+        Args:
+            dataset_id (Optional[ObjectId]): the dataset ID to operate on
+        """
         self._dataset_id = dataset_id
 
+    @abstractmethod
     def create_store(
-        self, store_name, metadata: Dict[str, Any] = None
+        self, store_name: str, metadata: Optional[Dict[str, Any]] = None
     ) -> StoreDocument:
-        """Creates a store associated with the current context."""
+        """Create a store in the store collection.
+
+        Args:
+            store_name (str): the name of the store to create
+            metadata (Optional[Dict[str, Any]]): the metadata to store with the store
+
+        Returns:
+            StoreDocument: the created store document
+        """
+        pass
+
+    @abstractmethod
+    def get_store(self, store_name: str) -> Optional[StoreDocument]:
+        """Get a store from the store collection.
+
+        Args:
+            store_name (str): the name of the store to get
+
+        Returns:
+            Optional[StoreDocument]: the store document, or None if the store does not exist
+        """
+        pass
+
+    @abstractmethod
+    def has_store(self, store_name: str) -> bool:
+        """Check if a store exists in the store collection.
+
+        Args:
+            store_name (str): the name of the store to check
+
+        Returns:
+            bool: True if the store exists, False otherwise
+        """
+
+    @abstractmethod
+    def list_stores(self) -> List[str]:
+        """List all stores in the store collection.
+
+        Returns:
+            List[str]: a list of store names
+        """
+        pass
+
+    @abstractmethod
+    def count_stores(self) -> int:
+        """Count the number of stores in the store collection.
+
+        Returns:
+            int: the number of stores
+        """
+        pass
+
+    @abstractmethod
+    def delete_store(self, store_name: str) -> int:
+        """Delete a store.
+
+        Args:
+            store_name (str): the name of the store to delete
+
+        Returns:
+            int: the number of documents deleted
+        """
+        pass
+
+    @abstractmethod
+    def set_key(
+        self, store_name: str, key: str, value: Any, ttl: Optional[int] = None
+    ) -> KeyDocument:
+        """Set a key in a store.
+
+        Args:
+            store_name (str): the name of the store to set the key in
+            key (str): the key to set
+            value (Any): the value to set
+            ttl (Optional[int]): the TTL of the key
+        """
+        pass
+
+    @abstractmethod
+    def has_key(self, store_name: str, key: str) -> bool:
+        """Check if a key exists in a store.
+
+        Args:
+            store_name (str): the name of the store to check
+            key (str): the key to check
+
+        Returns:
+            bool: True if the key exists, False otherwise
+        """
+        pass
+
+    @abstractmethod
+    def get_key(self, store_name: str, key: str) -> Optional[KeyDocument]:
+        """Get a key from a store.
+
+        Args:
+            store_name (str): the name of the store to get the key from
+            key (str): the key to get
+
+        Returns:
+            Optional[KeyDocument]: the key document, or None if the key does not exist
+        """
+
+    @abstractmethod
+    def update_ttl(self, store_name: str, key: str, ttl: int) -> bool:
+        """Update the TTL of a key.
+
+        Args:
+            store_name (str): the name of the store to update the TTL for
+            key (str): the key to update the TTL for
+            ttl (int): the new TTL
+
+        Returns:
+            bool: True if the TTL was updated, False otherwise
+        """
+        pass
+
+    @abstractmethod
+    def delete_key(self, store_name: str, key: str) -> bool:
+        """Delete a key from a store.
+
+        Args:
+            store_name (str): the name of the store to delete the key from
+            key (str): the key to delete
+
+        Returns:
+            bool: True if the key was deleted, False otherwise
+        """
+
+    @abstractmethod
+    def list_keys(self, store_name: str) -> List[str]:
+        """List all keys in a store.
+
+        Args:
+            store_name (str): the name of the store to list keys for
+
+        Returns:
+            List[str]: a list of keys in the store
+        """
+        pass
+
+    @abstractmethod
+    def count_keys(self, store_name: str) -> int:
+        """Count the number of keys in a store.
+
+        Args:
+            store_name (str): the name of the store to count keys for
+
+        Returns:
+            int: the number of keys in the store
+        """
+        pass
+
+    @abstractmethod
+    def cleanup(self) -> int:
+        """Delete all stores in the global store collection.
+
+        Returns:
+            int: the number of documents deleted
+        """
+        pass
+
+    @abstractmethod
+    def has_store_global(self, store_name: str) -> bool:
+        """Check if a store exists in the global store collection.
+
+        Args:
+            store_name (str): the name of the store to check
+
+        Returns:
+            bool: True if the store exists, False otherwise
+        """
+        pass
+
+    @abstractmethod
+    def list_stores_global(self) -> List[StoreDocument]:
+        """List all stores in the global store collection.
+
+        Returns:
+            List[StoreDocument]: a list of store documents
+        """
+        pass
+
+    @abstractmethod
+    def count_stores_global(self) -> int:
+        """Count the number of stores in the global store collection.
+
+        Returns:
+            int: the number of stores
+        """
+        pass
+
+    @abstractmethod
+    def delete_store_global(self, store_name: str) -> int:
+        """Delete a store from the global store collection.
+
+        Args:
+            store_name (str): the name of the store to delete
+
+        Returns:
+            int: the number of documents deleted
+        """
+        pass
+
+
+class MongoExecutionStoreRepo(ExecutionStoreRepo):
+    """MongoDB implementation of the execution store repository."""
+
+    COLLECTION_NAME = "execution_store"
+
+    def __init__(self, collection, dataset_id: Optional[ObjectId] = None):
+        super().__init__(dataset_id)
+        self._collection = collection
+        self._create_indexes()
+
+    def _create_indexes(self):
+        indices = [idx["name"] for idx in self._collection.list_indexes()]
+        expires_at_name = "expires_at"
+        store_name_name = "store_name"
+        key_name = "key"
+        full_key_name = "unique_store_index"
+        dataset_id_name = "dataset_id"
+
+        if expires_at_name not in indices:
+            self._collection.create_index(
+                expires_at_name, name=expires_at_name, expireAfterSeconds=0
+            )
+        if full_key_name not in indices:
+            self._collection.create_index(
+                [(store_name_name, 1), (key_name, 1), (dataset_id_name, 1)],
+                name=full_key_name,
+                unique=True,
+            )
+        for name in [store_name_name, key_name, dataset_id_name]:
+            if name not in indices:
+                self._collection.create_index(name, name=name)
+
+    def create_store(
+        self, store_name: str, metadata: Optional[Dict[str, Any]] = None
+    ) -> StoreDocument:
         store_doc = StoreDocument(
             store_name=store_name,
             dataset_id=self._dataset_id,
@@ -47,37 +286,30 @@ class ExecutionStoreRepo(object):
         self._collection.insert_one(store_doc.to_mongo_dict())
         return store_doc
 
-    def get_store(self, store_name) -> StoreDocument:
-        """Gets a store associated with the current context."""
+    def get_store(self, store_name: str) -> Optional[StoreDocument]:
         raw_store_doc = self._collection.find_one(
-            dict(
-                store_name=store_name,
-                key="__store__",
-                dataset_id=self._dataset_id,
-            )
+            {
+                "store_name": store_name,
+                "key": "__store__",
+                "dataset_id": self._dataset_id,
+            }
         )
         if not raw_store_doc and self.has_store(store_name):
             return StoreDocument(
                 store_name=store_name, dataset_id=self._dataset_id
             )
+        return StoreDocument(**raw_store_doc) if raw_store_doc else None
 
-        store_doc = StoreDocument(**raw_store_doc) if raw_store_doc else None
-        return store_doc
-
-    def has_store(self, store_name) -> bool:
-        """Checks whether a store with the given name exists in the current
-        context.
-        """
+    def has_store(self, store_name: str) -> bool:
         result = self._collection.find_one(
-            dict(
-                store_name=store_name,
-                dataset_id=self._dataset_id,
-            )
+            {
+                "store_name": store_name,
+                "dataset_id": self._dataset_id,
+            }
         )
         return bool(result)
 
-    def list_stores(self) -> list[str]:
-        """Lists the stores associated with the current context."""
+    def list_stores(self) -> List[str]:
         pipeline = [
             {"$match": {"dataset_id": self._dataset_id}},
             {"$group": {"_id": "$store_name"}},
@@ -85,28 +317,28 @@ class ExecutionStoreRepo(object):
         return [d["_id"] for d in self._collection.aggregate(pipeline)]
 
     def count_stores(self) -> int:
-        """Counts the stores associated with the current context."""
         pipeline = [
             {"$match": {"dataset_id": self._dataset_id}},
             {"$group": {"_id": "$store_name"}},
             {"$count": "total_stores"},
         ]
-
         result = list(self._collection.aggregate(pipeline))
         return result[0]["total_stores"] if result else 0
 
-    def delete_store(self, store_name) -> int:
-        """Deletes the specified store."""
+    def delete_store(self, store_name: str) -> int:
         result = self._collection.delete_many(
-            dict(store_name=store_name, dataset_id=self._dataset_id)
+            {
+                "store_name": store_name,
+                "dataset_id": self._dataset_id,
+            }
         )
         return result.deleted_count
 
-    def set_key(self, store_name, key, value, ttl=None) -> KeyDocument:
-        """Sets or updates a key in the specified store."""
+    def set_key(
+        self, store_name: str, key: str, value: Any, ttl: Optional[int] = None
+    ) -> KeyDocument:
         now = datetime.utcnow()
         expiration = KeyDocument.get_expiration(ttl)
-
         key_doc = KeyDocument(
             store_name=store_name,
             key=key,
@@ -115,7 +347,6 @@ class ExecutionStoreRepo(object):
             expires_at=expiration,
             dataset_id=self._dataset_id,
         )
-
         on_insert_fields = {
             "store_name": store_name,
             "key": key,
@@ -123,8 +354,6 @@ class ExecutionStoreRepo(object):
             "expires_at": expiration if ttl else None,
             "dataset_id": self._dataset_id,
         }
-
-        # Prepare the update operations
         update_fields = {
             "$set": {
                 k: v
@@ -141,92 +370,92 @@ class ExecutionStoreRepo(object):
             },
             "$setOnInsert": on_insert_fields,
         }
-
-        # Perform the upsert operation
         result = self._collection.update_one(
-            dict(store_name=store_name, key=key, dataset_id=self._dataset_id),
+            {
+                "store_name": store_name,
+                "key": key,
+                "dataset_id": self._dataset_id,
+            },
             update_fields,
             upsert=True,
         )
-
         if result.upserted_id:
             key_doc.created_at = now
         else:
             key_doc.updated_at = now
-
         return key_doc
 
-    def has_key(self, store_name, key) -> bool:
-        """Determines whether a key exists in the specified store."""
+    def has_key(self, store_name: str, key: str) -> bool:
         result = self._collection.find_one(
-            dict(store_name=store_name, key=key, dataset_id=self._dataset_id)
+            {
+                "store_name": store_name,
+                "key": key,
+                "dataset_id": self._dataset_id,
+            }
         )
         return bool(result)
 
-    def get_key(self, store_name, key) -> KeyDocument:
-        """Gets a key from the specified store."""
+    def get_key(self, store_name: str, key: str) -> Optional[KeyDocument]:
         raw_key_doc = self._collection.find_one(
-            dict(store_name=store_name, key=key, dataset_id=self._dataset_id)
+            {
+                "store_name": store_name,
+                "key": key,
+                "dataset_id": self._dataset_id,
+            }
         )
-        key_doc = KeyDocument(**raw_key_doc) if raw_key_doc else None
-        return key_doc
+        return KeyDocument(**raw_key_doc) if raw_key_doc else None
 
-    def update_ttl(self, store_name, key, ttl) -> bool:
-        """Updates the TTL for a key."""
+    def update_ttl(self, store_name: str, key: str, ttl: int) -> bool:
         expiration = KeyDocument.get_expiration(ttl)
         result = self._collection.update_one(
-            dict(store_name=store_name, key=key, dataset_id=self._dataset_id),
+            {
+                "store_name": store_name,
+                "key": key,
+                "dataset_id": self._dataset_id,
+            },
             {"$set": {"expires_at": expiration}},
         )
         return result.modified_count > 0
 
-    def delete_key(self, store_name, key) -> bool:
-        """Deletes the document that matches the store name and key, if one
-        exists.
-        """
+    def delete_key(self, store_name: str, key: str) -> bool:
         result = self._collection.delete_one(
-            dict(store_name=store_name, key=key, dataset_id=self._dataset_id)
+            {
+                "store_name": store_name,
+                "key": key,
+                "dataset_id": self._dataset_id,
+            }
         )
         return result.deleted_count > 0
 
-    def list_keys(self, store_name) -> list[str]:
-        """Lists all keys in the specified store."""
+    def list_keys(self, store_name: str) -> List[str]:
         result = self._collection.find(
-            dict(
-                store_name=store_name,
-                key={"$ne": "__store__"},
-                dataset_id=self._dataset_id,
-            ),
+            {
+                "store_name": store_name,
+                "key": {"$ne": "__store__"},
+                "dataset_id": self._dataset_id,
+            },
             {"key": 1},
         )
         return [d["key"] for d in result]
 
-    def count_keys(self, store_name) -> int:
-        """Counts the keys in the specified store."""
+    def count_keys(self, store_name: str) -> int:
         return self._collection.count_documents(
-            dict(
-                store_name=store_name,
-                key={"$ne": "__store__"},
-                dataset_id=self._dataset_id,
-            )
+            {
+                "store_name": store_name,
+                "key": {"$ne": "__store__"},
+                "dataset_id": self._dataset_id,
+            }
         )
 
     def cleanup(self) -> int:
-        """Deletes all stores and keys associated with the current context."""
-        result = self._collection.delete_many(
-            dict(dataset_id=self._dataset_id)
-        )
+        result = self._collection.delete_many({"dataset_id": self._dataset_id})
         return result.deleted_count
 
-    def has_store_global(self, store_name):
-        """Determines whether a store with the given name exists across all
-        datasets and the global context.
-        """
-        result = self._collection.find_one(dict(store_name=store_name), {})
+    def has_store_global(self, store_name: str) -> bool:
+        result = self._collection.find_one({"store_name": store_name})
         return bool(result)
 
-    def list_stores_global(self) -> list[StoreDocument]:
-        """Lists stores across all datasets and the global context."""
+    def list_stores_global(self) -> List[StoreDocument]:
         pipeline = [
             {
                 "$group": {
@@ -244,12 +473,10 @@ class ExecutionStoreRepo(object):
                 }
             },
         ]
-
         result = self._collection.aggregate(pipeline)
         return [StoreDocument(**d) for d in result]
 
     def count_stores_global(self) -> int:
-        """Counts stores across all datasets and the global context."""
         pipeline = [
             {
                 "$group": {
@@ -261,42 +488,149 @@ class ExecutionStoreRepo(object):
             },
             {"$count": "total_stores"},
         ]
-
         result = list(self._collection.aggregate(pipeline))
         return result[0]["total_stores"] if result else 0
 
-    def delete_store_global(self, store_name) -> int:
-        """Deletes the specified store across all datasets and the global
-        context.
-        """
-        result = self._collection.delete_many(dict(store_name=store_name))
+    def delete_store_global(self, store_name: str) -> int:
+        result = self._collection.delete_many({"store_name": store_name})
         return result.deleted_count
 
 
-class MongoExecutionStoreRepo(ExecutionStoreRepo):
-    """MongoDB implementation of execution store repository."""
+class InMemoryExecutionStoreRepo(ExecutionStoreRepo):
+    """In-memory implementation of execution store repository."""
 
-    def __init__(self, collection: Collection, dataset_id: ObjectId = None):
-        super().__init__(collection, dataset_id)
-        self._create_indexes()
+    def __init__(self, dataset_id: Optional[ObjectId] = None):
+        super().__init__(dataset_id)
+        self._docs = {}
 
-    def _create_indexes(self):
-        indices = [idx["name"] for idx in self._collection.list_indexes()]
-        expires_at_name = "expires_at"
-        store_name_name = "store_name"
-        key_name = "key"
-        full_key_name = "unique_store_index"
-        dataset_id_name = "dataset_id"
-        if expires_at_name not in indices:
-            self._collection.create_index(
-                expires_at_name, name=expires_at_name, expireAfterSeconds=0
+    def _doc_key(self, store_name: str, key: str) -> tuple:
+        return (store_name, key, self._dataset_id)
+
+    def create_store(
+        self, store_name: str, metadata: Optional[Dict[str, Any]] = None
+    ) -> StoreDocument:
+        store_doc = StoreDocument(
+            store_name=store_name,
+            dataset_id=self._dataset_id,
+            value=metadata,
+        )
+        key = self._doc_key(store_name, "__store__")
+        self._docs[key] = store_doc.to_mongo_dict()
+        return store_doc
+
+    def get_store(self, store_name: str) -> Optional[StoreDocument]:
+        key = self._doc_key(store_name, "__store__")
+        doc = self._docs.get(key)
+        if not doc and self.has_store(store_name):
+            return StoreDocument(
+                store_name=store_name, dataset_id=self._dataset_id
             )
-        if full_key_name not in indices:
-            self._collection.create_index(
-                [(store_name_name, 1), (key_name, 1), (dataset_id_name, 1)],
-                name=full_key_name,
-                unique=True,
-            )
-        for name in [store_name_name, key_name, dataset_id_name]:
-            if name not in indices:
-                self._collection.create_index(name, name=name)
+        return StoreDocument(**doc) if doc else None
+
+    def has_store(self, store_name: str) -> bool:
+        return any(
+            s == store_name and ds == self._dataset_id
+            for (s, _, ds) in self._docs.keys()
+        )
+
+    def list_stores(self) -> List[str]:
+        stores = {
+            s for (s, _, ds) in self._docs.keys() if ds == self._dataset_id
+        }
+        return list(stores)
+
+    def count_stores(self) -> int:
+        return len(self.list_stores())
+
+    def delete_store(self, store_name: str) -> int:
+        keys_to_delete = [
+            key
+            for key in self._docs
+            if key[0] == store_name and key[2] == self._dataset_id
+        ]
+        for key in keys_to_delete:
+            del self._docs[key]
+        return len(keys_to_delete)
+
+    def set_key(
+        self, store_name: str, key: str, value: Any, ttl: Optional[int] = None
+    ) -> KeyDocument:
+        now = datetime.utcnow()
+        expiration = KeyDocument.get_expiration(ttl)
+        key_doc = KeyDocument(
+            store_name=store_name,
+            key=key,
+            value=value,
+            updated_at=now,
+            expires_at=expiration,
+            dataset_id=self._dataset_id,
+        )
+        composite_key = self._doc_key(store_name, key)
+        if composite_key not in self._docs:
+            key_doc.created_at = now
+        self._docs[composite_key] = key_doc.to_mongo_dict()
+        return key_doc
+
+    def has_key(self, store_name: str, key: str) -> bool:
+        composite_key = self._doc_key(store_name, key)
+        return composite_key in self._docs
+
+    def get_key(self, store_name: str, key: str) -> Optional[KeyDocument]:
+        composite_key = self._doc_key(store_name, key)
+        doc = self._docs.get(composite_key)
+        return KeyDocument(**doc) if doc else None
+
+    def update_ttl(self, store_name: str, key: str, ttl: int) -> bool:
+        composite_key = self._doc_key(store_name, key)
+        doc = self._docs.get(composite_key)
+        if not doc:
+            return False
+        expiration = KeyDocument.get_expiration(ttl)
+        doc["expires_at"] = expiration
+        self._docs[composite_key] = doc
+        return True
+
+    def delete_key(self, store_name: str, key: str) -> bool:
+        composite_key = self._doc_key(store_name, key)
+        if composite_key in self._docs:
+            del self._docs[composite_key]
+            return True
+        return False
+
+    def list_keys(self, store_name: str) -> List[str]:
+        return [
+            k
+            for (s, k, ds) in self._docs.keys()
+            if s == store_name and ds == self._dataset_id and k != "__store__"
+        ]
+
+    def count_keys(self, store_name: str) -> int:
+        return len(self.list_keys(store_name))
+
+    def cleanup(self) -> int:
+        keys_to_delete = [
+            key for key in self._docs if key[2] == self._dataset_id
+        ]
+        count = len(keys_to_delete)
+        for key in keys_to_delete:
+            del self._docs[key]
+        return count
+
+    def has_store_global(self, store_name: str) -> bool:
+        return any(s == store_name for (s, _, _) in self._docs.keys())
+
+    def list_stores_global(self) -> List[StoreDocument]:
+        seen = {}
+        for s, _, ds in self._docs.keys():
+            if s not in seen:
+                seen[s] = StoreDocument(store_name=s, dataset_id=ds)
+        return list(seen.values())
+
+    def count_stores_global(self) -> int:
+        return len({s for (s, _, _) in self._docs.keys()})
+
+    def delete_store_global(self, store_name: str) -> int:
+        keys_to_delete = [key for key in self._docs if key[0] == store_name]
+        for key in keys_to_delete:
+            del self._docs[key]
+        return len(keys_to_delete)

--- a/fiftyone/operators/store/service.py
+++ b/fiftyone/operators/store/service.py
@@ -29,7 +29,12 @@ class ExecutionStoreService(object):
     Args:
         repo (None): a
             :class:`fiftyone.factory.repos.execution_store.ExecutionStoreRepo`
+            If not provided, a new
+            :class:`fiftyone.factory.repos.execution_store.MongoExecutionStoreRepo`
+            will be created
         dataset_id (None): a dataset ID to scope operations to
+        collection_name (None): a collection name to use for the execution
+            store. If `repo` is provided, this argument is ignored
     """
 
     def __init__(

--- a/tests/unittests/execution_store_repo_tests.py
+++ b/tests/unittests/execution_store_repo_tests.py
@@ -1,0 +1,126 @@
+"""
+FiftyOne execution store related unit tests.
+
+| Copyright 2017-2025, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+
+from bson import ObjectId
+
+from fiftyone.factory.repos.execution_store import InMemoryExecutionStoreRepo
+
+
+class TestInMemoryExecutionStoreRepo(unittest.TestCase):
+
+    def setUp(self):
+        self.dataset_id = ObjectId()
+        self.repo = InMemoryExecutionStoreRepo(dataset_id=self.dataset_id)
+
+    def test_create_and_get_store(self):
+        store_name = "test_store"
+        metadata = {"foo": "bar"}
+
+        created_store = self.repo.create_store(store_name, metadata)
+        self.assertEqual(created_store.store_name, store_name)
+        self.assertEqual(created_store.value, metadata)
+        self.assertEqual(created_store.dataset_id, self.dataset_id)
+
+        # get the store back
+        fetched_store = self.repo.get_store(store_name)
+        self.assertIsNotNone(fetched_store)
+        self.assertEqual(fetched_store.store_name, store_name)
+
+    def test_has_store_list_and_count(self):
+        store_name1 = "store1"
+        store_name2 = "store2"
+        self.repo.create_store(store_name1)
+        self.repo.create_store(store_name2)
+        self.assertTrue(self.repo.has_store(store_name1))
+        self.assertTrue(self.repo.has_store(store_name2))
+        stores = self.repo.list_stores()
+        self.assertIn(store_name1, stores)
+        self.assertIn(store_name2, stores)
+        self.assertEqual(self.repo.count_stores(), 2)
+
+    def test_delete_store(self):
+        store_name = "delete_store"
+        self.repo.create_store(store_name)
+        deleted_count = self.repo.delete_store(store_name)
+        self.assertEqual(deleted_count, 1)
+        self.assertFalse(self.repo.has_store(store_name))
+
+    def test_set_and_get_key(self):
+        store_name = "key_store"
+        key = "test_key"
+        value = "value1"
+        key_doc = self.repo.set_key(store_name, key, value, ttl=60)
+        self.assertEqual(key_doc.key, key)
+        self.assertEqual(key_doc.value, value)
+        self.assertTrue(self.repo.has_key(store_name, key))
+        fetched_key = self.repo.get_key(store_name, key)
+        self.assertEqual(fetched_key.value, value)
+
+    def test_update_ttl(self):
+        store_name = "ttl_store"
+        key = "ttl_key"
+        value = "value2"
+        key_doc = self.repo.set_key(store_name, key, value, ttl=60)
+        old_expiration = key_doc.expires_at
+        updated = self.repo.update_ttl(store_name, key, 120)
+        self.assertTrue(updated)
+        updated_key = self.repo.get_key(store_name, key)
+        # Ensure that the expiration timestamp has been updated (allowing for slight time differences)
+        self.assertNotEqual(updated_key.expires_at, old_expiration)
+
+    def test_delete_key(self):
+        store_name = "delete_key_store"
+        key = "delete_key"
+        self.repo.set_key(store_name, key, "value3", ttl=60)
+        deleted = self.repo.delete_key(store_name, key)
+        self.assertTrue(deleted)
+        self.assertFalse(self.repo.has_key(store_name, key))
+
+    def test_list_and_count_keys(self):
+        store_name = "keys_store"
+        keys = ["key1", "key2", "key3"]
+        # Create the store explicitly so that __store__ is inserted.
+        self.repo.create_store(store_name)
+        for k in keys:
+            self.repo.set_key(store_name, k, f"value_for_{k}", ttl=60)
+        listed_keys = self.repo.list_keys(store_name)
+        self.assertCountEqual(listed_keys, keys)
+        self.assertEqual(self.repo.count_keys(store_name), len(keys))
+
+    def test_cleanup(self):
+        store_name = "cleanup_store"
+        # Create a store and two keys.
+        self.repo.create_store(store_name)
+        self.repo.set_key(store_name, "key1", "value", ttl=60)
+        self.repo.set_key(store_name, "key2", "value", ttl=60)
+        deleted_count = self.repo.cleanup()
+        # Expecting deletion of the __store__ document and both key documents.
+        self.assertEqual(deleted_count, 3)
+        self.assertFalse(self.repo.has_store(store_name))
+        self.assertFalse(self.repo.has_key(store_name, "key1"))
+        self.assertFalse(self.repo.has_key(store_name, "key2"))
+
+    def test_global_operations(self):
+        store_name = "global_store"
+        # Create a store and set a key.
+        self.repo.create_store(store_name)
+        self.repo.set_key(store_name, "key_global", "global_value", ttl=60)
+        self.assertTrue(self.repo.has_store_global(store_name))
+        global_stores = self.repo.list_stores_global()
+        self.assertTrue(any(s.store_name == store_name for s in global_stores))
+        # Since we only have one store, count_stores_global should return 1.
+        self.assertEqual(self.repo.count_stores_global(), 1)
+        deleted_count = self.repo.delete_store_global(store_name)
+        self.assertGreater(deleted_count, 0)
+        self.assertFalse(self.repo.has_store_global(store_name))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittests/execution_store_unit_tests.py
+++ b/tests/unittests/execution_store_unit_tests.py
@@ -15,7 +15,7 @@ from bson import ObjectId
 
 from fiftyone.operators.store import ExecutionStoreService
 from fiftyone.operators.store.models import KeyDocument
-from fiftyone.factory.repo_factory import ExecutionStoreRepo
+from fiftyone.factory.repo_factory import MongoExecutionStoreRepo
 from fiftyone.operators.store import ExecutionStore
 
 
@@ -49,7 +49,7 @@ class TestKeyDocument(unittest.TestCase):
 class ExecutionStoreServiceIntegrationTests(unittest.TestCase):
     def setUp(self) -> None:
         self.mock_collection = MagicMock()
-        self.store_repo = ExecutionStoreRepo(self.mock_collection)
+        self.store_repo = MongoExecutionStoreRepo(self.mock_collection)
         self.store_service = ExecutionStoreService(self.store_repo)
 
     def test_set_key(self):
@@ -170,7 +170,7 @@ class ExecutionStoreServiceIntegrationTests(unittest.TestCase):
 class TestExecutionStoreIntegration(unittest.TestCase):
     def setUp(self) -> None:
         self.mock_collection = MagicMock()
-        self.store_repo = ExecutionStoreRepo(self.mock_collection)
+        self.store_repo = MongoExecutionStoreRepo(self.mock_collection)
         self.store_service = ExecutionStoreService(self.store_repo)
         self.store = ExecutionStore("mock_store", self.store_service)
 
@@ -239,7 +239,7 @@ class ExecutionStoreServiceDatasetIdTests(unittest.TestCase):
     def setUp(self) -> None:
         self.mock_collection = MagicMock()
         self.dataset_id = ObjectId()
-        self.store_repo = ExecutionStoreRepo(
+        self.store_repo = MongoExecutionStoreRepo(
             self.mock_collection, dataset_id=self.dataset_id
         )
         self.store_service = ExecutionStoreService(self.store_repo)


### PR DESCRIPTION
## What changes are proposed in this pull request?

We have both `ExecutionStoreRepo` and `MongoExecutionStoreRepo` but `ExecutionStoreRepo` is very tightly coupled to Mongo. This PR makes `ExecutionStoreRepo` an abstract base class that `MongoExecutionStoreRepo` concretizes. Also add an implementation for `InMemoryExecutionStoreRepo` that is a lightweight implementation of execution store repo we can use for unit / integration testing.

## How is this patch tested? If it is not, please explain why.

Unit tests

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?


-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a refined execution store interface with consistent operations, offering both persistent and in-memory management options.

- **Documentation**
  - Enhanced service documentation to clearly detail constructor parameters, ensuring proper configuration without ambiguity.

- **Tests**
  - Added comprehensive test suites covering core operations such as creation, retrieval, updating, deletion, and cleanup to ensure robust functionality.
  - Updated existing tests to utilize the new MongoDB execution store repository implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->