### PR TITLE
Update manifest-torch.json

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -220,7 +220,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "torchvision"],
+                "packages": ["torch", "torchvision", "sam2"],
                 "cpu": {
                     "support": true
                 },
@@ -255,7 +255,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "torchvision"],
+                "packages": ["torch", "torchvision", "sam2"],
                 "cpu": {
                     "support": true
                 },
@@ -290,7 +290,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "torchvision"],
+                "packages": ["torch", "torchvision", "sam2"],
                 "cpu": {
                     "support": true
                 },
@@ -325,7 +325,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "torchvision"],
+                "packages": ["torch", "torchvision", "sam2"],
                 "cpu": {
                     "support": true
                 },
@@ -359,7 +359,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "torchvision"],
+                "packages": ["torch", "torchvision", "sam2"],
                 "cpu": {
                     "support": true
                 },
@@ -394,7 +394,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "torchvision"],
+                "packages": ["torch", "torchvision", "sam2"],
                 "cpu": {
                     "support": true
                 },
@@ -429,7 +429,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "torchvision"],
+                "packages": ["torch", "torchvision", "sam2"],
                 "cpu": {
                     "support": true
                 },
@@ -464,7 +464,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "torchvision"],
+                "packages": ["torch", "torchvision", "sam2"],
                 "cpu": {
                     "support": true
                 },
@@ -498,7 +498,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "torchvision"],
+                "packages": ["torch", "torchvision", "sam2"],
                 "cpu": {
                     "support": true
                 },
@@ -541,7 +541,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "torchvision"],
+                "packages": ["torch", "torchvision", "sam2"],
                 "cpu": {
                     "support": true
                 },
@@ -578,7 +578,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "torchvision"],
+                "packages": ["torch", "torchvision", "sam2"],
                 "cpu": {
                     "support": true
                 },
@@ -615,7 +615,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "torchvision"],
+                "packages": ["torch", "torchvision", "sam2"],
                 "cpu": {
                     "support": true
                 },
@@ -652,7 +652,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "torchvision"],
+                "packages": ["torch", "torchvision", "sam2"],
                 "cpu": {
                     "support": true
                 },
@@ -688,7 +688,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "torchvision"],
+                "packages": ["torch", "torchvision", "sam2"],
                 "cpu": {
                     "support": true
                 },
@@ -725,7 +725,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "torchvision"],
+                "packages": ["torch", "torchvision", "sam2"],
                 "cpu": {
                     "support": true
                 },
@@ -762,7 +762,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "torchvision"],
+                "packages": ["torch", "torchvision", "sam2"],
                 "cpu": {
                     "support": true
                 },
@@ -799,7 +799,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "torchvision"],
+                "packages": ["torch", "torchvision", "sam2"],
                 "cpu": {
                     "support": true
                 },


### PR DESCRIPTION
zoo(manifest-torch.json): add `sam2` package requirement to SAM-2 / SAM-2.1 models

Models updated
--------------
segment-anything-2-hiera-tiny-image-torch
segment-anything-2-hiera-small-image-torch
segment-anything-2-hiera-base-plus-image-torch
segment-anything-2-hiera-large-image-torch
segment-anything-2-hiera-tiny-video-torch
segment-anything-2-hiera-small-video-torch
segment-anything-2-hiera-base-plus-video-torch
segment-anything-2-hiera-large-video-torch
segment-anything-2.1-hiera-tiny-image-torch
segment-anything-2.1-hiera-small-image-torch
segment-anything-2.1-hiera-base-plus-image-torch
segment-anything-2.1-hiera-large-image-torch
segment-anything-2.1-hiera-tiny-video-torch
segment-anything-2.1-hiera-small-video-torch
segment-anything-2.1-hiera-base-plus-video-torch
segment-anything-2.1-hiera-large-video-torch

Change
------
`"packages"` now reads: ["torch", "torchvision", "sam2"]

## What changes are proposed in this pull request?

* Adds `"sam2"` to the `packages` list of each SAM-2 and SAM-2.1 model block in  
  `fiftyone/zoo/models/manifest-torch.json`, i.e.  
  `["torch", "torchvision", "sam2"]`.

## How is this patch tested? If it is not, please explain why.

A Colab smoke test was run that installed the public FiftyOne release + `sam2`, then attempted to load **all 16** SAM-2 / SAM-2.1 models.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] **Yes** – Fixes an `ImportError: 'sam2'` when loading SAM-2/SAM-2.1
  models from the Model Zoo.

> **Fixed**: Added the missing `sam2` requirement so SAM-2 and SAM-2.1 image
> and video models now load out-of-the-box.

### What areas of FiftyOne does this PR affect?

- [ ] App
- [ ] Build
- [x] Core
- [ ] Documentation
- [ ] Other
