### PR TITLE
Support both locations for eta/brain installs

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -121,16 +121,24 @@ fi
 
 echo "***** INSTALLING FIFTYONE-BRAIN *****"
 if [ ${SOURCE_BRAIN_INSTALL} = true ]; then
-    git clone https://github.com/voxel51/fiftyone-brain
-    cd fiftyone-brain
+    if [[ ! -d "fiftyone-brain" ]] && [[ ! -d "../fiftyone-brain" ]]; then
+        echo "Cloning FiftyOne Brain repository"
+        git clone https://github.com/voxel51/fiftyone-brain
+    fi
+    if [[ -d "../fiftyone-brain" ]]; then
+        cd ../fiftyone-brain
+    else
+        cd fiftyone-brain
+    fi
     if [ ${DEV_INSTALL} = true ]; then
+        echo "Performing dev install"
         bash install.bash -d
     else
+        echo "Performing install"
         pip install .
     fi
-    cd ..
+    cd -
 else
-    echo "Cloning FiftyOne Brain repository"
     pip install --upgrade fiftyone-brain
 fi
 
@@ -141,27 +149,33 @@ if [ ${DEV_INSTALL} = true ]; then
     pre-commit install
     pip install -e .
 else
+    echo "Performing install"
     pip install .
 fi
 
 if [ ${SOURCE_ETA_INSTALL} = true ]; then
-    echo "***** INSTALLING ETA *****"
-    if [[ ! -d "eta" ]]; then
+    echo "***** INSTALLING ETA FROM SOURCE *****"
+    if [[ ! -d "eta" ]] && [[ ! -d "../eta" ]]; then
         echo "Cloning ETA repository"
         git clone https://github.com/voxel51/eta
     fi
-    cd eta
+    if [[ -d "../eta" ]]; then
+        cd ../eta
+    else
+        cd eta
+    fi
     if [ ${DEV_INSTALL} = true ]; then
+        echo "Performing dev install"
         pip install -e .
     else
+        echo "Performing install"
         pip install .
     fi
     if [[ ! -f eta/config.json ]]; then
         echo "Installing default ETA config"
         cp config-example.json eta/config.json
     fi
-    cd ..
+    cd -
 fi
-
 
 echo "***** INSTALLATION COMPLETE *****"

--- a/install.bat
+++ b/install.bat
@@ -55,15 +55,26 @@ IF %USE_FIFTY_ONE_DB%==true (
 
 echo ***** INSTALLING FIFTYONE-BRAIN *****
 IF %SOURCE_BRAIN_INSTALL%==true (
-  echo Cloning FiftyOne Brain repository
-  git clone https://github.com/voxel51/fiftyone-brain
-  cd fiftyone-brain
+  if not exist "fiftyone-brain\" (
+    if not exist "..\fiftyone-brain\" (
+      echo Cloning FiftyOne Brain repository
+      git clone https://github.com/voxel51/fiftyone-brain
+    )
+  )
+  pushd .
+  if exist "..\fiftyone-brain\" (
+    cd ..\fiftyone-brain
+  ) else (
+    cd fiftyone-brain
+  )
   IF %DEV_INSTALL%==true (
+    echo Performing dev install
     CALL install.bat -d
   ) else (
+    echo Performing install
     pip install .
   )
-  cd ..
+  popd
 ) else (
   pip install --upgrade fiftyone-brain
 )
@@ -75,26 +86,38 @@ IF %DEV_INSTALL%==true (
   pre-commit install
   pip install .
 ) else (
+  echo Performing install
   pip install -r requirements.txt
   pip install .
 )
 
 IF %SOURCE_ETA_INSTALL%==true (
-  echo ***** INSTALLING ETA *****
+  echo ***** INSTALLING ETA FROM SOURCE *****
   if not exist "eta\" (
-    echo Cloning ETA repository
-    git clone https://github.com/voxel51/eta
+    if not exist "..\eta\" (
+      echo Cloning ETA repository
+      git clone https://github.com/voxel51/eta
+    )
   )
-  cd eta
-  pip install .
+  pushd .
+  if exist "..\eta\" (
+    cd ..\eta
+  ) else (
+    cd eta
+  )
+  IF %DEV_INSTALL%==true (
+    echo Performing dev install
+    pip install .
+  ) else (
+    echo Performing install
+    pip install .
+  )
   if not exist "eta\config.json" (
     echo "Installing default ETA config"
     xcopy /y ".\config-example.json" ".\eta\config.*"
   )
-  cd ..
+  popd
 )
-
-
 
 echo ***** INSTALLATION COMPLETE *****
 exit /b


### PR DESCRIPTION
## Change log

- When performing source `fiftyone-brain` installs, don't try to `git clone` when the repository already exists locally
- Support nested (`fiftyone-brain/`) and sibling (`../fiftyone-brain/`) locations for Brain/ETA when installing from source


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved installation scripts to better detect existing local or parent directories for required repositories, reducing unnecessary cloning.
  * Added clearer messages during installation steps to indicate progress and type of install (dev or regular).
  * Enhanced directory handling for more robust and consistent installation experience across different setups.
  * Minor formatting and help message improvements for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->