### PR TITLE
Add support for setting new embedded document fields

### DIFF
--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -20,6 +20,7 @@ import fiftyone.core.utils as fou
 
 from .database import get_db_conn
 from .dataset import SampleFieldDocument
+from .embedded_document import DynamicEmbeddedDocument
 from .utils import (
     deserialize_value,
     serialize_value,
@@ -141,16 +142,26 @@ class DatasetMixin(object):
         chunks = field_name.split(".", 1)
 
         if len(chunks) > 1:
-            doc = self.get_field(chunks[0])
+            root = chunks[0]
+            doc = self.get_field(root)
+
+            if doc is None:
+                doc = DynamicEmbeddedDocument()
+                self[root] = doc
+                self._changed_fields.remove(root)
 
             # handle sytnax: sample["field.0.attr"] = value
             if isinstance(doc, (mongoengine.base.BaseList, fof.ListField)):
                 chunks = chunks[1].split(".", 1)
                 doc = doc[int(chunks[0])]
+                field_name = root + "." + chunks[1]
 
-            return doc.set_field(chunks[1], value, create=create)
+            doc.set_field(chunks[1], value, create=create)
 
-        if not self.has_field(field_name):
+            if type(doc) != DynamicEmbeddedDocument:
+                return
+
+        if field is None:
             if create:
                 self.add_implied_field(
                     field_name,
@@ -164,7 +175,7 @@ class DatasetMixin(object):
                     "%s has no field '%s'" % (self._doc_name(), field_name)
                 )
         elif value is not None:
-            if validate:
+            if validate and field is not None:
                 field.validate(value)
 
             if dynamic:
@@ -175,6 +186,9 @@ class DatasetMixin(object):
                     validate=validate,
                     dynamic=dynamic,
                 )
+
+        if len(chunks) > 1:
+            return
 
         super().__setattr__(field_name, value)
 

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -145,7 +145,7 @@ class DatasetMixin(object):
             root = chunks[0]
             doc = self.get_field(root)
 
-            if doc is None:
+            if doc is None and create:
                 doc = DynamicEmbeddedDocument()
                 self[root] = doc
                 self._changed_fields.remove(root)
@@ -158,6 +158,15 @@ class DatasetMixin(object):
 
             doc.set_field(chunks[1], value, create=create)
 
+            #
+            # We treat attributes of `DynamicEmbeddedDocument` fields like
+            # top-level fields and automatically declare new attributes on the
+            # datasets's schema
+            #
+            # If the user is setting attributes of other embedded documents
+            # such as `Label` fields, then by convention we don't automatically
+            # declare new attributes on the dataset's schema
+            #
             if type(doc) != DynamicEmbeddedDocument:
                 return
 

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -7197,6 +7197,32 @@ class DynamicFieldTests(unittest.TestCase):
         self.assertFalse(frame.has_field("field"))
         self.assertFalse(frame.predictions.detections[0].has_field("field"))
 
+    @drop_datasets
+    def test_set_new_embedded_document_field(self):
+        dataset = fo.Dataset()
+
+        sample = fo.Sample(filepath="image.jpg")
+        dataset.add_sample(sample)
+
+        dataset.add_sample_field(
+            "data",
+            fo.EmbeddedDocumentField,
+            embedded_doc_type=fo.DynamicEmbeddedDocument,
+        )
+
+        self.assertTrue(dataset.has_field("data"))
+        self.assertIsNone(sample["data"])
+
+        sample["data.foo"] = "bar"
+        sample.save()
+
+        self.assertTrue(dataset.has_field("data.foo"))
+
+        dataset.reload()
+
+        self.assertEqual(sample["data.foo"], "bar")
+        self.assertListEqual(dataset.values("data.foo"), ["bar"])
+
 
 class CustomEmbeddedDocumentTests(unittest.TestCase):
     @drop_datasets

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -1827,6 +1827,34 @@ class SetValuesTests(unittest.TestCase):
             dataset.values("frames.still_labels.classifications.fluffy"),
         )
 
+    @drop_datasets
+    def test_set_new_embedded_document_field(self):
+        dataset = fo.Dataset()
+
+        sample = fo.Sample(
+            filepath="image.jpg",
+            data=fo.DynamicEmbeddedDocument(foo="bar"),
+        )
+        dataset.add_sample(sample, dynamic=True)
+
+        self.assertTrue(dataset.has_field("data.foo"))
+
+        view = dataset.select_fields()
+
+        sample_view = view.first()
+
+        sample_view["data.spam"] = "eggs"
+        sample_view.save()
+
+        self.assertTrue(dataset.has_field("data.spam"))
+
+        dataset.reload()
+
+        self.assertEqual(sample["data.foo"], "bar")
+        self.assertEqual(sample["data.spam"], "eggs")
+        self.assertListEqual(dataset.values("data.foo"), ["bar"])
+        self.assertListEqual(dataset.values("data.spam"), ["eggs"])
+
 
 class SetLabelValuesTests(unittest.TestCase):
     @drop_datasets


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone-plugins/pull/225#issuecomment-2825901286.

## Change log

- Adds support for populating new embedded document fields via `sample["new.field"] = value` and related syntaxes

## Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("cifar10", split="test", max_samples=10)

dataset.add_sample_field(
    "data",
    fo.EmbeddedDocumentField,
    embedded_doc_type=fo.DynamicEmbeddedDocument,
)

model = foz.load_zoo_model("clip-vit-base32-torch")

# previously would not work, now does!
dataset.apply_model(model, label_field="data.predictions")

print(dataset.values("data"))
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced nested field handling to support dynamic creation and proper validation of embedded documents, improving schema declaration and attribute setting.

- **Tests**
	- Added unit tests confirming dynamic addition and persistence of new embedded document fields, including nested fields, in datasets and views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->