### PR TITLE
Fix error entering non-object id in sidebar id search

### DIFF
--- a/tests/unittests/server_view_tests.py
+++ b/tests/unittests/server_view_tests.py
@@ -986,3 +986,41 @@ class ServerDocTests(unittest.TestCase):
         doc = Dataset.modifier({"_id": "id"})
         self.assertIn("frame_collection_name", doc)
         self.assertEqual(doc["frame_collection_name"], None)
+
+
+class GetExtendedViewTests(unittest.TestCase):
+    def test_filter_invalid_id_returns_none(self):
+        ds = fod.Dataset()
+        ds.add_sample(fos.Sample(filepath="image.png"))
+        view = fosv.get_extended_view(
+            ds.view(),
+            filters={
+                "id": {
+                    "values": ["invalidid"],
+                    "exclude": False,
+                    "isMatching": True,
+                }
+            },
+        )
+        self.assertEqual(len(view), 0)
+        ds.delete()
+
+    def test_filter_valid_id(self):
+        ds = fod.Dataset()
+        sample_id = ds.add_sample(
+            fos.Sample(
+                filepath="image.png",
+            )
+        )
+        view = fosv.get_extended_view(
+            ds.view(),
+            filters={
+                "id": {
+                    "values": [str(sample_id)],
+                    "exclude": False,
+                    "isMatching": True,
+                }
+            },
+        )
+        self.assertEqual(len(view), 1)
+        ds.delete()


### PR DESCRIPTION
## What changes are proposed in this pull request?

- fixes graphql error when invalid objectId searched in the sidebar id field
- FOEPD-688
- 
## How is this patch tested? If it is not, please explain why.

- added tests 
- verified running app locally and filtering by id


https://github.com/user-attachments/assets/84a596a3-06a2-4799-a115-4fc43a76aa78



## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


[FOEPD-688]: https://voxel51.atlassian.net/browse/FOEPD-688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ