### PR TITLE
Update UniqueFilenameMaker

### DIFF
--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1993,7 +1993,7 @@ class UniqueFilenameMaker(object):
     #         if "python" not in parent_process.name().lower():
     #             ppid = None
     #     except psutil.NoSuchProcess:
-    #         pass  # Proceed with ppid as None if parent process doesn't exist
+    #         ppid = None  # Proceed with ppid as None if parent process doesn't exist
 
     #     if ppid is None or chunk_size is not None:
     #         return super().__new__(cls)

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1970,39 +1970,44 @@ class UniqueFilenameMaker(object):
             output paths (False)
     """
 
-    def __new__(
-        cls,
-        output_dir=None,
-        rel_dir=None,
-        alt_dir=None,
-        chunk_size=None,
-        default_ext=None,
-        ignore_exts=False,
-        ignore_existing=False,
-        idempotent=True,
-    ):
-        ppid = None
-        try:
-            ppid = psutil.Process(os.getpid()).ppid()
-            parent_process = psutil.Process(ppid)
-            if "python" not in parent_process.name().lower():
-                ppid = None
-        except psutil.NoSuchProcess:
-            pass  # Proceed with ppid as None if parent process doesn't exist
+    # =========================================================================
+    # Removing automatic implementation switch of UniqueFilenameMaker. Bug in
+    # detecting processes needs to be resolved before adding this back in.
+    # =========================================================================
 
-        if ppid is None or chunk_size is not None:
-            return super().__new__(cls)
+    # def __new__(
+    #     cls,
+    #     output_dir=None,
+    #     rel_dir=None,
+    #     alt_dir=None,
+    #     chunk_size=None,
+    #     default_ext=None,
+    #     ignore_exts=False,
+    #     ignore_existing=False,
+    #     idempotent=True,
+    # ):
+    #     ppid = None
+    #     try:
+    #         ppid = psutil.Process(os.getpid()).ppid()
+    #         parent_process = psutil.Process(ppid)
+    #         if "python" not in parent_process.name().lower():
+    #             ppid = None
+    #     except psutil.NoSuchProcess:
+    #         pass  # Proceed with ppid as None if parent process doesn't exist
 
-        return MultiProcessUniqueFilenameMaker(
-            ppid,
-            output_dir,
-            rel_dir,
-            alt_dir,
-            default_ext,
-            ignore_exts,
-            ignore_existing,
-            idempotent,
-        )
+    #     if ppid is None or chunk_size is not None:
+    #         return super().__new__(cls)
+
+    #     return MultiProcessUniqueFilenameMaker(
+    #         ppid,
+    #         output_dir,
+    #         rel_dir,
+    #         alt_dir,
+    #         default_ext,
+    #         ignore_exts,
+    #         ignore_existing,
+    #         idempotent,
+    #     )
 
     def __init__(
         self,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Prevent automatic selection of `UniqueFilenameMaker` implementation

## How is this patch tested? If it is not, please explain why.

Run the unit tests. 

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Disabled automatic switching between filename maker implementations due to a bug in process detection.
- **Tests**
  - Disabled tests related to automatic implementation switching.
  - Updated multiprocessing test logic to use a unified argument structure and explicitly instantiate the multiprocessing filename maker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->