### PR TITLE
Fix label tags sidebar filter for Query Performance

### DIFF
--- a/app/packages/core/src/components/Sidebar/Entries/EntryCounts.test.ts
+++ b/app/packages/core/src/components/Sidebar/Entries/EntryCounts.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import type { TestSelectorFamily } from "../../../../../../__mocks__/recoil";
+import { setMockAtoms } from "../../../../../../__mocks__/recoil";
+import * as entryCounts from "./EntryCounts";
+
+vi.mock("recoil");
+vi.mock("recoil-relay");
+
+const MOCK_NO_RESULT = { count: null, results: [] };
+
+const MOCK_RESULT = {
+  count: 1,
+  results: [{ count: 1, value: "label_tag" }],
+};
+
+const getSelector = (extended: boolean, modal: boolean) => {
+  const selector = <TestSelectorFamily<typeof entryCounts.labelTagsCount>>(
+    (<unknown>entryCounts.labelTagsCount({ extended, modal }))
+  );
+  return selector();
+};
+
+describe("test label tag counts", () => {
+  it("should disable results with query performance only in the grid", () => {
+    setMockAtoms({
+      queryPerformance: true,
+      cumulativeCounts: () => ({ label_tag: 1 }),
+    });
+
+    // grid
+    expect(getSelector(false, false)).toStrictEqual(MOCK_NO_RESULT);
+    expect(getSelector(true, false)).toStrictEqual(MOCK_NO_RESULT);
+
+    // modal
+    expect(getSelector(false, true)).toStrictEqual(MOCK_RESULT);
+    expect(getSelector(true, true)).toStrictEqual(MOCK_RESULT);
+  });
+
+  it("should enable results without query performance", () => {
+    setMockAtoms({
+      queryPerformance: false,
+      cumulativeCounts: () => ({ label_tag: 1 }),
+    });
+
+    expect(getSelector(false, false)).toStrictEqual(MOCK_RESULT);
+    expect(getSelector(true, false)).toStrictEqual(MOCK_RESULT);
+
+    // modal
+    expect(getSelector(false, true)).toStrictEqual(MOCK_RESULT);
+    expect(getSelector(true, true)).toStrictEqual(MOCK_RESULT);
+  });
+});

--- a/app/packages/state/src/recoil/pathData/counts.ts
+++ b/app/packages/state/src/recoil/pathData/counts.ts
@@ -67,9 +67,10 @@ export const count = selectorFamily({
         }
 
         if (first === "_label_tags" && value) {
-          return get(cumulativeCounts({ ...params, ...MATCH_LABEL_TAGS }))[
-            value
-          ];
+          return (
+            get(cumulativeCounts({ ...params, ...MATCH_LABEL_TAGS }))[value] ??
+            0
+          );
         }
 
         if (split.length < 2) {

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -3,6 +3,25 @@ FiftyOne Release Notes
 
 .. default-role:: code
 
+FiftyOne Enterprise 2.7.2
+-------------------------
+*Released April 1, 2025*
+
+Includes all updates from :ref:`FiftyOne 1.4.1 <release-notes-v1.4.1>`
+
+.. _release-notes-v1.4.1:
+
+FiftyOne 1.4.1
+--------------
+*Released April 1, 2025*
+
+App
+
+- Fixed label tags filtering in the
+  :ref:`Query Performance <app-optimizing-query-performance>` sidebar
+  `#5675 <https://github.com/voxel51/fiftyone/pull/5675>`_
+
+
 FiftyOne Enterprise 2.7.1
 -------------------------
 *Released March 24, 2025*


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes label tag filtering the QP sidebar


https://github.com/user-attachments/assets/17b84285-4175-4650-928f-bba8a503f13a


## How is this patch tested? If it is not, please explain why.

Selector tests

## Release Notes

* Fixed label tags filtering in the
  :ref:`Query Performance <app-optimizing-query-performance>` sidebar

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed label tags filtering in the Query Performance sidebar to ensure counts are displayed correctly in grid and modal views.
	- Enhanced count reliability by defaulting to zero when values are missing.
- **Documentation**
	- Updated release notes to include details for the latest releases (FiftyOne Enterprise 2.7.2 and FiftyOne 1.4.1) with pertinent bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->