### PR TITLE
Handle different drives on Windows

### DIFF
--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -2498,14 +2498,28 @@ def safe_relpath(path, start=None, default=None):
         if default is not None:
             return default
 
-        logger.warning(
-            "Path '%s' is not in '%s'. Using filename as unique identifier",
-            path,
-            start,
-        )
-        relpath = os.path.basename(path)
+        logger.debug("Path '%s' is not in '%s'", path, start)
+        relpath = path
 
     return relpath
+
+
+def get_module_name(path, start=None):
+    """Gets the Python module name for the given file or directory path.
+
+    Args:
+        path: a file or directory path
+        start (None): the relative prefix to strip from ``path``
+
+    Returns:
+        a ``module.name``
+    """
+    if start is not None:
+        path = safe_relpath(path, start)
+
+    path = os.path.splitdrive(path)[1]
+    path = os.path.splitext(path)[0]
+    return path.replace("\\", "/").strip("/").replace("/", ".")
 
 
 def compute_filehash(filepath, method=None, chunk_size=None):

--- a/fiftyone/plugins/context.py
+++ b/fiftyone/plugins/context.py
@@ -12,6 +12,7 @@ import sys
 import traceback
 
 import fiftyone as fo
+import fiftyone.core.utils as fou
 import fiftyone.plugins as fop
 
 from fiftyone.operators.decorators import plugins_cache
@@ -129,9 +130,9 @@ class PluginContext(object):
             if not os.path.isfile(module_path):
                 return
 
-            module_name = os.path.relpath(
+            module_name = fou.get_module_name(
                 module_dir, fo.config.plugins_dir
-            ).replace("/", ".")
+            )
             spec = importlib.util.spec_from_file_location(
                 module_name, module_path
             )

--- a/fiftyone/plugins/definitions.py
+++ b/fiftyone/plugins/definitions.py
@@ -13,6 +13,7 @@ import yaml
 import eta.core.serial as etas
 
 import fiftyone as fo
+import fiftyone.core.utils as fou
 import fiftyone.plugins.constants as fpc
 
 
@@ -145,7 +146,7 @@ class PluginDefinition(object):
     @property
     def server_path(self):
         """The default server path to the plugin."""
-        relpath = os.path.relpath(self.directory, fo.config.plugins_dir)
+        relpath = fou.safe_relpath(self.directory, fo.config.plugins_dir)
         return "/" + os.path.join("plugins", relpath)
 
     @property

--- a/fiftyone/zoo/datasets/__init__.py
+++ b/fiftyone/zoo/datasets/__init__.py
@@ -1632,9 +1632,9 @@ class RemoteZooDataset(ZooDataset):
 
     def _import_module(self, dataset_dir):
         module_path = os.path.join(dataset_dir, "__init__.py")
-        module_name = os.path.relpath(
+        module_name = fou.get_module_name(
             dataset_dir, fo.config.dataset_zoo_dir
-        ).replace("/", ".")
+        )
         spec = importlib.util.spec_from_file_location(module_name, module_path)
         module = importlib.util.module_from_spec(spec)
         sys.modules[module.__name__] = module

--- a/fiftyone/zoo/models/__init__.py
+++ b/fiftyone/zoo/models/__init__.py
@@ -21,6 +21,7 @@ import eta.core.web as etaw
 
 import fiftyone as fo
 import fiftyone.core.models as fom
+import fiftyone.core.utils as fou
 from fiftyone.utils.github import GitHubRepository
 
 
@@ -589,9 +590,7 @@ def _parse_remote_model_parameters(model_name, model_path, ctx, params):
 
 def _import_zoo_module(model_dir):
     module_path = os.path.join(model_dir, "__init__.py")
-    module_name = os.path.relpath(model_dir, fo.config.model_zoo_dir).replace(
-        "/", "."
-    )
+    module_name = fou.get_module_name(model_dir, fo.config.model_zoo_dir)
     spec = importlib.util.spec_from_file_location(module_name, module_path)
     module = importlib.util.module_from_spec(spec)
     sys.modules[module.__name__] = module

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -7,6 +7,7 @@ FiftyOne utilities unit tests.
 """
 
 from datetime import datetime
+import sys
 import time
 import unittest
 from unittest.mock import MagicMock, patch
@@ -261,6 +262,74 @@ class CoreUtilsTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             fou.to_slug("a" * 101)  # too long
+
+    def test_get_module_name(self):
+        if sys.platform.startswith("win"):
+            self.assertEqual(
+                fou.get_module_name("C:\\tmp\\test\\module"),
+                "tmp.test.module",
+            )
+            self.assertEqual(
+                fou.get_module_name("C:\\tmp\\test\\module.py"),
+                "tmp.test.module",
+            )
+            self.assertEqual(
+                fou.get_module_name("C:\\tmp\\test\\module", "C:\\tmp"),
+                "test.module",
+            )
+            self.assertEqual(
+                fou.get_module_name("C:\\tmp\\test\\module.py", "C:\\tmp"),
+                "test.module",
+            )
+            self.assertEqual(
+                fou.get_module_name("C:\\tmp\\test\\module", "C:\\"),
+                "tmp.test.module",
+            )
+            self.assertEqual(
+                fou.get_module_name("C:\\tmp\\test\\module.py", "C:\\"),
+                "tmp.test.module",
+            )
+            self.assertEqual(
+                fou.get_module_name("C:\\tmp\\test\\module", "D:\\foo"),
+                "tmp.test.module",
+            )
+            self.assertEqual(
+                fou.get_module_name("C:\\tmp\\test\\module.py", "D:\\foo"),
+                "tmp.test.module",
+            )
+        else:
+            self.assertEqual(
+                fou.get_module_name("/tmp/test/module"),
+                "tmp.test.module",
+            )
+            self.assertEqual(
+                fou.get_module_name("/tmp/test/module.py"),
+                "tmp.test.module",
+            )
+            self.assertEqual(
+                fou.get_module_name("/tmp/test/module", "/tmp"),
+                "test.module",
+            )
+            self.assertEqual(
+                fou.get_module_name("/tmp/test/module.py", "/tmp"),
+                "test.module",
+            )
+            self.assertEqual(
+                fou.get_module_name("/tmp/test/module", "/"),
+                "tmp.test.module",
+            )
+            self.assertEqual(
+                fou.get_module_name("/tmp/test/module.py", "/"),
+                "tmp.test.module",
+            )
+            self.assertEqual(
+                fou.get_module_name("/tmp/test/module", "/foo"),
+                "tmp.test.module",
+            )
+            self.assertEqual(
+                fou.get_module_name("/tmp/test/module.py", "/foo"),
+                "tmp.test.module",
+            )
 
 
 class LabelsTests(unittest.TestCase):


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/6082

`os.path.relpath(a, b)` annoyingly raises a `ValueError` on Windows when `a` and `b` lie on different Drives. So we must manually handle that in a few places.
