### PR TITLE
FOEPD-1964 Torch num worker recommender respects configured max

### DIFF
--- a/fiftyone/core/map/process.py
+++ b/fiftyone/core/map/process.py
@@ -53,16 +53,7 @@ class ProcessMapper(fomm.LocalMapper):
         batch_size: Optional[int] = None,
         **__,
     ):
-        if multiprocessing.current_process().daemon:
-            num_workers = 1
-        elif num_workers is None:
-            num_workers = (
-                config.default_process_pool_workers
-                or fou.recommend_process_pool_workers()
-            )
-
-        if config.max_process_pool_workers is not None:
-            num_workers = min(num_workers, config.max_process_pool_workers)
+        num_workers = max(1, fou.recommend_process_pool_workers(num_workers))
 
         return super(ProcessMapper, cls).create(
             config=config,

--- a/fiftyone/core/map/process.py
+++ b/fiftyone/core/map/process.py
@@ -53,7 +53,7 @@ class ProcessMapper(fomm.LocalMapper):
         batch_size: Optional[int] = None,
         **__,
     ):
-        num_workers = max(1, fou.recommend_process_pool_workers(num_workers))
+        num_workers = fou.recommend_process_pool_workers(num_workers)
 
         return super(ProcessMapper, cls).create(
             config=config,

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -835,8 +835,7 @@ def _make_data_loader(
     # functionality
     use_numpy = not isinstance(model, TorchModelMixin)
 
-    if num_workers is None:
-        num_workers = fout.recommend_num_workers()
+    num_workers = fout.recommend_num_workers(num_workers)
 
     if model.has_collate_fn:
         user_collate_fn = model.collate_fn

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -1934,8 +1934,7 @@ def _make_patch_data_loader(
     # functionality
     use_numpy = not isinstance(model, TorchModelMixin)
 
-    if num_workers is None:
-        num_workers = fout.recommend_num_workers()
+    num_workers = fout.recommend_num_workers()
 
     dataset = fout.TorchImagePatchesDataset(
         samples=samples,

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -2916,12 +2916,13 @@ def recommend_process_pool_workers(num_workers=None, default_num_workers=None):
                     else multiprocessing.cpu_count()
                 )
             )
-    except Exception as e:
+    except Exception:
         logger.debug(
             "recommend_process_pool_workers: falling back to 4", exc_info=True
         )
         num_workers = 4
 
+    num_workers = int(num_workers)
     if fo.config.max_process_pool_workers is not None:
         num_workers = min(num_workers, fo.config.max_process_pool_workers)
     num_workers = max(num_workers, 0)

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -2909,14 +2909,22 @@ def recommend_process_pool_workers(num_workers=None, default_num_workers=None):
             # 3. System CPU count
             num_workers = (
                 fo.config.default_process_pool_workers
-                or default_num_workers
-                or multiprocessing.cpu_count()
+                if fo.config.default_process_pool_workers is not None
+                else (
+                    default_num_workers
+                    if default_num_workers is not None
+                    else multiprocessing.cpu_count()
+                )
             )
-    except:
+    except Exception as e:
+        logger.debug(
+            "recommend_process_pool_workers: falling back to 4", exc_info=True
+        )
         num_workers = 4
 
     if fo.config.max_process_pool_workers is not None:
         num_workers = min(num_workers, fo.config.max_process_pool_workers)
+    num_workers = max(num_workers, 0)
 
     return num_workers
 

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -2876,7 +2876,10 @@ def recommend_thread_pool_workers(num_workers=None):
 def recommend_process_pool_workers(num_workers=None, default_num_workers=None):
     """Recommends a number of workers for a process pool.
 
-    If this process is a daemon, the number of workers is 0.
+    If the number is 0, that means no multiprocessing is recommended.
+
+    If this process is a daemon, the number of workers is 0 since child
+    processes are disallowed in this context.
 
     If ``num_workers`` is None, the following order is used to determine the
     number of workers:
@@ -2893,9 +2896,10 @@ def recommend_process_pool_workers(num_workers=None, default_num_workers=None):
             ``num_workers`` is None and no configured default is set
 
     Returns:
-        a number of workers
+        a number of workers. 0 means no multiprocessing
     """
     try:
+        # "daemonic processes are not allowed to have children"
         if multiprocessing.current_process().daemon:
             num_workers = 0
         elif num_workers is None:

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -1680,7 +1680,7 @@ def recommend_num_workers(num_workers=None):
 
     try:
         default = multiprocessing.cpu_count() // 2
-    except:
+    except Exception:
         default = 4
 
     return fou.recommend_process_pool_workers(

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -1664,7 +1664,7 @@ class SemanticSegmenterOutputProcessor(OutputProcessor):
         return [fol.Segmentation(mask=mask) for mask in masks]
 
 
-def recommend_num_workers():
+def recommend_num_workers(num_workers=None):
     """Recommend a number of workers for running a
     :class:`torch:torch.utils.data.DataLoader`.
 
@@ -1678,9 +1678,13 @@ def recommend_num_workers():
         return 0
 
     try:
-        return multiprocessing.cpu_count() // 2
+        default = multiprocessing.cpu_count() // 2
     except:
-        return 4
+        default = None
+
+    return fou.recommend_process_pool_workers(
+        num_workers, default_num_workers=default
+    )
 
 
 def _to_bytes_array(strs):

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -1672,7 +1672,8 @@ def recommend_num_workers(num_workers=None):
         the recommended number of workers
     """
     if sys.platform.startswith("win"):
-        # Windows tends to have multiprocessing issues, so default to 0 workers
+        # Windows tends to have multiprocessing issues, especially with Torch,
+        # so default to 0 workers
         # https://github.com/voxel51/fiftyone/issues/1531
         # https://stackoverflow.com/q/20222534
         return 0
@@ -1680,7 +1681,7 @@ def recommend_num_workers(num_workers=None):
     try:
         default = multiprocessing.cpu_count() // 2
     except:
-        default = None
+        default = 4
 
     return fou.recommend_process_pool_workers(
         num_workers, default_num_workers=default

--- a/tests/unittests/map/test_process.py
+++ b/tests/unittests/map/test_process.py
@@ -42,33 +42,6 @@ class TestCreate:
             yield m
 
     @pytest.mark.parametrize(
-        "num_workers",
-        (
-            pytest.param(None, id="worker-is-unset"),
-            pytest.param(5, id="worker-is-set"),
-        ),
-    )
-    def test_force_one_worker(
-        self,
-        config,
-        num_workers,
-        current_process,
-        recommend_process_pool_workers,
-    ):
-        """test worker value"""
-        current_process.daemon = True
-
-        #####
-        mapper = fomp.ProcessMapper.create(
-            config=config, batch_cls=mock.Mock(), num_workers=num_workers
-        )
-        #####
-
-        assert not recommend_process_pool_workers.called
-
-        assert mapper.num_workers == 1
-
-    @pytest.mark.parametrize(
         "max_workers",
         [
             pytest.param(value, id=f"max-workers={value}")

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -12,6 +12,7 @@ import time
 import unittest
 from unittest.mock import MagicMock, patch
 
+import pytest
 from bson import ObjectId
 from bson import json_util
 import numpy as np
@@ -951,6 +952,65 @@ class ProgressBarTests(unittest.TestCase):
         self._test_correct_value(
             progress=False, global_progress=False, quiet=False, expected=True
         )
+
+
+class RecommendProcessPoolWorkersTests(unittest.TestCase):
+    @patch.object(fou.multiprocessing, "current_process")
+    def test_daemon(self, current_process_mock):
+        current_process_mock.daemon = True
+        self.assertEqual(fou.recommend_process_pool_workers(8, 4), 0)
+
+    def test_explicit(self):
+        # Uses explicitly passed workers
+        self.assertEqual(fou.recommend_process_pool_workers(8, 4), 8)
+
+        # Negative number coerced to 0
+        self.assertEqual(fou.recommend_process_pool_workers(-1), 0)
+
+        # Number is capped by config
+        with patch.object(fo.config, "max_process_pool_workers", 2):
+            self.assertEqual(fou.recommend_process_pool_workers(8, 4), 2)
+
+    def test_default_from_config(self):
+        # Uses default from config
+        with patch.object(fo.config, "default_process_pool_workers", 4):
+            self.assertEqual(
+                fou.recommend_process_pool_workers(default_num_workers=8), 4
+            )
+
+            # Number is capped by config
+            with patch.object(fo.config, "max_process_pool_workers", 2):
+                self.assertEqual(fou.recommend_process_pool_workers(), 2)
+
+    def test_default_passed_in(self):
+        # Uses default passed in
+        self.assertEqual(
+            fou.recommend_process_pool_workers(default_num_workers=8), 8
+        )
+
+        # Number is capped by config
+        with patch.object(fo.config, "max_process_pool_workers", 2):
+            self.assertEqual(
+                fou.recommend_process_pool_workers(default_num_workers=8), 2
+            )
+
+    @patch.object(fou.multiprocessing, "cpu_count")
+    def test_cpucount(self, cpu_count_mock):
+        cpu_count_mock.return_value = 10
+        self.assertEqual(fou.recommend_process_pool_workers(), 10)
+
+        # Number is capped by config
+        with patch.object(fo.config, "max_process_pool_workers", 2):
+            self.assertEqual(fou.recommend_process_pool_workers(), 2)
+
+    @patch.object(fou.multiprocessing, "cpu_count")
+    def test_cpucount_exception(self, cpu_count_mock):
+        cpu_count_mock.side_effect = ValueError
+        self.assertEqual(fou.recommend_process_pool_workers(), 4)
+
+        # Number is capped by config
+        with patch.object(fo.config, "max_process_pool_workers", 2):
+            self.assertEqual(fou.recommend_process_pool_workers(), 2)
 
 
 if __name__ == "__main__":

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -8,11 +8,9 @@ FiftyOne utilities unit tests.
 
 from datetime import datetime
 import sys
-import time
 import unittest
 from unittest.mock import MagicMock, patch
 
-import pytest
 from bson import ObjectId
 from bson import json_util
 import numpy as np
@@ -961,15 +959,16 @@ class RecommendProcessPoolWorkersTests(unittest.TestCase):
         self.assertEqual(fou.recommend_process_pool_workers(8, 4), 0)
 
     def test_explicit(self):
-        # Uses explicitly passed workers
-        self.assertEqual(fou.recommend_process_pool_workers(8, 4), 8)
+        with patch.object(fo.config, "default_process_pool_workers", None):
+            # Uses explicitly passed workers
+            self.assertEqual(fou.recommend_process_pool_workers(8, 4), 8)
 
-        # Negative number coerced to 0
-        self.assertEqual(fou.recommend_process_pool_workers(-1), 0)
+            # Negative number coerced to 0
+            self.assertEqual(fou.recommend_process_pool_workers(-1), 0)
 
-        # Number is capped by config
-        with patch.object(fo.config, "max_process_pool_workers", 2):
-            self.assertEqual(fou.recommend_process_pool_workers(8, 4), 2)
+            # Number is capped by config
+            with patch.object(fo.config, "max_process_pool_workers", 2):
+                self.assertEqual(fou.recommend_process_pool_workers(8, 4), 2)
 
     def test_default_from_config(self):
         # Uses default from config
@@ -982,35 +981,48 @@ class RecommendProcessPoolWorkersTests(unittest.TestCase):
             with patch.object(fo.config, "max_process_pool_workers", 2):
                 self.assertEqual(fou.recommend_process_pool_workers(), 2)
 
-    def test_default_passed_in(self):
-        # Uses default passed in
-        self.assertEqual(
-            fou.recommend_process_pool_workers(default_num_workers=8), 8
-        )
-
-        # Number is capped by config
-        with patch.object(fo.config, "max_process_pool_workers", 2):
+        # Test default from config is 0
+        with patch.object(fo.config, "default_process_pool_workers", 0):
             self.assertEqual(
-                fou.recommend_process_pool_workers(default_num_workers=8), 2
+                fou.recommend_process_pool_workers(default_num_workers=4), 0
             )
+
+    def test_default_passed_in(self):
+        with patch.object(fo.config, "default_process_pool_workers", None):
+            # Uses default passed in
+            self.assertEqual(
+                fou.recommend_process_pool_workers(default_num_workers=8), 8
+            )
+            self.assertEqual(
+                fou.recommend_process_pool_workers(default_num_workers=-1), 0
+            )
+
+            # Number is capped by config
+            with patch.object(fo.config, "max_process_pool_workers", 2):
+                self.assertEqual(
+                    fou.recommend_process_pool_workers(default_num_workers=8),
+                    2,
+                )
 
     @patch.object(fou.multiprocessing, "cpu_count")
     def test_cpucount(self, cpu_count_mock):
-        cpu_count_mock.return_value = 10
-        self.assertEqual(fou.recommend_process_pool_workers(), 10)
+        with patch.object(fo.config, "default_process_pool_workers", None):
+            cpu_count_mock.return_value = 10
+            self.assertEqual(fou.recommend_process_pool_workers(), 10)
 
-        # Number is capped by config
-        with patch.object(fo.config, "max_process_pool_workers", 2):
-            self.assertEqual(fou.recommend_process_pool_workers(), 2)
+            # Number is capped by config
+            with patch.object(fo.config, "max_process_pool_workers", 2):
+                self.assertEqual(fou.recommend_process_pool_workers(), 2)
 
     @patch.object(fou.multiprocessing, "cpu_count")
     def test_cpucount_exception(self, cpu_count_mock):
-        cpu_count_mock.side_effect = ValueError
-        self.assertEqual(fou.recommend_process_pool_workers(), 4)
+        with patch.object(fo.config, "default_process_pool_workers", None):
+            cpu_count_mock.side_effect = ValueError
+            self.assertEqual(fou.recommend_process_pool_workers(), 4)
 
-        # Number is capped by config
-        with patch.object(fo.config, "max_process_pool_workers", 2):
-            self.assertEqual(fou.recommend_process_pool_workers(), 2)
+            # Number is capped by config
+            with patch.object(fo.config, "max_process_pool_workers", 2):
+                self.assertEqual(fou.recommend_process_pool_workers(), 2)
 
 
 if __name__ == "__main__":

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -957,7 +957,7 @@ class ProgressBarTests(unittest.TestCase):
 class RecommendProcessPoolWorkersTests(unittest.TestCase):
     @patch.object(fou.multiprocessing, "current_process")
     def test_daemon(self, current_process_mock):
-        current_process_mock.daemon = True
+        current_process_mock.return_value.daemon = True
         self.assertEqual(fou.recommend_process_pool_workers(8, 4), 0)
 
     def test_explicit(self):


### PR DESCRIPTION

## What changes are proposed in this pull request?

Consolidate a couple different impls of recommending num workers / process pool workers.

In doing so, makes sure tests and checks are always run. As well as respecting the configured max in `fo.config.max_process_pool_workers`.

## How is this patch tested? If it is not, please explain why.

TBD

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worker recommendation utilities now accept optional hints to influence default worker counts across loaders and process pools.

* **Bug Fixes**
  * Unified worker-count resolution with robust fallbacks, clamping to configured maxima and enforcing non-negative values; daemon processes return 0 (no multiprocessing).

* **Documentation**
  * Clarified daemon behavior, 0 semantics, and resolution order for default worker counts.

* **Tests**
  * Added comprehensive tests for worker recommendation logic; removed obsolete single-worker enforcement test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->