### PR TITLE
fix: two typos in remote.rst

### DIFF
--- a/docs/source/dataset_zoo/remote.rst
+++ b/docs/source/dataset_zoo/remote.rst
@@ -87,7 +87,7 @@ Here's the basic recipe for working with remotely-sourced zoo datasets:
     You can delete the local copy of a remotely-sourced zoo dataset (or
     individual split(s) of it) via
     :meth:`delete_zoo_dataset() <fiftyone.zoo.datasets.delete_zoo_dataset>`
-    by providing either the datasets's name or the remote source from which
+    by providing either the datasets name or the remote source from which
     you downloaded it:
 
     .. code-block:: python
@@ -141,7 +141,7 @@ Here's the basic recipe for working with remotely-sourced zoo datasets:
     You can delete the local copy of a remotely-sourced zoo dataset (or
     individual split(s) of it) via
     :ref:`fiftyone zoo datasets delete <cli-fiftyone-zoo-datasets-delete>`
-    by providing either the datasets's name or the remote source from which
+    by providing either the datasets name or the remote source from which
     you downloaded it:
 
     .. code-block:: shell

--- a/docs/source/dataset_zoo/remote.rst
+++ b/docs/source/dataset_zoo/remote.rst
@@ -275,7 +275,7 @@ Here are two example dataset YAML files:
 
         name: voxel51/caltech101
         type: dataset
-        author: Fei-Fei1 Li, Marco Andreeto, Marc'Aurelio Ranzato, Pietro Perona
+        author: Fei-Fei Li, Marco Andreeto, Marc'Aurelio Ranzato, Pietro Perona
         version: 1.0.0
         url: https://github.com/voxel51/caltech101
         source: https://data.caltech.edu/records/mzrjq-6wc02

--- a/docs/source/dataset_zoo/remote.rst
+++ b/docs/source/dataset_zoo/remote.rst
@@ -87,7 +87,7 @@ Here's the basic recipe for working with remotely-sourced zoo datasets:
     You can delete the local copy of a remotely-sourced zoo dataset (or
     individual split(s) of it) via
     :meth:`delete_zoo_dataset() <fiftyone.zoo.datasets.delete_zoo_dataset>`
-    by providing either the datasets name or the remote source from which
+    by providing either the dataset's name or the remote source from which
     you downloaded it:
 
     .. code-block:: python
@@ -141,7 +141,7 @@ Here's the basic recipe for working with remotely-sourced zoo datasets:
     You can delete the local copy of a remotely-sourced zoo dataset (or
     individual split(s) of it) via
     :ref:`fiftyone zoo datasets delete <cli-fiftyone-zoo-datasets-delete>`
-    by providing either the datasets name or the remote source from which
+    by providing either the dataset's name or the remote source from which
     you downloaded it:
 
     .. code-block:: shell

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -5315,7 +5315,7 @@ Core
 - Updated the implementation of
   :meth:`Detection.to_polyline() <fiftyone.core.labels.Detection.to_polyline>`
   so that all attributes are included rather than just ETA-supported ones
-- Added support for including empty labels labels via an `include_missing`
+- Added support for including empty labels via an `include_missing`
   keyword argument in
   :func:`add_yolo_labels() <fiftyone.utils.yolo.add_yolo_labels>`
 - Added a


### PR DESCRIPTION
two instances of incorrect possessive of datasets's -> datasets in remote.rst

ongoing WIP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed grammar in release notes and the Remotely-Sourced Zoo Datasets docs to improve clarity (e.g., consistently refer to providing either the dataset name or the remote source).
  * Clarified wording for adding YOLO labels to mention including empty labels via `include_missing`.
  * Purely editorial updates; no behavioral or functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->