### PR TITLE
Add tqdm req

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -30,4 +30,5 @@ sse-starlette>=0.10.3
 starlette==0.40.0
 strawberry-graphql==0.257.0
 tabulate==0.8.10
+tqdm
 xmltodict==0.12.0


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add tqdm to common requirements to fix `ModuleNotFoundError: No module named 'tqdm'` error upon import after a fresh install 


## How is this patch tested? If it is not, please explain why.

- run pip install fiftyone and then import 
- asv tests run

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added the tqdm package as a new dependency for progress bar functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->