### PR TITLE
Release/v1.5.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push (not latest)
+      - name: Build and push (except latest)
         if: matrix.python != '3.11'
         uses: docker/build-push-action@v6
         with:
@@ -119,6 +119,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
+            voxel51/fiftyone:${{ env.fo_version }}
             voxel51/fiftyone:${{ env.fo_version }}-python${{ env.pyver }}
             voxel51/fiftyone:${{ env.fo_version }}-python${{ env.pyver }}-${{ env.today }}
-            latest
+            voxel51/fiftyone:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,6 +103,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          sbom: true
           tags: |
             voxel51/fiftyone:${{ env.fo_version }}-python${{ env.pyver }}
             voxel51/fiftyone:${{ env.fo_version }}-python${{ env.pyver }}-${{ env.today }}
@@ -118,6 +119,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          sbom: true
           tags: |
             voxel51/fiftyone:${{ env.fo_version }}
             voxel51/fiftyone:${{ env.fo_version }}-python${{ env.pyver }}

--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ docker: python
 	@docker build -t local/fiftyone .
 
 docker-export: docker
-	@docker save voxel51/fiftyone:latest | gzip > fiftyone.tar.gz
+	@docker save local/fiftyone | gzip > fiftyone.tar.gz

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -3,6 +3,25 @@ FiftyOne Release Notes
 
 .. default-role:: code
 
+FiftyOne Enterprise 2.8.2
+-------------------------
+*Released May 9, 2025*
+
+Includes all updates from :ref:`FiftyOne 1.5.2 <release-notes-v1.5.2>`
+
+.. _release-notes-v1.5.2:
+
+FiftyOne 1.5.2
+--------------
+*Released May 9, 2025*
+
+Core
+
+- Fixed a bug where the system would sometimes detect a multiprocess
+  environment incorrectly.
+  `#5884 <https://github.com/voxel51/fiftyone/pull/5884>`_
+
+
 FiftyOne Enterprise 2.8.1
 -------------------------
 *Released May 8, 2025*

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1970,39 +1970,44 @@ class UniqueFilenameMaker(object):
             output paths (False)
     """
 
-    def __new__(
-        cls,
-        output_dir=None,
-        rel_dir=None,
-        alt_dir=None,
-        chunk_size=None,
-        default_ext=None,
-        ignore_exts=False,
-        ignore_existing=False,
-        idempotent=True,
-    ):
-        ppid = None
-        try:
-            ppid = psutil.Process(os.getpid()).ppid()
-            parent_process = psutil.Process(ppid)
-            if "python" not in parent_process.name().lower():
-                ppid = None
-        except psutil.NoSuchProcess:
-            pass  # Proceed with ppid as None if parent process doesn't exist
+    # =========================================================================
+    # Removing automatic implementation switch of UniqueFilenameMaker. Bug in
+    # detecting processes needs to be resolved before adding this back in.
+    # =========================================================================
 
-        if ppid is None or chunk_size is not None:
-            return super().__new__(cls)
+    # def __new__(
+    #     cls,
+    #     output_dir=None,
+    #     rel_dir=None,
+    #     alt_dir=None,
+    #     chunk_size=None,
+    #     default_ext=None,
+    #     ignore_exts=False,
+    #     ignore_existing=False,
+    #     idempotent=True,
+    # ):
+    #     ppid = None
+    #     try:
+    #         ppid = psutil.Process(os.getpid()).ppid()
+    #         parent_process = psutil.Process(ppid)
+    #         if "python" not in parent_process.name().lower():
+    #             ppid = None
+    #     except psutil.NoSuchProcess:
+    #         ppid = None  # Proceed with ppid as None if parent process doesn't exist
 
-        return MultiProcessUniqueFilenameMaker(
-            ppid,
-            output_dir,
-            rel_dir,
-            alt_dir,
-            default_ext,
-            ignore_exts,
-            ignore_existing,
-            idempotent,
-        )
+    #     if ppid is None or chunk_size is not None:
+    #         return super().__new__(cls)
+
+    #     return MultiProcessUniqueFilenameMaker(
+    #         ppid,
+    #         output_dir,
+    #         rel_dir,
+    #         alt_dir,
+    #         default_ext,
+    #         ignore_exts,
+    #         ignore_existing,
+    #         idempotent,
+    #     )
 
     def __init__(
         self,

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import re
 from setuptools import setup, find_packages
 
 
-VERSION = "1.5.1"
+VERSION = "1.5.2"
 
 
 def get_version():


### PR DESCRIPTION
## What changes are proposed in this pull request?

release v1.5.2

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Disabled automatic switching between filename maker implementations due to a process detection issue.
- **Tests**
	- Updated and simplified multiprocessing tests for filename makers, removing the automatic implementation switching test and improving parameter handling.
- **Chores**
	- Updated Docker image tagging conventions and enabled Software Bill of Materials (SBOM) generation for all Docker builds.
	- Changed the exported Docker image tag for local builds.
	- Bumped the package version to 1.5.2.
- **Documentation**
	- Added release notes for FiftyOne 1.5.2 and FiftyOne Enterprise 2.8.2 releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->