### PR TITLE
Converts zero-shot transformers to torchimagemodel

### DIFF
--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -392,7 +392,7 @@ class ZeroShotTransformerEmbeddingsMixin(EmbeddingsMixin):
 
     @property
     def has_embeddings(self):
-        return _has_text_and_image_features(self.model)
+        return _has_text_and_image_features(self._model)
 
     def embed(self, arg):
         return self._embed(arg)[0]
@@ -403,8 +403,8 @@ class ZeroShotTransformerEmbeddingsMixin(EmbeddingsMixin):
     def _embed(self, args):
         inputs = self.processor(images=args, return_tensors="pt")
         with torch.no_grad():
-            image_features = self.model.base_model.get_image_features(
-                **inputs.to(self.device)
+            image_features = self._model.base_model.get_image_features(
+                **inputs.to(self._device)
             )
 
         return image_features.cpu().numpy()
@@ -415,7 +415,7 @@ class ZeroShotTransformerPromptMixin(PromptMixin):
 
     @property
     def can_embed_prompts(self):
-        return _has_text_and_image_features(self.model)
+        return _has_text_and_image_features(self._model)
 
     def embed_prompt(self, prompt):
         """Generates an embedding for the given text prompt.
@@ -442,8 +442,8 @@ class ZeroShotTransformerPromptMixin(PromptMixin):
     def _embed_prompts(self, prompts):
         inputs = self.processor(text=prompts, return_tensors="pt")
         with torch.no_grad():
-            text_features = self.model.base_model.get_text_features(
-                **inputs.to(self.device)
+            text_features = self._model.base_model.get_text_features(
+                **inputs.to(self._device)
             )
         return text_features
 
@@ -492,9 +492,9 @@ class FiftyOneTransformer(TransformerEmbeddingsMixin, Model):
 
 
 class FiftyOneZeroShotTransformer(
-    fout.TorchImageModel,
     ZeroShotTransformerEmbeddingsMixin,
     ZeroShotTransformerPromptMixin,
+    fout.TorchImageModel,
 ):
     """FiftyOne wrapper around a ``transformers`` model.
 

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -2755,7 +2755,9 @@
             "size_bytes": null,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneZeroShotTransformerForImageClassification",
-                "config": {}
+                "config": {
+                    "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor"
+                }
             },
             "requirements": {
                 "packages": ["torch", "torchvision", "transformers"],
@@ -2787,7 +2789,9 @@
             "size_bytes": null,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneZeroShotTransformerForObjectDetection",
-                "config": {}
+                "config": {
+                    "output_processor_cls": "fiftyone.utils.torch.DetectorOutputProcessor"
+                }
             },
             "requirements": {
                 "packages": ["torch", "torchvision", "transformers"],


### PR DESCRIPTION
## What changes are proposed in this pull request?

Converts zero-shot classification and detection transformer models to `TorchImageModel`.

## How is this patch tested? If it is not, please explain why.

```
import fiftyone as fo
import fiftyone.zoo as foz

dataset = fo.load_dataset("quickstart")
categories = dataset.distinct("ground_truth.detections.label")

model_name = <MODEL_ZOO_NAME>
zoo_model = foz.load_zoo_model(
    model_name,
    classes=categories
)
dataset.apply_model(zoo_model, label_field=<LABEL_FIELD>)

embeddings = dataset.compute_embeddings(model, embeddings_field=<EMB_FIELD>)
```
Results are compared against `develop` (non-TorchImageModel) results.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved integration of zero-shot transformer models with enhanced model and device management for greater consistency and reliability.
  - Standardized prediction outputs to return raw logits or processed results, providing clearer and more direct outputs.
  - Unified model configuration and processing logic for a more streamlined experience when working with zero-shot transformer models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->