### PR TITLE
fix: standardize Apache license format in model metadata

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -6318,7 +6318,7 @@
             "description": "Lightweight real-time object detector optimized for speed on edge devices",
             "source": "https://huggingface.co/PekingU/rtdetr_v2_r18vd",
             "author": "Wenyu Lv, et al.",
-            "license": "Apache-2.0",
+            "license": "Apache 2.0",
             "size_bytes": 161820194,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForObjectDetection",
@@ -6354,7 +6354,7 @@
             "description": "Balanced real-time object detector offering improved accuracy for production use",
             "source": "https://huggingface.co/PekingU/rtdetr_v2_r50vd",
             "author": "Wenyu Lv, et al.",
-            "license": "Apache-2.0",
+            "license": "Apache 2.0",
             "size_bytes": 344364318,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForObjectDetection",


### PR DESCRIPTION
- Change "Apache-2.0" to "Apache 2.0" for consistency
- Affected models: rtdetr-v2-s-coco-torch, rtdetr-v2-m-coco-torch
- Aligns with format used by other Apache-licensed models in the dataset