### PR TITLE
update paginate_samples to force dataset reload on first page of results

### DIFF
--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -111,10 +111,15 @@ async def paginate_samples(
         sort_by=sort_by,
         desc=desc,
     )
-    try:
-        view = await run_sync_task(run, False)
-    except:
+    if after is None:
+        # first page, force dataset reload
         view = await run_sync_task(run, True)
+    else:
+        # not first page, optimistically skip dataset reload
+        try:
+            view = await run_sync_task(run, False)
+        except:
+            view = await run_sync_task(run, True)
 
     if after is None:
         after = "-1"


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adjusts the `paginate_samples` logic to force a dataset reload on the first page of results. In testing, we have found cases where skipping this reload can result in missing label data when the underlying dataset schema has changed. Forcing this reload on the first page should eliminate these consistency issues.

## How is this patch tested? If it is not, please explain why.

local + deployed app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pagination reliability when browsing samples, ensuring smoother loading of the first and subsequent pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->