### PR TITLE
Add dynamic resolution of `operation.name`

### DIFF
--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -273,7 +273,7 @@ async def execute_or_delegate_operator(
                 operator=operator.uri,
                 context=ctx.serialize(),
                 delegation_target=ctx.delegation_target,
-                label=operator.name,
+                label=operator.resolve_run_name(ctx),
                 metadata=metadata,
             )
 

--- a/fiftyone/operators/operator.py
+++ b/fiftyone/operators/operator.py
@@ -287,6 +287,20 @@ class Operator(object):
         """
         return None
 
+    def resolve_run_name(self, ctx):
+        """Returns the resolved run name of the operator.
+
+        Subclasses can implement this method to define the run name of the
+        operator.
+
+        Args:
+            ctx: the :class:`fiftyone.operators.executor.ExecutionContext`
+
+        Returns:
+            a string, or None
+        """
+        return self.name
+
     def method_to_uri(self, method_name):
         """Converts a method name to a URI.
 


### PR DESCRIPTION
Allows operators to dynamically resolve their run name given the current `ExecutionContext`.

Note that this is a dependency for a 1.6.0 project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved labeling for delegated operations, allowing for more descriptive and context-aware run names in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->