### PR TITLE
Update decorators.py

### DIFF
--- a/tests/unittests/decorators.py
+++ b/tests/unittests/decorators.py
@@ -72,7 +72,7 @@ def skip_windows(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         if platform.system() == "Windows":
-            return unittest.skip(
+            raise unittest.SkipTest(
                 "We've been instructed to skip this test on Windows..."
             )
 


### PR DESCRIPTION
skip_windows: raise SkipTest instead of returning skip

## What changes are proposed in this pull request?

Replace `return unittest.skip(...)` with `raise unittest.SkipTest(...)`
inside `skip_windows` in `fiftyone/tests/unittests/decorators.py`.

* `unittest.skip()` is only a decorator factory; returning it at run-time
  never informs the test runner that the current test should be skipped.
* Raising `unittest.SkipTest` is the canonical mechanism the runner
  listens for, so the test is now formally marked as **skipped** with the
  provided reason string.
* No other logic or platforms are affected.

## How is this patch tested? If it is not, please explain why.

The correctness of this change follows directly from the documented
behavior of the `unittest` framework: the runner always intercepts
`SkipTest` and records a skip result. Because the fix employs that exact
mechanism, additional runtime verification is unnecessary.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [x] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other