### PR TITLE
[WIP] Temporary config change for bug reproduction

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -1075,7 +1075,8 @@
                     },
                     "output_processor_cls": "fiftyone.utils.torch.DetectorOutputProcessor",
                     "labels_path": "{{eta-resources}}/ms-coco-labels.txt",
-                    "confidence_thresh": 0.3
+                    "confidence_thresh": 0.3,
+                    "image_size": [640, 640]
                 }
             },
             "requirements": {


### PR DESCRIPTION
DO NOT MERGE

To reproduce the bug, run the following on `develop` (or with the same model manifest as `develop`):

```
import fiftyone as fo
import fiftyone.zoo as foz

model_name = "faster-rcnn-resnet50-fpn-coco-torch"
label_field = f"{model_name}"

dataset = fo.load_dataset("quickstart")
model = foz.load_zoo_model(model_name)
print("Model transforms ", model.transforms)
dataset.apply_model(model, label_field=label_field, skip_failures=False)
```

Pull the config changes from this PR and run the following:
```
import fiftyone as fo
import fiftyone.zoo as foz

model_name = "faster-rcnn-resnet50-fpn-coco-torch"
label_field = f"{model_name}_resize"

dataset = fo.load_dataset("quickstart")
model = foz.load_zoo_model(model_name)
print("Model transforms ", model.transforms) # this should have the resize function
dataset.apply_model(model, label_field=label_field, skip_failures=False)
```

Compare the bounding box output from `faster-rcnn-resnet50-fpn-coco-torch` and `faster-rcnn-resnet50-fpn-coco-torch_resize` in the app. You can also use:

```
model_name = "faster-rcnn-resnet50-fpn-coco-torch"
pred_field = f"{model_name}_resize"
gt_field = f"{model_name}"
results = dataset.evaluate_detections(pred_field, gt_field=gt_field, eval_key=f"{model_name}_compare")
```
