### PR TITLE
Fix incomplete search copy

### DIFF
--- a/app/packages/core/src/components/Filters/use-incomplete-results.tsx
+++ b/app/packages/core/src/components/Filters/use-incomplete-results.tsx
@@ -14,12 +14,12 @@ const IncompleteResults = () => {
   const theme = useTheme();
   return (
     <div style={{ textAlign: "right" }}>
-      Incomplete results.{" "}
+      Incomplete search.{" "}
       <ExternalLink
         style={{ color: theme.text.primary, textDecoration: "underline" }}
         href={QUERY_PERFORMANCE_RESULTS}
       >
-        incomplete search, create an index
+        create an index
         <Launch style={{ height: "1rem", marginTop: 4.5, marginLeft: 1 }} />
       </ExternalLink>
     </div>


### PR DESCRIPTION
Small typo PR. "Incomplete search. <ins>create an index</ins>" is correct
<img width="1470" alt="Screenshot 2025-04-29 at 4 01 08 PM" src="https://github.com/user-attachments/assets/329eca39-1c7d-4bd9-a2a2-d2f230cbf7b1" />
