### PR TITLE
chore: images after publish, fix version number

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,27 +41,8 @@ jobs:
         run: |
           python3 -m twine upload dist/*
 
-  build-image:
-    needs: [build, test]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Clone fiftyone
-        uses: actions/checkout@v4
-      - name: Download dist
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist
-      - name: docker
-        run: make docker-export -o python
-      - name: Upload image
-        uses: actions/upload-artifact@v4
-        with:
-          name: docker-image
-          path: fiftyone.tar.gz
-
   publish-docker-images:
-    needs: [build, test]
+    needs: [publish]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -77,7 +58,8 @@ jobs:
       - name: Set Env Vars
         run: |
           echo "today=$(date +%Y%m%d)" >> "$GITHUB_ENV"
-          echo "fo_version=${{ github.ref_name }}" >> "$GITHUB_ENV"
+          ref_name=${{ github.ref_name }}
+          echo "fo_version=${ref_name#v}" >> "$GITHUB_ENV"
           echo "pyver=${{ matrix.python }}" >> "$GITHUB_ENV"
 
       - name: Login to Docker Hub


### PR DESCRIPTION
## What changes are proposed in this pull request?

- run the docker image builder after the new fiftyone version is published
- don't build a local docker image as a github artifact
    - if people want a Docker Image they can use Docker Hub
- strip the `v` from `ref_name` for `fo_version`

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow to streamline Docker image publishing and version tagging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->