### PR TITLE
Add label `instance` to SDK 

### DIFF
--- a/docs/source/user_guide/app.rst
+++ b/docs/source/user_guide/app.rst
@@ -2386,12 +2386,12 @@ labels in the App:
 
     [
         {
-            'object_id': '5f99d2eb36208058abbfc02a',
+            'label_id': '5f99d2eb36208058abbfc02a',
             'sample_id': '5f99d2eb36208058abbfc030',
             'field': 'ground_truth',
         },
         {
-            'object_id': '5f99d2eb36208058abbfc02b',
+            'label_id': '5f99d2eb36208058abbfc02b',
             'sample_id': '5f99d2eb36208058abbfc030',
             'field': 'ground_truth',
         },

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -4186,7 +4186,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                     for _ids in fou.iter_batches(instance_ids, batch_size):
                         ops.append(
                             UpdateMany(
-                                {root + "instance._id": {"$in": _ids}},
+                                {root + ".instance._id": {"$in": _ids}},
                                 {
                                     "$set": {
                                         root: None,

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -4031,7 +4031,13 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         self._clear_groups(group_ids=group_ids)
 
     def delete_labels(
-        self, labels=None, ids=None, tags=None, view=None, fields=None
+        self,
+        labels=None,
+        ids=None,
+        instance_ids=None,
+        tags=None,
+        view=None,
+        fields=None,
     ):
         """Deletes the specified labels from the dataset.
 
@@ -4041,8 +4047,14 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             dicts in the format returned by
             :attr:`fiftyone.core.session.Session.selected_labels`
 
-        -   Provide the ``ids`` or ``tags`` arguments to specify the labels to
-            delete via their IDs and/or tags
+        -   Provide the ``ids`` argument to specify the labels to delete via
+            their IDs
+
+        -   Provide the ``instance_ids`` argument to specify the labels to
+            delete via their instance IDs
+
+        -   Provide the ``tags`` argument to specify the labels to delete via
+            their tags
 
         -   Provide the ``view`` argument to delete all of the labels in a view
             into this dataset. This syntax is useful if you have constructed a
@@ -4059,6 +4071,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 the format returned by
                 :attr:`fiftyone.core.session.Session.selected_labels`
             ids (None): an ID or iterable of IDs of the labels to delete
+            instance_ids (None): an instance ID or iterable of instance IDs of
+                the labels to delete
             tags (None): a tag or iterable of tags of the labels to delete
             view (None): a :class:`fiftyone.core.view.DatasetView` into this
                 dataset containing the labels to delete
@@ -4072,7 +4086,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             labels = view._get_selected_labels(fields=fields)
             self._delete_labels(labels, fields=fields)
 
-        if ids is None and tags is None:
+        if ids is None and instance_ids is None and tags is None:
             return
 
         if etau.is_str(ids):
@@ -4080,6 +4094,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         if ids is not None:
             ids = [ObjectId(_id) for _id in ids]
+
+        if etau.is_str(instance_ids):
+            instance_ids = [instance_ids]
+
+        if instance_ids is not None:
+            instance_ids = [ObjectId(_id) for _id in instance_ids]
 
         if etau.is_str(tags):
             tags = [tags]
@@ -4119,6 +4139,20 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                             )
                         )
 
+                if instance_ids is not None:
+                    for _ids in fou.iter_batches(instance_ids, batch_size):
+                        ops.append(
+                            UpdateMany(
+                                {root + ".instance._id": {"$in": _ids}},
+                                {
+                                    "$pull": {
+                                        root: {"instance._id": {"$in": _ids}}
+                                    },
+                                    "$set": {"last_modified_at": now},
+                                },
+                            )
+                        )
+
                 if tags is not None:
                     ops.append(
                         UpdateMany(
@@ -4139,6 +4173,20 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                         ops.append(
                             UpdateMany(
                                 {root + "._id": {"$in": _ids}},
+                                {
+                                    "$set": {
+                                        root: None,
+                                        "last_modified_at": now,
+                                    }
+                                },
+                            )
+                        )
+
+                if instance_ids is not None:
+                    for _ids in fou.iter_batches(instance_ids, batch_size):
+                        ops.append(
+                            UpdateMany(
+                                {root + "instance._id": {"$in": _ids}},
                                 {
                                     "$set": {
                                         root: None,

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -824,6 +824,7 @@ class Session(object):
 
         -   ``label_id``: the ID of the label
         -   ``sample_id``: the ID of the sample containing the label
+        -   ``instance_id``: the instance ID of the label (optional)
         -   ``field``: the field name containing the label
         -   ``frame_number``: the frame number containing the label (only
             applicable to video samples)
@@ -841,6 +842,7 @@ class Session(object):
         self,
         labels: t.Optional[t.List[dict]] = None,
         ids: t.Optional[t.Union[str, t.Iterable[str]]] = None,
+        instance_ids: t.Optional[t.Union[str, t.Iterable[str]]] = None,
         tags: t.Optional[t.Union[str, t.Iterable[str]]] = None,
         fields: t.Optional[t.Union[str, t.Iterable[str]]] = None,
     ) -> None:
@@ -853,12 +855,14 @@ class Session(object):
         Args:
             labels (None): a list of dicts specifying the labels to select
             ids (None): an ID or iterable of IDs of the labels to select
+            instance_ids (None): an instance ID or iterable of instance IDs of
+                the labels to select
             tags (None): a tag or iterable of tags of labels to select
             fields (None): a field or iterable of fields from which to select
         """
         if labels is None and self._collection:
             labels = self._collection._get_selected_labels(
-                ids=ids, tags=tags, fields=fields
+                ids=ids, instance_ids=instance_ids, tags=tags, fields=fields
             )
 
         self.selected_labels = list(labels or [])

--- a/fiftyone/utils/kitti.py
+++ b/fiftyone/utils/kitti.py
@@ -936,6 +936,10 @@ def _prepare_kitti_split(split_dir, overwrite=False, num_workers=None):
 
 def _load_kitti_annotations(labels_path, frame_size):
     gt2d = load_kitti_detection_annotations(labels_path, frame_size)
+
+    for index, detection in enumerate(gt2d.detections, 1):
+        detection.index = index
+
     gt3d = gt2d.copy()
 
     for detection in gt2d.detections:

--- a/tests/unittests/label_tests.py
+++ b/tests/unittests/label_tests.py
@@ -535,6 +535,159 @@ class LabelTests(unittest.TestCase):
 
 class LabelUtilsTests(unittest.TestCase):
     @drop_datasets
+    def test_label_to_instance_video(self):
+        sample = fo.Sample(filepath="video.mp4")
+        sample.frames[1] = fo.Frame(
+            ground_truth=fo.Detections(
+                detections=[
+                    fo.Detection(label="cat", index=1),
+                    fo.Detection(label="cat", index=2),
+                    fo.Detection(label="dog", index=1),
+                    fo.Detection(label="none"),
+                ]
+            )
+        )
+        sample.frames[2] = fo.Frame()
+        sample.frames[3] = fo.Frame(
+            ground_truth=fo.Detections(
+                detections=[
+                    fo.Detection(label="cat", index=1),
+                    fo.Detection(label="cat", index=2),
+                    fo.Detection(label="none"),
+                    fo.Detection(label="dog", index=1),
+                ]
+            )
+        )
+        sample.frames[4] = fo.Frame(ground_truth=fo.Detections())
+        sample.frames[5] = fo.Frame(
+            ground_truth=fo.Detections(
+                detections=[
+                    fo.Detection(label="cat", index=1),
+                    fo.Detection(label="cat", index=3),
+                    fo.Detection(label="none"),
+                    fo.Detection(label="dog", index=2),
+                ]
+            )
+        )
+        sample.frames[6] = fo.Frame(
+            ground_truth=fo.Detections(
+                detections=[
+                    fo.Detection(label="dog", index=2),
+                ]
+            )
+        )
+
+        dataset = fo.Dataset()
+        dataset.add_sample(sample)
+
+        foul.index_to_instance(
+            dataset, "frames.ground_truth", clear_index=True
+        )
+
+        instances = dataset.count_values(
+            "frames.ground_truth.detections.instance._id"
+        )
+        indexes = dataset.count_values("frames.ground_truth.detections.index")
+
+        cat1 = sample.frames[1].ground_truth.detections[0].instance._id
+        cat2 = sample.frames[1].ground_truth.detections[1].instance._id
+        cat3 = sample.frames[5].ground_truth.detections[1].instance._id
+        dog1 = sample.frames[1].ground_truth.detections[2].instance._id
+        dog2 = sample.frames[5].ground_truth.detections[3].instance._id
+
+        self.assertDictEqual(
+            instances, {cat1: 3, cat2: 2, cat3: 1, dog1: 2, dog2: 2, None: 3}
+        )
+        self.assertDictEqual(indexes, {None: 13})
+
+    @drop_datasets
+    def test_label_to_instance_group(self):
+        group1 = fo.Group()
+        left_sample1 = fo.Sample(
+            filepath="left-image1.jpg",
+            group=group1.element("left"),
+            ground_truth=fo.Detections(
+                detections=[
+                    fo.Detection(label="cat", index=1),
+                    fo.Detection(label="cat", index=2),
+                    fo.Detection(label="dog", index=1),
+                    fo.Detection(label="none"),
+                ]
+            ),
+        )
+        right_sample1 = fo.Sample(
+            filepath="right-image1.jpg",
+            group=group1.element("right"),
+            ground_truth=fo.Detections(
+                detections=[
+                    fo.Detection(label="cat", index=1),
+                    fo.Detection(label="dog", index=1),
+                    fo.Detection(label="none"),
+                    fo.Detection(label="dog", index=2),
+                ]
+            ),
+        )
+
+        group2 = fo.Group()
+        left_sample2 = fo.Sample(
+            filepath="left-image2.jpg",
+            group=group2.element("left"),
+        )
+        right_sample2 = fo.Sample(
+            filepath="right-image2.jpg",
+            group=group2.element("right"),
+            ground_truth=fo.Detections(
+                detections=[
+                    fo.Detection(label="cat", index=1),
+                    fo.Detection(label="dog", index=1),
+                    fo.Detection(label="none"),
+                ]
+            ),
+        )
+
+        group3 = fo.Group()
+        left_sample3 = fo.Sample(
+            filepath="left-image3.jpg",
+            group=group3.element("left"),
+            ground_truth=fo.Detections(),
+        )
+        right_sample3 = fo.Sample(
+            filepath="right-image3.jpg",
+            group=group3.element("right"),
+        )
+
+        dataset = fo.Dataset()
+        dataset.add_samples(
+            [
+                left_sample1,
+                right_sample1,
+                left_sample2,
+                right_sample2,
+                left_sample3,
+                right_sample3,
+            ]
+        )
+
+        foul.index_to_instance(dataset, "ground_truth", clear_index=True)
+
+        view = dataset.select_group_slices()
+        instances = view.count_values("ground_truth.detections.instance._id")
+        indexes = view.count_values("ground_truth.detections.index")
+
+        cat1 = left_sample1.ground_truth.detections[0].instance._id
+        cat2 = left_sample1.ground_truth.detections[1].instance._id
+        cat3 = right_sample2.ground_truth.detections[0].instance._id
+        dog1 = left_sample1.ground_truth.detections[2].instance._id
+        dog2 = right_sample1.ground_truth.detections[3].instance._id
+        dog3 = right_sample2.ground_truth.detections[1].instance._id
+
+        self.assertDictEqual(
+            instances,
+            {cat1: 2, cat2: 1, cat3: 1, dog1: 2, dog2: 1, dog3: 1, None: 3},
+        )
+        self.assertDictEqual(indexes, {None: 11})
+
+    @drop_datasets
     def test_perform_nms(self):
         detections = [
             fo.Detection(


### PR DESCRIPTION
## Change log

- Adds `instance_ids` argument to `select_labels()`, `match_labels()`, `exclude_labels()`, and `delete_labels()`
- Adds an `index_to_instance()` utility for converting old-style `index`s to `instance`s
- Fixes a bug with `set_values()` when setting frame fields via dict syntax where not all frame numbers are present

## Example usage

### Instance ID selection

```py
from bson import ObjectId

import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.labels as foul

dataset = foz.load_zoo_dataset("quickstart-video")
foul.index_to_instance(dataset, "frames.detections", clear_index=True)

instance_id = dataset.first().frames.first().detections.detections[0].instance.id

view = dataset.select_labels(instance_ids=instance_id, fields="frames.detections")
instances = view.count_values("frames.detections.detections.instance._id")

assert len(view) == 1
assert len(instances) == 1
assert ObjectId(instance_id) in instances

view = dataset.match_labels(instance_ids=instance_id, fields="frames.detections")
instances = view.count_values("frames.detections.detections.instance._id")

assert len(view) == 1
assert len(instances) > 1

view = dataset.exclude_labels(instance_ids=instance_id, fields="frames.detections")
instances = view.count_values("frames.detections.detections.instance._id")

assert len(view) == 10
assert len(instances) > 1
assert ObjectId(instance_id) not in instances

dataset.delete_labels(instance_ids=instance_id, fields="frames.detections")
instances = dataset.count_values("frames.detections.detections.instance._id")

assert ObjectId(instance_id) not in instances
```

### Video dataset: `index` -> `instance`

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.labels as foul

dataset = foz.load_zoo_dataset("quickstart-video")

# Convert old-style index to instance
foul.index_to_instance(dataset, "frames.detections", clear_index=True)

session = fo.launch_app(dataset)

# Verify that instances were populated
fo.pprint(dataset.count_values("frames.detections.detections.instance._id"))
fo.pprint(dataset.count_values("frames.detections.detections.index"))
```

### Group dataset: `index` -> `instance`

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.labels as foul

# I updated the dataset's source to include `index` attributes
# So delete our local copy so it will be redownloaded below
# foz.delete_zoo_dataset("quickstart-groups")

dataset = foz.load_zoo_dataset("quickstart-groups")

# Convert old-style index to instance
foul.index_to_instance(dataset, "ground_truth", clear_index=True)

session = fo.launch_app(dataset)

# Verify that instances were populated
view = dataset.select_group_slices(_allow_mixed=True)
fo.pprint(view.count_values("ground_truth.detections.instance._id"))
fo.pprint(view.count_values("ground_truth.detections.index"))
```
