### PR TITLE
fix(PluginDefinition): fix server path resolution for built in plugins

### DIFF
--- a/fiftyone/plugins/definitions.py
+++ b/fiftyone/plugins/definitions.py
@@ -152,13 +152,17 @@ class PluginDefinition(object):
         else:
             # For user plugins, compute path relative to the user's plugins directory
             relpath = fou.safe_relpath(self.directory, fo.config.plugins_dir)
-        return "/" + os.path.join("plugins", relpath)
+        # Normalize OS path separators to URL-style forward slashes
+        normalized_relpath = relpath.replace(os.sep, "/")
+        return "/" + "/".join(["plugins", normalized_relpath])
 
     @property
     def js_bundle_server_path(self):
         """The default server path to the JS bundle."""
         if self.has_js:
-            return os.path.join(self.server_path, self.js_bundle)
+            # Normalize JS bundle path to URL-style forward slashes
+            normalized_js_bundle = self.js_bundle.replace(os.sep, "/")
+            return "/".join([self.server_path, normalized_js_bundle])
 
     @property
     def js_bundle_hash(self):

--- a/fiftyone/plugins/definitions.py
+++ b/fiftyone/plugins/definitions.py
@@ -146,7 +146,12 @@ class PluginDefinition(object):
     @property
     def server_path(self):
         """The default server path to the plugin."""
-        relpath = fou.safe_relpath(self.directory, fo.config.plugins_dir)
+        if self.builtin:
+            # For builtin plugins, compute path relative to the builtin plugins directory
+            relpath = fou.safe_relpath(self.directory, fpc.BUILTIN_PLUGINS_DIR)
+        else:
+            # For user plugins, compute path relative to the user's plugins directory
+            relpath = fou.safe_relpath(self.directory, fo.config.plugins_dir)
         return "/" + os.path.join("plugins", relpath)
 
     @property

--- a/tests/unittests/plugins/core_tests.py
+++ b/tests/unittests/plugins/core_tests.py
@@ -15,6 +15,8 @@ import yaml
 
 import fiftyone as fo
 import fiftyone.plugins as fop
+import fiftyone.plugins.definitions as fpd
+import fiftyone.plugins.constants as fpc
 import fiftyone.utils.github as foug
 
 
@@ -161,6 +163,38 @@ def test_duplicate_plugins(mocker, fiftyone_plugins_dir):
     fop.enable_plugin("test-plugin1-name")
     _ = fop.find_plugin("test-plugin1-name")
     _ = fop.get_plugin("test-plugin1-name")
+
+
+def test_plugin_definition_server_path_builtin():
+    builtin_plugin_dir = os.path.join(
+        fpc.BUILTIN_PLUGINS_DIR, "test-builtin-plugin"
+    )
+
+    metadata = {"name": "test-builtin-plugin"}
+    plugin_def = fpd.PluginDefinition(builtin_plugin_dir, metadata)
+
+    assert plugin_def.builtin is True
+
+    expected_relpath = "test-builtin-plugin"
+    expected_server_path = "/plugins/" + expected_relpath
+    assert plugin_def.server_path == expected_server_path
+
+
+def test_plugin_definition_server_path_user_plugin(
+    mocker, fiftyone_plugins_dir
+):
+    mocker.patch("fiftyone.config.plugins_dir", fiftyone_plugins_dir)
+
+    user_plugin_dir = os.path.join(fiftyone_plugins_dir, "test-user-plugin")
+
+    metadata = {"name": "test-user-plugin"}
+    plugin_def = fpd.PluginDefinition(user_plugin_dir, metadata)
+
+    assert plugin_def.builtin is False
+
+    expected_relpath = "test-user-plugin"
+    expected_server_path = "/plugins/" + expected_relpath
+    assert plugin_def.server_path == expected_server_path
 
 
 def test_github_repository_parse_url():


### PR DESCRIPTION
Fixes an issue where builtin plugin definitions server paths were resovled incorrectly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of plugin server paths to correctly distinguish between built-in and user plugins, ensuring consistent URL formatting across operating systems.

* **Tests**
  * Added unit tests to verify correct server path generation for both built-in and user plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->