### PR TITLE
Fix missing ultralytics package requirement

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -5660,7 +5660,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch>=1.7.0", "torchvision>=0.8.1"],
+                "packages": ["torch>=1.7.0", "torchvision>=0.8.1", "ultralytics"],
                 "cpu": {
                     "support": true
                 },


### PR DESCRIPTION
Fix missing ultralytics package requirement for yolov5x-coco-torch.

## What changes are proposed in this pull request?

Adds the missing `ultralytics` package to the requirements for the `yolov5x-coco-torch` model.

## How is this patch tested? If it is not, please explain why.

Verified build and that the model can be successfully downloaded and loaded after this change.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

  - [x] No. You can skip the rest of this section.
  - [ ] Yes. Give a description of this change to be included in the release
    notes for FiftyOne users.

Fixed a bug where the `yolov5x-coco-torch` model from the zoo failed to load due to a missing package dependency.