### PR TITLE
fix(useBrowserStorage): improve handling of undefined values

### DIFF
--- a/app/packages/state/src/hooks/useBrowserStorage.test.ts
+++ b/app/packages/state/src/hooks/useBrowserStorage.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useBrowserStorage } from "./useBrowserStorage";
+
+// Utility wrapper for cleaner access
+const useTestableState = (...args: Parameters<typeof useBrowserStorage>) => {
+  const [value, setState] = useBrowserStorage(...args);
+  return { value, setState };
+};
+
+describe("useBrowserStorage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  describe("undefined value handling", () => {
+    it("should remove item from storage when setting undefined (no parseFn)", () => {
+      const { result } = renderHook(() => useTestableState("test-key", "default"));
+
+      act(() => {
+        result.current.setState("test-value");
+      });
+      expect(localStorage.getItem("test-key")).toBe('"test-value"');
+
+      act(() => {
+        result.current.setState(undefined as any);
+      });
+      expect(localStorage.getItem("test-key")).toBeNull();
+    });
+
+    it("should remove item from storage when setting undefined (with parseFn)", () => {
+      const parseFn = {
+        parse: (value: string) => JSON.parse(value),
+        stringify: (value: any) => JSON.stringify(value),
+      };
+
+      const { result } = renderHook(() =>
+        useTestableState("test-key", { default: "value" }, false, parseFn)
+      );
+
+      act(() => {
+        result.current.setState({ test: "data" });
+      });
+      expect(localStorage.getItem("test-key")).toBe('{"test":"data"}');
+
+      act(() => {
+        result.current.setState(undefined as any);
+      });
+      expect(localStorage.getItem("test-key")).toBeNull();
+    });
+
+    it("should handle function updates that return undefined", () => {
+      const { result } = renderHook(() => useTestableState("test-key", 0));
+
+      act(() => {
+        result.current.setState((prev: number) => prev + 1);
+      });
+      expect(result.current.value).toBe(1);
+      expect(localStorage.getItem("test-key")).toBe("1");
+
+      act(() => {
+        result.current.setState(() => undefined as any);
+      });
+      expect(localStorage.getItem("test-key")).toBeNull();
+    });
+  });
+
+  describe("reading 'undefined' string from storage", () => {
+    it("should treat stored 'undefined' string as null and use default value", () => {
+      localStorage.setItem("test-key", "undefined");
+
+      const { result } = renderHook(() => useTestableState("test-key", "default-value"));
+      expect(result.current.value).toBe("default-value");
+    });
+
+    it("should treat stored 'undefined' string as null with custom parseFn", () => {
+      localStorage.setItem("test-key", "undefined");
+
+      const parseFn = {
+        parse: (value: string) => JSON.parse(value),
+        stringify: (value: any) => JSON.stringify(value),
+      };
+
+      const { result } = renderHook(() =>
+        useTestableState("test-key", { default: "value" }, false, parseFn)
+      );
+
+      expect(result.current.value).toEqual({ default: "value" });
+    });
+  });
+
+  describe("sessionStorage support", () => {
+    it("should handle undefined values in sessionStorage", () => {
+      const { result } = renderHook(() => useTestableState("test-key", "default", true));
+
+      act(() => {
+        result.current.setState("test-value");
+      });
+      expect(sessionStorage.getItem("test-key")).toBe('"test-value"');
+
+      act(() => {
+        result.current.setState(undefined as any);
+      });
+      expect(sessionStorage.getItem("test-key")).toBeNull();
+    });
+
+    it("should treat stored 'undefined' string as null in sessionStorage", () => {
+      sessionStorage.setItem("test-key", "undefined");
+
+      const { result } = renderHook(() => useTestableState("test-key", "default-value", true));
+      expect(result.current.value).toBe("default-value");
+    });
+  });
+
+  describe("null value handling", () => {
+    it("should handle null values by not removing from storage", () => {
+      const { result } = renderHook(() => useTestableState("test-key", "default"));
+
+      act(() => {
+        result.current.setState("test-value");
+      });
+      expect(localStorage.getItem("test-key")).toBe('"test-value"');
+
+      act(() => {
+        result.current.setState(null as any);
+      });
+      expect(localStorage.getItem("test-key")).toEqual("null");
+    });
+  });
+
+  describe("basic functionality", () => {
+    it("should work with normal values", () => {
+      const { result } = renderHook(() => useTestableState("test-key", "default"));
+
+      act(() => {
+        result.current.setState("test-value");
+      });
+
+      expect(result.current.value).toBe("test-value");
+      expect(localStorage.getItem("test-key")).toBe('"test-value"');
+    });
+
+    it("should work with objects", () => {
+      const { result } = renderHook(() => useTestableState("test-key", {}));
+
+      const testObj = { name: "test", value: 123 };
+      act(() => {
+        result.current.setState(testObj);
+      });
+
+      expect(result.current.value).toEqual(testObj);
+      expect(localStorage.getItem("test-key")).toBe(JSON.stringify(testObj));
+    });
+
+    it("should work with numbers", () => {
+      const { result } = renderHook(() => useTestableState("test-key", 0));
+
+      act(() => {
+        result.current.setState(42);
+      });
+
+      expect(result.current.value).toBe(42);
+      expect(localStorage.getItem("test-key")).toBe("42");
+    });
+
+    it("should work with function updates", () => {
+      const { result } = renderHook(() => useTestableState("test-key", 41));
+
+      act(() => {
+        result.current.setState((prev: number) => prev + 10);
+      });
+
+      expect(result.current.value).toBe(51);
+      expect(localStorage.getItem("test-key")).toBe("51");
+    });
+  });
+});

--- a/app/packages/state/src/hooks/useBrowserStorage.ts
+++ b/app/packages/state/src/hooks/useBrowserStorage.ts
@@ -16,11 +16,15 @@ export const useBrowserStorage = <T = string>(
 
   // Pass initial state function to useState so logic is only executed once
   const [storedValue, setStoredValue] = useState<T>(() => {
-    const item = storage.getItem(key);
+    let item = storage.getItem(key);
 
     if (item) {
       if (parseFn) {
         return parseFn.parse(item);
+      }
+      // Workaround for existing "undefined" values in storage
+      if (item === "undefined") {
+        return;
       }
 
       return JSON.parse(item);
@@ -44,12 +48,17 @@ export const useBrowserStorage = <T = string>(
         setStoredValue(value);
       }
 
+      // Convert undefined to null to avoid "undefined" values in storage
+      if (valueToStore === undefined) {  
+        valueToStore = null;
+      }
+
       storage.setItem(
         key,
         parseFn ? parseFn.stringify(valueToStore) : JSON.stringify(valueToStore)
       );
     },
-    [key, storage]
+    [key, storage, parseFn]
   );
 
   return [storedValue, setValue] as const;

--- a/app/packages/state/src/hooks/useBrowserStorage.ts
+++ b/app/packages/state/src/hooks/useBrowserStorage.ts
@@ -48,9 +48,17 @@ export const useBrowserStorage = <T = string>(
         setStoredValue(value);
       }
 
-      // Convert undefined to null to avoid "undefined" values in storage
-      if (valueToStore === undefined) {  
-        valueToStore = null;
+      // Only apply undefined handling when no parseFn is provided
+      if (parseFn) {
+        // Let the custom parser handle undefined however it wants
+        storage.setItem(key, parseFn.stringify(valueToStore));
+      } else {
+        // For JSON.stringify, handle undefined specially to avoid "undefined" strings
+        if (valueToStore !== undefined) {
+          storage.setItem(key, JSON.stringify(valueToStore));
+        } else {
+          storage.removeItem(key);
+        }
       }
 
       storage.setItem(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes an issue where the `useBrowserStorage` utility would persist an `"undefined"` value in localStorage, which is not valid JSON:

<img width="323" alt="image" src="https://github.com/user-attachments/assets/8d160054-47ef-468f-a5e9-29f7ba84053f" />

[FOEPD-1648](https://voxel51.atlassian.net/browse/FOEPD-1648)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


[FOEPD-1648]: https://voxel51.atlassian.net/browse/FOEPD-1648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of "undefined" values in browser storage to prevent errors and unintended behavior.
  * Ensured that undefined values are removed from storage instead of storing the string "undefined".
  * Enhanced reliability when using custom parsing functions.
* **Tests**
  * Added comprehensive tests for browser storage behavior, including handling of undefined, null, and custom parsing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->