### PR TITLE
FOEPD-1593 DO - group_id->parent_id

### DIFF
--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -189,11 +189,11 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
                 )
             )
 
-        if "group_id_1" not in index_names:
+        if "parent_id_1" not in index_names:
             indices_to_create.append(
                 IndexModel(
-                    [("group_id", pymongo.ASCENDING)],
-                    name="group_id_1",
+                    [("parent_id", pymongo.ASCENDING)],
+                    name="parent_id_1",
                 )
             )
 
@@ -393,7 +393,7 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             # If a parent operation is failed, also mark the children as failed
             self._collection.update_many(
                 {
-                    "group_id": doc["_id"],
+                    "parent_id": doc["_id"],
                     "run_state": {"$nin": ["failed", "completed"]},
                 },
                 {

--- a/fiftyone/factory/repos/delegated_operation_doc.py
+++ b/fiftyone/factory/repos/delegated_operation_doc.py
@@ -60,8 +60,8 @@ class DelegatedOperationDocument(object):
         self.log_size = None
         self.log_path = None
 
-        # grouped fields
-        self.group_id = None  # Only on children
+        # distributed task fields
+        self.parent_id = None  # Only on children
 
     @property
     def num_distributed_tasks(self):
@@ -92,7 +92,7 @@ class DelegatedOperationDocument(object):
         self.updated_at = doc.get("updated_at", None)
 
         # grouped fields
-        self.group_id = doc.get("group_id", None)
+        self.parent = doc.get("parent_id", None)
 
         # internal fields
         self.id = doc["_id"]

--- a/fiftyone/factory/repos/delegated_operation_doc.py
+++ b/fiftyone/factory/repos/delegated_operation_doc.py
@@ -92,7 +92,7 @@ class DelegatedOperationDocument(object):
         self.updated_at = doc.get("updated_at", None)
 
         # grouped fields
-        self.parent = doc.get("parent_id", None)
+        self.parent_id = doc.get("parent_id", None)
 
         # internal fields
         self.id = doc["_id"]

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -319,7 +319,7 @@ class DelegatedOperationService(object):
         doc = self._repo.get(_id=doc_id)
         if doc is None:
             raise ValueError(f"No delegated operation with {doc_id=} found")
-        if doc.group_id:
+        if doc.parent_id:
             raise ValueError("Cannot rerun a child delegated operation.")
         return self._repo.queue_operation(**doc.__dict__)
 

--- a/tests/unittests/operators/delegated_tests.py
+++ b/tests/unittests/operators/delegated_tests.py
@@ -479,7 +479,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         child_doc = copy.deepcopy(d)
         child_doc["run_state"] = ExecutionRunState.SCHEDULED
         child_doc.pop("num_partitions", None)
-        child_doc["group_id"] = ObjectId(parent_id)
+        child_doc["parent_id"] = ObjectId(parent_id)
         children = [
             {**child_doc, "_id": ObjectId()} for i in range(num_partitions)
         ]
@@ -869,7 +869,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
 
     def test_rerun_child_do_fail(self, mock_get_operator):
         mock_child_doc = mock.MagicMock(spec=DelegatedOperationDocument)
-        mock_child_doc.group_id = ObjectId()
+        mock_child_doc.parent_id = ObjectId()
 
         with patch.object(self.svc._repo, "get", return_value=mock_child_doc):
             with patch.object(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Changing terminology from group_id -> parent_id

## How is this patch tested? If it is not, please explain why.

unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Renamed the field representing parent-child relationships in delegated operations from "group_id" to "parent_id" for improved clarity and consistency across the application.
- **Tests**
  - Updated tests to use "parent_id" instead of "group_id" to reflect the new naming convention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->