### PR TITLE
use foc.VERSION in logs

### DIFF
--- a/fiftyone/core/logging.py
+++ b/fiftyone/core/logging.py
@@ -13,6 +13,7 @@ import sys
 import time
 
 import fiftyone as fo
+import fiftyone.constants as foc
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +33,7 @@ class JsonFormatter(logging.Formatter):
             "filename": record.filename,
             "lineno": record.lineno,
             "function": record.funcName,
-            "fiftyone_version": fo.__version__,
+            "fiftyone_version": foc.VERSION,
         }
 
         if record.exc_info:


### PR DESCRIPTION
## What changes are proposed in this pull request?

- use foc.VERSION because fo.__version__ in teams will sometimes throw an error that fo has no attribute __version__

## How is this patch tested? If it is not, please explain why.

- run app locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal handling of version information in log entries. No visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->