### PR TITLE
FOEPD-306 No singleton cache mode

### DIFF
--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -138,6 +138,10 @@ FiftyOne supports the configuration options described below:
 |                                  |                                           |                               | operations such reading/writing large datasets or activating FiftyOne                  |
 |                                  |                                           |                               | Brain methods on datasets.                                                             |
 +----------------------------------+-------------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `singleton_cache`                | `FIFTYONE_SINGLETON_CACHE`                | `True`                        | Whether to treat :class:`Dataset <fiftyone.core.dataset.Dataset>`,                     |
+|                                  |                                           |                               | :class:`Sample <fiftyone.core.sample.Sample>`, and                                     |
+|                                  |                                           |                               | :class:`Frame <fiftyone.core.frame.Frame>` instances as singletons.                    |
++----------------------------------+-------------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `timezone`                       | `FIFTYONE_TIMEZONE`                       | `None`                        | An optional timezone string. If provided, all datetimes read from FiftyOne datasets    |
 |                                  |                                           |                               | will be expressed in this timezone. See :ref:`this section <configuring-timezone>` for |
 |                                  |                                           |                               | more information.                                                                      |
@@ -201,6 +205,7 @@ and the CLI:
             "plugins_dir": null,
             "requirement_error_level": 0,
             "show_progress_bars": true,
+            "singleton_cache": true,
             "timezone": null
         }
 
@@ -254,6 +259,7 @@ and the CLI:
             "plugins_dir": null,
             "requirement_error_level": 0,
             "show_progress_bars": true,
+            "singleton_cache": true,
             "timezone": null
         }
 

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -280,6 +280,12 @@ class FiftyOneConfig(EnvConfig):
             env_var="FIFTYONE_EXECUTION_CACHE_ENABLED",
             default=True,
         )
+        self.singleton_cache = self.parse_bool(
+            d,
+            "singleton_cache",
+            env_var="FIFTYONE_SINGLETON_CACHE",
+            default=True,
+        )
         self._init()
 
     @property

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -347,6 +347,10 @@ class FiftyOneConfig(EnvConfig):
                         e,
                     )
 
+        # Default no singleton cache for fiftyone app server
+        if os.environ.get("FIFTYONE_SERVER", False):
+            self.singleton_cache = True
+
         if self.timezone and self.timezone.lower() not in {"local", "utc"}:
             try:
                 pytz.timezone(self.timezone)

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -142,7 +142,7 @@ def _validate_dataset_name(name, skip=None):
     return slug
 
 
-def load_dataset(name, create_if_necessary=False):
+def load_dataset(name, create_if_necessary=False, reload=False):
     """Loads the FiftyOne dataset with the given name.
 
     To create a new dataset, use the :class:`Dataset` constructor.
@@ -156,6 +156,7 @@ def load_dataset(name, create_if_necessary=False):
     Args:
         name: the name of the dataset
         create_if_necessary (False): if no dataset exists, create an empty one
+        reload (False): whether to reload the dataset if necessary
 
     Raises:
         DatasetNotFoundError: if the dataset does not exist and
@@ -165,7 +166,7 @@ def load_dataset(name, create_if_necessary=False):
         a :class:`Dataset`
     """
     try:
-        return Dataset(name, _create=False)
+        return Dataset(name, _create=False, _reload=reload)
     except DatasetNotFoundError as ex:
         if create_if_necessary:
             return Dataset(name, _create=True)
@@ -314,6 +315,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         overwrite=False,
         _create=True,
         _virtual=False,
+        _reload=False,
         **kwargs,
     ):
         if name is None and _create:

--- a/fiftyone/core/map/process.py
+++ b/fiftyone/core/map/process.py
@@ -243,7 +243,7 @@ def _init_worker(
     # pylint:disable-next=protected-access
     food._disconnect()
 
-    dataset = fo.load_dataset(dataset_name)
+    dataset = fo.load_dataset(dataset_name, reload=True)
     if view_stages:
         # pylint:disable-next=protected-access
         process_sample_collection = fov.DatasetView._build(

--- a/fiftyone/core/odm/utils.py
+++ b/fiftyone/core/odm/utils.py
@@ -698,13 +698,14 @@ class DocumentRegistryError(Exception):
 _document_registry = DocumentRegistry()
 
 
-def load_dataset(id=None, name=None):
+def load_dataset(id=None, name=None, reload=False):
     """Loads the dataset from the database by its unique id or name. Throws
     an error if neither id nor name is provided.
 
     Args:
         id (None): the unique id of the dataset
         name (None): the name of the dataset
+        reload (False): whether to reload the dataset if necessary
 
     Returns:
         a :class:`fiftyone.core.dataset.Dataset`
@@ -713,20 +714,20 @@ def load_dataset(id=None, name=None):
     import fiftyone.core.dataset as fod
 
     if name:
-        return fod.load_dataset(name)
+        return fod.load_dataset(name, reload=reload)
 
     if not id:
         raise ValueError("Must provide either id or name")
 
     db = foo.get_db_conn()
     try:
-        uid = ObjectId(id)
+        _id = ObjectId(id)
     except:
         # Although _id is an ObjectId by default, it's possible to set it to
         # something else
-        uid = id
+        _id = id
 
-    res = db.datasets.find_one({"_id": uid}, {"name": True})
+    res = db.datasets.find_one({"_id": _id}, {"name": True})
     if not res:
-        raise ValueError(f"Dataset with _id={uid} does not exist")
-    return fod.load_dataset(res.get("name"))
+        raise ValueError(f"Dataset with _id={_id} does not exist")
+    return fod.load_dataset(res.get("name"), reload=reload)

--- a/fiftyone/core/singletons.py
+++ b/fiftyone/core/singletons.py
@@ -11,7 +11,8 @@ import weakref
 
 import fiftyone.core.utils as fou
 
-# TODO fix this
+# This is required to avoid circular imports, in order to get `fo.config` at
+#   runtime.
 fo = fou.lazy_import("fiftyone")
 
 
@@ -29,7 +30,16 @@ class DatasetSingleton(type):
         cls._instances = weakref.WeakValueDictionary()
         return cls
 
+    def _make_instance(cls, name, _create, *args, **kwargs):
+        instance = cls.__new__(cls)
+        instance.__init__(name=name, _create=_create, *args, **kwargs)
+        return instance
+
     def __call__(cls, name=None, _create=True, _reload=False, *args, **kwargs):
+        skip_cache = not fo.config.singleton_cache
+        if skip_cache:
+            return cls._make_instance(name, _create, *args, **kwargs)
+
         instance = cls._instances.pop(name, None)
 
         if (
@@ -38,8 +48,9 @@ class DatasetSingleton(type):
             or instance.deleted
             or instance.name is None
         ):
-            instance = cls.__new__(cls)
-            instance.__init__(name=name, _create=_create, *args, **kwargs)
+            instance = cls._make_instance(
+                name=name, _create=_create, *args, **kwargs
+            )
             name = instance.name  # `__init__` may have changed `name`
         else:
             try:
@@ -54,10 +65,9 @@ class DatasetSingleton(type):
             if _reload:
                 instance.reload()
 
-        if fo.config.singleton_cache:
-            # If the singleton cache is enabled, we store the instance
-            #  so that it can be retrieved later
-            cls._instances[name] = instance
+        # If the singleton cache is enabled, we store the instance
+        #  so that it can be retrieved later
+        cls._instances[name] = instance
 
         return instance
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -8168,7 +8168,7 @@ class ToPatches(ViewStage):
             name = None
 
         try:
-            last_dataset = fod.load_dataset(name)
+            last_dataset = fod.load_dataset(name, reload=reload)
         except:
             last_dataset = None
 
@@ -8328,7 +8328,7 @@ class ToEvaluationPatches(ViewStage):
             name = None
 
         try:
-            last_dataset = fod.load_dataset(name)
+            last_dataset = fod.load_dataset(name, reload=reload)
         except:
             last_dataset = None
 
@@ -8501,7 +8501,7 @@ class ToClips(ViewStage):
             name = None
 
         try:
-            last_dataset = fod.load_dataset(name)
+            last_dataset = fod.load_dataset(name, reload=reload)
         except:
             last_dataset = None
 
@@ -8651,7 +8651,7 @@ class ToTrajectories(ViewStage):
             name = None
 
         try:
-            last_dataset = fod.load_dataset(name)
+            last_dataset = fod.load_dataset(name, reload=reload)
         except:
             last_dataset = None
 
@@ -8857,7 +8857,7 @@ class ToFrames(ViewStage):
             name = None
 
         try:
-            last_dataset = fod.load_dataset(name)
+            last_dataset = fod.load_dataset(name, reload=reload)
         except:
             last_dataset = None
 

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -162,25 +162,16 @@ class StateDescription(etas.Serializable):
         """
         dataset = d.get("dataset", None)
         if dataset is not None:
-            dataset = fod.load_dataset(dataset)
+            dataset = fod.load_dataset(dataset, reload=True)
 
         stages = d.get("view", None)
         view = None
         view_name = d.get("view_name", None)
         if dataset is not None:
             if view_name:
-                try:
-                    view = dataset.load_saved_view(view_name)
-                except Exception as e:
-                    dataset.reload()
-                    view = dataset.load_saved_view(view_name)
-
+                view = dataset.load_saved_view(view_name)
             elif stages:
-                try:
-                    view = fov.DatasetView._build(dataset, stages)
-                except:
-                    dataset.reload()
-                    view = fov.DatasetView._build(dataset, stages)
+                view = fov.DatasetView._build(dataset, stages)
 
         config = (
             fo.AppConfig.from_dict(d["config"])

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -545,7 +545,7 @@ class ExecutionContext(object):
         # id if it is available
         uid = self.request_params.get("dataset_id", None)
         if uid:
-            self._dataset = focu.load_dataset(id=uid)
+            self._dataset = focu.load_dataset(id=uid, reload=True)
 
             # Set the dataset_name using the dataset object in case the dataset
             # has been renamed or changed since the context was created
@@ -553,12 +553,7 @@ class ExecutionContext(object):
         else:
             uid = self.request_params.get("dataset_name", None)
             if uid:
-                self._dataset = focu.load_dataset(name=uid)
-
-        # TODO: refactor so that this additional reload post-load is not
-        #  required
-        if self._dataset is not None:
-            self._dataset.reload()
+                self._dataset = focu.load_dataset(name=uid, reload=True)
 
         if (
             self.group_slice is not None
@@ -588,7 +583,6 @@ class ExecutionContext(object):
         if self._view is not None:
             return self._view
 
-        # Always derive the view from the context's dataset
         dataset = self.dataset
         view_name = self.request_params.get("view_name", None)
         stages = self.request_params.get("view", None)
@@ -604,7 +598,6 @@ class ExecutionContext(object):
                 stages=stages,
                 filters=filters,
                 extended_stages=extended,
-                reload=False,
             )
         else:
             self._view = dataset.load_saved_view(view_name)

--- a/fiftyone/server/color.py
+++ b/fiftyone/server/color.py
@@ -198,7 +198,7 @@ class SetColorScheme:
             color_scheme.id = str(ObjectId())
 
         def run():
-            dataset = fo.load_dataset(dataset_name)
+            dataset = fo.load_dataset(dataset_name, reload=True)
             dataset.app_config.color_scheme = (
                 _to_odm_color_scheme(color_scheme) if color_scheme else None
             )

--- a/fiftyone/server/events/initialize.py
+++ b/fiftyone/server/events/initialize.py
@@ -134,7 +134,7 @@ def handle_dataset_change(
         initializer: an app initializer
     """
     try:
-        state.dataset = fod.load_dataset(initializer.dataset)
+        state.dataset = fod.load_dataset(initializer.dataset, reload=True)
         state.group_id = None
         state.group_slice = state.dataset.group_slice
         state.sample_id = None

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -89,7 +89,9 @@ class Mutation(SetColorScheme):
         info: Info,
     ) -> bool:
         state = get_state()
-        state.dataset = fod.load_dataset(name) if name is not None else None
+        state.dataset = (
+            fod.load_dataset(name, reload=True) if name is not None else None
+        )
 
         state.color_scheme = build_color_scheme(
             None, state.dataset, state.config
@@ -218,7 +220,7 @@ class Mutation(SetColorScheme):
             return None
 
         result_view = None
-        ds = fod.load_dataset(dataset_name)
+        ds = fod.load_dataset(dataset_name, reload=True)
         state.dataset = ds
 
         # Create the view using the saved view doc if loading a saved view
@@ -232,7 +234,7 @@ class Mutation(SetColorScheme):
         # Otherwise, build the view using the params
         if result_view is None:
             result_view = await get_view(
-                dataset_name,
+                ds,
                 stages=view if view else None,
                 filters=form.filters if form else None,
                 extended_stages=form.extended if form else None,
@@ -290,7 +292,7 @@ class Mutation(SetColorScheme):
         dataset = state.dataset
         use_state = dataset is not None
         if dataset is None:
-            dataset = fod.load_dataset(dataset_name)
+            dataset = fod.load_dataset(dataset_name, reload=True)
 
         if dataset is None:
             raise ValueError(
@@ -313,7 +315,6 @@ class Mutation(SetColorScheme):
             view_name, result_view, description=description, color=color
         )
         if use_state:
-            dataset.reload()
             state.view = dataset.load_saved_view(view_name)
             await dispatch_event(subscription, fose.StateUpdate(state=state))
 
@@ -341,7 +342,7 @@ class Mutation(SetColorScheme):
                 view_name,
             )
 
-        dataset = fod.load_dataset(dataset_name)
+        dataset = fod.load_dataset(dataset_name, reload=True)
         if not dataset:
             raise ValueError(f"No dataset found with name {dataset_name}")
 
@@ -379,16 +380,16 @@ class Mutation(SetColorScheme):
         """Updates the editable fields of a saved view
 
         Args:
+            view_name: name of the existing saved view
             subscription: str identifier used for syncing App state
             session: str identifier use for syncing App state
-            view_name: name of the existing saved view
             updated_info: input type with values only for fields requiring
-            update
-
+                update
+            dataset_name: name of the dataset to which the saved view belongs
         """
         state = get_state()
         if state is None or state.dataset is None:
-            dataset = fod.load_dataset(dataset_name)
+            dataset = fod.load_dataset(dataset_name, reload=True)
         else:
             dataset = state.dataset
 
@@ -402,7 +403,7 @@ class Mutation(SetColorScheme):
                 "%s",
                 view_name,
             )
-        dataset.reload()
+
         current_name = (
             updated_info["name"]
             if "name" in updated_info and updated_info["name"] is not None
@@ -441,7 +442,7 @@ class Mutation(SetColorScheme):
         state = get_state()
         dataset = state.dataset
         if dataset is None:
-            dataset = fod.load_dataset(dataset_name)
+            dataset = fod.load_dataset(dataset_name, reload=True)
 
         try:
             view = dataset.select_fields(meta_filter=meta_filter)

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -459,7 +459,6 @@ class Query(fosa.AggregateQuery):
         t.Union[Connection[SampleItem, str], QueryTimeout],
         gql.union("PaginateSamplesResponse"),
     ]:
-
         try:
             return await paginate_samples(
                 dataset,
@@ -513,8 +512,7 @@ class Query(fosa.AggregateQuery):
     @gql.field
     def saved_views(self, dataset_name: str) -> t.Optional[t.List[SavedView]]:
         try:
-            ds = fod.load_dataset(dataset_name)
-            ds.reload()  # reload to avoid singleton issues
+            ds = fod.load_dataset(dataset_name, reload=True)
             return [
                 SavedView.from_doc(view_doc)
                 for view_doc in ds._doc.saved_views
@@ -529,7 +527,7 @@ class Query(fosa.AggregateQuery):
         view_stages: BSONArray,
     ) -> SchemaResult:
         try:
-            ds = fod.load_dataset(dataset_name)
+            ds = fod.load_dataset(dataset_name, reload=True)
             if view_stages:
                 view = fov.DatasetView._build(ds, view_stages or [])
 
@@ -610,8 +608,11 @@ async def serialize_dataset(
         if not fod.dataset_exists(dataset_name):
             return None
 
-        dataset = fo.Dataset(dataset_name, _create=False, _force_load=True)
-        dataset.reload()
+        try:
+            dataset = fo.load_dataset(dataset_name, reload=True)
+        except fod.DatasetNotFoundError:
+            return None
+
         view_name = None
         try:
             doc = dataset._get_saved_view_doc(saved_view_slug, slug=True)

--- a/fiftyone/server/routes/embeddings.py
+++ b/fiftyone/server/routes/embeddings.py
@@ -12,7 +12,6 @@ import traceback
 from starlette.endpoints import HTTPEndpoint
 from starlette.requests import Request
 
-import fiftyone.core.dataset as fod
 import fiftyone.core.fields as fof
 import fiftyone.core.stages as fos
 from fiftyone.core.utils import run_sync_task
@@ -62,7 +61,7 @@ class OnPlotLoad(HTTPEndpoint):
         slices = data["slices"]
 
         try:
-            dataset = fod.load_dataset(dataset_name, reload=True)
+            dataset = fosu.load_and_cache_dataset(dataset_name)
             results = dataset.load_brain_results(brain_key)
         except Exception as e:
             msg = (
@@ -196,7 +195,7 @@ class EmbeddingsSelection(HTTPEndpoint):
         if not filters and not extended_stages and not extended_selection:
             return {"selected": None}
 
-        dataset = fod.load_dataset(dataset_name, reload=True)
+        dataset = fosu.load_and_cache_dataset(dataset_name)
         results = dataset.load_brain_results(brain_key)
 
         view = fosv.get_view(
@@ -336,7 +335,7 @@ class ColorByChoices(HTTPEndpoint):
         dataset_name = data["datasetName"]
         brain_key = data["brainKey"]
 
-        dataset = fod.load_dataset(dataset_name, reload=True)
+        dataset = fosu.load_and_cache_dataset(dataset_name)
         info = dataset.get_brain_info(brain_key)
 
         patches_field = info.config.patches_field

--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -109,20 +109,11 @@ async def paginate_samples(
         pagination_data=pagination_data,
         extended_stages=extended_stages,
         sample_filter=sample_filter,
-        reload=reload,
         sort_by=sort_by,
         desc=desc,
         dynamic_group=dynamic_group,
     )
-    if after is None:
-        # first page, force dataset reload
-        view = await run_sync_task(run, True)
-    else:
-        # not first page, optimistically skip dataset reload
-        try:
-            view = await run_sync_task(run, False)
-        except:
-            view = await run_sync_task(run, True)
+    view = await run_sync_task(run)
 
     if after is None:
         after = "-1"
@@ -240,7 +231,6 @@ def _needs_full_lookup(view: SampleCollection):
         return False
 
     for stage in view._stages:
-
         if isinstance(
             stage,
             (

--- a/fiftyone/server/utils.py
+++ b/fiftyone/server/utils.py
@@ -12,8 +12,8 @@ import cachetools
 from dacite import Config, from_dict as _from_dict
 from dacite.core import T
 from dacite.data import Data
+from deprecated import deprecated
 
-import fiftyone.core.dataset as fod
 import fiftyone.core.fields as fof
 
 
@@ -21,34 +21,9 @@ _cache = cachetools.TTLCache(maxsize=10, ttl=900)  # ttl in seconds
 _dacite_config = Config(check_types=False)
 
 
-def load_and_cache_dataset(name):
-    """Loads the dataset with the given name and caches it.
-
-    This method is a wrapper around :func:`fiftyone.core.dataset.load_dataset`
-    that stores a reference to every dataset it loads in a TTL cache to ensure
-    that references to recently used datasets exist in memory so that dataset
-    objects aren't garbage collected between async calls.
-
-    It is desirable to avoid dataset objects being garbage collected because
-    datasets are singletons and may have objects (eg brain results) that are
-    expensive to load cached on them.
-
-    Args:
-        name: the dataset name
-
-    Returns:
-        a :class:`fiftyone.core.dataset.Dataset`
-    """
-    dataset = fod.load_dataset(name)
-
-    # Store reference in TTL cache to defer garbage collection
-    # IMPORTANT: we don't return already cached objects here because a dataset
-    # can be deleted and another created with the same name
-    _cache[name] = dataset
-
-    return dataset
-
-
+@deprecated(
+    "Marked for removal. Users of this function must use something else."
+)
 def cache_dataset(dataset):
     """Caches the given dataset.
 

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -43,11 +43,10 @@ async def load_view(
     form: Optional[ExtendedViewForm] = None,
     view_name: Optional[str] = None,
 ) -> foc.SampleCollection:
-
     form = form if form else ExtendedViewForm()
 
     def run() -> foc.SampleCollection:
-        dataset = fod.load_dataset(dataset_name)
+        dataset = fod.load_dataset(dataset_name, reload=True)
         if view_name:
             view = dataset.load_saved_view(view_name)
             if serialized_view:
@@ -119,10 +118,7 @@ def get_view(
 
     def run(dataset, stages):
         if isinstance(dataset, str):
-            dataset = fod.load_dataset(dataset)
-
-        if reload:
-            dataset.reload()
+            dataset = fod.load_dataset(dataset, reload=reload)
 
         if view_name is not None:
             return dataset.load_saved_view(view_name)
@@ -236,7 +232,6 @@ def get_extended_view(
 
     for stage in view._stages:
         if isinstance(stage, fosg.GroupBy):
-
             view = view.mongo(
                 [{"$addFields": {"_group": stage._get_group_expr(view)[0]}}]
             )

--- a/plugins/operators/model_evaluation/__init__.py
+++ b/plugins/operators/model_evaluation/__init__.py
@@ -6,6 +6,7 @@ Scenario plugin.
 |
 """
 
+import fiftyone as fo
 import fiftyone.operators as foo
 import fiftyone.operators.types as types
 import fiftyone.core.fields as fof
@@ -1069,7 +1070,10 @@ class ConfigureScenario(foo.Operator):
         return [scenario.get("name") for _, scenario in scenarios.items()]
 
     def resolve_input(self, ctx):
-        cache_dataset(self.get_dataset(ctx))
+        # Force ctx.dataset to load and store dataset so it remains consistent.
+        d = self.get_dataset(ctx)
+        if fo.config.singleton_cache:
+            cache_dataset(d)
 
         inputs = types.Object()
 

--- a/plugins/panels/model_evaluation/__init__.py
+++ b/plugins/panels/model_evaluation/__init__.py
@@ -7,26 +7,27 @@ Model evaluation panel.
 """
 
 import os
-import fiftyone.utils.eval as foue
-import numpy as np
-import fiftyone.operators.types as types
-import fiftyone.core.view as fov
+from collections import Counter, defaultdict
 
-from collections import defaultdict, Counter
+import numpy as np
 from bson import ObjectId
+
+import fiftyone as fo
+import fiftyone.core.view as fov
+import fiftyone.operators.types as types
+import fiftyone.utils.eval as foue
 from fiftyone import ViewField as F
 from fiftyone.core.plots.plotly import _to_log_colorscale
+from fiftyone.operators.cache import execution_cache
 from fiftyone.operators.categories import Categories
 from fiftyone.operators.panel import Panel, PanelConfig
-from fiftyone.operators.cache import execution_cache
 from plugins.utils.model_evaluation import (
     get_dataset_id,
-    get_store,
     get_scenarios,
+    get_store,
     get_subsets_from_custom_code,
     set_scenarios,
 )
-
 
 STORE_NAME = "model_evaluation_panel_builtin"
 STATUS_LABELS = {
@@ -1207,14 +1208,14 @@ def _init_segmentation_results(dataset, results, gt_field):
         # Already initialized
         return
 
-    #
-    # Ensure the dataset singleton is cached so that subsequent callbacks on
-    # this panel will use the same `dataset` and hence `results`
-    #
+    if fo.config.singleton_cache:
+        #
+        # Ensure the dataset singleton is cached so that subsequent callbacks on
+        # this panel will use the same `dataset` and hence `results`
+        #
+        import fiftyone.server.utils as fosu
 
-    import fiftyone.server.utils as fosu
-
-    fosu.cache_dataset(dataset)
+        fosu.cache_dataset(dataset)
 
     #
     # `results.classes` and App callbacks could contain any of the


### PR DESCRIPTION
## What changes are proposed in this pull request?
- Make singleton cache optional (`fo.config.singleton_cache` defaults `True`)
- Default to _disabling_ singleton cache for the app server
- Consolidate `refresh()` calls into `load_dataset(name, refresh=True)`. So that that function can take care of whether to reload or not (if no singleton cache we don't need to reload even if refresh is True).

Utilizes https://github.com/voxel51/fiftyone/pull/3956 and https://github.com/voxel51/fiftyone/pull/3945
It was easier to redo the changes than to merge/rebase

## How is this patch tested? If it is not, please explain why.

Testing document (mostly about app)
https://docs.google.com/document/d/1lrkmwq6ec2mtEFJ3JTdm9IuvVWv2lWgjHWRVzBe4Tgg/edit?tab=t.0

### Usage in SDK
But also note that it can help performance tremendously in certain cases of SDK usage.

```python
import time
import fiftyone as fo
ds = fo.load_dataset("bdd100k-validation")

def test_it(ds):
  # We have to hold a ref to the sample otherwise the singleton will be kicked out of the weakref dict
  samps=[]
  for s in ds:
    samps.append(s)

  st = time.time()
  ds.set_values("blah", [51] * len(ds))
  et = time.time()

  del samps
  return et-st

fo.config.singleton_cache=False
print("No Singleton:", test_it(ds))
fo.config.singleton_cache=True
print("Singleton:", test_it(ds))
```
```
No Singleton: 0.3039100170135498
Singleton: 48.95887994766235
```

## Question
Should we disable singleton cache across the board? Currently unable to find a case where having the singleton makes anything significantly faster in the first place.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Disables singleton cache by default for the app server.
Re-enable by setting `fo.config.singleton_cache=True`

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
