### PR TITLE
Update document.py

### DIFF
--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -354,7 +354,7 @@ class MongoEngineBaseDocument(SerializableDocument):
         if len(chunks) > 1:
             doc = self.get_field(chunks[0])
 
-            # handle sytnax: sample["field.0.attr"] = value
+            # handle syntax: sample["field.0.attr"] = value
             if isinstance(doc, (mongoengine.base.BaseList, fof.ListField)):
                 chunks = chunks[1].split(".", 1)
                 doc = doc[int(chunks[0])]


### PR DESCRIPTION
fix: correct typo "sytnax" to "syntax" in document.py

## What changes are proposed in this pull request?

This pull request fixes a minor typo in `fiftyone/core/odm/document.py`, correcting the word "sytnax" to the correct spelling "syntax". No functional code changes are involved.

## How is this patch tested? If it is not, please explain why.

This is a typo correction in a comment or non-functional text and does not affect runtime behavior. No additional tests are required.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Corrected a typo in a comment to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->