### PR TITLE
Add support for passing custom batchers to `add_samples()`

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -3227,7 +3227,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Returns:
             the ID of the sample in the dataset
         """
-        # call manually because this is typically done by the batcher
         sample = self._transform_sample(
             sample,
             expand_schema=expand_schema,
@@ -3245,6 +3244,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         expand_schema=True,
         dynamic=False,
         validate=True,
+        batcher=None,
         progress=None,
         num_samples=None,
     ):
@@ -3265,6 +3265,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 document fields that are encountered
             validate (True): whether to validate that the fields of each sample
                 are compliant with the dataset schema before adding it
+            batcher (None): an optional :class:`fiftyone.core.utils.Batcher`
+                class to use to batch the samples, or ``False`` to add all
+                samples in a single batch. By default,
+                ``fiftyone.config.default_batcher`` is used
             progress (None): whether to render a progress bar (True/False), use
                 the default value ``fiftyone.config.show_progress_bars``
                 (None), or a progress callback function to invoke instead
@@ -3288,10 +3292,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         batcher = fou.get_default_batcher(
             samples,
-            progress=progress,
-            total=num_samples,
+            batcher=batcher,
             transform_fn=transform_fn,
             size_calc_fn=self._calculate_size,
+            progress=progress,
+            total=num_samples,
         )
 
         sample_ids = []
@@ -3355,13 +3360,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         return self.skip(num_samples).values("id")
 
     def _add_samples_batch(self, samples_and_docs):
-        """Writes the given samples and backing docs to the database and returns their IDs
-
-        Args:
-            samples_and_docs: a list of tuples of the form (sample, dict) where the dict
-                is the sample's backing document
-        Returns:
-            a list of IDs of the samples that were added to this dataset
+        """Writes the given samples and backing docs to the database and
+        returns their IDs.
         """
         dicts = [doc for _, doc in samples_and_docs]
         try:
@@ -3385,6 +3385,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         expand_schema=True,
         dynamic=False,
         validate=True,
+        batcher=None,
         progress=None,
         num_samples=None,
     ):
@@ -3399,9 +3400,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         batcher = fou.get_default_batcher(
             samples,
-            progress=progress,
+            batcher=batcher,
             transform_fn=transform_fn,
             size_calc_fn=self._calculate_size,
+            progress=progress,
             total=num_samples,
         )
 
@@ -3412,27 +3414,17 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     def _transform_sample(
         self,
         sample,
-        expand_schema,
-        dynamic,
-        validate,
+        expand_schema=True,
+        dynamic=False,
+        validate=True,
         copy=False,
         include_id=False,
     ):
-        """Transforms the given sample and returns the transformed sample and dict as a pair
+        """Transforms the given sample and returns the transformed sample and
+        dict as a pair.
 
-        This method handles schema expansion, validation, and preparing the sample's
-        backing document before adding it to the database.
-
-        Args:
-            sample: The sample to transform
-            expand_schema: Whether to dynamically add new sample fields encountered
-            dynamic: Whether to declare dynamic attributes of embedded document fields
-            validate: Whether to validate the sample against the dataset schema
-            copy: Whether to create a copy of the sample if it's already in a dataset
-            include_id: Whether to include the sample's ID in the backing document
-
-        Returns:
-            A tuple of (transformed_sample, backing_document_dict)
+        This method handles schema expansion, validation, and preparing the
+        sample's backing document before adding it to the database.
         """
         if copy and sample._in_db:
             sample = sample.copy()
@@ -3465,12 +3457,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             return len(str(sample[1]))
 
     def _upsert_samples_batch(self, samples_and_docs):
-        """Upserts the given samples and their backing docs to the database
-
-        Args:
-            samples_and_docs: a list of tuples of the form (sample, dict) where the dict
-                is the sample's backing document
-        """
+        """Upserts the given samples and their backing docs to the database."""
         ops = []
         for sample, d in samples_and_docs:
             if sample.id:

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -791,7 +791,14 @@ def _import_collection_multi(json_dir):
     return docs, len(json_paths)
 
 
-def insert_documents(docs, coll, ordered=False, progress=None, num_docs=None):
+def insert_documents(
+    docs,
+    coll,
+    ordered=False,
+    batcher=None,
+    progress=None,
+    num_docs=None,
+):
     """Inserts documents into a collection.
 
     The ``_id`` field of the input documents will be populated if it is not
@@ -801,6 +808,10 @@ def insert_documents(docs, coll, ordered=False, progress=None, num_docs=None):
         docs: an iterable of BSON document dicts
         coll: a pymongo collection
         ordered (False): whether the documents must be inserted in order
+        batcher (None): an optional :class:`fiftyone.core.utils.Batcher` class
+            to use to batch the documents, or ``False`` to strictly insert the
+            documents in a single batch. By default,
+            ``fiftyone.config.default_batcher`` is used
         progress (None): whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
@@ -812,7 +823,12 @@ def insert_documents(docs, coll, ordered=False, progress=None, num_docs=None):
         a list of IDs of the inserted documents
     """
     ids = []
-    batcher = fou.get_default_batcher(docs, progress=progress, total=num_docs)
+    batcher = fou.get_default_batcher(
+        docs,
+        batcher=batcher,
+        progress=progress,
+        total=num_docs,
+    )
 
     try:
         with batcher:
@@ -828,18 +844,22 @@ def insert_documents(docs, coll, ordered=False, progress=None, num_docs=None):
     return ids
 
 
-def bulk_write(ops, coll, ordered=False, progress=False):
+def bulk_write(ops, coll, ordered=False, batcher=None, progress=False):
     """Performs a batch of write operations on a collection.
 
     Args:
         ops: a list of pymongo operations
         coll: a pymongo collection
         ordered (False): whether the operations must be performed in order
+        batcher (None): an optional :class:`fiftyone.core.utils.Batcher` class
+            to use to batch the operations, or ``False`` to strictly perform
+            the the operations in a single batch. By default,
+            ``fiftyone.config.default_batcher`` is used
         progress (False): whether to render a progress bar (True/False), use
             the default value ``fiftyone.config.show_progress_bars`` (None), or
             a progress callback function to invoke instead
     """
-    batcher = fou.get_default_batcher(ops, progress=progress)
+    batcher = fou.get_default_batcher(ops, batcher=batcher, progress=progress)
 
     try:
         with batcher:

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -13,6 +13,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from copy import deepcopy
 from datetime import date, datetime
+from functools import partial
 import glob
 import hashlib
 import importlib
@@ -1068,14 +1069,31 @@ def _report_progress_dt(progress, dt):
     return progress_dt
 
 
-class BaseBatcher(abc.ABC):
+class Batcher(abc.ABC):
+    """Base class for iterating over the elements of an iterable in batches.
+
+    Args:
+        iterable: an iterable to batch over
+        transform_fn (None): a transform function to apply to each item
+        return_views (False): whether to return each batch as a
+            :class:`fiftyone.core.view.DatasetView`. Only applicable when the
+            iterable is a :class:`fiftyone.core.collections.SampleCollection`
+        progress (False): whether to render a progress bar tracking the
+            consumption of the batches (True/False), use the default value
+            ``fiftyone.config.show_progress_bars`` (None), or a progress
+            callback function to invoke instead
+        total (None): the length of ``iterable``. Only applicable when
+            ``progress=True``. If not provided, it is computed via
+            ``len(iterable)``, if possible
+    """
+
     def __init__(
         self,
         iterable,
+        transform_fn=None,
         return_views=False,
         progress=False,
         total=None,
-        transform_fn=None,
     ):
         import fiftyone.core.collections as foc
 
@@ -1086,6 +1104,7 @@ class BaseBatcher(abc.ABC):
             progress = fo.config.show_progress_bars
 
         self.iterable = iterable
+        self.transform_fn = transform_fn
         self.return_views = return_views
         self.progress = progress
         self.total = total
@@ -1097,7 +1116,6 @@ class BaseBatcher(abc.ABC):
         self._render_progress = bool(progress)  # callback function: True
         self._last_offset = None
         self._num_samples = None
-        self._transform_fn = transform_fn
 
     def __enter__(self):
         self._in_context = True
@@ -1135,8 +1153,8 @@ class BaseBatcher(abc.ABC):
                 )
                 self._render_progress = False
 
-        if self._transform_fn is not None:
-            self._iter = map(self._transform_fn, self._iter)
+        if self.transform_fn is not None:
+            self._iter = map(self.transform_fn, self._iter)
 
         return self
 
@@ -1145,8 +1163,9 @@ class BaseBatcher(abc.ABC):
         pass
 
 
-class BaseChunkyBatcher(BaseBatcher):
-    """Base class for iterating over the elements of an iterable in batches.
+class BaseChunkyBatcher(Batcher):
+    """Base class for iterating over the elements of an iterable in chunks.
+
     Batch sizes are determined per chunk using ``_compute_batch_size``.
     """
 
@@ -1155,7 +1174,6 @@ class BaseChunkyBatcher(BaseBatcher):
             self._pb.update(count=self._last_batch_size)
 
         batch_size = self._compute_batch_size()
-        self._last_batch_size = batch_size
 
         if self.iterable is None:
             return batch_size
@@ -1165,26 +1183,35 @@ class BaseChunkyBatcher(BaseBatcher):
                 raise StopIteration
 
             offset = self._last_offset
-            self._last_offset += batch_size
+            if batch_size >= 0:
+                self._last_offset += batch_size
+                self._last_batch_size = batch_size
+                batch = self.iterable[offset : (offset + batch_size)]
+            else:
+                self._last_offset = self._num_samples
+                self._last_batch_size = self._num_samples - offset
+                if offset > 0:
+                    batch = self.iterable[offset:]
+                else:
+                    batch = self.iterable
 
-            batch = self.iterable[offset : (offset + batch_size)]
-            if self._transform_fn is not None:
-                batch = [self._transform_fn(item) for item in batch]
+            if self.transform_fn is not None:
+                batch = [self.transform_fn(item) for item in batch]
+
             return batch
 
         batch = []
         idx = 0
 
         try:
-            while idx < batch_size:
+            while idx < batch_size or batch_size < 0:
                 batch.append(next(self._iter))
                 idx += 1
-
         except StopIteration:
-            self._last_batch_size = len(batch)
-
             if not batch:
                 raise StopIteration
+
+        self._last_batch_size = len(batch)
 
         return batch
 
@@ -1213,17 +1240,17 @@ class BaseDynamicBatcher(BaseChunkyBatcher):
         min_batch_size=1,
         max_batch_size=None,
         max_batch_beta=None,
+        transform_fn=None,
         return_views=False,
         progress=False,
         total=None,
-        transform_fn=None,
     ):
         super().__init__(
             iterable,
+            transform_fn=transform_fn,
             return_views=return_views,
             progress=progress,
             total=total,
-            transform_fn=transform_fn,
         )
 
         self.target_measurement = target_measurement
@@ -1305,7 +1332,7 @@ class LatencyDynamicBatcher(BaseDynamicBatcher):
     Args:
         iterable: an iterable to batch over. If ``None``, the result of
             ``next()`` will be a batch size instead of a batch, and is an
-            infinite iterator.
+            infinite iterator
         target_latency (0.2): the target latency between ``next()``
             calls, in seconds
         init_batch_size (1): the initial batch size to use
@@ -1313,6 +1340,7 @@ class LatencyDynamicBatcher(BaseDynamicBatcher):
         max_batch_size (None): an optional maximum allowed batch size
         max_batch_beta (None): an optional lower/upper bound on the ratio
             between successive batch sizes
+        transform_fn (None): a transform function to apply to each item
         return_views (False): whether to return each batch as a
             :class:`fiftyone.core.view.DatasetView`. Only applicable when the
             iterable is a :class:`fiftyone.core.collections.SampleCollection`
@@ -1323,7 +1351,6 @@ class LatencyDynamicBatcher(BaseDynamicBatcher):
         total (None): the length of ``iterable``. Only applicable when
             ``progress=True``. If not provided, it is computed via
             ``len(iterable)``, if possible
-        transform_fn (None): a transform function to apply to each item of the batch
     """
 
     def __init__(
@@ -1334,10 +1361,10 @@ class LatencyDynamicBatcher(BaseDynamicBatcher):
         min_batch_size=1,
         max_batch_size=None,
         max_batch_beta=None,
+        transform_fn=None,
         return_views=False,
         progress=False,
         total=None,
-        transform_fn=None,
     ):
         super().__init__(
             iterable,
@@ -1346,10 +1373,10 @@ class LatencyDynamicBatcher(BaseDynamicBatcher):
             min_batch_size=min_batch_size,
             max_batch_size=max_batch_size,
             max_batch_beta=max_batch_beta,
+            transform_fn=transform_fn,
             return_views=return_views,
             progress=progress,
             total=total,
-            transform_fn=transform_fn,
         )
 
         self._last_time = None
@@ -1418,13 +1445,14 @@ class ContentSizeDynamicBatcher(BaseDynamicBatcher):
     Args:
         iterable: an iterable to batch over. If ``None``, the result of
             ``next()`` will be a batch size instead of a batch, and is an
-            infinite iterator.
+            infinite iterator
         target_size (1048576): the target batch bson content size, in bytes
         init_batch_size (1): the initial batch size to use
         min_batch_size (1): the minimum allowed batch size
         max_batch_size (None): an optional maximum allowed batch size
         max_batch_beta (None): an optional lower/upper bound on the ratio
             between successive batch sizes
+        transform_fn (None): a transform function to apply to each item
         return_views (False): whether to return each batch as a
             :class:`fiftyone.core.view.DatasetView`. Only applicable when the
             iterable is a :class:`fiftyone.core.collections.SampleCollection`
@@ -1435,7 +1463,6 @@ class ContentSizeDynamicBatcher(BaseDynamicBatcher):
         total (None): the length of ``iterable``. Only applicable when
             ``progress=True``. If not provided, it is computed via
             ``len(iterable)``, if possible
-        transform_fn (None): a transform function to apply to each item of the batch
     """
 
     def __init__(
@@ -1446,14 +1473,15 @@ class ContentSizeDynamicBatcher(BaseDynamicBatcher):
         min_batch_size=1,
         max_batch_size=None,
         max_batch_beta=None,
+        transform_fn=None,
         return_views=False,
         progress=False,
         total=None,
-        transform_fn=None,
     ):
         # If unset or larger, max batch size must be 1 byte per object
         if max_batch_size is None or max_batch_size > target_size:
             max_batch_size = target_size
+
         super().__init__(
             iterable,
             target_size,
@@ -1461,11 +1489,12 @@ class ContentSizeDynamicBatcher(BaseDynamicBatcher):
             min_batch_size=min_batch_size,
             max_batch_size=max_batch_size,
             max_batch_beta=max_batch_beta,
+            transform_fn=transform_fn,
             return_views=return_views,
             progress=progress,
             total=total,
-            transform_fn=transform_fn,
         )
+
         self._last_batch_content_size = 0
         self._manually_applied_backpressure = True
 
@@ -1520,8 +1549,9 @@ class StaticBatcher(BaseChunkyBatcher):
     Args:
         iterable: an iterable to batch over. If ``None``, the result of
             ``next()`` will be a batch size instead of a batch, and is an
-            infinite iterator.
+            infinite iterator
         batch_size: size of batches to generate
+        transform_fn (None): a transform function to apply to each item
         return_views (False): whether to return each batch as a
             :class:`fiftyone.core.view.DatasetView`. Only applicable when the
             iterable is a :class:`fiftyone.core.collections.SampleCollection`
@@ -1532,24 +1562,23 @@ class StaticBatcher(BaseChunkyBatcher):
         total (None): the length of ``iterable``. Only applicable when
             ``progress=True``. If not provided, it is computed via
             ``len(iterable)``, if possible
-        transform_fn (None): a transform function to apply to each item of the batch
     """
 
     def __init__(
         self,
         iterable,
         batch_size,
+        transform_fn=None,
         return_views=False,
         progress=False,
         total=None,
-        transform_fn=None,
     ):
         super().__init__(
             iterable,
+            transform_fn=transform_fn,
             return_views=return_views,
             progress=progress,
             total=total,
-            transform_fn=transform_fn,
         )
 
         self.batch_size = batch_size
@@ -1558,7 +1587,7 @@ class StaticBatcher(BaseChunkyBatcher):
         return self.batch_size
 
 
-class ContentSizeBatcher(BaseBatcher):
+class ContentSizeBatcher(Batcher):
     """Class for iterating over the elements of an iterable with a dynamic
     batch size to achieve a desired content size.
 
@@ -1591,8 +1620,11 @@ class ContentSizeBatcher(BaseBatcher):
     Args:
         iterable: an iterable to batch over. If ``None``, the result of
             ``next()`` will be a batch size instead of a batch, and is an
-            infinite iterator.
-        target_size (1048576): the target batch bson content size, in bytes
+            infinite iterator
+        target_size (1048576): the target batch BSON content size, in bytes
+        transform_fn (None): a transform function to apply to each item
+        size_calc_fn (None): a function that calculates the size of each item.
+            This is applied after ``transform_fn`` if both are provided
         progress (False): whether to render a progress bar tracking the
             consumption of the batches (True/False), use the default value
             ``fiftyone.config.show_progress_bars`` (None), or a progress
@@ -1600,34 +1632,33 @@ class ContentSizeBatcher(BaseBatcher):
         total (None): the length of ``iterable``. Only applicable when
             ``progress=True``. If not provided, it is computed via
             ``len(iterable)``, if possible
-        transform_fn (None): a transform function to apply to each item of the batch
     """
 
     def __init__(
         self,
         iterable,
-        size_calculation_fn=None,
         target_size=2**20,
         max_batch_size=None,
+        transform_fn=None,
+        size_calc_fn=None,
         progress=False,
         total=None,
-        transform_fn=None,
     ):
+        if size_calc_fn is None:
+            size_calc_fn = default_calc_size
+
         super().__init__(
             iterable,
+            transform_fn=transform_fn,
             return_views=False,
             progress=progress,
             total=total,
-            transform_fn=transform_fn,
         )
-        self.max_batch_size = max_batch_size
+
         self.target_size = target_size
+        self.max_batch_size = max_batch_size
+        self.size_calc_fn = size_calc_fn
         self._next_element = None
-        self._size_calculation_fn = (
-            size_calculation_fn
-            if size_calculation_fn
-            else default_calculate_size
-        )
 
     def __iter__(self):
         super().__iter__()
@@ -1644,19 +1675,17 @@ class ContentSizeBatcher(BaseBatcher):
             self._pb.update(count=self._last_batch_size)
 
         if self._next_element is None:
-            raise StopIteration()
+            raise StopIteration
 
         # Must have at least 1 element in a batch
-        batch_content_size = self._size_calculation_fn(self._next_element)
+        batch_content_size = self.size_calc_fn(self._next_element)
         curr_batch = [self._next_element]
 
         while True:
             try:
                 # Peek at next element and get its size
                 self._next_element = next(self._iter)
-                next_element_size = self._size_calculation_fn(
-                    self._next_element
-                )
+                next_element_size = self.size_calc_fn(self._next_element)
 
                 # If adding next element would put this batch over the limit,
                 #   stop here
@@ -1683,7 +1712,7 @@ class ContentSizeBatcher(BaseBatcher):
         return curr_batch
 
 
-def default_calculate_size(obj):
+def default_calc_size(obj):
     try:
         obj = (
             obj.to_mongo_dict(include_id=True)
@@ -1697,21 +1726,29 @@ def default_calculate_size(obj):
 
 def get_default_batcher(
     iterable,
+    batcher=None,
+    transform_fn=None,
+    size_calc_fn=None,
     progress=False,
     total=None,
-    size_calc_fn=None,
-    transform_fn=None,
 ):
     """Returns a :class:`Batcher` over ``iterable`` using defaults from your
     FiftyOne config.
 
-    Uses ``fiftyone.config.default_batcher`` to determine the implementation
-    to use, and related configuration values as needed for each.
+    If no ``batcher`` is provided, this method uses
+    ``fiftyone.config.default_batcher`` to determine the implementation to use
+    and related configuration values as needed for each.
 
     Args:
         iterable: an iterable to batch over. If ``None``, the result of
             ``next()`` will be a batch size instead of a batch, and is an
-            infinite iterator.
+            infinite iterator
+        batcher (None): a specific :class:`Batcher` subclass to use, or
+            ``False`` to disable batching
+        transform_fn (None): a transform function to apply to each item
+        size_calc_fn (None): a function that calculates the size of each item.
+            This is applied after ``transform_fn`` if both are provided.
+            Only applicable when ``fiftyone.config.default_batcher="size"``
         progress (False): whether to render a progress bar tracking the
             consumption of the batches (True/False), use the default value
             ``fiftyone.config.show_progress_bars`` (None), or a progress
@@ -1719,14 +1756,21 @@ def get_default_batcher(
         total (None): the length of ``iterable``. Only applicable when
             ``progress=True``. If not provided, it is computed via
             ``len(iterable)``, if possible
-        size_calc_fn (None): a function used to calculate the size of each item
-            before adding them to the batch to ensure we are under max batch size.
-            This is applied after transform_fn if both are provided.
-        transform_fn (None): a transform function to apply to each item of the batch
 
     Returns:
-        a :class:`Batcher`
+        a :class:`Batcher` instance
     """
+    if batcher is False:
+        batcher = partial(StaticBatcher, batch_size=-1)
+
+    if batcher is not None:
+        return batcher(
+            iterable,
+            transform_fn=transform_fn,
+            progress=progress,
+            total=total,
+        )
+
     default_batcher = fo.config.default_batcher
     if default_batcher == "latency":
         target_latency = fo.config.batcher_target_latency
@@ -1736,29 +1780,29 @@ def get_default_batcher(
             init_batch_size=1,
             max_batch_beta=8.0,
             max_batch_size=100000,
+            transform_fn=transform_fn,
             progress=progress,
             total=total,
-            transform_fn=transform_fn,
         )
     elif default_batcher == "size":
         target_content_size = fo.config.batcher_target_size_bytes
         return ContentSizeBatcher(
-            iterable=iterable,
+            iterable,
             target_size=target_content_size,
             max_batch_size=100000,
-            progress=progress,
-            size_calculation_fn=size_calc_fn,
-            total=total,
             transform_fn=transform_fn,
+            size_calc_fn=size_calc_fn,
+            progress=progress,
+            total=total,
         )
     elif default_batcher == "static":
         batch_size = fo.config.batcher_static_size
         return StaticBatcher(
             iterable,
             batch_size=batch_size,
+            transform_fn=transform_fn,
             progress=progress,
             total=total,
-            transform_fn=transform_fn,
         )
     else:
         raise ValueError(

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -9,6 +9,7 @@ FiftyOne dataset-related unit tests.
 import time
 from copy import deepcopy, copy
 from datetime import date, datetime, timedelta
+from functools import partial
 import gc
 import os
 import random
@@ -26,6 +27,7 @@ import eta.core.utils as etau
 import fiftyone as fo
 import fiftyone.core.fields as fof
 import fiftyone.core.odm as foo
+import fiftyone.core.utils as fou
 from fiftyone.operators.store import ExecutionStoreService
 import fiftyone.utils.data as foud
 from fiftyone import ViewField as F
@@ -1697,6 +1699,26 @@ class DatasetTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             _ = dataset.one(F("filepath").ends_with(".jpg"), exact=True)
+
+    @drop_datasets
+    def test_add_samples_batcher(self):
+        samples = [fo.Sample(filepath=f"image{i}.jpg") for i in range(10)]
+
+        # No batching
+        batcher = False
+
+        dataset = fo.Dataset()
+        dataset.add_samples(samples, batcher=batcher)
+
+        assert len(dataset) == 10
+
+        # Custom batcher
+        batcher = partial(fou.StaticBatcher, batch_size=2)
+
+        dataset = fo.Dataset()
+        dataset.add_samples(samples, batcher=batcher)
+
+        assert len(dataset) == 10
 
     @drop_datasets
     def test_merge_sample(self):


### PR DESCRIPTION
## Change log

- Adds support for passing your own batcher to `add_samples(..., batcher=)`.
- Adds a shorthand `add_samples(..., batcher=False)` syntax to add all samples in a single batch (ie disable batching for that particular method invocation)

## Commentary

I originally implemented this as a means to achieve the same outcome of https://github.com/voxel51/fiftyone-plugins/pull/227 of reintroducing the progress callbacks; specifically, I was using `add_samples(..., batcher=False)` to add samples in batches that we manually constructed by `@voxel51/io/import_samples`. However, I then came up with https://github.com/voxel51/fiftyone/pull/5666, which seemed a bit cleaner.

Nonetheless, it is still potentially interesting and useful to let users build + pass their own batchers, so I thought I'd throw up a PR for discussion anyway, even though this is new capability isn't in use anywhere just yet.

Some of my thoughts while implementing this:
- Allowing users to pass `batcher=False` is a bit scary as you can't send arbitrarily large batches over API in general
- The `partial()` syntax to configure some parameters of a custom `Batcher` class is cute, but perhaps too cute?
- Ideally, my OCD would want us to expose `batcher` in all the relevant places throughout the codebase, not *just* `add_samples()`. EG like I did in https://github.com/voxel51/fiftyone/pull/566

## Example ussage

```py
from functools import partial

import fiftyone as fo
import fiftyone.core.utils as fou

samples = [fo.Sample(filepath=f"image{i}.jpg") for i in range(1000)]

#
# No batching
#

dataset = fo.Dataset()
dataset.add_samples(samples, batcher=False)

assert len(dataset) == 1000

#
# Custom batcher
#

batcher = partial(fou.StaticBatcher, batch_size=10)

dataset = fo.Dataset()
dataset.add_samples(samples, batcher=batcher)

assert len(dataset) == 1000
```
