### PR TITLE
FOEPD-1976: Save predicted sample labels in background thread

### DIFF
--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -1219,6 +1219,18 @@ def _compute_image_embeddings_data_loader(
         pb = context.enter_context(fou.ProgressBar(samples, progress=progress))
         if embeddings_field is not None:
             ctx = context.enter_context(foc.SaveContext(samples))
+        submit = context.enter_context(
+            fou.async_executor(
+                max_workers=1,
+                skip_failures=skip_failures,
+                warning="Async failure saving embeddings",
+            )
+        )
+
+        def save_batch(sample_batch, embeddings_batch):
+            for sample, embedding in zip(sample_batch, embeddings_batch):
+                sample[embeddings_field] = embedding
+                ctx.save(sample)
 
         for sample_batch, imgs in zip(
             fou.iter_batches(samples, batch_size),
@@ -1244,9 +1256,7 @@ def _compute_image_embeddings_data_loader(
                 )
 
             if embeddings_field is not None:
-                for sample, embedding in zip(sample_batch, embeddings_batch):
-                    sample[embeddings_field] = embedding
-                    ctx.save(sample)
+                submit(save_batch, sample_batch, embeddings_batch)
             else:
                 embeddings.extend(embeddings_batch)
 

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -85,6 +85,7 @@ def handle_batch_error(skip_failures, sample_batch):
             sample_batch[0].id,
             sample_batch[-1].id,
             e,
+            exc_info=True,
         )
 
 

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -480,21 +480,21 @@ def _apply_image_model_data_loader(
     else:
         samples = samples.select_fields()
 
-    def save_batch(sample_batch, labels_batch):
-        for sample, labels in zip(sample_batch, labels_batch):
-            if filename_maker is not None:
-                _export_arrays(labels, sample.filepath, filename_maker)
-
-            sample.add_labels(
-                labels,
-                label_field=label_field,
-                confidence_thresh=confidence_thresh,
-            )
-            ctx.save(sample)
-
     with contextlib.ExitStack() as context:
         pb = context.enter_context(fou.ProgressBar(samples, progress=progress))
         ctx = context.enter_context(foc.SaveContext(samples))
+
+        def save_batch(sample_batch, labels_batch):
+            for sample, labels in zip(sample_batch, labels_batch):
+                if filename_maker is not None:
+                    _export_arrays(labels, sample.filepath, filename_maker)
+
+                sample.add_labels(
+                    labels,
+                    label_field=label_field,
+                    confidence_thresh=confidence_thresh,
+                )
+                ctx.save(sample)
 
         with futures(
             max_workers=1,

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -62,7 +62,7 @@ def futures(*, max_workers, skip_failures=False, warning="Async failure"):
             except Exception as e:
                 if not skip_failures:
                     raise e
-                logger.warning(warning, e)
+                logger.warning(warning, exc_info=True)
 
 
 def apply_model(

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -73,7 +73,7 @@ def futures(*, max_workers, skip_failures=False, warning="Async failure"):
 
 
 @contextlib.contextmanager
-def handle_batch_error(skip_failures, sample_batch):
+def _handle_batch_error(skip_failures, sample_batch):
     try:
         yield
     except Exception as e:
@@ -502,7 +502,7 @@ def _apply_image_model_data_loader(
         ctx = context.enter_context(foc.SaveContext(samples))
 
         def save_batch(sample_batch, labels_batch):
-            with handle_batch_error(skip_failures, sample_batch):
+            with _handle_batch_error(skip_failures, sample_batch):
                 for sample, labels in zip(sample_batch, labels_batch):
                     if filename_maker is not None:
                         _export_arrays(labels, sample.filepath, filename_maker)
@@ -523,7 +523,7 @@ def _apply_image_model_data_loader(
                 fou.iter_batches(samples, batch_size),
                 data_loader,
             ):
-                with handle_batch_error(skip_failures, sample_batch):
+                with _handle_batch_error(skip_failures, sample_batch):
                     if isinstance(imgs, Exception):
                         raise imgs
 

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -6,7 +6,6 @@ FiftyOne models.
 |
 """
 
-from concurrent.futures import ThreadPoolExecutor
 import contextlib
 import inspect
 import logging

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -55,7 +55,14 @@ _ALLOWED_PATCH_TYPES = (
 def futures(*, max_workers, skip_failures=False, warning="Async failure"):
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         _futures = []
-        yield lambda *args: _futures.append(executor.submit(*args))
+
+        def submit(*args, **kwargs):
+            future = executor.submit(*args, **kwargs)
+            _futures.append(future)
+            return future
+
+        yield submit
+
         for future in _futures:
             try:
                 future.result()

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -1231,10 +1231,11 @@ def _compute_image_embeddings_data_loader(
         )
 
         def save_batch(sample_batch, embeddings_batch):
-            for sample, embedding in zip(sample_batch, embeddings_batch):
-                sample[embeddings_field] = embedding
-                if ctx:
-                    ctx.save(sample)
+            with _handle_batch_error(skip_failures, sample_batch):
+                for sample, embedding in zip(sample_batch, embeddings_batch):
+                    sample[embeddings_field] = embedding
+                    if ctx:
+                        ctx.save(sample)
 
         for sample_batch, imgs in zip(
             fou.iter_batches(samples, batch_size),

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -1219,6 +1219,9 @@ def _compute_image_embeddings_data_loader(
         pb = context.enter_context(fou.ProgressBar(samples, progress=progress))
         if embeddings_field is not None:
             ctx = context.enter_context(foc.SaveContext(samples))
+        else:
+            ctx = None
+
         submit = context.enter_context(
             fou.async_executor(
                 max_workers=1,
@@ -1230,7 +1233,8 @@ def _compute_image_embeddings_data_loader(
         def save_batch(sample_batch, embeddings_batch):
             for sample, embedding in zip(sample_batch, embeddings_batch):
                 sample[embeddings_field] = embedding
-                ctx.save(sample)
+                if ctx:
+                    ctx.save(sample)
 
         for sample_batch, imgs in zip(
             fou.iter_batches(samples, batch_size),

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -52,7 +52,9 @@ _ALLOWED_PATCH_TYPES = (
 
 
 @contextlib.contextmanager
-def futures(*, max_workers, skip_failures=False, warning="Async failure"):
+def _async_executor(
+    *, max_workers, skip_failures=False, warning="Async failure"
+):
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         _futures = []
 
@@ -514,7 +516,7 @@ def _apply_image_model_data_loader(
                     )
                     ctx.save(sample)
 
-        with futures(
+        with _async_executor(
             max_workers=1,
             skip_failures=skip_failures,
             warning="Async failure labeling batches",

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -3149,6 +3149,25 @@ fos = lazy_import("fiftyone.core.storage")
 def async_executor(
     *, max_workers, skip_failures=False, warning="Async failure"
 ):
+    """
+    Context manager that provides a function for submitting tasks to a thread
+    pool executor. All tasks are joined when the context is exited.
+
+    Example:
+
+        with async_executor(max_workers=4) as submit:
+            for item in items:
+                submit(process_item, item)
+
+    Args:
+        max_workers: the maximum number of workers to use
+        skip_failures (False): whether to skip exceptions raised by tasks
+        warning ("Async failure"): the warning message to log if a task
+            raises an exception and ``skip_failures == True``
+
+    Raises:
+        Exception: if a task raises an exception and ``skip_failures == False``
+    """
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         _futures = []
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR updates `_apply_image_model_data_loader` to execute DB writes on a background thread so calls to `predict_all` aren't blocked. It only moves the top-level I/O-bound bottleneck off the main thread, it does not address any CPU-bound bottlenecks within `predict_all`.

## How is this patch tested? If it is not, please explain why.

Ran following script on voxelcompute instance and profiled with both built-in cProfile module and [line-profiler](https://pypi.org/project/line-profiler/).
```python
import sys

import fiftyone as fo
import fiftyone.zoo as foz


if __name__ == "__main__":
    suffix = sys.argv[1] if len(sys.argv) > 1 else "baseline"
    dataset = foz.load_zoo_dataset("coco-2017", split="validation")
    if not dataset.persistent:
        dataset.persistent = True
    classes = dataset.distinct("ground_truth.detections.label")
    model = foz.load_zoo_model("omdet-turbo-swin-tiny-torch", classes=classes)
    dataset.apply_model(
	    model,
        num_workers=32,
        batch_size=16,
        confidence_thresh=0.1,
        label_field=f"profile_{suffix}"
	)
```
Code on develop ran in 5m47s, with 327s spent in `apply_model` and 198s in `predict_all` (60%); 77s was spent saving collections.
<img width="882" height="358" alt="Screenshot 2025-08-20 at 12 30 28 PM" src="https://github.com/user-attachments/assets/19519850-a2a4-4070-aa37-0504e2687a4c" />
I do see some screwy behavior in the Snakeviz diagram, specifically that `apply_model` takes 327s, which besides the 275s in `predict_all` and saving collections also includes calling `check_perm_wrapper` for 327s (wat). Snakeviz says that calls the same `apply_model` model function. From looking at the code I'm not sure there's really any recursion happening and it's possibly a data collision in the cProfile data, but I don't know for sure, so I also profiled `_apply_image_model_data_loader` with line_profiler, which indicated that the 40% of non-`predict_all` time is spent in `sample.add_labels(...)` and `ctx.save(sample)`.

Code in this PR ran in 4m15s, with 236s spent in `apply_model` and 227s in `predict_all` (96%). Line-profile shows similar results.

Note that these changes make an overall improvement but `predict_all` is now slower:
![visualization (2)](https://github.com/user-attachments/assets/8514a126-d89b-4f4c-b327-90c424eab5fb)
I tracked that difference down to a line in a library that only turns a tensor into a tuple, so the change is likely due to thrashing the GIL between threads. Preliminary investigation shows that it would be faster to use a background process instead of a thread, but some of the objects being saved cannot be pickled, so it's not possible to hand them off to another process.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch labeling and embedding saves now run asynchronously to improve throughput and reduce blocking during disk writes.
  * Added a configurable background executor to schedule and run batch save tasks.

* **Bug Fixes / Reliability**
  * Centralized, configurable batch-level error handling: optionally skip failed batches while continuing processing.
  * Clear warnings for skipped batches include contextual sample identifiers to aid diagnosis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->