### PR TITLE
chore: kaleido revved to 1.0.0 and we didn`t notice

### DIFF
--- a/docs/source/enterprise/installation.rst
+++ b/docs/source/enterprise/installation.rst
@@ -130,16 +130,6 @@ Replace ``X.Y.Z`` with the proper version
 
     poetry add --source fiftyone-enterprise fiftyone==X.Y.Z
 
-.. note::
-
-    Due to an `unresolved misalignment <https://github.com/python-poetry/poetry/issues/4046>`_
-    with ``poetry`` and a FiftyOne dependency, ``kaleido``, you must add it
-    to your own dependencies as well:
-
-    .. code-block::
-
-        poetry add kaleido==0.2.1
-
 You should then see snippets in the ``pyproject.toml`` file like the following
 (the ``priority`` line will be different for ``poetry<v1.5``):
 

--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,6 @@ INSTALL_REQUIRES = [
     "humanize",
     "hypercorn>=0.13.2",
     "Jinja2>=3",
-    # kaleido indirectly required by plotly for image export
-    # https://plotly.com/python/static-image-export/
-    "kaleido!=0.2.1.post1",
     "matplotlib",
     "mongoengine~=0.29.1",
     "motor~=3.6.0",
@@ -54,7 +51,7 @@ INSTALL_REQUIRES = [
     "packaging",
     "pandas",
     "Pillow>=6.2",
-    "plotly>=4.14",
+    "plotly>=6.1.1",
     "pprintpp",
     "psutil",
     "pymongo~=4.9.2",


### PR DESCRIPTION
## What changes are proposed in this pull request?

When we weren't paying attention, the good people at plotly released version 1.0.0 of [kaleido](https://pypi.org/project/kaleido/1.0.0/)

Since the only thing we were doing was _excluding_ the `0.2.1.post1` version, we just started installing it when we weren't paying attention

```
❯ docker run -it --rm voxel51/fiftyone:1.6.0 pip freeze | grep kaleido
kaleido @ file:///builder/wheels/kaleido-1.0.0-py3-none-any.whl#sha256=a7e8bd95648378d2746f6c86084d419d15f95b1ec7bb0ec810289b7feb25b18d
```

Pretty much happened invisibly, so let's just roll with it!

## How is this patch tested? If it is not, please explain why

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
