### PR TITLE
Handle missing label tags in looker

### DIFF
--- a/app/packages/looker/src/overlays/util.ts
+++ b/app/packages/looker/src/overlays/util.ts
@@ -111,12 +111,12 @@ export const getHashLabel = (label: RegularLabel): string => {
 };
 
 export const shouldShowLabelTag = (
-  selectedLabelTags: string[], // labelTags that are active
-  labelTags: string[] // current label's tags
+  selectedLabelTags?: string[], // labelTags that are active
+  labelTags?: string[] // current label's tags
 ) => {
-  return (
-    (selectedLabelTags?.length == 0 && labelTags.length > 0) ||
-    selectedLabelTags?.some((tag) => labelTags.includes(tag))
+  return Boolean(
+    (!selectedLabelTags?.length && labelTags?.length > 0) ||
+      selectedLabelTags?.some((tag) => labelTags.includes(tag))
   );
 };
 

--- a/app/packages/looker/src/overlays/utils.test.ts
+++ b/app/packages/looker/src/overlays/utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldShowLabelTag } from "./util";
+
+describe("shouldShowLabelTag", () => {
+  it("handles missing tags", () => {
+    expect(shouldShowLabelTag(undefined, undefined)).toBe(false);
+    expect(shouldShowLabelTag(undefined, ["one"])).toBe(true);
+    expect(shouldShowLabelTag(["one"], ["one"])).toBe(true);
+    expect(shouldShowLabelTag(["one"], ["two"])).toBe(false);
+  });
+});


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixe rendering a lookers when `tags` is `None` on a label

```python
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
first = dataset.first()
first.ground_truth.detections[0].tags = None
first.save()
``` 
<img width="1470" alt="Screenshot 2025-04-03 at 9 49 12 AM" src="https://github.com/user-attachments/assets/aacd2328-4f13-4e9e-b85b-aa258c59516c" />

## How is this patch tested? If it is not, please explain why.

Unit test

## Release Notes

* Fixed rendering a samples in the App that are missing a label tags list

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
