### PR TITLE
version warning for other media type

### DIFF
--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -119,13 +119,16 @@ The following media types are available:
     | `group`       | Datasets that contain                             |
     |               | :ref:`grouped data slices <groups>`               |
     +---------------+---------------------------------------------------+
-    | `unknown`     | Fallback value for Datasets that contain          |
+    | `unknown` †   | Fallback value for Datasets that contain          |
     |               | samples which are not one of the other listed     |
     |               | media types                                       |
     +---------------+---------------------------------------------------+
-    | custom type   | Datasets that contain samples with a custom media |
+    | custom type † | Datasets that contain samples with a custom media |
     |               | type will inherit that type                       |
     +---------------+---------------------------------------------------+
+
+† Warning for Enterprise users: Your deployment must be upgraded to version
+  `>=2.8.0` in order to use the `unknown` or "custom type" options.
 
 .. _dataset-persistence:
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add a warning to the docs to explain the minimum version for the custom media type

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the user guide to clarify that Enterprise deployments require version 2.8.0 or higher to use the "unknown" or "custom type" media types, with a new warning note added to the relevant table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->