### PR TITLE
Incorrect attribute ref. in zero-shot transformer embeddings

### DIFF
--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -524,7 +524,7 @@ class ZeroShotTransformerEmbeddingsMixin(EmbeddingsMixin):
         # and because HFT offer a cleaner way to do this
         # via get_image_features
         if self.preprocess:
-            inputs = self.processor(images=args, return_tensors="pt")
+            inputs = self.transforms.processor(images=args, return_tensors="pt")
         with torch.no_grad():
             image_features = self._model.get_image_features(
                 **inputs.to(self._device)


### PR DESCRIPTION
The _embed() method in ZeroShotTransformerEmbeddingsMixin was incorrectly referencing self.processor instead of self.transforms.processor, causing an AttributeError when calling embed() or embed_all() on zero-shot transformer models.

This affected all zero-shot transformer models in the zoo, including:
- zero-shot-classification-transformer-torch
- zero-shot-detection-transformer-torch
- siglip-base-patch16-224-torch
- owlvit-base-patch16-torch
- omdet-turbo-swin-tiny-torch
- group-vit-segmentation-transformer-torch

The bug prevented users from extracting embeddings from these models, while predictions continued to work normally.

The fix corrects the attribute path to use self.transforms.processor, which is properly initialized during model setup.

## What changes are proposed in this pull request?

This PR fixes a single line in `fiftyone/utils/transformers.py` in the `ZeroShotTransformerEmbeddingsMixin._embed()` method (line 527):

Changed `inputs = self.processor(images=args, return_tensors="pt")` to `inputs = self.transforms.processor(images=args, return_tensors="pt")`

This corrects the attribute path to use the existing processor that is properly initialized through the `_HFTransformsHandler` wrapper.

## How is this patch tested? If it is not, please explain why.

Comprehensive testing was performed:
1. Created a test script that reproduced the AttributeError on all 6 zero-shot transformer models in the zoo
2. Verified that `self.processor` does not exist while `self.transforms.processor` does exist and contains the correct HuggingFace processor
3. Applied the fix and confirmed that `embed()` and `embed_all()` work correctly on all affected models
4. Verified embeddings have correct shapes and reasonable values (mean, std, norm)

All zero-shot transformer models can now successfully extract embeddings after this fix.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixed a bug that prevented extracting embeddings from zero-shot transformer models using the `embed()` and `embed_all()` methods. All zero-shot models in the model zoo now properly support embedding extraction.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image preprocessing for embeddings to ensure more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->