### PR TITLE
Avoid duplicate filenames when uploading to CVAT

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -4356,22 +4356,24 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         files = {}
         open_files = []
 
+        filename_maker = fou.UniqueFilenameMaker()
+
         if len(paths) == 1 and fom.get_media_type(paths[0]) == fom.VIDEO:
             # Video task
-            filename = os.path.basename(paths[0])
+            filename = filename_maker.get_output_path(paths[0])
             f = open(paths[0], "rb")
             files["client_files[0]"] = (filename, f)
             open_files.append(f)
         else:
             # Image task
             for idx, path in enumerate(paths):
-                filename = os.path.basename(path)
+                filename = filename_maker.get_output_path(path)
                 if self._server_version < Version("2.4.6"):
                     # IMPORTANT: older versions of CVAT organizes media within
                     # a task alphabetically by filename, so we must give CVAT
                     # filenames whose alphabetical order matches the order of
                     # `paths`
-                    filename = "%06d_%s" % (idx, os.path.basename(path))
+                    filename = "%06d_%s" % (idx, filename)
 
                 if self._server_version >= Version("2.3"):
                     with open(path, "rb") as f:


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/5917

## Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video")

view = dataset.limit(2).to_frames(sample_frames=True)

# now works!
results1 = view.annotate("test1", label_field="detections", launch_editor=True)

# this also works
results2 = view.annotate(
    "test2",
    label_field="detections",
    launch_editor=True,
    task_size=120,
)
```

```py
results1.cleanup()
results2.cleanup()
```
