### PR TITLE
Use `get_mask()` to retrieve instance segmentations

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -6495,15 +6495,15 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     continue
 
                 if self._server_version >= Version("2.3"):
+                    mask = det.get_mask()
                     x, y, w, h = det.bounding_box
                     frame_width, frame_height = frame_size
-                    mask_height, mask_width = det.mask.shape
+                    mask_height, mask_width = mask.shape
                     xtl, ytl = round(x * frame_width), round(y * frame_height)
                     w, h = round(w * frame_width), round(h * frame_height)
                     xbr, ybr = xtl + w, ytl + h
 
                     # -1 to convert from CVAT indexing
-                    mask = det.mask
                     if w != mask_width or h != mask_height:
                         mask = etai.resize(
                             mask.astype("uint8"), width=w, height=h

--- a/fiftyone/utils/iou.py
+++ b/fiftyone/utils/iou.py
@@ -536,11 +536,11 @@ def _dense_iou(gt, pred, gt_crowd=False):
     Returns:
         the IoU, in ``[0, 1]``
     """
-    gt_mask = gt.mask
+    gt_mask = gt.get_mask()
     gt_bb = gt.bounding_box  # x,y,w,h of box
     gt_mask_h, gt_mask_w = gt_mask.shape
 
-    pred_mask = pred.mask
+    pred_mask = pred.get_mask()
     pred_bb = pred.bounding_box  # x,y,w,h of box
     pred_mask_h, pred_mask_w = pred_mask.shape
 


### PR DESCRIPTION
We must use `Detection.get_mask()` in all builtin methods that operate on instance segmentations, as the actual mask may be stored in the `mask` or `mask_path` attribute.

I did a quick audit of the codebase and most of it was already using `get_mask()`, but there were two instances where we were directly using `.mask`. This PR fixes those.

## Tested by

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.core.storage as fos
import fiftyone.utils.labels as foul

dataset = foz.load_zoo_dataset("quickstart", max_samples=5)

model = foz.load_zoo_model("segment-anything-vitb-torch")

dataset.apply_model(model, label_field="gt_instances", prompt_field="ground_truth")
dataset.apply_model(model, label_field="pred_instances", prompt_field="predictions")

foul.export_segmentations(
    dataset,
    "gt_instances",
    output_dir="/tmp/instance-segmentation/gt_instances",
)

foul.export_segmentations(
    dataset,
    "pred_instances",
    output_dir="/tmp/instance-segmentation/pred_instances",
)

# works!
results = dataset.evaluate_detections(
    "pred_instances",
    gt_field="gt_instances",
    eval_key="eval",
    use_masks=True,
)
results.print_report()
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of instance masks imported from CVAT to ensure correct dimensions and resizing, reducing errors and misalignments in annotations.
  * Enhanced reliability of evaluation metrics by ensuring IoU calculations consistently use the correct mask data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->