### PR TITLE
bump strawberry to 0.257

### DIFF
--- a/fiftyone/server/aggregate.py
+++ b/fiftyone/server/aggregate.py
@@ -5,6 +5,7 @@ FiftyOne Server aggregations
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from datetime import date, datetime, timedelta
 import typing as t
 
@@ -54,10 +55,12 @@ class StrCountValuesResponse(CountValuesResponse[str]):
     values: t.List[ValueCount[str]]
 
 
-CountValuesResponses = gql.union(
-    "CountValuesResponses",
-    (BoolCountValuesResponse, IntCountValuesResponse, StrCountValuesResponse),
-)
+CountValuesResponses = t.Annotated[
+    t.Union[
+        BoolCountValuesResponse, IntCountValuesResponse, StrCountValuesResponse
+    ],
+    gql.union("CountValuesResponses"),
+]
 COUNT_VALUES_TYPES = {fo.BooleanField, fo.IntField, fo.StringField}
 
 
@@ -105,14 +108,14 @@ class Aggregate:
     histogram_values: t.Optional[HistogramValues] = None
 
 
-HistogramValuesResponses = gql.union(
-    "HistogramValuesResponses",
-    (
+HistogramValuesResponses = t.Annotated[
+    t.Union[
         DatetimeHistogramValuesResponse,
         FloatHistogramValuesResponse,
         IntHistogramValuesResponse,
-    ),
-)
+    ],
+    gql.union("HistogramValuesResponses"),
+]
 
 
 HISTOGRAM_VALUES_TYPES = {
@@ -134,9 +137,8 @@ class AggregateQuery:
         view_name: t.Optional[str] = None,
         form: t.Optional[ExtendedViewForm] = None,
     ) -> t.List[
-        gql.union(
-            "AggregationResponses",
-            (
+        t.Annotated[
+            t.Union[
                 CountResponse,
                 BoolCountValuesResponse,
                 IntCountValuesResponse,
@@ -144,8 +146,9 @@ class AggregateQuery:
                 DatetimeHistogramValuesResponse,
                 FloatHistogramValuesResponse,
                 IntHistogramValuesResponse,
-            ),
-        )
+            ],
+            gql.union("AggregationResponses"),
+        ]
     ]:
         view = await load_view(
             dataset_name=dataset_name,

--- a/fiftyone/server/aggregations.py
+++ b/fiftyone/server/aggregations.py
@@ -96,17 +96,17 @@ class StringAggregation(Aggregation):
     values: t.Optional[t.List[StringAggregationValue]] = None
 
 
-AggregateResult = gql.union(
-    "AggregateResult",
-    (
+AggregateResult = t.Annotated[
+    t.Union[
         BooleanAggregation,
         DataAggregation,
         IntAggregation,
         FloatAggregation,
         RootAggregation,
         StringAggregation,
-    ),
-)
+    ],
+    gql.union("AggregateResult"),
+]
 
 
 async def aggregate_resolver(

--- a/fiftyone/server/lightning.py
+++ b/fiftyone/server/lightning.py
@@ -109,9 +109,8 @@ INT_CLS = {
     fof.IntField: IntLightningResult,
 }
 
-LightningResults = gql.union(
-    "LightningResults",
-    (
+LightningResults = t.Annotated[
+    t.Union[
         BooleanLightningResult,
         DateLightningResult,
         DateTimeLightningResult,
@@ -119,8 +118,9 @@ LightningResults = gql.union(
         IntLightningResult,
         ObjectIdLightningResult,
         StringLightningResult,
-    ),
-)
+    ],
+    gql.union("LightningResults"),
+]
 
 
 async def lightning_resolver(

--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -68,16 +68,13 @@ class VideoSample(Sample):
     frame_rate: float
 
 
-SampleItem = gql.union(
-    "SampleItem",
-    types=(
-        ImageSample,
-        PointCloudSample,
-        ThreeDSample,
-        VideoSample,
-        UnknownSample,
-    ),
-)
+SampleItem = t.Annotated[
+    t.Union[
+        ImageSample, PointCloudSample, ThreeDSample, VideoSample, UnknownSample
+    ],
+    gql.union("SampleItem"),
+]
+
 
 MEDIA_TYPES = collections.defaultdict(lambda: UnknownSample)
 MEDIA_TYPES.update(

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ INSTALL_REQUIRES = [
     "sseclient-py>=1.7.2,<2",
     "sse-starlette>=0.10.3,<1",
     "starlette>=0.24.0",
-    "strawberry-graphql",
+    "strawberry-graphql~=0.257.0",
     "tabulate",
     "xmltodict",
     "universal-analytics-python3>=1.0.1,<2",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Addresses a [vulnerability](https://www.wiz.io/vulnerability-database/cve/cve-2025-22151) in strawberry.

I scanned for all breaking changes between 0.243 and 0.257. `gql.union` syntax was changed in 0.254, and this PR addresses that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal type definitions for union types to improve compatibility with Python typing and GraphQL integration. No changes to user-facing logic or features.
  - Restricted the "strawberry-graphql" package dependency to version 0.257.x for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->