### PR TITLE
FOTD: use `make_optimized_select_view`

### DIFF
--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -1674,9 +1674,6 @@ class FiftyOneTorchDataset(Dataset):
         self._dataset = fo.load_dataset(self.name)
         if self.stages is not None:
             self._samples = fov.DatasetView._build(self._dataset, self.stages)
-            self._samples = fov.make_optimized_select_view(
-                self._samples, self.ids, ordered=True
-            )
         else:
             self._samples = self._dataset
 
@@ -1701,7 +1698,9 @@ class FiftyOneTorchDataset(Dataset):
 
         if self.cached_fields is None:
             # pylint: disable=unsubscriptable-object
-            sample = self._samples[self.ids[index]]
+            sample = fov.make_optimized_select_view(
+                self._samples, self.ids[index]
+            ).first()
             return self._get_item(sample)
 
         else:
@@ -1718,7 +1717,9 @@ class FiftyOneTorchDataset(Dataset):
         if self.cached_fields is None:
             ids = [self.ids[i] for i in indices]
             # pylint: disable=unsubscriptable-object
-            samples = self._samples.select(ids, ordered=True)
+            samples = fov.make_optimized_select_view(
+                self._samples, ids, ordered=True
+            )
             return [self._get_item(s) for s in samples]
 
         else:

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -1674,6 +1674,9 @@ class FiftyOneTorchDataset(Dataset):
         self._dataset = fo.load_dataset(self.name)
         if self.stages is not None:
             self._samples = fov.DatasetView._build(self._dataset, self.stages)
+            self._samples = fov.make_optimized_select_view(
+                self._samples, self.ids, ordered=True
+            )
         else:
             self._samples = self._dataset
 
@@ -1698,7 +1701,7 @@ class FiftyOneTorchDataset(Dataset):
 
         if self.cached_fields is None:
             # pylint: disable=unsubscriptable-object
-            sample = self._dataset[self.ids[index]]
+            sample = self._samples[self.ids[index]]
             return self._get_item(sample)
 
         else:
@@ -1715,7 +1718,7 @@ class FiftyOneTorchDataset(Dataset):
         if self.cached_fields is None:
             ids = [self.ids[i] for i in indices]
             # pylint: disable=unsubscriptable-object
-            samples = self._dataset.select(ids, ordered=True)
+            samples = self._samples.select(ids, ordered=True)
             return [self._get_item(s) for s in samples]
 
         else:


### PR DESCRIPTION
## What changes are proposed in this pull request?

When I first made FOTD, I noticed that when using complicated views as the samples for the dataset, the dataset was a lot slower. This is because calling `samples[ids]` on a complicated view requires computing the entire aggregation from scratch each time.

In order to get around this, I replaced the `samples[ids]` calls with `samples._dataset[ids]`. While this gives the intended result, it means that the entire sample is always constructed. If the user has many fields, and only some are needed for the `get_item`, this is wasteful.

`fiftyone.core.view.make_optimized_select_view` resolves this. It allows for fast select queries such as `samples[ids]`, while maintaining leaner resulting samples based on what we select beforehand.

## How is this patch tested? If it is not, please explain why.

### testing speedup on complicated view with selected fields

```python
from time import time_ns

import torch

import fiftyone as fo

def dummy_get_item(sample):
    return {
        "id": sample['id'],
        "filepath": sample['filepath'],
        "label": sample['ground_truth.label'],
    }

if __name__ == "__main__":

    dataset = fo.load_dataset("stanford-dogs")

    # create complicated view
    view = dataset.select_fields(["id", "filepath", "ground_truth.label"])
    view = view.shuffle()
    view = view.match_tags("train")
    view = view.take(3000)

    torch_dataset = view.to_torch(dummy_get_item)

    dataloader = torch.utils.data.DataLoader(
        torch_dataset,
        batch_size=32,
        shuffle=False,
        num_workers=0,
    )

    time_start = time_ns()

    result = []
    for batch in dataloader:
        result.append(batch)

    time_end = time_ns()

    print("Time taken to load data:", (time_end - time_start) / 1e9, "Seconds")

    # Check the result
    all_ids = []
    all_filepaths = []
    all_labels = []
    for batch in result:
        all_ids.extend(batch["id"])
        all_filepaths.extend(batch["filepath"])
        all_labels.extend(batch["label"])

    ids = view.values("id")
    filepaths = view.values("filepath")
    labels = view.values("ground_truth.label")

    assert ids == all_ids
    assert filepaths == all_filepaths
    assert labels == all_labels
    print("All data loaded successfully!")
```

#### Before
```
Serializing 3000 elements to byte tensors and concatenating them all ...
Serialized dataset takes 0.11 MiB
Time taken to load data: 8.543914254 Seconds
All data loaded successfully!
```

#### After
```
Serializing 3000 elements to byte tensors and concatenating them all ...
Serialized dataset takes 0.11 MiB
Time taken to load data: 2.132819383 Seconds
All data loaded successfully!
```

### testing potential slowdown for simple views

Like the above snippet but use the entire dataset rather than a specific view.

#### Before

```
Serializing 20580 elements to byte tensors and concatenating them all ...
Serialized dataset takes 0.77 MiB
Time taken to load data: 58.754564715 Seconds
All data loaded successfully!
```

#### After

```
Serializing 20580 elements to byte tensors and concatenating them all ...
Serialized dataset takes 0.77 MiB
Time taken to load data: 57.251618432 Seconds
All data loaded successfully!
```

### Conclusion

Improves performance as expected, doesn't undo previous optimization. Good to go imo.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other: `fiftyone.utils.torch`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**  
  - Enhanced sample retrieval by optimizing how individual and multiple samples are accessed, improving performance and reliability during dataset interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->