### PR TITLE
Store empty `Classification()` when `apply_model()` produces no output for classification tasks

### DIFF
--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -273,14 +273,12 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
     };
 
     const CLASSIFICATION_RENDERER = (path, param: Classification) => {
-      if (!param.label) {
-        return null;
-      }
+      const label = param.label ?? "null";
 
       return {
         path,
-        value: param.label,
-        title: `${path}: ${param.label}`,
+        value: label,
+        title: `${path}: ${label}`,
         color: getAssignedColor({
           coloring,
           path,

--- a/app/packages/looker/src/overlays/classifications.ts
+++ b/app/packages/looker/src/overlays/classifications.ts
@@ -399,5 +399,5 @@ const getText = (_cls: string, label) => {
     return label.value;
   }
 
-  return label.label;
+  return label.label ?? "null";
 };

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -789,7 +789,7 @@ def _apply_confidence_thresh(label, confidence_thresh):
         label.apply_confidence_threshold(confidence_thresh)
     elif hasattr(label, "confidence"):
         if label.confidence is None or label.confidence < confidence_thresh:
-            label = None
+            label.label = None
 
     return label
 

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -1337,7 +1337,7 @@ class ClassifierOutputProcessor(OutputProcessor):
         preds = []
         for prediction, score, _logits in zip(predictions, scores, logits):
             if confidence_thresh is not None and score < confidence_thresh:
-                classification = None
+                classification = fol.Classification()
             else:
                 classification = fol.Classification(
                     label=self.classes[prediction],


### PR DESCRIPTION
## Change log

For classification tasks, if `apply_model(field, ...)` processes a sample but produces no sufficiently high confidence prediction, store `field=Classification(label=None)` rather than `field=None` for all builtin zoo models. This allows us to distinguish "processed but nothing found" (former) from "unprocessed" (latter).

This is analogous to how `field=Detections(detections=[])` is emitted when no suitably high confidence objects are found for detection tasks.

## Implementation notes

Note that we can't **guarantee** that every model will return `field=Classification(label=None)`, as each model has full control over its own `predict()` method. Namely, if `Model.predict()` returns `None`, then that's what will be stored. We're effectively adopting a new convention, and this PR ensures that `ClassifierOutputProcessor` and `Sample.add_labels()` respect this new convention, which I believe covers all builtin zoo models.

## ~TODO~

~The App needs a couple small tweaks to properly render `Classification(label=None)` tags:~
- [x] in the grid overlays: show `null`, not `and 1 more`
- [x] in the modal overlays: show `null (<conf>)`, not `undefined (<conf>)`

Run the test code below to reproduce these screenshots:

<img width="1133" height="857" alt="Screenshot 2025-08-18 at 10 44 13 PM" src="https://github.com/user-attachments/assets/4d23d003-431b-4e14-910f-1ade15f46757" />
<img width="1120" height="971" alt="Screenshot 2025-08-18 at 10 44 23 PM" src="https://github.com/user-attachments/assets/a23181ba-467a-4b34-973e-4a2489ec4c01" />

## Tested by

```py
import random

import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("cifar10", split="test", max_samples=100, shuffle=True, seed=51)

model = foz.load_zoo_model("clip-vit-base32-torch")
dataset.apply_model(model, label_field="clip", confidence_thresh=0.9)

# ✅
print(dataset.count_values("clip.label"))

# Replace 'cat' with None
dataset.match(F("ground_truth.label") == "cat").set_field("ground_truth.label", None).save()

# ✅
session = fo.launch_app(dataset)

# ✅
print(dataset.count_values("ground_truth.label"))

# ✅
dataset.export(
    export_dir="/tmp/cifar10-test",
    dataset_type=fo.types.ImageClassificationDirectoryTree,
    overwrite=True,
)
"""
ls -lah /tmp/cifar10-test
"""

# ✅
dataset.export(
    export_dir="/tmp/cifar10-test",
    dataset_type=fo.types.FiftyOneImageClassificationDataset,
    # dataset_type=fo.types.CSVDataset, fields="ground_truth.label",
    overwrite=True,
)
"""
cat /tmp/cifar10-test/labels.json
"""

# ✅
dataset.export(
    export_dir="/tmp/cifar10-test",
    dataset_type=fo.types.CSVDataset,
    fields="ground_truth.label",
    overwrite=True,
)
"""
cat /tmp/cifar10-test/labels.csv
"""

classes = dataset.distinct("ground_truth.label")
classes.append(None)

def jitter(val):
    if random.random() < 0.10:
        return random.choice(classes)

    return val

predictions = [
    fo.Classification(label=jitter(gt.label), confidence=random.random())
    for gt in dataset.values("ground_truth")
]

dataset.set_values("predictions", predictions)

results = dataset.evaluate_classifications(
    "predictions",
    gt_field="ground_truth",
    eval_key="eval",
)

# ✅
results.print_report()
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Low-confidence predictions are now retained as empty labels when applying confidence thresholds, instead of being removed.
  * Preserves container structure (lists/dicts) and provides consistent behavior across prediction outputs.
  * Visualizations, filters, and exports may show empty entries where low-confidence predictions exist.
  * Workflows relying on missing/None values for low-confidence cases may need adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->