### PR TITLE
build(fiftyone-db): Fix fiftyone-db publishing

### DIFF
--- a/.github/workflows/build-db.yml
+++ b/.github/workflows/build-db.yml
@@ -116,7 +116,7 @@ jobs:
           path: downloads
       - name: Install dependencies
         run: |
-          pip install twine
+          pip install twine packaging
       - name: Set environment
         env:
           RELEASE_TAG: ${{ github.ref }}


### PR DESCRIPTION
## What changes are proposed in this pull request?

fiftyone-db publishing is [failing](https://github.com/voxel51/fiftyone/actions/runs/16005159123/job/45150495514). We've seen this before and it was due to an old `packaging` with a new `twine` (https://github.com/pypa/twine/issues/1216).

Let's make this match our `fiftyone` publishing.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build process to install an additional Python package, improving the reliability of publishing steps in the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->