### PR TITLE
FOEPD-1939 Prevent hard error for 3D detections on 2D Lookers

### DIFF
--- a/app/packages/looker/src/overlays/detection.ts
+++ b/app/packages/looker/src/overlays/detection.ts
@@ -133,7 +133,8 @@ export default class DetectionOverlay<
 
     !state.config.thumbnail && this.drawLabelText(ctx, state);
 
-    if (this.label.dimensions && this.label.location) {
+    if (this.label.convexHull) {
+      // only fill 3d when 'convexHull' is defined
       this.fillRectFor3d(ctx, state, strokeColor);
     } else {
       this.strokeRect(ctx, state, strokeColor);


### PR DESCRIPTION
## What changes are proposed in this pull request?

When 3D detection data is added to a 2D sample (e.g. image), the convex hull is not defined we should not draw the 

## How is this patch tested? If it is not, please explain why.

```python
import fiftyone as fo

ds = fo.load_dataset("quickstart")
sample = ds.first()
sample["test_3d"] = fo.Detection(
      label="test",
      location=[-4.4986433 , 15.25332251,  0.3963935 ],
      rotation=[-0.0048193484383920425, 0.0029248552715340024, -1.5421369136360792],
      dimensions=[10.201, 2.877,  3.595],
)
sample.save()
``` 

## Release Notes

* Fixed the sample modal when 3D |Detections| are defined on a 2D sample

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved 3D detection overlay rendering to prevent unintended fills when 3D shape data is incomplete.
  * Ensures 3D regions are filled only when sufficient geometry is available; otherwise, displays an outline for clarity.
  * Reduces visual inconsistencies in detection overlays, improving readability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->