### PR TITLE
chore(tests): Switch from _get_logger to logger

### DIFF
--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -298,7 +298,7 @@ def _delete_non_persistent_datasets_if_allowed():
             )
         )
     except:
-        logger.warning(
+        logger.debug(
             "Skipping automatic non-persistent dataset cleanup. This action "
             "requires read access of the 'admin' database"
         )
@@ -1811,10 +1811,11 @@ def _delete_stores(conn, dataset_ids):
     conn.execution_store.delete_many({"dataset_id": {"$in": dataset_ids}})
 
 
-def _get_fcv_and_version(
+def _get_fcv_and_version_if_allowed(
     client: pymongo.MongoClient,
 ) -> Tuple[Version, Version]:
-    """Fetches the current FCV and server version.
+    """Fetches the current FCV and server version, if we have permission to
+    read the ``admin`` database.
 
     Args:
         client: a ``pymongo.MongoClient`` to connect to the database
@@ -1822,8 +1823,8 @@ def _get_fcv_and_version(
     Returns:
         a tuple of
 
-        -   a ``Version`` of the FCV
-        -   a ``Version`` of the server version
+        -   a ``Version`` of the FCV, or ``None`` if not allowed
+        -   a ``Version`` of the server version, or ``None`` if not allowed
 
     Raises:
         ConnectionError: if a connection to ``mongod`` could not be established
@@ -1839,6 +1840,12 @@ def _get_fcv_and_version(
         return current_fcv, server_version
     except ServerSelectionTimeoutError as e:
         raise ConnectionError("Could not connect to `mongod`") from e
+    except:
+        logger.debug(
+            "Skipping feature compatibility version check. This action "
+            "requires read access of the 'admin' database"
+        )
+        return None, None
 
 
 def _is_fcv_upgradeable(fc_version: Version, server_version: Version) -> bool:
@@ -1864,11 +1871,8 @@ def _is_fcv_upgradeable(fc_version: Version, server_version: Version) -> bool:
     Returns:
         whether a version upgrade is possible
     """
-
-    _logger = _get_logger()
-
     if fc_version > server_version:
-        _logger.warning(
+        logger.warning(
             "Your MongoDB feature compatibility is greater than your "
             "server version. "
             "This may result in unexpected consequences. "
@@ -1884,7 +1888,7 @@ def _is_fcv_upgradeable(fc_version: Version, server_version: Version) -> bool:
         server_version.major - fc_version.major
         > foc.MONGODB_MAX_ALLOWABLE_FCV_DELTA
     ):
-        _logger.warning(
+        logger.warning(
             "Your MongoDB server version is more than %s "
             "ahead of your database's feature compatibility version. "
             "Please manually update your database's feature "
@@ -1898,7 +1902,7 @@ def _is_fcv_upgradeable(fc_version: Version, server_version: Version) -> bool:
     elif (fc_version.major == foc.MONGODB_MIN_VERSION.major) or (
         server_version.major == foc.MONGODB_MIN_VERSION.major
     ):
-        _logger.warning(
+        logger.warning(
             "You are running the oldest supported major version of MongoDB. "
             "Please refer to https://deprecation.voxel51.com "
             "for deprecation notices. You can suppress this exception by setting your "
@@ -1926,8 +1930,10 @@ def _update_fc_version(client: pymongo.MongoClient):
 
     global _db_service
 
-    fc_version, server_version = _get_fcv_and_version(client)
-    _logger = _get_logger()
+    fc_version, server_version = _get_fcv_and_version_if_allowed(client)
+
+    if fc_version is None:
+        return
 
     if (
         _is_fcv_upgradeable(fc_version, server_version)
@@ -1944,7 +1950,7 @@ def _update_fc_version(client: pymongo.MongoClient):
             cmd["confirm"] = True
 
         try:
-            _logger.warning(
+            logger.warning(
                 "Your MongoDB server version is newer than your feature "
                 "compatibility version. "
                 "Upgrading the feature compatibility version now. "
@@ -1956,7 +1962,7 @@ def _update_fc_version(client: pymongo.MongoClient):
             client.admin.command(cmd)
 
         except OperationFailure as e:
-            _logger.error(
+            logger.error(
                 "Operation failed while updating database's feature "
                 "compatibility version - %s. "
                 "Please manually set it to %s. "
@@ -1967,7 +1973,7 @@ def _update_fc_version(client: pymongo.MongoClient):
             )
 
         except PyMongoError as e:
-            _logger.error(
+            logger.error(
                 "MongoDB error while updating database's feature "
                 "compatibility version - %s. "
                 "Please manually set it to %s. "

--- a/tests/unittests/fcv_tests.py
+++ b/tests/unittests/fcv_tests.py
@@ -46,17 +46,14 @@ class TestUpdateFCV(unittest.TestCase):
             with self.subTest(
                 server_version=server_version, fc_version=fc_version
             ), patch("pymongo.MongoClient") as mock_client, patch(
-                "fiftyone.core.odm.database._get_logger"
-            ) as mock_get_logger:
+                "fiftyone.core.odm.database.logger"
+            ) as mock_logger:
 
                 mock_admin = MagicMock()
                 mock_client.admin = mock_admin
                 mock_client.server_info.return_value = {
                     "version": str(server_version)
                 }
-
-                mock_get_logger.return_value = MagicMock()
-                mock_logger = mock_get_logger.return_value
 
                 mock_admin.command.return_value = {
                     "featureCompatibilityVersion": {"version": str(fc_version)}
@@ -69,7 +66,7 @@ class TestUpdateFCV(unittest.TestCase):
                     Version(f"{server_version.major}.0")
                 )
                 mock_admin.command.assert_any_call(expected_call)
-
+                
                 mock_logger.warning.assert_any_call(
                     "Your MongoDB server version is newer than your feature "
                     "compatibility version. "
@@ -82,9 +79,9 @@ class TestUpdateFCV(unittest.TestCase):
 
     @patch("fiftyone.core.odm.database._db_service")
     @patch("pymongo.MongoClient")
-    @patch("fiftyone.core.odm.database._get_logger")
+    @patch("fiftyone.core.odm.database.logger")
     def test_update_fcv_success_minor_and_patch_versions(
-        self, mock_get_logger, mock_client, mock_db_service
+        self, mock_logger, mock_client, mock_db_service
     ):
         """Tests that minor and patch mongoDB versions are upgraded
         as expected.
@@ -96,9 +93,6 @@ class TestUpdateFCV(unittest.TestCase):
         mock_admin = MagicMock()
         mock_client.admin = mock_admin
         mock_client.server_info.return_value = {"version": str(server_version)}
-
-        mock_get_logger.return_value = MagicMock()
-        mock_logger = mock_get_logger.return_value
 
         mock_admin.command.return_value = {
             "featureCompatibilityVersion": {"version": str(fc_version)}
@@ -134,9 +128,9 @@ class TestUpdateFCV(unittest.TestCase):
 
     @patch("fiftyone.core.odm.database._db_service")
     @patch("pymongo.MongoClient")
-    @patch("fiftyone.core.odm.database._get_logger")
+    @patch("fiftyone.core.odm.database.logger")
     def test_update_fcv_success_fcv_less_than_min_version(
-        self, mock_get_logger, mock_client, mock_db_service
+        self, mock_logger, mock_client, mock_db_service
     ):
         """Tests an edge case where the FCV is less than the minimum
         supported version while the server version is the minimum version.
@@ -150,9 +144,6 @@ class TestUpdateFCV(unittest.TestCase):
         mock_client.admin = mock_admin
         mock_client.server_info.return_value = {"version": str(server_version)}
 
-        mock_get_logger.return_value = MagicMock()
-        mock_logger = mock_get_logger.return_value
-
         mock_admin.command.return_value = {
             "featureCompatibilityVersion": {"version": str(fc_version)}
         }
@@ -187,9 +178,9 @@ class TestUpdateFCV(unittest.TestCase):
 
     @patch("fiftyone.core.odm.database._db_service")
     @patch("pymongo.MongoClient")
-    @patch("fiftyone.core.odm.database._get_logger")
+    @patch("fiftyone.core.odm.database.logger")
     def test_update_fcv_log_minimum_version(
-        self, mock_get_logger, mock_client, mock_db_service
+        self, mock_logger, mock_client, mock_db_service
     ):
         """Tests an edge case where the both the FCV and server
         version are the oldest supported version. No actions should
@@ -202,9 +193,6 @@ class TestUpdateFCV(unittest.TestCase):
         mock_admin = MagicMock()
         mock_client.admin = mock_admin
         mock_client.server_info.return_value = {"version": str(server_version)}
-
-        mock_get_logger.return_value = MagicMock()
-        mock_logger = mock_get_logger.return_value
 
         mock_admin.command.return_value = {
             "featureCompatibilityVersion": {"version": str(fc_version)}
@@ -259,9 +247,9 @@ class TestUpdateFCV(unittest.TestCase):
 
     @patch("fiftyone.core.odm.database._db_service")
     @patch("pymongo.MongoClient")
-    @patch("fiftyone.core.odm.database._get_logger")
+    @patch("fiftyone.core.odm.database.logger")
     def test_version_diff_warning(
-        self, mock_get_logger, mock_client, mock_db_service
+        self, mock_logger, mock_client, mock_db_service
     ):
         """Tests the warning that's generated in the event that
         the FO DB is more than 1 version outside of our expected
@@ -274,9 +262,6 @@ class TestUpdateFCV(unittest.TestCase):
         mock_admin = MagicMock()
         mock_client.admin = mock_admin
         mock_client.server_info.return_value = {"version": str(server_version)}
-
-        mock_get_logger.return_value = MagicMock()
-        mock_logger = mock_get_logger.return_value
 
         mock_admin.command.return_value = {
             "featureCompatibilityVersion": {"version": str(fc_version)}
@@ -298,9 +283,9 @@ class TestUpdateFCV(unittest.TestCase):
 
     @patch("fiftyone.core.odm.database._db_service")
     @patch("pymongo.MongoClient")
-    @patch("fiftyone.core.odm.database._get_logger")
+    @patch("fiftyone.core.odm.database.logger")
     def test_fcv_greater_than_server_version_warning(
-        self, mock_get_logger, mock_client, mock_db_service
+        self, mock_logger, mock_client, mock_db_service
     ):
         """Tests the warning that's generated in the event that
         the feature compatability version is ahead of the server version.
@@ -312,9 +297,6 @@ class TestUpdateFCV(unittest.TestCase):
         mock_admin = MagicMock()
         mock_client.admin = mock_admin
         mock_client.server_info.return_value = {"version": str(server_version)}
-
-        mock_get_logger.return_value = MagicMock()
-        mock_logger = mock_get_logger.return_value
 
         mock_admin.command.return_value = {
             "featureCompatibilityVersion": {"version": str(fc_version)}
@@ -337,9 +319,9 @@ class TestUpdateFCV(unittest.TestCase):
 
     @patch("fiftyone.core.odm.database._db_service")
     @patch("pymongo.MongoClient")
-    @patch("fiftyone.core.odm.database._get_logger")
+    @patch("fiftyone.core.odm.database.logger")
     def test_oldest_supported_version_warning(
-        self, mock_get_logger, mock_client, mock_db_service
+        self, mock_logger, mock_client, mock_db_service
     ):
         """Tests the warning that's generated in the event that
         the feature compatability version is currently the oldest supported
@@ -351,9 +333,6 @@ class TestUpdateFCV(unittest.TestCase):
         mock_client.server_info.return_value = {
             "version": str(foc.MONGODB_MIN_VERSION)
         }
-
-        mock_get_logger.return_value = MagicMock()
-        mock_logger = mock_get_logger.return_value
 
         mock_admin.command.return_value = {
             "featureCompatibilityVersion": {
@@ -376,9 +355,9 @@ class TestUpdateFCV(unittest.TestCase):
 
     @patch("fiftyone.core.odm.database._db_service")
     @patch("pymongo.MongoClient")
-    @patch("fiftyone.core.odm.database._get_logger")
+    @patch("fiftyone.core.odm.database.logger")
     def test_update_fc_version_operation_failure(
-        self, mock_get_logger, mock_client, mock_db_service
+        self, mock_logger, mock_client, mock_db_service
     ):
         """Tests the error that's generated in the event that
         the feature compatability version update failed.
@@ -389,9 +368,6 @@ class TestUpdateFCV(unittest.TestCase):
         mock_admin = MagicMock()
         mock_client.admin = mock_admin
         mock_client.server_info.return_value = {"version": str(server_version)}
-
-        mock_get_logger.return_value = MagicMock()
-        mock_logger = mock_get_logger.return_value
 
         mock_admin.command.side_effect = [
             {"featureCompatibilityVersion": {"version": str(fc_version)}},
@@ -413,9 +389,9 @@ class TestUpdateFCV(unittest.TestCase):
 
     @patch("fiftyone.core.odm.database._db_service")
     @patch("pymongo.MongoClient")
-    @patch("fiftyone.core.odm.database._get_logger")
+    @patch("fiftyone.core.odm.database.logger")
     def test_update_fc_version_pymongo_failure(
-        self, mock_get_logger, mock_client, mock_db_service
+        self, mock_logger, mock_client, mock_db_service
     ):
         """Tests the error that's generated in the event that
         the feature compatability version update failed.
@@ -426,9 +402,6 @@ class TestUpdateFCV(unittest.TestCase):
         mock_admin = MagicMock()
         mock_client.admin = mock_admin
         mock_client.server_info.return_value = {"version": str(server_version)}
-
-        mock_get_logger.return_value = MagicMock()
-        mock_logger = mock_get_logger.return_value
 
         mock_admin.command.side_effect = [
             {"featureCompatibilityVersion": {"version": str(fc_version)}},
@@ -450,8 +423,8 @@ class TestUpdateFCV(unittest.TestCase):
 
     @patch("fiftyone.core.odm.database._db_service", new=None)
     @patch("pymongo.MongoClient")
-    @patch("fiftyone.core.odm.database._get_logger")
-    def test_no_action_unless_managed(self, mock_get_logger, mock_client):
+    @patch("fiftyone.core.odm.database.logger")
+    def test_no_action_unless_managed(self, mock_logger, mock_client):
         """Tests that actions are only logged, not taken, if
         we aren't managing the mongodb instance (_db_service is None).
         """
@@ -462,9 +435,6 @@ class TestUpdateFCV(unittest.TestCase):
         mock_admin = MagicMock()
         mock_client.admin = mock_admin
         mock_client.server_info.return_value = {"version": str(server_version)}
-
-        mock_get_logger.return_value = MagicMock()
-        mock_logger = mock_get_logger.return_value
 
         mock_admin.command.return_value = {
             "featureCompatibilityVersion": {"version": str(fc_version)}


### PR DESCRIPTION
## What changes are proposed in this pull request?

In https://github.com/voxel51/fiftyone/pull/5872, we switched from `_get_logger` to the top level `logger. This code tests the log statements because of the admin actions that are being taken. The rationale of testing the logs was the make sure the proper info was displayed to an admin at the right times.

## How is this patch tested? If it is not, please explain why.

```shell
 % python -m unittest ./tests/unittests/fcv_tests.py           
...........
----------------------------------------------------------------------
Ran 11 tests in 0.009s

OK
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
