### PR TITLE
feat(ctx): active_fields

### DIFF
--- a/app/packages/operators/src/CustomPanel.tsx
+++ b/app/packages/operators/src/CustomPanel.tsx
@@ -142,6 +142,7 @@ export function defineCustomPanel({
   on_change_group_slice,
   on_change_query_performance,
   on_change_spaces,
+  on_change_active_fields,
   panel_name,
   panel_label,
 }) {
@@ -163,6 +164,7 @@ export function defineCustomPanel({
         onChangeGroupSlice={on_change_group_slice}
         onChangeQueryPerformance={on_change_query_performance}
         onChangeSpaces={on_change_spaces}
+        onChangeActiveFields={on_change_active_fields}
         dimensions={dimensions}
         panelName={panel_name}
         panelLabel={panel_label}

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -37,6 +37,7 @@ import {
 } from "./operators";
 import { useShowOperatorIO } from "./state";
 import usePanelEvent from "./usePanelEvent";
+import { Clear } from "@mui/icons-material";
 
 //
 // BUILT-IN OPERATORS
@@ -1179,6 +1180,32 @@ export class SetActiveFields extends Operator {
   }
 }
 
+export class ClearActiveFields extends Operator {
+  get config(): OperatorConfig {
+    return new OperatorConfig({
+      name: "clear_active_fields",
+      label: "Clear active fields",
+    });
+  }
+  useHooks(): {
+    setActiveFields: (fields: string[]) => void;
+  } {
+    return {
+      clearActiveFields: useRecoilCallback(({ snapshot, set }) => async () => {
+        const modal = !!(await snapshot.getPromise(fos.modal));
+        set(fos.activeFields({ modal }), []);
+      }),
+    };
+  }
+  async resolveInput(): Promise<types.Property> {
+    const inputs = new types.Object();
+    return new types.Property(inputs);
+  }
+  async execute(ctx: ExecutionContext): Promise<void> {
+    ctx.hooks.clearActiveFields();
+  }
+}
+
 export class TrackEvent extends Operator {
   get config(): OperatorConfig {
     return new OperatorConfig({
@@ -1531,6 +1558,7 @@ export function registerBuiltInOperators() {
     _registerBuiltInOperator(ShowSidebar);
     _registerBuiltInOperator(HideSidebar);
     _registerBuiltInOperator(ToggleSidebar);
+    _registerBuiltInOperator(ClearActiveFields);
   } catch (e) {
     console.error("Error registering built-in operators");
     console.error(e);

--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -98,6 +98,7 @@ export type RawContext = {
   spaces: SpaceNodeJSON;
   workspaceName: string;
   promptId: string | null;
+  activeFields: string[];
 };
 
 export class ExecutionContext {
@@ -154,6 +155,9 @@ export class ExecutionContext {
   }
   public get promptId(): string | null {
     return this._currentContext.promptId;
+  }
+  public get activeFields(): string[] {
+    return this._currentContext.activeFields;
   }
   getCurrentPanelId(): string | null {
     return this.params.panel_id || this.currentPanel?.id || null;
@@ -570,6 +574,7 @@ async function executeOperatorAsGenerator(
       spaces: currentContext.spaces,
       workspace_name: currentContext.workspaceName,
       prompt_id: ctx.promptId,
+      active_fields: ctx.activeFields,
     },
     "json-stream"
   );
@@ -737,6 +742,7 @@ export async function executeOperatorWithContext(
           spaces: currentContext.spaces,
           workspace_name: currentContext.workspaceName,
           prompt_id: ctx.promptId,
+          active_fields: ctx.activeFields,
         }
       );
       result = serverResult.result;
@@ -808,6 +814,7 @@ type CurrentContext = {
   };
   state: any;
   delegationTarget?: string;
+  activeFields: string[];
 };
 
 export async function resolveRemoteType(
@@ -844,6 +851,7 @@ export async function resolveRemoteType(
       spaces: currentContext.spaces,
       workspace_name: currentContext.workspaceName,
       prompt_id: ctx.promptId,
+      active_fields: ctx.activeFields,
     }
   );
 
@@ -921,6 +929,7 @@ export async function resolveExecutionOptions(
       query_performance: currentContext.queryPerformance,
       spaces: currentContext.spaces,
       workspace_name: currentContext.workspaceName,
+      active_fields: ctx.activeFields,
     }
   );
 
@@ -955,6 +964,7 @@ export async function fetchRemotePlacements(ctx: ExecutionContext) {
       query_performance: currentContext.queryPerformance,
       spaces: currentContext.spaces,
       workspace_name: currentContext.workspaceName,
+      active_fields: ctx.activeFields,
     }
   );
   if (result && result.error) {

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -94,6 +94,7 @@ export const usePromptOperatorInput = () => {
 const globalContextSelector = selector({
   key: "globalContext",
   get: ({ get }) => {
+    const modal = !!get(fos.modal);
     const datasetName = get(fos.datasetName);
     const view = get(fos.view);
     const extended = get(fos.extendedStages);
@@ -106,6 +107,7 @@ const globalContextSelector = selector({
     const queryPerformance = get(fos.queryPerformance);
     const spaces = get(fos.sessionSpaces);
     const workspaceName = spaces?._name;
+    const activeFields = get(fos.activeFields({ modal }));
 
     return {
       datasetName,
@@ -120,6 +122,7 @@ const globalContextSelector = selector({
       queryPerformance,
       spaces,
       workspaceName,
+      activeFields,
     };
   },
 });
@@ -163,6 +166,7 @@ const useExecutionContext = (operatorName, hooks = {}) => {
     queryPerformance,
     spaces,
     workspaceName,
+    activeFields,
   } = curCtx;
   const [analyticsInfo] = useAnalyticsInfo();
   const promptingOperator = useRecoilValue(promptingOperatorState);
@@ -186,6 +190,7 @@ const useExecutionContext = (operatorName, hooks = {}) => {
         spaces,
         workspaceName,
         promptId,
+        activeFields,
       },
       hooks
     );
@@ -205,6 +210,7 @@ const useExecutionContext = (operatorName, hooks = {}) => {
     spaces,
     workspaceName,
     promptId,
+    activeFields,
   ]);
 
   return ctx;

--- a/app/packages/operators/src/useCustomPanelHooks.ts
+++ b/app/packages/operators/src/useCustomPanelHooks.ts
@@ -29,6 +29,7 @@ export interface CustomPanelProps {
   onChangeQueryPerformance?: boolean;
   onChangeSpaces?: string;
   onChangeWorkspace?: string;
+  onChangeActiveFields?: string;
   dimensions: DimensionsType | null;
   panelName?: string;
   panelLabel?: string;
@@ -152,6 +153,12 @@ export function useCustomPanelHooks(props: CustomPanelProps): CustomPanelHooks {
     panelId,
     ctx.workspaceName,
     props.onChangeWorkspace
+  );
+  useCtxChangePanelEvent(
+    isLoaded,
+    panelId,
+    ctx.activeFields,
+    props.onChangeActiveFields
   );
 
   useEffect(() => {

--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -2009,6 +2009,19 @@ subsequent sections.
             ctx.panel.set_state("event", "on_change_selected_labels")
             ctx.panel.set_data("event_data", event)
 
+        def on_change_active_fields(self, ctx):
+            """Implement this method to set panel state/data when the current
+            active fields change in the sidebar.
+
+            The active fields will be available via ``ctx.active_fields``.
+            """
+            event = {
+                "data": ctx.active_fields,
+                "description": "the current active fields",
+            }
+            ctx.panel.set_state("event", "on_change_active_fields")
+            ctx.panel.set_data("event_data", event)
+
         def on_change_extended_selection(self, ctx):
             """Implement this method to set panel state/data when the current
             extended selection changes.

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -143,6 +143,8 @@ def execute_operator(operator_uri, ctx=None, **kwargs):
                 execution, if supported by the operator
             -   ``delegation_target`` (None): an optional orchestrator on which
                 to schedule the operation, if it is delegated
+            -   ``active_fields`` ([]): a list of active field names
+
         **kwargs: you can optionally provide any of the supported ``ctx`` keys
             as keyword arguments rather than including them in ``ctx``
 
@@ -754,6 +756,11 @@ class ExecutionContext(object):
     def operator_uri(self):
         """The URI of the target operator."""
         return self._operator_uri
+
+    @property
+    def active_fields(self):
+        """The list of currently active fields."""
+        return self.request_params.get("active_fields", [])
 
     def prompt(
         self,

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -323,6 +323,7 @@ class Operations(object):
         on_change_extended_selection=None,
         on_change_group_slice=None,
         on_change_query_performance=None,
+        on_change_active_fields=None,
         allow_duplicates=False,
         priority=None,
         _builtin=False,
@@ -369,6 +370,8 @@ class Operations(object):
                 slice changes
             on_change_query_performance (None): an operator to invoke when the
                 query performance changes
+            on_change_active_fields (None): an operator to invoke when the
+                active fields change
             allow_duplicates (False): whether to allow multiple instances of
                 the panel to the opened
             priority (None): the priority of the panel, used for sort order
@@ -399,6 +402,7 @@ class Operations(object):
             "on_change_extended_selection": on_change_extended_selection,
             "on_change_group_slice": on_change_group_slice,
             "on_change_query_performance": on_change_query_performance,
+            "on_change_active_fields": on_change_active_fields,
             "allow_duplicates": allow_duplicates,
             "priority": priority,
             "_builtin": _builtin,
@@ -694,6 +698,10 @@ class Operations(object):
     def toggle_sidebar(self):
         """Toggle the visibility of the App's sidebar."""
         return self._ctx.trigger("toggle_sidebar")
+
+    def clear_active_fields(self):
+        """Clear the active fields in the App."""
+        return self._ctx.trigger("clear_active_fields")
 
 
 def _serialize_view(view):

--- a/fiftyone/operators/panel.py
+++ b/fiftyone/operators/panel.py
@@ -144,6 +144,7 @@ class Panel(Operator):
             "on_change_extended_selection",
             "on_change_group_slice",
             "on_change_query_performance",
+            "on_change_active_fields",
         ]
         for method in methods + ctx_change_events:
             if hasattr(self, method) and callable(getattr(self, method)):


### PR DESCRIPTION
## What changes are proposed in this pull request?

See [this fiftyone-plugins PR](https://github.com/voxel51/fiftyone-plugins/pull/232/files) for an example of how to use this new feature.

 - adds `ctx.active_fields` which includes the currently active/visible fields in the sidebar
 - adds `ctx.ops.clear_active_fields()` operator
 - adds `on_change_active_fields` event for python panels

## How is this patch tested? If it is not, please explain why.

Local app with the plugin linked above.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Added a new property `active_fields` to the `ExecutionContext`. Operators and panels can now read the currently active fields. Added a new operator `clear_active_fields` for hiding all sidebar fields.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
