### PR TITLE
Fix incorrect tag for yoloev8s-seg-torch model

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -4891,7 +4891,7 @@
                     "support": true
                 }
             },
-            "tags": ["segmentation", "torch", "yolo", "zero-shot", "official"],
+            "tags": ["instances", "torch", "yolo", "zero-shot", "official"],
             "date_added": "2025-04-10 12:24:41"
         },
         {


### PR DESCRIPTION
Change tag from "segmentation" to "instances" for yoloev8s-seg-torch  since it performs instance segmentation (outputs both masks and boxes). This completes the standardization of these model tags.