### PR TITLE
Refresh grid when schema changes

### DIFF
--- a/app/packages/core/src/components/Grid/useRefreshers.ts
+++ b/app/packages/core/src/components/Grid/useRefreshers.ts
@@ -37,6 +37,7 @@ export default function useRefreshers() {
     fieldVisibilityStage;
     mediaField;
     refresher;
+    schema;
     return uuid();
   }, [cropToContent, fieldVisibilityStage, mediaField, refresher, schema]);
 

--- a/app/packages/core/src/components/Grid/useRefreshers.ts
+++ b/app/packages/core/src/components/Grid/useRefreshers.ts
@@ -27,6 +27,9 @@ export default function useRefreshers() {
   );
   const sort = useRecoilValue(fos.gridSortBy);
   const view = fos.filterView(useRecoilValue(fos.view) ?? []);
+  const schema = useRecoilValue(
+    fos.fieldSchema({ space: fos.State.SPACE.SAMPLE })
+  );
 
   // only reload, attempt to return to the last grid location
   const layoutReset = useMemoOne(() => {
@@ -35,7 +38,7 @@ export default function useRefreshers() {
     mediaField;
     refresher;
     return uuid();
-  }, [cropToContent, fieldVisibilityStage, mediaField, refresher]);
+  }, [cropToContent, fieldVisibilityStage, mediaField, refresher, schema]);
 
   // the values reset the page, i.e. return to the top
   const pageReset = useMemoOne(() => {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Ensure page data resets when the schema changes

## How is this patch tested? If it is not, please explain why.

Locally

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved grid layout refresh behavior to ensure updates occur when the field schema changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->