### PR TITLE
populate dataset information for all pytorch zoo models

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -49,7 +49,7 @@
                 "alexnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -101,7 +101,7 @@
                 "deeplabv3",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -144,7 +144,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
             "date_added": "2023-05-12 11:40:51"
         },
         {
@@ -187,7 +187,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
             "date_added": "2023-05-12 11:40:51"
         },
         {
@@ -229,7 +229,7 @@
                 "zero-shot",
                 "transformer"
             ],
-            "training_data": [],
+            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
             "date_added": "2023-05-12 11:40:51"
         },
         {
@@ -265,7 +265,7 @@
                 }
             },
             "tags": ["segment-anything", "torch", "zero-shot"],
-            "training_data": [],
+            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -307,7 +307,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -349,7 +349,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -391,7 +391,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -433,7 +433,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -476,7 +476,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -519,7 +519,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -561,7 +561,7 @@
                 "video",
                 "transformer"
             ],
-            "training_data": [],
+            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -604,7 +604,16 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [
+                            {
+                                            "name": "SA-Med2D-20M",
+                                            "url": "https://github.com/OpenGVLab/SAM-Med2D"
+                            },
+                            {
+                                            "name": "Medical Video Datasets",
+                                            "url": "https://github.com/MedicineToken/Medical-SAM2"
+                            }
+            ],
             "date_added": "2024-08-17 14:48:00"
         },
         {
@@ -642,7 +651,7 @@
                 }
             },
             "tags": ["segment-anything", "torch", "zero-shot", "transformer"],
-            "training_data": [],
+            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -686,7 +695,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -730,7 +739,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -774,7 +783,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -817,7 +826,7 @@
                 "video",
                 "transformer"
             ],
-            "training_data": [],
+            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -862,7 +871,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -907,7 +916,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -952,7 +961,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -1004,7 +1013,7 @@
                 "deeplabv3",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1056,7 +1065,7 @@
                 "densenet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1107,7 +1116,7 @@
                 "torch",
                 "densenet"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1159,7 +1168,7 @@
                 "densenet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1211,7 +1220,7 @@
                 "densenet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1258,7 +1267,7 @@
                 "resnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1310,7 +1319,7 @@
                 "resnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1362,7 +1371,7 @@
                 "resnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1414,7 +1423,7 @@
                 "googlenet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1465,7 +1474,7 @@
                 "inception",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1538,7 +1547,7 @@
                 "resnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1584,7 +1593,7 @@
                 "resnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1636,7 +1645,7 @@
                 "mnasnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1688,7 +1697,7 @@
                 "mnasnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1740,7 +1749,7 @@
                 "mobilenet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1792,7 +1801,7 @@
                 "resnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1844,7 +1853,7 @@
                 "resnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1896,7 +1905,7 @@
                 "resnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1948,7 +1957,7 @@
                 "resnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2000,7 +2009,7 @@
                 "resnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2052,7 +2061,7 @@
                 "resnext",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2103,7 +2112,7 @@
                 "torch",
                 "resnext"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2143,7 +2152,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "retinanet", "resnet"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2195,7 +2204,7 @@
                 "shufflenet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2247,7 +2256,7 @@
                 "shufflenet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2290,7 +2299,7 @@
                 }
             },
             "tags": ["classification", "imagenet", "torch", "squeezenet"],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2339,7 +2348,7 @@
                 "squeezenet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2391,7 +2400,7 @@
                 "vgg",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2441,7 +2450,7 @@
                 "vgg",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2493,7 +2502,7 @@
                 "vgg",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2543,7 +2552,7 @@
                 "vgg",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2595,7 +2604,7 @@
                 "vgg",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2645,7 +2654,7 @@
                 "vgg",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2697,7 +2706,7 @@
                 "vgg",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2747,7 +2756,7 @@
                 "vgg",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2799,7 +2808,7 @@
                 "wide-resnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2851,7 +2860,7 @@
                 "wide-resnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2896,7 +2905,7 @@
                 "zero-shot",
                 "transformer"
             ],
-            "training_data": [],
+            "training_data": [{"name": "LAION-2B", "url": "https://laion.ai/blog/laion-5b/"}],
             "date_added": "2023-12-13 14:25:51"
         },
         {
@@ -2962,7 +2971,7 @@
                 "transformers",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2024-01-17 14:25:51"
         },
         {
@@ -3131,7 +3140,7 @@
                 "zero-shot",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "WebLI", "url": "https://arxiv.org/abs/2209.06794"}],
             "date_added": "2024-01-17 14:25:51"
         },
         {
@@ -3216,7 +3225,16 @@
                 "zero-shot",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [
+                            {
+                                            "name": "YFCC-100M",
+                                            "url": "https://multimediacommons.wordpress.com/yfcc100m-core-dataset/"
+                            },
+                            {
+                                            "name": "Conceptual Captions 12M",
+                                            "url": "https://github.com/google-research-datasets/conceptual-12m"
+                            }
+            ],
             "date_added": "2025-05-15 15:20:35"
         },
         {
@@ -3252,7 +3270,7 @@
                 "zero-shot",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "WebLI", "url": "https://arxiv.org/abs/2209.06794"}],
             "date_added": "2024-01-17 14:25:51"
         },
         {
@@ -3288,7 +3306,7 @@
                 "zero-shot",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "WebLI", "url": "https://arxiv.org/abs/2209.06794"}],
             "date_added": "2025-07-15 13:49:00"
         },
         {
@@ -3324,7 +3342,7 @@
                 "zero-shot",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "WebLI", "url": "https://arxiv.org/abs/2209.06794"}],
             "date_added": "2025-07-28 15:25:00"
         },
         {
@@ -3360,7 +3378,20 @@
                 "zero-shot",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [
+                            {
+                                            "name": "Objects365v1",
+                                            "url": "https://www.objects365.org"
+                            },
+                            {
+                                            "name": "OpenImages V6",
+                                            "url": "https://storage.googleapis.com/openimages/web/index.html"
+                            },
+                            {
+                                            "name": "MS COCO 2017",
+                                            "url": "https://cocodataset.org"
+                            }
+            ],
             "date_added": "2024-01-17 14:25:51"
         },
         {
@@ -3413,7 +3444,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "WIT-400M", "url": "https://github.com/openai/CLIP"}],
             "date_added": "2022-04-12 17:49:51"
         },
         {
@@ -3452,7 +3483,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "LVD-142M", "url": "https://arxiv.org/abs/2304.07193"}],
             "date_added": "2023-07-31 10:17:51"
         },
         {
@@ -3491,7 +3522,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "LVD-142M", "url": "https://arxiv.org/abs/2304.07193"}],
             "date_added": "2023-07-31 10:17:51"
         },
         {
@@ -3530,7 +3561,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "LVD-142M", "url": "https://arxiv.org/abs/2304.07193"}],
             "date_added": "2023-07-31 10:17:51"
         },
         {
@@ -3569,7 +3600,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "LVD-142M", "url": "https://arxiv.org/abs/2304.07193"}],
             "date_added": "2023-07-31 10:17:51"
         },
         {
@@ -3608,7 +3639,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "LVD-142M", "url": "https://arxiv.org/abs/2304.07193"}],
             "date_added": "2023-12-02 16:42:00"
         },
         {
@@ -3647,7 +3678,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "LVD-142M", "url": "https://arxiv.org/abs/2304.07193"}],
             "date_added": "2023-12-02 16:42:00"
         },
         {
@@ -3686,7 +3717,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "LVD-142M", "url": "https://arxiv.org/abs/2304.07193"}],
             "date_added": "2023-12-02 16:42:00"
         },
         {
@@ -3725,7 +3756,7 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "LVD-142M", "url": "https://arxiv.org/abs/2304.07193"}],
             "date_added": "2023-12-02 16:42:00"
         },
         {
@@ -3766,7 +3797,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2025-05-22 14:14:45"
         },
         {
@@ -3807,7 +3838,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2025-05-22 14:14:45"
         },
         {
@@ -3848,7 +3879,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2025-05-22 14:14:45"
         },
         {
@@ -3889,7 +3920,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2025-05-22 14:14:45"
         },
         {
@@ -3930,7 +3961,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -3971,7 +4002,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -4012,7 +4043,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -4053,7 +4084,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -4094,7 +4125,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -4135,7 +4166,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-04-02 19:22:51"
         },
         {
@@ -4176,7 +4207,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-04-02 19:22:51"
         },
         {
@@ -4217,7 +4248,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-04-02 19:22:51"
         },
         {
@@ -4258,7 +4289,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-04-02 19:22:51"
         },
         {
@@ -4299,7 +4330,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-04-02 19:22:51"
         },
         {
@@ -4340,7 +4371,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -4381,7 +4412,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -4422,7 +4453,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-04-02 19:22:51"
         },
         {
@@ -4463,7 +4494,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-04-02 19:22:51"
         },
         {
@@ -4504,7 +4535,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-07-01 19:22:51"
         },
         {
@@ -4545,7 +4576,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-07-01 19:22:51"
         },
         {
@@ -4586,7 +4617,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-07-01 19:22:51"
         },
         {
@@ -4627,7 +4658,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-07-01 19:22:51"
         },
         {
@@ -4668,7 +4699,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-07-01 19:22:51"
         },
         {
@@ -4709,7 +4740,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -4750,7 +4781,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -4791,7 +4822,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -4832,7 +4863,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -4873,7 +4904,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -4914,7 +4945,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -4955,7 +4986,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -4996,7 +5027,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -5037,7 +5068,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -5078,7 +5109,7 @@
                 }
             },
             "tags": ["instances", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-10-05 19:22:51"
         },
         {
@@ -5119,7 +5150,24 @@
                 }
             },
             "tags": ["instances", "torch", "yolo", "zero-shot", "official"],
-            "training_data": [],
+            "training_data": [
+                            {
+                                            "name": "Objects365v1",
+                                            "url": "https://www.objects365.org"
+                            },
+                            {
+                                            "name": "GQA",
+                                            "url": "https://cs.stanford.edu/people/dorarad/gqa/"
+                            },
+                            {
+                                            "name": "Flickr30k",
+                                            "url": "https://shannon.cs.illinois.edu/DenotationGraph/"
+                            },
+                            {
+                                            "name": "CC3M-Lite",
+                                            "url": "Not publicly available"
+                            }
+            ],
             "date_added": "2025-04-10 12:24:41"
         },
         {
@@ -5160,7 +5208,24 @@
                 }
             },
             "tags": ["instances", "torch", "yolo", "zero-shot", "official"],
-            "training_data": [],
+            "training_data": [
+                            {
+                                            "name": "Objects365v1",
+                                            "url": "https://www.objects365.org"
+                            },
+                            {
+                                            "name": "GQA",
+                                            "url": "https://cs.stanford.edu/people/dorarad/gqa/"
+                            },
+                            {
+                                            "name": "Flickr30k",
+                                            "url": "https://shannon.cs.illinois.edu/DenotationGraph/"
+                            },
+                            {
+                                            "name": "CC3M-Lite",
+                                            "url": "Not publicly available"
+                            }
+            ],
             "date_added": "2025-04-10 12:24:41"
         },
         {
@@ -5201,7 +5266,24 @@
                 }
             },
             "tags": ["instances", "torch", "yolo", "zero-shot", "official"],
-            "training_data": [],
+            "training_data": [
+                            {
+                                            "name": "Objects365v1",
+                                            "url": "https://www.objects365.org"
+                            },
+                            {
+                                            "name": "GQA",
+                                            "url": "https://cs.stanford.edu/people/dorarad/gqa/"
+                            },
+                            {
+                                            "name": "Flickr30k",
+                                            "url": "https://shannon.cs.illinois.edu/DenotationGraph/"
+                            },
+                            {
+                                            "name": "CC3M-Lite",
+                                            "url": "Not publicly available"
+                            }
+            ],
             "date_added": "2025-04-10 12:24:41"
         },
         {
@@ -5242,7 +5324,24 @@
                 }
             },
             "tags": ["instances", "torch", "yolo", "zero-shot", "official"],
-            "training_data": [],
+            "training_data": [
+                            {
+                                            "name": "Objects365v1",
+                                            "url": "https://www.objects365.org"
+                            },
+                            {
+                                            "name": "GQA",
+                                            "url": "https://cs.stanford.edu/people/dorarad/gqa/"
+                            },
+                            {
+                                            "name": "Flickr30k",
+                                            "url": "https://shannon.cs.illinois.edu/DenotationGraph/"
+                            },
+                            {
+                                            "name": "CC3M-Lite",
+                                            "url": "Not publicly available"
+                            }
+            ],
             "date_added": "2025-04-10 12:24:41"
         },
         {
@@ -5283,7 +5382,24 @@
                 }
             },
             "tags": ["instances", "torch", "yolo", "zero-shot", "official"],
-            "training_data": [],
+            "training_data": [
+                            {
+                                            "name": "Objects365v1",
+                                            "url": "https://www.objects365.org"
+                            },
+                            {
+                                            "name": "GQA",
+                                            "url": "https://cs.stanford.edu/people/dorarad/gqa/"
+                            },
+                            {
+                                            "name": "Flickr30k",
+                                            "url": "https://shannon.cs.illinois.edu/DenotationGraph/"
+                            },
+                            {
+                                            "name": "CC3M-Lite",
+                                            "url": "Not publicly available"
+                            }
+            ],
             "date_added": "2025-04-10 12:24:41"
         },
         {
@@ -5324,7 +5440,24 @@
                 }
             },
             "tags": ["instances", "torch", "yolo", "zero-shot", "official"],
-            "training_data": [],
+            "training_data": [
+                            {
+                                            "name": "Objects365v1",
+                                            "url": "https://www.objects365.org"
+                            },
+                            {
+                                            "name": "GQA",
+                                            "url": "https://cs.stanford.edu/people/dorarad/gqa/"
+                            },
+                            {
+                                            "name": "Flickr30k",
+                                            "url": "https://shannon.cs.illinois.edu/DenotationGraph/"
+                            },
+                            {
+                                            "name": "CC3M-Lite",
+                                            "url": "Not publicly available"
+                            }
+            ],
             "date_added": "2025-04-10 12:24:41"
         },
         {
@@ -5372,7 +5505,7 @@
                 "rtdetr",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-07-01 19:22:51"
         },
         {
@@ -5420,7 +5553,7 @@
                 "rtdetr",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2024-07-01 19:22:51"
         },
         {
@@ -5461,7 +5594,20 @@
                 }
             },
             "tags": ["detection", "torch", "yolo", "zero-shot", "official"],
-            "training_data": [],
+            "training_data": [
+                            {
+                                            "name": "Objects365v1",
+                                            "url": "https://www.objects365.org"
+                            },
+                            {
+                                            "name": "GQA",
+                                            "url": "https://cs.stanford.edu/people/dorarad/gqa/"
+                            },
+                            {
+                                            "name": "Flickr30k",
+                                            "url": "https://shannon.cs.illinois.edu/DenotationGraph/"
+                            }
+            ],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -5502,7 +5648,20 @@
                 }
             },
             "tags": ["detection", "torch", "yolo", "zero-shot", "official"],
-            "training_data": [],
+            "training_data": [
+                            {
+                                            "name": "Objects365v1",
+                                            "url": "https://www.objects365.org"
+                            },
+                            {
+                                            "name": "GQA",
+                                            "url": "https://cs.stanford.edu/people/dorarad/gqa/"
+                            },
+                            {
+                                            "name": "Flickr30k",
+                                            "url": "https://shannon.cs.illinois.edu/DenotationGraph/"
+                            }
+            ],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -5543,7 +5702,20 @@
                 }
             },
             "tags": ["detection", "torch", "yolo", "zero-shot", "official"],
-            "training_data": [],
+            "training_data": [
+                            {
+                                            "name": "Objects365v1",
+                                            "url": "https://www.objects365.org"
+                            },
+                            {
+                                            "name": "GQA",
+                                            "url": "https://cs.stanford.edu/people/dorarad/gqa/"
+                            },
+                            {
+                                            "name": "Flickr30k",
+                                            "url": "https://shannon.cs.illinois.edu/DenotationGraph/"
+                            }
+            ],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -5584,7 +5756,20 @@
                 }
             },
             "tags": ["detection", "torch", "yolo", "zero-shot", "official"],
-            "training_data": [],
+            "training_data": [
+                            {
+                                            "name": "Objects365v1",
+                                            "url": "https://www.objects365.org"
+                            },
+                            {
+                                            "name": "GQA",
+                                            "url": "https://cs.stanford.edu/people/dorarad/gqa/"
+                            },
+                            {
+                                            "name": "Flickr30k",
+                                            "url": "https://shannon.cs.illinois.edu/DenotationGraph/"
+                            }
+            ],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -5632,7 +5817,7 @@
                 "obb",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "DOTA-v1.0", "url": "https://captain-whu.github.io/DOTA/"}],
             "date_added": "2024-04-05 19:22:51"
         },
         {
@@ -5680,7 +5865,7 @@
                 "obb",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "DOTA-v1.0", "url": "https://captain-whu.github.io/DOTA/"}],
             "date_added": "2024-04-05 19:22:51"
         },
         {
@@ -5728,7 +5913,7 @@
                 "obb",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "DOTA-v1.0", "url": "https://captain-whu.github.io/DOTA/"}],
             "date_added": "2024-04-05 19:22:51"
         },
         {
@@ -5776,7 +5961,7 @@
                 "obb",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "DOTA-v1.0", "url": "https://captain-whu.github.io/DOTA/"}],
             "date_added": "2024-04-05 19:22:51"
         },
         {
@@ -5824,7 +6009,7 @@
                 "obb",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "DOTA-v1.0", "url": "https://captain-whu.github.io/DOTA/"}],
             "date_added": "2024-04-05 19:22:51"
         },
         {
@@ -5865,7 +6050,7 @@
                 }
             },
             "tags": ["detection", "oiv7", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "Open Images V7", "url": "https://storage.googleapis.com/openimages/web/index.html"}],
             "date_added": "2024-05-20 19:22:51"
         },
         {
@@ -5906,7 +6091,7 @@
                 }
             },
             "tags": ["detection", "oiv7", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "Open Images V7", "url": "https://storage.googleapis.com/openimages/web/index.html"}],
             "date_added": "2024-05-20 19:22:51"
         },
         {
@@ -5947,7 +6132,7 @@
                 }
             },
             "tags": ["detection", "oiv7", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "Open Images V7", "url": "https://storage.googleapis.com/openimages/web/index.html"}],
             "date_added": "2024-05-20 19:22:51"
         },
         {
@@ -5988,7 +6173,7 @@
                 }
             },
             "tags": ["detection", "oiv7", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "Open Images V7", "url": "https://storage.googleapis.com/openimages/web/index.html"}],
             "date_added": "2024-05-20 19:22:51"
         },
         {
@@ -6029,7 +6214,7 @@
                 }
             },
             "tags": ["detection", "oiv7", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "Open Images V7", "url": "https://storage.googleapis.com/openimages/web/index.html"}],
             "date_added": "2024-05-20 19:22:51"
         },
         {
@@ -6059,7 +6244,16 @@
                 }
             },
             "tags": ["detection", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [
+                            {
+                                            "name": "MS COCO 2017",
+                                            "url": "https://cocodataset.org"
+                            },
+                            {
+                                            "name": "Objects365",
+                                            "url": "https://www.objects365.org"
+                            }
+            ],
             "date_added": "2024-01-06 08:51:14"
         },
         {
@@ -6100,7 +6294,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "yolo", "official"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2025-05-22 14:14:45"
         },
         {
@@ -6138,7 +6332,7 @@
                 "transformers",
                 "convnext"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6177,7 +6371,7 @@
                 "convnext",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6216,7 +6410,7 @@
                 "convnext",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6254,7 +6448,7 @@
                 "transformers",
                 "convnext"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6293,7 +6487,16 @@
                 "convnext",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [
+                            {
+                                            "name": "ImageNet-22K",
+                                            "url": "https://www.image-net.org"
+                            },
+                            {
+                                            "name": "ImageNet-1K",
+                                            "url": "https://www.image-net.org"
+                            }
+            ],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6332,7 +6535,7 @@
                 "efficientnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6371,7 +6574,7 @@
                 "efficientnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6410,7 +6613,7 @@
                 "efficientnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6449,7 +6652,7 @@
                 "efficientnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6488,7 +6691,7 @@
                 "efficientnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6527,7 +6730,7 @@
                 "efficientnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6566,7 +6769,7 @@
                 "efficientnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6605,7 +6808,7 @@
                 "efficientnet",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6643,7 +6846,7 @@
                 "swin-transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2025-07-02 12:00:00"
         },
         {
@@ -6681,7 +6884,7 @@
                 "swin-transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2025-07-02 12:00:00"
         },
         {
@@ -6719,7 +6922,7 @@
                 "swin-transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2025-07-02 12:00:00"
         },
         {
@@ -6757,7 +6960,7 @@
                 "swin-transformer",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
             "date_added": "2025-07-02 12:00:00"
         },
         {
@@ -6788,7 +6991,7 @@
                 }
             },
             "tags": ["detection", "coco", "torch", "transformers", "rtdetr"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2025-07-03 12:00:00"
         },
         {
@@ -6826,7 +7029,7 @@
                 "rtdetr",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2025-07-03 12:00:00"
         },
         {
@@ -6861,7 +7064,7 @@
                 "detr",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2025-07-15 23:00:00"
         },
         {
@@ -6896,7 +7099,7 @@
                 "detr",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2025-07-15 23:00:00"
         },
         {
@@ -6931,7 +7134,7 @@
                 "detr",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2025-07-15 23:00:00"
         },
         {
@@ -6966,7 +7169,7 @@
                 "detr",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2025-07-15 23:00:00"
         },
         {
@@ -7001,7 +7204,7 @@
                 "detr",
                 "official"
             ],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2025-07-15 23:00:00"
         },
         {
@@ -7033,7 +7236,7 @@
                 }
             },
             "tags": ["segmentation", "torch", "segformer", "official"],
-            "training_data": [],
+            "training_data": [{"name": "ADE20K", "url": "https://groups.csail.mit.edu/vision/datasets/ADE20K/"}],
             "date_added": "2025-08-04 12:34:17"
         },
         {
@@ -7065,7 +7268,7 @@
                 }
             },
             "tags": ["segmentation", "torch", "segformer", "official"],
-            "training_data": [],
+            "training_data": [{"name": "ADE20K", "url": "https://groups.csail.mit.edu/vision/datasets/ADE20K/"}],
             "date_added": "2025-08-04 12:34:20"
         },
         {
@@ -7097,7 +7300,7 @@
                 }
             },
             "tags": ["segmentation", "torch", "segformer", "official"],
-            "training_data": [],
+            "training_data": [{"name": "ADE20K", "url": "https://groups.csail.mit.edu/vision/datasets/ADE20K/"}],
             "date_added": "2025-08-04 12:34:22"
         },
         {
@@ -7129,7 +7332,7 @@
                 }
             },
             "tags": ["segmentation", "torch", "segformer", "official"],
-            "training_data": [],
+            "training_data": [{"name": "ADE20K", "url": "https://groups.csail.mit.edu/vision/datasets/ADE20K/"}],
             "date_added": "2025-08-04 12:34:24"
         },
         {
@@ -7161,7 +7364,7 @@
                 }
             },
             "tags": ["segmentation", "torch", "segformer", "official"],
-            "training_data": [],
+            "training_data": [{"name": "ADE20K", "url": "https://groups.csail.mit.edu/vision/datasets/ADE20K/"}],
             "date_added": "2025-08-04 12:34:25"
         },
         {
@@ -7193,7 +7396,7 @@
                 }
             },
             "tags": ["segmentation", "torch", "segformer", "official"],
-            "training_data": [],
+            "training_data": [{"name": "ADE20K", "url": "https://groups.csail.mit.edu/vision/datasets/ADE20K/"}],
             "date_added": "2025-08-04 12:34:27"
         }
     ]

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -7236,7 +7236,7 @@
                 }
             },
             "tags": ["segmentation", "torch", "segformer", "official"],
-            "training_data": [{"name": "ADE20K", "url": "https://groups.csail.mit.edu/vision/datasets/ADE20K/"}],
+            "training_data": [{"name": "ADE20K", "url": "https://github.com/CSAILVision/ADE20K"}],
             "date_added": "2025-08-04 12:34:17"
         },
         {
@@ -7268,7 +7268,7 @@
                 }
             },
             "tags": ["segmentation", "torch", "segformer", "official"],
-            "training_data": [{"name": "ADE20K", "url": "https://groups.csail.mit.edu/vision/datasets/ADE20K/"}],
+            "training_data": [{"name": "ADE20K", "url": "https://github.com/CSAILVision/ADE20K"}],
             "date_added": "2025-08-04 12:34:20"
         },
         {
@@ -7300,7 +7300,7 @@
                 }
             },
             "tags": ["segmentation", "torch", "segformer", "official"],
-            "training_data": [{"name": "ADE20K", "url": "https://groups.csail.mit.edu/vision/datasets/ADE20K/"}],
+            "training_data": [{"name": "ADE20K", "url": "https://github.com/CSAILVision/ADE20K"}],
             "date_added": "2025-08-04 12:34:22"
         },
         {
@@ -7332,7 +7332,7 @@
                 }
             },
             "tags": ["segmentation", "torch", "segformer", "official"],
-            "training_data": [{"name": "ADE20K", "url": "https://groups.csail.mit.edu/vision/datasets/ADE20K/"}],
+            "training_data": [{"name": "ADE20K", "url": "https://github.com/CSAILVision/ADE20K"}],
             "date_added": "2025-08-04 12:34:24"
         },
         {
@@ -7364,7 +7364,7 @@
                 }
             },
             "tags": ["segmentation", "torch", "segformer", "official"],
-            "training_data": [{"name": "ADE20K", "url": "https://groups.csail.mit.edu/vision/datasets/ADE20K/"}],
+            "training_data": [{"name": "ADE20K", "url": "https://github.com/CSAILVision/ADE20K"}],
             "date_added": "2025-08-04 12:34:25"
         },
         {
@@ -7396,7 +7396,7 @@
                 }
             },
             "tags": ["segmentation", "torch", "segformer", "official"],
-            "training_data": [{"name": "ADE20K", "url": "https://groups.csail.mit.edu/vision/datasets/ADE20K/"}],
+            "training_data": [{"name": "ADE20K", "url": "https://github.com/CSAILVision/ADE20K"}],
             "date_added": "2025-08-04 12:34:27"
         }
     ]

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -49,7 +49,7 @@
                 "alexnet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1065,7 +1065,7 @@
                 "densenet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1116,7 +1116,7 @@
                 "torch",
                 "densenet"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1168,7 +1168,7 @@
                 "densenet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1220,7 +1220,7 @@
                 "densenet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1423,7 +1423,7 @@
                 "googlenet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1474,7 +1474,7 @@
                 "inception",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1645,7 +1645,7 @@
                 "mnasnet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1697,7 +1697,7 @@
                 "mnasnet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1749,7 +1749,7 @@
                 "mobilenet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1801,7 +1801,7 @@
                 "resnet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1853,7 +1853,7 @@
                 "resnet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1905,7 +1905,7 @@
                 "resnet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1957,7 +1957,7 @@
                 "resnet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2009,7 +2009,7 @@
                 "resnet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2061,7 +2061,7 @@
                 "resnext",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2112,7 +2112,7 @@
                 "torch",
                 "resnext"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2204,7 +2204,7 @@
                 "shufflenet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2256,7 +2256,7 @@
                 "shufflenet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2299,7 +2299,7 @@
                 }
             },
             "tags": ["classification", "imagenet", "torch", "squeezenet"],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2348,7 +2348,7 @@
                 "squeezenet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2400,7 +2400,7 @@
                 "vgg",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2450,7 +2450,7 @@
                 "vgg",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2502,7 +2502,7 @@
                 "vgg",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2552,7 +2552,7 @@
                 "vgg",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2604,7 +2604,7 @@
                 "vgg",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2654,7 +2654,7 @@
                 "vgg",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2706,7 +2706,7 @@
                 "vgg",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2756,7 +2756,7 @@
                 "vgg",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2808,7 +2808,7 @@
                 "wide-resnet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2860,7 +2860,7 @@
                 "wide-resnet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -2971,7 +2971,7 @@
                 "transformers",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2024-01-17 14:25:51"
         },
         {
@@ -6332,7 +6332,7 @@
                 "transformers",
                 "convnext"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6371,7 +6371,7 @@
                 "convnext",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6410,7 +6410,7 @@
                 "convnext",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6448,7 +6448,7 @@
                 "transformers",
                 "convnext"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6490,11 +6490,11 @@
             "training_data": [
                             {
                                             "name": "ImageNet-22K",
-                                            "url": "https://www.image-net.org"
+                                            "url": "https://www.image-net.org/download.php"
                             },
                             {
                                             "name": "ImageNet-1K",
-                                            "url": "https://www.image-net.org"
+                                            "url": "https://www.image-net.org/download.php"
                             }
             ],
             "date_added": "2025-06-30 12:00:00"
@@ -6535,7 +6535,7 @@
                 "efficientnet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6574,7 +6574,7 @@
                 "efficientnet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6613,7 +6613,7 @@
                 "efficientnet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6652,7 +6652,7 @@
                 "efficientnet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6691,7 +6691,7 @@
                 "efficientnet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6730,7 +6730,7 @@
                 "efficientnet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6769,7 +6769,7 @@
                 "efficientnet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6808,7 +6808,7 @@
                 "efficientnet",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2025-06-30 12:00:00"
         },
         {
@@ -6846,7 +6846,7 @@
                 "swin-transformer",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2025-07-02 12:00:00"
         },
         {
@@ -6884,7 +6884,7 @@
                 "swin-transformer",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2025-07-02 12:00:00"
         },
         {
@@ -6922,7 +6922,7 @@
                 "swin-transformer",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2025-07-02 12:00:00"
         },
         {
@@ -6960,7 +6960,7 @@
                 "swin-transformer",
                 "official"
             ],
-            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org"}],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2025-07-02 12:00:00"
         },
         {

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -5223,7 +5223,7 @@
                             },
                             {
                                             "name": "CC3M-Lite",
-                                            "url": "Not publicly available"
+                                            "url": null
                             }
             ],
             "date_added": "2025-04-10 12:24:41"
@@ -5281,7 +5281,7 @@
                             },
                             {
                                             "name": "CC3M-Lite",
-                                            "url": "Not publicly available"
+                                            "url": null
                             }
             ],
             "date_added": "2025-04-10 12:24:41"
@@ -5339,7 +5339,7 @@
                             },
                             {
                                             "name": "CC3M-Lite",
-                                            "url": "Not publicly available"
+                                            "url": null
                             }
             ],
             "date_added": "2025-04-10 12:24:41"
@@ -5397,7 +5397,7 @@
                             },
                             {
                                             "name": "CC3M-Lite",
-                                            "url": "Not publicly available"
+                                            "url": null
                             }
             ],
             "date_added": "2025-04-10 12:24:41"
@@ -5455,7 +5455,7 @@
                             },
                             {
                                             "name": "CC3M-Lite",
-                                            "url": "Not publicly available"
+                                            "url": null
                             }
             ],
             "date_added": "2025-04-10 12:24:41"

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -5165,7 +5165,7 @@
                             },
                             {
                                             "name": "CC3M-Lite",
-                                            "url": "Not publicly available"
+                                            "url": null
                             }
             ],
             "date_added": "2025-04-10 12:24:41"


### PR DESCRIPTION
This commit populates the `training_data` field established in the previous pull request with verified dataset information for PyTorch model zoo entries. Each entry contains structured dataset references including canonical names and authoritative URLs. 

## What changes are proposed in this pull request?

The `training_data` field in `manifest-torch.json` has been populated with dataset metadata for 163 models. Each populated field contains an array of dataset objects with `name` and `url` properties. Original JSON formatting has been preserved with modifications limited to `training_data` fields. Models utilizing multiple training datasets have all relevant datasets documented.

## How is this patch tested? If it is not, please explain why.

- JSON schema validation ensures the manifest remains valid
- Manual diff review confirms only `training_data` fields were modified
- FiftyOne builds successfully with the populated manifest
- Model zoo retrieval tested successfully (loaded models from the zoo to verify functionality)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

PyTorch model zoo entries now include training dataset metadata, providing users with information about the datasets used to train each model.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other