### PR TITLE
update doc string for "none" compression

### DIFF
--- a/docs/source/enterprise/api_connection.rst
+++ b/docs/source/enterprise/api_connection.rst
@@ -36,7 +36,7 @@ FiftyOne config as described below:
 |                               |                                       |                               | generate one.                                                                          |
 +-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `api_compressor`              | `FIFTYONE_API_COMPRESSOR`             | `lz4`                         | If data being sent to the server should be compressed. Recommended when on VPN or      |
-|                               |                                       |                               | poor internet connection. Defaults to `lz4` but accepts `''` (None), `bz2`, `zlib` and |
+|                               |                                       |                               | poor internet connection. Defaults to `lz4` but accepts `none`, `bz2`, `zlib` and      |
 |                               |                                       |                               | `lzma`.                                                                                |
 +-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `api_transfer_method`         | `FIFTYONE_API_TRANSFER_METHOD`        | `bytes`                       | How data should be encoded and transferred to the server. Default is `bytes` but       |


### PR DESCRIPTION
## What changes are proposed in this pull request?

Update string to be "none" for no compressor used instead of an empty string which would be ignored and default back to lz4.

## How is this patch tested? If it is not, please explain why.

n/a

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to specify that the value to disable API compression is now `none` instead of an empty string. The list of accepted values has been revised accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->