### PR TITLE
[Bug fix] Bug fix for map samples for empty collection

### DIFF
--- a/fiftyone/core/map/mapper.py
+++ b/fiftyone/core/map/mapper.py
@@ -168,6 +168,8 @@ class Mapper(abc.ABC):
             Iterator[Tuple[bson.ObjectId, R]]: The sample ID and the result of
               the map function for the sample.
         """
+        if len(sample_collection) == 0:
+            return
 
         if check_if_return_is_sample(sample_collection, map_fcn):
             raise ValueError("`map_fcn` should not return Samples objects.")

--- a/fiftyone/core/map/mapper.py
+++ b/fiftyone/core/map/mapper.py
@@ -168,10 +168,15 @@ class Mapper(abc.ABC):
             Iterator[Tuple[bson.ObjectId, R]]: The sample ID and the result of
               the map function for the sample.
         """
-        if len(sample_collection) == 0:
-            return
+        try:
+            result = check_if_return_is_sample(sample_collection, map_fcn)
+        except ValueError as e:
+            if "is empty" in str(e):
+                return
+            else:
+                raise e
 
-        if check_if_return_is_sample(sample_collection, map_fcn):
+        if result:
             raise ValueError("`map_fcn` should not return Samples objects.")
 
         yield from self._map_samples(

--- a/tests/unittests/map/test_mapper.py
+++ b/tests/unittests/map/test_mapper.py
@@ -13,6 +13,8 @@ from unittest import mock
 import bson
 import pytest
 
+import fiftyone as fo
+from fiftyone import ViewField as F
 import fiftyone.core.sample as focs
 import fiftyone.core.map.batcher as fomb
 import fiftyone.core.map.mapper as fomm
@@ -77,9 +79,11 @@ class Mapper(fomm.LocalMapper):
     """Test implementation for abstract class"""
 
     @classmethod
-    def create(cls, *_, **__): ...
+    def create(cls, *_, **__):
+        ...
 
-    def _map_samples_multiple_workers(self, *_, **__): ...
+    def _map_samples_multiple_workers(self, *_, **__):
+        ...
 
 
 @pytest.mark.parametrize(
@@ -298,3 +302,21 @@ class TestMapSamples:
         assert {sample_id for sample_id, _ in results} == {
             sample.id for sample in samples
         }
+
+    def test_empty_dataset(self, num_workers):
+        dataset = fo.Dataset()
+        for _, result in dataset.map_samples(
+            lambda s: 1, num_workers=num_workers
+        ):
+            pass
+        assert len(dataset) == 0
+
+    def test_empty_view(self, num_workers):
+        dataset = fo.Dataset()
+        dataset.add_sample(focs.Sample(filepath="sample.jpg"))
+        empty_view = dataset.match(F("filepath") == "non_existent_path.jpg")
+        for _, result in empty_view.map_samples(
+            lambda s: 1, num_workers=num_workers
+        ):
+            pass
+        assert len(empty_view) == 0


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently, for `map_samples`, we do `_sample_collection.first` to get a sample and test if `map_fcn` can operate successfully on the sample, and inspect the returned object and validate that it is not a Fiftyone document. 

When the dataset or view is empty, `first(...)` will raise an exception.

## How is this patch tested? If it is not, please explain why.

* Manual testing (✅ )
* Unit test (✅ )

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
