### PR TITLE
FOEPD-1814: Annotation schema prototype

### DIFF
--- a/fiftyone/core/annotation.py
+++ b/fiftyone/core/annotation.py
@@ -99,7 +99,8 @@ def compute_annotation_schema(collection, field_name):
         - tags
 
     Args:
-        field_name: the field to process
+        collection: a :class:`SampleCollection`
+        field_name: the field name to process
 
     Raises:
         ValueError: if the field does not exists or annotation for its

--- a/fiftyone/core/annotation.py
+++ b/fiftyone/core/annotation.py
@@ -99,8 +99,8 @@ def compute_annotation_schema(collection, field_name):
         - tags
 
     Args:
-        collection: a :class:`SampleCollection`
-        field_name: the field name to process
+        collection: a :class:`fiftyone.core.collections.SampleCollection`
+        field_name: a field name or ``embedded.field.name`` to process
 
     Raises:
         ValueError: if the field does not exists or annotation for its
@@ -108,7 +108,6 @@ def compute_annotation_schema(collection, field_name):
 
     Returns:
         an annotation schema dictionary
-
     """
     if collection.media_type != fom.IMAGE:
         raise ValueError("only image datasets are supported")

--- a/fiftyone/core/annotation.py
+++ b/fiftyone/core/annotation.py
@@ -8,7 +8,6 @@ Annotation runs framework.
 
 import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
-import fiftyone.core.media as fom
 from fiftyone.core.runs import (
     BaseRun,
     BaseRunConfig,
@@ -109,9 +108,6 @@ def compute_annotation_schema(collection, field_name):
     Returns:
         an annotation schema dictionary
     """
-    if collection.media_type != fom.IMAGE:
-        raise ValueError("only image datasets are supported")
-
     if field_name is None:
         raise ValueError("field_name is required")
 
@@ -134,7 +130,9 @@ def compute_annotation_schema(collection, field_name):
             return {"default": None, "type": "input"}
 
     if is_list:
-        raise ValueError(f"unsupported annotation field {field}")
+        raise ValueError(
+            f"unsupported annotation field {field}; only StringField lists are supported"
+        )
 
     if isinstance(field, fof.BooleanField):
         return {
@@ -157,16 +155,6 @@ def compute_annotation_schema(collection, field_name):
 
     if not isinstance(field, fof.EmbeddedDocumentField):
         raise ValueError(f"unsupported annotation field {field}")
-
-    if not field.document_type in (
-        fol.Classification,
-        fol.Classifications,
-        fol.Detection,
-        fol.Detections,
-    ):
-        raise ValueError(
-            f"unsupported annotation document type {field.document_type}"
-        )
 
     _type = str(field.document_type.__name__).lower()
     if issubclass(field.document_type, fol._HasLabelList):

--- a/fiftyone/core/annotation.py
+++ b/fiftyone/core/annotation.py
@@ -5,6 +5,10 @@ Annotation runs framework.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
+import fiftyone.core.fields as fof
+import fiftyone.core.labels as fol
+import fiftyone.core.media as fom
 from fiftyone.core.runs import (
     BaseRun,
     BaseRunConfig,
@@ -78,3 +82,119 @@ class AnnotationResults(BaseRunResults):
     """Base class for annotation run results."""
 
     pass
+
+
+def compute_annotation_schema(collection, field_name):
+    """Compute the annotation schema for a collection's field
+
+    An annotation schema is defined by a type. A field type and an annotation
+    type informs the annotation form type and allowed values
+
+    Annotation types are:
+        - checkbox
+        - input
+        - select
+        - radio
+        - text
+        - tags
+
+    Args:
+        field_name: the field to process
+
+    Raises:
+        ValueError: if the field does not exists or annotation for its
+        field type is not supported
+
+    Returns:
+        an annotation schema dictionary
+
+    """
+    if collection.media_type != fom.IMAGE:
+        raise ValueError("only image datasets are supported")
+
+    if field_name is None:
+        raise ValueError("should we allow a full schema computation?")
+
+    field = collection.get_field(field_name)
+    if field is None:
+        raise ValueError(f"field '{field_name} does not exist")
+
+    is_list = isinstance(field, fof.ListField)
+    if is_list:
+        field = field.field
+
+    if isinstance(field, fof.StringField):
+        try:
+            return {
+                "default": None,
+                "type": "checkbox" if is_list else "select",
+                "values": collection.distinct(field_name),
+            }
+        except:
+            # too many distinct values
+            return {"default": None, "type": "input"}
+
+    if is_list:
+        raise ValueError(f"unsupported annotation field {field}")
+
+    if isinstance(field, fof.BooleanField):
+        return {
+            "default": None,
+            "type": "radio",
+            "values": [True, False, None],
+        }
+
+    if isinstance(
+        field,
+        (
+            fof.DateField,
+            fof.DateTimeField,
+            fof.ObjectIdField,
+            fof.FloatField,
+            fof.IntField,
+        ),
+    ):
+        return {"type": "input", "default": None}
+
+    if not isinstance(field, fof.EmbeddedDocumentField):
+        raise ValueError(f"unsupported annotation field {field}")
+
+    if not field.document_type in (
+        fol.Classification,
+        fol.Classifications,
+        fol.Detection,
+        fol.Detections,
+    ):
+        raise ValueError(
+            f"unsupported annotation document type {field.document_type}"
+        )
+
+    _type = str(field.document_type.__name__).lower()
+    if issubclass(field.document_type, fol._HasLabelList):
+        field_name = f"{field_name}.{field.document_type._LABEL_LIST_FIELD}"
+        field = collection.get_field(field_name).field
+
+    attributes = {}
+    classes = []
+    for f in field.fields:
+        if f.name == "label":
+            classes = collection.distinct(f"{field_name}.label")
+            continue
+
+        if f.name == "bounding_box" and field.document_type == fol.Detection:
+            # bounding_box is a list of floats field, but really a 4-tuple of
+            # [0, 1] floats, omit for special handling by the App
+            continue
+
+        try:
+            attributes[f.name] = compute_annotation_schema(
+                collection, f"{field_name}.{f.name}"
+            )
+        except:
+            pass
+
+    return {
+        "type": _type,
+        "attributes": attributes,
+        "classes": classes,
+    }

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -3352,7 +3352,7 @@ class SampleCollection(object):
         Returns:
             an annotation schema dictionary
         """
-        return foua.compute_annotation_schema(self, field_name)
+        return foan.compute_annotation_schema(self, field_name)
 
     def apply_model(
         self,

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -3340,10 +3340,22 @@ class SampleCollection(object):
         )
 
     def compute_annotation_schema(self, field_name):
-        """Compute the annotation schema for a field
+        """Compute the annotation schema for a collection's field
+
+        An annotation schema is defined by a type. A field type and an annotation
+        type informs the annotation form type and allowed values
+
+        Annotation types are:
+            - checkbox
+            - input
+            - select
+            - radio
+            - text
+            - tags
 
         Args:
-            field_name: the field to process
+            collection: a :class:`fiftyone.core.collections.SampleCollection`
+            field_name: a field name or ``embedded.field.name`` to process
 
         Raises:
             ValueError: if the field does not exists or annotation for its

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -3339,6 +3339,21 @@ class SampleCollection(object):
             progress=progress,
         )
 
+    def compute_annotation_schema(self, field_name):
+        """Compute the annotation schema for a field
+
+        Args:
+            field_name: the field to process
+
+        Raises:
+            ValueError: if the field does not exists or annotation for its
+            field type is not supported
+
+        Returns:
+            an annotation schema dictionary
+        """
+        return foua.compute_annotation_schema(self, field_name)
+
     def apply_model(
         self,
         model,

--- a/tests/unittests/annotation_schema_tests.py
+++ b/tests/unittests/annotation_schema_tests.py
@@ -1,0 +1,196 @@
+"""
+FiftyOne annotation schema unit tests.
+
+| Copyright 2017-2025, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from datetime import date, datetime
+import fiftyone as fo
+from fiftyone.core.annotation import compute_annotation_schema
+import unittest
+
+
+from decorators import drop_datasets
+
+
+class AnnotationSchemaTests(unittest.TestCase):
+    @drop_datasets
+    def test_date(self):
+        dataset = fo.Dataset()
+        dataset.add_sample_field("date_field", fo.DateField)
+        dataset.add_sample(
+            fo.Sample(filepath="image.png", date_field=date.today())
+        )
+        self.assertEqual(
+            compute_annotation_schema(dataset, "date_field"),
+            {
+                "default": None,
+                "type": "input",
+            },
+        )
+
+    @drop_datasets
+    def test_datetime(self):
+        dataset = fo.Dataset()
+        dataset.add_sample(
+            fo.Sample(filepath="image.png", datetime_field=datetime.now())
+        )
+        self.assertEqual(
+            compute_annotation_schema(dataset, "datetime_field"),
+            {
+                "default": None,
+                "type": "input",
+            },
+        )
+
+    @drop_datasets
+    def test_float(self):
+        dataset = fo.Dataset()
+        dataset.add_sample(fo.Sample(filepath="image.png", float_field=0.0))
+        self.assertEqual(
+            compute_annotation_schema(dataset, "float_field"),
+            {
+                "default": None,
+                "type": "input",
+            },
+        )
+
+    @drop_datasets
+    def test_int(self):
+        dataset = fo.Dataset()
+        dataset.add_sample(fo.Sample(filepath="image.png", int_field=0))
+        self.assertEqual(
+            compute_annotation_schema(dataset, "int_field"),
+            {
+                "default": None,
+                "type": "input",
+            },
+        )
+
+    @drop_datasets
+    def test_string(self):
+        dataset = fo.Dataset()
+        dataset.add_sample(
+            fo.Sample(filepath="image.png", string_field="test")
+        )
+        self.assertEqual(
+            compute_annotation_schema(dataset, "string_field"),
+            {"default": None, "type": "select", "values": ["test"]},
+        )
+
+    @drop_datasets
+    def test_string_list(self):
+        dataset = fo.Dataset()
+        dataset.add_sample(
+            fo.Sample(filepath="image.png", string_list_field=["test"])
+        )
+        self.assertEqual(
+            compute_annotation_schema(dataset, "string_list_field"),
+            {"default": None, "type": "checkbox", "values": ["test"]},
+        )
+
+    @drop_datasets
+    def test_classification(self):
+        dataset = fo.Dataset()
+        dataset.add_sample(
+            fo.Sample(
+                filepath="image.png",
+                classification_field=fo.Classification(label="test"),
+            )
+        )
+        self.assertEqual(
+            compute_annotation_schema(dataset, "classification_field"),
+            {
+                "classes": ["test"],
+                "type": "classification",
+                "attributes": {
+                    "id": {"default": None, "type": "input"},
+                    "tags": {
+                        "default": None,
+                        "type": "checkbox",
+                        "values": [],
+                    },
+                },
+            },
+        )
+
+    @drop_datasets
+    def test_classifications(self):
+        dataset = fo.Dataset()
+        dataset.add_sample(
+            fo.Sample(
+                filepath="image.png",
+                classifications_field=fo.Classifications(
+                    classifications=[fo.Classification(label="test")]
+                ),
+            )
+        )
+        self.assertEqual(
+            compute_annotation_schema(dataset, "classifications_field"),
+            {
+                "classes": ["test"],
+                "type": "classifications",
+                "attributes": {
+                    "id": {"default": None, "type": "input"},
+                    "tags": {
+                        "default": None,
+                        "type": "checkbox",
+                        "values": [],
+                    },
+                },
+            },
+        )
+
+    @drop_datasets
+    def test_detection(self):
+        dataset = fo.Dataset()
+        dataset.add_sample(
+            fo.Sample(
+                filepath="image.png",
+                detection_field=fo.Detection(label="test"),
+            )
+        )
+        self.assertEqual(
+            compute_annotation_schema(dataset, "detection_field"),
+            {
+                "classes": ["test"],
+                "type": "detection",
+                "attributes": {
+                    "id": {"default": None, "type": "input"},
+                    "tags": {
+                        "default": None,
+                        "type": "checkbox",
+                        "values": [],
+                    },
+                },
+            },
+        )
+
+    @drop_datasets
+    def test_detections(self):
+        dataset = fo.Dataset()
+        dataset.add_sample(
+            fo.Sample(
+                filepath="image.png",
+                detections_field=fo.Detections(
+                    detections=[fo.Detection(label="test")]
+                ),
+            )
+        )
+        self.assertEqual(
+            compute_annotation_schema(dataset, "detections_field"),
+            {
+                "classes": ["test"],
+                "type": "detections",
+                "attributes": {
+                    "id": {"default": None, "type": "input"},
+                    "tags": {
+                        "default": None,
+                        "type": "checkbox",
+                        "values": [],
+                    },
+                },
+            },
+        )


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds a proposed `SampleCollection.compute_annotation_schema` method

This is a starting point to drill down on initial boundaries for human annotation.

Questions to consider
* Should we persist annotation schemas? Where should they live? e.g. on a field document?
* Which annotation types should inspect the sample collection for possible values?
* The dataset schema (which defines field types) already exists. An annotation schema should supplement (and not contradict) this information

This work takes inspiration from the already documented [label schemas](https://docs.voxel51.com/user_guide/annotation.html#label-schema) used for third-party integrations

## How is this patch tested? If it is not, please explain why.

Python tests

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to compute and retrieve a UI-facing annotation schema for a specific dataset field via the public API and collection-level method. Supports categorical, boolean, date/number, and nested annotation types, returning type, attributes, and classes for UI consumption.

* **Tests**
  * Added unit tests validating schema generation across multiple primitive and annotation field types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->