### PR TITLE
Optimize lightning mode distinct pipeline

### DIFF
--- a/tests/unittests/server_lightning_tests.py
+++ b/tests/unittests/server_lightning_tests.py
@@ -1004,54 +1004,55 @@ class TestStringLightningQueries(unittest.IsolatedAsyncioTestCase):
         """
 
         result = await _execute(query, dataset, fo.StringField, keys)
-        self.assertListEqual(
-            result.data["lightning"],
-            [
-                {"path": "classification.none", "values": ["none"]},
-                {"path": "classification.str", "values": ["lower", "upper"]},
-                {
-                    "path": "classification.str_list",
-                    "values": ["lower", "upper"],
-                },
-                {"path": "detections.detections.none", "values": ["none"]},
-                {
-                    "path": "detections.detections.str",
-                    "values": ["lower", "upper"],
-                },
-                {
-                    "path": "detections.detections.str_list",
-                    "values": ["lower", "upper"],
-                },
-                {"path": "frames.classification.none", "values": ["none"]},
-                {
-                    "path": "frames.classification.str",
-                    "values": ["lower", "upper"],
-                },
-                {
-                    "path": "frames.classification.str_list",
-                    "values": ["lower", "upper"],
-                },
-                {
-                    "path": "frames.detections.detections.none",
-                    "values": ["none"],
-                },
-                {
-                    "path": "frames.detections.detections.str",
-                    "values": ["lower", "upper"],
-                },
-                {
-                    "path": "frames.detections.detections.str_list",
-                    "values": ["lower", "upper"],
-                },
-                {"path": "frames.none", "values": ["none"]},
-                {"path": "frames.str", "values": ["lower", "upper"]},
-                {"path": "frames.str_list", "values": ["lower", "upper"]},
-                {"path": "metadata.encoding_str", "values": []},
-                {"path": "none", "values": ["none"]},
-                {"path": "str", "values": ["lower", "upper"]},
-                {"path": "str_list", "values": ["lower", "upper"]},
-            ],
-        )
+
+        expected = [
+            {"path": "classification.none", "values": ["none"]},
+            {"path": "classification.str", "values": ["lower", "upper"]},
+            {
+                "path": "classification.str_list",
+                "values": ["lower", "upper"],
+            },
+            {"path": "detections.detections.none", "values": ["none"]},
+            {
+                "path": "detections.detections.str",
+                "values": ["lower", "upper"],
+            },
+            {
+                "path": "detections.detections.str_list",
+                "values": ["lower", "upper"],
+            },
+            {"path": "frames.classification.none", "values": ["none"]},
+            {
+                "path": "frames.classification.str",
+                "values": ["lower", "upper"],
+            },
+            {
+                "path": "frames.classification.str_list",
+                "values": ["lower", "upper"],
+            },
+            {
+                "path": "frames.detections.detections.none",
+                "values": ["none"],
+            },
+            {
+                "path": "frames.detections.detections.str",
+                "values": ["lower", "upper"],
+            },
+            {
+                "path": "frames.detections.detections.str_list",
+                "values": ["lower", "upper"],
+            },
+            {"path": "frames.none", "values": ["none"]},
+            {"path": "frames.str", "values": ["lower", "upper"]},
+            {"path": "frames.str_list", "values": ["lower", "upper"]},
+            {"path": "metadata.encoding_str", "values": []},
+            {"path": "none", "values": ["none"]},
+            {"path": "str", "values": ["lower", "upper"]},
+            {"path": "str_list", "values": ["lower", "upper"]},
+        ]
+        for i, res in enumerate(result.data["lightning"]):
+            self.assertEqual(res["path"], expected[i]["path"])
+            self.assertListEqual(sorted(res["values"]), expected[i]["values"])
 
         # test search
         result = await _execute(
@@ -1258,7 +1259,7 @@ class TestObjectIdLightningQueries(unittest.IsolatedAsyncioTestCase):
             self.assertListEqual(path["values"], [])
 
 
-def _add_samples(dataset: fo.Dataset, *sample_data: t.List[t.Dict]):
+def _add_samples(dataset: fo.Dataset, *sample_data: t.Dict):
     samples = []
     keys = set()
     for idx, data in enumerate(sample_data):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Improve sidebar filtering performance by:

- use project and set instead of group to get distinct values. which allows the aggregation to now use indexes
- remove sort


## How is this patch tested? If it is not, please explain why.

- tested by running locally on 30M sample dataset with coinciding filters 
- 
https://github.com/user-attachments/assets/7043f6da-5db1-4c45-b1d4-c943800bc696

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the backend logic for retrieving unique values, ensuring consistent and efficient processing.

- **Tests**
  - Updated test assertions to verify that unique results are returned correctly with more granular checks.
  - Enhanced sample data handling in tests for greater flexibility and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->