### PR TITLE
build(actions): Remove pip upgrade

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install requirements
         if: steps.pip-cache.outputs.cache-hit != true
         run: |
-          pip install -U pip wheel setuptools
+          pip install -U wheel setuptools
           pip install -r requirements/github.txt
       - name: Install fiftyone
         run: |

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -35,7 +35,6 @@ jobs:
             requirements/test.txt
       - name: Install requirements
         if: steps.pip-cache.outputs.cache-hit != true
-        # Pinning pip version as the latest throws an error
         run: |
           pip install -U wheel setuptools
           pip install -r requirements/github.txt

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -37,7 +37,7 @@ jobs:
         if: steps.pip-cache.outputs.cache-hit != true
         # Pinning pip version as the latest throws an error
         run: |
-          pip install -U pip==25.0.1 wheel setuptools
+          pip install -U wheel setuptools
           pip install -r requirements/github.txt
       - name: Install fiftyone
         run: |


### PR DESCRIPTION
## What changes are proposed in this pull request?

The `pip install --upgrade pip` seems to break windows. Let's use the cached versions on the runners.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow steps to no longer upgrade or pin the pip version during dependency installation on all platforms. Only wheel and setuptools are now upgraded before installing requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->