### PR TITLE
[BUG] Fix values unwind with []

### DIFF
--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -2889,7 +2889,7 @@ class Values(Aggregation):
             fcn = self._field.to_python
             level = 1 + self._num_list_fields
 
-            values = _transform_values(values, fcn, level=level)
+            return _transform_values(values, fcn, level=level)
 
         return values
 

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -2875,17 +2875,6 @@ class Values(Aggregation):
             return values
 
         if self._field is not None:
-            # Edge case: since values() doesn't automatically unwind list
-            # fields, but supports the [] syntax, we need to parse the inner
-            # field type if the field name ends with [] and the field is a
-            # ListField
-            if (
-                self.field_name.endswith("[]")
-                and isinstance(self._field, fof.ListField)
-                and not self._unwind
-            ):
-                self._field = self._field.field
-
             fcn = self._field.to_python
             level = 1 + self._num_list_fields
 
@@ -3305,6 +3294,9 @@ def _remove_prefix(expr, prefix):
 
 
 def _get_field_type(sample_collection, field_name, unwind=True):
+    if field_name.endswith("[]"):
+        unwind = True
+
     # Remove array references
     field_name = "".join(field_name.split("[]"))
 

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -2957,8 +2957,6 @@ _MONGO_TO_FIFTYONE_TYPES = {
 
 
 def _transform_values(values, fcn, level=1):
-    print("_transform_values", values)
-    print("_transform_values level", level)
     if values is None:
         return None
 

--- a/tests/unittests/aggregation_tests.py
+++ b/tests/unittests/aggregation_tests.py
@@ -621,6 +621,11 @@ class DatasetTests(unittest.TestCase):
         )
 
         self.assertListEqual(
+            d.values("predictions.detections[]"),
+            d.values("predictions.detections", unwind=True),
+        )
+
+        self.assertListEqual(
             d.values("predictions.detections.label", missing_value="missing"),
             [
                 ["cat", "dog"],
@@ -679,36 +684,40 @@ class DatasetTests(unittest.TestCase):
 
     @drop_datasets
     def test_values_unwind(self):
+        frames_classifications = [
+            [fo.Classification(label="cat")],
+            [fo.Classification(label="dog")],
+            [fo.Classification(label="cat"), fo.Classification(label="dog")],
+            [fo.Classification(label="rabbit")],
+            [fo.Classification(label="squirrel")],
+        ]
         sample1 = fo.Sample(filepath="video1.mp4")
         sample1.frames[1] = fo.Frame(
             ground_truth=fo.Classifications(
-                classifications=[fo.Classification(label="cat")]
+                classifications=frames_classifications[0]
             )
         )
         sample1.frames[2] = fo.Frame()
         sample1.frames[3] = fo.Frame(
             ground_truth=fo.Classifications(
-                classifications=[fo.Classification(label="dog")]
+                classifications=frames_classifications[1]
             )
         )
 
         sample2 = fo.Sample(filepath="video2.mp4")
         sample2.frames[1] = fo.Frame(
             ground_truth=fo.Classifications(
-                classifications=[
-                    fo.Classification(label="cat"),
-                    fo.Classification(label="dog"),
-                ]
+                classifications=frames_classifications[2]
             )
         )
         sample2.frames[2] = fo.Frame(
             ground_truth=fo.Classifications(
-                classifications=[fo.Classification(label="rabbit")]
+                classifications=frames_classifications[3]
             )
         )
         sample2.frames[3] = fo.Frame(
             ground_truth=fo.Classifications(
-                classifications=[fo.Classification(label="squirrel")]
+                classifications=frames_classifications[4]
             )
         )
 
@@ -743,6 +752,25 @@ class DatasetTests(unittest.TestCase):
         expected = ["cat", "dog", "cat", "dog", "rabbit", "squirrel"]
         self.assertListEqual(values1, expected)
         self.assertListEqual(values2, expected)
+
+        # [num_samples x num_frames]
+        values = dataset.values("frames.ground_truth.classifications[]")
+        frames_classifications_by_sample = [
+            frames_classifications[0] + frames_classifications[1],
+            frames_classifications[2]
+            + frames_classifications[3]
+            + frames_classifications[4],
+        ]
+        for i in range(len(values)):
+            self.assertListEqual(
+                values[i], frames_classifications_by_sample[i]
+            )
+
+        values1 = dataset.values("frames[].ground_truth.classifications[]")
+        values2 = dataset.values(
+            "frames.ground_truth.classifications", unwind=True
+        )
+        self.assertListEqual(values1, values2)
 
     @drop_datasets
     def test_nan_inf(self):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Error when trying to call values with `[]` on the last field:

```
import fiftyone as fo
ds=fo.load_dataset('quickstart')
vals=ds.values('ground_truth.detections[]')

---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[1], line 3
      1 import fiftyone as fo
      2 ds=fo.load_dataset('quickstart')
----> 3 vals=ds.values('ground_truth.detections[]')

File ~/Dev/voxel51/fiftyone/fiftyone/core/collections.py:10751, in SampleCollection._parse_big_result(self, aggregation, result)
  10749 def _parse_big_result(self, aggregation, result):
  10750     if result:
> 10751         return aggregation.parse_result(result)
  10753     return aggregation.default_result()

File ~/Dev/voxel51/fiftyone/fiftyone/core/aggregations.py:2881, in Values.parse_result(self, d)
   2878     fcn = self._field.to_python
   2879     level = 1 + self._num_list_fields
-> 2881     return _transform_values(values, fcn, level=level)
   2883 return values

AttributeError: 'ObjectId' object has no attribute 'items'


```


## How is this patch tested? If it is not, please explain why.

- added automated tests
- verified running locally that snippet above does not give an error.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of list fields in value aggregations to ensure correct type conversion when using explicit "[]" notation without unwinding.

- **Tests**
  - Enhanced and expanded tests to verify consistent behavior between explicit list notation and the unwind parameter in value aggregations, especially for nested list fields in video frame data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->