### PR TITLE
Add SegFormer Model Family to Zoo

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -6538,6 +6538,168 @@
             },
             "tags": ["detection", "coco", "torch", "transformers", "detr", "official"],
             "date_added": "2025-07-15 23:00:00"
+        },
+        {
+            "base_name": "segformer-b0-ade20k-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Efficient transformer-based semantic segmentation model for scene parsing with 150 classes",
+            "source": "https://huggingface.co/nvidia/segformer-b0-finetuned-ade-512-512",
+            "author": "Enze Xie, et al.",
+            "license": "MIT",
+            "size_bytes": 15012832,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForSemanticSegmentation",
+                "config": {
+                    "name_or_path": "nvidia/segformer-b0-finetuned-ade-512-512"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segmentation", "torch", "segformer", "official"],
+            "date_added": "2025-08-04 12:34:17"
+        },
+        {
+            "base_name": "segformer-b1-ade20k-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Balanced SegFormer model providing good accuracy-efficiency tradeoff for scene understanding",
+            "source": "https://huggingface.co/nvidia/segformer-b1-finetuned-ade-512-512",
+            "author": "Enze Xie, et al.",
+            "license": "MIT",
+            "size_bytes": 54865248,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForSemanticSegmentation",
+                "config": {
+                    "name_or_path": "nvidia/segformer-b1-finetuned-ade-512-512"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segmentation", "torch", "segformer", "official"],
+            "date_added": "2025-08-04 12:34:20"
+        },
+        {
+            "base_name": "segformer-b2-ade20k-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Medium-sized SegFormer delivering enhanced segmentation quality for complex scenes",
+            "source": "https://huggingface.co/nvidia/segformer-b2-finetuned-ade-512-512",
+            "author": "Enze Xie, et al.",
+            "license": "MIT",
+            "size_bytes": 109854048,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForSemanticSegmentation",
+                "config": {
+                    "name_or_path": "nvidia/segformer-b2-finetuned-ade-512-512"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segmentation", "torch", "segformer", "official"],
+            "date_added": "2025-08-04 12:34:22"
+        },
+        {
+            "base_name": "segformer-b3-ade20k-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Larger SegFormer model with improved accuracy for detailed semantic segmentation",
+            "source": "https://huggingface.co/nvidia/segformer-b3-finetuned-ade-512-512",
+            "author": "Enze Xie, et al.",
+            "license": "MIT",
+            "size_bytes": 189357408,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForSemanticSegmentation",
+                "config": {
+                    "name_or_path": "nvidia/segformer-b3-finetuned-ade-512-512"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segmentation", "torch", "segformer", "official"],
+            "date_added": "2025-08-04 12:34:24"
+        },
+        {
+            "base_name": "segformer-b4-ade20k-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "High-capacity SegFormer achieving excellent results on challenging segmentation tasks",
+            "source": "https://huggingface.co/nvidia/segformer-b4-finetuned-ade-512-512",
+            "author": "Enze Xie, et al.",
+            "license": "MIT",
+            "size_bytes": 256439648,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForSemanticSegmentation",
+                "config": {
+                    "name_or_path": "nvidia/segformer-b4-finetuned-ade-512-512"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segmentation", "torch", "segformer", "official"],
+            "date_added": "2025-08-04 12:34:25"
+        },
+        {
+            "base_name": "segformer-b5-ade20k-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Largest SegFormer model delivering the best semantic segmentation performance in its family",
+            "source": "https://huggingface.co/nvidia/segformer-b5-finetuned-ade-640-640",
+            "author": "Enze Xie, et al.",
+            "license": "MIT",
+            "size_bytes": 338840928,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForSemanticSegmentation",
+                "config": {
+                    "name_or_path": "nvidia/segformer-b5-finetuned-ade-640-640"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segmentation", "torch", "segformer", "official"],
+            "date_added": "2025-08-04 12:34:27"
         }
     ]
 }


### PR DESCRIPTION
## Add 6 SegFormer semantic segmentation models from NVIDIA:

* `segformer-b0-ade20k-torch` (15MB)
* `segformer-b1-ade20k-torch` (55MB)
* `segformer-b2-ade20k-torch` (110MB)
* `segformer-b3-ade20k-torch` (189MB)
* `segformer-b4-ade20k-torch` (256MB)
* `segformer-b5-ade20k-torch` (339MB)

All models:
* Use existing `FiftyOneTransformerForSemanticSegmentation` wrapper
* Support both CPU and GPU inference
* Trained on ADE20K dataset (150 classes)
* MIT licensed

Note: `nvidia/segformer-b0-finetuned-ade-512-512` is already FiftyOne's default segmentation model. This adds the complete model family.

## What changes are proposed in this pull request?

Added 6 SegFormer model configurations to `fiftyone/zoo/models/manifest-torch.json` using the existing transformer wrapper.

## How is this patch tested? If it is not, please explain why.

Tested all 6 models:
* Loaded from HuggingFace hub
* Performed segmentation on COCO validation images
* Verified mask outputs and model sizes
* Confirmed wrapper compatibility

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?
-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Added 6 SegFormer semantic segmentation models to the model zoo (b0-b5 variants).

### What areas of FiftyOne does this PR affect?
-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other