### PR TITLE
python panel tweaks

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Status.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/Status.tsx
@@ -1,11 +1,11 @@
 import { ColoredDot } from "@fiftyone/components";
+import { useTriggerPanelEvent } from "@fiftyone/operators";
 import { useMutation } from "@fiftyone/state";
 import { Chip, MenuItem, Select, Stack, Typography } from "@mui/material";
-import { useTriggerEvent } from "./utils";
 
 export default function Status(props: StatusProps) {
   const { status, canEdit, readOnly, setStatusEvent } = props;
-  const triggerEvent = useTriggerEvent();
+  const triggerEvent = useTriggerPanelEvent();
   const [enable, message] = useMutation(canEdit, "update evaluation status");
 
   if (!readOnly) {

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/overview/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/overview/index.tsx
@@ -1,5 +1,6 @@
 import { useTrackEvent } from "@fiftyone/analytics";
 import { Dialog } from "@fiftyone/components";
+import { useTriggerPanelEvent } from "@fiftyone/operators";
 import { usePanelStatePartial } from "@fiftyone/spaces";
 import { editingFieldAtom, useMutation } from "@fiftyone/state";
 import { EditNote, ExpandMore } from "@mui/icons-material";
@@ -20,7 +21,6 @@ import { useEffect, useMemo, useState } from "react";
 import { useSetRecoilState } from "recoil";
 import Error from "../../Error";
 import EvaluationNotes from "../../EvaluationNotes";
-import { useTriggerEvent } from "../../utils";
 import ClassPerformance from "./ClassPerformance";
 import ConfusionMatrices from "./ConfusionMatrices";
 import MetricPerformance from "./MetricPerformance";
@@ -81,7 +81,7 @@ export default function Overview(props) {
     }
   }, [compareEvaluation, compareKey]);
 
-  const triggerEvent = useTriggerEvent();
+  const triggerEvent = useTriggerPanelEvent();
   const setEditingField = useSetRecoilState(editingFieldAtom);
 
   const trackEvent = useTrackEvent();

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/index.tsx
@@ -1,4 +1,5 @@
 import { PanelCTA } from "@fiftyone/components";
+import { useTriggerPanelEvent } from "@fiftyone/operators";
 import { constants } from "@fiftyone/utilities";
 import { Box } from "@mui/material";
 import React, { useCallback, useMemo } from "react";
@@ -7,11 +8,7 @@ import ConfirmationDialog from "./ConfirmationDialog";
 import Evaluate from "./Evaluate";
 import Evaluation from "./Evaluation";
 import Overview from "./Overview";
-import {
-  openModelEvalDialog,
-  selectedModelEvaluation,
-  useTriggerEvent,
-} from "./utils";
+import { openModelEvalDialog, selectedModelEvaluation } from "./utils";
 
 const TRY_LINK = "http://voxel51.com/try-evaluation";
 
@@ -61,7 +58,7 @@ export default function NativeModelEvaluationView(props) {
   const { page = "overview", key, id, compareKey } = viewState;
   const showEmptyOverview =
     computedEvaluations.length === 0 && pending_evaluations.length === 0;
-  const triggerEvent = useTriggerEvent();
+  const triggerEvent = useTriggerPanelEvent();
   const [showCTA, setShowCTA] = React.useState(false);
   const onEvaluate = useCallback(() => {
     if (constants.IS_APP_MODE_FIFTYONE) {

--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/utils.ts
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/utils.ts
@@ -1,29 +1,7 @@
-import { usePanelEvent } from "@fiftyone/operators";
-import { usePanelId } from "@fiftyone/spaces";
 import { formatValueAsNumber } from "@fiftyone/utilities";
 import { capitalize } from "lodash";
-import { useCallback } from "react";
 import { atom } from "recoil";
 import { NONE_CLASS } from "./constants";
-
-export function useTriggerEvent() {
-  const panelId = usePanelId();
-  const handleEvent = usePanelEvent();
-
-  const triggerEvent = useCallback(
-    (event: string, params?: any, prompt?: boolean, callback?: any) => {
-      handleEvent(panelId, {
-        operator: event,
-        params,
-        prompt,
-        callback,
-      });
-    },
-    [handleEvent, panelId]
-  );
-
-  return triggerEvent;
-}
 
 export function getNumericDifference(
   value,
@@ -40,6 +18,7 @@ export function getNumericDifference(
     }
     return formatValueAsNumber(difference, fractionDigits);
   }
+  return NaN;
 }
 
 export function getMatrix(

--- a/app/packages/operators/src/index.ts
+++ b/app/packages/operators/src/index.ts
@@ -28,4 +28,7 @@ export {
   useOperatorPlacements,
 } from "./state";
 export * as types from "./types";
-export { default as usePanelEvent } from "./usePanelEvent";
+export {
+  default as usePanelEvent,
+  useTriggerPanelEvent,
+} from "./usePanelEvent";

--- a/app/packages/operators/src/types-internal.ts
+++ b/app/packages/operators/src/types-internal.ts
@@ -17,3 +17,5 @@ export type OperatorExecutorOptions = {
   callback?: ExecutionCallback;
   skipErrorNotification?: boolean;
 };
+
+export type ParamsType = Record<string, any>;

--- a/app/packages/operators/src/usePanelEvent.ts
+++ b/app/packages/operators/src/usePanelEvent.ts
@@ -1,10 +1,10 @@
-import { usePanelStateByIdCallback } from "@fiftyone/spaces";
+import { usePanelId, usePanelStateByIdCallback } from "@fiftyone/spaces";
 import { useNotification } from "@fiftyone/state";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useActivePanelEventsCount } from "./hooks";
 import { executeOperator, OperatorResult } from "./operators";
 import { usePromptOperatorInput } from "./state";
-import { ExecutionCallback } from "./types-internal";
+import { ExecutionCallback, ParamsType } from "./types-internal";
 import { PanelEventError } from "@fiftyone/utilities";
 
 type HandlerOptions = {
@@ -26,11 +26,11 @@ type TriggerEventFn = (panelId: string, options: HandlerOptions) => void;
 
 /**
  * A hook that can be used to trigger an operator on a panel.
- * 
+ *
  * @returns A function that can be used to trigger an operator on a panel.
- * 
+ *
  * Example:
- * 
+ *
  * ```ts
  * const panelId = usePanelId();
  * const triggerEvent = usePanelEvent();
@@ -39,13 +39,13 @@ type TriggerEventFn = (panelId: string, options: HandlerOptions) => void;
  *   params: { param1: "value1" },
  * });
  * ```
- */   
+ */
 export default function usePanelEvent(): TriggerEventFn {
   const promptForOperator = usePromptOperatorInput();
   // notify is still used for missing operator
   const notify = useNotification();
   const { increment, decrement } = useActivePanelEventsCount("");
-  const {setPendingError} = usePendingPanelEventError();
+  const { setPendingError } = usePendingPanelEventError();
 
   return usePanelStateByIdCallback((panelId, panelState, args) =>
     handlePanelEvent(
@@ -151,8 +151,10 @@ export function handlePanelEvent(
   }
 }
 
-
-export function usePendingPanelEventError(): {setPendingError: (err: PendingError) => void, pendingError: PendingError} {
+export function usePendingPanelEventError(): {
+  setPendingError: (err: PendingError) => void;
+  pendingError: PendingError;
+} {
   const [pendingError, setPendingError] = useState<PendingError>(null);
 
   useEffect(() => {
@@ -160,9 +162,39 @@ export function usePendingPanelEventError(): {setPendingError: (err: PendingErro
       const { message, error, operator } = pendingError;
       setPendingError(null); // Clear the pending error
       const [operatorUri, eventName] = operator.split("#");
-      throw new PanelEventError(message, error?.stack || error?.message || String(error), operatorUri, eventName);
+      throw new PanelEventError(
+        message,
+        error?.stack || error?.message || String(error),
+        operatorUri,
+        eventName
+      );
     }
   }, [pendingError]);
 
-  return {setPendingError, pendingError};
+  return { setPendingError, pendingError };
+}
+
+export function useTriggerPanelEvent() {
+  const panelId = usePanelId();
+  const handleEvent = usePanelEvent();
+
+  const triggerEvent = useCallback(
+    (
+      event: string,
+      params?: ParamsType,
+      prompt?: boolean,
+      callback?: ExecutionCallback
+    ) => {
+      handleEvent(panelId, {
+        operator: event,
+        params,
+        prompt,
+        callback,
+        panelId,
+      });
+    },
+    [handleEvent, panelId]
+  );
+
+  return triggerEvent;
 }

--- a/fiftyone/operators/panel.py
+++ b/fiftyone/operators/panel.py
@@ -167,11 +167,13 @@ class Panel(Operator):
         if hasattr(self, method_name):
             method = getattr(self, method_name)
             ctx.event_args = event_args
-            method(ctx)
+            result = method(ctx)
 
         # render
         panel_output = self.render(ctx)
         ctx.ops.show_panel_output(panel_output)
+
+        return result
 
 
 class WriteOnlyError(Exception):


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Add new hook for easily invoking python panel event from JS (useful in hybrid panels)
- Return the return-value for panel event as an operator result

## How is this patch tested? If it is not, please explain why.

Using a hybrid python panel (ME)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

- Add new hook for easily invoking python panel event from JS (useful in hybrid panels)
- Return the return-value for panel event as an operator result

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

## Usage
```py
# Python
class PanelTwo(Panel):
    @property
    def config(self):
        return PanelConfig(
            name="panel_two",
            label="Panel Two",
            icon="looks_two",
        )

    def load_samples_count(self, ctx):
        return ctx.view.count()

    def render(self, ctx):
        panel = types.Object()
        return types.Property(
            panel,
            view=types.View(
                component="CustomViewTwo",
                composite_view=True,
                load_samples_count=self.load_samples_count,
            ),
        )
```

```js
// JavaScript
import { Box, Button, Typography } from "@mui/material";
import { useTriggerPanelEvent } from "@fiftyone/operators";
import { useState } from "react";

export default function CustomViewTwo(props) {
  const { load_samples_count } = props.schema.view;
  const [count, setCount] = useState();
  const triggerPanelEvent = useTriggerPanelEvent();

  return (
    <Box>
      <Button
        onClick={() => {
          triggerPanelEvent(load_samples_count, {}, false, (result) => {
            setCount(result.result);
          });
        }}
      >
        Load count
      </Button>
      <Typography>Count: {count ?? "Count is not yet loaded"}</Typography>
    </Box>
  );
}

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a simplified way to trigger panel events, making event handling more streamlined in the user interface.

* **Bug Fixes**
  * Improved numeric difference calculations to handle invalid input values more clearly.

* **Chores**
  * Updated internal event handling for model evaluation views to use a more consistent and maintainable approach.
  * Minor improvements to type definitions and code formatting for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->