### PR TITLE
FOEPD-1948 target view utility followup

### DIFF
--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -808,6 +808,9 @@ class Object(BaseType):
         self.add_property(name, _property)
         return _property
 
+    # Alias for common word reversal
+    target_view = view_target
+
     def to_json(self):
         """Converts the object definition to JSON.
 
@@ -2837,12 +2840,14 @@ class ViewTargetProperty(Property):
         """
 
         # Determine which target views are available
-        has_base_view = ctx.has_generated_view
-
+        has_base_view = (
+            ctx.view._is_generated  # pylint: disable=protected-access
+        )
         if has_base_view:
-            has_custom_view = ctx.has_custom_generated_view
+            has_view = ctx.view != ctx.view._base_view
         else:
-            has_custom_view = ctx.has_custom_view
+            has_view = ctx.view != ctx.dataset.view()
+
         has_selected_samples = allow_selected_samples and bool(ctx.selected)
         has_selected_labels = allow_selected_labels and bool(
             ctx.selected_labels
@@ -2854,7 +2859,7 @@ class ViewTargetProperty(Property):
             choice_view,
             action_description=action_description,
             include_base_view=has_base_view,
-            include_current_view=has_custom_view,
+            include_current_view=has_view,
             include_dataset=not has_base_view,
             include_dataset_view=allow_dataset_view,
             include_selected_labels=has_selected_labels,
@@ -2880,7 +2885,7 @@ class ViewTargetProperty(Property):
             default_target = options.values()[-1]  # last option
 
         # Only 1 option so no need for a radio group, just hide it.
-        if len(options.values()) == 1:
+        if len(options.values()) <= 1:
             choice_view = HiddenView(read_only=False)
 
         super().__init__(

--- a/tests/unittests/operators/target_view_tests.py
+++ b/tests/unittests/operators/target_view_tests.py
@@ -17,178 +17,190 @@ from fiftyone.operators import types
 
 class TestResolveOperatorTargetViewInputs(unittest.TestCase):
     def test_all_options(self):
-        request_params = {
-            "dataset_name": "dataset",
-            "dataset_id": bson.ObjectId(),
-            "view": [
-                {
-                    "_cls": "fiftyone.core.stages.Limit",
-                    "kwargs": [["limit", 3]],
-                }
-            ],
-            "selected": ["sample_id_one"],
-            "selected_labels": ["label_id_one"],
-        }
-        ctx = foo.ExecutionContext(
-            operator_uri="test_operator",
-            request_params=request_params,
-        )
-        inputs = types.Object()
-        res = inputs.view_target(
-            ctx,
-            action_description="Borks",
-            allow_dataset_view=True,
-            allow_selected_labels=True,
-            default_target=foo.constants.ViewTarget.SELECTED_SAMPLES,
-        )
-        prop = inputs.properties["view_target"]
-        self.assertIs(res, prop)
-        self.assertIsInstance(prop.type, types.Enum)
-        self.assertListEqual(
-            prop.type.values,
-            [
-                foo.constants.ViewTarget.DATASET,
-                foo.constants.ViewTarget.DATASET_VIEW,
-                foo.constants.ViewTarget.CURRENT_VIEW,
-                foo.constants.ViewTarget.SELECTED_SAMPLES,
-                foo.constants.ViewTarget.SELECTED_LABELS,
-            ],
-        )
-        self.assertListEqual(
-            prop.options.values(),
-            [
-                foo.constants.ViewTarget.DATASET,
-                foo.constants.ViewTarget.DATASET_VIEW,
-                foo.constants.ViewTarget.CURRENT_VIEW,
-                foo.constants.ViewTarget.SELECTED_SAMPLES,
-                foo.constants.ViewTarget.SELECTED_LABELS,
-            ],
-        )
-        self.assertEqual(
-            prop.default, foo.constants.ViewTarget.SELECTED_SAMPLES
-        )
-        self.assertIsInstance(prop.view, types.RadioGroup)
-        self.assertListEqual(
-            [choice.label for choice in prop.view.choices],
-            [
-                "Entire dataset",
-                "Dataset",
-                "Current view",
-                "Selected samples",
-                "Selected labels",
-            ],
-        )
-        self.assertListEqual(
-            [choice.description for choice in prop.view.choices],
-            [
-                "Borks the entire dataset",
-                "Borks the dataset view",
-                "Borks the current view",
-                "Borks only the selected samples",
-                "Borks only the selected labels",
-            ],
-        )
+        ds = fo.Dataset(persistent=True)
+        try:
+            request_params = {
+                "dataset_name": ds.name,
+                "dataset_id": ds._doc.id,
+                "view": [
+                    {
+                        "_cls": "fiftyone.core.stages.Limit",
+                        "kwargs": [["limit", 3]],
+                    }
+                ],
+                "selected": ["sample_id_one"],
+                "selected_labels": ["label_id_one"],
+            }
+            ctx = foo.ExecutionContext(
+                operator_uri="test_operator",
+                request_params=request_params,
+            )
+            inputs = types.Object()
+            res = inputs.view_target(
+                ctx,
+                action_description="Borks",
+                allow_dataset_view=True,
+                allow_selected_labels=True,
+                default_target=foo.constants.ViewTarget.SELECTED_SAMPLES,
+            )
+            prop = inputs.properties["view_target"]
+            self.assertIs(res, prop)
+            self.assertIsInstance(prop.type, types.Enum)
+            self.assertListEqual(
+                prop.type.values,
+                [
+                    foo.constants.ViewTarget.DATASET,
+                    foo.constants.ViewTarget.DATASET_VIEW,
+                    foo.constants.ViewTarget.CURRENT_VIEW,
+                    foo.constants.ViewTarget.SELECTED_SAMPLES,
+                    foo.constants.ViewTarget.SELECTED_LABELS,
+                ],
+            )
+            self.assertListEqual(
+                prop.options.values(),
+                [
+                    foo.constants.ViewTarget.DATASET,
+                    foo.constants.ViewTarget.DATASET_VIEW,
+                    foo.constants.ViewTarget.CURRENT_VIEW,
+                    foo.constants.ViewTarget.SELECTED_SAMPLES,
+                    foo.constants.ViewTarget.SELECTED_LABELS,
+                ],
+            )
+            self.assertEqual(
+                prop.default, foo.constants.ViewTarget.SELECTED_SAMPLES
+            )
+            self.assertIsInstance(prop.view, types.RadioGroup)
+            self.assertListEqual(
+                [choice.label for choice in prop.view.choices],
+                [
+                    "Entire dataset",
+                    "Dataset",
+                    "Current view",
+                    "Selected samples",
+                    "Selected labels",
+                ],
+            )
+            self.assertListEqual(
+                [choice.description for choice in prop.view.choices],
+                [
+                    "Borks the entire dataset",
+                    "Borks the dataset view",
+                    "Borks the current view",
+                    "Borks only the selected samples",
+                    "Borks only the selected labels",
+                ],
+            )
+        finally:
+            ds.delete()
 
     def test_no_options(self):
-        request_params = {
-            "dataset_name": "dataset",
-            "dataset_id": bson.ObjectId(),
-        }
-        ctx = foo.ExecutionContext(
-            operator_uri="test_operator",
-            request_params=request_params,
-        )
-        inputs = types.Object()
-        res = inputs.view_target(
-            ctx,
-            allow_selected_labels=True,
-        )
-        prop = inputs.properties["view_target"]
-        self.assertIs(prop, res)
-        self.assertListEqual(
-            prop.options.values(), [foo.constants.ViewTarget.DATASET]
-        )
-        self.assertIsInstance(prop.view, types.HiddenView)
+        ds = fo.Dataset(persistent=True)
+        try:
+            request_params = {
+                "dataset_name": ds.name,
+                "dataset_id": ds._doc.id,
+            }
+            ctx = foo.ExecutionContext(
+                operator_uri="test_operator",
+                request_params=request_params,
+            )
+            inputs = types.Object()
+            res = inputs.view_target(
+                ctx,
+                allow_selected_labels=True,
+            )
+            prop = inputs.properties["view_target"]
+            self.assertIs(prop, res)
+            self.assertListEqual(
+                prop.options.values(), [foo.constants.ViewTarget.DATASET]
+            )
+            self.assertIsInstance(prop.view, types.HiddenView)
+        finally:
+            ds.delete()
 
     def test_label_description_override(self):
-        request_params = {
-            "dataset_name": "dataset",
-            "dataset_id": bson.ObjectId(),
-            "view": [
-                {
-                    "_cls": "fiftyone.core.stages.Limit",
-                    "kwargs": [["limit", 3]],
-                }
-            ],
-            "selected": ["sample_id_one"],
-            "selected_labels": ["label_id_one"],
-        }
-        ctx = foo.ExecutionContext(
-            operator_uri="test_operator",
-            request_params=request_params,
-        )
-        inputs = types.Object()
+        ds = fo.Dataset(persistent=True)
+        try:
+            request_params = {
+                "dataset_name": ds.name,
+                "dataset_id": ds._doc.id,
+                "view": [
+                    {
+                        "_cls": "fiftyone.core.stages.Limit",
+                        "kwargs": [["limit", 3]],
+                    }
+                ],
+                "selected": ["sample_id_one"],
+                "selected_labels": ["label_id_one"],
+            }
+            ctx = foo.ExecutionContext(
+                operator_uri="test_operator",
+                request_params=request_params,
+            )
+            inputs = types.Object()
 
-        #####
-        res = inputs.view_target(
-            ctx,
-            action_description="Borks",
-            allow_dataset_view=True,
-            allow_selected_labels=True,
-            dataset_label="Blah dataset",
-            dataset_description="Blah dataset description",
-            dataset_view_label="Blah dataset view",
-            dataset_view_description="Blah dataset view description",
-            current_view_label="Blah current view",
-            current_view_description="Blah current view description",
-            selected_samples_label="Blah selected samples",
-            selected_samples_description="Blah selected samples description",
-            selected_labels_label="Blah selected labels",
-            selected_labels_description="Blah selected labels description",
-        )
-        #####
+            #####
+            res = inputs.view_target(
+                ctx,
+                action_description="Borks",
+                allow_dataset_view=True,
+                allow_selected_labels=True,
+                dataset_label="Blah dataset",
+                dataset_description="Blah dataset description",
+                dataset_view_label="Blah dataset view",
+                dataset_view_description="Blah dataset view description",
+                current_view_label="Blah current view",
+                current_view_description="Blah current view description",
+                selected_samples_label="Blah selected samples",
+                selected_samples_description="Blah selected samples description",
+                selected_labels_label="Blah selected labels",
+                selected_labels_description="Blah selected labels description",
+            )
+            #####
 
-        prop = inputs.properties["view_target"]
-        self.assertIs(prop, res)
-        self.assertIsInstance(prop.type, types.Enum)
-        self.assertListEqual(
-            prop.type.values,
-            [
-                foo.constants.ViewTarget.DATASET,
-                foo.constants.ViewTarget.DATASET_VIEW,
-                foo.constants.ViewTarget.CURRENT_VIEW,
-                foo.constants.ViewTarget.SELECTED_SAMPLES,
-                foo.constants.ViewTarget.SELECTED_LABELS,
-            ],
-        )
-        self.assertListEqual(
-            prop.options.values(),
-            [
-                foo.constants.ViewTarget.DATASET,
-                foo.constants.ViewTarget.DATASET_VIEW,
-                foo.constants.ViewTarget.CURRENT_VIEW,
-                foo.constants.ViewTarget.SELECTED_SAMPLES,
-                foo.constants.ViewTarget.SELECTED_LABELS,
-            ],
-        )
-        self.assertIsInstance(prop.view, types.RadioGroup)
-        self.assertListEqual(
-            [choice.label for choice in prop.view.choices],
-            [
-                "Blah dataset",
-                "Blah dataset view",
-                "Blah current view",
-                "Blah selected samples",
-                "Blah selected labels",
-            ],
-        )
-        self.assertListEqual(
-            [choice.description for choice in prop.view.choices],
-            [
-                "Blah dataset description",
-                "Blah dataset view description",
-                "Blah current view description",
-                "Blah selected samples description",
-                "Blah selected labels description",
-            ],
-        )
+            prop = inputs.properties["view_target"]
+            self.assertIs(prop, res)
+            self.assertIsInstance(prop.type, types.Enum)
+            self.assertListEqual(
+                prop.type.values,
+                [
+                    foo.constants.ViewTarget.DATASET,
+                    foo.constants.ViewTarget.DATASET_VIEW,
+                    foo.constants.ViewTarget.CURRENT_VIEW,
+                    foo.constants.ViewTarget.SELECTED_SAMPLES,
+                    foo.constants.ViewTarget.SELECTED_LABELS,
+                ],
+            )
+            self.assertListEqual(
+                prop.options.values(),
+                [
+                    foo.constants.ViewTarget.DATASET,
+                    foo.constants.ViewTarget.DATASET_VIEW,
+                    foo.constants.ViewTarget.CURRENT_VIEW,
+                    foo.constants.ViewTarget.SELECTED_SAMPLES,
+                    foo.constants.ViewTarget.SELECTED_LABELS,
+                ],
+            )
+            self.assertIsInstance(prop.view, types.RadioGroup)
+            self.assertListEqual(
+                [choice.label for choice in prop.view.choices],
+                [
+                    "Blah dataset",
+                    "Blah dataset view",
+                    "Blah current view",
+                    "Blah selected samples",
+                    "Blah selected labels",
+                ],
+            )
+            self.assertListEqual(
+                [choice.description for choice in prop.view.choices],
+                [
+                    "Blah dataset description",
+                    "Blah dataset view description",
+                    "Blah current view description",
+                    "Blah selected samples description",
+                    "Blah selected labels description",
+                ],
+            )
+        finally:
+            ds.delete()


### PR DESCRIPTION
## What changes are proposed in this pull request?

Followup from PR comment: https://github.com/voxel51/fiftyone/pull/6235#discussion_r2278116003

Originally I was trying to minimize work in `resolve_input()` since that can get called a lot. Premature optimization it turns out... Tested on 2M sample dataset and the different between using `ctx.view` and not, has no impact.

So instead of reinventing the wheel of determining if the thing has a generated view, current_view, etc., we will use what we have on `ctx.view`.

## How is this patch tested? If it is not, please explain why.

Same as that PR - compute metadata plugin with all different views and selections etc.
