### PR TITLE
[WIP] Adding support for private fields

### DIFF
--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -42,6 +42,8 @@ class ClipView(fos.SampleView):
             filtered in this view
     """
 
+    __slots__ = ()
+
     @property
     def _sample_id(self):
         return ObjectId(self._doc.sample_id)

--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -528,7 +528,8 @@ def _flatten(
         field = field.field
 
     if isinstance(field, EmbeddedDocumentField):
-        for name, _field in field.get_field_schema().items():
+        _schema = field.get_field_schema(include_private=include_private)
+        for name, _field in _schema.items():
             _flatten(
                 schema,
                 prefix,

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -263,8 +263,8 @@ class Frames(object):
         frame_number,
         frame,
         expand_schema=True,
-        validate=True,
         dynamic=False,
+        **kwargs,
     ):
         """Adds the frame to this instance.
 
@@ -281,7 +281,6 @@ class Frames(object):
             expand_schema (True): whether to dynamically add new frame fields
                 encountered to the dataset schema. If False, an error is raised
                 if the frame's schema is not a subset of the dataset schema
-            validate (True): whether to validate values for existing fields
             dynamic (False): whether to declare dynamic embedded document
                 fields
         """
@@ -301,18 +300,18 @@ class Frames(object):
             d = {"_sample_id": self._sample_id}
             doc = self._dataset._frame_dict_to_doc(d)
 
-            for field, value in _frame.iter_fields():
+            for field, value in _frame.iter_fields(include_private=True):
                 doc.set_field(
                     field,
                     value,
                     create=expand_schema,
-                    validate=validate,
                     dynamic=dynamic,
-                    _enforce_read_only=False,
+                    enforce_read_only=False,
+                    **kwargs,
                 )
 
             doc.set_field(
-                "frame_number", frame_number, _enforce_read_only=False
+                "frame_number", frame_number, enforce_read_only=False
             )
             frame._set_backing_doc(doc, dataset=self._dataset)
         else:
@@ -341,8 +340,8 @@ class Frames(object):
         frames,
         overwrite=True,
         expand_schema=True,
-        validate=True,
         dynamic=False,
+        **kwargs,
     ):
         """Adds the frame labels to this instance.
 
@@ -360,7 +359,6 @@ class Frames(object):
             expand_schema (True): whether to dynamically add new frame fields
                 encountered to the dataset schema. If False, an error is raised
                 if the frame's schema is not a subset of the dataset schema
-            validate (True): whether to validate values for existing fields
             dynamic (False): whether to declare dynamic embedded document
                 fields
         """
@@ -373,8 +371,8 @@ class Frames(object):
                     frame_number,
                     frame,
                     expand_schema=expand_schema,
-                    validate=validate,
                     dynamic=dynamic,
+                    **kwargs,
                 )
 
     def merge(
@@ -385,8 +383,8 @@ class Frames(object):
         merge_lists=True,
         overwrite=True,
         expand_schema=True,
-        validate=True,
         dynamic=False,
+        **kwargs,
     ):
         """Merges the given frames into this instance.
 
@@ -441,7 +439,6 @@ class Frames(object):
             expand_schema (True): whether to dynamically add new frame fields
                 encountered to the dataset schema. If False, an error is raised
                 if the frame's schema is not a subset of the dataset schema
-            validate (True): whether to validate values for existing fields
             dynamic (False): whether to declare dynamic embedded document
                 fields
         """
@@ -457,8 +454,8 @@ class Frames(object):
                     merge_lists=merge_lists,
                     overwrite=overwrite,
                     expand_schema=expand_schema,
-                    validate=validate,
                     dynamic=dynamic,
+                    **kwargs,
                 )
             else:
                 if fields is not None or omit_fields is not None:
@@ -468,8 +465,8 @@ class Frames(object):
                     frame_number,
                     frame,
                     expand_schema=expand_schema,
-                    validate=validate,
                     dynamic=dynamic,
+                    **kwargs,
                 )
 
     def clear(self):
@@ -907,8 +904,8 @@ class FramesView(Frames):
         frame_number,
         frame,
         expand_schema=True,
-        validate=True,
         dynamic=False,
+        **kwargs,
     ):
         """Adds the frame to this instance.
 
@@ -925,7 +922,6 @@ class FramesView(Frames):
             expand_schema (True): whether to dynamically add new frame fields
                 encountered to the dataset schema. If False, an error is raised
                 if the frame's schema is not a subset of the dataset schema
-            validate (True): whether to validate values for existing fields
             dynamic (False): whether to declare dynamic embedded document
                 fields
         """
@@ -940,19 +936,19 @@ class FramesView(Frames):
         frame_view = self._make_frame({"_sample_id": self._sample_id})
         doc = frame_view._doc
 
-        for field, value in frame.iter_fields():
+        for field, value in frame.iter_fields(include_private=True):
             doc.set_field(
                 field,
                 value,
                 create=expand_schema,
-                validate=validate,
                 dynamic=dynamic,
-                _enforce_read_only=False,
+                enforce_read_only=False,
+                **kwargs,
             )
             if frame_view._selected_fields is not None:
                 frame_view._selected_fields.add(field)
 
-        doc.set_field("frame_number", frame_number, _enforce_read_only=False)
+        doc.set_field("frame_number", frame_number, enforce_read_only=False)
         self._set_replacement(frame_view)
 
     def reload(self):
@@ -1069,6 +1065,8 @@ class Frame(Document, metaclass=FrameSingleton):
         **kwargs: frame fields and values
     """
 
+    __slots__ = ()
+
     _NO_DATASET_DOC_CLS = foo.NoDatasetFrameDocument
 
     @property
@@ -1144,6 +1142,8 @@ class FrameView(DocumentView):
         filtered_fields (None): a set of field names of list fields that are
             filtered in this frame view, if any
     """
+
+    __slots__ = ()
 
     _DOCUMENT_CLS = Frame
 

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -28,6 +28,8 @@ _NO_MATCH_ID = ""
 
 
 class _PatchView(fos.SampleView):
+    __slots__ = ()
+
     @property
     def _sample_id(self):
         return ObjectId(self._doc.sample_id)
@@ -62,7 +64,7 @@ class PatchView(_PatchView):
             filtered in this view
     """
 
-    pass
+    __slots__ = ()
 
 
 class EvaluationPatchView(_PatchView):
@@ -82,7 +84,7 @@ class EvaluationPatchView(_PatchView):
             filtered in this view
     """
 
-    pass
+    __slots__ = ()
 
 
 class _PatchesView(fov.DatasetView):

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -49,6 +49,8 @@ class FrameView(fos.SampleView):
             filtered in this view
     """
 
+    __slots__ = ()
+
     @property
     def _sample_id(self):
         return ObjectId(self._doc.sample_id)
@@ -174,7 +176,7 @@ class FramesView(fov.DatasetView):
         self.__media_type = media_type
 
     def _get_sample_only_fields(
-        self, include_private=False, use_db_fields=False
+        self, include_private=True, use_db_fields=False
     ):
         sample_only_fields = set(
             self._get_default_sample_fields(
@@ -331,9 +333,7 @@ class FramesView(fov.DatasetView):
         self._sync_source_schema()
 
         dst_dataset = self._source_collection._root_dataset
-        sample_only_fields = self._get_sample_only_fields(
-            include_private=True, use_db_fields=True
-        )
+        sample_only_fields = self._get_sample_only_fields(use_db_fields=True)
 
         updates = {
             k: v
@@ -353,9 +353,7 @@ class FramesView(fov.DatasetView):
 
     def _sync_source(self, fields=None, ids=None, update=True, delete=False):
         dst_dataset = self._source_collection._root_dataset
-        sample_only_fields = self._get_sample_only_fields(
-            include_private=True, use_db_fields=True
-        )
+        sample_only_fields = self._get_sample_only_fields(use_db_fields=True)
 
         if fields is not None:
             fields = [f for f in fields if f not in sample_only_fields]
@@ -443,9 +441,7 @@ class FramesView(fov.DatasetView):
             # collection and, if requested, delete any source fields that
             # aren't in this view
 
-            default_fields = set(
-                self._get_default_sample_fields(include_private=True)
-            )
+            default_fields = set(self._get_default_sample_fields())
 
             for field_name in schema.keys():
                 if (


### PR DESCRIPTION
## Change log

- Adds support for storing/declaring private fields on samples, frames, and embedded documents
- Creating private fields is not allowed by default; users must opt into allowing this by passing a (mostly) undocumented `allow_private=True` parameter to the relevant methods
- Private fields **are not** exposed by default by user-facing schema constructs like `get_field_schema()` and `print(sample)`, but they **are** available to system-facing constructs like `__getattr__`, `__getitem__`, `has_field()`, `values()`, etc. in such a way that it should "just work" to write methods that can optionally read/write from private fields

## TODO

- Use this feature internally to validate that the design results in clean code
- Should we document `allow_private=True` in more docstrings?

## Example usage

### Private fields

```py
import fiftyone as fo

dataset = fo.Dataset()

# Private fields can be manually declared...
dataset.add_sample_field("_private", fo.IntField, allow_private=True)

# ...in which case new samples can have private fields
sample = fo.Sample(filepath="image.jpg", _private=1)
dataset.add_sample(sample)

# The API allows checking for the existence of private fields
assert dataset.has_field("_private")
assert "_private" in dataset.get_field_schema(include_private=True)

# ...but they are not exposed to the user by default
assert "_private" not in dataset.get_field_schema()

# Private fields are not shown to the user...
print(sample)
print(dataset)

# ...but the data is in fact there
print(sample._private)
print(dataset.values("_private"))

# Private fields can be edited as you would expect
sample._private = 2
sample.save()

print(dataset.values("_private"))

# Private fields can be renamed and cloned
# `allow_private=True` is required when the *new* fields are private
dataset.rename_sample_field("_private", "_still_private", allow_private=True)
dataset.clone_sample_field("_still_private", "_also_private", allow_private=True)

print(sample._still_private)
print(sample._also_private)
print(dataset.values("_still_private"))
print(dataset.values("_also_private"))

# Private fields can be deleted
dataset.delete_sample_field("_also_private")

assert not dataset.has_field("_also_private")

# Private fields can be set in bulk
dataset.set_values("_still_private", [3])

# New private fields can be declared in bulk
dataset.set_values("_yep_private", [4], allow_private=True)

print(sample._yep_private)

# Private fields cannot be dynamically added to samples by default...
try:
    sample._not_allowed = 5
except:
    print("ERROR")
    sample.reload()

# ...but they can be added like this if necessary
sample.set_field("_is_allowed", 6, allow_private=True)
sample.save()

assert dataset.has_field("_is_allowed")

print(dataset.values("_is_allowed"))

# Private fields cannot be dynamically added by default...
sample = fo.Sample(filepath="image.jpg", _also_not_allowed=7)
try:
    dataset.add_sample(sample)
except:
    print("ERROR")

# ...but they can be added like this
sample = fo.Sample(filepath="image.jpg", _also_is_allowed=8)
dataset.add_sample(sample, allow_private=True)

assert dataset.has_field("_also_is_allowed")
print(dataset.values("_also_is_allowed"))
```

### Private attributes

```py
import fiftyone as fo

dataset = fo.Dataset()

# Private attributes can be added to embedded documents
sample = fo.Sample(
    filepath="image1.jpg",
    ground_truth=fo.Detections(
        detections=[fo.Detection(label="cat", _private=1)],
    ),
)

# You must pass `allow_private=True` in order to dynamically declare them
dataset.add_sample(sample, dynamic=True, allow_private=True)

assert dataset.has_field("ground_truth.detections._private")
assert "ground_truth.detections._private" in dataset.get_field_schema(flat=True, include_private=True)

# Private attributes aren't presented to the user...
detection = sample.ground_truth.detections[0]
print(detection)

# ...but the data is in fact there
print(detection._private)

# Private attributes can be edited at any time
detection._private = 2
sample.save()

print(dataset.values("ground_truth.detections._private"))

# Private attributes can also be added later
detection._also_private = 3
sample.save()

print(dataset.get_dynamic_field_schema(include_private=True))

# Private attributes can be manually declared at any time
dataset.add_sample_field(
    "ground_truth.detections._also_private",
    fo.IntField,
    allow_private=True,
)

assert dataset.has_field("ground_truth.detections._also_private")
print(dataset.values("ground_truth.detections._also_private"))

# Private attributes can be renamed and cloned
# `allow_private=True` is required when the *new* fields are private
dataset.rename_sample_field(
    "ground_truth.detections._private",
    "ground_truth.detections._still_private",
    allow_private=True,
)
dataset.clone_sample_field(
    "ground_truth.detections._still_private",
    "ground_truth.detections._also_still_private",
    allow_private=True,
)

detection = sample.ground_truth.detections[0]

print(detection._still_private)
print(detection._also_still_private)
print(dataset.values("ground_truth.detections._still_private"))
print(dataset.values("ground_truth.detections._also_still_private"))

# Private attributes can be deleted
dataset.delete_sample_field("ground_truth.detections._also_still_private")

assert not dataset.has_field("ground_truth.detections._also_still_private")

# Existing private attributes can be edited in bulk...
dataset.set_values("ground_truth.detections._still_private", [[4]])

print(dataset.values("ground_truth.detections._still_private"))

# ...and new private attributes can be declared in bulk
dataset.set_values(
    "ground_truth.detections._yep_private",
    [[5]],
    dynamic=True,
    allow_private=True,
)

assert dataset.has_field("ground_truth.detections._yep_private")

detection = sample.ground_truth.detections[0]
print(detection._yep_private)
```
