### PR TITLE
FOEPD-1823 apply color after transformation of up vector

### DIFF
--- a/app/packages/looker-3d/src/fo3d/mesh/Ply.tsx
+++ b/app/packages/looker-3d/src/fo3d/mesh/Ply.tsx
@@ -37,10 +37,12 @@ const PlyWithPointsMaterial = ({
   name,
   geometry,
   defaultMaterial,
+  quaternion,
 }: {
   name: string;
   geometry: BufferGeometry;
   defaultMaterial: FoMeshMaterial;
+  quaternion: Quaternion;
 }) => {
   const { pointCloudSettings, setHoverMetadata } = useFo3dContext();
   const [currentHoveredPoint, setCurrentHoveredPoint] = useRecoilState(
@@ -61,7 +63,8 @@ const PlyWithPointsMaterial = ({
     name,
     geometry,
     overrideMaterial,
-    pointsContainerRef
+    pointsContainerRef,
+    quaternion
   );
 
   const mesh = useMemo(() => new Points(geometry), [geometry]);
@@ -270,6 +273,7 @@ export const Ply = ({
           name={name}
           geometry={geometry}
           defaultMaterial={defaultMaterial}
+          quaternion={quaternion}
         />
       );
     }

--- a/app/packages/looker-3d/src/fo3d/mesh/Ply.tsx
+++ b/app/packages/looker-3d/src/fo3d/mesh/Ply.tsx
@@ -38,7 +38,7 @@ const PlyWithPointsMaterial = ({
   quaternion,
   position,
   scale,
-  vextexColorsAvailable,
+  vertexColorsAvailable,
 }: {
   name: string;
   geometry: BufferGeometry;
@@ -46,7 +46,7 @@ const PlyWithPointsMaterial = ({
   quaternion: Quaternion;
   position: Vector3;
   scale: Vector3;
-  vextexColorsAvailable: boolean;
+  vertexColorsAvailable: boolean;
 }) => {
   const overrideMaterial = {
     shadingMode: "height",
@@ -64,7 +64,7 @@ const PlyWithPointsMaterial = ({
     overrideMaterial,
     pointsContainerRef,
     quaternion,
-    vextexColorsAvailable
+    vertexColorsAvailable
   );
 
   const mesh = useMemo(() => new Points(geometry), [geometry]);
@@ -229,7 +229,7 @@ export const Ply = ({
           quaternion={quaternion}
           position={position}
           scale={scale}
-          vextexColorsAvailable={isUsingVertexColors}
+          vertexColorsAvailable={isUsingVertexColors}
         />
       );
     }

--- a/app/packages/looker-3d/src/fo3d/mesh/Ply.tsx
+++ b/app/packages/looker-3d/src/fo3d/mesh/Ply.tsx
@@ -38,6 +38,7 @@ const PlyWithPointsMaterial = ({
   quaternion,
   position,
   scale,
+  vextexColorsAvailable,
 }: {
   name: string;
   geometry: BufferGeometry;
@@ -45,6 +46,7 @@ const PlyWithPointsMaterial = ({
   quaternion: Quaternion;
   position: Vector3;
   scale: Vector3;
+  vextexColorsAvailable: boolean;
 }) => {
   const overrideMaterial = {
     shadingMode: "height",
@@ -61,7 +63,8 @@ const PlyWithPointsMaterial = ({
     geometry,
     overrideMaterial,
     pointsContainerRef,
-    quaternion
+    quaternion,
+    vextexColorsAvailable
   );
 
   const mesh = useMemo(() => new Points(geometry), [geometry]);
@@ -226,6 +229,7 @@ export const Ply = ({
           quaternion={quaternion}
           position={position}
           scale={scale}
+          vextexColorsAvailable={isUsingVertexColors}
         />
       );
     }

--- a/app/packages/looker-3d/src/fo3d/point-cloud/Pcd.tsx
+++ b/app/packages/looker-3d/src/fo3d/point-cloud/Pcd.tsx
@@ -91,10 +91,20 @@ export const Pcd = ({
 
       if (points.geometry.hasAttribute("position")) {
         const posAttr = points.geometry.getAttribute("position");
-        md.coord = [posAttr.getX(idx), posAttr.getY(idx), posAttr.getZ(idx)];
-        setCurrentHoveredPoint(
-          new Vector3(posAttr.getX(idx), posAttr.getY(idx), posAttr.getZ(idx))
+        const localPosition = new Vector3(
+          posAttr.getX(idx),
+          posAttr.getY(idx),
+          posAttr.getZ(idx)
         );
+        md.coord = [localPosition.x, localPosition.y, localPosition.z];
+
+        // transform the local position to world position using the pcd's transformation
+        const worldPosition = localPosition.clone();
+        worldPosition.applyQuaternion(quaternion);
+        worldPosition.multiply(scale);
+        worldPosition.add(position);
+
+        setCurrentHoveredPoint(worldPosition);
       }
 
       // dynamically handle all other attributes
@@ -109,7 +119,7 @@ export const Pcd = ({
         attributes: md,
       });
     },
-    [points, setHoverMetadata, shadingMode]
+    [points, setHoverMetadata, shadingMode, quaternion, scale, position]
   );
 
   const hoverProps = useMemo(() => {

--- a/app/packages/looker-3d/src/fo3d/point-cloud/Pcd.tsx
+++ b/app/packages/looker-3d/src/fo3d/point-cloud/Pcd.tsx
@@ -64,7 +64,13 @@ export const Pcd = ({
     isColormapModalOpen,
     setIsColormapModalOpen,
     handleColormapSave,
-  } = usePcdMaterial(name, points.geometry, defaultMaterial, pcdContainerRef);
+  } = usePcdMaterial(
+    name,
+    points.geometry,
+    defaultMaterial,
+    pcdContainerRef,
+    quaternion
+  );
 
   const pointerMoveHandler = useMemo(
     () => (e: ThreeEvent<MouseEvent>) => {

--- a/app/packages/looker-3d/src/fo3d/point-cloud/Pcd.tsx
+++ b/app/packages/looker-3d/src/fo3d/point-cloud/Pcd.tsx
@@ -1,7 +1,5 @@
 import { getSampleSrc } from "@fiftyone/state";
-import { ThreeEvent } from "@react-three/fiber";
 import { useEffect, useMemo, useRef } from "react";
-import { useRecoilState } from "recoil";
 import type { Quaternion } from "three";
 import { Vector3 } from "three";
 import PcdColormapModal, {
@@ -9,10 +7,10 @@ import PcdColormapModal, {
 } from "../../components/PcdColormapModal";
 import type { PcdAsset } from "../../hooks";
 import { useFoLoader } from "../../hooks/use-fo-loaders";
+import { usePointCloudHover } from "../../hooks/use-point-cloud-hover";
 import { DynamicPCDLoader } from "../../loaders/dynamic-pcd-loader";
-import { currentHoveredPointAtom } from "../../state";
-import { useFo3dContext } from "../context";
 import { HoveredPointMarker } from "../components/HoveredPointMarker";
+import { useFo3dContext } from "../context";
 import { getResolvedUrlForFo3dAsset } from "../utils";
 import { usePcdMaterial } from "./use-pcd-material";
 
@@ -31,11 +29,7 @@ export const Pcd = ({
   scale: Vector3;
   children?: React.ReactNode;
 }) => {
-  const { fo3dRoot, pointCloudSettings, setHoverMetadata } = useFo3dContext();
-
-  const [currentHoveredPoint, setCurrentHoveredPoint] = useRecoilState(
-    currentHoveredPointAtom
-  );
+  const { fo3dRoot, setHoverMetadata } = useFo3dContext();
 
   const pcdUrl = useMemo(
     () =>
@@ -72,73 +66,14 @@ export const Pcd = ({
     quaternion
   );
 
-  const pointerMoveHandler = useMemo(
-    () => (e: ThreeEvent<MouseEvent>) => {
-      const idx = e.index;
-      if (idx === undefined) return;
-
-      const md: Record<string, any> = { index: idx };
-
-      if (points.geometry.hasAttribute("rgb")) {
-        const colorAttr = points.geometry.getAttribute("rgb");
-
-        md.rgb = [
-          colorAttr.getX(idx),
-          colorAttr.getY(idx),
-          colorAttr.getZ(idx),
-        ];
-      }
-
-      if (points.geometry.hasAttribute("position")) {
-        const posAttr = points.geometry.getAttribute("position");
-        const localPosition = new Vector3(
-          posAttr.getX(idx),
-          posAttr.getY(idx),
-          posAttr.getZ(idx)
-        );
-        md.coord = [localPosition.x, localPosition.y, localPosition.z];
-
-        // transform the local position to world position using the pcd's transformation
-        const worldPosition = localPosition.clone();
-        worldPosition.applyQuaternion(quaternion);
-        worldPosition.multiply(scale);
-        worldPosition.add(position);
-
-        setCurrentHoveredPoint(worldPosition);
-      }
-
-      // dynamically handle all other attributes
-      Object.keys(points.geometry.attributes).forEach((attr) => {
-        if (attr === "rgb" || attr === "position") return;
-        md[attr] = points.geometry.attributes[attr].getX(idx);
-      });
-
-      setHoverMetadata({
-        assetName: name,
-        renderModeDescriptor: shadingMode,
-        attributes: md,
-      });
-    },
-    [points, setHoverMetadata, shadingMode, quaternion, scale, position]
-  );
-
-  const hoverProps = useMemo(() => {
-    if (!pointCloudSettings.enableTooltip) return {};
-
-    return {
-      // fires on *every* intersected point
-      onPointerMove: pointerMoveHandler,
-      onPointerOut: () => {
-        setCurrentHoveredPoint(null);
-      },
-    };
-  }, [pointCloudSettings.enableTooltip, pointerMoveHandler]);
-
-  useEffect(() => {
-    return () => {
-      setCurrentHoveredPoint(null);
-    };
-  }, [pointerMoveHandler]);
+  const { hoverProps, currentHoveredPoint } = usePointCloudHover({
+    geometry: points.geometry,
+    assetName: name,
+    shadingMode,
+    position,
+    quaternion,
+    scale,
+  });
 
   useEffect(() => {
     setHoverMetadata((prev) => ({

--- a/app/packages/looker-3d/src/fo3d/point-cloud/use-pcd-material.tsx
+++ b/app/packages/looker-3d/src/fo3d/point-cloud/use-pcd-material.tsx
@@ -59,7 +59,8 @@ export const usePcdMaterial = (
   geometry: BufferGeometry,
   defaultMaterial: PcdAsset["defaultMaterial"],
   pcdContainerRef: React.RefObject<any>,
-  quaternion?: Quaternion
+  quaternion?: Quaternion,
+  vextexColorsAvailable: boolean = false
 ) => {
   const { upVector, pluginSettings } = useFo3dContext();
 
@@ -211,6 +212,7 @@ export const usePcdMaterial = (
             size={isPointSizeAttenuated ? pointSize / 1000 : pointSize / 2}
             opacity={opacity}
             sizeAttenuation={isPointSizeAttenuated}
+            vertexColors={Boolean(vextexColorsAvailable)}
           />
         );
 

--- a/app/packages/looker-3d/src/fo3d/point-cloud/use-pcd-material.tsx
+++ b/app/packages/looker-3d/src/fo3d/point-cloud/use-pcd-material.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from "react";
-import type { BufferGeometry } from "three";
+import type { BufferGeometry, Quaternion } from "three";
 import {
   SHADE_BY_CUSTOM,
   SHADE_BY_HEIGHT,
@@ -58,7 +58,8 @@ export const usePcdMaterial = (
   name: string,
   geometry: BufferGeometry,
   defaultMaterial: PcdAsset["defaultMaterial"],
-  pcdContainerRef: React.RefObject<any>
+  pcdContainerRef: React.RefObject<any>,
+  quaternion?: Quaternion
 ) => {
   const { upVector, pluginSettings } = useFo3dContext();
 
@@ -138,23 +139,27 @@ export const usePcdMaterial = (
   const pointsMaterial = useMemo(() => {
     // to trigger rerender
     const key = `${name}-${opacity}-${pointSize}-${isPointSizeAttenuated}-${shadeBy}-${customColor}-${minMaxCoordinates}-${minIntensity}-${maxIntensity}-${upVector}-${
-      colorMap ? JSON.stringify(colorMap) : ""
-    }-${activeThreshold ? JSON.stringify(activeThreshold) : ""}`;
+      quaternion
+        ? JSON.stringify([
+            quaternion.x,
+            quaternion.y,
+            quaternion.z,
+            quaternion.w,
+          ])
+        : ""
+    }-${colorMap ? JSON.stringify(colorMap) : ""}-${
+      activeThreshold ? JSON.stringify(activeThreshold) : ""
+    }`;
 
     switch (shadeBy) {
       case SHADE_BY_HEIGHT:
-        /**
-         * FIX ME: while `pointsMaterial` respects `upVector` in shade-by-height, it disregards rotation / translation / scale
-         * applied to the pcd. This is because the shader is applied to the points, not the pcd container.
-         *
-         * The behavior is undefined if the pcd is rotated / translated / scaled.
-         */
         return (
           <ShadeByHeight
             colorMap={colorMap}
             min={minMaxCoordinates?.at(0) ?? 0}
             max={minMaxCoordinates?.at(1) ?? 100}
             upVector={upVector}
+            quaternion={quaternion}
             key={key}
             pointSize={pointSize}
             opacity={opacity}
@@ -251,6 +256,7 @@ export const usePcdMaterial = (
     maxIntensity,
     geometry,
     upVector,
+    quaternion,
     opacity,
     name,
     colorMap,

--- a/app/packages/looker-3d/src/fo3d/point-cloud/use-pcd-material.tsx
+++ b/app/packages/looker-3d/src/fo3d/point-cloud/use-pcd-material.tsx
@@ -60,7 +60,7 @@ export const usePcdMaterial = (
   defaultMaterial: PcdAsset["defaultMaterial"],
   pcdContainerRef: React.RefObject<any>,
   quaternion?: Quaternion,
-  vextexColorsAvailable: boolean = false
+  vertexColorsAvailable: boolean = false
 ) => {
   const { upVector, pluginSettings } = useFo3dContext();
 
@@ -212,7 +212,7 @@ export const usePcdMaterial = (
             size={isPointSizeAttenuated ? pointSize / 1000 : pointSize / 2}
             opacity={opacity}
             sizeAttenuation={isPointSizeAttenuated}
-            vertexColors={Boolean(vextexColorsAvailable)}
+            vertexColors={Boolean(vertexColorsAvailable)}
           />
         );
 

--- a/app/packages/looker-3d/src/hooks/use-point-cloud-hover.tsx
+++ b/app/packages/looker-3d/src/hooks/use-point-cloud-hover.tsx
@@ -56,8 +56,10 @@ export const usePointCloudHover = ({
 
         // transform the local position to world position using the transformation
         const worldPosition = localPosition.clone();
-        worldPosition.applyQuaternion(quaternion);
+
+        // make sure it's TRS (scale, rotate, translate)
         worldPosition.multiply(scale);
+        worldPosition.applyQuaternion(quaternion);
         worldPosition.add(position);
 
         setCurrentHoveredPoint(worldPosition);

--- a/app/packages/looker-3d/src/hooks/use-point-cloud-hover.tsx
+++ b/app/packages/looker-3d/src/hooks/use-point-cloud-hover.tsx
@@ -1,0 +1,120 @@
+import { ThreeEvent } from "@react-three/fiber";
+import { useCallback, useEffect, useMemo } from "react";
+import { useRecoilState } from "recoil";
+import type { BufferGeometry, Quaternion } from "three";
+import { Vector3 } from "three";
+import { currentHoveredPointAtom } from "../state";
+import { useFo3dContext } from "../fo3d/context";
+
+interface UsePointCloudHoverProps {
+  geometry: BufferGeometry;
+  assetName: string;
+  shadingMode: string;
+  position: Vector3;
+  quaternion: Quaternion;
+  scale: Vector3;
+}
+
+export const usePointCloudHover = ({
+  geometry,
+  assetName,
+  shadingMode,
+  position,
+  quaternion,
+  scale,
+}: UsePointCloudHoverProps) => {
+  const { pointCloudSettings, setHoverMetadata } = useFo3dContext();
+  const [currentHoveredPoint, setCurrentHoveredPoint] = useRecoilState(
+    currentHoveredPointAtom
+  );
+
+  const pointerMoveHandler = useCallback(
+    (e: ThreeEvent<MouseEvent>) => {
+      const idx = e.index;
+      if (idx === undefined) return;
+
+      const md: Record<string, any> = { index: idx };
+
+      if (geometry.hasAttribute("rgb")) {
+        const colorAttr = geometry.getAttribute("rgb");
+
+        md.rgb = [
+          colorAttr.getX(idx),
+          colorAttr.getY(idx),
+          colorAttr.getZ(idx),
+        ];
+      }
+
+      if (geometry.hasAttribute("position")) {
+        const posAttr = geometry.getAttribute("position");
+        const localPosition = new Vector3(
+          posAttr.getX(idx),
+          posAttr.getY(idx),
+          posAttr.getZ(idx)
+        );
+        md.coord = [localPosition.x, localPosition.y, localPosition.z];
+
+        // transform the local position to world position using the transformation
+        const worldPosition = localPosition.clone();
+        worldPosition.applyQuaternion(quaternion);
+        worldPosition.multiply(scale);
+        worldPosition.add(position);
+
+        setCurrentHoveredPoint(worldPosition);
+      }
+
+      // dynamically handle all other attributes
+      Object.keys(geometry.attributes).forEach((attr) => {
+        if (attr === "rgb" || attr === "position") return;
+        md[attr] = geometry.attributes[attr].getX(idx);
+      });
+
+      setHoverMetadata({
+        assetName,
+        renderModeDescriptor: shadingMode,
+        attributes: md,
+      });
+    },
+    [
+      geometry,
+      setHoverMetadata,
+      shadingMode,
+      assetName,
+      quaternion,
+      position,
+      scale,
+    ]
+  );
+
+  const hoverProps = useMemo(() => {
+    if (!pointCloudSettings.enableTooltip) return {};
+
+    return {
+      // fires on *every* intersected point
+      onPointerMove: pointerMoveHandler,
+      onPointerOut: () => {
+        setCurrentHoveredPoint(null);
+      },
+    };
+  }, [pointCloudSettings.enableTooltip, pointerMoveHandler]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      setCurrentHoveredPoint(null);
+    };
+  }, [pointerMoveHandler]);
+
+  // Update hover metadata when shading mode changes
+  useEffect(() => {
+    setHoverMetadata((prev) => ({
+      ...prev,
+      renderModeDescriptor: shadingMode,
+    }));
+  }, [shadingMode, setHoverMetadata]);
+
+  return {
+    currentHoveredPoint,
+    hoverProps,
+  };
+};

--- a/app/packages/looker-3d/src/labels/polygon-fill-utils.test.ts
+++ b/app/packages/looker-3d/src/labels/polygon-fill-utils.test.ts
@@ -1,0 +1,557 @@
+import { describe, it, expect, vi } from "vitest";
+import * as THREE from "three";
+import {
+  buildClosedLoopsFromSegments,
+  newellNormal,
+  createFilledPolygonMesh,
+  createFilledPolygonMeshes,
+} from "./polygon-fill-utils";
+
+describe("polygon-fill-utils", () => {
+  describe("buildClosedLoopsFromSegments", () => {
+    it("should build a simple closed loop from segments", () => {
+      const segments: THREE.Vector3Tuple[][] = [
+        [
+          [0, 0, 0],
+          [1, 0, 0],
+        ],
+        [
+          [1, 0, 0],
+          [1, 1, 0],
+        ],
+        [
+          [1, 1, 0],
+          [0, 1, 0],
+        ],
+        [
+          [0, 1, 0],
+          [0, 0, 0],
+        ],
+      ];
+
+      const result = buildClosedLoopsFromSegments(segments);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toHaveLength(4);
+      expect(result[0]).toEqual([
+        [0, 0, 0],
+        [1, 0, 0],
+        [1, 1, 0],
+        [0, 1, 0],
+      ]);
+    });
+
+    it("should handle duplicate segments", () => {
+      const segments: THREE.Vector3Tuple[][] = [
+        [
+          [0, 0, 0],
+          [1, 0, 0],
+        ],
+        [
+          [1, 0, 0],
+          [1, 1, 0],
+        ],
+        [
+          [1, 1, 0],
+          [0, 1, 0],
+        ],
+        [
+          [0, 1, 0],
+          [0, 0, 0],
+        ],
+        [
+          [0, 0, 0],
+          [1, 0, 0],
+        ], // duplicate
+        [
+          [1, 0, 0],
+          [1, 1, 0],
+        ], // duplicate
+      ];
+
+      const result = buildClosedLoopsFromSegments(segments);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toHaveLength(4);
+    });
+
+    it("should handle multiple disconnected loops", () => {
+      const segments: THREE.Vector3Tuple[][] = [
+        // First square
+        [
+          [0, 0, 0],
+          [1, 0, 0],
+        ],
+        [
+          [1, 0, 0],
+          [1, 1, 0],
+        ],
+        [
+          [1, 1, 0],
+          [0, 1, 0],
+        ],
+        [
+          [0, 1, 0],
+          [0, 0, 0],
+        ],
+        // Second square (offset)
+        [
+          [2, 0, 0],
+          [3, 0, 0],
+        ],
+        [
+          [3, 0, 0],
+          [3, 1, 0],
+        ],
+        [
+          [3, 1, 0],
+          [2, 1, 0],
+        ],
+        [
+          [2, 1, 0],
+          [2, 0, 0],
+        ],
+      ];
+
+      const result = buildClosedLoopsFromSegments(segments);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toHaveLength(4);
+      expect(result[1]).toHaveLength(4);
+    });
+
+    it("should ignore self-loops", () => {
+      const segments: THREE.Vector3Tuple[][] = [
+        [
+          [0, 0, 0],
+          [0, 0, 0],
+        ], // self-loop
+        [
+          [0, 0, 0],
+          [1, 0, 0],
+        ],
+        [
+          [1, 0, 0],
+          [1, 1, 0],
+        ],
+        [
+          [1, 1, 0],
+          [0, 1, 0],
+        ],
+        [
+          [0, 1, 0],
+          [0, 0, 0],
+        ],
+      ];
+
+      const result = buildClosedLoopsFromSegments(segments);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toHaveLength(4);
+    });
+
+    it("should ignore invalid segments with less than 2 points", () => {
+      const segments: THREE.Vector3Tuple[][] = [
+        [[0, 0, 0]], // invalid - only 1 point
+        [
+          [0, 0, 0],
+          [1, 0, 0],
+        ],
+        [
+          [1, 0, 0],
+          [1, 1, 0],
+        ],
+        [
+          [1, 1, 0],
+          [0, 1, 0],
+        ],
+        [
+          [0, 1, 0],
+          [0, 0, 0],
+        ],
+      ];
+
+      const result = buildClosedLoopsFromSegments(segments);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toHaveLength(4);
+    });
+
+    it("should return empty array for no valid loops", () => {
+      const segments: THREE.Vector3Tuple[][] = [
+        [
+          [0, 0, 0],
+          [1, 0, 0],
+        ], // dangling edge
+        [
+          [2, 0, 0],
+          [3, 0, 0],
+        ], // another dangling edge
+      ];
+
+      const result = buildClosedLoopsFromSegments(segments);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it("should handle complex polygon with many vertices", () => {
+      const segments: THREE.Vector3Tuple[][] = [
+        [
+          [0, 0, 0],
+          [1, 0, 0],
+        ],
+        [
+          [1, 0, 0],
+          [2, 0, 0],
+        ],
+        [
+          [2, 0, 0],
+          [2, 1, 0],
+        ],
+        [
+          [2, 1, 0],
+          [2, 2, 0],
+        ],
+        [
+          [2, 2, 0],
+          [1, 2, 0],
+        ],
+        [
+          [1, 2, 0],
+          [0, 2, 0],
+        ],
+        [
+          [0, 2, 0],
+          [0, 1, 0],
+        ],
+        [
+          [0, 1, 0],
+          [0, 0, 0],
+        ],
+      ];
+
+      const result = buildClosedLoopsFromSegments(segments);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toHaveLength(8);
+    });
+  });
+
+  describe("newellNormal", () => {
+    it("should compute normal for a simple square in XY plane", () => {
+      const pts = [
+        new THREE.Vector3(0, 0, 0),
+        new THREE.Vector3(1, 0, 0),
+        new THREE.Vector3(1, 1, 0),
+        new THREE.Vector3(0, 1, 0),
+      ];
+
+      const normal = newellNormal(pts);
+
+      expect(normal.x).toBeCloseTo(0, 6);
+      expect(normal.y).toBeCloseTo(0, 6);
+      expect(normal.z).toBeCloseTo(1, 6);
+    });
+
+    it("should compute normal for a triangle in XY plane", () => {
+      const pts = [
+        new THREE.Vector3(0, 0, 0),
+        new THREE.Vector3(1, 0, 0),
+        new THREE.Vector3(0, 1, 0),
+      ];
+
+      const normal = newellNormal(pts);
+
+      expect(normal.x).toBeCloseTo(0, 6);
+      expect(normal.y).toBeCloseTo(0, 6);
+      expect(normal.z).toBeCloseTo(1, 6);
+    });
+
+    it("should compute normal for a polygon in XZ plane", () => {
+      const pts = [
+        new THREE.Vector3(0, 0, 0),
+        new THREE.Vector3(1, 0, 0),
+        new THREE.Vector3(1, 0, 1),
+        new THREE.Vector3(0, 0, 1),
+      ];
+
+      const normal = newellNormal(pts);
+
+      expect(normal.x).toBeCloseTo(0, 6);
+      expect(normal.y).toBeCloseTo(-1, 6);
+      expect(normal.z).toBeCloseTo(0, 6);
+    });
+
+    it("should handle degenerate case and return default normal", () => {
+      const pts = [
+        new THREE.Vector3(0, 0, 0),
+        new THREE.Vector3(0, 0, 0), // duplicate point
+        new THREE.Vector3(0, 0, 0), // another duplicate
+      ];
+
+      const normal = newellNormal(pts);
+
+      expect(normal.x).toBeCloseTo(0, 6);
+      expect(normal.y).toBeCloseTo(0, 6);
+      expect(normal.z).toBeCloseTo(1, 6);
+    });
+
+    it("should compute normal for a polygon with non-zero Z coordinates", () => {
+      const pts = [
+        new THREE.Vector3(0, 0, 1),
+        new THREE.Vector3(1, 0, 1),
+        new THREE.Vector3(1, 1, 1),
+        new THREE.Vector3(0, 1, 1),
+      ];
+
+      const normal = newellNormal(pts);
+
+      expect(normal.x).toBeCloseTo(0, 6);
+      expect(normal.y).toBeCloseTo(0, 6);
+      expect(normal.z).toBeCloseTo(1, 6);
+    });
+  });
+
+  describe("createFilledPolygonMesh", () => {
+    it("should create a mesh for a simple square", () => {
+      const loop: THREE.Vector3Tuple[] = [
+        [0, 0, 0],
+        [1, 0, 0],
+        [1, 1, 0],
+        [0, 1, 0],
+      ];
+      const material = new THREE.MeshBasicMaterial();
+
+      const mesh = createFilledPolygonMesh(loop, material);
+
+      expect(mesh).not.toBeNull();
+      expect(mesh).toBeInstanceOf(THREE.Mesh);
+      expect(mesh?.geometry).toBeInstanceOf(THREE.BufferGeometry);
+      expect(mesh?.material).toBe(material);
+    });
+
+    it("should create a mesh for a triangle", () => {
+      const loop: THREE.Vector3Tuple[] = [
+        [0, 0, 0],
+        [1, 0, 0],
+        [0, 1, 0],
+      ];
+      const material = new THREE.MeshBasicMaterial();
+
+      const mesh = createFilledPolygonMesh(loop, material);
+
+      expect(mesh).not.toBeNull();
+      expect(mesh).toBeInstanceOf(THREE.Mesh);
+    });
+
+    it("should handle polygon in different plane", () => {
+      const loop: THREE.Vector3Tuple[] = [
+        [0, 0, 0],
+        [1, 0, 0],
+        [1, 0, 1],
+        [0, 0, 1],
+      ];
+      const material = new THREE.MeshBasicMaterial();
+
+      const mesh = createFilledPolygonMesh(loop, material);
+
+      expect(mesh).not.toBeNull();
+      expect(mesh).toBeInstanceOf(THREE.Mesh);
+    });
+
+    it("should return null for invalid polygon (less than 3 points)", () => {
+      const loop: THREE.Vector3Tuple[] = [
+        [0, 0, 0],
+        [1, 0, 0],
+      ];
+      const material = new THREE.MeshBasicMaterial();
+
+      const mesh = createFilledPolygonMesh(loop, material);
+
+      expect(mesh).toBeNull();
+    });
+
+    it("should return null for degenerate polygon with duplicate points", () => {
+      // Create a degenerate polygon with duplicate points
+      const loop: THREE.Vector3Tuple[] = [
+        [0, 0, 0],
+        [0, 0, 0], // duplicate point
+        [0, 0, 0], // another duplicate
+      ];
+      const material = new THREE.MeshBasicMaterial();
+
+      const mesh = createFilledPolygonMesh(loop, material);
+
+      expect(mesh).toBeNull();
+    });
+
+    it("should handle triangulation failure gracefully", () => {
+      // Create a polygon that would cause issues with the basis construction
+      // by making the normal vector very close to the reference axis
+      const loop: THREE.Vector3Tuple[] = [
+        [0, 0, 0],
+        [1, 0, 0],
+        [1, 0.0001, 0], // Very small Y offset to make normal close to (0,0,1)
+        [0, 0.0001, 0],
+      ];
+      const material = new THREE.MeshBasicMaterial();
+
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      // Mock the crossVectors method to throw an error
+      const originalCrossVectors = THREE.Vector3.prototype.crossVectors;
+      THREE.Vector3.prototype.crossVectors = vi.fn().mockImplementation(() => {
+        throw new Error("Cross product failed");
+      });
+
+      const mesh = createFilledPolygonMesh(loop, material);
+
+      expect(mesh).toBeNull();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Failed to create filled polygon mesh:",
+        expect.any(Error)
+      );
+
+      // Restore original method
+      THREE.Vector3.prototype.crossVectors = originalCrossVectors;
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("createFilledPolygonMeshes", () => {
+    it("should create meshes from segments", () => {
+      const points3d: THREE.Vector3Tuple[][] = [
+        [
+          [0, 0, 0],
+          [1, 0, 0],
+        ],
+        [
+          [1, 0, 0],
+          [1, 1, 0],
+        ],
+        [
+          [1, 1, 0],
+          [0, 1, 0],
+        ],
+        [
+          [0, 1, 0],
+          [0, 0, 0],
+        ],
+      ];
+      const material = new THREE.MeshBasicMaterial();
+
+      const meshes = createFilledPolygonMeshes(points3d, material);
+
+      expect(meshes).not.toBeNull();
+      expect(meshes).toHaveLength(1);
+      expect(meshes![0]).toBeInstanceOf(THREE.Mesh);
+    });
+
+    it("should handle single polyline as closed loop", () => {
+      const points3d: THREE.Vector3Tuple[][] = [
+        [
+          [0, 0, 0],
+          [1, 0, 0],
+          [1, 1, 0],
+          [0, 1, 0],
+          [0, 0, 0], // closed loop
+        ],
+      ];
+      const material = new THREE.MeshBasicMaterial();
+
+      const meshes = createFilledPolygonMeshes(points3d, material);
+
+      expect(meshes).not.toBeNull();
+      expect(meshes).toHaveLength(1);
+      expect(meshes![0]).toBeInstanceOf(THREE.Mesh);
+    });
+
+    it("should handle multiple disconnected loops", () => {
+      const points3d: THREE.Vector3Tuple[][] = [
+        // First square
+        [
+          [0, 0, 0],
+          [1, 0, 0],
+        ],
+        [
+          [1, 0, 0],
+          [1, 1, 0],
+        ],
+        [
+          [1, 1, 0],
+          [0, 1, 0],
+        ],
+        [
+          [0, 1, 0],
+          [0, 0, 0],
+        ],
+        // Second square
+        [
+          [2, 0, 0],
+          [3, 0, 0],
+        ],
+        [
+          [3, 0, 0],
+          [3, 1, 0],
+        ],
+        [
+          [3, 1, 0],
+          [2, 1, 0],
+        ],
+        [
+          [2, 1, 0],
+          [2, 0, 0],
+        ],
+      ];
+      const material = new THREE.MeshBasicMaterial();
+
+      const meshes = createFilledPolygonMeshes(points3d, material);
+
+      expect(meshes).not.toBeNull();
+      expect(meshes).toHaveLength(2);
+      expect(meshes![0]).toBeInstanceOf(THREE.Mesh);
+      expect(meshes![1]).toBeInstanceOf(THREE.Mesh);
+    });
+
+    it("should return null for no valid polygons", () => {
+      const points3d: THREE.Vector3Tuple[][] = [
+        [
+          [0, 0, 0],
+          [1, 0, 0],
+        ], // dangling edge
+        [
+          [2, 0, 0],
+          [3, 0, 0],
+        ], // another dangling edge
+      ];
+      const material = new THREE.MeshBasicMaterial();
+
+      const meshes = createFilledPolygonMeshes(points3d, material);
+
+      expect(meshes).toBeNull();
+    });
+
+    it("should return null for single polyline with less than 3 points", () => {
+      const points3d: THREE.Vector3Tuple[][] = [
+        [
+          [0, 0, 0],
+          [1, 0, 0],
+        ], // only 2 points
+      ];
+      const material = new THREE.MeshBasicMaterial();
+
+      const meshes = createFilledPolygonMeshes(points3d, material);
+
+      expect(meshes).toBeNull();
+    });
+
+    it("should handle empty input", () => {
+      const points3d: THREE.Vector3Tuple[][] = [];
+      const material = new THREE.MeshBasicMaterial();
+
+      const meshes = createFilledPolygonMeshes(points3d, material);
+
+      expect(meshes).toBeNull();
+    });
+  });
+});

--- a/app/packages/looker-3d/src/labels/polygon-fill-utils.ts
+++ b/app/packages/looker-3d/src/labels/polygon-fill-utils.ts
@@ -1,0 +1,326 @@
+import * as THREE from "three";
+import { Matrix4, Shape, ShapeGeometry, Vector3 } from "three";
+
+/**
+ * POLYGON FILLING UTILITIES
+ *
+ * The polyline filling algorithm reconstructs closed loops from unordered line
+ * segments and creates filled polygon meshes positioned in 3D space.
+ *
+ * Key Algorithm Steps:
+ * 1. Reconstruct closed loops from unordered segments
+ * 2. Estimate plane of each loop using Newell's method
+ * 3. Build orthonormal basis for the plane
+ * 4. Project 3D vertices to 2D in the loop's plane
+ * 5. Triangulate the 2D polygon using THREE.ShapeGeometry
+ * 6. Map triangles back to 3D by applying plane basis transform
+ * 7. Render with transparent, double-sided material
+ */
+
+const EPS = 1e-6;
+
+/**
+ * Creates a unique string key for a 3D point to use in graph operations.
+ * This enables efficient vertex deduplication and adjacency tracking.
+ */
+const keyFor = (p: THREE.Vector3Tuple): string =>
+  `${p[0].toFixed(6)},${p[1].toFixed(6)},${p[2].toFixed(6)}`;
+
+/**
+ * Reconstructs closed loops from unordered line segments.
+ *
+ * Algorithm:
+ * 1. Build adjacency sets and edge multiset from segments
+ * 2. While unused edges remain:
+ *    - Start at any vertex with degree > 0
+ *    - Follow available edges to form a cycle
+ *    - Consume edges as they're traversed
+ *    - Validate cycle: ≥3 unique vertices and returns to start
+ *
+ * Edge cases handled:
+ * - Duplicate segments (handled by edge multiset)
+ * - Tiny back-and-forth edges
+ * - Dangling edges (ignored when they cannot close)
+ */
+export function buildClosedLoopsFromSegments(
+  segments: THREE.Vector3Tuple[][]
+): THREE.Vector3Tuple[][] {
+  // Undirected multigraph representation using endpoint keys
+  const neighbors = new Map<string, Set<string>>();
+  const pointByKey = new Map<string, THREE.Vector3Tuple>();
+  const edgeCount = new Map<string, number>();
+
+  /**
+   * Adds an undirected edge between two points to the graph.
+   * Handles duplicate edges by maintaining a count in edgeCount.
+   */
+  const addEdge = (a: THREE.Vector3Tuple, b: THREE.Vector3Tuple) => {
+    const ka = keyFor(a);
+    const kb = keyFor(b);
+
+    // Skip self-loops
+    if (ka === kb) return;
+
+    // Initialize adjacency sets if needed
+    if (!neighbors.has(ka)) neighbors.set(ka, new Set());
+    if (!neighbors.has(kb)) neighbors.set(kb, new Set());
+
+    // Add bidirectional edges
+    neighbors.get(ka)!.add(kb);
+    neighbors.get(kb)!.add(ka);
+
+    // Store point data for later reconstruction
+    pointByKey.set(ka, a);
+    pointByKey.set(kb, b);
+
+    // Track edge usage count (for multigraph support)
+    const e1 = `${ka}|${kb}`;
+    const e2 = `${kb}|${ka}`;
+    edgeCount.set(e1, (edgeCount.get(e1) || 0) + 1);
+    edgeCount.set(e2, (edgeCount.get(e2) || 0) + 1);
+  };
+
+  // Build graph from all segments
+  for (const seg of segments) {
+    // Skip invalid segments
+    if (seg.length < 2) continue;
+    addEdge(seg[0], seg[1]);
+  }
+
+  /**
+   * Consumes one usage of an edge and returns true if successful.
+   * Returns false if the edge has no remaining uses.
+   */
+  const useEdge = (ka: string, kb: string): boolean => {
+    const e1 = `${ka}|${kb}`;
+    const e2 = `${kb}|${ka}`;
+    const c1 = (edgeCount.get(e1) || 0) - 1;
+    const c2 = (edgeCount.get(e2) || 0) - 1;
+
+    if (c1 < 0 || c2 < 0) return false; // No more uses available
+
+    // Update or remove edge counts
+    if (c1 === 0) edgeCount.delete(e1);
+    else edgeCount.set(e1, c1);
+    if (c2 === 0) edgeCount.delete(e2);
+    else edgeCount.set(e2, c2);
+
+    return true;
+  };
+
+  const loops: THREE.Vector3Tuple[][] = [];
+
+  /**
+   * Finds any vertex that still has unused edges.
+   * Used to start new loop construction.
+   */
+  const pickAnyVertexWithEdges = (): string | null => {
+    for (const k of neighbors.keys()) {
+      for (const n of neighbors.get(k) || []) {
+        if (edgeCount.get(`${k}|${n}`)) return k;
+      }
+    }
+    return null;
+  };
+
+  // Main loop: extract cycles while edges remain
+  while (true) {
+    const start = pickAnyVertexWithEdges();
+    if (!start) break; // No more edges to process
+
+    const loopKeys: string[] = [];
+    let current = start;
+    let prev: string | null = null;
+
+    loopKeys.push(current);
+
+    // Walk along edges until we return to start or hit a dead-end
+    while (true) {
+      const nbrs = Array.from(neighbors.get(current) || []);
+
+      // Prefer neighbor that still has an unused edge and isn't the previous vertex
+      let next: string | null = null;
+      for (const n of nbrs) {
+        if (prev && n === prev) continue; // Avoid backtracking
+        if (edgeCount.get(`${current}|${n}`)) {
+          next = n;
+          break;
+        }
+      }
+
+      // Fallback to previous vertex if that's the only remaining option
+      if (!next && prev && edgeCount.get(`${current}|${prev}`)) next = prev;
+      if (!next) break; // No more edges from this vertex
+
+      // Consume the edge and move to next vertex
+      useEdge(current, next);
+      prev = current;
+      current = next;
+      loopKeys.push(current);
+
+      // Check if we've completed a cycle
+      if (current === start) break;
+    }
+
+    // Validate the extracted cycle
+    // Must have at least 4 points (including duplicate start/end) and be closed
+    if (loopKeys.length >= 4 && loopKeys[0] === loopKeys[loopKeys.length - 1]) {
+      // Convert keys back to 3D points, dropping the duplicate last point
+      const pts: THREE.Vector3Tuple[] = loopKeys
+        .slice(0, -1)
+        .map((k) => pointByKey.get(k)!);
+
+      // Ensure we have at least 3 unique points (minimum for a polygon)
+      if (pts.length >= 3) loops.push(pts);
+    }
+  }
+
+  return loops;
+}
+
+/**
+ * Computes the unit normal vector for a polygon using Newell's method.
+ *
+ * Newell's method computes the normal as the
+ * average of the cross products of adjacent edges.
+ */
+export function newellNormal(pts: Vector3[]): Vector3 {
+  const n = new Vector3(0, 0, 0);
+
+  for (let i = 0; i < pts.length; i++) {
+    const cur = pts[i];
+    // Wrap around to first point
+    const nxt = pts[(i + 1) % pts.length];
+
+    // accumulate cross products
+    n.x += (cur.y - nxt.y) * (cur.z + nxt.z);
+    n.y += (cur.z - nxt.z) * (cur.x + nxt.x);
+    n.z += (cur.x - nxt.x) * (cur.y + nxt.y);
+  }
+
+  // normalize the result, fallback to (0,0,1) if degenerate
+  return n.length() > EPS ? n.normalize() : new Vector3(0, 0, 1);
+}
+
+/**
+ * Creates a filled polygon mesh from a closed loop of 3D points.
+ *
+ * This function implements the complete polygon filling pipeline:
+ * 1. Plane estimation using Newell's method
+ * 2. Construction of orthonormal basis for the plane
+ * 3. Projection of 3D points to 2D
+ * 4. Triangulation using THREE.ShapeGeometry
+ * 5. Lifting back to 3D space
+ */
+export function createFilledPolygonMesh(
+  loop: THREE.Vector3Tuple[],
+  material: THREE.Material
+): THREE.Mesh | null {
+  try {
+    // Validate input: need at least 3 points for a polygon
+    if (loop.length < 3) {
+      return null;
+    }
+
+    // Convert tuples to Vector3 objects for calculations
+    const pts3 = loop.map((p) => new Vector3(p[0], p[1], p[2]));
+
+    // Check for degenerate cases (all points are the same)
+    const firstPoint = pts3[0];
+    const allSame = pts3.every(
+      (pt) =>
+        Math.abs(pt.x - firstPoint.x) < EPS &&
+        Math.abs(pt.y - firstPoint.y) < EPS &&
+        Math.abs(pt.z - firstPoint.z) < EPS
+    );
+    if (allSame) {
+      return null;
+    }
+
+    const origin = pts3[0].clone();
+
+    // Step 1: Estimate the plane normal using Newell's method
+    const normal = newellNormal(pts3);
+
+    // Step 2: Build orthonormal basis for the plane
+    // Choose a stable reference axis that's not too close to the normal
+    const ref =
+      Math.abs(normal.x) < 0.9 ? new Vector3(1, 0, 0) : new Vector3(0, 1, 0);
+
+    // Construct basis vectors: u = normal × ref, v = normal × u
+    const u = new Vector3().crossVectors(normal, ref).normalize();
+    const v = new Vector3().crossVectors(normal, u).normalize();
+
+    // Step 3: Project 3D points to 2D in the plane
+    const toLocal = (p: Vector3) => {
+      const d = new Vector3().subVectors(p, origin);
+      return new THREE.Vector2(d.dot(u), d.dot(v));
+    };
+    const pts2 = pts3.map(toLocal);
+
+    // Step 4: Build THREE.Shape from 2D points and ensure closure
+    const shape = new Shape();
+    shape.moveTo(pts2[0].x, pts2[0].y);
+
+    // Add line segments between points
+    for (let i = 1; i < pts2.length; i++) {
+      shape.lineTo(pts2[i].x, pts2[i].y);
+    }
+
+    // Explicitly close the shape by returning to the first point
+    shape.lineTo(pts2[0].x, pts2[0].y);
+
+    // Step 5: Generate triangulated geometry using Earcut
+    const geom2d = new ShapeGeometry(shape);
+
+    // Step 6: Transform from XY plane back to the original 3D plane
+    // Create basis matrix [u, v, normal] with origin translation
+    const basis = new Matrix4().makeBasis(u, v, normal);
+    basis.setPosition(origin);
+
+    // Apply the transformation to move triangles to 3D space
+    geom2d.applyMatrix4(basis);
+
+    // Step 7: Create and return the mesh
+    return new THREE.Mesh(geom2d, material);
+  } catch (error) {
+    // Handle triangulation failures gracefully
+    console.warn("Failed to create filled polygon mesh:", error);
+    return null;
+  }
+}
+
+/**
+ * Creates filled polygon meshes from polyline segments.
+ *
+ * This is the main entry point for polygon filling. It handles the complete
+ * pipeline from unordered segments to rendered filled polygons.
+ *
+ * @param points3d - Array of line segments
+ * @param material - THREE material to use for the meshes
+ * @returns Array of THREE.Mesh objects, or null if no valid polygons found
+ */
+export function createFilledPolygonMeshes(
+  points3d: THREE.Vector3Tuple[][],
+  material: THREE.Material
+): THREE.Mesh[] | null {
+  // Case 1: Single polyline with 3+ points (already a closed loop)
+  const candidateLoops: THREE.Vector3Tuple[][] =
+    points3d.length === 1 && points3d[0].length >= 3
+      ? [points3d[0]]
+      : buildClosedLoopsFromSegments(points3d);
+
+  if (candidateLoops.length === 0) {
+    return null;
+  }
+
+  const meshes: THREE.Mesh[] = [];
+  for (const loop of candidateLoops) {
+    const mesh = createFilledPolygonMesh(loop, material);
+    if (mesh) {
+      meshes.push(mesh);
+    }
+  }
+
+  return meshes.length > 0 ? meshes : null;
+}

--- a/app/packages/looker-3d/src/renderables/pcd/shaders/components.tsx
+++ b/app/packages/looker-3d/src/renderables/pcd/shaders/components.tsx
@@ -65,6 +65,7 @@ export const ShadeByHeight = ({
   min,
   max,
   upVector,
+  quaternion,
   pointSize,
   opacity,
   isPointSizeAttenuated,
@@ -73,6 +74,12 @@ export const ShadeByHeight = ({
   const upVectorVec3 = useMemo(() => {
     return [upVector.x, upVector.y, upVector.z];
   }, [upVector]);
+
+  const quaternionVec4 = useMemo(() => {
+    return quaternion
+      ? [quaternion.x, quaternion.y, quaternion.z, quaternion.w]
+      : [0, 0, 0, 1];
+  }, [quaternion]);
 
   return (
     <shaderMaterial
@@ -83,6 +90,7 @@ export const ShadeByHeight = ({
           min: { value: min },
           max: { value: max },
           upVector: { value: upVectorVec3 },
+          quaternion: { value: quaternionVec4 },
           gradientMap: { value: gradientMap },
           pointSize: { value: pointSize },
           isPointSizeAttenuated: { value: isPointSizeAttenuated },

--- a/app/packages/looker-3d/src/renderables/pcd/shaders/types.ts
+++ b/app/packages/looker-3d/src/renderables/pcd/shaders/types.ts
@@ -10,5 +10,6 @@ export type ShaderProps = {
   isPointSizeAttenuated: boolean;
   opacity?: number;
   upVector?: THREE.Vector3;
+  quaternion?: THREE.Quaternion;
   pcdType?: "intensity" | "rgb";
 };


### PR DESCRIPTION
## What changes are proposed in this pull request?

Point-cloud height shader now accounts for asset-level transformation. In the past, only "up" vector was accounted for and any asset-level transformation was ignored. That would result in incorrect shading for rotated point clouds.

This PR also fixes following additional bugs:
1. Tooltip hover coordinates now account for asset-level transformation
2. PLY point clouds that have vertex normals render with correct shading

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Orientation-aware point-cloud rendering and height shading that respect model rotation.
  * Filled-polygon rendering for polylines (renders fills in addition to outlines).
  * Centralized hover hook with precise point markers and richer tooltips (coords, RGB, attributes).

* **Improvements**
  * Better support for vertex colors when shading is disabled.
  * More reliable hover metadata updates when switching shading modes.

* **Tests**
  * New test suite covering polygon-fill utilities and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->