### PR TITLE
Address docs theme feedback

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -74,7 +74,7 @@ jobs:
           echo "Installing docs requirements"
           pip install -r requirements/docs.txt
           echo "Installing fiftyone-teams requirements"
-          pip install -r fiftyone-teams/requirements/common.txt
+          pip install ./fiftyone-teams
           echo "Installing fiftyone-brain and fiftyone-db"
           pip install fiftyone-brain fiftyone-db
           echo "Installing fiftyone"

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,14 +27,20 @@ Before building the docs locally, ensure you have:
 
 To build the documentation locally, follow these steps:
 
-1.  Ensure documentation-specific requirements are installed:
+1. Install FiftyOne:
 
 ```shell
 cd ..
+bash install.bash
+```
+
+2. Install documentation-specific requirements:
+
+```shell
 pip install -r requirements/docs.txt
 ```
 
-2.  To use the `fiftyone` repository to autogenerate docs, you need to add it
+3.  To use the `fiftyone` repository to autogenerate docs, you need to add it
     to your `PYTHONPATH`:
 
 ```shell

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -1,5 +1,5 @@
 :root {
-  --feedback-primary-color: #181a1b;
+  --feedback-primary-color: #181a1b !important;
   --docsearch-primary-color: #ff6d04;
 }
 
@@ -298,10 +298,35 @@ table.highlighttable td.code pre {
   white-space: pre;
 }
 
+.highlight pre {
+  line-height: 1.6;
+}
+
+span.linenos {
+  background-color: #f8f8f8;
+  margin-right: 1em;
+  display: inline-block;
+  min-width: 4em;
+  text-align: center;
+  margin-left: -1.5em;
+  padding-bottom: 0.1em;
+  margin-bottom: -0.05em;
+}
+
+span.linenos.first-linenos {
+  padding-top: 1.375rem;
+  margin-top: -1.375rem;
+}
+
+span.linenos.last-linenos {
+  padding-bottom: 1.375rem;
+  margin-bottom: -1.375rem;
+}
+
 /* tweaks copied from sphinx-rtd-theme */
 
-.rst-content .section > img,
-.rst-content .section > a > img {
+.rst-content section > img,
+.rst-content section > a > img {
   margin-bottom: 24px;
 }
 
@@ -692,4 +717,9 @@ a.with-right-arrow,
 
 .DocSearch-Hits mark {
   padding: 0;
+}
+
+/* API reference */
+.toctree-wrapper.compound li:has(> a.has-code) {
+  display: none;
 }

--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -62,8 +62,15 @@ $(function () {
   $(window).on("scroll", updateSidebar);
   $(".pytorch-right-menu").on("click", updateSidebar);
 
-  // Hide API docs classes and methods from toctree
-  $(window).on("load", function () {
-    $(".toctree-wrapper.compound li:has(> a.has-code)").hide();
-  });
+  // Mark first and last line numbers for proper styling
+  function markLineNumbers() {
+    $("pre").each(function () {
+      const $lineNumbers = $(this).find("span.linenos");
+      if ($lineNumbers.length > 0) {
+        $lineNumbers.first().addClass("first-linenos");
+        $lineNumbers.last().addClass("last-linenos");
+      }
+    });
+  }
+  markLineNumbers();
 });

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,3 @@
--r common.txt
 -r extras.txt
 -r test.txt
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,5 +1,4 @@
 # fiftyone requirements
--r common.txt
 pycocotools
 tensorflow
 torch
@@ -26,5 +25,5 @@ sphinx-tabs==3.4.7
 Sphinx==8.1.3 
 sphinx-copybutton==0.5.2
 sphinxcontrib-jquery==4.1
-sphinx-pushfeedback==0.1.3
+sphinx-pushfeedback==0.1.7
 sphinx-docsearch==0.1.0


### PR DESCRIPTION
## What changes are proposed in this pull request?

Addresses feedback received by @brimoor and @AdonaiVera :

* Removed class and method names from the module tree at the top of each API reference page.
* Restored newline spacing after media content blocks.
* Re-applied background color and padding to code blocks with line numbers.
* Fixed missing `pushfeedback.css` on child pages.
* Resolved rebase conflicts introduced in https://github.com/voxel51/fiftyone/commit/be5889872e0b820df117b574105f0ce498f88d8b.
* Fixed GitHub Pages script to include `requirements/commons.txt`.

## How is this patch tested? If it is not, please explain why.

Built the docs locally and verified all the changes are rendering as expected.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
