### PR TITLE
chore: add dev-docs publish action

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,5 +1,4 @@
 name: Build docs
-
 on:
   push:
     branches:
@@ -44,15 +43,51 @@ jobs:
     env:
       FIFTYONE_DO_NOT_TRACK: true
     steps:
-      - name: Clone fiftyone
+      - name: Clone fiftyone for tag builds
+        if: github.ref_type == 'tag'
+        uses: actions/checkout@v4
+        with:
+          # Fetch full history for rev-parse to work
+          fetch-depth: 0
+      - name: Clone fiftyone for branch builds
+        if: github.ref_type == 'branch'
         uses: actions/checkout@v4
       - name: Get Branch Name
-        # This is somewhat redundant if we were triggered by a branch push
-        #   but it makes it work with tags too
         id: get_branch
-        run: TAG_COMMIT=$(git rev-parse ${{ github.ref }})
-          BRANCH_NAME=$(git branch -r --contains $TAG_COMMIT | head -n1 | cut -c3-)
-          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+        run: |
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            TAG_SHA=$(git rev-parse ${{ github.ref }})
+            case "${{ github.ref_name }}" in
+              docs-publish|v*)
+                MAIN_SHA=$(git rev-parse origin/main)
+                if [[ "${MAIN_SHA}" == "${TAG_SHA}" ]]; then
+                  echo "branch_name=main" >> "${GITHUB_OUTPUT}"
+                else
+                  echo "docs-publish should only be performed on 'main'"
+                  exit 1
+                fi
+                ;;
+              dev-docs-publish)
+                DEVELOP_SHA=$(git rev-parse origin/develop)
+                if [[ "${DEVELOP_SHA}" == "${TAG_SHA}" ]]; then
+                  echo "branch_name=develop" >> "${GITHUB_OUTPUT}"
+                else
+                  echo "dev-docs-publish should only be performed on 'develop'"
+                  exit 1
+                fi
+                ;;
+            esac
+          else
+            case "${{ github.ref_name }}" in
+              main|develop)
+                echo "branch_name=${{ github.ref_name }}" >> "${GITHUB_OUTPUT}"
+                ;;
+              *)
+                # use `main` because arbitrary branch names may not exist on `fiftyone-teams` or `eta`
+                echo "branch_name=main" >> "${GITHUB_OUTPUT}"
+                ;;
+            esac
+          fi
       - name: Checkout fiftyone-teams
         uses: actions/checkout@v4
         with:
@@ -107,11 +142,13 @@ jobs:
         with:
           name: docs
           path: docs/build/html/
+    outputs:
+      branch_name: ${{ steps.get_branch.outputs.branch_name}}
 
   publish:
     needs: [build]
     if: |
-      steps.get_branch.outputs.branch_name == 'origin/main' &&
+      needs.build.outputs.branch_name == 'main' &&
       (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/tags/docs-publish')
     runs-on: ubuntu-latest
     steps:
@@ -132,7 +169,7 @@ jobs:
   dev-publish:
     needs: [build]
     if: |
-      steps.get_branch.outputs.branch_name == 'origin/develop' &&
+      needs.build.outputs.branch_name == 'develop' &&
       github.ref == 'refs/tags/dev-docs-publish'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,10 +3,8 @@ name: Build docs
 on:
   push:
     branches:
-      # - develop
       - docs-*
       - github-actions-*
-      # - main
       - rel-*
       - release-*
       - release/*
@@ -48,13 +46,20 @@ jobs:
     steps:
       - name: Clone fiftyone
         uses: actions/checkout@v4
+      - name: Get Branch Name
+        # This is somewhat redundant if we were triggered by a branch push
+        #   but it makes it work with tags too
+        id: get_branch
+        run: TAG_COMMIT=$(git rev-parse ${{ github.ref }})
+          BRANCH_NAME=$(git branch -r --contains $TAG_COMMIT | head -n1 | cut -c3-)
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
       - name: Checkout fiftyone-teams
         uses: actions/checkout@v4
         with:
           repository: voxel51/fiftyone-teams
           path: fiftyone-teams
           token: ${{ secrets.RO_FOT_FG_PAT }}
-          ref: main
+          ref: ${{ steps.get_branch.outputs.branch_name }}
       - name: Set up Python 3.9
         uses: actions/setup-python@v5
         with:
@@ -64,7 +69,7 @@ jobs:
           pip install --upgrade pip setuptools wheel build
       - name: Install ETA from source
         run: |
-          git clone https://github.com/voxel51/eta eta --depth 1 --branch develop
+          git clone https://github.com/voxel51/eta eta --depth 1 --branch "${{ steps.get_branch.outputs.branch_name }}"
           cd eta
           python -Im build
           pip install ./dist/*.whl
@@ -106,7 +111,7 @@ jobs:
   publish:
     needs: [build]
     if: |
-      github.ref == 'refs/heads/main' &&
+      steps.get_branch.outputs.branch_name == 'origin/main' &&
       (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/tags/docs-publish')
     runs-on: ubuntu-latest
     steps:
@@ -127,7 +132,8 @@ jobs:
   dev-publish:
     needs: [build]
     if: |
-      github.ref == 'refs/heads/develop' && github.ref == 'refs/tags/dev-docs-publish'
+      steps.get_branch.outputs.branch_name == 'origin/develop' &&
+      github.ref == 'refs/tags/dev-docs-publish'
     runs-on: ubuntu-latest
     steps:
       - name: Download docs

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,17 +3,17 @@ name: Build docs
 on:
   push:
     branches:
-      - develop
+      # - develop
       - docs-*
       - github-actions-*
-      - main
+      # - main
       - rel-*
       - release-*
       - release/*
     tags:
-      - v*
-      - docs-publish
       - dev-docs-publish
+      - docs-publish
+      - v*
     paths:
       - .github/workflows/build-docs.yml
       - docs/**

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,15 +3,17 @@ name: Build docs
 on:
   push:
     branches:
-      # - develop
+      - develop
+      - docs-*
+      - github-actions-*
+      - main
       - rel-*
       - release-*
       - release/*
-      - docs-*
-      - github-actions-*
     tags:
       - v*
       - docs-publish
+      - dev-docs-publish
     paths:
       - .github/workflows/build-docs.yml
       - docs/**
@@ -103,7 +105,9 @@ jobs:
 
   publish:
     needs: [build]
-    if: (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'rc')) || github.ref == 'refs/tags/docs-publish'
+    if: |
+      github.ref == 'refs/heads/main' &&
+      (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/tags/docs-publish')
     runs-on: ubuntu-latest
     steps:
       - name: Download docs
@@ -119,3 +123,23 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
       - name: publish
         run: gsutil -m rsync -dR -x '^SBOMs/.*' docs-download gs://docs.voxel51.com
+
+  dev-publish:
+    needs: [build]
+    if: |
+      github.ref == 'refs/heads/develop' && github.ref == 'refs/tags/dev-docs-publish'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download docs
+        uses: actions/download-artifact@v4
+        with:
+          name: docs
+          path: docs-download/
+      - name: Authorize gcloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: "${{ secrets.DOCS_GCP_CREDENTIALS }}"
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+      - name: publish
+        run: gsutil -m rsync -dR docs-download gs://docs.dev.voxel51.com


### PR DESCRIPTION
## What changes are proposed in this pull request?

We'd like to add a docs.dev.fiftyone.ai site to publish docs from `develop`

This PR should:
- make it so that `docs-publish` can only be run on `main`
- make it so that `dev-docs-publish` will publish to a new docs.dev.fiftyone.ai bucket, if the tag is on `develop`

## How is this patch tested? If it is not, please explain why.

not super sure how to do that... will probably have to iterate...

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new process to publish documentation to a separate development site.

* **Chores**
  * Updated workflow triggers and publishing conditions for documentation deployments.
  * Improved branch handling and dynamic repository checkouts in documentation build workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->