### PR TITLE
add compressor and transfer method configuration options to API docs

### DIFF
--- a/docs/source/enterprise/api_connection.rst
+++ b/docs/source/enterprise/api_connection.rst
@@ -36,7 +36,8 @@ FiftyOne config as described below:
 |                               |                                       |                               | generate one.                                                                          |
 +-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `api_compressor`              | `FIFTYONE_API_COMPRESSOR`             | `lz4`                         | If data being sent to the server should be compressed. Recommended when on VPN or      |
-|                               |                                       |                               | poor internet connection. Defaults to `lz4` but accepts `''` (None), `bz2` and `lzma`. |
+|                               |                                       |                               | poor internet connection. Defaults to `lz4` but accepts `''` (None), `bz2`, `zlib` and |
+|                               |                                       |                               | `lzma`.                                                                                |
 +-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `api_transfer_method`         | `FIFTYONE_API_TRANSFER_METHOD`        | `bytes`                       | How data should be encoded and transferred to the server. Default is `bytes` but       |
 |                               |                                       |                               | accepts `str` as well which will base64 encode and convert to string before sending.   |

--- a/docs/source/enterprise/api_connection.rst
+++ b/docs/source/enterprise/api_connection.rst
@@ -38,7 +38,7 @@ FiftyOne config as described below:
 | `api_compressor`              | `FIFTYONE_API_COMPRESSOR`             | `lz4`                         | If data being sent to the server should be compressed. Recommended when on VPN or      |
 |                               |                                       |                               | poor internet connection. Defaults to `lz4` but accepts None, `bz2` and `lzma`.        |
 +-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `api_transfer_method`         | `FIFTYONE_API_TRANSFER_METHOD`        | `bytes`                       | How data should be encoded and transfered to the server. Default is `bytes` but        |
+| `api_transfer_method`         | `FIFTYONE_API_TRANSFER_METHOD`        | `bytes`                       | How data should be encoded and transferred to the server. Default is `bytes` but       |
 |                               |                                       |                               | accepts `str` as well which will base64 encode and convert to string before sending.   |
 +-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 

--- a/docs/source/enterprise/api_connection.rst
+++ b/docs/source/enterprise/api_connection.rst
@@ -27,13 +27,20 @@ Configuring an API connection
 You can configure an API connection by adding an API URI and API key to your
 FiftyOne config as described below:
 
-+-------------------------------+-------------------------------------+--------------------------------------------------------------------------------------------------+
-| Config field                  | Environment variable                | Description                                                                                      |
-+===============================+=====================================+==================================================================================================+
-| `api_uri`                     | `FIFTYONE_API_URI`                  | The URI of your FiftyOne Enterprise API. Ask your deployment admin for this value.               |
-+-------------------------------+-------------------------------------+--------------------------------------------------------------------------------------------------+
-| `api_key`                     | `FIFTYONE_API_KEY`                  | Your FiftyOne Enterprise API key. :ref:`See here <enterprise-generate-api-key>` to generate one. |
-+-------------------------------+-------------------------------------+--------------------------------------------------------------------------------------------------+
++-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| Config field                  | Environment variable                  | Default value                 | Description                                                                            |
++===============================+=======================================+===============================+========================================================================================+
+| `api_uri`                     | `FIFTYONE_API_URI`                    | `None`                        | The URI of your FiftyOne Enterprise API. Ask your deployment admin for this value.     |
++-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `api_key`                     | `FIFTYONE_API_KEY`                    | `None`                        | Your FiftyOne Enterprise API key. :ref:`See here <enterprise-generate-api-key>` to     |
+|                               |                                       |                               | generate one.                                                                          |
++-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `api_compressor`              | `FIFTYONE_API_COMPRESSOR`             | `lz4`                         | If data being sent to the server should be compressed. Recommended when on VPN or      |
+|                               |                                       |                               | poor internet connection. Defaults to `lz4` but accepts None, `bz2` and `lzma`.        |
++-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `api_transfer_method`         | `FIFTYONE_API_TRANSFER_METHOD`        | `bytes`                       | How data should be encoded and transfered to the server. Default is `bytes` but        |
+|                               |                                       |                               | accepts `str` as well which will base64 encode and convert to string before sending.   |
++-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 
 For example, you can set environment variables:
 

--- a/docs/source/enterprise/api_connection.rst
+++ b/docs/source/enterprise/api_connection.rst
@@ -36,7 +36,7 @@ FiftyOne config as described below:
 |                               |                                       |                               | generate one.                                                                          |
 +-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `api_compressor`              | `FIFTYONE_API_COMPRESSOR`             | `lz4`                         | If data being sent to the server should be compressed. Recommended when on VPN or      |
-|                               |                                       |                               | poor internet connection. Defaults to `lz4` but accepts `''` (None), `bz2` and `lzma`.   |
+|                               |                                       |                               | poor internet connection. Defaults to `lz4` but accepts `''` (None), `bz2` and `lzma`. |
 +-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `api_transfer_method`         | `FIFTYONE_API_TRANSFER_METHOD`        | `bytes`                       | How data should be encoded and transferred to the server. Default is `bytes` but       |
 |                               |                                       |                               | accepts `str` as well which will base64 encode and convert to string before sending.   |

--- a/docs/source/enterprise/api_connection.rst
+++ b/docs/source/enterprise/api_connection.rst
@@ -36,7 +36,7 @@ FiftyOne config as described below:
 |                               |                                       |                               | generate one.                                                                          |
 +-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `api_compressor`              | `FIFTYONE_API_COMPRESSOR`             | `lz4`                         | If data being sent to the server should be compressed. Recommended when on VPN or      |
-|                               |                                       |                               | poor internet connection. Defaults to `lz4` but accepts `` (None), `bz2` and `lzma`.   |
+|                               |                                       |                               | poor internet connection. Defaults to `lz4` but accepts `''` (None), `bz2` and `lzma`.   |
 +-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `api_transfer_method`         | `FIFTYONE_API_TRANSFER_METHOD`        | `bytes`                       | How data should be encoded and transferred to the server. Default is `bytes` but       |
 |                               |                                       |                               | accepts `str` as well which will base64 encode and convert to string before sending.   |

--- a/docs/source/enterprise/api_connection.rst
+++ b/docs/source/enterprise/api_connection.rst
@@ -36,7 +36,7 @@ FiftyOne config as described below:
 |                               |                                       |                               | generate one.                                                                          |
 +-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `api_compressor`              | `FIFTYONE_API_COMPRESSOR`             | `lz4`                         | If data being sent to the server should be compressed. Recommended when on VPN or      |
-|                               |                                       |                               | poor internet connection. Defaults to `lz4` but accepts None, `bz2` and `lzma`.        |
+|                               |                                       |                               | poor internet connection. Defaults to `lz4` but accepts `` (None), `bz2` and `lzma`.   |
 +-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `api_transfer_method`         | `FIFTYONE_API_TRANSFER_METHOD`        | `bytes`                       | How data should be encoded and transferred to the server. Default is `bytes` but       |
 |                               |                                       |                               | accepts `str` as well which will base64 encode and convert to string before sending.   |


### PR DESCRIPTION
## What changes are proposed in this pull request?

add compressor and transfer method configuration options to API docs

## How is this patch tested? If it is not, please explain why.

n/a

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced the API connection documentation with a new table format that includes default values for configuration settings.
- **New Features**
  - Introduced new configuration options for data compression (defaulting to "lz4") and data transfer method (defaulting to "bytes" with base64 encoding option).
  - Clarified default values for existing connection parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->