### PR TITLE
Enterprise Management SDK right-nav shows all modules

### DIFF
--- a/docs/source/enterprise/management_sdk.rst
+++ b/docs/source/enterprise/management_sdk.rst
@@ -19,8 +19,6 @@ keys, and more.
 
 .. _enterprise-sdk-api-reference:
 
-API reference
-_____________
 
 .. _enterprise-sdk-connections:
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Remove the “API reference” heading to ensure all Management SDK modules appear in the right nav.

## How is this patch tested? If it is not, please explain why.
Build docs in local:
<img width="1203" height="507" alt="Screenshot from 2025-08-19 13-23-27" src="https://github.com/user-attachments/assets/b09f1830-99b4-4e9e-9b3c-8d0c95965e65" />

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [x] No. You can skip the rest of this section.

### What areas of FiftyOne does this PR affect?

* [x] Documentation: FiftyOne documentation changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined the Enterprise Management SDK docs by removing a redundant “API reference” heading while preserving the existing anchor.
  * “Connections” now appears immediately after the anchor for a cleaner layout and improved readability.
  * No content changes; navigation, deep links, and references remain intact.
  * Purely a formatting update with no impact on functionality or APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->