### PR TITLE
Bugfix for confidence threshold = 0 for ultralytics

### DIFF
--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -597,7 +597,7 @@ class FiftyOneYOLOModel(fout.TorchImageModel):
         if self._using_half_precision:
             images = images.half()
 
-        if self.config.confidence_thresh:
+        if self.config.confidence_thresh is not None:
             self._model.predictor.args.conf = self.config.confidence_thresh
 
         output = self._forward_pass(images)


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR enables setting confidence threshold to 0 for YOLO models which was previously broken.

## How is this patch tested? If it is not, please explain why.

```
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("coco-2017", split="validation")
categories = dataset.distinct("ground_truth.detections.label")

model_name = "yolov8m-world-torch"
model = foz.load_zoo_model(
    model_name,
    classes=categories,
)

print(dataset.count("test_yolow_0.detections")) # 1500000
print(len(dataset.filter_labels("test_yolow_0", F("confidence") < 0.25))) # 5000

```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
