### PR TITLE
add "billboard" style label text indicator for 3d bounding boxes

### DIFF
--- a/app/packages/core/src/components/Modal/Group/index.tsx
+++ b/app/packages/core/src/components/Modal/Group/index.tsx
@@ -35,12 +35,14 @@ const Group = () => {
 
     // hide 3d looker and carousel if `hasGroupSlices`
     if (
+      dynamic &&
       dynamicGroupsViewMode === "video" &&
       (isLooker3DVisible || isCarouselVisible)
     ) {
       setIsMainLookerVisible(true);
     }
   }, [
+    dynamic,
     dynamicGroupsViewMode,
     isNestedDynamicGroup,
     isOrderedDynamicGroup,

--- a/app/packages/looker-3d/src/labels/cuboid.tsx
+++ b/app/packages/looker-3d/src/labels/cuboid.tsx
@@ -1,4 +1,8 @@
-import { useCursor } from "@react-three/drei";
+import {
+  currentModalUniqueIdJotaiAtom,
+  jotaiStore,
+} from "@fiftyone/state/src/jotai";
+import { Billboard, Plane, Text, useCursor } from "@react-three/drei";
 import { extend } from "@react-three/fiber";
 import { useMemo, useState } from "react";
 import { useRecoilValue } from "recoil";
@@ -6,11 +10,57 @@ import * as THREE from "three";
 import { LineMaterial } from "three/examples/jsm/lines/LineMaterial";
 import { LineSegments2 } from "three/examples/jsm/lines/LineSegments2";
 import { LineSegmentsGeometry } from "three/examples/jsm/lines/LineSegmentsGeometry";
+import { useFo3dContext } from "../fo3d/context";
 import { use3dLabelColor } from "../hooks/use-3d-label-color";
 import { useSimilarLabels3d } from "../hooks/use-similar-labels-3d";
-import { cuboidLabelLineWidthAtom } from "../state";
+import { cuboidLabelLineWidthAtom, showIndexAtom } from "../state";
+import { OverlayLabel } from "./loader";
 import type { OverlayProps } from "./shared";
 extend({ LineSegments2, LineMaterial, LineSegmentsGeometry });
+
+let cache: Record<
+  string,
+  {
+    latestIndex: number;
+    instanceIdToIndexId: Record<string, number>;
+  }
+> = {};
+let lastModalUniqueId = "";
+
+const getIndexIdFromInstanceIdForLabel = (
+  instanceId: string,
+  label: OverlayLabel
+) => {
+  const currentModalUniqueId = jotaiStore.get(currentModalUniqueIdJotaiAtom);
+
+  if (currentModalUniqueId !== lastModalUniqueId) {
+    lastModalUniqueId = currentModalUniqueId;
+    cache = {};
+  }
+
+  const key = `${currentModalUniqueId}-${label.label.toLocaleLowerCase()}`;
+
+  if (
+    cache[key] &&
+    cache[key].instanceIdToIndexId &&
+    typeof cache[key].instanceIdToIndexId[instanceId] === "number"
+  ) {
+    return cache[key].instanceIdToIndexId[instanceId];
+  } else if (cache[key] && cache[key].instanceIdToIndexId) {
+    cache[key].instanceIdToIndexId[instanceId] = cache[key].latestIndex + 1;
+    cache[key].latestIndex += 1;
+    return cache[key].instanceIdToIndexId[instanceId];
+  } else {
+    cache[key] = {
+      latestIndex: 1,
+      instanceIdToIndexId: {
+        [instanceId]: 1,
+      },
+    };
+  }
+
+  return cache[key].instanceIdToIndexId[instanceId];
+};
 
 export interface CuboidProps extends OverlayProps {
   location: THREE.Vector3Tuple;
@@ -97,6 +147,30 @@ export const Cuboid = ({
     ]
   );
 
+  const { isSceneInitialized, upVector } = useFo3dContext();
+
+  const showIndex = useRecoilValue(showIndexAtom);
+
+  const labelBillboardPosition = useMemo(() => {
+    // Compute the cuboid's extent along the up vector
+    const upNorm = upVector.clone().normalize();
+    const cuboidExtent =
+      Math.abs(dimensions[0] * upNorm.x) +
+      Math.abs(dimensions[1] * upNorm.y) +
+      Math.abs(dimensions[2] * upNorm.z);
+    const margin = 0.2 * Math.max(...dimensions); // 10% of the largest dimension
+    // Offset from the cuboid center along the up vector
+    return upNorm.multiplyScalar(cuboidExtent / 2 + margin);
+  }, [upVector, dimensions]);
+
+  let labelText = label.label;
+  if (showIndex && typeof label.index === "number") {
+    labelText += " " + Number(label.index).toLocaleString();
+  } else if (showIndex && label.instance?._id && label.instance.index) {
+    labelText +=
+      " " + getIndexIdFromInstanceIdForLabel(label.instance._id, label);
+  }
+
   const { onPointerOver, onPointerOut, ...restEventHandlers } = useMemo(() => {
     return {
       ...tooltip.getMeshProps(label),
@@ -132,6 +206,28 @@ export const Cuboid = ({
         }}
         {...restEventHandlers}
       >
+        <Billboard position={labelBillboardPosition} follow={true}>
+          {/* Faint white background plane behind the label */}
+          <Plane
+            args={[
+              // width based on label length
+              Math.max(2, labelText.length * 0.6),
+              // height slightly larger than fontSize
+              1.4,
+            ]}
+            // slightly behind the text
+            position={[0, 0, -0.02]}
+          >
+            <meshBasicMaterial
+              color={strokeAndFillColor}
+              transparent
+              opacity={isCuboidHovered || isSimilarLabelHovered ? 0.7 : 0.3}
+            />
+          </Plane>
+          <Text fontSize={1} color="white">
+            {labelText}
+          </Text>
+        </Billboard>
         <boxGeometry args={dimensions} />
         <meshBasicMaterial
           transparent={isSimilarLabelHovered ? false : true}

--- a/app/packages/looker-3d/src/labels/index.tsx
+++ b/app/packages/looker-3d/src/labels/index.tsx
@@ -21,7 +21,11 @@ import { useRecoilState, useRecoilValue } from "recoil";
 import { PANEL_ORDER_LABELS } from "../constants";
 import { usePathFilter } from "../hooks";
 import { type Looker3dSettings, defaultPluginSettings } from "../settings";
-import { cuboidLabelLineWidthAtom, polylineLabelLineWidthAtom } from "../state";
+import {
+  cuboidLabelLineWidthAtom,
+  polylineLabelLineWidthAtom,
+  showIndexAtom,
+} from "../state";
 import { toEulerFromDegreesArray } from "../utils";
 import { Cuboid, type CuboidProps } from "./cuboid";
 import { type OverlayLabel, load3dOverlays } from "./loader";
@@ -49,6 +53,7 @@ export const ThreeDLabels = ({ sampleMap }: ThreeDLabelsProps) => {
   const [polylineWidth, setPolylineWidth] = useRecoilState(
     polylineLabelLineWidthAtom
   );
+  const [showIndex, setShowIndex] = useRecoilState(showIndexAtom);
   const selectedLabels = useRecoilValue(fos.selectedLabelMap);
   const tooltip = fos.useTooltip();
   const labelAlpha = colorScheme.opacity;
@@ -74,6 +79,13 @@ export const ThreeDLabels = ({ sampleMap }: ThreeDLabelsProps) => {
         setPolylineWidth(value);
       },
     },
+    showIndex: {
+      value: showIndex,
+      label: `Show Index`,
+      onChange: (value: boolean) => {
+        setShowIndex(value);
+      },
+    },
   };
 
   const [labelConfig] = useControls(
@@ -83,7 +95,7 @@ export const ThreeDLabels = ({ sampleMap }: ThreeDLabelsProps) => {
         collapsed: true,
       }),
     }),
-    [setCuboidLineWidth, setPolylineWidth]
+    [setCuboidLineWidth, setPolylineWidth, setShowIndex]
   );
 
   const handleSelect = useCallback(

--- a/app/packages/looker-3d/src/labels/loader.ts
+++ b/app/packages/looker-3d/src/labels/loader.ts
@@ -13,6 +13,7 @@ export type OverlayLabel = {
   label?: string;
   sampleId?: string;
   _cls: string;
+  index?: number;
 
   /**
    * Unlike id, instanceId is not guaranteed to be unique across samples.

--- a/app/packages/looker-3d/src/state.ts
+++ b/app/packages/looker-3d/src/state.ts
@@ -199,3 +199,13 @@ export const polylineLabelLineWidthAtom = atom({
     }),
   ],
 });
+
+export const showIndexAtom = atom<boolean>({
+  key: "fo3d-showIndex",
+  default: true,
+  effects: [
+    getBrowserStorageEffectForKey("fo3d-showIndex", {
+      valueClass: "boolean",
+    }),
+  ],
+});


### PR DESCRIPTION
This PR helps achieve feature parity with the 2D looker so that label texts are displayed on top of 3D bounding boxes. The bounding boxes always face the camera.

The user can turn this on/off from Scene Preferences -> Labels dynamically in the app.

![billboard_small](https://github.com/user-attachments/assets/9151bc30-2b0e-44f9-b94e-b240515bf27f)
