### PR TITLE
Fix instance segmentation model tags in zoo manifest

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -3803,7 +3803,7 @@
                     "support": true
                 }
             },
-            "tags": ["segmentation", "coco", "torch", "yolo", "official"],
+            "tags": ["instances", "coco", "torch", "yolo", "official"],
             "date_added": "2024-04-02 19:22:51"
         },
         {
@@ -3843,7 +3843,7 @@
                     "support": true
                 }
             },
-            "tags": ["segmentation", "coco", "torch", "yolo", "official"],
+            "tags": ["instances", "coco", "torch", "yolo", "official"],
             "date_added": "2024-04-02 19:22:51"
         },
         {
@@ -3883,7 +3883,7 @@
                     "support": true
                 }
             },
-            "tags": ["segmentation", "coco", "torch", "yolo", "official"],
+            "tags": ["instances", "coco", "torch", "yolo", "official"],
             "date_added": "2024-04-02 19:22:51"
         },
         {
@@ -3923,7 +3923,7 @@
                     "support": true
                 }
             },
-            "tags": ["segmentation", "coco", "torch", "yolo", "official"],
+            "tags": ["instances", "coco", "torch", "yolo", "official"],
             "date_added": "2024-04-02 19:22:51"
         },
         {
@@ -3963,7 +3963,7 @@
                     "support": true
                 }
             },
-            "tags": ["segmentation", "coco", "torch", "yolo", "official"],
+            "tags": ["instances", "coco", "torch", "yolo", "official"],
             "date_added": "2024-04-02 19:22:51"
         },
         {
@@ -4083,7 +4083,7 @@
                     "support": true
                 }
             },
-            "tags": ["segmentation", "coco", "torch", "yolo", "official"],
+            "tags": ["instances", "coco", "torch", "yolo", "official"],
             "date_added": "2024-04-02 19:22:51"
         },
         {
@@ -4123,7 +4123,7 @@
                     "support": true
                 }
             },
-            "tags": ["segmentation", "coco", "torch", "yolo", "official"],
+            "tags": ["instances", "coco", "torch", "yolo", "official"],
             "date_added": "2024-04-02 19:22:51"
         },
         {
@@ -4563,7 +4563,7 @@
                     "support": true
                 }
             },
-            "tags": ["segmentation", "coco", "torch", "yolo", "official"],
+            "tags": ["instances", "coco", "torch", "yolo", "official"],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -4603,7 +4603,7 @@
                     "support": true
                 }
             },
-            "tags": ["segmentation", "coco", "torch", "yolo", "official"],
+            "tags": ["instances", "coco", "torch", "yolo", "official"],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -4643,7 +4643,7 @@
                     "support": true
                 }
             },
-            "tags": ["segmentation", "coco", "torch", "yolo", "official"],
+            "tags": ["instances", "coco", "torch", "yolo", "official"],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -4683,7 +4683,7 @@
                     "support": true
                 }
             },
-            "tags": ["segmentation", "coco", "torch", "yolo", "official"],
+            "tags": ["instances", "coco", "torch", "yolo", "official"],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -4723,7 +4723,7 @@
                     "support": true
                 }
             },
-            "tags": ["segmentation", "coco", "torch", "yolo", "official"],
+            "tags": ["instances", "coco", "torch", "yolo", "official"],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -4763,7 +4763,7 @@
                     "support": true
                 }
             },
-            "tags": ["segmentation", "torch", "yolo", "zero-shot", "official"],
+            "tags": ["instances", "torch", "yolo", "zero-shot", "official"],
             "date_added": "2025-04-10 12:24:41"
         },
         {
@@ -4803,7 +4803,7 @@
                     "support": true
                 }
             },
-            "tags": ["segmentation", "torch", "yolo", "zero-shot", "official"],
+            "tags": ["instances", "torch", "yolo", "zero-shot", "official"],
             "date_added": "2025-04-10 12:24:41"
         },
         {
@@ -4843,7 +4843,7 @@
                     "support": true
                 }
             },
-            "tags": ["segmentation", "torch", "yolo", "zero-shot", "official"],
+            "tags": ["instances", "torch", "yolo", "zero-shot", "official"],
             "date_added": "2025-04-10 12:24:41"
         },
         {
@@ -4923,7 +4923,7 @@
                     "support": true
                 }
             },
-            "tags": ["segmentation", "torch", "yolo", "zero-shot", "official"],
+            "tags": ["instances", "torch", "yolo", "zero-shot", "official"],
             "date_added": "2025-04-10 12:24:41"
         },
         {
@@ -4963,7 +4963,7 @@
                     "support": true
                 }
             },
-            "tags": ["segmentation", "torch", "yolo", "zero-shot", "official"],
+            "tags": ["instances", "torch", "yolo", "zero-shot", "official"],
             "date_added": "2025-04-10 12:24:41"
         },
         {


### PR DESCRIPTION
Update 18 YOLO segmentation models entries in the model zoo (manifest-torch.json) to use "instances" tag instead of  "segmentation" tag. These models output Detection labels with masks  (instance segmentation) rather than Segmentation labels (semantic  segmentation), so they should be tagged as "instances" for consistency.

Affected models:
- All yolov8*-seg models
- All yolov9*-seg models  
- All yolo11*-seg models
- All yoloe* segmentation models

## What changes are proposed in this pull request?

This PR updates the tags for 18 YOLO segmentation models in `manifest-torch.json` from `"segmentation"` to `"instances"`. These models perform instance segmentation (detecting individual objects with masks) rather than semantic segmentation (pixel-wise classification), so their tags should reflect this distinction. The change ensures consistency across the model zoo where instance segmentation models use the "instances" tag.

## How is this patch tested? If it is not, please explain why.

This is a metadata-only change to the model manifest JSON file. The change can be and was verified by:
- Checking that the JSON remains valid after the tag updates
- Confirming that model filtering/searching by "instances" tag now includes these YOLO segmentation models
- Verifying that the models still load correctly through the model zoo
- Pulling the branch, building, and loading the affected models.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixed model zoo tagging: YOLO segmentation models are now correctly tagged as "instances" instead of "segmentation" to reflect that they perform instance segmentation.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other