### PR TITLE
Add notice about CVAT <=v2.30.0 support

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -180,6 +180,10 @@ FiftyOne:
 Setup
 _____
 
+.. warning::
+
+   This integration `currently supports <https://github.com/voxel51/fiftyone/issues/5771>`_.  CVAT server versions <=v2.30.0.
+
 FiftyOne supports both `app.cvat.ai <https://app.cvat.ai>`_ and
 `self-hosted servers <https://opencv.github.io/cvat/docs/administration/basics/installation/>`_.
 

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -182,7 +182,7 @@ _____
 
 .. warning::
 
-   This integration `currently supports <https://github.com/voxel51/fiftyone/issues/5771>`_.  CVAT server versions <=v2.30.0.
+   This integration currently only `supports CVAT server versions <=v2.30.0 <https://github.com/voxel51/fiftyone/issues/5771>`_.
 
 FiftyOne supports both `app.cvat.ai <https://app.cvat.ai>`_ and
 `self-hosted servers <https://opencv.github.io/cvat/docs/administration/basics/installation/>`_.

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -182,7 +182,8 @@ _____
 
 .. warning::
 
-   This integration currently only `supports CVAT server versions <=v2.30.0 <https://github.com/voxel51/fiftyone/issues/5771>`_.
+   This integration currently only
+   `supports CVAT server versions <= 2.30 <https://github.com/voxel51/fiftyone/issues/5771>`_.
 
 FiftyOne supports both `app.cvat.ai <https://app.cvat.ai>`_ and
 `self-hosted servers <https://opencv.github.io/cvat/docs/administration/basics/installation/>`_.

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3815,8 +3815,10 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
 
         if self._server_version > Version("2.30"):
             raise RuntimeError(
-                "CVAT server version '%s' is not currently supported. Supported CVAT range is <=v2.30.0. https://github.com/voxel51/fiftyone/issues/5771"
-                % self._server_version
+                f"CVAT server version '{self._server_version}' is not "
+                "currently supported. Please use CVAT <= 2.30.\n\n"
+                "See https://github.com/voxel51/fiftyone/issues/5771 for "
+                "details"
             )
 
     def _add_referer(self):

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3818,7 +3818,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 f"CVAT server version '{self._server_version}' is not "
                 "currently supported. Please use CVAT <= 2.30.\n\n"
                 "See https://github.com/voxel51/fiftyone/issues/5771 for "
-                "details"
+                "details."
             )
 
     def _add_referer(self):

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3813,6 +3813,12 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
 
         logger.debug("CVAT server version: %s", self._server_version)
 
+        if self._server_version > Version("2.30"):
+            raise RuntimeError(
+                "CVAT server version '%s' is not currently supported. Supported CVAT range is <=v2.30.0. https://github.com/voxel51/fiftyone/issues/5771"
+                % self._server_version
+            )
+
     def _add_referer(self):
         if "Referer" not in self._session.headers:
             self._session.headers["Referer"] = self.login_url


### PR DESCRIPTION
## What changes are proposed in this pull request?

Until https://github.com/voxel51/fiftyone/issues/5771 is resolved, add a docs warning and raise an error when attempting to use the CVAT integration with a CVAT server >=v2.30.0

![image](https://github.com/user-attachments/assets/f1b93fc5-459d-4169-9af8-14782d7cd37d)


## How is this patch tested? If it is not, please explain why.

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
dataset.annotate("test", label_field="ground_truth") 
```

```
RuntimeError: CVAT server version '2.31.0' is not currently supported. Please use CVAT <= 2.30.

See https://github.com/voxel51/fiftyone/issues/5771 for details
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for CVAT integration and model evaluation panels to prevent crashes in unsupported scenarios.
  - Ensured the MIME type in metadata displays a default message when unavailable.
  - Addressed potential singleton issues when loading saved dataset views.
  - Disabled debug mode in value aggregation routes.

- **Documentation**
  - Added a warning in the CVAT integration docs about supported server versions.

- **Chores**
  - Updated and relaxed dependency versions for better compatibility, including TensorFlow, matplotlib, packaging, plotly, strawberry-graphql, and pytest.
  - Bumped version to 1.5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->