### PR TITLE
fix ME scenario analysis for sample field subsets

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/Scenarios.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/Scenarios.tsx
@@ -1604,10 +1604,10 @@ function getLegendProps(props) {
 }
 
 const X_AXIS_TITLES = {
-  view: "Saved Views",
-  label_attribute: "Label Attributes",
-  sample_field: "Sample Fields",
-  custom_code: "Scenarios",
+  view: "Saved view",
+  label_attribute: "Attribute value",
+  sample_field: "Field value",
+  custom_code: "Subset",
 };
 
 const PLOT_TOOLTIP_TEMPLATES = {

--- a/plugins/operators/model_evaluation/__init__.py
+++ b/plugins/operators/model_evaluation/__init__.py
@@ -357,13 +357,13 @@ class ConfigureScenario(foo.Operator):
         preview_container = inputs.grid("grid", height="400px", width="100%")
         preview_height = "300px"
         scenario_type = ctx.params.get("scenario_type", None)
-        x_axis_title = "Scenarios"
+        x_axis_title = "Subset"
         if scenario_type == ScenarioType.LABEL_ATTRIBUTE:
-            x_axis_title = "Label Attributes"
+            x_axis_title = "Attribute value"
         elif scenario_type == ScenarioType.SAMPLE_FIELD:
-            x_axis_title = "Sample Fields"
+            x_axis_title = "Field value"
         elif scenario_type == ScenarioType.VIEW:
-            x_axis_title = "Saved Views"
+            x_axis_title = "Saved view"
 
         preview_container.plot(
             "plot_preview",

--- a/plugins/panels/model_evaluation/__init__.py
+++ b/plugins/panels/model_evaluation/__init__.py
@@ -980,8 +980,9 @@ class EvaluationPanel(Panel):
                 scenario_data["subsets_data"][subset] = subset_data
         elif scenario_type == "sample_field":
             scenario_subsets = scenario.get("subsets", [])
+            field_name = scenario.get("field", None)
             for subset in scenario_subsets:
-                subset_def = dict(type="field", field=subset)
+                subset_def = dict(type="field", field=field_name, value=subset)
                 subset_data = self.get_subset_def_data(
                     info, results, subset_def, is_compare
                 )


### PR DESCRIPTION
## What changes are proposed in this pull request?

fix ME scenario analysis for sample field subsets

## How is this patch tested? If it is not, please explain why.

Using model evaluation panel

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated x-axis titles in charts and visualizations to use more specific and consistent wording (e.g., "Saved view", "Attribute value", "Field value", "Subset") for improved clarity.

- **Bug Fixes**
  - Enhanced subset definitions for sample field scenarios to display both field and value, ensuring more accurate representation in scenario data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->