### PR TITLE
Various simple typo fixes

### DIFF
--- a/docs/source/recipes/torch-dataset-examples/simple_training_example.ipynb
+++ b/docs/source/recipes/torch-dataset-examples/simple_training_example.ipynb
@@ -57,7 +57,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we will look at an actual traing script with `FiftyOneTorchDataset`"
+    "Now we will look at an actual training script with `FiftyOneTorchDataset`"
    ]
   },
   {

--- a/docs/source/user_guide/export_datasets.rst
+++ b/docs/source/user_guide/export_datasets.rst
@@ -3636,7 +3636,7 @@ You can export a FiftyOne dataset to disk in the above format as follows:
             --export-dir $EXPORT_DIR \
             --type fiftyone.types.FiftyOneDataset
 
-You can export datasets in this this format without copying the source media
+You can export datasets in this format without copying the source media
 files by including `export_media=False` in your call to
 :meth:`export() <fiftyone.core.collections.SampleCollection.export>`.
 

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -299,7 +299,7 @@ class ColorScheme(EmbeddedDocument):
             -   ``list`` (optional): a list of dicts of colorscale values
 
                 -   ``value``: a float number between 0 and 1. A valid list
-                    must have have colors defined for 0 and 1
+                    must have colors defined for 0 and 1
                 -   ``color``: an RGB color string
         colorscales (None): an optional list of dicts of per-field custom
             colorscales with the following keys:
@@ -312,7 +312,7 @@ class ColorScheme(EmbeddedDocument):
                 the following keys:
 
                 -   ``value``: a float number between 0 and 1. A valid list
-                    must have have colors defined for 0 and 1
+                    must have colors defined for 0 and 1
                 -   ``color``: an RGB color string
         label_tags (None): an optional dict specifying custom colors for label
             tags with the following keys:

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -310,7 +310,7 @@ def available_patterns():
 
 
 def fill_patterns(string):
-    """Fills the patterns in in the given string.
+    """Fills the patterns in the given string.
 
     Use :meth:`available_patterns` to see the available patterns that can be
     used.

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -640,7 +640,7 @@ async def serialize_dataset(
 
         collection = dataset.view()
         if view is not None:
-            # unique id for for the relay global store
+            # unique id for the relay global store
             #
             # until a schema is with respect to a view and not a dataset this
             # is required

--- a/fiftyone/utils/activitynet.py
+++ b/fiftyone/utils/activitynet.py
@@ -127,7 +127,7 @@ def download_activitynet_split(
 class ActivityNetDatasetImporter(
     foud.FiftyOneTemporalDetectionDatasetImporter
 ):
-    """Class for importing AcitivityNet dataset splits downloaded via
+    """Class for importing ActivityNet dataset splits downloaded via
     :meth:`download_activitynet_split`.
 
     Args:

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -2318,7 +2318,7 @@ class AnnotationResults(foa.AnnotationResults):
 
     @property
     def _is_frames(self):
-        """Whether this annotation run was perfromed on a frames view."""
+        """Whether this annotation run was performed on a frames view."""
         return "_frames" in self.id_map
 
     def _finalize_id_map(self):

--- a/fiftyone/utils/cityscapes.py
+++ b/fiftyone/utils/cityscapes.py
@@ -56,7 +56,7 @@ def parse_cityscapes_dataset(
             gtBbox_cityPersons_trainval.zip     # optional
 
     Args:
-        source_dir: the directory continaining the manually downloaded
+        source_dir: the directory containing the manually downloaded
             Cityscapes files
         dataset_dir: the directory in which to build the output dataset
         scratch_dir: a scratch directory to use for temporary files
@@ -66,7 +66,7 @@ def parse_cityscapes_dataset(
             (False), or only if the ZIP file exists (None)
         coarse_annos (None): whether to load the coarse annotations (True), or
             not (False), or only if the ZIP file exists (None)
-        person_annos (None): whether to load the personn detections (True), or
+        person_annos (None): whether to load the person detections (True), or
             not (False), or only if the ZIP file exists (None)
 
     Raises:

--- a/fiftyone/utils/dicom.py
+++ b/fiftyone/utils/dicom.py
@@ -120,7 +120,7 @@ class DICOMSampleParser(foud.LabeledImageSampleParser):
 class DICOMDatasetImporter(
     foud.LabeledImageDatasetImporter, foud.ImportPathsMixin
 ):
-    """Importer for DICOM datasets datasets stored on disk.
+    """Importer for DICOM datasets stored on disk.
 
     See :ref:`this page <DICOMDataset-import>` for format details.
 

--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -377,7 +377,7 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
         project-level role.
 
         If the user is not a member of the project's parent organization, an
-        email invitivation will be sent.
+        email invitation will be sent.
 
         Args:
             project: the ``labelbox.schema.project.Project``

--- a/fiftyone/utils/openlabel.py
+++ b/fiftyone/utils/openlabel.py
@@ -1351,7 +1351,7 @@ class OpenLABELShapes(AttributeParser):
         return self._to_individual_labels(label, attributes, width, height)
 
     @property
-    def _homogenous_shape_types(self):
+    def _homogeneous_shape_types(self):
         types = [type(s) for s in self.shapes]
 
         if len(set(types)) > 1:
@@ -1373,7 +1373,7 @@ class OpenLABELShapes(AttributeParser):
         if not self.shapes:
             return labels
 
-        if not self._homogenous_shape_types or not isinstance(
+        if not self._homogeneous_shape_types or not isinstance(
             self.shapes[0], OpenLABELPoint
         ):
             raise ValueError(

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -1402,7 +1402,7 @@ class DetectorOutputProcessor(OutputProcessor):
 
 
 class InstanceSegmenterOutputProcessor(OutputProcessor):
-    """Output processor for instance segementers.
+    """Output processor for instance segmenters.
 
     Args:
         classes (None): the list of class labels for the model
@@ -1595,7 +1595,7 @@ class KeypointDetectorOutputProcessor(OutputProcessor):
 
 
 class SemanticSegmenterOutputProcessor(OutputProcessor):
-    """Output processor for semantic segementers.
+    """Output processor for semantic segmenters.
 
     Args:
         classes (None): the list of class labels for the model. This parameter

--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -191,7 +191,7 @@ def to_classifications(results, confidence_thresh=None, store_logits=False):
 
     Args:
         results: a single or list of ``ultralytics.engine.results.Results``
-        confidence_thresh (None): a confidence threshold to filter clasifications
+        confidence_thresh (None): a confidence threshold to filter classifications
 
     Returns:
         a single or list of :class:`fiftyone.core.labels.Classification`

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -587,7 +587,7 @@ def compute_orthographic_projection_images(
 
             -   a dict mapping values in ``[0, 1]`` to ``(R, G, B)`` tuples in
                 ``[0, 255]``
-            -   a list of of ``(R, G, B)`` tuples in ``[0, 255]`` that cover
+            -   a list of ``(R, G, B)`` tuples in ``[0, 255]`` that cover
                 ``[0, 1]`` linearly spaced
         subsampling_rate (None): an optional unsigned int that, if provided,
             defines a uniform subsampling rate. The selected point indices are
@@ -709,7 +709,7 @@ def compute_orthographic_projection_image(
 
             -   a dict mapping values in ``[0, 1]`` to ``(R, G, B)`` tuples in
                 ``[0, 255]``
-            -   a list of of ``(R, G, B)`` tuples in ``[0, 255]`` that cover
+            -   a list of ``(R, G, B)`` tuples in ``[0, 255]`` that cover
                 ``[0, 1]`` linearly spaced
         subsampling_rate (None): an unsigned ``int`` that, if defined,
             defines a uniform subsampling rate. The selected point indices are

--- a/fiftyone/utils/youtube.py
+++ b/fiftyone/utils/youtube.py
@@ -68,7 +68,7 @@ def download_youtube_videos(
         ]
 
     You can also use the optional ``ext`` and ``resolution`` arguments to
-    specify a deisred video codec and resolution to download, if possible.
+    specify a desired video codec and resolution to download, if possible.
 
     YouTube videos are regularly taken down. Therefore, this method provides an
     optional ``max_videos`` argument that you can use in conjunction with

--- a/tests/unittests/synchronization_tests.py
+++ b/tests/unittests/synchronization_tests.py
@@ -189,7 +189,7 @@ class SingleProcessSynchronizationTests(unittest.TestCase):
 
 class ScopedObjectsSynchronizationTests(unittest.TestCase):
     """Tests ensuring that when a dataset or samples in a dataset are modified,
-    those changes are passed on the the database and can be seen in different
+    those changes are passed on the database and can be seen in different
     scopes (or processes!).
     """
 


### PR DESCRIPTION
Simple one-word typo fix in docstring for def add_member: 

invitivation -> invitation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected multiple typographical errors and duplicated words across code docstrings, comments, and user guide documentation for improved clarity and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->