### PR TITLE
Correctly handle existing files when using `UniqueFilenameMaker` with `ignore_exts=True`

### DIFF
--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1969,7 +1969,12 @@ class UniqueFilenameMaker(object):
 
         self._idx = len(filenames)
         for filename in filenames:
-            self._filename_counts[filename] += 1
+            if self.ignore_exts:
+                key, _ = os.path.splitext(filename)
+            else:
+                key = filename
+
+            self._filename_counts[key] += 1
 
     def seen_input_path(self, input_path):
         """Checks whether we've already seen the given input path.


### PR DESCRIPTION
## Change log

- Fixed a bug in `UniqueFilenameMaker` when `ignore_exts=True` and `ignore_existing=False` where existing filenames would not be correctly "de-extensioned" 

## Tested by

```shell
mkdir -p /tmp/ufm
touch /tmp/ufm/000001.jpg
```

```py
import fiftyone.core.utils as fou

filename_maker = fou.UniqueFilenameMaker(
    output_dir="/tmp/ufm",
    ignore_exts=True,
    ignore_existing=False,
    idempotent=True,
)

print(filename_maker.get_output_path("/datasets/cifar10/test/000001.jpg"))
print(filename_maker.get_output_path("/datasets/cifar10/test/000001.jpg"))
print(filename_maker.get_output_path("/datasets/cifar10/test/000001.png"))
print(filename_maker.get_output_path("/datasets/cifar10/test/000001.png"))
print(filename_maker.get_output_path("/datasets/cifar10/validation/000001.jpg"))
print(filename_maker.get_output_path("/datasets/cifar10/validation/000001.jpg"))
```

```
/tmp/ufm/000001-2.jpg
/tmp/ufm/000001-2.jpg
/tmp/ufm/000001-3.png
/tmp/ufm/000001-3.png
/tmp/ufm/000001-4.jpg
/tmp/ufm/000001-4.jpg
```

Explanation of correctness of output paths
- Output filenames start at `000001-2` because of `ignore_exts=True` + `ignore_existing=False` and the existing `000001` filename in the output directory
- Output filenames come in pairs because of `idempotent=True`
- Second unique output filename is `000001-3` because `ignore_exts=True` causes `000001.jpg` and `000001.png` to be seen as the clashing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of filename uniqueness by optionally ignoring file extensions when generating unique filenames, ensuring more accurate collision detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->