### PR TITLE
Update cvat.rst

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -2043,7 +2043,7 @@ attributes between annotation runs.
 Using CVAT groups
 -----------------
 
-The CVAT UI provides a way to group objects together both visually and though
+The CVAT UI provides a way to group objects together both visually and through
 a group id in the API.
 
 You can configure CVAT annotation runs so that the state of the group id is


### PR DESCRIPTION
* Remove duplicate **“the”** in the `"keep"` description for the `unexpected`
  parameter (appears twice: in *Loading annotations* and *Unexpected
  annotations* sections)

* Change **“though a group id”** → **“through a group id”** in the
  *_cvat-group-id* section


## What changes are proposed in this pull request?

This PR fixes three minor wording errors in the CVAT integration guide:

* Eliminates the duplicated word **“the”** in two instances of the `"keep"`
  bullet that explains the `unexpected` parameter
* Corrects a typo (**“though”** → **“through”**) in the opening sentence of
  the *_cvat-group-id* section

There are **no code changes**; documentation only.

## How is this patch tested? If it is not, please explain why.

* Built the docs locally with `make html`  
  * Pages render without warnings  
  * Corrected sentences display as intended  
  * No anchors or links were affected  

Unit/integration tests are not applicable for doc-only edits.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [x] Documentation: FiftyOne documentation changes
- [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typographical error in the "Using CVAT groups" section to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->