### PR TITLE
Fix docs formatting issues

### DIFF
--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -219,7 +219,7 @@ The following fields are available:
     +------------------------------+-----------+-----------------------------------------------------------------------------+
     | `operators`                  |           | A list of operator names registered by the plugin, if any                   |
     +------------------------------+-----------+-----------------------------------------------------------------------------+
-    | `panels`                     |           | A list of panel names registered by the plugin, if any                       |
+    | `panels`                     |           | A list of panel names registered by the plugin, if any                      |
     +------------------------------+-----------+-----------------------------------------------------------------------------+
     | `secrets`                    |           | A list of secret keys that may be used by the plugin, if any                |
     +------------------------------+-----------+-----------------------------------------------------------------------------+
@@ -2603,7 +2603,7 @@ Here's an example of caching a sample using custom serialization:
     See the :func:`execution_cache <fiftyone.operators.cache.execution_cache>`
     documentation for more details.
 
-.. _panel-saved-workspaces
+.. _panel-saved-workspaces:
 
 Saved workspaces
 ----------------


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed minor formatting issues in the plugin development documentation, including removal of a trailing space and addition of a missing colon in section labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->