### PR TITLE
build(timeout): AS-673 add timeouts to test workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on: workflow_call
 jobs:
   test-app:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,6 +25,7 @@ jobs:
 
   test-python:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
     env:
       FIFTYONE_DO_NOT_TRACK: true
     strategy:

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -5,6 +5,7 @@ on: workflow_call
 jobs:
   test-python:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
     env:
       FIFTYONE_DO_NOT_TRACK: true
     strategy:


### PR DESCRIPTION
## What changes are proposed in this pull request?

We recently had a situation where we had some infinitely running tests on windows machines. Unfortunately, the github action default timeout is 6 hours. Across the 4 windows tests, this was 24 hours per commit! We can set reasonable timeouts on the python tests so that, in the event of runaway tests, we don't chew through runner minutes.

Unfortunately, timeouts must be set at the job level (not at the workflow or organization levels). In this PR, I add a timeout to the python tests on both linux and windows.

## How is this patch tested? If it is not, please explain why.

Tested via the below action in a private repo:

```yaml
name: test cancels

on:
  workflow_call:

jobs:
  test-cancel:
    runs-on: ubuntu-latest
    timeout-minutes: 2

    steps:
      - name: sleep
        run: |
          sleep 180
```

and made sure it was canceled as expected.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Set a 90-minute maximum execution time for test jobs in the workflow to prevent excessively long runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->