### PR TITLE
Update manifest-torch.json

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -239,7 +239,7 @@
             "source": "https://ai.meta.com/sam2/",
             "author": "Nikhila Ravi, et al.",
             "license": "Apache 2.0,BSD 3-Clause",
-            "size_bytes": 155906050,
+            "size_bytes": 184309650,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
                 "config": {
@@ -274,7 +274,7 @@
             "source": "https://ai.meta.com/sam2/",
             "author": "Nikhila Ravi, et al.",
             "license": "Apache 2.0,BSD 3-Clause",
-            "size_bytes": 155906050,
+            "size_bytes": 323493298,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
                 "config": {
@@ -309,7 +309,7 @@
             "source": "https://ai.meta.com/sam2/",
             "author": "Nikhila Ravi, et al.",
             "license": "Apache 2.0,BSD 3-Clause",
-            "size_bytes": 155906050,
+            "size_bytes": 897952466,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
                 "config": {
@@ -378,7 +378,7 @@
             "source": "https://ai.meta.com/sam2/",
             "author": "Nikhila Ravi, et al.",
             "license": "Apache 2.0,BSD 3-Clause",
-            "size_bytes": 155906050,
+            "size_bytes": 184309650,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
                 "config": {
@@ -413,7 +413,7 @@
             "source": "https://ai.meta.com/sam2/",
             "author": "Nikhila Ravi, et al.",
             "license": "Apache 2.0,BSD 3-Clause",
-            "size_bytes": 155906050,
+            "size_bytes": 323493298,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
                 "config": {
@@ -448,7 +448,7 @@
             "source": "https://ai.meta.com/sam2/",
             "author": "Nikhila Ravi, et al.",
             "license": "Apache 2.0,BSD 3-Clause",
-            "size_bytes": 155906050,
+            "size_bytes": 897952466,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
                 "config": {
@@ -560,7 +560,7 @@
             "source": "https://ai.meta.com/sam2/",
             "author": "Nikhila Ravi, et al.",
             "license": "Apache 2.0,BSD 3-Clause",
-            "size_bytes": 155906050,
+            "size_bytes": 184416285,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
                 "config": {
@@ -597,7 +597,7 @@
             "source": "https://ai.meta.com/sam2/",
             "author": "Nikhila Ravi, et al.",
             "license": "Apache 2.0,BSD 3-Clause",
-            "size_bytes": 155906050,
+            "size_bytes": 323606802,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
                 "config": {
@@ -634,7 +634,7 @@
             "source": "https://ai.meta.com/sam2/",
             "author": "Nikhila Ravi, et al.",
             "license": "Apache 2.0,BSD 3-Clause",
-            "size_bytes": 155906050,
+            "size_bytes": 898083611,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
                 "config": {
@@ -707,7 +707,7 @@
             "source": "https://ai.meta.com/sam2/",
             "author": "Nikhila Ravi, et al.",
             "license": "Apache 2.0,BSD 3-Clause",
-            "size_bytes": 155906050,
+            "size_bytes": 184416285,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
                 "config": {
@@ -744,7 +744,7 @@
             "source": "https://ai.meta.com/sam2/",
             "author": "Nikhila Ravi, et al.",
             "license": "Apache 2.0,BSD 3-Clause",
-            "size_bytes": 155906050,
+            "size_bytes": 323606802,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
                 "config": {
@@ -781,7 +781,7 @@
             "source": "https://ai.meta.com/sam2/",
             "author": "Nikhila Ravi, et al.",
             "license": "Apache 2.0,BSD 3-Clause",
-            "size_bytes": 155906050,
+            "size_bytes": 898083611,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
                 "config": {


### PR DESCRIPTION
The `size_bytes` field in the model zoo manifest previously listed an incorrect size (155906050 bytes, corresponding to the "Tiny" variant) for all larger SAM 2 Hiera model entries.

This commit updates the `size_bytes` for the following "Small", "Base Plus", and "Large" SAM 2 and SAM 2.1 Hiera image and video models to reflect their actual measured file sizes after download:

- segment-anything-2-hiera-small-image-torch
- segment-anything-2-hiera-base-plus-image-torch
- segment-anything-2-hiera-large-image-torch
- segment-anything-2-hiera-small-video-torch
- segment-anything-2-hiera-base-plus-video-torch
- segment-anything-2-hiera-large-video-torch
- segment-anything-2.1-hiera-small-image-torch
- segment-anything-2.1-hiera-base-plus-image-torch
- segment-anything-2.1-hiera-large-image-torch
- segment-anything-2.1-hiera-small-video-torch
- segment-anything-2.1-hiera-base-plus-video-torch
- segment-anything-2.1-hiera-large-video-torch

The "Tiny" variant sizes were already correct or had negligible differences and remain unchanged as per review. This change ensures more accurate metadata for users selecting these models.

## What changes are proposed in this pull request?

This pull request updates the `size_bytes` field in the FiftyOne model zoo manifest JSON files for specific Segment Anything Model 2 (SAM 2 and SAM 2.1) Hiera variants. The previously listed size for "Small", "Base Plus", and "Large" variants incorrectly reflected the size of the "Tiny" variant. These have been replaced with the actual measured byte sizes of the corresponding downloaded checkpoint files. The download URLs and other metadata for these models remain unchanged, as they were found to be correct.

## How is this patch tested? If it is not, please explain why.

The corrected `size_bytes` values were determined by the following process:
1. A Python script utilizing the `fiftyone` library was developed.
2. This script temporarily configured a custom `model_zoo_dir`.
3. For each SAM 2 and SAM 2.1 Hiera variant (Tiny, Small, Base Plus, Large, for both image and video types), the script called `fiftyone.zoo.download_zoo_model()` to ensure the model checkpoint was downloaded from its specified URL into the custom directory.
4. Subsequently, `fiftyone.zoo.find_zoo_model()` was used to get the local path to the downloaded checkpoint file.
5. The `os.path.getsize()` function was then used to measure the exact byte size of this downloaded file.
6. The `size_bytes` fields in the relevant manifest entries were then updated to these measured values.
The URLs in the manifests were confirmed to point to the correct model checkpoints (e.g., `sam2_hiera_small.pt` for small variants, etc.) during the download process. The "Tiny" model sizes were confirmed to be largely accurate in the original manifest.

This process directly verifies the file sizes that a FiftyOne user would encounter when downloading these specific models.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Corrected the reported model file sizes (`size_bytes`) in the Model Zoo for various SAM 2 and SAM 2.1 Hiera "Small", "Base Plus", and "Large" variants, which previously displayed an incorrect size. This ensures more accurate metadata for users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes (Specifically, changes to the model zoo manifest files, which are part of the core library's data)
-   [ ] Documentation: FiftyOne documentation changes (Implicitly, as the model zoo info displayed in docs would be more accurate, though no direct doc files changed)
-   [ ] Other