### PR TITLE
many typo fixes

### DIFF
--- a/app/packages/state/src/recoil/groups.ts
+++ b/app/packages/state/src/recoil/groups.ts
@@ -537,7 +537,7 @@ export const groupStatistics = atomFamily<"group" | "slice", boolean>({
 
 /**
  * A group view, i.e. all slices of a group, can potentially be of a dynamic
- * group. The GroupBy stage is filtered to accomodate this
+ * group. The GroupBy stage is filtered to accommodate this
  */
 export const groupView = selector<State.Stage[]>({
   key: "groupView",

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -1077,7 +1077,7 @@ supported values are:
     unexpected labels
 -   `"ignore"`: automatically ignore any unexpected labels
 -   ``"keep"``: automatically keep all unexpected labels in a field whose name
-    matches the the label type
+    matches the label type
 -   `"return"`: return a dict containing all unexpected labels, if any
 
 See :ref:`this section <cvat-unexpected-annotations>` for more details.
@@ -1531,7 +1531,7 @@ supported values are:
 -   `"prompt"` (**default**): present an interactive prompt to direct/discard
     unexpected labels
 -   ``"keep"``: automatically keep all unexpected labels in a field whose name
-    matches the the label type
+    matches the label type
 -   `"ignore"`: automatically ignore any unexpected labels
 -   `"return"`: return a dict containing all unexpected labels, if any
 

--- a/docs/source/user_guide/annotation.rst
+++ b/docs/source/user_guide/annotation.rst
@@ -958,7 +958,7 @@ supported values are:
 -   `"prompt"` (**default**): present an interactive prompt to direct/discard
     unexpected labels
 -   ``"keep"``: automatically keep all unexpected labels in a field whose name
-    matches the the label type
+    matches the label type
 -   `"ignore"`: automatically ignore any unexpected labels
 -   `"return"`: return a dict containing all unexpected labels, if any
 

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -3687,12 +3687,12 @@ class PluginsListCommand(Command):
 
 
 def _print_plugins_list(enabled, builtin, names_only):
-    plugin_defintions = fop.list_plugins(
+    plugin_definitions = fop.list_plugins(
         enabled=enabled, builtin=builtin, shadowed="all"
     )
 
     if names_only:
-        for pd in plugin_defintions:
+        for pd in plugin_definitions:
             print(pd.name)
 
         return
@@ -3700,7 +3700,7 @@ def _print_plugins_list(enabled, builtin, names_only):
     enabled_plugins = set(fop.list_enabled_plugins())
 
     shadowed_paths = set()
-    for pd in plugin_defintions:
+    for pd in plugin_definitions:
         if pd.shadow_paths:
             shadowed_paths.update(pd.shadow_paths)
 
@@ -3713,7 +3713,7 @@ def _print_plugins_list(enabled, builtin, names_only):
         "directory",
     ]
     rows = []
-    for pd in plugin_defintions:
+    for pd in plugin_definitions:
         shadowed = pd.directory in shadowed_paths
         enabled = (pd.builtin or pd.name in enabled_plugins) and not shadowed
         rows.append(

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -10135,10 +10135,10 @@ class SampleCollection(object):
                     direct/discard unexpected labels
                 -   ``"ignore"``: automatically ignore any unexpected labels
                 -   ``"keep"``: automatically keep all unexpected labels in a
-                    field whose name matches the the label type
+                    field whose name matches the label type
                 -   ``"return"``: return a dict containing all unexpected
                     labels, or ``None`` if there aren't any
-            cleanup (False): whether to delete any informtation regarding this
+            cleanup (False): whether to delete any information regarding this
                 run from the annotation backend after loading the annotations
             progress (None): whether to render a progress bar (True/False), use
                 the default value ``fiftyone.config.show_progress_bars``
@@ -10682,7 +10682,7 @@ class SampleCollection(object):
         frame_labels_dir=None,
         pretty_print=False,
     ):
-        """Writes the colllection to disk in JSON format.
+        """Writes the collection to disk in JSON format.
 
         Args:
             json_path: the path to write the JSON

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -1039,10 +1039,10 @@ def load_annotations(
                 unexpected labels
             -   ``"ignore"``: automatically ignore any unexpected labels
             -   ``"keep"``: automatically keep all unexpected labels in a field
-                whose name matches the the label type
+                whose name matches the label type
             -   ``"return"``: return a dict containing all unexpected labels,
                 or ``None`` if there aren't any
-        cleanup (False): whether to delete any informtation regarding this run
+        cleanup (False): whether to delete any information regarding this run
             from the annotation backend after loading the annotations
         progress (None): whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -531,7 +531,7 @@ class MigrationTests(unittest.TestCase):
         pkg_ver = foc.VERSION
         future_ver = str(int(pkg_ver[0]) + 1) + pkg_ver[1:]
 
-        # Uprading to a future version is not allowed
+        # Upgrading to a future version is not allowed
 
         with self.assertRaises(EnvironmentError):
             MigrationRunner(pkg_ver, future_ver)


### PR DESCRIPTION
Corrected lone typo "Uprading" -> "Upgrading"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Corrected typos in comments, docstrings, variable names, and documentation across multiple files for improved clarity and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->