### PR TITLE
Parse label attributes as lists when loading from CVAT

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -7052,6 +7052,10 @@ class CVATLabel(object):
         self.attributes = {}
         self.fo_attributes = {}
 
+        self._reserved_attr_types = {
+            "tags": list,
+        }
+
         # Parse attributes
         attr_id_map_rev = {v: k for k, v in attr_id_map[cvat_id].items()}
         for attr in attrs:
@@ -7087,10 +7091,21 @@ class CVATLabel(object):
             label.id = self.id
 
         for name, value in self.attributes.items():
+            value = self._check_reserved_attr_value(name, value)
             label[name] = value
 
         if self.fo_attributes:
             label.attributes = self.fo_attributes
+
+    def _check_reserved_attr_value(self, name, value):
+        if name not in self._reserved_attr_types:
+            return value
+
+        attr_type = self._reserved_attr_types[name]
+        if not isinstance(value, attr_type):
+            value = attr_type(value)
+
+        return value
 
 
 class CVATShape(CVATLabel):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Previously, when loading labels with a tag attribute from CVAT, it was possible to load them as non-list types. This PR ensures that all tag attributes of labels are loaded as lists when calling `dataset.load_annotations()` from CVAT.

## How is this patch tested? If it is not, please explain why.

```python
import fiftyone as fo
import fiftyone.zoo as foz
dataset = foz.load_zoo_dataset("quickstart", max_samples=10).clone()

dataset.annotate("test1", label_schema={
    "clsfield": {
        "type": "classifications",
        "classes": ["cat", "dog"],
        "attributes": {
            "tags": {
                "type": "text",
                "values": [],
            },
        }
    },
    }
)

# Add a Tag label in CVAT and type in a value under the tag attribute

dataset.load_annotations("test1")
```

![image](https://github.com/user-attachments/assets/16642191-9b7c-4383-b12b-4027de7bb103)

Previously:
```
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
Cell In[5], line 1
----> 1 dataset.load_annotations("test1")

File ~/work/fiftyone/fiftyone/fiftyone/core/collections.py:10154, in SampleCollection.load_annotations(self, anno_key, dest_field, unexpected, cleanup, progress, **kwargs)
  10109 def load_annotations(
  10110     self,
  10111     anno_key,
   (...)
  10116     **kwargs,
  10117 ):
  10118     """Downloads the labels from the given annotation run from the
  10119     annotation backend and merges them into this collection.
  10120 
   (...)
  10152         found, in which case a dict containing the extra labels is returned
  10153     """
> 10154     return foua.load_annotations(
  10155         self,
  10156         anno_key,
  10157         dest_field=dest_field,
  10158         unexpected=unexpected,
  10159         cleanup=cleanup,
  10160         progress=progress,
  10161         **kwargs,
  10162     )

File ~/work/fiftyone/fiftyone/fiftyone/utils/annotations.py:1107, in load_annotations(samples, anno_key, dest_field, unexpected, cleanup, progress, **kwargs)
   1098         _merge_scalars(
   1099             dataset,
   1100             annos,
   (...)
   1104             progress=progress,
   1105         )
   1106     else:
-> 1107         _merge_labels(
   1108             dataset,
   1109             annos,
   1110             results,
   1111             label_field,
   1112             label_type,
   1113             label_info=label_info,
   1114             global_attrs=global_attrs,
   1115             class_attrs=class_attrs,
   1116             progress=progress,
   1117         )
   1118 else:
   1119     # Unexpected labels
   1120     if not allow_additions:

File ~/work/fiftyone/fiftyone/fiftyone/utils/annotations.py:1635, in _merge_labels(dataset, anno_dict, results, label_field, label_type, label_info, global_attrs, class_attrs, progress)
   1633 if is_list:
   1634     label_ids = list(image_annos.keys())
-> 1635     image[field] = fo_label_type(
   1636         **{list_field: list(image_annos.values())}
   1637     )
   1639     if is_clips_view:
   1640         added_id_map[clip_id][frame_id].extend(label_ids)

File ~/work/fiftyone/fiftyone/fiftyone/core/odm/embedded_document.py:61, in DynamicEmbeddedDocument.__init__(self, *args, **kwargs)
     58     self._raise_reserved_attribute_exception(e)
     59     raise e
---> 61 self.validate()

File ~/.pyenv/versions/3.10.13/envs/fo/lib/python3.10/site-packages/mongoengine/base/document.py:440, in BaseDocument.validate(self, clean)
    438     pk = self._instance.pk
    439 message = f"ValidationError ({self._class_name}:{pk}) "
--> 440 raise ValidationError(message, errors=errors)

ValidationError: ValidationError (Classifications:None) (Only lists and tuples may be used in a list field: ['classifications'])
```

After this change:

The attribute is loaded as a list on the `Classification` objects.


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fix error when loading non-list tag attributes from CVAT labels.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of reserved attribute values to ensure they have the correct data types when working with labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->