### PR TITLE
Add feedback widget to docs

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -1,3 +1,7 @@
+:root {
+  --feedback-primary-color: #181a1b;
+}
+
 body {
   font-family: "Palanquin", "Lato", "proxima-nova", "Helvetica Neue", Arial,
     sans-serif;

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -220,7 +220,7 @@ html_context = {
 
 # -- Options for pushfeedback extension ---------------------------------------
 pushfeedback_project = "1nx7ekqhts"
-feedback_button_text = "Feedback"
+pushfeedback_feedback_button_text = "Feedback"
 
 # -- Custom app setup --------------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -220,6 +220,7 @@ html_context = {
 
 # -- Options for pushfeedback extension ---------------------------------------
 pushfeedback_project = "1nx7ekqhts"
+feedback_button_text = "Feedback"
 
 # -- Custom app setup --------------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,6 +65,7 @@ extensions = [
     "nbsphinx",
     "sphinx_tabs.tabs",
     "sphinx_copybutton",
+    "sphinx_pushfeedback",
     "autodocsumm",
     "myst_parser",
 ]
@@ -216,6 +217,9 @@ html_context = {
     "link_voxel51_blog": "https://voxel51.com/blog/",
     "og_image": "https://voxel51.com/wp-content/uploads/2024/03/3.24_webpages_Home_AV.png",
 }
+
+# -- Options for pushfeedback extension ---------------------------------------
+pushfeedback_project = "1nx7ekqhts"
 
 # -- Custom app setup --------------------------------------------------------
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -17,3 +17,4 @@ sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-napoleon==0.7
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
+sphinx-pushfeedback==0.1.3


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds a feedback widget to the documentation, powered by [PushFeedback](https://pushfeedback.com/).

![image](https://github.com/user-attachments/assets/a4c28999-4883-41d0-8f5e-6df9b2b21ffa)

![image](https://github.com/user-attachments/assets/d342e7e0-2059-4106-a29a-e1665ae5ff43)

All feedback submitted through the widget is directed to the PushFeedback account owned by @jimmyguerrero.

## How is this patch tested? If it is not, please explain why.

- [x] Feedback widget renders on every page
- [x] Feedback widget styled
- [x] Feedback reaches Pushfeedback.com panel

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
