### PR TITLE
Ignore fields not defined in dataset schema

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -8533,6 +8533,7 @@ def _create_sample_document_cls(
 ):
     cls = type(sample_collection_name, (foo.DatasetSampleDocument,), {})
     cls._dataset = dataset
+    cls.STRICT = True
 
     _declare_fields(dataset, cls, field_docs=field_docs)
     return cls

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -8533,7 +8533,6 @@ def _create_sample_document_cls(
 ):
     cls = type(sample_collection_name, (foo.DatasetSampleDocument,), {})
     cls._dataset = dataset
-    cls.STRICT = True
 
     _declare_fields(dataset, cls, field_docs=field_docs)
     return cls

--- a/fiftyone/core/odm/sample.py
+++ b/fiftyone/core/odm/sample.py
@@ -77,7 +77,7 @@ class DatasetSampleDocument(DatasetMixin, Document):
     this class.
     """
 
-    meta = {"abstract": True}
+    meta = {"abstract": True, "strict": False}
 
     _is_frames_doc = False
 

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -4100,6 +4100,30 @@ class DatasetTests(unittest.TestCase):
                 dataset3.default_skeleton, dataset.default_skeleton
             )
 
+    @drop_datasets
+    def test_ignore_fields_not_in_schema(self):
+        dataset = fo.Dataset()
+
+        sample = fo.Sample(filepath="image.jpg", foo="bar", bar="baz")
+        dataset.add_sample(sample)
+        field = "not_in_schema"
+        dataset._sample_collection.update_one(
+            {}, {"$set": {field: "some data"}}
+        )
+
+        # Load sample
+        loaded_sample = dataset.first()
+
+        # Verify that the field is not in the loaded sample
+        self.assertTrue(field not in loaded_sample)
+
+        # Verify that the field is in the database
+        doc = dataset._sample_collection.find_one(
+            {"filepath": loaded_sample.filepath}
+        )
+        self.assertTrue(field in doc)
+        self.assertEqual(doc[field], "some data")
+
 
 class DatasetExtrasTests(unittest.TestCase):
     @drop_datasets


### PR DESCRIPTION
## What changes are proposed in this pull request?

- currently samples with fields not in the dataset schema will throw an error during iter_samples() when the sample instances are created. This can be very confusing and unnecessarily limiting. 
```
FieldDoesNotExist: The fields "{'not_in_dataset_schema'}" do not exist on the document "samples.67d77c98dcc49de74086ebf8"
```
It would be better just to ignore undefined fields. This would also allow "hidden" fields to exist for internal features without needing to declare them on the dataset schema and resolve them during iter_samples().



## How is this patch tested? If it is not, please explain why.

- add automated tests

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of extra fields not defined in the dataset schema, ensuring they are ignored when loading samples, but still stored in the database.
- **Tests**
  - Added a unit test to verify that undeclared fields are ignored by the sample loading mechanism while remaining in the database.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->