### PR TITLE
Fix aggregation test merge conflict

### DIFF
--- a/tests/unittests/aggregation_tests.py
+++ b/tests/unittests/aggregation_tests.py
@@ -629,6 +629,10 @@ class DatasetTests(unittest.TestCase):
                 None,
             ],
         )
+        self.assertListEqual(
+            d.values("predictions.detections[]"),
+            d.values("predictions.detections", unwind=True),
+        )
 
         actual = d.values(
             "predictions.detections.label", missing_value="missing"
@@ -640,16 +644,7 @@ class DatasetTests(unittest.TestCase):
         )
         self.assertListEqual(actual, itered_actual)
         self.assertListEqual(
-<<<<<<< HEAD
             actual,
-=======
-            d.values("predictions.detections[]"),
-            d.values("predictions.detections", unwind=True),
-        )
-
-        self.assertListEqual(
-            d.values("predictions.detections.label", missing_value="missing"),
->>>>>>> release/v1.6.0
             [
                 ["cat", "dog"],
                 ["cat", "rabbit", "squirrel"],


### PR DESCRIPTION
## What changes are proposed in this pull request?

fix merge conflict

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved unit tests to verify that using the "[]" suffix in field paths produces results equivalent to using the unwind option.
  - Simplified assertions in the aggregation tests for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->