### PR TITLE
chore(constants): AS-428 bump min verison

### DIFF
--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -426,7 +426,7 @@ python package.
 Using a different MongoDB version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-FiftyOne is designed for **MongoDB v5.0 or later**.
+FiftyOne is designed for **MongoDB v6.0 or later**.
 
 If you wish to connect FiftyOne to a MongoDB database whose version is not
 explicitly supported, you will also need to set the `database_validation`

--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -103,7 +103,7 @@ MIGRATIONS_REVISIONS_DIR = os.path.join(
 
 # We should bump this to Version("6.0") after fiftyone-db is published.
 # This should be done as part of AS-428.
-MONGODB_MIN_VERSION = Version("5.0")
+MONGODB_MIN_VERSION = Version("6.0")
 MONGODB_MAX_ALLOWABLE_FCV_DELTA = 1
 MONGODB_SERVER_FCV_REQUIRED_CONFIRMATION = Version("7.0")
 DATABASE_APPNAME = "fiftyone"


### PR DESCRIPTION
## What changes are proposed in this pull request?

In https://github.com/voxel51/fiftyone/pull/5984, we bumped the mongoDB 5 versions in `fiftyone-db` to mongodb 6. We should deprecate mongodb 5 entirely by no longer supporting that version in FO moving forward.

## How is this patch tested? If it is not, please explain why.

Testing was done as part of https://github.com/voxel51/fiftyone/pull/5984.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

FiftyOne no longer supports versions older than MongoDB 6.0. If you are using and MongoDB with version 5 or older, please upgrade your MongoDB instance.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated user guide to state that MongoDB v6.0 or later is now required.

* **Chores**
  * Updated the minimum required MongoDB version to 6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->