### PR TITLE
Allow loading of new training_data key for zoo model class

### DIFF
--- a/fiftyone/zoo/models/__init__.py
+++ b/fiftyone/zoo/models/__init__.py
@@ -510,6 +510,32 @@ class ZooModel(etam.Model):
         "See https://docs.voxel51.com/user_guide/config.html for details."
     )
 
+    def attributes(self):
+        """Returns the list of class attributes that will be serialized."""
+        attrs = super().attributes()
+        attrs.append("training_data")
+        return attrs
+
+    @classmethod
+    def from_dict(cls, d, subdir=None):
+        """Constructs a ZooModel from a JSON dictionary.
+
+        Args:
+            d: a JSON dictionary
+            subdir (optional): a subdirectory for the model
+
+        Returns:
+            a ZooModel instance
+        """
+        model = super().from_dict(d, subdir=subdir)
+
+        if "training_data" in d:
+            model.training_data = d["training_data"]
+        else:
+            model.training_data = None
+
+        return model
+
 
 class RemoteZooModel(ZooModel):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add new `training_data` key from ML to the `ZooModel` class so that subsequent SDK methods can recognize and import this new key

## How is this patch tested? If it is not, please explain why.

Locally w/ VAL

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Model configurations now include training data metadata, enabling richer context when saving and sharing models.
  - Importing model configurations will automatically restore associated training data details when available, improving reproducibility and portability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->