### PR TITLE
Resolve CVAT instance segmentation mask resolution issue

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -6508,7 +6508,9 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     # -1 to convert from CVAT indexing
                     mask = det.mask
                     if w != mask_width or h != mask_height:
-                        mask = etai.resize(mask, width=w, height=h)
+                        mask = etai.resize(
+                            mask.astype("uint8"), width=w, height=h
+                        )
 
                     rle = HasCVATBinaryMask._mask_to_cvat_rle(mask)
                     rle.extend([xtl, ytl, xbr - 1, ybr - 1])

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -6498,14 +6498,19 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     continue
 
                 if self._server_version >= Version("2.3"):
-                    x, y, _, _ = det.bounding_box
+                    x, y, w, h = det.bounding_box
                     frame_width, frame_height = frame_size
                     mask_height, mask_width = det.mask.shape
                     xtl, ytl = round(x * frame_width), round(y * frame_height)
-                    xbr, ybr = xtl + mask_width, ytl + mask_height
+                    w, h = round(w * frame_width), round(h * frame_height)
+                    xbr, ybr = xtl + w, ytl + h
 
                     # -1 to convert from CVAT indexing
-                    rle = HasCVATBinaryMask._mask_to_cvat_rle(det.mask)
+                    mask = det.mask
+                    if w != mask_width or h != mask_height:
+                        mask = etai.resize(mask, width=w, height=h)
+
+                    rle = HasCVATBinaryMask._mask_to_cvat_rle(mask)
                     rle.extend([xtl, ytl, xbr - 1, ybr - 1])
 
                     shape = {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Resize instance segmentation masks when uploading them to CVAT. Otherwise, the masks will be uploaded at their native resolution at the tlx, tly coordinate of the bounding box, and will not properly cover the segmented region.

## How is this patch tested? If it is not, please explain why.

Test snippet to see the effect of uploading different sized masks before and after this change:

```python
import fiftyone as fo
import fiftyone.zoo as foz
import eta.core.image as etai

dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    max_samples=10,
    label_types=["segmentations"],
)

sample = dataset.first()
detection = sample.ground_truth.detections[0]
mask = detection.mask

# Get mask dims
w,h = mask.shape[:2]

resized_mask = etai.resize(mask.astype("uint8"), width=int(w/2), height=int(h/2)) 

sample["resized_mask"] = fo.Detections(
    detections=[
        fo.Detection(label="test", bounding_box=detection.bounding_box, mask=resized_mask)
    ]
)
sample.save()

results = dataset[:1].annotate(
    "full_mask",
    label_field="ground_truth",
    label_type="instances",
    launch_editor=True
)

results = dataset[:1].annotate(
    "resized_mask",
    label_field="resized_mask",
    label_type="instances",
    launch_editor=True
)

```

Full res mask:
![image](https://github.com/user-attachments/assets/8bde906c-1d93-4e69-9ac4-6e624b3f9702)

Half res mask before fix:
![image](https://github.com/user-attachments/assets/0ebf5c89-f924-4509-aab4-ebd92a38710b)


Half res mask after fix:
![image](https://github.com/user-attachments/assets/6e21472e-9575-4ace-b3d6-7dff098b31e3)


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Resolve CVAT instance segmentation mask resolution issue.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
