### PR TITLE
fix issue where renaming workspace create a new workspace with the new name

### DIFF
--- a/app/packages/spaces/src/components/Workspaces/Workspace.tsx
+++ b/app/packages/spaces/src/components/Workspaces/Workspace.tsx
@@ -61,7 +61,7 @@ export default function Workspace(props: WorkspacePropsType) {
                 ...state,
                 open: true,
                 edit: true,
-                oldName: name,
+                old_name: name,
                 name,
                 description,
                 color,

--- a/app/packages/spaces/src/components/Workspaces/WorkspaceEditor.tsx
+++ b/app/packages/spaces/src/components/Workspaces/WorkspaceEditor.tsx
@@ -139,7 +139,7 @@ export default function WorkspaceEditor() {
                 SAVE_WORKSPACE_OPERATOR,
                 {
                   ...state,
-                  current_name: edit ? state.oldName : undefined,
+                  current_name: edit ? state.old_name : undefined,
                   spaces: await getSessionSpaces(),
                 },
                 {
@@ -148,15 +148,11 @@ export default function WorkspaceEditor() {
                       reset();
                       handleClose();
                       setStatus("");
-                      if (!edit) {
-                        executeOperator(
-                          LOAD_WORKSPACE_OPERATOR,
-                          {
-                            name: state.name,
-                          },
-                          { skipOutput: true }
-                        );
-                      }
+                      executeOperator(
+                        LOAD_WORKSPACE_OPERATOR,
+                        { name: state.name },
+                        { skipOutput: true }
+                      );
                     }
                   },
                   skipOutput: true,

--- a/app/packages/spaces/src/state.ts
+++ b/app/packages/spaces/src/state.ts
@@ -106,7 +106,7 @@ export const workspaceEditorStateAtom = atom({
   key: "workspaceEditorState",
   default: {
     open: false,
-    oldName: "",
+    old_name: "",
     name: "",
     description: "",
     color: COLOR_OPTIONS[0].color,

--- a/plugins/operators/__init__.py
+++ b/plugins/operators/__init__.py
@@ -8,6 +8,7 @@ Builtin operators.
 
 import json
 import os
+import logging
 
 from bson import ObjectId
 
@@ -19,6 +20,8 @@ import fiftyone.operators.types as types
 from fiftyone.core.odm.workspace import default_workspace_factory
 from .group_by import GroupBy
 from .model_evaluation import ConfigureScenario
+
+logger = logging.getLogger(__name__)
 
 
 class EditFieldInfo(foo.Operator):
@@ -2352,6 +2355,7 @@ class SaveWorkspace(foo.Operator):
         description = ctx.params.get("description", None)
         color = ctx.params.get("color", None)
         spaces = ctx.params.get("spaces", None)
+        old_name = ctx.params.get("old_name", None)
 
         curr_spaces = spaces is None
         if curr_spaces:
@@ -2366,6 +2370,12 @@ class SaveWorkspace(foo.Operator):
             color=color,
             overwrite=True,
         )
+
+        if old_name is not None and old_name != name:
+            try:
+                ctx.dataset.delete_workspace(old_name)
+            except Exception as e:
+                logger.warning(f"Failed to delete workspace '{old_name}': {e}")
 
         if curr_spaces:
             ctx.ops.set_spaces(name=name)


### PR DESCRIPTION
## What changes are proposed in this pull request?

fix issue where renaming workspace create a new workspace with the new name

## How is this patch tested? If it is not, please explain why.

Using Workspace UI in the app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

fix issue where renaming workspace create a new workspace with the new name

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when renaming workspaces by ensuring old workspace entries are properly cleaned up after a rename.
  * Fixed inconsistencies in workspace editor behavior when saving changes.

* **Chores**
  * Updated internal property naming for workspace state to improve consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->