### PR TITLE
Remove incorrect default in group by operator

### DIFF
--- a/plugins/operators/group_by.py
+++ b/plugins/operators/group_by.py
@@ -116,7 +116,6 @@ def _create(ctx, obj):
 
         input(
             "order_by_key",
-            default=False,
             required=False,
             label="Order by key",
             description=(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Removes an incorrect `default` value the group by operator

## How is this patch tested? If it is not, please explain why.

Locally

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated configuration for the "order by key" input field to improve consistency in input handling. No changes to visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->