### PR TITLE
fix(secrets.py): resolve attribute collisions

### DIFF
--- a/fiftyone/plugins/secrets.py
+++ b/fiftyone/plugins/secrets.py
@@ -23,7 +23,7 @@ class PluginSecretsResolver:
     def __new__(cls):
         if cls._instance is None:
             cls._instance = super(PluginSecretsResolver, cls).__new__(cls)
-            cls._instance.client = _get_secrets_client()
+            cls._instance._client = _get_secrets_client()
         return cls._instance
 
     def register_operator(
@@ -31,10 +31,9 @@ class PluginSecretsResolver:
     ) -> None:
         self._registered_secrets[operator_uri] = required_secrets
 
+    @property
     def client(self) -> fois.ISecretProvider:
-        if not self._instance:
-            self._instance = self.__new__(self.__class__)
-        return self._instance.client
+        return self._client
 
     async def get_secret(
         self, key: str, operator_uri: str, **kwargs
@@ -198,7 +197,7 @@ class SecretsDictionary:
 
         return {k: None for k in self.__secrets.keys()}
 
-    def __dict__(self):
+    def to_dict(self):
         return {k: True for k, v in self.__secrets.items() if v is not None}
 
     def copy(self):


### PR DESCRIPTION
* **PluginSecretsResolver:** rename backing field `client` → `_client`; expose via read-only `@property client` to eliminate name clash  
* **SecretsDictionary:** rename custom `__dict__()` → `to_dict()` to restore normal reflection  

Call-site updates: use `resolver.client` (not `resolver.client()`) and `secrets.to_dict()`.

---

## What changes are proposed in this pull request?

This PR removes two silent attribute collisions that could lead to runtime errors and broken introspection:

* **PluginSecretsResolver**
  * Stores the secrets client in `_client` instead of `client`.
  * Provides a property `client` that returns `_client`, ensuring `resolver.client` is always an `ISecretProvider` and never a method.

* **SecretsDictionary**
  * Replaces a custom `__dict__()` method with `to_dict()`, restoring Python’s built-in `obj.__dict__` so debuggers, serializers, and `vars()` work normally.

No functional behaviour changes beyond these naming fixes.

---

## How is this patch tested? If it is not, please explain why.

No new automated tests were added. The change is purely structural: it removes name collisions without altering logic paths. Correctness was verified by code inspection (attribute resolution order) and by confirming existing unit tests continue to pass locally.

---

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.  
- [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

**Release-note blurb:**  
Fixed internal attribute collisions in plugin secret handling. `PluginSecretsResolver.client` is now a property (access without parentheses), and `SecretsDictionary` exposes `to_dict()` instead of overriding `__dict__()`.

### What areas of FiftyOne does this PR affect?

- [ ] App
- [ ] Build
- [x] Core
- [ ] Documentation
- [ ] Other