### PR TITLE
Fix/ec ephem clear cache

### DIFF
--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -2528,8 +2528,8 @@ To cache a function's result scoped to the current ``ctx.dataset``, use the
     # Clear all cache entries for the function
     expensive_query.clear_all_caches()
 
-    # NOTE: dataset_id is required if link_to_dataset=True
-    expensive_query.clear_all_caches(dataset_id=dataset._doc.id)
+    # NOTE: ctx or dataset_id is required if link_to_dataset=True
+    expensive_query.clear_all_caches(ctx=ctx)
 
 .. note::
 

--- a/fiftyone/operators/cache/decorator.py
+++ b/fiftyone/operators/cache/decorator.py
@@ -265,6 +265,8 @@ def execution_cache(
                 jwt_scoped=jwt_scoped,
                 collection_name=collection_name,
             )
+            print("store", store)
+            print("memory_cache", memory_cache)
             if store:
                 store.delete(cache_key)
             if memory_cache is not None and cache_key in memory_cache:

--- a/fiftyone/operators/cache/decorator.py
+++ b/fiftyone/operators/cache/decorator.py
@@ -302,10 +302,11 @@ def execution_cache(
 
         wrapper.set_cache = set_cache
 
-        def clear_all_caches(dataset_id=None):
+        def clear_all_caches(dataset_id=None, ctx=None):
+            dataset_id = dataset_id or (ctx.dataset._doc.id if ctx else None)
             if dataset_id is None and func.link_to_dataset:
                 raise ValueError(
-                    "dataset_id must be provided when link_to_dataset=True"
+                    "dataset_id or ctx must be provided when link_to_dataset=True"
                 )
             if residency == "ephemeral" or residency == "hybrid":
                 func_id = _get_function_id(func)

--- a/fiftyone/operators/cache/decorator.py
+++ b/fiftyone/operators/cache/decorator.py
@@ -10,6 +10,8 @@ from fiftyone.operators.cache.utils import (
     _get_ctx_from_args,
     resolve_cache_info,
     _get_store_for_func,
+    _get_function_id,
+    get_ephemeral_cache,
 )
 from fiftyone.operators.cache.serialization import (
     auto_deserialize,
@@ -305,6 +307,11 @@ def execution_cache(
                 raise ValueError(
                     "dataset_id must be provided when link_to_dataset=True"
                 )
+            if residency == "ephemeral" or residency == "hybrid":
+                func_id = _get_function_id(func)
+                memory_cache = get_ephemeral_cache(func_id, max_size=max_size)
+                if memory_cache is not None:
+                    memory_cache.clear()
             store = _get_store_for_func(
                 func, dataset_id=dataset_id, collection_name=collection_name
             )

--- a/fiftyone/operators/cache/utils.py
+++ b/fiftyone/operators/cache/utils.py
@@ -24,7 +24,7 @@ def resolve_cache_info(
     key_fn,
     func,
     *,
-    residency="transient",
+    residency="hybrid",
     operator_scoped=False,
     user_scoped=False,
     prompt_scoped=False,

--- a/tests/unittests/execution_cache/execution_cache_io_tests.py
+++ b/tests/unittests/execution_cache/execution_cache_io_tests.py
@@ -196,3 +196,28 @@ class TestExecutionCacheWithSamples(unittest.TestCase):
             @execution_cache(residency="wat")
             def bad(ctx, tag):
                 return f"nope-{tag}"
+
+    @drop_datasets
+    @drop_collection(TEST_COLLECTION_NAME)
+    def test_clear_all_caches(self):
+        calls = []
+
+        @execution_cache(collection_name=TEST_COLLECTION_NAME)
+        def cached(ctx, tag):
+            calls.append(tag)
+            return f"tag-{tag}"
+
+        dataset = create_test_dataset()
+        ctx = setup_ctx(dataset)
+
+        # Cache miss
+        self.assertEqual(cached(ctx, "a"), "tag-a")
+
+        # Clear all caches
+        cached.clear_all_caches(ctx=ctx)
+
+        # Cache miss again after clearing
+        self.assertEqual(cached(ctx, "a"), "tag-a")
+
+        # Two calls should have been made
+        self.assertEqual(calls, ["a", "a"])


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes an issue where `fn.clear_all_caches()` was not clearing ephemeral caches.

## How is this patch tested? If it is not, please explain why.

Automated tests and in the dashboard cache implementation via the app and dasbhoard plugin.