### PR TITLE
fix(zoo): load centernet-mnv2 checkpoint (#1536)

### DIFF
--- a/fiftyone/zoo/models/manifest-tf.json
+++ b/fiftyone/zoo/models/manifest-tf.json
@@ -1645,7 +1645,7 @@
         },
         {
             "base_name": "centernet-mobilenet-v2-fpn-512-coco-tf2",
-            "base_filename": "centernet_mobilenetv2_fpn_od",
+            "base_filename": "centernet_mobilenetv2_fpn_od.tar.gz",
             "version": null,
             "description": "CenterNet model from `Objects as Points <https://arxiv.org/abs/1904.07850>`_ with the MobileNetV2 backbone trained on COCO resized to 512x512",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",

--- a/fiftyone/zoo/models/manifest-tf.json
+++ b/fiftyone/zoo/models/manifest-tf.json
@@ -1645,7 +1645,7 @@
         },
         {
             "base_name": "centernet-mobilenet-v2-fpn-512-coco-tf2",
-            "base_filename": "centernet_mobilenetv2fpn_512x512_coco17_od.tar.gz",
+            "base_filename": "centernet_mobilenetv2_fpn_od.tar.gz",
             "version": null,
             "description": "CenterNet model from `Objects as Points <https://arxiv.org/abs/1904.07850>`_ with the MobileNetV2 backbone trained on COCO resized to 512x512",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",

--- a/fiftyone/zoo/models/manifest-tf.json
+++ b/fiftyone/zoo/models/manifest-tf.json
@@ -1645,7 +1645,7 @@
         },
         {
             "base_name": "centernet-mobilenet-v2-fpn-512-coco-tf2",
-            "base_filename": "centernet_mobilenetv2_fpn_od.tar.gz",
+            "base_filename": "centernet_mobilenetv2_fpn_od",
             "version": null,
             "description": "CenterNet model from `Objects as Points <https://arxiv.org/abs/1904.07850>`_ with the MobileNetV2 backbone trained on COCO resized to 512x512",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",


### PR DESCRIPTION
The CenterNet MobileNet-V2 FPN checkpoint linked in manifest-tf.json ships as `centernet_mobilenetv2fpn_512x512_coco17_od.tar.gz` but the directory inside the archive is `centernet_mobilenetv2_fpn_od/`

Since FiftyOne matches the extracted folder name to `base_filename` (stem), loading failed with `FileNotFoundError` (see #1536).

**Updated the model manifest**

  `centernet-mobilenet-v2-fpn-512-coco-tf2`  
  `base_filename` → **`centernet_mobilenetv2_fpn_od.tar.gz`**

No code changes required; the loader now locates `saved_model/`correctly and the model can be loaded and applied to datasets as expected.

Resolves: #1536

## What changes are proposed in this pull request?

* Fixes loading of **centernet-mobilenet-v2-fpn-512-coco-tf2** by aligning `base_filename` with the folder contained in the official TF-2 tarball.

## How is this patch tested?

* Cleared the local model cache and ran `foz.load_zoo_model("centernet-mobilenet-v2-fpn-512-coco-tf2")` → the archive downloaded, extracted, and the loader returned a model object with no `FileNotFoundError`.

* Confirmed that after extraction the folder `~/.fiftyone/models/centernet_mobilenetv2_fpn_od/` exists and contains
  `saved_model/`, demonstrating that the new `base_filename` aligns with the directory inside the tarball.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

Fixed the Centernet MobileNet-V2 FPN TF-2 model in the Model Zoo (`centernet-mobilenet-v2-fpn-512-coco-tf2`) so it now downloads and loads correctly (`foz.load_zoo_model`) on all platforms.

### What areas of FiftyOne does this PR affect?

- [ ] App
- [ ] Build
- [ ] Core
- [ ] Documentation
- [x] Other (Model Zoo manifest)
