### PR TITLE
scenario analysis permission fixes

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/Actions.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/Actions.tsx
@@ -13,7 +13,7 @@ import ConfirmDelete from "../../components/ConfirmDelete";
 import TooltipProvider from "../../../TooltipProvider";
 
 export default function Actions(props) {
-  const { onDelete, onEdit, readOnly } = props;
+  const { onDelete, onEdit, canEdit, canDelete } = props;
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
   const [deleteOpen, setDeleteOpen] = React.useState(false);
@@ -23,9 +23,6 @@ export default function Actions(props) {
   const handleClose = () => {
     setAnchorEl(null);
   };
-  const tooltipTitle = readOnly
-    ? "You do not have permission to create scenarios"
-    : null;
 
   return (
     <Stack>
@@ -38,13 +35,17 @@ export default function Actions(props) {
         open={open}
         onClose={handleClose}
       >
-        <TooltipProvider title={tooltipTitle}>
+        <TooltipProvider
+          title={
+            canEdit ? undefined : "You do not have permission to edit scenario"
+          }
+        >
           <MenuItem
             onClick={() => {
               onEdit?.();
               handleClose();
             }}
-            disabled={readOnly}
+            disabled={!canEdit}
           >
             <ListItemIcon>
               <EditOutlined fontSize="small" color="secondary" />
@@ -52,14 +53,19 @@ export default function Actions(props) {
             <Typography color="secondary">Edit</Typography>
           </MenuItem>
         </TooltipProvider>
-        <TooltipProvider title={tooltipTitle}>
+        <TooltipProvider
+          title={
+            canEdit
+              ? undefined
+              : "You do not have permission to delete scenario"
+          }
+        >
           <MenuItem
             onClick={() => {
               setDeleteOpen(true);
               handleClose();
             }}
-            disabled={readOnly}
-            title={tooltipTitle}
+            disabled={!canDelete}
           >
             <ListItemIcon>
               <DeleteOutline fontSize="small" color="error" />

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/Scenarios.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/Scenarios.tsx
@@ -96,6 +96,9 @@ export default function Scenarios(props) {
   const scenariosArray = scenarios ? Object.values(scenarios) : [];
   const scenariosIds = Object.keys(scenarios);
   const readOnly = !data.permissions?.can_delete_scenario;
+  const canCreate = data.permissions?.can_create_scenario;
+  const canEdit = data.permissions?.can_edit_scenario;
+  const canDelete = data.permissions?.can_delete_scenario;
 
   useEffect(() => {
     if (!scenario) {
@@ -353,9 +356,15 @@ export default function Scenarios(props) {
             }}
             evalKey={key}
             compareKey={compareKey}
-            readOnly={readOnly}
+            readOnly={!canCreate}
           />
-          <Actions onDelete={onDelete} onEdit={onEdit} readOnly={readOnly} />
+          <Actions
+            onDelete={onDelete}
+            onEdit={onEdit}
+            canCreate={canCreate}
+            canEdit={canEdit}
+            canDelete={canDelete}
+          />
         </Stack>
       </Stack>
       {scenario && (

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/index.tsx
@@ -28,7 +28,7 @@ export default function EvaluationScenarioAnalysis(props) {
           gt_field={evaluationConfig.gt_field}
           evalKey={key}
           compareKey={compareKey}
-          readOnly={!data.permissions?.can_delete_scenario}
+          readOnly={!data.permissions?.can_create_scenario}
         />
       ) : (
         <Scenarios {...props} />

--- a/plugins/panels/model_evaluation/__init__.py
+++ b/plugins/panels/model_evaluation/__init__.py
@@ -68,6 +68,8 @@ class EvaluationPanel(Panel):
             "can_edit_status": True,
             "can_delete_evaluation": True,
             "can_rename": True,
+            "can_create_scenario": True,
+            "can_edit_scenario": True,
             "can_delete_scenario": True,
         }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

scenario analysis permission fixes

## How is this patch tested? If it is not, please explain why.

Using Model Evaluation panel

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added more granular scenario permissions, allowing separate control over creating, editing, and deleting scenarios.
- **Improvements**
  - Updated tooltips and action buttons to display specific permission messages for editing and deleting scenarios.
  - UI now reflects individual permissions for scenario actions, providing clearer feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->