### PR TITLE
Update manifest-torch.json

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -123,7 +123,7 @@
                     "support": true
                 }
             },
-            "tags": ["segment-anything", "sa-1b", "torch", "zero-shot"],
+            "tags": ["segment-anything", "sa-1b", "torch", "zero-shot", "transformer"],
             "date_added": "2023-05-12 11:40:51"
         },
         {
@@ -158,7 +158,7 @@
                     "support": true
                 }
             },
-            "tags": ["segment-anything", "sa-1b", "torch", "zero-shot"],
+            "tags": ["segment-anything", "sa-1b", "torch", "zero-shot", "transformer"],
             "date_added": "2023-05-12 11:40:51"
         },
         {
@@ -193,7 +193,7 @@
                     "support": true
                 }
             },
-            "tags": ["segment-anything", "sa-1b", "torch", "zero-shot"],
+            "tags": ["segment-anything", "sa-1b", "torch", "zero-shot", "transformer"],
             "date_added": "2023-05-12 11:40:51"
         },
         {
@@ -263,7 +263,7 @@
                     "support": true
                 }
             },
-            "tags": ["segment-anything", "torch", "zero-shot"],
+            "tags": ["segment-anything", "torch", "zero-shot", "transformer"],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -298,7 +298,7 @@
                     "support": true
                 }
             },
-            "tags": ["segment-anything", "torch", "zero-shot"],
+            "tags": ["segment-anything", "torch", "zero-shot", "transformer"],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -333,7 +333,7 @@
                     "support": true
                 }
             },
-            "tags": ["segment-anything", "torch", "zero-shot"],
+            "tags": ["segment-anything", "torch", "zero-shot", "transformer"],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -367,7 +367,7 @@
                     "support": true
                 }
             },
-            "tags": ["segment-anything", "torch", "zero-shot", "video"],
+            "tags": ["segment-anything", "torch", "zero-shot", "video", "transformer"],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -402,7 +402,7 @@
                     "support": true
                 }
             },
-            "tags": ["segment-anything", "torch", "zero-shot", "video"],
+            "tags": ["segment-anything", "torch", "zero-shot", "video", "transformer"],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -437,7 +437,7 @@
                     "support": true
                 }
             },
-            "tags": ["segment-anything", "torch", "zero-shot", "video"],
+            "tags": ["segment-anything", "torch", "zero-shot", "video", "transformer"],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -472,7 +472,7 @@
                     "support": true
                 }
             },
-            "tags": ["segment-anything", "torch", "zero-shot", "video"],
+            "tags": ["segment-anything", "torch", "zero-shot", "video", "transformer"],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -511,7 +511,8 @@
                 "torch",
                 "zero-shot",
                 "video",
-                "med-SAM"
+                "med-SAM",
+                "transformer"
             ],
             "date_added": "2024-08-17 14:48:00"
         },
@@ -549,7 +550,7 @@
                     "support": true
                 }
             },
-            "tags": ["segment-anything", "torch", "zero-shot"],
+            "tags": ["segment-anything", "torch", "zero-shot", "transformer"],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -586,7 +587,7 @@
                     "support": true
                 }
             },
-            "tags": ["segment-anything", "torch", "zero-shot"],
+            "tags": ["segment-anything", "torch", "zero-shot", "transformer"],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -623,7 +624,7 @@
                     "support": true
                 }
             },
-            "tags": ["segment-anything", "torch", "zero-shot"],
+            "tags": ["segment-anything", "torch", "zero-shot", "transformer"],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -660,7 +661,7 @@
                     "support": true
                 }
             },
-            "tags": ["segment-anything", "torch", "zero-shot"],
+            "tags": ["segment-anything", "torch", "zero-shot", "transformer"],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -696,7 +697,7 @@
                     "support": true
                 }
             },
-            "tags": ["segment-anything", "torch", "zero-shot", "video"],
+            "tags": ["segment-anything", "torch", "zero-shot", "video", "transformer"],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -733,7 +734,7 @@
                     "support": true
                 }
             },
-            "tags": ["segment-anything", "torch", "zero-shot", "video"],
+            "tags": ["segment-anything", "torch", "zero-shot", "video", "transformer"],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -770,7 +771,7 @@
                     "support": true
                 }
             },
-            "tags": ["segment-anything", "torch", "zero-shot", "video"],
+            "tags": ["segment-anything", "torch", "zero-shot", "video", "transformer"],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -807,7 +808,7 @@
                     "support": true
                 }
             },
-            "tags": ["segment-anything", "torch", "zero-shot", "video"],
+            "tags": ["segment-anything", "torch", "zero-shot", "video", "transformer"],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -2628,7 +2629,8 @@
                 "embeddings",
                 "torch",
                 "clip",
-                "zero-shot"
+                "zero-shot",    
+                "transformer"
             ],
             "date_added": "2023-12-13 14:25:51"
         },
@@ -3043,7 +3045,8 @@
                 "embeddings",
                 "torch",
                 "clip",
-                "zero-shot"
+                "zero-shot",    
+                "transformer"
             ],
             "date_added": "2022-04-12 17:49:51"
         },
@@ -3075,7 +3078,7 @@
                     "support": true
                 }
             },
-            "tags": ["embeddings", "torch", "dinov2"],
+            "tags": ["embeddings", "torch", "dinov2", "transformer"],
             "date_added": "2023-07-31 10:17:51"
         },
         {
@@ -3106,7 +3109,7 @@
                     "support": true
                 }
             },
-            "tags": ["embeddings", "torch", "dinov2"],
+            "tags": ["embeddings", "torch", "dinov2", "transformer"],
             "date_added": "2023-07-31 10:17:51"
         },
         {
@@ -3137,7 +3140,7 @@
                     "support": true
                 }
             },
-            "tags": ["embeddings", "torch", "dinov2"],
+            "tags": ["embeddings", "torch", "dinov2", "transformer"],
             "date_added": "2023-07-31 10:17:51"
         },
         {
@@ -3168,7 +3171,7 @@
                     "support": true
                 }
             },
-            "tags": ["embeddings", "torch", "dinov2"],
+            "tags": ["embeddings", "torch", "dinov2", "transformer"],
             "date_added": "2023-07-31 10:17:51"
         },
         {
@@ -3199,7 +3202,7 @@
                     "support": true
                 }
             },
-            "tags": ["embeddings", "torch", "dinov2"],
+            "tags": ["embeddings", "torch", "dinov2", "transformer"],
             "date_added": "2023-12-02 16:42:00"
         },
         {
@@ -3230,7 +3233,7 @@
                     "support": true
                 }
             },
-            "tags": ["embeddings", "torch", "dinov2"],
+            "tags": ["embeddings", "torch", "dinov2", "transformer"],
             "date_added": "2023-12-02 16:42:00"
         },
         {
@@ -3261,7 +3264,7 @@
                     "support": true
                 }
             },
-            "tags": ["embeddings", "torch", "dinov2"],
+            "tags": ["embeddings", "torch", "dinov2", "transformer"],
             "date_added": "2023-12-02 16:42:00"
         },
         {
@@ -3292,7 +3295,7 @@
                     "support": true
                 }
             },
-            "tags": ["embeddings", "torch", "dinov2"],
+            "tags": ["embeddings", "torch", "dinov2", "transformer"],
             "date_added": "2023-12-02 16:42:00"
         },
         {


### PR DESCRIPTION
Fix inconsistent transformer tags in model zoo

- Add missing "transformer" tag to models using transformer architecture:
  - SAM/SAM2 models (ViT backbone)
  - DINOv2 models (Vision Transformer)
  - CLIP/Open-CLIP models

## What changes are proposed in this pull request?

This PR adds the "transformer" architecture tag to 29 models in the model zoo that use transformer-based architectures but were missing this tag. This improves consistency and helps users find transformer-based models when filtering by tags.

## How is this patch tested? If it is not, please explain why.

Manually verified that all models with transformer architectures now have the appropriate tag. The changes are to the model zoo manifest JSON only and don't affect functionality.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other