### PR TITLE
make distribution preview toggle always visible

### DIFF
--- a/plugins/operators/model_evaluation/__init__.py
+++ b/plugins/operators/model_evaluation/__init__.py
@@ -313,11 +313,13 @@ class ConfigureScenario(foo.Operator):
         return True
 
     def render_empty_sample_distribution(
-        self, inputs, params, description=None
+        self, ctx, inputs, params, description=None
     ):
         scenario_type = self.get_scenario_type(params)
         # NOTE: custom code validation happens at render_custom_code when exec() is called
         is_invalid = scenario_type != ScenarioType.CUSTOM_CODE
+
+        self.render_plot_preview_toggle(ctx, inputs)
 
         inputs.view(
             "empty_sample_distribution",
@@ -364,7 +366,9 @@ class ConfigureScenario(foo.Operator):
 
     def render_sample_distribution(self, ctx, inputs, scenario_type, values):
         if not values:
-            return self.render_empty_sample_distribution(inputs, ctx.params)
+            return self.render_empty_sample_distribution(
+                ctx, inputs, ctx.params
+            )
 
         subsets = {}
         if scenario_type == ScenarioType.LABEL_ATTRIBUTE:
@@ -395,6 +399,7 @@ class ConfigureScenario(foo.Operator):
                 ctx.params
             ):
                 return self.render_empty_sample_distribution(
+                    ctx,
                     inputs,
                     ctx.params,
                     description="You can toggle the 'View sample distribution' to see the preview.",
@@ -403,9 +408,7 @@ class ConfigureScenario(foo.Operator):
                 # NOTE: values for custom_code is the parsed custom code expression
                 self.render_sample_distribution_graph(ctx, inputs, values)
 
-    def render_sample_distribution_graph(
-        self, ctx, inputs, subset_expressions
-    ):
+    def render_plot_preview_toggle(self, ctx, inputs):
         preview_toggle_container = inputs.h_stack(
             "preview_toggle_container", align_x="right"
         )
@@ -415,12 +418,18 @@ class ConfigureScenario(foo.Operator):
             default=self.get_default_for_distribution_preview(ctx),
         )
 
+    def render_sample_distribution_graph(
+        self, ctx, inputs, subset_expressions
+    ):
+        self.render_plot_preview_toggle(ctx, inputs)
+
         plot_preview_enabled = ctx.params.get(
             "preview_toggle_container", {}
         ).get("plot_preview_enabled", False)
 
         if not plot_preview_enabled:
             return self.render_empty_sample_distribution(
+                ctx,
                 inputs,
                 ctx.params,
                 description="Distribution preview is not enabled. Turn on distribution preview"
@@ -739,6 +748,7 @@ class ConfigureScenario(foo.Operator):
                 )
             )
             self.render_empty_sample_distribution(
+                ctx,
                 inputs,
                 ctx.params,
                 description=f"Select a {sub} to view sample distribution",
@@ -878,6 +888,7 @@ class ConfigureScenario(foo.Operator):
                 )
             )
             self.render_empty_sample_distribution(
+                ctx,
                 inputs,
                 ctx.params,
                 description=f"Select a {sub} to view sample distribution",
@@ -957,6 +968,7 @@ class ConfigureScenario(foo.Operator):
             self.render_scenario_picker_view(ctx, label_attr, inputs)
         else:
             self.render_empty_sample_distribution(
+                ctx,
                 inputs,
                 ctx.params,
                 description=f"Select an attribute to view sample distribution",
@@ -1019,6 +1031,7 @@ class ConfigureScenario(foo.Operator):
             self.render_scenario_picker_view(ctx, field_name, inputs)
         else:
             self.render_empty_sample_distribution(
+                ctx,
                 inputs,
                 ctx.params,
                 description=f"Select a field to view sample distribution",


### PR DESCRIPTION
## What changes are proposed in this pull request?

make distribution preview toggle always visible

## How is this patch tested? If it is not, please explain why.

Using configure scenario in MEP

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a toggle switch to enable or disable the distribution preview in the sample distribution view.
  - The preview toggle is now consistently available in both empty and graph views for improved user control.

- **Refactor**
  - Improved consistency in the display of the distribution preview toggle across relevant views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->