### PR TITLE
normalize urls in async rendering for imavid

### DIFF
--- a/app/packages/looker/src/lookers/imavid/index.ts
+++ b/app/packages/looker/src/lookers/imavid/index.ts
@@ -1,3 +1,4 @@
+import { getStandardizedUrls } from "@fiftyone/state";
 import {
   BufferManager,
   DETECTION,
@@ -263,7 +264,7 @@ export class ImaVidLooker extends AbstractLooker<ImaVidState, Sample> {
       const { image: _cachedImage, ...sampleWithoutImage } =
         this.frameStoreController.store.samples.get(sampleIdFromFramesStore);
       sample = sampleWithoutImage.sample;
-      this.state.config.sources = sampleWithoutImage.urls;
+      this.state.config.sources = getStandardizedUrls(sampleWithoutImage.urls);
     } else if (this.sample) {
       sample = this.sample;
     }


### PR DESCRIPTION
`urls` needs to be normalized or else it's sometimes an array.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of displayed image URLs by standardizing them before use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->