### PR TITLE
chore: allow for the use of eta 0.15.0 (#6264)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ INSTALL_REQUIRES = [
     # internal packages
     "fiftyone-brain>=0.21.2,<0.22",
     "fiftyone-db>=0.4,<2.0",
-    "voxel51-eta>=0.14.3,<0.15",
+    "voxel51-eta>=0.14.4,<0.16",
 ]
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

bump eta for this release - it contains changes for Enterprise release that should go out this cycle.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated dependency constraints to support newer minor releases while maintaining stability. This expands compatibility to environments using voxel51-eta 0.15.x and above (but below 0.16), with no expected changes to behavior or user workflows.
  - Improves future compatibility and reduces version conflicts during installation without altering existing features.
  - No action required from users; installations will automatically resolve to compatible versions where available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->