### PR TITLE
chore: don`t delete the robots.txt

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -189,4 +189,4 @@ jobs:
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v2
       - name: publish
-        run: gsutil -m rsync -dR docs-download gs://docs.dev.voxel51.com
+        run: gsutil -m rsync -dR -x '^robots.txt' docs-download gs://docs.dev.voxel51.com


### PR DESCRIPTION
## What changes are proposed in this pull request?

the docs.dev.voxel51.com site has a `robots.txt` and we shouldn't delete that

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation publishing process to prevent the `robots.txt` file from being overwritten or deleted during sync operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->