### PR TITLE
add missing model sizes to manifest

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -2673,7 +2673,7 @@
             "source": "https://huggingface.co/docs/transformers/tasks/image_classification",
             "author": "Thomas Wolf, et al.",
             "license": "Apache 2.0",
-            "size_bytes": null,
+            "size_bytes": 346351599,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForImageClassification",
                 "config": {}
@@ -2822,7 +2822,7 @@
             "source": "https://huggingface.co/docs/transformers/tasks/zero_shot_image_classification",
             "author": "Thomas Wolf, et al.",
             "license": "Apache 2.0",
-            "size_bytes": null,
+            "size_bytes": 812762989,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneZeroShotTransformerForImageClassification",
                 "config": {
@@ -2892,7 +2892,7 @@
             "source": "https://huggingface.co/docs/transformers/en/tasks/mask_generation",
             "author": "Thomas Wolf, et al.",
             "license": "Apache 2.0",
-            "size_bytes": null,
+            "size_bytes": 223137427,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneZeroShotTransformerForSemanticSegmentation",
                 "config": {


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR adds the missing `size_bytes` field for three models in the manifest that previously had this field set to `null`. The byte sizes were obtained by downloading the actual model files from Hugging Face and measuring their exact sizes.

## How is this patch tested? If it is not, please explain why.
Tested by downloading each model using the Hugging Face Hub API and verifying the exact file sizes of the `pytorch_model.bin` files. The sizes were confirmed to match the values added to the manifest.

## Release Notes
### Is this a user-facing change that should be mentioned in the release notes?
-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

Fixed missing model size information in the model zoo manifest for vit-base-patch16-224-imagenet-torch, siglip-base-patch16-224-torch, and group-vit-segmentation-transformer-torch models.

### What areas of FiftyOne does this PR affect?
-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other