### PR TITLE
Add torch packages to test requirements

### DIFF
--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -22,7 +22,6 @@ from PIL import Image
 import eta.core.geometry as etag
 import eta.core.learning as etal
 import eta.core.utils as etau
-from torchvision.models.feature_extraction import create_feature_extractor
 
 import fiftyone.core.config as foc
 import fiftyone.core.labels as fol
@@ -36,11 +35,14 @@ import fiftyone.core.sample as fos
 import fiftyone.core.view as fov
 
 fou.ensure_torch()
+
 import torch
-import torchvision
-from torchvision.transforms import functional as F
 from torch.utils.data import Dataset
 import torch.distributed as dist
+
+import torchvision
+from torchvision.models.feature_extraction import create_feature_extractor
+from torchvision.transforms import functional as F
 
 
 logger = logging.getLogger(__name__)

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,5 +8,7 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 pytest-asyncio
 shapely
-tensorflow==2.17.0
+tensorflow>=2.17.0
+torch>=2.2.2
+torchvision>=0.17.2
 twine>=3

--- a/tests/unittests/torch_dataset_tests.py
+++ b/tests/unittests/torch_dataset_tests.py
@@ -121,7 +121,6 @@ class FiftyOneTorchDatasetTests(unittest.TestCase):
             )
 
     def test_skip_failures(self):
-
         with ShortLivedDataset() as dataset:
             for i, sample in enumerate(dataset):
                 sample["foo"] = 1 if i % 2 == 0 else None


### PR DESCRIPTION
I pulled the latest `develop` and got unit test failures due to the new `tests/unittests/torch_dataset_tests.py` tests that were added by @jacobsela in https://github.com/voxel51/fiftyone/pull/5703.

Upon inspection, the solution was to upgrade my `torch` and `torchvision` packages, so I've pinned sufficiently new versions to `requirements/test.txt` to ensure that others don't encounter this bug, assuming they follow the dev install instructions and run `bash install.bash -d`.