### PR TITLE
remove dead code in queue_operation thats impossible to get to

### DIFF
--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -218,25 +218,20 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             )
         elif isinstance(op.context, ExecutionContext):
             context = op.context
-        if not op.dataset_id:
-            # For consistency, set the dataset_id using the
-            # ExecutionContext.dataset
-            # rather than calling load_dataset() on a potentially stale
-            # dataset_name in the request_params
-            try:
-                op.dataset_id = context.dataset._doc.id
-            except:
-                # If we can't resolve the dataset_id, it is possible the
-                # dataset doesn't exist (deleted/being created). However,
-                # it's also possible that future operators can run
-                # dataset-less, so don't raise an error here and just log it
-                # in case we need to debug later.
-                logger.debug("Could not resolve dataset_id for operation. ")
-        elif op.dataset_id:
-            # If the dataset_id is provided, we set it in the request_params
-            # to ensure that the operation is executed on the correct dataset
-            context.request_params["dataset_id"] = str(op.dataset_id)
-            context.request_params["dataset_name"] = context.dataset.name
+
+        # For consistency, set the dataset_id using the
+        # ExecutionContext.dataset
+        # rather than calling load_dataset() on a potentially stale
+        # dataset_name in the request_params
+        try:
+            op.dataset_id = context.dataset._doc.id
+        except:
+            # If we can't resolve the dataset_id, it is possible the
+            # dataset doesn't exist (deleted/being created). However,
+            # it's also possible that future operators can run
+            # dataset-less, so don't raise an error here and just log it
+            # in case we need to debug later.
+            logger.debug("Could not resolve dataset_id for operation. ")
 
         op.context = context
         doc = self._collection.insert_one(op.to_pymongo())

--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -209,7 +209,6 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
 
         op.delegation_target = kwargs.get("delegation_target", None)
         op.metadata = kwargs.get("metadata") or {}
-        op.num_partitions = kwargs.get("num_partitions", None)
 
         context = None
         if isinstance(op.context, dict):

--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -379,25 +379,6 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             return_document=pymongo.ReturnDocument.AFTER,
         )
 
-        if (
-            doc
-            and doc.get("num_partitions")
-            and run_state is ExecutionRunState.FAILED
-        ):
-            # If a parent operation is failed, also mark the children as failed
-            self._collection.update_many(
-                {
-                    "parent_id": doc["_id"],
-                    "run_state": {"$nin": ["failed", "completed"]},
-                },
-                {
-                    "$set": {
-                        **update["$set"],
-                        "result": {"error": "parent operation failed"},
-                    }
-                },
-            )
-
         return (
             DelegatedOperationDocument().from_pymongo(doc)
             if doc is not None

--- a/tests/unittests/operators/delegated_tests.py
+++ b/tests/unittests/operators/delegated_tests.py
@@ -454,51 +454,6 @@ class DelegatedOperationServiceTests(unittest.TestCase):
     @patch(
         "fiftyone.core.odm.utils.load_dataset",
     )
-    def test_set_failed_for_partitioned_do(
-        self, mock_load_dataset, mock_get_operator
-    ):
-        mock_load_dataset.return_value = MockDataset()
-        mock_get_operator.return_value = MockOperatorWithIO()
-
-        num_partitions = 3
-
-        # create parent
-        doc = self.svc._repo.queue_operation(
-            operator=f"{TEST_DO_PREFIX}/operator/distributed_foo",
-            label=mock_get_operator.return_value.name,
-            delegation_target="test_target",
-            context=ExecutionContext(
-                request_params={"foo": "bar", "dataset_id": str(ObjectId())}
-            ),
-            num_partitions=num_partitions,
-        )
-
-        # create children
-        parent_id = doc.id
-        d = doc.to_pymongo()
-        child_doc = copy.deepcopy(d)
-        child_doc["run_state"] = ExecutionRunState.SCHEDULED
-        child_doc.pop("num_partitions", None)
-        child_doc["parent_id"] = ObjectId(parent_id)
-        children = [
-            {**child_doc, "_id": ObjectId()} for i in range(num_partitions)
-        ]
-        inserted = self.svc._repo._collection.insert_many(children)
-
-        # test
-        doc = self.svc.set_failed(
-            doc_id=parent_id,
-            result=ExecutionResult(error=str(ValueError("oops!"))),
-        )
-
-        self.assertEqual(doc.run_state, ExecutionRunState.FAILED)
-        for child_id in inserted.inserted_ids:
-            child_doc = self.svc.get(child_id)
-            self.assertEqual(child_doc.run_state, ExecutionRunState.FAILED)
-
-    @patch(
-        "fiftyone.core.odm.utils.load_dataset",
-    )
     def test_sets_progress(self, mock_load_dataset, mock_get_operator):
         mock_load_dataset.return_value = MockDataset()
         mock_get_operator.return_value = MockOperator(sets_progress=True)


### PR DESCRIPTION
Removing dead code - the "elif" case is impossible to get to. The operation is newly created a few lines above and then dataset_id never is set nor is it a computed property, so there's never a chance for `op.dataset_id` to be True.

Also getting rid of `num_partitions` as that is not a thing anymore. Removing child/parent stuff from set-failed as it is not in this repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal handling of dataset identification during operation queuing and removed propagation of failure states to child operations. No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->