### PR TITLE
add industry-based filtering to main Getting Started index and menu

### DIFF
--- a/docs/source/getting_started_guides/index.rst
+++ b/docs/source/getting_started_guides/index.rst
@@ -1,0 +1,108 @@
+.. _getting_started_guides:
+
+Getting Started Guides
+======================
+
+.. default-role:: code
+
+Welcome to FiftyOne's guided learning experiences! These step-by-step tutorials will walk you through complete workflows, helping you master FiftyOne's capabilities through hands-on practice.
+
+Each guide is designed as a sequential learning experience with navigation between steps, allowing you to progress through the material at your own pace.
+
+.. Guide cards section -------------------------------------------------------
+
+.. raw:: html
+
+    <div id="tutorial-cards-container">
+
+    <nav class="navbar navbar-expand-lg navbar-light tutorials-nav col-12">
+        <div class="tutorial-tags-container">
+            <div id="dropdown-filter-tags">
+                <div class="tutorial-filter-menu">
+                    <div class="tutorial-filter filter-btn all-tag-selected" data-tag="all">All</div>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <hr class="tutorials-hr">
+
+    <div class="row">
+
+    <div id="tutorial-cards">
+    <div class="list">
+
+.. Add guide cards below
+
+.. customcarditem::
+    :header: Object Detection Guide
+    :description: Master object detection workflows with COCO, YOLOv8, and comprehensive model evaluation. Learn dataset curation, mistake analysis, and performance assessment through hands-on practice.
+    :link: object_detection/index.html
+    :image: https://cdn.voxel51.com/dice_dataset.webp
+    :tags: Core-Fiftyone,Research
+
+.. customcarditem::
+    :header: Medical Imaging Guide
+    :description: Explore medical imaging workflows with DICOM, CT scans, and volumetric data. Learn to handle medical formats, create segmentation masks, and organize datasets for analysis.
+    :link: medical_imaging/index.html
+    :image: https://cdn.voxel51.com/all_patients_ct.webp
+    :tags: Healthcare,Research
+
+.. customcarditem::
+    :header: Self-Driving Guide
+    :description: Dive into autonomous vehicle data workflows with advanced techniques for sensor fusion, trajectory analysis, and multi-modal data processing for self-driving applications.
+    :link: self_driving/index.html
+    :image: https://cdn.voxel51.com/getting_started_self_driving/notebook1/enuscenes.webp
+    :tags: Autonomous-Vehicles,Robotics
+
+.. customcarditem::
+    :header: 3D Visual AI Guide
+    :description: Master 3D computer vision workflows with point clouds, mesh data, and spatial analysis. Learn to load, visualize, and analyze 3D datasets effectively.
+    :link: threed_visual_ai/index.html
+    :image: https://docs.voxel51.com/_images/pointe_headphones_fo.gif
+    :tags: Manufacturing,Robotics,Research
+
+.. customcarditem::
+    :header: Model Evaluation Guide
+    :description: Comprehensive model evaluation workflows with advanced analysis techniques. Learn to assess model performance, identify failure cases, and optimize your computer vision models.
+    :link: model_evaluation/index.html
+    :image: ../_static/images/tutorials/evaluate_classifications.png
+    :tags: Core-Fiftyone,Research
+
+.. End of guide cards
+
+.. raw:: html
+
+    </div>
+
+    <div class="pagination d-flex justify-content-center"></div>
+
+    </div>
+
+    </div>
+
+.. End Guide cards section ---------------------------------------------------
+
+.. _quick-assessment:
+
+Not sure where to start? Take our quick assessment:
+
+**Working with object detection?** → :doc:`Explore the Object Detection Guide <object_detection/index>`
+
+**Have medical imaging data?** → :doc:`Begin with Medical Imaging Guide <medical_imaging/index>`
+
+**Working on autonomous vehicles?** → :doc:`Jump to Self-Driving Guide <self_driving/index>`
+
+**Need 3D computer vision?** → :doc:`Explore 3D Visual AI Guide <threed_visual_ai/index>`
+
+**Want to evaluate model performance?** → :doc:`Start with Model Evaluation Guide <model_evaluation/index>`
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   Object Detection Guide <object_detection/index>
+   Medical Imaging Guide <medical_imaging/index>
+   Self-Driving Guide <self_driving/index>
+   3D Visual AI Guide <threed_visual_ai/index>
+   Model Evaluation Guide <model_evaluation/index> 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -493,6 +493,7 @@ us at support@voxel51.com.
    FiftyOne Enterprise 🚀 <enterprise/index>
    Installation <getting_started/install>
    Environments <environments/index>
+   Getting Started Guides <getting_started_guides/index>
    Tutorials <tutorials/index>
    Recipes <recipes/index>
    Cheat Sheets <cheat_sheets/index>


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR integrates the base structure for the new Getting Started guides, with support for filter tags focused on industry (e.g., retail, self-driving, healthcare). It also updates the main menu to include a link to this improved index page.

## How is this patch tested? If it is not, please explain why.

Tested locally by building the docs and confirming:
- The new Getting Started index renders correctly
- Filter tags are visible and reflect industry categories
- The main menu includes a working link to the new index

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Introduces an updated Getting Started index with industry-focused filtering to help users quickly discover guides relevant to their domain.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes  
-   [ ] Build: Build and test infrastructure changes  
-   [ ] Core: Core `fiftyone` Python library changes  
-   [x] Documentation: FiftyOne documentation changes  
-   [ ] Other



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Getting Started Guides" index page, featuring organized guide cards for various tutorials and a quick assessment section to help users choose relevant guides.
  * Updated the documentation index with a link to the new "Getting Started Guides" section for improved navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->