### PR TITLE
Update CODEOWNERS for /docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,3 +27,6 @@ Dockerfile                   @voxel51/aloha-shirts
 setup.py                     @voxel51/aloha-shirts
 requirements.txt             @voxel51/aloha-shirts
 requirements/                @voxel51/aloha-shirts
+
+# Documentation
+/docs/                       @voxel51/dev-rel


### PR DESCRIPTION
Setting @voxel51/dev-rel as the owners of `/docs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership rules to assign the documentation folder to a specific team.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->