### PR TITLE
Fix evaluate_detections for non-overlapping bboxes

### DIFF
--- a/fiftyone/utils/iou.py
+++ b/fiftyone/utils/iou.py
@@ -681,7 +681,16 @@ def _compute_bbox_ious(
                 ious[i, j] = iou
                 if is_symmetric:
                     ious[j, i] = iou
-
+        # If a prediction has no intersection with a ground_truth,
+        # find the nearest and assign iou=0
+        if sparse and not ious.get(pred.id):
+            # pylint: disable=not-an-iterable
+            for nearest in rtree_index.nearest(box, 1):
+                gt = gts[nearest]
+                iou = 0
+                ious[pred.id].append((gt.id, iou))
+                if is_symmetric:
+                    ious[gt.id].append((pred.id, iou))
     return ious
 
 

--- a/tests/unittests/utils/iou_tests.py
+++ b/tests/unittests/utils/iou_tests.py
@@ -1,0 +1,63 @@
+import unittest
+
+from bson import ObjectId
+
+import fiftyone as fo
+from fiftyone.utils.iou import compute_ious
+
+
+class ComputeIouTests(unittest.TestCase):
+    def test_compute_iou_bbox_sparse_nonoverlapping(self):
+        iscrowd = None
+        classwise = False
+        sparse = True
+        eval_results = {
+            "mask": None,
+            "mask_path": None,
+            "confidence": None,
+            "index": None,
+            "eval_iou": None,
+            "eval_id": "",
+        }
+        ids = [ObjectId() for _ in range(4)]
+        gt = [
+            fo.Detection(
+                id=ids[0],
+                label="test",
+                bounding_box=[0.1, 0.1, 0.1, 0.1],
+                **eval_results
+            )
+        ]
+        preds = [
+            fo.Detection(
+                id=ids[1],
+                label="test",
+                bounding_box=[0.1, 0.1, 0.5, 0.5],
+                **eval_results
+            ),
+            fo.Detection(
+                id=ids[2],
+                label="test",
+                bounding_box=[0.0, 0.0, 0.1, 0.1],
+                **eval_results
+            ),
+            fo.Detection(
+                id=ids[3],
+                label="test",
+                bounding_box=[0.9, 0.9, 0.1, 0.1],
+                **eval_results
+            ),
+        ]
+        detection_with_intersection = str(ids[1])
+
+        results = compute_ious(
+            preds, gt, iscrowd=iscrowd, classwise=classwise, sparse=sparse
+        )
+
+        for pred in preds:
+            assert pred.id in results
+            assert results[pred.id][0][0] == gt[0].id
+            if pred.id == detection_with_intersection:
+                assert results[pred.id][0][1] > 0.0
+            else:
+                assert results[pred.id][0][1] == 0.0


### PR DESCRIPTION
## What changes are proposed in this pull request?

- https://github.com/voxel51/fiftyone/issues/5335
- ensures that predictions that don't overlap with any ground truth are assigned a fp for the closest ground truth

## How is this patch tested? If it is not, please explain why.

- add unit test
- test running compute_evaluations and verify results:
```
import fiftyone as fo

from fiftyone import ViewField as F
dataset = fo.Dataset()
gt = fo.Detections(detections=[fo.Detection(label="test", bounding_box=[0.1,0.1,0.1,0.1])])
preds = fo.Detections(detections=[
    fo.Detection(label="test", bounding_box=[0.1,0.1,0.5,0.5]),
    fo.Detection(label="test", bounding_box=[0.0,0.0,0.1,0.1]),
    fo.Detection(label="test", bounding_box=[0.9,0.9,0.1,0.1]),
])
sample = fo.Sample(filepath="fake.png", ground_truth=gt, predictions=preds)
dataset.add_sample(sample)
eval_key = "eval"
pred_field="predictions"
gt_field = "ground_truth"
results = dataset.evaluate_detections(
    pred_field=pred_field,
    gt_field=gt_field,
    eval_key=eval_key,
    classwise=False,
    iou=0.5,
)
print(dataset.values(eval_key+"_fp"))
# v1.0.2: [3]
# v1.1: [2]
# now: [3]
print(dataset.values(pred_field+".detections."+eval_key))
# v1.0.2: [['fp', 'fp', 'fp']]
# v1.1: [['fp', 'fp', None]]
# now: [['fp', 'fp', 'fp']]

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
