### PR TITLE
chore: publish docker images to docker hub on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,3 +59,66 @@ jobs:
         with:
           name: docker-image
           path: fiftyone.tar.gz
+
+  publish-docker-images:
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+    steps:
+      - name: Clone fiftyone
+        uses: actions/checkout@v4
+
+      - name: Set Env Vars
+        run: |
+          echo "today=$(date +%Y%m%d)" >> "$GITHUB_ENV"
+          echo "fo_version=${{ github.ref_name }}" >> "$GITHUB_ENV"
+          echo "pyver=${{ matrix.python }}" >> "$GITHUB_ENV"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@3
+        with:
+          username: ${{ secrets.RW_DOCKERHUB_USER }}
+          password: ${{ secrets.RW_DOCKERHUB_PAT }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push (not latest)
+        if: matrix.python != '3.11'
+        uses: docker/build-push-action@v6
+        with:
+          build-args: |
+            BUILD_TYPE=released
+            FO_VERSION=${fo_version}
+            PYTHON_VERSION=${pyver}
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            voxel51/fiftyone:${fo_version}-python${pyver}
+            voxel51/fiftyone:${fo_version}-python${pyver}-${today}
+
+      - name: Build and push (latest)
+        if: matrix.python == '3.11'
+        uses: docker/build-push-action@v6
+        with:
+          build-args: |
+            BUILD_TYPE=released
+            FO_VERSION=${fo_version}
+            PYTHON_VERSION=${pyver}
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            voxel51/fiftyone:${fo_version}-python${pyver}
+            voxel51/fiftyone:${fo_version}-python${pyver}-${today}
+            latest


### PR DESCRIPTION
## What changes are proposed in this pull request?

I've been doing this manually after releases; let's automate it

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced deployment process that builds and publishes multi-platform Docker images.
  - Now supports container images optimized for several Python versions, with clear version tagging and a primary "latest" release for streamlined integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->