### PR TITLE
Add 5 D-FINE models from HuggingFace Transformers

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -6293,6 +6293,201 @@
                 "rtdetr"
             ],
             "date_added": "2025-07-03 12:00:00"
+        },
+        {
+            "base_name": "dfine-nano-coco-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "D-FINE Nano from `D-FINE: Redefine Regression Task in DETRs as Fine-grained Distribution Refinement` trained on COCO. Ultra-lightweight real-time object detector.",
+            "source": "https://github.com/Peterande/D-FINE",
+            "author": "Yansong Peng, et al.",
+            "license": "Apache 2.0",
+            "size_bytes": 14680064,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": null
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForObjectDetection",
+                "config": {
+                    "name_or_path": "ustc-community/dfine-nano-coco"
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch",
+                    "torchvision",
+                    "transformers",
+                    "pillow",
+                    "scipy"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch", "transformers", "detr"],
+            "date_added": "2025-07-15 23:00:00"
+        },
+        {
+            "base_name": "dfine-small-coco-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "D-FINE Small from `D-FINE: Redefine Regression Task in DETRs as Fine-grained Distribution Refinement` trained on COCO. Balanced real-time object detector.",
+            "source": "https://github.com/Peterande/D-FINE",
+            "author": "Yansong Peng, et al.",
+            "license": "Apache 2.0",
+            "size_bytes": 25165824,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": null
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForObjectDetection",
+                "config": {
+                    "name_or_path": "ustc-community/dfine-small-coco"
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch",
+                    "torchvision",
+                    "transformers",
+                    "pillow",
+                    "scipy"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch", "transformers", "detr"],
+            "date_added": "2025-07-15 23:00:00"
+        },
+        {
+            "base_name": "dfine-medium-coco-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "D-FINE Medium from `D-FINE: Redefine Regression Task in DETRs as Fine-grained Distribution Refinement` trained on COCO. Mid-size real-time object detector.",
+            "source": "https://github.com/Peterande/D-FINE",
+            "author": "Yansong Peng, et al.",
+            "license": "Apache 2.0",
+            "size_bytes": 31457280,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": null
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForObjectDetection",
+                "config": {
+                    "name_or_path": "ustc-community/dfine-medium-coco"
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch",
+                    "torchvision",
+                    "transformers",
+                    "pillow",
+                    "scipy"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch", "transformers", "detr"],
+            "date_added": "2025-07-15 23:00:00"
+        },
+        {
+            "base_name": "dfine-large-coco-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "D-FINE Large from `D-FINE: Redefine Regression Task in DETRs as Fine-grained Distribution Refinement` trained on COCO. Achieves 54.0% AP at 124 FPS on T4 GPU.",
+            "source": "https://github.com/Peterande/D-FINE",
+            "author": "Yansong Peng, et al.",
+            "license": "Apache 2.0",
+            "size_bytes": 52428800,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": null
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForObjectDetection",
+                "config": {
+                    "name_or_path": "ustc-community/dfine-large-coco"
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch",
+                    "torchvision",
+                    "transformers",
+                    "pillow",
+                    "scipy"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch", "transformers", "detr"],
+            "date_added": "2025-07-15 23:00:00"
+        },
+        {
+            "base_name": "dfine-xlarge-coco-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "D-FINE XLarge from `D-FINE: Redefine Regression Task in DETRs as Fine-grained Distribution Refinement` trained on COCO. Achieves 55.8% AP at 78 FPS on T4 GPU.",
+            "source": "https://github.com/Peterande/D-FINE",
+            "author": "Yansong Peng, et al.",
+            "license": "Apache 2.0",
+            "size_bytes": 128974848,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": null
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForObjectDetection",
+                "config": {
+                    "name_or_path": "ustc-community/dfine-xlarge-coco"
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch",
+                    "torchvision",
+                    "transformers",
+                    "pillow",
+                    "scipy"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch", "transformers", "detr"],
+            "date_added": "2025-07-15 23:00:00"
         }
     ]
 }


### PR DESCRIPTION
## Add 5 new D-FINE object detection models from HuggingFace Transformers:

D-FINE models (5 variants):
* dfine-nano-coco-torch (ultra-lightweight)
* dfine-small-coco-torch
* dfine-medium-coco-torch
* dfine-large-coco-torch (54.0% AP at 124 FPS)
* dfine-xlarge-coco-torch (55.8% AP at 78 FPS)

All models:
* Use existing FiftyOneTransformerForObjectDetection wrapper
* Support both CPU and GPU inference
* Tested on COCO object detection
* Extract embeddings for similarity matching
* Apache 2.0 licensed

D-FINE redefines DETR's regression task through Fine-grained Distribution Refinement (FDR) and Global Optimal Localization Self-Distillation (GO-LSD), achieving state-of-the-art real-time performance.

## What changes are proposed in this pull request?

Added 5 D-FINE model configurations to `fiftyone/zoo/models/manifest-torch.json` using the existing transformer wrapper.

## How is this patch tested? If it is not, please explain why.

Tested all 5 models:
* Loaded from HuggingFace hub (ustc-community namespace)
* Performed object detection on COCO validation images
* Verified outputs match direct HuggingFace inference
* Tested embedding extraction

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Added 5 D-FINE real-time object detection models to the model zoo (nano through xlarge).

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other