### PR TITLE
Remove tests using quantiles with inf and nan

### DIFF
--- a/tests/unittests/aggregation_tests.py
+++ b/tests/unittests/aggregation_tests.py
@@ -945,11 +945,6 @@ class DatasetTests(unittest.TestCase):
         self.assertTrue(math.isnan(dataset.mean("float")))
         self.assertTrue(math.isnan(dataset.sum("float")))
         self.assertTrue(math.isnan(dataset.std("float")))
-        self.assertTrue(math.isnan(dataset.quantiles("float", 0)))
-        self.assertTrue(math.isnan(dataset.quantiles("float", 0.25)))
-        self.assertTrue(math.isinf(dataset.quantiles("float", 0.50)))
-        self.assertAlmostEqual(dataset.quantiles("float", 0.75), 1.0)
-        self.assertTrue(math.isinf(dataset.quantiles("float", 1)))
 
         counts, edges, other = dataset.histogram_values("float")
         self.assertEqual(other, 5)  # captures None, nan, inf


### PR DESCRIPTION
`quantiles()` uses server-side JS function to sort. Sorting `inf` and `nan` is undefined, and we see that in Mongo 8 the order is somewhat different. The other assertions in this test are reasonable, but the quantile ones are not really.

Besides, this (server side JS) is deprecated functionality in mongo 8 anyways.

## What changes are proposed in this pull request?

Remove offending lines

## How is this patch tested? If it is not, please explain why.

Tests pass in MongoDB 8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated unit tests by removing specific assertions related to quantile calculations with NaN and infinite values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->