### PR TITLE
Do not create sort indexes for grid sorting

### DIFF
--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -86,7 +86,7 @@ def get_view(
     reload=True,
     awaitable=False,
     sort_by=None,
-    desc=None,
+    desc=False,
 ):
     """Gets the view defined by the given request parameters.
 
@@ -105,6 +105,8 @@ def get_view(
             :class:`fiftyone.server.filters.SampleFilter`
         reload (True): whether to reload the dataset
         awaitable (False): whether to return an awaitable coroutine
+        sort_by (None): a field name to sort by
+        desc (False): whether to sort in descending order
 
     Returns:
         a :class:`fiftyone.core.view.DatasetView`
@@ -135,7 +137,7 @@ def get_view(
             elif sample_filter.id:
                 view = fov.make_optimized_select_view(view, sample_filter.id)
 
-        if filters or extended_stages or pagination_data:
+        if filters or extended_stages or pagination_data or sort_by:
             view = get_extended_view(
                 view,
                 filters,
@@ -161,7 +163,7 @@ def get_extended_view(
     pagination_data=False,
     media_types=None,
     sort_by=None,
-    desc=None,
+    desc=False,
 ):
     """Create an extended view with the provided filters.
 
@@ -171,6 +173,8 @@ def get_extended_view(
         extended_stages (None): extended view stages
         pagination_data (False): filters label data
         media_types (None): the media types to consider
+        sort_by (None): a field name to sort by
+        desc (False): whether to sort in descending order
 
     Returns:
         a :class:`fiftyone.core.view.DatasetView`
@@ -219,7 +223,7 @@ def get_extended_view(
         )
 
     if sort_by:
-        view = view.sort_by(sort_by, reverse=bool(desc))
+        view = view.sort_by(sort_by, reverse=bool(desc), create_index=False)
 
     if pagination_data:
         # omit all dict field values for performance, not needed by grid

--- a/tests/unittests/server_view_tests.py
+++ b/tests/unittests/server_view_tests.py
@@ -944,6 +944,33 @@ class ServerViewTests(unittest.TestCase):
         )
         self.assertEqual(len(view), 1)
 
+    @drop_datasets
+    def test_sort_by(self):
+        dataset = fod.Dataset("test")
+        dataset.add_sample(fo.Sample(filepath="image.png", value="value"))
+
+        view = fosv.get_view(dataset.name, sort_by="value")
+        result = view._serialize()[0]["kwargs"]
+        self.assertEqual(
+            result,
+            [
+                ["field_or_expr", "value"],
+                ["reverse", False],
+                ["create_index", False],
+            ],
+        )
+
+        view = fosv.get_view(dataset.name, sort_by="value", desc=True)
+        result = view._serialize()[0]["kwargs"]
+        self.assertEqual(
+            result,
+            [
+                ["field_or_expr", "value"],
+                ["reverse", True],
+                ["create_index", False],
+            ],
+        )
+
 
 class AysncServerViewTests(unittest.IsolatedAsyncioTestCase):
     @drop_datasets


### PR DESCRIPTION
## What changes are proposed in this pull request?

The `SortBy` stage creates an index by default. This interferes with a sort that is already valid via a compound index

## How is this patch tested? If it is not, please explain why.

Server tests

## Release Notes

* Fixed unwanted index creation for grid sorting when a compound index already applies

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sorting behavior to consistently default to ascending order unless specified otherwise.
  - Sorting now explicitly disables index creation for better performance and predictability.

- **Documentation**
  - Updated descriptions to clarify sorting options and behaviors.

- **Tests**
  - Added tests to verify sorting order and parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->