### PR TITLE
Add `prompt_id` and `operator_uri` to `ExecutionContext`

### DIFF
--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -97,6 +97,7 @@ export type RawContext = {
   queryPerformance?: boolean;
   spaces: SpaceNodeJSON;
   workspaceName: string;
+  promptId: string | null;
 };
 
 export class ExecutionContext {
@@ -151,7 +152,9 @@ export class ExecutionContext {
   public get workspaceName(): string {
     return this._currentContext.workspaceName;
   }
-
+  public get promptId(): string | null {
+    return this._currentContext.promptId;
+  }
   getCurrentPanelId(): string | null {
     return this.params.panel_id || this.currentPanel?.id || null;
   }
@@ -562,6 +565,7 @@ async function executeOperatorAsGenerator(
       query_performance: currentContext.queryPerformance,
       spaces: currentContext.spaces,
       workspace_name: currentContext.workspaceName,
+      prompt_id: ctx.promptId,
     },
     "json-stream"
   );
@@ -728,6 +732,7 @@ export async function executeOperatorWithContext(
           query_performance: currentContext.queryPerformance,
           spaces: currentContext.spaces,
           workspace_name: currentContext.workspaceName,
+          prompt_id: ctx.promptId,
         }
       );
       result = serverResult.result;
@@ -834,6 +839,7 @@ export async function resolveRemoteType(
       query_performance: currentContext.queryPerformance,
       spaces: currentContext.spaces,
       workspace_name: currentContext.workspaceName,
+      prompt_id: ctx.promptId,
     }
   );
 

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -40,7 +40,6 @@ import { OperatorExecutorOptions } from "./types-internal";
 import { ValidationContext } from "./validation";
 import { Markdown } from "@fiftyone/components";
 import { generateOperatorSessionId } from "./utils";
-import { NonNullChain } from "typescript";
 
 export const promptingOperatorState = atom({
   key: "promptingOperator",

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -39,6 +39,8 @@ import { OperatorPromptType, Places } from "./types";
 import { OperatorExecutorOptions } from "./types-internal";
 import { ValidationContext } from "./validation";
 import { Markdown } from "@fiftyone/components";
+import { generateOperatorSessionId } from "./utils";
+import { NonNullChain } from "typescript";
 
 export const promptingOperatorState = atom({
   key: "promptingOperator",
@@ -83,6 +85,7 @@ export const usePromptOperatorInput = () => {
       params,
       options,
       initialParams: params,
+      id: generateOperatorSessionId(),
     });
   };
 
@@ -163,6 +166,8 @@ const useExecutionContext = (operatorName, hooks = {}) => {
     workspaceName,
   } = curCtx;
   const [analyticsInfo] = useAnalyticsInfo();
+  const promptingOperator = useRecoilValue(promptingOperatorState);
+  const promptId = promptingOperator?.id || null;
   const ctx = useMemo(() => {
     return new ExecutionContext(
       params,
@@ -181,6 +186,7 @@ const useExecutionContext = (operatorName, hooks = {}) => {
         queryPerformance,
         spaces,
         workspaceName,
+        promptId,
       },
       hooks
     );
@@ -199,6 +205,7 @@ const useExecutionContext = (operatorName, hooks = {}) => {
     queryPerformance,
     spaces,
     workspaceName,
+    promptId,
   ]);
 
   return ctx;

--- a/app/packages/operators/src/utils.ts
+++ b/app/packages/operators/src/utils.ts
@@ -2,6 +2,7 @@ import { getFetchParameters } from "@fiftyone/utilities";
 import { debounce, DebounceSettings, memoize } from "lodash";
 import { KeyboardEventHandler } from "react";
 import { OperatorPromptType, PromptView, ValidationErrorsType } from "./types";
+import uuid from "react-uuid";
 
 export function stringifyError(error, fallback?) {
   if (typeof error === "string") return error;
@@ -141,3 +142,7 @@ type MemoizeResolver = (...args) => any;
 type MemoizedDebounceOptions = DebounceSettings & {
   resolver: MemoizeResolver;
 };
+
+export function generateOperatorSessionId() {
+  return uuid();
+}

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -479,7 +479,9 @@ class ExecutionContext(object):
         operator_uri=None,
         required_secrets=None,
     ):
-        self.request_params = request_params or {}
+        if request_params is None:
+            request_params = {}
+        self.request_params = request_params
         self.params = self.request_params.get("params", {})
         self.executor = executor
         self.user = None

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -494,6 +494,9 @@ class ExecutionContext(object):
         self._secrets = {}
         self._secrets_client = PluginSecretsResolver()
         self._required_secret_keys = required_secrets
+
+        self._prompt_id = request_params.get("prompt_id", None)
+
         if self._required_secret_keys:
             self._secrets_client.register_operator(
                 operator_uri=self._operator_uri,
@@ -737,6 +740,18 @@ class ExecutionContext(object):
     def query_performance(self):
         """Whether query performance is enabled."""
         return self.request_params.get("query_performance", None)
+
+    @property
+    def prompt_id(self):
+        """An identifier for the prompt, unique to each instance of a user
+        opening a prompt in the FiftyOne App.
+        """
+        return self._prompt_id
+
+    @property
+    def operator_uri(self):
+        """The URI of the target operator."""
+        return self._operator_uri
 
     def prompt(
         self,


### PR DESCRIPTION
**Background**

 - `prompt_id` - is a requirement of the new `execution_cache`. We must have some way of caching values ONLY for the lifetime of the operator prompt (the form that allows users to input params when executing an operator).
 - `operator_uri` is also useful for isolating cache entries per operator.

**Testing**

Automed tests are added in a following PR. This has been manually tested with the app

**Release notes**

```rst
 - Added :attr:`ctx.prompt_id <fiftyone.operators.executor.ExecutionContext.prompt_id>` to the execution context
 - Added :attr:`ctx.operator_uri <fiftyone.operators.executor.ExecutionContext.operator_uri>` to the execution context
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Improved operator session management by integrating unique prompt identifiers into operator interactions.
  - Enhanced execution context by exposing additional details, including prompt IDs, that support consistent operator operations.
  - Introduced a robust mechanism for generating unique session IDs, ensuring better tracking of prompt sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->