### PR TITLE
Fix #6137: use named function to avoid pickle error

### DIFF
--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -1955,8 +1955,12 @@ def _make_patch_data_loader(
         dataset,
         batch_size=1,
         num_workers=num_workers,
-        collate_fn=lambda batch: batch[0],  # return patches directly
+        collate_fn=_patch_collate_fn,
     )
+
+
+def _patch_collate_fn(batch):
+    return batch[0]  # return patches directly
 
 
 def _parse_batch_size(batch_size, model, use_data_loader):


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/6137

The code in https://github.com/voxel51/fiftyone/issues/6137 now runs successfully on macOS **without** forcing `num_workers=0` or forcing `fork` multiprocessing to be used ✅ 
