### PR TITLE
Add dynamic resolution of `operation.name`

### DIFF
--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -7,7 +7,9 @@ FiftyOne's public interface.
 """
 
 import fiftyone.core.config as _foc
+import fiftyone.utils.databricks as _foud
 
+_foud.with_fiftyone_useragent()
 config = _foc.load_config()
 annotation_config = _foc.load_annotation_config()
 evaluation_config = _foc.load_evaluation_config()

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -7,13 +7,13 @@ FiftyOne's public interface.
 """
 
 import fiftyone.core.config as _foc
-import fiftyone.utils.databricks as _foud
+import fiftyone.utils.useragent as _foua
 
-_foud.with_fiftyone_useragent()
 config = _foc.load_config()
 annotation_config = _foc.load_annotation_config()
 evaluation_config = _foc.load_evaluation_config()
 app_config = _foc.load_app_config()
+_foua.with_fiftyone_useragent()
 
 from .core.aggregations import (
     Aggregation,

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -273,7 +273,7 @@ async def execute_or_delegate_operator(
                 operator=operator.uri,
                 context=ctx.serialize(),
                 delegation_target=ctx.delegation_target,
-                label=operator.name,
+                label=operator.resolve_run_name(ctx),
                 metadata=metadata,
             )
 

--- a/fiftyone/operators/operator.py
+++ b/fiftyone/operators/operator.py
@@ -287,6 +287,20 @@ class Operator(object):
         """
         return None
 
+    def resolve_run_name(self, ctx):
+        """Returns the resolved run name of the operator.
+
+        Subclasses can implement this method to define the run name of the
+        operator.
+
+        Args:
+            ctx: the :class:`fiftyone.operators.executor.ExecutionContext`
+
+        Returns:
+            a string, or None
+        """
+        return self.name
+
     def method_to_uri(self, method_name):
         """Converts a method name to a URI.
 

--- a/fiftyone/utils/databricks.py
+++ b/fiftyone/utils/databricks.py
@@ -1,0 +1,18 @@
+"""
+Databricks utilities.
+
+| Copyright 2017-2025, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import fiftyone as fo
+import fiftyone.core.utils as fou
+
+
+def with_fiftyone_useragent():
+    try:
+        useragent = fou.lazy_import("databricks.sdk.useragent")
+        useragent.with_partner("voxel51")
+        useragent.with_product("fiftyone", fo.__version__)
+    except ImportError:
+        pass

--- a/fiftyone/utils/useragent.py
+++ b/fiftyone/utils/useragent.py
@@ -1,18 +1,19 @@
 """
-Databricks utilities.
+User agent utilities.
 
 | Copyright 2017-2025, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import fiftyone as fo
+import fiftyone.constants as foc
 import fiftyone.core.utils as fou
 
 
 def with_fiftyone_useragent():
     try:
-        useragent = fou.lazy_import("databricks.sdk.useragent")
+        from databricks.sdk import useragent
+
         useragent.with_partner("voxel51")
-        useragent.with_product("fiftyone", fo.__version__)
+        useragent.with_product("fiftyone", foc.VERSION)
     except ImportError:
         pass


### PR DESCRIPTION
Allows operators to dynamically resolve their run name given the current `ExecutionContext`.

Note that this is a dependency for a 1.6.0 project.