### PR TITLE
Upgrade pillow to 11.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ INSTALL_REQUIRES = [
     "numpy",
     "packaging",
     "pandas",
-    "Pillow>=6.2",
+    "Pillow>=11.3.0",
     "plotly>=4.14",
     "pprintpp",
     "psutil",


### PR DESCRIPTION
## What changes are proposed in this pull request?

pillow upgraded to [11.3.0](https://pillow.readthedocs.io/en/stable/releasenotes/11.3.0.html#) from version [6.2.0](https://pillow.readthedocs.io/en/stable/releasenotes/6.2.0.html) due to the vulnerability [CVE-2025-48379](https://www.cve.org/CVERecord?id=CVE-2025-48379)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
