### PR TITLE
Map samples: use `deque`, `reload()`, and `fo.config`

### DIFF
--- a/fiftyone/core/map/__init__.py
+++ b/fiftyone/core/map/__init__.py
@@ -10,6 +10,8 @@ import types
 
 from fiftyone.core.map.mapper import Mapper
 from fiftyone.core.map.factory import MapperFactory
+from fiftyone.core.map.process import ProcessMapper
+from fiftyone.core.map.threading import ThreadMapper
 
 # This enables Sphinx refs to directly use paths imported here
 __all__ = [

--- a/fiftyone/core/map/factory.py
+++ b/fiftyone/core/map/factory.py
@@ -1,5 +1,6 @@
 """
-Factory for mapping backends
+Factory for mapping backends.
+
 | Copyright 2017-2025, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
@@ -8,8 +9,7 @@ Factory for mapping backends
 import multiprocessing
 from typing import Dict, List, Optional, Type
 
-
-import fiftyone.core.config as focc
+import fiftyone as fo
 import fiftyone.core.map.batcher as fomb
 import fiftyone.core.map.mapper as fomm
 import fiftyone.core.map.process as fomp
@@ -50,10 +50,6 @@ class MapperFactory:
     ) -> fomm.Mapper:
         """Create a mapper instance"""
 
-        # Loading config dynamically here as it causes actual unit tests to fail
-        # without importing the world and using globals.
-        config = focc.load_config()
-
         if batch_method is None:
             batch_method = "id"
 
@@ -70,7 +66,7 @@ class MapperFactory:
         if mapper_key is None:
             # If the default parallelization method is set in the config, use
             # it no matter what.
-            mapper_key = config.default_parallelization_method
+            mapper_key = fo.config.default_parallelization_method
 
             # If a parallelization method is not explicitly provided and
             # no default was set, try to use multiprocessing as default, if it
@@ -89,7 +85,7 @@ class MapperFactory:
             )
 
         return cls._MAPPER_CLASSES[mapper_key].create(
-            config=config,
+            config=fo.config,
             batch_cls=batch_cls,
             num_workers=num_workers,
             batch_size=batch_size,

--- a/tests/unittests/map/test_factory.py
+++ b/tests/unittests/map/test_factory.py
@@ -9,7 +9,7 @@ from unittest import mock
 
 import pytest
 
-import fiftyone.core.config as focc
+import fiftyone as fo
 import fiftyone.core.map.batcher as fomb
 import fiftyone.core.map.factory as fomf
 import fiftyone.core.map.process as fomp
@@ -17,10 +17,10 @@ import fiftyone.core.map.threading as fomt
 
 
 @pytest.fixture(name="config", autouse=True)
-def patch_load_config():
-    """patch load config"""
-    with mock.patch.object(focc, "load_config") as load_config:
-        config = load_config.return_value = mock.Mock()
+def patch_fiftyone_config():
+    """patch fiftyone.config global"""
+
+    with mock.patch.object(fo, "config") as config:
         config.default_parallelization_method = None
         yield config
 


### PR DESCRIPTION
## Change log

A small collection of enhancements to the `map_samples()` + `update_samples()` backends:

- Use `collections.deque` to exhaust generators in `update_samples()` for efficiency
- Add `reload()` calls when using multiprocessing so that schema changes are reflected in the main process, for consistency with the user experience when `num_workers=0` or `parallelize_method="thread"` are used
- Use global `fo.config` rather than loading a separate copy from disk, for consistency with the rest of the library 

## Tested by

- Unit tests added

## Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

# update_samples()

def update_fcn(sample):
    sample["foo"] = "bar"

# Empty view
dataset.limit(0).update_samples(update_fcn)
assert not dataset.has_field("foo")

# Full dataset
dataset.update_samples(update_fcn)
assert dataset.has_field("foo")

# map_samples()

def map_fcn(sample):
    sample["spam"] = "eggs"
    return "eggs"

# Empty view
for _ in dataset.limit(0).map_samples(map_fcn, save=True):
    pass

assert not dataset.has_field("spam")

# Full dataset
for _ in dataset.map_samples(map_fcn, save=True):
    pass

assert dataset.has_field("spam")
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved synchronization of schema changes when processing samples in parallel, ensuring updates made during mapping or updating are accurately reflected in the main dataset.

- **Bug Fixes**
  - Addressed issues where schema edits in worker processes were not visible in the main process after parallel operations.

- **Tests**
  - Enhanced and expanded test coverage for parallel sample processing, including new tests for public interface methods and improved dataset setup and cleanup.

- **Chores**
  - Updated internal imports and configuration handling for improved maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->