### PR TITLE
Gracefully handle a single unique datetime value in `histogram_values()`

### DIFF
--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -1448,7 +1448,15 @@ class HistogramValues(Aggregation):
             bounds = [-1, -1]
 
         bounds, self._is_datetime = _handle_dates(bounds)
-        db = 1 if self._is_datetime else 1e-6
+
+        if self._is_datetime:
+            if bounds[1] - bounds[0] < self._num_bins:
+                # each datetime bucket must be at least 1ms
+                db = self._num_bins
+            else:
+                db = 1
+        else:
+            db = 1e-6
 
         return list(np.linspace(bounds[0], bounds[1] + db, self._num_bins + 1))
 

--- a/tests/unittests/aggregation_tests.py
+++ b/tests/unittests/aggregation_tests.py
@@ -1057,6 +1057,14 @@ class DatasetTests(unittest.TestCase):
             for edge in edges:
                 self.assertIsInstance(edge, datetime)
 
+        # Ensure that we gracefully handle a single unique datetime value
+
+        counts, _, _ = dataset.limit(1).histogram_values("dates")
+        self.assertEqual(counts[0], 1)
+
+        counts, _, _ = dataset.limit(1).histogram_values("ms")
+        self.assertEqual(counts[0], 1)
+
     @drop_datasets
     def test_order(self):
         d = fo.Dataset()


### PR DESCRIPTION
## Change log

- Fixes a bug where `samples.histogram_values()` would raise an error when processing a datetime field whose range is less then `1ms x len(samples)`

## Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
view = dataset[:1]

# previously errored; now succeeds
fo.pprint(view.histogram_values("created_at"))
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of histogram bin calculations for datetime fields, especially when the data range is small relative to the number of bins.

- **Tests**
  - Added tests to verify correct histogram behavior for datetime fields with a single unique value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->