### PR TITLE
allow negative up vectors and fix lookAt bug

### DIFF
--- a/app/packages/looker-3d/src/fo3d/Gizmos.tsx
+++ b/app/packages/looker-3d/src/fo3d/Gizmos.tsx
@@ -58,9 +58,9 @@ const FoAxesHelper = ({
       .filter(
         (axis) =>
           !(
-            (axis.color === AXIS_RED_COLOR && upVector.x === 1) ||
-            (axis.color === AXIS_GREEN_COLOR && upVector.y === 1) ||
-            (axis.color === AXIS_BLUE_COLOR && upVector.z === 1)
+            (axis.color === AXIS_RED_COLOR && Math.abs(upVector.x) === 1) ||
+            (axis.color === AXIS_GREEN_COLOR && Math.abs(upVector.y) === 1) ||
+            (axis.color === AXIS_BLUE_COLOR && Math.abs(upVector.z) === 1)
           )
       )
       .map((axis) => {
@@ -102,11 +102,11 @@ export const Gizmos = () => {
       return 0;
     }
 
-    if (upVector.x === 1) {
+    if (Math.abs(upVector.x) === 1) {
       return Math.max(sceneSize.y, sceneSize.z);
     }
 
-    if (upVector.y === 1) {
+    if (Math.abs(upVector.y) === 1) {
       return Math.max(sceneSize.x, sceneSize.z);
     }
 

--- a/app/packages/looker-3d/src/fo3d/scene-controls/SceneControls.tsx
+++ b/app/packages/looker-3d/src/fo3d/scene-controls/SceneControls.tsx
@@ -51,11 +51,14 @@ export const SceneControls = ({ scene }: { scene: FoScene }) => {
           UpVector: {
             value: dirFromUpVector,
             label: "Up",
-            options: ["X", "Y", "Z"],
+            options: ["X", "Y", "Z", "-X", "-Y", "-Z"],
             onChange: (value) => {
               if (value === "X") setUpVector(new Vector3(1, 0, 0));
               if (value === "Y") setUpVector(new Vector3(0, 1, 0));
               if (value === "Z") setUpVector(new Vector3(0, 0, 1));
+              if (value === "-X") setUpVector(new Vector3(-1, 0, 0));
+              if (value === "-Y") setUpVector(new Vector3(0, -1, 0));
+              if (value === "-Z") setUpVector(new Vector3(0, 0, -1));
             },
           },
           AutoRotate: {

--- a/app/packages/looker-3d/src/fo3d/scene-controls/lights/DefaultLights.tsx
+++ b/app/packages/looker-3d/src/fo3d/scene-controls/lights/DefaultLights.tsx
@@ -38,7 +38,7 @@ export const DefaultLights = () => {
 
     const offset = Math.max(Math.max(size.x, size.y, size.z)) + 1;
 
-    if (upVector.y === 1) {
+    if (Math.abs(upVector.y) === 1) {
       return [
         new Vector3(0, center.y + offset, 0), // top
         new Vector3(0, center.y - offset, 0), // bottom
@@ -49,7 +49,7 @@ export const DefaultLights = () => {
       ];
     }
 
-    if (upVector.x === 1) {
+    if (Math.abs(upVector.x) === 1) {
       return [
         new Vector3(center.x + offset, 0, 0), // top
         new Vector3(center.x - offset, 0, 0), // bottom
@@ -60,7 +60,7 @@ export const DefaultLights = () => {
       ];
     }
 
-    if (upVector.z === 1) {
+    if (Math.abs(upVector.z) === 1) {
       return [
         new Vector3(0, 0, center.z + offset), // top
         new Vector3(0, 0, center.z - offset), // bottom

--- a/app/packages/looker-3d/src/fo3d/utils.ts
+++ b/app/packages/looker-3d/src/fo3d/utils.ts
@@ -213,6 +213,18 @@ export const getOrthonormalAxis = (vec: Vector3Tuple | Vector3) => {
     return "Z";
   }
 
+  if (vec[0] === -1 && vec[1] === 0 && vec[2] === 0) {
+    return "-X";
+  }
+
+  if (vec[0] === 0 && vec[1] === -1 && vec[2] === 0) {
+    return "-Y";
+  }
+
+  if (vec[0] === 0 && vec[1] === 0 && vec[2] === -1) {
+    return "-Z";
+  }
+
   return null;
 };
 

--- a/fiftyone/core/threed/camera.py
+++ b/fiftyone/core/threed/camera.py
@@ -13,8 +13,8 @@ from .transformation import Vector3, Vec3UnionType, normalize_to_vec3
 from .validators import BaseValidatedDataClass, validate_choice, validate_float
 
 
-UP_DIRECTIONS = frozenset(["X", "Y", "Z"])
-UpDirection = Literal["X", "Y", "Z"]
+UP_DIRECTIONS = frozenset(["X", "Y", "Z", "-X", "-Y", "-Z"])
+UpDirection = Literal["X", "Y", "Z", "-X", "-Y", "-Z"]
 
 
 @dataclass


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR fixes a bug where scene wasn't marked as initialized when custom `lookAt` was used in FO3D as well as makes it possible for the user to specify negative UP directions (`-X`, `-Y`, and `-Z`).

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
