### PR TITLE
Fix QP summary field coloring

### DIFF
--- a/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
@@ -35,7 +35,7 @@ const NumericFieldFilter = ({ color, modal, named = true, path }: Props) => {
   const field = fos.useAssertedRecoilValue(fos.field(path));
 
   const { show, showLoadButton } = useShow(modal, named, path, showRange);
-  const icon = useQueryPerformanceIcon(modal, named, path);
+  const icon = useQueryPerformanceIcon(modal, named, path, color);
   if (!show) {
     return null;
   }

--- a/app/packages/core/src/components/Filters/StringFilter/StringFilter.tsx
+++ b/app/packages/core/src/components/Filters/StringFilter/StringFilter.tsx
@@ -83,7 +83,7 @@ const StringFilter = ({
   const theme = useTheme();
 
   const footer = useIncompleteResults(path);
-  const icon = useQueryPerformanceIcon(modal, named, path);
+  const icon = useQueryPerformanceIcon(modal, named, path, color);
   const queryPerformance = useRecoilValue(fos.queryPerformance);
   if (named && (!queryPerformance || modal) && !results?.count) {
     return null;

--- a/app/packages/core/src/components/Filters/use-query-performance-icon.tsx
+++ b/app/packages/core/src/components/Filters/use-query-performance-icon.tsx
@@ -3,16 +3,16 @@ import React from "react";
 import { useRecoilValue } from "recoil";
 import { LightningBolt } from "../Sidebar/Entries/FilterablePathEntry/Icon";
 
-const Icon = ({ path }: { path: string }) => {
+const Icon = ({ color, path }: { color?: string; path: string }) => {
   const hasFilters = useRecoilValue(fos.hasFilters(false));
   const filteredIndex = useRecoilValue(
     fos.pathHasIndexes({ path, withFilters: true })
   );
-  const color = useRecoilValue(fos.pathColor(path));
+  const pathColor = useRecoilValue(fos.pathColor(path));
 
   return (
     <LightningBolt
-      color={filteredIndex ? color : undefined}
+      color={filteredIndex ? color ?? pathColor : undefined}
       tooltip={filteredIndex && hasFilters ? "Compound index" : "Indexed"}
     />
   );
@@ -21,7 +21,8 @@ const Icon = ({ path }: { path: string }) => {
 export default function useQueryPerformanceIcon(
   modal: boolean,
   named: boolean,
-  path: string
+  path: string,
+  color?: string
 ) {
   const filteredIndex = useRecoilValue(
     fos.pathHasIndexes({ path, withFilters: true })
@@ -41,5 +42,5 @@ export default function useQueryPerformanceIcon(
     return null;
   }
 
-  return <Icon path={path} />;
+  return <Icon path={path} color={color} />;
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix coloring for summary fields with counts

```py
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video")
dataset.create_summary_field(
    "frames.detections.detections.label",
    field_name="frames_detections_label",
    include_counts=True,
)
``` 
### Before

<img width="1470" alt="Screenshot 2025-04-30 at 12 48 50 PM" src="https://github.com/user-attachments/assets/dcd626eb-3392-45e5-a7e5-6295ccf686ab" />

### After

<img width="1470" alt="Screenshot 2025-04-30 at 12 47 57 PM" src="https://github.com/user-attachments/assets/96914249-74d0-417d-a358-fc760c6deb6e" />


### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced icon customization in filter components by allowing color to be specified for performance icons. This provides more flexible visual styling in numeric and string filter interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->