### PR TITLE
Optimize frame lookups to be as late as possible in aggregations

### DIFF
--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -3114,6 +3114,10 @@ def _parse_field_and_expr(
         elif not context and not optimize:
             pipeline.append({"$project": {path: True}})
     elif unwind_list_fields:
+        if is_frame_field and unwind_list_fields[0] == "frames":
+            unwind_list_fields.pop(0)
+            pipeline.append({"$unwind": "$frames"})
+
         pipeline.append({"$project": {path: True}})
 
     (

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -10244,7 +10244,7 @@ class SampleCollection(object):
         """
         raise NotImplementedError("Subclass must implement _add_view_stage()")
 
-    def aggregate(self, aggregations):
+    def aggregate(self, aggregations, _mongo=False):
         """Aggregates one or more
         :class:`fiftyone.core.aggregations.Aggregation` instances.
 
@@ -10296,6 +10296,9 @@ class SampleCollection(object):
         for idx, pipeline in facet_pipelines.items():
             idx_map[idx] = len(pipelines)
             pipelines.append(pipeline)
+
+        if _mongo:
+            return pipelines[0] if scalar_result else pipelines
 
         # Run all aggregations
         _results = foo.aggregate(self._dataset._sample_collection, pipelines)

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -6539,7 +6539,7 @@ class SelectFields(ViewStage):
             return False
 
         if self._field_names is None:
-            return False
+            return True
 
         # @todo consider `meta_filter` here too?
         return any(

--- a/tests/unittests/server_samples_tests.py
+++ b/tests/unittests/server_samples_tests.py
@@ -106,7 +106,9 @@ class ServerSamplesTests(unittest.IsolatedAsyncioTestCase):
 
 async def _resolve_lookup_stage(view: fo.DatasetView):
     pipeline = await get_samples_pipeline(view, None)
-    return pipeline[0]
+    for stage in pipeline:
+        if "$lookup" in stage:
+            return stage
 
 
 def _get_expected_lookup_stage(view: fo.DatasetView, clips=False, limit=False):


### PR DESCRIPTION
## Change log

- Optimizes frame lookups to be as late as possible in aggregation pipelines

cc @ehofesmann this seemingly small change results in big performance improvements in certain cases:
1. Significantly improves the performance of frame-level aggregations on views where `len(view) << len(dataset)`
2. Resolves many (but *not yet* all) instances of "16MB errors", aka [#1607](https://github.com/voxel51/fiftyone/issues/1607)

See below for examples of these cases.

## Example optimizations

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart-video")
dataset.compute_metadata()
```

### Case 1: a view that doesn't filter on frame-level information

```py
view = dataset.match(F("metadata.size_bytes") > 2671165)
_ = view.count("frames")
```

#### Previous pipeline ❌ ❌ ❌ ❌ 

`$match` is between `$lookup` and `$unwind`, which means that this pipeline will fail with "16MB errors" on datasets with many frames.

```
[
    {
        '$lookup': {
            'from': 'frames.samples.67f7211b32b0fedf4532de6f',
            'let': {'sample_id': '$_id'},
            'pipeline': [
                {'$match': {'$expr': {'$eq': ['$$sample_id', '$_sample_id']}}},
                {'$sort': {'frame_number': 1}},
            ],
            'as': 'frames',
        },
    },
    {'$match': {'$expr': {'$gt': ['$metadata.size_bytes', 2671165]}}},
    {'$unwind': '$frames'},
    {'$count': 'count'},
]
```

#### New pipeline ✅ ✅ ✅ ✅   

`$match` comes first _and then_ `$lookup + $unwind` in immediate succession, which means no "16MB error" issues!

Additionally, `$lookup` is now only performed on samples that match the sample-level filter, which could result in *substantially faster* aggregations when `len(view) << len(dataset)`.

```
[
    {'$match': {'$expr': {'$gt': ['$metadata.size_bytes', 2671165]}}},
    {
        '$lookup': {
            'from': 'frames.samples.67f720ab45345727feab06bd',
            'let': {'sample_id': '$_id'},
            'pipeline': [
                {'$match': {'$expr': {'$eq': ['$$sample_id', '$_sample_id']}}},
                {'$sort': {'frame_number': 1}},
            ],
            'as': 'frames',
        },
    },
    {'$unwind': '$frames'},
    {'$count': 'count'},
]
```

### Case 2: an aggregation that involves explicit frame unwinding

```py
_ = dataset.values("frames[].frame_number")
```

#### Previous pipeline ❌ ❌ ❌ ❌ 

`$project` is between `$lookup` and `$unwind`, which means that this pipeline will fail with "16MB errors" on datasets with many frames.

```
[
    {
        '$lookup': {
            'from': 'frames.samples.67f7211b32b0fedf4532de6f',
            'let': {'sample_id': '$_id'},
            'pipeline': [
                {'$match': {'$expr': {'$eq': ['$$sample_id', '$_sample_id']}}},
                {'$sort': {'frame_number': 1}},
            ],
            'as': 'frames',
        },
    },
    {'$project': {'frames.frame_number': True}},
    {'$unwind': '$frames'},
    {
        '$project': {
            'values': {
                '$cond': {
                    'if': {'$gt': ['$frames.frame_number', None]},
                    'then': '$frames.frame_number',
                    'else': None,
                },
            },
        },
    },
]
```

#### New pipeline ✅ ✅ ✅ ✅   

`$lookup + $unwind` in immediate succession _and then_ `$project`, which means no "16MB error" issues!

```
[
    {
        '$lookup': {
            'from': 'frames.samples.67f720ab45345727feab06bd',
            'let': {'sample_id': '$_id'},
            'pipeline': [
                {'$match': {'$expr': {'$eq': ['$$sample_id', '$_sample_id']}}},
                {'$sort': {'frame_number': 1}},
            ],
            'as': 'frames',
        },
    },
    {'$unwind': '$frames'},
    {'$project': {'frames.frame_number': True}},
    {
        '$project': {
            'values': {
                '$cond': {
                    'if': {'$gt': ['$frames.frame_number', None]},
                    'then': '$frames.frame_number',
                    'else': None,
                },
            },
        },
    },
]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced an advanced option in aggregations that allows direct retrieval of underlying processing pipelines.
  
- **Refactor**
	- Enhanced video sample processing to ensure consistent handling of frame data.
	- Streamlined data view construction for more efficient integration of frame and group information.

- **Bug Fixes**
	- Improved frame label selection logic to correctly include frame-level data when no specific fields are chosen.
	- Adjusted aggregation pipeline construction to properly unwind video frames when needed.

- **Tests**
	- Added tests verifying correct aggregation behavior and pipeline structure for video frames and nested detections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->