### PR TITLE
Update slider numeric inputs to truncate to human-readable lengths

### DIFF
--- a/app/packages/core/src/components/Filters/NumericFieldFilter/Inputs.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/Inputs.tsx
@@ -1,9 +1,10 @@
 import * as fos from "@fiftyone/state";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import styled from "styled-components";
 import type { InputType } from "./Input";
 import { Input } from "./Input";
+import { getFormatter } from "../../Common/utils";
 
 const Container = styled.div`
   display: flex;
@@ -28,7 +29,26 @@ export default function Inputs({
       withBounds: false,
     })
   );
+  const bounds = useRecoilValue(fos.boundsAtom({ path, modal }));
   const setSnackBarErrors = useSetRecoilState(fos.snackbarErrors);
+
+  // Display a clipped value in the input to provide a simpler UX
+  const { formatter } = getFormatter(ftype, null, bounds);
+  const [minDisplay, setMinDisplay] = useState(
+    typeof min === "number" ? formatter(min) : null
+  );
+  const [maxDisplay, setMaxDisplay] = useState(
+    typeof max === "number" ? formatter(max) : null
+  );
+
+  // Synchronize with external state updates
+  // todo - move to recoil selector?
+  useEffect(() => {
+    setMinDisplay(typeof min === "number" ? formatter(min) : null);
+  }, [min]);
+  useEffect(() => {
+    setMaxDisplay(typeof max === "number" ? formatter(max) : null);
+  }, [max]);
 
   return (
     <Container>
@@ -44,7 +64,7 @@ export default function Inputs({
           setRange((cur) => [value, cur[1]]);
         }}
         placeholder="min"
-        value={min ?? null}
+        value={minDisplay}
       />
       <Input
         color={color}
@@ -58,7 +78,7 @@ export default function Inputs({
           setRange((cur) => [cur[0], value]);
         }}
         placeholder="max"
-        value={max ?? null}
+        value={maxDisplay}
       />
     </Container>
   );


### PR DESCRIPTION
## What changes are proposed in this pull request?

**This is currently a WIP; there is a known issue handling `datetime` fields with the current implementation.**

This PR updates the numeric inputs associated with sliders to truncate values to human-readable lengths. Currently, adjusting sliders causes the inputs fields to be populated with long float values. With this change, the inputs are formatted to match the slider's displayed precision. Manual inputs into the input fields are still respected, and the slider is updated accordingly.

## How is this patch tested? If it is not, please explain why.

local app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Numeric input fields now display formatted values based on the field type and bounds, improving readability.

* **Bug Fixes**
  * Displayed values for minimum and maximum inputs update automatically when their external values change, ensuring consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->