### PR TITLE
Limit grid rows virtualization to 200

### DIFF
--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -28,7 +28,7 @@ import useUpdates from "./useUpdates";
 import useZoomSetting from "./useZoomSetting";
 
 const MAX_INSTANCES = 200;
-const MAX_ROWS = 5151;
+const MAX_ROWS = 200;
 
 function Grid() {
   const id = useMemoOne(() => uuid(), []);


### PR DESCRIPTION
## What changes are proposed in this pull request?

Limits grid rows virtualization to 200

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* Improved grid memory consumption

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * The Grid’s Spotlight view now caps displayed rows at 200 (previously over 5,000), reducing excessively long lists.
  * Users may notice faster loading and smoother scrolling in views with many results.
  * If you need to see more than 200 items, refine with filters, sorting, or pagination.
  * No other visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->