### PR TITLE
Optimize values() mongodb call

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -10415,6 +10415,7 @@ class SampleCollection(object):
                     "Batchable aggregations must have pipelines with a single "
                     "$project stage; found %s" % _pipeline
                 )
+        project["_id"] = False
 
         return self._pipeline(
             pipeline=[{"$project": project}],


### PR DESCRIPTION
## What changes are proposed in this pull request?
This is the pipeline for a few cases of values() calls.
```
>> ds.values('filepath')
# pipeline
{'value0': {'$cond': {'if': {'$gt': ['$filepath', None]}, 'then': '$filepath', 'else': None}}}

# sample output
{'_id': ObjectId('67608096daa9bc771cbd3dcc'), 'value0': '/Users/stuart/fiftyone/quickstart/data/000880.jpg'}
...

>> ds.values(['filepath', 'id'])
# pipeline
{'value0': {'$cond': {'if': {'$gt': ['$filepath', None]}, 'then': '$filepath', 'else': None}}, 'value1': {'$cond': {'if': {'$gt': ['$_id', None]}, 'then': {'$toString': '$_id'}, 'else': None}}}

# sample output
{'_id': ObjectId('67608096daa9bc771cbd3dcc'), 'value0': '/Users/stuart/fiftyone/quickstart/data/000880.jpg', 'value1': '67608096daa9bc771cbd3dcc'}
...
```

Anything else (passing expr instead of field, unwinding a list with `[]`, is not considered "big batchable" and so is not the target of this limited PR.

### What/Why
If we add `"_id": False` to the projection, it will omit the object ID which we don't use. In the single scalar field values case, the amount of data transferred is cut almost in half. The bigger the field, that advantage shrinks. However this is a very prevalent use case.

It does not make a material difference when the database is local. But it won't hurt it either.
It does give a performance improvement (~10-20% speedup) on some datasets when the database is remote or proxied.

Note it does not improve for all datasets and fields, because if the samples are particularly dense, the mongodb load may completely overshadow the network transfer aspect. Or if the size of _id relative to the "real" data is small, it does not make a big difference.

### Change Safety
The change is on the generic aggregate() function however it's safe because:
1. It's only for big batchable pipelines
2. Only `Values` aggregation supports this (`_is_big_batchable`)
3. `Values.parse_result()` only uses its `_big_field` which is usually `value0`, `value1`, and so on.

Since the _id field is proven to be unused, there is no way this change can make things worse.

## How is this patch tested? If it is not, please explain why.

```python
ds = fo.load_dataset("open-images-v7-full") # 1.9M samples

with etau.Timer() as t:
  _=ds.values('filepath')
```
This is also machine and network dependent, but on my particular setup with direct remote database, I got an average of 58s, down to an average 50s.
With a proxied remote database, average of 62s goes down to average 55s

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Improved `values(scalar_field)` call performance 10-20% over a low-speed MongoDB connection.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
