### PR TITLE
chore: dacite no longer causes strawberry problems, so loosen the pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ INSTALL_REQUIRES = [
     "beautifulsoup4",
     "boto3",
     "cachetools",
-    "dacite>=1.6.0,<1.8.0",
+    "dacite>=1.6.0,<2",
     "dill",
     "Deprecated",
     "ftfy",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Back in the day, we had a problem with dacite and strawberry [not playing well together](https://voxel51.slack.com/archives/C0128P8LGGK/p1675194084875479) so we [pinned dacite to stay between 1.6.0 and 1.8.0](https://voxel51.slack.com/archives/C0128P8LGGK/p1675258296725109)

I've tested this in an ephemeral environment, and somewhere in the past 2.5 years this problem has been resolved.

So let's let people use newer versions of dacite!

## How is this patch tested? If it is not, please explain why.

tested in topher.ephem.fiftyone.ai
```
❯ kubectl -n topher-ephem-fiftyone-ai exec -it fiftyone-app-df986644b-4zcn4 -- pip freeze | grep dacite
dacite==1.9.2
```
results in a working quickstart dataset

<img width="1312" alt="Screenshot 2025-06-25 at 1 50 26 PM" src="https://github.com/user-attachments/assets/6369ec4c-7427-4d08-a803-167034c1f692" />

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
