### PR TITLE
Use title text to avoid label + sample selection display issues

### DIFF
--- a/app/packages/core/src/components/Actions/Selected/index.tsx
+++ b/app/packages/core/src/components/Actions/Selected/index.tsx
@@ -44,9 +44,12 @@ export default ({
     return null;
   }
 
-  let text = samples.size.toLocaleString();
+  let text: string | undefined = samples.size.toLocaleString();
+  let title = "Manage selected";
   if (samples.size > 0 && labels.size > 0) {
-    text = `${text} | ${labels.size.toLocaleString()}`;
+    // use title to display count
+    title = `${text} | ${labels.size.toLocaleString()}`;
+    text = undefined;
   } else if (labels.size > 0) {
     text = labels.size.toLocaleString();
   }
@@ -67,7 +70,7 @@ export default ({
         }}
         highlight={samples.size > 0 || open || (labels.size > 0 && modal)}
         text={text}
-        title={"Manage selected"}
+        title={title}
         tooltipPlacement={modal ? "bottom" : "top"}
         style={{
           cursor: loading ? "default" : "pointer",

--- a/app/packages/core/src/components/Actions/Selected/index.tsx
+++ b/app/packages/core/src/components/Actions/Selected/index.tsx
@@ -48,7 +48,9 @@ export default ({
   let title = "Manage selected";
   if (samples.size > 0 && labels.size > 0) {
     // use title to display count
-    title = `${text} | ${labels.size.toLocaleString()}`;
+    title = `${text} sample${
+      samples.size > 1 ? "s" : ""
+    } | ${labels.size.toLocaleString()} label${labels.size > 1 ? "s" : ""}`;
     text = undefined;
   } else if (labels.size > 0) {
     text = labels.size.toLocaleString();


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix styling issues with sample + label selection. Use the title to display sample/label specific counts when both are present. It is unclear how to (easily) fix the existing formatting issue directly 

### Before
<img width="1470" alt="Screenshot 2025-05-16 at 3 14 57 PM" src="https://github.com/user-attachments/assets/819ee9d4-4e1c-48c3-8d50-0fc6cadead45" />

### After

https://github.com/user-attachments/assets/413bb612-7d6a-48a0-8620-5c14d088a0aa


## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

N/A

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved tooltip content for the selection management button to display dynamic counts of selected samples and labels.
  - Button text now more accurately reflects current selection, showing sample or label counts as appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->