### PR TITLE
Add `policy` to `ExecutionStore`

### DIFF
--- a/fiftyone/factory/repos/execution_store.py
+++ b/fiftyone/factory/repos/execution_store.py
@@ -34,11 +34,12 @@ class ExecutionStoreRepo(ABC):
     methods that this class provides.
     """
 
-    def __init__(self, dataset_id: Optional[ObjectId] = None):
+    def __init__(self, dataset_id: Optional[ObjectId] = None, is_cache=False):
         """Initialize the execution store repository.
 
         Args:
             dataset_id (Optional[ObjectId]): the dataset ID to operate on
+            is_cache (False): whether the store is a cache store
         """
         self._dataset_id = dataset_id
 
@@ -294,8 +295,10 @@ class MongoExecutionStoreRepo(ExecutionStoreRepo):
 
     COLLECTION_NAME = "execution_store"
 
-    def __init__(self, collection, dataset_id: Optional[ObjectId] = None):
-        super().__init__(dataset_id)
+    def __init__(
+        self, collection, dataset_id: Optional[ObjectId] = None, is_cache=False
+    ):
+        super().__init__(dataset_id, is_cache)
         self._collection = collection
         self._create_indexes()
 

--- a/fiftyone/factory/repos/execution_store.py
+++ b/fiftyone/factory/repos/execution_store.py
@@ -455,6 +455,7 @@ class MongoExecutionStoreRepo(ExecutionStoreRepo):
                     "store_name",
                     "key",
                     "dataset_id",
+                    "policy",
                 }
             },
             "$setOnInsert": on_insert_fields,

--- a/fiftyone/factory/repos/execution_store.py
+++ b/fiftyone/factory/repos/execution_store.py
@@ -152,7 +152,7 @@ class ExecutionStoreRepo(ABC):
     @abstractmethod
     def set_cache_key(
         self, store_name: str, key: str, value: Any, ttl: Optional[int] = None
-    ) -> None:
+    ) -> KeyDocument:
         """Set a cache key in a store.
 
         Args:
@@ -160,6 +160,9 @@ class ExecutionStoreRepo(ABC):
             key (str): the cache key to set
             value (Any): the value to set
             ttl (Optional[int]): the TTL of the cache key
+
+        Returns:
+            KeyDocument: the created or updated cache key document
         """
         pass
 

--- a/fiftyone/factory/repos/execution_store.py
+++ b/fiftyone/factory/repos/execution_store.py
@@ -130,7 +130,7 @@ class ExecutionStoreRepo(ABC):
         key: str,
         value: Any,
         ttl: Optional[int] = None,
-        policy: str = "persistent",
+        policy: str = "persist",
     ) -> KeyDocument:
         """Set a key in a store.
         Args:

--- a/fiftyone/factory/repos/execution_store.py
+++ b/fiftyone/factory/repos/execution_store.py
@@ -475,7 +475,7 @@ class MongoExecutionStoreRepo(ExecutionStoreRepo):
         return key_doc
 
     def set_cache_key(self, store_name, key, value, ttl=None):
-        return super().set_cache_key(store_name, key, value, ttl)
+        return self.set_key(store_name, key, value, ttl, policy="evict")
 
     def has_key(self, store_name: str, key: str) -> bool:
         result = self._collection.find_one(

--- a/fiftyone/factory/repos/execution_store.py
+++ b/fiftyone/factory/repos/execution_store.py
@@ -34,12 +34,11 @@ class ExecutionStoreRepo(ABC):
     methods that this class provides.
     """
 
-    def __init__(self, dataset_id: Optional[ObjectId] = None, is_cache=False):
+    def __init__(self, dataset_id: Optional[ObjectId] = None):
         """Initialize the execution store repository.
 
         Args:
             dataset_id (Optional[ObjectId]): the dataset ID to operate on
-            is_cache (False): whether the store is a cache store
         """
         self._dataset_id = dataset_id
 
@@ -295,10 +294,8 @@ class MongoExecutionStoreRepo(ExecutionStoreRepo):
 
     COLLECTION_NAME = "execution_store"
 
-    def __init__(
-        self, collection, dataset_id: Optional[ObjectId] = None, is_cache=False
-    ):
-        super().__init__(dataset_id, is_cache)
+    def __init__(self, collection, dataset_id: Optional[ObjectId] = None):
+        super().__init__(dataset_id)
         self._collection = collection
         self._create_indexes()
 

--- a/fiftyone/factory/repos/execution_store.py
+++ b/fiftyone/factory/repos/execution_store.py
@@ -133,18 +133,7 @@ class ExecutionStoreRepo(ABC):
         ttl: Optional[int] = None,
         policy: str = "persistent",
     ) -> KeyDocument:
-        """
-        Sets a key in the specified store.
-
-        Keys can be either **persistent** or **cacheable**, depending on the provided
-        `policy` or whether a TTL (time-to-live) is set.
-
-        - If ``policy="persist"`` (default), the key will remain in the store until
-          explicitly deleted.
-        - If ``policy="evict"``, the key may be evicted by the system or manually
-          removed using :meth:`clear_cache`.
-        - If a TTL is provided, the key is **always** treated as ``policy="evict"``.
-
+        """Set a key in a store.
         Args:
             store_name (str): The name of the store to set the key in.
             key (str): The key to set.

--- a/fiftyone/operators/store/__init__.py
+++ b/fiftyone/operators/store/__init__.py
@@ -9,7 +9,7 @@ import types
 
 from .service import ExecutionStoreService
 from .store import ExecutionStore
-from .models import StoreDocument, KeyDocument
+from .models import StoreDocument, KeyDocument, KeyPolicy
 
 # This tells Sphinx to allow refs to imported objects in this module
 # https://stackoverflow.com/a/31594545/16823653

--- a/fiftyone/operators/store/models.py
+++ b/fiftyone/operators/store/models.py
@@ -9,8 +9,23 @@ Execution store models.
 from datetime import datetime, timedelta
 from dataclasses import dataclass, field, asdict
 from typing import Optional, Any
+from enum import Enum
 
 from bson import ObjectId
+
+
+class KeyPolicy(str, Enum):
+    """
+    Defines the eviction policy for a key in the execution store.
+
+    - ``PERSIST``: The key is stored persistently and will never be automatically
+      removed. It must be explicitly deleted.
+    - ``EVICT``: The key is considered cacheable and may be removed automatically
+      if a TTL is set, or manually via :meth:`clear_cache`.
+    """
+
+    PERSIST = "persist"
+    EVICT = "evict"
 
 
 @dataclass
@@ -25,6 +40,7 @@ class KeyDocument:
     created_at: datetime = field(default_factory=datetime.utcnow)
     updated_at: Optional[datetime] = None
     expires_at: Optional[datetime] = None
+    policy: KeyPolicy = KeyPolicy.PERSIST
 
     @staticmethod
     def get_expiration(ttl: Optional[int]) -> Optional[datetime]:

--- a/fiftyone/operators/store/models.py
+++ b/fiftyone/operators/store/models.py
@@ -53,9 +53,15 @@ class KeyDocument:
     @classmethod
     def from_dict(cls, doc: dict[str, Any]) -> "KeyDocument":
         """Creates a KeyDocument from a dictionary."""
+        doc = dict(doc)  # avoid mutating the original input
+        raw_policy = doc.pop("policy", None)
 
-        doc["policy"] = KeyPolicy(doc.get("policy", "persist"))
-        return cls(**doc)
+        fallback_policy = (
+            KeyPolicy.EVICT if doc.get("expires_at") else KeyPolicy.PERSIST
+        )
+        policy = KeyPolicy(raw_policy) if raw_policy else fallback_policy
+
+        return cls(**doc, policy=policy)
 
     def to_mongo_dict(self, exclude_id: bool = True) -> dict[str, Any]:
         """Serializes the document to a MongoDB dictionary."""

--- a/fiftyone/operators/store/models.py
+++ b/fiftyone/operators/store/models.py
@@ -50,12 +50,20 @@ class KeyDocument:
 
         return datetime.utcnow() + timedelta(seconds=ttl)
 
+    @classmethod
+    def from_dict(cls, doc: dict[str, Any]) -> "KeyDocument":
+        """Creates a KeyDocument from a dictionary."""
+
+        doc["policy"] = KeyPolicy(doc.get("policy", "persist"))
+        return cls(**doc)
+
     def to_mongo_dict(self, exclude_id: bool = True) -> dict[str, Any]:
         """Serializes the document to a MongoDB dictionary."""
         data = asdict(self)
         if exclude_id:
             data.pop("_id", None)
-
+        if self.policy:
+            data["policy"] = self.policy.value
         return data
 
 

--- a/fiftyone/operators/store/service.py
+++ b/fiftyone/operators/store/service.py
@@ -125,14 +125,27 @@ class ExecutionStoreService(object):
     ) -> KeyDocument:
         """Sets the value of a key in the specified store.
 
+        Keys can be either **persistent** or **cacheable**, depending on the provided
+        ``policy`` or whether a TTL (time-to-live) is set.
+
+        - If ``policy="persist"`` (default), the key will remain in the store until
+          explicitly deleted.
+        - If ``policy="evict"``, the key may be evicted by the system or manually
+          removed using :meth:`~clear_cache`.
+        - If a TTL is provided, the key is **always** treated as ``policy="evict"``.
+
         Args:
-            store_name: the name of the store
-            key: the key to set
-            value: the value to set
-            ttl (None): an optional TTL in seconds
+            store_name (str): The name of the store to set the key in.
+            key (str): The key to set.
+            value (Any): The value to associate with the key.
+            ttl (Optional[int]): Optional TTL (in seconds) after which the key
+                will expire and be automatically removed.
+            policy (str): The eviction policy for the key. One of:
+                - ``"persist"`` (default): Key is persistent until deleted.
+                - ``"evict"``: Key is eligible for eviction or cache clearing.
 
         Returns:
-            a :class:`fiftyone.store.models.KeyDocument`
+            KeyDocument: The created or updated key document.
         """
         return self._repo.set_key(store_name, key, value, ttl=ttl)
 

--- a/fiftyone/operators/store/service.py
+++ b/fiftyone/operators/store/service.py
@@ -121,7 +121,12 @@ class ExecutionStoreService(object):
         return self._repo.delete_store(store_name)
 
     def set_key(
-        self, store_name: str, key: str, value: Any, ttl: Optional[int] = None
+        self,
+        store_name: str,
+        key: str,
+        value: Any,
+        ttl: Optional[int] = None,
+        policy: str = "persist",
     ) -> KeyDocument:
         """Sets the value of a key in the specified store.
 
@@ -147,7 +152,9 @@ class ExecutionStoreService(object):
         Returns:
             KeyDocument: The created or updated key document.
         """
-        return self._repo.set_key(store_name, key, value, ttl=ttl)
+        return self._repo.set_key(
+            store_name, key, value, ttl=ttl, policy=policy
+        )
 
     def has_key(self, store_name: str, key: str) -> bool:
         """Determines whether the specified key exists in the specified store.

--- a/tests/unittests/execution_store_repo_tests.py
+++ b/tests/unittests/execution_store_repo_tests.py
@@ -11,6 +11,7 @@ import unittest
 from bson import ObjectId
 
 from fiftyone.factory.repos.execution_store import InMemoryExecutionStoreRepo
+from fiftyone.factory.repos.execution_store import KeyPolicy
 
 
 class TestInMemoryExecutionStoreRepo(unittest.TestCase):
@@ -58,6 +59,10 @@ class TestInMemoryExecutionStoreRepo(unittest.TestCase):
         key_doc = self.repo.set_key(store_name, key, value, ttl=60)
         self.assertEqual(key_doc.key, key)
         self.assertEqual(key_doc.value, value)
+        self.assertEqual(key_doc.store_name, store_name)
+        self.assertEqual(key_doc.dataset_id, self.dataset_id)
+        self.assertIsNotNone(key_doc.expires_at)
+        self.assertEqual(key_doc.policy, KeyPolicy.EVICT)
         self.assertTrue(self.repo.has_key(store_name, key))
         fetched_key = self.repo.get_key(store_name, key)
         self.assertEqual(fetched_key.value, value)
@@ -73,6 +78,7 @@ class TestInMemoryExecutionStoreRepo(unittest.TestCase):
         updated_key = self.repo.get_key(store_name, key)
         # Ensure that the expiration timestamp has been updated (allowing for slight time differences)
         self.assertNotEqual(updated_key.expires_at, old_expiration)
+        self.assertEqual(updated_key.policy, "evict")
 
     def test_update_policy(self):
         store_name = "policy_store"

--- a/tests/unittests/execution_store_service_tests.py
+++ b/tests/unittests/execution_store_service_tests.py
@@ -177,6 +177,7 @@ def test_get_key(svc):
     KEY = "key1"
     svc.set_key(NAME, KEY, "value1")
     key_doc = svc.get_key(NAME, KEY)
+    assert key_doc.policy == KeyPolicy.PERSIST, "Key policy should be PERSIST"
     assert key_doc.value == "value1"
     assert svc.get_key(NAME, "nonexistent") is None
 
@@ -403,6 +404,10 @@ def test_clear_cache(svc):
     initial_store_count = svc.count_stores()  # Ensure the store is created
     assert initial_store_count == 1, "There should be one store initially"
     svc.set_cache_key("cache_store", "cache_key", "cache_value")
+    key_doc = svc.get_key("cache_store", "cache_key")
+    assert key_doc.policy == KeyPolicy.EVICT, "Key policy should be EVICT"
+    assert key_doc.value == "cache_value", "Key value should match"
+    assert key_doc.policy == "evict", "Key policy should be 'evict'"
     assert svc.has_key(
         "cache_store", "cache_key"
     ), "Cache key should be present"


### PR DESCRIPTION
Depends on [this PR](https://github.com/voxel51/fiftyone/pull/5678)

**Background**

In order to implement the `execution_cache` mechanism, the `ExecutionStore` must provide a way to declare how keys are handled. This introduces a new param for all keys and store docs called "policy". This new param has two possible values:

 - `persist` - keys are guaranteed to be persisted and never automatically changed/deleted
 - `evict` - keys with this policy may be automatically evicted

> Note: `persist` is the default and existing behavior, however existing keys with expirations / ttls will be implicitly considered as `policy="evict"` keys.

**Testing**

Automated tests

**Release notes**

- Added a new `policy` param for creating `ExecutionStore` items with explicit eviction policies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced advanced key management that allows keys to be designated as persistent or evictable based on configurable policies and time-to-live settings.
  - Enabled a cache clearing capability for efficient removal of keys from a store, with options for both global and store-specific clearance.

- **Tests**
  - Expanded testing coverage to validate the correct behavior of key persistence, eviction, and cache clearing operations, including new tests for policy updates and cache management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->