### PR TITLE
Update manifest-torch.json

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -99,7 +99,7 @@
             "source": "https://segment-anything.com",
             "author": "Alexander Kirillov, et al.",
             "license": "Apache 2.0",
-            "size_bytes": 732512,
+            "size_bytes": 375042383,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
                 "config": {
@@ -134,7 +134,7 @@
             "source": "https://segment-anything.com",
             "author": "Alexander Kirillov, et al.",
             "license": "Apache 2.0",
-            "size_bytes": 5008896,
+            "size_bytes": 2564550879,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
                 "config": {
@@ -169,7 +169,7 @@
             "source": "https://segment-anything.com",
             "author": "Alexander Kirillov, et al.",
             "license": "Apache 2.0",
-            "size_bytes": 2440480,
+            "size_bytes": 1249524607,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
                 "config": {


### PR DESCRIPTION
The size\_bytes values for the three first-generation Segment-Anything models were 512× too small.  Updated **`manifest-torch.json`** with the actual sizes after download:

* segment-anything-vitb-torch : 375,042,383 B
* segment-anything-vitl-torch : 1,249,524,607 B
* segment-anything-vith-torch : 2,564,550,879 B

---

## What changes are proposed in this pull request?

* Replace the incorrect `size_bytes` values (732 512 B, 2 440 480 B, 5 008 896 B) with the true on-disk sizes for the three original SAM ViT checkpoints listed above.
* No other manifest entries are touched.

This ensures disk-space checks, download-skipping logic, and progress bars in the model-zoo API use accurate metadata.

---

## How is this patch tested? If it is not, please explain why.

* Downloaded each checkpoint via `foz.load_zoo_model()` and recorded `Path(...).stat().st_size`; the new values match those measurements exactly.
* Re-loaded the models after patching to confirm the manifest is parsed correctly and no other functionality is affected.

---

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [ ] No. You can skip the rest of this section.
* [x] Yes. Give a description of this change to be included in the release
  notes for FiftyOne users.

> **Model Zoo:** Fixed the reported `size_bytes` metadata for the three original Segment-Anything ViT checkpoints (`vitb`, `vitl`, `vith`) so disk-space checks and download progress indicators are accurate.

### What areas of FiftyOne does this PR affect?

* [ ] App: FiftyOne application changes
* [ ] Build: Build and test infrastructure changes
* [x] Core: Core `fiftyone` Python library changes (model-zoo manifest)
* [ ] Documentation: FiftyOne documentation changes
* [ ] Other