### PR TITLE
fix: prevent scroll from overriding sidebar highlight after click

### DIFF
--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -9,6 +9,7 @@ $(function () {
     10;
 
   let lastSection = undefined;
+  let suppressNextScroll = false;
 
   function updateSidebar(e) {
     let currentSection = undefined;
@@ -16,6 +17,10 @@ $(function () {
     if (e.target && e.target.href && e.target.href.indexOf("#") >= 0) {
       currentSection = e.target.href.split("#").pop();
       clicked = true;
+      suppressNextScroll = true;
+    } else if (suppressNextScroll) {
+      suppressNextScroll = false;
+      return;
     } else {
       for (let i = sections.length - 1; i >= 0; i--) {
         if (


### PR DESCRIPTION
## What changes are proposed in this pull request?

@prernadh  found the issue, and I tested it to confirm the problem. In the documentation site, when a user clicks a sidebar link, it briefly highlights the correct section, but a scroll event immediately fires and overrides it with the wrong one.
This PR introduces a hotfix by adding a flag to suppress the next scroll event after a click, ensuring the correct section stays highlighted.

https://github.com/user-attachments/assets/35022e96-1b59-4e98-8872-50fc3a94e365


I'm not sure if this is already fixed in the new documentation version, but this makes it work correctly in the current one.

## How is this patch tested? If it is not, please explain why.

Manually tested by clicking sidebar links and confirming that the correct section remains highlighted. Verified that the scroll suppression only applies once and resets correctly.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [x] No. You can skip the rest of this section.

### What areas of FiftyOne does this PR affect?

* [ ] App: FiftyOne application changes
* [ ] Build: Build and test infrastructure changes
* [ ] Core: Core `fiftyone` Python library changes
* [x] Documentation: FiftyOne documentation changes
* [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar behavior to prevent unwanted updates when clicking sidebar links, resulting in a smoother navigation experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->