### PR TITLE
Fix ordered compound grouping

### DIFF
--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -3753,8 +3753,15 @@ class GroupBy(ViewStage):
 
         if order_by is not None:
             order = -1 if self._reverse else 1
+            if isinstance(field_or_expr, (list, tuple)) and all(
+                etau.is_str(f) for f in field_or_expr
+            ):
+                spec = [(f, 1) for f in field_or_expr]
+            else:
+                spec = [(field_or_expr, 1)]
+
             stage = SortBy(
-                [(field_or_expr, 1), (order_by, order)],
+                spec + [(order_by, order)],
                 create_index=self._create_index,
             )
             stage.validate(sample_collection)

--- a/tests/unittests/group_tests.py
+++ b/tests/unittests/group_tests.py
@@ -2001,6 +2001,25 @@ class DynamicGroupTests(unittest.TestCase):
             default_indexes | {"_sample_id_1_device_id_1"},
         )
 
+        # test ordering
+        view = dataset.group_by(
+            ("sample_id", "device_id"), order_by="created_at"
+        )
+        self.assertEqual(len(view), 4)
+        self.assertSetEqual(
+            set(dataset.list_indexes()),
+            default_indexes
+            | {
+                "_sample_id_1_device_id_1",
+                "_sample_id_1_device_id_1_created_at_1",
+            },
+        )
+
+        also_view = fo.DatasetView._build(dataset, view._serialize())
+
+        self.assertEqual(len(also_view), 4)
+        self.assertEqual(also_view.media_type, "group")
+
     @drop_datasets
     def test_group_by_complex(self):
         dataset = _make_group_by_dataset()


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds support for the below. Currently, when `order_by` is used for a compound grouping, the injected `SortBy` stage fails

```python
import fiftyone.zoo as foz
ds = foz.load_zoo_dataset("quickstart")

scene = [0,1,0,1]
camera = [3,3,4,4]

ctr=0
for sample in ds:
    sample["scene"] = scene[ctr%4]
    sample["camera"] = camera[ctr%4]
    ctr+=1
    sample.save()
    
view = ds.group_by(["scene", "camera"], order_by="uniqueness")
``` 

Redacted trace
```
File ~/code/fiftyone/fiftyone/core/stages.py:7539, in <listcomp>(.0)
   7534     return field_or_expr.to_mongo()
   7536 if isinstance(field_or_expr, (list, tuple)):
   7537     return [
   7538         (_serialize_sort_expr(expr), _parse_sort_order(order))
-> 7539         for expr, order in field_or_expr
   7540     ]
   7542 return field_or_expr

ValueError: too many values to unpack (expected 2)
``` 

## How is this patch tested? If it is not, please explain why.

SDK assertions

## Release Notes

* Fixed compound key :ref:`groups <view-groups>` when `order_by` is provided

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of grouping by multiple fields when using the group by feature, ensuring correct sorting when ordering is specified.
- **Tests**
  - Added a test to verify grouping by multiple fields with ordering, checking both the results and dataset indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->