### PR TITLE
[NO MERGE] FOEPD-1505 Operator modal speedup component

### DIFF
--- a/app/packages/app/src/index.tsx
+++ b/app/packages/app/src/index.tsx
@@ -8,11 +8,12 @@ import Network from "./Network";
 import "./index.css";
 import { useRouter } from "./routing";
 
-const App: React.FC = () => {
-  const { context, environment } = useRouter();
+// In your App.tsx or similar entry point
+import { TestHarness } from '@fiftyone/operators'; // Import your harness
 
-  return <Network environment={environment} context={context} />;
-};
+const App: React.FC = () => {
+  return <TestHarness />;
+}
 
 createRoot(document.getElementById("root") as HTMLDivElement).render(
   <RecoilRoot>

--- a/app/packages/operators/src/TestHarness.tsx
+++ b/app/packages/operators/src/TestHarness.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from "react";
+import { Speedup } from "./components/OperatorPromptSpeedup"; // Adjust path
+import { Box, Paper, Typography } from "@mui/material";
+
+export const TestHarness = () => {
+  // Use state to make the component interactive
+  const [numBatches, setNumBatches] = useState(12);
+  const MAX_WORKERS = 8;
+
+  return (
+    <Box sx={{ p: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        Speedup Component Test Harness
+      </Typography>
+      <Paper sx={{ p: 3, mt: 2, maxWidth: "500px" }}>
+        <Speedup
+          value={numBatches}
+          onChange={setNumBatches}
+          maxWorkers={MAX_WORKERS}
+        />
+      </Paper>
+      <Typography variant="body1" sx={{ mt: 3 }}>
+        <strong>Current state value in harness:</strong> {numBatches}
+      </Typography>
+    </Box>
+  );
+};

--- a/app/packages/operators/src/components/OperatorPromptSpeedup.tsx
+++ b/app/packages/operators/src/components/OperatorPromptSpeedup.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { Box, Input, Typography } from "@mui/material";
+import { styled } from "@mui/material/styles";
+import SpeedIcon from "@mui/icons-material/Speed";
+
+// "NEW" badge, styled to match the app's theme
+const NewBadge = styled("span")(({ theme }) => ({
+  color: "rgb(255,141,76)",
+  padding: "2px 6px",
+  borderRadius: "4px",
+  fontSize: "1rem",
+  fontWeight: "bold",
+  marginLeft: theme.spacing(1),
+}));
+
+// A styled numeric input that matches the look in the images
+const StyledInput = styled(Input)(({ theme }) => ({
+  width: "60px",
+  height: "40px",
+  border: `1px solid ${theme.palette.divider}`,
+  borderRadius: "4px",
+  padding: "0 8px",
+  "& input[type=number]": {
+    textAlign: "center",
+    "-moz-appearance": "textfield",
+  },
+  "& input[type=number]::-webkit-outer-spin-button": {
+    "-webkit-appearance": "none",
+    margin: 0,
+  },
+  "& input[type=number]::-webkit-inner-spin-button": {
+    "-webkit-appearance": "none",
+    margin: 0,
+  },
+}));
+
+interface SpeedupProps {
+  value: number; // The current number of batches
+  onChange: (value: number) => void;
+  maxWorkers: number; // The maximum number of available workers
+}
+
+export const Speedup: React.FC<SpeedupProps> = ({
+  value,
+  onChange,
+  maxWorkers,
+}) => {
+  // Memoize derived state for performance and clarity
+  const { speedupText, speedupColor, showDescription } = React.useMemo(() => {
+    // Sanitize value to be an integer
+    const numBatches = Math.floor(value);
+
+    if (numBatches <= 1) {
+      return {
+        speedupText: "Standard speed",
+        speedupColor: "text.secondary", // Gray color for standard speed
+        showDescription: false,
+      };
+    }
+
+    const speedupFactor = Math.min(numBatches, maxWorkers);
+    return {
+      speedupText: `up to ${speedupFactor}x faster`,
+      speedupColor: "rgb(174,131,247)", // Purple color for speedup
+      showDescription: numBatches > maxWorkers,
+    };
+  }, [value, maxWorkers]);
+
+  const handleBatchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const num = parseInt(event.target.value, 10);
+    // Allow 0, but prevent negative numbers. Set to 0 if input is cleared (NaN).
+    onChange(isNaN(num) || num < 0 ? 0 : num);
+  };
+
+  return (
+    <Box sx={{ pt: 2, display: "flex", flexDirection: "column", gap: 2 }}>
+      {/* Title Row */}
+      <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+        <SpeedIcon style={{ color: "rgb(174,131,247)" }} />
+        <Typography variant="body1" sx={{ fontWeight: "bold" }}>
+          Speed-up processing
+        </Typography>
+        <NewBadge>NEW</NewBadge>
+      </Box>
+
+      <Typography variant="body2" color="text.secondary">
+        Applicable for scheduled runs only
+      </Typography>
+
+      {/* Input Row */}
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          mt: 1,
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+          <StyledInput
+            type="number"
+            value={value}
+            onChange={handleBatchChange}
+            inputProps={{ min: 0, "data-cy": "batches-input" }}
+            disableUnderline
+          />
+          <Typography>batches</Typography>
+        </Box>
+        <Typography
+          variant="body2"
+          sx={{ fontWeight: "bold", color: speedupColor }}
+        >
+          {speedupText}
+        </Typography>
+      </Box>
+
+      {/* Conditional Description */}
+      {showDescription && (
+        <Typography variant="body2" color="text.secondary">
+          You have up to {maxWorkers} workers to process batches in parallel.
+          Additional batches will result in shorter run times per batch, but no
+          additional speed-up.
+        </Typography>
+      )}
+    </Box>
+  );
+};

--- a/app/packages/operators/src/index.ts
+++ b/app/packages/operators/src/index.ts
@@ -6,6 +6,8 @@ export { default as OperatorCore } from "./OperatorCore";
 export { default as OperatorInvocationRequestExecutor } from "./OperatorInvocationRequestExecutor";
 export { default as OperatorIO } from "./OperatorIO";
 export { default as OperatorExecutionButton } from "./components/OperatorExecutionButton";
+export { TestHarness } from "./TestHarness";
+export { Speedup } from "./components/OperatorPromptSpeedup";
 export {
   OperatorPlacementWithErrorBoundary,
   default as OperatorPlacements,


### PR DESCRIPTION
## What changes are proposed in this pull request?
Draft of operator modal speedup React component, utilizing AI help. There is definitely bad code / practices in here, but maybe it's a starting place?

Figma design screenshot: 
![image](https://github.com/user-attachments/assets/27c1641e-6813-40a2-8223-194a8e09491f)

Draft prototype component (in test harness):
<img width="553" alt="image" src="https://github.com/user-attachments/assets/84e877d0-c36d-4102-a269-bd6625d5e2c5" />

## Missing
- Integration with operator modal
- Max workers as input that comes from a one-time API call
- Disabled with tooltip when in 'execute now' vs. 'schedule'

## How is this patch tested? If it is not, please explain why.

Used provided janky edit and test harness (obviously, DO NOT MERGE!!) then `yarn dev` serves the interactive component.
