### PR TITLE
Exclude core.models from backend ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@
 # Backend
 /fiftyone/api/         @voxel51/backend-devs
 /fiftyone/core/        @voxel51/backend-devs
+/fiftyone/core/models.py
 /fiftyone/factory/     @voxel51/backend-devs
 /fiftyone/internal/    @voxel51/backend-devs
 /fiftyone/management/  @voxel51/backend-devs


### PR DESCRIPTION
This change removes one file `fiftyone/core/models.py` from backend ownership.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated code ownership rules to explicitly include a specific backend file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->