### PR TITLE
[NO MERGE] Ray postprocessing and writes. kinda goes zoom.

### DIFF
--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -37,8 +37,8 @@ fout = fou.lazy_import("fiftyone.utils.torch")
 foutr = fou.lazy_import("fiftyone.utils.transformers")
 fouu = fou.lazy_import("fiftyone.utils.ultralytics")
 
-from fiftyone.core.ray.base import ActorPoolContext
-from fiftyone.core.ray.writers import LabelWriter
+foray = fou.lazy_import("fiftyone.core.ray.base")
+foray_writers = fou.lazy_import("fiftyone.core.ray.writers")
 
 logger = logging.getLogger(__name__)
 
@@ -462,7 +462,16 @@ def _apply_image_model_data_loader(
     with contextlib.ExitStack() as context:
         pb = context.enter_context(fou.ProgressBar(samples, progress=progress))
         output_processor = model._output_processor
-        ctx = context.enter_context(ActorPoolContext(samples, LabelWriter))
+        ctx = context.enter_context(
+            foray.ActorPoolContext(
+                samples,
+                foray_writers.LabelWriter,
+                num_workers=16,
+                label_field=label_field,
+                confidence_thresh=confidence_thresh,
+                post_processor=output_processor,
+            )
+        )
         context.enter_context(fou.SetAttributes(model, _output_processor=None))
 
         for sample_batch, imgs in zip(

--- a/fiftyone/core/ray/__init__.py
+++ b/fiftyone/core/ray/__init__.py
@@ -1,0 +1,3 @@
+import ray
+
+ray.init()

--- a/fiftyone/core/ray/__init__.py
+++ b/fiftyone/core/ray/__init__.py
@@ -1,3 +1,4 @@
 import ray
 
-ray.init()
+if not ray.is_initialized():
+    ray.init()

--- a/fiftyone/core/ray/base.py
+++ b/fiftyone/core/ray/base.py
@@ -1,0 +1,71 @@
+import ray
+
+import fiftyone.core.view as fov
+
+
+def serialize_samples(samples):
+    dataset_name = samples._root_dataset.name
+    stages = (
+        samples._serialize() if isinstance(samples, fov.DatasetView) else None
+    )
+    return dataset_name, stages
+
+
+def deserialize_samples(serialized_samples):
+    import fiftyone as fo
+
+    dataset_name, stages = serialized_samples
+
+    dataset = fo.load_dataset(dataset_name)
+    if stages is not None:
+        return fov.DatasetView._build(dataset, stages)
+    return dataset
+
+
+@ray.remote()
+class FiftyOneActor:
+    """Class for FiftyOne Ray actors.
+
+    Args:
+        serialized_samples: a serialized representation of a
+            :class:`fiftyone.core.collections.SampleCollection`
+    """
+
+    def __init__(self, serialized_samples, **kwargs):
+        super().__init__(**kwargs)
+        self.samples = deserialize_samples(serialized_samples)
+
+
+class ActorPoolContext:
+    """Context manager for a pool of Ray actors.
+
+    Args:
+        samples: a :class:`fiftyone.core.collections.SampleCollection`
+        actor_type: the :class:`FiftyOneActor` subclass to instantiate
+            for each worker
+        num_workers (int): the number of workers in the pool
+    """
+
+    def __init__(self, samples, actor_type, num_workers=4):
+        super().__init__()
+        self.serialized_samples_ref = ray.put(serialize_samples(samples))
+        self.num_workers = num_workers
+        self.actor_type = actor_type
+
+    def __enter__(self):
+        self.actors = [
+            self.actor_type.remote(self.serialized_samples_ref)
+            for _ in range(self.num_workers)
+        ]
+        self.pool = ray.util.ActorPool(self.actors)
+        return self
+
+    def __exit__(self, *args):
+        # Clean up refs
+        for actor in self.actors:
+            del actor
+
+        del self.serialized_samples_ref
+
+    def submit(self, ids, payloads):
+        self.pool.submit(lambda a, v: a.run.remote(*v), (ids, payloads))

--- a/fiftyone/core/ray/writers.py
+++ b/fiftyone/core/ray/writers.py
@@ -1,0 +1,35 @@
+import ray
+
+import fiftyone.core.ray.base as foray
+import fiftyone.core.collections as foc
+from fiftyone.core.ray.base import FiftyOneActor
+
+
+class LabelWriter(FiftyOneActor):
+    def __init__(
+        self,
+        serialized_samples,
+        label_field,
+        confidence_thresh=None,
+        post_processor=None,
+        **kwargs
+    ):
+        super().__init__(serialized_samples, **kwargs)
+        self.label_field = label_field
+        self.confidence_thresh = confidence_thresh
+        self.post_processor = post_processor
+        self.ctx = foc.SaveContext(self.samples)
+
+    def run(self, ids, payloads):
+        samples_batch = self.samples.select(ids)
+
+        if self.post_processor is not None:
+            payloads = self.post_processor(payloads)
+
+        for sample, payload in zip(samples_batch, payloads):
+            sample.add_labels(
+                payload,
+                label_field=self.label_field,
+                confidence_thresh=self.confidence_thresh,
+            )
+            self.ctx.save(sample)

--- a/fiftyone/core/ray/writers.py
+++ b/fiftyone/core/ray/writers.py
@@ -1,10 +1,12 @@
 import ray
+import torch
 
 import fiftyone.core.ray.base as foray
 import fiftyone.core.collections as foc
 from fiftyone.core.ray.base import FiftyOneActor
 
 
+@ray.remote
 class LabelWriter(FiftyOneActor):
     def __init__(
         self,
@@ -24,12 +26,15 @@ class LabelWriter(FiftyOneActor):
         samples_batch = self.samples.select(ids)
 
         if self.post_processor is not None:
-            payloads = self.post_processor(payloads)
-
-        for sample, payload in zip(samples_batch, payloads):
-            sample.add_labels(
-                payload,
-                label_field=self.label_field,
-                confidence_thresh=self.confidence_thresh,
+            payloads = self.post_processor(
+                *payloads, confidence_thresh=self.confidence_thresh
             )
-            self.ctx.save(sample)
+
+        with self.ctx:
+            for sample, payload in zip(samples_batch, payloads):
+                sample.add_labels(
+                    payload,
+                    label_field=self.label_field,
+                    confidence_thresh=self.confidence_thresh,
+                )
+                self.ctx.save(sample)

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -924,7 +924,7 @@ class TorchImageModel(
             if isinstance(output, torch.Tensor):
                 output = output.detach().cpu()
 
-            return output
+            return output, (width, height)
 
         if self.has_logits:
             self._output_processor.store_logits = self.store_logits
@@ -1922,11 +1922,12 @@ class FiftyOneTorchDataset(Dataset):
 
         res = []
         for i, d in enumerate(batch):
-            d["_id"] = _ids[i]
             if isinstance(d, Exception):
                 res.append(d)
             else:
-                res.append(self._get_item(d))
+                _processed = self._get_item(d)
+                _processed.update({"_id": _ids[i]})
+                res.append(_processed)
 
         return res
 


### PR DESCRIPTION
fully offload post processing and writes.

Loading and offloading tensors from GPU is still on main process. Not 100% how (and if we should) get them off. At this point it may be better to just scale horizontally with DOs.

```python
from time import time_ns

import fiftyone as fo
import fiftyone.zoo as foz

dataset = fo.load_dataset("coco-val")
classes = dataset.distinct("ground_truth.detections.label")
model = foz.load_zoo_model("omdet-turbo-swin-tiny-torch", classes=classes)

start = time_ns()
dataset.apply_model(
    model,
    label_field="predictions_ray",
    batch_size=16,
    num_workers=32,
    confidence_thresh=0.1,
    skip_failures=False,
)
end = time_ns()

print(f"Apply Model Time: {(end - start) / 1e9} seconds") # Apply Model Time: 147.059405114 seconds
```

<img width="1224" height="760" alt="Screenshot 2025-08-25 at 7 10 53 PM" src="https://github.com/user-attachments/assets/3e0c0f3e-1414-4c7d-b689-8d035505441c" />

all remaining time in `predict_all` that isn't forward pass is moving about tensors from cpu to gpu or back.
<img width="1627" height="817" alt="Screenshot 2025-08-25 at 7 20 01 PM" src="https://github.com/user-attachments/assets/1ba1a313-30bd-4c00-b145-f523fa7e1daf" />


I guess if anything this is where multithreading would shine. Not 100% sure how to integrate it here though...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Parallelized image model inference and label writing for faster processing on large datasets
  - Automatic initialization of the distributed runtime when using parallel processing
- Refactor
  - Improved propagation of sample IDs through data pipelines to correctly associate predictions
  - Enhanced handling of model outputs without an output processor, including CPU-safe tensors and image size returns
  - More flexible batching in transformer pipelines, allowing non-tensor fields to pass through without padding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->