### PR TITLE
Ensure that run results are cached + reused

### DIFF
--- a/fiftyone/server/utils.py
+++ b/fiftyone/server/utils.py
@@ -26,13 +26,11 @@ def load_and_cache_dataset(name):
     """Loads the dataset with the given name and caches it.
 
     This method is a wrapper around :func:`fiftyone.core.dataset.load_dataset`
-    that stores a reference to every dataset it loads in a TTL cache to ensure
-    that references to recently used datasets exist in memory so that dataset
-    objects aren't garbage collected between async calls.
-
-    It is desirable to avoid dataset objects being garbage collected because
-    datasets may be singletons and may have objects (eg brain results) that
-    are expensive to load cached on them.
+    that stores a reference to every dataset it loads in a TTL cache so that
+    subsequent calls to this method can return the cached dataset object rather
+    than reloading it. This is useful in situations where expensive objects
+    (eg brain results) are cached on the dataset and we want to avoid reloading
+    them.
 
     Args:
         name: the dataset name
@@ -40,37 +38,46 @@ def load_and_cache_dataset(name):
     Returns:
         a :class:`fiftyone.core.dataset.Dataset`
     """
-    if not fo.config.singleton_cache:
-        # If singleton cache is disabled, return the cached dataset if it exists
-        dataset = _cache.get(name)
-        if dataset:
-            dataset.reload()
-            return dataset
-
-    dataset = fod.load_dataset(name, reload=True)
-
-    # Store reference in TTL cache to cache / defer garbage collection
-    # IMPORTANT: we don't return already cached objects here if singleton
-    # is enabled, because a dataset can be deleted and another created
-    # with the same name
-    _cache[name] = dataset
-
-    return dataset
+    return _cache_dataset(name)
 
 
 def cache_dataset(dataset):
-    """Caches the given dataset.
+    """Returns a cached version of the given dataset.
 
-    This method ensures that subsequent calls to
-    :func:`fiftyone.core.dataset.load_dataset` in async calls will return this
-    dataset singleton.
+    If this dataset has already been cached, then the cached copy will be
+    returned. Otherwise, the provided dataset will be inserted into the cache
+    and then returned.
 
-    See :meth:`load_and_cache_dataset` for additional details.
+    See :func:`load_and_cache_dataset` for more context.
 
     Args:
         dataset: a :class:`fiftyone.core.dataset.Dataset`
+
+    Returns:
+        a :class:`fiftyone.core.dataset.Dataset`
     """
-    _cache[dataset.name] = dataset
+    return _cache_dataset(dataset.name, dataset=dataset)
+
+
+def _cache_dataset(name, dataset=None):
+    _dataset = _cache.get(name)
+
+    if _dataset is not None:
+        try:
+            _dataset.reload()
+            return _dataset
+        except:
+            # dataset was deleted
+            pass
+
+    if dataset is not None:
+        _dataset = dataset
+    else:
+        _dataset = fod.load_dataset(name, reload=True)
+
+    _cache[name] = _dataset
+
+    return _dataset
 
 
 def change_sample_tags(sample_collection, changes):

--- a/plugins/operators/model_evaluation/__init__.py
+++ b/plugins/operators/model_evaluation/__init__.py
@@ -10,7 +10,7 @@ import fiftyone as fo
 import fiftyone.operators as foo
 import fiftyone.operators.types as types
 import fiftyone.core.fields as fof
-from fiftyone.server.utils import cache_dataset
+import fiftyone.server.utils as fosu
 from fiftyone.operators.cache import execution_cache
 
 from bson import ObjectId
@@ -37,10 +37,6 @@ MAX_SAMPLES_FOR_DEFAULT_PREVIEW = 25000
 PROMPT_SCOPED_CACHE_TTL = 60 * 60  # 1 hour
 
 
-def dataset_serialize_deserialize(dataset):
-    return dataset
-
-
 class ConfigureScenario(foo.Operator):
     # tracks the last view type opened
     last_view_type_used = None
@@ -54,18 +50,13 @@ class ConfigureScenario(foo.Operator):
             unlisted=True,
         )
 
-    @execution_cache(
-        prompt_scoped=True,
-        residency="ephemeral",
-        serialize=dataset_serialize_deserialize,
-        deserialize=dataset_serialize_deserialize,
-        ttl=PROMPT_SCOPED_CACHE_TTL,
-    )
+    # we use `fosu.cache_dataset()` rather than `@execution_cache` here so that
+    # the cached dataset can be reused outside of the current prompt session
     def get_dataset(self, ctx):
         """
         Returns the dataset for the current context.
         """
-        return ctx.dataset
+        return fosu.cache_dataset(ctx.dataset)
 
     @execution_cache(
         prompt_scoped=True, residency="ephemeral", ttl=PROMPT_SCOPED_CACHE_TTL
@@ -197,13 +188,8 @@ class ConfigureScenario(foo.Operator):
 
         return key
 
-    @execution_cache(
-        prompt_scoped=True,
-        residency="ephemeral",
-        serialize=dataset_serialize_deserialize,
-        deserialize=dataset_serialize_deserialize,
-        ttl=PROMPT_SCOPED_CACHE_TTL,
-    )
+    # there is no need to use `@execution_cache` here because evaluation
+    # results are cached on the dataset, which is cached by `get_dataset()`
     def get_evaluations_results(self, ctx):
         """
         Returns the evaluation results for the current context.
@@ -1070,10 +1056,8 @@ class ConfigureScenario(foo.Operator):
         return [scenario.get("name") for _, scenario in scenarios.items()]
 
     def resolve_input(self, ctx):
-        # Force ctx.dataset to load and store dataset so it remains consistent.
-        d = self.get_dataset(ctx)
-        if fo.config.singleton_cache:
-            cache_dataset(d)
+        # force `ctx.dataset` to be cached
+        _ = self.get_dataset(ctx)
 
         inputs = types.Object()
 

--- a/plugins/panels/model_evaluation/__init__.py
+++ b/plugins/panels/model_evaluation/__init__.py
@@ -15,6 +15,7 @@ from bson import ObjectId
 import fiftyone as fo
 import fiftyone.core.view as fov
 import fiftyone.operators.types as types
+import fiftyone.server.utils as fosu
 import fiftyone.utils.eval as foue
 from fiftyone import ViewField as F
 from fiftyone.core.plots.plotly import _to_log_colorscale
@@ -56,6 +57,9 @@ class EvaluationPanel(Panel):
             category=Categories.ANALYZE,
         )
 
+    def get_dataset(self, ctx):
+        return fosu.cache_dataset(ctx.dataset)
+
     def get_evaluation_id(self, dataset, eval_key):
         try:
             return str(dataset._doc.evaluations[eval_key].id)
@@ -96,6 +100,9 @@ class EvaluationPanel(Panel):
         return self.get_permissions(ctx).get("can__scenario", False)
 
     def on_load(self, ctx):
+        # ensures that evaluation results will be cached + reused
+        dataset = self.get_dataset(ctx)
+
         store = get_store(ctx)
         statuses = store.get("statuses") or {}
         notes = store.get("notes") or {}
@@ -103,15 +110,13 @@ class EvaluationPanel(Panel):
         # To start, on load we populate the first menu with our current datasets evaluation keys
         view_state = ctx.panel.get_state("view") or {}
         evaluations = []
-        for key in ctx.dataset.list_evaluations():
-            if self.has_evaluation_results(ctx.dataset, key):
+        for key in dataset.list_evaluations():
+            if self.has_evaluation_results(dataset, key):
                 evaluation = {
                     "key": key,
-                    "id": self.get_evaluation_id(ctx.dataset, key),
-                    "type": ctx.dataset.get_evaluation_info(key).config.type,
-                    "method": ctx.dataset.get_evaluation_info(
-                        key
-                    ).config.method,
+                    "id": self.get_evaluation_id(dataset, key),
+                    "type": dataset.get_evaluation_info(key).config.type,
+                    "method": dataset.get_evaluation_info(key).config.method,
                 }
                 evaluations.append(evaluation)
         ctx.panel.set_state("evaluations", evaluations)
@@ -467,10 +472,11 @@ class EvaluationPanel(Panel):
         ctx.panel.set_data(f"scenarios", scenarios)
 
     def get_evaluation_data(self, ctx):
+        dataset = self.get_dataset(ctx)
         view_state = ctx.panel.get_state("view") or {}
         eval_key = view_state.get("key")
         computed_eval_key = ctx.params.get("key", eval_key)
-        info = ctx.dataset.get_evaluation_info(computed_eval_key)
+        info = dataset.get_evaluation_info(computed_eval_key)
         evaluation_type = info.config.type
         serialized_info = info.serialize()
         if evaluation_type not in SUPPORTED_EVALUATION_TYPES:
@@ -480,13 +486,13 @@ class EvaluationPanel(Panel):
             )
             return
 
-        results = ctx.dataset.load_evaluation_results(computed_eval_key)
+        results = dataset.load_evaluation_results(computed_eval_key)
         gt_field = info.config.gt_field
         mask_targets = None
 
         if evaluation_type == "segmentation":
-            mask_targets = _get_mask_targets(ctx.dataset, gt_field)
-            _init_segmentation_results(ctx.dataset, results, gt_field)
+            mask_targets = _get_mask_targets(dataset, gt_field)
+            _init_segmentation_results(dataset, results, gt_field)
 
         metrics = results.metrics()
         per_class_metrics = self.get_per_class_metrics(info, results)
@@ -630,6 +636,7 @@ class EvaluationPanel(Panel):
         # ctx.panel.state.view = "eval"
 
     def load_view(self, ctx):
+        dataset = self.get_dataset(ctx)
         view_type = ctx.params.get("type", None)
 
         if view_type == "clear":
@@ -641,8 +648,8 @@ class EvaluationPanel(Panel):
 
         eval_key = view_state.get("key")
         eval_key = view_options.get("key", eval_key)
-        eval_view = ctx.dataset.load_evaluation_view(eval_key)
-        info = ctx.dataset.get_evaluation_info(eval_key)
+        eval_view = dataset.load_evaluation_view(eval_key)
+        info = dataset.get_evaluation_info(eval_key)
         pred_field = info.config.pred_field
         gt_field = info.config.gt_field
 
@@ -650,7 +657,7 @@ class EvaluationPanel(Panel):
         pred_field2 = None
         gt_field2 = None
         if eval_key2:
-            info2 = ctx.dataset.get_evaluation_info(eval_key2)
+            info2 = dataset.get_evaluation_info(eval_key2)
             pred_field2 = info2.config.pred_field
             if info2.config.gt_field != gt_field:
                 gt_field2 = info2.config.gt_field
@@ -709,12 +716,12 @@ class EvaluationPanel(Panel):
                     expr = F(f"{eval_key}") == field
                     view = eval_view.match(expr)
         elif info.config.type == "detection":
-            _, gt_root = ctx.dataset._get_label_field_path(gt_field)
-            _, pred_root = ctx.dataset._get_label_field_path(pred_field)
+            _, gt_root = dataset._get_label_field_path(gt_field)
+            _, pred_root = dataset._get_label_field_path(pred_field)
             if gt_field2 is not None:
-                _, gt_root2 = ctx.dataset._get_label_field_path(gt_field2)
+                _, gt_root2 = dataset._get_label_field_path(gt_field2)
             if pred_field2 is not None:
-                _, pred_root2 = ctx.dataset._get_label_field_path(pred_field2)
+                _, pred_root2 = dataset._get_label_field_path(pred_field2)
 
             if view_type == "class":
                 # All GT/predictions of class `x`
@@ -781,8 +788,8 @@ class EvaluationPanel(Panel):
                         pred_field, F(eval_key) == field, only_matches=True
                     )
         elif info.config.type == "segmentation":
-            results = ctx.dataset.load_evaluation_results(eval_key)
-            _init_segmentation_results(ctx.dataset, results, gt_field)
+            results = dataset.load_evaluation_results(eval_key)
+            _init_segmentation_results(dataset, results, gt_field)
             if results.ytrue_ids is None or results.ypred_ids is None:
                 # Legacy format segmentations
                 return
@@ -791,22 +798,20 @@ class EvaluationPanel(Panel):
                 if gt_field2 is None:
                     gt_field2 = gt_field
 
-                results2 = ctx.dataset.load_evaluation_results(eval_key2)
-                _init_segmentation_results(ctx.dataset, results2, gt_field2)
+                results2 = dataset.load_evaluation_results(eval_key2)
+                _init_segmentation_results(dataset, results2, gt_field2)
                 if results2.ytrue_ids is None or results2.ypred_ids is None:
                     # Legacy format segmentations
                     return
             else:
                 results2 = None
 
-            _, gt_id = ctx.dataset._get_label_field_path(gt_field, "_id")
-            _, pred_id = ctx.dataset._get_label_field_path(pred_field, "_id")
+            _, gt_id = dataset._get_label_field_path(gt_field, "_id")
+            _, pred_id = dataset._get_label_field_path(pred_field, "_id")
             if gt_field2 is not None:
-                _, gt_id2 = ctx.dataset._get_label_field_path(gt_field2, "_id")
+                _, gt_id2 = dataset._get_label_field_path(gt_field2, "_id")
             if pred_field2 is not None:
-                _, pred_id2 = ctx.dataset._get_label_field_path(
-                    pred_field2, "_id"
-                )
+                _, pred_id2 = dataset._get_label_field_path(pred_field2, "_id")
 
             if view_type == "class":
                 # All GT/predictions that contain class `x`
@@ -857,6 +862,7 @@ class EvaluationPanel(Panel):
             ctx.ops.set_view(view)
 
     def load_compare_evaluation_results(self, ctx):
+        dataset = self.get_dataset(ctx)
         base_model_key = (
             ctx.params.get("panel_state", {}).get("view", {}).get("key", None)
         )
@@ -869,8 +875,8 @@ class EvaluationPanel(Panel):
         if base_model_key is None:
             raise ValueError("No base model key provided")
 
-        eval_a_results = ctx.dataset.load_evaluation_results(base_model_key)
-        eval_b_results = ctx.dataset.load_evaluation_results(compare_model_key)
+        eval_a_results = dataset.load_evaluation_results(base_model_key)
+        eval_b_results = dataset.load_evaluation_results(compare_model_key)
 
         return (
             base_model_key,
@@ -904,11 +910,12 @@ class EvaluationPanel(Panel):
             }
 
     def get_scenario_data(self, ctx, scenario):
+        dataset = self.get_dataset(ctx)
         view_state = ctx.panel.get_state("view") or {}
         eval_key = view_state.get("key")
         computed_eval_key = ctx.params.get("key", eval_key)
-        results = ctx.dataset.load_evaluation_results(computed_eval_key)
-        info = ctx.dataset.get_evaluation_info(computed_eval_key)
+        results = dataset.load_evaluation_results(computed_eval_key)
+        info = dataset.get_evaluation_info(computed_eval_key)
         scenario_type = scenario.get("type", None)
         scenario_data = scenario.copy()
         scenario_data["subsets_data"] = {}
@@ -1207,15 +1214,6 @@ def _init_segmentation_results(dataset, results, gt_field):
     if getattr(results, "_classes_map", None):
         # Already initialized
         return
-
-    if fo.config.singleton_cache:
-        #
-        # Ensure the dataset singleton is cached so that subsequent callbacks on
-        # this panel will use the same `dataset` and hence `results`
-        #
-        import fiftyone.server.utils as fosu
-
-        fosu.cache_dataset(dataset)
 
     #
     # `results.classes` and App callbacks could contain any of the


### PR DESCRIPTION
The goal behind `fosu.load_and_cache_dataset()` and `fosu.cache_dataset()` is to ensure that `Dataset` objects are cached + reused between async calls in features like Embeddings and Model Evaluation panels that load potentially expensive brain/evaluation results and cache them on the `Dataset` object so that they are only loaded once (per pod, at least).

Note that we want the above behavior **even when** singletons are disabled for other use cases, which as of https://github.com/voxel51/fiftyone/pull/6161 they will now be in all App server + plugin contexts by default.

Disclaimer: I have not fully tested this PR, but I believe that it applies the desired logic.