### PR TITLE
Add support for listing schemas without traversing embedded list fields

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1340,6 +1340,7 @@ class SampleCollection(object):
         path,
         ftype=None,
         embedded_doc_type=None,
+        subfield=None,
         read_only=None,
         include_private=False,
         leaf=False,
@@ -1349,11 +1350,15 @@ class SampleCollection(object):
 
         Args:
             path: a field path
-            ftype (None): an optional field type to enforce. Must be a subclass
-                of :class:`fiftyone.core.fields.Field`
-            embedded_doc_type (None): an optional embedded document type to
-                enforce. Must be a subclass of
+            ftype (None): an optional field type or iterable of types to
+                enforce. Must be subclass(es) of
+                :class:`fiftyone.core.fields.Field`
+            embedded_doc_type (None): an optional embedded document type or
+                iterable of types to enforce. Must be subclass(es) of
                 :class:`fiftyone.core.odm.BaseEmbeddedDocument`
+            subfield (None): an optional subfield type or iterable of subfield
+                types to enforce. Must be subclass(es) of
+                :class:`fiftyone.core.fields.Field`
             read_only (None): whether to optionally enforce that the field is
                 read-only (True) or not read-only (False)
             include_private (False): whether to include fields that start with
@@ -1369,6 +1374,7 @@ class SampleCollection(object):
         fof.validate_constraints(
             ftype=ftype,
             embedded_doc_type=embedded_doc_type,
+            subfield=subfield,
             read_only=read_only,
         )
 
@@ -1381,6 +1387,7 @@ class SampleCollection(object):
             path=path,
             ftype=ftype,
             embedded_doc_type=embedded_doc_type,
+            subfield=subfield,
             read_only=read_only,
         )
 
@@ -1447,11 +1454,13 @@ class SampleCollection(object):
         self,
         ftype=None,
         embedded_doc_type=None,
+        subfield=None,
         read_only=None,
         info_keys=None,
         created_after=None,
         include_private=False,
         flat=False,
+        unwind=True,
         mode=None,
     ):
         """Returns a schema dictionary describing the fields of the samples in
@@ -1465,6 +1474,9 @@ class SampleCollection(object):
                 iterable of types to which to restrict the returned schema.
                 Must be subclass(es) of
                 :class:`fiftyone.core.odm.BaseEmbeddedDocument`
+            subfield (None): an optional subfield type or iterable of subfield
+                types to which to restrict the returned schema. Must be
+                subclass(es) of :class:`fiftyone.core.fields.Field`
             read_only (None): whether to restrict to (True) or exclude (False)
                 read-only fields. By default, all fields are included
             info_keys (None): an optional key or list of keys that must be in
@@ -1475,10 +1487,12 @@ class SampleCollection(object):
                 ``_`` in the returned schema
             flat (False): whether to return a flattened schema where all
                 embedded document fields are included as top-level keys
+            unwind (True): whether to traverse into list fields. Only
+                applicable when ``flat=True``
             mode (None): whether to apply the above constraints before and/or
-                after flattening the schema. Only applicable when ``flat`` is
-                True. Supported values are ``("before", "after", "both")``.
-                The default is ``"after"``
+                after flattening the schema. Only applicable when ``flat=True``.
+                Supported values are ``("before", "after", "both")``. The
+                default is ``"after"``
 
         Returns:
             a dict mapping field names to :class:`fiftyone.core.fields.Field`
@@ -1490,11 +1504,13 @@ class SampleCollection(object):
         self,
         ftype=None,
         embedded_doc_type=None,
+        subfield=None,
         read_only=None,
         info_keys=None,
         created_after=None,
         include_private=False,
         flat=False,
+        unwind=True,
         mode=None,
     ):
         """Returns a schema dictionary describing the fields of the frames in
@@ -1509,6 +1525,9 @@ class SampleCollection(object):
             embedded_doc_type (None): an optional embedded document type to
                 which to restrict the returned schema. Must be a subclass of
                 :class:`fiftyone.core.odm.BaseEmbeddedDocument`
+            subfield (None): an optional subfield type or iterable of subfield
+                types to which to restrict the returned schema. Must be
+                subclass(es) of :class:`fiftyone.core.fields.Field`
             read_only (None): whether to restrict to (True) or exclude (False)
                 read-only fields. By default, all fields are included
             info_keys (None): an optional key or list of keys that must be in
@@ -1519,10 +1538,12 @@ class SampleCollection(object):
                 ``_`` in the returned schema
             flat (False): whether to return a flattened schema where all
                 embedded document fields are included as top-level keys
+            unwind (True): whether to traverse into list fields. Only
+                applicable when ``flat=True``
             mode (None): whether to apply the above constraints before and/or
-                after flattening the schema. Only applicable when ``flat`` is
-                True. Supported values are ``("before", "after", "both")``.
-                The default is ``"after"``
+                after flattening the schema. Only applicable when ``flat=True``.
+                Supported values are ``("before", "after", "both")``. The
+                default is ``"after"``
 
         Returns:
             a dict mapping field names to :class:`fiftyone.core.fields.Field`
@@ -1822,23 +1843,36 @@ class SampleCollection(object):
                         "Frame field '%s' does not exist" % field_name
                     )
 
-    def validate_field_type(self, path, ftype=None, embedded_doc_type=None):
+    def validate_field_type(
+        self,
+        path,
+        ftype=None,
+        embedded_doc_type=None,
+        subfield=None,
+    ):
         """Validates that the collection has a field of the given type.
 
         Args:
             path: a field name or ``embedded.field.name``
-            ftype (None): an optional field type to enforce. Must be a subclass
-                of :class:`fiftyone.core.fields.Field`
+            ftype (None): an optional field type or iterable of types to
+                enforce. Must be subclass(es) of
+                :class:`fiftyone.core.fields.Field`
             embedded_doc_type (None): an optional embedded document type or
-                iterable of types to enforce. Must be a subclass(es) of
+                iterable of types to enforce. Must be subclass(es) of
                 :class:`fiftyone.core.odm.BaseEmbeddedDocument`
+            subfield (None): an optional subfield type or iterable of subfield
+                types to enforce. Must be subclass(es) of
+                :class:`fiftyone.core.fields.Field`
 
         Raises:
             ValueError: if the field does not exist or does not have the
                 expected type
         """
         field = self.get_field(
-            path, ftype=ftype, embedded_doc_type=embedded_doc_type
+            path,
+            ftype=ftype,
+            embedded_doc_type=embedded_doc_type,
+            subfield=subfield,
         )
 
         if field is None:

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1349,11 +1349,13 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         self,
         ftype=None,
         embedded_doc_type=None,
+        subfield=None,
         read_only=None,
         info_keys=None,
         created_after=None,
         include_private=False,
         flat=False,
+        unwind=True,
         mode=None,
     ):
         """Returns a schema dictionary describing the fields of the samples in
@@ -1367,6 +1369,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 iterable of types to which to restrict the returned schema.
                 Must be subclass(es) of
                 :class:`fiftyone.core.odm.BaseEmbeddedDocument`
+            subfield (None): an optional subfield type or iterable of subfield
+                types to which to restrict the returned schema. Must be
+                subclass(es) of :class:`fiftyone.core.fields.Field`
             read_only (None): whether to restrict to (True) or exclude (False)
                 read-only fields. By default, all fields are included
             info_keys (None): an optional key or list of keys that must be in
@@ -1377,10 +1382,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 ``_`` in the returned schema
             flat (False): whether to return a flattened schema where all
                 embedded document fields are included as top-level keys
+            unwind (True): whether to traverse into list fields. Only
+                applicable when ``flat=True``
             mode (None): whether to apply the above constraints before and/or
-                after flattening the schema. Only applicable when ``flat`` is
-                True. Supported values are ``("before", "after", "both")``.
-                The default is ``"after"``
+                after flattening the schema. Only applicable when ``flat=True``.
+                Supported values are ``("before", "after", "both")``. The
+                default is ``"after"``
 
         Returns:
             a dict mapping field names to :class:`fiftyone.core.fields.Field`
@@ -1389,11 +1396,13 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         return self._sample_doc_cls.get_field_schema(
             ftype=ftype,
             embedded_doc_type=embedded_doc_type,
+            subfield=subfield,
             read_only=read_only,
             info_keys=info_keys,
             created_after=created_after,
             include_private=include_private,
             flat=flat,
+            unwind=unwind,
             mode=mode,
         )
 
@@ -1401,11 +1410,13 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         self,
         ftype=None,
         embedded_doc_type=None,
+        subfield=None,
         read_only=None,
         info_keys=None,
         created_after=None,
         include_private=False,
         flat=False,
+        unwind=True,
         mode=None,
     ):
         """Returns a schema dictionary describing the fields of the frames of
@@ -1421,6 +1432,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 iterable of types to which to restrict the returned schema.
                 Must be subclass(es) of
                 :class:`fiftyone.core.odm.BaseEmbeddedDocument`
+            subfield (None): an optional subfield type or iterable of subfield
+                types to which to restrict the returned schema. Must be
+                subclass(es) of :class:`fiftyone.core.fields.Field`
             read_only (None): whether to restrict to (True) or exclude (False)
                 read-only fields. By default, all fields are included
             info_keys (None): an optional key or list of keys that must be in
@@ -1431,10 +1445,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 ``_`` in the returned schema
             flat (False): whether to return a flattened schema where all
                 embedded document fields are included as top-level keys
+            unwind (True): whether to traverse into list fields. Only
+                applicable when ``flat=True``
             mode (None): whether to apply the above constraints before and/or
-                after flattening the schema. Only applicable when ``flat`` is
-                True. Supported values are ``("before", "after", "both")``.
-                The default is ``"after"``
+                after flattening the schema. Only applicable when ``flat=True``.
+                Supported values are ``("before", "after", "both")``. The
+                default is ``"after"``
 
         Returns:
             a dict mapping field names to :class:`fiftyone.core.fields.Field`
@@ -1446,11 +1462,13 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         return self._frame_doc_cls.get_field_schema(
             ftype=ftype,
             embedded_doc_type=embedded_doc_type,
+            subfield=subfield,
             read_only=read_only,
             info_keys=info_keys,
             created_after=created_after,
             include_private=include_private,
             flat=flat,
+            unwind=unwind,
             mode=mode,
         )
 

--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -26,6 +26,7 @@ import fiftyone.core.utils as fou
 def validate_constraints(
     ftype=None,
     embedded_doc_type=None,
+    subfield=None,
     read_only=None,
     info_keys=None,
     created_after=None,
@@ -38,6 +39,8 @@ def validate_constraints(
         embedded_doc_type (None): an optional embedded document type or
             iterable of types to enforce. Must be subclass(es) of
             :class:`fiftyone.core.odm.BaseEmbeddedDocument`
+        subfield (None): an optional subfield type or iterable of subfield
+            types to enforce. Must be subclass(es) of :class:`Field`
         read_only (None): whether to optionally enforce that the field is
             read-only (True) or not read-only (False)
         info_keys (None): an optional key or list of keys that must be in the
@@ -67,14 +70,6 @@ def validate_constraints(
                     "Field type %s is not a subclass of %s" % (_ftype, Field)
                 )
 
-            if embedded_doc_type is not None and not issubclass(
-                _ftype, EmbeddedDocumentField
-            ):
-                raise ValueError(
-                    "embedded_doc_type can only be specified if ftype is a "
-                    "subclass of %s" % EmbeddedDocumentField
-                )
-
     if embedded_doc_type is not None:
         has_contraints = True
 
@@ -88,6 +83,21 @@ def validate_constraints(
                 raise ValueError(
                     "Embedded doc type %s is not a subclass of %s"
                     % (_embedded_doc_type, foo.BaseEmbeddedDocument)
+                )
+
+    if subfield is not None:
+        has_contraints = True
+
+        if etau.is_container(subfield):
+            subfield = tuple(subfield)
+        else:
+            subfield = (subfield,)
+
+        for _subfield in subfield:
+            if not issubclass(_subfield, Field):
+                raise ValueError(
+                    "Subfield type %s is not a subclass of %s"
+                    % (_subfield, Field)
                 )
 
     if read_only is not None:
@@ -113,6 +123,7 @@ def matches_constraints(
     field,
     ftype=None,
     embedded_doc_type=None,
+    subfield=None,
     read_only=None,
     info_keys=None,
     created_after=None,
@@ -126,6 +137,8 @@ def matches_constraints(
         embedded_doc_type (None): an optional embedded document type or
             iterable of types to enforce. Must be subclass(es) of
             :class:`fiftyone.core.odm.BaseEmbeddedDocument`
+        subfield (None): an optional subfield type or iterable of subfield
+            types to enforce. Must be subclass(es) of :class:`Field`
         read_only (None): whether to optionally enforce that the field is
             read-only (True) or not read-only (False)
         info_keys (None): an optional key or list of keys that must be in the
@@ -136,6 +149,13 @@ def matches_constraints(
     Returns:
         True/False
     """
+    if ftype is None:
+        if embedded_doc_type is not None:
+            ftype = EmbeddedDocumentField
+
+        if subfield is not None:
+            ftype = (ListField, DictField)
+
     if ftype is not None:
         if etau.is_container(ftype):
             ftype = tuple(ftype)
@@ -147,8 +167,17 @@ def matches_constraints(
         if etau.is_container(embedded_doc_type):
             embedded_doc_type = tuple(embedded_doc_type)
 
-        if not isinstance(field, EmbeddedDocumentField) or not issubclass(
+        if isinstance(field, EmbeddedDocumentField) and not issubclass(
             field.document_type, embedded_doc_type
+        ):
+            return False
+
+    if subfield is not None:
+        if etau.is_container(subfield):
+            subfield = tuple(subfield)
+
+        if isinstance(field, (ListField, DictField)) and not isinstance(
+            field.field, subfield
         ):
             return False
 
@@ -175,6 +204,7 @@ def validate_field(
     path=None,
     ftype=None,
     embedded_doc_type=None,
+    subfield=None,
     read_only=None,
 ):
     """Validates that the field matches the given constraints.
@@ -188,13 +218,15 @@ def validate_field(
         embedded_doc_type (None): an optional embedded document type or
             iterable of types to enforce. Must be subclass(es) of
             :class:`fiftyone.core.odm.BaseEmbeddedDocument`
+        subfield (None): an optional subfield type or iterable of subfield
+            types to enforce. Must be subclass(es) of :class:`Field`
         read_only (None): whether to optionally enforce that the field is
             read-only (True) or not read-only (False)
 
     Raises:
         ValueError: if the constraints are not valid
     """
-    if ftype is None and embedded_doc_type is None:
+    if ftype is None and embedded_doc_type is None and subfield is None:
         return
 
     if field is None:
@@ -224,6 +256,22 @@ def validate_field(
             raise ValueError(
                 "%s has document type %s, not %s"
                 % (_make_prefix(path), field.document_type, embedded_doc_type)
+            )
+
+    if subfield is not None:
+        if etau.is_container(subfield):
+            subfield = tuple(subfield)
+
+        if not isinstance(field, (ListField, DictField)):
+            raise ValueError(
+                "%s has type %s, not %s"
+                % (_make_prefix(path), type(field), (ListField, DictField))
+            )
+
+        if not isinstance(field.field, subfield):
+            raise ValueError(
+                "%s has subfield type %s, not %s"
+                % (_make_prefix(path), type(field.field), subfield)
             )
 
     if read_only is not None:
@@ -266,11 +314,13 @@ def filter_schema(
     schema,
     ftype=None,
     embedded_doc_type=None,
+    subfield=None,
     read_only=None,
     info_keys=None,
     created_after=None,
     include_private=False,
     flat=False,
+    unwind=True,
     mode=None,
 ):
     """Filters the schema according to the given constraints.
@@ -284,6 +334,9 @@ def filter_schema(
             iterable of types to which to restrict the returned schema.
             Must be subclass(es) of
             :class:`fiftyone.core.odm.BaseEmbeddedDocument`
+        subfield (None): an optional subfield type or iterable of subfield
+            types to which to restrict the returned schema. Must be
+            subclass(es) of :class:`Field`
         read_only (None): whether to restrict to (True) or exclude (False)
             read-only fields. By default, all fields are included
         info_keys (None): an optional key or list of keys that must be in the
@@ -294,8 +347,10 @@ def filter_schema(
             ``_`` in the returned schema
         flat (False): whether to return a flattened schema where all
             embedded document fields are included as top-level keys
+        unwind (True): whether to traverse into list fields. Only applicable
+            when ``flat=True``
         mode (None): whether to apply the above constraints before and/or after
-            flattening the schema. Only applicable when ``flat`` is True.
+            flattening the schema. Only applicable when ``flat=True``.
             Supported values are ``("before", "after", "both")``. The default
             is ``"after"``
 
@@ -305,6 +360,7 @@ def filter_schema(
     has_contraints = validate_constraints(
         ftype=ftype,
         embedded_doc_type=embedded_doc_type,
+        subfield=subfield,
         read_only=read_only,
         info_keys=info_keys,
         created_after=created_after,
@@ -314,6 +370,7 @@ def filter_schema(
         kwargs = dict(
             ftype=ftype,
             embedded_doc_type=embedded_doc_type,
+            subfield=subfield,
             read_only=read_only,
             info_keys=info_keys,
             created_after=created_after,
@@ -354,7 +411,10 @@ def filter_schema(
 
     if flat:
         schema = flatten_schema(
-            schema, **after_kwargs, include_private=include_private
+            schema,
+            **after_kwargs,
+            unwind=unwind,
+            include_private=include_private,
         )
 
     return schema
@@ -364,6 +424,8 @@ def flatten_schema(
     schema,
     ftype=None,
     embedded_doc_type=None,
+    subfield=None,
+    unwind=True,
     read_only=None,
     info_keys=None,
     created_after=None,
@@ -380,6 +442,10 @@ def flatten_schema(
         embedded_doc_type (None): an optional embedded document type or
             iterable of types to which to restrict the returned schema. Must be
             subclass(es) of :class:`fiftyone.core.odm.BaseEmbeddedDocument`
+        subfield (None): an optional subfield type or iterable of subfield
+            types to which to restrict the returned schema. Must be
+            subclass(es) of :class:`Field`
+        unwind (True): whether to traverse into list fields
         read_only (None): whether to restrict to (True) or exclude (False)
             read-only fields. By default, all fields are included
         info_keys (None): an optional key or list of keys that must be in the
@@ -395,6 +461,7 @@ def flatten_schema(
     validate_constraints(
         ftype=ftype,
         embedded_doc_type=embedded_doc_type,
+        subfield=subfield,
         read_only=read_only,
         info_keys=info_keys,
         created_after=created_after,
@@ -409,6 +476,8 @@ def flatten_schema(
             field,
             ftype,
             embedded_doc_type,
+            subfield,
+            unwind,
             read_only,
             info_keys,
             created_after,
@@ -425,6 +494,8 @@ def _flatten(
     field,
     ftype,
     embedded_doc_type,
+    subfield,
+    unwind,
     read_only,
     info_keys,
     created_after,
@@ -442,6 +513,7 @@ def _flatten(
         field,
         ftype=ftype,
         embedded_doc_type=embedded_doc_type,
+        subfield=subfield,
         read_only=read_only,
         info_keys=info_keys,
         created_after=created_after,
@@ -449,6 +521,9 @@ def _flatten(
         schema[prefix] = field
 
     while isinstance(field, (ListField, DictField)):
+        if not unwind:
+            return
+
         field = field.field
 
     if isinstance(field, EmbeddedDocumentField):
@@ -460,6 +535,8 @@ def _flatten(
                 _field,
                 ftype,
                 embedded_doc_type,
+                subfield,
+                unwind,
                 read_only,
                 info_keys,
                 created_after,
@@ -1838,9 +1915,11 @@ class EmbeddedDocumentField(mongoengine.fields.EmbeddedDocumentField, Field):
         self,
         ftype=None,
         embedded_doc_type=None,
+        subfield=None,
         read_only=None,
         include_private=False,
         flat=False,
+        unwind=True,
         mode=None,
     ):
         """Returns a schema dictionary describing the fields of the embedded
@@ -1854,16 +1933,21 @@ class EmbeddedDocumentField(mongoengine.fields.EmbeddedDocumentField, Field):
                 iterable of types to which to restrict the returned schema.
                 Must be subclass(es) of
                 :class:`fiftyone.core.odm.BaseEmbeddedDocument`
+            subfield (None): an optional subfield type or iterable of subfield
+                types to which to restrict the returned schema. Must be
+                subclass(es) of :class:`Field`
             read_only (None): whether to restrict to (True) or exclude (False)
                 read-only fields. By default, all fields are included
             include_private (False): whether to include fields that start with
                 ``_`` in the returned schema
             flat (False): whether to return a flattened schema where all
                 embedded document fields are included as top-level keys
+            unwind (True): whether to traverse into list fields. Only
+                applicable when ``flat=True``
             mode (None): whether to apply the above constraints before and/or
-                after flattening the schema. Only applicable when ``flat`` is
-                True. Supported values are ``("before", "after", "both")``.
-                The default is ``"after"``
+                after flattening the schema. Only applicable when ``flat=True``.
+                Supported values are ``("before", "after", "both")``. The
+                default is ``"after"``
 
         Returns:
             a dict mapping field names to :class:`Field` instances
@@ -1879,9 +1963,11 @@ class EmbeddedDocumentField(mongoengine.fields.EmbeddedDocumentField, Field):
             schema,
             ftype=ftype,
             embedded_doc_type=embedded_doc_type,
+            subfield=subfield,
             read_only=read_only,
             include_private=include_private,
             flat=flat,
+            unwind=unwind,
             mode=mode,
         )
 

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -186,11 +186,13 @@ class DatasetMixin(object):
         cls,
         ftype=None,
         embedded_doc_type=None,
+        subfield=None,
         read_only=None,
         info_keys=None,
         created_after=None,
         include_private=False,
         flat=False,
+        unwind=True,
         mode=None,
     ):
         """Returns a schema dictionary describing the fields of this document.
@@ -206,6 +208,9 @@ class DatasetMixin(object):
                 iterable of types to which to restrict the returned schema.
                 Must be subclass(es) of
                 :class:`fiftyone.core.odm.BaseEmbeddedDocument`
+            subfield (None): an optional subfield type or iterable of subfield
+                types to which to restrict the returned schema. Must be
+                subclass(es) of :class:`fiftyone.core.fields.Field`
             read_only (None): whether to restrict to (True) or exclude (False)
                 read-only fields. By default, all fields are included
             info_keys (None): an optional key or list of keys that must be in
@@ -216,10 +221,12 @@ class DatasetMixin(object):
                 ``_`` in the returned schema
             flat (False): whether to return a flattened schema where all
                 embedded document fields are included as top-level keys
-            mode (None): whether to apply the `above constraints before and/or
-                after flattening the schema. Only applicable when ``flat`` is
-                True. Supported values are ``("before", "after", "both")``.
-                The default is ``"after"``
+            unwind (True): whether to traverse into list fields. Only
+                applicable when ``flat=True``
+            mode (None): whether to apply the above constraints before and/or
+                after flattening the schema. Only applicable when ``flat=True``.
+                Supported values are ``("before", "after", "both")``. The
+                default is ``"after"``
 
         Returns:
             a dict mapping field names to :class:`fiftyone.core.fields.Field`
@@ -234,11 +241,13 @@ class DatasetMixin(object):
             schema,
             ftype=ftype,
             embedded_doc_type=embedded_doc_type,
+            subfield=subfield,
             read_only=read_only,
             info_keys=info_keys,
             created_after=created_after,
             include_private=include_private,
             flat=flat,
+            unwind=unwind,
             mode=mode,
         )
 

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -928,11 +928,13 @@ class DatasetView(foc.SampleCollection):
         self,
         ftype=None,
         embedded_doc_type=None,
+        subfield=None,
         read_only=None,
         info_keys=None,
         created_after=None,
         include_private=False,
         flat=False,
+        unwind=True,
         mode=None,
     ):
         """Returns a schema dictionary describing the fields of the samples in
@@ -946,6 +948,9 @@ class DatasetView(foc.SampleCollection):
                 iterable of types to which to restrict the returned schema.
                 Must be subclass(es) of
                 :class:`fiftyone.core.odm.BaseEmbeddedDocument`
+            subfield (None): an optional subfield type or iterable of subfield
+                types to which to restrict the returned schema. Must be
+                subclass(es) of :class:`fiftyone.core.fields.Field`
             read_only (None): whether to restrict to (True) or exclude (False)
                 read-only fields. By default, all fields are included
             info_keys (None): an optional key or list of keys that must be in
@@ -956,9 +961,11 @@ class DatasetView(foc.SampleCollection):
                 ``_`` in the returned schema
             flat (False): whether to return a flattened schema where all
                 embedded document fields are included as top-level keys
+            unwind (True): whether to traverse into list fields. Only
+                applicable when ``flat=True``
             mode (None): whether to apply the above constraints before and/or
-                after flattening the schema. Only applicable when ``flat`` is
-                True. Supported values are ``("before", "after", "both")``. The
+                after flattening the schema. Only applicable when ``flat=True``.
+                Supported values are ``("before", "after", "both")``. The
                 default is ``"after"``
 
         Returns:
@@ -975,11 +982,13 @@ class DatasetView(foc.SampleCollection):
             schema,
             ftype=ftype,
             embedded_doc_type=embedded_doc_type,
+            subfield=subfield,
             read_only=read_only,
             info_keys=info_keys,
             created_after=created_after,
             include_private=include_private,
             flat=flat,
+            unwind=unwind,
             mode=mode,
         )
 
@@ -987,11 +996,13 @@ class DatasetView(foc.SampleCollection):
         self,
         ftype=None,
         embedded_doc_type=None,
+        subfield=None,
         read_only=None,
         info_keys=None,
         created_after=None,
         include_private=False,
         flat=False,
+        unwind=True,
         mode=None,
     ):
         """Returns a schema dictionary describing the fields of the frames of
@@ -1007,6 +1018,9 @@ class DatasetView(foc.SampleCollection):
                 iterable of types to which to restrict the returned schema.
                 Must be subclass(es) of
                 :class:`fiftyone.core.odm.BaseEmbeddedDocument`
+            subfield (None): an optional subfield type or iterable of subfield
+                types to which to restrict the returned schema. Must be
+                subclass(es) of :class:`fiftyone.core.fields.Field`
             read_only (None): whether to restrict to (True) or exclude (False)
                 read-only fields. By default, all fields are included
             info_keys (None): an optional key or list of keys that must be in
@@ -1017,10 +1031,12 @@ class DatasetView(foc.SampleCollection):
                 ``_`` in the returned schema
             flat (False): whether to return a flattened schema where all
                 embedded document fields are included as top-level keys
+            unwind (True): whether to traverse into list fields. Only
+                applicable when ``flat=True``
             mode (None): whether to apply the above constraints before and/or
-                after flattening the schema. Only applicable when ``flat`` is
-                True. Supported values are ``("before", "after", "both")``.
-                The default is ``"after"``
+                after flattening the schema. Only applicable when ``flat=True``.
+                Supported values are ``("before", "after", "both")``. The
+                default is ``"after"``
 
         Returns:
             a dict mapping field names to :class:`fiftyone.core.fields.Field`
@@ -1039,11 +1055,13 @@ class DatasetView(foc.SampleCollection):
             schema,
             ftype=ftype,
             embedded_doc_type=embedded_doc_type,
+            subfield=subfield,
             read_only=read_only,
             info_keys=info_keys,
             created_after=created_after,
             include_private=include_private,
             flat=flat,
+            unwind=unwind,
             mode=mode,
         )
 

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -634,14 +634,10 @@ def _get_label_type(samples, backend, label_type, label_field, label_info):
     if "type" in label_info:
         label_type = label_info["type"]
 
-    field_name, is_frame_field = samples._handle_frame_field(label_field)
+    field = samples.get_field(label_field)
+    is_frame_field = samples._is_frame_field(label_field)
 
-    if is_frame_field:
-        schema = samples.get_frame_field_schema()
-    else:
-        schema = samples.get_field_schema()
-
-    if field_name not in schema:
+    if field is None:
         if label_type is None:
             raise ValueError(
                 "You must specify a type for new label field '%s'"
@@ -650,7 +646,7 @@ def _get_label_type(samples, backend, label_type, label_field, label_info):
 
         return label_type, is_frame_field, False, False
 
-    _existing_type = _get_backend_field_type(backend, schema[field_name])
+    _existing_type = _get_backend_field_type(backend, field)
     _multiple_types = isinstance(_existing_type, list)
 
     if label_type is not None:
@@ -1261,14 +1257,9 @@ def _prompt_field(
         fo_label_type = _LABEL_TYPES_MAP[label_type]
 
     if label_field:
-        _, is_frame_field = dataset._handle_frame_field(label_field)
+        is_frame_field = dataset._is_frame_field(label_field)
     else:
-        _, is_frame_field = dataset._handle_frame_field(new_field)
-
-    if is_frame_field:
-        schema = dataset.get_frame_field_schema()
-    else:
-        schema = dataset.get_field_schema()
+        is_frame_field = dataset._is_frame_field(new_field)
 
     while True:
         if is_frame_field and not dataset._is_frame_field(new_field):
@@ -1282,18 +1273,14 @@ def _prompt_field(
         is_good_field = _new_field not in label_schema
 
         if is_good_field:
-            if is_frame_field:
-                field, _ = dataset._handle_frame_field(new_field)
-            else:
-                field = new_field
-
-            if field not in schema:
+            _field = dataset.get_field(new_field)
+            if _field is None:
                 break  # new field
 
             try:
-                field_type = schema[field].document_type
+                field_type = _field.document_type
             except:
-                field_type = type(schema[field])
+                field_type = type(_field)
 
             if label_type == "scalar":
                 # As long as it is not an embedded document field, assume the


### PR DESCRIPTION
Often when building plugins, I want to accept a field from a user which contains "anything categorical that is 1-1 with samples".

For example, I may want to allow string fields or list(string) fields, even if they are embedded within a [dynamic document](https://docs.voxel51.com/user_guide/using_datasets.html#defining-custom-documents-on-the-fly), but *NOT* if they are embedded within a list of documents (eg within a `Detections` field).

This PR adds new `subfield=` and `unwind=False` parameters to `get_field_schema()` that allow me to succinctly describe this schema request 🎉 

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

# Closest existing syntax is not quite what I want
schema = dataset.get_field_schema(ftype=(fo.StringField, fo.ListField), flat=True)
print(schema)

"""
{
    'filepath': <fiftyone.core.fields.StringField object at 0x7fc20b65f850>,
    'tags': <fiftyone.core.fields.ListField object at 0x7fc20b65f4c0>,
    'metadata.mime_type': <fiftyone.core.fields.StringField object at 0x7fc20b65f490>,
    'ground_truth.detections': <fiftyone.core.fields.ListField object at 0x7fc20b65f910>,
    'ground_truth.detections.tags': <fiftyone.core.fields.ListField object at 0x7fc20b65f790>,
    'ground_truth.detections.label': <fiftyone.core.fields.StringField object at 0x7fc20b65f670>,
    'ground_truth.detections.bounding_box': <fiftyone.core.fields.ListField object at 0x7fc20b65f610>,
    'ground_truth.detections.mask_path': <fiftyone.core.fields.StringField object at 0x7fc20b65f940>,
    'predictions.detections': <fiftyone.core.fields.ListField object at 0x7fc20b6662e0>,
    'predictions.detections.tags': <fiftyone.core.fields.ListField object at 0x7fc20b65fbe0>,
    'predictions.detections.label': <fiftyone.core.fields.StringField object at 0x7fc20b666250>,
    'predictions.detections.bounding_box': <fiftyone.core.fields.ListField object at 0x7fc20b6661f0>,
    'predictions.detections.mask_path': <fiftyone.core.fields.StringField object at 0x7fc20b666310>,
}
"""

# This new syntax supports what I want!
schema = dataset.get_field_schema(
    ftype=(fo.StringField, fo.ListField),
    subfield=fo.StringField,  # new parameter
    flat=True,
    unwind=False,  # new parameter
)
print(schema)

"""
{
    'filepath': <fiftyone.core.fields.StringField object at 0x7fc20b65f850>,
    'tags': <fiftyone.core.fields.ListField object at 0x7fc20b65f4c0>,
    'metadata.mime_type': <fiftyone.core.fields.StringField object at 0x7fc20b65f490>,
}
"""
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced field schema retrieval with options to filter by specific subfield types.
  - Added control over traversal into nested list fields during schema retrieval.
  - Streamlined label and frame field detection for improved field type handling.

- **Tests**
  - Expanded test coverage to validate the robustness of updated field filtering and schema management features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->