### PR TITLE
build(fiftyone-db): Use pip3 and python3

### DIFF
--- a/.github/workflows/build-db.yml
+++ b/.github/workflows/build-db.yml
@@ -116,7 +116,7 @@ jobs:
           path: downloads
       - name: Install dependencies
         run: |
-          pip install twine packaging
+          pip3 install twine packaging
       - name: Set environment
         env:
           RELEASE_TAG: ${{ github.ref }}
@@ -128,4 +128,4 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_NON_INTERACTIVE: 1
         run: |
-          python -m twine upload downloads/dist-*/*
+          python3 -m twine upload downloads/dist-*/*

--- a/.github/workflows/build-db.yml
+++ b/.github/workflows/build-db.yml
@@ -116,7 +116,7 @@ jobs:
           path: downloads
       - name: Install dependencies
         run: |
-          pip3 install twine packaging
+          pip3 install -U twine packaging
       - name: Set environment
         env:
           RELEASE_TAG: ${{ github.ref }}


### PR DESCRIPTION
## What changes are proposed in this pull request?

We should `pip` install as the user to make site packages writable. We should also use `pip3` and `python3` instead of `python` and `pip`.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
