### PR TITLE
Fix failing PluginDefinition test

### DIFF
--- a/tests/unittests/plugins/core_tests.py
+++ b/tests/unittests/plugins/core_tests.py
@@ -183,7 +183,7 @@ def test_plugin_definition_server_path_builtin():
 def test_plugin_definition_server_path_user_plugin(
     mocker, fiftyone_plugins_dir
 ):
-    mocker.patch("fiftyone.config.plugins_dir", fiftyone_plugins_dir)
+    mocker.patch("fiftyone.config.plugins_dir", str(fiftyone_plugins_dir))
 
     user_plugin_dir = os.path.join(fiftyone_plugins_dir, "test-user-plugin")
 


### PR DESCRIPTION
Fix failing test by ensuring we are using `str` instead of `PosixPath`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of a plugin-related test by updating how plugin directory paths are handled during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->