### PR TITLE
Enable OperatorRegistery to load all loadable plugins

### DIFF
--- a/fiftyone/plugins/context.py
+++ b/fiftyone/plugins/context.py
@@ -37,9 +37,12 @@ def build_plugin_contexts(enabled=True):
     """
     plugin_contexts = []
     for pd in fop.list_plugins(enabled=enabled, builtin="all"):
-        pctx = PluginContext(pd)
-        pctx.register_all()
-        plugin_contexts.append(pctx)
+        try:
+            pctx = PluginContext(pd)
+            pctx.register_all()
+            plugin_contexts.append(pctx)
+        except Exception as e:
+            logger.error(f"Failed to register plugin '{pd.name}': {e}")
 
     return plugin_contexts
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently the OperatorRegistery imports all operators at once and if any fail, it can affect the ability of non-buggy operators to load. Wrapping in a try/catch will prevent blocking unrelated operations.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin loading stability by ensuring that errors in individual plugins do not prevent other plugins from being registered. Error details are now logged for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->