### PR TITLE
Add legacy tag to TF1 models in model zoo

### DIFF
--- a/fiftyone/zoo/models/manifest-tf.json
+++ b/fiftyone/zoo/models/manifest-tf.json
@@ -39,7 +39,7 @@
                     ]
                 }
             },
-            "tags": ["segmentation", "cityscapes", "tf", "deeplabv3"],
+            "tags": ["segmentation", "cityscapes", "tf", "deeplabv3", "legacy"],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -81,7 +81,7 @@
                     ]
                 }
             },
-            "tags": ["segmentation", "cityscapes", "tf", "deeplabv3"],
+            "tags": ["segmentation", "cityscapes", "tf", "deeplabv3", "legacy"],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -122,7 +122,7 @@
                     "packages": ["tensorflow-gpu>=1.14,<2"]
                 }
             },
-            "tags": ["detection", "coco", "tf1", "efficientdet"],
+            "tags": ["detection", "coco", "tf1", "efficientdet", "legacy"],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -163,7 +163,7 @@
                     "packages": ["tensorflow-gpu>=1.14,<2"]
                 }
             },
-            "tags": ["detection", "coco", "tf1", "efficientdet"],
+            "tags": ["detection", "coco", "tf1", "efficientdet", "legacy"],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -204,7 +204,7 @@
                     "packages": ["tensorflow-gpu>=1.14,<2"]
                 }
             },
-            "tags": ["detection", "coco", "tf1", "efficientdet"],
+            "tags": ["detection", "coco", "tf1", "efficientdet", "legacy"],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -245,7 +245,7 @@
                     "packages": ["tensorflow-gpu>=1.14,<2"]
                 }
             },
-            "tags": ["detection", "coco", "tf1", "efficientdet"],
+            "tags": ["detection", "coco", "tf1", "efficientdet", "legacy"],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -286,7 +286,7 @@
                     "packages": ["tensorflow-gpu>=1.14,<2"]
                 }
             },
-            "tags": ["detection", "coco", "tf1", "efficientdet"],
+            "tags": ["detection", "coco", "tf1", "efficientdet", "legacy"],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -327,7 +327,7 @@
                     "packages": ["tensorflow-gpu>=1.14,<2"]
                 }
             },
-            "tags": ["detection", "coco", "tf1", "efficientdet"],
+            "tags": ["detection", "coco", "tf1", "efficientdet", "legacy"],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -368,7 +368,7 @@
                     "packages": ["tensorflow-gpu>=1.14,<2"]
                 }
             },
-            "tags": ["detection", "coco", "tf1", "efficientdet"],
+            "tags": ["detection", "coco", "tf1", "efficientdet", "legacy"],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -461,7 +461,8 @@
                 "tf",
                 "faster-rcnn",
                 "inception",
-                "resnet"
+                "resnet",
+                "legacy"
             ],
             "date_added": "2020-12-11 13:45:51"
         },
@@ -582,7 +583,7 @@
                     ]
                 }
             },
-            "tags": ["detection", "coco", "tf", "faster-rcnn"],
+            "tags": ["detection", "coco", "tf", "faster-rcnn", "legacy"],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -622,7 +623,7 @@
                     ]
                 }
             },
-            "tags": ["detection", "coco", "tf", "faster-rcnn", "resnet"],
+            "tags": ["detection", "coco", "tf", "faster-rcnn", "resnet", "legacy"],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -662,7 +663,7 @@
                     ]
                 }
             },
-            "tags": ["detection", "coco", "tf", "faster-rcnn", "resnet"],
+            "tags": ["detection", "coco", "tf", "faster-rcnn", "resnet", "legacy"],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -742,7 +743,7 @@
                     ]
                 }
             },
-            "tags": ["detection", "coco", "tf", "faster-rcnn", "resnet"],
+            "tags": ["detection", "coco", "tf", "faster-rcnn", "resnet", "legacy"],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -836,7 +837,8 @@
                 "logits",
                 "imagenet",
                 "tf1",
-                "inception"
+                "inception",
+                "legacy"
             ],
             "date_added": "2020-12-11 13:45:51"
         },
@@ -964,7 +966,7 @@
                     ]
                 }
             },
-            "tags": ["instances", "coco", "tf", "mask-rcnn", "resnet"],
+            "tags": ["instances", "coco", "tf", "mask-rcnn", "resnet", "legacy"],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1004,7 +1006,7 @@
                     ]
                 }
             },
-            "tags": ["instances", "coco", "tf", "mask-rcnn", "resnet"],
+            "tags": ["instances", "coco", "tf", "mask-rcnn", "resnet", "legacy"],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1097,7 +1099,8 @@
                 "logits",
                 "imagenet",
                 "tf1",
-                "resnet"
+                "resnet",
+                "legacy"
             ],
             "date_added": "2020-12-11 13:45:51"
         },
@@ -1144,7 +1147,8 @@
                 "logits",
                 "imagenet",
                 "tf1",
-                "resnet"
+                "resnet",
+                "legacy"
             ],
             "date_added": "2020-12-11 13:45:51"
         },
@@ -1185,7 +1189,7 @@
                     ]
                 }
             },
-            "tags": ["detection", "coco", "tf", "rfcn", "resnet"],
+            "tags": ["detection", "coco", "tf", "rfcn", "resnet", "legacy"],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1265,7 +1269,7 @@
                     ]
                 }
             },
-            "tags": ["detection", "coco", "tf", "ssd", "mobilenet"],
+            "tags": ["detection", "coco", "tf", "ssd", "mobilenet", "legacy"],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1305,7 +1309,7 @@
                     ]
                 }
             },
-            "tags": ["detection", "coco", "tf", "ssd", "mobilenet"],
+            "tags": ["detection", "coco", "tf", "ssd", "mobilenet", "legacy"],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1345,7 +1349,7 @@
                     ]
                 }
             },
-            "tags": ["detection", "coco", "tf", "ssd", "resnet"],
+            "tags": ["detection", "coco", "tf", "ssd", "resnet", "legacy"],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1390,7 +1394,8 @@
                 "logits",
                 "imagenet",
                 "tf1",
-                "vgg"
+                "vgg",
+                "legacy"
             ],
             "date_added": "2020-12-11 13:45:51"
         },
@@ -1430,7 +1435,7 @@
                     "packages": ["tensorflow-gpu<2"]
                 }
             },
-            "tags": ["detection", "coco", "tf1", "yolo"],
+            "tags": ["detection", "coco", "tf1", "yolo", "legacy"],
             "date_added": "2020-12-11 13:45:51"
         },
         {


### PR DESCRIPTION
Update model categorization to mark TF1 models as legacy as per new model categorization schema. This helps users understand the current support status of these models.

## What changes are proposed in this pull request?
Adds the "legacy" tag to all TensorFlow 1.x models in the `voxel51-tf-models.json` file. This update reflects the deprecated status of TF1 and ensures users are aware these models are no longer actively maintained.

## How is this patch tested? If it is not, please explain why.
Manually verified that:
- All TF1 models (identified by "tf1" tag or tensorflow<2 requirements) now include the "legacy" tag
- The JSON file remains valid
- Model zoo loads correctly with the updated tags

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?
-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

TensorFlow 1.x models in the model zoo are now marked as "legacy" to indicate they are no longer actively maintained due to TF1's deprecation.

### What areas of FiftyOne does this PR affect?
-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other