### PR TITLE
Fix virtual environment name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ on the installer to run it, and follow the steps in the installer.
 -   Activate the environment typing this in the command line window
     `fiftyone_env\Scripts\activate`
 -   After activation, your command prompt should change and show the name of
-    the virtual environment `(fiftyon_env) C:\path\to\your\project`
+    the virtual environment `(fiftyone_env) C:\path\to\your\project`
 
 #### 5. Install FFmpeg (optional)
 


### PR DESCRIPTION
Correct the Windows setup instructions to display the proper environment name. The prompt now shows (fiftyone_env) instead of the erroneously spelled (fiftyon_env) after activation, matching the environment users create earlier in the example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typographical error in the Windows installation instructions for the virtual environment name in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->