### PR TITLE
Hide Scenario Analysis tab until ready

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -296,7 +296,7 @@ export default function Evaluation(props: EvaluationProps) {
           sx={tabStyles.tabs}
         >
           <Tab label="Overview" value="overview" />
-          <Tab label="Scenario Analysis" value="scenario" />
+          {/* <Tab label="Scenario Analysis" value="scenario" /> */}
           <Tab label="Execution Info" value="info" />
         </Tabs>
       </Box>

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/components/CreateScenario.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/components/CreateScenario.tsx
@@ -38,7 +38,7 @@ export default function CreateScenario(props) {
           promptOperator(panelId, {
             params: {
               gt_field,
-              scenario_type: "custom_code",
+              scenario_type: "sample_field",
               scenario_name: "",
               key: evalKey,
               compare_key: compareKey,

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/Scenarios.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/Scenarios.tsx
@@ -369,6 +369,7 @@ export default function Scenarios(props) {
           onDelete={onDelete}
           onEdit={onEdit}
           readOnly={readOnly}
+          trackEvent={trackEvent}
         />
       )}
     </Stack>
@@ -388,6 +389,7 @@ function Scenario(props) {
     onDelete,
     onEdit,
     readOnly,
+    trackEvent,
   } = props;
   const { key, compareKey } = data?.view;
   let scenario = data?.[`scenario_${id}_${key}`];
@@ -491,6 +493,7 @@ function Scenario(props) {
           evaluation={props.evaluation}
           compareEvaluation={props.compareEvaluation}
           loadView={loadView}
+          trackEvent={trackEvent}
         />
       ) : (
         <ScenarioTables
@@ -947,7 +950,7 @@ const MODEL_PERFORMANCE_METRICS = [
 ];
 
 function PredictionStatisticsChart(props) {
-  const { scenario, compareScenario, loadView } = props;
+  const { scenario, compareScenario, loadView, trackEvent } = props;
   const { subsets, subsets_data } = scenario;
   const compareSubsetsData = compareScenario?.subsets_data;
   const [metric, setMetric] = useState("all");
@@ -1107,6 +1110,11 @@ function PredictionStatisticsChart(props) {
           const { id, isCompare } = firstPoint.data;
           const subset = firstPoint.x;
           const subsetDef = getSubsetDef(scenario, subset);
+          trackEvent("evaluation_plot_click", {
+            id,
+            subsetDef,
+            plotName: "prediction_statistics",
+          });
           loadView("field", { field: id, subset_def: subsetDef });
         }}
       />
@@ -1191,7 +1199,7 @@ function ScenarioModelPerformanceChart(props) {
 }
 
 function ConfusionMatrixChart(props) {
-  const { scenario, compareScenario, loadView } = props;
+  const { scenario, compareScenario, loadView, trackEvent } = props;
   const { subsets } = scenario;
   const [subset, setSubset] = useState(subsets[0]);
   const subsetData = scenario.subsets_data[subset];
@@ -1249,6 +1257,11 @@ function ConfusionMatrixChart(props) {
             onClick={({ points }) => {
               const firstPoint = points[0];
               const subsetDef = getSubsetDef(scenario, subset);
+              trackEvent("evaluation_plot_click", {
+                id: scenario.id,
+                subsetDef,
+                plotName: "confusion_matrix",
+              });
               loadView("matrix", {
                 x: firstPoint.x,
                 y: firstPoint.y,
@@ -1379,7 +1392,7 @@ function ConfidenceDistributionChart(props) {
 }
 
 function MetricPerformanceChart(props) {
-  const { scenario, compareScenario, loadView } = props;
+  const { scenario, compareScenario, loadView, trackEvent } = props;
   const { subsets, subsets_data } = scenario;
   const compareSubsetsData = compareScenario?.subsets_data;
   const [metric, setMetric] = useState("average_confidence");
@@ -1434,6 +1447,11 @@ function MetricPerformanceChart(props) {
           const subset = points[0]?.x;
           const subsetDef = getSubsetDef(scenario, subset);
           if (!subsetDef) return;
+          trackEvent("evaluation_plot_click", {
+            id: scenario.id,
+            subsetDef,
+            plotName: "metric_performance",
+          });
           return loadView("subset", { subset_def: subsetDef });
         }}
       />
@@ -1443,7 +1461,7 @@ function MetricPerformanceChart(props) {
 }
 
 function SubsetDistributionChart(props) {
-  const { scenario, compareScenario, loadView } = props;
+  const { scenario, compareScenario, loadView, trackEvent } = props;
   const { subsets, subsets_data } = scenario;
   const compareSubsetsData = compareScenario?.subsets_data;
   const { key, compareKey } = props.data?.view;
@@ -1479,6 +1497,11 @@ function SubsetDistributionChart(props) {
           const subset = points[0]?.x;
           const subsetDef = getSubsetDef(scenario, subset);
           if (!subsetDef) return;
+          trackEvent("evaluation_plot_click", {
+            id: scenario.id,
+            subsetDef,
+            plotName: "subset_distribution",
+          });
           return loadView("subset", { subset_def: subsetDef });
         }}
       />

--- a/plugins/operators/model_evaluation/__init__.py
+++ b/plugins/operators/model_evaluation/__init__.py
@@ -65,7 +65,7 @@ class ConfigureScenario(foo.Operator):
 
         inputs.str(
             "scenario_name",
-            label="Scenario Name",
+            label="Scenario name",
             default=scenario_name,
             required=True,
             view=types.TextFieldView(
@@ -153,10 +153,7 @@ class ConfigureScenario(foo.Operator):
 
         return key
 
-    # NOTE: TTL is 7 days - subject to fine-tuning
-    @execution_cache(
-        key_fn=get_subset_def_data_for_eval_key, ttl=7 * 24 * 60 * 60
-    )
+    @execution_cache(key_fn=get_subset_def_data_for_eval_key)
     def get_subset_def_data_for_eval(
         self, ctx, _, eval_result, name, subset_def
     ):
@@ -809,7 +806,7 @@ class ConfigureScenario(foo.Operator):
         inputs.enum(
             "scenario_label_attribute",
             label_choices.values(),
-            default=label_attr,
+            default=label_attr if label_attr in valid_options else None,
             label="Label attribute",
             description="Select a label attribute",
             view=label_choices,
@@ -1133,6 +1130,16 @@ class ConfigureScenario(foo.Operator):
 
         scenarios[eval_id_a] = scenarios_for_eval
         store.set("scenarios", scenarios)
+
+        ctx.ops.track_event(
+            "scenario_created",
+            {
+                "id": scenario_id_str,
+                "name": scenario_name,
+                "type": scenario_type,
+                "subsets": scenario_subsets,
+            },
+        )
 
         return {
             "scenario_type": ctx.params.get("radio_choices", ""),

--- a/plugins/operators/model_evaluation/__init__.py
+++ b/plugins/operators/model_evaluation/__init__.py
@@ -803,17 +803,19 @@ class ConfigureScenario(foo.Operator):
             # NOTE: we show the last part of the path as the label attribute
             label_choices.add_choice(option, label=option.split(".")[-1])
 
+        label_attr_exists = True if label_attr in valid_options else False
+
         inputs.enum(
             "scenario_label_attribute",
             label_choices.values(),
-            default=label_attr if label_attr in valid_options else None,
+            default=label_attr if label_attr_exists else None,
             label="Label attribute",
             description="Select a label attribute",
             view=label_choices,
             required=True,
         )
 
-        if label_attr:
+        if label_attr and label_attr_exists:
             self.render_scenario_picker_view(ctx, label_attr, inputs)
         else:
             self.render_empty_sample_distribution(
@@ -863,9 +865,11 @@ class ConfigureScenario(foo.Operator):
         for option in valid_options:
             field_choices.add_choice(option, label=option)
 
+        label_attr_exists = True if field_name in valid_options else False
+
         inputs.str(
             "scenario_field",
-            default=None,
+            default=field_name if label_attr_exists else None,
             label="Field",
             description=("Choose applicable sample field values."),
             view=field_choices,

--- a/plugins/operators/model_evaluation/__init__.py
+++ b/plugins/operators/model_evaluation/__init__.py
@@ -119,10 +119,7 @@ class ConfigureScenario(foo.Operator):
     ):
         """
         Builds and returns an execution cache key for each type of scenario.
-        - custom code: we use the expression
-        - label attribute: selected field and value
-        - sample field: selected field and vlue
-        - saved view: selected view
+        - eval key + name + type + subset definition
         """
         scenario_type = self.get_scenario_type(ctx.params)
 
@@ -131,6 +128,7 @@ class ConfigureScenario(foo.Operator):
                 "sample-distribution-data",
                 eval_key,
                 name,
+                scenario_type,
                 str(subset_def),
             ]
         elif scenario_type == ScenarioType.VIEW:
@@ -142,13 +140,15 @@ class ConfigureScenario(foo.Operator):
                 subset_def.get("view", ""),
             ]
         else:
+            if isinstance(subset_def, list):
+                subset_def = subset_def[0]
+
             key = [
                 "sample-distribution-data",
                 eval_key,
                 name,
                 scenario_type,
-                subset_def.get("field", ""),
-                subset_def.get("value", ""),
+                str(subset_def),
             ]
 
         return key
@@ -1020,7 +1020,6 @@ class ConfigureScenario(foo.Operator):
                 componentsProps={
                     "container": {
                         "sx": {
-                            "border": "1px solid #333",
                             "padding": "0 2rem 0 1rem",
                         }
                     },

--- a/plugins/panels/model_evaluation/__init__.py
+++ b/plugins/panels/model_evaluation/__init__.py
@@ -917,10 +917,7 @@ class EvaluationPanel(Panel):
             scenario_subsets,
         ]
 
-    # NOTE: TTL is 7 days - subject to fine-tuning
-    @execution_cache(
-        key_fn=get_subset_def_data_for_eval_key, ttl=7 * 24 * 60 * 60
-    )
+    @execution_cache(key_fn=get_subset_def_data_for_eval_key)
     def get_scenario_data(self, ctx, scenario):
         view_state = ctx.panel.get_state("view") or {}
         eval_key = view_state.get("key")


### PR DESCRIPTION
## What changes are proposed in this pull request?

merged to develop, need this for release - specially hiding the scenario tab

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added event tracking for user clicks on evaluation plots and scenario creation or updates.
- **Bug Fixes**
	- Improved handling of default values in scenario configuration to prevent invalid selections.
- **Style**
	- Minor UI text and styling adjustments for scenario labels and checkbox containers.
- **Chores**
	- Updated cache configuration for scenario data to use default settings. 
- **Refactor**
	- Disabled the "Scenario Analysis" tab from the UI (temporarily hidden).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->