### PR TITLE
fix frame field support type rendering bug

### DIFF
--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -462,8 +462,12 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           // none-list field value is in ['value'] format
           // need to convert to 'value' to pass in the filter
 
-          filter(path, values) &&
-            pushList(PRIMITIVE_RENDERERS[field.ftype], values);
+          if (filter(path, values)) {
+            const toPush =
+              field.ftype === FRAME_SUPPORT_FIELD ? [values] : values;
+            pushList(PRIMITIVE_RENDERERS[field.ftype], toPush);
+          }
+
           continue;
         }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix a bug where support values where not being passed as an array, which the renderer expects

Before:
![2025-06-12 12 49 16](https://github.com/user-attachments/assets/9c226a1a-ada4-4730-8338-9b6e7c7ad3c4)


After:
![2025-06-12 12 49 30](https://github.com/user-attachments/assets/e9dc34cd-ee70-490d-87c6-97e7291a6771)


## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of tag rendering for certain field types to ensure values are correctly displayed, especially for fields that require single-element arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->