### PR TITLE
chore: save SBOM directory for docs.fiftyone.ai

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -118,4 +118,4 @@ jobs:
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v2
       - name: publish
-        run: gsutil -m rsync -dR docs-download gs://docs.voxel51.com
+        run: gsutil -m rsync -dR -x '^SBOMs/.*' docs-download gs://docs.voxel51.com


### PR DESCRIPTION
## What changes are proposed in this pull request?

We have a number of customers who have asked for Software Bill of Materials (SBOMs) for our images.  Making this publicly available is 'simplest' if we create a subdirectory on docs.voxel51.com.

The current deploy command wipes out unmatched files on the remote directory.  This will exclude the `SBOMs` directory contents from that rsync.

## How is this patch tested? If it is not, please explain why.

Without `-x`:
```
❯ gcloud storage ls gs://topher-rsync-test/SBOMs
gs://topher-rsync-test/SBOMs/fiftyone-enterprise-2.10.0-sboms.tar.gz
❯ gsutil -m rsync -dR random-files gs://topher-rsync-test
Building synchronization state...

Starting synchronization...

Removing gs://topher-rsync-test/SBOMs/fiftyone-enterprise-2.10.0-sboms.tar.gz
```

With `-x`:
```
❯ gcloud storage cp fiftyone-enterprise-2.10.0-sboms.tar.gz gs://topher-rsync-test/SBOMs/fiftyone-enterprise-2.10.0-sboms.tar.gz
Copying file://fiftyone-enterprise-2.10.0-sboms.tar.gz to gs://topher-rsync-test/SBOMs/fiftyone-enterprise-2.10.0-sboms.tar.gz
  Completed files 1/1 | 10.9MiB/10.9MiB

❯ gsutil -m rsync -dR -x '^SBOMs/.*' random-files gs://topher-rsync-test
Building synchronization state...

Starting synchronization...

❯ gcloud storage ls gs://topher-rsync-test/SBOMs
gs://topher-rsync-test/SBOMs/fiftyone-enterprise-2.10.0-sboms.tar.gz
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation publishing process to exclude the contents of the SBOMs directory from being uploaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->