### PR TITLE
optimize fiftyone migrate --info

### DIFF
--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -4186,10 +4186,7 @@ class MigrateCommand(Command):
 
                 return
 
-            dataset_vers = {
-                name: fom.get_dataset_revision(name)
-                for name in fod.list_datasets()
-            }
+            dataset_vers = fom.get_datasets_revisions()
 
             _print_migration_table(db_ver, dataset_vers)
             return

--- a/fiftyone/migrations/__init__.py
+++ b/fiftyone/migrations/__init__.py
@@ -10,6 +10,7 @@ import types
 from .runner import (
     get_database_revision,
     get_dataset_revision,
+    get_datasets_revisions,
     migrate_all,
     migrate_database_if_necessary,
     migrate_dataset_if_necessary,

--- a/fiftyone/migrations/runner.py
+++ b/fiftyone/migrations/runner.py
@@ -64,6 +64,19 @@ def get_dataset_revision(name):
     return dataset_doc.get("version", None)
 
 
+def get_datasets_revisions():
+    """Gets the current revision of all datasets.
+
+    Returns:
+        a dictionary mapping dataset names to their revision strings
+    """
+    conn = foo.get_db_conn()
+    return {
+        dataset_doc["name"]: dataset_doc.get("version", None)
+        for dataset_doc in conn.datasets.find({}, {"name": 1, "version": 1})
+    }
+
+
 def migrate_all(destination=None, error_level=0, verbose=False):
     """Migrates the database and all datasets to the specified destination
     revision.


### PR DESCRIPTION
## What changes are proposed in this pull request?

- improve `fiftyone migrate --info` so that it no longer loops through all datasets to get names and version separately

## How is this patch tested? If it is not, please explain why.

- run `fiftyone migrate --info` and returns almost instantly now (used to hang forever for 10k)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an enhancement that retrieves all dataset version information in a single, efficient operation.
- **Refactor**
	- Streamlined the process for gathering dataset revisions, reducing overhead and potentially enhancing migration performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->