### PR TITLE
`main` to `develop`

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -118,4 +118,4 @@ jobs:
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v2
       - name: publish
-        run: gsutil -m rsync -dR docs-download gs://docs.voxel51.com
+        run: gsutil -m rsync -dR -x '^SBOMs/.*' docs-download gs://docs.voxel51.com

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/Input.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/Input.tsx
@@ -36,7 +36,11 @@ const StyledInputContainer = styled.div`
 
 const StyledInput = styled.input`
   &::-webkit-calendar-picker-indicator {
-    display: none;
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="15" viewBox="0 0 24 24"><path fill="${({
+      theme,
+    }) =>
+      theme.text
+        .secondary}" d="M20 3h-1V1h-2v2H7V1H5v2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 18H4V8h16v13z"/></svg>');
   }
 
   &::-webkit-outer-spin-button,

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/RangeSlider.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/RangeSlider.tsx
@@ -80,7 +80,7 @@ const RangeSlider = ({
           valueAtom={fos.rangeAtom({
             modal,
             path,
-            withBounds: true,
+            withBounds: false,
           })}
           boundsAtom={fos.boundsAtom({
             path,

--- a/app/packages/core/src/components/Filters/StringFilter/state.ts
+++ b/app/packages/core/src/components/Filters/StringFilter/state.ts
@@ -92,44 +92,42 @@ export const stringSearchResults = selectorFamily<
         };
       }
 
-      const noneCount = get(fos.noneCount({ path, modal, extended: false }));
-
       if (isLabelTag) {
         const labels = get(labelTagsCount({ modal, extended: false }));
-        data = {
-          count: labels.count,
+        return {
+          count: labels.count ?? 0,
           values: labels.results,
         };
-      } else {
-        data = await getFetchFunction()("POST", "/values", {
-          dataset: get(fos.datasetName),
-          view: get(fos.view),
-          path,
-          search,
-          selected: filter ? [] : selected,
-          filters: filter
-            ? {
-                [filter.path]: {
-                  exclude: get(stringExcludeAtom({ path, modal })),
-                  isMatching: get(isMatchingAtom({ path, modal })),
-                  values: [filter.value],
-                },
-              }
-            : get(pathSearchFilters({ modal, path })),
-          group_id: modal ? get(fos.groupId) || null : null,
-          mixed,
-          slice: get(fos.groupSlice),
-          slices: mixed ? null : get(fos.currentSlices(modal)), // when mixed, slice is not needed
-          sample_id:
-            modal && !get(fos.groupId) && !mixed
-              ? get(fos.modalSampleId)
-              : null,
-          ...sorting,
-        });
       }
+
+      data = await getFetchFunction()("POST", "/values", {
+        dataset: get(fos.datasetName),
+        view: get(fos.view),
+        path,
+        search,
+        selected: filter ? [] : selected,
+        filters: filter
+          ? {
+              [filter.path]: {
+                exclude: get(stringExcludeAtom({ path, modal })),
+                isMatching: get(isMatchingAtom({ path, modal })),
+                values: [filter.value],
+              },
+            }
+          : get(pathSearchFilters({ modal, path })),
+        group_id: modal ? get(fos.groupId) || null : null,
+        mixed,
+        slice: get(fos.groupSlice),
+        slices: mixed ? null : get(fos.currentSlices(modal)), // when mixed, slice is not needed
+        sample_id:
+          modal && !get(fos.groupId) && !mixed ? get(fos.modalSampleId) : null,
+        ...sorting,
+      });
 
       let { values, count } = data;
       count ??= 0;
+      const noneCount = get(fos.noneCount({ path, modal, extended: false }));
+
       if (noneCount > 0 && "None".includes(search)) {
         values = [...values, { value: null, count: noneCount }]
           .sort(nullSort(sorting))

--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/pagination/index.tsx
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/pagination/index.tsx
@@ -57,20 +57,16 @@ export const GroupElementsLinkBar = React.memo(() => {
     ({ set, snapshot }) =>
       async (sample: fos.ModalSample) => {
         const current = await snapshot.getPromise(fos.modalSelector);
-        const currentGroup = await snapshot.getPromise(fos.groupByFieldValue);
-        const nextGroup = String(
-          getValue(sample.sample, dynamicGroupParameters.groupBy)
-        );
 
         if (current && current.id !== sample.id) {
           set(modalSelector, (current) => {
             return {
               ...current,
               id: sample.id,
-              groupId:
-                groupField && currentGroup === nextGroup
-                  ? (getValue(sample.sample, groupField)._id as string)
-                  : current.groupId,
+              groupId: groupField
+                ? // if we are in a grouped dataset, get the next group id
+                  (getValue(sample.sample, groupField)._id as string)
+                : null,
             };
           });
         }
@@ -107,7 +103,9 @@ export const GroupElementsLinkBar = React.memo(() => {
     }
   }, [map, setCursor, deferred, setSample]);
 
-  const elementsCount = useRecoilValue(fos.dynamicGroupsElementCount(null));
+  const elementsCount = useRecoilValue(
+    fos.dynamicGroupsElementCount({ modal: true })
+  );
 
   const [isTextBoxEmpty, setIsTextBoxEmpty] = useState(false);
   const textBoxRef = useRef<HTMLInputElement>(null);

--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/useDynamicGroupSamples.ts
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/useDynamicGroupSamples.ts
@@ -7,6 +7,7 @@ import { useRecoilValue } from "recoil";
 export const useDynamicGroupSamples = () => {
   const environment = useRelayEnvironment();
   const slice = useRecoilValue(fos.groupSlice);
+  const modalSlice = useRecoilValue(fos.modalGroupSlice);
   const view = useRecoilValue(fos.view);
   const dynamicGroup = useRecoilValue(fos.groupByFieldValue);
   const dataset = useRecoilValue(fos.datasetName);
@@ -14,8 +15,10 @@ export const useDynamicGroupSamples = () => {
   const shouldRenderImavid = useRecoilValue(fos.shouldRenderImaVidLooker(true));
 
   const filter = useMemo(
-    () => (slice ? { group: { slice, slices: [slice] } } : {}),
-    [slice]
+    // slice is how the group was accessed, i.e. from the grid
+    // modalSlice is the currently selected modal slice
+    () => (slice ? { group: { slice, slices: [modalSlice] } } : {}),
+    [slice, modalSlice]
   );
   const loadDynamicGroupSamples = useCallback(
     (cursor?: number) => {

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/overview/Summary.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/overview/Summary.tsx
@@ -157,7 +157,7 @@ export default function Summary(props) {
       property: "Incorrect",
       value: evaluationMetrics.num_incorrect,
       compareValue: compareEvaluationMetrics.num_incorrect,
-      lesserIsBetter: false,
+      lesserIsBetter: true,
       filterable: true,
       hide: !isNoneBinaryClassification,
     },
@@ -223,9 +223,13 @@ export default function Summary(props) {
           const zeroRatio = ratio === 0;
           const negativeRatio = ratio < 0;
           const ratioColor = positiveRatio
-            ? "#8BC18D"
+            ? lesserIsBetter
+              ? "#FF6464"
+              : "#8BC18D"
             : negativeRatio
-            ? "#FF6464"
+            ? lesserIsBetter
+              ? "#8BC18D"
+              : "#FF6464"
             : theme.palette.text.tertiary;
           const showTrophy = lesserIsBetter ? difference < 0 : difference > 0;
           const activeStyle: SxProps = {

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/Scenarios.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/Scenarios.tsx
@@ -48,6 +48,7 @@ import Actions from "./Actions";
 import Legends from "./Legends";
 import LoadingError from "./LoadingError";
 import { getSubsetDef } from "./utils";
+import { ErrorBoundary } from "@fiftyone/components";
 
 const CONFIGURE_SCENARIO_ACTION = "model_evaluation_configure_scenario";
 
@@ -390,25 +391,27 @@ export default function Scenarios(props) {
           />
         </Stack>
       </Stack>
-      {scenario && (
-        <Scenario
-          key={scenario}
-          id={scenario}
-          data={data}
-          loadScenario={loadScenario}
-          mode={mode}
-          loading={loadingScenario}
-          differenceMode={differenceMode}
-          evaluation={evaluation}
-          compareEvaluation={compareEvaluation}
-          selectedSubsets={selectedSubsets}
-          loadView={loadView}
-          onDelete={onDelete}
-          onEdit={onEdit}
-          readOnly={readOnly}
-          trackEvent={trackEvent}
-        />
-      )}
+      <ErrorBoundary>
+        {scenario && (
+          <Scenario
+            key={scenario}
+            id={scenario}
+            data={data}
+            loadScenario={loadScenario}
+            mode={mode}
+            loading={loadingScenario}
+            differenceMode={differenceMode}
+            evaluation={evaluation}
+            compareEvaluation={compareEvaluation}
+            selectedSubsets={selectedSubsets}
+            loadView={loadView}
+            onDelete={onDelete}
+            onEdit={onEdit}
+            readOnly={readOnly}
+            trackEvent={trackEvent}
+          />
+        )}
+      </ErrorBoundary>
     </Stack>
   );
 }
@@ -507,6 +510,18 @@ function Scenario(props) {
     if (compareScenario) {
       compareScenario = { ...compareScenario, subsets: selectedSubsets };
     }
+  }
+
+  if (scenario.subsets.length === 0) {
+    return (
+      <Stack
+        sx={{ minHeight: 300 }}
+        alignItems="center"
+        justifyContent="center"
+      >
+        <Typography>No subset defined</Typography>
+      </Stack>
+    );
   }
 
   return (
@@ -1188,6 +1203,12 @@ function ScenarioModelPerformanceChart(props) {
   const [subset, setSubset] = usePanelStatePartial(`${id}_mps`, subsets[0]);
   const subsetData = scenario.subsets_data[subset];
   const compareSubsetData = compareScenario?.subsets_data[subset];
+
+  // when subset is empty, do not render the chart
+  if (!subsetData) {
+    return <></>;
+  }
+
   const { metrics } = subsetData;
   const compareMetrics = compareSubsetData?.metrics;
   const { key, compareKey } = props.data?.view;

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/utils.ts
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/utils.ts
@@ -121,6 +121,7 @@ export function getMatrix(
 }
 
 export function getClasses(matrices, maskTargets?) {
+  if (!matrices) return [];
   const sortBy = "az";
   const classes = matrices[`${sortBy}_classes`];
   return classes.map((c) => {

--- a/app/packages/embeddings/src/useColorByChoices.tsx
+++ b/app/packages/embeddings/src/useColorByChoices.tsx
@@ -2,19 +2,29 @@ import { useEffect, useState } from "react";
 import { useRecoilValue } from "recoil";
 import * as fos from "@fiftyone/state";
 import { useBrainResult } from "./useBrainResult";
+import { usePanelStatePartial } from "@fiftyone/spaces";
 import { fetchColorByChoices } from "./fetch";
 
 export function useColorByChoices() {
   const datasetName = useRecoilValue(fos.datasetName);
   const [brainKey] = useBrainResult();
+  const view = useRecoilValue(fos.view);
+  const slices = useRecoilValue(fos.currentSlices(false));
+  const [loadedPlot] = usePanelStatePartial("loadedPlot", null, true);
+
   const [isLoading, setIsLoading] = useState(false);
   const [availableFields, setAvailableFields] = useState(null);
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    if (brainKey) {
+    if (loadedPlot && brainKey) {
       setIsLoading(true);
-      fetchColorByChoices({ datasetName, brainKey })
+      fetchColorByChoices({
+        datasetName,
+        view,
+        slices,
+        patchesField: loadedPlot.patches_field,
+      })
         .then((r) => {
           setIsLoading(false);
           setAvailableFields(["uncolored", ...r.fields]);
@@ -24,8 +34,7 @@ export function useColorByChoices() {
           setError(e);
         });
     }
-  }, [datasetName, brainKey]);
-
+  }, [datasetName, brainKey, view, slices, loadedPlot?.patches_field]);
   return {
     availableFields,
     isLoading,

--- a/app/packages/spaces/src/components/Workspaces/Workspace.tsx
+++ b/app/packages/spaces/src/components/Workspaces/Workspace.tsx
@@ -61,7 +61,7 @@ export default function Workspace(props: WorkspacePropsType) {
                 ...state,
                 open: true,
                 edit: true,
-                oldName: name,
+                old_name: name,
                 name,
                 description,
                 color,

--- a/app/packages/spaces/src/components/Workspaces/WorkspaceEditor.tsx
+++ b/app/packages/spaces/src/components/Workspaces/WorkspaceEditor.tsx
@@ -139,7 +139,7 @@ export default function WorkspaceEditor() {
                 SAVE_WORKSPACE_OPERATOR,
                 {
                   ...state,
-                  current_name: edit ? state.oldName : undefined,
+                  current_name: edit ? state.old_name : undefined,
                   spaces: await getSessionSpaces(),
                 },
                 {
@@ -148,15 +148,11 @@ export default function WorkspaceEditor() {
                       reset();
                       handleClose();
                       setStatus("");
-                      if (!edit) {
-                        executeOperator(
-                          LOAD_WORKSPACE_OPERATOR,
-                          {
-                            name: state.name,
-                          },
-                          { skipOutput: true }
-                        );
-                      }
+                      executeOperator(
+                        LOAD_WORKSPACE_OPERATOR,
+                        { name: state.name },
+                        { skipOutput: true }
+                      );
                     }
                   },
                   skipOutput: true,

--- a/app/packages/spaces/src/state.ts
+++ b/app/packages/spaces/src/state.ts
@@ -106,7 +106,7 @@ export const workspaceEditorStateAtom = atom({
   key: "workspaceEditorState",
   default: {
     open: false,
-    oldName: "",
+    old_name: "",
     name: "",
     description: "",
     color: COLOR_OPTIONS[0].color,

--- a/app/packages/state/src/hooks/useCreateLooker.ts
+++ b/app/packages/state/src/hooks/useCreateLooker.ts
@@ -196,7 +196,7 @@ export default <T extends AbstractLooker<BaseState>>(
 
         if (create === ImaVidLooker) {
           const totalFrameCountPromise = getPromise(
-            dynamicGroupsElementCount(sample._group)
+            dynamicGroupsElementCount({ value: sample._group })
           );
           const page = snapshot
             .getLoadable(

--- a/app/packages/state/src/recoil/aggregations.ts
+++ b/app/packages/state/src/recoil/aggregations.ts
@@ -49,6 +49,7 @@ export const aggregationQuery = graphQLSelectorFamily<
     mixed?: boolean;
     paths: string[];
     root?: boolean;
+    useSelection?: boolean;
   },
   Aggregation[]
 >({
@@ -66,13 +67,15 @@ export const aggregationQuery = graphQLSelectorFamily<
       modal,
       paths,
       root = false,
+      useSelection = true,
     }) =>
     ({ get }) => {
       const dataset = get(selectors.datasetName);
       if (!dataset) return null;
 
       const useSidebarSampleId = !root && modal && !get(groupId) && !mixed;
-      const sampleIds = useSidebarSampleId ? [get(sidebarSampleId)] : [];
+      const sampleIds =
+        useSidebarSampleId && useSelection ? [get(sidebarSampleId)] : [];
 
       if (useSidebarSampleId && sampleIds[0] === null) {
         return null;
@@ -89,7 +92,7 @@ export const aggregationQuery = graphQLSelectorFamily<
           extended && !root
             ? get(modal ? filterAtoms.modalFilters : filterAtoms.filters)
             : null,
-        groupId: !root && modal ? get(groupId) || null : null,
+        groupId: !root && modal && useSelection ? get(groupId) || null : null,
         hiddenLabels: !root ? get(selectors.hiddenLabelsArray) : [],
         paths,
         mixed,

--- a/app/packages/state/src/recoil/pathData/groups.ts
+++ b/app/packages/state/src/recoil/pathData/groups.ts
@@ -1,3 +1,4 @@
+import type { SerializableParam } from "recoil";
 import { selectorFamily } from "recoil";
 import { aggregationQuery } from "../aggregations";
 import { groupByFieldValue } from "../dynamicGroups";
@@ -5,15 +6,22 @@ import { groupByFieldValue } from "../dynamicGroups";
 export const dynamicGroupsElementCount = selectorFamily({
   key: "dynamicGroupsElementCount",
   get:
-    (value = null) =>
+    ({
+      value = null,
+      modal = false,
+    }: {
+      value?: SerializableParam;
+      modal: boolean;
+    }) =>
     ({ get }) => {
       return (
         get(
           aggregationQuery({
             dynamicGroup: value === null ? get(groupByFieldValue) : value,
             extended: false,
-            modal: false,
+            modal,
             paths: [""],
+            useSelection: false,
           })
         ).at(0)?.count ?? 0
       );

--- a/app/packages/state/src/recoil/pathFilters/numeric.test.ts
+++ b/app/packages/state/src/recoil/pathFilters/numeric.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { helperFunction } from "./numeric";
+
+describe("helperFunction tests", () => {
+  it("handles start or end", () => {
+    expect(helperFunction(-1, false, 0, null)).toBe(false);
+    expect(helperFunction(1, false, 0, null)).toBe(true);
+
+    expect(helperFunction(-1, false, null, 0)).toBe(true);
+    expect(helperFunction(1, false, null, 0)).toBe(false);
+  });
+
+  it("handles start and end", () => {
+    expect(helperFunction(0.5, false, 0, 1)).toBe(true);
+    expect(helperFunction(1.5, false, 0, 1)).toBe(false);
+  });
+
+  it("handles exclude start or end", () => {
+    expect(helperFunction(-1, true, 0, null)).toBe(true);
+    expect(helperFunction(1, true, 0, null)).toBe(false);
+
+    expect(helperFunction(-1, true, null, 0)).toBe(false);
+    expect(helperFunction(1, true, null, 0)).toBe(true);
+  });
+
+  it("handles exclude start and end", () => {
+    expect(helperFunction(0.5, true, 0, 1)).toBe(false);
+    expect(helperFunction(1.5, true, 0, 1)).toBe(true);
+  });
+
+  it("handles datetime", () => {
+    expect(
+      helperFunction({ _cls: "DateTime", datetime: 0.5 }, false, 0, 1)
+    ).toBe(true);
+    expect(
+      helperFunction({ _cls: "DateTime", datetime: 1.5 }, false, 0, 1)
+    ).toBe(false);
+  });
+});

--- a/app/packages/state/src/recoil/pathFilters/numeric.ts
+++ b/app/packages/state/src/recoil/pathFilters/numeric.ts
@@ -332,17 +332,19 @@ type DatetimeValue = {
   _cls: "DateTime";
 };
 
-const helperFunction = (
+export const helperFunction = (
   value: DatetimeValue | number | string | null,
   exclude: boolean,
-  start: number,
-  end: number,
-  none: boolean,
-  inf: boolean,
-  ninf: boolean,
-  nan: boolean
+  start: number | null,
+  end: number | null,
+  none?: boolean,
+  inf?: boolean,
+  ninf?: boolean,
+  nan?: boolean
 ) => {
-  const noRange = start === null || end === null;
+  if (start === null && end === null) {
+    return true;
+  }
 
   if (nan && value === "nan") {
     return !exclude;
@@ -360,28 +362,39 @@ const helperFunction = (
     return !exclude;
   }
 
+  let v = value;
   if (
-    typeof value !== "string" &&
-    typeof value !== "number" &&
-    Number(value?.datetime)
+    typeof v !== "string" &&
+    typeof v !== "number" &&
+    v?.datetime !== undefined
   ) {
-    const time = value.datetime;
-    return noRange
-      ? true
-      : exclude
-      ? Number(time) < start || Number(time) > end
-      : Number(time) >= start && Number(time) <= end;
+    v = v.datetime;
   }
 
-  if (typeof Number(value) === "number") {
-    return noRange
-      ? true
-      : exclude
-      ? Number(value) < start || Number(value) > end
-      : Number(value) >= start && Number(value) <= end;
+  v = Number(v);
+
+  if (exclude) {
+    // If both bounds are set, exclude only values within [start, end]
+    if (start !== null && end !== null) {
+      return !(v >= start && v <= end);
+    }
+
+    if (start !== null) {
+      return v < start;
+    }
+
+    return v > end;
   }
 
-  return false;
+  if (start !== null && v < start) {
+    return false;
+  }
+
+  if (end !== null && v > end) {
+    return false;
+  }
+
+  return true;
 };
 
 // this is where the final filtering for looker occurs in the App

--- a/docs/source/deprecation.rst
+++ b/docs/source/deprecation.rst
@@ -10,6 +10,17 @@ FiftyOne Deprecation Notices
    Deprecation notices below are ordered in reverse chronological order
    (most recent at the top).
 
+.. _deprecation-kubernetes-1.30:
+
+Kubernetes 1.30
+---------------
+*Support ending July 11, 2025*
+
+`Kubernetes 1.30 <https://kubernetes.io/releases/>`_
+transitioned to `end-of-life` effective June of 2025. FiftyOne Enterprise
+releases after July 11, 2025 might no longer be compatible with
+Kubernetes 1.30 and older.
+
 .. _deprecation-mongodb-5.0:
 
 MongoDB 5.0

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -3,6 +3,86 @@ FiftyOne Release Notes
 
 .. default-role:: code
 
+FiftyOne Enterprise 2.10.1
+--------------------------
+*Released July 21, 2025*
+
+Includes all updates from :ref:`FiftyOne 1.7.1 <release-notes-v1.7.1>`, plus:
+
+- Optimized the :ref:`pinned datasets widget <enterprise-pinned-datasets>`
+- Enhanced connection handling for HTTP requests, allowing faster failure and
+  more robust retry behavior after a successful connection has been
+  established
+- Changed the `sizeEstimate` fields on both datasets and dataset snapshots to
+  return a float indicating size in megabytes, rather than in bytes
+- Fixed an error that could prevent
+  :ref:`dataset snapshots <dataset_versioning>` from loading in the App in
+  certain contexts
+
+.. _release-notes-v1.7.1:
+
+FiftyOne 1.7.1
+--------------
+*Released July 21, 2025*
+
+App
+
+- Updated the :ref:`Scenario Analysis <app-scenario-analysis>` summary table to
+  correctly interpret and display metrics where a lower value is better, such
+  as the "Incorrect" metric
+  `#6111 <https://github.com/voxel51/fiftyone/pull/6111>`_
+- Improved error handling in :ref:`Scenario Analysis <app-scenario-analysis>`
+  when empty subsets are defined
+  `#6127 <https://github.com/voxel51/fiftyone/pull/6127>`_
+- Added calendar picker support for |DateField| and |DateTimeField| inputs in
+  the sidebar
+  `#6120 <https://github.com/voxel51/fiftyone/pull/6120>`_
+- Polished the sidebar's slider UX to improve how we handle numeric precision
+  `#6147 <https://github.com/voxel51/fiftyone/pull/6147>`_
+- The :ref:`Embeddings panel <app-embeddings-panel>` now supports
+  :ref:`frame patch views <frame-patches-views>`
+  `#6129 <https://github.com/voxel51/fiftyone/pull/6129>`_
+- Updated :ref:`custom color scheme <dataset-app-config-color-scheme>` to allow
+  `color_pool` to be optional
+  `#6128 <https://github.com/voxel51/fiftyone/pull/6128>`_
+- Fixed an issue where renaming a :ref:`saved workspace <app-workspaces>` would
+  create a new workspace instead
+  `#6125 <https://github.com/voxel51/fiftyone/pull/6125>`_
+- Fixed search results for `label tags` in the sidebar when 
+  :ref:`Query Performance <app-optimizing-query-performance>` is disabled 
+  `#6095 <https://github.com/voxel51/fiftyone/pull/6095>`_
+- Fixed an issue where the `useBrowserStorage` utility would persist an invalid
+  `undefined` value in localStorage
+  `#6116 <https://github.com/voxel51/fiftyone/pull/6116>`_
+
+Core
+
+- Improved handling of path resolution on Windows machines with multiple drives
+  `#6088 <https://github.com/voxel51/fiftyone/pull/6088>`_,
+  `#6136 <https://github.com/voxel51/fiftyone/pull/6136>`_
+- Fixed a recent regression that prevented calling evaluation methods like
+  :meth:`evaluate_detections() <fiftyone.core.collections.SampleCollection.evaluate_detections>`
+  without providing an `eval_key`
+  `#6126 <https://github.com/voxel51/fiftyone/pull/6126>`_
+- Added a
+  :ref:`deprecation notice for Kubernetes 1.30 <deprecation-kubernetes-1.30>`
+  indicating support will end on July 11, 2025 and future releases may not be
+  compatible with this version
+  `#6132 <https://github.com/voxel51/fiftyone/pull/6132>`_
+
+Zoo
+
+- Improved semantics when performing inference with
+  :ref:`Ultralytics models <ultralytics-integration>` and no suitable objects
+  were found in an image
+  `#6131 <https://github.com/voxel51/fiftyone/pull/6131>`_
+- Fixed a bug that prevented applying models to image patches with
+  `num_workers>0` on macOS
+  `#6138 <https://github.com/voxel51/fiftyone/pull/6138>`_
+- Fixed a bug that would prevent extracting embeddings from zero-shot
+  transformer models with preprocessing disabled
+  `#6122 <https://github.com/voxel51/fiftyone/pull/6122>`_
+
 FiftyOne Enterprise 2.10.0
 --------------------------
 *Released July 1, 2025*

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -1955,8 +1955,12 @@ def _make_patch_data_loader(
         dataset,
         batch_size=1,
         num_workers=num_workers,
-        collate_fn=lambda batch: batch[0],  # return patches directly
+        collate_fn=_patch_collate_fn,
     )
+
+
+def _patch_collate_fn(batch):
+    return batch[0]  # return patches directly
 
 
 def _parse_batch_size(batch_size, model, use_data_loader):

--- a/fiftyone/server/app.py
+++ b/fiftyone/server/app.py
@@ -137,6 +137,7 @@ app = Starlette(
             app=Static(
                 directory=os.path.join(os.path.dirname(__file__), "static"),
                 html=True,
+                follow_symlink=True,
             ),
             name="static",
         ),

--- a/fiftyone/server/routes/embeddings.py
+++ b/fiftyone/server/routes/embeddings.py
@@ -41,7 +41,7 @@ class OnPlotLoad(HTTPEndpoint):
     @route
     async def post(self, request: Request, data: dict) -> dict:
         """Loads an embeddings plot based on the current view."""
-        try :
+        try:
             return await run_sync_task(self._post_sync, data)
         except Exception as e:
             msg = "Unknown error occurred."
@@ -64,12 +64,18 @@ class OnPlotLoad(HTTPEndpoint):
             dataset = fosu.load_and_cache_dataset(dataset_name)
             results = dataset.load_brain_results(brain_key)
         except Exception as e:
-            msg = f"Failed to load results for brain run with key '{brain_key}'."
+            msg = (
+                f"Failed to load results for brain run with key '{brain_key}'."
+            )
             error_message = str(e)
             stack = traceback.format_exc()
             logger.error(stack)
             ui_error = f"{msg} Try regenerating the results."
-            return {"error": ui_error, "details": error_message, "stack": stack}
+            return {
+                "error": ui_error,
+                "details": error_message,
+                "stack": stack,
+            }
 
         if results is None:
             msg = (
@@ -85,11 +91,11 @@ class OnPlotLoad(HTTPEndpoint):
             sample_filter=get_sample_filter(slices),
         )
 
-        is_patches_view = view._is_patches
-
         patches_field = results.config.patches_field
-        is_patches_plot = patches_field is not None
         points_field = results.config.points_field
+
+        is_patches_view = view._is_patches
+        is_patches_plot = patches_field is not None
 
         # Determines which points from `results` are in `view`, which are the
         # only points we want to display in the embeddings plot
@@ -117,19 +123,20 @@ class OnPlotLoad(HTTPEndpoint):
 
         # Color by data
         if label_field:
-            if is_patches_view and not is_patches_plot:
-                # Must use the root dataset in order to retrieve colors for the
-                # plot, which is linked to samples, not patches
-                view = view._root_dataset
+            if is_patches_view:
+                root_view = _strip_patches_view(view)
 
-            if is_patches_view and is_patches_plot:
-                # `label_field` is always provided with respect to root
-                # dataset, so we must translate for patches views
-                _, root = dataset._get_label_field_path(patches_field)
-                leaf = label_field[len(root) + 1 :]
-                _, label_field = view._get_label_field_path(
-                    patches_field, leaf
-                )
+                if is_patches_plot:
+                    # `label_field` is always provided with respect to the root
+                    # view, so we must translate it to the patches view
+                    _, root = root_view._get_label_field_path(patches_field)
+                    leaf = label_field[len(root) + 1 :]
+                    _, label_field = view._get_label_field_path(
+                        patches_field, leaf
+                    )
+                else:
+                    # The plot is linked to samples, not patches
+                    view = root_view
 
             labels = view._get_values_by_id(
                 label_field, ids, link_field=patches_field
@@ -327,18 +334,26 @@ class ColorByChoices(HTTPEndpoint):
 
     def _post_sync(self, data):
         dataset_name = data["datasetName"]
-        brain_key = data["brainKey"]
+        stages = data["view"]
+        slices = data["slices"]
+        patches_field = data["patchesField"]  # patches field of plot, or None
 
-        dataset = fosu.load_and_cache_dataset(dataset_name)
-        info = dataset.get_brain_info(brain_key)
+        view = fosv.get_view(
+            dataset_name,
+            stages=stages,
+            sample_filter=get_sample_filter(slices),
+        )
 
-        patches_field = info.config.patches_field
         is_patches_plot = patches_field is not None
+        is_patches_view = view._is_patches
 
-        schema = dataset.get_field_schema(flat=True)
+        if is_patches_view:
+            view = _strip_patches_view(view)
+
+        schema = view.get_field_schema(flat=True)
 
         if is_patches_plot:
-            _, root = dataset._get_label_field_path(patches_field)
+            _, root = view._get_label_field_path(patches_field)
             root += "."
             schema = {k: v for k, v in schema.items() if k.startswith(root)}
 
@@ -386,3 +401,15 @@ def _add_to_trace(traces, style, points, id, sample_id, label, selected):
             "selected": selected,
         }
     )
+
+
+def _strip_patches_view(view):
+    if not view._is_patches:
+        return view
+
+    stages = view._base_view._all_stages[:-1]
+    view = view._root_dataset.view()
+    for stage in stages:
+        view = view.add_stage(stage)
+
+    return view

--- a/fiftyone/utils/eval/classification.py
+++ b/fiftyone/utils/eval/classification.py
@@ -123,10 +123,12 @@ def evaluate_classifications(
         progress=progress,
     )
     eval_method.compute_custom_metrics(samples, eval_key, results)
-    eval_method.save_run_results(samples, eval_key, results)
-    eval_method.add_fields_to_sidebar_group(
-        samples, eval_key, omit_fields=(pred_field, gt_field)
-    )
+
+    if eval_key is not None:
+        eval_method.save_run_results(samples, eval_key, results)
+        eval_method.add_fields_to_sidebar_group(
+            samples, eval_key, omit_fields=(pred_field, gt_field)
+        )
 
     return results
 

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -231,10 +231,12 @@ def evaluate_detections(
         progress=progress,
     )
     eval_method.compute_custom_metrics(samples, eval_key, results)
-    eval_method.save_run_results(samples, eval_key, results)
-    eval_method.add_fields_to_sidebar_group(
-        samples, eval_key, omit_fields=(pred_field, gt_field)
-    )
+
+    if eval_key is not None:
+        eval_method.save_run_results(samples, eval_key, results)
+        eval_method.add_fields_to_sidebar_group(
+            samples, eval_key, omit_fields=(pred_field, gt_field)
+        )
 
     return results
 

--- a/fiftyone/utils/eval/regression.py
+++ b/fiftyone/utils/eval/regression.py
@@ -113,10 +113,12 @@ def evaluate_regressions(
         samples, eval_key=eval_key, missing=missing, progress=progress
     )
     eval_method.compute_custom_metrics(samples, eval_key, results)
-    eval_method.save_run_results(samples, eval_key, results)
-    eval_method.add_fields_to_sidebar_group(
-        samples, eval_key, omit_fields=(pred_field, gt_field)
-    )
+
+    if eval_key is not None:
+        eval_method.save_run_results(samples, eval_key, results)
+        eval_method.add_fields_to_sidebar_group(
+            samples, eval_key, omit_fields=(pred_field, gt_field)
+        )
 
     return results
 

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -128,10 +128,12 @@ def evaluate_segmentations(
         progress=progress,
     )
     eval_method.compute_custom_metrics(samples, eval_key, results)
-    eval_method.save_run_results(samples, eval_key, results)
-    eval_method.add_fields_to_sidebar_group(
-        samples, eval_key, omit_fields=(pred_field, gt_field)
-    )
+
+    if eval_key is not None:
+        eval_method.save_run_results(samples, eval_key, results)
+        eval_method.add_fields_to_sidebar_group(
+            samples, eval_key, omit_fields=(pred_field, gt_field)
+        )
 
     return results
 

--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -510,26 +510,22 @@ class ZeroShotTransformerEmbeddingsMixin(EmbeddingsMixin):
 
     @property
     def has_embeddings(self):
-        return _has_text_and_image_features(self._model)
+        return hasattr(self._model, "get_image_features")
 
     def embed(self, arg):
-        return self._embed(arg)[0]
+        return self.embed_all([arg])[0]
 
     def embed_all(self, args):
-        return self._embed(args)
-
-    def _embed(self, args):
-        # don't use the regular TransformerEmbeddingsMixin
-        # because doing the whole forward pass is slow
-        # and because HFT offer a cleaner way to do this
-        # via get_image_features
         if self.preprocess:
-            inputs = self.transforms.processor(images=args, return_tensors="pt")
+            args = {"images": args}
+            args = self.collate_fn(self.transforms(args))
+
         with torch.no_grad():
-            image_features = self._model.get_image_features(
-                **inputs.to(self._device)
+            for k, v in args.items():
+                args[k] = v.to(self.device)
+            return (
+                self._model.get_image_features(**args).detach().cpu().numpy()
             )
-        return image_features.cpu().numpy()
 
 
 class ZeroShotTransformerPromptMixin(PromptMixin):

--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -90,7 +90,7 @@ def to_detections(results, confidence_thresh=None):
 
 def _to_detections(result, confidence_thresh=None):
     if result.boxes is None:
-        return None
+        return fol.Detections()
 
     classes = np.rint(result.boxes.cls.detach().cpu().numpy()).astype(int)
     boxes = result.boxes.xywhn.detach().cpu().numpy().astype(float)
@@ -142,7 +142,7 @@ def to_instances(results, confidence_thresh=None):
 
 def _to_instances(result, confidence_thresh=None):
     if result.masks is None:
-        return None
+        return fol.Detections()
 
     classes = np.rint(result.boxes.cls.detach().cpu().numpy()).astype(int)
     boxes = result.boxes.xywhn.detach().cpu().numpy().astype(float)
@@ -227,6 +227,7 @@ def _to_classifications(result, confidence_thresh=None, store_logits=False):
         )
         if store_logits:
             classification.logits = logits
+
     return classification
 
 
@@ -259,7 +260,8 @@ def obb_to_polylines(results, confidence_thresh=None, filled=False):
 
 def _obb_to_polylines(result, filled, confidence_thresh=None):
     if result.obb is None:
-        return None
+        return fol.Polylines()
+
     classes = np.rint(result.obb.cls.detach().cpu().numpy()).astype(int)
     confs = result.obb.conf.detach().cpu().numpy().astype(float)
     points = result.obb.xyxyxyxyn.detach().cpu().numpy()
@@ -280,6 +282,7 @@ def _obb_to_polylines(result, filled, confidence_thresh=None):
             filled=filled,
         )
         polylines.append(polyline)
+
     return fol.Polylines(polylines=polylines)
 
 
@@ -315,7 +318,7 @@ def to_polylines(results, confidence_thresh=None, tolerance=2, filled=True):
 
 def _to_polylines(result, tolerance, filled, confidence_thresh=None):
     if result.masks is None:
-        return None
+        return fol.Polylines()
 
     classes = np.rint(result.boxes.cls.detach().cpu().numpy()).astype(int)
     confs = result.boxes.conf.detach().cpu().numpy().astype(float)
@@ -381,7 +384,7 @@ def to_keypoints(results, confidence_thresh=None):
 
 def _to_keypoints(result, confidence_thresh=None):
     if result.keypoints is None:
-        return None
+        return fol.Keypoints()
 
     classes = np.rint(result.boxes.cls.detach().cpu().numpy()).astype(int)
     points = result.keypoints.xyn.detach().cpu().numpy().astype(float)
@@ -851,7 +854,8 @@ class UltralyticsDetectionOutputProcessor(
 
     def _parse_output(self, output, frame_size, confidence_thresh):
         if not output:
-            return None
+            return fol.Detections()
+
         detections = super()._parse_output(
             output, frame_size, confidence_thresh
         )

--- a/plugins/operators/__init__.py
+++ b/plugins/operators/__init__.py
@@ -8,6 +8,7 @@ Builtin operators.
 
 import json
 import os
+import logging
 
 from bson import ObjectId
 
@@ -19,6 +20,8 @@ import fiftyone.operators.types as types
 from fiftyone.core.odm.workspace import default_workspace_factory
 from .group_by import GroupBy
 from .model_evaluation import ConfigureScenario
+
+logger = logging.getLogger(__name__)
 
 
 class EditFieldInfo(foo.Operator):
@@ -2352,6 +2355,7 @@ class SaveWorkspace(foo.Operator):
         description = ctx.params.get("description", None)
         color = ctx.params.get("color", None)
         spaces = ctx.params.get("spaces", None)
+        old_name = ctx.params.get("old_name", None)
 
         curr_spaces = spaces is None
         if curr_spaces:
@@ -2366,6 +2370,12 @@ class SaveWorkspace(foo.Operator):
             color=color,
             overwrite=True,
         )
+
+        if old_name is not None and old_name != name:
+            try:
+                ctx.dataset.delete_workspace(old_name)
+            except Exception as e:
+                logger.warning(f"Failed to delete workspace '{old_name}': {e}")
 
         if curr_spaces:
             ctx.ops.set_spaces(name=name)

--- a/plugins/operators/model_evaluation/__init__.py
+++ b/plugins/operators/model_evaluation/__init__.py
@@ -319,10 +319,6 @@ class ConfigureScenario(foo.Operator):
     def render_empty_sample_distribution(
         self, ctx, inputs, params, description=None
     ):
-        scenario_type = self.get_scenario_type(params)
-        # NOTE: custom code validation happens at render_custom_code when exec() is called
-        is_invalid = scenario_type != ScenarioType.CUSTOM_CODE
-
         self.render_plot_preview_toggle(ctx, inputs)
 
         inputs.view(
@@ -353,6 +349,8 @@ class ConfigureScenario(foo.Operator):
                     },
                 },
             ),
+            invalid=True,
+            error_message="No values selected",
         )
 
     def get_label_attribute_path(self, params):
@@ -707,6 +705,8 @@ class ConfigureScenario(foo.Operator):
                 },
             },
         )
+        # Must at least select one subset
+        is_invalid = len(selected_values) < 1
 
         if with_description:
             stack.view(
@@ -733,6 +733,8 @@ class ConfigureScenario(foo.Operator):
                 default=True if label in selected_values else False,
                 label=formatted_label,
                 view=types.CheckboxView(space=4),
+                error_message="Please select at least one option.",
+                invalid=is_invalid,
             )
 
         stack.define_property(key, obj)
@@ -751,6 +753,7 @@ class ConfigureScenario(foo.Operator):
                     else "saved view"
                 )
             )
+
             self.render_empty_sample_distribution(
                 ctx,
                 inputs,
@@ -1106,6 +1109,7 @@ class ConfigureScenario(foo.Operator):
 
         if scenario_type == ScenarioType.CUSTOM_CODE:
             self.render_custom_code(ctx, inputs)
+
         if scenario_type == ScenarioType.LABEL_ATTRIBUTE:
             selected_scenario_field = ctx.params.get(
                 "scenario_label_attribute", None

--- a/plugins/utils/model_evaluation/__init__.py
+++ b/plugins/utils/model_evaluation/__init__.py
@@ -18,6 +18,8 @@ def get_subsets_from_custom_code(ctx, custom_code):
         local_vars = {}
         exec(custom_code, {"ctx": ctx}, local_vars)
         data = local_vars.get("subsets", {})
+        if len(data) == 0:
+            return None, "No subsets found in the custom code."
         return data, None
     except Exception as e:
         return None, str(e)

--- a/tests/unittests/evaluation_tests.py
+++ b/tests/unittests/evaluation_tests.py
@@ -136,6 +136,21 @@ class RegressionTests(unittest.TestCase):
         self.assertNotIn("eval2", dataset.get_field_schema())
 
     @drop_datasets
+    def test_evaluate_regressions_no_eval_key(self):
+        dataset = self._make_regression_dataset()
+
+        results = dataset.evaluate_regressions(
+            "predictions",
+            gt_field="ground_truth",
+            method="simple",
+        )
+
+        results.print_metrics()
+
+        metrics = results.metrics()
+        self.assertEqual(metrics["support"], 2)
+
+    @drop_datasets
     def test_evaluate_regressions_embedded_fields(self):
         dataset = self._make_regression_dataset()
 
@@ -573,6 +588,22 @@ class ClassificationTests(unittest.TestCase):
 
         self.assertNotIn("eval2", dataset.list_evaluations())
         self.assertNotIn("eval2", dataset.get_field_schema())
+
+    @drop_datasets
+    def test_evaluate_classifications_no_eval_key(self):
+        dataset = self._make_classification_dataset()
+
+        results = dataset.evaluate_classifications(
+            "predictions",
+            gt_field="ground_truth",
+            method="simple",
+        )
+
+        results.report()
+        results.print_report()
+
+        metrics = results.metrics()
+        self.assertEqual(metrics["support"], 3)
 
     @drop_datasets
     def test_evaluate_classifications_top_k(self):
@@ -2014,6 +2045,25 @@ class DetectionsTests(unittest.TestCase):
             detection["eval2"]
 
     @drop_datasets
+    def test_evaluate_detections_no_eval_key(self):
+        dataset = self._make_detections_dataset()
+
+        results = dataset.evaluate_detections(
+            "predictions",
+            gt_field="ground_truth",
+            method="coco",
+            compute_mAP=True,
+            classwise=True,  # don't allow matches w/ different classes
+        )
+
+        results.report()
+        results.print_report()
+        results.mAP()
+
+        metrics = results.metrics()
+        self.assertEqual(metrics["support"], 3)
+
+    @drop_datasets
     def test_evaluate_detections_embedded_fields(self):
         dataset = self._make_detections_dataset()
 
@@ -3063,6 +3113,26 @@ class SegmentationTests(unittest.TestCase):
         self.assertNotIn("eval2_accuracy", dataset.get_field_schema())
         self.assertNotIn("eval2_precision", dataset.get_field_schema())
         self.assertNotIn("eval2_recall", dataset.get_field_schema())
+
+    @drop_datasets
+    def test_evaluate_segmentations_no_eval_key(self):
+        dataset = self._make_segmentation_dataset()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")  # suppress missing masks warning
+
+            results = dataset.evaluate_segmentations(
+                "predictions",
+                gt_field="ground_truth",
+                method="simple",
+                mask_targets={0: "background", 1: "cat", 2: "dog"},
+            )
+
+        results.report()
+        results.print_report()
+
+        metrics = results.metrics()
+        self.assertEqual(metrics["support"], 4)
 
     @drop_datasets
     def test_evaluate_segmentations_on_disk_simple(self):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Supersedes https://github.com/voxel51/fiftyone/pull/6160

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a deprecation notice for Kubernetes 1.30, with support ending July 11, 2025.
  * Enhanced sidebar sliders to support more precise numeric and date/time input with improved calendar picker visuals.
  * Improved error handling and feedback in scenario analysis, sample distribution, and checkbox selection UIs.
  * Embeddings panel now better supports patch views and color-by field selection.

* **Bug Fixes**
  * Fixed workspace renaming issues and ensured proper cleanup of old workspace names.
  * Corrected label tag search results and prevented invalid values from being stored in localStorage.
  * Addressed issues with evaluation methods when no evaluation key is provided.
  * Fixed macOS bug in model application to image patches with multiple workers.
  * Standardized output for Ultralytics models to return empty label objects instead of null.

* **Improvements**
  * Numeric precision in sidebar sliders is now dynamically determined based on field type and bounds.
  * Scenario Analysis summary table now correctly handles metrics where lower values are better.
  * Improved static file serving to follow symlinks.
  * Optimized pinned datasets widget and HTTP connection handling.
  * Enhanced test coverage for numeric filters and evaluation methods.

* **Documentation**
  * Added release notes for FiftyOne Enterprise 2.10.1 and FiftyOne 1.7.1.
  * Updated deprecation documentation for Kubernetes 1.30.

* **Tests**
  * Added new tests for numeric filter helpers and evaluation without explicit evaluation keys.

* **Chores**
  * Updated workflows to exclude certain files from documentation publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->