### PR TITLE
docs(FIFTYONE_MEDIA_CACHE_SIZE_BYTES): describe actual behavior

### DIFF
--- a/docs/source/enterprise/cloud_media.rst
+++ b/docs/source/enterprise/cloud_media.rst
@@ -870,12 +870,13 @@ of the FiftyOne Enterprise client to use:
 
 **Runtime**
 
-Lambda/GCFs cannot use services, so you must disable the media the cache by
-setting the following runtime environment variable:
+Lambda/GCFs cannot use services, so you must disable the media the cache cleanup
+service by setting the following runtime environment variable.
 
 .. code-block:: shell
 
-    export FIFTYONE_MEDIA_CACHE_SIZE_BYTES=-1  # disable media cache
+    # `-1` disables the media cache garbage collection (and cache size is unlimited).
+    export FIFTYONE_MEDIA_CACHE_SIZE_BYTES=-1
 
 From there, you can configure your database URI and any necessary cloud storage
 credentials via runtime environment variables as you normally would, eg:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Explain the actual behavior of the media cache.  The developers mentioned that value of `-1` doesn't disable the cache, but instead disables the garbage collection for the cache (this not setting a limit).

## How is this patch tested? If it is not, please explain why.

@ehofesmann contributed to crafting the message.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified instructions for disabling the media cache cleanup service in the cloud media documentation.
  - Expanded explanation for the environment variable controlling media cache size, specifying that setting it to -1 disables garbage collection and makes the cache unlimited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->