### PR TITLE
Tweak ultralytics batch inference docs

### DIFF
--- a/docs/source/integrations/ultralytics.rst
+++ b/docs/source/integrations/ultralytics.rst
@@ -525,9 +525,9 @@ them as kwargs to
 .. code-block:: python
     :linenos:
 
+    # Use rectangular resizing with a batch size of 1
     model = foz.load_zoo_model(model_name, overrides={"rect": True})
-
-    dataset.apply_model(model, label_field="predictions", batch_size=16)
+    dataset.apply_model(model, label_field="predictions", batch_size=1)
 
 .. note::
 

--- a/docs/source/integrations/ultralytics.rst
+++ b/docs/source/integrations/ultralytics.rst
@@ -513,24 +513,6 @@ you can request batch inference via the pattern below:
         batch_size=batch_size,
     )
 
-The manual inference loops can be also executed using batch inference via the
-pattern below:
-
-.. code-block:: python
-    :linenos:
-
-    from fiftyone.core.utils import iter_batches
-
-    filepaths = dataset.values("filepath")
-    batch_size = 16
-
-    predictions = []
-    for paths in iter_batches(filepaths, batch_size):
-        results = model(paths)
-        predictions.extend(fou.to_detections(results))
-
-    dataset.set_values("predictions", predictions)
-
 Alternatively, to run inference on a batch size of 1 with rectangular resizing,
 use overrides as shown below:
 
@@ -549,6 +531,24 @@ use overrides as shown below:
         label_field="predictions",
         batch_size=batch_size,
     )
+
+The manual inference loops can be also executed using batch inference via the
+pattern below:
+
+.. code-block:: python
+    :linenos:
+
+    from fiftyone.core.utils import iter_batches
+
+    filepaths = dataset.values("filepath")
+    batch_size = 16
+
+    predictions = []
+    for paths in iter_batches(filepaths, batch_size):
+        results = model(paths)
+        predictions.extend(fou.to_detections(results))
+
+    dataset.set_values("predictions", predictions)
 
 .. note::
 

--- a/docs/source/integrations/ultralytics.rst
+++ b/docs/source/integrations/ultralytics.rst
@@ -493,44 +493,12 @@ Batch inference
 
 When using
 :meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`,
-you can request batch inference via the pattern below:
+you can request batch inference by passing the optional `batch_size` parameter:
 
 .. code-block:: python
     :linenos:
 
-    batch_size = 16
-
-    # Tell model to use batch inference
-    model = foz.load_zoo_model(
-        model_name,
-        overrides={"batch": batch_size},
-    )
-
-    # Tell FiftyOne to use batch dataloading
-    dataset.apply_model(
-        model,
-        label_field="predictions",
-        batch_size=batch_size,
-    )
-
-Alternatively, to run inference on a batch size of 1 with rectangular resizing,
-use overrides as shown below:
-
-.. code-block:: python
-    :linenos:
-
-    batch_size = 1
-
-    model = foz.load_zoo_model(
-        model_name,
-        overrides={"rect": True, "batch": batch_size},
-    )
-
-    dataset.apply_model(
-        model,
-        label_field="predictions",
-        batch_size=batch_size,
-    )
+    dataset.apply_model(model, label_field="predictions", batch_size=16)
 
 The manual inference loops can be also executed using batch inference via the
 pattern below:
@@ -549,6 +517,17 @@ pattern below:
         predictions.extend(fou.to_detections(results))
 
     dataset.set_values("predictions", predictions)
+
+You can also provide overrides to the underlying Ultralytics model by passing
+them as kwargs to
+:meth:`load_zoo_model() <fiftyone.zoo.models.load_zoo_model>`:
+
+.. code-block:: python
+    :linenos:
+
+    model = foz.load_zoo_model(model_name, overrides={"rect": True})
+
+    dataset.apply_model(model, label_field="predictions", batch_size=16)
 
 .. note::
 

--- a/docs/source/integrations/ultralytics.rst
+++ b/docs/source/integrations/ultralytics.rst
@@ -235,7 +235,6 @@ You can also load YOLOv8, YOLOv9, and YOLO11 segmentation models from the
     # model_name = "yolo11m-seg-coco-torch"
     # model_name = "yolo11l-seg-coco-torch"
     # model_name = "yolo11x-seg-coco-torch"
-    
 
     model = foz.load_zoo_model(model_name)
 
@@ -494,12 +493,25 @@ Batch inference
 
 When using
 :meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`,
-you can request batch inference by passing the optional `batch_size` parameter:
+you can request batch inference via the pattern below:
 
 .. code-block:: python
     :linenos:
 
-    dataset.apply_model(model, label_field="predictions", batch_size=16)
+    batch_size = 16
+
+    # Tell model to use batch inference
+    model = foz.load_zoo_model(
+        model_name,
+        overrides={"batch": batch_size},
+    )
+
+    # Tell FiftyOne to use batch dataloading
+    dataset.apply_model(
+        model,
+        label_field="predictions",
+        batch_size=batch_size,
+    )
 
 The manual inference loops can be also executed using batch inference via the
 pattern below:
@@ -519,26 +531,24 @@ pattern below:
 
     dataset.set_values("predictions", predictions)
 
-Note that the `batch_size` parameter in :meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`
-only controls the batch size for dataloading. Set the batch size of the underlying Ultralytics model predictor via
-overrides to avoid using the default batch size set by Ultralytics.
+Alternatively, to run inference on a batch size of 1 with rectangular resizing,
+use overrides as shown below:
 
 .. code-block:: python
     :linenos:
 
-    kwargs = {"overrides": {"batch": 32}}
-    model = foz.load_zoo_model(m_name, **kwargs)
-    dataset.apply_model(model, label_field="predictions", batch_size=32)
+    batch_size = 1
 
+    model = foz.load_zoo_model(
+        model_name,
+        overrides={"rect": True, "batch": batch_size},
+    )
 
-To run inference on a batch size of 1 with rectangular resizing, use overrides as shown below when loading a model for inference:
-
-.. code-block:: python
-    :linenos:
-
-    kwargs = {"overrides": {"rect": True, "batch": 1}}
-    model = foz.load_zoo_model(m_name, **kwargs)
-    dataset.apply_model(model, label_field="predictions", batch_size=1)
+    dataset.apply_model(
+        model,
+        label_field="predictions",
+        batch_size=batch_size,
+    )
 
 .. note::
 


### PR DESCRIPTION
Clarifies in Ultralytics documentation how to achieve **full** batch inference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved and clarified instructions for batch inference with Ultralytics models, including explicit examples for setting batch size and using rectangular resizing.
  - Consolidated and updated code examples for better clarity, removing redundant notes and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->