### PR TITLE
remove redundant fetch possibility

### DIFF
--- a/app/packages/map/src/Map.tsx
+++ b/app/packages/map/src/Map.tsx
@@ -16,7 +16,10 @@ import { useRecoilState, useRecoilValue } from "recoil";
 import useResizeObserver from "use-resize-observer";
 
 import DrawControl from "./Draw";
-import useGeoLocations, { SampleLocationMap } from "./useGeoLocations";
+import useFetchGeoLocations, {
+  SampleLocationMap,
+  sampleLocationMapAtom,
+} from "./useFetchGeoLocations";
 
 import { useSetPanelCloseEffect } from "@fiftyone/spaces";
 import {
@@ -88,13 +91,14 @@ const Panel: React.FC<{}> = () => {
     ) as unknown as typeof fos.extendedStages;
   }, [unFilteredExtended]);
 
-  const { loading, sampleLocationMap } = useGeoLocations({
+  const { loading } = useFetchGeoLocations({
     dataset,
     filters,
     view,
     extended,
     path: useRecoilValue(activeField),
   });
+  const sampleLocationMap = useRecoilValue(sampleLocationMapAtom);
 
   const settings = usePluginSettings<Required<Settings>>(
     "map",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Remove redundant fetch. This might happen when panels are reconfigured in between calls to `/geo`.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved state management for map location data, enhancing performance and reliability.
  - Streamlined loading state handling for location data on the map.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->