### PR TITLE
Automatically update `last_modified_at` when deleting samples/frames

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -4949,6 +4949,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         self._clear()
 
     def _clear(self, view=None, sample_ids=None):
+        now = datetime.utcnow()
+
         if view is not None:
             contains_videos = view._contains_videos(any_slice=True)
 
@@ -4966,15 +4968,14 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             )
 
             for _ids in fou.iter_batches(sample_ids, batch_size):
-                ops.append(
-                    DeleteMany(
-                        {"_id": {"$in": [ObjectId(_id) for _id in _ids]}}
-                    )
-                )
+                _oids = [ObjectId(_id) for _id in _ids]
+                ops.append(DeleteMany({"_id": {"$in": _oids}}))
         else:
             ops.append(DeleteMany({}))
 
         foo.bulk_write(ops, self._sample_collection)
+        self._update_last_modified_at(now)
+
         fos.Sample._reset_docs(
             self._sample_collection_name, sample_ids=sample_ids
         )
@@ -5050,6 +5051,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if not sample_collection._contains_videos(any_slice=True):
             return
 
+        now = datetime.utcnow()
+
         if self._is_clips:
             if sample_ids is not None:
                 view = self.select(sample_ids)
@@ -5060,22 +5063,41 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 frame_ids = view.values("frames.id", unwind=True)
 
         if frame_ids is not None:
-            ops = []
+            sample_ids = []
+            sample_ops = []
+            frame_ops = []
+
             batch_size = fou.recommend_batch_size_for_value(
                 ObjectId(), max_size=100000
             )
 
             for _ids in fou.iter_batches(frame_ids, batch_size):
-                ops.append(
-                    DeleteMany(
-                        {"_id": {"$in": [ObjectId(_id) for _id in _ids]}}
-                    )
+                _frame_ids = [ObjectId(_id) for _id in _ids]
+                _sample_ids = list(
+                    self._frame_collection.find(
+                        {"_id": {"$in": _frame_ids}}
+                    ).distinct("_sample_id")
                 )
 
-            foo.bulk_write(ops, self._frame_collection)
+                sample_ids.extend(_sample_ids)
+                sample_ops.append(
+                    UpdateMany(
+                        {"_id": {"$in": _sample_ids}},
+                        {"$set": {"last_modified_at": now}},
+                    )
+                )
+                frame_ops.append(DeleteMany({"_id": {"$in": _frame_ids}}))
+
+            foo.bulk_write(frame_ops, self._frame_collection)
+            foo.bulk_write(sample_ops, self._sample_collection)
+
+            fos.Sample._reload_docs(
+                self._sample_collection_name, sample_ids=sample_ids
+            )
             fofr.Frame._reset_docs_by_frame_id(
                 self._frame_collection_name, frame_ids
             )
+
             return
 
         if view is not None:
@@ -5084,26 +5106,34 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
             sample_ids = view.values("id")
 
-        ops = []
+        sample_ops = []
+        frame_ops = []
         if sample_ids is not None:
             batch_size = fou.recommend_batch_size_for_value(
                 ObjectId(), max_size=100000
             )
 
             for _ids in fou.iter_batches(sample_ids, batch_size):
-                ops.append(
-                    DeleteMany(
-                        {
-                            "_sample_id": {
-                                "$in": [ObjectId(_id) for _id in _ids]
-                            }
-                        }
+                _oids = [ObjectId(_id) for _id in _ids]
+                sample_ops.append(
+                    UpdateMany(
+                        {"_id": {"$in": _oids}},
+                        {"$set": {"last_modified_at": now}},
                     )
                 )
+                frame_ops.append(DeleteMany({"_sample_id": {"$in": _oids}}))
         else:
-            ops.append(DeleteMany({}))
+            sample_ops.append(
+                UpdateMany({}, {"$set": {"last_modified_at": now}})
+            )
+            frame_ops.append(DeleteMany({}))
 
-        foo.bulk_write(ops, self._frame_collection)
+        foo.bulk_write(frame_ops, self._frame_collection)
+        foo.bulk_write(sample_ops, self._sample_collection)
+
+        fos.Sample._reload_docs(
+            self._sample_collection_name, sample_ids=sample_ids
+        )
         fofr.Frame._reset_docs(
             self._frame_collection_name, sample_ids=sample_ids
         )
@@ -5118,6 +5148,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         if view is None:
             return
+
+        now = datetime.utcnow()
 
         if view.media_type == fom.GROUP:
             view = view.select_group_slices(media_type=fom.VIDEO)
@@ -5140,13 +5172,14 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 ["id", "frames.frame_number"]
             )
 
-        ops = []
+        sample_ops = []
+        frame_ops = []
         for sample_id, fns in zip(sample_ids, frame_numbers):
             # Note: this may fail if `fns` is too large (eg >100k frames), but
             # to address this we'd need to do something like lookup all frame
             # numbers on the dataset and reverse the $not in-memory, which
             # would be quite expensive...
-            ops.append(
+            frame_ops.append(
                 DeleteMany(
                     {
                         "_sample_id": ObjectId(sample_id),
@@ -5155,10 +5188,22 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 )
             )
 
-        if not ops:
+        if not frame_ops:
             return
 
-        foo.bulk_write(ops, self._frame_collection)
+        sample_ops.append(
+            UpdateMany(
+                {"_id": {"$in": [ObjectId(_id) for _id in set(sample_ids)]}},
+                {"$set": {"last_modified_at": now}},
+            )
+        )
+
+        foo.bulk_write(frame_ops, self._frame_collection)
+        foo.bulk_write(sample_ops, self._sample_collection)
+
+        fos.Sample._reload_docs(
+            self._sample_collection_name, sample_ids=sample_ids
+        )
         for sample_id, fns in zip(sample_ids, frame_numbers):
             fofr.Frame._reset_docs_for_sample(
                 self._frame_collection_name, sample_id, fns, keep=True
@@ -8092,6 +8137,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             return
 
         self._doc._update_last_loaded_at()
+
+    def _update_last_modified_at(self, last_modified_at=None):
+        self._doc._update_last_modified_at(last_modified_at=last_modified_at)
 
 
 def _get_random_characters(n):

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -800,6 +800,13 @@ class Document(BaseDocument, mongoengine.Document):
         self.last_loaded_at = datetime.utcnow()
         self.save(virtual=True)
 
+    def _update_last_modified_at(self, last_modified_at=None):
+        if last_modified_at is None:
+            last_modified_at = datetime.utcnow()
+
+        self.last_modified_at = last_modified_at
+        self.save(virtual=True)
+
     def _do_updates(self, _id, updates, upsert):
         updated_existing = True
 

--- a/fiftyone/core/singletons.py
+++ b/fiftyone/core/singletons.py
@@ -120,7 +120,7 @@ class SampleSingleton(DocumentSingleton):
 
     def _reload_instance(cls, obj):
         # pylint: disable=no-value-for-parameter
-        cls._reload_doc(obj._doc.collection_name, obj.id)
+        cls._reload_doc(obj._doc.collection_name, obj.id, include_frames=True)
 
     def _rename_fields(cls, collection_name, field_names, new_field_names):
         """Renames the field on all in-memory samples in the collection."""
@@ -154,7 +154,9 @@ class SampleSingleton(DocumentSingleton):
             for field_name in field_names:
                 sample._doc._data.pop(field_name, None)
 
-    def _reload_doc(cls, collection_name, sample_id, hard=False):
+    def _reload_doc(
+        cls, collection_name, sample_id, hard=False, include_frames=False
+    ):
         """Reloads the backing document for the given sample if it is
         in-memory.
         """
@@ -163,9 +165,11 @@ class SampleSingleton(DocumentSingleton):
 
         sample = cls._instances[collection_name].get(str(sample_id), None)
         if sample is not None:
-            sample.reload(hard=hard)
+            sample.reload(hard=hard, include_frames=include_frames)
 
-    def _reload_docs(cls, collection_name, sample_ids=None, hard=False):
+    def _reload_docs(
+        cls, collection_name, sample_ids=None, hard=False, include_frames=False
+    ):
         """Reloads the backing documents for in-memory samples in the
         collection.
 
@@ -180,12 +184,14 @@ class SampleSingleton(DocumentSingleton):
             sample_ids = set(str(_id) for _id in sample_ids)
             for sample in samples.values():
                 if sample.id in sample_ids:
-                    sample.reload(hard=hard)
+                    sample.reload(hard=hard, include_frames=include_frames)
         else:
             for sample in samples.values():
-                sample.reload(hard=hard)
+                sample.reload(hard=hard, include_frames=include_frames)
 
-    def _sync_docs(cls, collection_name, sample_ids, hard=False):
+    def _sync_docs(
+        cls, collection_name, sample_ids, hard=False, include_frames=False
+    ):
         """Syncs the backing documents for all in-memory samples in the
         collection according to the following rules:
 
@@ -201,7 +207,7 @@ class SampleSingleton(DocumentSingleton):
         reset_ids = set()
         for sample in samples.values():
             if sample.id in sample_ids:
-                sample.reload(hard=hard)
+                sample.reload(hard=hard, include_frames=include_frames)
             else:
                 reset_ids.add(sample.id)
                 sample._reset_backing_doc()

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -616,6 +616,46 @@ class DatasetTests(unittest.TestCase):
         self.assertEqual(last_modified_at2, last_modified_at1)
 
     @drop_datasets
+    def test_last_modified_at_deletions(self):
+        samples = [
+            fo.Sample(filepath="image1.jpg"),
+            fo.Sample(filepath="image2.png"),
+            fo.Sample(filepath="image3.jpg"),
+            fo.Sample(filepath="image4.jpg"),
+            fo.Sample(filepath="image5.jpg"),
+            fo.Sample(filepath="image6.jpg"),
+        ]
+
+        dataset = fo.Dataset()
+        dataset.add_samples(samples)
+
+        last_modified_at1 = dataset.last_modified_at
+
+        dataset[:5].keep()
+        last_modified_at2 = dataset.last_modified_at
+
+        self.assertEqual(len(dataset), 5)
+        self.assertTrue(last_modified_at2 > last_modified_at1)
+
+        dataset[-1:].clear()
+        last_modified_at3 = dataset.last_modified_at
+
+        self.assertEqual(len(dataset), 4)
+        self.assertTrue(last_modified_at3 > last_modified_at2)
+
+        dataset.delete_samples(dataset[:2])
+        last_modified_at4 = dataset.last_modified_at
+
+        self.assertEqual(len(dataset), 2)
+        self.assertTrue(last_modified_at4 > last_modified_at3)
+
+        dataset.clear()
+        last_modified_at5 = dataset.last_modified_at
+
+        self.assertEqual(len(dataset), 0)
+        self.assertTrue(last_modified_at5 > last_modified_at4)
+
+    @drop_datasets
     def test_indexes(self):
         dataset = fo.Dataset()
 

--- a/tests/unittests/video_tests.py
+++ b/tests/unittests/video_tests.py
@@ -743,6 +743,120 @@ class VideoTests(unittest.TestCase):
         self.assertNotEqual(frame3.id, frame_id)
 
     @drop_datasets
+    def test_last_modified_at_deletions(self):
+        samples = [
+            fo.Sample(
+                filepath=f"video{i}.mp4",
+                metadata=fo.VideoMetadata(total_frame_count=5),
+            )
+            for i in range(4)
+        ]
+
+        dataset = fo.Dataset()
+        dataset.add_samples(samples)
+
+        dataset.ensure_frames()
+        last_modified_at1 = dataset.last_modified_at
+        last_modified_at2 = dataset.max("last_modified_at")
+
+        self.assertEqual(dataset.count("frames"), 20)
+
+        frame_ids = dataset.match_frames(F("frame_number") == 5).values(
+            "frames.id", unwind=True
+        )
+        dataset.delete_frames(frame_ids)
+        last_modified_at3 = dataset.max("last_modified_at")
+
+        self.assertEqual(dataset.count("frames"), 16)
+        self.assertTrue(last_modified_at3 > last_modified_at2)
+
+        dataset.match_frames(F("frame_number") <= 2).keep_frames()
+        last_modified_at4 = dataset.max("last_modified_at")
+
+        self.assertEqual(dataset.count("frames"), 8)
+        self.assertTrue(last_modified_at4 > last_modified_at3)
+
+        dataset[:2].clear_frames()
+        last_modified_at5 = dataset.max("last_modified_at")
+
+        self.assertEqual(dataset.count("frames"), 4)
+        self.assertTrue(last_modified_at5 > last_modified_at4)
+
+        dataset.clear_frames()
+        last_modified_at6 = dataset.max("last_modified_at")
+
+        self.assertEqual(dataset.count("frames"), 0)
+        self.assertTrue(last_modified_at6 > last_modified_at5)
+
+        dataset.reload()
+        last_modified_at7 = dataset.last_modified_at
+
+        self.assertEqual(last_modified_at1, last_modified_at7)
+
+        dataset.sync_last_modified_at()
+        last_modified_at8 = dataset.last_modified_at
+
+        self.assertTrue(last_modified_at8 > last_modified_at7)
+
+    @drop_datasets
+    def test_last_modified_at_deletions_frames(self):
+        samples = [
+            fo.Sample(
+                filepath=f"video{i}.mp4",
+                metadata=fo.VideoMetadata(total_frame_count=5),
+            )
+            for i in range(2)
+        ]
+
+        dataset = fo.Dataset()
+        dataset.add_samples(samples)
+
+        dataset.ensure_frames()
+        last_modified_at1 = dataset.last_modified_at
+
+        self.assertEqual(dataset.count("frames"), 10)
+
+        sample = dataset.first()
+        last_modified_at2 = sample.last_modified_at
+
+        del sample.frames[1]
+        del sample.frames[3]
+        del sample.frames[5]
+
+        sample.save()
+        last_modified_at3 = sample.last_modified_at
+
+        self.assertEqual(dataset.count("frames"), 7)
+        self.assertTrue(last_modified_at3 > last_modified_at2)
+
+        sample.reload()
+        last_modified_at4 = sample.last_modified_at
+
+        self.assertEqual(last_modified_at4, last_modified_at3)
+
+        sample.frames.clear()
+        sample.save()
+        last_modified_at5 = sample.last_modified_at
+
+        self.assertEqual(dataset.count("frames"), 5)
+        self.assertTrue(last_modified_at5 > last_modified_at4)
+
+        sample.reload()
+        last_modified_at6 = sample.last_modified_at
+
+        self.assertEqual(last_modified_at6, last_modified_at5)
+
+        dataset.reload()
+        last_modified_at7 = dataset.last_modified_at
+
+        self.assertEqual(last_modified_at7, last_modified_at1)
+
+        dataset.sync_last_modified_at()
+        last_modified_at8 = dataset.last_modified_at
+
+        self.assertTrue(last_modified_at8 > last_modified_at7)
+
+    @drop_datasets
     def test_save_frame_view(self):
         dataset = fo.Dataset()
 


### PR DESCRIPTION
## Change log

- `Dataset.last_modified_at` is now automatically updated when samples are deleted
- `Sample.last_modified_at` is now automatically updated when frames are deleted

## Motivation

Currently the behavior of the `last_modified_at` properties of datasets/samples/frames is as follows:
1. Modifications to a dataset's schema/metadata automatically increment `Dataset.last_modified_at`
2. Modifications to samples automatically increment `Sample.last_modified_at`
3. Modifications to frames automatically increment `Frame.last_modified_at`
4. Users can call `Dataset.sync_last_modified_at()` to manually pull timestamps "up one level":
    - `Dataset.last_modified_at` is increased if samples have been updated more recently than the dataset's metadata
    - `Sample.last_modified_at` is increased if that sample's frames have been updated more recently than the sample itself

This current logic leaves a gap: if a user **deletes** a sample/frame, then (unless that sample/frame happens to be the *newest*), there is no way to detect that a change has been made via the available mechanisms:
- `dataset.last_modified_at`: currently only tracks last update to dataset metadata
- `dataset.max("last_modified_at")`: currently only tracks last update to *currently existing* samples
- `dataset.max("frames.last_modified_at")`: currently only tracks last update to *currently existing* frames

With this PR, there is now an available mechanism to check for sample/frame deletions:
- Check `dataset.last_modified_at` to see if samples have been deleted 
- Check `dataset.max("last_modified_at")` to see if frames have been deleted

## Use case 

Why might one care about detecting deletions? Detecting when saved views need to be refreshed for example! https://github.com/voxel51/fiftyone-plugins/pull/122

## Implementation discussion

It is noted that the chosen implementation (automatic syncing "one level up") is inconsistent with Point 4 above (manual syncing "one level up"). But something needed to be done.

So, why did we choose "manual syncing" in Point 4 rather than "automatic syncing" in the first place? The thinking was that edits are extremely common, and thus it would be very expensive to increment `last_modified_at` in another collection as a side effect of a sample/frame update. Instead, we chose to index `last_modified_at` by default so that operations like `dataset.max("last_modified_at")` are performant.

Deletions are far less common operations (and moreover they are usually *batched*; indeed we only have `delete_samples()` and `delete_frames()` and no singular counterparts) so the cost of the extra `$set` for deletions is typically negligible.

## Example usage

### Image datasets

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
last_modified_at1 = dataset.last_modified_at

# DatasetView.keep()
dataset.take(150).keep()
last_modified_at2 = dataset.last_modified_at
assert last_modified_at2 > last_modified_at1

# DatasetView.clear()
dataset.take(50).clear()
last_modified_at3 = dataset.last_modified_at
assert last_modified_at3 > last_modified_at2

# Dataset.delete_samples()
dataset.delete_samples(dataset.take(50))
last_modified_at4 = dataset.last_modified_at
assert last_modified_at4 > last_modified_at3

# Dataset.clear()
dataset.clear()
last_modified_at5 = dataset.last_modified_at
assert last_modified_at5 > last_modified_at4
```

### Video datasets

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart-video")
last_modified_at1 = dataset.last_modified_at

# Dataset.delete_samples()
dataset.delete_samples(dataset.take(1))
last_modified_at2 = dataset.last_modified_at
assert last_modified_at2 > last_modified_at1

# Dataset.delete_frames()
frame_ids = dataset.match_frames(F("frame_number") > 100).values("frames.id", unwind=True)
dataset.delete_frames(frame_ids)
last_modified_at3 = dataset.max("last_modified_at")
assert last_modified_at3 > last_modified_at2

# DatasetView.keep_frames()
dataset.match_frames(F("frame_number") <= 50).keep_frames()
last_modified_at4 = dataset.max("last_modified_at")
assert last_modified_at4 > last_modified_at3

# DatasetView.clear_frames()
dataset.take(4).clear_frames()
last_modified_at5 = dataset.max("last_modified_at")
assert last_modified_at5 > last_modified_at4

# Dataset.clear_frames()
dataset.clear_frames()
last_modified_at6 = dataset.max("last_modified_at")
assert last_modified_at6 > last_modified_at5

# Frame deletions increment Sample.last_modified_at but *not* Dataset.last_modified_at
last_modified_at7 = dataset.last_modified_at
assert last_modified_at7 == last_modified_at2

# Call Dataset.sync_last_modified_at() to update Dataset.last_modified_at
dataset.sync_last_modified_at()
last_modified_at8 = dataset.last_modified_at
assert last_modified_at8 > last_modified_at7
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced dataset tracking now updates modification timestamps automatically after sample and video frame changes.
  - Improved video sample handling with optional reloading of frame data for more precise control.
  
- **Tests**
  - Added comprehensive tests ensuring modification timestamps accurately reflect changes to dataset and video content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->