### PR TITLE
Add RT-DETRv2 models to manifest-torch.json #6105

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -6184,6 +6184,80 @@
                 "swin-transformer"
             ],
             "date_added": "2025-07-02 12:00:00"
+        },
+        {
+            "base_name": "rtdetr-v2-s-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Lightweight real-time object detector optimized for speed on edge devices",
+            "source": "https://huggingface.co/PekingU/rtdetr_v2_r18vd",
+            "author": "Wenyu Lv, et al.",
+            "license": "Apache-2.0",
+            "size_bytes": 161820194,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForObjectDetection",
+                "config": {
+                    "name_or_path": "PekingU/rtdetr_v2_r18vd",
+                    "transformers_processor_kwargs": {
+                        "return_tensors": "pt"
+                    }
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": [
+                "detection",
+                "coco",
+                "torch",
+                "transformers",
+                "real-time",
+                "rtdetr"
+            ],
+            "date_added": "2025-07-03 12:00:00"
+        },
+        {
+            "base_name": "rtdetr-v2-m-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Balanced real-time object detector offering improved accuracy for production use",
+            "source": "https://huggingface.co/PekingU/rtdetr_v2_r50vd",
+            "author": "Wenyu Lv, et al.",
+            "license": "Apache-2.0",
+            "size_bytes": 344364318,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForObjectDetection",
+                "config": {
+                    "name_or_path": "PekingU/rtdetr_v2_r50vd",
+                    "transformers_processor_kwargs": {
+                        "return_tensors": "pt"
+                    }
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": [
+                "detection",
+                "coco",
+                "torch",
+                "transformers",
+                "real-time",
+                "rtdetr"
+            ],
+            "date_added": "2025-07-03 12:00:00"
         }
     ]
 }

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -6223,7 +6223,7 @@
             "date_added": "2025-07-03 12:00:00"
         },
         {
-            "base_name": "rtdetr-v2-m-torch",
+            "base_name": "rtdetr-v2-m-coco-torch",
             "base_filename": null,
             "version": null,
             "description": "Balanced real-time object detector offering improved accuracy for production use",

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -6186,7 +6186,7 @@
             "date_added": "2025-07-02 12:00:00"
         },
         {
-            "base_name": "rtdetr-v2-s-torch",
+            "base_name": "rtdetr-v2-s-coco-torch",
             "base_filename": null,
             "version": null,
             "description": "Lightweight real-time object detector optimized for speed on edge devices",

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -6217,7 +6217,6 @@
                 "coco",
                 "torch",
                 "transformers",
-                "real-time",
                 "rtdetr"
             ],
             "date_added": "2025-07-03 12:00:00"
@@ -6254,7 +6253,6 @@
                 "coco",
                 "torch",
                 "transformers",
-                "real-time",
                 "rtdetr"
             ],
             "date_added": "2025-07-03 12:00:00"


### PR DESCRIPTION
## Added RT-DETRv2 models (2 variants):
* `rtdetr-v2-s-torch` (ResNet-18 backbone)
* `rtdetr-v2-m-torch` (ResNet-50 backbone)

All models:
* Use existing `FiftyOneTransformerForObjectDetection` wrapper
* Support both CPU and GPU inference
* Tested on COCO object detection with validation images
* Successfully extract 256-dimensional embeddings
* Leverage HuggingFace hub for automatic model downloads

RT-DETRv2 brings improved real-time detection transformers with bag-of-freebies optimizations, offering better accuracy than v1 while maintaining the same inference speeds for edge and production deployments.

## What changes are proposed in this pull request?

This PR adds 2 RT-DETRv2 object detection models to the FiftyOne model zoo by adding their configurations to `fiftyone/zoo/models/manifest-torch.json`. The models include:

* **RT-DETRv2 family**: Improved real-time detection transformers that incorporate bag-of-freebies optimizations including flexible deformable attention, discrete sampling operators, and enhanced training strategies

All models use the existing `FiftyOneTransformerForObjectDetection` wrapper and load directly from HuggingFace hub.

## How is this patch tested? If it is not, please explain why.

Created and ran a comprehensive test script that:
* Loads both RT-DETRv2 models from HuggingFace
* Performs actual object detection on COCO validation images
* Verifies detection outputs match between direct HuggingFace inference and FiftyOne wrapper
* Tests embedding extraction capabilities (256-dimensional vectors)
* Confirms compatibility with the existing transformer wrapper
* All models successfully detected objects (horses, sheep, cows) and passed all tests

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Added 2 new RT-DETRv2 real-time object detection models to the model zoo (small and medium variants). Users can now load these improved detection transformers via `foz.load_zoo_model()` for object detection tasks, with models automatically downloaded from HuggingFace hub.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other