### PR TITLE
Add Getting Started guide card with new directive and styles

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -1,1 +1,1936 @@
-@font-face{font-display:swap;font-family:'Geist';font-style:normal;font-weight:400;src:url("/_static/fonts/geist-v3-latin-regular.woff2") format("woff2")}@font-face{font-display:swap;font-family:'Geist';font-style:normal;font-weight:500;src:url("/_static/fonts/geist-v3-latin-500.woff2") format("woff2")}@font-face{font-display:swap;font-family:'Geist';font-style:normal;font-weight:600;src:url("/_static/fonts/geist-v3-latin-600.woff2") format("woff2")}@font-face{font-display:swap;font-family:'Geist';font-style:normal;font-weight:700;src:url("/_static/fonts/geist-v3-latin-700.woff2") format("woff2")}@font-face{font-display:swap;font-family:'Geist Mono';font-style:normal;font-weight:400;src:url("/_static/fonts/geist-mono-v3-latin-regular.woff2") format("woff2")}@font-face{font-display:swap;font-family:'Geist Mono';font-style:normal;font-weight:500;src:url("/_static/fonts/geist-mono-v3-latin-500.woff2") format("woff2")}@font-face{font-display:swap;font-family:'Geist Mono';font-style:normal;font-weight:600;src:url("/_static/fonts/geist-mono-v3-latin-600.woff2") format("woff2")}@font-face{font-display:swap;font-family:'Geist Mono';font-style:normal;font-weight:700;src:url("/_static/fonts/geist-mono-v3-latin-700.woff2") format("woff2")}:root{--pst-font-family-base: Geist,Geist Fallback,sans-serif;--pst-font-family-heading: Geist,Geist Fallback,sans-serif;--pst-font-family-monospace: Geist Mono,monospace;--pst-font-size-h1: 3rem;--pst-font-size-h2: 2.25rem;--pst-font-size-h3: 1.5rem;--pst-font-size-h4: 1rem;--pst-font-size-h5: 1rem;--pst-font-size-h6: 1rem;--pst-font-weight-heading: 500;--sd-color-primary: #ff6d04;--feedback-primary-color: #181a1b !important;--docsearch-primary-color: #ff6d04}html[data-theme="light"]{--pst-color-primary: #ff6d04;--pst-color-secondary: #ff6d04;--pst-color-secondary-highlight: #e85a00;--pst-color-accent: #ff6d04;--color-background: #f1ecea;--color-dropdown-background: #fbfaf9;--pst-border-color: rgba(0,0,0,0.125);--pst-color-text-base: #181a1b;--pst-color-text-secondary: #5d5e5f;--pst-color-link: #181a1b;--pst-color-link-hover: #5d5e5f;--pst-color-inline-code: #181a1b;--pst-headerlink-color: #5d5e5f;--pst-color-surface: #f3f4f5;--pst-color-linenos-background: rgba(255,255,255,0.101961);--pst-color-info-bg: #eef6ef;--pst-color-warning-bg: #fff8e1;--pst-color-danger-bg: #fdecea;--pst-color-success-bg: #e6f4ea;--pst-color-info-icon: #6b705c;--pst-color-warning-icon: #f9a825;--pst-color-danger-icon: #c62828;--pst-color-success-icon: #2e7d32;--pst-color-table-heading-bg: transparent;--pst-color-table-row-zebra-low-bg: transparent;--pst-color-table-outer-border: #e0dbd9;--pst-color-table-inner-border: #e8e3e1;--bs-table-color: #181a1b99}details.sd-dropdown.sd-card{box-shadow:none !important;border-bottom:1px solid #00000010 !important;margin-bottom:0 !important}details.sd-dropdown.sd-card summary.sd-summary-title.sd-card-header{background-color:#fff !important;border-left:0 !important;font-weight:600;padding:16px 0px}details.sd-dropdown.sd-card summary.sd-summary-title.sd-card-header:hover{filter:brightness(1)}details.sd-dropdown.sd-card summary.sd-summary-title.sd-card-header:hover .sd-summary-state-marker.sd-summary-chevron-right{background-color:#00000020}details.sd-dropdown.sd-card summary.sd-summary-title.sd-card-header .sd-summary-state-marker.sd-summary-chevron-right{background-color:#00000010;padding:10px 12px;border-radius:40px;height:24px;width:40px}details.sd-dropdown.sd-card summary.sd-summary-title.sd-card-header .sd-summary-state-marker.sd-summary-chevron-right svg{transform:rotate(90deg);transition:0.25s}details.sd-dropdown.sd-card div.sd-summary-content.sd-card-body{border:0 !important;padding:0;padding-bottom:1rem}details.sd-dropdown.sd-card:not(:has(+details.sd-dropdown)){border-bottom:0 !important;margin-bottom:1rem !important}details.sd-dropdown.sd-card:not(:has(+details.sd-dropdown)):not(:first-of-type){border-bottom:0 !important;margin-bottom:1rem !important}details.sd-dropdown.sd-card[open] summary.sd-summary-title.sd-card-header .sd-summary-state-marker.sd-summary-chevron-right{transform:rotate(0deg)}details.sd-dropdown.sd-card[open] summary.sd-summary-title.sd-card-header .sd-summary-state-marker.sd-summary-chevron-right svg{transform:rotate(270deg)}div.admonition{border:0 !important;border-radius:8px !important;padding:24px !important;box-shadow:none !important}div.admonition.note,div.admonition.tip,div.admonition.hint,div.admonition.important{background-color:var(--pst-color-info-bg)}div.admonition.note .admonition-title:after,div.admonition.tip .admonition-title:after,div.admonition.hint .admonition-title:after,div.admonition.important .admonition-title:after{background-image:url("../images/icons/info.svg");background-color:var(--pst-color-info-icon)}div.admonition.warning,div.admonition.caution,div.admonition.attention{background-color:var(--pst-color-warning-bg)}div.admonition.warning .admonition-title:after,div.admonition.caution .admonition-title:after,div.admonition.attention .admonition-title:after{background-image:url("../images/icons/warning.svg");background-color:var(--pst-color-warning-icon)}div.admonition.danger,div.admonition.error{background-color:var(--pst-color-danger-bg)}div.admonition.danger .admonition-title:after,div.admonition.error .admonition-title:after{background-image:url("../images/icons/danger.svg");background-color:var(--pst-color-danger-icon)}div.admonition.success{background-color:var(--pst-color-success-bg)}div.admonition.success .admonition-title:after{background-image:url("../images/icons/success.svg");background-color:var(--pst-color-success-icon)}div.admonition .admonition-title{background-color:transparent !important;line-height:1.2;padding-top:0;padding-bottom:10px;padding-left:48px;position:relative}div.admonition .admonition-title:after{content:"" !important;position:absolute;left:0;top:0;width:32px;height:32px;background-size:16px;background-position:center;background-repeat:no-repeat;border-radius:4px}div.admonition p.admonition-title~*{margin-right:0;margin-left:2.4rem}div.admonition>ol,div.admonition>ul{margin-left:2em}dl[class]:not(.option-list,.field-list,.footnote,.glossary,.simple){margin-bottom:2rem}dl[class]:not(.option-list,.field-list,.footnote,.glossary,.simple) dt.field-odd,dl[class]:not(.option-list,.field-list,.footnote,.glossary,.simple) dt.field-even{background-color:transparent}dl[class]:not(.option-list,.field-list,.footnote,.glossary,.simple) dd{margin-left:4rem}dl[class]:not(.option-list,.field-list,.footnote,.glossary,.simple) dd.field-odd,dl[class]:not(.option-list,.field-list,.footnote,.glossary,.simple) dd.field-even{margin-left:2rem}dt.sig.sig-object{position:relative;margin-bottom:12px;font-style:normal;font-weight:400;padding:8px}dt.sig.sig-object:has(>em:first-child){padding:8px 50px 8px 64px}dt.sig.sig-object span.pre{padding:2px 6px;font-weight:400;font-style:normal;font-size:1rem}dt.sig.sig-object em{font-style:normal;font-size:1rem}dt.sig.sig-object em.property{position:absolute;left:0.5rem;margin-top:2px}dl.property dt.sig.sig-object,dl.attribute dt.sig.sig-object,dl.method dt.sig.sig-object{padding:8px}dl.property dt.sig.sig-object em.property,dl.attribute dt.sig.sig-object em.property,dl.method dt.sig.sig-object em.property{position:static}a.reference code{color:var(--pst-color-link);font-weight:400}a.reference code:hover{color:var(--pst-color-link-hover)}.toctree-wrapper.compound li:has(>a>code){display:none}#pst-back-to-top{background-color:var(--pst-color-link);font-size:14px;top:95vh}#pst-back-to-top:hover{background-color:var(--pst-color-link);text-decoration:none}ul.bd-breadcrumbs li.breadcrumb-item a,ul.bd-breadcrumbs li.breadcrumb-item a:hover,ul.bd-breadcrumbs li.breadcrumb-item span,ul.bd-breadcrumbs li.breadcrumb-item .ellipsis{font-weight:500;text-decoration:underline;color:#000;font-size:14px;padding:6px;margin:0;text-underline-offset:4px}ul.bd-breadcrumbs li.breadcrumb-item:not(.breadcrumb-home):before{font-size:10px;color:#00000099}.breadcrumb-home{width:27.75px}.sd-btn.sd-btn-primary{background-color:var(--pst-color-link) !important;color:#fff !important;border-radius:40px;font-size:14px;font-weight:500;text-decoration:none;padding:8px 20px;border-width:0 !important;letter-spacing:0.14px}.sd-btn.sd-btn-primary:hover{background-color:color-mix(in oklab, var(--pst-color-link) 90%, transparent) !important;text-decoration:none}.sd-btn.sd-btn-primary.book-a-demo{display:flex;align-items:center;flex-direction:row;padding:3px 4px;position:relative}.sd-btn.sd-btn-primary.book-a-demo .arrow{background-color:#fa5300;border-radius:50%;display:flex;align-items:center;justify-content:center;width:42px;height:42px;transition:all 0.15s ease;transform:translateX(0)}@media (min-width: 960px){.sd-btn.sd-btn-primary.book-a-demo .arrow{width:34px;height:34px}}.sd-btn.sd-btn-primary.book-a-demo .text{letter-spacing:-0.01em;line-height:1.3;padding:0px 16px;transition:all 0.15s ease;transform:translateX(0)}.sd-btn.sd-btn-primary.book-a-demo:hover .arrow{transform:translate3d(116.22px, 0px, 0px)}.sd-btn.sd-btn-primary.book-a-demo:hover .text{transform:translate3d(-42px, 0px, 0px)}@media (min-width: 960px){.sd-btn.sd-btn-primary.book-a-demo:hover .text{transform:translate3d(-34px, 0px, 0px)}}.arrow svg{width:12px;height:12px}.dropdown-arrow{color:#181a1b66;transform:rotate(-90deg)}.back-arrow{color:#181a1b99;transform:rotate(90deg)}.back-text{margin-left:10px}.btn.with-right-arrow.callout-button{font-size:14px;padding:0;display:inline-flex;align-items:center;gap:10px;border:0}.btn.with-right-arrow.callout-button:hover{color:var(--pst-color-link)}.btn.with-right-arrow.callout-button:before{content:"";display:inline-flex;align-items:center;justify-content:center;width:42px;height:42px;flex-shrink:0;background-color:color-mix(in oklab, var(--pst-color-link) 25%, transparent);border-radius:50%;transition:all 0.3s ease;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M5 12h14'/%3E%3Cpath d='m12 5 7 7-7 7'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:center;background-size:16px 16px}.btn.with-right-arrow.callout-button:hover:before{background-color:var(--pst-color-link)}.row #tutorial-cards{width:100%}.row #tutorial-cards .list{display:flex;flex-wrap:wrap}.row #tutorial-cards .list .col-md-6{padding:16px 0}@media (min-width: 768px){.row #tutorial-cards .list .col-md-6:nth-child(odd){padding:0 16px 16px 0}.row #tutorial-cards .list .col-md-6:nth-child(even){padding:0 0 16px 16px}}.row #tutorial-cards .pagination{padding:8px 16px;border-radius:8px;border:1px solid var(--pst-border-color);width:fit-content;margin:0 auto}.row #tutorial-cards .pagination li{margin:0 5px}.row #tutorial-cards .pagination li a.page{display:flex;align-items:center;justify-content:center;text-decoration:none;height:32px;width:32px;border-radius:4px;border:1px solid var(--pst-border-color)}.row #tutorial-cards .pagination li.active a.page{color:#fff;background-color:var(--pst-color-primary);border:1px solid var(--pst-color-primary)}div.card.tutorials-card{border-radius:8px;height:100%;cursor:pointer}div.card.tutorials-card .card-body{padding:0}div.card.tutorials-card .card-body .tutorials-image{overflow:hidden;border-radius:8px 8px 0 0}div.card.tutorials-card .card-body .tutorials-image img{width:100%;height:100%;object-fit:cover;transition:transform 0.3s ease-in-out;aspect-ratio:16/9}div.card.tutorials-card .card-body .tutorials-image img:hover{transform:scale(1.05)}div.card.tutorials-card .card-body .tutorials-card-content{padding:16px}div.card.tutorials-card .card-body .tutorials-card-content .card-title-container{margin-bottom:8px}div.card.tutorials-card .card-body .tutorials-card-content .card-title-container strong{font-weight:600}div.card.tutorials-card .card-body .tutorials-card-content .card-summary{font-size:14px;margin-bottom:8px}div.card.tutorials-card .card-body .tutorials-card-content .tags{font-size:14px;margin-bottom:0}div.card.tutorials-card .card-body .tutorials-card-content .card-summary,div.card.tutorials-card .card-body .tutorials-card-content .tags{font-size:14px;color:var(--pst-color-text-secondary)}code.literal{border:none;font-size:1em;background-color:#f3f4f5}p .code .pre{font-size:15px}div.nbinput.container{margin-bottom:1.15rem}div.nbinput.container div.input_area{border:0}div.nbinput.container div.input_area div.highlight>pre{padding:1rem}div.nboutput.container{margin-bottom:1.15rem}div.nboutput.container div.output_area div.highlight>pre{color:#000000}div.nboutput.container div.output_area .copybtn{display:none}div.highlight pre{border-radius:8px;line-height:1.5 !important;position:relative;overflow-x:auto;overflow-y:hidden;border:0}div.highlight pre .nb,div.highlight pre .mi,div.highlight pre .kc,div.highlight pre code.xref,div.highlight pre a code,div.highlight pre .fm,div.highlight pre .ow,div.highlight pre .nb,div.highlight pre .nt,div.highlight pre .nc,div.highlight pre .k,div.highlight pre .kn{color:#1E5AA5 !important;text-decoration:none !important}div.highlight pre .s1,div.highlight pre .s2,div.highlight pre .ne,div.highlight pre .m,div.highlight pre .l,div.highlight pre .vm,div.highlight pre .nv{color:#7A3BBF !important}div.highlight pre span.linenos{background-color:var(--color-background) !important;margin-right:1em;display:inline-block;min-width:4em;text-align:center;margin-left:-1.5em;padding-bottom:0.1em;margin-bottom:-0.05em}div.highlight pre span.linenos.first-linenos{padding-top:1.375rem;margin-top:-1.375rem}div.highlight pre span.linenos.last-linenos{padding-bottom:1.375rem;margin-bottom:-1.375rem}div.highlight button.copybtn,div.highlight button.copybtn:not(.success),div.highlight button.copybtn:hover,div.highlight button.copybtn:hover:not(.success){top:8px;right:8px;color:#000000CC;background-color:#FFFFFF40;border-radius:40px;height:32px;width:32px}blockquote{border-color:var(--pst-color-primary);background-color:transparent}.nbinput .prompt,.nboutput .prompt{display:none}.dropdown{position:relative}.dropdown .dropdown-toggle{cursor:default}.dropdown .dropdown-toggle::after{display:none}.dropdown .dropdown-menu{opacity:0;visibility:hidden;transform:translateY(-10px) scale(0.95);transition:all 0.2s cubic-bezier(0.25, 0.8, 0.25, 1);transform-origin:top center;background-color:var(--color-dropdown-background);border:4px solid #fff;border-radius:12px;box-shadow:0 2px 10px rgba(0,0,0,0.1);min-width:200px;top:100%;left:0;padding:8px;z-index:1000;margin-top:16px}.dropdown .dropdown-menu.show{display:none}.dropdown .dropdown-menu .dropdown-item{font-size:14px;font-weight:500;color:#181a1b;padding:8px;transition:all 0.2s ease;border-radius:8px;opacity:0;transform:translateY(10px);animation-fill-mode:both}.dropdown .dropdown-menu .dropdown-item:hover{background-color:var(--color-background)}.dropdown .dropdown-menu .dropdown-divider{border-top:1px solid rgba(0,0,0,0.125);margin:0.5rem 0}.dropdown:hover .dropdown-menu{opacity:1;visibility:visible;transform:translateY(0) scale(1);display:block}.dropdown:hover .dropdown-menu .dropdown-item{opacity:1;transform:translateY(0);animation:fadeInUp 0.3s ease-out forwards}.dropdown .dropdown-menu:hover{opacity:1;visibility:visible;transform:translateY(0) scale(1);display:block}@keyframes fadeInUp{from{opacity:0;transform:translateY(10px)}to{opacity:1;transform:translateY(0)}}@media (max-width: 960px){#pst-primary-sidebar-modal .dropdown-menu{display:none !important;visibility:hidden !important;opacity:0 !important}}a:hover{text-decoration-thickness:1px}a.headerlink{user-select:none;cursor:pointer;font-size:0;line-height:0}a.headerlink::before{content:"";display:inline-block;background-image:url("../images/icons/link-icon.svg");background-size:contain;background-repeat:no-repeat;background-position:center;width:16px;height:16px}h1>a.headerlink::before,h2>a.headerlink::before{width:24px;height:24px}.social-links{margin-bottom:1.5rem}.social-links #social-links-table{display:flex;flex-direction:column;gap:1rem}.social-links #social-links-table tbody{display:flex;flex-direction:column}.social-links #social-links-table tbody tr{display:flex;flex-direction:column}.social-links #social-links-table tbody tr th{padding:0;border:none;text-align:center;margin-bottom:1rem;display:block}.social-links #social-links-table tbody tr th a{display:inline-flex;align-items:center;justify-content:center;padding:1rem;border:1px solid var(--color-background);border-radius:12px;color:var(--pst-color-link);font-weight:500;transition:all 0.3s ease;text-decoration:none;width:100%;letter-spacing:0.14px}.social-links #social-links-table tbody tr th a:hover{background-color:var(--color-background)}.social-links #social-links-table tbody tr th img{width:24px;height:24px;object-fit:contain;margin-right:0.5rem}@media (min-width: 960px){.social-links #social-links-table{flex-direction:row}.social-links #social-links-table tbody{flex-direction:row}.social-links #social-links-table tbody tr{display:flex;flex-direction:row;gap:32px}.social-links #social-links-table tbody tr th{display:flex;margin-bottom:0}.social-links #social-links-table tbody tr th a{max-width:280px}}.fo-notebook-links{margin-bottom:1.5rem;width:100%;display:flex;flex-direction:column;gap:1rem}.fo-notebook-links tbody{display:flex;flex-direction:column}.fo-notebook-links tbody tr{display:flex;flex-direction:column}.fo-notebook-links tbody tr td{padding:0;border:none;text-align:center;margin-bottom:1rem;display:block}.fo-notebook-links tbody tr td a{display:inline-flex;align-items:center;justify-content:center;padding:1rem;border:1px solid var(--color-background);border-radius:12px;color:var(--pst-color-link);font-weight:500;transition:all 0.3s ease;text-decoration:none;width:100%}.fo-notebook-links tbody tr td a:hover{background-color:var(--color-background)}.fo-notebook-links tbody tr td img{width:24px;height:24px;object-fit:contain;margin-right:0.5rem}@media (min-width: 960px){.fo-notebook-links{flex-direction:row}.fo-notebook-links tbody{flex-direction:row}.fo-notebook-links tbody tr{display:flex;flex-direction:row;gap:32px}.fo-notebook-links tbody tr td{display:flex;margin-bottom:0}.fo-notebook-links tbody tr td a{max-width:280px}}.navbar-brand.logo img{width:118px;height:auto}.integrations-logos{display:flex;flex-wrap:wrap;justify-content:center}.integrations-logos>div{display:flex;flex-direction:column;padding:5px 15px 15px 15px;vertical-align:middle;text-align:center;justify-content:center;width:140px;min-height:96px}.integrations-logos img{max-height:52px;max-width:110px;width:auto !important;height:auto}.sub-header{position:relative}.sub-header .sub-header-item{display:flex;align-items:center;justify-content:space-between;width:100%;padding:12px 0px;font-size:14px;font-weight:500;border:0;background-color:transparent}.sub-header .sub-header-item[aria-expanded="true"] .dropdown-arrow{transform:rotate(180deg)}.sub-header .sub-header-item .dropdown-arrow{transform:rotate(0deg);width:14px;height:14px;transition:transform 0.3s ease}.mobile-nav-dropdown{width:100%;height:0;overflow:hidden;transition:height 0.3s ease-in-out;position:static !important;display:block !important}.mobile-nav-dropdown.open{height:calc(100dvh - 64px);overflow-y:auto}.mobile-nav-dropdown .toctree-toggle{align-items:center;cursor:pointer;display:inline-flex;height:30px;justify-content:center;position:absolute;right:16px;top:0;width:30px}.mobile-nav-dropdown li.has-children{position:relative}.mobile-nav-dropdown li.has-children>details[open]>summary .toctree-toggle .fa-chevron-down{transform:rotate(180deg)}.mobile-nav-dropdown__content{padding:16px 20px}.mobile-nav-dropdown__content *,.mobile-nav-dropdown__content *::before,.mobile-nav-dropdown__content *::after{list-style:none !important}.mobile-nav-dropdown__content *::marker,.mobile-nav-dropdown__content *::before::marker,.mobile-nav-dropdown__content *::after::marker{display:none !important;content:none !important}@media (min-width: 960px){.sub-header{display:none !important}.mobile-nav-dropdown{display:none !important}}.prev-next-footer{margin-top:12px}.prev-next-footer .prev-next-area .left-prev .prev-next-title,.prev-next-footer .prev-next-area .right-next .prev-next-title{font-size:16px;font-weight:400}.prev-next-footer .prev-next-area .left-prev:hover .prev-next-title,.prev-next-footer .prev-next-area .right-next:hover .prev-next-title{text-decoration-thickness:1px}.DocSearch-Button{background:transparent;border-radius:8px;border:1px solid var(--color-background);color:var(--pst-color-text-base);height:40px;margin:0;width:100%}.DocSearch-Button:hover,.DocSearch-Button:active,.DocSearch-Button:focus{box-shadow:none}.DocSearch-Button .DocSearch-Search-Icon{color:var(--pst-color-text-base)}.DocSearch-Container{z-index:300}.DocSearch-Hit-content-wrapper{overflow:hidden}.DocSearch-Hits mark{padding:0}.DocSearch-MagnifierLabel{color:var(--pst-color-text-base)}.DocSearch-Button-Keys{display:none}.DocSearch-Form{box-shadow:inset 0 0 0 2px var(--color-background)}@media (max-width: 768px){.DocSearch-Button-Placeholder{display:block}}#searchbox{min-height:40px}#searchbox-mobile .DocSearch-Button{margin-bottom:16px}.table{border:0;margin-bottom:2.5rem;width:100%}.table .check-icon{background-color:var(--pst-color-primary);display:flex;align-items:center;height:18px;border-radius:40px;width:100%;margin-top:3px}.table .check-icon.secondary{background-color:var(--pst-color-text-base)}.table .check-icon img{height:10px;width:10px;margin:0 6px;color:#fff;filter:brightness(0) saturate(100%) invert(100%)}.table thead tr{border-bottom:1px solid var(--pst-color-table-outer-border)}.table thead tr th{font-weight:600}.table tbody{color:var(--bs-table-color)}.table tbody tr{border-bottom:1px solid var(--pst-color-table-inner-border)}.table tbody tr th{font-weight:400}.table td~td,.table td~th,.table th~td,.table th~th{border-left:0}.sphinx-tabs-panel{border:0}[role="tablist"]{position:relative;border-bottom:1px solid var(--color-background);overflow-x:auto;overflow-y:hidden;white-space:nowrap;scrollbar-width:none}.sphinx-tabs-tab[aria-selected="true"],.sphinx-tabs-tab:hover{border:0;border-bottom:0;margin:0;color:var(--pst-color-text-base)}.sphinx-tabs-tab,.sphinx-tabs-tab[aria-selected="true"]{padding:8px 0;font-size:14px;font-weight:500}.sphinx-tabs-tab{font-family:var(--pst-font-family-base);color:#181a1b99}.closeable{display:flex;gap:40px}.tabs-sliding-indicator{position:absolute;bottom:0;left:0;width:0;height:1px;background-color:#000;transition:all 0.3s ease;opacity:0;z-index:1;pointer-events:none}div.tutorial-filter-menu{display:flex;flex-wrap:wrap;gap:8px}div.tutorial-filter-menu div.tutorial-filter{padding:6px 8px;border:1px solid var(--pst-color-text-base);border-radius:6px;font-size:12px;font-weight:500;line-height:1.1;text-transform:uppercase;cursor:pointer;color:var(--pst-color-text-base);letter-spacing:0.14px}div.tutorial-filter-menu div.tutorial-filter.all-tag-selected,div.tutorial-filter-menu div.tutorial-filter.filter-btn.selected{background-color:var(--pst-color-text-base);color:#fff}#youtube{width:100%;height:auto;aspect-ratio:16 / 9}footer.bd-footer{padding:48px 0;background-color:#000;color:#ffffff66;font-size:14px;font-weight:500;border-top:0}@media (min-width: 768px){footer.bd-footer{padding:48px 0 64px 0}}footer.bd-footer a{color:#ffffff66;text-decoration:none}footer.bd-footer a:hover{color:#ffffff;text-decoration:none}footer.bd-footer .bd-footer__inner{flex-direction:column;padding:0 20px}footer.bd-footer .footer-logo{display:flex;justify-content:space-between;flex-direction:column;align-items:flex-start;gap:24px}@media (min-width: 768px){footer.bd-footer .footer-logo{flex-direction:row}}footer.bd-footer .footer-logo .logo__image{height:32px}footer.bd-footer .footer-logo .book-a-demo{height:50px;background-color:#ffffff40 !important}footer.bd-footer .footer-logo .book-a-demo .arrow{height:42px;width:42px;background-color:#ffffff40}footer.bd-footer .footer-logo .book-a-demo:hover .arrow{transform:translate3d(153.19px, 0px, 0px);color:#000;background-color:#ffffff}footer.bd-footer .footer-logo .book-a-demo:hover .text{transform:translate3d(-42px, 0px, 0px)}footer.bd-footer .footer-links{display:grid;margin-top:48px;padding-top:24px;border-top:1px solid #181a1b;grid-template-columns:repeat(4, minmax(0, 1fr));column-gap:16px;row-gap:48px}@media (min-width: 768px){footer.bd-footer .footer-links{grid-template-columns:repeat(12, 1fr)}}footer.bd-footer .footer-links .footer-links__item{display:flex;flex-direction:column;gap:16px;line-height:1.3;grid-column:span 2;letter-spacing:-0.14px}footer.bd-footer .footer-links .footer-links__item div{color:#ffffff;width:fit-content}footer.bd-footer .footer-links .footer-links__item a{color:#ffffff99;width:fit-content}footer.bd-footer .footer-links .footer-links__item a:hover{color:#ffffff}footer.bd-footer .footer-links .social-icons{display:flex;gap:8px;grid-column:span 4;flex-wrap:wrap;align-content:flex-start}@media (min-width: 768px){footer.bd-footer .footer-links .social-icons{grid-column:span 2}}footer.bd-footer .footer-links .social-icons a{height:42px;width:42px;color:#ffffff;border-radius:50%;background-color:#313435;display:flex;align-items:center;justify-content:center;transition:background-color 0.15s ease}footer.bd-footer .footer-links .social-icons a:hover{background-color:#313435cc}footer.bd-footer .footer-links .social-icons a svg{height:16px;width:16px}footer.bd-footer .footer-items{display:flex;margin-top:48px;padding-top:24px;gap:16px;flex-direction:column;line-height:1.3}@media (min-width: 768px){footer.bd-footer .footer-items{flex-direction:row}}footer.bd-footer .footer-items .footer-items__end{display:flex;justify-content:center;align-items:flex-start;letter-spacing:-0.14px}@media (min-width: 768px){footer.bd-footer .footer-items .footer-items__end{align-items:flex-end}}footer.bd-footer .footer-items .footer-items__end .footer-legal-links{display:flex;align-items:center}footer.bd-footer .footer-items .footer-links__divider{display:inline-block;width:1px;height:12px;background-color:#ffffff66;margin:0 8px}.footer-links__item,.footer-items{letter-spacing:0.14px}header.bd-header{box-shadow:none;border-bottom:1px solid var(--color-background);z-index:200}header.bd-header .bd-header__inner{flex-direction:row-reverse;padding:0 20px}header.bd-header .bd-header__inner .primary-sidebar-toggle{margin-right:0;position:relative;padding:8px 16px;background-color:var(--color-background);border:none;border-radius:3.40282e+38px;color:#181a1b99;font-size:14px;font-weight:500;gap:10px;height:40px;line-height:1.5}header.bd-header .bd-header__inner .primary-sidebar-toggle:hover:before{border:0}header.bd-header .bd-header__inner .primary-sidebar-toggle .primary-toggle-text{letter-spacing:-0.01em}header.bd-header .bd-header__inner .primary-sidebar-toggle .primary-toggle-icon{width:16px;height:16px;position:relative;display:flex;flex-direction:column;justify-content:center;align-items:center;cursor:pointer}header.bd-header .bd-header__inner .primary-sidebar-toggle .primary-toggle-icon .line1,header.bd-header .bd-header__inner .primary-sidebar-toggle .primary-toggle-icon .line2{width:16px;height:1.5px;background-color:#68615D;transition:all 0.3s ease;transform-origin:center}header.bd-header .bd-header__inner .primary-sidebar-toggle .primary-toggle-icon .line1{margin-bottom:3px}header.bd-header .bd-header__inner .primary-sidebar-toggle .primary-toggle-icon .line2{margin-top:3px}header.bd-header .bd-header__inner .primary-sidebar-toggle .primary-toggle-icon.active .line1{transform:translateY(3.75px) rotate(45deg)}header.bd-header .bd-header__inner .primary-sidebar-toggle .primary-toggle-icon.active .line2{transform:translateY(-3.75px) rotate(-45deg)}header.bd-header .bd-header__inner .secondary-toggle{display:none}header.bd-header .bd-header__inner .navbar-header-items__start{flex:1}@media (min-width: 960px){header.bd-header .bd-header__inner{flex-direction:row}header.bd-header .bd-header__inner .primary-sidebar-toggle{display:none}}main p{line-height:1.5}main h1{line-height:1.1;word-break:break-word}main h2,main h3,main h4,main h5,main h6{line-height:1.2;word-break:break-word}main h4{font-weight:600}main div.tutorials-callout-container{margin-bottom:24px}main div.tutorials-callout-container .row{display:flex;flex-wrap:wrap;margin:0}main div.tutorials-callout-container .row p:empty{display:none}main div.tutorials-callout-container .row .col-md-6{padding:16px 0}@media (min-width: 768px){main div.tutorials-callout-container .row .col-md-6:nth-child(even){padding:0 16px 16px 0}main div.tutorials-callout-container .row .col-md-6:nth-child(odd){padding:0 0 16px 16px}}main div.tutorials-callout-container .row .col-md-6 .text-container{display:flex;flex-direction:column;height:100%;padding:10px 0px}main div.tutorials-callout-container .row .col-md-6 .text-container .body-paragraph{color:var(--pst-color-link-hover);flex:1}main div.tutorials-callout-container .row .col-md-6 .text-container p:has(.btn.with-right-arrow.callout-button){margin-top:auto}main div.tutorials-callout-container .row .col-md-6 .text-container div:has(img){flex:1;display:flex;align-items:center}main div.tutorials-callout-container .row .col-md-6 .text-container div:has(img) img{width:100%;height:250px;object-fit:cover}main section>img,main section>a>img{margin-bottom:24px}*:focus-visible{box-shadow:none !important;outline:none !important}@media (min-width: 960px){.bd-page-width{max-width:82.5rem}}.nav.bd-sidenav .toctree-l1{font-size:14px;font-weight:500;margin-bottom:4px}.nav.bd-sidenav .toctree-l1 a.reference{padding:8px;border-radius:8px;color:var(--pst-color-text-base);box-shadow:none;margin-bottom:4px;overflow-wrap:break-word;word-break:break-word;max-width:100%;min-height:32px;margin-right:16px;padding-right:30px;line-height:100%}.nav.bd-sidenav .toctree-l1 a.reference:hover{color:var(--pst-color-text-base);text-decoration:none;background-color:var(--color-background)}.nav.bd-sidenav .toctree-l1 a.reference.current{font-weight:500;background-color:var(--color-background)}.nav.bd-sidenav .toctree-l2{font-size:14px;font-weight:500;margin-bottom:4px}.nav.bd-sidenav .toctree-l2 a.reference{padding:8px;border-radius:8px;color:var(--pst-color-text-base);box-shadow:none;margin-bottom:4px;overflow-wrap:break-word;word-break:break-word;max-width:100%;min-height:32px;margin-right:16px;padding-right:30px;line-height:100%}.nav.bd-sidenav .toctree-l2 a.reference:hover{color:var(--pst-color-text-base);text-decoration:none;background-color:var(--color-background)}.nav.bd-sidenav .toctree-l2 a.reference.current{font-weight:500;background-color:var(--color-background)}.nav.bd-sidenav .toctree-l3{font-size:14px;font-weight:500;margin-bottom:4px}.nav.bd-sidenav .toctree-l3 a.reference{padding:8px;border-radius:8px;color:var(--pst-color-text-base);box-shadow:none;margin-bottom:4px;overflow-wrap:break-word;word-break:break-word;max-width:100%;min-height:32px;margin-right:16px;padding-right:30px;line-height:100%}.nav.bd-sidenav .toctree-l3 a.reference:hover{color:var(--pst-color-text-base);text-decoration:none;background-color:var(--color-background)}.nav.bd-sidenav .toctree-l3 a.reference.current{font-weight:500;background-color:var(--color-background)}.nav.bd-sidenav .toctree-l4{font-size:14px;font-weight:500;margin-bottom:4px}.nav.bd-sidenav .toctree-l4 a.reference{padding:8px;border-radius:8px;color:var(--pst-color-text-base);box-shadow:none;margin-bottom:4px;overflow-wrap:break-word;word-break:break-word;max-width:100%;min-height:32px;margin-right:16px;padding-right:30px;line-height:100%}.nav.bd-sidenav .toctree-l4 a.reference:hover{color:var(--pst-color-text-base);text-decoration:none;background-color:var(--color-background)}.nav.bd-sidenav .toctree-l4 a.reference.current{font-weight:500;background-color:var(--color-background)}.nav.bd-sidenav .toctree-l5{font-size:14px;font-weight:500;margin-bottom:4px}.nav.bd-sidenav .toctree-l5 a.reference{padding:8px;border-radius:8px;color:var(--pst-color-text-base);box-shadow:none;margin-bottom:4px;overflow-wrap:break-word;word-break:break-word;max-width:100%;min-height:32px;margin-right:16px;padding-right:30px;line-height:100%}.nav.bd-sidenav .toctree-l5 a.reference:hover{color:var(--pst-color-text-base);text-decoration:none;background-color:var(--color-background)}.nav.bd-sidenav .toctree-l5 a.reference.current{font-weight:500;background-color:var(--color-background)}.nav.bd-sidenav .toctree-l6{font-size:14px;font-weight:500;margin-bottom:4px}.nav.bd-sidenav .toctree-l6 a.reference{padding:8px;border-radius:8px;color:var(--pst-color-text-base);box-shadow:none;margin-bottom:4px;overflow-wrap:break-word;word-break:break-word;max-width:100%;min-height:32px;margin-right:16px;padding-right:30px;line-height:100%}.nav.bd-sidenav .toctree-l6 a.reference:hover{color:var(--pst-color-text-base);text-decoration:none;background-color:var(--color-background)}.nav.bd-sidenav .toctree-l6 a.reference.current{font-weight:500;background-color:var(--color-background)}.navbar-nav,.dropdown-items-container{justify-content:center;flex-direction:column}.navbar-nav .nav-item,.dropdown-items-container .nav-item{margin:0 1rem}.navbar-nav .nav-item .nav-link,.navbar-nav .nav-item .dropdown-item,.dropdown-items-container .nav-item .nav-link,.dropdown-items-container .nav-item .dropdown-item{color:var(--pst-color-text-base);font-size:14px;font-weight:500;width:100%}.navbar-nav .nav-item .nav-link:hover,.navbar-nav .nav-item .dropdown-item:hover,.dropdown-items-container .nav-item .nav-link:hover,.dropdown-items-container .nav-item .dropdown-item:hover{text-decoration:none}.navbar .container,.navbar .container-fluid{display:flex;justify-content:center;align-items:center}.bd-navbar{justify-content:center}.bd-navbar .navbar-nav{margin:0 auto}.navbar-header-items__start,.navbar-header-items__end{flex:0 0 auto}.navbar-header-items__center{flex:1 1 auto;display:flex;justify-content:center;align-items:center}.navbar-header-items__center .navbar-nav{display:flex;justify-content:center;align-items:center}.navbar-nav .nav-item+.nav-item{margin-left:1rem}@media (min-width: 960px){.bd-sidebar-primary li.has-children>details>summary .toctree-toggle{right:16px}.navbar-nav .nav-item .nav-link{height:64px;display:flex;align-items:center}}@media (max-width: 1200px){.navbar-nav{width:auto;justify-content:flex-start}}.bd-container .bd-container__inner dialog.bd-sidebar::backdrop{background-color:transparent;top:var(--pst-header-height);opacity:0}.bd-container .bd-container__inner dialog.bd-sidebar-primary{border-top:1px solid var(--color-background);height:calc(100vh - var(--pst-header-height));width:100%;max-width:100%;top:var(--pst-header-height);background-color:var(--pst-color-on-background);padding:20px;transition:none}.bd-container .bd-container__inner dialog.bd-sidebar-primary .sidebar-header-items__center .navbar-nav,.bd-container .bd-container__inner dialog.bd-sidebar-primary .sidebar-header-items__center .dropdown-items-container,.bd-container .bd-container__inner dialog.bd-sidebar-primary .dropdown-nav-container .navbar-nav,.bd-container .bd-container__inner dialog.bd-sidebar-primary .dropdown-nav-container .dropdown-items-container{align-items:normal}.bd-container .bd-container__inner dialog.bd-sidebar-primary .sidebar-header-items__center .navbar-nav .nav-item,.bd-container .bd-container__inner dialog.bd-sidebar-primary .sidebar-header-items__center .dropdown-items-container .nav-item,.bd-container .bd-container__inner dialog.bd-sidebar-primary .dropdown-nav-container .navbar-nav .nav-item,.bd-container .bd-container__inner dialog.bd-sidebar-primary .dropdown-nav-container .dropdown-items-container .nav-item{height:57px;border-radius:8px;padding-inline:16px;background-color:var(--color-background);margin-inline:0px;margin-bottom:4px;display:flex;align-items:center;justify-content:space-between}.bd-container .bd-container__inner dialog.bd-sidebar-primary .sidebar-header-items__end .navbar-item{margin-top:28px}.bd-container .bd-container__inner dialog.bd-sidebar-primary .sidebar-header-items__end .navbar-item .sd-btn{display:flex;align-items:center;height:50px}.bd-container .bd-container__inner dialog.bd-sidebar-primary .sidebar-primary-items__start{display:none}.bd-sidebar-primary{border:0;padding:1rem 1rem 1rem}.sidebar-secondary-item{border:0}.sidebar-secondary-item .page-toc.tocsection.onthispage{font-size:14px;font-weight:500;margin-bottom:20px;line-height:1}.sidebar-secondary-item .page-toc ul li a.nav-link{color:var(--pst-color-text-base);font-weight:500;border-radius:8px;position:relative;padding-left:8px;margin-left:-8px}.sidebar-secondary-item .page-toc ul li a.nav-link:hover{color:var(--pst-color-text-base);text-decoration:none}.sidebar-secondary-item .page-toc ul li a.nav-link.active{box-shadow:none}.sidebar-secondary-item .page-toc ul li a.nav-link.active:not(:has(+ul .nav-link.active))::before{content:'';display:block;width:8px;height:8px;background-color:var(--pst-color-primary);border-radius:50%;position:absolute;left:-8px;top:50%;transform:translateY(-50%)}@media (min-width: 960px){dialog.bd-sidebar-primary{display:none}}
+@font-face {
+  font-display: swap;
+  font-family: "Geist";
+  font-style: normal;
+  font-weight: 400;
+  src: url("/_static/fonts/geist-v3-latin-regular.woff2") format("woff2");
+}
+@font-face {
+  font-display: swap;
+  font-family: "Geist";
+  font-style: normal;
+  font-weight: 500;
+  src: url("/_static/fonts/geist-v3-latin-500.woff2") format("woff2");
+}
+@font-face {
+  font-display: swap;
+  font-family: "Geist";
+  font-style: normal;
+  font-weight: 600;
+  src: url("/_static/fonts/geist-v3-latin-600.woff2") format("woff2");
+}
+@font-face {
+  font-display: swap;
+  font-family: "Geist";
+  font-style: normal;
+  font-weight: 700;
+  src: url("/_static/fonts/geist-v3-latin-700.woff2") format("woff2");
+}
+@font-face {
+  font-display: swap;
+  font-family: "Geist Mono";
+  font-style: normal;
+  font-weight: 400;
+  src: url("/_static/fonts/geist-mono-v3-latin-regular.woff2") format("woff2");
+}
+@font-face {
+  font-display: swap;
+  font-family: "Geist Mono";
+  font-style: normal;
+  font-weight: 500;
+  src: url("/_static/fonts/geist-mono-v3-latin-500.woff2") format("woff2");
+}
+@font-face {
+  font-display: swap;
+  font-family: "Geist Mono";
+  font-style: normal;
+  font-weight: 600;
+  src: url("/_static/fonts/geist-mono-v3-latin-600.woff2") format("woff2");
+}
+@font-face {
+  font-display: swap;
+  font-family: "Geist Mono";
+  font-style: normal;
+  font-weight: 700;
+  src: url("/_static/fonts/geist-mono-v3-latin-700.woff2") format("woff2");
+}
+:root {
+  --pst-font-family-base: Geist, Geist Fallback, sans-serif;
+  --pst-font-family-heading: Geist, Geist Fallback, sans-serif;
+  --pst-font-family-monospace: Geist Mono, monospace;
+  --pst-font-size-h1: 3rem;
+  --pst-font-size-h2: 2.25rem;
+  --pst-font-size-h3: 1.5rem;
+  --pst-font-size-h4: 1rem;
+  --pst-font-size-h5: 1rem;
+  --pst-font-size-h6: 1rem;
+  --pst-font-weight-heading: 500;
+  --sd-color-primary: #ff6d04;
+  --feedback-primary-color: #181a1b !important;
+  --docsearch-primary-color: #ff6d04;
+}
+html[data-theme="light"] {
+  --pst-color-primary: #ff6d04;
+  --pst-color-secondary: #ff6d04;
+  --pst-color-secondary-highlight: #e85a00;
+  --pst-color-accent: #ff6d04;
+  --color-background: #f1ecea;
+  --color-dropdown-background: #fbfaf9;
+  --pst-border-color: rgba(0, 0, 0, 0.125);
+  --pst-color-text-base: #181a1b;
+  --pst-color-text-secondary: #5d5e5f;
+  --pst-color-link: #181a1b;
+  --pst-color-link-hover: #5d5e5f;
+  --pst-color-inline-code: #181a1b;
+  --pst-headerlink-color: #5d5e5f;
+  --pst-color-surface: #f3f4f5;
+  --pst-color-linenos-background: rgba(255, 255, 255, 0.101961);
+  --pst-color-info-bg: #eef6ef;
+  --pst-color-warning-bg: #fff8e1;
+  --pst-color-danger-bg: #fdecea;
+  --pst-color-success-bg: #e6f4ea;
+  --pst-color-info-icon: #6b705c;
+  --pst-color-warning-icon: #f9a825;
+  --pst-color-danger-icon: #c62828;
+  --pst-color-success-icon: #2e7d32;
+  --pst-color-table-heading-bg: transparent;
+  --pst-color-table-row-zebra-low-bg: transparent;
+  --pst-color-table-outer-border: #e0dbd9;
+  --pst-color-table-inner-border: #e8e3e1;
+  --bs-table-color: #181a1b99;
+}
+details.sd-dropdown.sd-card {
+  box-shadow: none !important;
+  border-bottom: 1px solid #00000010 !important;
+  margin-bottom: 0 !important;
+}
+details.sd-dropdown.sd-card summary.sd-summary-title.sd-card-header {
+  background-color: #fff !important;
+  border-left: 0 !important;
+  font-weight: 600;
+  padding: 16px 0px;
+}
+details.sd-dropdown.sd-card summary.sd-summary-title.sd-card-header:hover {
+  filter: brightness(1);
+}
+details.sd-dropdown.sd-card
+  summary.sd-summary-title.sd-card-header:hover
+  .sd-summary-state-marker.sd-summary-chevron-right {
+  background-color: #00000020;
+}
+details.sd-dropdown.sd-card
+  summary.sd-summary-title.sd-card-header
+  .sd-summary-state-marker.sd-summary-chevron-right {
+  background-color: #00000010;
+  padding: 10px 12px;
+  border-radius: 40px;
+  height: 24px;
+  width: 40px;
+}
+details.sd-dropdown.sd-card
+  summary.sd-summary-title.sd-card-header
+  .sd-summary-state-marker.sd-summary-chevron-right
+  svg {
+  transform: rotate(90deg);
+  transition: 0.25s;
+}
+details.sd-dropdown.sd-card div.sd-summary-content.sd-card-body {
+  border: 0 !important;
+  padding: 0;
+  padding-bottom: 1rem;
+}
+details.sd-dropdown.sd-card:not(:has(+ details.sd-dropdown)) {
+  border-bottom: 0 !important;
+  margin-bottom: 1rem !important;
+}
+details.sd-dropdown.sd-card:not(:has(+ details.sd-dropdown)):not(:first-of-type) {
+  border-bottom: 0 !important;
+  margin-bottom: 1rem !important;
+}
+details.sd-dropdown.sd-card[open]
+  summary.sd-summary-title.sd-card-header
+  .sd-summary-state-marker.sd-summary-chevron-right {
+  transform: rotate(0deg);
+}
+details.sd-dropdown.sd-card[open]
+  summary.sd-summary-title.sd-card-header
+  .sd-summary-state-marker.sd-summary-chevron-right
+  svg {
+  transform: rotate(270deg);
+}
+div.admonition {
+  border: 0 !important;
+  border-radius: 8px !important;
+  padding: 24px !important;
+  box-shadow: none !important;
+}
+div.admonition.note,
+div.admonition.tip,
+div.admonition.hint,
+div.admonition.important {
+  background-color: var(--pst-color-info-bg);
+}
+div.admonition.note .admonition-title:after,
+div.admonition.tip .admonition-title:after,
+div.admonition.hint .admonition-title:after,
+div.admonition.important .admonition-title:after {
+  background-image: url("../images/icons/info.svg");
+  background-color: var(--pst-color-info-icon);
+}
+div.admonition.warning,
+div.admonition.caution,
+div.admonition.attention {
+  background-color: var(--pst-color-warning-bg);
+}
+div.admonition.warning .admonition-title:after,
+div.admonition.caution .admonition-title:after,
+div.admonition.attention .admonition-title:after {
+  background-image: url("../images/icons/warning.svg");
+  background-color: var(--pst-color-warning-icon);
+}
+div.admonition.danger,
+div.admonition.error {
+  background-color: var(--pst-color-danger-bg);
+}
+div.admonition.danger .admonition-title:after,
+div.admonition.error .admonition-title:after {
+  background-image: url("../images/icons/danger.svg");
+  background-color: var(--pst-color-danger-icon);
+}
+div.admonition.success {
+  background-color: var(--pst-color-success-bg);
+}
+div.admonition.success .admonition-title:after {
+  background-image: url("../images/icons/success.svg");
+  background-color: var(--pst-color-success-icon);
+}
+div.admonition .admonition-title {
+  background-color: transparent !important;
+  line-height: 1.2;
+  padding-top: 0;
+  padding-bottom: 10px;
+  padding-left: 48px;
+  position: relative;
+}
+div.admonition .admonition-title:after {
+  content: "" !important;
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 32px;
+  height: 32px;
+  background-size: 16px;
+  background-position: center;
+  background-repeat: no-repeat;
+  border-radius: 4px;
+}
+div.admonition p.admonition-title ~ * {
+  margin-right: 0;
+  margin-left: 2.4rem;
+}
+div.admonition > ol,
+div.admonition > ul {
+  margin-left: 2em;
+}
+dl[class]:not(.option-list, .field-list, .footnote, .glossary, .simple) {
+  margin-bottom: 2rem;
+}
+dl[class]:not(.option-list, .field-list, .footnote, .glossary, .simple)
+  dt.field-odd,
+dl[class]:not(.option-list, .field-list, .footnote, .glossary, .simple)
+  dt.field-even {
+  background-color: transparent;
+}
+dl[class]:not(.option-list, .field-list, .footnote, .glossary, .simple) dd {
+  margin-left: 4rem;
+}
+dl[class]:not(.option-list, .field-list, .footnote, .glossary, .simple)
+  dd.field-odd,
+dl[class]:not(.option-list, .field-list, .footnote, .glossary, .simple)
+  dd.field-even {
+  margin-left: 2rem;
+}
+dt.sig.sig-object {
+  position: relative;
+  margin-bottom: 12px;
+  font-style: normal;
+  font-weight: 400;
+  padding: 8px;
+}
+dt.sig.sig-object:has(> em:first-child) {
+  padding: 8px 50px 8px 64px;
+}
+dt.sig.sig-object span.pre {
+  padding: 2px 6px;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 1rem;
+}
+dt.sig.sig-object em {
+  font-style: normal;
+  font-size: 1rem;
+}
+dt.sig.sig-object em.property {
+  position: absolute;
+  left: 0.5rem;
+  margin-top: 2px;
+}
+dl.property dt.sig.sig-object,
+dl.attribute dt.sig.sig-object,
+dl.method dt.sig.sig-object {
+  padding: 8px;
+}
+dl.property dt.sig.sig-object em.property,
+dl.attribute dt.sig.sig-object em.property,
+dl.method dt.sig.sig-object em.property {
+  position: static;
+}
+a.reference code {
+  color: var(--pst-color-link);
+  font-weight: 400;
+}
+a.reference code:hover {
+  color: var(--pst-color-link-hover);
+}
+.toctree-wrapper.compound li:has(> a > code) {
+  display: none;
+}
+#pst-back-to-top {
+  background-color: var(--pst-color-link);
+  font-size: 14px;
+  top: 95vh;
+}
+#pst-back-to-top:hover {
+  background-color: var(--pst-color-link);
+  text-decoration: none;
+}
+ul.bd-breadcrumbs li.breadcrumb-item a,
+ul.bd-breadcrumbs li.breadcrumb-item a:hover,
+ul.bd-breadcrumbs li.breadcrumb-item span,
+ul.bd-breadcrumbs li.breadcrumb-item .ellipsis {
+  font-weight: 500;
+  text-decoration: underline;
+  color: #000;
+  font-size: 14px;
+  padding: 6px;
+  margin: 0;
+  text-underline-offset: 4px;
+}
+ul.bd-breadcrumbs li.breadcrumb-item:not(.breadcrumb-home):before {
+  font-size: 10px;
+  color: #00000099;
+}
+.breadcrumb-home {
+  width: 27.75px;
+}
+.sd-btn.sd-btn-primary {
+  background-color: var(--pst-color-link) !important;
+  color: #fff !important;
+  border-radius: 40px;
+  font-size: 14px;
+  font-weight: 500;
+  text-decoration: none;
+  padding: 8px 20px;
+  border-width: 0 !important;
+  letter-spacing: 0.14px;
+}
+.sd-btn.sd-btn-primary:hover {
+  background-color: color-mix(
+    in oklab,
+    var(--pst-color-link) 90%,
+    transparent
+  ) !important;
+  text-decoration: none;
+}
+.sd-btn.sd-btn-primary.book-a-demo {
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  padding: 3px 4px;
+  position: relative;
+}
+.sd-btn.sd-btn-primary.book-a-demo .arrow {
+  background-color: #fa5300;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  transition: all 0.15s ease;
+  transform: translateX(0);
+}
+@media (min-width: 960px) {
+  .sd-btn.sd-btn-primary.book-a-demo .arrow {
+    width: 34px;
+    height: 34px;
+  }
+}
+.sd-btn.sd-btn-primary.book-a-demo .text {
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+  padding: 0px 16px;
+  transition: all 0.15s ease;
+  transform: translateX(0);
+}
+.sd-btn.sd-btn-primary.book-a-demo:hover .arrow {
+  transform: translate3d(116.22px, 0px, 0px);
+}
+.sd-btn.sd-btn-primary.book-a-demo:hover .text {
+  transform: translate3d(-42px, 0px, 0px);
+}
+@media (min-width: 960px) {
+  .sd-btn.sd-btn-primary.book-a-demo:hover .text {
+    transform: translate3d(-34px, 0px, 0px);
+  }
+}
+.arrow svg {
+  width: 12px;
+  height: 12px;
+}
+.dropdown-arrow {
+  color: #181a1b66;
+  transform: rotate(-90deg);
+}
+.back-arrow {
+  color: #181a1b99;
+  transform: rotate(90deg);
+}
+.back-text {
+  margin-left: 10px;
+}
+.btn.with-right-arrow.callout-button {
+  font-size: 14px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  border: 0;
+}
+.btn.with-right-arrow.callout-button:hover {
+  color: var(--pst-color-link);
+}
+.btn.with-right-arrow.callout-button:before {
+  content: "";
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  flex-shrink: 0;
+  background-color: color-mix(in oklab, var(--pst-color-link) 25%, transparent);
+  border-radius: 50%;
+  transition: all 0.3s ease;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M5 12h14'/%3E%3Cpath d='m12 5 7 7-7 7'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 16px 16px;
+}
+.btn.with-right-arrow.callout-button:hover:before {
+  background-color: var(--pst-color-link);
+}
+.row #tutorial-cards {
+  width: 100%;
+}
+.row #tutorial-cards .list {
+  display: flex;
+  flex-wrap: wrap;
+}
+.row #tutorial-cards .list .col-md-6 {
+  padding: 16px 0;
+}
+@media (min-width: 768px) {
+  .row #tutorial-cards .list .col-md-6:nth-child(odd) {
+    padding: 0 16px 16px 0;
+  }
+  .row #tutorial-cards .list .col-md-6:nth-child(even) {
+    padding: 0 0 16px 16px;
+  }
+}
+.row #tutorial-cards .pagination {
+  padding: 8px 16px;
+  border-radius: 8px;
+  border: 1px solid var(--pst-border-color);
+  width: fit-content;
+  margin: 0 auto;
+}
+.row #tutorial-cards .pagination li {
+  margin: 0 5px;
+}
+.row #tutorial-cards .pagination li a.page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  height: 32px;
+  width: 32px;
+  border-radius: 4px;
+  border: 1px solid var(--pst-border-color);
+}
+.row #tutorial-cards .pagination li.active a.page {
+  color: #fff;
+  background-color: var(--pst-color-primary);
+  border: 1px solid var(--pst-color-primary);
+}
+div.card.tutorials-card {
+  border-radius: 8px;
+  height: 100%;
+  cursor: pointer;
+}
+div.card.tutorials-card .card-body {
+  padding: 0;
+}
+div.card.tutorials-card .card-body .tutorials-image {
+  overflow: hidden;
+  border-radius: 8px 8px 0 0;
+}
+div.card.tutorials-card .card-body .tutorials-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.3s ease-in-out;
+  aspect-ratio: 16/9;
+}
+div.card.tutorials-card .card-body .tutorials-image img:hover {
+  transform: scale(1.05);
+}
+div.card.tutorials-card .card-body .tutorials-card-content {
+  padding: 16px;
+}
+div.card.tutorials-card
+  .card-body
+  .tutorials-card-content
+  .card-title-container {
+  margin-bottom: 8px;
+}
+div.card.tutorials-card
+  .card-body
+  .tutorials-card-content
+  .card-title-container
+  strong {
+  font-weight: 600;
+}
+div.card.tutorials-card .card-body .tutorials-card-content .card-summary {
+  font-size: 14px;
+  margin-bottom: 8px;
+}
+div.card.tutorials-card .card-body .tutorials-card-content .tags {
+  font-size: 14px;
+  margin-bottom: 0;
+}
+div.card.tutorials-card .card-body .tutorials-card-content .card-summary,
+div.card.tutorials-card .card-body .tutorials-card-content .tags {
+  font-size: 14px;
+  color: var(--pst-color-text-secondary);
+}
+code.literal {
+  border: none;
+  font-size: 1em;
+  background-color: #f3f4f5;
+}
+p .code .pre {
+  font-size: 15px;
+}
+div.nbinput.container {
+  margin-bottom: 1.15rem;
+}
+div.nbinput.container div.input_area {
+  border: 0;
+}
+div.nbinput.container div.input_area div.highlight > pre {
+  padding: 1rem;
+}
+div.nboutput.container {
+  margin-bottom: 1.15rem;
+}
+div.nboutput.container div.output_area div.highlight > pre {
+  color: #000000;
+}
+div.nboutput.container div.output_area .copybtn {
+  display: none;
+}
+div.highlight pre {
+  border-radius: 8px;
+  line-height: 1.5 !important;
+  position: relative;
+  overflow-x: auto;
+  overflow-y: hidden;
+  border: 0;
+}
+div.highlight pre .nb,
+div.highlight pre .mi,
+div.highlight pre .kc,
+div.highlight pre code.xref,
+div.highlight pre a code,
+div.highlight pre .fm,
+div.highlight pre .ow,
+div.highlight pre .nb,
+div.highlight pre .nt,
+div.highlight pre .nc,
+div.highlight pre .k,
+div.highlight pre .kn {
+  color: #1e5aa5 !important;
+  text-decoration: none !important;
+}
+div.highlight pre .s1,
+div.highlight pre .s2,
+div.highlight pre .ne,
+div.highlight pre .m,
+div.highlight pre .l,
+div.highlight pre .vm,
+div.highlight pre .nv {
+  color: #7a3bbf !important;
+}
+div.highlight pre span.linenos {
+  background-color: var(--color-background) !important;
+  margin-right: 1em;
+  display: inline-block;
+  min-width: 4em;
+  text-align: center;
+  margin-left: -1.5em;
+  padding-bottom: 0.1em;
+  margin-bottom: -0.05em;
+}
+div.highlight pre span.linenos.first-linenos {
+  padding-top: 1.375rem;
+  margin-top: -1.375rem;
+}
+div.highlight pre span.linenos.last-linenos {
+  padding-bottom: 1.375rem;
+  margin-bottom: -1.375rem;
+}
+div.highlight button.copybtn,
+div.highlight button.copybtn:not(.success),
+div.highlight button.copybtn:hover,
+div.highlight button.copybtn:hover:not(.success) {
+  top: 8px;
+  right: 8px;
+  color: #000000cc;
+  background-color: #ffffff40;
+  border-radius: 40px;
+  height: 32px;
+  width: 32px;
+}
+blockquote {
+  border-color: var(--pst-color-primary);
+  background-color: transparent;
+}
+.nbinput .prompt,
+.nboutput .prompt {
+  display: none;
+}
+.dropdown {
+  position: relative;
+}
+.dropdown .dropdown-toggle {
+  cursor: default;
+}
+.dropdown .dropdown-toggle::after {
+  display: none;
+}
+.dropdown .dropdown-menu {
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-10px) scale(0.95);
+  transition: all 0.2s cubic-bezier(0.25, 0.8, 0.25, 1);
+  transform-origin: top center;
+  background-color: var(--color-dropdown-background);
+  border: 4px solid #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  min-width: 200px;
+  top: 100%;
+  left: 0;
+  padding: 8px;
+  z-index: 1000;
+  margin-top: 16px;
+}
+.dropdown .dropdown-menu.show {
+  display: none;
+}
+.dropdown .dropdown-menu .dropdown-item {
+  font-size: 14px;
+  font-weight: 500;
+  color: #181a1b;
+  padding: 8px;
+  transition: all 0.2s ease;
+  border-radius: 8px;
+  opacity: 0;
+  transform: translateY(10px);
+  animation-fill-mode: both;
+}
+.dropdown .dropdown-menu .dropdown-item:hover {
+  background-color: var(--color-background);
+}
+.dropdown .dropdown-menu .dropdown-divider {
+  border-top: 1px solid rgba(0, 0, 0, 0.125);
+  margin: 0.5rem 0;
+}
+.dropdown:hover .dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0) scale(1);
+  display: block;
+}
+.dropdown:hover .dropdown-menu .dropdown-item {
+  opacity: 1;
+  transform: translateY(0);
+  animation: fadeInUp 0.3s ease-out forwards;
+}
+.dropdown .dropdown-menu:hover {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0) scale(1);
+  display: block;
+}
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@media (max-width: 960px) {
+  #pst-primary-sidebar-modal .dropdown-menu {
+    display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+  }
+}
+a:hover {
+  text-decoration-thickness: 1px;
+}
+a.headerlink {
+  user-select: none;
+  cursor: pointer;
+  font-size: 0;
+  line-height: 0;
+}
+a.headerlink::before {
+  content: "";
+  display: inline-block;
+  background-image: url("../images/icons/link-icon.svg");
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  width: 16px;
+  height: 16px;
+}
+h1 > a.headerlink::before,
+h2 > a.headerlink::before {
+  width: 24px;
+  height: 24px;
+}
+.social-links {
+  margin-bottom: 1.5rem;
+}
+.social-links #social-links-table {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.social-links #social-links-table tbody {
+  display: flex;
+  flex-direction: column;
+}
+.social-links #social-links-table tbody tr {
+  display: flex;
+  flex-direction: column;
+}
+.social-links #social-links-table tbody tr th {
+  padding: 0;
+  border: none;
+  text-align: center;
+  margin-bottom: 1rem;
+  display: block;
+}
+.social-links #social-links-table tbody tr th a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  border: 1px solid var(--color-background);
+  border-radius: 12px;
+  color: var(--pst-color-link);
+  font-weight: 500;
+  transition: all 0.3s ease;
+  text-decoration: none;
+  width: 100%;
+  letter-spacing: 0.14px;
+}
+.social-links #social-links-table tbody tr th a:hover {
+  background-color: var(--color-background);
+}
+.social-links #social-links-table tbody tr th img {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+  margin-right: 0.5rem;
+}
+@media (min-width: 960px) {
+  .social-links #social-links-table {
+    flex-direction: row;
+  }
+  .social-links #social-links-table tbody {
+    flex-direction: row;
+  }
+  .social-links #social-links-table tbody tr {
+    display: flex;
+    flex-direction: row;
+    gap: 32px;
+  }
+  .social-links #social-links-table tbody tr th {
+    display: flex;
+    margin-bottom: 0;
+  }
+  .social-links #social-links-table tbody tr th a {
+    max-width: 280px;
+  }
+}
+.fo-notebook-links {
+  margin-bottom: 1.5rem;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.fo-notebook-links tbody {
+  display: flex;
+  flex-direction: column;
+}
+.fo-notebook-links tbody tr {
+  display: flex;
+  flex-direction: column;
+}
+.fo-notebook-links tbody tr td {
+  padding: 0;
+  border: none;
+  text-align: center;
+  margin-bottom: 1rem;
+  display: block;
+}
+.fo-notebook-links tbody tr td a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  border: 1px solid var(--color-background);
+  border-radius: 12px;
+  color: var(--pst-color-link);
+  font-weight: 500;
+  transition: all 0.3s ease;
+  text-decoration: none;
+  width: 100%;
+}
+.fo-notebook-links tbody tr td a:hover {
+  background-color: var(--color-background);
+}
+.fo-notebook-links tbody tr td img {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+  margin-right: 0.5rem;
+}
+@media (min-width: 960px) {
+  .fo-notebook-links {
+    flex-direction: row;
+  }
+  .fo-notebook-links tbody {
+    flex-direction: row;
+  }
+  .fo-notebook-links tbody tr {
+    display: flex;
+    flex-direction: row;
+    gap: 32px;
+  }
+  .fo-notebook-links tbody tr td {
+    display: flex;
+    margin-bottom: 0;
+  }
+  .fo-notebook-links tbody tr td a {
+    max-width: 280px;
+  }
+}
+.navbar-brand.logo img {
+  width: 118px;
+  height: auto;
+}
+.integrations-logos {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.integrations-logos > div {
+  display: flex;
+  flex-direction: column;
+  padding: 5px 15px 15px 15px;
+  vertical-align: middle;
+  text-align: center;
+  justify-content: center;
+  width: 140px;
+  min-height: 96px;
+}
+.integrations-logos img {
+  max-height: 52px;
+  max-width: 110px;
+  width: auto !important;
+  height: auto;
+}
+.sub-header {
+  position: relative;
+}
+.sub-header .sub-header-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 12px 0px;
+  font-size: 14px;
+  font-weight: 500;
+  border: 0;
+  background-color: transparent;
+}
+.sub-header .sub-header-item[aria-expanded="true"] .dropdown-arrow {
+  transform: rotate(180deg);
+}
+.sub-header .sub-header-item .dropdown-arrow {
+  transform: rotate(0deg);
+  width: 14px;
+  height: 14px;
+  transition: transform 0.3s ease;
+}
+.mobile-nav-dropdown {
+  width: 100%;
+  height: 0;
+  overflow: hidden;
+  transition: height 0.3s ease-in-out;
+  position: static !important;
+  display: block !important;
+}
+.mobile-nav-dropdown.open {
+  height: calc(100dvh - 64px);
+  overflow-y: auto;
+}
+.mobile-nav-dropdown .toctree-toggle {
+  align-items: center;
+  cursor: pointer;
+  display: inline-flex;
+  height: 30px;
+  justify-content: center;
+  position: absolute;
+  right: 16px;
+  top: 0;
+  width: 30px;
+}
+.mobile-nav-dropdown li.has-children {
+  position: relative;
+}
+.mobile-nav-dropdown
+  li.has-children
+  > details[open]
+  > summary
+  .toctree-toggle
+  .fa-chevron-down {
+  transform: rotate(180deg);
+}
+.mobile-nav-dropdown__content {
+  padding: 16px 20px;
+}
+.mobile-nav-dropdown__content *,
+.mobile-nav-dropdown__content *::before,
+.mobile-nav-dropdown__content *::after {
+  list-style: none !important;
+}
+.mobile-nav-dropdown__content *::marker,
+.mobile-nav-dropdown__content *::before::marker,
+.mobile-nav-dropdown__content *::after::marker {
+  display: none !important;
+  content: none !important;
+}
+@media (min-width: 960px) {
+  .sub-header {
+    display: none !important;
+  }
+  .mobile-nav-dropdown {
+    display: none !important;
+  }
+}
+.prev-next-footer {
+  margin-top: 12px;
+}
+.prev-next-footer .prev-next-area .left-prev .prev-next-title,
+.prev-next-footer .prev-next-area .right-next .prev-next-title {
+  font-size: 16px;
+  font-weight: 400;
+}
+.prev-next-footer .prev-next-area .left-prev:hover .prev-next-title,
+.prev-next-footer .prev-next-area .right-next:hover .prev-next-title {
+  text-decoration-thickness: 1px;
+}
+.DocSearch-Button {
+  background: transparent;
+  border-radius: 8px;
+  border: 1px solid var(--color-background);
+  color: var(--pst-color-text-base);
+  height: 40px;
+  margin: 0;
+  width: 100%;
+}
+.DocSearch-Button:hover,
+.DocSearch-Button:active,
+.DocSearch-Button:focus {
+  box-shadow: none;
+}
+.DocSearch-Button .DocSearch-Search-Icon {
+  color: var(--pst-color-text-base);
+}
+.DocSearch-Container {
+  z-index: 300;
+}
+.DocSearch-Hit-content-wrapper {
+  overflow: hidden;
+}
+.DocSearch-Hits mark {
+  padding: 0;
+}
+.DocSearch-MagnifierLabel {
+  color: var(--pst-color-text-base);
+}
+.DocSearch-Button-Keys {
+  display: none;
+}
+.DocSearch-Form {
+  box-shadow: inset 0 0 0 2px var(--color-background);
+}
+@media (max-width: 768px) {
+  .DocSearch-Button-Placeholder {
+    display: block;
+  }
+}
+#searchbox {
+  min-height: 40px;
+}
+#searchbox-mobile .DocSearch-Button {
+  margin-bottom: 16px;
+}
+.table {
+  border: 0;
+  margin-bottom: 2.5rem;
+  width: 100%;
+}
+.table .check-icon {
+  background-color: var(--pst-color-primary);
+  display: flex;
+  align-items: center;
+  height: 18px;
+  border-radius: 40px;
+  width: 100%;
+  margin-top: 3px;
+}
+.table .check-icon.secondary {
+  background-color: var(--pst-color-text-base);
+}
+.table .check-icon img {
+  height: 10px;
+  width: 10px;
+  margin: 0 6px;
+  color: #fff;
+  filter: brightness(0) saturate(100%) invert(100%);
+}
+.table thead tr {
+  border-bottom: 1px solid var(--pst-color-table-outer-border);
+}
+.table thead tr th {
+  font-weight: 600;
+}
+.table tbody {
+  color: var(--bs-table-color);
+}
+.table tbody tr {
+  border-bottom: 1px solid var(--pst-color-table-inner-border);
+}
+.table tbody tr th {
+  font-weight: 400;
+}
+.table td ~ td,
+.table td ~ th,
+.table th ~ td,
+.table th ~ th {
+  border-left: 0;
+}
+.sphinx-tabs-panel {
+  border: 0;
+}
+[role="tablist"] {
+  position: relative;
+  border-bottom: 1px solid var(--color-background);
+  overflow-x: auto;
+  overflow-y: hidden;
+  white-space: nowrap;
+  scrollbar-width: none;
+}
+.sphinx-tabs-tab[aria-selected="true"],
+.sphinx-tabs-tab:hover {
+  border: 0;
+  border-bottom: 0;
+  margin: 0;
+  color: var(--pst-color-text-base);
+}
+.sphinx-tabs-tab,
+.sphinx-tabs-tab[aria-selected="true"] {
+  padding: 8px 0;
+  font-size: 14px;
+  font-weight: 500;
+}
+.sphinx-tabs-tab {
+  font-family: var(--pst-font-family-base);
+  color: #181a1b99;
+}
+.closeable {
+  display: flex;
+  gap: 40px;
+}
+.tabs-sliding-indicator {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 0;
+  height: 1px;
+  background-color: #000;
+  transition: all 0.3s ease;
+  opacity: 0;
+  z-index: 1;
+  pointer-events: none;
+}
+div.tutorial-filter-menu {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+div.tutorial-filter-menu div.tutorial-filter {
+  padding: 6px 8px;
+  border: 1px solid var(--pst-color-text-base);
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.1;
+  text-transform: uppercase;
+  cursor: pointer;
+  color: var(--pst-color-text-base);
+  letter-spacing: 0.14px;
+}
+div.tutorial-filter-menu div.tutorial-filter.all-tag-selected,
+div.tutorial-filter-menu div.tutorial-filter.filter-btn.selected {
+  background-color: var(--pst-color-text-base);
+  color: #fff;
+}
+#youtube {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 16 / 9;
+}
+footer.bd-footer {
+  padding: 48px 0;
+  background-color: #000;
+  color: #ffffff66;
+  font-size: 14px;
+  font-weight: 500;
+  border-top: 0;
+}
+@media (min-width: 768px) {
+  footer.bd-footer {
+    padding: 48px 0 64px 0;
+  }
+}
+footer.bd-footer a {
+  color: #ffffff66;
+  text-decoration: none;
+}
+footer.bd-footer a:hover {
+  color: #ffffff;
+  text-decoration: none;
+}
+footer.bd-footer .bd-footer__inner {
+  flex-direction: column;
+  padding: 0 20px;
+}
+footer.bd-footer .footer-logo {
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 24px;
+}
+@media (min-width: 768px) {
+  footer.bd-footer .footer-logo {
+    flex-direction: row;
+  }
+}
+footer.bd-footer .footer-logo .logo__image {
+  height: 32px;
+}
+footer.bd-footer .footer-logo .book-a-demo {
+  height: 50px;
+  background-color: #ffffff40 !important;
+}
+footer.bd-footer .footer-logo .book-a-demo .arrow {
+  height: 42px;
+  width: 42px;
+  background-color: #ffffff40;
+}
+footer.bd-footer .footer-logo .book-a-demo:hover .arrow {
+  transform: translate3d(153.19px, 0px, 0px);
+  color: #000;
+  background-color: #ffffff;
+}
+footer.bd-footer .footer-logo .book-a-demo:hover .text {
+  transform: translate3d(-42px, 0px, 0px);
+}
+footer.bd-footer .footer-links {
+  display: grid;
+  margin-top: 48px;
+  padding-top: 24px;
+  border-top: 1px solid #181a1b;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  column-gap: 16px;
+  row-gap: 48px;
+}
+@media (min-width: 768px) {
+  footer.bd-footer .footer-links {
+    grid-template-columns: repeat(12, 1fr);
+  }
+}
+footer.bd-footer .footer-links .footer-links__item {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  line-height: 1.3;
+  grid-column: span 2;
+  letter-spacing: -0.14px;
+}
+footer.bd-footer .footer-links .footer-links__item div {
+  color: #ffffff;
+  width: fit-content;
+}
+footer.bd-footer .footer-links .footer-links__item a {
+  color: #ffffff99;
+  width: fit-content;
+}
+footer.bd-footer .footer-links .footer-links__item a:hover {
+  color: #ffffff;
+}
+footer.bd-footer .footer-links .social-icons {
+  display: flex;
+  gap: 8px;
+  grid-column: span 4;
+  flex-wrap: wrap;
+  align-content: flex-start;
+}
+@media (min-width: 768px) {
+  footer.bd-footer .footer-links .social-icons {
+    grid-column: span 2;
+  }
+}
+footer.bd-footer .footer-links .social-icons a {
+  height: 42px;
+  width: 42px;
+  color: #ffffff;
+  border-radius: 50%;
+  background-color: #313435;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.15s ease;
+}
+footer.bd-footer .footer-links .social-icons a:hover {
+  background-color: #313435cc;
+}
+footer.bd-footer .footer-links .social-icons a svg {
+  height: 16px;
+  width: 16px;
+}
+footer.bd-footer .footer-items {
+  display: flex;
+  margin-top: 48px;
+  padding-top: 24px;
+  gap: 16px;
+  flex-direction: column;
+  line-height: 1.3;
+}
+@media (min-width: 768px) {
+  footer.bd-footer .footer-items {
+    flex-direction: row;
+  }
+}
+footer.bd-footer .footer-items .footer-items__end {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  letter-spacing: -0.14px;
+}
+@media (min-width: 768px) {
+  footer.bd-footer .footer-items .footer-items__end {
+    align-items: flex-end;
+  }
+}
+footer.bd-footer .footer-items .footer-items__end .footer-legal-links {
+  display: flex;
+  align-items: center;
+}
+footer.bd-footer .footer-items .footer-links__divider {
+  display: inline-block;
+  width: 1px;
+  height: 12px;
+  background-color: #ffffff66;
+  margin: 0 8px;
+}
+.footer-links__item,
+.footer-items {
+  letter-spacing: 0.14px;
+}
+header.bd-header {
+  box-shadow: none;
+  border-bottom: 1px solid var(--color-background);
+  z-index: 200;
+}
+header.bd-header .bd-header__inner {
+  flex-direction: row-reverse;
+  padding: 0 20px;
+}
+header.bd-header .bd-header__inner .primary-sidebar-toggle {
+  margin-right: 0;
+  position: relative;
+  padding: 8px 16px;
+  background-color: var(--color-background);
+  border: none;
+  border-radius: 3.40282e38px;
+  color: #181a1b99;
+  font-size: 14px;
+  font-weight: 500;
+  gap: 10px;
+  height: 40px;
+  line-height: 1.5;
+}
+header.bd-header .bd-header__inner .primary-sidebar-toggle:hover:before {
+  border: 0;
+}
+header.bd-header
+  .bd-header__inner
+  .primary-sidebar-toggle
+  .primary-toggle-text {
+  letter-spacing: -0.01em;
+}
+header.bd-header
+  .bd-header__inner
+  .primary-sidebar-toggle
+  .primary-toggle-icon {
+  width: 16px;
+  height: 16px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+}
+header.bd-header
+  .bd-header__inner
+  .primary-sidebar-toggle
+  .primary-toggle-icon
+  .line1,
+header.bd-header
+  .bd-header__inner
+  .primary-sidebar-toggle
+  .primary-toggle-icon
+  .line2 {
+  width: 16px;
+  height: 1.5px;
+  background-color: #68615d;
+  transition: all 0.3s ease;
+  transform-origin: center;
+}
+header.bd-header
+  .bd-header__inner
+  .primary-sidebar-toggle
+  .primary-toggle-icon
+  .line1 {
+  margin-bottom: 3px;
+}
+header.bd-header
+  .bd-header__inner
+  .primary-sidebar-toggle
+  .primary-toggle-icon
+  .line2 {
+  margin-top: 3px;
+}
+header.bd-header
+  .bd-header__inner
+  .primary-sidebar-toggle
+  .primary-toggle-icon.active
+  .line1 {
+  transform: translateY(3.75px) rotate(45deg);
+}
+header.bd-header
+  .bd-header__inner
+  .primary-sidebar-toggle
+  .primary-toggle-icon.active
+  .line2 {
+  transform: translateY(-3.75px) rotate(-45deg);
+}
+header.bd-header .bd-header__inner .secondary-toggle {
+  display: none;
+}
+header.bd-header .bd-header__inner .navbar-header-items__start {
+  flex: 1;
+}
+@media (min-width: 960px) {
+  header.bd-header .bd-header__inner {
+    flex-direction: row;
+  }
+  header.bd-header .bd-header__inner .primary-sidebar-toggle {
+    display: none;
+  }
+}
+main p {
+  line-height: 1.5;
+}
+main h1 {
+  line-height: 1.1;
+  word-break: break-word;
+}
+main h2,
+main h3,
+main h4,
+main h5,
+main h6 {
+  line-height: 1.2;
+  word-break: break-word;
+}
+main h4 {
+  font-weight: 600;
+}
+main div.tutorials-callout-container {
+  margin-bottom: 24px;
+}
+main div.tutorials-callout-container .row {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0;
+}
+main div.tutorials-callout-container .row p:empty {
+  display: none;
+}
+main div.tutorials-callout-container .row .col-md-6 {
+  padding: 16px 0;
+}
+@media (min-width: 768px) {
+  main div.tutorials-callout-container .row .col-md-6:nth-child(even) {
+    padding: 0 16px 16px 0;
+  }
+  main div.tutorials-callout-container .row .col-md-6:nth-child(odd) {
+    padding: 0 0 16px 16px;
+  }
+}
+main div.tutorials-callout-container .row .col-md-6 .text-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 10px 0px;
+}
+main
+  div.tutorials-callout-container
+  .row
+  .col-md-6
+  .text-container
+  .body-paragraph {
+  color: var(--pst-color-link-hover);
+  flex: 1;
+}
+main
+  div.tutorials-callout-container
+  .row
+  .col-md-6
+  .text-container
+  p:has(.btn.with-right-arrow.callout-button) {
+  margin-top: auto;
+}
+main
+  div.tutorials-callout-container
+  .row
+  .col-md-6
+  .text-container
+  div:has(img) {
+  flex: 1;
+  display: flex;
+  align-items: center;
+}
+main
+  div.tutorials-callout-container
+  .row
+  .col-md-6
+  .text-container
+  div:has(img)
+  img {
+  width: 100%;
+  height: 250px;
+  object-fit: cover;
+}
+main section > img,
+main section > a > img {
+  margin-bottom: 24px;
+}
+*:focus-visible {
+  box-shadow: none !important;
+  outline: none !important;
+}
+@media (min-width: 960px) {
+  .bd-page-width {
+    max-width: 82.5rem;
+  }
+}
+.nav.bd-sidenav .toctree-l1 {
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+.nav.bd-sidenav .toctree-l1 a.reference {
+  padding: 8px;
+  border-radius: 8px;
+  color: var(--pst-color-text-base);
+  box-shadow: none;
+  margin-bottom: 4px;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  max-width: 100%;
+  min-height: 32px;
+  margin-right: 16px;
+  padding-right: 30px;
+  line-height: 100%;
+}
+.nav.bd-sidenav .toctree-l1 a.reference:hover {
+  color: var(--pst-color-text-base);
+  text-decoration: none;
+  background-color: var(--color-background);
+}
+.nav.bd-sidenav .toctree-l1 a.reference.current {
+  font-weight: 500;
+  background-color: var(--color-background);
+}
+.nav.bd-sidenav .toctree-l2 {
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+.nav.bd-sidenav .toctree-l2 a.reference {
+  padding: 8px;
+  border-radius: 8px;
+  color: var(--pst-color-text-base);
+  box-shadow: none;
+  margin-bottom: 4px;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  max-width: 100%;
+  min-height: 32px;
+  margin-right: 16px;
+  padding-right: 30px;
+  line-height: 100%;
+}
+.nav.bd-sidenav .toctree-l2 a.reference:hover {
+  color: var(--pst-color-text-base);
+  text-decoration: none;
+  background-color: var(--color-background);
+}
+.nav.bd-sidenav .toctree-l2 a.reference.current {
+  font-weight: 500;
+  background-color: var(--color-background);
+}
+.nav.bd-sidenav .toctree-l3 {
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+.nav.bd-sidenav .toctree-l3 a.reference {
+  padding: 8px;
+  border-radius: 8px;
+  color: var(--pst-color-text-base);
+  box-shadow: none;
+  margin-bottom: 4px;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  max-width: 100%;
+  min-height: 32px;
+  margin-right: 16px;
+  padding-right: 30px;
+  line-height: 100%;
+}
+.nav.bd-sidenav .toctree-l3 a.reference:hover {
+  color: var(--pst-color-text-base);
+  text-decoration: none;
+  background-color: var(--color-background);
+}
+.nav.bd-sidenav .toctree-l3 a.reference.current {
+  font-weight: 500;
+  background-color: var(--color-background);
+}
+.nav.bd-sidenav .toctree-l4 {
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+.nav.bd-sidenav .toctree-l4 a.reference {
+  padding: 8px;
+  border-radius: 8px;
+  color: var(--pst-color-text-base);
+  box-shadow: none;
+  margin-bottom: 4px;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  max-width: 100%;
+  min-height: 32px;
+  margin-right: 16px;
+  padding-right: 30px;
+  line-height: 100%;
+}
+.nav.bd-sidenav .toctree-l4 a.reference:hover {
+  color: var(--pst-color-text-base);
+  text-decoration: none;
+  background-color: var(--color-background);
+}
+.nav.bd-sidenav .toctree-l4 a.reference.current {
+  font-weight: 500;
+  background-color: var(--color-background);
+}
+.nav.bd-sidenav .toctree-l5 {
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+.nav.bd-sidenav .toctree-l5 a.reference {
+  padding: 8px;
+  border-radius: 8px;
+  color: var(--pst-color-text-base);
+  box-shadow: none;
+  margin-bottom: 4px;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  max-width: 100%;
+  min-height: 32px;
+  margin-right: 16px;
+  padding-right: 30px;
+  line-height: 100%;
+}
+.nav.bd-sidenav .toctree-l5 a.reference:hover {
+  color: var(--pst-color-text-base);
+  text-decoration: none;
+  background-color: var(--color-background);
+}
+.nav.bd-sidenav .toctree-l5 a.reference.current {
+  font-weight: 500;
+  background-color: var(--color-background);
+}
+.nav.bd-sidenav .toctree-l6 {
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+.nav.bd-sidenav .toctree-l6 a.reference {
+  padding: 8px;
+  border-radius: 8px;
+  color: var(--pst-color-text-base);
+  box-shadow: none;
+  margin-bottom: 4px;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  max-width: 100%;
+  min-height: 32px;
+  margin-right: 16px;
+  padding-right: 30px;
+  line-height: 100%;
+}
+.nav.bd-sidenav .toctree-l6 a.reference:hover {
+  color: var(--pst-color-text-base);
+  text-decoration: none;
+  background-color: var(--color-background);
+}
+.nav.bd-sidenav .toctree-l6 a.reference.current {
+  font-weight: 500;
+  background-color: var(--color-background);
+}
+.navbar-nav,
+.dropdown-items-container {
+  justify-content: center;
+  flex-direction: column;
+}
+.navbar-nav .nav-item,
+.dropdown-items-container .nav-item {
+  margin: 0 1rem;
+}
+.navbar-nav .nav-item .nav-link,
+.navbar-nav .nav-item .dropdown-item,
+.dropdown-items-container .nav-item .nav-link,
+.dropdown-items-container .nav-item .dropdown-item {
+  color: var(--pst-color-text-base);
+  font-size: 14px;
+  font-weight: 500;
+  width: 100%;
+}
+.navbar-nav .nav-item .nav-link:hover,
+.navbar-nav .nav-item .dropdown-item:hover,
+.dropdown-items-container .nav-item .nav-link:hover,
+.dropdown-items-container .nav-item .dropdown-item:hover {
+  text-decoration: none;
+}
+.navbar .container,
+.navbar .container-fluid {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.bd-navbar {
+  justify-content: center;
+}
+.bd-navbar .navbar-nav {
+  margin: 0 auto;
+}
+.navbar-header-items__start,
+.navbar-header-items__end {
+  flex: 0 0 auto;
+}
+.navbar-header-items__center {
+  flex: 1 1 auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.navbar-header-items__center .navbar-nav {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.navbar-nav .nav-item + .nav-item {
+  margin-left: 1rem;
+}
+@media (min-width: 960px) {
+  .bd-sidebar-primary li.has-children > details > summary .toctree-toggle {
+    right: 16px;
+  }
+  .navbar-nav .nav-item .nav-link {
+    height: 64px;
+    display: flex;
+    align-items: center;
+  }
+}
+@media (max-width: 1200px) {
+  .navbar-nav {
+    width: auto;
+    justify-content: flex-start;
+  }
+}
+.bd-container .bd-container__inner dialog.bd-sidebar::backdrop {
+  background-color: transparent;
+  top: var(--pst-header-height);
+  opacity: 0;
+}
+.bd-container .bd-container__inner dialog.bd-sidebar-primary {
+  border-top: 1px solid var(--color-background);
+  height: calc(100vh - var(--pst-header-height));
+  width: 100%;
+  max-width: 100%;
+  top: var(--pst-header-height);
+  background-color: var(--pst-color-on-background);
+  padding: 20px;
+  transition: none;
+}
+.bd-container
+  .bd-container__inner
+  dialog.bd-sidebar-primary
+  .sidebar-header-items__center
+  .navbar-nav,
+.bd-container
+  .bd-container__inner
+  dialog.bd-sidebar-primary
+  .sidebar-header-items__center
+  .dropdown-items-container,
+.bd-container
+  .bd-container__inner
+  dialog.bd-sidebar-primary
+  .dropdown-nav-container
+  .navbar-nav,
+.bd-container
+  .bd-container__inner
+  dialog.bd-sidebar-primary
+  .dropdown-nav-container
+  .dropdown-items-container {
+  align-items: normal;
+}
+.bd-container
+  .bd-container__inner
+  dialog.bd-sidebar-primary
+  .sidebar-header-items__center
+  .navbar-nav
+  .nav-item,
+.bd-container
+  .bd-container__inner
+  dialog.bd-sidebar-primary
+  .sidebar-header-items__center
+  .dropdown-items-container
+  .nav-item,
+.bd-container
+  .bd-container__inner
+  dialog.bd-sidebar-primary
+  .dropdown-nav-container
+  .navbar-nav
+  .nav-item,
+.bd-container
+  .bd-container__inner
+  dialog.bd-sidebar-primary
+  .dropdown-nav-container
+  .dropdown-items-container
+  .nav-item {
+  height: 57px;
+  border-radius: 8px;
+  padding-inline: 16px;
+  background-color: var(--color-background);
+  margin-inline: 0px;
+  margin-bottom: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.bd-container
+  .bd-container__inner
+  dialog.bd-sidebar-primary
+  .sidebar-header-items__end
+  .navbar-item {
+  margin-top: 28px;
+}
+.bd-container
+  .bd-container__inner
+  dialog.bd-sidebar-primary
+  .sidebar-header-items__end
+  .navbar-item
+  .sd-btn {
+  display: flex;
+  align-items: center;
+  height: 50px;
+}
+.bd-container
+  .bd-container__inner
+  dialog.bd-sidebar-primary
+  .sidebar-primary-items__start {
+  display: none;
+}
+.bd-sidebar-primary {
+  border: 0;
+  padding: 1rem 1rem 1rem;
+}
+.sidebar-secondary-item {
+  border: 0;
+}
+.sidebar-secondary-item .page-toc.tocsection.onthispage {
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 20px;
+  line-height: 1;
+}
+.sidebar-secondary-item .page-toc ul li a.nav-link {
+  color: var(--pst-color-text-base);
+  font-weight: 500;
+  border-radius: 8px;
+  position: relative;
+  padding-left: 8px;
+  margin-left: -8px;
+}
+.sidebar-secondary-item .page-toc ul li a.nav-link:hover {
+  color: var(--pst-color-text-base);
+  text-decoration: none;
+}
+.sidebar-secondary-item .page-toc ul li a.nav-link.active {
+  box-shadow: none;
+}
+.sidebar-secondary-item
+  .page-toc
+  ul
+  li
+  a.nav-link.active:not(:has(+ ul .nav-link.active))::before {
+  content: "";
+  display: block;
+  width: 8px;
+  height: 8px;
+  background-color: var(--pst-color-primary);
+  border-radius: 50%;
+  position: absolute;
+  left: -8px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+@media (min-width: 960px) {
+  dialog.bd-sidebar-primary {
+    display: none;
+  }
+}
+
+.guides-card {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  height: 100%;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.guides-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.guides-card .card-body {
+  display: flex;
+  flex-direction: column;
+  padding: 1rem 1.5rem 1.5rem;
+}
+
+.guides-card .card-title {
+  color: #2c3e50;
+  font-weight: 600;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+  font-size: 1.1rem;
+}
+
+.guides-card .card-text {
+  flex-grow: 1;
+  color: #666;
+  font-size: 14px;
+  margin-bottom: 15px;
+  line-height: 1.4;
+}
+
+.guides-card .badge {
+  font-size: 11px;
+  margin-right: 5px;
+  padding: 4px 10px;
+  background: #181a1b;
+  color: #fff;
+  border-radius: 6px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+.guides-card .btn-outline-primary {
+  background-color: var(--pst-color-primary);
+  color: #fff;
+  border-color: var(--pst-color-primary);
+  font-weight: 600;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.guides-card .btn-outline-primary:hover,
+.guides-card .btn-outline-primary:focus {
+  background-color: #fff;
+  color: var(--pst-color-primary);
+  border-color: var(--pst-color-primary);
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,6 +21,7 @@ from custom_directives import (
     CustomCalloutItemDirective,
     CustomCardItemDirective,
     CustomImageLinkDirective,
+    CustomGuidesCardDirective,
 )
 from redirects import generate_redirects
 
@@ -271,3 +272,4 @@ def setup(app):
     app.add_directive("customcalloutitem", CustomCalloutItemDirective)
     app.add_directive("customcarditem", CustomCardItemDirective)
     app.add_directive("customimagelink", CustomImageLinkDirective)
+    app.add_directive("customguidescard", CustomGuidesCardDirective)

--- a/docs/source/custom_directives.py
+++ b/docs/source/custom_directives.py
@@ -10,6 +10,64 @@ from docutils.statemachine import StringList
 from docutils import nodes
 
 
+class CustomGuidesCardDirective(Directive):
+    """A custom guides card for use on getting started pages that contain guided learning experiences.
+
+    The guides card provides a title, description, level, time estimate, and a link to the guide.
+
+    Example usage::
+
+        .. customguidescard::
+            :title: Medical Imaging Guide
+            :description: Explore medical imaging workflows with DICOM, CT scans, and volumetric data.
+            :level: Beginner
+            :time: 15-25 min
+            :link: getting_started_guides/medical_imaging/index.html
+    """
+
+    option_spec = {
+        "title": directives.unchanged,
+        "description": directives.unchanged,
+        "level": directives.unchanged,
+        "time": directives.unchanged,
+        "link": directives.unchanged,
+    }
+
+    def run(self):
+        title = self.options.get("title", "")
+        description = self.options.get("description", "")
+        level = self.options.get("level", "")
+        time = self.options.get("time", "")
+        link = self.options.get("link", "")
+
+        html = _CUSTOM_GUIDES_CARD_TEMPLATE.format(
+            title=title,
+            description=description,
+            level=level,
+            time=time,
+            link=link,
+        )
+
+        return [nodes.raw("", html, format="html")]
+
+
+_CUSTOM_GUIDES_CARD_TEMPLATE = """
+    <div class="col-md-4 getting-started-card mb-4">
+        <div class="card h-100 guides-card">
+            <div class="card-body d-flex flex-column">
+                <h5 class="card-title">{title}</h5>
+                <p class="card-text">{description}</p>
+                <div class="d-flex align-items-center" style="margin-bottom: 15px;">
+                    <span class="badge">{level}</span>
+                    <span class="badge bg-secondary">{time}</span>
+                </div>
+                <a href="{link}" class="btn btn-outline-primary btn-sm mt-auto">Start Guide</a>
+            </div>
+        </div>
+    </div>
+"""
+
+
 class CustomCardItemDirective(Directive):
     """A custom card item for use on pages that contain a list of links with
     short descriptions and optional images.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -59,6 +59,61 @@ failure modes, finding annotation mistakes, and much more!
     :button_text: Install FiftyOne!
     :button_link: getting_started/install.html
 
+Where to Begin?
+===============
+
+Ready to dive into FiftyOne? Choose a guided learning experience tailored 
+to your use case:
+
+.. raw:: html
+
+    <div class="row getting-started-cards">
+
+.. customguidescard::
+    :title: Medical Imaging Guide
+    :description: Explore medical imaging workflows with DICOM, CT scans, and volumetric data.
+    :level: Beginner
+    :time: 15-25 min
+    :link: getting_started_guides/medical_imaging/index.html
+.. customguidescard::
+    :title: Self-Driving Guide
+    :description: Dive into autonomous vehicle data workflows with sensor fusion and trajectory analysis.
+    :level: Beginner
+    :time: 20-30 min
+    :link: getting_started_guides/self_driving/index.html
+.. customguidescard::
+    :title: Model Evaluation Guide
+    :description: Comprehensive model evaluation workflows with advanced analysis techniques.
+    :level: Beginner
+    :time: 15-25 min
+    :link: getting_started_guides/model_evaluation/index.html
+
+.. raw:: html
+
+    </div>
+
+.. raw:: html
+
+    <div class="text-center" style="margin: 1rem 0 2rem 0;">
+        <a href="getting_started_guides/index.html" class="sd-btn sd-btn-primary" style="font-size: 1rem; padding: 12px 24px;">
+            Explore All Getting Started Guides
+        </a>
+    </div>
+
+
+Not sure where to start? Take our quick assessment:
+
+**Working with object detection?** → :doc:`Explore the Object Detection Guide <getting_started_guides/object_detection/index>`
+
+**Have medical imaging data?** → :doc:`Begin with Medical Imaging Guide <getting_started_guides/medical_imaging/index>`
+
+**Working on autonomous vehicles?** → :doc:`Jump to Self-Driving Guide <getting_started_guides/self_driving/index>`
+
+**Need 3D computer vision?** → :doc:`Explore 3D Visual AI Guide <getting_started_guides/threed_visual_ai/index>`
+
+**Want to evaluate model performance?** → :doc:`Start with Model Evaluation Guide <getting_started_guides/model_evaluation/index>`
+
+
 FiftyOne integrates naturally with your favorite tools. Click on a logo to
 learn how:
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds a new **Getting Started Guide card** to the main index page of the docs.
Introduces a custom reStructuredText directive to render guide cards in HTML, along with dedicated CSS for consistent styling and hover effects.

## How is this patch tested?

Manually tested in the documentation build to verify:

* Card renders correctly in the index page
* Layout displays in a responsive grid using Bootstrap
* Styles are applied consistently across viewports

## Release Notes

-   [x] No. You can skip the rest of this section.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced visually styled "guides card" components to the documentation, showcasing key guides with descriptions, difficulty, time estimates, and direct links.
  * Added a new section, "Where to Begin?", on the documentation homepage to help users quickly find relevant guides and resources.

* **Style**
  * Improved CSS formatting for easier readability and maintenance.
  * Added new styles for the guides card component, including hover effects and button styling.

* **Documentation**
  * Enhanced the index page with a quick assessment list and prominent guide cards to streamline user onboarding.

* **Chores**
  * Registered a new Sphinx directive for rendering custom guides cards in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->