### PR TITLE
Update default num workers for torch

### DIFF
--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -1634,13 +1634,6 @@ def recommend_num_workers():
         # https://stackoverflow.com/q/20222534
         return 0
 
-    if sys.platform == "darwin" and not torch.cuda.is_available():
-        # There is a parallelism bug on macOS with CPU that prevents us from
-        # using `num_workers > 0`
-        # https://stackoverflow.com/q/64772335
-        # https://github.com/pytorch/pytorch/issues/46409
-        return 0
-
     try:
         return multiprocessing.cpu_count() // 2
     except:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Removed num workers being set to 0 on Mac.

## How is this patch tested? If it is not, please explain why.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved worker recommendation logic on macOS by removing the restriction that set the number of workers to zero, allowing better parallelism on macOS systems without CUDA.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->