### PR TITLE
fix load_view for ME panel

### DIFF
--- a/plugins/panels/model_evaluation/__init__.py
+++ b/plugins/panels/model_evaluation/__init__.py
@@ -654,7 +654,7 @@ class EvaluationPanel(Panel):
 
         # Restrict to subset, if applicable
         subset_def = view_options.get("subset_def", None)
-        subset_def_type = subset_def.get("type", None)
+        subset_def_type = subset_def.get("type", None) if subset_def else None
 
         if subset_def_type == "custom_code":
             code = subset_def.get("code", None)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes broken load_view event when subset def is missing

## How is this patch tested? If it is not, please explain why.

Using ME panel charts

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixes plot interactivity in ME panel

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to prevent potential issues when accessing missing data in model evaluation panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->