### PR TITLE
labels correspondence bug fix: consistency in different label types hovering behavior

### DIFF
--- a/app/packages/looker/src/overlays/detection.ts
+++ b/app/packages/looker/src/overlays/detection.ts
@@ -70,16 +70,17 @@ export default class DetectionOverlay<
       return;
     }
 
-    let doesInstanceMatch = false;
+    /**
+     * Four possible cases for stroke style if it's a label _with an instance_:
+     * 1. Label is neither selected nor hovered: default color
+     * 2. Label is hovered: white stroke
+     * 3. Instance is selected: stroke with dash of white and default color
+     * 4. Instance is selected and hovered: stroke with dash of orange and default color
+     */
 
-    if (
+    const doesInstanceMatch =
       this.label.instance?._id &&
-      isHoveringParticularLabelWithInstanceConfig(this.label.instance._id)
-    ) {
-      doesInstanceMatch = true;
-      ctx.strokeStyle = INFO_COLOR;
-      ctx.lineWidth = 2;
-    }
+      isHoveringParticularLabelWithInstanceConfig(this.label.instance._id);
 
     const isSelected = this.isSelected(state);
 

--- a/app/packages/looker/src/overlays/keypoint.ts
+++ b/app/packages/looker/src/overlays/keypoint.ts
@@ -14,6 +14,7 @@ import {
 import { distance, distanceFromLineSegment, multiply } from "../util";
 import { CONTAINS, CoordinateOverlay, PointInfo, RegularLabel } from "./base";
 import { t } from "./util";
+import { isHoveringParticularLabelWithInstanceConfig } from "@fiftyone/state/src/jotai";
 
 interface KeypointLabel extends RegularLabel {
   points: [NONFINITE, NONFINITE][];
@@ -42,6 +43,9 @@ export default class KeypointOverlay<
   draw(ctx: CanvasRenderingContext2D, state: Readonly<State>): void {
     const color = this.getColor(state);
     const selected = this.isSelected(state);
+    const doesInstanceMatch =
+      this.label.instance?._id &&
+      isHoveringParticularLabelWithInstanceConfig(this.label.instance._id);
     ctx.lineWidth = 0;
 
     const skeleton = getSkeleton(this.field, state);
@@ -71,7 +75,7 @@ export default class KeypointOverlay<
         continue;
       }
 
-      ctx.fillStyle = pointColor(i);
+      ctx.fillStyle = doesInstanceMatch ? INFO_COLOR : pointColor(i);
       ctx.beginPath();
       const [x, y] = t(state, ...point);
       ctx.arc(

--- a/app/packages/looker/src/overlays/util.ts
+++ b/app/packages/looker/src/overlays/util.ts
@@ -4,7 +4,7 @@
 
 import { COLOR_BY, REGRESSION, getColor } from "@fiftyone/utilities";
 import colorString from "color-string";
-import { INFO_COLOR } from "../constants";
+import { INFO_COLOR, SELECTED_AND_HOVERED_COLOR } from "../constants";
 import type {
   BaseState,
   Coloring,
@@ -287,3 +287,41 @@ const getLabelColorByValue = ({
     return getColor(coloring.pool, coloring.seed, label[key]);
   }
 };
+
+/**
+ * Four possible cases for stroke style if it's a label _with an instance_:
+ * 1. Label is neither selected nor hovered: default color
+ * 2. Label is hovered: white stroke
+ * 3. Instance is selected: stroke with dash of white and default color
+ * 4. Instance is selected and hovered: stroke with dash of orange and default color
+ */
+export function getInstanceStrokeStyles({
+  isSelected,
+  getColor,
+  isHoveringInstance,
+  dashLength,
+}: {
+  isSelected: boolean;
+  getColor: () => string;
+  isHoveringInstance: boolean;
+  dashLength: number;
+}) {
+  // Main stroke color
+  let strokeColor = getColor();
+  let overlayStrokeColor: string | null = null;
+  let overlayDash: number | null = null;
+
+  if (isHoveringInstance && !isSelected) {
+    strokeColor = INFO_COLOR;
+  }
+
+  if (isSelected && isHoveringInstance) {
+    overlayStrokeColor = SELECTED_AND_HOVERED_COLOR;
+    overlayDash = dashLength;
+  } else if (isSelected) {
+    overlayStrokeColor = INFO_COLOR;
+    overlayDash = dashLength;
+  }
+
+  return { strokeColor, overlayStrokeColor, overlayDash };
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Standardizes hover and selection states across detection, keypoint, and polyline overlays
- Removes duplicate styling logic from individual overlay components

Gif below has keypoints and polylines for image samples, and detections for the 3d sample:
![detection-keypoint-polyline](https://github.com/user-attachments/assets/1d0cd522-9bf0-4380-ae38-e4b313c82d85)


## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
