### PR TITLE
Map Samples: UniqueFilenameMaker

### DIFF
--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -5,6 +5,7 @@ Core utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import abc
 import atexit
 from bson import json_util
@@ -24,6 +25,7 @@ import multiprocessing
 import numbers
 import os
 from packaging.version import Version
+import psutil
 import platform
 import re
 import signal
@@ -31,8 +33,10 @@ import string
 import struct
 import subprocess
 import sys
+import shutil
 import timeit
 import types
+import uuid
 from xml.parsers.expat import ExpatError
 import zlib
 
@@ -1866,7 +1870,7 @@ def disable_progress_bars():
         fo.config.show_progress_bars = prev_show_progress_bars
 
 
-class UniqueFilenameMaker(object):
+class InMemoryUniqueFilenameMaker(object):
     """A class that generates unique output paths in a directory.
 
     This class provides a :meth:`get_output_path` method that generates unique
@@ -1970,7 +1974,13 @@ class UniqueFilenameMaker(object):
 
         self._idx = len(filenames)
         for filename in filenames:
-            self._filename_counts[filename] += 1
+            key = filename
+
+            # Adding ignore extension to filename counts
+            if self.ignore_exts:
+                key, _ = os.path.splitext(filename)
+
+            self._filename_counts[key] += 1
 
     def seen_input_path(self, input_path):
         """Checks whether we've already seen the given input path.
@@ -1998,8 +2008,28 @@ class UniqueFilenameMaker(object):
         if found_input:
             input_path = fos.normalize_path(input_path)
 
-            if self.idempotent and input_path in self._filepath_map:
-                return self._filepath_map[input_path]
+            if self.idempotent:
+                # Adding ignore extension to idempotent check
+                if self.ignore_exts:
+                    input_path_sans_ext, input_path_ext = os.path.splitext(
+                        input_path
+                    )
+
+                    matched_output_path = next(
+                        (
+                            o
+                            for i, o in self._filepath_map.items()
+                            if os.path.splitext(i)[0] == input_path_sans_ext
+                        ),
+                        None,
+                    )
+
+                    if matched_output_path is not None:
+                        return_path, _ = os.path.splitext(matched_output_path)
+                        return return_path + input_path_ext
+
+                elif input_path in self._filepath_map:
+                    return self._filepath_map[input_path]
 
         self._idx += 1
 
@@ -2063,6 +2093,371 @@ class UniqueFilenameMaker(object):
         root_dir = alt_dir or self.alt_dir or self.output_dir
         rel_path = os.path.relpath(output_path, self.output_dir)
         return os.path.join(root_dir, rel_path)
+
+
+class MultiProcessUniqueFilenameMaker(object):
+    """A class that generates unique output paths in a directory.
+
+    This class provides a :meth:`get_output_path` method that generates unique
+    filenames in the specified output directory.
+
+    If an input path is provided, its filename is maintained, unless a name
+    conflict in ``output_dir`` would occur, in which case an index of the form
+    ``"-%d" % count`` is appended to the filename.
+
+    If no input filename is provided, an output filename of the form
+    ``<output_dir>/<count><default_ext>`` is generated, where ``count`` is the
+    number of files in ``output_dir``.
+
+    If no ``output_dir`` is provided, then unique filenames with no base
+    directory are generated.
+
+    If a ``rel_dir`` is provided, then this path will be stripped from each
+    input path to generate the identifier of each file (rather than just its
+    basename). This argument allows for populating nested subdirectories in
+    ``output_dir`` that match the shape of the input paths.
+
+    If ``alt_dir`` is provided, you can use :meth:`get_alt_path` to retrieve
+    the equivalent path rooted in this directory rather than ``output_dir``.
+
+    Args:
+        output_dir (None): a directory in which to generate output paths
+        rel_dir (None): an optional relative directory to strip from each path.
+            The path is converted to an absolute path (if necessary) via
+            :func:`fiftyone.core.storage.normalize_path`
+        alt_dir (None): an optional alternate directory in which to generate
+            paths when :meth:`get_alt_path` is called
+        default_ext (None): the file extension to use when generating default
+            output paths
+        ignore_exts (False): whether to omit file extensions when checking for
+            duplicate filenames
+        ignore_existing (False): whether to ignore existing files in
+            ``output_dir`` for output filename generation purposes
+        idempotent (True): whether to return the same output path when the same
+            input path is provided multiple times (True) or to generate new
+            output paths (False)
+    """
+
+    def __init__(
+        self,
+        output_dir=None,
+        rel_dir=None,
+        alt_dir=None,
+        default_ext=None,
+        ignore_exts=False,
+        ignore_existing=False,
+        idempotent=True,
+    ):
+        if rel_dir is not None:
+            rel_dir = fos.normalize_path(rel_dir)
+
+        self.output_dir = output_dir
+        self.rel_dir = rel_dir
+        self.alt_dir = alt_dir
+        self.default_ext = default_ext or ""
+        self.ignore_exts = ignore_exts
+        self.ignore_existing = ignore_existing
+        self.idempotent = idempotent
+
+        self.starting_filepaths = set()
+        self.starting_filepath_counts = defaultdict(int)
+
+        if self.output_dir:
+            etau.ensure_dir(self.output_dir)
+
+            if not self.ignore_existing:
+                recursive = self.rel_dir is not None
+
+                self.starting_filepaths = {
+                    os.path.join(self.output_dir, filename)
+                    for filename in etau.list_files(
+                        self.output_dir, recursive=recursive
+                    )
+                }
+
+                # self._idx = len(filenames)
+                for filepath in self.starting_filepaths:
+                    key = filepath
+                    if self.ignore_exts:
+                        key, _ = os.path.splitext(filepath)
+
+                    self.starting_filepath_counts[key] += 1
+
+        # Get the root temporary directory of the "main process"
+        pid = os.getpid()
+        ppid = None
+        try:
+            _ppid = psutil.Process(pid).ppid()
+            parent_process = psutil.Process(_ppid)
+            if "python" in parent_process.name().lower():
+                ppid = _ppid
+        except psutil.NoSuchProcess:
+            ...
+        tmp_dir_prefix = f"/tmp/fo-unq/{ppid or pid}"
+
+        # If the temporary directory does not exist, create it and ensure
+        # it gets cleaned up when the main process exits only once
+        try:
+            os.makedirs(tmp_dir_prefix, exist_ok=False)
+        except OSError:
+            ...
+        else:
+
+            def cleanup_tmp_dir(dirname):
+                try:
+                    shutil.rmtree(dirname)
+                except Exception:
+                    ...
+
+            atexit.register(cleanup_tmp_dir, tmp_dir_prefix)
+
+        # Get a string representation fo the constructor parameters
+        hashed_params = hashlib.md5(
+            "|".join(
+                str(value)
+                for value in (
+                    output_dir,
+                    rel_dir,
+                    alt_dir,
+                    default_ext,
+                    ignore_exts,
+                    ignore_existing,
+                    idempotent,
+                )
+            ).encode("utf-8")
+        ).hexdigest()
+
+        # Create a temporary directory in main process directory for touched
+        # files based on constructor parameters
+        self.tmp_dir = os.path.join(tmp_dir_prefix, hashed_params)
+        etau.ensure_dir(self.tmp_dir)
+
+    def seen_input_path(self, input_path):
+        """Checks whether we've already seen the given input path.
+
+        Args:
+            input_path: an input path
+
+        Returns:
+            True/False
+        """
+        output_path = self.__get_output_path(input_path)
+
+        if self.output_dir:
+            output_path = os.path.join(self.output_dir, output_path)
+
+        # TODO: make this work
+
+        # return fos.normalize_path(input_path) in self._filepath_map
+
+    def __get_output_path(self, filepath, output_ext=None):
+        filepath = fos.normalize_path(filepath)
+
+        if self.rel_dir is not None:
+            filepath = safe_relpath(filepath, self.rel_dir)
+        else:
+            filepath = os.path.basename(filepath)
+
+        filename_sans_ext, ext = os.path.splitext(filepath)
+
+        # URL handling
+        # @todo improve this, while still maintaining Unix/Windows path support
+        filename_sans_ext = filename_sans_ext.replace("%", "-")
+        ext = output_ext if output_ext is not None else ext.split("?")[0]
+
+        return filename_sans_ext + ext
+
+    def get_output_path(self, input_path=None, output_ext=None):
+        """Returns a unique output path.
+
+        Args:
+            input_path (None): an input path
+            output_ext (None): an optional output extension to use
+
+        Returns:
+            the output path
+        """
+        if bool(input_path):
+            output_path = self.__get_output_path(
+                input_path, output_ext=output_ext
+            )
+        else:
+            output_path = str(uuid.uuid4()) + self.default_ext
+
+        if self.output_dir:
+            output_path = os.path.join(self.output_dir, output_path)
+
+        output_dir = os.path.dirname(output_path)
+        output_name = os.path.basename(output_path)
+        output_name_sans_ext, output_ext = os.path.splitext(output_name)
+
+        number = (
+            self.starting_filepath_counts.get(
+                (
+                    os.path.splitext(output_path)[0]
+                    if self.ignore_exts
+                    else output_path
+                ),
+                0,
+            )
+            + 1
+        )
+        last_attempted_number = None
+        while True:
+            # Add  file number to the output path with if necessary
+            if number > 1:
+                output_path = os.path.join(
+                    output_dir,
+                    output_name_sans_ext + f"-{number}" + output_ext,
+                )
+
+            try:
+                # Attempt to create a placeholder file to show  the output
+                # path has been claimed
+                touch_filename = os.path.basename(output_path)
+
+                if self.ignore_exts:
+                    touch_filename, _ = os.path.splitext(touch_filename)
+
+                touch_path = os.path.join(self.tmp_dir, touch_filename)
+                with open(touch_path, "x", encoding="utf-8"):
+                    ...
+
+            except FileExistsError:
+                # The output path has already been claimed with a placeholder
+
+                if self.idempotent:
+                    break
+            else:
+                # The output path was successfully claimed with a placeholder.
+                break
+
+            last_attempted_number = number
+
+            touch_prefix = os.path.join(self.tmp_dir, output_name_sans_ext)
+            glob_pattern = glob.glob(glob.escape(touch_prefix) + "*")
+            re_pattern = re.escape(touch_prefix) + r"-(\d+).*"
+
+            touch_paths = [
+                f
+                for f in glob_pattern
+                if self.ignore_exts or os.path.splitext(f)[0] == output_ext
+            ]
+
+            new_number = None
+            for filepath in touch_paths:
+                if m := re.match(re_pattern, filepath):
+                    n = int(m.group(1))
+                    if new_number is None or n > new_number:
+                        new_number = n
+
+            if new_number is None:
+                new_number = len(touch_paths)
+
+            new_number += 1
+
+            if new_number > last_attempted_number:
+                number = new_number
+            else:
+                number = last_attempted_number + 1
+
+        return output_path
+
+    def get_alt_path(self, output_path, alt_dir=None):
+        """Returns the alternate path for the given output path generated by
+        :meth:`get_output_path`.
+
+        Args:
+            output_path: an output path
+            alt_dir (None): a directory in which to return the alternate path.
+                If not provided, :attr:`alt_dir` is used
+
+        Returns:
+            the corresponding alternate path
+        """
+        root_dir = alt_dir or self.alt_dir or self.output_dir
+        rel_path = os.path.relpath(output_path, self.output_dir)
+        return os.path.join(root_dir, rel_path)
+
+
+class UniqueFilenameMaker(object):
+    """A class that generates unique output paths in a directory.
+
+    This class provides a :meth:`get_output_path` method that generates unique
+    filenames in the specified output directory.
+
+    If an input path is provided, its filename is maintained, unless a name
+    conflict in ``output_dir`` would occur, in which case an index of the form
+    ``"-%d" % count`` is appended to the filename.
+
+    If no input filename is provided, an output filename of the form
+    ``<output_dir>/<count><default_ext>`` is generated, where ``count`` is the
+    number of files in ``output_dir``.
+
+    If no ``output_dir`` is provided, then unique filenames with no base
+    directory are generated.
+
+    If a ``rel_dir`` is provided, then this path will be stripped from each
+    input path to generate the identifier of each file (rather than just its
+    basename). This argument allows for populating nested subdirectories in
+    ``output_dir`` that match the shape of the input paths.
+
+    If ``alt_dir`` is provided, you can use :meth:`get_alt_path` to retrieve
+    the equivalent path rooted in this directory rather than ``output_dir``.
+
+    Args:
+        output_dir (None): a directory in which to generate output paths
+        rel_dir (None): an optional relative directory to strip from each path.
+            The path is converted to an absolute path (if necessary) via
+            :func:`fiftyone.core.storage.normalize_path`
+        alt_dir (None): an optional alternate directory in which to generate
+            paths when :meth:`get_alt_path` is called
+        chunk_size (None): if provided, output paths will be nested in
+            subdirectories of ``output_dir`` with at most this many files per
+            subdirectory. Has no effect if a ``rel_dir`` is provided
+        default_ext (None): the file extension to use when generating default
+            output paths
+        ignore_exts (False): whether to omit file extensions when checking for
+            duplicate filenames
+        ignore_existing (False): whether to ignore existing files in
+            ``output_dir`` for output filename generation purposes
+        idempotent (True): whether to return the same output path when the same
+            input path is provided multiple times (True) or to generate new
+            output paths (False)
+    """
+
+    def __new__(
+        cls,
+        output_dir=None,
+        rel_dir=None,
+        alt_dir=None,
+        chunk_size=None,
+        default_ext=None,
+        ignore_exts=False,
+        ignore_existing=False,
+        idempotent=True,
+    ):
+        if chunk_size is not None:
+            return InMemoryUniqueFilenameMaker(
+                output_dir,
+                rel_dir,
+                alt_dir,
+                chunk_size,
+                default_ext,
+                ignore_exts,
+                ignore_existing,
+                idempotent,
+            )
+
+        return MultiProcessUniqueFilenameMaker(
+            output_dir,
+            rel_dir,
+            alt_dir,
+            default_ext,
+            ignore_exts,
+            ignore_existing,
+            idempotent,
+        )
 
 
 def safe_relpath(path, start=None, default=None):

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -1262,6 +1262,7 @@ class MediaExporter(object):
             manifest_path = self.export_path
             manifest = {}
 
+        # Not multi-process safe when user chunk size
         self._filename_maker = fou.UniqueFilenameMaker(
             output_dir=output_dir,
             rel_dir=self.rel_dir,
@@ -1882,9 +1883,9 @@ class LegacyFiftyOneDatasetExporter(GenericSampleDatasetExporter):
         self._metadata["name"] = sample_collection._dataset.name
         self._metadata["media_type"] = sample_collection.media_type
         if sample_collection.media_type == fomm.GROUP:
-            self._metadata[
-                "group_media_types"
-            ] = sample_collection.group_media_types
+            self._metadata["group_media_types"] = (
+                sample_collection.group_media_types
+            )
 
         schema = sample_collection._serialize_field_schema()
         self._metadata["sample_fields"] = schema
@@ -1918,17 +1919,17 @@ class LegacyFiftyOneDatasetExporter(GenericSampleDatasetExporter):
             info["mask_targets"] = sample_collection._serialize_mask_targets()
 
         if sample_collection.default_mask_targets:
-            info[
-                "default_mask_targets"
-            ] = sample_collection._serialize_default_mask_targets()
+            info["default_mask_targets"] = (
+                sample_collection._serialize_default_mask_targets()
+            )
 
         if sample_collection.skeletons:
             info["skeletons"] = sample_collection._serialize_skeletons()
 
         if sample_collection.default_skeleton:
-            info[
-                "default_skeleton"
-            ] = sample_collection._serialize_default_skeleton()
+            info["default_skeleton"] = (
+                sample_collection._serialize_default_skeleton()
+            )
 
         if sample_collection.app_config.is_custom():
             info["app_config"] = sample_collection.app_config.to_dict(

--- a/tests/unittests/utils/test_unique_filename_maker.py
+++ b/tests/unittests/utils/test_unique_filename_maker.py
@@ -210,7 +210,7 @@ def test_non_existent_input_paths(default_ext):
         pytest.param(
             {"chunk_size": 100},
             focu.InMemoryUniqueFilenameMaker,
-            id="chunk_size-is-set",
+            id="chunk_size-set",
         ),
         pytest.param(
             {}, focu.MultiProcessUniqueFilenameMaker, id="chunk_size-unset"

--- a/tests/unittests/utils/test_unique_filename_maker.py
+++ b/tests/unittests/utils/test_unique_filename_maker.py
@@ -1,0 +1,252 @@
+import multiprocessing
+import os
+import random
+import shutil
+import tempfile
+import time
+from typing import Any, Dict, Optional, Union, Type
+
+import pytest
+
+import fiftyone.core.utils as focu
+
+
+INPUT_PATHS = [
+    "alpha",
+    "alpha.jpg",
+    "alpha.jpg",
+    "alpha.png",
+    "bravo.png",
+    "bravo.png",
+    "bravo.png",
+    "charlie.jpg",
+    "charlie.png",
+    "delta.png",
+    "echo",
+    "echo.jpg",
+    "echo.png",
+    "foxtrot.png",
+    "foxtrot.png",
+    "foxtrot.png",
+    "golf.jpg",
+    "golf.png",
+    "hotel.png",
+    "india.jpg",
+    "india.png",
+    "juliet",
+    "juliet.png",
+]
+
+
+@pytest.fixture(autouse=True, scope="session")
+def cleanup():
+    """cleanup after all tests complete"""
+    pid = os.getpid()
+
+    yield
+
+    # registered `atexit` cleanup function is not working with pytest, however
+    # it does work when manually running
+    # cleaning up touched files after the session finishes
+    try:
+        shutil.rmtree(f"/tmp/fo-unq/{pid}")
+    except Exception:
+        ...
+
+
+@pytest.mark.parametrize(
+    "existing_filepaths",
+    (
+        pytest.param(set(), id="empty-directory"),
+        pytest.param(set([INPUT_PATHS[0]]), id="one-file-exists"),
+        pytest.param(
+            {i for i in INPUT_PATHS if "alpha" in i},
+            id="some-files-exist",
+        ),
+        pytest.param(set(INPUT_PATHS), id="all-files-exist"),
+    ),
+)
+@pytest.mark.parametrize(
+    "unique_filename_maker_kwargs",
+    (
+        pytest.param({}, id="{idempotent=True}"),
+        pytest.param({"idempotent": False}, id="{idempotent=False}"),
+        pytest.param(
+            {"ignore_existing": True, "idempotent": False},
+            id="{ignore_existing=True, idempotent=False}",
+        ),
+        pytest.param(
+            {"ignore_existing": True},
+            id="{ignore_existing=True, idempotent=True}",
+        ),
+        pytest.param(
+            {"ignore_exts": True, "idempotent": False},
+            id="{ignore_exts=True, idempotent=False}",
+        ),
+        pytest.param(
+            {"ignore_exts": True, "idempotent": True},
+            id="{ignore_exts=True, idempotent=True}",
+        ),
+    ),
+)
+@pytest.mark.parametrize(
+    "unique_filename_maker_cls",
+    (
+        # The following is the original UniqueFilenameMaker just renamed
+        # Uncomment to see that it does not work when run with multiprocessing
+        # ====================================================================
+        # pytest.param(focu.InMemoryUniqueFilenameMaker),
+        # ====================================================================
+        pytest.param(focu.MultiProcessUniqueFilenameMaker),
+    ),
+)
+def test_existing_input_paths(
+    unique_filename_maker_cls,
+    unique_filename_maker_kwargs,
+    existing_filepaths,
+):
+    """test baseline vs parallel with existing input paths"""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        for existing_filepath in existing_filepaths:
+            with open(
+                os.path.join(tmp_dir, existing_filepath),
+                "w",
+                encoding="utf-8",
+            ):
+                ...
+
+        # The following is the original UniqueFilenameMaker just renamed
+        filename_maker = focu.InMemoryUniqueFilenameMaker(
+            tmp_dir, **unique_filename_maker_kwargs
+        )
+
+        # This is the original behavior of `get_output_path``, used as the
+        # baseline.
+        expected = [
+            filename_maker.get_output_path(input_path)
+            for input_path in INPUT_PATHS
+        ]
+
+        # Run multiple workers with their own instance UniqueFilenameMaker and
+        # aggregate the calls to `get_output_path`.
+        with multiprocessing.Pool(
+            processes=4,
+            initializer=initialize_worker,
+            initargs=(
+                unique_filename_maker_cls,
+                tmp_dir,
+                unique_filename_maker_kwargs,
+            ),
+        ) as pool:
+            actual = list(pool.imap_unordered(worker, INPUT_PATHS))
+
+        # Normalize results
+        ignore_exts = unique_filename_maker_kwargs.get("ignore_exts") is True
+        for output_paths in (expected, actual):
+            for idx, output_path in enumerate(output_paths):
+                # The numbering should be the same but the extension might be
+                #  different as the order called isn't ensured.
+                if ignore_exts:
+                    output_path, _ = os.path.splitext(output_path)
+
+                output_paths[idx] = output_path
+
+        assert sorted(expected) == sorted(actual)
+
+
+@pytest.mark.parametrize(
+    "default_ext",
+    (
+        pytest.param(None, id="default_ext=None"),
+        *[
+            pytest.param(ext, id=f"default_ext='{ext}'")
+            for ext in (".jpg", ".jpeg", ".png")
+        ],
+    ),
+)
+def test_non_existent_input_paths(default_ext):
+    """test with input path set to None"""
+
+    with (
+        tempfile.TemporaryDirectory() as tmp_dir_1,
+        tempfile.TemporaryDirectory() as tmp_dir_2,
+    ):
+        input_paths = [None for _ in range(100)]
+
+        # This is the original class just renamed
+        filename_maker = focu.InMemoryUniqueFilenameMaker(
+            tmp_dir_1, default_ext=default_ext
+        )
+
+        expected = [
+            filename_maker.get_output_path(input_path)
+            for input_path in input_paths
+        ]
+
+        with multiprocessing.Pool(
+            processes=4,
+            initializer=initialize_worker,
+            initargs=(
+                focu.MultiProcessUniqueFilenameMaker,
+                tmp_dir_2,
+                {"default_ext": default_ext},
+            ),
+        ) as pool:
+            actual = list(pool.imap_unordered(worker, input_paths))
+
+        assert len(expected) == len(actual)
+
+        if default_ext:
+            for output_paths in (expected, actual):
+                for output_path in output_paths:
+                    _, ext = os.path.splitext(output_path)
+                    assert default_ext == ext
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_cls"),
+    (
+        pytest.param(
+            {"chunk_size": 100},
+            focu.InMemoryUniqueFilenameMaker,
+            id="chunk_size-is-set",
+        ),
+        pytest.param(
+            {}, focu.MultiProcessUniqueFilenameMaker, id="chunk_size-unset"
+        ),
+    ),
+)
+def test_implementation_switch(kwargs, expected_cls):
+    """select unique filename maker implementation"""
+    filename_maker = focu.UniqueFilenameMaker(**kwargs)
+    assert isinstance(filename_maker, expected_cls)
+
+
+def initialize_worker(
+    cls: Type[
+        Union[
+            focu.InMemoryUniqueFilenameMaker,
+            focu.MultiProcessUniqueFilenameMaker,
+        ]
+    ],
+    output_dir: str,
+    unique_filename_maker_kwargs: Optional[Dict[str, Any]] = None,
+) -> None:
+    """initialize multiprocessing worker"""
+
+    # pylint:disable-next=global-variable-undefined
+    global worker_filename_maker
+
+    worker_filename_maker = cls(
+        output_dir, **(unique_filename_maker_kwargs or {})
+    )
+
+
+def worker(input_path: str) -> str:
+    """multiprocessing worker"""
+
+    # random sleep to allow for multiprocessing to get names out of order
+    time.sleep(random.randint(0, 10) / 100)
+
+    return worker_filename_maker.get_output_path(input_path)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Update `UniqueFilenameMaker` to work with multiprocessing. Added a new implementation and kept the old one for chunking and comparison tests. 


As you can see below the original filename maker (renamed from `UniqueFilenameMaker` to `InMemoryUniqueFilenameMaker`) does not return the same output in all cases when run with multiprocessing, while the new filename maker (`MultiProcessUniqueFilenameMaker`) does.

```
[InMemoryUniqueFilenameMaker-{idempotent=True}-empty-directory] PASSED               
[InMemoryUniqueFilenameMaker-{idempotent=True}-one-file-exists] PASSED               
[InMemoryUniqueFilenameMaker-{idempotent=True}-some-files-exist] PASSED              
[InMemoryUniqueFilenameMaker-{idempotent=True}-all-files-exist] PASSED               
[InMemoryUniqueFilenameMaker-{idempotent=False}-empty-directory] FAILED              
[InMemoryUniqueFilenameMaker-{idempotent=False}-one-file-exists] FAILED              
[InMemoryUniqueFilenameMaker-{idempotent=False}-some-files-exist] FAILED             
[InMemoryUniqueFilenameMaker-{idempotent=False}-all-files-exist] FAILED              
[InMemoryUniqueFilenameMaker-{ignore_existing=True, idempotent=False}-empty-directory] FAILED 
[InMemoryUniqueFilenameMaker-{ignore_existing=True, idempotent=False}-one-file-exists] FAILED 
[InMemoryUniqueFilenameMaker-{ignore_existing=True, idempotent=False}-some-files-exist] FAILED 
[InMemoryUniqueFilenameMaker-{ignore_existing=True, idempotent=False}-all-files-exist] FAILED 
[InMemoryUniqueFilenameMaker-{ignore_existing=True, idempotent=True}-empty-directory] PASSED 
[InMemoryUniqueFilenameMaker-{ignore_existing=True, idempotent=True}-one-file-exists] PASSED 
[InMemoryUniqueFilenameMaker-{ignore_existing=True, idempotent=True}-some-files-exist] PASSED 
[InMemoryUniqueFilenameMaker-{ignore_existing=True, idempotent=True}-all-files-exist] PASSED 
[InMemoryUniqueFilenameMaker-{ignore_exts=True, idempotent=False}-empty-directory] FAILED 
[InMemoryUniqueFilenameMaker-{ignore_exts=True, idempotent=False}-one-file-exists] FAILED 
[InMemoryUniqueFilenameMaker-{ignore_exts=True, idempotent=False}-some-files-exist] FAILED 
[InMemoryUniqueFilenameMaker-{ignore_exts=True, idempotent=False}-all-files-exist] FAILED 
[InMemoryUniqueFilenameMaker-{ignore_exts=True, idempotent=True}-empty-directory] PASSED 
[InMemoryUniqueFilenameMaker-{ignore_exts=True, idempotent=True}-one-file-exists] PASSED 
[InMemoryUniqueFilenameMaker-{ignore_exts=True, idempotent=True}-some-files-exist] PASSED 
[InMemoryUniqueFilenameMaker-{ignore_exts=True, idempotent=True}-all-files-exist] PASSED 

[MultiProcessUniqueFilenameMaker-{idempotent=True}-empty-directory] PASSED           
[MultiProcessUniqueFilenameMaker-{idempotent=True}-one-file-exists] PASSED           
[MultiProcessUniqueFilenameMaker-{idempotent=True}-some-files-exist] PASSED          
[MultiProcessUniqueFilenameMaker-{idempotent=True}-all-files-exist] PASSED           
[MultiProcessUniqueFilenameMaker-{idempotent=False}-empty-directory] PASSED          
[MultiProcessUniqueFilenameMaker-{idempotent=False}-one-file-exists] PASSED          
[MultiProcessUniqueFilenameMaker-{idempotent=False}-some-files-exist] PASSED         
[MultiProcessUniqueFilenameMaker-{idempotent=False}-all-files-exist] PASSED          
[MultiProcessUniqueFilenameMaker-{ignore_existing=True, idempotent=False}-empty-directory] PASSED 
[MultiProcessUniqueFilenameMaker-{ignore_existing=True, idempotent=False}-one-file-exists] PASSED 
[MultiProcessUniqueFilenameMaker-{ignore_existing=True, idempotent=False}-some-files-exist] PASSED 
[MultiProcessUniqueFilenameMaker-{ignore_existing=True, idempotent=False}-all-files-exist] PASSED 
[MultiProcessUniqueFilenameMaker-{ignore_existing=True, idempotent=True}-empty-directory] PASSED 
[MultiProcessUniqueFilenameMaker-{ignore_existing=True, idempotent=True}-one-file-exists] PASSED 
[MultiProcessUniqueFilenameMaker-{ignore_existing=True, idempotent=True}-some-files-exist] PASSED 
[MultiProcessUniqueFilenameMaker-{ignore_existing=True, idempotent=True}-all-files-exist] PASSED 
[MultiProcessUniqueFilenameMaker-{ignore_exts=True, idempotent=False}-empty-directory] PASSED 
[MultiProcessUniqueFilenameMaker-{ignore_exts=True, idempotent=False}-one-file-exists] PASSED 
[MultiProcessUniqueFilenameMaker-{ignore_exts=True, idempotent=False}-some-files-exist] PASSED 
[MultiProcessUniqueFilenameMaker-{ignore_exts=True, idempotent=False}-all-files-exist] PASSED 
[MultiProcessUniqueFilenameMaker-{ignore_exts=True, idempotent=True}-empty-directory] PASSED 
[MultiProcessUniqueFilenameMaker-{ignore_exts=True, idempotent=True}-one-file-exists] PASSED 
[MultiProcessUniqueFilenameMaker-{ignore_exts=True, idempotent=True}-some-files-exist] PASSED 
[MultiProcessUniqueFilenameMaker-{ignore_exts=True, idempotent=True}-all-files-exist] PASSED 

```

## How is this patch tested? If it is not, please explain why.

Automated test can be executed by running following file with `pytest`:
  - [tests/unittests/utils/test_unique_filename_maker.py](https://github.com/voxel51/fiftyone/compare/project/map-samples...project/map-samples-unique-filename-maker?expand=1#diff-a398ac9496c44cbc8bd7e09b2d0d89d1082774d2bf634dbe91d0daa6ae86d1b8)


Manual testing can be executed by modifying the following code snippet:
```py
import multiprocessing
from typing import Any, Dict, List

import fiftyone.core.utils as focu


# region MODIFY ME
PROCESSES: int = 4
INPUT_PATHS: List[str] = []
OUTPUT_DIR: str = ""
FILENAME_MAKER_KWARGS: Dict[str, Any] = {"output_dir": OUTPUT_DIR}
# endregion MODIFY ME


def initialize_worker(filename_maker_kwargs: Dict[str, Any]) -> None:
    """initialize multiprocessing worker"""

    # pylint:disable-next=global-variable-undefined
    global worker_filename_maker

    worker_filename_maker = focu.MultiProcessUniqueFilenameMaker(
        **filename_maker_kwargs
    )


def worker(input_path: str) -> str:
    """multiprocessing worker"""
    return worker_filename_maker.get_output_path(input_path)


with multiprocessing.Pool(
    processes=PROCESSES,
    initializer=initialize_worker,
    initargs=(FILENAME_MAKER_KWARGS),
) as pool:
    for output_path in pool.imap_unordered(worker, INPUT_PATHS):
        print(output_path)


```


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
