### PR TITLE
Update manifest-torch.json

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -3251,7 +3251,7 @@
             "source": "https://pytorch.org/hub/ultralytics_yolov5",
             "author": "Glenn Jocher, et al.",
             "license": "AGPL-3.0",
-            "size_bytes": 7936,
+            "size_bytes": 4062133,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.torch.TorchImageModel",
                 "config": {
@@ -3284,7 +3284,7 @@
             "source": "https://pytorch.org/hub/ultralytics_yolov5",
             "author": "Glenn Jocher, et al.",
             "license": "AGPL-3.0",
-            "size_bytes": 28928,
+            "size_bytes": 14808437,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.torch.TorchImageModel",
                 "config": {
@@ -3317,7 +3317,7 @@
             "source": "https://pytorch.org/hub/ultralytics_yolov5",
             "author": "Glenn Jocher, et al.",
             "license": "AGPL-3.0",
-            "size_bytes": 83872,
+            "size_bytes": 42806829,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.torch.TorchImageModel",
                 "config": {
@@ -3350,7 +3350,7 @@
             "source": "https://pytorch.org/hub/ultralytics_yolov5",
             "author": "Glenn Jocher, et al.",
             "license": "AGPL-3.0",
-            "size_bytes": 197504,
+            "size_bytes": 93622629,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.torch.TorchImageModel",
                 "config": {
@@ -5452,7 +5452,7 @@
             "source": "https://pytorch.org/hub/ultralytics_yolov5",
             "author": "Glenn Jocher, et al.",
             "license": "AGPL-3.0",
-            "size_bytes": 360496,
+            "size_bytes": 174114333,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.torch.TorchImageModel",
                 "config": {


### PR DESCRIPTION
This commit updates the `size_bytes` metadata in
`fiftyone/zoo/models/manifest-torch.json` for the Ultralytics YOLOv5 series (yolov5n, yolov5s, yolov5m, yolov5l, and yolov5x) to reflect their actual downloaded file sizes.

The previous values were significantly understated (often by a factor of ~500x), and these changes ensure more accurate model size information for users of the FiftyOne Model Zoo.

Corrected sizes:
- yolov5n-coco-torch: 4062133 bytes
- yolov5s-coco-torch: 14808437 bytes
- yolov5m-coco-torch: 42806829 bytes
- yolov5l-coco-torch: 93622629 bytes
- yolov5x-coco-torch: 174114333 bytes

## What changes are proposed in this pull request?

This pull request corrects the `size_bytes` attribute for five Ultralytics YOLOv5 models within the `fiftyone/zoo/models/manifest-torch.json` file. The specific models and their updated sizes are:
- `yolov5n-coco-torch`: Updated from `7936` to `4062133` bytes.
- `yolov5s-coco-torch`: Updated from `28928` to `14808437` bytes.
- `yolov5m-coco-torch`: Updated from `83872` to `42806829` bytes.
- `yolov5l-coco-torch`: Updated from `197504` to `93622629` bytes.
- `yolov5x-coco-torch`: Updated from `360496` to `174114333` bytes.

These changes ensure the metadata accurately reflects the actual disk space required for these model weights when downloaded via PyTorch Hub, which is the mechanism FiftyOne uses for these specific models.

## How is this patch tested? If it is not, please explain why.

The corrected sizes were determined by programmatically downloading each YOLOv5 model variant (`yolov5n`, `yolov5s`, `yolov5m`, `yolov5l`, `yolov5x`) using `torch.hub.load('ultralytics/yolov5', ..., pretrained=True)`. This process mimics how FiftyOne retrieves these specific models.

Once downloaded, the `.pt` model weight files were located in the local file system (specifically, in the current working directory of the execution environment, `/content/`, during Colab testing, as per the download behavior of `ultralytics/yolov5` hub scripts). The `os.path.getsize()` function was then used to determine the exact file size in bytes for each model.

The change is a metadata update in a JSON file and does not affect core library functionality. The primary test is the verification of the new byte sizes against the actual downloaded files.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Corrected `size_bytes` metadata for Ultralytics YOLOv5 (n, s, m, l, x) models in the Torch model manifest to reflect accurate downloaded file sizes.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes (specifically, model zoo metadata which is part of the core library distribution)
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other