### PR TITLE
Optimize server queries

### DIFF
--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -578,17 +578,13 @@ def _make_range_query(path: str, field: fof.Field, args):
         ops["$gte"] = mn
     if mx is not None:
         ops["$lte"] = mx
-    if not exclude and range_:
+    if range_:
+        if exclude:
+            return {
+                path: {"$not": ops},
+            }
         return {
             path: ops,
-        }
-
-    if range_:
-        expr = [{path: {k: v}} for k, v in ops.items()]
-        if len(expr) == 1:
-            return expr[0]
-        return {
-            "$or": expr,
         }
 
     if exclude:

--- a/tests/unittests/server_view_tests.py
+++ b/tests/unittests/server_view_tests.py
@@ -1003,23 +1003,13 @@ class AysncServerViewTests(unittest.IsolatedAsyncioTestCase):
             for sample in samples
             if intervals[0][0] <= sample.field1 <= intervals[0][1]
         }
-        nin_range1 = {
-            sample.id
-            for sample in samples
-            if (intervals[0][0] > sample.field1)
-            or (sample.field1 > intervals[0][1])
-        }
+        nin_range1 = {sid for sid in sample_ids if sid not in in_range1}
         in_range2 = {
             sample.id
             for sample in samples
             if intervals[1][0] <= sample.field2 <= intervals[1][1]
         }
-        nin_range2 = {
-            sample.id
-            for sample in samples
-            if (intervals[1][0] > sample.field2)
-            or (sample.field2 > intervals[1][1])
-        }
+        nin_range2 = {sid for sid in sample_ids if sid not in in_range2}
         filters = [
             (
                 {
@@ -1108,8 +1098,6 @@ class AysncServerViewTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual({sample.id for sample in view}, expected)
 
 
-# making match stage filters {'created_at': {'isMatching': True, 'exclude': True, 'range': [1740188819225.95, 1740189455632.93], 'none': True, 'nan': True, 'inf': True, 'ninf': True}, 'last_modified_at': {'isMatching': True, 'exclude': False, 'range': [1743104634233.11, 1743382219212], 'none': True, 'nan': True, 'inf': True, 'ninf': True}}
-# making match stage filters {'created_at': {'isMatching': True, 'exclude': True, 'range': [1740188819225.95, 1740189455632.93], 'none': True, 'nan': True, 'inf': True, 'ninf': True}, 'last_modified_at': {'isMatching': True, 'exclude': False, 'range': [1743104634233.11, 1743382219212], 'none': True, 'nan': True, 'inf': True, 'ninf': True}}
 class ServerDocTests(unittest.TestCase):
     def test_dataset_doc(self):
         doc = Dataset.modifier({"_id": "id"})


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Simplify sidebar aggregations by removing excessive $and and $or expressions for conditions for the same field. This improves query performance. 
- For example: 
```
# without opt:
: [{'$match': {'$and': [{'$and': [{'created_at': {'$gte': datetime.datetime(2025, 2, 22, 1, 47, 47, 438600)}}, {'created_at': {'$lte': datetime.datetime(2025, 2, 22, 1, 58, 14, 203050)}}]}, {'$and': [{'last_modified_at': {'$gte': datetime.datetime(2025, 3, 13, 9, 13, 1, 162280)}}, {'last_modified_at': {'$lte': datetime.datetime(2025, 3, 22, 19, 41, 10, 895700)}}]}]}}]

# now:
[{'$match': {'$and': [{'created_at': {'$gte': datetime.datetime(2025, 2, 22, 1, 48, 6, 723660), '$lte': datetime.datetime(2025, 2, 22, 1, 56, 47, 420280)}}, {'last_modified_at': {'$gte': datetime.datetime(2025, 3, 13, 18, 23, 53, 448770), '$lte': datetime.datetime(2025, 3, 22, 4, 23, 3, 751550)}}]}}]

```

## How is this patch tested? If it is not, please explain why.
- run app locally and trigger different sidebar filters
- verified improvement in performance by running aggregation directly in mongosh with `.explain('executionStats')`
```
# without opt:
db.getCollection("samples.67db2c042f68425480fb68d3").aggregate( 
 [{'$match': {'$and': [{'$and': [{'created_at': {'$gte': ISODate('2025-02-22T01:48:45.293780+00:00')}}, {'created_at': {'$lte': ISODate('2025-02-22T03:48:45.293780+00:00')}}]}, {'$and': [{'last_modified_at': {'$gte': ISODate('2025-03-11T01:48:45.293780+00:00')}}, {'last_modified_at': {'$lte': ISODate('2026-02-22T01:48:45.293780+00:00')}}]}]}}, {'$count': 'count'}]
).explain('executionStats')
# "executionTimeMillisEstimate" : Long("10180")


# with opt:
db.getCollection("samples.67db2c042f68425480fb68d3").aggregate( 
 [{"$project":{"created_at":1,"last_modified_at":1}},{'$match': {'$and': [{'created_at': {'$gte': ISODate('2025-02-22T01:48:45.293780+00:00'), '$lte': ISODate('2025-02-22T03:48:45.293780+00:00')}}, {'last_modified_at': {'$gte': ISODate('2025-03-11T01:48:45.293780+00:00'), '$lte': ISODate('2026-02-22T01:48:45.293780+00:00')}}]}}, {'$count': 'count'}]
)
.explain('executionStats')
# "executionTimeMillisEstimate" : Long("8560")
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the logic for constructing and processing query conditions, ensuring more efficient handling of single and multiple criteria.
  - Streamlined the range query setup for clearer and more concise operations.
  - Adjusted exclusion handling for improved consistency in data filtering.

- **Tests**
  - Added a new asynchronous test to verify the functionality of range queries on dataset fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->