### PR TITLE
chore: invert deprecation notices to put most recent on top

### DIFF
--- a/docs/source/deprecation.rst
+++ b/docs/source/deprecation.rst
@@ -5,6 +5,49 @@ FiftyOne Deprecation Notices
 
 .. default-role:: code
 
+.. _deprecation-mongodb-5.0:
+
+MongoDB 5.0
+---------------
+*Support ending July 1, 2025*
+
+`MongoDB 5.0 <https://www.mongodb.com/legal/support-policy/lifecycles>`_
+transitioned to `end-of-life` effective October of 2024. FiftyOne
+releases after July 1, 2025 might no longer be compatible with
+MongoDB 5.0 and older.
+
+.. _deprecation-mongodb-4.4:
+
+MongoDB 4.4
+---------------
+*Support ended March 1, 2025*
+
+`MongoDB 4.4 <https://www.mongodb.com/legal/support-policy/lifecycles>`_
+transitioned to `end-of-life` effective February of 2024. FiftyOne
+releases after March 1, 2025 might no longer be compatible with
+MongoDB 4.4 and older.
+
+.. _deprecation-kubernetes-1.2.7:
+
+Kubernetes 1.27
+---------------
+*Support ended November 1, 2024*
+
+`Kubernetes 1.27 <https://kubernetes.io/releases/>`_
+transitioned to `end-of-life` effective July of 2024. FiftyOne Enterprise
+releases after October 31, 2024 might no longer be compatible with
+Kubernetes 1.27 and older.
+
+.. _deprecation-python-3.8:
+
+Python 3.8
+----------
+*Support ended October 1, 2024*
+
+`Python 3.8 <https://devguide.python.org/versions/>`_
+transitions to `end-of-life` effective October of 2024. FiftyOne releases after
+September 30, 2024 will no longer support Python 3.8.
+
 .. _deprecation-fiftyone-desktop:
 
 FiftyOne Desktop
@@ -17,39 +60,3 @@ package is no longer available as of `fiftyone==0.25.0`.
 Chromium-based browsers, Firefox, or a :ref:`notebook <notebooks>` environment
 are recommended for the best FiftyOne experience.
 
-.. _deprecation-python-3.8:
-
-Python 3.8
-----------
-*Support ended October 1, 2024*
-
-`Python 3.8 <https://devguide.python.org/versions/>`_
-transitions to `end-of-life` effective October of 2024. FiftyOne releases after
-September 30, 2024 will no longer support Python 3.8.
-
-Kubernetes 1.27
----------------
-*Support ended November 1, 2024*
-
-`Kubernetes 1.27 <https://kubernetes.io/releases/>`_
-transitioned to `end-of-life` effective July of 2024. FiftyOne Enterprise
-releases after October 31, 2024 might no longer be compatible with
-Kubernetes 1.27 and older.
-
-MongoDB 4.4
----------------
-*Support ended March 1, 2025*
-
-`MongoDB 4.4 <https://www.mongodb.com/legal/support-policy/lifecycles>`_
-transitioned to `end-of-life` effective February of 2024. FiftyOne 
-releases after March 1, 2025 might no longer be compatible with
-MongoDB 4.4 and older.
-
-MongoDB 5.0
----------------
-*Support ending July 1, 2025*
-
-`MongoDB 5.0 <https://www.mongodb.com/legal/support-policy/lifecycles>`_
-transitioned to `end-of-life` effective October of 2024. FiftyOne 
-releases after July 1, 2025 might no longer be compatible with
-MongoDB 5.0 and older.

--- a/docs/source/deprecation.rst
+++ b/docs/source/deprecation.rst
@@ -30,7 +30,7 @@ transitioned to `end-of-life` effective February of 2024. FiftyOne
 releases after March 1, 2025 might no longer be compatible with
 MongoDB 4.4 and older.
 
-.. _deprecation-kubernetes-1.2.7:
+.. _deprecation-kubernetes-1.27:
 
 Kubernetes 1.27
 ---------------

--- a/docs/source/deprecation.rst
+++ b/docs/source/deprecation.rst
@@ -5,6 +5,9 @@ FiftyOne Deprecation Notices
 
 .. default-role:: code
 
+.. note::
+   Deprecation notices below are ordered in reverse chronological order (most recent at the top).
+
 .. _deprecation-mongodb-5.0:
 
 MongoDB 5.0


### PR DESCRIPTION
## What changes are proposed in this pull request?

Deprecation notices, much like release notes, should put the newest information on top.

This does that.
## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved clarity in the deprecation notices by reorganizing and relabeling sections.
  - Updated support timelines and compatibility warnings for MongoDB, Kubernetes, Python, and FiftyOne Desktop.
  - Enhanced phrasing to better emphasize support end dates and upcoming changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->