### PR TITLE
`panel_config.alpha`

### DIFF
--- a/app/packages/operators/src/Panel/register.tsx
+++ b/app/packages/operators/src/Panel/register.tsx
@@ -26,6 +26,7 @@ export default function registerPanel(ctx: ExecutionContext) {
       allowDuplicates: ctx.params.allow_duplicates,
       helpMarkdown: ctx.params.help_markdown,
       surfaces: ctx.params.surfaces,
+      alpha: ctx.params.alpha,
       beta: ctx.params.beta,
       category: ctx.params.category,
       isNew: ctx.params.is_new,

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -1004,6 +1004,7 @@ class RegisterPanel extends Operator {
     inputs.str("icon", { label: "Icon" });
     inputs.str("help_markdown", { label: "Help markdown" });
     inputs.str("category", { label: "Category" });
+    inputs.bool("alpha", { label: "Alpha", default: false });
     inputs.bool("beta", { label: "Beta", default: false });
     inputs.bool("is_new", { label: "NEW", default: false });
     inputs.str("dark_icon", { label: "Icon for dark mode" });

--- a/app/packages/plugins/src/index.ts
+++ b/app/packages/plugins/src/index.ts
@@ -373,6 +373,14 @@ type PanelOptions = {
   category?: CategoryID;
 
   /**
+   * Whether the plugin is in alpha.
+   * This is used to highlight alpha plugins.
+   *
+   * Defaults to `false`.
+   */
+  alpha?: boolean;
+
+  /**
    * Whether the plugin is in beta.
    * This is used to highlight beta plugins.
    *

--- a/app/packages/spaces/src/components/AddPanelButton.tsx
+++ b/app/packages/spaces/src/components/AddPanelButton.tsx
@@ -96,6 +96,7 @@ export default function AddPanelButton({ node, spaceId }: AddPanelButtonProps) {
                     name={panel.name}
                     label={panel.label}
                     spaceId={spaceId}
+                    showAlpha={panel.panelOptions?.alpha ?? false}
                     showBeta={panel.panelOptions?.beta ?? false}
                     showNew={panel.panelOptions?.isNew ?? false}
                     onClick={() => setOpen(false)}

--- a/app/packages/spaces/src/components/AddPanelItem.tsx
+++ b/app/packages/spaces/src/components/AddPanelItem.tsx
@@ -13,6 +13,7 @@ export default function AddPanelItem({
   label,
   onClick,
   spaceId,
+  showAlpha,
   showBeta,
   showNew,
 }: AddPanelItemProps) {
@@ -65,6 +66,17 @@ export default function AddPanelItem({
           }}
         >
           NEW
+        </span>
+      )}
+      {showAlpha && (
+        <span
+          style={{
+            color: theme.custom.primarySoft,
+            fontSize: "11px",
+            marginLeft: "5px",
+          }}
+        >
+          ALPHA
         </span>
       )}
       {showBeta && (

--- a/app/packages/spaces/src/components/PanelTab.tsx
+++ b/app/packages/spaces/src/components/PanelTab.tsx
@@ -56,6 +56,7 @@ export default function PanelTab({ node, active, spaceId }: PanelTabProps) {
       {panel && !loading && <PanelIcon name={panelName as string} />}
       {panel && <Typography>{title || panel.label || panel.name}</Typography>}
       <PanelTabMeta
+        showAlpha={panel?.panelOptions?.alpha ?? false}
         showBeta={panel?.panelOptions?.beta ?? false}
         showNew={panel?.panelOptions?.isNew ?? false}
       />
@@ -91,9 +92,11 @@ export default function PanelTab({ node, active, spaceId }: PanelTabProps) {
 }
 
 function PanelTabMeta({
+  showAlpha,
   showBeta,
   showNew,
 }: {
+  showAlpha: boolean;
   showBeta: boolean;
   showNew: boolean;
 }) {
@@ -108,6 +111,17 @@ function PanelTabMeta({
           }}
         >
           NEW
+        </Grid>
+      )}
+      {showAlpha && (
+        <Grid
+          item
+          style={{
+            color: "var(--fo-palette-custom-primarySoft)",
+            fontSize: 11,
+          }}
+        >
+          ALPHA
         </Grid>
       )}
       {showBeta && (

--- a/app/packages/spaces/src/types.ts
+++ b/app/packages/spaces/src/types.ts
@@ -14,6 +14,7 @@ export type AddPanelItemProps = {
   Icon?: React.ComponentType;
   onClick?: () => void;
   spaceId: string;
+  showAlpha?: boolean;
   showBeta?: boolean;
   showNew?: boolean;
 };

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -303,6 +303,7 @@ class Operations(object):
         label,
         help_markdown=None,
         category=Categories.CUSTOM,
+        alpha=False,
         beta=False,
         is_new=False,
         icon=None,
@@ -340,6 +341,7 @@ class Operations(object):
                 is in dark mode
             surfaces ('grid'): surfaces in which to show the panel. Must be
                 one of 'grid', 'modal', or 'grid modal'
+            alpha (False): whether the panel is in alpha
             beta (False): whether the panel is in beta
             is_new (False): whether the panel is new
             category (Categories.CUSTOM): the category of the panel
@@ -377,6 +379,7 @@ class Operations(object):
             "panel_label": label,
             "help_markdown": help_markdown,
             "category": category.value if category is not None else None,
+            "alpha": alpha,
             "beta": beta,
             "is_new": is_new,
             "icon": icon,

--- a/fiftyone/operators/panel.py
+++ b/fiftyone/operators/panel.py
@@ -40,6 +40,7 @@ class PanelConfig(OperatorConfig):
         name,
         label,
         help_markdown=None,
+        alpha=False,
         beta=False,
         is_new=False,
         category=None,
@@ -63,6 +64,7 @@ class PanelConfig(OperatorConfig):
         self.on_startup = True
         self.surfaces = surfaces
         self.category = category
+        self.alpha = alpha
         self.beta = beta
         self.is_new = is_new
         self.priority = priority
@@ -74,6 +76,7 @@ class PanelConfig(OperatorConfig):
             "label": self.label,
             "help_markdown": self.help_markdown,
             "category": str(self.category) if self.category else None,
+            "alpha": self.alpha,
             "beta": self.beta,
             "is_new": self.is_new,
             "icon": self.icon,
@@ -123,6 +126,7 @@ class Panel(Operator):
             "light_icon": self.config.light_icon,
             "surfaces": self.config.surfaces,
             "category": self.config.category,
+            "alpha": self.config.alpha,
             "beta": self.config.beta,
             "is_new": self.config.is_new,
             "priority": self.config.priority,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds a similar setting as the `beta` flag, but for `alpha` panels.

<img width="310" alt="image" src="https://github.com/user-attachments/assets/e23a7553-3409-4385-8e0f-db3bc5f0eac8" />
<img width="734" alt="image" src="https://github.com/user-attachments/assets/973cf0e9-1e6c-4e13-8e62-3b4ca3c94199" />


## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for marking panels as "ALPHA" to indicate their early-stage status.
  - Panels with the "ALPHA" status now display an "ALPHA" label alongside existing "NEW" and "BETA" labels in panel lists and tabs.

- **User Interface**
  - Visual indicators for "ALPHA" panels are now shown in relevant UI components for easier identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->