### PR TITLE
Restore docs newline spacing after images

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -327,7 +327,7 @@ span.linenos.last-linenos {
 
 .rst-content section > img,
 .rst-content section > a > img {
-  margin-bottom: 24px;
+  margin-bottom: 24px !important;
 }
 
 .rst-content .align-center {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Addresses https://github.com/voxel51/fiftyone/pull/6201#issuecomment-3137772116

## How is this patch tested? If it is not, please explain why.

Local build:

<img width="3024" height="1714" alt="image" src="https://github.com/user-attachments/assets/e1e98954-5092-4db4-8bcc-6cf2b00c21eb" />

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
