### PR TITLE
chore: forgot the v in v3

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,0 +1,70 @@
+name: Build OSS Docker Images Without Publishing
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+-dockerbuild
+      - v[0-9]+.[0-9]+.[0-9]+rc[0-9]+-dockerbuild
+
+jobs:
+  build-docker-images:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+    steps:
+      - name: Clone fiftyone
+        uses: actions/checkout@v4
+
+      - name: Set Env Vars
+        run: |
+          echo "today=$(date +%Y%m%d)" >> "$GITHUB_ENV"
+          echo "fo_version=${{ github.ref_name }}" >> "$GITHUB_ENV"
+          echo "pyver=${{ matrix.python }}" >> "$GITHUB_ENV"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.RW_DOCKERHUB_USER }}
+          password: ${{ secrets.RW_DOCKERHUB_PAT }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push (not latest)
+        if: matrix.python != '3.11'
+        uses: docker/build-push-action@v6
+        with:
+          build-args: |
+            BUILD_TYPE=released
+            FO_VERSION=${{ env.fo_version }}
+            PYTHON_VERSION=${{ env.pyver }}
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: |
+            voxel51/fiftyone:${{ env.fo_version }}-python${{ env.pyver }}
+            voxel51/fiftyone:${{ env.fo_version }}-python${{ env.pyver }}-${{ env.today }}
+
+      - name: Build and push (latest)
+        if: matrix.python == '3.11'
+        uses: docker/build-push-action@v6
+        with:
+          build-args: |
+            BUILD_TYPE=released
+            FO_VERSION=${fo_version}
+            PYTHON_VERSION=${pyver}
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: |
+            voxel51/fiftyone:${{ env.fo_version }}-python${{ env.pyver }}
+            voxel51/fiftyone:${{ env.fo_version }}-python${{ env.pyver }}-${{ env.today }}
+            latest

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -59,8 +59,8 @@ jobs:
         with:
           build-args: |
             BUILD_TYPE=released
-            FO_VERSION=${fo_version}
-            PYTHON_VERSION=${pyver}
+            FO_VERSION=${{ env.fo_version }}
+            PYTHON_VERSION=${{ env.pyver }}
           context: .
           platforms: linux/amd64,linux/arm64
           push: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,8 +113,8 @@ jobs:
         with:
           build-args: |
             BUILD_TYPE=released
-            FO_VERSION=${fo_version}
-            PYTHON_VERSION=${pyver}
+            FO_VERSION=${{ env.fo_version }}
+            PYTHON_VERSION=${{ env.pyver }}
           context: .
           platforms: linux/amd64,linux/arm64
           push: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,14 +98,14 @@ jobs:
         with:
           build-args: |
             BUILD_TYPE=released
-            FO_VERSION=${fo_version}
-            PYTHON_VERSION=${pyver}
+            FO_VERSION=${{ env.fo_version }}
+            PYTHON_VERSION=${{ env.pyver }}
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            voxel51/fiftyone:${fo_version}-python${pyver}
-            voxel51/fiftyone:${fo_version}-python${pyver}-${today}
+            voxel51/fiftyone:${{ env.fo_version }}-python${{ env.pyver }}
+            voxel51/fiftyone:${{ env.fo_version }}-python${{ env.pyver }}-${{ env.today }}
 
       - name: Build and push (latest)
         if: matrix.python == '3.11'
@@ -119,6 +119,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            voxel51/fiftyone:${fo_version}-python${pyver}
-            voxel51/fiftyone:${fo_version}-python${pyver}-${today}
+            voxel51/fiftyone:${{ env.fo_version }}-python${{ env.pyver }}
+            voxel51/fiftyone:${{ env.fo_version }}-python${{ env.pyver }}-${{ env.today }}
             latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,7 @@ jobs:
           echo "pyver=${{ matrix.python }}" >> "$GITHUB_ENV"
 
       - name: Login to Docker Hub
-        uses: docker/login-action@3
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.RW_DOCKERHUB_USER }}
           password: ${{ secrets.RW_DOCKERHUB_PAT }}


### PR DESCRIPTION
## What changes are proposed in this pull request?

some fixes to the workflow for building-and-publishing docker images to docker hub

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved environment variable referencing in the publishing workflow for greater reliability.
  - Updated Docker login action version for enhanced compatibility.
  - Added a new workflow to build Docker images for multiple Python versions and platforms without publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->