### PR TITLE
bump eta version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ INSTALL_REQUIRES = [
     # internal packages
     "fiftyone-brain>=0.21.2,<0.22",
     "fiftyone-db>=0.4,<2.0",
-    "voxel51-eta>=0.14.1,<0.15",
+    "voxel51-eta>=0.14.2,<0.15",
 ]
 
 


### PR DESCRIPTION
Require `voxel51-eta>=0.14.2` to resolve https://github.com/voxel51/eta/pull/653.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the minimum required version of an internal package dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->