### PR TITLE
feat: Add Swin V2 models to manifest-torch.json

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -6040,6 +6040,150 @@
                 "efficientnet"
             ],
             "date_added": "2025-06-30 12:00:00"
+        },
+        {
+            "base_name": "swin-v2-tiny-patch4-window8-256-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Tiny hierarchical transformer for efficient visual recognition on edge devices",
+            "source": "https://huggingface.co/microsoft/swinv2-tiny-patch4-window8-256",
+            "author": "Ze Liu, et al.",
+            "license": "MIT",
+            "size_bytes": null,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForImageClassification",
+                "config": {
+                    "name_or_path": "microsoft/swinv2-tiny-patch4-window8-256",
+                    "transformers_processor_kwargs": {
+                        "return_tensors": "pt"
+                    }
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": [
+                "classification",
+                "imagenet",
+                "torch",
+                "transformers",
+                "swin-transformer"
+            ],
+            "date_added": "2025-07-02 12:00:00"
+        },
+        {
+            "base_name": "swin-v2-small-patch4-window8-256-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Small hierarchical transformer balancing efficiency and performance for practical use",
+            "source": "https://huggingface.co/microsoft/swinv2-small-patch4-window8-256",
+            "author": "Ze Liu, et al.",
+            "license": "MIT",
+            "size_bytes": null,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForImageClassification",
+                "config": {
+                    "name_or_path": "microsoft/swinv2-small-patch4-window8-256",
+                    "transformers_processor_kwargs": {
+                        "return_tensors": "pt"
+                    }
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": [
+                "classification",
+                "imagenet",
+                "torch",
+                "transformers",
+                "swin-transformer"
+            ],
+            "date_added": "2025-07-02 12:00:00"
+        },
+        {
+            "base_name": "swin-v2-base-patch4-window8-256-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Base hierarchical transformer delivering strong results across vision tasks",
+            "source": "https://huggingface.co/microsoft/swinv2-base-patch4-window8-256",
+            "author": "Ze Liu, et al.",
+            "license": "MIT",
+            "size_bytes": null,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForImageClassification",
+                "config": {
+                    "name_or_path": "microsoft/swinv2-base-patch4-window8-256",
+                    "transformers_processor_kwargs": {
+                        "return_tensors": "pt"
+                    }
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": [
+                "classification",
+                "imagenet",
+                "torch",
+                "transformers",
+                "swin-transformer"
+            ],
+            "date_added": "2025-07-02 12:00:00"
+        },
+        {
+            "base_name": "swin-v2-large-patch4-window12to16-192to256-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Large hierarchical transformer with enhanced capacity for demanding applications",
+            "source": "https://huggingface.co/microsoft/swinv2-large-patch4-window12to16-192to256-22kto1k-ft",
+            "author": "Ze Liu, et al.",
+            "license": "MIT",
+            "size_bytes": null,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForImageClassification",
+                "config": {
+                    "name_or_path": "microsoft/swinv2-large-patch4-window12to16-192to256-22kto1k-ft",
+                    "transformers_processor_kwargs": {
+                        "return_tensors": "pt"
+                    }
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": [
+                "classification",
+                "imagenet",
+                "torch",
+                "transformers",
+                "swin-transformer"
+            ],
+            "date_added": "2025-07-02 12:00:00"
         }
     ]
 }


### PR DESCRIPTION
Add 4 new image classification models from HuggingFace Transformers:

Swin V2 models (4 variants):
* swin-v2-tiny-patch4-window8-256-torch
* swin-v2-small-patch4-window8-256-torch
* swin-v2-base-patch4-window8-256-torch
* swin-v2-large-patch4-window12to16-192to256-torch

All models:
* Use existing FiftyOneTransformerForImageClassification wrapper
* Support both CPU and GPU inference
* Tested with single image and batch inference on COCO validation images
* Successfully extract embeddings with configurable dimensions
* Leverage HuggingFace hub for automatic model downloads

Swin V2 brings hierarchical vision transformers with shifted window attention, offering excellent performance across vision tasks with improved training stability and position encoding compared to V1.

## What changes are proposed in this pull request?

This PR adds 4 Swin V2 transformer models to the FiftyOne model zoo by adding their configurations to `fiftyone/zoo/models/manifest-torch.json`. The models include:

* **Swin V2 family**: Hierarchical vision transformers that use shifted window attention for efficient processing, with improvements including residual post-norm, scaled cosine attention, and log-spaced continuous position bias

All models use the existing `FiftyOneTransformerForImageClassification` wrapper and load directly from HuggingFace hub.

## How is this patch tested? If it is not, please explain why.

Created and ran a comprehensive test script that:
* Loads all 4 models from HuggingFace
* Performs actual image classification on COCO validation images
* Verifies correct model initialization and inference (single image and batch)
* Tests embedding extraction capabilities with varying dimensions (768, 1024, 1536)
* Validates channels_last configurations for memory layout options
* Confirms compatibility with the existing transformer wrapper
* All models successfully classified test images and passed all tests

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Added 4 new Swin V2 hierarchical transformer models to the model zoo (tiny, small, base, large). Users can now load these state-of-the-art vision transformers via `foz.load_zoo_model()` for image classification tasks, with models automatically downloaded from HuggingFace hub.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other