### PR TITLE
Ultralytics: return empty labels, not None, when no objects are found

### DIFF
--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -90,7 +90,7 @@ def to_detections(results, confidence_thresh=None):
 
 def _to_detections(result, confidence_thresh=None):
     if result.boxes is None:
-        return None
+        return fol.Detections()
 
     classes = np.rint(result.boxes.cls.detach().cpu().numpy()).astype(int)
     boxes = result.boxes.xywhn.detach().cpu().numpy().astype(float)
@@ -142,7 +142,7 @@ def to_instances(results, confidence_thresh=None):
 
 def _to_instances(result, confidence_thresh=None):
     if result.masks is None:
-        return None
+        return fol.Detections()
 
     classes = np.rint(result.boxes.cls.detach().cpu().numpy()).astype(int)
     boxes = result.boxes.xywhn.detach().cpu().numpy().astype(float)
@@ -227,6 +227,7 @@ def _to_classifications(result, confidence_thresh=None, store_logits=False):
         )
         if store_logits:
             classification.logits = logits
+
     return classification
 
 
@@ -259,7 +260,8 @@ def obb_to_polylines(results, confidence_thresh=None, filled=False):
 
 def _obb_to_polylines(result, filled, confidence_thresh=None):
     if result.obb is None:
-        return None
+        return fol.Polylines()
+
     classes = np.rint(result.obb.cls.detach().cpu().numpy()).astype(int)
     confs = result.obb.conf.detach().cpu().numpy().astype(float)
     points = result.obb.xyxyxyxyn.detach().cpu().numpy()
@@ -280,6 +282,7 @@ def _obb_to_polylines(result, filled, confidence_thresh=None):
             filled=filled,
         )
         polylines.append(polyline)
+
     return fol.Polylines(polylines=polylines)
 
 
@@ -315,7 +318,7 @@ def to_polylines(results, confidence_thresh=None, tolerance=2, filled=True):
 
 def _to_polylines(result, tolerance, filled, confidence_thresh=None):
     if result.masks is None:
-        return None
+        return fol.Polylines()
 
     classes = np.rint(result.boxes.cls.detach().cpu().numpy()).astype(int)
     confs = result.boxes.conf.detach().cpu().numpy().astype(float)
@@ -381,7 +384,7 @@ def to_keypoints(results, confidence_thresh=None):
 
 def _to_keypoints(result, confidence_thresh=None):
     if result.keypoints is None:
-        return None
+        return fol.Keypoints()
 
     classes = np.rint(result.boxes.cls.detach().cpu().numpy()).astype(int)
     points = result.keypoints.xyn.detach().cpu().numpy().astype(float)
@@ -851,7 +854,8 @@ class UltralyticsDetectionOutputProcessor(
 
     def _parse_output(self, output, frame_size, confidence_thresh):
         if not output:
-            return None
+            return fol.Detections()
+
         detections = super()._parse_output(
             output, frame_size, confidence_thresh
         )


### PR DESCRIPTION
## Change log

When performing inference with `ultralytics` models, if no suitable objects were found, return empty labels (eg `Detections()`) rather than `None`.

This is important because the `Detections()` vs `None` distinction is semantically meaningful for downstream applications:
- `Detections()`: sample was processed but no suitable objects were found
- `None`: sample has not been processed

## Tested by

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=3)
model = foz.load_zoo_model("yolov8s-coco-torch")

dataset.apply_model(model, label_field="boxes", confidence_thresh=0.999999)

print(dataset.values("boxes"))
```

```
[<Detections: {'detections': []}>,
 <Detections: {'detections': []}>,
 <Detections: {'detections': []}>]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency by returning empty label containers instead of `None` when no detection, instance, classification, OBB, polyline, or keypoint data is present. This ensures more predictable behavior when handling empty results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->