### PR TITLE
Use GeoWithin for Map Queries

### DIFF
--- a/app/packages/embeddings/src/useExtendedStageEffect.tsx
+++ b/app/packages/embeddings/src/useExtendedStageEffect.tsx
@@ -14,7 +14,7 @@ export default function useExtendedStageEffect() {
   const setOverrideStage = useSetRecoilState(
     fos.extendedSelectionOverrideStage
   );
-  const { selection } = useRecoilValue(fos.extendedSelection);
+  const { selection, spatialSelection } = useRecoilValue(fos.extendedSelection);
   const getCurrentDataset = useRecoilCallback(({ snapshot }) => async () => {
     return snapshot.getPromise(fos.datasetName);
   });
@@ -41,6 +41,9 @@ export default function useExtendedStageEffect() {
       }).then(async (res) => {
         const currentDataset = await getCurrentDataset();
         if (currentDataset !== datasetName) return;
+        if (spatialSelection) {
+          return;
+        }
         setOverrideStage({
           [res._cls]: res.kwargs,
         });

--- a/app/packages/map/src/Map.tsx
+++ b/app/packages/map/src/Map.tsx
@@ -91,12 +91,14 @@ const Panel: React.FC<{}> = () => {
     ) as unknown as typeof fos.extendedStages;
   }, [unFilteredExtended]);
 
+  const currentField = useRecoilValue(activeField);
+
   const { loading } = useFetchGeoLocations({
     dataset,
     filters,
     view,
     extended,
-    path: useRecoilValue(activeField),
+    path: currentField,
   });
   const sampleLocationMap = useRecoilValue(sampleLocationMapAtom);
 
@@ -168,6 +170,10 @@ const Panel: React.FC<{}> = () => {
 
       setExtendedSelection({
         selection: Array.from(selected),
+        spatialSelection: {
+          polygon: polygon.geometry.coordinates,
+          field: currentField,
+        },
         scope: SELECTION_SCOPE,
       });
     },

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -245,7 +245,14 @@ export const extendedSelection = (() => {
   let current = { selection: null };
   return graphQLSyncFragmentAtom<
     datasetFragment$key,
-    { selection: string[]; scope?: string }
+    {
+      selection: string[];
+      scope?: string;
+      spatialSelection?: {
+        polygon: Array<Array<number>>;
+        field: string;
+      } | null;
+    }
   >(
     {
       fragments: [datasetFragment],

--- a/app/packages/state/src/recoil/selectors.ts
+++ b/app/packages/state/src/recoil/selectors.ts
@@ -472,13 +472,26 @@ export const similarityMethods = selector<{
 export const extendedStagesUnsorted = selector({
   key: "extendedStagesUnsorted",
   get: ({ get }) => {
-    const sampleIds = get(atoms.extendedSelection)?.selection;
+    const extendedSelection = get(atoms.extendedSelection);
+    const sampleIds = extendedSelection?.selection;
+    const spatialSelection = extendedSelection?.spatialSelection;
     const extendedSelectionOverrideStage = get(
       atoms.extendedSelectionOverrideStage
     );
 
     if (extendedSelectionOverrideStage) {
       return extendedSelectionOverrideStage;
+    }
+
+    if (spatialSelection) {
+      return {
+        "fiftyone.core.stages.GeoWithin": {
+          boundary: spatialSelection.polygon,
+          location_field: spatialSelection.field,
+          strict: true,
+          create_index: true,
+        },
+      };
     }
     return {
       "fiftyone.core.stages.Select":

--- a/app/packages/state/src/recoil/selectors.ts
+++ b/app/packages/state/src/recoil/selectors.ts
@@ -489,7 +489,7 @@ export const extendedStagesUnsorted = selector({
           boundary: spatialSelection.polygon,
           location_field: spatialSelection.field,
           strict: true,
-          create_index: true,
+          create_index: false,
         },
       };
     }


### PR DESCRIPTION
Refactor the map panel selection to use GeoWithin instead of Select (by id).

[FOEPD-1690](https://voxel51.atlassian.net/browse/FOEPD-1690)

[FOEPD-1690]: https://voxel51.atlassian.net/browse/FOEPD-1690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for spatial selection using polygons, allowing users to select data based on geographic areas.
* **Improvements**
  * Enhanced consistency and reliability when handling spatial selections and active fields in map interactions.
* **Bug Fixes**
  * Prevented override updates when a spatial selection is active, ensuring correct selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->