### PR TITLE
Update ISSUE_TRIAGE.md

### DIFF
--- a/ISSUE_TRIAGE.md
+++ b/ISSUE_TRIAGE.md
@@ -46,7 +46,7 @@ You should assign a priority to each issue you triage.
 
 ## Label relevant areas
 
-Assign one more labels for relevant areas. As a principle, we aim to have the
+Assign one or more labels for relevant areas. As a principle, we aim to have the
 minimal set of labels needed to help route issues and PRs to appropriate
 contributors.
 


### PR DESCRIPTION
Replaced “Assign one more labels for relevant areas” with “Assign one or more labels for relevant areas” to resolve the grammatical error and improve clarity. (Article omission)

## What changes are proposed in this pull request?

- Corrects the wording in the **“Issue Triage”** guide under “Label relevant areas”  
  - **Before:** “Assign one more labels for relevant areas.”  
  - **After:**  “Assign **one or more** labels for relevant areas.”  
- Eliminates a grammatical error and clarifies the instruction.

## How is this patch tested? If it is not, please explain why.

This is a documentation-only change.

- Built the docs locally (`mkdocs serve`) and verified the updated sentence renders correctly.
- Ran a spell-check to confirm no new issues were introduced.

No automated tests are required because no executable code paths are affected.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request.-->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [x] Documentation: FiftyOne documentation changes
- [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typographical error to clarify instructions about assigning one or more labels in the issue triage documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->