### PR TITLE
Add new is_read_only and required operator settings

### DIFF
--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -218,6 +218,8 @@ export type OperatorConfigOptions = {
   resolveExecutionOptionsOnChange?: boolean;
   skipInput?: boolean;
   skipOutput?: boolean;
+  required?: boolean;
+  isReadOnly?: boolean;
 };
 export class OperatorConfig {
   public name: string;
@@ -236,6 +238,8 @@ export class OperatorConfig {
   public resolveExecutionOptionsOnChange = false;
   public skipInput: boolean;
   public skipOutput: boolean;
+  public required: boolean;
+  public isReadOnly: boolean;
 
   constructor(options: OperatorConfigOptions) {
     this.name = options.name;
@@ -256,6 +260,8 @@ export class OperatorConfig {
       options.resolveExecutionOptionsOnChange || false;
     this.skipInput = options.skipInput || false;
     this.skipOutput = options.skipOutput || false;
+    this.required = options.required;
+    this.isReadOnly = options.isReadOnly;
   }
   static fromJSON(json) {
     return new OperatorConfig({
@@ -275,6 +281,8 @@ export class OperatorConfig {
       resolveExecutionOptionsOnChange: json.resolve_execution_options_on_change,
       skipInput: json.skip_input,
       skipOutput: json.skip_output,
+      required: json.required,
+      isReadOnly: json.is_read_only,
     });
   }
 }

--- a/fiftyone/operators/operator.py
+++ b/fiftyone/operators/operator.py
@@ -44,6 +44,8 @@ class OperatorConfig(object):
         resolve_execution_options_on_change (None): whether to resolve
             execution options dynamically when inputs change. By default, this
             behavior will match the ``dynamic`` setting
+        required (False): whether the operator must always be enabled.
+            Builtin operators may set this to True to prevent disabling them.
     """
 
     def __init__(
@@ -65,6 +67,8 @@ class OperatorConfig(object):
         allow_delegated_execution=False,
         default_choice_to_delegated=False,
         resolve_execution_options_on_change=None,
+        required=False,
+        is_read_only=None,
         **kwargs
     ):
         self.name = name
@@ -83,6 +87,8 @@ class OperatorConfig(object):
         self.allow_immediate_execution = allow_immediate_execution
         self.allow_delegated_execution = allow_delegated_execution
         self.default_choice_to_delegated = default_choice_to_delegated
+        self.required = required
+        self.is_read_only = is_read_only
         if resolve_execution_options_on_change is None:
             self.resolve_execution_options_on_change = dynamic
         else:
@@ -110,6 +116,8 @@ class OperatorConfig(object):
             "allow_delegated_execution": self.allow_delegated_execution,
             "default_choice_to_delegated": self.default_choice_to_delegated,
             "resolve_execution_options_on_change": self.resolve_execution_options_on_change,
+            "required": self.required,
+            "is_read_only": self.is_read_only,
         }
 
 


### PR DESCRIPTION
Adds two new configuration params for operators.

`is_read_only` - set this to `True` to tell the permissions sub system that this operator will only need read only access.

`required` - do not allow disabling this operator when this setting is `True`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for "required" and "read-only" flags in operator configuration, allowing operators to indicate if they must always be enabled or are read-only.
- **Documentation**
  - Updated operator configuration documentation to reflect the new "required" and "read-only" properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->