### PR TITLE
Update fcv_tests.py

### DIFF
--- a/tests/unittests/fcv_tests.py
+++ b/tests/unittests/fcv_tests.py
@@ -288,7 +288,7 @@ class TestUpdateFCV(unittest.TestCase):
         self, mock_logger, mock_client, mock_db_service
     ):
         """Tests the warning that's generated in the event that
-        the feature compatability version is ahead of the server version.
+        the feature compatibility version is ahead of the server version.
         """
 
         server_version = Version(f"{foc.MONGODB_MIN_VERSION.major}.0.0")
@@ -324,7 +324,7 @@ class TestUpdateFCV(unittest.TestCase):
         self, mock_logger, mock_client, mock_db_service
     ):
         """Tests the warning that's generated in the event that
-        the feature compatability version is currently the oldest supported
+        the feature compatibility version is currently the oldest supported
         version.
         """
 
@@ -360,7 +360,7 @@ class TestUpdateFCV(unittest.TestCase):
         self, mock_logger, mock_client, mock_db_service
     ):
         """Tests the error that's generated in the event that
-        the feature compatability version update failed.
+        the feature compatibility version update failed.
         """
 
         server_version = Version(f"{foc.MONGODB_MIN_VERSION.major + 1}.0.0")
@@ -394,7 +394,7 @@ class TestUpdateFCV(unittest.TestCase):
         self, mock_logger, mock_client, mock_db_service
     ):
         """Tests the error that's generated in the event that
-        the feature compatability version update failed.
+        the feature compatibility version update failed.
         """
 
         server_version = Version(f"{foc.MONGODB_MIN_VERSION.major + 1}.0.0")


### PR DESCRIPTION
Fixed multiple misspellings of "compatibility" in FCV-related test docstrings and log messages to improve clarity and consistency. No functional changes.

## What changes are proposed in this pull request?

This PR corrects the repeated misspelling of the word "compatibility" (previously written as "compatability") across the feature compatibility version (FCV) test suite.

## How is this patch tested? If it is not, please explain why.

N/A

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other (tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected a spelling error in docstrings, changing "compatability" to "compatibility" in test descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->