### PR TITLE
Add Training Data field to all model manifest entries

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -49,6 +49,7 @@
                 "alexnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -100,6 +101,7 @@
                 "deeplabv3",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -142,6 +144,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2023-05-12 11:40:51"
         },
         {
@@ -184,6 +187,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2023-05-12 11:40:51"
         },
         {
@@ -225,6 +229,7 @@
                 "zero-shot",
                 "transformer"
             ],
+            "training_data": [],
             "date_added": "2023-05-12 11:40:51"
         },
         {
@@ -260,6 +265,7 @@
                 }
             },
             "tags": ["segment-anything", "torch", "zero-shot"],
+            "training_data": [],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -301,6 +307,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -342,6 +349,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -383,6 +391,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -424,6 +433,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -466,6 +476,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -508,6 +519,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -549,6 +561,7 @@
                 "video",
                 "transformer"
             ],
+            "training_data": [],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -591,6 +604,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-08-17 14:48:00"
         },
         {
@@ -628,6 +642,7 @@
                 }
             },
             "tags": ["segment-anything", "torch", "zero-shot", "transformer"],
+            "training_data": [],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -671,6 +686,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -714,6 +730,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -757,6 +774,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -799,6 +817,7 @@
                 "video",
                 "transformer"
             ],
+            "training_data": [],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -843,6 +862,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -887,6 +907,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -931,6 +952,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -982,6 +1004,7 @@
                 "deeplabv3",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1033,6 +1056,7 @@
                 "densenet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1083,6 +1107,7 @@
                 "torch",
                 "densenet"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1134,6 +1159,7 @@
                 "densenet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1185,6 +1211,7 @@
                 "densenet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1231,6 +1258,7 @@
                 "resnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1282,6 +1310,7 @@
                 "resnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1333,6 +1362,7 @@
                 "resnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1384,6 +1414,7 @@
                 "googlenet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1434,6 +1465,7 @@
                 "inception",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1506,6 +1538,7 @@
                 "resnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1551,6 +1584,7 @@
                 "resnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1602,6 +1636,7 @@
                 "mnasnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1653,6 +1688,7 @@
                 "mnasnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1704,6 +1740,7 @@
                 "mobilenet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1755,6 +1792,7 @@
                 "resnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1806,6 +1844,7 @@
                 "resnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1857,6 +1896,7 @@
                 "resnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1908,6 +1948,7 @@
                 "resnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1959,6 +2000,7 @@
                 "resnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2010,6 +2052,7 @@
                 "resnext",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2060,6 +2103,7 @@
                 "torch",
                 "resnext"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2099,6 +2143,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "retinanet", "resnet"],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2150,6 +2195,7 @@
                 "shufflenet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2201,6 +2247,7 @@
                 "shufflenet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2243,6 +2290,7 @@
                 }
             },
             "tags": ["classification", "imagenet", "torch", "squeezenet"],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2291,6 +2339,7 @@
                 "squeezenet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2342,6 +2391,7 @@
                 "vgg",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2391,6 +2441,7 @@
                 "vgg",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2442,6 +2493,7 @@
                 "vgg",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2491,6 +2543,7 @@
                 "vgg",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2542,6 +2595,7 @@
                 "vgg",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2591,6 +2645,7 @@
                 "vgg",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2642,6 +2697,7 @@
                 "vgg",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2691,6 +2747,7 @@
                 "vgg",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2742,6 +2799,7 @@
                 "wide-resnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2793,6 +2851,7 @@
                 "wide-resnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2837,6 +2896,7 @@
                 "zero-shot",
                 "transformer"
             ],
+            "training_data": [],
             "date_added": "2023-12-13 14:25:51"
         },
         {
@@ -2869,6 +2929,7 @@
                 "transformers",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-01-17 14:25:51"
         },
         {
@@ -2901,6 +2962,7 @@
                 "transformers",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-01-17 14:25:51"
         },
         {
@@ -2933,6 +2995,7 @@
                 "transformers",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-01-17 14:25:51"
         },
         {
@@ -2963,6 +3026,7 @@
                 }
             },
             "tags": ["segmentation", "torch", "transformers", "official"],
+            "training_data": [],
             "date_added": "2024-01-17 14:25:51"
         },
         {
@@ -2988,6 +3052,7 @@
                 }
             },
             "tags": ["depth", "torch", "transformers"],
+            "training_data": [],
             "date_added": "2024-02-06 14:25:51"
         },
         {
@@ -3026,6 +3091,7 @@
                 "zero-shot",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-01-17 14:25:51"
         },
         {
@@ -3065,6 +3131,7 @@
                 "zero-shot",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-01-17 14:25:51"
         },
         {
@@ -3098,6 +3165,7 @@
                 "zero-shot",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-01-17 14:25:51"
         },
         {
@@ -3148,6 +3216,7 @@
                 "zero-shot",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-05-15 15:20:35"
         },
         {
@@ -3183,6 +3252,7 @@
                 "zero-shot",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-01-17 14:25:51"
         },
         {
@@ -3218,6 +3288,7 @@
                 "zero-shot",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-07-15 13:49:00"
         },
         {
@@ -3253,6 +3324,7 @@
                 "zero-shot",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-07-28 15:25:00"
         },
         {
@@ -3288,6 +3360,7 @@
                 "zero-shot",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-01-17 14:25:51"
         },
         {
@@ -3340,6 +3413,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2022-04-12 17:49:51"
         },
         {
@@ -3378,6 +3452,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2023-07-31 10:17:51"
         },
         {
@@ -3416,6 +3491,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2023-07-31 10:17:51"
         },
         {
@@ -3454,6 +3530,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2023-07-31 10:17:51"
         },
         {
@@ -3492,6 +3569,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2023-07-31 10:17:51"
         },
         {
@@ -3530,6 +3608,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2023-12-02 16:42:00"
         },
         {
@@ -3568,6 +3647,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2023-12-02 16:42:00"
         },
         {
@@ -3606,6 +3686,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2023-12-02 16:42:00"
         },
         {
@@ -3644,6 +3725,7 @@
                 "transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2023-12-02 16:42:00"
         },
         {
@@ -3684,6 +3766,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2025-05-22 14:14:45"
         },
         {
@@ -3724,6 +3807,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2025-05-22 14:14:45"
         },
         {
@@ -3764,6 +3848,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2025-05-22 14:14:45"
         },
         {
@@ -3804,6 +3889,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2025-05-22 14:14:45"
         },
         {
@@ -3844,6 +3930,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -3884,6 +3971,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -3924,6 +4012,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -3964,6 +4053,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -4004,6 +4094,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -4044,6 +4135,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-04-02 19:22:51"
         },
         {
@@ -4084,6 +4176,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-04-02 19:22:51"
         },
         {
@@ -4124,6 +4217,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-04-02 19:22:51"
         },
         {
@@ -4164,6 +4258,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-04-02 19:22:51"
         },
         {
@@ -4204,6 +4299,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-04-02 19:22:51"
         },
         {
@@ -4244,6 +4340,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -4284,6 +4381,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -4324,6 +4422,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-04-02 19:22:51"
         },
         {
@@ -4364,6 +4463,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-04-02 19:22:51"
         },
         {
@@ -4404,6 +4504,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-07-01 19:22:51"
         },
         {
@@ -4444,6 +4545,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-07-01 19:22:51"
         },
         {
@@ -4484,6 +4586,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-07-01 19:22:51"
         },
         {
@@ -4524,6 +4627,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-07-01 19:22:51"
         },
         {
@@ -4564,6 +4668,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-07-01 19:22:51"
         },
         {
@@ -4604,6 +4709,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -4644,6 +4750,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -4684,6 +4791,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -4724,6 +4832,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -4764,6 +4873,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -4804,6 +4914,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -4844,6 +4955,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -4884,6 +4996,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -4924,6 +5037,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -4964,6 +5078,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -5004,6 +5119,7 @@
                 }
             },
             "tags": ["instances", "torch", "yolo", "zero-shot", "official"],
+            "training_data": [],
             "date_added": "2025-04-10 12:24:41"
         },
         {
@@ -5044,6 +5160,7 @@
                 }
             },
             "tags": ["instances", "torch", "yolo", "zero-shot", "official"],
+            "training_data": [],
             "date_added": "2025-04-10 12:24:41"
         },
         {
@@ -5084,6 +5201,7 @@
                 }
             },
             "tags": ["instances", "torch", "yolo", "zero-shot", "official"],
+            "training_data": [],
             "date_added": "2025-04-10 12:24:41"
         },
         {
@@ -5124,6 +5242,7 @@
                 }
             },
             "tags": ["instances", "torch", "yolo", "zero-shot", "official"],
+            "training_data": [],
             "date_added": "2025-04-10 12:24:41"
         },
         {
@@ -5164,6 +5283,7 @@
                 }
             },
             "tags": ["instances", "torch", "yolo", "zero-shot", "official"],
+            "training_data": [],
             "date_added": "2025-04-10 12:24:41"
         },
         {
@@ -5204,6 +5324,7 @@
                 }
             },
             "tags": ["instances", "torch", "yolo", "zero-shot", "official"],
+            "training_data": [],
             "date_added": "2025-04-10 12:24:41"
         },
         {
@@ -5251,6 +5372,7 @@
                 "rtdetr",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-07-01 19:22:51"
         },
         {
@@ -5298,6 +5420,7 @@
                 "rtdetr",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-07-01 19:22:51"
         },
         {
@@ -5338,6 +5461,7 @@
                 }
             },
             "tags": ["detection", "torch", "yolo", "zero-shot", "official"],
+            "training_data": [],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -5378,6 +5502,7 @@
                 }
             },
             "tags": ["detection", "torch", "yolo", "zero-shot", "official"],
+            "training_data": [],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -5418,6 +5543,7 @@
                 }
             },
             "tags": ["detection", "torch", "yolo", "zero-shot", "official"],
+            "training_data": [],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -5458,6 +5584,7 @@
                 }
             },
             "tags": ["detection", "torch", "yolo", "zero-shot", "official"],
+            "training_data": [],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -5505,6 +5632,7 @@
                 "obb",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-04-05 19:22:51"
         },
         {
@@ -5552,6 +5680,7 @@
                 "obb",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-04-05 19:22:51"
         },
         {
@@ -5599,6 +5728,7 @@
                 "obb",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-04-05 19:22:51"
         },
         {
@@ -5646,6 +5776,7 @@
                 "obb",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-04-05 19:22:51"
         },
         {
@@ -5693,6 +5824,7 @@
                 "obb",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2024-04-05 19:22:51"
         },
         {
@@ -5733,6 +5865,7 @@
                 }
             },
             "tags": ["detection", "oiv7", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-05-20 19:22:51"
         },
         {
@@ -5773,6 +5906,7 @@
                 }
             },
             "tags": ["detection", "oiv7", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-05-20 19:22:51"
         },
         {
@@ -5813,6 +5947,7 @@
                 }
             },
             "tags": ["detection", "oiv7", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-05-20 19:22:51"
         },
         {
@@ -5853,6 +5988,7 @@
                 }
             },
             "tags": ["detection", "oiv7", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-05-20 19:22:51"
         },
         {
@@ -5893,6 +6029,7 @@
                 }
             },
             "tags": ["detection", "oiv7", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-05-20 19:22:51"
         },
         {
@@ -5922,6 +6059,7 @@
                 }
             },
             "tags": ["detection", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2024-01-06 08:51:14"
         },
         {
@@ -5962,6 +6100,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
+            "training_data": [],
             "date_added": "2025-05-22 14:14:45"
         },
         {
@@ -5999,6 +6138,7 @@
                 "transformers",
                 "convnext"
             ],
+            "training_data": [],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6037,6 +6177,7 @@
                 "convnext",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6075,6 +6216,7 @@
                 "convnext",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6112,6 +6254,7 @@
                 "transformers",
                 "convnext"
             ],
+            "training_data": [],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6150,6 +6293,7 @@
                 "convnext",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6188,6 +6332,7 @@
                 "efficientnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6226,6 +6371,7 @@
                 "efficientnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6264,6 +6410,7 @@
                 "efficientnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6302,6 +6449,7 @@
                 "efficientnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6340,6 +6488,7 @@
                 "efficientnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6378,6 +6527,7 @@
                 "efficientnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6416,6 +6566,7 @@
                 "efficientnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6454,6 +6605,7 @@
                 "efficientnet",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6491,6 +6643,7 @@
                 "swin-transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-07-02 12:00:00"
         },
         {
@@ -6528,6 +6681,7 @@
                 "swin-transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-07-02 12:00:00"
         },
         {
@@ -6565,6 +6719,7 @@
                 "swin-transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-07-02 12:00:00"
         },
         {
@@ -6602,6 +6757,7 @@
                 "swin-transformer",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-07-02 12:00:00"
         },
         {
@@ -6632,6 +6788,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "transformers", "rtdetr"],
+            "training_data": [],
             "date_added": "2025-07-03 12:00:00"
         },
         {
@@ -6669,6 +6826,7 @@
                 "rtdetr",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-07-03 12:00:00"
         },
         {
@@ -6703,6 +6861,7 @@
                 "detr",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-07-15 23:00:00"
         },
         {
@@ -6737,6 +6896,7 @@
                 "detr",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-07-15 23:00:00"
         },
         {
@@ -6771,6 +6931,7 @@
                 "detr",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-07-15 23:00:00"
         },
         {
@@ -6805,6 +6966,7 @@
                 "detr",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-07-15 23:00:00"
         },
         {
@@ -6839,6 +7001,7 @@
                 "detr",
                 "official"
             ],
+            "training_data": [],
             "date_added": "2025-07-15 23:00:00"
         },
         {
@@ -6870,6 +7033,7 @@
                 }
             },
             "tags": ["segmentation", "torch", "segformer", "official"],
+            "training_data": [],
             "date_added": "2025-08-04 12:34:17"
         },
         {
@@ -6901,6 +7065,7 @@
                 }
             },
             "tags": ["segmentation", "torch", "segformer", "official"],
+            "training_data": [],
             "date_added": "2025-08-04 12:34:20"
         },
         {
@@ -6932,6 +7097,7 @@
                 }
             },
             "tags": ["segmentation", "torch", "segformer", "official"],
+            "training_data": [],
             "date_added": "2025-08-04 12:34:22"
         },
         {
@@ -6963,6 +7129,7 @@
                 }
             },
             "tags": ["segmentation", "torch", "segformer", "official"],
+            "training_data": [],
             "date_added": "2025-08-04 12:34:24"
         },
         {
@@ -6994,6 +7161,7 @@
                 }
             },
             "tags": ["segmentation", "torch", "segformer", "official"],
+            "training_data": [],
             "date_added": "2025-08-04 12:34:25"
         },
         {
@@ -7025,6 +7193,7 @@
                 }
             },
             "tags": ["segmentation", "torch", "segformer", "official"],
+            "training_data": [],
             "date_added": "2025-08-04 12:34:27"
         }
     ]


### PR DESCRIPTION
In preparation for documenting each model's training datasets, this PR adds an empty "Training Data" array field to all model entries in the manifest. 

This establishes the schema that will contain:
- Dataset names
- Dataset URLs (where publicly available)

Future PRs will populate these fields with verified information for each model family. No existing fields or formatting have been changed.

## What changes are proposed in this pull request?

This PR adds a new `"Training Data": []` field to all 169 models in the PyTorch model zoo manifest (`manifest-torch.json`). The field is currently an empty array that will be populated in subsequent PRs with structured dataset information. The field is positioned before the `date_added` field in each model entry to maintain logical ordering.

## How is this patch tested? If it is not, please explain why.

- Automated validation script confirms all 169 models have the new field
- JSON schema validation ensures the manifest remains valid
- Manual diff review confirms no other fields or formatting were changed
- File size increase is consistent with adding 169 empty array fields (~4.5KB total)
- FiftyOne builds successfully with the modified manifest
- Model zoo retrieval tested successfully (loaded a model from the zoo to verify functionality)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other