### PR TITLE
Lower limit of cached grid instances

### DIFF
--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -27,7 +27,7 @@ import useSpotlightPager from "./useSpotlightPager";
 import useUpdates from "./useUpdates";
 import useZoomSetting from "./useZoomSetting";
 
-const MAX_INSTANCES = 5151;
+const MAX_INSTANCES = 200;
 const MAX_ROWS = 5151;
 
 function Grid() {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Limit looker instances to 200 in the grid cache. Even with low resolution media, memory consumption is considerable as the number of instances grows, .e.g. with `cifar10`

## How is this patch tested? If it is not, please explain why.
Locally

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Reduced the maximum number of hidden cached grid items to improve performance and resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->