### PR TITLE
chore(constants): AS-428 removes the comments

### DIFF
--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -101,8 +101,6 @@ MIGRATIONS_REVISIONS_DIR = os.path.join(
     FIFTYONE_DIR, "migrations", "revisions"
 )
 
-# We should bump this to Version("6.0") after fiftyone-db is published.
-# This should be done as part of AS-428.
 MONGODB_MIN_VERSION = Version("6.0")
 MONGODB_MAX_ALLOWABLE_FCV_DELTA = 1
 MONGODB_SERVER_FCV_REQUIRED_CONFIRMATION = Version("7.0")


### PR DESCRIPTION
## What changes are proposed in this pull request?

In https://github.com/voxel51/fiftyone/pull/6091, we bumped the `MONGODB_MIN_VERSION`. However, we forgot to remove our lingering comment. We should clean those up!

## How is this patch tested? If it is not, please explain why.

N/a just removing comments.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed unnecessary comment lines for improved code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->