### PR TITLE
fix: add version numbers for SqueezeNet models

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -2262,7 +2262,7 @@
         {
             "base_name": "squeezenet-1.1-imagenet-torch",
             "base_filename": "squeezenet1_1-f364aa15.pth",
-            "version": null,
+            "version": "1.1",
             "description": "Tiny image classifier that fits in just five megabytes for embedded devices",
             "source": "https://pytorch.org/vision/main/models.html",
             "author": "Forrest Iandola",
@@ -2305,7 +2305,7 @@
         {
             "base_name": "squeezenet-imagenet-torch",
             "base_filename": "squeezenet1_0-a815701f.pth",
-            "version": null,
+            "version": "1.0",
             "description": "Ultra-compact image classifier perfect for severely resource-constrained hardware and applications",
             "source": "https://pytorch.org/vision/main/models.html",
             "author": "Forrest Iandola",


### PR DESCRIPTION
- Set version "1.0" for squeezenet-imagenet-torch
- Set version "1.1" for squeezenet-1.1-imagenet-torch

## What changes are proposed in this pull request?

Updates the `version` field for SqueezeNet models in the model zoo configuration. SqueezeNet is one of the few models with explicit semantic versioning (1.0 and 1.1)

## How is this patch tested? If it is not, please explain why.

Validated JSON syntax and verified that the version fields are correctly set for both SqueezeNet model entries. These are metadata-only changes that don't affect model functionality.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other