### PR TITLE
Update average default to binary for binary classification eval

### DIFF
--- a/fiftyone/utils/eval/base.py
+++ b/fiftyone/utils/eval/base.py
@@ -739,14 +739,10 @@ class BaseClassificationResults(BaseEvaluationResults):
             self.ytrue, self.ypred, labels=labels, weights=self.weights
         )
 
-        precision, recall, fscore, _ = skm.precision_recall_fscore_support(
-            self.ytrue,
-            self.ypred,
+        precision, recall, fscore = self._precision_recall_fscore(
             average=average,
             labels=labels,
             beta=beta,
-            sample_weight=self.weights,
-            zero_division=0,
         )
 
         support = _compute_support(
@@ -891,6 +887,18 @@ class BaseClassificationResults(BaseEvaluationResults):
             return np.asarray(classes)
 
         return np.array([c for c in self.classes if c != self.missing])
+
+    def _precision_recall_fscore(self, labels, average, beta=1.0):
+        precision, recall, fscore, _ = skm.precision_recall_fscore_support(
+            self.ytrue,
+            self.ypred,
+            average=average,
+            labels=labels,
+            beta=beta,
+            sample_weight=self.weights,
+            zero_division=0,
+        )
+        return precision, recall, fscore
 
     def _confusion_matrix(
         self,

--- a/fiftyone/utils/eval/classification.py
+++ b/fiftyone/utils/eval/classification.py
@@ -5,6 +5,7 @@ Classification evaluation.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from copy import deepcopy
 import inspect
 import itertools
@@ -900,6 +901,26 @@ class BinaryClassificationResults(ClassificationResults):
             backend=backend,
             **kwargs,
         )
+
+    def metrics(self, classes=None, average="binary", beta=1.0):
+        return super().metrics(classes, average, beta)
+
+    def _precision_recall_fscore(self, labels, average, beta=1.0):
+        if average == "binary":
+            pos_label = self._pos_label
+        else:
+            pos_label = 1  # set to sklearn default to suppress warning
+        precision, recall, fscore, _ = skm.precision_recall_fscore_support(
+            self.ytrue,
+            self.ypred,
+            average=average,
+            labels=labels,
+            beta=beta,
+            sample_weight=self.weights,
+            zero_division=0,
+            pos_label=pos_label,
+        )
+        return precision, recall, fscore
 
     def _parse_classes(self, classes):
         if classes is not None:


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

1. Test https://docs.voxel51.com/user_guide/evaluation.html#binary-evaluation

```
dataset = fo.load_dataset("cifar10-binary")
classes = ["other", "cat"]

results = dataset.evaluate_classifications(
    "predictions",
    gt_field="ground_truth",
    eval_key="eval_binary", # eval_binary_dev on develop for the same dataset
    method="binary",
    classes=classes,
)

results.print_report()
```
<img width="1660" height="420" alt="Screenshot from 2025-08-21 13-52-59" src="https://github.com/user-attachments/assets/ed2c1d03-ed9b-47ba-8635-6c2badae5bcc" />

2. Compare that other evaluations remain unchanged on `develop` vs this branch
- done for simple classification and detection type evaluations

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
