### PR TITLE
Display the value 0 correctly in LabelValueView

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/LabelValueView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/LabelValueView.tsx
@@ -17,7 +17,11 @@ export default function LabelValueView(props) {
           {label || schema?.id}:
         </Typography>
         <Typography {...getComponentProps(props, "value")}>
-          {(data || defaultValue)?.toString() || "No value provided"}
+          {data != null
+            ? data.toString()
+            : defaultValue != null
+            ? defaultValue.toString()
+            : "No value provided"}
         </Typography>
       </Stack>
     </Box>


### PR DESCRIPTION
## What changes are proposed in this pull request?

It has been pointed out here https://github.com/voxel51/fiftyone-plugins/pull/238#pullrequestreview-3039595237 that 0 is not displayed properly when it is the value of an operator's output. This PR attempts to fix that by explicitly catching the value 0 in `LabelValueView.tsx`

<img width="1850" height="1053" alt="image" src="https://github.com/user-attachments/assets/1d0c047e-d818-45f5-82bd-258037a2c592" />


## How is this patch tested? If it is not, please explain why.

Tested with fo-brain operators that display the value 0 in their `resolve_output` method.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?


-   [ x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [ x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display logic to ensure valid values like `0` or `false` are shown correctly instead of being replaced by default or fallback text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->