### PR TITLE
FOEPD-1990 Fix dynamic group carousel

### DIFF
--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/carousel/DynamicGroupsFlashlightWrapper.tsx
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/carousel/DynamicGroupsFlashlightWrapper.tsx
@@ -37,7 +37,7 @@ const pageParams = selector({
           };
           return {
             ...params,
-            dynamicGroup: get(fos.groupByFieldValue),
+            dynamicGroup: await snapshot.getPromise(fos.groupByFieldValue),
             filter: {},
             after: page ? String(page * pageSize - 1) : null,
             count: pageSize,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix incorrect usage of `get` inside a Recoil selector callback

## How is this patch tested? If it is not, please explain why.

https://github.com/user-attachments/assets/cdd3c94c-428a-4b04-9e54-a5b4b27682c7

## Release Notes

* Fixed the carousel mode for dynamic groups

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of grouped content in modals/carousels, ensuring groups match the current view.
  * Resolved occasional issues where groups could appear incorrect or missing on first load.
  * Reduced instances of stale or out-of-date group data when switching views.

* **Performance/Stability**
  * Smoother, more consistent loading of grouped items within the carousel.
  * Enhanced stability when navigating between views with grouped content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->