### PR TITLE
Reload for saved views

### DIFF
--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -501,6 +501,7 @@ class Query(fosa.AggregateQuery):
     def saved_views(self, dataset_name: str) -> t.Optional[t.List[SavedView]]:
         try:
             ds = fod.load_dataset(dataset_name)
+            ds.reload()  # reload to avoid singleton issues
             return [
                 SavedView.from_doc(view_doc)
                 for view_doc in ds._doc.saved_views


### PR DESCRIPTION
## What changes are proposed in this pull request?

Reload the dataset when retrieving saved views to avoid stale state from singletons
### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when accessing saved views by ensuring datasets are properly refreshed before use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->