### PR TITLE
read-only mode support in model evaluation panel

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/ActionMenu.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/ActionMenu.tsx
@@ -1,3 +1,5 @@
+import { TooltipProvider } from "@fiftyone/components";
+import { useMutation } from "@fiftyone/state";
 import { DeleteOutline, MoreVert } from "@mui/icons-material";
 import {
   Box,
@@ -11,11 +13,8 @@ import React, { useState } from "react";
 import { useSetRecoilState } from "recoil";
 import { openModelEvalDialog, selectedModelEvaluation } from "./utils";
 
-type ActionMenuProps = {
-  evaluationName: string;
-};
-
-const ActionMenu: React.FC<ActionMenuProps> = (props) => {
+export default function ActionMenu(props: ActionMenuProps) {
+  const { canDelete } = props;
   const setOpenModelEvalDialog = useSetRecoilState(openModelEvalDialog);
   const setEvaluation = useSetRecoilState(selectedModelEvaluation);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -24,6 +23,7 @@ const ActionMenu: React.FC<ActionMenuProps> = (props) => {
     event.preventDefault();
     setAnchorEl(event.currentTarget);
   };
+  const [enable, message] = useMutation(canDelete, "delete evaluation");
 
   return (
     <Box>
@@ -35,38 +35,33 @@ const ActionMenu: React.FC<ActionMenuProps> = (props) => {
         open={Boolean(anchorEl)}
         onClose={() => setAnchorEl(null)}
       >
-        {/* <MenuItem
-        onClick={() => {
-          // Handle re-evaluate action
-          handleReEvaluate();
-          setAnchorEl(null);
-        }}
-      >
-        <ListItemIcon>
-          <Refresh fontSize="small" />
-        </ListItemIcon>
-        <ListItemText>Re-evaluate</ListItemText>
-      </MenuItem> */}
-        <MenuItem
-          onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
-            event.stopPropagation();
-            event.preventDefault();
-            setEvaluation(props.evaluationName);
-            setOpenModelEvalDialog(true);
-            setAnchorEl(null);
-          }}
-        >
-          <ListItemIcon>
-            <DeleteOutline fontSize="small" color="error" />
-          </ListItemIcon>
-          <ListItemText
-            primary="Delete"
-            primaryTypographyProps={{ color: "error" }}
-          />
-        </MenuItem>
+        <TooltipProvider title={message}>
+          <MenuItem
+            onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+              event.stopPropagation();
+              event.preventDefault();
+              setEvaluation(props.evaluationName);
+              setOpenModelEvalDialog(true);
+              setAnchorEl(null);
+            }}
+            disabled={!enable}
+            title={message}
+          >
+            <ListItemIcon>
+              <DeleteOutline fontSize="small" color="error" />
+            </ListItemIcon>
+            <ListItemText
+              primary="Delete"
+              primaryTypographyProps={{ color: "error" }}
+            />
+          </MenuItem>
+        </TooltipProvider>
       </Menu>
     </Box>
   );
-};
+}
 
-export default ActionMenu;
+type ActionMenuProps = {
+  evaluationName: string;
+  canDelete: boolean;
+};

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluate.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluate.tsx
@@ -1,4 +1,5 @@
 import { MuiButton } from "@fiftyone/components";
+import { useMutation } from "@fiftyone/state";
 import { Add } from "@mui/icons-material";
 import { Box } from "@mui/material";
 import React from "react";
@@ -6,16 +7,15 @@ import React from "react";
 export default function Evaluate(props: EvaluateProps) {
   const { onEvaluate, permissions } = props;
   const canEvaluate = permissions.can_evaluate;
+  const [enable, message, cursor] = useMutation(canEvaluate, "evaluate model");
+
   return (
-    <Box
-      title={canEvaluate ? "" : "You do not have permission to evaluate model"}
-      sx={{ cursor: canEvaluate ? "pointer" : "not-allowed" }}
-    >
+    <Box title={message} sx={{ cursor }}>
       <MuiButton
         onClick={onEvaluate}
         startIcon={<Add />}
         variant="contained"
-        disabled={!canEvaluate}
+        disabled={!enable}
       >
         Evaluate Model
       </MuiButton>

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Evaluation.tsx
@@ -26,6 +26,7 @@ import Status from "./Status";
 import { tabStyles } from "./styles";
 import { ConcreteEvaluationType } from "./Types";
 import { computeSortedCompareKeys } from "./utils";
+import { useMutation } from "@fiftyone/state";
 
 export default function Evaluation(props: EvaluationProps) {
   const {
@@ -81,7 +82,9 @@ export default function Evaluation(props: EvaluationProps) {
   const status = useMemo(() => {
     return statuses[id];
   }, [statuses, id]);
-  const { can_edit_status, can_rename } = data?.permissions || {};
+  const { can_edit_status, can_rename, can_delete_evaluation } =
+    data?.permissions || {};
+  const [canRename, renameMsg] = useMutation(can_rename, "rename evaluation");
 
   useEffect(() => {
     if (!evaluation) {
@@ -153,12 +156,8 @@ export default function Evaluation(props: EvaluationProps) {
               onSave={(newLabel) => {
                 onRename(name, newLabel);
               }}
-              disabled={!can_rename}
-              title={
-                !can_rename
-                  ? "You do not have permission to rename evaluation"
-                  : undefined
-              }
+              disabled={!canRename}
+              title={renameMsg}
             />
           </Stack>
 
@@ -260,7 +259,12 @@ export default function Evaluation(props: EvaluationProps) {
             status={status}
             canEdit={can_edit_status}
           />
-          {!compareKey && <ActionMenu evaluationName={evaluation.info.key} />}
+          {!compareKey && (
+            <ActionMenu
+              evaluationName={evaluation.info.key}
+              canDelete={can_delete_evaluation}
+            />
+          )}
         </Stack>
       </Stack>
 

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/EvaluationIcon.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/EvaluationIcon.tsx
@@ -4,12 +4,13 @@ import CrisisAlertOutlinedIcon from "@mui/icons-material/CrisisAlertOutlined";
 import Layers from "@mui/icons-material/Layers";
 import PieChartOutlinedIcon from "@mui/icons-material/PieChartOutlined";
 import ShowChartOutlinedIcon from "@mui/icons-material/ShowChartOutlined";
-import { IconButton } from "@mui/material";
+import { Box } from "@mui/material";
 import { capitalize } from "lodash";
+import React from "react";
 import { ConcreteEvaluationType } from "./Types";
 
 interface Props {
-  type: ConcreteEvaluationType;
+  type?: ConcreteEvaluationType;
   method?: string;
   color?: string;
 }
@@ -17,40 +18,26 @@ interface Props {
 export default function EvaluationIcon(props: Props) {
   const { type, method, color } = props;
 
-  let evalIcon = <Layers />;
+  let IconComponent = Layers;
   if (type === "classification" && method === "binary") {
-    evalIcon = <CallSplitOutlinedIcon />;
+    IconComponent = CallSplitOutlinedIcon;
   } else if (type === "classification" && method !== "binary") {
-    evalIcon = <Layers />;
+    IconComponent = Layers;
   } else if (type === "detection") {
-    evalIcon = <CrisisAlertOutlinedIcon />;
+    IconComponent = CrisisAlertOutlinedIcon;
   } else if (type === "segmentation") {
-    evalIcon = <PieChartOutlinedIcon />;
+    IconComponent = PieChartOutlinedIcon;
   } else if (type === "regression") {
-    evalIcon = <ShowChartOutlinedIcon />;
+    IconComponent = ShowChartOutlinedIcon;
   }
 
   return (
     <TooltipProvider
-      title={
-        <span style={{ fontSize: "1rem", fontWeight: "normal" }}>
-          Evaluation type: {capitalize(type)}
-        </span>
-      }
-      arrow
-      placement="bottom"
+      title={type ? `Evaluation type: ${capitalize(type)}` : undefined}
     >
-      <IconButton
-        size="small"
-        sx={{
-          color: color ?? "#FFC48B",
-          "&:hover": {
-            backgroundColor: "transparent",
-          },
-        }}
-      >
-        {evalIcon}
-      </IconButton>
+      <Box sx={{ display: "flex" }}>
+        <IconComponent sx={{ color: color ?? "#FFC48B" }} />
+      </Box>
     </TooltipProvider>
   );
 }

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Overview.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Overview.tsx
@@ -11,6 +11,7 @@ import {
   OverviewProps,
 } from "./Types";
 import ActionMenu from "./ActionMenu";
+import { useMutation } from "@fiftyone/state";
 
 export default function Overview(props: OverviewProps) {
   const {
@@ -24,6 +25,7 @@ export default function Overview(props: OverviewProps) {
     onRename,
   } = props;
   const count = evaluations.length;
+  const { can_delete_evaluation, can_rename } = permissions;
 
   return (
     <Stack spacing={2} sx={{ p: 2 }}>
@@ -55,7 +57,8 @@ export default function Overview(props: OverviewProps) {
             method={method}
             onSelect={onSelect}
             onRename={onRename}
-            hasRenamePermission={permissions?.can_rename}
+            hasDeletePermission={can_delete_evaluation}
+            hasRenamePermission={can_rename}
           />
         );
       })}
@@ -90,9 +93,15 @@ function EvaluationCard(props: EvaluationCardProps) {
     type,
     method,
     onRename,
+    hasDeletePermission,
     hasRenamePermission,
   } = props;
   const [hovering, setHovering] = React.useState(false);
+
+  const [enable, message] = useMutation(
+    hasRenamePermission,
+    "rename evaluation"
+  );
 
   return (
     <CardActionArea
@@ -107,7 +116,7 @@ function EvaluationCard(props: EvaluationCardProps) {
     >
       <Card
         sx={{ p: 2, cursor: "pointer" }}
-        onClick={(event: React.MouseEvent<HTMLDivElement>) => {
+        onClick={() => {
           onSelect(eval_key, id);
         }}
       >
@@ -128,12 +137,8 @@ function EvaluationCard(props: EvaluationCardProps) {
                 onRename(eval_key, newName);
               }}
               showEditIcon={hovering}
-              disabled={!hasRenamePermission}
-              title={
-                !hasRenamePermission
-                  ? "You do not have permission to rename evaluation"
-                  : undefined
-              }
+              disabled={!enable}
+              title={message}
             />
           </Stack>
           <Stack direction="row" spacing={0.5} alignItems={"center"}>
@@ -154,7 +159,12 @@ function EvaluationCard(props: EvaluationCardProps) {
               />
             )}
             {status && <Status status={status} readOnly />}
-            {!pending && <ActionMenu evaluationName={eval_key} />}
+            {!pending && (
+              <ActionMenu
+                evaluationName={eval_key}
+                canDelete={hasDeletePermission}
+              />
+            )}
           </Stack>
         </Stack>
         {note && <EvaluationNotes notes={note} variant="overview" />}

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Status.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Status.tsx
@@ -1,4 +1,5 @@
 import { ColoredDot } from "@fiftyone/components";
+import { useMutation } from "@fiftyone/state";
 import { Chip, MenuItem, Select, Stack, Typography } from "@mui/material";
 import React from "react";
 import { useTriggerEvent } from "./utils";
@@ -6,6 +7,7 @@ import { useTriggerEvent } from "./utils";
 export default function Status(props: StatusProps) {
   const { status, canEdit, readOnly, setStatusEvent } = props;
   const triggerEvent = useTriggerEvent();
+  const [enable, message] = useMutation(canEdit, "update evaluation status");
 
   if (!readOnly) {
     return (
@@ -14,20 +16,16 @@ export default function Status(props: StatusProps) {
           height: "28px",
           borderRadius: 16,
           backgroundColor: (theme) => theme.palette.action.selected,
-          "& fieldset": {
-            border: "none",
-          },
+          "& fieldset": { border: "none" },
         }}
         defaultValue={status || "needs_review"}
         onChange={(e) => {
-          triggerEvent(setStatusEvent, { status: e.target.value });
+          if (setStatusEvent) {
+            triggerEvent(setStatusEvent, { status: e.target.value });
+          }
         }}
-        title={
-          canEdit
-            ? ""
-            : "You do not have permission to update evaluation status"
-        }
-        disabled={!canEdit}
+        title={message}
+        disabled={!enable}
       >
         {STATUSES.map((status) => {
           const color = COLOR_BY_STATUS[status];
@@ -67,10 +65,10 @@ export default function Status(props: StatusProps) {
 }
 
 type StatusProps = {
-  status?: string;
-  canEdit?: boolean;
+  status: string;
+  canEdit: boolean;
   readOnly?: boolean;
-  setStatusEvent: string;
+  setStatusEvent?: string;
 };
 
 const STATUS_LABELS = {

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Types.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Types.tsx
@@ -35,7 +35,8 @@ export type EvaluationCardProps = {
   pending?: boolean;
   status?: string;
   onRename: OverviewProps["onRename"];
-  hasRenamePermission?: boolean;
+  hasRenamePermission: boolean;
+  hasDeletePermission: boolean;
 };
 
 export type ConcreteEvaluationType =

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/components/CreateScenario.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/components/CreateScenario.tsx
@@ -2,10 +2,12 @@ import { useTrackEvent } from "@fiftyone/analytics";
 import { TooltipProvider } from "@fiftyone/components";
 import { usePanelEvent } from "@fiftyone/operators";
 import { usePanelId } from "@fiftyone/spaces";
+import { useMutation } from "@fiftyone/state";
 import Add from "@mui/icons-material/Add";
 import { Button } from "@mui/material";
+import React from "react";
 
-export default function CreateScenario(props) {
+export default function CreateScenario(props: CreateScenarioPropsType) {
   const {
     evalKey,
     compareKey,
@@ -13,23 +15,17 @@ export default function CreateScenario(props) {
     gt_field,
     onAdd,
     eval_id,
-    readOnly,
     variant = "icon",
+    canCreate,
   } = props;
 
   const panelId = usePanelId();
   const promptOperator = usePanelEvent();
   const trackEvent = useTrackEvent();
+  const [enable, message] = useMutation(canCreate, "create scenario");
 
   return (
-    <TooltipProvider
-      title={
-        readOnly
-          ? "You do not have permission to create scenarios"
-          : "Create Scenario"
-      }
-      placement="bottom"
-    >
+    <TooltipProvider title={message} placement="bottom">
       <Button
         size="small"
         variant="contained"
@@ -45,7 +41,7 @@ export default function CreateScenario(props) {
             },
             operator: CONFIGURE_SCENARIO_ACTION,
             prompt: true,
-            callback: (results) => {
+            callback: (results: unknown) => {
               trackEvent("create_scenario_modal_open", {
                 eval_id,
               });
@@ -56,7 +52,7 @@ export default function CreateScenario(props) {
           });
         }}
         sx={{ minWidth: "auto", height: "100%" }}
-        disabled={readOnly}
+        disabled={!enable}
       >
         {variant === "icon" && <Add />}
         {variant === "text" && "Create a scenario"}
@@ -66,3 +62,14 @@ export default function CreateScenario(props) {
 }
 
 const CONFIGURE_SCENARIO_ACTION = "model_evaluation_configure_scenario";
+
+type CreateScenarioPropsType = {
+  evalKey: string;
+  compareKey?: string;
+  loadScenarios: (callback: () => void) => void;
+  gt_field: string;
+  onAdd?: (id: string) => void;
+  eval_id: string;
+  canCreate: boolean;
+  variant?: "icon" | "text";
+};

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/overview/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/overview/index.tsx
@@ -25,6 +25,7 @@ import MetricPerformance from "./MetricPerformance";
 import Summary from "./Summary";
 import { useTrackEvent } from "@fiftyone/analytics";
 import { usePanelStatePartial } from "@fiftyone/spaces";
+import { useMutation } from "@fiftyone/state";
 
 export default function Overview(props) {
   const {
@@ -64,6 +65,10 @@ export default function Overview(props) {
   }, [notes, id]);
 
   const { can_edit_note } = data?.permissions || {};
+  const [enable, message, cursor] = useMutation(
+    can_edit_note,
+    "edit evaluation note"
+  );
 
   useEffect(() => {
     if (!evaluation) {
@@ -111,14 +116,7 @@ export default function Overview(props) {
       <Card sx={{ p: 2, mb: 2 }}>
         <Stack direction="row" sx={{ justifyContent: "space-between" }}>
           <Typography color="secondary">Evaluation notes</Typography>
-          <Box
-            title={
-              can_edit_note
-                ? ""
-                : "You do not have permission to edit evaluation notes"
-            }
-            sx={{ cursor: can_edit_note ? "pointer" : "not-allowed" }}
-          >
+          <Box title={message} sx={{ cursor }}>
             <IconButton
               size="small"
               color="secondary"
@@ -126,7 +124,7 @@ export default function Overview(props) {
               onClick={() => {
                 setEditNoteState((note) => ({ ...note, open: true }));
               }}
-              disabled={!can_edit_note}
+              disabled={!enable}
             >
               <EditNote />
             </IconButton>

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/Actions.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/Actions.tsx
@@ -1,4 +1,5 @@
 import { TooltipProvider } from "@fiftyone/components";
+import { useMutation } from "@fiftyone/state";
 import { DeleteOutline, EditOutlined } from "@mui/icons-material";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import {
@@ -12,7 +13,7 @@ import {
 import React from "react";
 import ConfirmDelete from "../../components/ConfirmDelete";
 
-export default function Actions(props) {
+export default function Actions(props: ActionsPropsType) {
   const { onDelete, onEdit, canEdit, canDelete } = props;
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
@@ -23,6 +24,8 @@ export default function Actions(props) {
   const handleClose = () => {
     setAnchorEl(null);
   };
+  const [enableDelete, deleteMsg] = useMutation(canDelete, "delete scenario");
+  const [enableEdit, editMsg] = useMutation(canEdit, "edit scenario");
 
   return (
     <Stack>
@@ -35,17 +38,13 @@ export default function Actions(props) {
         open={open}
         onClose={handleClose}
       >
-        <TooltipProvider
-          title={
-            canEdit ? undefined : "You do not have permission to edit scenario"
-          }
-        >
+        <TooltipProvider title={editMsg}>
           <MenuItem
             onClick={() => {
               onEdit?.();
               handleClose();
             }}
-            disabled={!canEdit}
+            disabled={!enableEdit}
           >
             <ListItemIcon>
               <EditOutlined fontSize="small" color="secondary" />
@@ -53,19 +52,13 @@ export default function Actions(props) {
             <Typography color="secondary">Edit</Typography>
           </MenuItem>
         </TooltipProvider>
-        <TooltipProvider
-          title={
-            canEdit
-              ? undefined
-              : "You do not have permission to delete scenario"
-          }
-        >
+        <TooltipProvider title={deleteMsg}>
           <MenuItem
             onClick={() => {
               setDeleteOpen(true);
               handleClose();
             }}
-            disabled={!canDelete}
+            disabled={!enableDelete}
           >
             <ListItemIcon>
               <DeleteOutline fontSize="small" color="error" />
@@ -84,3 +77,10 @@ export default function Actions(props) {
     </Stack>
   );
 }
+
+type ActionsPropsType = {
+  onDelete: () => void;
+  onEdit?: () => void;
+  canEdit: boolean;
+  canDelete: boolean;
+};

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/EmptyScenario.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/EmptyScenario.tsx
@@ -4,12 +4,12 @@ import CreateScenario from "../../components/CreateScenario";
 import EvaluationIcon from "../../EvaluationIcon";
 import { scenarioCardStyles } from "../../styles";
 
-export default function EmptyScenario(props) {
+export default function EmptyScenario(props: EmptyScenarioPropsType) {
   return (
     <Box sx={scenarioCardStyles.emptyState}>
       <Stack spacing={1.5} alignItems="center">
         <Box sx={scenarioCardStyles.iconContainer}>
-          <EvaluationIcon type="scenario" />
+          <EvaluationIcon />
         </Box>
         <Typography variant="h6">No scenarios yet</Typography>
         <Typography variant="body1" color="text.secondary">
@@ -17,7 +17,18 @@ export default function EmptyScenario(props) {
           data segments.
         </Typography>
       </Stack>
-      <CreateScenario variant="text" {...props} />
+      <Box>
+        <CreateScenario variant="text" {...props} />
+      </Box>
     </Box>
   );
 }
+
+type EmptyScenarioPropsType = {
+  eval_id: string;
+  loadScenarios: (callback: () => void) => void;
+  gt_field: string;
+  evalKey: string;
+  compareKey?: string;
+  canCreate: boolean;
+};

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/Scenarios.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/Scenarios.tsx
@@ -385,12 +385,11 @@ export default function Scenarios(props) {
             }}
             evalKey={key}
             compareKey={compareKey}
-            readOnly={!canCreate}
+            canCreate={canCreate}
           />
           <Actions
             onDelete={onDelete}
             onEdit={onEdit}
-            canCreate={canCreate}
             canEdit={canEdit}
             canDelete={canDelete}
           />

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/index.tsx
@@ -5,13 +5,14 @@ import EmptyScenario from "./EmptyScenario";
 import Scenarios from "./Scenarios";
 
 export default function EvaluationScenarioAnalysis(props) {
-  const { evaluation, data, loadScenarios } = props;
+  const { evaluation, data = {}, loadScenarios } = props;
   const { scenarios } = data;
   const evaluationInfo = evaluation.info;
   const evaluationConfig = evaluationInfo.config;
   const scenariosArray = scenarios ? Object.values(scenarios) : [];
   const isEmpty = scenariosArray.length === 0;
-  const { key, compareKey } = data?.view || {};
+  const { view = {}, permissions = {} } = data;
+  const { id, key, compareKey } = view;
 
   return (
     <Card sx={{ p: 2 }}>
@@ -23,12 +24,12 @@ export default function EvaluationScenarioAnalysis(props) {
       </Stack>
       {isEmpty ? (
         <EmptyScenario
-          eval_id={data?.view?.id}
+          eval_id={id}
           loadScenarios={loadScenarios}
           gt_field={evaluationConfig.gt_field}
           evalKey={key}
           compareKey={compareKey}
-          readOnly={!data.permissions?.can_create_scenario}
+          canCreate={permissions.can_create_scenario}
         />
       ) : (
         <Scenarios {...props} />

--- a/app/packages/state/src/hooks/index.ts
+++ b/app/packages/state/src/hooks/index.ts
@@ -49,6 +49,7 @@ export { default as useToPatches } from "./useToPatches";
 export { default as useUnboundState } from "./useUnboundState";
 export { default as useUpdateSamples } from "./useUpdateSamples";
 export { default as withSuspense } from "./withSuspense";
+export { default as useMutation } from "./useMutation";
 
 // types
 export * from "./types";

--- a/app/packages/state/src/hooks/useMutation.ts
+++ b/app/packages/state/src/hooks/useMutation.ts
@@ -1,0 +1,8 @@
+import { useRecoilValue } from "recoil";
+import { readOnly } from "../recoil/permission";
+import { canPerformAction } from "@fiftyone/utilities";
+
+export default function useMutation(hasPermission: boolean, mutation?: string) {
+  const isReadOnly = useRecoilValue(readOnly) as boolean;
+  return canPerformAction(hasPermission, isReadOnly, mutation);
+}

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -356,41 +356,6 @@ export const theme = atom<"dark" | "light">({
   effects: [getBrowserStorageEffectForKey("mui-mode")],
 });
 
-export const canEditSavedViews = sessionAtom({
-  key: "canEditSavedViews",
-  default: { enabled: true, message: null },
-});
-
-export const canEditWorkspaces = sessionAtom({
-  key: "canEditWorkspaces",
-  default: { enabled: true, message: null },
-});
-
-export const canEditCustomColors = sessionAtom({
-  key: "canEditCustomColors",
-  default: { enabled: true, message: null },
-});
-
-export const canCreateNewField = sessionAtom({
-  key: "canCreateNewField",
-  default: { enabled: true, message: null },
-});
-
-export const canModifySidebarGroup = sessionAtom({
-  key: "canModifySidebarGroup",
-  default: { enabled: true, message: null },
-});
-
-export const canTagSamplesOrLabels = sessionAtom({
-  key: "canTagSamplesOrLabels",
-  default: { enabled: true, message: null },
-});
-
-export const readOnly = sessionAtom({
-  key: "readOnly",
-  default: false,
-});
-
 export const sessionSpaces = sessionAtom({
   key: "sessionSpaces",
   default: GRID_SPACES_DEFAULT,

--- a/app/packages/state/src/recoil/index.ts
+++ b/app/packages/state/src/recoil/index.ts
@@ -29,3 +29,4 @@ export * from "./sidebarExpanded";
 export * from "./types";
 export * from "./utils";
 export * from "./view";
+export * from "./permission";

--- a/app/packages/state/src/recoil/permission.ts
+++ b/app/packages/state/src/recoil/permission.ts
@@ -1,0 +1,36 @@
+import { sessionAtom } from "../session";
+
+export const canEditSavedViews = sessionAtom({
+  key: "canEditSavedViews",
+  default: { enabled: true, message: null },
+});
+
+export const canEditWorkspaces = sessionAtom({
+  key: "canEditWorkspaces",
+  default: { enabled: true, message: null },
+});
+
+export const canEditCustomColors = sessionAtom({
+  key: "canEditCustomColors",
+  default: { enabled: true, message: null },
+});
+
+export const canCreateNewField = sessionAtom({
+  key: "canCreateNewField",
+  default: { enabled: true, message: null },
+});
+
+export const canModifySidebarGroup = sessionAtom({
+  key: "canModifySidebarGroup",
+  default: { enabled: true, message: null },
+});
+
+export const canTagSamplesOrLabels = sessionAtom({
+  key: "canTagSamplesOrLabels",
+  default: { enabled: true, message: null },
+});
+
+export const readOnly = sessionAtom({
+  key: "readOnly",
+  default: false,
+});

--- a/app/packages/utilities/src/index.ts
+++ b/app/packages/utilities/src/index.ts
@@ -17,6 +17,7 @@ export { default as sizeBytesEstimate } from "./size-bytes-estimate";
 export * as styles from "./styles";
 export * from "./type-check";
 export * from "./format";
+export * from "./permission";
 
 interface O {
   [key: string]: O | any;

--- a/app/packages/utilities/src/permission.ts
+++ b/app/packages/utilities/src/permission.ts
@@ -1,0 +1,22 @@
+export function canPerformAction(
+  allowed: boolean,
+  readOnly: boolean,
+  action?: string
+): CanPerformActionReturnType {
+  const enable = allowed && !readOnly;
+  let message;
+  if (action) {
+    if (!allowed) {
+      message = `You do not have permission to ${action}`;
+    } else if (readOnly) {
+      message = `You cannot ${action} in read-only mode`;
+    }
+  }
+  return [enable, message, enable ? "pointer" : "not-allowed"];
+}
+
+type CanPerformActionReturnType = [
+  boolean,
+  string | undefined,
+  "pointer" | "not-allowed"
+];


### PR DESCRIPTION
## What changes are proposed in this pull request?

read-only mode support in model evaluation panel

## How is this patch tested? If it is not, please explain why.

Using model evaluation panel with readonly forced to true

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced permission-based controls for evaluation actions such as renaming, deleting, editing notes, and creating scenarios, providing clearer UI feedback and dynamic tooltips based on user permissions.
  - Added dynamic tooltips, cursor styles, and disabled states for action buttons and menu items, improving user guidance when actions are unavailable.

- **Refactor**
  - Unified permission logic across evaluation components using a new mutation-based hook for consistent user experience.
  - Improved TypeScript typings for component props, making permission requirements explicit.
  - Simplified icon and tooltip rendering for evaluation status and scenario components.
  - Updated component props and handlers to better reflect permission states and improve UI safety.

- **Chores**
  - Introduced new utility functions and hooks for centralized permission checking and messaging.
  - Reorganized permission-related state atoms for better session management and consistency.
  - Extended public APIs to include permission utilities and hooks for broader use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->