### PR TITLE
Patch 5686

### DIFF
--- a/app/packages/looker/src/overlays/util.test.ts
+++ b/app/packages/looker/src/overlays/util.test.ts
@@ -3,12 +3,14 @@ import { describe, expect, it } from "vitest";
 import { shouldShowLabelTag } from "./util";
 
 describe("shouldShowLabelTag", () => {
-   it("handles missing tags and overlapping tags when filtering labels", () => {
+  it("handles missing tags and overlapping tags when filtering labels", () => {
     // when no label tag filter is applied
     expect(shouldShowLabelTag(null, null)).toBe(false);
-    expect(shouldShowLabelTag(null, ["one"])).toBe(true);
+    expect(shouldShowLabelTag(null, ["one"])).toBe(false);
+    expect(shouldShowLabelTag([], ["one"])).toBe(true);
     expect(shouldShowLabelTag(undefined, undefined)).toBe(false);
-    expect(shouldShowLabelTag(undefined, ["one"])).toBe(true);
+    expect(shouldShowLabelTag(undefined, ["one"])).toBe(false);
+    expect(shouldShowLabelTag([], ["one"])).toBe(true);
 
     // when filter tag is applied and overlaps
     expect(shouldShowLabelTag(["one"], ["one", "two", "three"])).toBe(true);

--- a/app/packages/looker/src/overlays/util.ts
+++ b/app/packages/looker/src/overlays/util.ts
@@ -111,11 +111,11 @@ export const getHashLabel = (label: RegularLabel): string => {
 };
 
 export const shouldShowLabelTag = (
-  selectedLabelTags?: string[], // labelTags that are active
-  labelTags?: string[] // current label's tags
+  selectedLabelTags?: null | string[], // labelTags that are active
+  labelTags?: null | string[] // current label's tags
 ) => {
   return Boolean(
-    (!selectedLabelTags?.length && labelTags?.length > 0) ||
+    (selectedLabelTags?.length === 0 && labelTags?.length > 0) ||
       selectedLabelTags?.some((tag) => labelTags?.includes(tag))
   );
 };

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -5,7 +5,7 @@ FiftyOne Release Notes
 
 FiftyOne Enterprise 2.7.2
 -------------------------
-*Released April 1, 2025*
+*Released April 4, 2025*
 
 Includes all updates from :ref:`FiftyOne 1.4.1 <release-notes-v1.4.1>`
 
@@ -13,10 +13,18 @@ Includes all updates from :ref:`FiftyOne 1.4.1 <release-notes-v1.4.1>`
 
 FiftyOne 1.4.1
 --------------
-*Released April 1, 2025*
+*Released April 4, 2025*
 
 App
 
+- Fixed rendering of samples in the App that are missing a label tags list
+  `#5686 <https://github.com/voxel51/fiftyone/pull/5686>`_
+- Fixed built-in sort by similarity for patches views
+  `#5685 <https://github.com/voxel51/fiftyone/pull/5685>`_
+- Enabled sample tagging in the modal when a selection is present regardless of
+  sidebar filters `#5684 <https://github.com/voxel51/fiftyone/pull/5684>`_
+- Fixed tagging in the modal for video samples
+  `#5683 <https://github.com/voxel51/fiftyone/pull/5683>`_
 - Fixed label tags filtering in the
   :ref:`Query Performance <app-optimizing-query-performance>` sidebar
   `#5675 <https://github.com/voxel51/fiftyone/pull/5675>`_


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes a regression from #5686. `selectedLabelTags` should be a list for the positive case. Also updates release notes

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refined tag display behavior to ensure consistent handling for missing and empty tag selections.
- **Tests**
  - Updated scenarios to validate the revised logic for tag selection and display outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->