### PR TITLE
`map_samples()` and `update_samples()`

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -1120,7 +1120,7 @@ Annotation
 
 Core
 
-- Added support for :ref:`save contexts <efficient-batch-edits>` to generated
+- Added support for :ref:`save contexts <save-contexts>` to generated
   views (patches, frames, and clips)
   `#4636 <https://github.com/voxel51/fiftyone/pull/4636>`_
 - Added support for downloading plugins from branches that contain slashes `/`
@@ -1447,11 +1447,11 @@ App
 
 Core
 
-- All :ref:`autosave contexts <efficient-batch-edits>` now respect the
+- All :ref:`save contexts <save-contexts>` now respect the
   :ref:`default batching strategy <configuring-fiftyone>` and can be configured
   to use content size-based batching
   `#4243 <https://github.com/voxel51/fiftyone/pull/4243>`_
-- All SDK methods now use :ref:`autosave contexts <efficient-batch-edits>`
+- All SDK methods now use :ref:`save contexts <save-contexts>`
   rather than calling :meth:`sample.save() <fiftyone.core.sample.Sample.save>`
   in a loop
   `#4243 <https://github.com/voxel51/fiftyone/pull/4243>`_
@@ -4014,8 +4014,8 @@ App
 
 Core
 
-- Added a save context that enables
-  :ref:`efficient batch edits <efficient-batch-edits>` of datasets and views
+- Added :ref:`save contexts <save-contexts>`, which enable efficient batch
+  edits of datasets and views
   `#1727 <https://github.com/voxel51/fiftyone/pull/1727>`_
 - Added Plotly v5 support
   `#1981 <https://github.com/voxel51/fiftyone/pull/1981>`_

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -98,6 +98,10 @@ FiftyOne supports the configuration options described below:
 | `logging_level`               | `FIFTYONE_LOGGING_LEVEL`              | `INFO`                        | Controls FiftyOne's package-wide logging level. Can be any valid ``logging`` level as  |
 |                               |                                       |                               | a string: ``DEBUG, INFO, WARNING, ERROR, CRITICAL``.                                   |
 +-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `default_map_workers`         | `FIFTYONE_DEFAULT_MAP_WORKERS`        | `None`                        | The default number of worker processes to use when                                     |
+|                               |                                       |                               | :meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>` is      |
+|                               |                                       |                               | called.                                                                                |
++-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `max_thread_pool_workers`     | `FIFTYONE_MAX_THREAD_POOL_WORKERS`    | `None`                        | An optional maximum number of workers to use when creating thread pools                |
 +-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `max_process_pool_workers`    | `FIFTYONE_MAX_PROCESS_POOL_WORKERS`   | `None`                        | An optional maximum number of workers to use when creating process pools               |
@@ -173,6 +177,7 @@ and the CLI:
             "default_batcher": "latency",
             "default_dataset_dir": "~/fiftyone",
             "default_image_ext": ".jpg",
+            "default_map_workers": null,
             "default_ml_backend": "torch",
             "default_sequence_idx": "%06d",
             "default_video_ext": ".mp4",
@@ -223,6 +228,7 @@ and the CLI:
             "default_batcher": "latency",
             "default_dataset_dir": "~/fiftyone",
             "default_image_ext": ".jpg",
+            "default_map_workers": null,
             "default_ml_backend": "torch",
             "default_sequence_idx": "%06d",
             "default_video_ext": ".mp4",

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -5644,10 +5644,10 @@ to manipulate the fields or subfields of embedded documents in your dataset:
     # Delete an embedded field
     dataset.delete_sample_field("predictions.detections.still_label")
 
-.. _efficient-batch-edits:
+.. _save-contexts:
 
-Efficient batch edits
----------------------
+Save contexts
+-------------
 
 You are always free to perform arbitrary edits to a |Dataset| by iterating over
 its contents and editing the samples directly:
@@ -5717,16 +5717,15 @@ The benefit of the above approach versus passing ``autosave=True`` to
 to be explicit about which samples you are editing, which avoids unnecessary
 computations if your loop only edits certain samples.
 
-.. _map-reduce-operations:
+.. _updating-samples:
 
-Map-reduce operations
----------------------
+Updating samples
+----------------
 
 The
-:meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
-method provides a powerful and efficient interface for iterating over samples,
-applying a function to each sample, saving any sample edits performed, and
-optionally reducing the map function outputs:
+:meth:`update_samples() <fiftyone.core.collections.SampleCollection.update_samples>`
+method provides an efficient interface for applying a function to each sample
+in a collection and saving the sample edits:
 
 .. code-block:: python
     :linenos:
@@ -5737,49 +5736,23 @@ optionally reducing the map function outputs:
     dataset = foz.load_zoo_dataset("cifar10", split="train")
     view = dataset.select_fields("ground_truth")
 
-    def map_fcn(sample):
+    def update_fcn(sample):
         sample.ground_truth.label = sample.ground_truth.label.upper()
 
-    view.map_samples(map_fcn)
+    view.update_samples(update_fcn)
 
     print(dataset.count_values("ground_truth.label"))
+    # {'DEER': 5000, 'HORSE': 5000, 'AIRPLANE': 5000, ..., 'DOG': 5000}
 
-.. code-block:: text
+.. note::
 
-    Batch 04/16: 100%|█████████████████████████████████████████████████| 3125/3125 [899.01it/s]
-    Batch 03/16: 100%|█████████████████████████████████████████████████| 3125/3125 [894.90it/s]
-    Batch 11/16: 100%|█████████████████████████████████████████████████| 3125/3125 [900.14it/s]
-    Batch 06/16: 100%|█████████████████████████████████████████████████| 3125/3125 [895.61it/s]
-    Batch 13/16: 100%|█████████████████████████████████████████████████| 3125/3125 [903.09it/s]
-    Batch 08/16: 100%|█████████████████████████████████████████████████| 3125/3125 [895.33it/s]
-    Batch 05/16: 100%|█████████████████████████████████████████████████| 3125/3125 [893.26it/s]
-    Batch 02/16: 100%|█████████████████████████████████████████████████| 3125/3125 [889.17it/s]
-    Batch 01/16: 100%|█████████████████████████████████████████████████| 3125/3125 [888.16it/s]
-    Batch 09/16: 100%|█████████████████████████████████████████████████| 3125/3125 [893.69it/s]
-    Batch 12/16: 100%|█████████████████████████████████████████████████| 3125/3125 [896.80it/s]
-    Batch 14/16: 100%|█████████████████████████████████████████████████| 3125/3125 [903.28it/s]
-    Batch 10/16: 100%|█████████████████████████████████████████████████| 3125/3125 [893.63it/s]
-    Batch 07/16: 100%|█████████████████████████████████████████████████| 3125/3125 [891.26it/s]
-    Batch 15/16: 100%|█████████████████████████████████████████████████| 3125/3125 [905.06it/s]
-    Batch 16/16: 100%|█████████████████████████████████████████████████| 3125/3125 [911.72it/s]
-    {'DEER': 5000, 'HORSE': 5000, 'AIRPLANE': 5000, ..., 'DOG': 5000}
+    As the above snippet shows, you should optimize your iteration by
+    :ref:`selecting only <efficient-iteration-views>` the required fields.
 
-The above example demonstrates some important properties of
-:meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`:
-
--   :meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
-    does not process samples in any particular order
-
--   Your ``map_fcn`` may edit samples, but it should not modify global state
-    or variables defined outside of the function
-
--   You can optimize the operation by
-    :ref:`selecting only <efficient-iteration-views>` the required fields
-
-As you can see,
-:meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
-can leverage a multiprocessing pool to parallelize the work across a number of
-batches, resulting in signficant performance improvements over the equivalent
+By default,
+:meth:`update_samples() <fiftyone.core.collections.SampleCollection.update_samples>`
+leverages a multiprocessing pool to parallelize the work across a number of
+workers, resulting in signficant performance improvements over the equivalent
 :meth:`iter_samples(autosave=True) <fiftyone.core.dataset.Dataset.iter_samples>`
 syntax:
 
@@ -5787,66 +5760,166 @@ syntax:
     :linenos:
 
     for sample in view.iter_samples(autosave=True, progress=True):
-        map_fcn(sample)
+        update_fcn(sample)
 
-You can also perform map-reduce operations with
+Keep the following points in mind while using
+:meth:`update_samples() <fiftyone.core.collections.SampleCollection.update_samples>`:
+
+-   The samples are not processed in any particular order
+
+-   Your ``update_fcn`` should not modify global state or variables defined
+    outside of the function
+
+You can configure the number of workers that
+:meth:`update_samples() <fiftyone.core.collections.SampleCollection.update_samples>`
+uses in a variety of ways:
+
+-   Configure the default number of workers used by all
+    :meth:`update_samples() <fiftyone.core.collections.SampleCollection.update_samples>`
+    calls by setting the ``default_map_workers`` value in your
+    :ref:`FiftyOne config <configuring-fiftyone>`
+
+-   Manually configure the number of workers for a particular
+    :meth:`update_samples() <fiftyone.core.collections.SampleCollection.update_samples>`
+    call by passing the ``num_workers`` parameter
+
+-   If neither of the above settings are applied,
+    :meth:`update_samples() <fiftyone.core.collections.SampleCollection.update_samples>`
+    will use
+    :func:`recommend_process_pool_workers() <fiftyone.core.utils.recommend_process_pool_workers>`
+    to choose a number of worker processes, unless the method is called in a
+    daemon process (subprocess), in which case no workers are used
+
+.. note::
+
+    You can set ``default_map_workers<=1`` or ``num_workers<=1`` to disable the
+    use of multiprocessing pools in
+    :meth:`update_samples() <fiftyone.core.collections.SampleCollection.update_samples>`.
+
+By default,
+:meth:`update_samples() <fiftyone.core.collections.SampleCollection.update_samples>`
+evenly distributes samples to all workers in a single shard per worker.
+However, you can pass the ``shard_size`` parameter to customize the number of
+samples sent to each worker at a time:
+
+.. code-block:: python
+    :linenos:
+
+    view.update_samples(update_fcn, shard_size=50, num_workers=4)
+
+You can also pass `progress="workers"` to
+:meth:`update_samples() <fiftyone.core.collections.SampleCollection.update_samples>`
+to render progress bar(s) for each worker:
+
+.. code-block:: python
+    :linenos:
+
+    view.update_samples(update_fcn, num_workers=16, progress="workers")
+
+.. code-block:: text
+
+    Batch 01/16: 100%|█████████████████████████████████████████████████| 3125/3125 [899.01it/s]
+    Batch 02/16: 100%|█████████████████████████████████████████████████| 3125/3125 [894.90it/s]
+    Batch 03/16: 100%|█████████████████████████████████████████████████| 3125/3125 [900.14it/s]
+    Batch 04/16: 100%|█████████████████████████████████████████████████| 3125/3125 [895.61it/s]
+    Batch 05/16: 100%|█████████████████████████████████████████████████| 3125/3125 [903.09it/s]
+    Batch 06/16: 100%|█████████████████████████████████████████████████| 3125/3125 [895.33it/s]
+    Batch 07/16: 100%|█████████████████████████████████████████████████| 3125/3125 [893.26it/s]
+    Batch 08/16: 100%|█████████████████████████████████████████████████| 3125/3125 [889.17it/s]
+    Batch 09/16: 100%|█████████████████████████████████████████████████| 3125/3125 [888.16it/s]
+    Batch 10/16: 100%|█████████████████████████████████████████████████| 3125/3125 [893.69it/s]
+    Batch 11/16: 100%|█████████████████████████████████████████████████| 3125/3125 [896.80it/s]
+    Batch 12/16: 100%|█████████████████████████████████████████████████| 3125/3125 [903.28it/s]
+    Batch 13/16: 100%|█████████████████████████████████████████████████| 3125/3125 [893.63it/s]
+    Batch 14/16: 100%|█████████████████████████████████████████████████| 3125/3125 [891.26it/s]
+    Batch 15/16: 100%|█████████████████████████████████████████████████| 3125/3125 [905.06it/s]
+    Batch 16/16: 100%|█████████████████████████████████████████████████| 3125/3125 [911.72it/s]
+
+.. _map-reduce-operations:
+
+Map-reduce operations
+---------------------
+
+The
 :meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
-by providing a ``reduce_fcn``:
+method provides a powerful and efficient interface for iterating over samples,
+applying a function to each sample, and optionally reducing/aggregating the
+results:
+
+.. code-block:: python
+    :linenos:
+
+    from collections import Counter
+
+    import fiftyone as fo
+    import fiftyone.zoo as foz
+
+    dataset = foz.load_zoo_dataset("cifar10", split="train")
+    view = dataset.select_fields("ground_truth")
+
+    def map_fcn(sample):
+        return sample.ground_truth.label.upper()
+
+    counter = Counter()
+    for _, label in view.map_samples(map_fcn):
+        counter[label] += 1
+
+    print(dict(counter))
+    # {'DEER': 5000, 'HORSE': 5000, 'AIRPLANE': 5000, ..., 'DOG': 5000}
+
+.. note::
+
+    As the above snippet shows, you should optimize your iteration by
+    :ref:`selecting only <efficient-iteration-views>` the required fields.
+
+By default,
+:meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
+leverages a multiprocessing pool to parallelize the work across a number of
+workers, resulting in signficant performance improvements over the equivalent
+:meth:`iter_samples() <fiftyone.core.dataset.Dataset.iter_samples>` syntax:
+
+.. code-block:: python
+    :linenos:
+
+    counter = Counter()
+    for sample in view.iter_samples(progress=True):
+        label = map_fcn(sample)
+        counter[label] += 1
+
+Keep the following points in mind while using
+:meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`:
+
+-   The samples are not processed in any particular order
+
+-   Your ``map_fcn`` should not modify global state or variables defined
+    outside of the function
+
+-   If your ``map_fcn`` modifies samples in-place, you must pass ``save=True``
+    to save these edits
+
+You can also perform map-reduce and map-aggregate operations with
+:meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
+by providing a ``reduce_fcn`` or ``aggregate_fcn``:
 
 .. tabs::
 
     .. group-tab:: Reduce function
 
+        Reduce functions allow you to efficiently accumulate the outputs of the
+        map function as they are emitted:
+
         .. code-block:: python
             :linenos:
-
-            from collections import Counter
 
             def map_fcn(sample):
-                return sample.ground_truth.label.lower()
-
-            def reduce_fcn(sample_collection, values):
-                return dict(Counter(values.values()))
-
-            counts = view.map_samples(map_fcn, reduce_fcn=reduce_fcn)
-
-            print(counts)
-            # {'deer': 5000, 'horse': 5000, 'airplane': 5000, ..., 'dog': 5000}
-
-        Under the hood,
-        :meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
-        method effectively performs the following operation with the outer loop
-        in parallel:
-
-        .. code-block:: python
-            :linenos:
-
-            import fiftyone.core.utils as fou
-
-            outputs = {}
-
-            for batch_view in fou.iter_slices(view, batch_size=3125):
-                for sample in batch_view.iter_samples(autosave=True):
-                    outputs[sample.id] = map_fcn(sample)
-
-            output = reduce_fcn(view, outputs)
-
-    .. group-tab:: Reduce class
-
-        .. code-block:: python
-            :linenos:
-
-            from collections import Counter
-
-            def map_fcn(sample):
-                return sample.ground_truth.label.lower()
+                return sample.ground_truth.label.upper()
 
             class ReduceFcn(fo.ReduceFcn):
                 def init(self):
                     self.accumulator = Counter()
 
-                def update(self, outputs):
-                    self.accumulator.update(Counter(outputs.values()))
+                def add(self, sample_id, output):
+                    self.accumulator[output] += 1
 
                 def finalize(self):
                     return dict(self.accumulator)
@@ -5854,12 +5927,12 @@ by providing a ``reduce_fcn``:
             counts = view.map_samples(map_fcn, reduce_fcn=ReduceFcn)
 
             print(counts)
-            # {'deer': 5000, 'horse': 5000, 'airplane': 5000, ..., 'dog': 5000}
+            # {'DEER': 5000, 'HORSE': 5000, 'AIRPLANE': 5000, ..., 'DOG': 5000}
 
         Under the hood,
         :meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
-        method effectively performs the following operation with the outer loop
-        in parallel:
+        with a reduce function effectively performs the following operation
+        with the outer loop in parallel:
 
         .. code-block:: python
             :linenos:
@@ -5870,13 +5943,48 @@ by providing a ``reduce_fcn``:
             reducer.init()
 
             for batch_view in fou.iter_slices(view, batch_size=3125):
-                outputs = {}
-                for sample in batch_view.iter_samples(autosave=True):
-                    outputs[sample.id] = map_fcn(sample)
-
-                reducer.update(outputs)
+                for sample in batch_view.iter_samples():
+                    sample_output = map_fcn(sample)
+                    reducer.add(sample.id, sample_output)
 
             output = reducer.finalize()
+
+    .. group-tab:: Aggregate function
+
+        Aggregate functions allow you to perform an action on the dictionary of
+        all map function outputs:
+
+        .. code-block:: python
+            :linenos:
+
+            def map_fcn(sample):
+                return sample.ground_truth.label.upper()
+
+            def aggregate_fcn(sample_collection, outputs):
+                return dict(Counter(outputs.values()))
+
+            counts = view.map_samples(map_fcn, aggregate_fcn=aggregate_fcn)
+
+            print(counts)
+            # {'DEER': 5000, 'HORSE': 5000, 'AIRPLANE': 5000, ..., 'DOG': 5000}
+
+        Under the hood,
+        :meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
+        with an aggregate function effectively performs the following operation
+        with the outer loop in parallel:
+
+        .. code-block:: python
+            :linenos:
+
+            import fiftyone.core.utils as fou
+
+            outputs = {}
+
+            for batch_view in fou.iter_slices(view, batch_size=3125):
+                for sample in batch_view.iter_samples():
+                    outputs[sample.id] = map_fcn(sample)
+
+            output = aggregate_fcn(view, outputs)
 
 You can configure the number of workers that
 :meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
@@ -5884,8 +5992,7 @@ uses in a variety of ways:
 
 -   Configure the default number of workers used by all
     :meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
-    calls by setting the
-    ``default_map_workers`` value in your
+    calls by setting the ``default_map_workers`` value in your
     :ref:`FiftyOne config <configuring-fiftyone>`
 
 -   Manually configure the number of workers for a particular
@@ -5896,7 +6003,8 @@ uses in a variety of ways:
     :meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
     will use
     :func:`recommend_process_pool_workers() <fiftyone.core.utils.recommend_process_pool_workers>`
-    to choose a number of worker processes
+    to choose a number of worker processes, unless the method is called in a
+    daemon process (subprocess), in which case no workers are used
 
 .. note::
 
@@ -5913,7 +6021,35 @@ samples sent to each worker at a time:
 .. code-block:: python
     :linenos:
 
-    view.map_samples(map_fcn, shard_size=50, num_workers=4, progress="global")
+    view.map_samples(map_fcn, reduce_fcn=ReduceFcn, shard_size=50, num_workers=4)
+
+You can also pass `progress="workers"` to
+:meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
+to render progress bar(s) for each worker:
+
+.. code-block:: python
+    :linenos:
+
+    view.map_samples(map_fcn, reduce_fcn=ReduceFcn, num_workers=16, progress="workers")
+
+.. code-block:: text
+
+    Batch 01/16: 100%|█████████████████████████████████████████████████| 3125/3125 [899.01it/s]
+    Batch 02/16: 100%|█████████████████████████████████████████████████| 3125/3125 [894.90it/s]
+    Batch 03/16: 100%|█████████████████████████████████████████████████| 3125/3125 [900.14it/s]
+    Batch 04/16: 100%|█████████████████████████████████████████████████| 3125/3125 [895.61it/s]
+    Batch 05/16: 100%|█████████████████████████████████████████████████| 3125/3125 [903.09it/s]
+    Batch 06/16: 100%|█████████████████████████████████████████████████| 3125/3125 [895.33it/s]
+    Batch 07/16: 100%|█████████████████████████████████████████████████| 3125/3125 [893.26it/s]
+    Batch 08/16: 100%|█████████████████████████████████████████████████| 3125/3125 [889.17it/s]
+    Batch 09/16: 100%|█████████████████████████████████████████████████| 3125/3125 [888.16it/s]
+    Batch 10/16: 100%|█████████████████████████████████████████████████| 3125/3125 [893.69it/s]
+    Batch 11/16: 100%|█████████████████████████████████████████████████| 3125/3125 [896.80it/s]
+    Batch 12/16: 100%|█████████████████████████████████████████████████| 3125/3125 [903.28it/s]
+    Batch 13/16: 100%|█████████████████████████████████████████████████| 3125/3125 [893.63it/s]
+    Batch 14/16: 100%|█████████████████████████████████████████████████| 3125/3125 [891.26it/s]
+    Batch 15/16: 100%|█████████████████████████████████████████████████| 3125/3125 [905.06it/s]
+    Batch 16/16: 100%|█████████████████████████████████████████████████| 3125/3125 [911.72it/s]
 
 .. _set-values:
 

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -5717,6 +5717,151 @@ The benefit of the above approach versus passing ``autosave=True`` to
 to be explicit about which samples you are editing, which avoids unnecessary
 computations if your loop only edits certain samples.
 
+.. _map-reduce-operations:
+
+Map-reduce operations
+---------------------
+
+The
+:meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
+method provides a powerful and efficient interface for iterating over samples,
+applying a function to each sample, saving any sample edits performed, and
+optionally reducing the map function outputs:
+
+.. code-block:: python
+    :linenos:
+
+    import fiftyone as fo
+    import fiftyone.zoo as foz
+
+    dataset = foz.load_zoo_dataset("cifar10", split="train")
+    view = dataset.select_fields("ground_truth")
+
+    def map_fcn(sample):
+        sample.ground_truth.label = sample.ground_truth.label.upper()
+
+    view.map_samples(map_fcn)
+
+    print(dataset.count_values("ground_truth.label"))
+
+.. code-block:: text
+
+    Batch 04/16: 100%|█████████████████████████████████████████████████| 3125/3125 [899.01it/s]
+    Batch 03/16: 100%|█████████████████████████████████████████████████| 3125/3125 [894.90it/s]
+    Batch 11/16: 100%|█████████████████████████████████████████████████| 3125/3125 [900.14it/s]
+    Batch 06/16: 100%|█████████████████████████████████████████████████| 3125/3125 [895.61it/s]
+    Batch 13/16: 100%|█████████████████████████████████████████████████| 3125/3125 [903.09it/s]
+    Batch 08/16: 100%|█████████████████████████████████████████████████| 3125/3125 [895.33it/s]
+    Batch 05/16: 100%|█████████████████████████████████████████████████| 3125/3125 [893.26it/s]
+    Batch 02/16: 100%|█████████████████████████████████████████████████| 3125/3125 [889.17it/s]
+    Batch 01/16: 100%|█████████████████████████████████████████████████| 3125/3125 [888.16it/s]
+    Batch 09/16: 100%|█████████████████████████████████████████████████| 3125/3125 [893.69it/s]
+    Batch 12/16: 100%|█████████████████████████████████████████████████| 3125/3125 [896.80it/s]
+    Batch 14/16: 100%|█████████████████████████████████████████████████| 3125/3125 [903.28it/s]
+    Batch 10/16: 100%|█████████████████████████████████████████████████| 3125/3125 [893.63it/s]
+    Batch 07/16: 100%|█████████████████████████████████████████████████| 3125/3125 [891.26it/s]
+    Batch 15/16: 100%|█████████████████████████████████████████████████| 3125/3125 [905.06it/s]
+    Batch 16/16: 100%|█████████████████████████████████████████████████| 3125/3125 [911.72it/s]
+    {'DEER': 5000, 'HORSE': 5000, 'AIRPLANE': 5000, ..., 'DOG': 5000}
+
+The above example demonstrates some important properties of
+:meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`:
+
+-   :meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
+    does not process samples in any particular order
+
+-   Your ``map_fcn`` may edit samples, but it should not modify global state
+    or variables defined outside of the function
+
+-   You can optimize the operation by
+    :ref:`selecting only <efficient-iteration-views>` the required fields
+
+As you can see,
+:meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
+can leverage a multiprocessing pool to parallelize the work across a number of
+batches, resulting in signficant performance improvements over the equivalent
+:meth:`iter_samples(autosave=True) <fiftyone.core.dataset.Dataset.iter_samples>`
+syntax:
+
+.. code-block:: python
+    :linenos:
+
+    for sample in view.iter_samples(autosave=True, progress=True):
+        map_fcn(sample)
+
+You can also perform map-reduce operations with
+:meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
+by providing a ``reduce_fcn``:
+
+.. code-block:: python
+    :linenos:
+
+    def map_fcn(sample):
+        return sample.ground_truth.label.lower()
+
+    def reduce_fcn(sample_collection, values):
+        from collections import Counter
+        return dict(Counter(values.values()))
+
+    counts = view.map_samples(map_fcn, reduce_fcn=reduce_fcn)
+
+    print(counts)
+    # {'deer': 5000, 'horse': 5000, 'airplane': 5000, ..., 'dog': 5000}
+
+Under the hood,
+:meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
+method effectively performs the following operation with the outer loop in
+parallel:
+
+.. code-block:: python
+    :linenos:
+
+    import fiftyone.core.utils as fou
+
+    outputs = {}
+    for batch_view in fou.iter_slices(view, batch_size=3125):
+        for sample in batch_view.iter_samples(autosave=True):
+            outputs[sample.id] = map_fcn(sample)
+
+    output = reduce_fcn(view, outputs)
+
+You can configure the number of workers that
+:meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
+uses in a variety of ways:
+
+-   Configure the default number of workers used by all
+    :meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
+    calls by setting the
+    ``default_map_workers`` value in your
+    :ref:`FiftyOne config <configuring-fiftyone>`
+
+-   Manually configure the number of workers for a particular
+    :meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
+    call by passing the ``num_workers`` parameter
+
+-   If neither of the above settings are applied,
+    :meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
+    will use
+    :func:`recommend_process_pool_workers() <fiftyone.core.utils.recommend_process_pool_workers>`
+    to choose a number of worker processes
+
+.. note::
+
+    You can set ``default_map_workers<=1`` or ``num_workers<=1`` to disable the
+    use of multiprocessing pools in
+    :meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`.
+
+By default,
+:meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
+evenly distributes samples to all workers in a single shard per worker.
+However, you can pass the ``shard_size`` parameter to customize the number of
+samples sent to each worker at a time:
+
+.. code-block:: python
+    :linenos:
+
+    view.map_samples(map_fcn, shard_size=50, num_workers=4, progress="global")
+
 .. _set-values:
 
 Setting values

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -260,6 +260,7 @@ from .utils.eval.detection import (
     DetectionEvaluationConfig,
     DetectionResults,
 )
+from .utils.multiprocessing import ReduceFcn
 from .utils.eval.regression import (
     evaluate_regressions,
     RegressionEvaluationConfig,

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -260,7 +260,6 @@ from .utils.eval.detection import (
     DetectionEvaluationConfig,
     DetectionResults,
 )
-from .utils.multiprocessing import ReduceFcn
 from .utils.eval.regression import (
     evaluate_regressions,
     RegressionEvaluationConfig,

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -3265,7 +3265,7 @@ class SampleCollection(object):
         When only a ``map_fcn`` is provided, this function effectively performs
         the following map operation with the outer loop in parallel::
 
-            for batch_view in fou.iter_batches(sample_collection, shard_size):
+            for batch_view in fou.iter_slices(sample_collection, shard_size):
                 for sample in batch_view.iter_samples(autosave=True):
                     map_fcn(sample)
 
@@ -3273,8 +3273,8 @@ class SampleCollection(object):
         the following map-reduce operation with the outer loop in parallel::
 
             values = {}
-            for batch_view in fou.iter_batches(sample_collection, shard_size):
-                for sample in batch_view.iter_samples(autosave=save):
+            for batch_view in fou.iter_slices(sample_collection, shard_size):
+                for sample in batch_view.iter_samples(autosave=True):
                     values[sample.id] = map_fcn(sample)
 
             output = reduce_fcn(sample_collection, values)

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -3383,6 +3383,9 @@ class SampleCollection(object):
         if num_workers is None:
             num_workers = fo.config.default_map_workers
 
+        if num_workers is None:
+            num_workers = fou.recommend_process_pool_workers()
+
         if num_workers is not None and num_workers <= 1:
             return self._map_samples_single(
                 map_fcn,

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -12,7 +12,6 @@ from datetime import datetime
 import fnmatch
 import itertools
 import logging
-import multiprocessing
 import numbers
 import os
 import random
@@ -26,7 +25,6 @@ from pymongo import InsertOne, UpdateOne, UpdateMany, WriteConcern
 import eta.core.serial as etas
 import eta.core.utils as etau
 
-import fiftyone as fo
 import fiftyone.core.aggregations as foa
 import fiftyone.core.annotation as foan
 import fiftyone.core.brain as fob
@@ -3249,18 +3247,84 @@ class SampleCollection(object):
     def _delete_labels(self, ids, fields=None):
         self._dataset.delete_labels(ids=ids, fields=fields)
 
-    def map_samples(
+    def update_samples(
         self,
-        map_fcn,
-        reduce_fcn=None,
-        aggregate_fcn=None,
-        save=None,
+        update_fcn,
         num_workers=None,
         shard_size=None,
         shard_method="id",
         progress=None,
     ):
-        """Applies the given function to each sample in the collection.
+        """Applies the given function to each sample in the collection and
+        saves the resulting sample edits.
+
+        By default, a multiprocessing pool is used to parallelize the work,
+        unless this method is called in a daemon process (subprocess), in which
+        case no workers are used.
+
+        This function effectively performs the following map operation with the
+        outer loop in parallel::
+
+            for batch_view in fou.iter_slices(sample_collection, shard_size):
+                for sample in batch_view.iter_samples(autosave=True):
+                    map_fcn(sample)
+
+        Example::
+
+            import fiftyone as fo
+            import fiftyone.zoo as foz
+
+            dataset = foz.load_zoo_dataset("cifar10", split="train")
+            view = dataset.select_fields("ground_truth")
+
+            def update_fcn(sample):
+                sample.ground_truth.label = sample.ground_truth.label.upper()
+
+            view.update_samples(update_fcn)
+
+            print(dataset.count_values("ground_truth.label"))
+
+        Args:
+            update_fcn: a function to apply to each sample in the collection
+            num_workers (None): the number of workers to use. By default,
+                ``fiftyone.config.default_map_workers`` workers are used if
+                this value is set, else
+                :meth:`fiftyone.core.utils.recommend_process_pool_workers`
+                workers are used. If this value is <= 1, all work is done in
+                the main process
+            shard_size (None): an optional number of samples to distribute to
+                each worker at a time. By default, samples are evenly
+                distributed to workers with one shard per worker
+            shard_method ("id"): whether to use IDs (``"id"``) or slices
+                (``"slice"``) to assign samples to workers
+            progress (None): whether to render a progress bar (True/False), use
+                the default value ``fiftyone.config.show_progress_bars``
+                (None), or a progress callback function to invoke instead, or
+                "workers" to render per-worker progress bars
+        """
+        return self._map_samples(
+            update_fcn,
+            return_outputs=False,
+            save=True,
+            num_workers=num_workers,
+            shard_size=shard_size,
+            shard_method=shard_method,
+            progress=progress,
+        )
+
+    def map_samples(
+        self,
+        map_fcn,
+        reduce_fcn=None,
+        aggregate_fcn=None,
+        save=False,
+        num_workers=None,
+        shard_size=None,
+        shard_method="id",
+        progress=None,
+    ):
+        """Applies the given function to each sample in the collection and
+        optionally reduces/aggregates the results.
 
         By default, a multiprocessing pool is used to parallelize the work,
         unless this method is called in a daemon process (subprocess), in which
@@ -3270,22 +3334,20 @@ class SampleCollection(object):
         the following map operation with the outer loop in parallel::
 
             for batch_view in fou.iter_slices(sample_collection, shard_size):
-                for sample in batch_view.iter_samples(autosave=True):
-                    map_fcn(sample)
+                for sample in batch_view.iter_samples(autosave=save):
+                    sample_output = map_fcn(sample)
+                    yield sample.id, sample_output
 
-        When a ``reduce_fcn`` class is provided, this function effectively
-        performs the following map-reduce operation with the outer loop in
-        parallel::
+        When a ``reduce_fcn`` is provided, this function effectively performs
+        the following map-reduce operation with the outer loop in parallel::
 
             reducer = reduce_fcn(sample_collection)
             reducer.init()
 
             for batch_view in fou.iter_slices(sample_collection, shard_size):
-                outputs = {}
-                for sample in batch_view.iter_samples(autosave=True):
-                    outputs[sample.id] = map_fcn(sample)
-
-                reducer.update(outputs)
+                for sample in batch_view.iter_samples(autosave=save):
+                    sample_output = map_fcn(sample)
+                    reducer.add(sample.id, sample_output)
 
             output = reducer.finalize()
 
@@ -3296,7 +3358,7 @@ class SampleCollection(object):
             outputs = {}
 
             for batch_view in fou.iter_slices(sample_collection, shard_size):
-                for sample in batch_view.iter_samples(autosave=True):
+                for sample in batch_view.iter_samples(autosave=save):
                     outputs[sample.id] = map_fcn(sample)
 
             output = aggregate_fcn(sample_collection, outputs)
@@ -3316,25 +3378,27 @@ class SampleCollection(object):
             #
 
             def map_fcn(sample):
-                sample.ground_truth.label = sample.ground_truth.label.upper()
+                return sample.ground_truth.label.upper()
 
-            view.map_samples(map_fcn)
+            counter = Counter()
+            for _, label in view.map_samples(map_fcn):
+                counter[label] += 1
 
-            print(dataset.count_values("ground_truth.label"))
+            print(dict(counter))
 
             #
             # Example 2: map-reduce
             #
 
             def map_fcn(sample):
-                return sample.ground_truth.label.lower()
+                return sample.ground_truth.label.upper()
 
             class ReduceFcn(fo.ReduceFcn):
                 def init(self):
                     self.accumulator = Counter()
 
-                def update(self, outputs):
-                    self.accumulator.update(Counter(outputs.values()))
+                def add(self, sample_id, output):
+                    self.accumulator[output] += 1
 
                 def finalize(self):
                     return dict(self.accumulator)
@@ -3347,10 +3411,10 @@ class SampleCollection(object):
             #
 
             def map_fcn(sample):
-                return sample.ground_truth.label.lower()
+                return sample.ground_truth.label.upper()
 
-            def aggregate_fcn(sample_collection, values):
-                return dict(Counter(values.values()))
+            def aggregate_fcn(sample_collection, outputs):
+                return dict(Counter(outputs.values()))
 
             counts = view.map_samples(map_fcn, aggregate_fcn=aggregate_fcn)
             print(counts)
@@ -3362,9 +3426,8 @@ class SampleCollection(object):
                 reduce the map outputs. See above for usage information
             aggregate_fcn (None): an optional function to aggregate the map
                 outputs. See above for usage information
-            save (None): whether to save any sample edits applied by
-                ``map_fcn``. By default this is True when no ``reduce_fcn`` or
-                ``aggregate_fcn`` is provided and False otherwise
+            save (False): whether to save any sample edits applied by
+                ``map_fcn``
             num_workers (None): the number of workers to use. By default,
                 ``fiftyone.config.default_map_workers`` workers are used if
                 this value is set, else
@@ -3376,35 +3439,16 @@ class SampleCollection(object):
                 distributed to workers with one shard per worker
             shard_method ("id"): whether to use IDs (``"id"``) or slices
                 (``"slice"``) to assign samples to workers
-            progress (None): whether to render a progress bar for each worker
-                (True/False), use the default value
-                ``fiftyone.config.show_progress_bars`` (None), or "global" to
-                render a single global progress bar, or a progress callback
-                function to invoke instead
+            progress (None): whether to render a progress bar (True/False), use
+                the default value ``fiftyone.config.show_progress_bars``
+                (None), or a progress callback function to invoke instead, or
+                "workers" to render per-worker progress bars
 
         Returns:
             the output of ``reduce_fcn`` or ``aggregate_fcn``, if provided,
-            else None
+            otherwise a generator that emits ``(sample_id, map_output)`` tuples
         """
-        if num_workers is None:
-            if multiprocessing.current_process().daemon:
-                num_workers = 1
-            elif fo.config.default_map_workers is not None:
-                num_workers = fo.config.default_map_workers
-            else:
-                num_workers = fou.recommend_process_pool_workers()
-
-        if num_workers is not None and num_workers <= 1:
-            return self._map_samples_single(
-                map_fcn,
-                reduce_fcn=reduce_fcn,
-                aggregate_fcn=aggregate_fcn,
-                save=save,
-                progress=progress,
-            )
-
-        return foum.map_samples(
-            self,
+        return self._map_samples(
             map_fcn,
             reduce_fcn=reduce_fcn,
             aggregate_fcn=aggregate_fcn,
@@ -3415,37 +3459,30 @@ class SampleCollection(object):
             progress=progress,
         )
 
-    def _map_samples_single(
+    def _map_samples(
         self,
         map_fcn,
         reduce_fcn=None,
         aggregate_fcn=None,
-        save=None,
-        progress=False,
+        return_outputs=True,
+        save=False,
+        num_workers=None,
+        shard_size=None,
+        shard_method="id",
+        progress=None,
     ):
-        if reduce_fcn is not None:
-            reducer = reduce_fcn(self)
-        elif aggregate_fcn is not None:
-            reducer = foum.ReduceFcn(self, aggregate_fcn=aggregate_fcn)
-        else:
-            reducer = None
-
-        if save is None:
-            save = reducer is None
-
-        if reducer is not None:
-            reducer.init()
-
-        if progress == "global":
-            progress = True
-
-        for sample in self.iter_samples(autosave=save, progress=progress):
-            sample_output = map_fcn(sample)
-            if reducer is not None and sample_output is not None:
-                reducer.update({sample.id: sample_output})
-
-        if reducer is not None:
-            return reducer.finalize()
+        return foum.map_samples(
+            self,
+            map_fcn,
+            reduce_fcn=reduce_fcn,
+            aggregate_fcn=aggregate_fcn,
+            return_outputs=return_outputs,
+            save=save,
+            num_workers=num_workers,
+            shard_size=shard_size,
+            shard_method=shard_method,
+            progress=progress,
+        )
 
     def compute_metadata(
         self,

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -244,6 +244,12 @@ class FiftyOneConfig(EnvConfig):
         self.timezone = self.parse_string(
             d, "timezone", env_var="FIFTYONE_TIMEZONE", default=None
         )
+        self.default_map_workers = self.parse_int(
+            d,
+            "default_map_workers",
+            env_var="FIFTYONE_DEFAULT_MAP_WORKERS",
+            default=None,
+        )
         self.max_thread_pool_workers = self.parse_int(
             d,
             "max_thread_pool_workers",

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -17,7 +17,7 @@ from typing import Tuple
 import asyncio
 from bson import json_util, ObjectId
 from bson.codec_options import CodecOptions
-from mongoengine import connect
+import mongoengine
 import motor.motor_asyncio as mtr
 
 from packaging.version import Version
@@ -222,7 +222,7 @@ def establish_db_conn(config):
     # Register cleanup method
     atexit.register(_delete_non_persistent_datasets_if_allowed)
 
-    connect(config.database_name, **_connection_kwargs)
+    mongoengine.connect(config.database_name, **_connection_kwargs)
 
     db_config = get_db_config()
     if db_config.type != foc.CLIENT_TYPE:
@@ -244,6 +244,13 @@ def _connect():
         global _connection_kwargs
 
         establish_db_conn(fo.config)
+
+
+def _disconnect():
+    global _client, _async_client
+    _client = None
+    _async_client = None
+    mongoengine.disconnect_all()
 
 
 def _async_connect(use_global=False):

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -2480,6 +2480,10 @@ def recommend_thread_pool_workers(num_workers=None):
 def recommend_process_pool_workers(num_workers=None):
     """Recommends a number of workers for a process pool.
 
+    By default, ``multiprocessing.cpu_count()`` workers will be recommended if
+    you are running on macOS or Linux, while a single worker will be
+    recommended on Windows.
+
     If a ``fo.config.max_process_pool_workers`` is set, this limit is applied.
 
     Args:

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -23,6 +23,7 @@ import logging
 import multiprocessing
 import numbers
 import os
+from packaging.version import Version
 import platform
 import re
 import signal
@@ -2434,26 +2435,23 @@ def _is_podman():
 def get_multiprocessing_context():
     """Returns the preferred ``multiprocessing`` context for the current OS.
 
+    When running on macOS or Linux with no start method configured, this method
+    will set the default start method to ``"fork"``.
+
     Returns:
         a ``multiprocessing`` context
     """
     if (
-        sys.platform == "darwin"
+        sys.platform in ("darwin", "linux")
         and multiprocessing.get_start_method(allow_none=True) is None
+        and Version(platform.python_version()) < Version("3.14")
     ):
-        #
-        # If we're running on macOS and the user didn't manually configure the
-        # default multiprocessing context, force 'fork' to be used
-        #
-        # Background: on macOS, multiprocessing's default context was changed
-        # from 'fork' to 'spawn' in Python 3.8, but we prefer 'fork' because
-        # the startup time is much shorter. Also, this is not fully proven, but
-        # @brimoor believes he's seen cases where 'spawn' causes some of our
-        # `multiprocessing.Pool.imap_unordered()` calls to run twice...
-        #
-        return multiprocessing.get_context("fork")
+        # We prefer 'fork' because the startup time is shorter.
+        # Also, note that we intentionally set the start method here so that
+        # subsequent usage of things like `multiprocessing.Queue()` will not
+        # cause the default start method to switch to 'spawn'
+        multiprocessing.set_start_method("fork", force=True)
 
-    # Use the default context
     return multiprocessing.get_context()
 
 

--- a/fiftyone/utils/multiprocessing.py
+++ b/fiftyone/utils/multiprocessing.py
@@ -32,7 +32,7 @@ def map_samples(
     When only a ``map_fcn`` is provided, this function effectively performs
     the following map operation with the outer loop in parallel::
 
-        for batch_view in fou.iter_batches(sample_collection, shard_size):
+        for batch_view in fou.iter_slices(sample_collection, shard_size):
             for sample in batch_view.iter_samples(autosave=True):
                 map_fcn(sample)
 
@@ -40,8 +40,8 @@ def map_samples(
     the following map-reduce operation with the outer loop in parallel::
 
         values = {}
-        for batch_view in fou.iter_batches(sample_collection, shard_size):
-            for sample in batch_view.iter_samples(autosave=save):
+        for batch_view in fou.iter_slices(sample_collection, shard_size):
+            for sample in batch_view.iter_samples(autosave=True):
                 values[sample.id] = map_fcn(sample)
 
         output = reduce_fcn(sample_collection, values)

--- a/fiftyone/utils/multiprocessing.py
+++ b/fiftyone/utils/multiprocessing.py
@@ -1,0 +1,294 @@
+"""
+Multiprocessing utilities.
+
+| Copyright 2017-2025, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import itertools
+
+from bson import ObjectId
+import numpy as np
+from tqdm.auto import tqdm
+
+import fiftyone as fo
+import fiftyone.core.utils as fou
+import fiftyone.core.view as fov
+
+
+def map_samples(
+    sample_collection,
+    map_fcn,
+    reduce_fcn=None,
+    save=None,
+    num_workers=None,
+    shard_size=None,
+    shard_method="id",
+    progress=None,
+):
+    """Applies the given function to each sample in the collection via a
+    multiprocessing pool.
+
+    When only a ``map_fcn`` is provided, this function effectively performs
+    the following map operation with the outer loop in parallel::
+
+        for batch_view in fou.iter_batches(sample_collection, shard_size):
+            for sample in batch_view.iter_samples(autosave=True):
+                map_fcn(sample)
+
+    When a ``reduce_fcn`` is provided, this function effectively performs
+    the following map-reduce operation with the outer loop in parallel::
+
+        values = {}
+        for batch_view in fou.iter_batches(sample_collection, shard_size):
+            for sample in batch_view.iter_samples(autosave=save):
+                values[sample.id] = map_fcn(sample)
+
+        output = reduce_fcn(sample_collection, values)
+
+    Example::
+
+        import fiftyone as fo
+        import fiftyone.utils.multiprocessing as foum
+        import fiftyone.zoo as foz
+
+        dataset = foz.load_zoo_dataset("cifar10", split="train")
+        view = dataset.select_fields("ground_truth")
+
+        #
+        # Example 1: map
+        #
+
+        def map_fcn(sample):
+            sample.ground_truth.label = sample.ground_truth.label.upper()
+
+        foum.map_samples(view, map_fcn)
+
+        print(dataset.count_values("ground_truth.label"))
+
+        #
+        # Example 2: map-reduce
+        #
+
+        def map_fcn(sample):
+            return sample.ground_truth.label.lower()
+
+        def reduce_fcn(sample_collection, values):
+            from collections import Counter
+            return dict(Counter(values.values()))
+
+        counts = foum.map_samples(view, map_fcn, reduce_fcn=reduce_fcn)
+        print(counts)
+
+    Args:
+        sample_collection: a
+            :class:`fiftyone.core.collections.SampleCollection`
+        map_fcn: a function to apply to each sample
+        reduce_fcn (None): an optional function to reduce the map outputs. See
+            the docstring above for usage information
+        save (None): whether to save any sample edits applied by ``map_fcn``.
+            By default this is True when no ``reduce_fcn`` is provided and
+            False when a ``reduce_fcn`` is provided
+        num_workers (None): the number of workers to use. The default is
+            :meth:`fiftyone.core.utils.recommend_process_pool_workers`
+        shard_size (None): an optional number of samples to distribute to each
+            worker at a time. By default, samples are evenly distributed to
+            workers with one shard per worker
+        shard_method ("id"): whether to use IDs (``"id"``) or slices
+            (``"slice"``) to assign samples to workers
+        progress (None): whether to render a progress bar for each worker
+            (True/False), use the default value
+            ``fiftyone.config.show_progress_bars`` (None), or "global" to
+            render a single global progress bar, or a progress callback
+            function to invoke instead
+
+    Returns:
+        the output of ``reduce_fcn``, if provided, else None
+    """
+    if isinstance(sample_collection, fov.DatasetView):
+        dataset_name = sample_collection._root_dataset.name
+        view_stages = sample_collection._serialize()
+    else:
+        dataset_name = sample_collection.name
+        view_stages = None
+
+    batches, num_workers = _init_batches(
+        sample_collection,
+        shard_size=shard_size,
+        shard_method=shard_method,
+        num_workers=num_workers,
+    )
+
+    if save is None:
+        save = reduce_fcn is None
+
+    if progress is None:
+        progress = fo.config.show_progress_bars
+
+    return_outputs = reduce_fcn is not None
+    global_progress = False
+    lock = None
+
+    ctx = fou.get_multiprocessing_context()
+
+    if progress is True:
+        lock = ctx.RLock()
+        tqdm.set_lock(lock)
+    elif progress == "global":
+        global_progress = True
+        progress = False
+    elif callable(progress):
+        global_progress = progress
+        progress = False
+
+    pool = ctx.Pool(
+        processes=num_workers,
+        initializer=_init_worker,
+        initargs=(
+            dataset_name,
+            view_stages,
+            map_fcn,
+            save,
+            return_outputs,
+            progress,
+            lock,
+        ),
+    )
+
+    outputs = {}
+
+    pb = fou.ProgressBar(
+        total=len(batches),
+        progress=global_progress,
+        iters_str="batches",
+    )
+
+    with pb, pool:
+        for _outputs in pb(pool.imap_unordered(_map_batch, batches)):
+            if _outputs is not None:
+                outputs.update(_outputs)
+
+    if reduce_fcn is not None:
+        return reduce_fcn(sample_collection, outputs)
+
+
+def _init_batches(
+    sample_collection,
+    shard_size=None,
+    shard_method="id",
+    num_workers=None,
+):
+    if shard_method == "slice":
+        n = len(sample_collection)
+    else:
+        ids = sample_collection.values("id")
+        n = len(ids)
+
+    if num_workers is None:
+        num_workers = fou.recommend_process_pool_workers()
+
+    # Must cap size of select(ids) stages
+    if shard_method == "id":
+        max_shard_size = fou.recommend_batch_size_for_value(
+            ObjectId(), max_size=100000
+        )
+
+        if shard_size is not None:
+            shard_size = min(shard_size, max_shard_size)
+        elif n > num_workers * max_shard_size:
+            shard_size = max_shard_size
+
+    if shard_size is not None:
+        # Fixed size shards
+        edges = list(range(0, n + 1, shard_size))
+        if edges[-1] < n:
+            edges.append(n)
+    else:
+        # Split collection into exactly `num_workers` shards
+        edges = [int(round(b)) for b in np.linspace(0, n, num_workers + 1)]
+
+    if shard_method == "slice":
+        # Slice batches
+        slices = list(zip(edges[:-1], edges[1:]))
+    else:
+        # ID batches
+        slices = [ids[i:j] for i, j in zip(edges[:-1], edges[1:])]
+
+    num_shards = len(slices)
+    batches = list(
+        zip(
+            range(num_shards),
+            itertools.repeat(num_shards),
+            slices,
+        )
+    )
+
+    num_workers = min(num_workers, num_shards)
+
+    return batches, num_workers
+
+
+def _init_worker(dataset_name, view_stages, m, s, r, p, l):
+    from tqdm.auto import tqdm
+
+    import fiftyone as fo
+    import fiftyone.core.odm.database as food
+    import fiftyone.core.view as fov
+
+    global sample_collection, map_fcn, save, return_outputs, progress
+
+    # Ensure that each process creates its own MongoDB clients
+    # https://pymongo.readthedocs.io/en/stable/faq.html#using-pymongo-with-multiprocessing
+    food._disconnect()
+
+    dataset = fo.load_dataset(dataset_name)
+    if view_stages:
+        sample_collection = fov.DatasetView._build(dataset, view_stages)
+    else:
+        sample_collection = dataset
+
+    map_fcn = m
+    save = s
+    return_outputs = r
+    progress = p
+
+    if l is not None:
+        tqdm.set_lock(l)
+
+
+def _map_batch(input):
+    i, num_batches, batch = input
+
+    if isinstance(batch, tuple):
+        # Slice batches
+        start, stop = batch
+        total = stop - start
+        batch_view = sample_collection[start:stop]
+    else:
+        # ID batches
+        sample_ids = batch
+        total = len(sample_ids)
+        batch_view = fov.make_optimized_select_view(
+            sample_collection, sample_ids
+        )
+
+    if return_outputs:
+        values = {}
+
+    if progress:
+        desc = f"Batch {i + 1:0{len(str(num_batches))}}/{num_batches}"
+        with tqdm(total=total, desc=desc, position=i) as pb:
+            for sample in batch_view.iter_samples(autosave=save):
+                result = map_fcn(sample)
+                if return_outputs and result is not None:
+                    values[sample.id] = result
+
+                pb.update()
+    else:
+        for sample in batch_view.iter_samples(autosave=save):
+            result = map_fcn(sample)
+            if return_outputs and result is not None:
+                values[sample.id] = result
+
+    if return_outputs:
+        return values

--- a/fiftyone/utils/multiprocessing.py
+++ b/fiftyone/utils/multiprocessing.py
@@ -7,6 +7,8 @@ Multiprocessing utilities.
 """
 import itertools
 import multiprocessing
+from queue import Empty
+import time
 
 from bson import ObjectId
 import dill as pickle
@@ -23,21 +25,24 @@ def map_samples(
     map_fcn,
     reduce_fcn=None,
     aggregate_fcn=None,
-    save=None,
+    return_outputs=True,
+    save=False,
     num_workers=None,
     shard_size=None,
     shard_method="id",
     progress=None,
 ):
     """Applies the given function to each sample in the collection via a
-    multiprocessing pool.
+    multiprocessing pool, optionally saving any sample edits and
+    reducing/aggregating the outputs.
 
     When only a ``map_fcn`` is provided, this function effectively performs
     the following map operation with the outer loop in parallel::
 
         for batch_view in fou.iter_slices(sample_collection, shard_size):
-            for sample in batch_view.iter_samples(autosave=True):
-                map_fcn(sample)
+            for sample in batch_view.iter_samples(autosave=save):
+                sample_output = map_fcn(sample)
+                yield sample.id, sample_output
 
     When a ``reduce_fcn`` is provided, this function effectively performs the
     following map-reduce operation with the outer loop in parallel::
@@ -46,11 +51,9 @@ def map_samples(
         reducer.init()
 
         for batch_view in fou.iter_slices(sample_collection, shard_size):
-            outputs = {}
-            for sample in batch_view.iter_samples(autosave=True):
-                outputs[sample.id] = map_fcn(sample)
-
-            reducer.update(outputs)
+            for sample in batch_view.iter_samples(autosave=save):
+                sample_output = map_fcn(sample)
+                reducer.add(sample.id, sample_output)
 
         output = reducer.finalize()
 
@@ -60,7 +63,7 @@ def map_samples(
         outputs = {}
 
         for batch_view in fou.iter_slices(sample_collection, shard_size):
-            for sample in batch_view.iter_samples(autosave=True):
+            for sample in batch_view.iter_samples(autosave=save):
                 outputs[sample.id] = map_fcn(sample)
 
         output = aggregate_fcn(sample_collection, outputs)
@@ -77,18 +80,31 @@ def map_samples(
         view = dataset.select_fields("ground_truth")
 
         #
-        # Example 1: map
+        # Example 1: update
         #
 
         def map_fcn(sample):
             sample.ground_truth.label = sample.ground_truth.label.upper()
 
-        foum.map_samples(view, map_fcn)
+        foum.map_samples(view, map_fcn, return_outputs=False, save=True)
 
         print(dataset.count_values("ground_truth.label"))
 
         #
-        # Example 2: map-reduce
+        # Example 2: map
+        #
+
+        def map_fcn(sample):
+            return sample.ground_truth.label.lower()
+
+        counter = Counter()
+        for _, label in foum.map_samples(view, map_fcn):
+            counter[label] += 1
+
+        print(dict(counter))
+
+        #
+        # Example 3: map-reduce
         #
 
         def map_fcn(sample):
@@ -98,8 +114,8 @@ def map_samples(
             def init(self):
                 self.accumulator = Counter()
 
-            def update(self, outputs):
-                self.accumulator.update(Counter(outputs.values()))
+            def add(self, sample_id, output):
+                self.accumulator[output] += 1
 
             def finalize(self):
                 return dict(self.accumulator)
@@ -108,14 +124,14 @@ def map_samples(
         print(counts)
 
         #
-        # Example 3: map-aggregate
+        # Example 4: map-aggregate
         #
 
         def map_fcn(sample):
             return sample.ground_truth.label.lower()
 
-        def aggregate_fcn(sample_collection, values):
-            return dict(Counter(values.values()))
+        def aggregate_fcn(sample_collection, outputs):
+            return dict(Counter(outputs.values()))
 
         counts = foum.map_samples(view, map_fcn, aggregate_fcn=aggregate_fcn)
         print(counts)
@@ -128,26 +144,49 @@ def map_samples(
             the map outputs. See above for usage information
         aggregate_fcn (None): an optional function to aggregate the map
             outputs. See above for usage information
-        save (None): whether to save any sample edits applied by ``map_fcn``.
-            By default this is True when no ``reduce_fcn`` or ``aggregate_fcn``
-            is provided and False otherwise
+        return_outputs (True): whether to return the map outputs. This has no
+            effect when a ``reduce_fcn`` or ``aggregate_fcn`` is provided
+        save (False): whether to save any sample edits applied by ``map_fcn``
         num_workers (None): the number of workers to use. The default is
-            :meth:`fiftyone.core.utils.recommend_process_pool_workers`
+            :meth:`fiftyone.core.utils.recommend_process_pool_workers`. If this
+            value is <= 1, all work is done in the main process
         shard_size (None): an optional number of samples to distribute to each
             worker at a time. By default, samples are evenly distributed to
             workers with one shard per worker
         shard_method ("id"): whether to use IDs (``"id"``) or slices
             (``"slice"``) to assign samples to workers
-        progress (None): whether to render a progress bar for each worker
-            (True/False), use the default value
-            ``fiftyone.config.show_progress_bars`` (None), or "global" to
-            render a single global progress bar, or a progress callback
-            function to invoke instead
+        progress (None): whether to render a progress bar (True/False), use the
+            default value ``fiftyone.config.show_progress_bars`` (None), or a
+            progress callback function to invoke instead, or "workers" to
+            render per-worker progress bars
 
     Returns:
-        the output of ``reduce_fcn`` or ``aggregate_fcn``, if provided, else
-        None
+        one of the following:
+
+        -   the output of ``reduce_fcn`` or ``aggregate_fcn``, if provided
+        -   a generator that emits ``(sample_id, map_output)`` tuples, if
+            ``return_outputs`` is True
+        -   None, otherwise
     """
+    if num_workers is None:
+        if multiprocessing.current_process().daemon:
+            num_workers = 1
+        elif fo.config.default_map_workers is not None:
+            num_workers = fo.config.default_map_workers
+        else:
+            num_workers = fou.recommend_process_pool_workers()
+
+    if num_workers <= 1:
+        return _map_samples_single(
+            sample_collection,
+            map_fcn,
+            reduce_fcn=reduce_fcn,
+            aggregate_fcn=aggregate_fcn,
+            return_outputs=return_outputs,
+            save=save,
+            progress=progress,
+        )
+
     if isinstance(sample_collection, fov.DatasetView):
         dataset_name = sample_collection._root_dataset.name
         view_stages = sample_collection._serialize()
@@ -155,12 +194,14 @@ def map_samples(
         dataset_name = sample_collection.name
         view_stages = None
 
-    batches, num_workers = _init_batches(
+    batches, num_workers, num_samples = _init_batches(
         sample_collection,
         shard_size=shard_size,
         shard_method=shard_method,
         num_workers=num_workers,
     )
+
+    ctx = fou.get_multiprocessing_context()
 
     if reduce_fcn is not None:
         reducer = reduce_fcn(sample_collection)
@@ -169,27 +210,33 @@ def map_samples(
     else:
         reducer = None
 
-    if save is None:
-        save = reducer is None
+    if reducer is not None:
+        return_outputs = True
 
     if progress is None:
         progress = fo.config.show_progress_bars
 
-    return_outputs = reducer is not None
-    global_progress = False
-    lock = None
-
-    ctx = fou.get_multiprocessing_context()
-
-    if progress is True:
+    if progress == "workers":
+        worker_progress = True
+        progress = False
         lock = ctx.RLock()
         tqdm.set_lock(lock)
-    elif progress == "global":
-        global_progress = True
-        progress = False
-    elif callable(progress):
-        global_progress = progress
-        progress = False
+    else:
+        worker_progress = False
+        lock = None
+
+    if return_outputs:
+        batch_count = multiprocessing.Value("i", 0)
+        sample_count = None
+        queue = multiprocessing.Queue()
+    elif progress != False:
+        batch_count = multiprocessing.Value("i", 0)
+        sample_count = multiprocessing.Value("i", 0)
+        queue = None
+    else:
+        batch_count = None
+        sample_count = None
+        queue = None
 
     pool = ctx.Pool(
         processes=num_workers,
@@ -198,36 +245,163 @@ def map_samples(
             dataset_name,
             view_stages,
             pickle.dumps(map_fcn),
+            batch_count,
+            sample_count,
+            queue,
             save,
-            return_outputs,
-            progress,
+            worker_progress,
             lock,
         ),
     )
 
-    pb = fou.ProgressBar(
-        total=len(batches),
-        progress=global_progress,
-        iters_str="batches",
-    )
+    pb = fou.ProgressBar(total=num_samples, progress=progress)
 
     if reducer is not None:
-        reducer.init()
+        return _do_map_reduce_samples(
+            pool, pb, batches, batch_count, queue, reducer
+        )
+    elif queue is not None:
+        return _do_map_samples(pool, pb, batches, batch_count, queue)
+    else:
+        return _do_update_samples(pool, pb, batches, batch_count, sample_count)
 
-    with pb, pool:
-        for _outputs in pb(pool.imap_unordered(_map_batch, batches)):
-            if _outputs is not None:
-                reducer.update(_outputs)
+
+def _do_update_samples(pool, pb, batches, batch_count, sample_count):
+    num_batches = len(batches)
+
+    with pool, pb:
+        pool.map_async(_map_batch, batches)
+
+        if batch_count is not None:
+            while batch_count.value < num_batches:
+                pb.set_iteration(sample_count.value)
+                time.sleep(0.01)
+
+            pb.set_iteration(sample_count.value)
+
+        pool.close()
+        pool.join()
+
+
+def _do_map_samples(pool, pb, batches, batch_count, queue):
+    num_batches = len(batches)
+
+    with pool, pb:
+        pool.map_async(_map_batch, batches)
+
+        while True:
+            try:
+                result = queue.get(timeout=0.01)
+                pb.update()
+                yield result
+            except Empty:
+                if batch_count.value >= num_batches:
+                    break
+
+        queue.close()
+        queue.join_thread()
+
+        pool.close()
+        pool.join()
+
+
+def _do_map_reduce_samples(pool, pb, batches, batch_count, queue, reducer):
+    num_batches = len(batches)
+
+    reducer.init()
+
+    with pool, pb:
+        pool.map_async(_map_batch, batches)
+
+        while True:
+            try:
+                result = queue.get(timeout=0.01)
+                pb.update()
+                reducer.add(*result)
+            except Empty:
+                if batch_count.value >= num_batches:
+                    break
+
+        queue.close()
+        queue.join_thread()
+
+        pool.close()
+        pool.join()
+
+    return reducer.finalize()
+
+
+def _map_samples_single(
+    sample_collection,
+    map_fcn,
+    reduce_fcn=None,
+    aggregate_fcn=None,
+    return_outputs=True,
+    save=False,
+    progress=None,
+):
+    if reduce_fcn is not None:
+        reducer = reduce_fcn(sample_collection)
+    elif aggregate_fcn is not None:
+        reducer = ReduceFcn(sample_collection, aggregate_fcn=aggregate_fcn)
+    else:
+        reducer = None
+
+    if progress == "workers":
+        progress = True
 
     if reducer is not None:
-        return reducer.finalize()
+        return _do_map_reduce_samples_single(
+            sample_collection, map_fcn, reducer, save=save, progress=progress
+        )
+    elif return_outputs:
+        return _do_map_samples_single(
+            sample_collection, map_fcn, save=save, progress=progress
+        )
+    else:
+        return _do_update_samples_single(
+            sample_collection, map_fcn, save=save, progress=progress
+        )
+
+
+def _do_update_samples_single(
+    sample_collection, map_fcn, save=False, progress=None
+):
+    for sample in sample_collection.iter_samples(
+        autosave=save, progress=progress
+    ):
+        map_fcn(sample)
+
+
+def _do_map_samples_single(
+    sample_collection, map_fcn, save=False, progress=None
+):
+    for sample in sample_collection.iter_samples(
+        autosave=save, progress=progress
+    ):
+        sample_output = map_fcn(sample)
+        yield sample.id, sample_output
+
+
+def _do_map_reduce_samples_single(
+    sample_collection, map_fcn, reducer, save=False, progress=None
+):
+    reducer.init()
+
+    for sample in sample_collection.iter_samples(
+        autosave=save, progress=progress
+    ):
+        sample_output = map_fcn(sample)
+        reducer.add(sample.id, sample_output)
+
+    return reducer.finalize()
 
 
 class ReduceFcn(object):
     """Base class for reducers for use with :func:`map_samples`.
 
-    Subclasses may optionally override :meth:`init`, :meth:`update`, and
-    :meth:`finalize` as necessary.
+    Subclasses may optionally override :meth:`init`, :meth:`add`,
+    :meth:`update`, and :meth:`finalize` as necessary.
     """
 
     def __init__(self, sample_collection, aggregate_fcn=None):
@@ -238,6 +412,15 @@ class ReduceFcn(object):
     def init(self):
         """Initializes the reducer."""
         self.accumulator = {}
+
+    def add(self, sample_id, output):
+        """Adds a map output to the reducer.
+
+        Args:
+            sample_id: a sample ID
+            output: a map output
+        """
+        self.accumulator[sample_id] = output
 
     def update(self, outputs):
         """Adds a batch of map outputs to the reducer.
@@ -310,17 +493,23 @@ def _init_batches(
 
     num_workers = min(num_workers, num_shards)
 
-    return batches, num_workers
+    return batches, num_workers, n
 
 
-def _init_worker(dataset_name, view_stages, m, s, r, p, l):
+def _init_worker(dataset_name, view_stages, m, bc, sc, q, s, p, l):
     from tqdm.auto import tqdm
 
     import fiftyone as fo
     import fiftyone.core.odm.database as food
     import fiftyone.core.view as fov
 
-    global sample_collection, map_fcn, save, return_outputs, progress
+    global sample_collection
+    global map_fcn
+    global batch_count
+    global sample_count
+    global queue
+    global save
+    global progress
 
     # Ensure that each process creates its own MongoDB clients
     # https://pymongo.readthedocs.io/en/stable/faq.html#using-pymongo-with-multiprocessing
@@ -333,8 +522,10 @@ def _init_worker(dataset_name, view_stages, m, s, r, p, l):
         sample_collection = dataset
 
     map_fcn = pickle.loads(m)
+    batch_count = bc
+    sample_count = sc
+    queue = q
     save = s
-    return_outputs = r
     progress = p
 
     if l is not None:
@@ -357,23 +548,25 @@ def _map_batch(input):
             sample_collection, sample_ids
         )
 
-    if return_outputs:
-        values = {}
-
     if progress:
         desc = f"Batch {i + 1:0{len(str(num_batches))}}/{num_batches}"
         with tqdm(total=total, desc=desc, position=i) as pb:
             for sample in batch_view.iter_samples(autosave=save):
-                result = map_fcn(sample)
-                if return_outputs and result is not None:
-                    values[sample.id] = result
+                sample_output = map_fcn(sample)
+                if queue is not None:
+                    queue.put((sample.id, sample_output))
 
                 pb.update()
     else:
         for sample in batch_view.iter_samples(autosave=save):
-            result = map_fcn(sample)
-            if return_outputs and result is not None:
-                values[sample.id] = result
+            sample_output = map_fcn(sample)
+            if queue is not None:
+                queue.put((sample.id, sample_output))
 
-    if return_outputs:
-        return values
+            if sample_count is not None:
+                with sample_count.get_lock():
+                    sample_count.value += 1
+
+    if batch_count is not None:
+        with batch_count.get_lock():
+            batch_count.value += 1

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ INSTALL_REQUIRES = [
     "starlette>=0.24.0",
     "strawberry-graphql~=0.257.0",
     "tabulate",
+    "tqdm",
     "xmltodict",
     "universal-analytics-python3>=1.0.1,<2",
     "pydash",

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ INSTALL_REQUIRES = [
     "cachetools",
     "dacite>=1.6.0,<1.8.0",
     "Deprecated",
+    "dill",
     "ftfy",
     "humanize",
     "hypercorn>=0.13.2",

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -1079,19 +1079,6 @@ class DatasetTests(unittest.TestCase):
         def map_fcn(sample):
             return sample.foo.upper()
 
-        class ReduceFcn(fo.ReduceFcn):
-            def init(self):
-                self.accumulator = Counter()
-
-            def add(self, sample_id, output):
-                self.accumulator[output] += 1
-
-            def finalize(self):
-                return dict(self.accumulator)
-
-        def aggregate_fcn(dataset, outputs):
-            return dict(Counter(outputs.values()))
-
         #
         # Multiple workers
         #
@@ -1104,26 +1091,6 @@ class DatasetTests(unittest.TestCase):
 
         self.assertDictEqual(counts, {"BAR": 50})
 
-        counts = dataset.map_samples(
-            map_fcn,
-            reduce_fcn=ReduceFcn,
-            num_workers=2,
-            shard_size=10,
-            shard_method="id",
-        )
-
-        self.assertDictEqual(counts, {"BAR": 50})
-
-        counts = dataset.map_samples(
-            map_fcn,
-            aggregate_fcn=aggregate_fcn,
-            num_workers=2,
-            shard_size=10,
-            shard_method="slice",
-        )
-
-        self.assertDictEqual(counts, {"BAR": 50})
-
         #
         # Main process
         #
@@ -1133,18 +1100,6 @@ class DatasetTests(unittest.TestCase):
             counter[value] += 1
 
         counts = dict(counter)
-
-        self.assertDictEqual(counts, {"BAR": 50})
-
-        counts = dataset.map_samples(
-            map_fcn, reduce_fcn=ReduceFcn, num_workers=1
-        )
-
-        self.assertDictEqual(counts, {"BAR": 50})
-
-        counts = dataset.map_samples(
-            map_fcn, aggregate_fcn=aggregate_fcn, num_workers=1
-        )
 
         self.assertDictEqual(counts, {"BAR": 50})
 

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -168,19 +168,6 @@ class DatasetViewTests(unittest.TestCase):
         def map_fcn(sample):
             return sample.foo.upper()
 
-        class ReduceFcn(fo.ReduceFcn):
-            def init(self):
-                self.accumulator = Counter()
-
-            def add(self, sample_id, output):
-                self.accumulator[output] += 1
-
-            def finalize(self):
-                return dict(self.accumulator)
-
-        def aggregate_fcn(view, outputs):
-            return dict(Counter(outputs.values()))
-
         #
         # Multiple workers
         #
@@ -193,26 +180,6 @@ class DatasetViewTests(unittest.TestCase):
 
         self.assertDictEqual(counts, {"BAR": 50})
 
-        counts = view.map_samples(
-            map_fcn,
-            reduce_fcn=ReduceFcn,
-            num_workers=2,
-            shard_size=10,
-            shard_method="id",
-        )
-
-        self.assertDictEqual(counts, {"BAR": 50})
-
-        counts = view.map_samples(
-            map_fcn,
-            aggregate_fcn=aggregate_fcn,
-            num_workers=2,
-            shard_size=10,
-            shard_method="slice",
-        )
-
-        self.assertDictEqual(counts, {"BAR": 50})
-
         #
         # Main process
         #
@@ -222,16 +189,6 @@ class DatasetViewTests(unittest.TestCase):
             counter[value] += 1
 
         counts = dict(counter)
-
-        self.assertDictEqual(counts, {"BAR": 50})
-
-        counts = view.map_samples(map_fcn, reduce_fcn=ReduceFcn, num_workers=1)
-
-        self.assertDictEqual(counts, {"BAR": 50})
-
-        counts = view.map_samples(
-            map_fcn, aggregate_fcn=aggregate_fcn, num_workers=1
-        )
 
         self.assertDictEqual(counts, {"BAR": 50})
 


### PR DESCRIPTION
## Change log

Adds two new methods to the `SampleCollection` interface that can leverage multiprocessing pools to perform efficient operations:
-  `update_samples()`: applies an `update_fcn` to each sample and saves and sample edits
- `map_samples()`: applies a `map_fcn` to each sample in the collection in parallel and returns the outputs as a generator

Notes 
- by default `multiprocessing.cpu_count()` workers are used to parallelize the work, unless the methods are invoked from daemon processes, in which case multiprocessing is automatically disabled.
- a new `fo.config.default_map_workers` setting allows for global configuration of the number of workers used by these methods
- the methods support both `'spawn'` and `'fork'` processes
- `shard_size` and `shard_method` options allow for optionally configuring how batching is performed

Refer to the included documentation for full details.

## Example 1: update

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("cifar10", split="train")
view = dataset.select_fields("ground_truth")

def update_fcn(sample):
    sample.ground_truth.label = sample.ground_truth.label.upper()

view.update_samples(update_fcn)

print(dataset.count_values("ground_truth.label"))
```

```
 100% |████████████████████████████████████████████████████████████████████████████████████| 50000/50000 [3.3s elapsed, 0s remaining, 15.2K samples/s]      
{'DEER': 5000, 'HORSE': 5000, 'AIRPLANE': 5000, 'FROG': 5000, 'BIRD': 5000, 'AUTOMOBILE': 5000, 'SHIP': 5000, 'CAT': 5000, 'TRUCK': 5000, 'DOG': 5000}
```

You can optionally show per-worker progress bars via `progress="workers"`:

```py
view.update_samples(update_fcn, progress="workers")
```

```
Batch 04/16: 100%|██████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 899.01it/s]
Batch 03/16: 100%|██████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 894.90it/s]
Batch 11/16: 100%|██████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 900.14it/s]
Batch 06/16: 100%|██████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 895.61it/s]
Batch 13/16: 100%|██████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 903.09it/s]
Batch 08/16: 100%|██████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 895.33it/s]
Batch 05/16: 100%|██████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 893.26it/s]
Batch 02/16: 100%|██████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 889.17it/s]
Batch 01/16: 100%|██████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 888.16it/s]
Batch 09/16: 100%|██████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 893.69it/s]
Batch 12/16: 100%|██████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 896.80it/s]
Batch 14/16: 100%|██████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 903.28it/s]
Batch 10/16: 100%|██████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 893.63it/s]
Batch 07/16: 100%|██████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 891.26it/s]
Batch 15/16: 100%|██████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 905.06it/s]
Batch 16/16: 100%|██████████████████████████████████████████████████████████████████| 3125/3125 [00:03<00:00, 911.72it/s]
{'DEER': 5000, 'HORSE': 5000, 'AIRPLANE': 5000, 'FROG': 5000, 'BIRD': 5000, 'AUTOMOBILE': 5000, 'SHIP': 5000, 'CAT': 5000, 'TRUCK': 5000, 'DOG': 5000}
```

## Example 2: map

```py
from collections import Counter

import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("cifar10", split="train")
view = dataset.select_fields("ground_truth")

def map_fcn(sample):
    return sample.ground_truth.label.upper()

counts = Counter()
for _, label in view.map_samples(map_fcn):
    counts[label] += 1

print(dict(counts))
```

```
 100% |████████████████████████████████████████████████████████████████████████████████████| 50000/50000 [3.6s elapsed, 0s remaining, 29.3K samples/s]      
{'FROG': 5000, 'TRUCK': 5000, 'CAT': 5000, 'AIRPLANE': 5000, 'SHIP': 5000, 'DEER': 5000, 'AUTOMOBILE': 5000, 'BIRD': 5000, 'HORSE': 5000, 'DOG': 5000}
```

You can optionally show per-worker progress bars via `progress="workers"`:

```py
counts = Counter()
for _, label in view.map_samples(map_fcn, progress="workers"):
    counts[label] += 1

print(dict(counts))
```

```
Batch 01/16: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████| 3125/3125 [00:02<00:00, 1259.59it/s]
Batch 04/16: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████| 3125/3125 [00:02<00:00, 1264.46it/s]
Batch 06/16: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████| 3125/3125 [00:02<00:00, 1264.68it/s]
Batch 02/16: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████| 3125/3125 [00:02<00:00, 1248.29it/s]
Batch 05/16: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████| 3125/3125 [00:02<00:00, 1253.60it/s]
Batch 03/16: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████| 3125/3125 [00:02<00:00, 1249.05it/s]
Batch 08/16: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████| 3125/3125 [00:02<00:00, 1257.83it/s]
Batch 10/16: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████| 3125/3125 [00:02<00:00, 1258.37it/s]
Batch 09/16: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████| 3125/3125 [00:02<00:00, 1254.71it/s]
Batch 07/16: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████| 3125/3125 [00:02<00:00, 1249.48it/s]
Batch 11/16: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████| 3125/3125 [00:02<00:00, 1257.21it/s]
Batch 12/16: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████| 3125/3125 [00:02<00:00, 1260.26it/s]
Batch 15/16: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████| 3125/3125 [00:02<00:00, 1269.78it/s]
Batch 13/16: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████| 3125/3125 [00:02<00:00, 1263.44it/s]
Batch 14/16: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████| 3125/3125 [00:02<00:00, 1262.08it/s]
Batch 16/16: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████| 3125/3125 [00:02<00:00, 1279.08it/s]
{'FROG': 5000, 'CAT': 5000, 'SHIP': 5000, 'TRUCK': 5000, 'AIRPLANE': 5000, 'DEER': 5000, 'HORSE': 5000, 'BIRD': 5000, 'AUTOMOBILE': 5000, 'DOG': 5000}
```
