### PR TITLE
Update tf.py

### DIFF
--- a/fiftyone/zoo/datasets/tf.py
+++ b/fiftyone/zoo/datasets/tf.py
@@ -286,10 +286,10 @@ class CIFAR100Dataset(TFDSDataset):
 class ImageNet2012Dataset(TFDSDataset):
     """The ImageNet 2012 dataset.
 
-    ImageNet, as known as ILSVRC 2012, is an image dataset organized according
+    ImageNet, also known as ILSVRC 2012, is an image dataset organized according
     to the WordNet hierarchy. Each meaningful concept in WordNet, possibly
     described by multiple words or word phrases, is called a "synonym set" or
-    "synset". There are more than 100,000 synsets in WordNet, majority of them
+    "synset". There are more than 100,000 synsets in WordNet, the majority of them
     are nouns (80,000+). ImageNet provides on average 1,000 images to
     illustrate each synset. Images of each concept are quality-controlled and
     human-annotated. In its completion, we hope ImageNet will offer tens of


### PR DESCRIPTION
This updates the ImageNet2012Dataset module-level docstring to read more naturally:

* “ImageNet, as known as ILSVRC 2012” ➜ “ImageNet, **also** known as ILSVRC 2012” 

(replaces awkward phrasing with the correct idiom)

* “…majority of them are nouns” ➜ “…**the** majority of them are nouns”

(adds missing definite article)

---

## What changes are proposed in this pull request?

- Edits only the `ImageNet2012Dataset` class docstring in
  `fiftyone/zoo/datasets/torchvision_datasets.py`, updating two sentences for standard English usage.
- **No** functional or API-level changes; code behavior is untouched.

---

## Release Notes

### Is this a user-facing change to mention in the release notes?

- [x] **No** — documentation-only update.

---

## Affected areas of FiftyOne

- [x] Documentation
- [ ] Core library
- [ ] App
- [ ] Build / CI
- [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected minor typos in the description of the ImageNet2012Dataset class for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->