### PR TITLE
correct ConvNeXt-XLarge model file size from 31.6EB to 1.4GB

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -5753,7 +5753,7 @@
             "source": "https://huggingface.co/facebook/convnext-xlarge-224-22k-1k",
             "author": "Zhuang Liu, et al.",
             "license": "Apache 2.0",
-            "size_bytes": 31647540445603633486,
+            "size_bytes": 1400917137,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForImageClassification",
                 "config": {


### PR DESCRIPTION
Fixed incorrect size_bytes value for convnext-xlarge-224-torch model.

Was: 31647540445603633486 bytes (31.6 exabytes - impossible)
Now: 1400917137 bytes (1.4 GB - verified from source)

## What changes are proposed in this pull request?

This PR fixes a data entry error in the FiftyOne model zoo configuration for the ConvNeXt-XLarge model. The `size_bytes` field contained an impossible value of approximately 31.6 exabytes (31,647,540,445,603,633,486 bytes), which is corrected to the actual file size of 1.4 GB (1,400,917,137 bytes).

## How is this patch tested? If it is not, please explain why.

The correct file size was verified by:
1. Downloading the model from the official HuggingFace repository (facebook/convnext-xlarge-224-22k-1k)
2. Checking the pytorch_model.bin file size via HTTP headers
3. Cross-referencing with the model's parameter count (~350M) and comparing with other ConvNeXt variants

Python script used for verification:
```python
import requests
response = requests.head("https://huggingface.co/facebook/convnext-xlarge-224-22k-1k/resolve/main/pytorch_model.bin")
print(response.headers.get('Content-Length'))  # Returns: 1400917137
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixed incorrect file size metadata for the ConvNeXt-XLarge model in the model zoo, which previously showed 31.6 exabytes instead of the correct 1.4 GB.

### What areas of FiftyOne does this PR affect?
-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other