### PR TITLE
Move build App step in install script

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -49,6 +49,29 @@ NODE_VERSION=22.14.0
 OS=$(uname -s)
 ARCH=$(uname -m)
 
+# Do this first so pip installs with a built app
+if [ ${BUILD_APP} = true ]; then
+    echo "***** INSTALLING FIFTYONE-APP *****"
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash
+    export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
+    nvm install ${NODE_VERSION}
+    nvm use ${NODE_VERSION}
+    npm -g install yarn
+    if [ -f ~/.bashrc ]; then
+        source ~/.bashrc
+    elif [ -f ~/.bash_profile ]; then
+        source ~/.bash_profile
+    else
+        echo "WARNING: unable to locate a bash profile to 'source'; you may need to start a new shell"
+    fi
+    cd app
+    echo "Building the App. This will take a minute or two..."
+    yarn install > /dev/null 2>&1
+    yarn build
+    cd ..
+fi
+
 if [ ${SCRATCH_MONGODB_INSTALL} = true ]; then
     echo "***** INSTALLING MONGODB FROM SCRATCH *****"
     MONGODB_VERSION=6.0.5
@@ -139,27 +162,5 @@ if [ ${SOURCE_ETA_INSTALL} = true ]; then
     cd ..
 fi
 
-# Do this last since `source` can exit Python virtual environments
-if [ ${BUILD_APP} = true ]; then
-    echo "***** INSTALLING FIFTYONE-APP *****"
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash
-    export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
-    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
-    nvm install ${NODE_VERSION}
-    nvm use ${NODE_VERSION}
-    npm -g install yarn
-    if [ -f ~/.bashrc ]; then
-        source ~/.bashrc
-    elif [ -f ~/.bash_profile ]; then
-        source ~/.bash_profile
-    else
-        echo "WARNING: unable to locate a bash profile to 'source'; you may need to start a new shell"
-    fi
-    cd app
-    echo "Building the App. This will take a minute or two..."
-    yarn install > /dev/null 2>&1
-    yarn build
-    cd ..
-fi
 
 echo "***** INSTALLATION COMPLETE *****"

--- a/install.bat
+++ b/install.bat
@@ -35,6 +35,17 @@ SHIFT
 GOTO parse
 :endparse
 
+:: Do this first so pip installs with a built app
+if %BUILD_APP%==true (
+  echo ***** INSTALLING FIFTYONE-APP *****
+  :: TODO - Add nvm and yarn installs
+  cd app
+  echo "Building the App. This will take a minute or two..."
+  call yarn install > /dev/null 2>&1
+  call yarn build:win32
+  cd ..
+)
+
 IF %USE_FIFTY_ONE_DB%==true (
   echo ***** INSTALLING FIFTYONE-DB *****
   pip install fiftyone-db
@@ -83,15 +94,7 @@ IF %SOURCE_ETA_INSTALL%==true (
   cd ..
 )
 
-if %BUILD_APP%==true (
-  echo ***** INSTALLING FIFTYONE-APP *****
-  :: TODO - Add nvm and yarn installs
-  cd app
-  echo "Building the App. This will take a minute or two..."
-  call yarn install > /dev/null 2>&1
-  call yarn build:win32
-  cd ..
-)
+
 
 echo ***** INSTALLATION COMPLETE *****
 exit /b


### PR DESCRIPTION
## What changes are proposed in this pull request?

Moves the build App step in the install script to the beginning to ensure `pip` installs the source with a populated `fiftyone/server/static` directory

## How is this patch tested? If it is not, please explain why.

Locally

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the installation process to build the app earlier during setup, with no changes to the installation logic or user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->