### PR TITLE
New integration of KAPA AI Agent directly in docs

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -670,3 +670,13 @@ a.with-right-arrow,
   height: auto;
   aspect-ratio: 16 / 9;
 }
+
+#kapa-widget-container {
+  z-index: 10000 !important;
+  position: absolute !important;
+}
+
+.mantine-Modal-root {
+  z-index: 10000;
+  position: absolute;
+}

--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -62,3 +62,20 @@ $(function () {
   $(window).on("scroll", updateSidebar);
   $(".pytorch-right-menu").on("click", updateSidebar);
 });
+
+document.addEventListener("DOMContentLoaded", function () {
+  var script = document.createElement("script");
+  script.src = "https://widget.kapa.ai/kapa-widget.bundle.js";
+  script.setAttribute(
+    "data-website-id",
+    "eb6a5a18-9704-41fc-9351-cae28372e763"
+  );
+  script.setAttribute("data-project-name", "Voxel51");
+  script.setAttribute("data-project-color", "#212529");
+  script.setAttribute(
+    "data-project-logo",
+    "https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png"
+  );
+  script.async = true;
+  document.head.appendChild(script);
+});


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR integrates the new Kapa AI agent into the FiftyOne documentation.
The current placement of the widget is temporary, once the new design is live, the agent will be moved to the top-right corner, adjacent to the Algolia-powered search bar.

Additionally, it clarifies that the Kapa Website Widget's integration (website) ID does not need to be hidden, as it is intended to be used publicly in the script tag embedded in the HTML.
<img width="1919" height="987" alt="Screenshot from 2025-08-04 15-45-57" src="https://github.com/user-attachments/assets/640bfe8f-3caf-4085-afd7-90b270a72c14" />

## How is this patch tested? If it is not, please explain why.

Tested manually in the documentation site by loading the widget and verifying that it initializes and responds correctly.
Design placement will be adjusted in a follow-up PR once the redesign is finalized.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [ ] No. You can skip the rest of this section.
* [x] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

This PR adds the Kapa AI agent widget to the documentation site to assist users with AI-powered support. Placement is temporary and will be updated in a future release.

### What areas of FiftyOne does this PR affect?

* [ ] App: FiftyOne application changes
* [ ] Build: Build and test infrastructure changes
* [ ] Core: Core `fiftyone` Python library changes
* [x] Documentation: FiftyOne documentation changes
* [ ] Other

