### PR TITLE
Match release 1.6 to 2.9

### DIFF
--- a/docs/source/integrations/ultralytics.rst
+++ b/docs/source/integrations/ultralytics.rst
@@ -519,6 +519,27 @@ pattern below:
 
     dataset.set_values("predictions", predictions)
 
+Note that the `batch_size` parameter in :meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`
+only controls the batch size for dataloading. Set the batch size of the underlying Ultralytics model predictor via
+overrides to avoid using the default batch size set by Ultralytics.
+
+.. code-block:: python
+    :linenos:
+
+    kwargs = {"overrides": {"batch": 32}}
+    model = foz.load_zoo_model(m_name, **kwargs)
+    dataset.apply_model(model, label_field="predictions", batch_size=32)
+
+
+To run inference on a batch size of 1 with rectangular resizing, use overrides as shown below when loading a model for inference:
+
+.. code-block:: python
+    :linenos:
+
+    kwargs = {"overrides": {"rect": True, "batch": 1}}
+    model = foz.load_zoo_model(m_name, **kwargs)
+    dataset.apply_model(model, label_field="predictions", batch_size=1)
+
 .. note::
 
     See :ref:`this section <batch-updates>` for more information about

--- a/docs/source/integrations/ultralytics.rst
+++ b/docs/source/integrations/ultralytics.rst
@@ -525,9 +525,9 @@ them as kwargs to
 .. code-block:: python
     :linenos:
 
+    # Use rectangular resizing with a batch size of 1
     model = foz.load_zoo_model(model_name, overrides={"rect": True})
-
-    dataset.apply_model(model, label_field="predictions", batch_size=16)
+    dataset.apply_model(model, label_field="predictions", batch_size=1)
 
 .. note::
 

--- a/docs/source/integrations/ultralytics.rst
+++ b/docs/source/integrations/ultralytics.rst
@@ -513,24 +513,6 @@ you can request batch inference via the pattern below:
         batch_size=batch_size,
     )
 
-The manual inference loops can be also executed using batch inference via the
-pattern below:
-
-.. code-block:: python
-    :linenos:
-
-    from fiftyone.core.utils import iter_batches
-
-    filepaths = dataset.values("filepath")
-    batch_size = 16
-
-    predictions = []
-    for paths in iter_batches(filepaths, batch_size):
-        results = model(paths)
-        predictions.extend(fou.to_detections(results))
-
-    dataset.set_values("predictions", predictions)
-
 Alternatively, to run inference on a batch size of 1 with rectangular resizing,
 use overrides as shown below:
 
@@ -549,6 +531,24 @@ use overrides as shown below:
         label_field="predictions",
         batch_size=batch_size,
     )
+
+The manual inference loops can be also executed using batch inference via the
+pattern below:
+
+.. code-block:: python
+    :linenos:
+
+    from fiftyone.core.utils import iter_batches
+
+    filepaths = dataset.values("filepath")
+    batch_size = 16
+
+    predictions = []
+    for paths in iter_batches(filepaths, batch_size):
+        results = model(paths)
+        predictions.extend(fou.to_detections(results))
+
+    dataset.set_values("predictions", predictions)
 
 .. note::
 

--- a/docs/source/integrations/ultralytics.rst
+++ b/docs/source/integrations/ultralytics.rst
@@ -493,44 +493,12 @@ Batch inference
 
 When using
 :meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`,
-you can request batch inference via the pattern below:
+you can request batch inference by passing the optional `batch_size` parameter:
 
 .. code-block:: python
     :linenos:
 
-    batch_size = 16
-
-    # Tell model to use batch inference
-    model = foz.load_zoo_model(
-        model_name,
-        overrides={"batch": batch_size},
-    )
-
-    # Tell FiftyOne to use batch dataloading
-    dataset.apply_model(
-        model,
-        label_field="predictions",
-        batch_size=batch_size,
-    )
-
-Alternatively, to run inference on a batch size of 1 with rectangular resizing,
-use overrides as shown below:
-
-.. code-block:: python
-    :linenos:
-
-    batch_size = 1
-
-    model = foz.load_zoo_model(
-        model_name,
-        overrides={"rect": True, "batch": batch_size},
-    )
-
-    dataset.apply_model(
-        model,
-        label_field="predictions",
-        batch_size=batch_size,
-    )
+    dataset.apply_model(model, label_field="predictions", batch_size=16)
 
 The manual inference loops can be also executed using batch inference via the
 pattern below:
@@ -549,6 +517,17 @@ pattern below:
         predictions.extend(fou.to_detections(results))
 
     dataset.set_values("predictions", predictions)
+
+You can also provide overrides to the underlying Ultralytics model by passing
+them as kwargs to
+:meth:`load_zoo_model() <fiftyone.zoo.models.load_zoo_model>`:
+
+.. code-block:: python
+    :linenos:
+
+    model = foz.load_zoo_model(model_name, overrides={"rect": True})
+
+    dataset.apply_model(model, label_field="predictions", batch_size=16)
 
 .. note::
 

--- a/docs/source/integrations/ultralytics.rst
+++ b/docs/source/integrations/ultralytics.rst
@@ -235,7 +235,6 @@ You can also load YOLOv8, YOLOv9, and YOLO11 segmentation models from the
     # model_name = "yolo11m-seg-coco-torch"
     # model_name = "yolo11l-seg-coco-torch"
     # model_name = "yolo11x-seg-coco-torch"
-    
 
     model = foz.load_zoo_model(model_name)
 
@@ -494,12 +493,25 @@ Batch inference
 
 When using
 :meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`,
-you can request batch inference by passing the optional `batch_size` parameter:
+you can request batch inference via the pattern below:
 
 .. code-block:: python
     :linenos:
 
-    dataset.apply_model(model, label_field="predictions", batch_size=16)
+    batch_size = 16
+
+    # Tell model to use batch inference
+    model = foz.load_zoo_model(
+        model_name,
+        overrides={"batch": batch_size},
+    )
+
+    # Tell FiftyOne to use batch dataloading
+    dataset.apply_model(
+        model,
+        label_field="predictions",
+        batch_size=batch_size,
+    )
 
 The manual inference loops can be also executed using batch inference via the
 pattern below:
@@ -519,26 +531,24 @@ pattern below:
 
     dataset.set_values("predictions", predictions)
 
-Note that the `batch_size` parameter in :meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`
-only controls the batch size for dataloading. Set the batch size of the underlying Ultralytics model predictor via
-overrides to avoid using the default batch size set by Ultralytics.
+Alternatively, to run inference on a batch size of 1 with rectangular resizing,
+use overrides as shown below:
 
 .. code-block:: python
     :linenos:
 
-    kwargs = {"overrides": {"batch": 32}}
-    model = foz.load_zoo_model(m_name, **kwargs)
-    dataset.apply_model(model, label_field="predictions", batch_size=32)
+    batch_size = 1
 
+    model = foz.load_zoo_model(
+        model_name,
+        overrides={"rect": True, "batch": batch_size},
+    )
 
-To run inference on a batch size of 1 with rectangular resizing, use overrides as shown below when loading a model for inference:
-
-.. code-block:: python
-    :linenos:
-
-    kwargs = {"overrides": {"rect": True, "batch": 1}}
-    model = foz.load_zoo_model(m_name, **kwargs)
-    dataset.apply_model(model, label_field="predictions", batch_size=1)
+    dataset.apply_model(
+        model,
+        label_field="predictions",
+        batch_size=batch_size,
+    )
 
 .. note::
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -9723,6 +9723,46 @@ class SampleCollection(object):
         if archive_path is not None:
             etau.make_archive(export_dir, archive_path, cleanup=True)
 
+    def to_torch(
+        self,
+        get_item,
+        vectorize=False,
+        skip_failures=False,
+        local_process_group=None,
+    ):
+        """Constructs a :class:`torch:torch.utils.data.Dataset` that loads data
+        from this collection via the provided
+        :class:`fiftyone.utils.torch.GetItem` instance.
+
+        Args:
+            get_item: a :class:`fiftyone.utils.torch.GetItem`
+            vectorize (False): whether to load and cache the required fields
+                from the sample collection upfront (True) or lazily load the
+                values from each sample when items are retrieved (False).
+                Vectorizing gives faster data loading times, but you must have
+                enough memory to store the required field values for the entire
+                sample collection. When ``vectorize=True``, all field values
+                must be serializable; ie ``pickle.dumps(field_value)`` must not
+                raise an error
+            skip_failures (False): whether to skip failures that occur when
+                calling ``get_item``. If True, the exception will be returned
+                rather than the intended field values
+            local_process_group (None): the local process group. Only used
+                during distributed training
+
+        Returns:
+            a :class:`torch:torch.utils.data.Dataset`
+        """
+        from fiftyone.utils.torch import FiftyOneTorchDataset
+
+        return FiftyOneTorchDataset(
+            self,
+            get_item,
+            vectorize=vectorize,
+            skip_failures=skip_failures,
+            local_process_group=local_process_group,
+        )
+
     def annotate(
         self,
         anno_key,
@@ -11668,12 +11708,6 @@ class SampleCollection(object):
             raise ValueError(f"Dataset has no store '{store_name}'")
 
         return foos.ExecutionStore(store_name, svc)
-
-    def to_torch(self, get_item, **kwargs):
-        """See fo.utils.torch.FiftyOneTorchDataset for documentation."""
-        from fiftyone.utils.torch import FiftyOneTorchDataset
-
-        return FiftyOneTorchDataset(self, get_item, **kwargs)
 
 
 def _iter_label_fields(sample_collection):

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -152,15 +152,36 @@ def apply_model(
             "(model.has_logits = %s)" % model.has_logits
         )
 
+    supports_get_item = isinstance(model, SupportsGetItem)
     needs_samples = isinstance(model, SamplesMixin)
+
+    if supports_get_item and needs_samples:
+        field_mapping = kwargs.pop("field_mapping", {})
+        needs_fields = kwargs.pop("needs_fields", {})
+        needs_fields.update(kwargs)
+    elif supports_get_item:
+        field_mapping = kwargs.pop("field_mapping", {})
+        field_mapping.update(kwargs)
+        needs_fields = None
+    elif needs_samples:
+        field_mapping = None
+        needs_fields = kwargs.pop("needs_fields", {})
+        needs_fields.update(kwargs)
+    else:
+        field_mapping = None
+        needs_fields = None
+
+    process_video_frames = (
+        samples.media_type == fom.VIDEO and model.media_type == "image"
+    )
+
     use_data_loader = (
-        isinstance(model, TorchModelMixin) and samples.media_type == fom.IMAGE
+        isinstance(model, (SupportsGetItem, TorchModelMixin))
+        and not process_video_frames
     )
 
     if num_workers is not None and not use_data_loader:
-        logger.warning(
-            "Ignoring `num_workers` parameter; only supported for Torch models"
-        )
+        logger.warning("Ignoring unsupported `num_workers` parameter")
 
     if output_dir is not None:
         filename_maker = fou.UniqueFilenameMaker(
@@ -190,18 +211,12 @@ def apply_model(
 
         if needs_samples:
             context.enter_context(
-                fou.SetAttributes(model, needs_fields=kwargs)
+                fou.SetAttributes(model, needs_fields=needs_fields)
             )
 
         context.enter_context(model)
 
-        if needs_samples:
-            fields = list(model.needs_fields.values())
-            samples = samples.select_fields(fields)
-        else:
-            samples = samples.select_fields()
-
-        if samples.media_type == fom.VIDEO and model.media_type == "video":
+        if model.media_type == "video":
             return _apply_video_model(
                 samples,
                 model,
@@ -214,7 +229,7 @@ def apply_model(
 
         batch_size = _parse_batch_size(batch_size, model, use_data_loader)
 
-        if samples.media_type == fom.VIDEO and model.media_type == "image":
+        if process_video_frames:
             label_field, _ = samples._handle_frame_field(label_field)
 
             if batch_size is not None:
@@ -250,6 +265,7 @@ def apply_model(
                 skip_failures,
                 filename_maker,
                 progress,
+                field_mapping,
             )
 
         if batch_size is not None:
@@ -319,6 +335,12 @@ def _apply_image_model_single(
 ):
     needs_samples = isinstance(model, SamplesMixin)
 
+    if needs_samples:
+        fields = list(model.needs_fields.values())
+        samples = samples.select_fields(fields)
+    else:
+        samples = samples.select_fields()
+
     with contextlib.ExitStack() as context:
         pb = context.enter_context(fou.ProgressBar(progress=progress))
         ctx = context.enter_context(foc.SaveContext(samples))
@@ -359,6 +381,12 @@ def _apply_image_model_batch(
     progress,
 ):
     needs_samples = isinstance(model, SamplesMixin)
+
+    if needs_samples:
+        fields = list(model.needs_fields.values())
+        samples = samples.select_fields(fields)
+    else:
+        samples = samples.select_fields()
 
     with contextlib.ExitStack() as context:
         pb = context.enter_context(fou.ProgressBar(samples, progress=progress))
@@ -410,12 +438,24 @@ def _apply_image_model_data_loader(
     skip_failures,
     filename_maker,
     progress,
+    field_mapping,
 ):
     needs_samples = isinstance(model, SamplesMixin)
 
     data_loader = _make_data_loader(
-        samples, model, batch_size, num_workers, skip_failures
+        samples,
+        model,
+        batch_size,
+        num_workers,
+        skip_failures,
+        field_mapping,
     )
+
+    if needs_samples:
+        fields = list(model.needs_fields.values())
+        samples = samples.select_fields(fields)
+    else:
+        samples = samples.select_fields()
 
     with contextlib.ExitStack() as context:
         pb = context.enter_context(fou.ProgressBar(samples, progress=progress))
@@ -473,6 +513,12 @@ def _apply_image_model_to_frames_single(
     needs_samples = isinstance(model, SamplesMixin)
     frame_counts, total_frame_count = _get_frame_counts(samples)
     is_clips = samples._dataset._is_clips
+
+    if needs_samples:
+        fields = list(model.needs_fields.values())
+        samples = samples.select_fields(fields)
+    else:
+        samples = samples.select_fields()
 
     with contextlib.ExitStack() as context:
         pb = context.enter_context(
@@ -534,6 +580,12 @@ def _apply_image_model_to_frames_batch(
     needs_samples = isinstance(model, SamplesMixin)
     frame_counts, total_frame_count = _get_frame_counts(samples)
     is_clips = samples._dataset._is_clips
+
+    if needs_samples:
+        fields = list(model.needs_fields.values())
+        samples = samples.select_fields(fields)
+    else:
+        samples = samples.select_fields()
 
     with contextlib.ExitStack() as context:
         pb = context.enter_context(
@@ -599,6 +651,12 @@ def _apply_video_model(
 ):
     needs_samples = isinstance(model, SamplesMixin)
     is_clips = samples._dataset._is_clips
+
+    if needs_samples:
+        fields = list(model.needs_fields.values())
+        samples = samples.select_fields(fields)
+    else:
+        samples = samples.select_fields()
 
     with contextlib.ExitStack() as context:
         pb = context.enter_context(fou.ProgressBar(progress=progress))
@@ -698,23 +756,27 @@ def _iter_batches(video_reader, batch_size):
         yield frame_numbers, imgs
 
 
-def _make_data_loader(samples, model, batch_size, num_workers, skip_failures):
-    # This function supports DataLoaders that emit numpy arrays that can
-    # therefore be used for non-Torch models; but we do not currently use this
-    # functionality
-    use_numpy = not isinstance(model, TorchModelMixin)
+class ErrorHandlingCollate(object):
+    def __init__(
+        self, skip_failures, ragged_batches, use_numpy, user_collate_fn=None
+    ):
+        self.skip_failures = skip_failures
 
-    if num_workers is None:
-        num_workers = fout.recommend_num_workers()
+        if ragged_batches:
+            self._collate_fn = self._ragged_batches
+        elif use_numpy:
+            self._collate_fn = self._use_numpy
+        else:
+            self._collate_fn = self._default
 
-    dataset = fout.TorchImageDataset(
-        samples=samples,
-        transform=model.transforms,
-        use_numpy=use_numpy,
-        force_rgb=True,
-        skip_failures=skip_failures,
-    )
+        self.user_collate_fn = user_collate_fn
+        if self.user_collate_fn is None:
+            self.user_collate_fn = tud.dataloader.default_collate
 
+    def __call__(self, batch):
+        return self._collate_fn(batch)
+
+    @staticmethod
     def handle_errors(batch):
         errors = [b for b in batch if isinstance(b, Exception)]
 
@@ -726,56 +788,93 @@ def _make_data_loader(samples, model, batch_size, num_workers, skip_failures):
 
         return Exception("\n" + "\n".join([str(e) for e in errors]))
 
-    if model.ragged_batches:
+    def _ragged_batches(self, batch):
+        error = ErrorHandlingCollate.handle_errors(batch)
+        if error is not None:
+            return error
 
-        def collate_fn(batch):
-            error = handle_errors(batch)
-            if error is not None:
-                return error
+        return batch
 
-            return batch  # return list
+    def _use_numpy(self, batch):
+        error = ErrorHandlingCollate.handle_errors(batch)
+        if error is not None:
+            return error
 
-    elif use_numpy:
+        try:
+            return np.stack(batch)
+        except Exception as e:
+            if not self.skip_failures:
+                raise e
 
-        def collate_fn(batch):
-            error = handle_errors(batch)
-            if error is not None:
-                return error
+            return e
 
-            try:
-                return np.stack(batch)
-            except Exception as e:
-                if not skip_failures:
-                    raise e
+    def _default(self, batch):
+        error = ErrorHandlingCollate.handle_errors(batch)
+        if error is not None:
+            return error
 
-                return e
+        try:
+            return self.user_collate_fn(batch)
+        except Exception as e:
+            if not self.skip_failures:
+                raise e
 
+            return e
+
+
+def _make_data_loader(
+    samples,
+    model,
+    batch_size,
+    num_workers,
+    skip_failures,
+    field_mapping,
+):
+    # This function supports DataLoaders that emit numpy arrays that can
+    # therefore be used for non-Torch models; but we do not currently use this
+    # functionality
+    use_numpy = not isinstance(model, TorchModelMixin)
+
+    if num_workers is None:
+        num_workers = fout.recommend_num_workers()
+
+    if model.has_collate_fn:
+        user_collate_fn = model.collate_fn
     else:
+        user_collate_fn = None
 
-        def collate_fn(batch):
-            error = handle_errors(batch)
-            if error is not None:
-                return error
-
-            try:
-                if model.has_collate_fn:
-                    return model.collate_fn(batch)
-                else:
-                    return tud.dataloader.default_collate(batch)
-            except Exception as e:
-                if not skip_failures:
-                    raise e
-
-                return e
+    collate_fn = ErrorHandlingCollate(
+        skip_failures,
+        ragged_batches=model.ragged_batches,
+        use_numpy=use_numpy,
+        user_collate_fn=user_collate_fn,
+    )
 
     if batch_size is None:
         batch_size = 1
+
+    if isinstance(model, SupportsGetItem):
+        get_item = model.build_get_item(field_mapping=field_mapping)
+        dataset = samples.to_torch(get_item, skip_failures=skip_failures)
+        worker_init_fn = fout.FiftyOneTorchDataset.worker_init
+    else:
+        dataset = fout.TorchImageDataset(
+            samples=samples,
+            transform=model.transforms,
+            use_numpy=use_numpy,
+            force_rgb=True,
+            skip_failures=skip_failures,
+        )
+        worker_init_fn = None
 
     return tud.DataLoader(
         dataset,
         batch_size=batch_size,
         num_workers=num_workers,
         collate_fn=collate_fn,
+        pin_memory=True,
+        persistent_workers=False,
+        worker_init_fn=worker_init_fn,
     )
 
 
@@ -883,14 +982,23 @@ def compute_embeddings(
             "('image', 'video')" % model.media_type
         )
 
+    if isinstance(model, SupportsGetItem):
+        field_mapping = kwargs.pop("field_mapping", {})
+        field_mapping.update(kwargs)
+    else:
+        field_mapping = None
+
+    process_video_frames = (
+        samples.media_type == fom.VIDEO and model.media_type == "image"
+    )
+
     use_data_loader = (
-        isinstance(model, TorchModelMixin) and samples.media_type == fom.IMAGE
+        isinstance(model, (SupportsGetItem, TorchModelMixin))
+        and not process_video_frames
     )
 
     if num_workers is not None and not use_data_loader:
-        logger.warning(
-            "Ignoring `num_workers` parameter; only supported for Torch models"
-        )
+        logger.warning("Ignoring unsupported `num_workers` parameter")
 
     if embeddings_field is not None:
         dataset = samples._dataset
@@ -918,16 +1026,14 @@ def compute_embeddings(
 
         context.enter_context(model)
 
-        samples = samples.select_fields()
-
-        if samples.media_type == fom.VIDEO and model.media_type == "video":
+        if model.media_type == "video":
             return _compute_video_embeddings(
                 samples, model, embeddings_field, skip_failures, progress
             )
 
         batch_size = _parse_batch_size(batch_size, model, use_data_loader)
 
-        if samples.media_type == fom.VIDEO and model.media_type == "image":
+        if process_video_frames:
             if batch_size is not None:
                 return _compute_frame_embeddings_batch(
                     samples,
@@ -951,6 +1057,7 @@ def compute_embeddings(
                 num_workers,
                 skip_failures,
                 progress,
+                field_mapping,
             )
 
         if batch_size is not None:
@@ -971,6 +1078,8 @@ def compute_embeddings(
 def _compute_image_embeddings_single(
     samples, model, embeddings_field, skip_failures, progress
 ):
+    samples = samples.select_fields()
+
     embeddings = []
     errors = False
 
@@ -1013,6 +1122,8 @@ def _compute_image_embeddings_single(
 def _compute_image_embeddings_batch(
     samples, model, embeddings_field, batch_size, skip_failures, progress
 ):
+    samples = samples.select_fields()
+
     embeddings = []
     errors = False
 
@@ -1068,10 +1179,18 @@ def _compute_image_embeddings_data_loader(
     num_workers,
     skip_failures,
     progress,
+    field_mapping,
 ):
     data_loader = _make_data_loader(
-        samples, model, batch_size, num_workers, skip_failures
+        samples,
+        model,
+        batch_size,
+        num_workers,
+        skip_failures,
+        field_mapping,
     )
+
+    samples = samples.select_fields()
 
     embeddings = []
     errors = False
@@ -1130,6 +1249,8 @@ def _compute_frame_embeddings_single(
 ):
     frame_counts, total_frame_count = _get_frame_counts(samples)
     is_clips = samples._dataset._is_clips
+
+    samples = samples.select_fields()
 
     embeddings_dict = {}
 
@@ -1194,6 +1315,8 @@ def _compute_frame_embeddings_batch(
 ):
     frame_counts, total_frame_count = _get_frame_counts(samples)
     is_clips = samples._dataset._is_clips
+
+    samples = samples.select_fields()
 
     embeddings_dict = {}
 
@@ -1262,6 +1385,8 @@ def _compute_video_embeddings(
     samples, model, embeddings_field, skip_failures, progress
 ):
     is_clips = samples._dataset._is_clips
+
+    samples = samples.select_fields()
 
     embeddings = []
     errors = False
@@ -1416,14 +1541,15 @@ def compute_patch_embeddings(
             % (handle_missing, _handle_missing_supported)
         )
 
+    process_video_frames = samples.media_type == fom.VIDEO
+
     use_data_loader = (
-        isinstance(model, TorchModelMixin) and samples.media_type == fom.IMAGE
+        isinstance(model, (SupportsGetItem, TorchModelMixin))
+        and not process_video_frames
     )
 
     if num_workers is not None and not use_data_loader:
-        logger.warning(
-            "Ignoring `num_workers` parameter; only supported for Torch models"
-        )
+        logger.warning("Ignoring unsupported `num_workers` parameter")
 
     if samples.media_type == fom.IMAGE:
         fov.validate_image_collection(samples)
@@ -1472,15 +1598,9 @@ def compute_patch_embeddings(
 
         context.enter_context(model)
 
-        if samples.media_type == fom.VIDEO:
-            _patches_field = samples._FRAMES_PREFIX + patches_field
-            samples = samples.select_fields(_patches_field)
-        else:
-            samples = samples.select_fields(patches_field)
-
         batch_size = _parse_batch_size(batch_size, model, use_data_loader)
 
-        if samples.media_type == fom.VIDEO:
+        if process_video_frames:
             return _embed_frame_patches(
                 samples,
                 model,
@@ -1535,6 +1655,8 @@ def _embed_patches(
     skip_failures,
     progress,
 ):
+    samples = samples.select_fields(patches_field)
+
     if embeddings_field is not None:
         label_parser = _make_label_parser(samples, patches_field)
     else:
@@ -1648,6 +1770,8 @@ def _embed_patches_data_loader(
         skip_failures,
     )
 
+    samples = samples.select_fields(patches_field)
+
     if embeddings_field is not None:
         label_parser = _make_label_parser(samples, patches_field)
     else:
@@ -1710,8 +1834,10 @@ def _embed_frame_patches(
     frame_counts, total_frame_count = _get_frame_counts(samples)
     is_clips = samples._dataset._is_clips
 
+    _patches_field = samples._FRAMES_PREFIX + patches_field
+    samples = samples.select_fields(_patches_field)
+
     if embeddings_field is not None:
-        _patches_field = samples._FRAMES_PREFIX + patches_field
         label_parser = _make_label_parser(samples, _patches_field)
     else:
         embeddings_dict = {}
@@ -2330,6 +2456,36 @@ class TorchModelMixin(object):
             the collated batch, which will be fed directly to the model
         """
         return batch
+
+
+class SupportsGetItem(object):
+    """Mixin for models that support inference with
+    :class:`fiftyone.utils.torch.FiftyOneTorchDataset`.
+
+    Models that implement this mixin must implement
+    :meth:`build_get_item` to build the :class:`fiftyone.utils.torch.GetItem`
+    instance that defines how their data should be loaded by data loaders.
+    """
+
+    @property
+    def required_keys(self):
+        """The required keys that must be provided as parameters to methods
+        like :func:`apply_model` and :func:`compute_embeddings` at runtime.
+        """
+        return self.build_get_item().required_keys
+
+    def build_get_item(self, field_mapping=None):
+        """Builds the :class:`fiftyone.utils.torch.GetItem` instance that
+        defines how the model's data should be loaded by data loaders.
+
+        Args:
+            field_mapping (None): a user-provided dict mapping required keys to
+                dataset field names
+
+        Returns:
+            a :class:`fiftyone.utils.torch.GetItem` instance
+        """
+        raise NotImplementedError("subclasses must implement build_get_item()")
 
 
 class ModelManagerConfig(etam.ModelManagerConfig):

--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -14,6 +14,7 @@ import warnings
 import numpy as np
 from PIL import Image
 
+import fiftyone as fo
 import fiftyone.core.labels as fol
 import fiftyone.core.utils as fou
 from fiftyone.core.models import EmbeddingsMixin, PromptMixin
@@ -295,7 +296,7 @@ class FiftyOneTransformerConfig(fout.TorchImageModelConfig, HasZooModel):
         super().__init__(d)
         self.name_or_path = self.parse_string(d, "name_or_path", default=None)
         self.hf_config = transformers.AutoConfig.from_pretrained(
-            self.name_or_path
+            self.name_or_path, cache_dir=fo.config.model_zoo_dir
         )
 
         # load classes if they exist
@@ -567,6 +568,8 @@ class FiftyOneTransformer(TransformerEmbeddingsMixin, fout.TorchImageModel):
                 "pretrained_model_name_or_path": config.name_or_path,
             }
 
+        config.entrypoint_args["cache_dir"] = fo.config.model_zoo_dir
+
         # default transforms
         if config.transforms_fcn is None:
             config.transforms_fcn = (
@@ -580,6 +583,7 @@ class FiftyOneTransformer(TransformerEmbeddingsMixin, fout.TorchImageModel):
             "pretrained_model_name_or_path": config.name_or_path,
             "use_fast": True,
             **config.transforms_args,
+            "cache_dir": fo.config.model_zoo_dir,
         }
         config.ragged_batches = False
 

--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -458,7 +458,7 @@ class FiftyOneYOLOModel(fout.TorchImageModel):
                 model.overrides[k] = v
 
         custom = {
-            "conf": 0.0,
+            "conf": config.confidence_thresh,
             "save": False,
             "mode": "predict",
             "rect": False,
@@ -594,6 +594,9 @@ class FiftyOneYOLOModel(fout.TorchImageModel):
         images = images.to(self._device)
         if self._using_half_precision:
             images = images.half()
+
+        if self.config.confidence_thresh:
+            self._model.predictor.args.conf = self.config.confidence_thresh
 
         output = self._forward_pass(images)
 

--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -19,6 +19,7 @@ import fiftyone.utils.torch as fout
 import fiftyone.core.utils as fou
 import fiftyone.zoo.models as fozm
 
+
 ultralytics = fou.lazy_import("ultralytics")
 torch = fou.lazy_import("torch")
 torchvision = fou.lazy_import("torchvision")
@@ -432,6 +433,22 @@ class FiftyOneYOLOModel(fout.TorchImageModel):
     def __init__(self, config):
         super().__init__(config)
 
+    @property
+    def has_collate_fn(self):
+        return True
+
+    @staticmethod
+    def collate_fn(batch):
+        orig_images = [img.get("orig_img") for img in batch]
+        orig_shapes = [_get_image_dims(img)[::-1] for img in orig_images]
+        images = [img.get("img") for img in batch]
+        images = torch.stack(images)
+        return {
+            "orig_imgs": orig_images,
+            "images": images,
+            "orig_shapes": orig_shapes,
+        }
+
     def _download_model(self, config):
         config.download_model_if_necessary()
 
@@ -441,12 +458,12 @@ class FiftyOneYOLOModel(fout.TorchImageModel):
                 model.overrides[k] = v
 
         custom = {
-            "conf": config.confidence_thresh,
-            "batch": 1,
+            "conf": 0.0,
             "save": False,
             "mode": "predict",
-            "rect": True,
+            "rect": False,
             "verbose": False,
+            "retina_masks": True,
             "device": self._device,
         }
         args = {**custom, **model.overrides}
@@ -510,7 +527,7 @@ class FiftyOneYOLOModel(fout.TorchImageModel):
         if config.ragged_batches is not None:
             ragged_batches = config.ragged_batches
         else:
-            ragged_batches = True
+            ragged_batches = False
 
         transforms = [self._preprocess_img]
         transforms = torchvision.transforms.Compose(transforms)
@@ -521,16 +538,16 @@ class FiftyOneYOLOModel(fout.TorchImageModel):
         if not isinstance(img, torch.Tensor):
             if isinstance(img, Image.Image):
                 img = img.convert("RGB")
-            orig_img = img
+            orig_img = np.asarray(img)
             return {
-                "img": self._ultralytics_preprocess([np.asarray(img)]),
+                "img": self._ultralytics_preprocess([orig_img]),
                 "orig_img": orig_img,
             }
         return {"img": img, "orig_img": img}
 
     def _ultralytics_preprocess(self, img):
         # Taken from ultralytics.engine.predictor.preprocess.
-        img = np.stack(self._model.predictor.pre_transform(img))
+        img = np.stack(self._pre_transform(img))
         img = img.transpose((0, 3, 1, 2))
         img = np.ascontiguousarray(img)
         img = torch.from_numpy(img)
@@ -538,47 +555,50 @@ class FiftyOneYOLOModel(fout.TorchImageModel):
         img /= 255
         return torch.squeeze(img, axis=0)
 
+    def _pre_transform(self, im):
+        # Taken from ultralytics.engine.predictor.pre_transform.
+        # TODO: Look into why self._model.predictor.pre_transform
+        # doesn't resize the image to (imgsz, imgsz) with rect=False.
+        same_shapes = len({x.shape for x in im}) == 1
+        letterbox = ultralytics.data.augment.LetterBox(
+            self._model.predictor.args.imgsz,
+            auto=same_shapes and self._model.predictor.args.rect,
+            stride=self._model.predictor.model.stride,
+        )
+        return [letterbox(image=x) for x in im]
+
     def _build_output_processor(self, config):
         if not config.output_processor_args:
             config.output_processor_args = {}
         config.output_processor_args[
             "post_processor"
         ] = self._model.predictor.postprocess
-        return super()._build_output_processor(config)
+        output_processor = super()._build_output_processor(config)
+        # Set post-processor to None for config JSON serialization.
+        config.output_processor_args["post_processor"] = None
+        return output_processor
 
     def _predict_all(self, imgs):
         if self._preprocess and self._transforms is not None:
             imgs = [self._transforms(img) for img in imgs]
+            if self.has_collate_fn:
+                imgs = self.collate_fn(imgs)
 
-        if isinstance(imgs, list) and len(imgs) and isinstance(imgs[0], dict):
-            orig_images = [img.get("orig_img") for img in imgs]
-            images = [img.get("img") for img in imgs]
-        else:
-            orig_images = imgs
-            images = imgs
+        orig_images = imgs["orig_imgs"]
+        images = imgs["images"]
+        width_height = imgs["orig_shapes"]
 
-        height, width = None, None
-        if self.config.raw_inputs:
-            # Feed images as list
-            if self._output_processor is not None:
-                image = imgs[0]
-                height, width = _get_image_dims(image)
-        else:
-            # Feed images as stacked Tensor
-            if isinstance(images, (list, tuple)):
-                images = torch.stack(images)
+        # Dummy value to ensure predictor batches have same length as images.
+        self._model.predictor.batch = [[""] * images.size()[0]]
 
-            height, width = images.size()[-2:]
-
-            images = images.to(self._device)
-            if self._using_half_precision:
-                images = images.half()
+        images = images.to(self._device)
+        if self._using_half_precision:
+            images = images.half()
 
         output = self._forward_pass(images)
 
         # This is required for Ultralytics post-processing.
         output["orig_imgs"] = orig_images
-        height, width = _get_image_dims(orig_images[0])
         output["imgs"] = images
 
         if self._output_processor is None:
@@ -593,7 +613,7 @@ class FiftyOneYOLOModel(fout.TorchImageModel):
 
         return self._output_processor(
             output,
-            (width, height),
+            width_height,
             confidence_thresh=self.config.confidence_thresh,
         )
 
@@ -624,7 +644,8 @@ class FiftyOneRTDETRModel(FiftyOneYOLOModel):
         config: a :class:`FiftyOneRTDETRModelConfig`
     """
 
-    pass
+    def _pre_transform(self, im):
+        return self._model.predictor.pre_transform(im)
 
 
 class FiftyOneYOLOClassificationModel(FiftyOneYOLOModel):
@@ -766,7 +787,6 @@ class UltralyticsPostProcessor(object):
             raise ValueError(
                 "Ultralytics post processor needs transformed and original images."
             )
-
         out = self.post_processor(preds, imgs, orig_imgs)
         return out
 
@@ -803,13 +823,16 @@ class UltralyticsDetectionOutputProcessor(
     def __call__(self, output, frame_size, confidence_thresh=None):
         results = self.post_process(output)
         preds = self._to_dict(results)
-        return super().__call__(preds, frame_size, confidence_thresh)
+        return [
+            self._parse_output(o, wh, confidence_thresh)
+            for o, wh in zip(preds, frame_size)
+        ]
 
     def _to_dict(self, results):
         batch = []
         for result in results:
             if not result.boxes:
-                continue
+                batch.append(None)
             else:
                 pred = {
                     "boxes": result.boxes.xyxy,
@@ -821,6 +844,8 @@ class UltralyticsDetectionOutputProcessor(
         return batch
 
     def _parse_output(self, output, frame_size, confidence_thresh):
+        if not output:
+            return None
         detections = super()._parse_output(
             output, frame_size, confidence_thresh
         )

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -3247,27 +3247,34 @@
         },
         {
             "base_name": "yolov5n-coco-torch",
+            "base_filename": "yolov5n-coco.pt",
             "description": "Ultralytics YOLOv5n model trained on COCO",
             "source": "https://pytorch.org/hub/ultralytics_yolov5",
             "author": "Glenn Jocher, et al.",
             "license": "AGPL-3.0",
-            "size_bytes": 7936,
-            "default_deployment_config_dict": {
-                "type": "fiftyone.utils.torch.TorchImageModel",
+            "size_bytes": 5562759,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
                 "config": {
-                    "entrypoint_fcn": "fiftyone.utils.torch.load_torch_hub_raw_model",
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolov5nu.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLOModel",
+                "config": {
+                    "entrypoint_fcn": "ultralytics.YOLO",
                     "entrypoint_args": {
-                        "repo_or_dir": "ultralytics/yolov5",
-                        "model": "yolov5n",
-                        "pretrained": true,
-                        "device": "cpu"
+                        "model": "yolov5nu.pt"
                     },
-                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
-                    "raw_inputs": true
+                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsDetectionOutputProcessor"
                 }
             },
             "requirements": {
-                "packages": ["torch>=1.7.0", "torchvision>=0.8.1"],
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics"
+                ],
                 "cpu": {
                     "support": true
                 },
@@ -3276,31 +3283,38 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo"],
-            "date_added": "2023-08-22 19:22:51"
+            "date_added": "2025-05-22 14:14:45"
         },
         {
             "base_name": "yolov5s-coco-torch",
+            "base_filename": "yolov5s-coco.pt",
             "description": "Ultralytics YOLOv5s model trained on COCO",
             "source": "https://pytorch.org/hub/ultralytics_yolov5",
             "author": "Glenn Jocher, et al.",
             "license": "AGPL-3.0",
-            "size_bytes": 28928,
-            "default_deployment_config_dict": {
-                "type": "fiftyone.utils.torch.TorchImageModel",
+            "size_bytes": 18581255,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
                 "config": {
-                    "entrypoint_fcn": "fiftyone.utils.torch.load_torch_hub_raw_model",
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolov5su.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLOModel",
+                "config": {
+                    "entrypoint_fcn": "ultralytics.YOLO",
                     "entrypoint_args": {
-                        "repo_or_dir": "ultralytics/yolov5",
-                        "model": "yolov5s",
-                        "pretrained": true,
-                        "device": "cpu"
+                        "model": "yolov5su.pt"
                     },
-                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
-                    "raw_inputs": true
+                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsDetectionOutputProcessor"
                 }
             },
             "requirements": {
-                "packages": ["torch>=1.7.0", "torchvision>=0.8.1"],
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics"
+                ],
                 "cpu": {
                     "support": true
                 },
@@ -3309,31 +3323,38 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo"],
-            "date_added": "2023-08-22 19:22:51"
+            "date_added": "2025-05-22 14:14:45"
         },
         {
             "base_name": "yolov5m-coco-torch",
+            "base_filename": "yolov5m-coco.pt",
             "description": "Ultralytics YOLOv5m model trained on COCO",
             "source": "https://pytorch.org/hub/ultralytics_yolov5",
             "author": "Glenn Jocher, et al.",
             "license": "AGPL-3.0",
-            "size_bytes": 83872,
-            "default_deployment_config_dict": {
-                "type": "fiftyone.utils.torch.TorchImageModel",
+            "size_bytes": 50589507,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
                 "config": {
-                    "entrypoint_fcn": "fiftyone.utils.torch.load_torch_hub_raw_model",
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolov5mu.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLOModel",
+                "config": {
+                    "entrypoint_fcn": "ultralytics.YOLO",
                     "entrypoint_args": {
-                        "repo_or_dir": "ultralytics/yolov5",
-                        "model": "yolov5m",
-                        "pretrained": true,
-                        "device": "cpu"
+                        "model": "yolov5mu.pt"
                     },
-                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
-                    "raw_inputs": true
+                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsDetectionOutputProcessor"
                 }
             },
             "requirements": {
-                "packages": ["torch>=1.7.0", "torchvision>=0.8.1"],
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics"
+                ],
                 "cpu": {
                     "support": true
                 },
@@ -3342,31 +3363,38 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo"],
-            "date_added": "2023-08-22 19:22:51"
+            "date_added": "2025-05-22 14:14:45"
         },
         {
             "base_name": "yolov5l-coco-torch",
+            "base_filename": "yolov5l-coco.pt",
             "description": "Ultralytics YOLOv5l model trained on COCO",
             "source": "https://pytorch.org/hub/ultralytics_yolov5",
             "author": "Glenn Jocher, et al.",
             "license": "AGPL-3.0",
-            "size_bytes": 197504,
-            "default_deployment_config_dict": {
-                "type": "fiftyone.utils.torch.TorchImageModel",
+            "size_bytes": 106913919,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
                 "config": {
-                    "entrypoint_fcn": "fiftyone.utils.torch.load_torch_hub_raw_model",
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolov5lu.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLOModel",
+                "config": {
+                    "entrypoint_fcn": "ultralytics.YOLO",
                     "entrypoint_args": {
-                        "repo_or_dir": "ultralytics/yolov5",
-                        "model": "yolov5l",
-                        "pretrained": true,
-                        "device": "cpu"
+                        "model": "yolov5lu.pt"
                     },
-                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
-                    "raw_inputs": true
+                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsDetectionOutputProcessor"
                 }
             },
             "requirements": {
-                "packages": ["torch>=1.7.0", "torchvision>=0.8.1"],
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics"
+                ],
                 "cpu": {
                     "support": true
                 },
@@ -3375,7 +3403,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo"],
-            "date_added": "2023-08-22 19:22:51"
+            "date_added": "2025-05-22 14:14:45"
         },
         {
             "base_name": "yolov8n-coco-torch",
@@ -3388,7 +3416,7 @@
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
                 "config": {
-                    "url": "https://github.com/ultralytics/assets/releases/download/v8.1.0/yolov8n.pt"
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolov8n.pt"
                 }
             },
             "default_deployment_config_dict": {
@@ -5448,23 +5476,26 @@
         },
         {
             "base_name": "yolov5x-coco-torch",
+            "base_filename": "yolov5x-coco.pt",
             "description": "Ultralytics YOLOv5x model trained on COCO",
             "source": "https://pytorch.org/hub/ultralytics_yolov5",
             "author": "Glenn Jocher, et al.",
             "license": "AGPL-3.0",
-            "size_bytes": 360496,
-            "default_deployment_config_dict": {
-                "type": "fiftyone.utils.torch.TorchImageModel",
+            "size_bytes": 195132283,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
                 "config": {
-                    "entrypoint_fcn": "fiftyone.utils.torch.load_torch_hub_raw_model",
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolov5xu.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLOModel",
+                "config": {
+                    "entrypoint_fcn": "ultralytics.YOLO",
                     "entrypoint_args": {
-                        "repo_or_dir": "ultralytics/yolov5",
-                        "model": "yolov5x",
-                        "pretrained": true,
-                        "device": "cpu"
+                        "model": "yolov5xu.pt"
                     },
-                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
-                    "raw_inputs": true
+                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsDetectionOutputProcessor"
                 }
             },
             "requirements": {
@@ -5477,7 +5508,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo"],
-            "date_added": "2023-08-22 19:22:51"
+            "date_added": "2025-05-22 14:14:45"
         }
     ]
 }

--- a/tests/unittests/get_item_tests.py
+++ b/tests/unittests/get_item_tests.py
@@ -1,0 +1,50 @@
+import unittest
+
+from fiftyone.utils.torch import GetItem
+
+
+class DummyGetItem(GetItem):
+    def __init__(self, field_mapping=None, **kwargs):
+        super().__init__(field_mapping, **kwargs)
+
+    def __call__(self, d):
+        return d["foo"] + d["bar"]
+
+    @property
+    def required_keys(self):
+        return ["foo", "bar"]
+
+
+class TestGetItem(unittest.TestCase):
+    def test_call(self):
+        gi = DummyGetItem()
+        d = {"foo": 1, "bar": 2}
+        self.assertEqual(gi(d), 3)
+
+    def test_required_keys(self):
+        gi = DummyGetItem()
+        self.assertEqual(set(gi.required_keys), set(["foo", "bar"]))
+
+    def test_default_field_mapping(self):
+        gi = DummyGetItem()
+        self.assertEqual(gi.field_mapping, {"foo": "foo", "bar": "bar"})
+
+    def test_field_mapping_setter_valid(self):
+        gi = DummyGetItem()
+        gi.field_mapping = {"foo": "oof", "bar": "rab"}
+        self.assertEqual(gi.field_mapping, {"foo": "oof", "bar": "rab"})
+
+    def test_field_mapping_setter_not_in_required_keys(self):
+        gi = DummyGetItem()
+        self.assertRaises(
+            ValueError, setattr, gi, "field_mapping", {"oof": "foo"}
+        )
+
+    def test_field_mapping_setter_partial(self):
+        gi = DummyGetItem()
+        gi.field_mapping = {"foo": "bar"}
+        self.assertEqual(gi.field_mapping, {"foo": "bar", "bar": "bar"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Matching release 1.6 to release 2.9. 

# Changes:
- 19d7553b21439b237a8e4dadcf44fc6e33f18154 - main `apply_model` refactor - never merged to 1.6
- ef9f7fbac724446d5278bceb987f89e1c403ddf5 - batching for ultralytics models
- 15791cb10708e42b8767e5f40a380c8fb828a66d - ultralytics confidence thresholding changes
- 572bb18235d3f74428aabd77636555977f11a73c - yolo v5
- 52ad6dcfae1ba0dc025d407b14ba33de66990b39 - transformers cache dir change to be model zoo dir
- https://github.com/voxel51/fiftyone/pull/5895

# checks
checked for reasonable diffs across this branch and `release/v2.9.0` for the following files:
1. fiftyone/core/models.py
2. fiftyone/core/collections.py
3. fiftyone/utils/torch.py
4. fiftyone/utils/transformers.py
5. fiftyone/utils/ultralytics.py
6. fiftyone/zoo/models/manifest-torch.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a method to convert sample collections directly to PyTorch datasets with advanced options for vectorization and error handling.
  - Introduced a formal interface for customizing how data is loaded from samples for PyTorch models.
  - Enhanced support for integrating custom and Ultralytics models with improved batch collation, preprocessing, and output parsing.
  - Specified a dedicated cache directory for Hugging Face Transformers models and processors.

- **Bug Fixes**
  - Improved error handling and field selection when applying models and computing embeddings.
  - Adjusted batching defaults and confidence threshold handling for Ultralytics models.

- **Documentation**
  - Clarified how to control batch sizes for Ultralytics integrations and added practical usage examples.

- **Tests**
  - Added and updated unit tests for the new data loading interface and dataset behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->