### PR TITLE
explicitly prep yarn

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -67,6 +67,8 @@ if [ ${BUILD_APP} = true ]; then
     fi
     cd app
     echo "Building the App. This will take a minute or two..."
+    corepack enable
+    corepack prepare yarn --activate
     yarn install > /dev/null 2>&1
     yarn build
     cd ..


### PR DESCRIPTION
## What changes are proposed in this pull request?

`yarn` commands fail because of the "Would you like to install Yarn?" prompt, which results in the app not getting installed and 404-ing. This PR fixes that.

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the installation script to ensure proper setup of package management tools before installing and building the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->