### PR TITLE
fix(embeddings): missing error case

### DIFF
--- a/app/packages/embeddings/src/ErrorWithStack.tsx
+++ b/app/packages/embeddings/src/ErrorWithStack.tsx
@@ -11,9 +11,9 @@ export default function ErrorWithStack({ error }) {
         paddingTop: 8
       }}
     >
-      <Typography variant="h6" gutterBottom>
-        {error.error}
-      </Typography>
+      {error.message && (<Typography variant="h6" gutterBottom>
+        {error.message}
+      </Typography>)}
       {error.details && (
         <Typography variant="subtitle1" color="text.secondary" gutterBottom>
           {error.details}

--- a/app/packages/embeddings/src/types.ts
+++ b/app/packages/embeddings/src/types.ts
@@ -1,16 +1,10 @@
 /**
- * Represents an error returned from the embeddings plot API.
- */
-export type PlotError = {
-    message: string;
-    stack: string;
-};
-
-/**
  * Response type for an error from the plot API.
  */
 export type PlotErrorResponse = {
-    error: PlotError;
+    error: string;
+    stack: string;
+    details?: string;
 };
 
 /**

--- a/app/packages/embeddings/src/useViewChangeEffect.tsx
+++ b/app/packages/embeddings/src/useViewChangeEffect.tsx
@@ -6,7 +6,7 @@ import { fetchPlot } from "./fetch";
 import { useBrainResult, usePointsField } from "./useBrainResult";
 import { useColorByField } from "./useLabelSelector";
 import { useWarnings } from "./useWarnings";
-import { PlotResponse, PlotSuccessResponse } from "./types";
+import { PlotErrorResponse, PlotResponse, PlotSuccessResponse } from "./types";
 import { NetworkError } from "@fiftyone/utilities";
 
 
@@ -66,7 +66,12 @@ export function useViewChangeEffect() {
         if (!res) return;
 
         if ('error' in res && res.error) {
-          setLoadingPlotError(res);
+          res = res as PlotErrorResponse;
+          setLoadingPlotError({
+            message: res.error,
+            details: res.details,
+            stack: res.stack,
+          });
           return;
         }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

When a visualization result is still executing, the brain run will be returned as `None` from `load_brain_result()`. This ensures that error is still correctly displayed to the user.

<!-- https://voxel51.atlassian.net/browse/FOEPD-1638 -->

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
