### PR TITLE
chore(deprecation): AS-711 deprecate kubernetes 1.29

### DIFF
--- a/docs/source/deprecation.rst
+++ b/docs/source/deprecation.rst
@@ -19,6 +19,17 @@ transitioned to `end-of-life` effective October of 2024. FiftyOne
 releases after July 1, 2025 might no longer be compatible with
 MongoDB 5.0 and older.
 
+.. _deprecation-kubernetes-1.29:
+
+Kubernetes 1.29
+---------------
+*Support ending June 1, 2025*
+
+`Kubernetes 1.29 <https://kubernetes.io/releases/>`_
+transitioned to `end-of-life` effective February of 2025. FiftyOne Enterprise
+releases after June 1, 2025 might no longer be compatible with
+Kubernetes 1.29 and older.
+
 .. _deprecation-mongodb-4.4:
 
 MongoDB 4.4


### PR DESCRIPTION
## What changes are proposed in this pull request?

Kubernetes 1.29 is [EOL](https://endoflife.date/kubernetes) and we are updating our [2.9.0 helm chart](https://github.com/voxel51/fiftyone-teams-app-deploy/pull/395) to no longer support it. We should document and reflect this. Note that this will be marked older than the `mongoDB` 5.0 deprecation since it will take effect sooner (back-dated June 1 to account for new release).

## How is this patch tested? If it is not, please explain why.

Docs-only PR to update `deprecation.voxel51.com`. See screenshot below:

<img width="891" alt="Screenshot 2025-06-09 at 3 42 39 PM" src="https://github.com/user-attachments/assets/421ed7ea-a49f-4bc1-8dd6-ab3c46396fd3" />


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

We are deprecating `kubernetes` versions `1.29` and older in our FiftyOne Enterprise product. Versions 1.29 and older of kubernetes might not be compatible with the FiftyOne Enterprise Helm Chart.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a deprecation notice for Kubernetes 1.29, indicating support ends June 1, 2025, and future releases may not be compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->