### PR TITLE
pin gl draw

### DIFF
--- a/app/packages/map/package.json
+++ b/app/packages/map/package.json
@@ -16,7 +16,7 @@
         "@fiftyone/components": "*",
         "@fiftyone/plugins": "*",
         "@fiftyone/state": "*",
-        "@mapbox/mapbox-gl-draw": "^1.3.0",
+        "@mapbox/mapbox-gl-draw": "1.4.3",
         "@turf/boolean-contains": "^6.5.0",
         "lodash.throttle": "^4.1.1",
         "mapbox-gl": "^2.9.2",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2518,7 +2518,7 @@ __metadata:
     "@fiftyone/components": "npm:*"
     "@fiftyone/plugins": "npm:*"
     "@fiftyone/state": "npm:*"
-    "@mapbox/mapbox-gl-draw": "npm:^1.3.0"
+    "@mapbox/mapbox-gl-draw": "npm:1.4.3"
     "@turf/boolean-contains": "npm:^6.5.0"
     "@types/mapbox-gl": "npm:^2.7.4"
     "@types/mapbox__mapbox-gl-draw": "npm:^1.2.5"
@@ -3167,7 +3167,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mapbox/mapbox-gl-draw@npm:^1.3.0":
+"@mapbox/mapbox-gl-draw@npm:1.4.3":
   version: 1.4.3
   resolution: "@mapbox/mapbox-gl-draw@npm:1.4.3"
   dependencies:


### PR DESCRIPTION
## What changes are proposed in this pull request?

https://github.com/mapbox/mapbox-gl-draw/issues/1357 is causing issues for internal builds. Pinning to 1.4.3 should solve

## How is this patch tested? If it is not, please explain why.

Locally

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
