### PR TITLE
Override modal tagging when a sample selection is present

### DIFF
--- a/app/packages/core/src/components/Actions/utils.test.ts
+++ b/app/packages/core/src/components/Actions/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import * as utils from "../../../src/components/Actions/utils";
+import * as utils from "./utils";
 
 vi.mock("recoil");
 vi.mock("recoil-relay");
@@ -40,5 +40,12 @@ describe("Resolves tag counts", () => {
       (<unknown>utils.tagStats({ modal: true, labels: true }))
     );
     expect(labelsModal()).toStrictEqual({ one: 1, two: 1 });
+  });
+
+  it("override filters for only a modal sample selection", () => {
+    expect(utils.overrideFilters(false, new Set())).toBe(false);
+    expect(utils.overrideFilters(false, new Set("sample"))).toBe(false);
+    expect(utils.overrideFilters(false, new Set())).toBe(false);
+    expect(utils.overrideFilters(true, new Set("sample"))).toBe(true);
   });
 });

--- a/app/packages/core/src/components/Actions/utils.test.ts
+++ b/app/packages/core/src/components/Actions/utils.test.ts
@@ -45,7 +45,7 @@ describe("Resolves tag counts", () => {
   it("override filters for only a modal sample selection", () => {
     expect(utils.overrideFilters(false, new Set())).toBe(false);
     expect(utils.overrideFilters(false, new Set("sample"))).toBe(false);
-    expect(utils.overrideFilters(false, new Set())).toBe(false);
+    expect(utils.overrideFilters(true, new Set())).toBe(false);
     expect(utils.overrideFilters(true, new Set("sample"))).toBe(true);
   });
 });

--- a/app/packages/core/src/components/Actions/utils.tsx
+++ b/app/packages/core/src/components/Actions/utils.tsx
@@ -61,6 +61,19 @@ export const useHighlightHover = (
   };
 };
 
+/**
+ * Returns true if filters should be omitted from tag parameters
+ *
+ * @param modal is modal context
+ * @param selectedSamples selected samples set
+ */
+export const overrideFilters = (
+  modal: boolean,
+  selectedSamples: Set<string>
+) => {
+  return modal && !!selectedSamples.size;
+};
+
 export const tagStatistics = selectorFamily<
   {
     count: number;
@@ -203,6 +216,9 @@ export const tagParameters = ({
 
   return {
     ...params,
+    filters: overrideFilters(params.modal, selectedSamples)
+      ? {}
+      : params.filters,
     label_fields: activeFields,
     target_labels: targetLabels,
     slices: groupData?.slices,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently if sidebar filters exclude a sample present in a group view, tagging is not possible.

New behavior recorded below

https://github.com/user-attachments/assets/ab414fe7-0612-4ac7-9857-8d79ce1d3b53

## How is this patch tested? If it is not, please explain why.

Override tests

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* Enabled sample tagging in the modal when a selection is present regardless of sidebar filters

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced filtering behavior so that tag parameters now adapt based on the modal state and the selection of items.
  - Introduced a new utility function to determine when filters should be omitted based on modal context and selected samples.

- **Tests**
  - Added test cases to verify the updated filtering logic under various modal and selection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->