### PR TITLE
make color_pool optional in ColorScheme gql type

### DIFF
--- a/app/packages/app/src/pages/datasets/__generated__/DatasetPageQuery.graphql.ts
+++ b/app/packages/app/src/pages/datasets/__generated__/DatasetPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d3d94eb29385217a7d6d59a2c685d87a>>
+ * @generated SignedSource<<da2bff8016ac119e2809cce123facfa2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -33,7 +33,7 @@ export type DatasetPageQuery$data = {
     readonly appConfig: {
       readonly colorScheme: {
         readonly colorBy: ColorBy | null;
-        readonly colorPool: ReadonlyArray<string>;
+        readonly colorPool: ReadonlyArray<string> | null;
         readonly colorscales: ReadonlyArray<{
           readonly list: ReadonlyArray<{
             readonly color: string;

--- a/app/packages/looker-3d/src/hooks/use-pcd-material-controls.tsx
+++ b/app/packages/looker-3d/src/hooks/use-pcd-material-controls.tsx
@@ -222,7 +222,7 @@ export const usePcdMaterialControls = (
 
     if (isDefaultAppConfigColormapAvailable) {
       const list = colorScheme.defaultColorscale?.list;
-      if (list) {
+      if (list && list.length > 0) {
         return {
           list,
           source: ColormapSource.DATASET_DEFAULT,

--- a/app/packages/relay/src/fragments/__generated__/colorSchemeFragment.graphql.ts
+++ b/app/packages/relay/src/fragments/__generated__/colorSchemeFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4eb93ca357784136884d2f56c71ed5e5>>
+ * @generated SignedSource<<025d078c4ae2fea256541d4dd4c76b64>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,7 +13,7 @@ export type ColorBy = "field" | "instance" | "value" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type colorSchemeFragment$data = {
   readonly colorBy: ColorBy | null;
-  readonly colorPool: ReadonlyArray<string>;
+  readonly colorPool: ReadonlyArray<string> | null;
   readonly colorscales: ReadonlyArray<{
     readonly list: ReadonlyArray<{
       readonly color: string;

--- a/app/packages/relay/src/queries/__generated__/datasetQuery.graphql.ts
+++ b/app/packages/relay/src/queries/__generated__/datasetQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f216986093aad671a42ff6230d22e41c>>
+ * @generated SignedSource<<6f5f0c4e9278aa35c02065203033d5e7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -30,7 +30,7 @@ export type datasetQuery$data = {
     readonly appConfig: {
       readonly colorScheme: {
         readonly colorBy: ColorBy | null;
-        readonly colorPool: ReadonlyArray<string>;
+        readonly colorPool: ReadonlyArray<string> | null;
         readonly colorscales: ReadonlyArray<{
           readonly list: ReadonlyArray<{
             readonly color: string;

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -143,7 +143,7 @@ enum ColorBy {
 
 type ColorScheme {
   id: ID!
-  colorPool: [String!]!
+  colorPool: [String!]
   colorBy: ColorBy
   fields: [CustomizeColor!]
   labelTags: LabelTagColor

--- a/fiftyone/server/color.py
+++ b/fiftyone/server/color.py
@@ -96,7 +96,7 @@ class ColorBy(Enum):
 @gql.type
 class ColorScheme:
     id: gql.ID = gql.field(default_factory=lambda: str(ObjectId()))
-    color_pool: t.List[str]
+    color_pool: t.Optional[t.List[str]] = None
     color_by: t.Optional[ColorBy] = None
     fields: t.Optional[t.List[CustomizeColor]] = None
     label_tags: t.Optional[LabelTagColor] = None


### PR DESCRIPTION
## What changes are proposed in this pull request?

`color_pool` should be optional, or should be initialized by `fo.ColorScheme()`'s constructor. This PR makes it optional.

Otherwise the following flow will break:

```
import fiftyone as fo

dataset = fo.Dataset(...)

dataset.app_config.color_scheme = fo.ColorScheme()

print(dataset.app_config.color_scheme.color_pool) # None
dataset.save()
```

But because in gql type, `color_pool` is marked non-optional, app crashes.

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty color map lists to prevent unintended behavior.

* **New Features**
  * The color pool field in color scheme settings can now be left unspecified or set to null, offering greater flexibility in configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->