### PR TITLE
Handle min or max in modal numeric filtering

### DIFF
--- a/app/packages/state/src/recoil/pathFilters/numeric.test.ts
+++ b/app/packages/state/src/recoil/pathFilters/numeric.test.ts
@@ -15,6 +15,19 @@ describe("helperFunction tests", () => {
     expect(helperFunction(1.5, false, 0, 1)).toBe(false);
   });
 
+  it("handles exclude start or end", () => {
+    expect(helperFunction(-1, true, 0, null)).toBe(true);
+    expect(helperFunction(1, true, 0, null)).toBe(false);
+
+    expect(helperFunction(-1, true, null, 0)).toBe(false);
+    expect(helperFunction(1, true, null, 0)).toBe(true);
+  });
+
+  it("handles exclude start and end", () => {
+    expect(helperFunction(0.5, true, 0, 1)).toBe(false);
+    expect(helperFunction(1.5, true, 0, 1)).toBe(true);
+  });
+
   it("handles datetime", () => {
     expect(
       helperFunction({ _cls: "DateTime", datetime: 0.5 }, false, 0, 1)

--- a/app/packages/state/src/recoil/pathFilters/numeric.test.ts
+++ b/app/packages/state/src/recoil/pathFilters/numeric.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { helperFunction } from "./numeric";
+
+describe("helperFunction tests", () => {
+  it("handles start or end", () => {
+    expect(helperFunction(-1, false, 0, null)).toBe(false);
+    expect(helperFunction(1, false, 0, null)).toBe(true);
+
+    expect(helperFunction(-1, false, null, 0)).toBe(true);
+    expect(helperFunction(1, false, null, 0)).toBe(false);
+  });
+
+  it("handles start and end", () => {
+    expect(helperFunction(0.5, false, 0, 1)).toBe(true);
+    expect(helperFunction(1.5, false, 0, 1)).toBe(false);
+  });
+
+  it("handles datetime", () => {
+    expect(
+      helperFunction({ _cls: "DateTime", datetime: 0.5 }, false, 0, 1)
+    ).toBe(true);
+    expect(
+      helperFunction({ _cls: "DateTime", datetime: 1.5 }, false, 0, 1)
+    ).toBe(false);
+  });
+});

--- a/app/packages/state/src/recoil/pathFilters/numeric.ts
+++ b/app/packages/state/src/recoil/pathFilters/numeric.ts
@@ -374,15 +374,16 @@ export const helperFunction = (
   v = Number(v);
 
   if (exclude) {
-    if (start !== null && v >= start) {
-      return false;
+    // If both bounds are set, exclude only values within [start, end]
+    if (start !== null && end !== null) {
+      return !(v >= start && v <= end);
     }
 
-    if (end !== null && v <= end) {
-      return false;
+    if (start !== null) {
+      return v < start;
     }
 
-    return true;
+    return v > end;
   }
 
   if (start !== null && v < start) {

--- a/app/packages/state/src/recoil/pathFilters/numeric.ts
+++ b/app/packages/state/src/recoil/pathFilters/numeric.ts
@@ -332,17 +332,19 @@ type DatetimeValue = {
   _cls: "DateTime";
 };
 
-const helperFunction = (
+export const helperFunction = (
   value: DatetimeValue | number | string | null,
   exclude: boolean,
-  start: number,
-  end: number,
-  none: boolean,
-  inf: boolean,
-  ninf: boolean,
-  nan: boolean
+  start: number | null,
+  end: number | null,
+  none?: boolean,
+  inf?: boolean,
+  ninf?: boolean,
+  nan?: boolean
 ) => {
-  const noRange = start === null || end === null;
+  if (start === null && end === null) {
+    return true;
+  }
 
   if (nan && value === "nan") {
     return !exclude;
@@ -360,28 +362,38 @@ const helperFunction = (
     return !exclude;
   }
 
+  let v = value;
   if (
-    typeof value !== "string" &&
-    typeof value !== "number" &&
-    Number(value?.datetime)
+    typeof v !== "string" &&
+    typeof v !== "number" &&
+    v?.datetime !== undefined
   ) {
-    const time = value.datetime;
-    return noRange
-      ? true
-      : exclude
-      ? Number(time) < start || Number(time) > end
-      : Number(time) >= start && Number(time) <= end;
+    v = v.datetime;
   }
 
-  if (typeof Number(value) === "number") {
-    return noRange
-      ? true
-      : exclude
-      ? Number(value) < start || Number(value) > end
-      : Number(value) >= start && Number(value) <= end;
+  v = Number(v);
+
+  if (exclude) {
+    if (start !== null && v >= start) {
+      return false;
+    }
+
+    if (end !== null && v <= end) {
+      return false;
+    }
+
+    return true;
   }
 
-  return false;
+  if (start !== null && v < start) {
+    return false;
+  }
+
+  if (end !== null && v > end) {
+    return false;
+  }
+
+  return true;
 };
 
 // this is where the final filtering for looker occurs in the App


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes having only one of min/max defined when using a modal filter


https://github.com/user-attachments/assets/a3d4bbf8-faa6-40d8-936b-aae7367d8933


## How is this patch tested? If it is not, please explain why.

Unit tests

## Release Notes

* Fixed filtering by only a min or max when using an expanded sample sidebar filter

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test cases to verify numeric range filtering, including boundary conditions and support for date-time objects.

* **Refactor**
  * Enhanced numeric range filtering logic for improved handling of null boundaries, exclusion flags, and date-time inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->