### PR TITLE
Fix built-in sort by similarity for patches views

### DIFF
--- a/app/packages/core/src/components/Actions/similar/utils.ts
+++ b/app/packages/core/src/components/Actions/similar/utils.ts
@@ -1,8 +1,10 @@
+import type { Method } from "@fiftyone/state";
 import * as fos from "@fiftyone/state";
-import { Method, selectedLabels, useBrowserStorage } from "@fiftyone/state";
+import { selectedLabels, useBrowserStorage } from "@fiftyone/state";
 import { getFetchFunction, toSnakeCase } from "@fiftyone/utilities";
 import { useMemo } from "react";
-import { Snapshot, selectorFamily, useRecoilCallback } from "recoil";
+import type { Snapshot } from "recoil";
+import { selectorFamily, useRecoilCallback } from "recoil";
 
 export const getQueryIds = async (
   snapshot: Snapshot,
@@ -10,13 +12,12 @@ export const getQueryIds = async (
 ): Promise<string[] | string | undefined> => {
   const selectedLabelIds = await snapshot.getPromise(fos.selectedLabelIds);
   const selectedLabels = await snapshot.getPromise(fos.selectedLabels);
-  const methods = await snapshot.getPromise(fos.similarityMethods);
-
-  const labels_field = methods.patches
-    .filter(([method]) => method.key === brainKey)
-    .map(([_, value]) => value)[0];
 
   if (selectedLabelIds.size) {
+    const methods = await snapshot.getPromise(fos.similarityMethods);
+    const labels_field = methods.patches
+      .filter(([method]) => method.key === brainKey)
+      .map(([_, value]) => value)[0];
     return [...selectedLabelIds].filter(
       (id) => selectedLabels[id].field === labels_field
     );
@@ -25,23 +26,6 @@ export const getQueryIds = async (
   const selectedSamples = Array.from(
     await snapshot.getPromise(fos.selectedSamples)
   );
-  const isPatches = await snapshot.getPromise(fos.isPatchesView);
-
-  if (isPatches) {
-    if (selectedSamples.length) {
-      return selectedSamples.map((id) => {
-        const sample = fos.getSample(id);
-        if (sample) {
-          return sample.sample[labels_field]._id as string;
-        }
-
-        throw new Error("sample not found");
-      });
-    }
-
-    return (await snapshot.getPromise(fos.modalSample)).sample[labels_field]
-      ._id as string;
-  }
 
   if (selectedSamples.length) {
     return [...selectedSamples];

--- a/app/packages/state/src/hooks/useLookerStore.ts
+++ b/app/packages/state/src/hooks/useLookerStore.ts
@@ -1,14 +1,9 @@
-import {
-  FrameLooker,
-  ImageLooker,
-  ImaVidLooker,
-  VideoLooker,
-} from "@fiftyone/looker";
+import type { Lookers } from "@fiftyone/looker";
 import { LRUCache } from "lru-cache";
 import { useState } from "react";
-import { ModalSample } from "../recoil";
+import type { ModalSample } from "../recoil";
 
-export type Lookers = FrameLooker | ImageLooker | ImaVidLooker | VideoLooker;
+export type { Lookers };
 
 const createLookerCache = <T extends Lookers>() => {
   return new LRUCache<string, T>({
@@ -28,17 +23,6 @@ export const stores = new Set<{
   samples: Map<string, ModalSample>;
   lookers: LRUCache<string, Lookers>;
 }>();
-
-export const getSample = (id: string): ModalSample | undefined => {
-  for (const { samples: store } of stores.keys()) {
-    const sample = store.get(id);
-    if (sample) {
-      return sample;
-    }
-  }
-
-  return undefined;
-};
 
 const create = <T extends Lookers>(): LookerStore<T> => {
   const indices = new Map<number, string>();


### PR DESCRIPTION
## What changes are proposed in this pull request?

Patches views are represented by separate collections whose label id matches the patch (sample id). There parsing the sample for a label id is unnecessary. 

`getSample` is no longer needed with this simplification

```python
import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

#
# Create a patch similarity index
#

index = fob.compute_similarity(
    dataset,
    brain_key="clip_sim_gt",
    patches_field="ground_truth",
    model="clip-vit-base32-torch",
    embeddings=False,
)

view = dataset.limit(30)
embeddings, sample_ids, label_ids = index.compute_embeddings(view,progress=True)
index.add_to_index(embeddings, sample_ids, label_ids=label_ids)
index.save()
``` 

https://github.com/user-attachments/assets/247fd991-e5b4-4076-85a1-5d178dadbb03


## How is this patch tested? If it is not, please explain why.

Locally. This is a net simplification without an existing coverage pattern. Will follow up if coverage is given priority

## Release Notes

* Fixed built-in sort by similarity for patches views

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the logic for retrieving selected samples, directly returning results when available.
  - Removed legacy condition checks and error handling in the sample selection flow.
  - Updated dependency imports to use type-only syntax for improved code clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->