### PR TITLE
Show calendar picker in sidebar inputs

### DIFF
--- a/app/packages/core/src/components/Filters/NumericFieldFilter/Input.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/Input.tsx
@@ -36,7 +36,11 @@ const StyledInputContainer = styled.div`
 
 const StyledInput = styled.input`
   &::-webkit-calendar-picker-indicator {
-    display: none;
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="15" viewBox="0 0 24 24"><path fill="${({
+      theme,
+    }) =>
+      theme.text
+        .secondary}" d="M20 3h-1V1h-2v2H7V1H5v2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 18H4V8h16v13z"/></svg>');
   }
 
   &::-webkit-outer-spin-button,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Show the calendar picker icon in Chrome

<img width="1469" alt="Screenshot 2025-07-09 at 11 23 55 AM" src="https://github.com/user-attachments/assets/a4167b85-8657-4864-a348-9561e1d5bb97" />


## Release Notes

* Added a calendar picker support for `DateField` and `DateTimeField` inputs in the sidebar

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the numeric field filter input to display a custom calendar icon, styled to match the theme, instead of hiding the calendar picker indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->