### PR TITLE
Fix App handling when an index exists for a field not in the schema

### DIFF
--- a/app/packages/state/src/recoil/grid.ts
+++ b/app/packages/state/src/recoil/grid.ts
@@ -80,9 +80,12 @@ export const gridSortFields = selector({
       ...valid.trailing.map(({ key }) => key),
     ]);
 
-    return [...all]
-      .sort()
-      .map((path) => get(fieldPath(path)))
-      .filter((path) => get(isNumericField(path)));
+    return (
+      [...all]
+        .sort()
+        .map((path) => get(fieldPath(path)))
+        // an index may exist, but the field may not be in the schema
+        .filter((path) => path && get(isNumericField(path)))
+    );
   },
 });

--- a/app/packages/state/src/recoil/schema.ts
+++ b/app/packages/state/src/recoil/schema.ts
@@ -332,8 +332,12 @@ export const fieldPath = selectorFamily({
       const parent = keys.slice(0, -1).join(".");
       const dbField = keys[keys.length - 1];
       const fieldData = parent.length
-        ? get(field(parent)).fields
+        ? get(field(parent))?.fields
         : get(fullSchema);
+
+      if (!fieldData) {
+        return null;
+      }
 
       let name = dbField;
       for (const key in fieldData) {


### PR DESCRIPTION
## What changes are proposed in this pull request?
Fixes the App when an index exists for an embedded field not in the schema

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart").clone("test_typerror", persistent=True)
dataset._sample_collection.create_index("fake.field", unique=False)
``` 

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

* Fixed handling of indexes for non-existent fields

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
