### PR TITLE
Add GroupViT to model zoo via transformers integration

### DIFF
--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -35,7 +35,6 @@ DEFAULT_SEGMENTATION_PATH = "nvidia/segformer-b0-finetuned-ade-512-512"
 DEFAULT_DEPTH_ESTIMATION_PATH = "Intel/dpt-hybrid-midas"
 DEFAULT_ZERO_SHOT_CLASSIFICATION_PATH = "openai/clip-vit-large-patch14"
 DEFAULT_ZERO_SHOT_DETECTION_PATH = "google/owlvit-base-patch32"
-DEFAULT_ZERO_SHOT_SEGMENTATION_PATH = "nvidia/groupvit-gcc-yfcc"
 
 
 def convert_transformers_model(model, task=None, **kwargs):
@@ -995,13 +994,7 @@ class FiftyOneTransformerForObjectDetection(FiftyOneTransformer):
 class FiftyOneZeroShotTransformerForSemanticSegmentationConfig(
     FiftyOneZeroShotTransformerConfig
 ):
-    def __init__(self, d):
-        if (
-            d.get("name_or_path", None) is None
-            and d.get("model", None) is None
-        ):
-            d["name_or_path"] = DEFAULT_ZERO_SHOT_SEGMENTATION_PATH
-        super().__init__(d)
+    pass
 
 
 class FiftyOneZeroShotTransformerForSemanticSegmentation(

--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -35,6 +35,7 @@ DEFAULT_SEGMENTATION_PATH = "nvidia/segformer-b0-finetuned-ade-512-512"
 DEFAULT_DEPTH_ESTIMATION_PATH = "Intel/dpt-hybrid-midas"
 DEFAULT_ZERO_SHOT_CLASSIFICATION_PATH = "openai/clip-vit-large-patch14"
 DEFAULT_ZERO_SHOT_DETECTION_PATH = "google/owlvit-base-patch32"
+DEFAULT_ZERO_SHOT_SEGMENTATION_PATH = "nvidia/groupvit-gcc-yfcc"
 
 
 def convert_transformers_model(model, task=None, **kwargs):
@@ -991,6 +992,36 @@ class FiftyOneTransformerForObjectDetection(FiftyOneTransformer):
         self.transforms.return_image_sizes = True
 
 
+class FiftyOneZeroShotTransformerForSemanticSegmentationConfig(
+    FiftyOneZeroShotTransformerConfig
+):
+    def __init__(self, d):
+        if (
+            d.get("name_or_path", None) is None
+            and d.get("model", None) is None
+        ):
+            d["name_or_path"] = DEFAULT_ZERO_SHOT_SEGMENTATION_PATH
+        super().__init__(d)
+
+
+class FiftyOneZeroShotTransformerForSemanticSegmentation(
+    FiftyOneZeroShotTransformer
+):
+    """FiftyOne wrapper around a ``transformers`` model for zero-shot image
+    classification.
+
+    Args:
+        config: a `FiftyOneZeroShotTransformerForSemanticSegmentationConfig`
+    """
+
+    def __init__(self, config):
+        # override output processor
+        if config.output_processor_cls is None:
+            config.output_processor_cls = "fiftyone.utils.transformers.TransformersSemanticSegmentatorOutputProcessor"
+
+        super().__init__(config)
+
+
 class FiftyOneTransformerForSemanticSegmentationConfig(
     FiftyOneTransformerConfig
 ):
@@ -1255,11 +1286,14 @@ class TransformersSemanticSegmentatorOutputProcessor(
     fout.SemanticSegmenterOutputProcessor
 ):
     def __init__(self, *args, **kwargs):
+        self.logits_key = kwargs.pop("logits_key", "logits")
         super().__init__(*args, **kwargs)
 
     def __call__(self, output, image_sizes, confidence_thresh=None):
         return super().__call__(
-            {"out": output.logits},  # to be compatible with the base class
+            {
+                "out": output[self.logits_key]
+            },  # to be compatible with the base class
             image_sizes,
             confidence_thresh=confidence_thresh,
         )
@@ -1293,7 +1327,6 @@ class TransformersDepthEstimatorOutputProcessor(fout.OutputProcessor):
                 )
 
     def __call__(self, output, image_sizes, confidence_thresh=None):
-
         output = self._depth_estimation_post_processor(output)
         output = np.array(
             [o["predicted_depth"].detach().cpu().numpy() for o in output]
@@ -1321,6 +1354,7 @@ MODEL_TYPE_TO_CONFIG_CLASS = {
     "depth-estimation": FiftyOneTransformerForDepthEstimationConfig,
     "zero-shot-image-classification": FiftyOneZeroShotTransformerForImageClassificationConfig,
     "zero-shot-object-detection": FiftyOneZeroShotTransformerForObjectDetectionConfig,
+    "zero-shot-semantic-segmentation": FiftyOneZeroShotTransformerForSemanticSegmentationConfig,
 }
 
 MODEL_TYPE_TO_MODEL_CLASS = {
@@ -1331,4 +1365,5 @@ MODEL_TYPE_TO_MODEL_CLASS = {
     "depth-estimation": FiftyOneTransformerForDepthEstimation,
     "zero-shot-image-classification": FiftyOneZeroShotTransformerForImageClassification,
     "zero-shot-object-detection": FiftyOneZeroShotTransformerForObjectDetection,
+    "zero-shot-semantic-segmentation": FiftyOneZeroShotTransformerForSemanticSegmentation,
 }

--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -1290,13 +1290,18 @@ class TransformersSemanticSegmentatorOutputProcessor(
         super().__init__(*args, **kwargs)
 
     def __call__(self, output, image_sizes, confidence_thresh=None):
-        return super().__call__(
-            {
-                "out": output[self.logits_key]
-            },  # to be compatible with the base class
-            image_sizes,
-            confidence_thresh=confidence_thresh,
-        )
+        logits = output[self.logits_key].detach().cpu()
+        probs = logits.softmax(dim=1).numpy()
+        masks = probs.argmax(axis=1)
+
+        confidence = probs.max(axis=1)
+        confidence_thresh = confidence_thresh if confidence_thresh else 0
+        conf_mask = confidence > confidence_thresh
+        masks[~conf_mask] = -1
+
+        # Increment class index by 1 since 0 is reserved for background in the app.
+        masks += 1
+        return [fol.Segmentation(mask=mask) for mask in masks]
 
 
 class TransformersDepthEstimatorOutputProcessor(fout.OutputProcessor):

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -2891,7 +2891,8 @@
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneZeroShotTransformerForSemanticSegmentation",
                 "config": {
-                    "entrypoint_fcn": "transformers.GroupViTModel.from_pretrained",
+                    "name_or_path": "nvidia/groupvit-gcc-yfcc",
+                    "entrypoint_fcn": "transformers.GroupViTMod1el.from_pretrained",
                     "entrypoint_args": {
                         "pretrained_model_name_or_path": "nvidia/groupvit-gcc-yfcc",
                         "output_segmentation": true

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -2880,6 +2880,53 @@
             "date_added": "2024-01-17 14:25:51"
         },
         {
+            "base_name": "group-vit-segmentation-transformer-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Hugging Face Transformers model for zero-shot semantic segmentation",
+            "source": "https://huggingface.co/docs/transformers/en/tasks/mask_generation",
+            "author": "Thomas Wolf, et al.",
+            "license": "Apache 2.0",
+            "size_bytes": null,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneZeroShotTransformerForSemanticSegmentation",
+                "config": {
+                    "entrypoint_fcn": "transformers.GroupViTModel.from_pretrained",
+                    "entrypoint_args": {
+                        "pretrained_model_name_or_path": "nvidia/groupvit-gcc-yfcc",
+                        "output_segmentation": true
+                    },
+                    "output_processor_args": {
+                        "logits_key": "segmentation_logits"
+                    },
+                    "transforms_args": {
+                        "use_fast": false
+                    },
+                    "transformers_processor_kwargs": {
+                        "padding": true,
+                        "return_tensors": "pt"
+                    }
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": [
+                "segmentation",
+                "embeddings",
+                "torch",
+                "transformers",
+                "zero-shot"
+            ],
+            "date_added": "2025-05-15 15:20:35"
+        },
+        {
             "base_name": "owlvit-base-patch16-torch",
             "base_filename": null,
             "version": null,


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds [GroupViT](https://huggingface.co/docs/transformers/en/model_doc/groupvit) to the model zoo via `transformers` integration

## How is this patch tested? If it is not, please explain why.

```
import fiftyone as fo
import fiftyone.operators as foo
import fiftyone.zoo as foz

# Add semantic segmentation via zoo model using apply_model
model = foz.load_zoo_model("group-vit-segmentation-transformer-torch",
                           text_prompt="a photo of a",
                           classes=["cat", "dog", "other"])
dataset.apply_model(model, label_field="grpvit_seg", batch_size=8)

# Add semantic segmentation via zoo model using model.predict_all
segmenataions_out = model.predict_all(images)
for idx, sample in enumerate(dataset):
    sample.add_labels(
        segmenataions_out[idx],
        label_field="grpvit_predict_seg",
    )
    sample.save()

# Add semantic segmentation via HF model
from PIL import Image
filepaths = dataset.values('filepath')
images = [Image.open(f) for f in filepaths]

from transformers import AutoProcessor, GroupViTModel
tr_model = GroupViTModel.from_pretrained("nvidia/groupvit-gcc-yfcc", output_segmentation=True)
processor = AutoProcessor.from_pretrained("nvidia/groupvit-gcc-yfcc")

inputs = processor(
    text=["a photo of a cat", "a photo of a dog", "a photo of a other"], images=images, return_tensors="pt",
    padding=True
)
outputs = tr_model(**inputs)

probs = (outputs.segmentation_logits).detach().cpu().numpy()
masks = probs.argmax(axis=1)

import fiftyone.core.labels as fol
segmentation = [fol.Segmentation(mask=mask) for mask in masks]
for idx, sample in enumerate(dataset):
    sample.add_labels(
        segmentation[idx],
        label_field="hf_grpvit_seg",
    )
    sample.save()
```
Compared outputs of all three methods -- same

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Adds `"group-vit-segmentation-transformer-torch"` to FiftyOne model zoo

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x ] Other
