### PR TITLE
Added optional `collate_fn` to `TorchImageModel`

### DIFF
--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -745,12 +745,6 @@ def _make_data_loader(samples, model, batch_size, num_workers, skip_failures):
                 return error
 
             try:
-                # collate_fn is just for TorchImageModels
-                # this means that it's fine to only assign
-                # collate_fn here, because other models
-                # use the other branches e.g. use_numpy==True
-                # or if a model has ragged_batches==True
-                # then it shouldn't have a collate_fn
                 if model.has_collate_fn:
                     return model.collate_fn(batch)
                 else:
@@ -2293,7 +2287,33 @@ class TorchModelMixin(object):
     applied to each input before prediction.
     """
 
-    pass
+    @property
+    def has_collate_fn(self):
+        """Whether this model has a custom collate function.
+        Set this to True if you want the method `collate_fn` to
+        be used instead of the default.
+        """
+        return False
+
+    @staticmethod
+    def collate_fn(batch):
+        """The collate function to use when creating a dataloader
+        for this model. By default, this is the identity function.
+
+        In order to enable this functionality, the model must set
+        the `has_collate_fn` property to True.
+
+        The user can override this method with a collate function of their choosing.
+        Please make sure this collate function is serializable so it is compatible
+        with multiprocessing for dataloaders.
+
+        Args:
+            batch: a list of items to collate
+
+        Returns:
+            the collated batch, this will be fed directly to the model
+        """
+        return batch
 
 
 class ModelManagerConfig(etam.ModelManagerConfig):

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -745,7 +745,17 @@ def _make_data_loader(samples, model, batch_size, num_workers, skip_failures):
                 return error
 
             try:
-                return tud.dataloader.default_collate(batch)
+                # collate_fn is just for TorchImageModels
+                # this means that it's fine to only assign
+                # collate_fn here, because other models
+                # use the other branches e.g. use_numpy==True
+                # or if a model has ragged_batches==True
+                # then it shouldn't have a collate_fn
+                return (
+                    tud.dataloader.default_collate(batch)
+                    if not hasattr(model, "collate_fn")
+                    else model.collate_fn(batch)
+                )
             except Exception as e:
                 if not skip_failures:
                     raise e

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -751,11 +751,10 @@ def _make_data_loader(samples, model, batch_size, num_workers, skip_failures):
                 # use the other branches e.g. use_numpy==True
                 # or if a model has ragged_batches==True
                 # then it shouldn't have a collate_fn
-                return (
-                    tud.dataloader.default_collate(batch)
-                    if not hasattr(model, "collate_fn")
-                    else model.collate_fn(batch)
-                )
+                if model.has_collate_fn:
+                    return model.collate_fn(batch)
+                else:
+                    return tud.dataloader.default_collate(batch)
             except Exception as e:
                 if not skip_failures:
                     raise e

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -2290,28 +2290,31 @@ class TorchModelMixin(object):
     @property
     def has_collate_fn(self):
         """Whether this model has a custom collate function.
-        Set this to True if you want the method `collate_fn` to
-        be used instead of the default.
+
+        Set this to ``True`` if you want :meth:`collate_fn` to be used during
+        inference.
         """
         return False
 
     @staticmethod
     def collate_fn(batch):
-        """The collate function to use when creating a dataloader
-        for this model. By default, this is the identity function.
+        """The collate function to use when creating dataloaders for this
+        model.
 
-        In order to enable this functionality, the model must set
-        the `has_collate_fn` property to True.
+        In order to enable this functionality, the model's
+        :meth:`has_collate_fn` property must return ``True``.
 
-        The user can override this method with a collate function of their choosing.
-        Please make sure this collate function is serializable so it is compatible
+        By default, this is the identity function, but subclasses can override
+        this method as necessary.
+
+        Note that this function must be serializable so it is compatible
         with multiprocessing for dataloaders.
 
         Args:
             batch: a list of items to collate
 
         Returns:
-            the collated batch, this will be fed directly to the model
+            the collated batch, which will be fed directly to the model
         """
         return batch
 

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -613,24 +613,26 @@ class TorchImageModel(
         """
         return self._transforms
 
-    @staticmethod
-    def collate_fn(batch):
-        """The collate function to use when creating a dataloader
-        for this model. By default, this is the default collate function for
-        :class:`torch:torch.utils.data.DataLoader`.
+    # optional, leaving commented out to avoid hasattr issues
+    # but want to have it here for reference
+    # @staticmethod
+    # def collate_fn(batch):
+    #     """The collate function to use when creating a dataloader
+    #     for this model. By default, this is the default collate function for
+    #     :class:`torch:torch.utils.data.DataLoader`.
 
-        If the user wants to use a custom collate function,
-        they can override this method with a collate function of their choosing.
-        Please make sure this collate function is serializable so it is compatible
-        with multiprocessing for dataloaders.
+    #     If the user wants to use a custom collate function,
+    #     they can override this method with a collate function of their choosing.
+    #     Please make sure this collate function is serializable so it is compatible
+    #     with multiprocessing for dataloaders.
 
-        Args:
-            batch: a list of items to collate
+    #     Args:
+    #         batch: a list of items to collate
 
-        Returns:
-            the collated batch, this will be fed directly to the model
-        """
-        return torch.utils.data.dataloader.default_collate(batch)
+    #     Returns:
+    #         the collated batch, this will be fed directly to the model
+    #     """
+    #     return torch.utils.data.dataloader.default_collate(batch)
 
     @property
     def preprocess(self):
@@ -724,6 +726,11 @@ class TorchImageModel(
     def _predict_all(self, imgs):
         if self._preprocess and self._transforms is not None:
             imgs = [self._transforms(img) for img in imgs]
+            if hasattr(self, "collate_fn"):
+                # models that have collate_fn defined
+                # will want to use it when doing _predict_all
+                # without a dataloader
+                imgs = self.collate_fn(imgs)
 
         height, width = None, None
 

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -613,6 +613,25 @@ class TorchImageModel(
         """
         return self._transforms
 
+    @staticmethod
+    def collate_fn(batch):
+        """The collate function to use when creating a dataloader
+        for this model. By default, this is the default collate function for
+        :class:`torch:torch.utils.data.DataLoader`.
+
+        If the user wants to use a custom collate function,
+        they can override this method with a collate function of their choosing.
+        Please make sure this collate function is serializable so it is compatible
+        with multiprocessing for dataloaders.
+
+        Args:
+            batch: a list of items to collate
+
+        Returns:
+            the collated batch, this will be fed directly to the model
+        """
+        return torch.utils.data.dataloader.default_collate(batch)
+
     @property
     def preprocess(self):
         """Whether to apply preprocessing transforms for inference, if any."""

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -624,30 +624,32 @@ class TorchImageModel(
     @property
     def has_collate_fn(self):
         """Whether this model has a custom collate function.
-        Set this to True if you want the method `collate_fn` to
-        be used instead of the default
-        `torch.utils.data.dataloader.default_collate`.
+
+        Set this to ``True`` if you want :meth:`collate_fn` to be used during
+        inference.
         """
         return False
 
     @staticmethod
     def collate_fn(batch):
-        """The collate function to use when creating a dataloader
-        for this model. By default, this is the default collate
-        function for :class:`torch:torch.utils.data.DataLoader`.
+        """The collate function to use when creating dataloaders for this
+        model.
 
-        In order to enable this functionality, the model must set
-        the `has_collate_fn` property to True.
+        In order to enable this functionality, the model's
+        :meth:`has_collate_fn` property must return ``True``.
 
-        The user can override this method with a collate function of their choosing.
-        Please make sure this collate function is serializable so it is compatible
+        By default, this is the default collate function for
+        :class:`torch:torch.utils.data.DataLoader`, but subclasses can override
+        this method as necessary.
+
+        Note that this function must be serializable so it is compatible
         with multiprocessing for dataloaders.
 
         Args:
             batch: a list of items to collate
 
         Returns:
-            the collated batch, this will be fed directly to the model
+            the collated batch, which will be fed directly to the model
         """
         return torch.utils.data.dataloader.default_collate(batch)
 

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -553,6 +553,15 @@ class TorchImageModel(
         self._transforms = transforms
         self._ragged_batches = ragged_batches
         self._preprocess = True
+        if hasattr(self, "collate_fn"):
+            if self._ragged_batches:
+                raise ValueError(
+                    "Cannot use collate_fn while ragged_batches is True. "
+                    "Set `ragged_batches=False` to use collate_fn. "
+                    "While the inputs to collate_fn may be ragged, "
+                    "the model has to flag itself as ragged_batches=False "
+                    "to enable proper dataloader support in apply_model."
+                )
 
         # Parse model details
         self._classes = self._parse_classes(config)

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -743,7 +743,7 @@ class TorchImageModel(
     def _predict_all(self, imgs):
         if self._preprocess and self._transforms is not None:
             imgs = [self._transforms(img) for img in imgs]
-            if hasattr(self, "collate_fn"):
+            if self.has_collate_fn:
                 # models that have collate_fn defined
                 # will want to use it when doing _predict_all
                 # without a dataloader


### PR DESCRIPTION
## What changes are proposed in this pull request?

Added and optional `collate_fn` method to `TorchImageModel`. This is useful for handling interesting transforms. For example, we may receive a batch with various image shapes, and may want to dynamically pad them.

## How is this patch tested? If it is not, please explain why.

Ran `test_apply_model` and `test_torch_hub_feature_extractor` from `fiftyone.tests.intensive.model_tests`
Commented out parts that are not relevant for torch model (i.e. the TF checks), as well as the `AssertRaises` for loading models, as those parts are not relevant for the correctness of the change.

## Release Notes

You can use custom collate functions now with `TorchImageModels`.

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

You can use custom collate functions now with `TorchImageModels`. Simply overwrite the `collate_fn` method in `TorchImageModel` and set the property `has_collate_fn` to `True`

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other: `fiftyone.utils.torch`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for custom batch collation functions in Torch-based image models, allowing users to override default data loading behavior.
- **Bug Fixes**
  - Enforced compatibility rules preventing simultaneous use of custom collation functions and ragged batches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->