### PR TITLE
Add Group Delegated Operation fields

### DIFF
--- a/fiftyone/factory/repos/delegated_operation_doc.py
+++ b/fiftyone/factory/repos/delegated_operation_doc.py
@@ -60,6 +60,10 @@ class DelegatedOperationDocument(object):
         self.log_size = None
         self.log_path = None
 
+        # grouped fields
+        self.num_partitions = None  # Only on parent
+        self.group_id = None  # Only on children
+
     def from_pymongo(self, doc: dict):
         # required fields
         self.operator = doc.get("operator")
@@ -81,6 +85,10 @@ class DelegatedOperationDocument(object):
         self.metadata = doc.get("metadata", None)
         self.label = doc.get("label", None)
         self.updated_at = doc.get("updated_at", None)
+
+        # grouped fields
+        self.num_partitions = doc.get("num_partitions", None)
+        self.group_id = doc.get("group_id", None)
 
         # internal fields
         self.id = doc["_id"]

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -41,6 +41,7 @@ class ExecutionRunState(object):
     SCHEDULED = "scheduled"
     QUEUED = "queued"
     RUNNING = "running"
+    WAITING = "waiting"
     COMPLETED = "completed"
     FAILED = "failed"
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Added fields (to data model) and constants to support splitting DOs. See [FOEPD-1276](https://voxel51.atlassian.net/browse/FOEPD-1276) for more information.

## How is this patch tested? If it is not, please explain why.

`n/a` just adding fields

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


[FOEPD-1276]: https://voxel51.atlassian.net/browse/FOEPD-1276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new attributes to support partitioning and grouping in delegated operations.
  - Introduced a new "WAITING" run state for operator executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->