### PR TITLE
Add support for adding samples as a generator

### DIFF
--- a/fiftyone/utils/data/parsers.py
+++ b/fiftyone/utils/data/parsers.py
@@ -24,7 +24,14 @@ import fiftyone.utils.image as foui
 import fiftyone.utils.video as fouv
 
 
-def add_images(dataset, samples, sample_parser, tags=None, progress=None):
+def add_images(
+    dataset,
+    samples,
+    sample_parser,
+    tags=None,
+    generator=False,
+    progress=None,
+):
     """Adds the given images to the dataset.
 
     This operation does not read the images.
@@ -40,6 +47,8 @@ def add_images(dataset, samples, sample_parser, tags=None, progress=None):
             parse the samples
         tags (None): an optional tag or iterable of tags to attach to each
             sample
+        generator (False): whether to yield ID batches as a generator as
+            samples are added to the dataset
         progress (None): whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
@@ -83,6 +92,7 @@ def add_images(dataset, samples, sample_parser, tags=None, progress=None):
     return dataset.add_samples(
         _samples,
         expand_schema=False,
+        generator=generator,
         progress=progress,
         num_samples=samples,
     )
@@ -96,6 +106,7 @@ def add_labeled_images(
     tags=None,
     expand_schema=True,
     dynamic=False,
+    generator=False,
     progress=None,
 ):
     """Adds the given labeled images to the dataset.
@@ -129,6 +140,8 @@ def add_labeled_images(
             if a sample's schema is not a subset of the dataset schema
         dynamic (False): whether to declare dynamic attributes of embedded
             document fields that are encountered
+        generator (False): whether to yield ID batches as a generator as
+            samples are added to the dataset
         progress (None): whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
@@ -201,12 +214,20 @@ def add_labeled_images(
         _samples,
         expand_schema=expand_schema,
         dynamic=dynamic,
+        generator=generator,
         progress=progress,
         num_samples=samples,
     )
 
 
-def add_videos(dataset, samples, sample_parser, tags=None, progress=None):
+def add_videos(
+    dataset,
+    samples,
+    sample_parser,
+    tags=None,
+    generator=False,
+    progress=None,
+):
     """Adds the given videos to the dataset.
 
     This operation does not read the videos.
@@ -222,6 +243,8 @@ def add_videos(dataset, samples, sample_parser, tags=None, progress=None):
             parse the samples
         tags (None): an optional tag or iterable of tags to attach to each
             sample
+        generator (False): whether to yield ID batches as a generator as
+            samples are added to the dataset
         progress (None): whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
@@ -260,6 +283,7 @@ def add_videos(dataset, samples, sample_parser, tags=None, progress=None):
     return dataset.add_samples(
         _samples,
         expand_schema=True,
+        generator=generator,
         progress=progress,
         num_samples=samples,
     )
@@ -273,6 +297,7 @@ def add_labeled_videos(
     tags=None,
     expand_schema=True,
     dynamic=False,
+    generator=False,
     progress=None,
 ):
     """Adds the given labeled videos to the dataset.
@@ -305,6 +330,8 @@ def add_labeled_videos(
             if a sample's schema is not a subset of the dataset schema
         dynamic (False): whether to declare dynamic attributes of embedded
             document fields that are encountered
+        generator (False): whether to yield ID batches as a generator as
+            samples are added to the dataset
         progress (None): whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
@@ -375,6 +402,7 @@ def add_labeled_videos(
         _samples,
         expand_schema=expand_schema,
         dynamic=dynamic,
+        generator=generator,
         progress=progress,
         num_samples=samples,
     )

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -1934,6 +1934,19 @@ class DatasetTests(unittest.TestCase):
             _ = dataset.one(F("filepath").ends_with(".jpg"), exact=True)
 
     @drop_datasets
+    def test_add_samples_generator(self):
+        samples = [fo.Sample(filepath=f"image{i}.jpg") for i in range(10)]
+
+        dataset = fo.Dataset()
+
+        sample_ids = []
+        for ids in dataset.add_samples(samples, generator=True):
+            sample_ids.extend(ids)
+
+        assert len(sample_ids) == 10
+        assert len(dataset) == 10
+
+    @drop_datasets
     def test_merge_sample(self):
         sample1 = fo.Sample(filepath="image.jpg", foo="bar", tags=["a"])
         sample2 = fo.Sample(filepath="image.jpg", spam="eggs", tags=["b"])


### PR DESCRIPTION
Adds an optional `generator=True` parameter to all `Dataset` methods that add samples to datasets that causes the methods to yield control to the caller after each batch of samples is added. 

This is useful in situations where the caller would like to perform some custom logic *during* the operation, such as report progress to an external entity as is done in https://github.com/voxel51/fiftyone-plugins/pull/227.

As a toy example, we can implement our own progress bar outside of `add_samples()` as follows:

```py
import fiftyone as fo

n = 5000
make_sample = lambda i: fo.Sample(filepath=f"image{i}.jpg")
samples = map(make_sample, range(n))

dataset = fo.Dataset()
with fo.ProgressBar(total=n) as pb:
    for ids in dataset.add_samples(samples, generator=True, progress=False):
        pb.update(len(ids))
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a generator option to dataset sample addition and import methods, allowing users to yield sample ID batches incrementally during data ingestion.
- **Documentation**
  - Updated docstrings to describe the new generator parameter and its behavior.
- **Tests**
  - Added tests to verify generator-based sample addition functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->