### PR TITLE
[Doc] Fix typos

### DIFF
--- a/docs/source/brain.rst
+++ b/docs/source/brain.rst
@@ -1730,7 +1730,7 @@ structures like `COCO <https://cocodataset.org/#home>`_.
 **Output**: A dictionary mapping IDs of samples with exact duplicates to lists
 of IDs of the duplicates for the corresponding sample
 
-**What to expect**: Exact duplicates analysis uses filehases to identify
+**What to expect**: Exact duplicates analysis uses filehashes to identify
 duplicate data, regardless of whether they are stored under the same or
 different filepaths in your dataset.
 

--- a/docs/source/dataset_zoo/remote.rst
+++ b/docs/source/dataset_zoo/remote.rst
@@ -232,7 +232,7 @@ about the dataset:
     | `splits`                     |           | A list of the dataset's supported splits. This should be omitted if the     |
     |                              |           | dataset does not contain splits                                             |
     +------------------------------+-----------+-----------------------------------------------------------------------------+
-    | `size_samples`               |           | The totaal number of samples in the dataset, or a list of per-split sizes   |
+    | `size_samples`               |           | The total number of samples in the dataset, or a list of per-split sizes   |
     +------------------------------+-----------+-----------------------------------------------------------------------------+
 
 Here are two example dataset YAML files:

--- a/docs/source/dataset_zoo/remote.rst
+++ b/docs/source/dataset_zoo/remote.rst
@@ -232,7 +232,7 @@ about the dataset:
     | `splits`                     |           | A list of the dataset's supported splits. This should be omitted if the     |
     |                              |           | dataset does not contain splits                                             |
     +------------------------------+-----------+-----------------------------------------------------------------------------+
-    | `size_samples`               |           | The total number of samples in the dataset, or a list of per-split sizes   |
+    | `size_samples`               |           | The total number of samples in the dataset, or a list of per-split sizes    |
     +------------------------------+-----------+-----------------------------------------------------------------------------+
 
 Here are two example dataset YAML files:

--- a/docs/source/enterprise/app.rst
+++ b/docs/source/enterprise/app.rst
@@ -7,7 +7,7 @@ FiftyOne Enterprise App
 
 The FiftyOne Enterprise App allows you to visualize, browse, and interact with your
 individual datasets like you can with the :ref:`FiftyOne App <fiftyone-app>`,
-but with expanded features for organizing, permissionsing, versioning, and
+but with expanded features for organizing, permissioning, versioning, and
 sharing your team's datasets, all from a centralized web portal.
 
 This page provides a brief overview of some features available only in the

--- a/docs/source/enterprise/data_quality.rst
+++ b/docs/source/enterprise/data_quality.rst
@@ -57,7 +57,7 @@ Clicking the "Scan Dataset" button presents two choices for execution:
 .. note::
 
     The "Execute" option is **only for testing**. In this mode, computation is
-    performend synchronously and will timeout if it does not complete within a
+    performed synchronously and will timeout if it does not complete within a
     few minutes.
 
     Choose "Schedule" for all production data, which schedules the scan for

--- a/docs/source/enterprise/plugins.rst
+++ b/docs/source/enterprise/plugins.rst
@@ -469,7 +469,7 @@ Runs page
 All users with at least **Can View** access to a dataset can visit the Runs
 page by clicking on the "Runs" tab.
 
-On the Runs page, you will see a table with a list of delgated operations.
+On the Runs page, you will see a table with a list of delegated operations.
 Admins can choose whether to view operations for all datasets or only the
 current dataset, while non-admins can only view operations associated with the
 current dataset.

--- a/docs/source/enterprise/query_performance.rst
+++ b/docs/source/enterprise/query_performance.rst
@@ -92,7 +92,7 @@ When you click "Execute", the index will be initiated and you'll see
 
 After the index creation has finished, the field that you indexed will have a
 lightning bolt icon in the sidebar, and you should notice that expanding the
-field's filter widget and performing queries on it will be noticably faster.
+field's filter widget and performing queries on it will be noticeably faster.
 
 .. warning::
 

--- a/docs/source/integrations/activitynet.rst
+++ b/docs/source/integrations/activitynet.rst
@@ -233,7 +233,7 @@ method provides builtin support for running
 
 ActivityNet-style evaluation is the default method when evaluating
 |TemporalDetections| labels, but you can also explicitly request it by setting
-the ``method`` parameter to ``"actvitynet"``.
+the ``method`` parameter to ``"activitynet"``.
 
 .. note::
 

--- a/docs/source/model_zoo/remote.rst
+++ b/docs/source/model_zoo/remote.rst
@@ -301,7 +301,7 @@ It can also provide optional metadata about the remote source itself:
     | `url`                            |           | The URL of the remote model source                                                        |
     +----------------------------------+-----------+-------------------------------------------------------------------------------------------+
 
-Here's an exaxmple model manifest file that declares a single model:
+Here's an example model manifest file that declares a single model:
 
 .. code-block:: json
 
@@ -395,7 +395,7 @@ below:
             model_name: the name of the model to load, as declared by the
                 ``base_name`` and optional ``version`` fields of the manifest
             model_path: the absolute filename or directory to which the model was
-                donwloaded, as declared by the ``base_filename`` field of the
+                downloaded, as declared by the ``base_filename`` field of the
                 manifest
             **kwargs: optional keyword arguments that configure how the model
                 is loaded
@@ -407,7 +407,7 @@ below:
         # The directory containing this file
         model_dir = os.path.dirname(model_path)
 
-        # Consturct the specified `Model` instance, generally by importing
+        # Construct the specified `Model` instance, generally by importing
         # other modules in `model_dir`
         model = ...
 

--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -219,7 +219,7 @@ The following fields are available:
     +------------------------------+-----------+-----------------------------------------------------------------------------+
     | `operators`                  |           | A list of operator names registered by the plugin, if any                   |
     +------------------------------+-----------+-----------------------------------------------------------------------------+
-    | `panels`                     |           | A list of panel names registred by the plugin, if any                       |
+    | `panels`                     |           | A list of panel names registered by the plugin, if any                       |
     +------------------------------+-----------+-----------------------------------------------------------------------------+
     | `secrets`                    |           | A list of secret keys that may be used by the plugin, if any                |
     +------------------------------+-----------+-----------------------------------------------------------------------------+
@@ -1805,7 +1805,7 @@ subsequent sections.
                 surfaces="grid",  # default = "grid"
 
                 # Markdown-formatted text that describes the panel. This is
-                # rendererd in a tooltip when the help icon in the panel
+                # rendered in a tooltip when the help icon in the panel
                 # title is hovered over
                 help_markdown="A description of the panel",
             )
@@ -2142,7 +2142,7 @@ behavior:
             surfaces="grid",  # default = "grid"
 
             # Markdown-formatted text that describes the panel. This is
-            # rendererd in a tooltip when the help icon in the panel
+            # rendered in a tooltip when the help icon in the panel
             # title is hovered over
             help_markdown="A description of the panel",
         )

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -878,7 +878,7 @@ Includes all updates from :ref:`FiftyOne 1.1.0 <release-notes-v1.1.0>`, plus:
 - Added support for evaluating models natively from the
   :ref:`Model Evaluation panel <app-model-evaluation-panel>`
 - Added support for :ref:`configuring an SMTP server <identity-providers>` for
-  sending user invitiations via email when running in
+  sending user invitations via email when running in
   :ref:`Internal Mode <internal-mode>`
 
 .. _release-notes-v1.1.0:
@@ -6903,7 +6903,7 @@ Docs
 - Added a recipe demonstrating how to
   :doc:`convert datasets </recipes/convert_datasets>` on disk between common
   formats
-- Added recipes demonstratings how to write your own
+- Added recipes demonstrating how to write your own
   :doc:`custom dataset importers </recipes/custom_importer>`,
   :doc:`custom dataset exporters </recipes/custom_exporter>`, and
   :doc:`custom sample parsers </recipes/custom_parser>`

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -396,7 +396,7 @@ You can optionally configure
 `MongoDB network compression <https://www.mongodb.com/developer/products/mongodb/mongodb-network-compression>`_
 via the `database_compressor` config setting.
 
-By default, compression is disabled, but enabling it can give a signifcant
+By default, compression is disabled, but enabling it can give a significant
 performance boost in suboptimal network environments.
 
 You can achieve this by adding the following entry to your
@@ -742,7 +742,7 @@ The FiftyOne App can be configured in the ways described below:
 | `media_fallback`           | `FIFTYONE_APP_MEDIA_FALLBACK`           | `False`       | Whether to fall back to the default media field (`"filepath"`) when the configured media   |
 |                            |                                         |               | field's value for a sample is not defined.                                                 |
 +----------------------------+-----------------------------------------+---------------+--------------------------------------------------------------------------------------------+
-| `multicolor_keypoints`     | `FIFTYONE_APP_MULTICOLOR_KEYPOINTS`     | `False`       | Whether to independently coloy keypoint points by their index                              |
+| `multicolor_keypoints`     | `FIFTYONE_APP_MULTICOLOR_KEYPOINTS`     | `False`       | Whether to independently color keypoint points by their index                              |
 +----------------------------+-----------------------------------------+---------------+--------------------------------------------------------------------------------------------+
 | `notebook_height`          | `FIFTYONE_APP_NOTEBOOK_HEIGHT`          | `800`         | The height of App instances displayed in notebook cells.                                   |
 +----------------------------+-----------------------------------------+---------------+--------------------------------------------------------------------------------------------+

--- a/docs/source/user_guide/dataset_creation/datasets.rst
+++ b/docs/source/user_guide/dataset_creation/datasets.rst
@@ -5019,7 +5019,7 @@ of the samples in the dataset, `annotations/` contains any serialized
 
 The contents of the `data/` directory may also be organized in nested
 subfolders, depending on how the dataset was exported, in which case the
-filepaths in `samples.json` should contain corerspondingly nested paths.
+filepaths in `samples.json` should contain correspondingly nested paths.
 
 Video datasets have an additional `frames.json` file that contains a serialized
 representation of the frame labels for each video in the dataset.

--- a/docs/source/user_guide/dataset_creation/samples.rst
+++ b/docs/source/user_guide/dataset_creation/samples.rst
@@ -975,7 +975,7 @@ classification or object detections) associated with the image.
         property that declares whether the sample parser can return an |ImageMetadata|
         for the current sample's image via
         :meth:`get_image_metadata() <fiftyone.utils.data.parsers.LabeledImageSampleParser.get_image_metadata>`.
-        Additionality, the
+        Additionally, the
         :meth:`label_cls <fiftyone.utils.data.parsers.LabeledImageSampleParser.label_cls>`
         property of the parser declares the type of label(s) that the parser
         will produce.

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -4342,7 +4342,7 @@ _________________________
 If you work with collections of related fields that you would like to organize
 under a single top-level field, you can achieve this by defining and using
 custom |EmbeddedDocument| and |DynamicEmbeddedDocument| classes to populate
-your datasetes.
+your datasets.
 
 Using custom embedded document classes enables you to access your data using
 the same object-oriented interface enjoyed by FiftyOne's
@@ -4964,7 +4964,7 @@ serializes the scene into an FO3D file.
 
     print(dataset.media_type)  # 3d
 
-To modify an exising scene, load it via
+To modify an existing scene, load it via
 :meth:`Scene.from_fo3d() <fiftyone.core.threed.Scene.from_fo3d>`, perform any
 necessary updates, and then re-write it to disk:
 
@@ -5806,7 +5806,7 @@ in a collection and saving the sample edits:
 By default,
 :meth:`update_samples() <fiftyone.core.collections.SampleCollection.update_samples>`
 leverages a multiprocessing pool to parallelize the work across a number of
-workers, resulting in signficant performance improvements over the equivalent
+workers, resulting in significant performance improvements over the equivalent
 :meth:`iter_samples(autosave=True) <fiftyone.core.dataset.Dataset.iter_samples>`
 syntax:
 
@@ -5928,7 +5928,7 @@ applying a function to each sample, and returning the results as a generator.
 By default,
 :meth:`map_samples() <fiftyone.core.collections.SampleCollection.map_samples>`
 leverages a multiprocessing pool to parallelize the work across a number of
-workers, resulting in signficant performance improvements over the equivalent
+workers, resulting in significant performance improvements over the equivalent
 :meth:`iter_samples() <fiftyone.core.dataset.Dataset.iter_samples>` syntax:
 
 .. code-block:: python


### PR DESCRIPTION
Found and fixed some typos  in the docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected multiple typographical errors throughout the documentation to improve clarity and accuracy. No changes to functionality or user experience were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->