### PR TITLE
FOTD Optimizations: Unify IDs with other fields, implement `__getitems__`, add tests.

### DIFF
--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -1567,52 +1567,42 @@ class FiftyOneTorchDataset(Dataset):
             else None
         )
         self.get_item = get_item
-        # make this a file we call for very large datasets
-        # TODO: remove duplication with cached_fields, just have
-        # ids always be one of the cached fields.
-        self.ids = _to_bytes_array(samples.values("id"))
+
+        self.ids = self._load_field(samples, "id", local_process_group)
 
         self.cached_fields = None
         self.cache_field_names = cache_field_names
-        self._load_cached_fields(
-            samples, cache_field_names, local_process_group
-        )
+        if cache_field_names is not None:
+            self.cached_fields = {}
+            for fn in cache_field_names:
+                self.cached_fields[fn] = self._load_field(
+                    samples, fn, local_process_group
+                )
 
         # initialized in worker
         self._dataset = None
         self._samples = None
 
-    # need a better solution
-    def _load_cached_fields(
-        self, samples, cache_field_names, local_process_group
-    ):
-        if cache_field_names is None:
-            return
+    def _load_field(self, samples, field_name, local_process_group):
+        if not samples.has_field(field_name):
+            raise ValueError(
+                f'Can\'t find field with name "{field_name}" in samples passed.'
+            )
 
-        self.cached_fields = {}
-        for field_name in cache_field_names:
-            if not samples.has_field(field_name):
-                raise ValueError(
-                    f'Can\'t find field with name "{field_name}" in samples passed.'
-                )
+        # don't get fancy if you don't have to
+        if local_process_group is None:
+            return TorchSerializedList(samples.values(field_name))
 
-            # don't get fancy if you don't have to
-            if local_process_group is None:
-                self.cached_fields[field_name] = TorchSerializedList(
-                    samples.values(field_name)
+        # have to get fancy
+        else:
+            if get_local_rank(local_process_group) == 0:
+                return TorchShmSerializedList(
+                    samples.values(field_name), local_process_group
                 )
-            # have to get fancy
             else:
-                if get_local_rank(local_process_group) == 0:
-                    self.cached_fields[field_name] = TorchShmSerializedList(
-                        samples.values(field_name), local_process_group
-                    )
-                else:
-                    # don't need to pass actual data if not local rank 0
-                    # we read it from shared memory anyways
-                    self.cached_fields[field_name] = TorchShmSerializedList(
-                        [], local_process_group
-                    )
+                # don't need to pass actual data if not local rank 0
+                # we read it from shared memory anyways
+                return TorchShmSerializedList([], local_process_group)
 
     @property
     def samples(self):
@@ -1687,7 +1677,7 @@ class FiftyOneTorchDataset(Dataset):
 
         if self.cached_fields is None:
             # pylint: disable=unsubscriptable-object
-            sample = self._dataset[self.ids[index].decode()]
+            sample = self._dataset[self.ids[index]]
             return self.get_item(sample)
 
         else:

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -1694,6 +1694,19 @@ class FiftyOneTorchDataset(Dataset):
             }
             return self.get_item(sample_dict)
 
+    def __getitems__(self, indices):
+        if self._samples is None:
+            self._load_samples()
+
+        if self.cached_fields is None:
+            ids = [self.ids[i] for i in indices]
+            # pylint: disable=unsubscriptable-object
+            samples = self._dataset.select(ids, ordered=True)
+            return [self.get_item(s) for s in samples]
+
+        else:
+            return [self.__getitem__(i) for i in indices]
+
     def __len__(self):
         return len(self.ids)
 

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -1572,9 +1572,16 @@ class FiftyOneTorchDataset(Dataset):
 
         self.cached_fields = None
         self.cache_field_names = cache_field_names
-        if cache_field_names is not None:
+        if self.cache_field_names is not None:
             self.cached_fields = {}
-            for fn in cache_field_names:
+
+            to_load = self.cache_field_names
+            if "id" in self.cache_field_names:
+                # we already load the id field
+                to_load.remove("id")
+                self.cached_fields["id"] = self.ids
+
+            for fn in to_load:
                 self.cached_fields[fn] = self._load_field(
                     samples, fn, local_process_group
                 )

--- a/tests/unittests/torch_dataset_tests.py
+++ b/tests/unittests/torch_dataset_tests.py
@@ -17,12 +17,12 @@ def id_get_item(sample):
 
 
 class ShortLivedDataset:
-    def __init__(self, **kwargs):
+    def __init__(self, num_samples=10, **kwargs):
         super().__init__()
         self._dataset = fo.Dataset(**kwargs)
 
         self._dataset.add_samples(
-            [fo.Sample(filepath=f"image{i}.png") for i in range(10)]
+            [fo.Sample(filepath=f"image{i}.png") for i in range(num_samples)]
         )
 
         self._dataset.persistent = True
@@ -101,6 +101,23 @@ class FiftyOneTorchDatasetTests(unittest.TestCase):
             self.assertTrue(
                 "id" not in torch_dataset.cached_fields,
                 "ID field found in cached fields",
+            )
+
+    def test_getitems(self):
+        with ShortLivedDataset(100) as dataset:
+            torch_dataset = dataset.to_torch(id_get_item)
+
+            indices = [12, 35, 66, 21, 4, 15]
+
+            ids = dataset.values("id")
+            ids = [ids[i] for i in indices]
+
+            _ids = torch_dataset.__getitems__(indices)
+
+            self.assertEqual(
+                _ids,
+                ids,
+                "Torch dataset getitem not equal to dataset values",
             )
 
 

--- a/tests/unittests/torch_dataset_tests.py
+++ b/tests/unittests/torch_dataset_tests.py
@@ -1,0 +1,109 @@
+"""
+FiftyOne torch dataset unit tests.
+
+| Copyright 2017-2025, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import os
+import unittest
+
+import fiftyone as fo
+from fiftyone.utils.torch import FiftyOneTorchDataset
+
+
+def id_get_item(sample):
+    return sample["id"]
+
+
+class ShortLivedDataset:
+    def __init__(self, **kwargs):
+        super().__init__()
+        self._dataset = fo.Dataset(**kwargs)
+
+        self._dataset.add_samples(
+            [fo.Sample(filepath=f"image{i}.png") for i in range(10)]
+        )
+
+        self._dataset.persistent = True
+
+    def __enter__(self):
+        return self._dataset
+
+    def __exit__(self, *args):
+        self._dataset.persistent = False
+        self._dataset.delete()
+
+
+class FiftyOneTorchDatasetTests(unittest.TestCase):
+    def test_ids_correct(self):
+        with ShortLivedDataset() as dataset:
+            torch_dataset = dataset.to_torch(id_get_item)
+            self.assertEqual(
+                [torch_dataset.ids[i] for i in range(len(torch_dataset))],
+                dataset.values("id"),
+            )
+
+    def test_cached_fields_correct(self):
+        with ShortLivedDataset() as dataset:
+            cfs = ["filepath", "metadata"]
+
+            torch_dataset = dataset.to_torch(
+                id_get_item, cache_field_names=cfs
+            )
+            for cf in cfs:
+                self.assertTrue(
+                    cf in torch_dataset.cached_fields,
+                    f"Cached field {cf} not found in cached fields",
+                )
+
+                self.assertEqual(
+                    [
+                        torch_dataset.cached_fields[cf][i]
+                        for i in range(len(torch_dataset))
+                    ],
+                    dataset.values(cf),
+                    f"Cached field {cf} not equal to dataset values",
+                )
+
+    def test_ids_correct_cached_fields(self):
+        with ShortLivedDataset() as dataset:
+            torch_dataset = dataset.to_torch(
+                id_get_item, cache_field_names=["filepath", "id"]
+            )
+            self.assertTrue(
+                "id" in torch_dataset.cached_fields,
+                "ID field not found in cached fields",
+            )
+            self.assertEqual(
+                [torch_dataset.ids[i] for i in range(len(torch_dataset))],
+                dataset.values("id"),
+            )
+            self.assertEqual(
+                [
+                    torch_dataset.cached_fields["id"][i]
+                    for i in range(len(torch_dataset))
+                ],
+                dataset.values("id"),
+                "ID field not equal to dataset values",
+            )
+
+    def test_ids_correct_cached_fields_no_ids(self):
+        with ShortLivedDataset() as dataset:
+            torch_dataset = dataset.to_torch(
+                id_get_item, cache_field_names=["filepath"]
+            )
+            self.assertEqual(
+                [torch_dataset.ids[i] for i in range(len(torch_dataset))],
+                dataset.values("id"),
+            )
+
+            self.assertTrue(
+                "id" not in torch_dataset.cached_fields,
+                "ID field found in cached fields",
+            )
+
+
+if __name__ == "__main__":
+    fo.config.show_progress_bars = False
+    unittest.main(verbosity=2)


### PR DESCRIPTION
# Changes
1. refactored `_load_cached_fields` to `_load_fields`
2. the field `id` (that's always loaded to memory) now goes through this path as well
3. unittests
4. implement __getitems__ rather than __getitem__

## Unifying IDs with other fields

startup time test:
- 32 workers
- 20000 samples

### snippet to test

```python
from time import time_ns
import torch
import fiftyone as fo

def dummy_get_item(sample):
    return "foo"

if __name__ == "__main__":
    import torch.multiprocessing as mp
    mp.set_start_method('forkserver')
    mp.set_forkserver_preload(['torch', 'fiftyone'])

    dataset = fo.load_dataset("quickstart")
    torch_dataset = dataset.to_torch(dummy_get_item)
    dataloader = torch.utils.data.DataLoader(
        torch_dataset,
        batch_size=1,
        num_workers=32,
    )

    time_start = time_ns()
    for _ in dataloader:
        break
    time_end = time_ns()

    print(f"Time taken to load first batch: {(time_end - time_start) / 1_000_000} ms")
```

### before:
```
Time taken to load first batch: 39445.790492 ms
```

### after:
```
Time taken to load first batch: 5597.779764 ms
```


## Changed the dataset to use `__getitems__` rather than `__getitem__`. This allows us to batch random access to the DB.

### Snippet to test:

```python
from time import time_ns
import torch
import fiftyone as fo

def id_get_item(sample):
    return sample['id']

if __name__ == "__main__":
    import torch.multiprocessing as mp
    mp.set_start_method('forkserver')
    mp.set_forkserver_preload(['torch', 'fiftyone'])

    BATCH_SIZES = [2 ** i for i in range(8)]

    dataset = fo.load_dataset("stanford-dogs")
    torch_dataset = dataset.to_torch(id_get_item)

    for batch_size in BATCH_SIZES:

        dataloader = torch.utils.data.DataLoader(
            torch_dataset,
            batch_size=batch_size,
            num_workers=32,
        )

        time_start = time_ns()
        for _ in dataloader:
            pass
        time_end = time_ns()

        print(f"==========================")
        print(f"Batch size: {batch_size}")
        print(f"Time to iterate dataset: {(time_end - time_start) / 1_000_000_000} s")
        print(f"Average time per sample: {(time_end - time_start) / len(torch_dataset) / 1_000_000_000} s")
        print(f"==========================")
```

### before:
```
==========================
Batch size: 1
Time to iterate dataset: 23.707311036 s
Average time per sample: 0.0011519587481049563 s
==========================
==========================
Batch size: 2
Time to iterate dataset: 19.771405401 s
Average time per sample: 0.0009607096890670554 s
==========================
==========================
Batch size: 4
Time to iterate dataset: 19.544799116 s
Average time per sample: 0.0009496986936831876 s
==========================
==========================
Batch size: 8
Time to iterate dataset: 19.451719468 s
Average time per sample: 0.0009451758730806609 s
==========================
==========================
Batch size: 16
Time to iterate dataset: 19.619153768 s
Average time per sample: 0.0009533116505344995 s
==========================
==========================
Batch size: 32
Time to iterate dataset: 19.764246164 s
Average time per sample: 0.0009603618155490768 s
==========================
==========================
Batch size: 64
Time to iterate dataset: 20.375881652 s
Average time per sample: 0.0009900817129251701 s
==========================
==========================
Batch size: 128
Time to iterate dataset: 20.963901022 s
Average time per sample: 0.001018654082701652 s
==========================
```

### after:
```
==========================
Batch size: 1
Time to iterate dataset: 24.225526209 s
Average time per sample: 0.001177139271574344 s
==========================
==========================
Batch size: 2
Time to iterate dataset: 12.845724885 s
Average time per sample: 0.0006241848826530612 s
==========================
==========================
Batch size: 4
Time to iterate dataset: 8.813464532 s
Average time per sample: 0.0004282538645286686 s
==========================
==========================
Batch size: 8
Time to iterate dataset: 6.333369983 s
Average time per sample: 0.00030774392531584063 s
==========================
==========================
Batch size: 16
Time to iterate dataset: 5.025789733 s
Average time per sample: 0.0002442074700194364 s
==========================
==========================
Batch size: 32
Time to iterate dataset: 4.908745474 s
Average time per sample: 0.00023852018824101068 s
==========================
==========================
Batch size: 64
Time to iterate dataset: 4.241359042 s
Average time per sample: 0.0002060913042759961 s
==========================
==========================
Batch size: 128
Time to iterate dataset: 4.304301925 s
Average time per sample: 0.00020914975340136053 s
==========================

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced dataset functionality with a more efficient field loading and caching mechanism.
  - Introduced a new method for batch retrieval of samples, simplifying multi-item access.

- **Tests**
  - Added comprehensive tests to ensure the accuracy and reliability of ID handling, caching, and batch sample retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->