### PR TITLE
release notes for OSS 1.7.1 / Enterprise 2.10.1

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -5,7 +5,7 @@ FiftyOne Release Notes
 
 FiftyOne Enterprise 2.10.1
 --------------------------
-*Released July 15, 2025*
+*Released July 16, 2025*
 
 Includes all updates from :ref:`FiftyOne 1.7.1 <release-notes-v1.7.1>`, plus:
 
@@ -24,7 +24,7 @@ Includes all updates from :ref:`FiftyOne 1.7.1 <release-notes-v1.7.1>`, plus:
 
 FiftyOne 1.7.1
 --------------
-*Released July 15, 2025*
+*Released July 16, 2025*
 
 App
 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -5,7 +5,7 @@ FiftyOne Release Notes
 
 FiftyOne Enterprise 2.10.1
 --------------------------
-*Released July 18, 2025*
+*Released July 21, 2025*
 
 Includes all updates from :ref:`FiftyOne 1.7.1 <release-notes-v1.7.1>`, plus:
 
@@ -24,7 +24,7 @@ Includes all updates from :ref:`FiftyOne 1.7.1 <release-notes-v1.7.1>`, plus:
 
 FiftyOne 1.7.1
 --------------
-*Released July 18, 2025*
+*Released July 21, 2025*
 
 App
 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -3,6 +3,82 @@ FiftyOne Release Notes
 
 .. default-role:: code
 
+FiftyOne Enterprise 2.10.1
+--------------------------
+*Released July 14, 2025*
+
+Includes all updates from :ref:`FiftyOne 1.7.1 <release-notes-v1.7.1>`, plus:
+
+- Optimized the loading of pinned datasets.
+- Changed the `sizeEstimate` fields on both datasets and dataset snapshots to
+  return a float indicating size in megabytes, rather than in bytes.
+- Enhanced connection handling for HTTP requests, allowing faster failure and
+  more robust retry behavior after a successful connection has been
+  established.
+- Fixed error when running `get_datasets_revisions()` in certain cases.
+- Fixed the loading of 
+  :ref:`dataset snapshots <dataset-versioning-snapshot-archival>` in the app.
+  `#1724 <https://github.com/voxel51/fiftyone-teams/pull/1724>`_
+
+.. _release-notes-v1.7.1:
+
+FiftyOne 1.7.1
+--------------
+*Released July 14, 2025*
+
+App
+
+- Updated the :ref:`Scenario Analysis <app-scenario-analysis>` summary table to
+  correctly interpret and display metrics where a lower value is better, such
+  as the "Incorrect" metric. `#6111
+  <https://github.com/voxel51/fiftyone/pull/6111>`_
+- Improved error handling in :ref:`Scenario Analysis <app-scenario-analysis>`
+  when empty subset is defined. `#6127
+  <https://github.com/voxel51/fiftyone/pull/6127>`_
+- Added calendar picker support for `DateField` and `DateTimeField` inputs in
+  the sidebar `#6120 <https://github.com/voxel51/fiftyone/pull/6120>`_
+- Fixed: fully support frame patch embeddings in 
+  :ref:`Embeddings panel <app-embeddings-panel>`. 
+  `#6129 <https://github.com/voxel51/fiftyone/pull/6129>`_
+- Fixed: updated `ColorScheme` to allow `color_pool` to be optional. 
+  `#6128 <https://github.com/voxel51/fiftyone/pull/6128>`_
+- Fixed issue where renaming workspace created a new workspace with the new
+  name. `#6125 <https://github.com/voxel51/fiftyone/pull/6125>`_
+- Fixed search results for `label tags` in the sidebar when 
+  :ref:`Query Performance <app-optimizing-query-performance>` is disabled 
+  `#6095 <https://github.com/voxel51/fiftyone/pull/6095>`_
+- Fixed an issue where the `useBrowserStorage` utility would persist an invalid
+  `"undefined"` value in localStorage. 
+  `#6116 <https://github.com/voxel51/fiftyone/pull/6116>`_
+
+Models
+
+- Fixed a Transformer issue with zero shot embeddings.
+  `#6122 <https://github.com/voxel51/fiftyone/pull/6122>`_
+- Improved semantics when performing inference with 
+  :ref:`Ultralytics models <ultralytics-integration>` and no suitable objects
+  were found. We now return empty labels (eg `Detections()`) rather than
+  `None`. `#6131 <https://github.com/voxel51/fiftyone/pull/6131>`_
+
+Core
+
+- Added a deprecation notice for Kubernetes 1.30, indicating support will end
+  on July 11, 2025 and future releases may not be compatible with this version.
+  `#6132 <https://github.com/voxel51/fiftyone/pull/6132>`_
+
+Utilities
+
+- Fixed `#6082 <https://github.com/voxel51/fiftyone/issues/6082>`_. Corrected
+  edge case with Python module names on Windows machines with multiple drives.
+  `#6124 <https://github.com/voxel51/fiftyone/pull/6124>`_
+- Fixed `#6115 <https://github.com/voxel51/fiftyone/issues/6115>`_. It is now
+  allowed to call `evaluate_XXX()` without providing an `eval_key`. In such
+  cases, the expected behavior is that evaluation metrics will be computed and
+  returned via an `EvaluationResults` object in-memory, but no evaluation info
+  will be stored on the dataset. `#6126
+  <https://github.com/voxel51/fiftyone/pull/6126>`_
+
+
 FiftyOne Enterprise 2.10.0
 --------------------------
 *Released July 1, 2025*

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -70,6 +70,12 @@ Core
   on July 11, 2025 and future releases may not be compatible with this version.
   `#6132 <https://github.com/voxel51/fiftyone/pull/6132>`_
 
+Plugins
+
+- Fixed an issue where builtin plugin definitions server paths were resovled
+  incorrectly.
+  `#6136 <https://github.com/voxel51/fiftyone/pull/6136>`_
+
 Utilities
 
 - Fixed `#6082 <https://github.com/voxel51/fiftyone/issues/6082>`_. Corrected
@@ -81,6 +87,10 @@ Utilities
   returned via an `EvaluationResults` object in-memory, but no evaluation info
   will be stored on the dataset.
   `#6126 <https://github.com/voxel51/fiftyone/pull/6126>`_
+- Fixed `#6137 <https://github.com/voxel51/fiftyone/issues/6137>`_: pickle
+  error in certain cases when using
+  :func:`compute_similarity() <fiftyone.brain.compute_similarity>`
+  `#6138 <https://github.com/voxel51/fiftyone/pull/6138>`_
 
 
 FiftyOne Enterprise 2.10.0

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -5,7 +5,7 @@ FiftyOne Release Notes
 
 FiftyOne Enterprise 2.10.1
 --------------------------
-*Released July 16, 2025*
+*Released July 18, 2025*
 
 Includes all updates from :ref:`FiftyOne 1.7.1 <release-notes-v1.7.1>`, plus:
 
@@ -24,7 +24,7 @@ Includes all updates from :ref:`FiftyOne 1.7.1 <release-notes-v1.7.1>`, plus:
 
 FiftyOne 1.7.1
 --------------
-*Released July 16, 2025*
+*Released July 18, 2025*
 
 App
 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -37,6 +37,8 @@ App
   <https://github.com/voxel51/fiftyone/pull/6127>`_
 - Added calendar picker support for `DateField` and `DateTimeField` inputs in
   the sidebar `#6120 <https://github.com/voxel51/fiftyone/pull/6120>`_
+- Polished the sidebar's slider UX to improve how we handle numeric precision.
+  `#6134 <https://github.com/voxel51/fiftyone/pull/6134>`_
 - Fixed: fully support frame patch embeddings in 
   :ref:`Embeddings panel <app-embeddings-panel>`. 
   `#6129 <https://github.com/voxel51/fiftyone/pull/6129>`_
@@ -53,7 +55,9 @@ App
 
 Models
 
-- Fixed a Transformer issue with zero shot embeddings.
+- Fixed `#6112 <https://github.com/voxel51/fiftyone/pull/6112>`_: a bug when
+  attempting to extract embeddings from zero-shot transformer models with
+  preprocessing disabled.
   `#6122 <https://github.com/voxel51/fiftyone/pull/6122>`_
 - Improved semantics when performing inference with 
   :ref:`Ultralytics models <ultralytics-integration>` and no suitable objects
@@ -70,13 +74,13 @@ Utilities
 
 - Fixed `#6082 <https://github.com/voxel51/fiftyone/issues/6082>`_. Corrected
   edge case with Python module names on Windows machines with multiple drives.
-  `#6124 <https://github.com/voxel51/fiftyone/pull/6124>`_
+  `#6088 <https://github.com/voxel51/fiftyone/pull/6088>`_
 - Fixed `#6115 <https://github.com/voxel51/fiftyone/issues/6115>`_. It is now
   allowed to call `evaluate_XXX()` without providing an `eval_key`. In such
   cases, the expected behavior is that evaluation metrics will be computed and
   returned via an `EvaluationResults` object in-memory, but no evaluation info
-  will be stored on the dataset. `#6126
-  <https://github.com/voxel51/fiftyone/pull/6126>`_
+  will be stored on the dataset.
+  `#6126 <https://github.com/voxel51/fiftyone/pull/6126>`_
 
 
 FiftyOne Enterprise 2.10.0

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -9,16 +9,15 @@ FiftyOne Enterprise 2.10.1
 
 Includes all updates from :ref:`FiftyOne 1.7.1 <release-notes-v1.7.1>`, plus:
 
-- Optimized the loading of pinned datasets.
-- Changed the `sizeEstimate` fields on both datasets and dataset snapshots to
-  return a float indicating size in megabytes, rather than in bytes.
+- Optimized the :ref:`pinned datasets widget <enterprise-pinned-datasets>`
 - Enhanced connection handling for HTTP requests, allowing faster failure and
   more robust retry behavior after a successful connection has been
-  established.
-- Fixed error when running `get_datasets_revisions()` in certain cases.
-- Fixed the loading of 
-  :ref:`dataset snapshots <dataset-versioning-snapshot-archival>` in the app.
-  `#1724 <https://github.com/voxel51/fiftyone-teams/pull/1724>`_
+  established
+- Changed the `sizeEstimate` fields on both datasets and dataset snapshots to
+  return a float indicating size in megabytes, rather than in bytes
+- Fixed an error that could prevent
+  :ref:`dataset snapshots <dataset_versioning>` from loading in the App in
+  certain contexts
 
 .. _release-notes-v1.7.1:
 
@@ -30,68 +29,59 @@ App
 
 - Updated the :ref:`Scenario Analysis <app-scenario-analysis>` summary table to
   correctly interpret and display metrics where a lower value is better, such
-  as the "Incorrect" metric. `#6111
-  <https://github.com/voxel51/fiftyone/pull/6111>`_
+  as the "Incorrect" metric
+  `#6111 <https://github.com/voxel51/fiftyone/pull/6111>`_
 - Improved error handling in :ref:`Scenario Analysis <app-scenario-analysis>`
-  when empty subset is defined. `#6127
-  <https://github.com/voxel51/fiftyone/pull/6127>`_
-- Added calendar picker support for `DateField` and `DateTimeField` inputs in
-  the sidebar `#6120 <https://github.com/voxel51/fiftyone/pull/6120>`_
-- Polished the sidebar's slider UX to improve how we handle numeric precision.
+  when empty subsets are defined
+  `#6127 <https://github.com/voxel51/fiftyone/pull/6127>`_
+- Added calendar picker support for |DateField| and |DateTimeField| inputs in
+  the sidebar
+  `#6120 <https://github.com/voxel51/fiftyone/pull/6120>`_
+- Polished the sidebar's slider UX to improve how we handle numeric precision
   `#6147 <https://github.com/voxel51/fiftyone/pull/6147>`_
-- Fixed: fully support frame patch embeddings in 
-  :ref:`Embeddings panel <app-embeddings-panel>`. 
+- The :ref:`Embeddings panel <app-embeddings-panel>` now supports
+  :ref:`frame patch views <frame-patches-views>`
   `#6129 <https://github.com/voxel51/fiftyone/pull/6129>`_
-- Fixed: updated `ColorScheme` to allow `color_pool` to be optional. 
+- Updated :ref:`custom color scheme <dataset-app-config-color-scheme>` to allow
+  `color_pool` to be optional
   `#6128 <https://github.com/voxel51/fiftyone/pull/6128>`_
-- Fixed issue where renaming workspace created a new workspace with the new
-  name. `#6125 <https://github.com/voxel51/fiftyone/pull/6125>`_
+- Fixed an issue where renaming a :ref:`saved workspace <app-workspaces>` would
+  create a new workspace instead
+  `#6125 <https://github.com/voxel51/fiftyone/pull/6125>`_
 - Fixed search results for `label tags` in the sidebar when 
   :ref:`Query Performance <app-optimizing-query-performance>` is disabled 
   `#6095 <https://github.com/voxel51/fiftyone/pull/6095>`_
 - Fixed an issue where the `useBrowserStorage` utility would persist an invalid
-  `"undefined"` value in localStorage. 
+  `undefined` value in localStorage
   `#6116 <https://github.com/voxel51/fiftyone/pull/6116>`_
-
-Models
-
-- Fixed `#6112 <https://github.com/voxel51/fiftyone/pull/6112>`_: a bug when
-  attempting to extract embeddings from zero-shot transformer models with
-  preprocessing disabled.
-  `#6122 <https://github.com/voxel51/fiftyone/pull/6122>`_
-- Improved semantics when performing inference with 
-  :ref:`Ultralytics models <ultralytics-integration>` and no suitable objects
-  were found. We now return empty labels (eg `Detections()`) rather than
-  `None`. `#6131 <https://github.com/voxel51/fiftyone/pull/6131>`_
 
 Core
 
-- Added a deprecation notice for Kubernetes 1.30, indicating support will end
-  on July 11, 2025 and future releases may not be compatible with this version.
+- Improved handling of path resolution on Windows machines with multiple drives
+  `#6088 <https://github.com/voxel51/fiftyone/pull/6088>`_,
+  `#6136 <https://github.com/voxel51/fiftyone/pull/6136>`_
+- Fixed a recent regression that prevented calling evaluation methods like
+  :meth:`evaluate_detections() <fiftyone.core.collections.SampleCollection.evaluate_detections>`
+  without providing an `eval_key`
+  `#6126 <https://github.com/voxel51/fiftyone/pull/6126>`_
+- Added a
+  :ref:`deprecation notice for Kubernetes 1.30 <deprecation-kubernetes-1.30>`
+  indicating support will end on July 11, 2025 and future releases may not be
+  compatible with this version
   `#6132 <https://github.com/voxel51/fiftyone/pull/6132>`_
 
-Plugins
+Zoo
 
-- Fixed an issue where builtin plugin definitions server paths were resovled
-  incorrectly.
-  `#6136 <https://github.com/voxel51/fiftyone/pull/6136>`_
-
-Utilities
-
-- Fixed `#6082 <https://github.com/voxel51/fiftyone/issues/6082>`_. Corrected
-  edge case with Python module names on Windows machines with multiple drives.
-  `#6088 <https://github.com/voxel51/fiftyone/pull/6088>`_
-- Fixed `#6115 <https://github.com/voxel51/fiftyone/issues/6115>`_. It is now
-  allowed to call `evaluate_XXX()` without providing an `eval_key`. In such
-  cases, the expected behavior is that evaluation metrics will be computed and
-  returned via an `EvaluationResults` object in-memory, but no evaluation info
-  will be stored on the dataset.
-  `#6126 <https://github.com/voxel51/fiftyone/pull/6126>`_
-- Fixed `#6137 <https://github.com/voxel51/fiftyone/issues/6137>`_: pickle
-  error in certain cases when using
-  :func:`compute_similarity() <fiftyone.brain.compute_similarity>`
+- Improved semantics when performing inference with
+  :ref:`Ultralytics models <ultralytics-integration>` and no suitable objects
+  were found in an image
+  `#6131 <https://github.com/voxel51/fiftyone/pull/6131>`_
+- Fixed a bug that prevented applying models to image patches with
+  `num_workers>0` on macOS
   `#6138 <https://github.com/voxel51/fiftyone/pull/6138>`_
-
+- Fixed a bug that would prevent extracting embeddings from zero-shot
+  transformer models with preprocessing disabled
+  `#6122 <https://github.com/voxel51/fiftyone/pull/6122>`_
 
 FiftyOne Enterprise 2.10.0
 --------------------------

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -5,7 +5,7 @@ FiftyOne Release Notes
 
 FiftyOne Enterprise 2.10.1
 --------------------------
-*Released July 14, 2025*
+*Released July 15, 2025*
 
 Includes all updates from :ref:`FiftyOne 1.7.1 <release-notes-v1.7.1>`, plus:
 
@@ -24,7 +24,7 @@ Includes all updates from :ref:`FiftyOne 1.7.1 <release-notes-v1.7.1>`, plus:
 
 FiftyOne 1.7.1
 --------------
-*Released July 14, 2025*
+*Released July 15, 2025*
 
 App
 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -38,7 +38,7 @@ App
 - Added calendar picker support for `DateField` and `DateTimeField` inputs in
   the sidebar `#6120 <https://github.com/voxel51/fiftyone/pull/6120>`_
 - Polished the sidebar's slider UX to improve how we handle numeric precision.
-  `#6134 <https://github.com/voxel51/fiftyone/pull/6134>`_
+  `#6147 <https://github.com/voxel51/fiftyone/pull/6147>`_
 - Fixed: fully support frame patch embeddings in 
   :ref:`Embeddings panel <app-embeddings-panel>`. 
   `#6129 <https://github.com/voxel51/fiftyone/pull/6129>`_


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release notes for FiftyOne Enterprise 2.10.1 and FiftyOne 1.7.1, highlighting faster loading of pinned datasets, improved metric interpretations, enhanced calendar picker and slider controls, bug fixes across the app and models, more robust HTTP connection handling, and a Kubernetes 1.30 deprecation notice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->