### PR TITLE
Scenario analysis bugfix: we don't yet support None values

### DIFF
--- a/plugins/operators/model_evaluation/__init__.py
+++ b/plugins/operators/model_evaluation/__init__.py
@@ -795,7 +795,8 @@ class ConfigureScenario(foo.Operator):
             return ShowOptionsMethod.CHECKBOX, {
                 "true": counts.get(True, 0),
                 "false": counts.get(False, 0),
-                "none": counts.get(None, 0),
+                # @todo consider supporting None
+                # "none": counts.get(None, 0),
             }
 
         # Retrieve distinct values (may be slow for large datasets)
@@ -821,10 +822,14 @@ class ConfigureScenario(foo.Operator):
 
         # NOTE: may be slow for large datasets
         values = dataset_or_view.count_values(field_name)
+
+        # @todo consider supporting None
+        values.pop(None, None)
+
         return (
             (ShowOptionsMethod.EMPTY, None)
             if not values
-            else (ShowOptionsMethod.CHECKBOX, dict(sorted(values.items())))
+            else (ShowOptionsMethod.CHECKBOX, values)
         )
 
     def render_auto_complete_view(self, ctx, values, inputs):


### PR DESCRIPTION
Scenario analysis doesn't yet support defining scenarios of the form `F(field) == None`. So, for now we update the Scenario analysis creation flow to **omit** `None` values from the UI.

```py
import random

import fiftyone as fo
import fiftyone.zoo as foz

ANIMALS = ["cat", "dog", None]
BOOLS = [True, False, None]

dataset = foz.load_zoo_dataset("quickstart")

animals = [random.choice(ANIMALS) for _ in range(len(dataset))]
dataset.set_values("animals", animals)

bools = [random.choice(BOOLS) for _ in range(len(dataset))]
dataset.set_values("bools", bools)

dataset.take(66).clear_sample_field("uniqueness")

dataset.evaluate_detections(
    "predictions",
    gt_field="ground_truth",
    eval_key="eval",
)

# Try to create scenarios based on `bools`, `animals`, and `uniqueness` fields
session = fo.launch_app(dataset)
```
