### PR TITLE
`@execution_cache` residency param

### DIFF
--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -2511,6 +2511,11 @@ To cache a function's result scoped to the current ``ctx.dataset``, use the
     def user_specific_query(ctx, path):
         return ctx.dataset.match(F("creator_id") == ctx.user_id).count_values(path)
 
+    @execution_cache(residency="ephemeral")
+    def example_custom_residency(ctx, path):
+        # this value will only be cached in memory
+        return ctx.dataset.count_values(path)
+
     # Bypass the cache
     result = expensive_query.uncached(ctx, path)
 
@@ -2552,6 +2557,10 @@ to the decorator:
 - ``prompt_scoped``: Cache is tied to the current prompt ID
 - ``jwt_scoped``: Cache is tied to the current user's JWT
 - ``serialize`` / ``deserialize``: Custom (de)serialization functions
+- ``residency``: Cache residency policy (default is ``hybrid``)
+
+See the :func:`execution_cache <fiftyone.operators.cache.execution_cache>`
+documentation for more details.
 
 For example, caching a sample using custom serialization:
 

--- a/fiftyone/operators/cache/decorator.py
+++ b/fiftyone/operators/cache/decorator.py
@@ -32,6 +32,7 @@ _FUNC_ATTRIBUTES = [
 def execution_cache(
     _func=None,
     *,
+    residency="transient",
     ttl=None,
     link_to_dataset=True,
     key_fn=None,
@@ -75,6 +76,17 @@ def execution_cache(
             a JSON-serializable value.
         deserialize (None): Custom deserialization given a JSON-serializable value and returns
             the original value.
+        residency ("hybrid"): The residency of the cache. Can be one of:
+            - "transient": Cache is stored in the execution store with policy="evict".
+            - "persistent": Cache is stored in the execution store with policy="persist".
+            - "ephemeral": Cache is stored in memory and is cleared when the process ends.
+            - "hybrid": (default) Combination of transient and ephemeral. Cache is stored in memory
+                and in the execution store. The memory cache is used first, and if
+                the value is not found, it falls back to the execution store.
+        max_size (None): Maximum size of the memory cache. Only applicable for
+            "ephemeral" and "hybrid" residency modes. If not provided, the default
+            size is 128. The cache will evict the least recently used items when
+            the size exceeds this limit.
 
     note::
 
@@ -149,13 +161,14 @@ def execution_cache(
         @wraps(func)
         def wrapper(*args, **kwargs):
             ctx, ctx_index = _get_ctx_from_args(args)
-            cache_key, store, skip_cache = resolve_cache_info(
+            cache_key, store, memory_cache, skip_cache = resolve_cache_info(
                 ctx,
                 ctx_index,
                 args,
                 kwargs,
                 key_fn,
                 func,
+                residency=residency,
                 operator_scoped=operator_scoped,
                 user_scoped=user_scoped,
                 prompt_scoped=prompt_scoped,
@@ -165,20 +178,48 @@ def execution_cache(
             if skip_cache:
                 return func(*args, **kwargs)
 
-            cached_value = store.get(cache_key)
+            # Hybrid and Ephemeral: Check memory cache first
+            if memory_cache is not None and cache_key in memory_cache:
+                cached_value = memory_cache[cache_key]
+                return (
+                    deserialize(cached_value)
+                    if deserialize
+                    else auto_deserialize(cached_value)
+                )
+
+            # Transient/Persistent/Hybrid: Check store (if applicable)
+            cached_value = None
+            if store is not None:
+                cached_value = store.get(cache_key)
+
             if cached_value is not None:
-                if deserialize is not None:
-                    return deserialize(cached_value)
-                else:
-                    return auto_deserialize(cached_value)
+                result = (
+                    deserialize(cached_value)
+                    if deserialize
+                    else auto_deserialize(cached_value)
+                )
 
+                # Hybrid: Warm memory cache
+                if memory_cache is not None:
+                    memory_cache[cache_key] = (
+                        serialize(result)
+                        if serialize
+                        else auto_serialize(result)
+                    )
+
+                return result
+
+            # Cache miss: compute result
             result = func(*args, **kwargs)
+            value_to_cache = (
+                serialize(result) if serialize else auto_serialize(result)
+            )
 
-            if serialize is not None:
-                value_to_cache = serialize(result)
-            else:
-                value_to_cache = auto_deserialize(result)
-            store.set_cache(cache_key, value_to_cache, ttl=ttl)
+            if store is not None:
+                store.set_cache(cache_key, value_to_cache, ttl=ttl)
+
+            if memory_cache is not None:
+                memory_cache[cache_key] = value_to_cache
 
             return result
 
@@ -189,45 +230,54 @@ def execution_cache(
 
         def clear_cache(*args, **kwargs):
             ctx, ctx_index = _get_ctx_from_args(args)
-            cache_key, store, _ = resolve_cache_info(
+            cache_key, store, memory_cache, _ = resolve_cache_info(
                 ctx,
                 ctx_index,
                 args,
                 kwargs,
                 key_fn,
                 func,
+                residency=residency,
                 operator_scoped=operator_scoped,
                 user_scoped=user_scoped,
                 prompt_scoped=prompt_scoped,
                 jwt_scoped=jwt_scoped,
                 collection_name=collection_name,
             )
-            store.delete(cache_key)
+            if store:
+                store.delete(cache_key)
+            if memory_cache is not None and cache_key in memory_cache:
+                del memory_cache[cache_key]
 
         wrapper.clear_cache = clear_cache
 
         def set_cache(*args, **kwargs):
             arg_to_cache = args[-1]
             regular_args = args[:-1]
-            ctx, ctx_index = _get_ctx_from_args(args)
-            cache_key, store, _ = resolve_cache_info(
+            ctx, ctx_index = _get_ctx_from_args(regular_args)
+            cache_key, store, memory_cache, _ = resolve_cache_info(
                 ctx,
                 ctx_index,
                 regular_args,
                 kwargs,
                 key_fn,
                 func,
+                residency=residency,
                 operator_scoped=operator_scoped,
                 user_scoped=user_scoped,
                 prompt_scoped=prompt_scoped,
                 jwt_scoped=jwt_scoped,
                 collection_name=collection_name,
             )
-            if serialize is not None:
-                value_to_cache = serialize(arg_to_cache)
-            else:
-                value_to_cache = auto_serialize(arg_to_cache)
-            store.set_cache(cache_key, value_to_cache, ttl=ttl)
+            value_to_cache = (
+                serialize(arg_to_cache)
+                if serialize
+                else auto_serialize(arg_to_cache)
+            )
+            if store:
+                store.set_cache(cache_key, value_to_cache, ttl=ttl)
+            if memory_cache is not None:
+                memory_cache[cache_key] = value_to_cache
 
         wrapper.set_cache = set_cache
 

--- a/fiftyone/operators/cache/decorator.py
+++ b/fiftyone/operators/cache/decorator.py
@@ -197,7 +197,7 @@ def execution_cache(
             if skip_cache:
                 return func(*args, **kwargs)
 
-            # Hybrid and Ephemeral: Check memory cache first
+            # Hybrid or Ephemeral
             if memory_cache is not None and cache_key in memory_cache:
                 cached_value = memory_cache[cache_key]
                 return (
@@ -206,7 +206,7 @@ def execution_cache(
                     else auto_deserialize(cached_value)
                 )
 
-            # Transient/Persistent/Hybrid: Check store (if applicable)
+            # Transient or Hybrid
             cached_value = None
             if store is not None:
                 cached_value = store.get(cache_key)
@@ -228,7 +228,7 @@ def execution_cache(
 
                 return result
 
-            # Cache miss: compute result
+            # Cache miss
             result = func(*args, **kwargs)
             value_to_cache = (
                 serialize(result) if serialize else auto_serialize(result)

--- a/fiftyone/operators/cache/decorator.py
+++ b/fiftyone/operators/cache/decorator.py
@@ -91,7 +91,7 @@ def execution_cache(
                 the value is not found, it falls back to the execution store.
         max_size (None): Maximum size of the memory cache. Only applicable for
             "ephemeral" and "hybrid" residency modes. If not provided, the default
-            size is 128. The cache will evict the least recently used items when
+            size is 1024. The cache will evict the least recently used items when
             the size exceeds this limit.
 
     note::
@@ -169,7 +169,7 @@ def execution_cache(
         # max_size is only applicable for ephemeral and hybrid residency
         if max_size is not None and residency not in ["ephemeral", "hybrid"]:
             raise ValueError(
-                f"max_size is only valid for ephemeral and hybrid residency."
+                "max_size is only valid for ephemeral and hybrid residency."
             )
 
         func.store_name = store_name

--- a/fiftyone/operators/cache/ephemeral.py
+++ b/fiftyone/operators/cache/ephemeral.py
@@ -1,0 +1,20 @@
+from cachetools import LRUCache
+from threading import Lock
+
+# Global registry for ephemeral/hybrid memory caches
+_EPHEMERAL_CACHE_REGISTRY = {}
+_EPHEMERAL_CACHE_LOCK = Lock()
+
+
+def get_ephemeral_cache(func_id, maxsize=128):
+    with _EPHEMERAL_CACHE_LOCK:
+        if func_id not in _EPHEMERAL_CACHE_REGISTRY:
+            _EPHEMERAL_CACHE_REGISTRY[func_id] = LRUCache(maxsize=maxsize)
+        return _EPHEMERAL_CACHE_REGISTRY[func_id]
+
+
+def clear_all_ephemeral_caches():
+    with _EPHEMERAL_CACHE_LOCK:
+        for cache in _EPHEMERAL_CACHE_REGISTRY.values():
+            cache.clear()
+        _EPHEMERAL_CACHE_REGISTRY.clear()

--- a/fiftyone/operators/cache/ephemeral.py
+++ b/fiftyone/operators/cache/ephemeral.py
@@ -6,7 +6,7 @@ _EPHEMERAL_CACHE_LOCK = Lock()
 
 
 def get_ephemeral_cache(func_id, max_size=None):
-    max_size = max_size or 1000
+    max_size = max_size or 1024
     with _EPHEMERAL_CACHE_LOCK:
         if func_id not in _EPHEMERAL_CACHE_REGISTRY:
             _EPHEMERAL_CACHE_REGISTRY[func_id] = LRUCache(maxsize=max_size)

--- a/fiftyone/operators/cache/ephemeral.py
+++ b/fiftyone/operators/cache/ephemeral.py
@@ -1,15 +1,15 @@
 from cachetools import LRUCache
 from threading import Lock
 
-# Global registry for ephemeral/hybrid memory caches
 _EPHEMERAL_CACHE_REGISTRY = {}
 _EPHEMERAL_CACHE_LOCK = Lock()
 
 
-def get_ephemeral_cache(func_id, maxsize=128):
+def get_ephemeral_cache(func_id, max_size=None):
+    max_size = max_size or 1000
     with _EPHEMERAL_CACHE_LOCK:
         if func_id not in _EPHEMERAL_CACHE_REGISTRY:
-            _EPHEMERAL_CACHE_REGISTRY[func_id] = LRUCache(maxsize=maxsize)
+            _EPHEMERAL_CACHE_REGISTRY[func_id] = LRUCache(maxsize=max_size)
         return _EPHEMERAL_CACHE_REGISTRY[func_id]
 
 

--- a/fiftyone/operators/cache/utils.py
+++ b/fiftyone/operators/cache/utils.py
@@ -30,6 +30,7 @@ def resolve_cache_info(
     prompt_scoped=False,
     jwt_scoped=False,
     collection_name=None,
+    max_size=None,
 ):
     """
     Resolves the cache key, store, and memory cache for a given function call,
@@ -41,9 +42,6 @@ def resolve_cache_info(
     cache_disabled = not fo.config.execution_cache_enabled
     if cache_disabled:
         return None, None, None, True
-
-    if residency not in ("ephemeral", "transient", "persistent", "hybrid"):
-        raise ValueError(f"Unsupported residency mode: {residency}")
 
     base_cache_key_tuple = _get_cache_key_tuple(
         ctx_index, args, kwargs, key_fn
@@ -65,16 +63,16 @@ def resolve_cache_info(
 
     if residency == "ephemeral":
         func_id = _get_function_id(func)
-        memory_cache = get_ephemeral_cache(func_id)
+        memory_cache = get_ephemeral_cache(func_id, max_size=max_size)
     elif residency == "hybrid":
         func_id = _get_function_id(func)
-        memory_cache = get_ephemeral_cache(func_id)
+        memory_cache = get_ephemeral_cache(func_id, max_size=max_size)
         store = _get_store_for_func(
             func,
             dataset_id=ctx.dataset._doc.id,
             collection_name=collection_name,
         )
-    elif residency in ("transient", "persistent"):
+    elif residency == "transient":
         store = _get_store_for_func(
             func,
             dataset_id=ctx.dataset._doc.id,

--- a/tests/unittests/execution_cache/execution_cache_io_tests.py
+++ b/tests/unittests/execution_cache/execution_cache_io_tests.py
@@ -186,7 +186,7 @@ class TestExecutionCacheWithSamples(unittest.TestCase):
         ctx = setup_ctx(dataset)
 
         self.assertEqual(cached(ctx, "c"), "hybrid-c")  # MISS
-        self.assertEqual(cached(ctx, "c"), "hybrid-c")  # HIT (mem or disk)
+        self.assertEqual(cached(ctx, "c"), "hybrid-c")  # HIT
 
         self.assertEqual(calls, ["c"])
 


### PR DESCRIPTION
Adds a new `residency` parameter to `@execution_cache`

```
residency ("hybrid"): The residency of the cache. Can be one of:
            - "transient": Cache is stored in the execution store with policy="evict".
            - "ephemeral": Cache is stored in memory and is cleared when the process ends.
            - "hybrid": (default) Combination of transient and ephemeral. Cache is stored in memory
                and in the execution store. The memory cache is used first, and if
                the value is not found, it falls back to the execution store.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced configurable cache residency modes ("transient", "ephemeral", "hybrid") for operator execution caching, supporting in-memory, persistent, or combined caching strategies.
  - Added support for setting a maximum size on in-memory caches with automatic LRU eviction.
- **Documentation**
  - Updated plugin development docs with examples and details on the new cache residency parameter.
- **Tests**
  - Added comprehensive tests covering caching behaviors, LRU eviction, and invalid residency parameter handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->