### PR TITLE
Add generic pose-estimation-transformer-torch to manifest

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -2815,6 +2815,31 @@
             "date_added": "2024-01-17 14:25:51"
         },
         {
+            "base_name": "pose-estimation-transformer-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Hugging Face Transformers model for pose estimation",
+            "source": "https://huggingface.co/docs/transformers/en/model_doc/vitpose",
+            "author": "Thomas Wolf, et al.",
+            "license": "Apache 2.0",
+            "size_bytes": null,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForPoseEstimation",
+                "config": {}
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["keypoints", "torch", "transformers"],
+            "date_added": "2025-07-16 09:49:00"
+        },
+        {
             "base_name": "siglip-base-patch16-224-torch",
             "base_filename": null,
             "version": null,


### PR DESCRIPTION
Add base transformer entry for pose estimation models following the pattern of other task-specific entries (detection, segmentation, etc). Re: PR #6118

## What changes are proposed in this pull request?

Adds a generic `pose-estimation-transformer-torch` entry to `manifest-torch.json` to support loading Hugging Face vitpose estimation models, following the established pattern for other task types (detection, segmentation, depth estimation, etc).

## How is this patch tested? If it is not, please explain why.

Tested as part of the main pose estimation PR #6118. The entry enables users to load pose estimation models via:
```python
model = foz.load_zoo_model("pose-estimation-transformer-torch", name_or_path="usyd-community/vitpose-base")
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Added support for loading Hugging Face vitpose estimation models through the model zoo (part of broader pose estimation support in PR #6118).

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other