### PR TITLE
apply_model: only pin memory when needed

### DIFF
--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -26,6 +26,7 @@ import fiftyone.core.media as fom
 import fiftyone.core.utils as fou
 import fiftyone.core.validation as fov
 
+torch = fou.lazy_import("torch")
 tud = fou.lazy_import("torch.utils.data")
 
 foue = fou.lazy_import("fiftyone.utils.eta")
@@ -854,12 +855,14 @@ def _make_data_loader(
         )
         worker_init_fn = None
 
+    pin_memory = isinstance(model, fout.TorchImageModel) and model._using_gpu
+
     return tud.DataLoader(
         dataset,
         batch_size=batch_size,
         num_workers=num_workers,
         collate_fn=collate_fn,
-        pin_memory=True,
+        pin_memory=pin_memory,
         persistent_workers=False,
         worker_init_fn=worker_init_fn,
     )

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -26,7 +26,6 @@ import fiftyone.core.media as fom
 import fiftyone.core.utils as fou
 import fiftyone.core.validation as fov
 
-torch = fou.lazy_import("torch")
 tud = fou.lazy_import("torch.utils.data")
 
 foue = fou.lazy_import("fiftyone.utils.eta")


### PR DESCRIPTION
## What changes are proposed in this pull request?

Make `pin_memory` value be True only when device is GPU.

## How is this patch tested? If it is not, please explain why.

Compared embeddings for clip-vit-base32-torch before and after on both CPU and GPU. Diff is maintained.

```
import os
os.environ['CUDA_VISIBLE_DEVICES'] = '1'

import numpy as np

import fiftyone as fo
import fiftyone.zoo as foz

model = foz.load_zoo_model("clip-vit-base32-torch")
print(model._device, model._using_gpu)
dataset.compute_embeddings(model, embeddings_field='pin_memory_test_gpu_dev')

# repeat on dev, this branch, cpu, and gpu

# compare cpu and gpu on develop
cpu_res_dev = np.array(dataset.values("pin_memory_test_cpu_dev"))
gpu_res_dev = np.array(dataset.values("pin_memory_test_gpu_dev"))
print(f"max difference: {np.max(np.abs(cpu_res_dev - gpu_res_dev))}")
print(f"mean difference: {np.mean(np.abs(cpu_res_dev - gpu_res_dev))}")

# compare cpu and gpu on branch
cpu_res = np.array(dataset.values("pin_memory_test_cpu"))
gpu_res = np.array(dataset.values("pin_memory_test_gpu"))
print(f"max difference: {np.max(np.abs(cpu_res - gpu_res))}")
print(f"mean difference: {np.mean(np.abs(cpu_res - gpu_res))}")

# compare dev vs branch cpu
print(f"cpu max difference: {np.max(np.abs(cpu_res - cpu_res_dev))}")
print(f"cpu mean difference: {np.mean(np.abs(cpu_res - cpu_res_dev))}")
# compare dev vs branch gpu
print(f"gpu max difference: {np.max(np.abs(gpu_res - gpu_res_dev))}")
print(f"gpu mean difference: {np.mean(np.abs(gpu_res - gpu_res_dev))}")
```

Diffs:

cpu vs gpu on develop:
```
max difference: 0.013804078102111816
mean difference: 0.0003587513998267866
```

cpu vs gpu on branch
```
max difference: 0.013804078102111816
mean difference: 0.0003587513998267866
```

dev vs branch
```
# compare dev vs branch cpu
cpu max difference: 0.0
cpu mean difference: 0.0
gpu max difference: 0.0
gpu mean difference: 0.0
```

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved memory management during data loading by conditionally enabling memory pinning only when using specific models with GPU acceleration. This may enhance performance and stability for certain workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->