### PR TITLE
Update manifest-tf.json

### DIFF
--- a/fiftyone/zoo/models/manifest-tf.json
+++ b/fiftyone/zoo/models/manifest-tf.json
@@ -2067,7 +2067,7 @@
             "base_name": "ssd-mobilenet-v1-fpn-640-coco17",
             "base_filename": "ssd_mobilenet_v1_fpn_640x640_coco17_tpu-8.tar.gz",
             "version": null,
-            "description": "MobileNetV1 model from `MobileNetV2: Inverted Residuals and Linear Bottlenecks <https://arxiv.org/pdf/1801.04381.pdf>`_ resized to 640x640",
+            "description": "FPN Single Shot Detector model from `SSD: Single Shot MultiBox Detector <https://arxiv.org/abs/1512.02325>`_ with MobileNetV1 backbone trained on COCO resized to 640x640",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
             "author": "Mark Sandler, et al.",
             "license": "Apache 2.0",


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR updates the `description` field for the `ssd-mobilenet-v1-fpn-640-coco17` entry in the model registry JSON. It replaces the incorrect MobileNetV2 citation with the proper reference to **“SSD: Single Shot MultiBox Detector”** and clarifies that this is an FPN‐based SSD with a MobileNetV1 backbone trained on COCO at 640×640 resolution.

## How is this patch tested? If it is not, please explain why.

Not applicable—this is a documentation-only change in the model registry JSON. It does not affect any code paths or functionality, so no tests are required.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [x] No. You can skip the rest of this section.

### What areas of FiftyOne does this PR affect?

* [x] Documentation: model registry descriptions