### PR TITLE
fix docstrings merge conflict executor.py

### DIFF
--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -122,47 +122,11 @@ class Executor(object):
 def execute_operator(operator_uri, ctx=None, **kwargs):
     """Executes the operator with the given name.
 
-        Args:
-            operator_uri: the URI of the operator
-            ctx (None): a dictionary of parameters defining the execution context.
-                The supported keys are:
+    Args:
+        operator_uri: the URI of the operator
+        ctx (None): a dictionary of parameters defining the execution context.
+            The supported keys are:
 
-<<<<<<< HEAD
-                -   ``dataset``: a :class:`fiftyone.core.dataset.Dataset` or the
-                    name of a dataset to process. This is required unless a
-                    ``view`` is provided
-                -   ``view`` (None): an optional
-                    :class:`fiftyone.core.view.DatasetView` to process
-                -   ``selected`` ([]): an optional list of selected sample IDs
-                -   ``selected_labels`` ([]): an optional list of selected labels
-                    in the format returned by
-                    :attr:`fiftyone.core.session.Session.selected_labels`
-                -   ``current_sample`` (None): an optional ID of the current sample
-                    being processed
-    <<<<<<< HEAD
-                -   ``active_fields`` ([]): an optional list of active fields
-    =======
-                -   ``extended_selection`` (None): an optional extended selection
-                    of the view.
-    >>>>>>> develop
-                -   ``params``: a dictionary of parameters for the operator.
-                    Consult the operator's documentation for details
-                -   ``request_delegation`` (False): whether to request delegated
-                    execution, if supported by the operator
-                -   ``delegation_target`` (None): an optional orchestrator on which
-                    to schedule the operation, if it is delegated
-    <<<<<<< HEAD
-    =======
-                -   ``workspace_name`` (None): an optional name of the workspace
-                    to use for the operation
-                -   ``spaces`` (None): an optional dictionary defining spaces to
-                    use for the operation
-                -   ``group_slice`` (None): an optional group slice to use for the
-                    operation's view. This is only applicable to group datasets
-                -   ``query_performance`` (None): whether to enable query
-                    performance
-    >>>>>>> develop
-=======
             -   ``dataset``: a :class:`fiftyone.core.dataset.Dataset` or the
                 name of a dataset to process. This is required unless a
                 ``view`` is provided
@@ -182,10 +146,7 @@ def execute_operator(operator_uri, ctx=None, **kwargs):
                 execution, if supported by the operator
             -   ``delegation_target`` (None): an optional orchestrator on which
                 to schedule the operation, if it is delegated
-<<<<<<< HEAD
             -   ``active_fields`` ([]): a list of active field names
->>>>>>> release/v1.6.0
-=======
             -   ``workspace_name`` (None): an optional name of the workspace
                 to use for the operation
             -   ``spaces`` (None): an optional dictionary defining spaces to
@@ -197,18 +158,14 @@ def execute_operator(operator_uri, ctx=None, **kwargs):
 
         **kwargs: you can optionally provide any of the supported ``ctx`` keys
             as keyword arguments rather than including them in ``ctx``
->>>>>>> develop
 
-            **kwargs: you can optionally provide any of the supported ``ctx`` keys
-                as keyword arguments rather than including them in ``ctx``
+    Returns:
+        an :class:`ExecutionResult`, or an ``asyncio.Task`` if you run this
+        method in a notebook context
 
-        Returns:
-            an :class:`ExecutionResult`, or an ``asyncio.Task`` if you run this
-            method in a notebook context
-
-        Raises:
-            ExecutionError: if an error occurred while immediately executing an
-                operation or scheduling a delegated operation
+    Raises:
+        ExecutionError: if an error occurred while immediately executing an
+            operation or scheduling a delegated operation
     """
     request_params = _parse_ctx(ctx=ctx, **kwargs)
     coroutine = execute_or_delegate_operator(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix merge conflict 

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved and clarified the docstring for the operator execution function, consolidating parameter descriptions and removing redundant or outdated information. No changes to functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->