### PR TITLE
replace default / shortcut with Ctrl/⌘+K in DocSearch

### DIFF
--- a/docs/source/_templates/sections/footer.html
+++ b/docs/source/_templates/sections/footer.html
@@ -112,7 +112,7 @@
     });
 
     document.addEventListener('keydown', function (event) {
-      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k') {
+      if (event.key === '/') {
         event.preventDefault();
         event.stopImmediatePropagation();
       }


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR updates the Algolia DocSearch integration to disable the default `/`  keyboard shortcut and instead open the search modal with `Ctrl/⌘ + K`.  The issue is that if you are talking with the agent, you cannot type anything containing a slash `/` because it automatically opens the search modal. Suggested by @paularamo 

## How is this patch tested? If it is not, please explain why.

Tested locally by building the Sphinx docs.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.


### What areas of FiftyOne does this PR affect?

-   [x] Documentation: FiftyOne documentation changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated mobile search shortcut: press “/” to open search, replacing the previous Ctrl/Cmd + K. This streamlines access on touch devices and avoids conflicts with system shortcuts. The search experience remains the same otherwise. Desktop behavior is unchanged, and the update works across supported mobile browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->