### PR TITLE
add FIFTYONE_DEFAULT_MEDIA_TYPE env var

### DIFF
--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -280,6 +280,12 @@ class FiftyOneConfig(EnvConfig):
             env_var="FIFTYONE_EXECUTION_CACHE_ENABLED",
             default=True,
         )
+        self.default_media_type = self.parse_string(
+            d,
+            "default_media_type",
+            env_var="FIFTYONE_DEFAULT_MEDIA_TYPE",
+            default="unknown",
+        )
         self._init()
 
     @property

--- a/fiftyone/core/media.py
+++ b/fiftyone/core/media.py
@@ -7,6 +7,7 @@ Sample media utilities.
 """
 import eta.core.image as etai
 import eta.core.video as etav
+from fiftyone.__public__ import config
 
 
 # Valid media types
@@ -43,7 +44,7 @@ def get_media_type(filepath):
     if filepath.endswith(".fo3d"):
         return THREE_D
 
-    return UNKNOWN
+    return config.default_media_type
 
 
 class MediaTypeError(TypeError):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Added a small environment variable (`FIFTYONE_DEFAULT_MEDIA_TYPE`) to be able to set the default value returned by `get_media_type`.

Not sure about the `from fiftyone.__public__ import config` though, config should probably be fetched some other way.

## How is this patch tested? If it is not, please explain why.

Tested by patching my fiftyone package in an other project.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable default media type setting, allowing users to specify the default media type via configuration or environment variable.
- **Improvements**
  - The system now uses the configurable default media type when the media type cannot be determined, instead of a fixed value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->