### PR TITLE
Optimize `split_labels()` and `delete_labels()`

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -2260,9 +2260,7 @@ class SampleCollection(object):
                 created if necessary
         """
         if not isinstance(self, fod.Dataset):
-            # The label IDs that we'll need to delete from `in_field`
-            _, id_path = self._get_label_field_path(in_field, "id")
-            del_ids = self.values(id_path, unwind=True)
+            labels = self._get_selected_labels(fields=in_field)
 
         dataset = self._dataset
         dataset.merge_samples(
@@ -2278,9 +2276,13 @@ class SampleCollection(object):
         )
 
         if isinstance(self, fod.Dataset):
-            dataset.delete_sample_field(in_field)
+            field_name, is_frame_field = self._handle_frame_field(in_field)
+            if is_frame_field:
+                dataset.delete_frame_field(field_name)
+            else:
+                dataset.delete_sample_field(field_name)
         else:
-            dataset.delete_labels(ids=del_ids, fields=in_field)
+            dataset.delete_labels(labels=labels)
 
     def set_values(
         self,

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -3979,11 +3979,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if labels is not None:
             self._delete_labels(labels, fields=fields)
 
-        if ids is None and tags is None and view is None:
-            return
+        if view is not None:
+            labels = view._get_selected_labels(fields=fields)
+            self._delete_labels(labels, fields=fields)
 
-        if view is not None and view._dataset is not self:
-            raise ValueError("`view` must be a view into the same dataset")
+        if ids is None and tags is None:
+            return
 
         if etau.is_str(ids):
             ids = [ids]
@@ -4005,41 +4006,29 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         now = datetime.utcnow()
 
+        batch_size = fou.recommend_batch_size_for_value(
+            ObjectId(), max_size=100000
+        )
+
         sample_ops = []
         frame_ops = []
         for field in fields:
-            if view is not None:
-                _, id_path = view._get_label_field_path(field, "_id")
-                view_ids = _discard_none(view.values(id_path, unwind=True))
-            else:
-                view_ids = None
-
             root, is_list_field = self._get_label_field_root(field)
             root, is_frame_field = self._handle_frame_field(root)
 
             ops = []
             if is_list_field:
-                if view_ids is not None:
-                    ops.append(
-                        UpdateMany(
-                            {root + "._id": {"$in": view_ids}},
-                            {
-                                "$pull": {root: {"_id": {"$in": view_ids}}},
-                                "$set": {"last_modified_at": now},
-                            },
-                        )
-                    )
-
                 if ids is not None:
-                    ops.append(
-                        UpdateMany(
-                            {root + "._id": {"$in": ids}},
-                            {
-                                "$pull": {root: {"_id": {"$in": ids}}},
-                                "$set": {"last_modified_at": now},
-                            },
+                    for _ids in fou.iter_batches(ids, batch_size):
+                        ops.append(
+                            UpdateMany(
+                                {root + "._id": {"$in": _ids}},
+                                {
+                                    "$pull": {root: {"_id": {"$in": _ids}}},
+                                    "$set": {"last_modified_at": now},
+                                },
+                            )
                         )
-                    )
 
                 if tags is not None:
                     ops.append(
@@ -4056,21 +4045,19 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                         )
                     )
             else:
-                if view_ids is not None:
-                    ops.append(
-                        UpdateMany(
-                            {root + "._id": {"$in": view_ids}},
-                            {"$set": {root: None, "last_modified_at": now}},
-                        )
-                    )
-
                 if ids is not None:
-                    ops.append(
-                        UpdateMany(
-                            {root + "._id": {"$in": ids}},
-                            {"$set": {root: None, "last_modified_at": now}},
+                    for _ids in fou.iter_batches(ids, batch_size):
+                        ops.append(
+                            UpdateMany(
+                                {root + "._id": {"$in": _ids}},
+                                {
+                                    "$set": {
+                                        root: None,
+                                        "last_modified_at": now,
+                                    }
+                                },
+                            )
                         )
-                    )
 
                 if tags is not None:
                     ops.append(


### PR DESCRIPTION
## Change log

- optimizes `split_labels()` and `delete_labels(view=view)` syntaxes by using optimized per-sample update operations that can leverage the `_id` index rather than requiring full collection scans
- fixed a "BSON too large" error that would previously occur when deleting a sufficiently long list of IDs via `delete_labels(ids=ids)`

## Tested by

- unit tests added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of label merging and deletion, especially for frame fields and views, ensuring more accurate and robust label management.
- **Tests**
  - Added new tests to verify correct behavior of label splitting and deletion for both sample-level and frame-level label fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->