### PR TITLE
chore(plugins): ensure changes to builtin plugins trigger tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,6 +41,7 @@ jobs:
               - 'setup.py'
               - '.github/workflows/build.yml'
               - '.github/workflows/test.yml'
+              - 'plugins/**'
 
   build:
     needs: modified-files


### PR DESCRIPTION
## What changes are proposed in this pull request?

Changes to `/plugins` (builtin python plugins) would not trigger pytests. This PR fixes that issue by including the `/plugins/**` files in the `pr` workflow path filters.

## How is this patch tested? If it is not, please explain why.

Created a [test PR](https://github.com/voxel51/fiftyone-teams/pull/1693) in the fiftyone-teams repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow to ensure changes in the `plugins` directory trigger relevant downstream jobs in pull request checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->