### PR TITLE
Update slider initialization logic to be consistent with linked inputs

### DIFF
--- a/app/packages/core/src/components/Common/RangeSlider.tsx
+++ b/app/packages/core/src/components/Common/RangeSlider.tsx
@@ -2,13 +2,7 @@ import { useTheme } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
 import { DATE_FIELD, DATE_TIME_FIELD } from "@fiftyone/utilities";
 import { Slider as SliderUnstyled } from "@mui/material";
-import React, {
-  ChangeEvent,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
+import React, { ChangeEvent, useLayoutEffect, useRef, useState } from "react";
 import type { RecoilState, RecoilValueReadOnly } from "recoil";
 import { useRecoilState, useRecoilValue } from "recoil";
 import styled from "styled-components";
@@ -159,14 +153,6 @@ const BaseSlider = <T extends Range | number>({
   const [clicking, setClicking] = useState(false);
 
   const hasBounds = bounds.every((b) => b !== null);
-
-  // Update min/max when bounds change
-  useEffect(() => {
-    if (hasBounds && Array.isArray(value)) {
-      onMinCommit?.(bounds[0]);
-      onMaxCommit?.(bounds[1]);
-    }
-  }, [bounds]);
 
   if (!hasBounds) {
     return null;

--- a/app/packages/core/src/components/Common/RangeSlider.tsx
+++ b/app/packages/core/src/components/Common/RangeSlider.tsx
@@ -326,10 +326,14 @@ export const RangeSlider = ({
       fieldType={fieldType}
       onChange={(_, v: Range) => setLocalValue(v)}
       onMinCommit={(v) => {
-        setValue((prev) => [parseFloat(v.toFixed(precision)), prev[1]]);
+        const newMin =
+          v === bounds[0] ? null : parseFloat(v.toFixed(precision));
+        setValue((prev) => [newMin, prev[1]]);
       }}
       onMaxCommit={(v) => {
-        setValue((prev) => [prev[0], parseFloat(v.toFixed(precision))]);
+        const newMax =
+          v === bounds[1] ? null : parseFloat(v.toFixed(precision));
+        setValue((prev) => [prev[0], newMax]);
       }}
       value={[...localValue]}
     />

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/RangeSlider.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/RangeSlider.tsx
@@ -80,7 +80,7 @@ const RangeSlider = ({
           valueAtom={fos.rangeAtom({
             modal,
             path,
-            withBounds: true,
+            withBounds: false,
           })}
           boundsAtom={fos.boundsAtom({
             path,


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR includes a couple fixes to the changes made in #6147:
* Inputs linked to sliders no longer have values populated on initialization. This had an undesired impact on filtering operations, as `null` values carry semantic information in the filtering process.
* Inputs linked to sliders are now cleared when the slider is at min/max values. Related to the first bullet, `null` carries semantic information here.

## How is this patch tested? If it is not, please explain why.

<video src="https://github.com/user-attachments/assets/41029fb4-af5c-43ec-9c35-f52e2834cf7e"/>

local app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of minimum and maximum values in range sliders to better reflect user input and bounds.
  * Adjusted range filter behavior to modify how bounds are considered during filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->