### PR TITLE
Update ViewStageParameter.tsx

### DIFF
--- a/app/packages/core/src/components/ViewBar/ViewStage/ViewStageParameter.tsx
+++ b/app/packages/core/src/components/ViewBar/ViewStage/ViewStageParameter.tsx
@@ -75,7 +75,7 @@ const ObjectEditorTextArea = animated(styled.textarea`
   color: ${({ theme }) => theme.text.primary};
   height: 100%;
   font-size: 14px;
-  will-change: tranform;
+  will-change: transform;
   resize: none;
 
   &::-webkit-scrollbar {
@@ -227,7 +227,7 @@ const ObjectEditor = ({
       containerRef.current.style.left = state.matches("editing")
         ? `${x}px`
         : "unset";
-      // barRef.current is oten undefined. Should it be set somehwere?
+      // barRef.current is oten undefined. Should it be set somewhere?
       const { x: barX, width: barWidth } = barRef.current
         ? barRef.current.getBoundingClientRect()
         : { x: "auto", width: "auto" };


### PR DESCRIPTION
* Fix “tranform” → “transform” in `ViewStageParameter.tsx`
* Fix “somehwere” → “somewhere” in the same file

## What changes are proposed in this pull request?

This patch corrects two spelling mistakes in the `ViewStageParameter.tsx` component:

1. Replaces the misspelled “tranform” with the correct “transform” (line 78).
2. Replaces the misspelled “somehwere” with “somewhere” (line 230).

The changes are purely editorial. No functional code changes.

## How is this patch tested? If it is not, please explain why.

N/A

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [X] No. You can skip the rest of this section.
* [ ] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

* [X] App: FiftyOne application changes
* [ ] Build: Build and test infrastructure changes
* [ ] Core: Core `fiftyone` Python library changes
* [ ] Documentation: FiftyOne documentation changes
* [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Corrected a typo in a CSS property to improve styling consistency.

- **Documentation**
	- Updated an in-code comment for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->