### PR TITLE
Fix icon path resolution in deployed environments

### DIFF
--- a/app/packages/looker/src/elements/metadata/util.ts
+++ b/app/packages/looker/src/elements/metadata/util.ts
@@ -26,10 +26,17 @@ export const getFileExtension = (path?: string): string | undefined => {
 
 export const getIcon = (path: string): string => {
   const extension = getFileExtension(path);
+
+  // icon may be a path or an object like {src: path} depending on the
+  // environment.
+  let icon: string | { src: string };
   if (!extension || !iconMapping[extension]) {
-    return defaultIcon;
+    icon = defaultIcon;
+  } else {
+    icon = iconMapping[extension];
   }
-  return iconMapping[extension];
+
+  return (icon as any as { src: string }).src ?? icon;
 };
 
 export const getFileName = (path?: string): string | undefined => {


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR fixes a bug which causes some SVG icons to not render correctly in deployed environments.

## How is this patch tested? If it is not, please explain why.

local app, ephemeral environment

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved icon handling to better support different icon formats, ensuring icons display correctly in more scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->