### PR TITLE
ci: remove test windows as a req for all-tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -92,12 +92,11 @@ jobs:
 
   all-tests:
     runs-on: ubuntu-latest
-    needs: [build, lint, test, test-windows, e2e]
+    needs: [build, lint, test, e2e]
     if: always()
     steps:
       - run: sh -c ${{
           (needs.build.result == 'success' || needs.build.result == 'skipped') &&
           (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&
           (needs.test.result == 'success' || needs.test.result == 'skipped') &&
-          (needs.test-windows.result == 'success' || needs.test-windows.result == 'skipped') &&
           (needs.e2e.result == 'success' || needs.e2e.result == 'skipped') }}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Windows tests are not reliable yet and so shouldn't be required. They will still run, though.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow to remove the dependency on Windows tests for the all-tests job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->