### PR TITLE
chore: deprecation notice for kubernetes 1.30

### DIFF
--- a/docs/source/deprecation.rst
+++ b/docs/source/deprecation.rst
@@ -10,6 +10,17 @@ FiftyOne Deprecation Notices
    Deprecation notices below are ordered in reverse chronological order
    (most recent at the top).
 
+.. _deprecation-kubernetes-1.30:
+
+Kubernetes 1.30
+---------------
+*Support ending July 11, 2025*
+
+`Kubernetes 1.30 <https://kubernetes.io/releases/>`_
+transitioned to `end-of-life` effective June of 2025. FiftyOne Enterprise
+releases after July 11, 2025 might no longer be compatible with
+Kubernetes 1.30 and older.
+
 .. _deprecation-mongodb-5.0:
 
 MongoDB 5.0


### PR DESCRIPTION
## What changes are proposed in this pull request?

Kubernetes version 1.30 went EOL in June of 2025.  We should make our official stance to only support kubernetes versions that are supported.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a deprecation notice for Kubernetes 1.30, indicating support will end on July 11, 2025 and future releases may not be compatible with this version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->