### PR TITLE
Fix search results for label tags

### DIFF
--- a/app/packages/core/src/components/Filters/StringFilter/state.ts
+++ b/app/packages/core/src/components/Filters/StringFilter/state.ts
@@ -92,44 +92,42 @@ export const stringSearchResults = selectorFamily<
         };
       }
 
-      const noneCount = get(fos.noneCount({ path, modal, extended: false }));
-
       if (isLabelTag) {
         const labels = get(labelTagsCount({ modal, extended: false }));
-        data = {
+        return {
           count: labels.count,
           values: labels.results,
         };
-      } else {
-        data = await getFetchFunction()("POST", "/values", {
-          dataset: get(fos.datasetName),
-          view: get(fos.view),
-          path,
-          search,
-          selected: filter ? [] : selected,
-          filters: filter
-            ? {
-                [filter.path]: {
-                  exclude: get(stringExcludeAtom({ path, modal })),
-                  isMatching: get(isMatchingAtom({ path, modal })),
-                  values: [filter.value],
-                },
-              }
-            : get(pathSearchFilters({ modal, path })),
-          group_id: modal ? get(fos.groupId) || null : null,
-          mixed,
-          slice: get(fos.groupSlice),
-          slices: mixed ? null : get(fos.currentSlices(modal)), // when mixed, slice is not needed
-          sample_id:
-            modal && !get(fos.groupId) && !mixed
-              ? get(fos.modalSampleId)
-              : null,
-          ...sorting,
-        });
       }
+
+      data = await getFetchFunction()("POST", "/values", {
+        dataset: get(fos.datasetName),
+        view: get(fos.view),
+        path,
+        search,
+        selected: filter ? [] : selected,
+        filters: filter
+          ? {
+              [filter.path]: {
+                exclude: get(stringExcludeAtom({ path, modal })),
+                isMatching: get(isMatchingAtom({ path, modal })),
+                values: [filter.value],
+              },
+            }
+          : get(pathSearchFilters({ modal, path })),
+        group_id: modal ? get(fos.groupId) || null : null,
+        mixed,
+        slice: get(fos.groupSlice),
+        slices: mixed ? null : get(fos.currentSlices(modal)), // when mixed, slice is not needed
+        sample_id:
+          modal && !get(fos.groupId) && !mixed ? get(fos.modalSampleId) : null,
+        ...sorting,
+      });
 
       let { values, count } = data;
       count ??= 0;
+      const noneCount = get(fos.noneCount({ path, modal, extended: false }));
+
       if (noneCount > 0 && "None".includes(search)) {
         values = [...values, { value: null, count: noneCount }]
           .sort(nullSort(sorting))

--- a/app/packages/core/src/components/Filters/StringFilter/state.ts
+++ b/app/packages/core/src/components/Filters/StringFilter/state.ts
@@ -95,7 +95,7 @@ export const stringSearchResults = selectorFamily<
       if (isLabelTag) {
         const labels = get(labelTagsCount({ modal, extended: false }));
         return {
-          count: labels.count,
+          count: labels.count ?? 0,
           values: labels.results,
         };
       }


### PR DESCRIPTION
## What changes are proposed in this pull request?
Fixes search results for `label tags` when Query Performance is disabled

<img width="1470" alt="Screenshot 2025-07-01 at 5 50 07 PM" src="https://github.com/user-attachments/assets/65cbf9b3-f6c6-47fd-a0b8-bd82db7c3bef" />

## How is this patch tested? If it is not, please explain why.

```python
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
patches = dataset.to_patches("predictions")
dataset.save_view("predictions", patches)
first = patches.first()

for i in range(0, 200):
    first.predictions.tags.append(str(i))

first.save()
``` 

## Release Notes

* Fixed search results for `label tags` in the sidebar when Query Performance is disabled

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the logic for handling filter results, resulting in a more streamlined and efficient experience when using string filters. No visible changes to the user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->