### PR TITLE
Update dataset_types.py

### DIFF
--- a/fiftyone/types/dataset_types.py
+++ b/fiftyone/types/dataset_types.py
@@ -890,7 +890,7 @@ class LegacyFiftyOneDataset(Dataset):
 
 
 class PlacesDataset(ImageClassificationDataset):
-    """A labeled dataset consisting of images and their associated lables
+    """A labeled dataset consisting of images and their associated labels
     from the `Places dataset <http://places2.csail.mit.edu/index.html>`.
     """
 


### PR DESCRIPTION
Typo fix in docstring lables ==> labels

## What changes are proposed in this pull request?

lables ==> labels

## How is this patch tested? If it is not, please explain why.

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typo in the description of the PlacesDataset class, changing "lables" to "labels".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->