### PR TITLE
add mongo network compression config option

### DIFF
--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -18,7 +18,10 @@ FiftyOne supports the configuration options described below:
 | Config field                  | Environment variable                  | Default value                 | Description                                                                            |
 +===============================+=======================================+===============================+========================================================================================+
 | `database_admin`              | `FIFTYONE_DATABASE_ADMIN`             | `True`                        | Whether the client is allowed to trigger database migrations. See                      |
-|                               |                                       |                               | :ref:`this section <database-migrations>` for more information.                        |
++-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `database_compression`        | `FIFTYONE_DATABASE_COMPRESSION`       | `None`                        | `MongoDB Network Compression                                                           |
+|                               |                                       |                               | <https://www.mongodb.com/developer/products/mongodb/mongodb-network-compression/>` to  |
+|                               |                                       |                               | use. Supported values are: None, `zstd` (recommended), `zlib`, or `snappy`.            |
 +-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `database_dir`                | `FIFTYONE_DATABASE_DIR`               | `~/.fiftyone/var/lib/mongo`   | The directory in which to store FiftyOne's backing database. Only applicable if        |
 |                               |                                       |                               | `database_uri` is not defined.                                                         |

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -21,7 +21,7 @@ FiftyOne supports the configuration options described below:
 |                               |                                       |                               | :ref:`this section <database-migrations>` for more information.                        |
 +-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `database_compressor`         | `FIFTYONE_DATABASE_COMPRESSOR`        | `None`                        | `MongoDB Network Compression                                                           |
-|                               |                                       |                               | <https://www.mongodb.com/developer/products/mongodb/mongodb-network-compression/>` to  |
+|                               |                                       |                               | <https://www.mongodb.com/developer/products/mongodb/mongodb-network-compression/>`_ to |
 |                               |                                       |                               | use. Supported values are: None, `zstd` (recommended), `zlib`, or `snappy`.            |
 +-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `database_dir`                | `FIFTYONE_DATABASE_DIR`               | `~/.fiftyone/var/lib/mongo`   | The directory in which to store FiftyOne's backing database. Only applicable if        |

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -18,8 +18,9 @@ FiftyOne supports the configuration options described below:
 | Config field                  | Environment variable                  | Default value                 | Description                                                                            |
 +===============================+=======================================+===============================+========================================================================================+
 | `database_admin`              | `FIFTYONE_DATABASE_ADMIN`             | `True`                        | Whether the client is allowed to trigger database migrations. See                      |
+|								|										|								| :ref:`this section <database-migrations>` for more information.						 |
 +-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `database_compressor`        | `FIFTYONE_DATABASE_COMPRESSOR`         | `None`                        | `MongoDB Network Compression                                                           |
+| `database_compressor`         | `FIFTYONE_DATABASE_COMPRESSOR`        | `None`                        | `MongoDB Network Compression                                                           |
 |                               |                                       |                               | <https://www.mongodb.com/developer/products/mongodb/mongodb-network-compression/>` to  |
 |                               |                                       |                               | use. Supported values are: None, `zstd` (recommended), `zlib`, or `snappy`.            |
 +-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -18,7 +18,7 @@ FiftyOne supports the configuration options described below:
 | Config field                  | Environment variable                  | Default value                 | Description                                                                            |
 +===============================+=======================================+===============================+========================================================================================+
 | `database_admin`              | `FIFTYONE_DATABASE_ADMIN`             | `True`                        | Whether the client is allowed to trigger database migrations. See                      |
-|								|										|								| :ref:`this section <database-migrations>` for more information.						 |
+|                               |                                       |                               | :ref:`this section <database-migrations>` for more information.                        |
 +-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `database_compressor`         | `FIFTYONE_DATABASE_COMPRESSOR`        | `None`                        | `MongoDB Network Compression                                                           |
 |                               |                                       |                               | <https://www.mongodb.com/developer/products/mongodb/mongodb-network-compression/>` to  |

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -19,7 +19,7 @@ FiftyOne supports the configuration options described below:
 +===============================+=======================================+===============================+========================================================================================+
 | `database_admin`              | `FIFTYONE_DATABASE_ADMIN`             | `True`                        | Whether the client is allowed to trigger database migrations. See                      |
 +-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `database_compression`        | `FIFTYONE_DATABASE_COMPRESSION`       | `None`                        | `MongoDB Network Compression                                                           |
+| `database_compressor`        | `FIFTYONE_DATABASE_COMPRESSOR`         | `None`                        | `MongoDB Network Compression                                                           |
 |                               |                                       |                               | <https://www.mongodb.com/developer/products/mongodb/mongodb-network-compression/>` to  |
 |                               |                                       |                               | use. Supported values are: None, `zstd` (recommended), `zlib`, or `snappy`.            |
 +-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -63,10 +63,10 @@ class FiftyOneConfig(EnvConfig):
         if d is None:
             d = {}
 
-        self.database_compression = self.parse_string(
+        self.database_compressor = self.parse_string(
             d,
-            "database_compression",
-            env_var="FIFTYONE_DATABASE_COMPRESSION",
+            "database_compressor",
+            env_var="FIFTYONE_DATABASE_COMPRESSOR",
             default=None,
         )
         self.database_uri = self.parse_string(

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -63,6 +63,12 @@ class FiftyOneConfig(EnvConfig):
         if d is None:
             d = {}
 
+        self.database_compression = self.parse_string(
+            d,
+            "database_compression",
+            env_var="FIFTYONE_DATABASE_COMPRESSION",
+            default=None,
+        )
         self.database_uri = self.parse_string(
             d, "database_uri", env_var="FIFTYONE_DATABASE_URI", default=None
         )

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -194,7 +194,8 @@ def establish_db_conn(config):
         _connection_kwargs["port"] = int(established_port)
     if config.database_uri is not None:
         _connection_kwargs["host"] = config.database_uri
-        _connection_kwargs["compressors"] = config.database_compressor
+        if config.database_compressor:
+            _connection_kwargs["compressors"] = config.database_compressor
     elif _db_service is None:
         if os.environ.get("FIFTYONE_DISABLE_SERVICES", False):
             return

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -194,6 +194,7 @@ def establish_db_conn(config):
         _connection_kwargs["port"] = int(established_port)
     if config.database_uri is not None:
         _connection_kwargs["host"] = config.database_uri
+        _connection_kwargs["compressors"] = config.database_compressor
     elif _db_service is None:
         if os.environ.get("FIFTYONE_DISABLE_SERVICES", False):
             return


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adding config option "FIFTYONE_DATABASE_COMPRESSOR" to optionally enable [MongoDB Network Compression](https://www.mongodb.com/developer/products/mongodb/mongodb-network-compression/).

TODO:
- Test ds.set_values()
- Test "faster" operations, like clone dataset, with less overall data transfer

## How is this patch tested? If it is not, please explain why.

Set my DATABASE_URI to a remote deployment of mongo containing a 10 million sample dataset, then ran dataset.values("filepath") with [various throttled internet speeds](https://github.com/sitespeedio/throttle) and compression settings:

![Screenshot 2025-04-04 at 2 37 40 PM](https://github.com/user-attachments/assets/246fe982-97d1-4f52-9d73-e968da9f42c4)

As you can see in all cases `zstd` is the fastest but with decreasing network quality it becomes significantly more performant than not using any compression.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Added support for configuring MongoDB Network Compression. Defaults to None, same as existing experience, but should give significant performance boost when connected to a remote deployment of mongo especially if your internet is sub-optimal or has extra routing. We recommend `zstd` as the preferred compressor based on our own benchmarking results, but any compressor supported by your version of mongo will work provided you've installed required python package.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a configuration option to specify MongoDB compression settings (None, zstd, zlib, or snappy) using an environment variable.

- **Documentation**
	- Updated the user guide to include details about the new compression option.
	- Removed an outdated reference to database migration capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->