### PR TITLE
Add OWL-ViT large-patch14 model to zoo (manifest-torch.json)

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -3000,6 +3000,41 @@
             "date_added": "2025-07-15 13:49:00"
         },
         {
+            "base_name": "owlvit-large-patch14-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Large OWL-ViT zero-shot object detector with ViT-L/14 backbone. Achieves higher accuracy than base models, especially for smaller objects.",
+            "source": "https://huggingface.co/google/owlvit-large-patch14",
+            "author": "Matthias Minderer, et al.",
+            "license": "Apache 2.0",
+            "size_bytes": 1735754597,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneZeroShotTransformerForObjectDetection",
+                "config": {
+                    "name_or_path": "google/owlvit-large-patch14"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": [
+                "detection",
+                "logits",
+                "embeddings",
+                "torch",
+                "transformers",
+                "zero-shot",
+                "official"
+            ],
+            "date_added": "2025-07-28 15:25:00"
+        },
+        {
             "base_name": "omdet-turbo-swin-tiny-torch",
             "base_filename": null,
             "version": null,


### PR DESCRIPTION
Added OWL-ViT large model with patch14 configuration:
- `owlvit-large-patch14-torch`

The model:
- Uses existing `FiftyOneZeroShotTransformerForObjectDetection` wrapper
- Supports both CPU and GPU inference
- Performs zero-shot object detection using text queries  
- Successfully extracts embeddings for similarity matching
- Provides ViT-L/14 backbone for improved accuracy over base models

OWL-ViT large-patch14 extends our zero-shot detection offerings by providing a higher-capacity model (compared to base) with improved accuracy, especially for smaller objects and complex scenes.

### What changes are proposed in this pull request?

This PR adds the OWL-ViT large-patch14 model configuration to `fiftyone/zoo/models/manifest-torch.json`, extending our OWL-ViT offerings with a large variant. The model uses the same wrapper class as the existing OWL-ViT variants but points to `google/owlvit-large-patch14` on HuggingFace hub.

### How is this patch tested? If it is not, please explain why.
Created and ran tests that:

- Load the model from HuggingFace via `foz.load_zoo_model("owlvit-large-patch14-torch")`
- Verify detection outputs and bounding box generation
- Test embedding extraction capabilities
- Apply model to FiftyOne quickstart dataset
- Confirm compatibility with the existing transformer wrapper

The model successfully detected objects (cats up to 82.3% confidence, birds, people) using various text prompts and passed all tests.

### Release Notes
**Is this a user-facing change that should be mentioned in the release notes?**
- [x] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

Added OWL-ViT large-patch14 model to the model zoo for zero-shot object detection. 

### What areas of FiftyOne does this PR affect?
- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core fiftyone Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [x] Other