### PR TITLE
Add support for deleting all visible labels in selected samples

### DIFF
--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -980,6 +980,8 @@ contains the following properties:
 -   `ctx.selected_labels` - the list of currently selected labels in the App,
     if any
 -   `ctx.extended_selection` - the extended selection of the view, if any
+-   `ctx.active_fields` - the list of currently active fields in the App
+    sidebar, if any
 -   `ctx.group_slice` - the active group slice in the App, if any
 -   `ctx.user_id` - the ID of the user that invoked the operator, if known
 -   `ctx.user` - an object of information about the user that invoked the

--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -330,6 +330,49 @@ class ClipsView(fov.DatasetView):
 
         super().reload()
 
+    def _delete_labels(self, labels, fields=None):
+        clip_labels, other_labels, src_labels = self._parse_labels(
+            labels, fields=fields
+        )
+
+        if clip_labels:
+            clip_ids = [d["sample_id"] for d in clip_labels]
+            self._clips_dataset.delete_samples(clip_ids)
+
+        if other_labels:
+            super()._delete_labels(other_labels, fields=fields)
+
+        if src_labels:
+            self._source_collection._delete_labels(src_labels, fields=fields)
+
+    def _parse_labels(self, labels, fields=None):
+        if etau.is_str(fields):
+            fields = [fields]
+
+        if fields is not None:
+            labels = [d for d in labels if d["field"] in fields]
+
+        frame_labels = [d for d in labels if d.get("frame_number") is not None]
+        labels = [d for d in labels if d.get("frame_number") is None]
+
+        field = self._classification_field
+
+        if field is not None:
+            clip_labels = [d for d in labels if d["field"] == field]
+            other_labels = [d for d in labels if d["field"] != field]
+        else:
+            clip_labels = []
+            other_labels = labels
+
+        src_labels = deepcopy(clip_labels + frame_labels)
+        if src_labels:
+            clip_ids = [d["sample_id"] for d in src_labels]
+            sample_ids = self._map_values(clip_ids, "id", "sample_id")
+            for d, sample_id in zip(src_labels, sample_ids):
+                d["sample_id"] = sample_id
+
+        return clip_labels, other_labels, src_labels
+
     def _sync_source_sample(self, sample):
         if not self._classification_field:
             return
@@ -366,7 +409,7 @@ class ClipsView(fov.DatasetView):
 
         update_ids = []
         update_docs = []
-        del_ids = set()
+        del_labels = []
         for label_id, sample_id, support, doc in zip(
             *sync_view.values(["id", "sample_id", "support", field], _raw=True)
         ):
@@ -376,7 +419,13 @@ class ClipsView(fov.DatasetView):
                 update_ids.append(sample_id)
                 update_docs.append(doc)
             else:
-                del_ids.add(label_id)
+                del_labels.append(
+                    {
+                        "sample_id": sample_id,
+                        "label_id": label_id,
+                        "field": field,
+                    }
+                )
 
         if delete:
             observed_ids = set(update_ids)
@@ -384,15 +433,19 @@ class ClipsView(fov.DatasetView):
                 *self._clips_dataset.values(["id", "sample_id"])
             ):
                 if sample_id not in observed_ids:
-                    del_ids.add(label_id)
+                    del_labels.append(
+                        {
+                            "sample_id": sample_id,
+                            "label_id": label_id,
+                            "field": field,
+                        }
+                    )
 
         if update:
             self._source_collection._set_labels(field, update_ids, update_docs)
 
-        if del_ids:
-            # @todo can we optimize this? we know exactly which samples each
-            # label to be deleted came from
-            self._source_collection._delete_labels(del_ids, fields=[field])
+        if del_labels:
+            self._source_collection._delete_labels(del_labels, fields=[field])
 
     def _sync_source_field_schema(self, path):
         root = path.split(".", 1)[0]

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -3291,8 +3291,19 @@ class SampleCollection(object):
                 ops, ids=ids, frames=is_frame_field, progress=progress
             )
 
-    def _delete_labels(self, ids, fields=None):
-        self._dataset.delete_labels(ids=ids, fields=fields)
+    def _delete_labels(self, labels, fields=None):
+        self._dataset._delete_labels(labels, fields=fields)
+
+    def _map_values(self, in_values, in_field, *out_fields):
+        view = self.select_by(in_field, in_values)
+        _in_values, *_all_out_values = view.values([in_field, *out_fields])
+
+        results = []
+        for out_field, _out_values in zip(out_fields, _all_out_values):
+            d = dict(zip(_in_values, _out_values))
+            results.append([d.get(v, None) for v in in_values])
+
+        return tuple(results) if len(results) > 1 else results[0]
 
     def compute_metadata(
         self,

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -342,6 +342,46 @@ class _PatchesView(fov.DatasetView):
 
         super().reload()
 
+    def _delete_labels(self, labels, fields=None):
+        patch_labels, other_labels, src_labels = self._parse_labels(
+            labels, fields=fields
+        )
+
+        if patch_labels:
+            patch_ids = [d["sample_id"] for d in patch_labels]
+            self._patches_dataset.delete_samples(patch_ids)
+
+        if other_labels:
+            super()._delete_labels(other_labels, fields=fields)
+
+        if src_labels:
+            self._source_collection._delete_labels(src_labels, fields=fields)
+
+    def _parse_labels(self, labels, fields=None):
+        if etau.is_str(fields):
+            fields = [fields]
+
+        if fields is not None:
+            labels = [d for d in labels if d["field"] in fields]
+
+        label_fields = self._label_fields
+
+        patch_labels = [d for d in labels if d["field"] in label_fields]
+        other_labels = [d for d in labels if d["field"] not in label_fields]
+
+        src_labels = deepcopy(patch_labels)
+        if src_labels:
+            patch_ids = [d["sample_id"] for d in src_labels]
+            sample_ids = self._map_values(patch_ids, "id", "sample_id")
+            for d, sample_id in zip(src_labels, sample_ids):
+                d["sample_id"] = sample_id
+
+        if len(label_fields) != 1:
+            other_labels += patch_labels
+            patch_labels = None
+
+        return patch_labels, other_labels, src_labels
+
     def _sync_source_sample(self, sample):
         for field in self._label_fields:
             self._sync_source_sample_field(sample, field)
@@ -391,13 +431,32 @@ class _PatchesView(fov.DatasetView):
 
         if delete:
             label_id_path = label_path + ".id"
-            all_ids = self._patches_dataset.values(label_id_path, unwind=True)
-            self_ids = self.values(label_id_path, unwind=True)
-            del_ids = set(all_ids) - set(self_ids)
+            self_ids = set(self.values(label_id_path, unwind=True))
+            all_sample_ids, all_label_ids = self._patches_dataset.values(
+                ["sample_id", label_id_path]
+            )
 
-            if del_ids:
+            del_labels = []
+            for sample_id, label_ids in zip(all_sample_ids, all_label_ids):
+                if label_ids is None:
+                    continue
+
+                if not etau.is_container(label_ids):
+                    label_ids = [label_ids]
+
+                for label_id in label_ids:
+                    if label_id not in self_ids:
+                        del_labels.append(
+                            {
+                                "label_id": label_id,
+                                "sample_id": sample_id,
+                                "field": field,
+                            }
+                        )
+
+            if del_labels:
                 self._source_collection._delete_labels(
-                    ids=del_ids, fields=field
+                    del_labels, fields=field
                 )
 
     def _sync_source_field_schema(self, path):

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -433,7 +433,7 @@ class _PatchesView(fov.DatasetView):
             label_id_path = label_path + ".id"
             self_ids = set(self.values(label_id_path, unwind=True))
             all_sample_ids, all_label_ids = self._patches_dataset.values(
-                ["sample_id", label_id_path]
+                [self._id_field, label_id_path]
             )
 
             del_labels = []

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -317,9 +317,13 @@ class FramesView(fov.DatasetView):
             super()._delete_labels(labels, fields=fields)
 
         if src_labels:
-            self._source_collection._delete_labels(
-                src_labels, fields=src_fields
-            )
+            src_collection = self._source_collection
+
+            # Clips views directly use their source collection's frames
+            if src_collection._is_clips:
+                src_collection = src_collection._source_collection
+
+            src_collection._delete_labels(src_labels, fields=src_fields)
 
     def _parse_labels(self, labels, fields=None):
         if etau.is_str(fields):

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -308,20 +308,47 @@ class FramesView(fov.DatasetView):
 
         self._sync_source(fields=[field_name], ids=sample_ids)
 
-    def _delete_labels(self, ids, fields=None):
-        super()._delete_labels(ids, fields=fields)
+    def _delete_labels(self, labels, fields=None):
+        labels, src_labels, src_fields = self._parse_labels(
+            labels, fields=fields
+        )
+
+        if labels:
+            super()._delete_labels(labels, fields=fields)
+
+        if src_labels:
+            self._source_collection._delete_labels(
+                src_labels, fields=src_fields
+            )
+
+    def _parse_labels(self, labels, fields=None):
+        if etau.is_str(fields):
+            fields = [fields]
 
         if fields is not None:
-            if etau.is_str(fields):
-                fields = [fields]
+            labels = [d for d in labels if d["field"] in fields]
 
-            frame_fields = [
-                self._source_collection._FRAMES_PREFIX + f for f in fields
-            ]
+        prefix = self._source_collection._FRAMES_PREFIX
+
+        src_labels = deepcopy(labels)
+        if src_labels:
+            frame_ids = [d["sample_id"] for d in src_labels]
+            sample_ids, frame_numbers = self._map_values(
+                frame_ids, "id", "sample_id", "frame_number"
+            )
+            for d, sample_id, frame_number in zip(
+                src_labels, sample_ids, frame_numbers
+            ):
+                d["sample_id"] = sample_id
+                d["field"] = prefix + d["field"]
+                d["frame_number"] = frame_number
+
+        if fields is not None:
+            src_fields = [prefix + f for f in fields]
         else:
-            frame_fields = None
+            src_fields = None
 
-        self._source_collection._delete_labels(ids, fields=frame_fields)
+        return labels, src_labels, src_fields
 
     def _sync_source_sample(self, sample):
         self._sync_source_schema()

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -137,13 +137,13 @@ def execute_operator(operator_uri, ctx=None, **kwargs):
                 :attr:`fiftyone.core.session.Session.selected_labels`
             -   ``current_sample`` (None): an optional ID of the current sample
                 being processed
+            -   ``active_fields`` ([]): an optional list of active fields
             -   ``params``: a dictionary of parameters for the operator.
                 Consult the operator's documentation for details
             -   ``request_delegation`` (False): whether to request delegated
                 execution, if supported by the operator
             -   ``delegation_target`` (None): an optional orchestrator on which
                 to schedule the operation, if it is delegated
-            -   ``active_fields`` ([]): a list of active field names
 
         **kwargs: you can optionally provide any of the supported ``ctx`` keys
             as keyword arguments rather than including them in ``ctx``
@@ -664,6 +664,11 @@ class ExecutionContext(object):
         return self.request_params.get("current_sample", None)
 
     @property
+    def active_fields(self):
+        """The list of currently active fields in the FiftyOne App sidebar."""
+        return self.request_params.get("active_fields", [])
+
+    @property
     def user_id(self):
         """The ID of the user executing the operation, if known."""
         return self.user.id if self.user else None
@@ -756,11 +761,6 @@ class ExecutionContext(object):
     def operator_uri(self):
         """The URI of the target operator."""
         return self._operator_uri
-
-    @property
-    def active_fields(self):
-        """The list of currently active fields."""
-        return self.request_params.get("active_fields", [])
 
     def prompt(
         self,

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -642,6 +642,10 @@ class Operations(object):
             "set_active_fields", params={"fields": fields}
         )
 
+    def clear_active_fields(self):
+        """Clear the active fields in the App."""
+        return self._ctx.trigger("clear_active_fields")
+
     def track_event(self, event, properties=None):
         """Track an event in the App.
 
@@ -698,10 +702,6 @@ class Operations(object):
     def toggle_sidebar(self):
         """Toggle the visibility of the App's sidebar."""
         return self._ctx.trigger("toggle_sidebar")
-
-    def clear_active_fields(self):
-        """Clear the active fields in the App."""
-        return self._ctx.trigger("clear_active_fields")
 
 
 def _serialize_view(view):

--- a/plugins/operators/__init__.py
+++ b/plugins/operators/__init__.py
@@ -6,6 +6,7 @@ Builtin operators.
 |
 """
 
+from copy import deepcopy
 import json
 import os
 
@@ -1039,14 +1040,68 @@ class DeleteSelectedLabels(foo.Operator):
     def resolve_input(self, ctx):
         inputs = types.Object()
 
-        count = len(ctx.selected_labels)
-        if count > 0:
-            label_text = "label" if count == 1 else "labels"
+        if ctx.selected_labels:
+            label_count = len(ctx.selected_labels)
+            label_text = "label" if label_count == 1 else "labels"
+
             inputs.str(
                 "msg",
-                label=f"Delete {count} selected {label_text}?",
+                label=f"Delete {label_count} selected {label_text}?",
                 view=types.Warning(),
             )
+        elif ctx.selected:
+            label_fields = _get_label_fields(ctx.view, fo.Label)
+
+            field_choices = types.AutocompleteView(allow_duplicates=False)
+            for field in label_fields:
+                field_choices.add_choice(field, label=field)
+
+            inputs.list(
+                "fields",
+                types.String(),
+                label="Label fields",
+                description="Choose specific field(s) whose labels to delete",
+                required=False,
+                default=[f for f in ctx.active_fields if f in label_fields],
+                view=field_choices,
+            )
+
+            fields = ctx.params.get("fields", None)
+
+            if fields:
+                view = ctx.view.select(ctx.selected)
+                label_count = len(view._get_selected_labels(fields=fields))
+                sample_count = len(ctx.selected)
+
+                if ctx.view._is_patches:
+                    sample_text = "patches" if sample_count > 1 else "patch"
+                elif ctx.view._is_frames:
+                    sample_text = "frames" if sample_count > 1 else "frame"
+                elif ctx.view._is_clips:
+                    sample_text = "clips" if sample_count > 1 else "clip"
+                else:
+                    sample_text = "samples" if sample_count > 1 else "sample"
+
+                if not fields:
+                    fields_text = ""
+                elif len(fields) > 1:
+                    fields_str = ", ".join(f"`{f}`" for f in fields)
+                    fields_text = f"the {fields_str} fields of "
+                else:
+                    fields_text = f"the `{fields[0]}` field of "
+
+                inputs.str(
+                    "msg",
+                    label=f"Delete {label_count} labels in {fields_text}{sample_count} selected {sample_text}?",
+                    view=types.Warning(),
+                )
+            else:
+                prop = inputs.str(
+                    "msg",
+                    label="You must select field(s) whose labels to delete",
+                    view=types.Warning(),
+                )
+                prop.invalid = True
         else:
             prop = inputs.str(
                 "msg",
@@ -1059,13 +1114,55 @@ class DeleteSelectedLabels(foo.Operator):
         return types.Property(inputs, view=view)
 
     def execute(self, ctx):
-        if not ctx.selected_labels:
+        has_selected_labels = bool(ctx.selected_labels)
+        has_selected_samples = bool(ctx.selected)
+
+        if has_selected_labels:
+            view = ctx.view
+            labels = ctx.selected_labels
+        elif has_selected_samples:
+            view = ctx.view.select(ctx.selected)
+            fields = ctx.params.get("fields", None)
+            labels = view._get_selected_labels(fields=fields)
+        else:
+            labels = None
+
+        if not labels:
             return
 
-        ctx.dataset.delete_labels(labels=ctx.selected_labels)
+        ctx.view._delete_labels(labels)
 
-        ctx.trigger("clear_selected_labels")
+        if has_selected_labels:
+            ctx.trigger("clear_selected_labels")
+
+        if has_selected_samples:
+            ctx.trigger("clear_selected_samples")
+
         ctx.trigger("reload_dataset")
+
+
+def _get_label_fields(sample_collection, label_types):
+    label_fields = []
+
+    schema = sample_collection.get_field_schema(
+        embedded_doc_type=label_types, flat=True, unwind=False
+    )
+
+    label_fields.extend(sorted(schema.keys()))
+
+    if sample_collection._has_frame_fields():
+        frame_schema = sample_collection.get_frame_field_schema(
+            embedded_doc_type=label_types, flat=True, unwind=False
+        )
+
+        label_fields.extend(
+            [
+                sample_collection._FRAMES_PREFIX + f
+                for f in sorted(frame_schema.keys())
+            ]
+        )
+
+    return label_fields
 
 
 class DeleteSampleField(foo.Operator):

--- a/plugins/operators/__init__.py
+++ b/plugins/operators/__init__.py
@@ -6,7 +6,6 @@ Builtin operators.
 |
 """
 
-from copy import deepcopy
 import json
 import os
 

--- a/tests/unittests/patches_tests.py
+++ b/tests/unittests/patches_tests.py
@@ -1127,6 +1127,72 @@ class PatchesTests(unittest.TestCase):
 
         self.assertSetEqual(set(view.list_indexes()), expected_indexes)
 
+    @drop_datasets
+    def test_patches_delete_labels(self):
+        dataset = fo.Dataset()
+
+        sample1 = fo.Sample(filepath="image1.png")
+        sample2 = fo.Sample(
+            filepath="image2.png",
+            ground_truth=fo.Detections(
+                detections=[
+                    fo.Detection(label="cat"),
+                    fo.Detection(label="dog"),
+                    fo.Detection(label="rabbit"),
+                ]
+            ),
+            predictions=fo.Detections(
+                detections=[
+                    fo.Detection(label="cat"),
+                    fo.Detection(label="dog"),
+                    fo.Detection(label="rabbit"),
+                ]
+            ),
+        )
+
+        dataset.add_samples([sample1, sample2])
+
+        view = dataset.to_patches("ground_truth")
+        patch = view.first()
+
+        labels = [
+            {
+                "label_id": patch.ground_truth.id,
+                "sample_id": patch.id,
+                "field": "ground_truth",
+            }
+        ]
+
+        view._delete_labels(labels)
+
+        self.assertEqual(len(view), 2)
+        self.assertEqual(dataset.count("ground_truth.detections"), 2)
+        self.assertEqual(dataset.count("predictions.detections"), 3)
+
+        view = dataset.to_patches("ground_truth", other_fields="predictions")
+        patch1 = view.first()
+        patch2 = view.last()
+
+        labels = [
+            {
+                "label_id": patch1.ground_truth.id,
+                "sample_id": patch1.id,
+                "field": "ground_truth",
+            },
+            {
+                "label_id": patch2.predictions.detections[0].id,
+                "sample_id": patch2.id,
+                "field": "predictions",
+            },
+        ]
+
+        view._delete_labels(labels)
+
+        self.assertEqual(len(view), 1)
+        self.assertEqual(view.count("predictions.detections"), 2)
+        self.assertEqual(dataset.count("ground_truth.detections"), 1)
+        self.assertEqual(dataset.count("predictions.detections"), 3)
+
 
 if __name__ == "__main__":
     fo.config.show_progress_bars = False


### PR DESCRIPTION
## Change log

- Upgrades the builtin `delete_selected_labels` to support deleting some/all labels in selected samples in the App
- This feature uses the new `ctx.active_fields` property to default to deleting only **visible** labels in the selected samples 🎉 
- Optimizes label deletion on generated views

## Example usage

### Regular dataset

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
session = fo.launch_app(dataset)
```

https://github.com/user-attachments/assets/1ab0a449-1392-43e9-86b3-2a4cf229a234

### Patches view

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
patches = dataset.to_patches("ground_truth")

session = fo.launch_app(patches)
```

https://github.com/user-attachments/assets/bbf051b1-30a0-4cc1-822e-97a6444624ce

### Frames view

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video")
frames = dataset.to_frames(sample_frames=True)

session = fo.launch_app(frames)
```

https://github.com/user-attachments/assets/a3d9faf5-4a3b-4f21-bb9e-a28926b31dff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced label deletion capabilities, allowing deletion of labels from selected samples and fields, with improved handling for video, patch, and clip views.
  - Added support for displaying and using active fields in plugin operators, providing more context-aware operations.
- **Bug Fixes**
  - Improved synchronization of label deletions between views (clips, frames, patches) and their source datasets for more accurate updates.
- **Documentation**
  - Updated plugin development documentation to describe the new active fields property in the operator and panel execution context.
- **Tests**
  - Added comprehensive tests to verify correct label deletion behavior for patches, clips, and frames in video datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->