### PR TITLE
Add encoding for batch building

### DIFF
--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -825,9 +825,7 @@ def insert_documents(docs, coll, ordered=False, progress=None, num_docs=None):
                 if hasattr(res, "nBytes") and hasattr(
                     batcher, "set_encoding_ratio"
                 ):
-                    batcher.set_encoding_ratio(
-                        res.bulk_api_result.get("nBytes")
-                    )
+                    batcher.set_encoding_ratio(res.nBytes)
 
     except BulkWriteError as bwe:
         msg = bwe.details["writeErrors"][0]["errmsg"]

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -820,9 +820,9 @@ def insert_documents(docs, coll, ordered=False, progress=None, num_docs=None):
         with batcher:
             for batch in batcher:
                 batch = list(batch)
-                res = coll.bulk_write(batch, ordered=ordered)
+                res = coll.insert_many(batch, ordered=ordered)
                 ids.extend(b["_id"] for b in batch)
-                if res.bulk_api_result.get("nBytes") and hasattr(
+                if hasattr(res, "nBytes") and hasattr(
                     batcher, "set_encoding_ratio"
                 ):
                     batcher.set_encoding_ratio(

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -820,8 +820,14 @@ def insert_documents(docs, coll, ordered=False, progress=None, num_docs=None):
         with batcher:
             for batch in batcher:
                 batch = list(batch)
-                coll.insert_many(batch, ordered=ordered)
+                res = coll.bulk_write(batch, ordered=ordered)
                 ids.extend(b["_id"] for b in batch)
+                if res.bulk_api_result.get("nBytes") and hasattr(
+                    batcher, "set_encoding_ratio"
+                ):
+                    batcher.set_encoding_ratio(
+                        res.bulk_api_result.get("nBytes")
+                    )
 
     except BulkWriteError as bwe:
         msg = bwe.details["writeErrors"][0]["errmsg"]
@@ -847,7 +853,13 @@ def bulk_write(ops, coll, ordered=False, progress=False):
         with batcher:
             for batch in batcher:
                 batch = list(batch)
-                coll.bulk_write(batch, ordered=ordered)
+                res = coll.bulk_write(batch, ordered=ordered)
+                if res.bulk_api_result.get("nBytes") and hasattr(
+                    batcher, "set_encoding_ratio"
+                ):
+                    batcher.set_encoding_ratio(
+                        res.bulk_api_result.get("nBytes")
+                    )
 
     except BulkWriteError as bwe:
         msg = bwe.details["writeErrors"][0]["errmsg"]

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1687,7 +1687,7 @@ class ContentSizeBatcher(BaseBatcher):
         return curr_batch
 
     def set_encoding_ratio(self, encoded_batch_size):
-        if self._last_batch_content_size:
+        if self._last_batch_content_size and encoded_batch_size > 0:
             self._encoding_ratio = (
                 self._last_batch_content_size / encoded_batch_size
             )

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1628,6 +1628,8 @@ class ContentSizeBatcher(BaseBatcher):
             if size_calculation_fn
             else default_calculate_size
         )
+        self._last_batch_content_size = None
+        self._encoding_ratio = 1.0
 
     def __iter__(self):
         super().__iter__()
@@ -1664,7 +1666,8 @@ class ContentSizeBatcher(BaseBatcher):
                     self.max_batch_size
                     and len(curr_batch) >= self.max_batch_size
                 ) or (
-                    batch_content_size + next_element_size > self.target_size
+                    batch_content_size + next_element_size
+                    > self.target_size * self._encoding_ratio
                 ):
                     break
 
@@ -1680,7 +1683,14 @@ class ContentSizeBatcher(BaseBatcher):
                 break
 
         self._last_batch_size = len(curr_batch)
+        self._last_batch_content_size = batch_content_size
         return curr_batch
+
+    def set_encoding_ratio(self, encoded_batch_size):
+        if self._last_batch_content_size:
+            self._encoding_ratio = (
+                self._last_batch_content_size / encoded_batch_size
+            )
 
 
 def default_calculate_size(obj):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Our content size batcher currently only uses the size of the object before any compression or encoding is applied. These changes factor that into our batch building calculation so theoretically our payloads could contain a lot more operations if it's compressed instead of being a constant number of operations with a variable size based on compression.

## How is this patch tested? If it is not, please explain why.

Set my batcher to size:
`export FIFTYONE_DEFAULT_BATCHER="size"`

Test script:

```
import fiftyone as fo
from typing import List
import bson

def generate_samples(num_samples: int) -> List[fo.Sample]:
    """Create testing samples"""
    fake_detections = [
        fo.Detection(label="test", bounding_box=[0.1 * i] * 4)
        for i in range(0, 10)
    ]
    samples = [
        fo.Sample(
            filepath=f"/path/to/fake_{bson.ObjectId()}.png",
            detections=fo.Detections(detections=fake_detections),
        )
        for _ in range(num_samples)
    ]

    return samples

num_samples = 200
ds = fo.load_dataset("quickstart")
clone = ds.clone()
print(clone)
clone.set_values("new_field_set_values_unique", list(range(num_samples)))
print(clone.values("new_field_set_values_unique"))

samples = generate_samples(num_samples)
clone.add_samples(samples)
print(clone)
```

Result:
```
Name:        2025.04.17.17.19.23
Media type:  image
Num samples: 200
Persistent:  False
Tags:        []
Sample fields:
    id:               fiftyone.core.fields.ObjectIdField
    filepath:         fiftyone.core.fields.StringField
    tags:             fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
    metadata:         fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
    created_at:       fiftyone.core.fields.DateTimeField
    last_modified_at: fiftyone.core.fields.DateTimeField
    ground_truth:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
    uniqueness:       fiftyone.core.fields.FloatField
    predictions:      fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199]
 100% |███████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [344.0ms elapsed, 0s remaining, 581.5 samples/s] 
Name:        2025.04.17.17.19.23
Media type:  image
Num samples: 400
Persistent:  False
Tags:        []
Sample fields:
    id:                          fiftyone.core.fields.ObjectIdField
    filepath:                    fiftyone.core.fields.StringField
    tags:                        fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
    metadata:                    fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
    created_at:                  fiftyone.core.fields.DateTimeField
    last_modified_at:            fiftyone.core.fields.DateTimeField
    ground_truth:                fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
    uniqueness:                  fiftyone.core.fields.FloatField
    predictions:                 fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
    new_field_set_values_unique: fiftyone.core.fields.IntField
    detections:                  fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Improved batch processing efficiency by dynamically adjusting batch sizes based on actual content size during sample insertion.
- **Enhancements**
	- Batch size calculations now adapt automatically to optimize data insertion performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->