### PR TITLE
Fix partial range filters in sidebar

### DIFF
--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -698,7 +698,12 @@ def _make_scalar_expression(f, args, field, list_field=None, is_label=False):
     if _is_support(field):
         if "range" in args:
             mn, mx = args["range"]
-            expr = (f[0] >= mn) & (f[1] <= mx)
+            if mn is not None and max is not None:
+                expr = (f[0] >= mn) & (f[1] <= mx)
+            elif mn is not None:
+                expr = f[0] >= mn
+            elif mx is not None:
+                expr = f[1] <= mx
     elif isinstance(field, fof.ListField):
         if isinstance(list_field, str):
             return f.filter(
@@ -723,14 +728,10 @@ def _make_scalar_expression(f, args, field, list_field=None, is_label=False):
         if not true and not false:
             expr = (f != True) & (f != False)
     elif _is_datetime(field):
-        if "range" in args:
-            mn, mx = args["range"]
-            p = fou.timestamp_to_datetime
-            expr = (f >= p(mn)) & (f <= p(mx))
+        expr = _make_range_expr(f, args, convert=fou.timestamp_to_datetime)
     elif isinstance(field, (fof.FloatField, fof.IntField)):
-        if "range" in args:
-            mn, mx = args["range"]
-            expr = (f >= mn) & (f <= mx)
+        expr = _make_range_expr(f, args)
+
     else:
         values = args["values"]
         if not values:
@@ -757,6 +758,22 @@ def _make_scalar_expression(f, args, field, list_field=None, is_label=False):
         return expr
 
     return _apply_others(expr, f, args, is_label)
+
+
+def _make_range_expr(f, args, convert=lambda v: v):
+    if "range" not in args:
+        return None
+
+    expr = None
+    mn, mx = args["range"]
+    if mn is not None and mx is not None:
+        expr = (f >= convert(mn)) & (f <= convert(mx))
+    elif mn is not None:
+        expr = f >= convert(mn)
+    elif mx is not None:
+        expr = f <= convert(mx)
+
+    return expr
 
 
 def _make_keypoint_list_filter(args, view, path, field):

--- a/tests/unittests/server_view_tests.py
+++ b/tests/unittests/server_view_tests.py
@@ -96,6 +96,17 @@ class ServerViewTests(unittest.TestCase):
         self.assertEqual(len(view.first().predictions.detections), 1)
 
         filters = {
+            "predictions.detections.confidence": {
+                "range": [0.5, None],
+                "exclude": False,
+                "isMatching": False,
+            },
+        }
+        view = fosv.get_view("test", filters=filters)
+        self.assertEqual(len(view), 1)
+        self.assertEqual(len(view.first().predictions.detections), 1)
+
+        filters = {
             "list_str": {
                 "values": ["one"],
                 "exclude": False,


### PR DESCRIPTION
## What changes are proposed in this pull request?

With manual input for numeric fields added, backend support for only a min _or_ a max was overlooked. Specifically for list fields

## How is this patch tested? If it is not, please explain why.

Updated server view test

## Release Notes

N/A

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
