### PR TITLE
Fix CVAT bug with rotation attribute of 3d labels

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -6484,7 +6484,9 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     "attributes": attributes,
                 }
 
-                if det.has_attribute("rotation"):
+                if det.has_attribute("rotation") and isinstance(
+                    det["rotation"], (int, float)
+                ):
                     shape["rotation"] = det["rotation"] or 0.0
 
                 curr_shapes.append(shape)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix this rotation attribute bug when running the example in our docs:
```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-groups")
view = dataset.select_group_slices("pcd")

#
# Populate a field on the dataset that points to the data to upload to CVAT
#
# This data can be as simple as a filepath to a .pcd file, or it could be a
# structured zip archive including reference images along with the PCD
#
pcd_filepaths = [f.replace(".fo3d", ".pcd") for f in view.values("filepath")]
view.set_values("pcd_filepath", pcd_filepaths)

results = view[1:2].annotate(
    "test",
    label_field="ground_truth",
    media_field="pcd_filepath",
    launch_editor=True,
)

# Annotate the cuboids in CVAT...

view.load_annotations("test")

# View the newly created/edited cuboids in FiftyOne
session = fo.launch_app(dataset)
```

```
Exception: 400 error for request <PreparedRequest [PUT]> to url https://cvat.dev.fiftyone.ai/api/tasks/1052/annotations with the reason Bad Request. Error content: b'{"shapes":[{"rotation":["A valid number is required."]},{"rotation":["A valid number is required."]},{"rotation":["A valid number is required."]},{"rotation":["A valid number is required."]},{"rotation":["A valid number is required."]},{"rotation":["A valid number is required."]},{"rotation":["A valid number is required."]},{"rotation":["A valid number is required."]},{"rotation":["A valid number is required."]},{"rotation":["A valid number is required."]},{"rotation":["A valid number is required."]},{"rotation":["A valid number is required."]}]}'
```
## How is this patch tested? If it is not, please explain why.

Ran the same code and confirmed the error no longer occurs.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fix rotation attribute error when annotating 3d labels with CVAT.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rotation values in detection shapes to ensure only numeric rotation values are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->