### PR TITLE
map_samples: remove check_if_return_is_sample validation

### DIFF
--- a/fiftyone/core/map/mapper.py
+++ b/fiftyone/core/map/mapper.py
@@ -169,8 +169,11 @@ class Mapper(abc.ABC):
               the map function for the sample.
         """
 
-        if check_if_return_is_sample(sample_collection, map_fcn):
-            raise ValueError("`map_fcn` should not return Samples objects.")
+        # TODO: consider adding this check back in lazily, so that we do not
+        #  have to create a full view iterator up front just to validate the
+        #  function return type.
+        # if check_if_return_is_sample(sample_collection, map_fcn):
+        #     raise ValueError("`map_fcn` should not return Samples objects.")
 
         yield from self._map_samples(
             sample_collection,


### PR DESCRIPTION
## What changes are proposed in this pull request?
Remove upfront validation of map function returning Samples.

See discussion in PR thread [here](https://github.com/voxel51/fiftyone/pull/5810#discussion_r2067966643)

## How is this patch tested? If it is not, please explain why.

```python
def fn(samp):
  return str(samp.id)

import fiftyone as fo
ds=fo.load_dataset("quickstart")

v=ds.limit(0)
list(v.map_samples(fn))  # no error
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Disabled a runtime check that previously raised an error when the mapping function returned a `Sample` object during sample mapping operations. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->