### PR TITLE
Make default dataset name have 6 digits microseconds always

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -180,9 +180,7 @@ def get_default_dataset_name():
         a dataset name
     """
     now = datetime.now()
-    name = now.strftime("%Y.%m.%d.%H.%M.%S")
-    if name in _list_datasets(include_private=True):
-        name = now.strftime("%Y.%m.%d.%H.%M.%S.%f")
+    name = now.strftime("%Y.%m.%d.%H.%M.%S.%f")
 
     return name
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Don't try to get away with only seconds precision for default dataset name, and then move to microseconds if we have to. List datasets can be expensive, or potentially inaccurate in some cases (perhaps you do not have permissions to see the dataset with this duplicate name for example).

This should cut down the likelihood of collision by 1 million (6 extra digits of precision).

I don't think there is a downside to always using microseconds, other than 7 more digits in the dataset name. But who cares.

## How is this patch tested? If it is not, please explain why.
```python
import fiftyone as fo
fo.Dataset().name  # 2025.04.23.15.19.01.741441
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the process for generating default dataset names, now always using microsecond-level timestamps to ensure uniqueness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->