### PR TITLE
Use to_list instead of list

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -10268,18 +10268,18 @@ class SampleCollection(object):
 
         # Parse batch results
         if batch_aggs:
-            result = list(_results[0])
+            result = _results[0].to_list()
             for idx, aggregation in batch_aggs.items():
                 results[idx] = self._parse_big_result(aggregation, result)
 
         # Parse big results
         for idx, aggregation in big_aggs.items():
-            result = list(_results[idx_map[idx]])
+            result = _results[idx_map[idx]].to_list()
             results[idx] = self._parse_big_result(aggregation, result)
 
         # Parse facet-able results
         for idx, aggregation in compiled_facet_aggs.items():
-            result = list(_results[idx_map[idx]])
+            result = _results[idx_map[idx]].to_list()
             data = self._parse_faceted_result(aggregation, result)
             if (
                 isinstance(aggregation, foa.FacetAggregations)
@@ -10327,7 +10327,7 @@ class SampleCollection(object):
 
             # Parse facet-able results
             for idx, aggregation in compiled_facet_aggs.items():
-                result = list(_results[idx_map[idx]])
+                result = _results[idx_map[idx]].to_list()
                 data = self._parse_faceted_result(aggregation, result)
                 if (
                     isinstance(aggregation, foa.FacetAggregations)

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -10269,8 +10269,10 @@ class SampleCollection(object):
         # Parse batch results
         if batch_aggs:
             try:
+                # Converts the contents of this cursor to a list more
+                # efficiently than iterating
                 result = _results[0].to_list()
-            except:
+            except AttributeError:
                 # foo.aggregate will have already exhausted the cursor
                 # when called with multiple pipelines, so we don't need
                 # to iterate over the results again

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -10274,12 +10274,12 @@ class SampleCollection(object):
 
         # Parse big results
         for idx, aggregation in big_aggs.items():
-            result = _results[idx_map[idx]].to_list()
+            result = list(_results[idx_map[idx]])
             results[idx] = self._parse_big_result(aggregation, result)
 
         # Parse facet-able results
         for idx, aggregation in compiled_facet_aggs.items():
-            result = _results[idx_map[idx]].to_list()
+            result = list(_results[idx_map[idx]])
             data = self._parse_faceted_result(aggregation, result)
             if (
                 isinstance(aggregation, foa.FacetAggregations)
@@ -10327,7 +10327,7 @@ class SampleCollection(object):
 
             # Parse facet-able results
             for idx, aggregation in compiled_facet_aggs.items():
-                result = _results[idx_map[idx]].to_list()
+                result = list(_results[idx_map[idx]])
                 data = self._parse_faceted_result(aggregation, result)
                 if (
                     isinstance(aggregation, foa.FacetAggregations)

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -10268,7 +10268,13 @@ class SampleCollection(object):
 
         # Parse batch results
         if batch_aggs:
-            result = _results[0].to_list()
+            try:
+                result = _results[0].to_list()
+            except:
+                # foo.aggregate will have already exhausted the cursor
+                # when called with multiple pipelines, so we don't need
+                # to iterate over the results again
+                result = _results[0]
             for idx, aggregation in batch_aggs.items():
                 results[idx] = self._parse_big_result(aggregation, result)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- use to_list() to exhaust the cursor instead of list() to improve performance, particularly beneficial if proxying results
- for ref: https://pymongo.readthedocs.io/en/stable/api/pymongo/cursor.html#pymongo.cursor.Cursor.to_list
- 

## How is this patch tested? If it is not, please explain why.

- tested locally on large datasets
```
import fiftyone as fo

ds=fo.load_dataset('places')
ds.values(['filepath'])
ds[900000:1000000].values(['filepath'])
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a new method for efficiently converting aggregation results for improved data handling.

- **Refactor**
  - Optimized aggregation operations to enhance performance when processing large datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->