### PR TITLE
explicit patch data loader num workers passed into recommendation func

### DIFF
--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -1934,7 +1934,7 @@ def _make_patch_data_loader(
     # functionality
     use_numpy = not isinstance(model, TorchModelMixin)
 
-    num_workers = fout.recommend_num_workers()
+    num_workers = fout.recommend_num_workers(num_workers)
 
     dataset = fout.TorchImagePatchesDataset(
         samples=samples,

--- a/fiftyone/utils/beam.py
+++ b/fiftyone/utils/beam.py
@@ -306,7 +306,9 @@ def beam_export(
             :meth:`fiftyone.core.collections.SampleCollection.export`
     """
     if options is None:
-        num_workers = min(num_shards, fou.recommend_process_pool_workers())
+        num_workers = max(
+            1, min(num_shards, fou.recommend_process_pool_workers())
+        )
         options = PipelineOptions(
             runner="direct",
             direct_num_workers=num_workers,
@@ -493,8 +495,7 @@ def beam_map(
         ids = sample_collection.values("id")
         n = len(ids)
 
-    if num_workers is None:
-        num_workers = fou.recommend_process_pool_workers()
+    num_workers = max(1, fou.recommend_process_pool_workers(num_workers))
 
     # Must cap size of select(ids) stages
     if batch_method == "id":

--- a/fiftyone/utils/kitti.py
+++ b/fiftyone/utils/kitti.py
@@ -1086,7 +1086,7 @@ def _convert_velodyne_to_pcd(
     etau.ensure_dir(pcd_dir)
 
     logger.info("Converting Velodyne scans to PCD format...")
-    num_workers = fou.recommend_process_pool_workers(num_workers)
+    num_workers = max(1, fou.recommend_process_pool_workers(num_workers))
     with fou.ProgressBar(total=len(inputs)) as pb:
         with fou.get_multiprocessing_context().Pool(
             processes=num_workers


### PR DESCRIPTION
doh
https://github.com/voxel51/fiftyone-teams/pull/1834#discussion_r2294711373

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Data loading and export/conversion routines now respect user-specified worker counts and always allocate at least one worker, preventing zero-worker cases.

* **Performance**
  * Standardized worker recommendation logic across utilities to incorporate user input and clamp to a minimum, improving throughput stability and resource usage predictability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->