### PR TITLE
Update CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,7 +3,7 @@
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
+contributors and maintainers pledge to make participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
 level of experience, education, socio-economic status, nationality, personal


### PR DESCRIPTION
Replace “pledge to making” with “pledge to make” for correct verb form.

## What changes are proposed in this pull request?

* Corrects a grammatical error in **CODE\_OF\_CONDUCT.md** by replacing the incorrect gerund phrase **“pledge to making”** with the proper infinitive **“pledge to make”** in the first sentence.

## How is this patch tested? If it is not, please explain why.

* This is a documentation-only change. No code behavior is affected, so no tests are necessary.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [x] No. You can skip the rest of this section.

### What areas of FiftyOne does this PR affect?

* [x] Documentation: FiftyOne documentation changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a grammatical error in the code of conduct to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->