### PR TITLE
Update manifest-torch.json

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -1378,7 +1378,7 @@
             "base_name": "mnasnet0.5-imagenet-torch",
             "base_filename": "mnasnet0.5_top1_67.823-3ffadce67e.pth",
             "version": null,
-            "description": "MNASNet model from from `MnasNet: Platform-Aware Neural Architecture Search for Mobile <https://arxiv.org/abs/1807.11626>`_ with depth multiplier of 0.5 trained on ImageNet",
+            "description": "MNASNet model from `MnasNet: Platform-Aware Neural Architecture Search for Mobile <https://arxiv.org/abs/1807.11626>`_ with depth multiplier of 0.5 trained on ImageNet",
             "source": "https://pytorch.org/vision/main/models.html",
             "author": "Mingxing Tan, et al.",
             "license": "BSD 3-Clause",


### PR DESCRIPTION
Removes a duplicate "from" preposition in the description string for the "mnasnet0.5-imagenet-torch" model in the manifest file.

## What changes are proposed in this pull request?

This pull request corrects a typographical error in the manifest file. Specifically, the `description` field for the `mnasnet0.5-imagenet-torch` model contained a repeated word ("from from"). This change removes the duplicate "from" to ensure the accuracy and clarity of the model's metadata.

The corrected line within the JSON structure would effectively change from:
`"description": "MNASNet model from from \`MnasNet: Platform-Aware Neural Architecture Search for Mobile <https://arxiv.org/abs/1807.11626>\`_ with depth multiplier of 0.5 trained on ImageNet",`

to:
`"description": "MNASNet model from \`MnasNet: Platform-Aware Neural Architecture Search for Mobile <https://arxiv.org/abs/1807.11626>\`_ with depth multiplier of 0.5 trained on ImageNet",`

## How is this patch tested? If it is not, please explain why.

This is a minor textual correction within a JSON manifest file. The change has been visually inspected for correctness. Automated testing for such a small, non-functional textual change in a data file is generally not implemented as it doesn't affect code logic or functionality. The primary validation is ensuring the JSON remains valid and the specific typo is corrected, which has been done.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.

(This is a minor internal metadata correction and does not impact user functionality or how they interact with the FiftyOne library or application.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other (Model manifest data)