### PR TITLE
Fix progress callbacks

### DIFF
--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -958,7 +958,7 @@ class ProgressBar(etau.ProgressBar):
 
         if callable(progress):
             callback = progress
-            progress = False
+            progress = fo.config.show_progress_bars
         else:
             callback = None
 
@@ -974,16 +974,25 @@ class ProgressBar(etau.ProgressBar):
         if foc.is_notebook_context() and "max_width" not in kwargs:
             kwargs["max_width"] = 90
 
-        super().__init__(**kwargs)
-
         self._progress = progress
         self._callback = callback
+
+        super().__init__(**kwargs)
 
     def set_iteration(self, *args, **kwargs):
         super().set_iteration(*args, **kwargs)
 
         if self._callback is not None:
             self._callback(self)
+
+    def _get_total(self, total, quiet):
+        # When callbacks are provided, we always want a total to be computed
+        # whenever possible so that the `progress` and `completed` properties
+        # are available to the callback
+        if self._callback is not None:
+            quiet = False
+
+        return super()._get_total(total, quiet)
 
 
 def report_progress(progress, n=None, dt=None):

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -891,11 +891,21 @@ class ExecutionContext(object):
             progress (None): an optional float between 0 and 1 (0% to 100%)
             label (None): an optional label to display
         """
-        if self._set_progress:
-            self._set_progress(
-                self._delegated_operation_id,
-                ExecutionProgress(progress, label),
-            )
+        if self._set_progress is not None:
+            try:
+                self._set_progress(
+                    self._delegated_operation_id,
+                    ExecutionProgress(progress=progress, label=label),
+                )
+            except Exception as e:
+                # Log warning rather than raise exception to prevent things
+                # like intermittent network errors from killing otherwise
+                # functional long-running operations
+                logger.warning(
+                    f"Failed to set progress for the operation: {str(e)}"
+                )
+        elif self.delegated:
+            logger.info(f"Progress: {progress} - {label}")
         else:
             self.log(f"Progress: {progress} - {label}")
 

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ INSTALL_REQUIRES = [
     # internal packages
     "fiftyone-brain>=0.21.2,<0.22",
     "fiftyone-db>=0.4,<2.0",
-    "voxel51-eta>=0.14.0,<0.15",
+    "voxel51-eta>=0.14.1,<0.15",
 ]
 
 


### PR DESCRIPTION
## Change log

- Fixes a bug where passing a progress callback would cause the `progress` and `total` properties of `ProgressBar` to always be None
- Gracefully continue when `ctx.set_progress()` calls fail during operator execution to prevent things like intermittent network errors from killing otherwise functional long-running operations 

## Tested by

With `fiftyone-plugins` from https://github.com/voxel51/fiftyone-plugins/pull/101 installed locally:

```shell
fiftyone delegated launch
```

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.operators as foo

dataset = foz.load_zoo_dataset("quickstart")

delegate = foo.get_operator("@voxel51/utils/delegate")
delegate(
    "fiftyone.brain.compute_visualization",
    dataset=dataset,
    brain_key="img_viz",
    progress=0.5,
)
```

```shell
fiftyone delegated list --dataset quickstart
```

```
id                        operator                 dataset     queued_at            state          completed
------------------------  -----------------------  ----------  -------------------  -------------  -----------
683bcfdea42758cffdeb36c9  @voxel51/utils/delegate  quickstart  2025-06-01 03:58:22  running (29%)
```
