### PR TITLE
Refresh should evict cached scenario

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/Scenarios.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/Scenarios.tsx
@@ -332,9 +332,14 @@ export default function Scenarios(props) {
             color="secondary"
             onClick={() => {
               setLoadingScenario(true);
-              loadScenario(scenario, undefined, () => {
-                setLoadingScenario(false);
-              });
+              loadScenario(
+                scenario,
+                undefined,
+                () => {
+                  setLoadingScenario(false);
+                },
+                true
+              );
             }}
           >
             <Autorenew />

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/index.tsx
@@ -158,8 +158,18 @@ export default function NativeModelEvaluationView(props) {
           loadScenarios={(callback) => {
             triggerEvent(load_scenarios, undefined, false, callback);
           }}
-          loadScenario={(id: string, key?: string, callback?: () => void) => {
-            triggerEvent(load_scenario, { id, key }, false, callback);
+          loadScenario={(
+            id: string,
+            key?: string,
+            callback?: () => void,
+            refresh_cache?: false
+          ) => {
+            triggerEvent(
+              load_scenario,
+              { id, key, refresh_cache },
+              false,
+              callback
+            );
           }}
           deleteScenario={(scenarioId: string, callback?: () => void) => {
             triggerEvent(

--- a/plugins/operators/model_evaluation/__init__.py
+++ b/plugins/operators/model_evaluation/__init__.py
@@ -153,7 +153,9 @@ class ConfigureScenario(foo.Operator):
 
         return key
 
-    @execution_cache(key_fn=get_subset_def_data_for_eval_key)
+    @execution_cache(
+        key_fn=get_subset_def_data_for_eval_key, prompt_scoped=True
+    )
     def get_subset_def_data_for_eval(
         self, ctx, _, eval_result, name, subset_def
     ):

--- a/plugins/panels/model_evaluation/__init__.py
+++ b/plugins/panels/model_evaluation/__init__.py
@@ -1111,6 +1111,13 @@ class EvaluationPanel(Panel):
                         None,
                     )
 
+                # refresh clicked
+                should_refresh_cache = ctx.params.get("refresh_cache", False)
+                if should_refresh_cache:
+                    self.get_scenario_data.clear_cache(
+                        self, ctx, validated_scenario
+                    )
+
                 scenario_data = self.get_scenario_data(ctx, validated_scenario)
 
                 ctx.panel.set_state("scenario_load_error", None)
@@ -1119,7 +1126,8 @@ class EvaluationPanel(Panel):
                     scenario_data,
                 )
                 ctx.panel.set_state("scenario_loading", False)
-        except Exception:
+        except Exception as e:
+            print("error", e)
             ctx.panel.set_state("scenario_loading", False)
             msg = f"We couldn't load this scenario because the underlying data has changed or been removed. To continue your analysis you can,"
             ctx.panel.set_state(


### PR DESCRIPTION
## What changes are proposed in this pull request?

@imanjra This is a quick codeto make the refresh btn evict the scenario cache in case I don't get to finish this up. thank you!
It is throwing an error right now.
It also uses `prompt_scoped=True` as we talked about for sample distribution graph data 💪 

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to refresh cached scenario data when loading scenarios, ensuring users can access the most up-to-date information.
- **Bug Fixes**
  - Improved error handling during scenario loading by displaying errors instead of silently failing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->