### PR TITLE
fix(execution-store): enforce ObjectId type for dataset_id and add test

### DIFF
--- a/fiftyone/factory/repos/execution_store.py
+++ b/fiftyone/factory/repos/execution_store.py
@@ -41,6 +41,10 @@ class ExecutionStoreRepo(ABC):
             dataset_id (Optional[ObjectId]): the dataset ID to operate on
             is_cache (False): whether the store is a cache store
         """
+        if dataset_id is not None and not isinstance(dataset_id, ObjectId):
+            raise ValueError(
+                f"dataset_id must be an ObjectId, got {type(dataset_id).__name__}"
+            )
         self._dataset_id = dataset_id
 
     @abstractmethod
@@ -301,6 +305,10 @@ class MongoExecutionStoreRepo(ExecutionStoreRepo):
     def __init__(
         self, collection, dataset_id: Optional[ObjectId] = None, is_cache=False
     ):
+        if dataset_id is not None and not isinstance(dataset_id, ObjectId):
+            raise ValueError(
+                f"dataset_id must be an ObjectId, got {type(dataset_id).__name__}"
+            )
         super().__init__(dataset_id, is_cache)
         self._collection = collection
         self._create_indexes()

--- a/fiftyone/operators/store/service.py
+++ b/fiftyone/operators/store/service.py
@@ -32,7 +32,7 @@ class ExecutionStoreService(object):
             If not provided, a new
             :class:`fiftyone.factory.repos.execution_store.MongoExecutionStoreRepo`
             will be created
-        dataset_id (None): a dataset ID to scope operations to
+        dataset_id (None): a dataset ID (ObjectId) to scope operations to
         collection_name (None): a collection name to use for the execution
             store. If `repo` is provided, this argument is ignored
     """

--- a/tests/unittests/execution_store_unit_tests.py
+++ b/tests/unittests/execution_store_unit_tests.py
@@ -357,20 +357,21 @@ class ExecutionStoreServiceDatasetIdTests(unittest.TestCase):
             }
         )
 
-        def test_create_store_with_dataset_id(self):
-            self.store_service.create_store("widgets")
-            self.mock_collection.insert_one.assert_called_once()
-            self.mock_collection.insert_one.assert_called_with(
-                {
-                    "store_name": "widgets",
-                    "key": "__store__",  # Include this in your expected call
-                    "value": None,
-                    "dataset_id": self.dataset_id,
-                    "created_at": IsDateTime(),
-                    "updated_at": None,
-                    "expires_at": None,
-                }
-            )
+    def test_create_store_with_dataset_id(self):
+        self.store_service.create_store("widgets")
+        self.mock_collection.insert_one.assert_called_once()
+        self.mock_collection.insert_one.assert_called_with(
+            {
+                "store_name": "widgets",
+                "key": "__store__",
+                "value": None,
+                "dataset_id": self.dataset_id,
+                "created_at": IsDateTime(),
+                "updated_at": None,
+                "expires_at": None,
+                "policy": "persist",
+            }
+        )
 
     def test_delete_store_with_dataset_id(self):
         self.store_service.delete_store("widgets")
@@ -407,3 +408,13 @@ class ExecutionStoreServiceDatasetIdTests(unittest.TestCase):
         assert_delta_seconds_approx(
             time_delta, 0
         )  # Check that the time difference is within the allowed EPSILON
+
+    def test_string_dataset_id_raises_exception(self):
+        """Test that creating a MongoExecutionStoreRepo with a string dataset_id raises an exception."""
+        mock_collection = MagicMock()
+        string_dataset_id = "507f1f77bcf86cd799439011"
+        
+        with self.assertRaises(ValueError) as context:
+            MongoExecutionStoreRepo(mock_collection, dataset_id=string_dataset_id)
+        
+        self.assertIn("dataset_id must be an ObjectId", str(context.exception))


### PR DESCRIPTION
This PR adds type checking for dataset_id in the execution store and includes tests.

```python
import fiftyone.operators.store as fos
import fiftyone as fo

ds = fo.load_dataset('quickstart')
dataset_id = ds._doc.id
str_dataset_id = str(dataset_id)

try:
    # this will now throw to prevent incorrect / confusing behavior
    svc = fos.ExecutionStoreService(dataset_id=str_dataset_id)
except Exception as e:
    # prints "dataset_id must be an ObjectId, got str"
    print(e)

svc = fos.ExecutionStoreService(dataset_id=dataset_id)
print(svc.count_stores_global()) # => 3
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for dataset IDs to ensure only valid ObjectId types are accepted, preventing errors with incorrect input.
  
- **Tests**
  - Added and corrected tests to verify proper dataset ID handling and error reporting for invalid types.

- **Documentation**
  - Clarified that dataset IDs must be of ObjectId type in service class documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->