### PR TITLE
Update header/footer to match main docs template

### DIFF
--- a/docs/source/_templates/navbar-links.html
+++ b/docs/source/_templates/navbar-links.html
@@ -4,40 +4,56 @@
     <a class="nav-link dropdown-toggle" href="#" id="productsDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
       Products
     </a>
-    <ul class="dropdown-menu" aria-labelledby="productsDropdown">
-      <li><a class="dropdown-item" href="{{link_fiftyone}}">Open Source</a></li>
-      <li><a class="dropdown-item" href="{{link_fiftyone_enterprise}}">Enterprise</a></li>
-      <li><a class="dropdown-item" href="{{link_usecases}}">Use Cases</a></li>
-      <li><a class="dropdown-item" href="{{link_success_stories}}">Success Stories</a></li>
+    <ul class="dropdown-menu" aria-labelledby="productDropdown">
+      <li><a class="dropdown-item" href="{{link_annotation}}">Data Annotation</a></li>
+      <li><a class="dropdown-item" href="{{link_curation}}">Data Curation</a></li>
+      <li><a class="dropdown-item" href="{{link_evaluation}}">Model Evaluation</a></li>
+      <li><a class="dropdown-item" href="{{link_integrations}}">Integrations</a></li>
+      <li><a class="dropdown-item" href="{{link_plugins}}">Plugins</a></li>
+    </ul>
+  </div>
+  <div class="nav-item dropdown">
+    <a class="nav-link dropdown-toggle" href="#" id="solutionsDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+      Solutions
+    </a>
+    <ul class="dropdown-menu" aria-labelledby="solutionsDropdown">
+      <li><a class="dropdown-item" href="{{link_agriculture}}">Agriculture</a></li>
+      <li><a class="dropdown-item" href="{{link_autonomous_systems}}">Autonomous Vehicles &amp; Systems</a></li>
+      <li><a class="dropdown-item" href="{{link_aviation}}">Aviation</a></li>
+      <li><a class="dropdown-item" href="{{link_defense}}">Defense</a></li>
+      <li><a class="dropdown-item" href="{{link_healthcare}}">Healthcare</a></li>
+      <li><a class="dropdown-item" href="{{link_manufacturing}}">Manufacturing</a></li>
+      <li><a class="dropdown-item" href="{{link_research}}">Research</a></li>
+      <li><a class="dropdown-item" href="{{link_retail}}">Retail</a></li>
+      <li><a class="dropdown-item" href="{{link_robotics}}">Robotics</a></li>
+      <li><a class="dropdown-item" href="{{link_security}}">Security</a></li>
+      <li><a class="dropdown-item" href="{{link_sports}}">Sports</a></li>
     </ul>
   </div>
 
-  <!-- Learn Dropdown -->
+  <!-- Customers Link -->
+  <div class="nav-item">
+    <a class="nav-link" href="{{link_customers}}">Customers</a>
+  </div>
+
+  <!-- Resources Dropdown -->
   <div class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" id="learnDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-      Learn
+    <a class="nav-link dropdown-toggle" href="#" id="resourcesDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+      Resources
     </a>
-    <ul class="dropdown-menu" aria-labelledby="learnDropdown">
-      <li><a class="dropdown-item" href="{{link_voxel51_discord}}">Discord Community</a></li>
+    <ul class="dropdown-menu" aria-labelledby="resourcesDropdown">
       <li><a class="dropdown-item" href="{{link_voxel51_blog}}">Blog</a></li>
-      <li><a class="dropdown-item" href="{{link_events}}">Events</a></li>
+      <li><a class="dropdown-item" href="{{link_events}}">Upcoming Events</a></li>
+      <li><a class="dropdown-item" href="{{link_webinars}}">On-Demand Webinars</a></li>
+      <li><a class="dropdown-item" href="{{link_whitepapers}}">Whitepapers & Reports</a></li>
+      <li><a class="dropdown-item" href="{{link_community}}">Computer Vision Community</a></li>
+      <li><a class="dropdown-item" href="{{link_research}}">CV Research</a></li>
+      <li><a class="dropdown-item" href="{{link_press}}">Newsroom</a></li>
     </ul>
   </div>
 
   <!-- Docs Link -->
   <div class="nav-item">
     <a class="nav-link" href="{{link_docs_fiftyone}}">Docs</a>
-  </div>
-
-  <!-- Company Dropdown -->
-  <div class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" id="companyDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-      Company
-    </a>
-    <ul class="dropdown-menu" aria-labelledby="companyDropdown">
-      <li><a class="dropdown-item" href="{{link_ourstory}}">About Us</a></li>
-      <li><a class="dropdown-item" href="{{link_voxel51_jobs}}">Careers</a></li>
-      <li><a class="dropdown-item" href="{{link_talk_to_sales}}">Talk to Sales</a></li>
-    </ul>
   </div>
 </div>

--- a/docs/source/_templates/sections/footer.html
+++ b/docs/source/_templates/sections/footer.html
@@ -2,7 +2,7 @@
 <div class="bd-footer__inner bd-page-width">
   <div class="footer-logo">
     <img src="{{ pathto('_static/voxel51-logo.svg', 1) }}" class="logo__image only-light" alt="Voxel51">
-    <a href="https://voxel51.com/sales" target="_blank" class="sd-btn sd-btn-primary book-a-demo" rel="noopener noreferrer">
+    <a href="{{link_sales}}" target="_blank" class="sd-btn sd-btn-primary book-a-demo" rel="noopener noreferrer">
       <div class="arrow">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="size-3">
         <path stroke="currentColor" stroke-width="1.5" d="M1.458 11.995h20.125M11.52 22.063 21.584 12 11.521 1.937" vector-effect="non-scaling-stroke"></path>
@@ -14,63 +14,62 @@
   <div class="footer-links">
     <div class="footer-links__item">
       <div>Product</div>
-      <a href="https://voxel51.com/annotation">Data Annotation</a>
-      <a href="https://voxel51.com/curation">Data Curation</a>
-      <a href="https://voxel51.com/evaluation">Model Evaluation</a>
-      <a href="https://voxel51.com/integrations">Integrations</a>
-      <a href="https://voxel51.com/plugins">Plugins</a>
-      <a href="https://voxel51.com/pricing">Pricing</a>
+      <a href="{{link_annotation}}">Data Annotation</a>
+      <a href="{{link_curation}}">Data Curation</a>
+      <a href="{{link_evaluation}}">Model Evaluation</a>
+      <a href="{{link_integrations}}">Integrations</a>
+      <a href="{{link_plugins}}">Plugins</a>
+      <a href="{{link_pricing}}">Pricing</a>
     </div>
     <div class="footer-links__item">
       <div>Solutions</div>
-      <a href="https://voxel51.com/industries/agriculture">Agriculture</a>
-      <a href="https://voxel51.com/industries/autonomous-vehicles-systems">Autonomous Systems</a>
-      <a href="https://voxel51.com/industries/defense">Defense</a>
-      <a href="https://voxel51.com/industries/healthcare">Healthcare</a>
-      <a href="https://voxel51.com/industries/manufacturing">Manufacturing</a>
-      <a href="https://voxel51.com/industries/retail">Retail</a>
-      <a href="https://voxel51.com/industries/robotics">Robotics</a>
-      <a href="https://voxel51.com/industries/security">Security</a>
+      <a href="{{link_agriculture}}">Agriculture</a>
+      <a href="{{link_autonomous_systems}}">Autonomous Systems</a>
+      <a href="{{link_defense}}">Defense</a>
+      <a href="{{link_healthcare}}">Healthcare</a>
+      <a href="{{link_manufacturing}}">Manufacturing</a>
+      <a href="{{link_retail}}">Retail</a>
+      <a href="{{link_robotics}}">Robotics</a>
+      <a href="{{link_security}}">Security</a>
     </div>
     <div class="footer-links__item">
       <div>Developers</div>
-      <a href="https://docs.voxel51.com/">Documentation</a>
-      <a href="https://voxel51.com/events">Events &amp; Meetups</a>
-      <a href="https://voxel51.com/learn">Learning Hub</a>
-      <a href="https://voxel51.com/glossary">Computer Vision Glossary</a>
-      <a href="https://voxel51.com/community">Community</a>
+      <a href="{{link_docs_fiftyone}}">Documentation</a>
+      <a href="{{link_events}}">Events &amp; Meetups</a>
+      <a href="{{link_glossary}}">Computer Vision Glossary</a>
+      <a href="{{link_community}}">Community</a>
     </div>
     <div class="footer-links__item">
       <div>Resources</div>
-      <a href="https://voxel51.com/blog">Blog</a>
-      <a href="https://voxel51.com/customers">Customer Stories</a>
-      <a href="https://docs.voxel51.com/model_zoo/models.html">Model Zoo</a>
-      <a href="https://docs.voxel51.com/dataset_zoo/datasets.html">Dataset Zoo</a>
-      <a href="https://voxel51.com/research">CV Research</a>
+      <a href="{{link_voxel51_blog}}">Blog</a>
+      <a href="{{link_customers}}">Customer Stories</a>
+      <a href="{{link_model_zoo}}">Model Zoo</a>
+      <a href="{{link_dataset_zoo}}">Dataset Zoo</a>
+      <a href="{{link_research}}">CV Research</a>
     </div>
     <div class="footer-links__item">
       <div>Company</div>
-      <a href="https://voxel51.com/about">About Voxel51</a>
-      <a href="https://voxel51.com/careers">Careers</a>
-      <a href="https://voxel51.com/press">Press</a>
+      <a href="{{link_about}}">About Voxel51</a>
+      <a href="{{link_careers}}">Careers</a>
+      <a href="{{link_press}}">Press</a>
     </div>
     <div class="social-icons">
-      <a aria-label="Discord" href="https://community.voxel51.com/">
+      <a aria-label="Discord" href="{{link_voxel51_discord}}">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
           <path fill="currentColor" fill-rule="evenodd" d="m14.963 2.978.731.144c1.141.227 2.267.559 3.362.997l1.402.56.482.193.12.505 2.696 11.322.202.851-.816.314-7.01 2.696-1.02.392-.3-1.05-.87-3.05h-3.884l-.871 3.05-.3 1.05-1.02-.392-7.01-2.696-.816-.314.203-.851L2.939 5.377l.12-.505.482-.192 1.402-.561c1.095-.438 2.22-.77 3.362-.997l.731-.144.348.659L10.103 5h3.793l.72-1.363.347-.66ZM6.608 16.852H17.39v-2H6.608v2ZM7 12V9h2v3H7Zm8-3v3h2V9h-2Z" clip-rule="evenodd"></path>
         </svg>
       </a>
-      <a aria-label="Linkedin" href="https://www.linkedin.com/company/voxel51/">
+      <a aria-label="Linkedin" href="{{link_linkedin}}">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
           <path fill="currentColor" fill-rule="evenodd" d="M2 1.5H1v6h6v-6H2ZM2 9H1v14h6V9H2Zm7 0h7a7 7 0 0 1 7 7v7h-6v-6a2 2 0 0 0-2-2v8H9V9Z" clip-rule="evenodd"></path>
         </svg>
       </a>
-      <a aria-label="Twitter" href="https://x.com/voxel51">
+      <a aria-label="Twitter" href="{{link_twitter}}">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
           <path fill="currentColor" d="m.75 2 8.417 11.223L.368 23h3.364l6.964-7.738L16.5 23H23l-8.758-11.678L22.632 2h-3.364l-6.555 7.284L7.25 2H.75Z"></path>
         </svg>
       </a>
-      <a aria-label="Youtube" href="https://www.youtube.com/@voxel51">
+      <a aria-label="Youtube" href="{{link_youtube}}">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
           <path fill="currentColor" fill-rule="evenodd" d="M0 8a6 6 0 0 1 6-6h12a6 6 0 0 1 6 6v8a6 6 0 0 1-6 6H6a6 6 0 0 1-6-6V8Zm8.494-.09a.5.5 0 0 1 .752-.432l7.012 4.09a.5.5 0 0 1 0 .864l-7.012 4.09a.5.5 0 0 1-.752-.432V7.91Z" clip-rule="evenodd"></path>
         </svg>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,7 +49,7 @@ if setup_version != foc.VERSION:
 # -- Project information -----------------------------------------------------
 
 project = "FiftyOne"
-copyright = foc.COPYRIGHT.rsplit('.', 1)[0]
+copyright = foc.COPYRIGHT.rsplit(".", 1)[0]
 author = foc.AUTHOR
 release = foc.VERSION
 
@@ -177,23 +177,9 @@ html_theme_options = {
     "navbar_persistent": [],
     "footer_start": ["copyright"],
     "footer_end": ["footer-links"],
-    # Navbar links
-    "link_docs_fiftyone": "https://docs.voxel51.com/",
-    "link_fiftyone": "https://voxel51.com/fiftyone/",
-    "link_fiftyone_enterprise": "https://voxel51.com/enterprise/",
-    "link_usecases": "https://voxel51.com/computer-vision-use-cases/",
-    "link_success_stories": "https://voxel51.com/success-stories/",
-    "link_talk_to_sales": "https://voxel51.com/talk-to-sales/",
-    "link_ourstory": "https://voxel51.com/ourstory/",
-    "link_events": "https://voxel51.com/computer-vision-events/",
-    "link_voxel51_jobs": "https://voxel51.com/jobs/",
-    "link_voxel51_discord": "https://community.voxel51.com",
-    "link_voxel51_blog": "https://voxel51.com/blog/",
 }
 
-html_sidebars = {
-    "**": ["algolia.html", "sidebar-nav"]
-}
+html_sidebars = {"**": ["algolia.html", "sidebar-nav"]}
 
 html_favicon = "_static/favicon/favicon.ico"
 
@@ -208,7 +194,7 @@ html_css_files = ["css/voxel51-website.css", "css/custom.css"]
 html_js_files = [
     "https://cdn.jsdelivr.net/npm/list.js@2.3.1/dist/list.min.js",
     "js/custom.js",
-    "js/tutorial-filters.js"
+    "js/tutorial-filters.js",
 ]
 
 # Prevent RST source files from being included in output
@@ -234,6 +220,41 @@ html_context = {
     "docsearch_app_id": docsearch_app_id,
     "docsearch_api_key": docsearch_api_key,
     "docsearch_index_name": docsearch_index_name,
+    "link_docs_fiftyone": "https://docs.voxel51.com/",
+    "link_events": "https://voxel51.com/computer-vision-events/",
+    "link_voxel51_blog": "https://voxel51.com/blog/",
+    "link_annotation": "https://voxel51.com/annotation",
+    "link_curation": "https://voxel51.com/curation",
+    "link_evaluation": "https://voxel51.com/evaluation",
+    "link_integrations": "https://voxel51.com/integrations",
+    "link_plugins": "https://voxel51.com/plugins",
+    "link_pricing": "https://voxel51.com/pricing",
+    "link_agriculture": "https://voxel51.com/industries/agriculture",
+    "link_autonomous_systems": "https://voxel51.com/industries/autonomous-vehicles-systems",
+    "link_aviation": "https://voxel51.com/industries/aviation",
+    "link_defense": "https://voxel51.com/industries/defense",
+    "link_healthcare": "https://voxel51.com/industries/healthcare",
+    "link_manufacturing": "https://voxel51.com/industries/manufacturing",
+    "link_research": "https://voxel51.com/research",
+    "link_retail": "https://voxel51.com/industries/retail",
+    "link_robotics": "https://voxel51.com/industries/robotics",
+    "link_security": "https://voxel51.com/industries/security",
+    "link_sports": "https://voxel51.com/industries/sports",
+    "link_customers": "https://voxel51.com/customers",
+    "link_webinars": "https://voxel51.com/webinars",
+    "link_whitepapers": "https://voxel51.com/whitepapers",
+    "link_community": "https://voxel51.com/community",
+    "link_press": "https://voxel51.com/press",
+    "link_sales": "https://voxel51.com/sales",
+    "link_glossary": "https://voxel51.com/glossary",
+    "link_model_zoo": "https://docs.voxel51.com/model_zoo/models.html",
+    "link_dataset_zoo": "https://docs.voxel51.com/dataset_zoo/datasets.html",
+    "link_about": "https://voxel51.com/about",
+    "link_careers": "https://voxel51.com/careers",
+    "link_linkedin": "https://www.linkedin.com/company/voxel51/",
+    "link_twitter": "https://x.com/voxel51",
+    "link_youtube": "https://www.youtube.com/@voxel51",
+    "link_voxel51_discord": "https://community.voxel51.com",
 }
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

* Updated the header to match the main voxel51 page.
* Updated the footer to use dynamic links from `config.py`.

## How is this patch tested? If it is not, please explain why.

Visual inspection of the updated header and footer during local dev server run.
No functional code changes; purely frontend/documentation layout.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-  [x] No. You can skip the rest of this section.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other