### PR TITLE
use built-in store instead of provided which may be missing

### DIFF
--- a/app/packages/operators/src/components/OperatorPromptForm.tsx
+++ b/app/packages/operators/src/components/OperatorPromptForm.tsx
@@ -4,11 +4,12 @@ import OperatorIO from "../OperatorIO";
 
 export function OperatorPromptForm({ operatorPrompt }) {
   const setFormState = useCallback(
-    (data) => {
+    (data, liteValues) => {
       const formData = { ...data };
       for (const field in formData) {
         operatorPrompt.setFieldValue(field, formData[field]);
       }
+      operatorPrompt.setLiteValues(liteValues);
     },
     [operatorPrompt]
   );
@@ -21,7 +22,6 @@ export function OperatorPromptForm({ operatorPrompt }) {
         data={operatorPrompt.promptingOperator.params}
         errors={operatorPrompt?.validationErrors || []}
         initialData={operatorPrompt.promptingOperator.initialParams}
-        store={operatorPrompt.store}
       />
     </Box>
   );

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -476,14 +476,14 @@ export const useOperatorPrompt = () => {
   const serializedParams = useMemo(() => {
     return JSON.stringify(ctx.params);
   }, [ctx.params]);
-  const storeRef = useRef({});
-  const store = storeRef.current;
+  const liteValuesRef = useRef({});
 
   const resolveInput = useCallback(
     debounce(
       async (ctx) => {
         try {
-          const optimizedCtx = optimizeCtx(ctx, store);
+          const liteValues = liteValuesRef.current;
+          const optimizedCtx = optimizeCtx(ctx, liteValues);
           if (operator.config.resolveExecutionOptionsOnChange) {
             execDetails.fetch(optimizedCtx);
           }
@@ -580,6 +580,11 @@ export const useOperatorPrompt = () => {
         }
       }
   );
+
+  const setLiteValues = useCallback((liteValues) => {
+    liteValuesRef.current = liteValues;
+  }, []);
+
   const execute = useCallback(
     async (options = {}) => {
       setPreparing(true);
@@ -686,7 +691,7 @@ export const useOperatorPrompt = () => {
     submitOptions,
     promptView,
     resolvedIO,
-    store,
+    setLiteValues,
   };
 };
 

--- a/app/packages/operators/src/utils.ts
+++ b/app/packages/operators/src/utils.ts
@@ -151,8 +151,7 @@ export function generateOperatorSessionId() {
   return uuid();
 }
 
-export function optimizeCtx(ctx, store) {
-  const liteValues = store?.liteValues || {};
+export function optimizeCtx(ctx, liteValues) {
   const originalParams = ctx.params || {};
 
   if (isEmpty(liteValues) || isEmpty(originalParams)) return ctx;


### PR DESCRIPTION
## What changes are proposed in this pull request?

use built-in store instead of provided which may be missing

## How is this patch tested? If it is not, please explain why.

Using operators and ME panel

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal management of form state and value propagation for operator prompts, consolidating lite value handling and simplifying callbacks.
  * Streamlined how value overrides are passed and managed throughout operator-related components, reducing reliance on external stores.
  * Updated function signatures and callback parameters to enhance consistency and maintainability across the operator prompt workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->