### PR TITLE
Fix datasets revision 

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -8316,7 +8316,9 @@ def _list_datasets_info(include_private=False, glob_patt=None, tags=None):
 
 def _list_datasets_query(include_private=False, glob_patt=None, tags=None):
     if include_private:
-        query = {}
+        # Protect against empty dataset docs, which can sometimes occur for
+        # reasons we don't fully understand
+        query = {"name": {"$exists": 1}}
     else:
         # Datasets whose sample collections don't start with `samples.` are
         # private e.g., patches or frames datasets

--- a/fiftyone/migrations/runner.py
+++ b/fiftyone/migrations/runner.py
@@ -73,7 +73,9 @@ def get_datasets_revisions():
     conn = foo.get_db_conn()
     return {
         dataset_doc["name"]: dataset_doc.get("version", None)
-        for dataset_doc in conn.datasets.find({}, {"name": 1, "version": 1})
+        for dataset_doc in conn.datasets.find(
+            {"name": {"$exists": 1}}, {"name": 1, "version": 1}
+        )
     }
 
 

--- a/fiftyone/migrations/runner.py
+++ b/fiftyone/migrations/runner.py
@@ -18,6 +18,8 @@ import fiftyone.constants as foc
 import fiftyone.core.odm as foo
 import fiftyone.core.utils as fou
 
+fod = fou.lazy_import("fiftyone.core.dataset")
+
 
 logger = logging.getLogger(__name__)
 
@@ -100,7 +102,7 @@ def migrate_all(destination=None, error_level=0, verbose=False):
     """
     migrate_database_if_necessary(destination=destination, verbose=verbose)
 
-    for name in fo.list_datasets():
+    for name in fod._list_datasets(include_private=True):
         migrate_dataset_if_necessary(
             name,
             destination=destination,

--- a/tests/unittests/migrations/runner_tests.py
+++ b/tests/unittests/migrations/runner_tests.py
@@ -1,0 +1,65 @@
+"""
+| Copyright 2017-2025, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import datetime
+import unittest
+from unittest.mock import patch, MagicMock
+
+from fiftyone.migrations import get_datasets_revisions
+
+
+class TestGetDatasetRevisions(unittest.TestCase):
+    @patch("fiftyone.core.odm.get_db_conn")
+    def test_all_fields_present(self, mock_get_db_conn):
+        mock_conn = MagicMock()
+        mock_conn.datasets.find.return_value = [
+            {"name": "dataset1", "version": "v1"},
+            {"name": "dataset2", "version": "v2"},
+        ]
+        mock_get_db_conn.return_value = mock_conn
+
+        result = get_datasets_revisions()
+        expected = {"dataset1": "v1", "dataset2": "v2"}
+        self.assertEqual(result, expected)
+
+    @patch("fiftyone.core.odm.get_db_conn")
+    def test_missing_version_field(self, mock_get_db_conn):
+        mock_conn = MagicMock()
+        mock_conn.datasets.find.return_value = [
+            {"name": "dataset1"},  # version is missing
+            {"name": "dataset2", "version": "v2"},
+        ]
+        mock_get_db_conn.return_value = mock_conn
+
+        result = get_datasets_revisions()
+        expected = {"dataset1": None, "dataset2": "v2"}
+        self.assertEqual(result, expected)
+
+    @patch("fiftyone.core.odm.get_db_conn")
+    def test_empty_collection(self, mock_get_db_conn):
+        mock_conn = MagicMock()
+        mock_conn.datasets.find.return_value = []
+        mock_get_db_conn.return_value = mock_conn
+
+        result = get_datasets_revisions()
+        self.assertEqual(result, {})
+
+    def test_missing_name(self):
+        import fiftyone.core.odm as foo
+
+        db = foo.get_db_conn()
+        inserted_id = None
+        try:
+            res = db.datasets.insert_one(
+                {"created_at": datetime.datetime.utcnow()}
+            )
+            inserted_id = res.inserted_id
+
+            result = get_datasets_revisions()
+            self.assertNotIn(None, result)
+        finally:
+            if inserted_id:
+                db.datasets.delete_one({"_id": inserted_id})

--- a/tests/unittests/migrations/runner_tests.py
+++ b/tests/unittests/migrations/runner_tests.py
@@ -59,7 +59,7 @@ class TestGetDatasetRevisions(unittest.TestCase):
         self.assertEqual(result, {None: "v2"})
 
     @patch("fiftyone.core.odm.get_db_conn")
-    def test_filter_on_name_exists(self, mock_get_db_conn):
+    def test_filter_same_as_list_datasets(self, mock_get_db_conn):
         mock_conn = MagicMock()
         mock_conn.datasets.find.return_value = [
             {"name": "dataset1", "version": "v1"},
@@ -67,8 +67,14 @@ class TestGetDatasetRevisions(unittest.TestCase):
         mock_get_db_conn.return_value = mock_conn
 
         result = get_datasets_revisions()
-        assert result == {"dataset1": "v1"}
+        self.assertEqual(result, {"dataset1": "v1"})
+
+        # Check that the same query used to list all datasets
+        # is used to list revisions
+        from fiftyone.core.dataset import _list_datasets_query
+
+        query = _list_datasets_query(include_private=True)
 
         mock_conn.datasets.find.assert_called_with(
-            {"name": {"$exists": 1}}, {"name": 1, "version": 1}
+            query, {"name": 1, "version": 1}
         )


### PR DESCRIPTION
## What changes are proposed in this pull request?

Filter out datasets that have no name when listing to match previous behavior. 
https://voxel51.atlassian.net/browse/FOEPD-1221

## How is this patch tested? If it is not, please explain why.

- Added dataset with no name and ran get_datasets_revisions()
- added unit and e2e test

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?


-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fix fiftyone migrate command to handle datasets with missing names.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dataset listing and migration processes to exclude database entries without a dataset name, preventing empty or invalid datasets from appearing.
- **Tests**
  - Added comprehensive tests to validate dataset revision retrieval, including handling of missing fields and ensuring correct database query filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->