### PR TITLE
rename TestPanel to MockPanel

### DIFF
--- a/tests/unittests/panels/panel_tests.py
+++ b/tests/unittests/panels/panel_tests.py
@@ -16,7 +16,7 @@ def simulate_event(panel, mock_ctx, event_name):
     panel.execute(mock_ctx)
 
 
-class TestPanel(Panel):
+class MockPanel(Panel):
     @property
     def config(self):
         return PanelConfig(name="test_panel", label="Test Panel")
@@ -46,7 +46,7 @@ def mock_ctx():
 
 @pytest.fixture
 def panel():
-    return TestPanel()
+    return MockPanel()
 
 
 def test_panel_initialization(panel):


### PR DESCRIPTION
## What changes are proposed in this pull request?

fix `PytestCollectionWarning: cannot collect test class 'TestPanel' because it has a __init__ constructor (from: tests/unittests/panels/panel_tests.py)
    class TestPanel(Panel):`

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated test class and fixture names for improved clarity in panel-related tests. No changes to test logic or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->