### PR TITLE
Fix transformers zero shot embeddings

### DIFF
--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -508,28 +508,23 @@ class TransformerEmbeddingsMixin(EmbeddingsMixin):
 class ZeroShotTransformerEmbeddingsMixin(EmbeddingsMixin):
     """Mixin for Transformers that can generate embeddings."""
 
-    @property
     def has_embeddings(self):
-        return _has_text_and_image_features(self._model)
+        return hasattr(self._model, "get_image_features")
 
     def embed(self, arg):
-        return self._embed(arg)[0]
+        return self.embed_all([arg])[0]
 
     def embed_all(self, args):
-        return self._embed(args)
-
-    def _embed(self, args):
-        # don't use the regular TransformerEmbeddingsMixin
-        # because doing the whole forward pass is slow
-        # and because HFT offer a cleaner way to do this
-        # via get_image_features
         if self.preprocess:
-            inputs = self.processor(images=args, return_tensors="pt")
+            args = {"images": args}
+            args = self.collate_fn(self.transforms(args))
+
         with torch.no_grad():
-            image_features = self._model.get_image_features(
-                **inputs.to(self._device)
+            for k, v in args.items():
+                args[k] = v.to(self.device)
+            return (
+                self._model.get_image_features(**args).detach().cpu().numpy()
             )
-        return image_features.cpu().numpy()
 
 
 class ZeroShotTransformerPromptMixin(PromptMixin):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Rewrite `ZeroShotTransformerEmbeddingsMixin`

## How is this patch tested? If it is not, please explain why.

```
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.transformers as fouht
import fiftyone.utils.torch as fout

import transformers

fo_model = foz.load_zoo_model(
    "zero-shot-classification-transformer-torch",
    name_or_path="BAAI/AltCLIP",
    classes=["cat", "dog", "car", "truck", "bicycle"],
)

model_name = fo_model.config.name_or_path

transformers_model = transformers.AutoModel.from_pretrained(model_name)
transformers_model.to("cuda:0")
transformers_model.eval()
transformers_processor = transformers.AutoProcessor.from_pretrained(model_name, use_fast=False)

dataset = fo.load_dataset("your-favorite-image-dataset")

dataset.compute_embeddings(
    fo_model,
    batch_size=128,
    num_workers=32,
    embeddings_field="test_fo",
    skip_failures=False
)

samples = dataset.limit(10)
images = [fout._load_image(s.filepath, False, True) for s in samples]
transformers_input = transformers_processor(images=images, return_tensors="pt")
with torch.no_grad():
    transformers_output = transformers_model.get_image_features(**transformers_input.to("cuda:0")).detach().cpu().numpy()

fo_output = np.array(samples.values("test_fo"))
diff = fo_output - transformers_output
print(f"Max diff: {np.max(np.abs(diff))}")
print(f"Min diff: {np.min(np.abs(diff))}")
print(f"Mean diff: {np.mean(np.abs(diff))}")
print(f"Std diff: {np.std(np.abs(diff))}")

fo_output_batch = fo_model.embed_all(images)
diff_batch = fo_output_batch - transformers_output
print(f"Max diff batch: {np.max(np.abs(diff_batch))}")
print(f"Min diff batch: {np.min(np.abs(diff_batch))}")
print(f"Mean diff batch: {np.mean(np.abs(diff_batch))}")
print(f"Std diff batch: {np.std(np.abs(diff_batch))}")

fo_output_single = fo_model.embed(images[0])
diff_single = fo_output_single - transformers_output[0]
print(f"Max diff batch: {np.max(np.abs(diff_batch))}")
print(f"Min diff batch: {np.min(np.abs(diff_batch))}")
print(f"Mean diff batch: {np.mean(np.abs(diff_batch))}")
print(f"Std diff batch: {np.std(np.abs(diff_batch))}")

```

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other - `fiftyone.utils.transformers`
