### PR TITLE
Properly handle skip failures in compute metadata

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -3472,7 +3472,7 @@ class SampleCollection(object):
         overwrite=False,
         num_workers=None,
         skip_failures=True,
-        warn_failures=False,
+        warn_failures=True,
         progress=None,
     ):
         """Populates the ``metadata`` field of all samples in the collection.
@@ -3485,7 +3485,7 @@ class SampleCollection(object):
             num_workers (None): a suggested number of threads to use
             skip_failures (True): whether to gracefully continue without
                 raising an error if metadata cannot be computed for a sample
-            warn_failures (False): whether to log a warning if metadata cannot
+            warn_failures (True): whether to log a warning if metadata cannot
                 be computed for a sample
             progress (None): whether to render a progress bar (True/False), use
                 the default value ``fiftyone.config.show_progress_bars``

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -361,7 +361,7 @@ def compute_metadata(
     overwrite=False,
     num_workers=None,
     skip_failures=True,
-    warn_failures=False,
+    warn_failures=True,
     progress=None,
 ):
     """Populates the ``metadata`` field of all samples in the collection.
@@ -376,7 +376,7 @@ def compute_metadata(
         num_workers (None): a suggested number of threads to use
         skip_failures (True): whether to gracefully continue without raising an
             error if metadata cannot be computed for a sample
-        warn_failures (False): whether to log a warning if metadata cannot
+        warn_failures (True): whether to log a warning if metadata cannot
             be computed for a sample
         progress (None): whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
@@ -480,7 +480,7 @@ def _compute_metadata(
     batch_size=1000,
     progress=None,
     skip_failures=True,
-    warn_failures=False,
+    warn_failures=True,
 ):
     if not overwrite:
         sample_collection = sample_collection.exists("metadata", False)
@@ -528,7 +528,7 @@ def _compute_metadata_multi(
     batch_size=1000,
     progress=None,
     skip_failures=True,
-    warn_failures=False,
+    warn_failures=True,
 ):
     if not overwrite:
         sample_collection = sample_collection.exists("metadata", False)
@@ -584,7 +584,7 @@ def _do_compute_metadata(args):
 
 
 def _compute_sample_metadata(
-    filepath, media_type, skip_failures=False, cache=None, warn_failures=False
+    filepath, media_type, skip_failures=False, cache=None, warn_failures=True
 ):
     try:
         return _get_metadata(filepath, media_type, cache=cache)

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -296,7 +296,7 @@ def _parse_assets(scene, scene_path, cache=None):
                 asset_size += metadata.size_bytes
                 continue
 
-        tasks.append((None, asset_path, fom.MIXED, cache, True, False))
+        tasks.append((None, asset_path, fom.MIXED, cache, True, True))
 
     results = []
     if len(tasks) <= 1:

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -227,13 +227,24 @@ class SceneMetadata(Metadata):
     asset_counts = fof.DictField()
 
     @classmethod
-    def build_for(cls, scene_path, mime_type=None, _cache=None):
+    def build_for(
+        cls,
+        scene_path,
+        mime_type=None,
+        _cache=None,
+        skip_failures=True,
+        warn_failures=True,
+    ):
         """Builds a :class:`SceneMetadata` object for the given 3D scene.
 
         Args:
             scene_path: a scene path
             mime_type (None): the MIME type of the scene. If not provided,
                 defaults to ``application/octet-stream``
+            skip_failures (True): whether to gracefully continue without raising an
+                error if metadata cannot be computed for a sample
+            warn_failures (True): whether to log a warning if metadata cannot
+                be computed for a sample
 
         Returns:
             a :class:`SceneMetadata`
@@ -244,11 +255,22 @@ class SceneMetadata(Metadata):
             )
 
         return cls._build_for_local(
-            scene_path, mime_type=mime_type, cache=_cache
+            scene_path,
+            mime_type=mime_type,
+            cache=_cache,
+            skip_failures=skip_failures,
+            warn_failures=warn_failures,
         )
 
     @classmethod
-    def _build_for_local(cls, scene_path, mime_type=None, cache=None):
+    def _build_for_local(
+        cls,
+        scene_path,
+        mime_type=None,
+        cache=None,
+        skip_failures=True,
+        warn_failures=True,
+    ):
         if mime_type is None:
             mime_type = "application/octet-stream"
 
@@ -256,7 +278,11 @@ class SceneMetadata(Metadata):
         scene = fo3d.Scene.from_fo3d(scene_path)
 
         asset_counts, asset_size = _parse_assets(
-            scene, scene_path, cache=cache
+            scene,
+            scene_path,
+            cache=cache,
+            skip_failures=skip_failures,
+            warn_failures=warn_failures,
         )
         size_bytes = scene_size + asset_size
 
@@ -273,7 +299,9 @@ class SceneMetadata(Metadata):
         raise ValueError("Scene URLs are not currently supported")
 
 
-def _parse_assets(scene, scene_path, cache=None):
+def _parse_assets(
+    scene, scene_path, cache=None, skip_failures=True, warn_failures=True
+):
     asset_paths = scene.get_asset_paths()
 
     asset_counts = defaultdict(int)
@@ -296,16 +324,37 @@ def _parse_assets(scene, scene_path, cache=None):
                 asset_size += metadata.size_bytes
                 continue
 
-        tasks.append((None, asset_path, fom.MIXED, cache, True, True))
+        tasks.append((None, asset_path, fom.MIXED, cache))
 
     results = []
     if len(tasks) <= 1:
         for task in tasks:
-            results.append(_do_compute_metadata(task))
+            metadata = _compute_sample_metadata(
+                filepath=task[1],
+                media_type=task[2],
+                cache=task[3],
+                skip_failures=skip_failures,
+                warn_failures=warn_failures,
+            )
+            results.append((task[0], metadata))
     else:
         num_workers = fou.recommend_thread_pool_workers(min(len(tasks), 8))
         with multiprocessing.dummy.Pool(processes=num_workers) as pool:
-            results.extend(pool.imap(_do_compute_metadata, tasks))
+            results.extend(
+                pool.imap(
+                    lambda task: (
+                        task[0],
+                        _compute_sample_metadata(
+                            filepath=task[1],
+                            media_type=task[2],
+                            cache=task[3],
+                            skip_failures=skip_failures,
+                            warn_failures=warn_failures,
+                        ),
+                    ),
+                    tasks,
+                )
+            )
 
     for task, result in zip(tasks, results):
         metadata = result[1]
@@ -318,13 +367,13 @@ def _parse_assets(scene, scene_path, cache=None):
     return dict(asset_counts), asset_size
 
 
-def compute_sample_metadata(sample, overwrite=False, skip_failures=False):
+def compute_sample_metadata(sample, overwrite=False, skip_failures=True):
     """Populates the ``metadata`` field of the sample.
 
     Args:
         sample: a :class:`fiftyone.core.sample.Sample`
         overwrite (False): whether to overwrite existing metadata
-        skip_failures (False): whether to gracefully continue without raising
+        skip_failures (True): whether to gracefully continue without raising
             an error if metadata cannot be computed
     """
     if not overwrite and sample.metadata is not None:
@@ -510,7 +559,21 @@ def _compute_metadata(
     try:
         with fou.ProgressBar(total=num_samples, progress=progress) as pb:
             for args in pb(inputs):
-                sample_id, metadata = _do_compute_metadata(args)
+                (
+                    sample_id,
+                    filepath,
+                    media_type,
+                    cache,
+                    skip_failures,
+                    warn_failures,
+                ) = args
+                metadata = _compute_sample_metadata(
+                    filepath,
+                    media_type,
+                    skip_failures=skip_failures,
+                    cache=cache,
+                    warn_failures=warn_failures,
+                )
                 values[sample_id] = metadata
                 if len(values) >= batch_size:
                     sample_collection.set_values(
@@ -551,15 +614,25 @@ def _compute_metadata_multi(
         filepaths,
         media_types,
         itertools.repeat(cache),
-        itertools.repeat(skip_failures),
-        itertools.repeat(warn_failures),
     )
 
     try:
         with multiprocessing.dummy.Pool(processes=num_workers) as pool:
             with fou.ProgressBar(total=num_samples, progress=progress) as pb:
                 for sample_id, metadata in pb(
-                    pool.imap_unordered(_do_compute_metadata, inputs)
+                    pool.imap_unordered(
+                        lambda args: (
+                            args[0],
+                            _compute_sample_metadata(
+                                filepath=args[1],
+                                media_type=args[2],
+                                skip_failures=skip_failures,
+                                cache=args[3],
+                                warn_failures=warn_failures,
+                            ),
+                        ),
+                        inputs,
+                    )
                 ):
                     values[sample_id] = metadata
                     if len(values) >= batch_size:
@@ -571,23 +644,17 @@ def _compute_metadata_multi(
         sample_collection.set_values("metadata", values, key_field="id")
 
 
-def _do_compute_metadata(args):
-    sample_id, filepath, media_type, cache, skip_failures, warn_failures = args
-    metadata = _compute_sample_metadata(
-        filepath,
-        media_type,
-        skip_failures=skip_failures,
-        cache=cache,
-        warn_failures=warn_failures,
-    )
-    return sample_id, metadata
-
-
 def _compute_sample_metadata(
-    filepath, media_type, skip_failures=False, cache=None, warn_failures=True
+    filepath, media_type, skip_failures=True, cache=None, warn_failures=True
 ):
     try:
-        return _get_metadata(filepath, media_type, cache=cache)
+        return _get_metadata(
+            filepath,
+            media_type,
+            cache=cache,
+            skip_failures=skip_failures,
+            warn_failures=warn_failures,
+        )
     except Exception as e:
         if warn_failures:
             logger.warning(
@@ -600,7 +667,9 @@ def _compute_sample_metadata(
         raise
 
 
-def _get_metadata(filepath, media_type, cache=None):
+def _get_metadata(
+    filepath, media_type, cache=None, skip_failures=True, warn_failures=True
+):
     if cache is not None:
         metadata = cache.get(filepath, None)
         if metadata is not None:
@@ -611,7 +680,12 @@ def _get_metadata(filepath, media_type, cache=None):
     elif media_type == fom.VIDEO:
         metadata = VideoMetadata.build_for(filepath)
     elif media_type == fom.THREE_D:
-        metadata = SceneMetadata.build_for(filepath, _cache=cache)
+        metadata = SceneMetadata.build_for(
+            filepath,
+            _cache=cache,
+            skip_failures=skip_failures,
+            warn_failures=warn_failures,
+        )
     else:
         metadata = Metadata.build_for(filepath)
 

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -296,7 +296,7 @@ def _parse_assets(scene, scene_path, cache=None):
                 asset_size += metadata.size_bytes
                 continue
 
-        tasks.append((None, asset_path, fom.MIXED, cache))
+        tasks.append((None, asset_path, fom.MIXED, cache, True, False))
 
     results = []
     if len(tasks) <= 1:

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -552,8 +552,6 @@ def _compute_metadata(
         filepaths,
         media_types,
         itertools.repeat(cache),
-        itertools.repeat(skip_failures),
-        itertools.repeat(warn_failures),
     )
 
     try:
@@ -564,8 +562,6 @@ def _compute_metadata(
                     filepath,
                     media_type,
                     cache,
-                    skip_failures,
-                    warn_failures,
                 ) = args
                 metadata = _compute_sample_metadata(
                     filepath,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Passing skip and warn failures all the way through compute metadata call stack. This will make it so there are no more silent failures (experienced this when we didn't have access to the media).

## How is this patch tested? If it is not, please explain why.

Copied the metadata.py over to FOT, then ran this script:

```
import fiftyone as fo

dataset_name = "quickstart-gcs-test-1"
fo.delete_dataset(dataset_name)
ds = fo.load_dataset("quickstart").clone(dataset_name)

filepaths = ds.values("filepath")

new_filepaths = []
for i in range(len(filepaths)):
    new_filepaths.append(f"gs://fiftyone-nonexistent-bucket/{i}")

ds.set_values("filepath", new_filepaths)

print(ds)
ds.compute_metadata(overwrite=True, warn_failures=True)
```

We are expecting to see a bunch of errors:
```
Failed to compute sample metadata for sample 'gs://fiftyone-nonexistent-bucket/196' due to: [Errno 2] No such file or directory: 'gs://fiftyone-nonexistent-bucket/196'
Failed to compute sample metadata for sample 'gs://fiftyone-nonexistent-bucket/197' due to: [Errno 2] No such file or directory: 'gs://fiftyone-nonexistent-bucket/197'
Failed to compute sample metadata for sample 'gs://fiftyone-nonexistent-bucket/198' due to: [Errno 2] No such file or directory: 'gs://fiftyone-nonexistent-bucket/198'
Failed to compute sample metadata for sample 'gs://fiftyone-nonexistent-bucket/199' due to: [Errno 2] No such file or directory: 'gs://fiftyone-nonexistent-bucket/199'
Failed to compute sample metadata for sample 'gs://fiftyone-nonexistent-bucket/1' due to: [Errno 2] No such file or directory: 'gs://fiftyone-nonexistent-bucket/1'
Failed to compute sample metadata for sample 'gs://fiftyone-nonexistent-bucket/165' due to: [Errno 2] No such file or directory: 'gs://fiftyone-nonexistent-bucket/165'
 100% |█████████████████████████████████████████████████████████████████████████████████████████| 200/200 [3.5ms elapsed, 0s remaining, 57.6K samples/s] 
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

If you have compute metadata skip failures set to False it will now end execution when a sample fails to compute instead of silently swallowing them and then outputting "X samples couldn't populate metadata".

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-sample failure-handling for metadata computation: options to skip failing samples and to emit warnings when a sample fails.
  * Applies to both single- and multi-worker processing for more resilient metadata runs.

* **Behavior Change**
  * Metadata APIs now default to emitting warnings for per-sample failures, so failures are reported by default but do not stop processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->