### PR TITLE
FOTD: added skip_failures

### DIFF
--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -1491,6 +1491,10 @@ class FiftyOneTorchDataset(Dataset):
         local_process_group (None) - only pass if running Distributed Data Parallel (DDP).
             The process group with each of the processes running the main train script
             on the machine this object is on.
+        skip_failures (False): whether to skip failures when loading samples.
+            If True, the dataset will return the exception that occurred in place of the
+            resulting get_item value.
+            If False, the code will fail normally.
 
     Notes:
         General:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Added `skip_failures` to FOTD.
Added a test.

to test:

```python
dataset = ...
torch_dataset = dataset.to_torch(get_item, skip_failures=True)
```

## How is this patch tested? If it is not, please explain why.
Added a test.

## Release Notes
N/A
### Is this a user-facing change that should be mentioned in the release notes?
-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other - `fiftyone.utils.torch`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to skip failures when loading samples in Torch datasets, allowing exceptions to be returned as results instead of being raised.
- **Tests**
  - Introduced new tests to verify the behavior of the failure-skipping option in Torch datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->