### PR TITLE
add fallback text when mime type cannot be determined

### DIFF
--- a/app/packages/core/src/components/Modal/MetadataLooker.tsx
+++ b/app/packages/core/src/components/Modal/MetadataLooker.tsx
@@ -34,7 +34,10 @@ const SampleMetadata = ({ sample }: { sample: Sample }) => {
 
         <Stack direction="row" spacing={8}>
           <LabeledMetadata label="Size" value={getFileSize(sample)} />
-          <LabeledMetadata label="Type" value={getMimeType(sample)} />
+          <LabeledMetadata
+            label="Type"
+            value={getMimeType(sample) ?? "Unknown mime type"}
+          />
           <LabeledMetadata
             label="Created"
             value={formatLongDateTime(sample.created_at?.datetime)}


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds fallback text to the metadata modal looker when the sample's mime type cannot be determined. The text currently displays as blank in this case.

## How is this patch tested? If it is not, please explain why.

local app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- The "Type" metadata label now displays "Unknown mime type" when the MIME type is unavailable, ensuring clearer information is shown to users instead of a blank or undefined value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->