### PR TITLE
labels-correspondence app follow-up work

### DIFF
--- a/app/packages/core/src/components/Modal/TooltipInfo.tsx
+++ b/app/packages/core/src/components/Modal/TooltipInfo.tsx
@@ -551,7 +551,7 @@ const CtrlToLock = () => {
       {shouldShowSimilar && (
         <ShortcutRow>
           <ShortcutAction variant="caption" color="gray" fontSize={"0.5rem"}>
-            Select similar
+            Select all
           </ShortcutAction>
           <ShortcutKey>
             <KeyboardKey>Shift</KeyboardKey>

--- a/app/packages/looker-3d/src/state.ts
+++ b/app/packages/looker-3d/src/state.ts
@@ -17,7 +17,7 @@ const fo3dAssetsParseStatusLog = atomFamily<AssetLoadingLog[], string>({
 export const fo3dAssetsParseStatusThisSample = selector<AssetLoadingLog[]>({
   key: "fo3d-assetsParseStatusLogs",
   get: ({ get }) => {
-    const thisModalUniqueId = `${get(groupId) ?? ""}/${get(
+    const thisModalUniqueId = `${get(groupId) ?? ""}-${get(
       nullableModalSampleId
     )}`;
     return get(fo3dAssetsParseStatusLog(`${thisModalUniqueId}`));
@@ -25,7 +25,7 @@ export const fo3dAssetsParseStatusThisSample = selector<AssetLoadingLog[]>({
   set: ({ get, set }, newValue) => {
     set(
       fo3dAssetsParseStatusLog(
-        `${get(groupId) ?? ""}/${get(nullableModalSampleId)}`
+        `${get(groupId) ?? ""}-${get(nullableModalSampleId)}`
       ),
       newValue
     );

--- a/app/packages/looker-3d/src/state.ts
+++ b/app/packages/looker-3d/src/state.ts
@@ -1,9 +1,8 @@
 import type { Range } from "@fiftyone/core/src/components/Common/RangeSlider";
 import {
-  currentModalUniqueId,
   getBrowserStorageEffectForKey,
   groupId,
-  modalSampleId,
+  nullableModalSampleId,
 } from "@fiftyone/state";
 import { atom, atomFamily, selector } from "recoil";
 import { SHADE_BY_HEIGHT } from "./constants";
@@ -18,15 +17,18 @@ const fo3dAssetsParseStatusLog = atomFamily<AssetLoadingLog[], string>({
 export const fo3dAssetsParseStatusThisSample = selector<AssetLoadingLog[]>({
   key: "fo3d-assetsParseStatusLogs",
   get: ({ get }) => {
-    const thisModalUniqueId = get(currentModalUniqueId);
-
+    const thisModalUniqueId = `${get(groupId) ?? ""}/${get(
+      nullableModalSampleId
+    )}`;
     return get(fo3dAssetsParseStatusLog(`${thisModalUniqueId}`));
   },
   set: ({ get, set }, newValue) => {
-    const thisSampleId = get(modalSampleId);
-    const thisGroupId = get(groupId) ?? "";
-
-    set(fo3dAssetsParseStatusLog(`${thisGroupId}/${thisSampleId}`), newValue);
+    set(
+      fo3dAssetsParseStatusLog(
+        `${get(groupId) ?? ""}/${get(nullableModalSampleId)}`
+      ),
+      newValue
+    );
   },
 });
 

--- a/app/packages/looker/src/elements/common/util.ts
+++ b/app/packages/looker/src/elements/common/util.ts
@@ -18,7 +18,7 @@ import {
   DispatchEvent,
 } from "../../state";
 
-import { getHashLabel } from "../../overlays/util";
+import { getHashLabelColorByInstance } from "../../overlays/util";
 import {
   LabelHoveredEvent,
   LabelUnhoveredEvent,
@@ -296,7 +296,7 @@ export function getAssignedColor({
         ? (param as string)
         : isPrimitive
         ? value
-        : getHashLabel(param as RegularLabel)
+        : getHashLabelColorByInstance(param as RegularLabel)
     );
   }
 

--- a/app/packages/looker/src/overlays/detection.ts
+++ b/app/packages/looker/src/overlays/detection.ts
@@ -232,7 +232,11 @@ export default class DetectionOverlay<
     let text =
       this.label.label && state.options.showLabel ? `${this.label.label}` : "";
 
-    const hasIndex = !isNaN(this.label.index);
+    const hasIndex =
+      (typeof this.label.index === "string" ||
+        typeof this.label.index === "number") &&
+      !isNaN(this.label.index);
+
     const hasInstanceId = Boolean(this.label.instance?._id);
 
     if (state.options.showIndex && (hasIndex || hasInstanceId)) {

--- a/app/packages/looker/src/overlays/detection.ts
+++ b/app/packages/looker/src/overlays/detection.ts
@@ -49,9 +49,9 @@ const getIndexIdFromInstanceIdForLabel = (
     return cache[key].instanceIdToIndexId[instanceId];
   } else {
     cache[key] = {
-      latestIndex: 0,
+      latestIndex: 1,
       instanceIdToIndexId: {
-        [instanceId]: 0,
+        [instanceId]: 1,
       },
     };
   }

--- a/app/packages/looker/src/overlays/detection.ts
+++ b/app/packages/looker/src/overlays/detection.ts
@@ -3,8 +3,12 @@
  */
 import { NONFINITES } from "@fiftyone/utilities";
 
-import { isHoveringParticularLabelWithInstanceConfig } from "@fiftyone/state/src/jotai";
-import { INFO_COLOR, SELECTED_AND_HOVERED_COLOR } from "../constants";
+import {
+  currentModalUniqueIdJotaiAtom,
+  isHoveringParticularLabelWithInstanceConfig,
+  jotaiStore,
+} from "@fiftyone/state/src/jotai";
+import { INFO_COLOR } from "../constants";
 import { BaseState, BoundingBox, Coordinates, NONFINITE } from "../state";
 import { distanceFromLineSegment } from "../util";
 import { RENDER_STATUS_PAINTED, RENDER_STATUS_PENDING } from "../worker/shared";
@@ -15,8 +19,45 @@ import {
   PointInfo,
   RegularLabel,
 } from "./base";
-import { t } from "./util";
-import { getInstanceStrokeStyles } from "./util";
+import { getInstanceStrokeStyles, t } from "./util";
+
+let cache = {};
+let lastModalUniqueId = "";
+
+const getIndexIdFromInstanceIdForLabel = (
+  instanceId: string,
+  label: DetectionLabel
+) => {
+  const currentModalUniqueId = jotaiStore.get(currentModalUniqueIdJotaiAtom);
+
+  if (currentModalUniqueId !== lastModalUniqueId) {
+    lastModalUniqueId = currentModalUniqueId;
+    cache = {};
+  }
+
+  const key = `${currentModalUniqueId}-${label.label.toLocaleLowerCase()}`;
+
+  if (
+    cache[key] &&
+    cache[key].instanceIdToIndexId &&
+    typeof cache[key].instanceIdToIndexId[instanceId] === "number"
+  ) {
+    return cache[key].instanceIdToIndexId[instanceId];
+  } else if (cache[key] && cache[key].instanceIdToIndexId) {
+    cache[key].instanceIdToIndexId[instanceId] = cache[key].latestIndex + 1;
+    cache[key].latestIndex += 1;
+    return cache[key].instanceIdToIndexId[instanceId];
+  } else {
+    cache[key] = {
+      latestIndex: 0,
+      instanceIdToIndexId: {
+        [instanceId]: 0,
+      },
+    };
+  }
+
+  return cache[key].instanceIdToIndexId[instanceId];
+};
 
 export interface DetectionLabel extends RegularLabel {
   mask?: LabelMask;
@@ -191,9 +232,23 @@ export default class DetectionOverlay<
     let text =
       this.label.label && state.options.showLabel ? `${this.label.label}` : "";
 
-    if (state.options.showIndex && !isNaN(this.label.index)) {
-      text.length && (text += " ");
-      text += `${Number(this.label.index).toLocaleString()}`;
+    const hasIndex = this.label.index && !isNaN(this.label.index);
+    const hasInstanceId = Boolean(this.label.instance?._id);
+
+    if (state.options.showIndex && (hasIndex || hasInstanceId)) {
+      if (text.length > 0) {
+        text += " ";
+      }
+
+      // index takes precedence over instance id
+      if (hasIndex) {
+        text += `${Number(this.label.index).toLocaleString()}`;
+      } else {
+        text += `${getIndexIdFromInstanceIdForLabel(
+          this.label.instance._id,
+          this.label
+        )}`;
+      }
     }
 
     if (

--- a/app/packages/looker/src/overlays/detection.ts
+++ b/app/packages/looker/src/overlays/detection.ts
@@ -232,7 +232,7 @@ export default class DetectionOverlay<
     let text =
       this.label.label && state.options.showLabel ? `${this.label.label}` : "";
 
-    const hasIndex = this.label.index && !isNaN(this.label.index);
+    const hasIndex = !isNaN(this.label.index);
     const hasInstanceId = Boolean(this.label.instance?._id);
 
     if (state.options.showIndex && (hasIndex || hasInstanceId)) {

--- a/app/packages/looker/src/overlays/detection.ts
+++ b/app/packages/looker/src/overlays/detection.ts
@@ -21,7 +21,13 @@ import {
 } from "./base";
 import { getInstanceStrokeStyles, t } from "./util";
 
-let cache = {};
+let cache: Record<
+  string,
+  {
+    latestIndex: number;
+    instanceIdToIndexId: Record<string, number>;
+  }
+> = {};
 let lastModalUniqueId = "";
 
 const getIndexIdFromInstanceIdForLabel = (

--- a/app/packages/looker/src/overlays/index.test.ts
+++ b/app/packages/looker/src/overlays/index.test.ts
@@ -46,8 +46,8 @@ describe("label overlay processing", () => {
       label: "only-label-no-index-no-id",
     } as RegularLabel);
 
-    expect(hashLabelWithIndex0).toEqual("zero-index-label.0");
-    expect(hashLabelWithIndex1).toEqual("one-index-label.1");
+    expect(hashLabelWithIndex0).toEqual("zero-index-label-0-");
+    expect(hashLabelWithIndex1).toEqual("one-index-label-1-");
     expect(hashLabelWithUndefinedIndex).toEqual("label-no-index.id-no-index");
     expect(hashLabelWithUndefinedIndexUndefinedId).toEqual(
       "only-label-no-index-no-id"

--- a/app/packages/looker/src/overlays/index.test.ts
+++ b/app/packages/looker/src/overlays/index.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { RegularLabel } from "./base";
 import DetectionOverlay from "./detection";
 import * as index from "./index";
-import { getHashLabel } from "./util";
+import { getHashLabelColorByInstance } from "./util";
 
 describe("label overlay processing", () => {
   it("omits undefined labels", () => {
@@ -25,24 +25,24 @@ describe("label overlay processing", () => {
   });
 
   it("label hash is generated correctly", () => {
-    const hashLabelWithIndex0 = getHashLabel({
+    const hashLabelWithIndex0 = getHashLabelColorByInstance({
       id: "id-0",
       label: "zero-index-label",
       index: 0,
     } as RegularLabel);
 
-    const hashLabelWithIndex1 = getHashLabel({
+    const hashLabelWithIndex1 = getHashLabelColorByInstance({
       id: "id-1",
       label: "one-index-label",
       index: 1,
     } as RegularLabel);
 
-    const hashLabelWithUndefinedIndex = getHashLabel({
+    const hashLabelWithUndefinedIndex = getHashLabelColorByInstance({
       id: "id-no-index",
       label: "label-no-index",
     } as RegularLabel);
 
-    const hashLabelWithUndefinedIndexUndefinedId = getHashLabel({
+    const hashLabelWithUndefinedIndexUndefinedId = getHashLabelColorByInstance({
       label: "only-label-no-index-no-id",
     } as RegularLabel);
 

--- a/app/packages/looker/src/overlays/util.ts
+++ b/app/packages/looker/src/overlays/util.ts
@@ -100,7 +100,7 @@ export const convertId = (obj: Record<string, any>): Record<string, any> => {
   );
 };
 
-export const getHashLabel = (label: RegularLabel): string => {
+export const getHashLabelColorByInstance = (label: RegularLabel): string => {
   const hasIndex =
     (typeof label.index === "string" || typeof label.index === "number") &&
     !isNaN(label.index);
@@ -153,7 +153,11 @@ export const getLabelColor = ({
   const field = customizeColorSetting.find((s) => s.path === path);
 
   if (coloring.by === COLOR_BY.INSTANCE) {
-    return getColor(coloring.pool, coloring.seed, getHashLabel(label));
+    return getColor(
+      coloring.pool,
+      coloring.seed,
+      getHashLabelColorByInstance(label)
+    );
   }
 
   if (coloring.by === COLOR_BY.FIELD) {

--- a/app/packages/looker/src/overlays/util.ts
+++ b/app/packages/looker/src/overlays/util.ts
@@ -101,7 +101,11 @@ export const convertId = (obj: Record<string, any>): Record<string, any> => {
 };
 
 export const getHashLabel = (label: RegularLabel): string => {
-  if (!isNaN(label.index)) {
+  const hasIndex =
+    (typeof label.index === "string" || typeof label.index === "number") &&
+    !isNaN(label.index);
+
+  if (hasIndex) {
     return `${label.label}-${label.index}-${label.instance?._id ?? ""}`;
   }
 

--- a/app/packages/looker/src/overlays/util.ts
+++ b/app/packages/looker/src/overlays/util.ts
@@ -101,9 +101,14 @@ export const convertId = (obj: Record<string, any>): Record<string, any> => {
 };
 
 export const getHashLabel = (label: RegularLabel): string => {
-  if (["number", "string"].includes(typeof label?.index)) {
-    return `${label.label}.${label.index}`;
+  if (typeof label?.index !== "undefined") {
+    return `${label.label}-${label.index}-${label.instance?._id ?? ""}`;
   }
+
+  if (typeof label?.instance?._id !== "undefined") {
+    return `${label.label}-${label.instance?._id}`;
+  }
+
   if (typeof label?.label !== "undefined" && typeof label?.id !== "undefined") {
     return `${label.label}.${label.id}`;
   }

--- a/app/packages/looker/src/overlays/util.ts
+++ b/app/packages/looker/src/overlays/util.ts
@@ -101,7 +101,7 @@ export const convertId = (obj: Record<string, any>): Record<string, any> => {
 };
 
 export const getHashLabel = (label: RegularLabel): string => {
-  if (label?.index && !isNaN(label.index)) {
+  if (!isNaN(label.index)) {
     return `${label.label}-${label.index}-${label.instance?._id ?? ""}`;
   }
 

--- a/app/packages/looker/src/overlays/util.ts
+++ b/app/packages/looker/src/overlays/util.ts
@@ -101,11 +101,11 @@ export const convertId = (obj: Record<string, any>): Record<string, any> => {
 };
 
 export const getHashLabel = (label: RegularLabel): string => {
-  if (typeof label?.index !== "undefined") {
+  if (label?.index && !isNaN(label.index)) {
     return `${label.label}-${label.index}-${label.instance?._id ?? ""}`;
   }
 
-  if (typeof label?.instance?._id !== "undefined") {
+  if (label?.instance?._id) {
     return `${label.label}-${label.instance?._id}`;
   }
 

--- a/app/packages/looker/src/worker/painter.ts
+++ b/app/packages/looker/src/worker/painter.ts
@@ -2,7 +2,7 @@ import { COLOR_BY, get32BitColor, rgbToHexCached } from "@fiftyone/utilities";
 import colorString from "color-string";
 import { ARRAY_TYPES, OverlayMask, TypedArray } from "../numpy";
 import {
-  getHashLabel,
+  getHashLabelColorByInstance,
   isRgbMaskTargets,
   shouldShowLabelTag,
 } from "../overlays/util";
@@ -40,7 +40,7 @@ export const PainterFactory = (requestColor) => ({
       color = await requestColor(
         coloring.pool,
         coloring.seed,
-        getHashLabel(label)
+        getHashLabelColorByInstance(label)
       );
     }
     if (coloring.by === COLOR_BY.FIELD) {

--- a/app/packages/state/src/jotai/index.ts
+++ b/app/packages/state/src/jotai/index.ts
@@ -88,4 +88,10 @@ export const removeAllHoveredInstances = atom(null, (_get, set) => {
   set(hoveredInstances, false);
 });
 
+/**
+ * Current modal unique id.
+ * It's a concatenation of the group id and the sample id.
+ */
+export const currentModalUniqueIdJotaiAtom = atom<string>("");
+
 export * from "./jotai-store";

--- a/app/packages/state/src/recoil/modal.ts
+++ b/app/packages/state/src/recoil/modal.ts
@@ -76,20 +76,6 @@ export const currentSampleId = selector({
   },
 });
 
-export const currentModalUniqueId = selector({
-  key: "currentModalId",
-  get: ({ get }) => {
-    const currentSampleIdVal = get(nullableModalSampleId);
-    const currentGroupIdVal = get(groupId);
-
-    if (!currentSampleIdVal && !currentGroupIdVal) {
-      return null;
-    }
-
-    return `${currentGroupIdVal ?? ""}/${currentSampleIdVal}`;
-  },
-});
-
 export type ModalSampleData = Exclude<
   Exclude<
     ResponseFrom<mainSampleQuery>["sample"],

--- a/e2e-pw/src/oss/fixtures/index.ts
+++ b/e2e-pw/src/oss/fixtures/index.ts
@@ -28,7 +28,12 @@ const customFixtures = base.extend<object, CustomFixturesWithoutPage>({
         return;
       }
 
-      await use(3050 + workerInfo.workerIndex + workerInfo.parallelIndex);
+      // random number [0, 99] to avoid port collisions (rare edge case)
+      const rand = Math.floor(Math.random() * 100);
+
+      await use(
+        3050 + workerInfo.workerIndex + workerInfo.parallelIndex + rand
+      );
     },
     { scope: "worker" },
   ],


### PR DESCRIPTION
## What changes are proposed in this pull request?

Compliments @brimoor's https://github.com/voxel51/fiftyone/pull/5918

### Changelog

- Instance IDs now render distinct overlay indices if `.index` is missing
- Update tooltip from “Select similar” to “Select all”
- Stable "Color by instance" mode (was flickering previously because of missing index and no support for `instance._id`

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved modal management with a unique identifier for enhanced cross-state synchronization.
- **Enhancements**
  - Detection overlays now display more precise label indices, including support for instance-based indexing.
  - Tooltip shortcut text updated from "Select similar" to "Select all" for improved clarity.
  - Label hash generation now includes instance IDs for greater uniqueness.
  - Reduced port collision risk in end-to-end testing by adding random offset to server port assignment.
- **Refactor**
  - Internal state handling streamlined for modal and overlay components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->