### PR TITLE
Add `last_deletion_at` property to datasets

### DIFF
--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -2157,6 +2157,7 @@ including:
     :attr:`app_config <fiftyone.core.dataset.Dataset.app_config>` are edited
 -   when fields are added or deleted from the dataset's schema
 -   when group slices are added or deleted from the dataset's schema
+-   when saved views or workspaces are added, edited, or deleted
 
 .. code-block:: python
     :linenos:

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -2158,6 +2158,8 @@ including:
 -   when fields are added or deleted from the dataset's schema
 -   when group slices are added or deleted from the dataset's schema
 -   when saved views or workspaces are added, edited, or deleted
+-   when annotation, brain, evaluation, or custom runs are added, edited, or
+    deleted
 
 .. code-block:: python
     :linenos:

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -11070,9 +11070,20 @@ class SampleCollection(object):
         return _handle_id_fields(self, field_name)
 
     def _is_full_collection(self):
+        # Full dataset
         if isinstance(self, fod.Dataset) and self.media_type != fom.GROUP:
             return True
 
+        # Full view (possibly generated)
+        # pylint:disable=no-member
+        if (
+            isinstance(self, fov.DatasetView)
+            and self._dataset.media_type != fom.GROUP
+            and not self._stages
+        ):
+            return True
+
+        # Full group slices view
         # pylint:disable=no-member
         if (
             isinstance(self, fov.DatasetView)

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -8115,6 +8115,7 @@ class SampleCollection(object):
                     etau.is_str(field_or_expr)
                     and field_or_expr == "frames"
                     and self._has_frame_fields()
+                    and not self._is_clips
                 )
             )
         ):

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -604,7 +604,8 @@ class SampleCollection(object):
         """Syncs the ``last_modified_at`` property(s) of the dataset.
 
         Updates the :attr:`last_modified_at` property of the dataset if
-        necessary to incorporate any modification timestamps to its samples.
+        necessary to incorporate any modification/deletion timestamps to its
+        samples.
 
         If ``include_frames==True``, the ``last_modified_at`` property of
         each video sample is first updated if necessary to incorporate any
@@ -667,7 +668,10 @@ class SampleCollection(object):
     def _sync_dataset_last_modified_at(self):
         dataset = self._root_dataset
         curr_lma = dataset.last_modified_at
-        lma = self._max("last_modified_at")
+        lma = _none_max(
+            dataset.last_deletion_at,
+            self._max("last_modified_at"),
+        )
 
         if lma is not None and (curr_lma is None or lma > curr_lma):
             dataset._doc.last_modified_at = lma
@@ -8505,6 +8509,23 @@ class SampleCollection(object):
         Returns:
             the minimum value
         """
+
+        # Optimization: use `_min()` when possible
+        if (
+            isinstance(field_or_expr, str)
+            and (
+                field_or_expr in ("last_modified_at", "created_at")
+                or (
+                    self._contains_videos(any_slice=True)
+                    and field_or_expr
+                    in ("frames.last_modified_at", "frames.created_at")
+                )
+            )
+            and expr is None
+            and self._is_full_collection()
+        ):
+            return self._min(field_or_expr)
+
         make = lambda field_or_expr: foa.Min(
             field_or_expr, expr=expr, safe=safe
         )
@@ -8589,6 +8610,23 @@ class SampleCollection(object):
         Returns:
             the maximum value
         """
+
+        # Optimization: use `_max()` when possible
+        if (
+            isinstance(field_or_expr, str)
+            and (
+                field_or_expr in ("last_modified_at", "created_at")
+                or (
+                    self._contains_videos(any_slice=True)
+                    and field_or_expr
+                    in ("frames.last_modified_at", "frames.created_at")
+                )
+            )
+            and expr is None
+            and self._is_full_collection()
+        ):
+            return self._max(field_or_expr)
+
         make = lambda field_or_expr: foa.Max(
             field_or_expr, expr=expr, safe=safe
         )
@@ -12474,3 +12512,7 @@ def _add_db_fields_to_schema(schema):
             additions[field.db_field] = field
 
     schema.update(additions)
+
+
+def _none_max(*args, default=None):
+    return max((a for a in args if a is not None), default=default)

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -726,6 +726,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         -   when fields are added or deleted from the dataset's schema
         -   when group slices are added or deleted from the dataset's schema
         -   when saved views or workspaces are added, edited, or deleted
+        -   when annotation, brain, evaluation, or custom runs are added,
+            edited, or deleted
 
         This property is **not** updated when samples are added, edited, or
         deleted. Use

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -725,6 +725,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             :attr:`app_config` are edited
         -   when fields are added or deleted from the dataset's schema
         -   when group slices are added or deleted from the dataset's schema
+        -   when saved views or workspaces are added, edited, or deleted
 
         This property is **not** updated when samples are added, edited, or
         deleted. Use

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -898,6 +898,7 @@ class DatasetDocument(Document):
     version = StringField(required=True, null=True)
     created_at = DateTimeField()
     last_modified_at = DateTimeField()
+    last_deletion_at = DateTimeField()
     last_loaded_at = DateTimeField()
     sample_collection_name = StringField(unique=True, required=True)
     frame_collection_name = StringField()

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -807,6 +807,13 @@ class Document(BaseDocument, mongoengine.Document):
         self.last_modified_at = last_modified_at
         self.save(virtual=True)
 
+    def _update_last_deletion_at(self, last_deletion_at=None):
+        if last_deletion_at is None:
+            last_deletion_at = datetime.utcnow()
+
+        self.last_deletion_at = last_deletion_at
+        self.save(virtual=True)
+
     def _do_updates(self, _id, updates, upsert):
         updated_existing = True
 

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -617,7 +617,7 @@ class DatasetTests(unittest.TestCase):
         self.assertEqual(last_modified_at2, last_modified_at1)
 
     @drop_datasets
-    def test_last_modified_at_deletions(self):
+    def test_last_deletion_at(self):
         samples = [
             fo.Sample(filepath="image1.jpg"),
             fo.Sample(filepath="image2.png"),
@@ -630,31 +630,33 @@ class DatasetTests(unittest.TestCase):
         dataset = fo.Dataset()
         dataset.add_samples(samples)
 
-        last_modified_at1 = dataset.last_modified_at
+        last_deletion_at1 = dataset.last_deletion_at
+        self.assertIsNone(last_deletion_at1)
 
         dataset[:5].keep()
-        last_modified_at2 = dataset.last_modified_at
+        last_deletion_at2 = dataset.last_deletion_at
 
         self.assertEqual(len(dataset), 5)
-        self.assertTrue(last_modified_at2 > last_modified_at1)
+        self.assertIsNotNone(last_deletion_at2)
+        self.assertTrue(last_deletion_at2 > dataset.created_at)
 
         dataset[-1:].clear()
-        last_modified_at3 = dataset.last_modified_at
+        last_deletion_at3 = dataset.last_deletion_at
 
         self.assertEqual(len(dataset), 4)
-        self.assertTrue(last_modified_at3 > last_modified_at2)
+        self.assertTrue(last_deletion_at3 > last_deletion_at2)
 
         dataset.delete_samples(dataset[:2])
-        last_modified_at4 = dataset.last_modified_at
+        last_deletion_at4 = dataset.last_deletion_at
 
         self.assertEqual(len(dataset), 2)
-        self.assertTrue(last_modified_at4 > last_modified_at3)
+        self.assertTrue(last_deletion_at4 > last_deletion_at3)
 
         dataset.clear()
-        last_modified_at5 = dataset.last_modified_at
+        last_deletion_at5 = dataset.last_deletion_at
 
         self.assertEqual(len(dataset), 0)
-        self.assertTrue(last_modified_at5 > last_modified_at4)
+        self.assertTrue(last_deletion_at5 > last_deletion_at4)
 
     @drop_datasets
     def test_indexes(self):

--- a/tests/unittests/video_tests.py
+++ b/tests/unittests/video_tests.py
@@ -743,7 +743,7 @@ class VideoTests(unittest.TestCase):
         self.assertNotEqual(frame3.id, frame_id)
 
     @drop_datasets
-    def test_last_modified_at_deletions(self):
+    def test_last_modified_at_frame_deletions1(self):
         samples = [
             fo.Sample(
                 filepath=f"video{i}.mp4",
@@ -756,50 +756,46 @@ class VideoTests(unittest.TestCase):
         dataset.add_samples(samples)
 
         dataset.ensure_frames()
-        last_modified_at1 = dataset.last_modified_at
-        last_modified_at2 = dataset.max("last_modified_at")
+        last_deletion_at1 = dataset.last_deletion_at
+        last_modified_at1 = dataset.max("last_modified_at")
 
+        self.assertIsNone(last_deletion_at1)
         self.assertEqual(dataset.count("frames"), 20)
 
         frame_ids = dataset.match_frames(F("frame_number") == 5).values(
             "frames.id", unwind=True
         )
         dataset.delete_frames(frame_ids)
-        last_modified_at3 = dataset.max("last_modified_at")
+        last_modified_at2 = dataset.max("last_modified_at")
 
         self.assertEqual(dataset.count("frames"), 16)
-        self.assertTrue(last_modified_at3 > last_modified_at2)
+        self.assertTrue(last_modified_at2 > last_modified_at1)
 
         dataset.match_frames(F("frame_number") <= 2).keep_frames()
-        last_modified_at4 = dataset.max("last_modified_at")
+        last_modified_at3 = dataset.max("last_modified_at")
 
         self.assertEqual(dataset.count("frames"), 8)
-        self.assertTrue(last_modified_at4 > last_modified_at3)
+        self.assertTrue(last_modified_at3 > last_modified_at2)
 
         dataset[:2].clear_frames()
-        last_modified_at5 = dataset.max("last_modified_at")
+        last_modified_at4 = dataset.max("last_modified_at")
 
         self.assertEqual(dataset.count("frames"), 4)
-        self.assertTrue(last_modified_at5 > last_modified_at4)
+        self.assertTrue(last_modified_at4 > last_modified_at3)
 
         dataset.clear_frames()
-        last_modified_at6 = dataset.max("last_modified_at")
+        last_modified_at5 = dataset.max("last_modified_at")
 
         self.assertEqual(dataset.count("frames"), 0)
-        self.assertTrue(last_modified_at6 > last_modified_at5)
+        self.assertTrue(last_modified_at5 > last_modified_at4)
 
         dataset.reload()
-        last_modified_at7 = dataset.last_modified_at
+        last_deletion_at2 = dataset.last_deletion_at
 
-        self.assertEqual(last_modified_at1, last_modified_at7)
-
-        dataset.sync_last_modified_at()
-        last_modified_at8 = dataset.last_modified_at
-
-        self.assertTrue(last_modified_at8 > last_modified_at7)
+        self.assertIsNone(last_deletion_at2)
 
     @drop_datasets
-    def test_last_modified_at_deletions_frames(self):
+    def test_last_modified_at_frame_deletions2(self):
         samples = [
             fo.Sample(
                 filepath=f"video{i}.mp4",
@@ -812,49 +808,45 @@ class VideoTests(unittest.TestCase):
         dataset.add_samples(samples)
 
         dataset.ensure_frames()
-        last_modified_at1 = dataset.last_modified_at
+        last_deletion_at1 = dataset.last_deletion_at
 
+        self.assertIsNone(last_deletion_at1)
         self.assertEqual(dataset.count("frames"), 10)
 
         sample = dataset.first()
-        last_modified_at2 = sample.last_modified_at
+        last_modified_at1 = sample.last_modified_at
 
         del sample.frames[1]
         del sample.frames[3]
         del sample.frames[5]
 
         sample.save()
-        last_modified_at3 = sample.last_modified_at
+        last_modified_at2 = sample.last_modified_at
 
         self.assertEqual(dataset.count("frames"), 7)
-        self.assertTrue(last_modified_at3 > last_modified_at2)
+        self.assertTrue(last_modified_at2 > last_modified_at1)
 
         sample.reload()
-        last_modified_at4 = sample.last_modified_at
+        last_modified_at3 = sample.last_modified_at
 
-        self.assertEqual(last_modified_at4, last_modified_at3)
+        self.assertEqual(last_modified_at3, last_modified_at2)
 
         sample.frames.clear()
         sample.save()
-        last_modified_at5 = sample.last_modified_at
+        last_modified_at4 = sample.last_modified_at
 
         self.assertEqual(dataset.count("frames"), 5)
-        self.assertTrue(last_modified_at5 > last_modified_at4)
+        self.assertTrue(last_modified_at4 > last_modified_at3)
 
         sample.reload()
-        last_modified_at6 = sample.last_modified_at
+        last_modified_at5 = sample.last_modified_at
 
-        self.assertEqual(last_modified_at6, last_modified_at5)
+        self.assertEqual(last_modified_at5, last_modified_at4)
 
         dataset.reload()
-        last_modified_at7 = dataset.last_modified_at
+        last_deletion_at2 = dataset.last_deletion_at
 
-        self.assertEqual(last_modified_at7, last_modified_at1)
-
-        dataset.sync_last_modified_at()
-        last_modified_at8 = dataset.last_modified_at
-
-        self.assertTrue(last_modified_at8 > last_modified_at7)
+        self.assertIsNone(last_deletion_at2)
 
     @drop_datasets
     def test_save_frame_view(self):


### PR DESCRIPTION
## Change log

- Adds a `Dataset.last_deletion_at` property that is automatically updated when samples are deleted
- `Dataset.last_modified_at` is no longer automatically updated when samples are deleted
- Adds documentation for the behavior of FiftyOne's builtin datetime fields to the user guide
- Updates `_is_full_collection()` to include full views, eg `dataset.view()` and full generated views like `to_patches()`

## Motivation

https://github.com/voxel51/fiftyone/pull/5723 added automatic incrementing of `Dataset.last_modified_at` when samples are deleted. This was released in `fiftyone==1.5.0`.

After reflecting on this implementation in the context of use cases like https://github.com/voxel51/fiftyone-plugins/pull/122, I strongly believe that deletion times should be tracked separately from other dataset metadata changes.

For example, changing a dataset's description and creating a new saved view both increment `Dataset.last_modified_at`, but these have no effect on whether a saved `to_patches()` view needs to be reloaded.

As penance for my decision to change course from how deletion is tracked in `fiftyone==1.5.0`, I've added previously non-existent documentation on automatic datetime fields to the user guide 🙇 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new property to datasets that records the datetime when a sample was last deleted.
  - Enhanced documentation with a comprehensive guide on builtin datetime fields for datasets and samples, including new examples and usage notes.

- **Bug Fixes**
  - Improved accuracy of dataset modification and deletion timestamps for better tracking.

- **Tests**
  - Updated and expanded tests to verify correct behavior of the new deletion timestamp and collection status features.

- **Documentation**
  - Expanded user guide with detailed explanations and examples for all builtin datetime fields and their update semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->