### PR TITLE
chore: removing `latest` tag from automation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -119,6 +119,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
+            voxel51/fiftyone:${{ env.fo_version }}
             voxel51/fiftyone:${{ env.fo_version }}-python${{ env.pyver }}
             voxel51/fiftyone:${{ env.fo_version }}-python${{ env.pyver }}-${{ env.today }}
-            latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push (not latest)
+      - name: Build and push (not 3.11)
         if: matrix.python != '3.11'
         uses: docker/build-push-action@v6
         with:
@@ -107,7 +107,7 @@ jobs:
             voxel51/fiftyone:${{ env.fo_version }}-python${{ env.pyver }}
             voxel51/fiftyone:${{ env.fo_version }}-python${{ env.pyver }}-${{ env.today }}
 
-      - name: Build and push (latest)
+      - name: Build and push (3.11)
         if: matrix.python == '3.11'
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push (not 3.11)
+      - name: Build and push (except latest)
         if: matrix.python != '3.11'
         uses: docker/build-push-action@v6
         with:
@@ -107,7 +107,7 @@ jobs:
             voxel51/fiftyone:${{ env.fo_version }}-python${{ env.pyver }}
             voxel51/fiftyone:${{ env.fo_version }}-python${{ env.pyver }}-${{ env.today }}
 
-      - name: Build and push (3.11)
+      - name: Build and push (latest)
         if: matrix.python == '3.11'
         uses: docker/build-push-action@v6
         with:
@@ -122,3 +122,4 @@ jobs:
             voxel51/fiftyone:${{ env.fo_version }}
             voxel51/fiftyone:${{ env.fo_version }}-python${{ env.pyver }}
             voxel51/fiftyone:${{ env.fo_version }}-python${{ env.pyver }}-${{ env.today }}
+            voxel51/fiftyone:latest

--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ docker: python
 	@docker build -t local/fiftyone .
 
 docker-export: docker
-	@docker save voxel51/fiftyone:latest | gzip > fiftyone.tar.gz
+	@docker save local/fiftyone | gzip > fiftyone.tar.gz


### PR DESCRIPTION
## What changes are proposed in this pull request?

During the v1.5.1 release we had a failure, because the `latest` tag didn't include `voxel51/fiftyone:`

let's fix that

also - the `make` target should use the image it built, or it will just pull an old image from Docker Hub.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Docker image tagging for Python 3.11 builds in the publishing workflow, adding a version-only tag and fully qualifying the "latest" tag.
  - Modified Docker image export process to align with updated local image tagging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->