### PR TITLE
fix subsets filter not applying to confidence distribution chart

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/Scenarios.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/Scenarios.tsx
@@ -1395,7 +1395,7 @@ function ConfidenceDistributionChart(props) {
     });
     if (compareSubsetsData) {
       const compareY = [];
-      for (const subset in compareSubsetsData) {
+      for (const subset of subsets) {
         const subsetData = compareSubsetsData[subset];
         const { confidence_distribution } = subsetData;
         compareY.push(confidence_distribution[mode]);
@@ -1422,7 +1422,7 @@ function ConfidenceDistributionChart(props) {
       const compareLowerfence = [];
       const compareUpperfence = [];
 
-      for (const subset in subsets_data) {
+      for (const subset of subsets) {
         const subsetData = subsets_data[subset];
         const compareSubsetData = compareSubsetsData[subset];
         const { confidence_distribution } = subsetData;
@@ -1473,7 +1473,7 @@ function ConfidenceDistributionChart(props) {
       const lowerfence = [];
       const upperfence = [];
 
-      for (const subset in subsets_data) {
+      for (const subset of subsets) {
         const subsetData = subsets_data[subset];
         const { confidence_distribution } = subsetData;
         x.push(subset);


### PR DESCRIPTION
## What changes are proposed in this pull request?

fix subsets filter not applying to confidence distribution chart

## How is this patch tested? If it is not, please explain why.

Using the model evaluation panel

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the way subsets are processed in confidence distribution charts for more consistent data handling. No changes to visible features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->