### PR TITLE
Update transformers.py

### DIFF
--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -256,7 +256,7 @@ class FiftyOneTransformerConfig(fout.TorchImageModelConfig, HasZooModel):
             ``transformers`` processor during input processing.
         embeddings_output_key (None): The key in the model output to access for embeddings.
             if set to `None`, the default value will be picked based on what is
-            avaliable in the model's output with the following priority:
+            available in the model's output with the following priority:
             1. `pooler_output`
             2. `last_hidden_state`
             3. `hidden_states` - in this case, `output['hidden_states'][-1]`
@@ -385,7 +385,7 @@ class TransformerEmbeddingsMixin(EmbeddingsMixin):
     This is mainly due to what is exposed by the model's forward pass. For
     example, the image classification models typically don't return pooled
     or normalized embeddings in HuggingFace. While this can be addressed
-    here, there is no gurantee that this generic solution will work for
+    here, there is no guarantee that this generic solution will work for
     the model passed.
     """
 
@@ -593,7 +593,7 @@ class FiftyOneTransformer(TransformerEmbeddingsMixin, fout.TorchImageModel):
         }
         config.ragged_batches = False
 
-        # handle unsuported arguments
+        # handle unsupported arguments
         if config.use_half_precision:
             config.use_half_precision = False
             logger.warning(


### PR DESCRIPTION
Various typo fixes in docstrings and comments.

“avaliable” → “available.”

“gurantee” → “guarantee.”

“unsuported” → “unsupported.”

## What changes are proposed in this pull request?

typo fixes

## How is this patch tested? If it is not, please explain why.

N/A

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected minor typos in comments and docstrings to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->