### PR TITLE
Fix dino patch embedding computation

### DIFF
--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -5,6 +5,7 @@ PyTorch utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import functools
 import itertools
 import logging
@@ -1017,6 +1018,8 @@ class TorchImageModel(
         elif config.image_dim:
             transforms.append(torchvision.transforms.Resize(config.image_dim))
         elif config.image_patch_size:
+            if config.image_min_dim:
+                transforms.append(MinResize(config.image_min_dim))
             transforms.append(PatchSize(config.image_patch_size))
         else:
             if config.image_min_size:

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -3174,6 +3174,7 @@
                         "model": "dinov2_vits14"
                     },
                     "image_patch_size": 14,
+                    "image_min_dim": 14,
                     "embeddings_layer": "head"
                 }
             },
@@ -3205,6 +3206,7 @@
                         "model": "dinov2_vitb14"
                     },
                     "image_patch_size": 14,
+                    "image_min_dim": 14,
                     "embeddings_layer": "head"
                 }
             },
@@ -3236,6 +3238,7 @@
                         "model": "dinov2_vitl14"
                     },
                     "image_patch_size": 14,
+                    "image_min_dim": 14,
                     "embeddings_layer": "head"
                 }
             },
@@ -3267,6 +3270,7 @@
                         "model": "dinov2_vitg14"
                     },
                     "image_patch_size": 14,
+                    "image_min_dim": 14,
                     "embeddings_layer": "head"
                 }
             },
@@ -3298,6 +3302,7 @@
                         "model": "dinov2_vits14_reg"
                     },
                     "image_patch_size": 14,
+                    "image_min_dim": 14,
                     "embeddings_layer": "head"
                 }
             },
@@ -3329,6 +3334,7 @@
                         "model": "dinov2_vitb14_reg"
                     },
                     "image_patch_size": 14,
+                    "image_min_dim": 14,
                     "embeddings_layer": "head"
                 }
             },
@@ -3360,6 +3366,7 @@
                         "model": "dinov2_vitl14_reg"
                     },
                     "image_patch_size": 14,
+                    "image_min_dim": 14,
                     "embeddings_layer": "head"
                 }
             },
@@ -3391,6 +3398,7 @@
                         "model": "dinov2_vitg14_reg"
                     },
                     "image_patch_size": 14,
+                    "image_min_dim": 14,
                     "embeddings_layer": "head"
                 }
             },


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR [fixes](https://github.com/voxel51/fiftyone/issues/6167) patch embedding computation with dino models. Using dino for patch embeddings requires patch size to a be multiple of 14. With the current implementation, smaller patches with size < 14, result into 0 dimension height / width. This throws the following error:  

```
RuntimeError: Calculated padded input size per channel: (14 x 0). Kernel size: (14 x 14). Kernel size can't be greater than actual input size
```

This PR adds a `minresize` transform to dino model transforms such that any patch with dim < 14 is resized (via interpolation) such that min dim is 14.

## How is this patch tested? If it is not, please explain why.

```
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("coco-2017", split="validation")

# Compute patch embeddings with all dino models on this branch
dino_models = foz.list_zoo_models(tags=["dinov2"])
for mname in dino_models:
    model = foz.load_zoo_model(mname)
    dataset.compute_patch_embeddings(model, "ground_truth", embeddings_field=f"emb_{mname}_patch")

# Compare this branch against develop
model = foz.load_zoo_model("dinov2-vitb14-torch")
dataset.compute_embeddings(model, embeddings_field="emb_dino")

dino_dev = dataset.values("emb_dino_dev") # on develop
dino = dataset.values("emb_dino")

for emb_dino, emb_dino_dev in zip(dino, dino_dev):
    assert np.array_equal(emb_dino, emb_dino_dev)
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

When computing dino patch embeddings, image patches are resized (using interpolation) to have a minimum dimension of 14.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved image preprocessing by ensuring images are resized to a minimum dimension before cropping when both minimum size and patch size are specified in the settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->