### PR TITLE
fix incorrect confusion matrix colorscale in scenario analysis

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/overview/ConfusionMatrices.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/overview/ConfusionMatrices.tsx
@@ -33,7 +33,9 @@ export default function ConfusionMatrices(props) {
       compareEvaluation?.confusion_matrices,
       confusionMatrixConfig,
       evaluationMaskTargets,
-      compareEvaluationMaskTargets
+      compareEvaluationMaskTargets,
+      undefined,
+      true
     );
   }, [
     compareEvaluation,

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/Scenarios.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/Scenarios.tsx
@@ -1332,8 +1332,9 @@ function ScenarioModelPerformanceChart(props) {
 }
 
 function ConfusionMatrixChart(props) {
-  const { scenario, compareScenario, loadView, trackEvent } = props;
+  const { scenario, compareScenario, loadView, trackEvent, data } = props;
   const { subsets, id } = scenario;
+  const compareKey = data?.view?.compareKey;
   const [subset, setSubset] = usePanelStatePartial(`${id}_cms`, subsets[0]);
   const subsetData = scenario.subsets_data[subset];
   const compareSubsetData = compareScenario?.subsets_data[subset];
@@ -1360,6 +1361,7 @@ function ConfusionMatrixChart(props) {
           config,
           evaluationMaskTargets,
           compareEvaluationMaskTargets,
+          true,
           true
         )?.plot,
       ]
@@ -1423,6 +1425,21 @@ function ConfusionMatrixChart(props) {
           <Stack sx={{ width: "50%" }}>
             <Plot
               data={comparePlotData}
+              onClick={({ points }) => {
+                const firstPoint = points[0];
+                const subsetDef = getSubsetDef(scenario, subset);
+                trackEvent("evaluation_plot_click", {
+                  id: scenario.id,
+                  subsetDef,
+                  plotName: "confusion_matrix",
+                });
+                loadView("matrix", {
+                  x: firstPoint.x,
+                  y: firstPoint.y,
+                  subset_def: subsetDef,
+                  key: compareKey,
+                });
+              }}
               tooltip={(event: any) => {
                 const [point] = event.points;
                 const x = point.x;

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/utils.ts
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/utils.ts
@@ -47,14 +47,16 @@ export function getMatrix(
   config,
   maskTargets?,
   compareMaskTargets?,
-  plot?
+  plot?,
+  isCompare?
 ) {
   if (!matrices) return;
   const { sortBy = "az", limit } = config;
+  const colorscale_key_suffix = isCompare ? "colorscale_blues" : "colorscale";
   const parsedLimit = typeof limit === "number" ? limit : undefined;
   const originalClasses = matrices[`${sortBy}_classes`];
   const originalMatrix = matrices[`${sortBy}_matrix`];
-  const originalColorscale = matrices[`${sortBy}_colorscale`];
+  const originalColorscale = matrices[`${sortBy}_${colorscale_key_suffix}`];
   const chosenClasses = config?.classes;
   const hasChosenClasses =
     Array.isArray(chosenClasses) && chosenClasses?.length;


### PR DESCRIPTION
## What changes are proposed in this pull request?

fix incorrect confusion matrix colorscale in scenario analysis

## How is this patch tested? If it is not, please explain why.

Using scenario analysis tab in MEP

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

fix incorrect confusion matrix colorscale in scenario analysis

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for an alternative "blues" colorscale option in confusion matrix visualizations, enhancing comparison views.
  - Introduced improved caching for scenario data retrieval, potentially speeding up loading times in some cases.

- **Bug Fixes**
  - Adjusted confusion matrix display logic to ensure correct colorscale selection during comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->