### PR TITLE
Fix resolving builtin plugin dir

### DIFF
--- a/fiftyone/plugins/constants.py
+++ b/fiftyone/plugins/constants.py
@@ -5,8 +5,6 @@ FiftyOne plugins constants.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import os
+from importlib.resources import files
 
-BUILTIN_PLUGINS_DIR = os.path.normpath(
-    os.path.join(os.path.dirname(__file__), "..", "..", "plugins")
-)
+BUILTIN_PLUGINS_DIR = files("fiftyone").joinpath("plugins")

--- a/fiftyone/plugins/constants.py
+++ b/fiftyone/plugins/constants.py
@@ -6,5 +6,9 @@ FiftyOne plugins constants.
 |
 """
 from importlib.resources import files
+from pathlib import Path
 
-BUILTIN_PLUGINS_DIR = files("fiftyone").joinpath("plugins")
+current_file = Path(__file__).resolve()
+BUILTIN_PLUGINS_DIR = current_file.parent.parent.parent / "plugins"
+
+print(BUILTIN_PLUGINS_DIR)

--- a/fiftyone/plugins/constants.py
+++ b/fiftyone/plugins/constants.py
@@ -5,10 +5,8 @@ FiftyOne plugins constants.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-from importlib.resources import files
+
 from pathlib import Path
 
 current_file = Path(__file__).resolve()
 BUILTIN_PLUGINS_DIR = current_file.parent.parent.parent / "plugins"
-
-print(BUILTIN_PLUGINS_DIR)

--- a/fiftyone/plugins/definitions.py
+++ b/fiftyone/plugins/definitions.py
@@ -47,7 +47,7 @@ class PluginDefinition(object):
     @property
     def builtin(self):
         """Whether the plugin is a builtin plugin."""
-        return self.directory.startswith(fpc.BUILTIN_PLUGINS_DIR)
+        return self.directory.startswith(str(fpc.BUILTIN_PLUGINS_DIR))
 
     @property
     def shadow_paths(self):


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Make BUILTIN_PLUGIN_DIR path safe for multiple platforms (windows) and notebooks
- potential fix for https://github.com/voxel51/fiftyone/issues/5484

## How is this patch tested? If it is not, please explain why.

- verified that app launches on mac
- TODO: verify fixes windows issues

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
