### PR TITLE
refactor: remove unused is_cache parameter from ExecutionStoreRepo

### DIFF
--- a/fiftyone/factory/repos/execution_store.py
+++ b/fiftyone/factory/repos/execution_store.py
@@ -34,12 +34,11 @@ class ExecutionStoreRepo(ABC):
     methods that this class provides.
     """
 
-    def __init__(self, dataset_id: Optional[ObjectId] = None, is_cache=False):
+    def __init__(self, dataset_id: Optional[ObjectId] = None):
         """Initialize the execution store repository.
 
         Args:
             dataset_id (Optional[ObjectId]): the dataset ID to operate on
-            is_cache (False): whether the store is a cache store
         """
         self._dataset_id = dataset_id
 
@@ -299,9 +298,9 @@ class MongoExecutionStoreRepo(ExecutionStoreRepo):
     COLLECTION_NAME = "execution_store"
 
     def __init__(
-        self, collection, dataset_id: Optional[ObjectId] = None, is_cache=False
+        self, collection, dataset_id: Optional[ObjectId] = None
     ):
-        super().__init__(dataset_id, is_cache)
+        super().__init__(dataset_id)
         self._collection = collection
         self._create_indexes()
 


### PR DESCRIPTION
Removes an unused parameter in the `ExecutionStoreRepo`.