### PR TITLE
Add guard to prevent dereferencing None values

### DIFF
--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -405,6 +405,10 @@ def _make_match_stage(view, filters):
         path_field = view.get_field(path)
 
         field = view.get_field(parent_path)
+
+        if field is None or path_field is None:
+            continue
+
         is_label_field = _is_label_type(field)
         if (
             is_label_field
@@ -461,6 +465,10 @@ def _make_label_filter_stages(
 
         field = view.get_field(path)
         label_field = view.get_field(label_path)
+
+        if field is None or label_field is None:
+            continue
+
         if issubclass(
             label_field.document_type, (fol.Keypoint, fol.Keypoints)
         ) and isinstance(field, fof.ListField):


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds guards to the result of several `get_field` calls to prevent attempting to dereference a `None` value.

## How is this patch tested? If it is not, please explain why.

local app, unit tests

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
