### PR TITLE
Apply confidence to Keypoint instances correctly

### DIFF
--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -10,15 +10,16 @@ import itertools
 import warnings
 from functools import partial
 
+from bson import ObjectId
 import cv2
-import eta.core.frameutils as etaf
-import eta.core.image as etai
-import eta.core.utils as etau
 import numpy as np
 import scipy.ndimage as spn
 import skimage.measure as skm
 import skimage.segmentation as sks
-from bson import ObjectId
+
+import eta.core.frameutils as etaf
+import eta.core.image as etai
+import eta.core.utils as etau
 
 import fiftyone.core.fields as fof
 import fiftyone.core.metadata as fom
@@ -1092,6 +1093,27 @@ class Keypoint(_HasAttributesDict, _HasID, _HasInstance, Label):
             points = [(x * w, y * h) for x, y in points]
 
         return sg.MultiPoint(points)
+
+    def apply_confidence_threshold(self, confidence_thresh):
+        """Replaces all ``points`` on this instance whose confidence are below
+        the provided threshold with ``np.nan``.
+
+        Use
+        :meth:`filter_keypoints <fiftyone.core.collections.SampleCollection.filter_keypoints`
+        to perform this operation as temporary view rather than a permanent
+        data transformation.
+
+        Args:
+            confidence_thresh: a confidence threshold
+        """
+        if self.confidence is None:
+            return
+
+        _points = np.array(self.points)
+        _confs = np.array(self.confidence)
+        _points[_confs < confidence_thresh] = np.nan
+
+        self.points = _points.tolist()
 
 
 class Keypoints(_HasLabelList, Label):

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -775,6 +775,9 @@ def _apply_confidence_thresh(label, confidence_thresh):
             k: _apply_confidence_thresh(v, confidence_thresh)
             for k, v in label.items()
         }
+    elif isinstance(label, fol.Keypoints):
+        for keypoint in label.keypoints:
+            keypoint.apply_confidence_threshold(confidence_thresh)
     elif isinstance(label, fol._HasLabelList):
         labels = [
             l
@@ -782,6 +785,8 @@ def _apply_confidence_thresh(label, confidence_thresh):
             if l.confidence is not None and l.confidence >= confidence_thresh
         ]
         setattr(label, label._LABEL_LIST_FIELD, labels)
+    elif isinstance(label, fol.Keypoint):
+        label.apply_confidence_threshold(confidence_thresh)
     elif hasattr(label, "confidence"):
         if label.confidence is None or label.confidence < confidence_thresh:
             label = None

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -5,6 +5,7 @@ PyTorch utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import itertools
 import multiprocessing
@@ -1420,11 +1421,15 @@ class KeypointDetectorOutputProcessor(OutputProcessor):
             ]
 
             points = []
-            for p in kpts:
-                if p[2] > 0:
-                    points.append((p[0] / width, p[1] / height))
-                else:
+            for p, p_conf in zip(kpts, kpt_scores):
+                if confidence_thresh and p_conf < confidence_thresh:
+                    # Low confidence
                     points.append((float("nan"), float("nan")))
+                elif p[2] == 0:
+                    # Not visible
+                    points.append((float("nan"), float("nan")))
+                else:
+                    points.append((p[0] / width, p[1] / height))
 
             _detections.append(
                 fol.Detection(
@@ -1734,7 +1739,6 @@ class FiftyOneTorchDataset(Dataset):
             return e
 
     def __getitem__(self, index):
-
         # if self._samples is None at this point then
         # worker_init was probably never called
         # meaning we are working on main process


### PR DESCRIPTION
## Change log

- Adds a `Keypoint.apply_confidence_threshold()` method that applies a confidence threshold to the keypoints
- Updates `Sample.add_labels(..., confidence_thresh=)` to correctly apply confidence thresholds to `Keypoint` instances
- Updates `KeypointDetectorOutputProcessor` to apply confidence thresholds to individual points

## Tested by

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    label_types="detections",
    classes=["person"],
    max_samples=10,
    only_matching=True,
)

model = foz.load_zoo_model("keypoint-rcnn-resnet50-fpn-coco-torch")

# This correctly injects `np.nan` values into the predicted keypoints
dataset.apply_model(
    model,
    label_field="predictions",
    confidence_thresh=0.5,
)
```
