### PR TITLE
use dataset oid for get_scenarios_store

### DIFF
--- a/plugins/utils/model_evaluation/__init__.py
+++ b/plugins/utils/model_evaluation/__init__.py
@@ -7,6 +7,7 @@ FiftyOne builtin plugins.
 """
 
 from fiftyone.operators.store import ExecutionStore
+from bson import ObjectId
 
 
 STORE_NAME = "model_evaluation_panel_builtin"
@@ -38,7 +39,10 @@ def get_scenarios_store(ctx):
     Get the scenarios store from the context.
     """
     dataset_id = get_dataset_id(ctx)
-    return ExecutionStore.create(STORE_NAME, dataset_id)
+
+    dataset_oid = ObjectId(dataset_id)
+
+    return ExecutionStore.create(STORE_NAME, dataset_oid)
 
 
 def get_scenarios(ctx):


### PR DESCRIPTION
## What changes are proposed in this pull request?

use dataset oid for get_scenarios_store

## How is this patch tested? If it is not, please explain why.

Using ME panel

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of dataset identifiers to ensure compatibility and prevent potential errors when accessing scenario data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->