### PR TITLE
Enable configuring additional debug loggers

### DIFF
--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -236,10 +236,10 @@ class FiftyOneConfig(EnvConfig):
         )
         # comma-separated list of non-FiftyOne debug loggers,
         # e.g. "pymongo.command,hypercorn.access"
-        self.debug_loggers = self.parse_string(
+        self.logging_debug_targets = self.parse_string(
             d,
-            "debug_loggers",
-            env_var="DEBUG_LOGGERS",
+            "logging_debug_loggers",
+            env_var="FIFTYONE_LOGGING_DEBUG_TARGETS",
             default="",
         )
         self._show_progress_bars = None  # declare

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -234,6 +234,14 @@ class FiftyOneConfig(EnvConfig):
             env_var="FIFTYONE_LOGGING_LEVEL",
             default="INFO",
         )
+        # comma-separated list of non-FiftyOne debug loggers,
+        # e.g. "pymongo.command,hypercorn.access"
+        self.debug_loggers = self.parse_string(
+            d,
+            "debug_loggers",
+            env_var="DEBUG_LOGGERS",
+            default="",
+        )
         self._show_progress_bars = None  # declare
         self.show_progress_bars = self.parse_bool(
             d,

--- a/fiftyone/core/logging.py
+++ b/fiftyone/core/logging.py
@@ -32,6 +32,7 @@ class JsonFormatter(logging.Formatter):
             "filename": record.filename,
             "lineno": record.lineno,
             "function": record.funcName,
+            "fiftyone_version": fo.__version__,
         }
 
         if record.exc_info:
@@ -102,15 +103,15 @@ def _get_loggers():
         logging.getLogger("fiftyone"),
         logging.getLogger("eta"),
     ]
-    if fo.config.debug_loggers:
+    if fo.config.logging_debug_targets:
         try:
-            for debug_logger in fo.config.debug_loggers.split(","):
+            for debug_logger in fo.config.logging_debug_targets.split(","):
                 if logger_name := debug_logger.strip():
                     loggers.append(logging.getLogger(logger_name))
         except Exception as e:
             logger.error(
                 "Failed to add debug loggers `%s`: %s."
-                % (fo.config.debug_loggers, e)
+                % (fo.config.logging_debug_targets, e)
             )
     return loggers
 

--- a/fiftyone/core/logging.py
+++ b/fiftyone/core/logging.py
@@ -110,8 +110,9 @@ def _get_loggers():
                     loggers.append(logging.getLogger(logger_name))
         except Exception as e:
             logger.error(
-                "Failed to add debug loggers `%s`: %s."
-                % (fo.config.logging_debug_targets, e)
+                "Failed to add debug loggers `%s`: %s.",
+                fo.config.logging_debug_targets,
+                e,
             )
     return loggers
 

--- a/fiftyone/core/logging.py
+++ b/fiftyone/core/logging.py
@@ -26,9 +26,12 @@ class JsonFormatter(logging.Formatter):
         log_entry = {
             "timestamp": f'{self.formatTime(record, "%Y-%m-%dT%H:%M:%S")}{record.msecs/1000:.3f}Z',
             "severity": record.levelname,
+            "level": record.levelno,
+            "logger": record.name,
             "message": record.getMessage(),
             "filename": record.filename,
             "lineno": record.lineno,
+            "function": record.funcName,
         }
 
         if record.exc_info:
@@ -107,8 +110,7 @@ def _get_loggers():
         except Exception as e:
             logger.error(
                 "Failed to add debug loggers `%s`: %s."
-                % fo.config.debug_loggers,
-                e,
+                % (fo.config.debug_loggers, e)
             )
     return loggers
 

--- a/fiftyone/core/logging.py
+++ b/fiftyone/core/logging.py
@@ -95,10 +95,21 @@ def set_logging_level(level):
 
 
 def _get_loggers():
-    return [
+    loggers = [
         logging.getLogger("fiftyone"),
         logging.getLogger("eta"),
     ]
+    if fo.config.debug_loggers:
+        try:
+            for debug_logger in fo.config.debug_loggers.split(","):
+                loggers.append(logging.getLogger(debug_logger.strip()))
+        except Exception as e:
+            logger.error(
+                "Failed to add debug loggers `%s`: %s."
+                % fo.config.debug_loggers,
+                e,
+            )
+    return loggers
 
 
 def _parse_logging_level():

--- a/fiftyone/core/logging.py
+++ b/fiftyone/core/logging.py
@@ -102,7 +102,8 @@ def _get_loggers():
     if fo.config.debug_loggers:
         try:
             for debug_logger in fo.config.debug_loggers.split(","):
-                loggers.append(logging.getLogger(debug_logger.strip()))
+                if logger_name := debug_logger.strip():
+                    loggers.append(logging.getLogger(logger_name))
         except Exception as e:
             logger.error(
                 "Failed to add debug loggers `%s`: %s."

--- a/fiftyone/core/logging.py
+++ b/fiftyone/core/logging.py
@@ -119,6 +119,7 @@ def _get_loggers():
                 if logger_name := debug_logger.strip():
                     loggers.append(logging.getLogger(logger_name))
         except Exception as e:
+            # Note that invalid names will not raise an exception
             logger.warning(
                 "Failed to parse logging debug targets '%s': %s",
                 fo.config.logging_debug_targets,


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Enable passing a list of packages for which to enable debug logging configured with the fiftyone logger. For example, it can be helpful to enable pymongo.command logs for diagnosing performance issues.
- https://voxel51.atlassian.net/browse/FOEPD-1860

## How is this patch tested? If it is not, please explain why.

- Run app locally with DEBUG_LOGGERS="pymongo.command":
```
{"clientId": {"$oid": "689144fc4f9a4fd829c08cce"}, "message": "Command started", "command": "{\"aggregate\": \"datasets\", \"pipeline\": [{\"$match\": {\"sample_collection_name\": {\"$regex\": \"^samples\\\\.\"}}}, {\"$sort\": {\"created_at\": 1}}, {\"$limit\": 101}], \"allowDiskUse\": true, \"lsid\": {\"id\": {\"$binary\": {\"base64\": \"xX00zqKCQVeThz5trHfZyA==\", \"subType\": \"04\"}}}, \"$db\": \"fiftyone\"}", "commandName": "aggregate", "databaseName": "fiftyone", "requestId": 16531729, "operationId": 16531729, "driverConnectionId": 2, "serverPort": 26017}
{"clientId": {"$oid": "689144fc4f9a4fd829c08cce"}, "message": "Command started", "command": "{\"aggregate\": \"datasets\", \"pipeline\": [{\"$match\": {\"sample_collection_name\": {\"$regex\": \"^samples\\\\.\"}}}, {\"$sort\": {\"created_at\": 1}}, {\"$count\": \"total\"}], \"allowDiskUse\": true, \"lsid\": {\"id\": {\"$binary\": {\"base64\": \"HjdtWpf9TyK24a7xcA/9gg==\", \"subType\": \"04\"}}}, \"$db\": \"fiftyone\"}", "commandName": "aggregate", "databaseName": "fiftyone", "requestId": 823378840, "operationId": 823378840, "driverConnectionId": 1, "serverPort": 26017}
{"clientId": {"$oid": "689144fc4f9a4fd829c08cce"}, "message": "Command succeeded", "durationMS": 97.016, "reply": "{\"cursor\": {\"firstBatch\": [{\"total\": 10085}], \"ns\": \"fiftyone.datasets\"}, \"ok\": 1.0}", "commandName": "aggregate", "databaseName": "fiftyone", "requestId": 823378840, "operationId": 823378840, "driverConnectionId": 1, "serverPort": 26017}
{"clientId": {"$oid": "689144fc4f9a4fd829c08cce"}, "message": "Command started", "command": "{\"count\": \"datasets\", \"lsid\": {\"id\": {\"$binary\": {\"base64\": \"HjdtWpf9TyK24a7xcA/9gg==\", \"subType\": \"04\"}}}, \"$db\": \"fiftyone\"}", "commandName": "count", "databaseName": "fiftyone", "requestId": 1474833169, "operationId": 1474833169, "driverConnectionId": 3, "serverConnectionId": 822272, "serverHost": "dev-mongodb.fiftyone.ai", "serverPort": 26017}
{"clientId": {"$oid": "689144fc4f9a4fd829c08cce"}, "message": "Command succeeded", "durationMS": 74.114, "reply": "{\"n\": 10105, \"ok\": 1.0}", "commandName": "count", "databaseName": "fiftyone", "requestId": 1474833169, "operationId": 1474833169, "driverConnectionId": 3,"serverPort": 26017}
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying additional debug loggers via configuration or environment variable, allowing users to include non-FiftyOne loggers in debug output.
  * Enhanced JSON log output to include log level, logger name, function name, and FiftyOne version for improved log detail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->