### PR TITLE
fix(embeddings): fix useViewChangeEffect error due to undefined refer…

### DIFF
--- a/app/packages/embeddings/src/useViewChangeEffect.tsx
+++ b/app/packages/embeddings/src/useViewChangeEffect.tsx
@@ -7,6 +7,7 @@ import { useBrainResult, usePointsField } from "./useBrainResult";
 import { useColorByField } from "./useLabelSelector";
 import { useWarnings } from "./useWarnings";
 import { PlotResponse, PlotSuccessResponse } from "./types";
+import { NetworkError } from "@fiftyone/utilities";
 
 
 
@@ -44,13 +45,25 @@ export function useViewChangeEffect() {
     setLoadingPlot(true);
     fetchPlot({ datasetName, brainKey, view, labelField, slices })
       .catch((err: Error) => {
-        setLoadingPlotError({
-          message: err.message,
-          stack: err.stack,
-        });
+        if (err instanceof NetworkError) {
+          setLoadingPlotError({
+            message: "Network Error",
+            stack: [
+              err.stack,
+              "See console for network error details."
+            ].join("\n"),
+          });
+        } else {
+          setLoadingPlotError({
+            message: err.message,
+            stack: err.stack,
+          });
+        }
       })
       .then((res: PlotResponse) => {
         warnings.clear();
+
+        if (!res) return;
 
         if ('error' in res && res.error) {
           setLoadingPlotError(res);


### PR DESCRIPTION
Fixes an issue where showing the stack trace for an embeddings error would cause an reference to an undefined object.

Also adds a note for users to find more details about network errors in the console.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to clearly indicate network errors with a specific message and guidance.
  * Enhanced stability by preventing further processing if a fetch response is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->