### PR TITLE
add dataset to activator ctx

### DIFF
--- a/app/packages/spaces/src/hooks.ts
+++ b/app/packages/spaces/src/hooks.ts
@@ -126,7 +126,8 @@ export function usePanels(
   const schema = useRecoilValue(
     fos.fieldSchema({ space: fos.State.SPACE.SAMPLE })
   );
-  const ctx = useMemo(() => ({ schema }), [schema]);
+  const dataset = useRecoilValue(fos.dataset);
+  const ctx = useMemo(() => ({ schema, dataset }), [schema, dataset]);
   const plots = useActivePlugins(PluginComponentType.Plot, ctx);
   const panels = useActivePlugins(PluginComponentType.Panel, ctx);
 


### PR DESCRIPTION
Allows for this sort of syntax:

```tsx
import { PluginComponentType, registerComponent } from "@fiftyone/plugins";

registerComponent({
  name: SAMPLE_MODAL_PLUGIN_NAME,
  component: ModalSample,
  label: "Sample",
  type: PluginComponentType.Panel,
  panelOptions: {
    surfaces: "modal",
    priority: BUILT_IN_PANEL_PRIORITY_CONST,
  },
  activator: (ctx) => ctx.dataset.mediaType == "splat",
  Icon: ViewInAr,
});
```
