### PR TITLE
[WIP] chore(tests): Using cross platform file paths

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -8,7 +8,7 @@ ftfy==6.1.1
 httpx==0.23.0
 hypercorn==0.13.2
 kaleido==0.2.1
-matplotlib==3.10.1
+matplotlib==3.7.1
 mongoengine~=0.29.1
 motor~=3.6.0
 packaging==20.3

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -8,7 +8,7 @@ ftfy==6.1.1
 httpx==0.23.0
 hypercorn==0.13.2
 kaleido==0.2.1
-matplotlib==3.5.2
+matplotlib==3.10.1
 mongoengine~=0.29.1
 motor~=3.6.0
 packaging==20.3

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -8,7 +8,7 @@ ftfy==6.1.1
 httpx==0.23.0
 hypercorn==0.13.2
 kaleido==0.2.1
-matplotlib==3.7.1
+matplotlib==3.8.4
 mongoengine~=0.29.1
 motor~=3.6.0
 packaging==20.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,6 +3,7 @@
 -r extras.txt
 -r test.txt
 
+freezegun==1.5.1
 ipython==8.12.3
 pre-commit==2.18.1
 pylint==2.13.9

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,6 @@
 -r extras.txt
 -r test.txt
 
-freezegun==1.5.1
 ipython==8.12.3
 pre-commit==2.18.1
 pylint==2.13.9

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,5 @@
 awscli==1.37.2
+freezegun==1.5.1
 open3d>=0.16.0
 werkzeug>=2.0.3
 pydicom<3

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -6,7 +6,6 @@ FiftyOne dataset-related unit tests.
 |
 """
 
-import time
 from copy import deepcopy, copy
 from datetime import date, datetime, timedelta
 import gc
@@ -17,6 +16,7 @@ import unittest
 from unittest.mock import patch
 
 from bson import ObjectId
+from freezegun import freeze_time
 from mongoengine import ValidationError
 import numpy as np
 import pytz
@@ -1052,17 +1052,9 @@ class DatasetTests(unittest.TestCase):
         self.assertEqual(int((sample.date - date1).total_seconds()), 0)
 
         # Now change system time to something GMT+
-        system_timezone = os.environ.get("TZ")
-        try:
-            os.environ["TZ"] = "Europe/Madrid"
-            time.tzset()
+        now = datetime.now()
+        with freeze_time(now, tz_offset=1):
             dataset.reload()
-        finally:
-            if system_timezone is None:
-                del os.environ["TZ"]
-            else:
-                os.environ["TZ"] = system_timezone
-            time.tzset()
 
         self.assertEqual(type(sample.date), date)
         self.assertEqual(int((sample.date - date1).total_seconds()), 0)

--- a/tests/unittests/execution_cache/serialization_tests.py
+++ b/tests/unittests/execution_cache/serialization_tests.py
@@ -57,7 +57,7 @@ class TestCacheSerialization(unittest.TestCase):
         self.assertEqual(deserialized["dt"].isoformat(), dt.isoformat())
 
     def test_auto_deserialize_recursive_with_sample(self):
-        expected_path = str(Path("hello", "world.jpg"))
+        expected_path = str(Path(Path.cwd().anchor, "hello", "world.jpg"))
         sample_dict = {
             "filepath": expected_path,
             "ground_truth": {"label": "cat", "confidence": 0.9},
@@ -85,7 +85,7 @@ class TestCacheSerialization(unittest.TestCase):
         self.assertIsInstance(result["b"]["date"], datetime.datetime)
 
     def test_auto_serialize_sample(self):
-        expected_path = str(Path("tmp", "image.jpg"))
+        expected_path = str(Path(Path.cwd().anchor, "tmp", "image.jpg"))
         sample = fo.Sample(
             filepath=expected_path,
             ground_truth=fo.Classification(label="cat"),
@@ -97,7 +97,7 @@ class TestCacheSerialization(unittest.TestCase):
         self.assertEqual(result["_cls"], "fiftyone.core.sample.Sample")
 
     def test_auto_serialize_nested_samples(self):
-        expected_path = str(Path("tmp", "image.jpg"))
+        expected_path = str(Path(Path.cwd().anchor, "tmp", "image.jpg"))
         sample = fo.Sample(
             filepath=expected_path,
             ground_truth=fo.Classification(label="cat"),
@@ -108,7 +108,7 @@ class TestCacheSerialization(unittest.TestCase):
         self.assertEqual(result[0]["_cls"], "fiftyone.core.sample.Sample")
 
     def test_auto_deserialize_sample(self):
-        expected_path = str(Path("tmp", "image.jpg"))
+        expected_path = str(Path(Path.cwd().anchor, "tmp", "image.jpg"))
         sample_dict = {
             "filepath": expected_path,
             "ground_truth": {"label": "cat", "confidence": 0.9},
@@ -122,8 +122,8 @@ class TestCacheSerialization(unittest.TestCase):
         self.assertAlmostEqual(result["ground_truth"]["confidence"], 0.9)
 
     def test_auto_deserialize_nested_samples(self):
-        expected_path_img1 = str(Path("tmp", "image.jpg"))
-        expected_path_img2 = str(Path("tmp", "image2.jpg"))
+        expected_path_img1 = str(Path(Path.cwd().anchor, "tmp", "image.jpg"))
+        expected_path_img2 = str(Path(Path.cwd().anchor, "tmp", "image2.jpg"))
 
         sample_dict = {
             "_cls": "fiftyone.core.sample.Sample",

--- a/tests/unittests/execution_cache/serialization_tests.py
+++ b/tests/unittests/execution_cache/serialization_tests.py
@@ -5,6 +5,7 @@ Unit tests for cache serialization.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import datetime
 import numpy as np
 from pathlib import Path

--- a/tests/unittests/execution_cache/serialization_tests.py
+++ b/tests/unittests/execution_cache/serialization_tests.py
@@ -5,9 +5,10 @@ Unit tests for cache serialization.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import unittest
 import datetime
 import numpy as np
+from pathlib import Path
+import unittest
 
 import fiftyone as fo
 from fiftyone import ViewField as F
@@ -56,8 +57,9 @@ class TestCacheSerialization(unittest.TestCase):
         self.assertEqual(deserialized["dt"].isoformat(), dt.isoformat())
 
     def test_auto_deserialize_recursive_with_sample(self):
+        expected_path = str(Path("hello", "world.jpg"))
         sample_dict = {
-            "filepath": "/hello/world.jpg",
+            "filepath": expected_path,
             "ground_truth": {"label": "cat", "confidence": 0.9},
             "_cls": "fiftyone.core.sample.Sample",
         }
@@ -79,12 +81,13 @@ class TestCacheSerialization(unittest.TestCase):
         self.assertEqual(result["b"]["nested"], 10)
         self.assertAlmostEqual(result["b"]["float"], 1.23)
         self.assertIsInstance(result["b"]["sample"], fo.Sample)
-        self.assertEqual(result["b"]["sample"].filepath, "/hello/world.jpg")
+        self.assertEqual(result["b"]["sample"].filepath, expected_path)
         self.assertIsInstance(result["b"]["date"], datetime.datetime)
 
     def test_auto_serialize_sample(self):
+        expected_path = str(Path("tmp", "image.jpg"))
         sample = fo.Sample(
-            filepath="/tmp/image.jpg",
+            filepath=expected_path,
             ground_truth=fo.Classification(label="cat"),
         )
         result = auto_serialize(sample)
@@ -94,8 +97,9 @@ class TestCacheSerialization(unittest.TestCase):
         self.assertEqual(result["_cls"], "fiftyone.core.sample.Sample")
 
     def test_auto_serialize_nested_samples(self):
+        expected_path = str(Path("tmp", "image.jpg"))
         sample = fo.Sample(
-            filepath="/tmp/image.jpg",
+            filepath=expected_path,
             ground_truth=fo.Classification(label="cat"),
         )
         nested = [sample]
@@ -104,8 +108,9 @@ class TestCacheSerialization(unittest.TestCase):
         self.assertEqual(result[0]["_cls"], "fiftyone.core.sample.Sample")
 
     def test_auto_deserialize_sample(self):
+        expected_path = str(Path("tmp", "image.jpg"))
         sample_dict = {
-            "filepath": "/tmp/image.jpg",
+            "filepath": expected_path,
             "ground_truth": {"label": "cat", "confidence": 0.9},
             "_cls": "fiftyone.core.sample.Sample",
         }
@@ -113,17 +118,20 @@ class TestCacheSerialization(unittest.TestCase):
         result = auto_deserialize(sample_dict)
 
         self.assertIsInstance(result, fo.Sample)
-        self.assertEqual(result["filepath"], "/tmp/image.jpg")
+        self.assertEqual(result["filepath"], expected_path)
         self.assertAlmostEqual(result["ground_truth"]["confidence"], 0.9)
 
     def test_auto_deserialize_nested_samples(self):
+        expected_path_img1 = str(Path("tmp", "image.jpg"))
+        expected_path_img2 = str(Path("tmp", "image2.jpg"))
+
         sample_dict = {
             "_cls": "fiftyone.core.sample.Sample",
-            "filepath": "/tmp/image.jpg",
+            "filepath": expected_path_img1,
             "ground_truth": {"label": "cat", "confidence": 0.9},
             "other": [
                 {
-                    "filepath": "/tmp/image2.jpg",
+                    "filepath": expected_path_img2,
                     "ground_truth": {"label": "dog", "confidence": 0.8},
                 }
             ],

--- a/tests/unittests/group_tests.py
+++ b/tests/unittests/group_tests.py
@@ -12,6 +12,7 @@ import os
 from pathlib import Path
 import random
 import string
+import tempfile
 import unittest
 
 from bson import ObjectId
@@ -53,15 +54,15 @@ class GroupTests(unittest.TestCase):
         group = fo.Group()
         samples = [
             fo.Sample(
-                filepath=str(Path(Path.cwd().anchor, "left-image.jpg")),
+                filepath=_anchor_test_file("left-image.jpg"),
                 group_field=group.element("left"),
             ),
             fo.Sample(
-                filepath=str(Path(Path.cwd().anchor, "ego-video.mp4")),
+                filepath=_anchor_test_file("ego-video.mp4"),
                 group_field=group.element("ego"),
             ),
             fo.Sample(
-                filepath=str(Path(Path.cwd().anchor, "right-image.jpg")),
+                filepath=_anchor_test_file("right-image.jpg"),
                 group_field=group.element("right"),
             ),
         ]
@@ -111,11 +112,11 @@ class GroupTests(unittest.TestCase):
         dataset.add_samples(
             [
                 fo.Sample(
-                    filepath=str(Path(Path.cwd().anchor, "left-image.jpg")),
+                    filepath=_anchor_test_file("left-image.jpg"),
                     group_field=group.element("left"),
                 ),
                 fo.Sample(
-                    filepath=str(Path(Path.cwd().anchor, "right-image.jpg")),
+                    filepath=_anchor_test_file("right-image.jpg"),
                     group_field=group.element("right"),
                 ),
             ]
@@ -1754,22 +1755,22 @@ def _make_group_dataset():
 
     samples = [
         fo.Sample(
-            filepath=str(Path(Path.cwd().anchor, "left-image1.jpg")),
+            filepath=_anchor_test_file("left-image1.jpg"),
             group_field=group1.element("left"),
             field=1,
         ),
         fo.Sample(
-            filepath=str(Path(Path.cwd().anchor, "ego-video1.mp4")),
+            filepath=_anchor_test_file("ego-video1.mp4"),
             group_field=group1.element("ego"),
             field=2,
         ),
         fo.Sample(
-            filepath=str(Path(Path.cwd().anchor, "right-image1.jpg")),
+            filepath=_anchor_test_file("right-image1.jpg"),
             group_field=group1.element("right"),
             field=3,
         ),
         fo.Sample(
-            filepath=str(Path(Path.cwd().anchor, "left-image2.jpg")),
+            filepath=_anchor_test_file("left-image2.jpg"),
             group_field=group2.element("left"),
             field=4,
         ),
@@ -1779,7 +1780,7 @@ def _make_group_dataset():
             field=5,
         ),
         fo.Sample(
-            filepath=str(Path(Path.cwd().anchor, "right-image2.jpg")),
+            filepath=_anchor_test_file("right-image2.jpg"),
             group_field=group2.element("right"),
             field=6,
         ),
@@ -2347,8 +2348,14 @@ class DynamicGroupTests(unittest.TestCase):
 
         group = fo.Group()
         samples = [
-            fo.Sample(filepath="video.mp4", group=group.element("video")),
-            fo.Sample(filepath="image.png", group=group.element("image")),
+            fo.Sample(
+                filepath=_anchor_test_file("video.mp4"),
+                group=group.element("video"),
+            ),
+            fo.Sample(
+                filepath=_anchor_test_file("image.png"),
+                group=group.element("image"),
+            ),
         ]
         dataset.add_samples(samples)
 
@@ -2384,27 +2391,27 @@ def _make_group_by_dataset():
 
     samples = [
         fo.Sample(
-            filepath="frame11.jpg",
+            filepath=_anchor_test_file("frame11.jpg"),
             sample_id=sample_id1,
             frame_number=1,
         ),
         fo.Sample(
-            filepath="frame22.jpg",
+            filepath=_anchor_test_file("frame22.jpg"),
             sample_id=sample_id2,
             frame_number=2,
         ),
         fo.Sample(
-            filepath="frame13.jpg",
+            filepath=_anchor_test_file("frame13.jpg"),
             sample_id=sample_id1,
             frame_number=3,
         ),
         fo.Sample(
-            filepath="frame21.jpg",
+            filepath=_anchor_test_file("frame21.jpg"),
             sample_id=sample_id2,
             frame_number=1,
         ),
         fo.Sample(
-            filepath="frame12.jpg",
+            filepath=_anchor_test_file("frame12.jpg"),
             sample_id=sample_id1,
             frame_number=2,
         ),
@@ -2427,32 +2434,32 @@ def _make_group_by_group_dataset():
 
     samples = [
         fo.Sample(
-            filepath=str(Path(Path.cwd().anchor, "left-image1.jpg")),
+            filepath=_anchor_test_file("left-image1.jpg"),
             group_field=group1.element("left"),
             scene="foo",
         ),
         fo.Sample(
-            filepath=str(Path(Path.cwd().anchor, "right-image1.jpg")),
+            filepath=_anchor_test_file("right-image1.jpg"),
             group_field=group1.element("right"),
             scene="foo",
         ),
         fo.Sample(
-            filepath=str(Path(Path.cwd().anchor, "left-image2.jpg")),
+            filepath=_anchor_test_file("left-image2.jpg"),
             group_field=group2.element("left"),
             scene="foo",
         ),
         fo.Sample(
-            filepath=str(Path(Path.cwd().anchor, "right-image2.jpg")),
+            filepath=_anchor_test_file("right-image2.jpg"),
             group_field=group2.element("right"),
             scene="foo",
         ),
         fo.Sample(
-            filepath=str(Path(Path.cwd().anchor, "left-image3.jpg")),
+            filepath=_anchor_test_file("left-image3.jpg"),
             group_field=group3.element("left"),
             scene="bar",
         ),
         fo.Sample(
-            filepath=str(Path(Path.cwd().anchor, "right-image3.jpg")),
+            filepath=_anchor_test_file("right-image3.jpg"),
             group_field=group3.element("right"),
             scene="bar",
         ),
@@ -2465,6 +2472,11 @@ def _make_group_by_group_dataset():
 
 def _rle(values):
     return dict((k, len(list(group))) for k, group in groupby(values))
+
+
+def _anchor_test_file(file: str) -> str:
+    td = tempfile.gettempdir()
+    return str(Path(Path(td).anchor, file))
 
 
 if __name__ == "__main__":

--- a/tests/unittests/group_tests.py
+++ b/tests/unittests/group_tests.py
@@ -9,6 +9,7 @@ FiftyOne group-related unit tests.
 from itertools import groupby
 import json
 import os
+from pathlib import Path
 import random
 import string
 import unittest
@@ -52,15 +53,15 @@ class GroupTests(unittest.TestCase):
         group = fo.Group()
         samples = [
             fo.Sample(
-                filepath="left-image.jpg",
+                filepath=str(Path(Path.cwd().anchor, "left-image.jpg")),
                 group_field=group.element("left"),
             ),
             fo.Sample(
-                filepath="ego-video.mp4",
+                filepath=str(Path(Path.cwd().anchor, "ego-video.mp4")),
                 group_field=group.element("ego"),
             ),
             fo.Sample(
-                filepath="right-image.jpg",
+                filepath=str(Path(Path.cwd().anchor, "right-image.jpg")),
                 group_field=group.element("right"),
             ),
         ]
@@ -110,11 +111,11 @@ class GroupTests(unittest.TestCase):
         dataset.add_samples(
             [
                 fo.Sample(
-                    filepath="left-image.jpg",
+                    filepath=str(Path(Path.cwd().anchor, "left-image.jpg")),
                     group_field=group.element("left"),
                 ),
                 fo.Sample(
-                    filepath="right-image.jpg",
+                    filepath=str(Path(Path.cwd().anchor, "right-image.jpg")),
                     group_field=group.element("right"),
                 ),
             ]
@@ -1753,32 +1754,32 @@ def _make_group_dataset():
 
     samples = [
         fo.Sample(
-            filepath="left-image1.jpg",
+            filepath=str(Path(Path.cwd().anchor, "left-image1.jpg")),
             group_field=group1.element("left"),
             field=1,
         ),
         fo.Sample(
-            filepath="ego-video1.mp4",
+            filepath=str(Path(Path.cwd().anchor, "ego-video1.mp4")),
             group_field=group1.element("ego"),
             field=2,
         ),
         fo.Sample(
-            filepath="right-image1.jpg",
+            filepath=str(Path(Path.cwd().anchor, "right-image1.jpg")),
             group_field=group1.element("right"),
             field=3,
         ),
         fo.Sample(
-            filepath="left-image2.jpg",
+            filepath=str(Path(Path.cwd().anchor, "left-image2.jpg")),
             group_field=group2.element("left"),
             field=4,
         ),
         fo.Sample(
-            filepath="ego-video2.mp4",
+            filepath=str(Path(Path.cwd().anchor, "ego-video2.mp4")),
             group_field=group2.element("ego"),
             field=5,
         ),
         fo.Sample(
-            filepath="right-image2.jpg",
+            filepath=str(Path(Path.cwd().anchor, "right-image2.jpg")),
             group_field=group2.element("right"),
             field=6,
         ),
@@ -2426,32 +2427,32 @@ def _make_group_by_group_dataset():
 
     samples = [
         fo.Sample(
-            filepath="left-image1.jpg",
+            filepath=str(Path(Path.cwd().anchor, "left-image1.jpg")),
             group_field=group1.element("left"),
             scene="foo",
         ),
         fo.Sample(
-            filepath="right-image1.jpg",
+            filepath=str(Path(Path.cwd().anchor, "right-image1.jpg")),
             group_field=group1.element("right"),
             scene="foo",
         ),
         fo.Sample(
-            filepath="left-image2.jpg",
+            filepath=str(Path(Path.cwd().anchor, "left-image2.jpg")),
             group_field=group2.element("left"),
             scene="foo",
         ),
         fo.Sample(
-            filepath="right-image2.jpg",
+            filepath=str(Path(Path.cwd().anchor, "right-image2.jpg")),
             group_field=group2.element("right"),
             scene="foo",
         ),
         fo.Sample(
-            filepath="left-image3.jpg",
+            filepath=str(Path(Path.cwd().anchor, "left-image3.jpg")),
             group_field=group3.element("left"),
             scene="bar",
         ),
         fo.Sample(
-            filepath="right-image3.jpg",
+            filepath=str(Path(Path.cwd().anchor, "right-image3.jpg")),
             group_field=group3.element("right"),
             scene="bar",
         ),

--- a/tests/unittests/group_tests.py
+++ b/tests/unittests/group_tests.py
@@ -1425,7 +1425,7 @@ class GroupTests(unittest.TestCase):
 
 class GroupImportExportTests(unittest.TestCase):
     def setUp(self):
-        temp_dir = etau.TempDir()
+        temp_dir = etau.TempDir(basedir=tempfile.gettempdir())
         tmp_dir = temp_dir.__enter__()
 
         self._temp_dir = temp_dir

--- a/tests/unittests/group_tests.py
+++ b/tests/unittests/group_tests.py
@@ -1425,7 +1425,7 @@ class GroupTests(unittest.TestCase):
 
 class GroupImportExportTests(unittest.TestCase):
     def setUp(self):
-        temp_dir = etau.TempDir(basedir=tempfile.gettempdir())
+        temp_dir = etau.TempDir()
         tmp_dir = temp_dir.__enter__()
 
         self._temp_dir = temp_dir
@@ -1775,7 +1775,7 @@ def _make_group_dataset():
             field=4,
         ),
         fo.Sample(
-            filepath=str(Path(Path.cwd().anchor, "ego-video2.mp4")),
+            filepath=_anchor_test_file("ego-video2.mp4"),
             group_field=group2.element("ego"),
             field=5,
         ),

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -5364,21 +5364,21 @@ class ThreeDMediaTests(unittest.TestCase):
             )
 
             scene1 = fo.Scene.from_fo3d(
-                os.path.join(export_dir, "label1/test/s.fo3d")
+                os.path.join(export_dir, "label1", "test", "s.fo3d")
             )
-            self.assertEqual(scene1.background.image, "../../image.jpeg")
+            self.assertEqual(scene1.background.image, os.path.join("..", "..", "image.jpeg"))
 
             for file in scene1.get_asset_paths():
-                with open(os.path.join(export_dir, "label1/test/", file)) as f:
+                with open(os.path.join(export_dir, "label1", "test", file)) as f:
                     self.assertEqual(f.read(), os.path.basename(file))
 
             scene2 = fo.Scene.from_fo3d(
-                os.path.join(export_dir, "label2/test/s.fo3d")
+                os.path.join(export_dir, "label2", "test", "s.fo3d")
             )
-            self.assertEqual(scene2.background.image, "../../image.jpeg")
+            self.assertEqual(scene2.background.image, os.path.join("..", "..", "image.jpeg"))
 
             for file in scene2.get_asset_paths():
-                with open(os.path.join(export_dir, "label2/test/", file)) as f:
+                with open(os.path.join(export_dir, "label2", "test", file)) as f:
                     if file.endswith("image.jpeg"):
                         continue
                     self.assertEqual(

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -5366,19 +5366,27 @@ class ThreeDMediaTests(unittest.TestCase):
             scene1 = fo.Scene.from_fo3d(
                 os.path.join(export_dir, "label1", "test", "s.fo3d")
             )
-            self.assertEqual(scene1.background.image, os.path.join("..", "..", "image.jpeg"))
+            self.assertEqual(
+                scene1.background.image, os.path.join("..", "..", "image.jpeg")
+            )
 
             for file in scene1.get_asset_paths():
-                with open(os.path.join(export_dir, "label1", "test", file)) as f:
+                with open(
+                    os.path.join(export_dir, "label1", "test", file)
+                ) as f:
                     self.assertEqual(f.read(), os.path.basename(file))
 
             scene2 = fo.Scene.from_fo3d(
                 os.path.join(export_dir, "label2", "test", "s.fo3d")
             )
-            self.assertEqual(scene2.background.image, os.path.join("..", "..", "image.jpeg"))
+            self.assertEqual(
+                scene2.background.image, os.path.join("..", "..", "image.jpeg")
+            )
 
             for file in scene2.get_asset_paths():
-                with open(os.path.join(export_dir, "label2", "test", file)) as f:
+                with open(
+                    os.path.join(export_dir, "label2", "test", file)
+                ) as f:
                     if file.endswith("image.jpeg"):
                         continue
                     self.assertEqual(

--- a/tests/unittests/sample_tests.py
+++ b/tests/unittests/sample_tests.py
@@ -198,7 +198,10 @@ class SampleTests(unittest.TestCase):
         self.assertEqual(img.width, width)
         self.assertEqual(img.height, height)
 
-        with tempfile.NamedTemporaryFile("w") as image_file:
+        # Use temp dirs instead of temp files for windows file locking
+        with tempfile.TemporaryDirectory() as tmpdir:
+            image_path = os.path.join(tmpdir, "test.jpg")
+
             # Test all possible orientations. width/height only flipped with
             #   5, 6, 7, 8
             for orientation in range(1, 10):
@@ -208,9 +211,9 @@ class SampleTests(unittest.TestCase):
                 expected_width, expected_height = width, height
                 if orientation in {5, 6, 7, 8}:
                     expected_width, expected_height = height, width
-                img.save(image_file.name, "jpeg", exif=exif)
+                img.save(image_path, "jpeg", exif=exif)
 
-                sample = fo.Sample(image_file.name, media_type="image")
+                sample = fo.Sample(image_path, media_type="image")
                 sample.compute_metadata()
 
                 self.assertEqual(sample.metadata.width, expected_width)
@@ -218,8 +221,8 @@ class SampleTests(unittest.TestCase):
                 self.assertEqual(sample.metadata.num_channels, 3)
 
             # Finally a normal non-exif file
-            img.save(image_file.name, "jpeg")
-            sample = fo.Sample(image_file.name, media_type="image")
+            img.save(image_path, "jpeg")
+            sample = fo.Sample(image_path, media_type="image")
             sample.compute_metadata()
             self.assertEqual(sample.metadata.width, width)
             self.assertEqual(sample.metadata.height, height)

--- a/tests/unittests/utils3d_tests.py
+++ b/tests/unittests/utils3d_tests.py
@@ -331,9 +331,9 @@ class GetSceneAssetPaths(unittest.TestCase):
             ]
 
             scene1 = fo3d.Scene()
-            scene1.background = fo3d.SceneBackground(image="back/ground.jpeg")
+            scene1.background = fo3d.SceneBackground(image=os.path.join("back", "ground.jpeg"))
             scene1.add(fo3d.ObjMesh("blah-obj", "relative.obj"))
-            scene1.add(fo3d.PointCloud("blah-pcd", f"{temp_dir}/absolute.pcd"))
+            scene1.add(fo3d.PointCloud("blah-pcd", os.path.join(temp_dir, "absolute.pcd")))
             scene1.write(scene_paths[0])
 
             scene2 = fo3d.Scene()

--- a/tests/unittests/utils3d_tests.py
+++ b/tests/unittests/utils3d_tests.py
@@ -5,6 +5,7 @@ FiftyOne 3D utilities unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import os
 import tempfile
 import unittest
@@ -343,7 +344,9 @@ class GetSceneAssetPaths(unittest.TestCase):
             scene1.write(scene_paths[0])
 
             scene2 = fo3d.Scene()
-            scene2.background = fo3d.SceneBackground(image="back/ground.jpeg")
+            scene2.background = fo3d.SceneBackground(
+                image=os.path.join("back", "ground.jpeg")
+            )
             scene2.add(fo3d.StlMesh("blah-obj", "relative2.stl"))
             scene2.write(scene_paths[1])
 

--- a/tests/unittests/utils3d_tests.py
+++ b/tests/unittests/utils3d_tests.py
@@ -331,9 +331,15 @@ class GetSceneAssetPaths(unittest.TestCase):
             ]
 
             scene1 = fo3d.Scene()
-            scene1.background = fo3d.SceneBackground(image=os.path.join("back", "ground.jpeg"))
+            scene1.background = fo3d.SceneBackground(
+                image=os.path.join("back", "ground.jpeg")
+            )
             scene1.add(fo3d.ObjMesh("blah-obj", "relative.obj"))
-            scene1.add(fo3d.PointCloud("blah-pcd", os.path.join(temp_dir, "absolute.pcd")))
+            scene1.add(
+                fo3d.PointCloud(
+                    "blah-pcd", os.path.join(temp_dir, "absolute.pcd")
+                )
+            )
             scene1.write(scene_paths[0])
 
             scene2 = fo3d.Scene()

--- a/tests/unittests/utils3d_tests.py
+++ b/tests/unittests/utils3d_tests.py
@@ -352,15 +352,15 @@ class GetSceneAssetPaths(unittest.TestCase):
             self.assertSetEqual(
                 set(asset_paths[scene_paths[0]]),
                 {
-                    "back/ground.jpeg",
+                    os.path.join("back", "ground.jpeg"),
                     "relative.obj",
-                    f"{temp_dir}/absolute.pcd",
+                    os.path.join(temp_dir, "absolute.pcd"),
                 },
             )
             self.assertSetEqual(
                 set(asset_paths[scene_paths[1]]),
                 {
-                    "back/ground.jpeg",
+                    os.path.join("back", "ground.jpeg"),
                     "relative2.stl",
                 },
             )
@@ -376,16 +376,16 @@ class GetSceneAssetPaths(unittest.TestCase):
             self.assertSetEqual(
                 set(asset_paths[scene_paths[0]]),
                 {
-                    f"{temp_dir}/back/ground.jpeg",
-                    f"{temp_dir}/relative.obj",
-                    f"{temp_dir}/absolute.pcd",
+                    os.path.join(temp_dir, "back", "ground.jpeg"),
+                    os.path.join(temp_dir, "relative.obj"),
+                    os.path.join(temp_dir, "absolute.pcd"),
                 },
             )
             self.assertSetEqual(
                 set(asset_paths[scene_paths[1]]),
                 {
-                    f"{temp_dir}/back/ground.jpeg",
-                    f"{temp_dir}/relative2.stl",
+                    os.path.join(temp_dir, "back", "ground.jpeg"),
+                    os.path.join(temp_dir, "relative2.stl"),
                 },
             )
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

> [!NOTE]
> This is a work in progress.

A lot of our tests fail on windows. This gives a big red ❌ on PRs and it's harder to tell if tests are passing or failing. I would like to take a test at:

1. Changing posix path to cross-platform paths using os.path or pathlib
2. removing the `time.tzset` invocations
3. looking into the other export issues


## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
