### PR TITLE
update compute scene metadata for url definition

### DIFF
--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -251,7 +251,11 @@ class SceneMetadata(Metadata):
         """
         if scene_path.startswith("http"):
             return cls._build_for_url(
-                scene_path, mime_type=mime_type, cache=_cache
+                scene_path,
+                mime_type=mime_type,
+                cache=_cache,
+                skip_failures=skip_failures,
+                warn_failures=warn_failures,
             )
 
         return cls._build_for_local(
@@ -293,7 +297,14 @@ class SceneMetadata(Metadata):
         )
 
     @classmethod
-    def _build_for_url(cls, scene_path, mime_type=None, cache=None):
+    def _build_for_url(
+        cls,
+        scene_path,
+        mime_type=None,
+        cache=None,
+        skip_failures=True,
+        warn_failures=True,
+    ):
         # Unclear how asset paths should be handled; the rest of the library is
         # not equipped to handle URL asset paths
         raise ValueError("Scene URLs are not currently supported")


### PR DESCRIPTION
## What changes are proposed in this pull request?

Parody with build_for_local

## How is this patch tested? If it is not, please explain why.

n/a

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized handling of failure options (skip/warn) when initiating scene metadata builds from URLs, aligning behavior with local paths.
  * No functional changes for users; URL-based metadata builds remain unsupported.

* **Chores**
  * Internal adjustments to enable future improvements in URL metadata processing and error handling consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->