### PR TITLE
Update basic_example.ipynb

### DIFF
--- a/docs/source/recipes/torch-dataset-examples/basic_example.ipynb
+++ b/docs/source/recipes/torch-dataset-examples/basic_example.ipynb
@@ -276,7 +276,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# This is also a good opprotunity to debug your get_item in case you need to"
+    "# This is also a good opportunity to debug your get_item in case you need to"
    ]
   },
   {
@@ -346,7 +346,7 @@
     "# utils.get_item_quickstart is the same get_item as above.\n",
     "torch_dataset = some_interesting_view.to_torch(utils.get_item_quickstart)\n",
     "\"\"\"\n",
-    "The code we are runnig is as follows:\n",
+    "The code we are running is as follows:\n",
     "def simple_collate_fn(batch):\n",
     "    return tuple(zip(*batch))\n",
     "def create_dataloader_simple(torch_dataset):\n",
@@ -357,7 +357,7 @@
     "                                             worker_init_fn=FiftyOneTorchDataset.worker_init, # this is required for the dataloader to work\n",
     "                                             collate_fn=simple_collate_fn)\n",
     "\n",
-    "We are running it from a seperate file because Jupyter Notebooks are not compatible with the 'spawn' and 'forkserver' start methods\n",
+    "We are running it from a separate file because Jupyter Notebooks are not compatible with the 'spawn' and 'forkserver' start methods\n",
     "for code that is written *in* the notebook.\n",
     "\"\"\"\n",
     "dataloader = utils.create_dataloader_simple(torch_dataset)"


### PR DESCRIPTION
three typo fixes:

line 279: “opprotunity” → “opportunity”

line 349: “runnig” → “running”

line 360: “seperate” → “separate”

## What changes are proposed in this pull request?

three typo fixes:

## How is this patch tested? If it is not, please explain why.

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected typographical errors in comments and markdown cells within the example notebook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->