### PR TITLE
Open all links in a new tab to prevent users from leaving the docs

### DIFF
--- a/docs/source/_templates/footer-links.html
+++ b/docs/source/_templates/footer-links.html
@@ -1,5 +1,5 @@
 <div class="footer-legal-links">
-  <a href="https://voxel51.com/terms-of-service/">Terms of Service</a>
+  <a href="https://voxel51.com/terms-of-service/" target="_blank">Terms of Service</a>
   <div class="footer-links__divider"></div>
-  <a href="https://voxel51.com/privacy-policy/">Privacy Policy</a>
+  <a href="https://voxel51.com/privacy-policy/" target="_blank">Privacy Policy</a>
 </div>

--- a/docs/source/_templates/navbar-links.html
+++ b/docs/source/_templates/navbar-links.html
@@ -5,11 +5,11 @@
       Products
     </a>
     <ul class="dropdown-menu" aria-labelledby="productsDropdown">
-      <li><a class="dropdown-item" href="{{link_annotation}}">Data Annotation</a></li>
-      <li><a class="dropdown-item" href="{{link_curation}}">Data Curation</a></li>
-      <li><a class="dropdown-item" href="{{link_evaluation}}">Model Evaluation</a></li>
-      <li><a class="dropdown-item" href="{{link_integrations}}">Integrations</a></li>
-      <li><a class="dropdown-item" href="{{link_plugins}}">Plugins</a></li>
+      <li><a class="dropdown-item" href="{{link_annotation}}" target="_blank">Data Annotation</a></li>
+      <li><a class="dropdown-item" href="{{link_curation}}" target="_blank">Data Curation</a></li>
+      <li><a class="dropdown-item" href="{{link_evaluation}}" target="_blank">Model Evaluation</a></li>
+      <li><a class="dropdown-item" href="{{link_integrations}}" target="_blank">Integrations</a></li>
+      <li><a class="dropdown-item" href="{{link_plugins}}" target="_blank">Plugins</a></li>
     </ul>
   </div>
   <div class="nav-item dropdown">
@@ -17,23 +17,23 @@
       Solutions
     </a>
     <ul class="dropdown-menu" aria-labelledby="solutionsDropdown">
-      <li><a class="dropdown-item" href="{{link_agriculture}}">Agriculture</a></li>
-      <li><a class="dropdown-item" href="{{link_autonomous_systems}}">Autonomous Vehicles &amp; Systems</a></li>
-      <li><a class="dropdown-item" href="{{link_aviation}}">Aviation</a></li>
-      <li><a class="dropdown-item" href="{{link_defense}}">Defense</a></li>
-      <li><a class="dropdown-item" href="{{link_healthcare}}">Healthcare</a></li>
-      <li><a class="dropdown-item" href="{{link_manufacturing}}">Manufacturing</a></li>
-      <li><a class="dropdown-item" href="{{link_research}}">Research</a></li>
-      <li><a class="dropdown-item" href="{{link_retail}}">Retail</a></li>
-      <li><a class="dropdown-item" href="{{link_robotics}}">Robotics</a></li>
-      <li><a class="dropdown-item" href="{{link_security}}">Security</a></li>
-      <li><a class="dropdown-item" href="{{link_sports}}">Sports</a></li>
+      <li><a class="dropdown-item" href="{{link_agriculture}}" target="_blank">Agriculture</a></li>
+      <li><a class="dropdown-item" href="{{link_autonomous_systems}}" target="_blank">Autonomous Vehicles &amp; Systems</a></li>
+      <li><a class="dropdown-item" href="{{link_aviation}}" target="_blank">Aviation</a></li>
+      <li><a class="dropdown-item" href="{{link_defense}}" target="_blank">Defense</a></li>
+      <li><a class="dropdown-item" href="{{link_healthcare}}" target="_blank">Healthcare</a></li>
+      <li><a class="dropdown-item" href="{{link_manufacturing}}" target="_blank">Manufacturing</a></li>
+      <li><a class="dropdown-item" href="{{link_research}}" target="_blank">Research</a></li>
+      <li><a class="dropdown-item" href="{{link_retail}}" target="_blank">Retail</a></li>
+      <li><a class="dropdown-item" href="{{link_robotics}}" target="_blank">Robotics</a></li>
+      <li><a class="dropdown-item" href="{{link_security}}" target="_blank">Security</a></li>
+      <li><a class="dropdown-item" href="{{link_sports}}" target="_blank">Sports</a></li>
     </ul>
   </div>
 
   <!-- Customers Link -->
   <div class="nav-item">
-    <a class="nav-link" href="{{link_customers}}">Customers</a>
+    <a class="nav-link" href="{{link_customers}}" target="_blank">Customers</a>
   </div>
 
   <!-- Resources Dropdown -->
@@ -42,13 +42,13 @@
       Resources
     </a>
     <ul class="dropdown-menu" aria-labelledby="resourcesDropdown">
-      <li><a class="dropdown-item" href="{{link_voxel51_blog}}">Blog</a></li>
-      <li><a class="dropdown-item" href="{{link_events}}">Upcoming Events</a></li>
-      <li><a class="dropdown-item" href="{{link_webinars}}">On-Demand Webinars</a></li>
-      <li><a class="dropdown-item" href="{{link_whitepapers}}">Whitepapers & Reports</a></li>
-      <li><a class="dropdown-item" href="{{link_community}}">Computer Vision Community</a></li>
-      <li><a class="dropdown-item" href="{{link_research}}">CV Research</a></li>
-      <li><a class="dropdown-item" href="{{link_press}}">Newsroom</a></li>
+      <li><a class="dropdown-item" href="{{link_voxel51_blog}}" target="_blank">Blog</a></li>
+      <li><a class="dropdown-item" href="{{link_events}}" target="_blank">Upcoming Events</a></li>
+      <li><a class="dropdown-item" href="{{link_webinars}}" target="_blank">On-Demand Webinars</a></li>
+      <li><a class="dropdown-item" href="{{link_whitepapers}}" target="_blank">Whitepapers & Reports</a></li>
+      <li><a class="dropdown-item" href="{{link_community}}" target="_blank">Computer Vision Community</a></li>
+      <li><a class="dropdown-item" href="{{link_research}}" target="_blank">CV Research</a></li>
+      <li><a class="dropdown-item" href="{{link_press}}" target="_blank">Newsroom</a></li>
     </ul>
   </div>
 

--- a/docs/source/_templates/sections/footer.html
+++ b/docs/source/_templates/sections/footer.html
@@ -14,62 +14,62 @@
   <div class="footer-links">
     <div class="footer-links__item">
       <div>Product</div>
-      <a href="{{link_annotation}}">Data Annotation</a>
-      <a href="{{link_curation}}">Data Curation</a>
-      <a href="{{link_evaluation}}">Model Evaluation</a>
-      <a href="{{link_integrations}}">Integrations</a>
-      <a href="{{link_plugins}}">Plugins</a>
-      <a href="{{link_pricing}}">Pricing</a>
+      <a href="{{link_annotation}}" target="_blank">Data Annotation</a>
+      <a href="{{link_curation}}" target="_blank">Data Curation</a>
+      <a href="{{link_evaluation}}" target="_blank">Model Evaluation</a>
+      <a href="{{link_integrations}}" target="_blank">Integrations</a>
+      <a href="{{link_plugins}}" target="_blank">Plugins</a>
+      <a href="{{link_pricing}}" target="_blank">Pricing</a>
     </div>
     <div class="footer-links__item">
       <div>Solutions</div>
-      <a href="{{link_agriculture}}">Agriculture</a>
-      <a href="{{link_autonomous_systems}}">Autonomous Systems</a>
-      <a href="{{link_defense}}">Defense</a>
-      <a href="{{link_healthcare}}">Healthcare</a>
-      <a href="{{link_manufacturing}}">Manufacturing</a>
-      <a href="{{link_retail}}">Retail</a>
-      <a href="{{link_robotics}}">Robotics</a>
-      <a href="{{link_security}}">Security</a>
+      <a href="{{link_agriculture}}" target="_blank">Agriculture</a>
+      <a href="{{link_autonomous_systems}}" target="_blank">Autonomous Systems</a>
+      <a href="{{link_defense}}" target="_blank">Defense</a>
+      <a href="{{link_healthcare}}" target="_blank">Healthcare</a>
+      <a href="{{link_manufacturing}}" target="_blank">Manufacturing</a>
+      <a href="{{link_retail}}" target="_blank">Retail</a>
+      <a href="{{link_robotics}}" target="_blank">Robotics</a>
+      <a href="{{link_security}}" target="_blank">Security</a>
     </div>
     <div class="footer-links__item">
       <div>Developers</div>
-      <a href="{{link_docs_fiftyone}}">Documentation</a>
-      <a href="{{link_events}}">Events &amp; Meetups</a>
-      <a href="{{link_glossary}}">Computer Vision Glossary</a>
-      <a href="{{link_community}}">Community</a>
+      <a href="{{link_docs_fiftyone}}" target="_blank">Documentation</a>
+      <a href="{{link_events}}" target="_blank">Events &amp; Meetups</a>
+      <a href="{{link_glossary}}" target="_blank">Computer Vision Glossary</a>
+      <a href="{{link_community}}" target="_blank">Community</a>
     </div>
     <div class="footer-links__item">
       <div>Resources</div>
-      <a href="{{link_voxel51_blog}}">Blog</a>
-      <a href="{{link_customers}}">Customer Stories</a>
-      <a href="{{link_model_zoo}}">Model Zoo</a>
-      <a href="{{link_dataset_zoo}}">Dataset Zoo</a>
-      <a href="{{link_research}}">CV Research</a>
+      <a href="{{link_voxel51_blog}}" target="_blank">Blog</a>
+      <a href="{{link_customers}}" target="_blank">Customer Stories</a>
+      <a href="{{link_model_zoo}}" target="_blank">Model Zoo</a>
+      <a href="{{link_dataset_zoo}}" target="_blank">Dataset Zoo</a>
+      <a href="{{link_research}}" target="_blank">CV Research</a>
     </div>
     <div class="footer-links__item">
       <div>Company</div>
-      <a href="{{link_about}}">About Voxel51</a>
-      <a href="{{link_careers}}">Careers</a>
-      <a href="{{link_press}}">Press</a>
+      <a href="{{link_about}}" target="_blank">About Voxel51</a>
+      <a href="{{link_careers}}" target="_blank">Careers</a>
+      <a href="{{link_press}}" target="_blank">Press</a>
     </div>
     <div class="social-icons">
-      <a aria-label="Discord" href="{{link_voxel51_discord}}">
+      <a aria-label="Discord" href="{{link_voxel51_discord}}" target="_blank">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
           <path fill="currentColor" fill-rule="evenodd" d="m14.963 2.978.731.144c1.141.227 2.267.559 3.362.997l1.402.56.482.193.12.505 2.696 11.322.202.851-.816.314-7.01 2.696-1.02.392-.3-1.05-.87-3.05h-3.884l-.871 3.05-.3 1.05-1.02-.392-7.01-2.696-.816-.314.203-.851L2.939 5.377l.12-.505.482-.192 1.402-.561c1.095-.438 2.22-.77 3.362-.997l.731-.144.348.659L10.103 5h3.793l.72-1.363.347-.66ZM6.608 16.852H17.39v-2H6.608v2ZM7 12V9h2v3H7Zm8-3v3h2V9h-2Z" clip-rule="evenodd"></path>
         </svg>
       </a>
-      <a aria-label="Linkedin" href="{{link_linkedin}}">
+      <a aria-label="Linkedin" href="{{link_linkedin}}" target="_blank">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
           <path fill="currentColor" fill-rule="evenodd" d="M2 1.5H1v6h6v-6H2ZM2 9H1v14h6V9H2Zm7 0h7a7 7 0 0 1 7 7v7h-6v-6a2 2 0 0 0-2-2v8H9V9Z" clip-rule="evenodd"></path>
         </svg>
       </a>
-      <a aria-label="Twitter" href="{{link_twitter}}">
+      <a aria-label="Twitter" href="{{link_twitter}}" target="_blank">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
           <path fill="currentColor" d="m.75 2 8.417 11.223L.368 23h3.364l6.964-7.738L16.5 23H23l-8.758-11.678L22.632 2h-3.364l-6.555 7.284L7.25 2H.75Z"></path>
         </svg>
       </a>
-      <a aria-label="Youtube" href="{{link_youtube}}">
+      <a aria-label="Youtube" href="{{link_youtube}}" target="_blank">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
           <path fill="currentColor" fill-rule="evenodd" d="M0 8a6 6 0 0 1 6-6h12a6 6 0 0 1 6 6v8a6 6 0 0 1-6 6H6a6 6 0 0 1-6-6V8Zm8.494-.09a.5.5 0 0 1 .752-.432l7.012 4.09a.5.5 0 0 1 0 .864l-7.012 4.09a.5.5 0 0 1-.752-.432V7.91Z" clip-rule="evenodd"></path>
         </svg>


### PR DESCRIPTION
## What changes are proposed in this pull request?

Opens all clickable links in the documentation in a new tab instead of the same tab, preventing users from unintentionally leaving the docs.

## How is this patch tested? If it is not, please explain why.

Manually verified that all modified links now open in a new browser tab.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [x] No. You can skip the rest of this section.

### What areas of FiftyOne does this PR affect?

* [x] Documentation: FiftyOne documentation changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated navbar, footer, and footer-links so most external links open in a new tab/window for smoother browsing.
  * Affected areas include Products, Solutions, Resources, Company, Developers, Customers, and social media icons.
  * Terms of Service and Privacy Policy links now open in a new tab.
  * Existing behavior for the Docs link and the “Talk to a CV expert” button remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->