### PR TITLE
Get multiple secrets at once

### DIFF
--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -827,7 +827,7 @@ class ExecutionContext(object):
             keys, self._operator_uri, **kwargs
         )
         if secrets:
-            for _, secret in secrets.items():
+            for secret in secrets.values():
                 self._secrets[secret.key] = secret.value
 
     def trigger(self, operator_name, params=None):

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -823,11 +823,11 @@ class ExecutionContext(object):
         if None in (self._secrets_client, keys):
             return None
 
-        for key in keys:
-            secret = await self._secrets_client.get_secret(
-                key, self._operator_uri, **kwargs
-            )
-            if secret:
+        secrets = await self._secrets_client.get_multiple(
+            keys, self._operator_uri, **kwargs
+        )
+        if secrets:
+            for _, secret in secrets.items():
                 self._secrets[secret.key] = secret.value
 
     def trigger(self, operator_name, params=None):

--- a/tests/unittests/plugins/secrets_tests.py
+++ b/tests/unittests/plugins/secrets_tests.py
@@ -40,7 +40,13 @@ class TestExecutionContext:
         mock.get_secret.side_effect = lambda key, operator: MockSecret(
             key, self.secrets.get(key)
         )
-        mock.config_cache = {self.operator_uri: self.plugin_secrets}
+        mock.get_multiple.side_effect = lambda keys, operator: {
+            key: MockSecret(key, self.secrets.get(key)) for key in keys
+        }
+        mock.get_secret_sync.side_effect = lambda key, operator: MockSecret(
+            key, self.secrets.get(key)
+        )
+        mock._registered_secrets = {self.operator_uri: self.plugin_secrets}
         return mock
 
     def test_secret(self):


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Use get_multiple to retrieve multiple secrets from the client at once. This doesn't make much of a difference for env var secrets, however to maintain parody with teams, it needs to be introduced here first

- [FOEPD-814]

## How is this patch tested? If it is not, please explain why.

- updated unit tests
- tested locally by adding multiple secrets to a fiftyone.yml

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


[FOEPD-814]: https://voxel51.atlassian.net/browse/FOEPD-814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to retrieve multiple secrets at once, improving efficiency for secret management.

- **Bug Fixes**
  - Improved validation and error handling when fetching secrets, ensuring more consistent and reliable secret retrieval.

- **Tests**
  - Enhanced test coverage and improved test mocks to support the new multiple secret retrieval functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->