### PR TITLE
[docs] Allow custom tag for independent deployments

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -114,7 +114,7 @@ nbsphinx_requirejs_path = ""
 nbsphinx_execute = "never"
 
 # Adds helpful external links to the built HTML
-ref = "v%s" % foc.VERSION
+ref = os.getenv("FO_DOCS_REF", f"v{foc.VERSION}")
 nbsphinx_prolog = """
 
 .. raw:: html


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds support for setting a custom doc deployment tag using the `FO_DOCS_REF` environment variable:

```python
ref = os.getenv("FO_DOCS_REF", f"v{foc.VERSION}")
````
Previously, docs deployments always used the tag in the setup.py config file. This could lead to mismatches if Colab notebooks or code examples had not yet been updated in the latest release. With this change, we can explicitly set which version tag the docs target, ensuring that deployed docs are in sync with the intended code and notebook versions.


## How is this patch tested? If it is not, please explain why.

Manually tested by setting different values for `FO_DOCS_REF` and verifying that the build process uses the specified tag for deployment.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [x] No. You can skip the rest of this section.

### What areas of FiftyOne does this PR affect?

* [ ] App: FiftyOne application changes
* [ ] Build: Build and test infrastructure changes
* [ ] Core: Core `fiftyone` Python library changes
* [x] Documentation: FiftyOne documentation changes
* [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Notebook links (Colab, GitHub, download) now adapt to the configured docs reference, enabling version/branch-specific links.
  * Supports environment-based override for the docs reference; defaults to the current version when not provided.
  * Improves accuracy of cross-links in hosted docs across releases and preview builds.
  * Ensure your docs build sets a valid reference to avoid broken links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->