### PR TITLE
Add support for storing instance segmentations on disk in `apply_model()`

### DIFF
--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -654,6 +654,19 @@ def _do_export_array(label, input_path, filename_maker):
             input_path, output_ext=".png"
         )
         label.export_map(map_path, update=True)
+    elif isinstance(label, fol.Detection):
+        if label.mask is not None:
+            mask_path = filename_maker.get_output_path(
+                input_path, output_ext=".png"
+            )
+            label.export_mask(mask_path, update=True)
+    elif isinstance(label, fol.Detections):
+        for detection in label.detections:
+            if detection.mask is not None:
+                mask_path = filename_maker.get_output_path(
+                    input_path, output_ext=".png"
+                )
+                detection.export_mask(mask_path, update=True)
 
 
 def _get_frame_counts(samples):


### PR DESCRIPTION
## Change log

- Adds support for passing `output_dir` to `apply_model()` to store instance segmentation masks on disk rather than in the database

## Tested by

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=5)
model = foz.load_zoo_model("segment-anything-vitb-torch")

dataset.apply_model(
    model,
    label_field="segmentations",
    prompt_field="ground_truth",
    output_dir="/tmp/segment-anything",
)

# Ensure that `mask_path` is populated, not `mask`
print(dataset.values("segmentations"))
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for exporting mask images associated with detection labels, enabling users to export detection results with masks as image files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->