### PR TITLE
separate error boundary markup component and side effect component

### DIFF
--- a/app/packages/components/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/app/packages/components/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,11 +1,12 @@
+import { useTrackEvent } from "@fiftyone/analytics";
 import { useClearModal } from "@fiftyone/state";
 import {
   GraphQLError,
   NetworkError,
   NotFoundError,
   OperatorError,
-  ServerError,
   PanelEventError,
+  ServerError,
 } from "@fiftyone/utilities";
 import { Clear } from "@mui/icons-material";
 import classnames from "classnames";
@@ -20,7 +21,6 @@ import { scrollable } from "../../scrollable.module.css";
 import CodeBlock from "../CodeBlock";
 import Loading from "../Loading";
 import style from "./ErrorBoundary.module.css";
-import { useTrackEvent } from "@fiftyone/analytics";
 
 type AppError =
   | GraphQLError
@@ -34,7 +34,105 @@ interface Props<T extends AppError> extends FallbackProps {
   error: T;
 }
 
-const Errors = (onReset?: () => void, disableReset?: boolean) => {
+interface ErrorDisplayProps<T extends AppError> {
+  error: T;
+  onReset?: () => void;
+  disableReset?: boolean;
+  resetErrorBoundary: () => void;
+}
+
+/**
+ * Note: we shouldn't add any side effects to this component.
+ * For that, use `ErrorsDisplayWithSideEffects`.
+ */
+export const ErrorDisplayMarkup = <T extends AppError>({
+  error,
+  onReset,
+  disableReset,
+  resetErrorBoundary,
+}: ErrorDisplayProps<T>) => {
+  if (error instanceof NotFoundError) {
+    return <Loading>{error.message}</Loading>;
+  }
+
+  let messages: { message: string; content: string }[] = [];
+
+  if (error instanceof GraphQLError) {
+    messages = error.errors.map((e: any) => ({
+      message: e.message,
+      content: "\n\n" + e.extensions.stack.join("\n"),
+    }));
+  } else if (error instanceof NetworkError) {
+    messages = [];
+    if (error.code)
+      messages.push({ message: "Code", content: String(error.code) });
+    if (error.route) messages.push({ message: "Route", content: error.route });
+    if (error.payload)
+      messages.push({
+        message: "Payload",
+        content: JSON.stringify(error.payload, null, 2),
+      });
+  } else if (error instanceof OperatorError) {
+    if (error.operator) {
+      messages.push({ message: "Operator", content: error.operator });
+    }
+    if (error instanceof PanelEventError) {
+      messages.push({ message: "Event", content: error.event });
+    }
+    messages.push({ message: error.message, content: error.stack });
+  }
+  if (error.stack && !(error instanceof OperatorError)) {
+    messages = [...messages, { message: "Trace", content: error.stack }];
+  }
+
+  function handleReset() {
+    if (onReset) {
+      onReset();
+    }
+    resetErrorBoundary();
+  }
+
+  return (
+    <div
+      className={classnames(style.wrapper, scrollable)}
+      data-cy={"error-boundary"}
+    >
+      <div className={classnames(style.container, scrollable)}>
+        <div className={style.heading}>
+          <div>
+            {error.name}
+            {error.message ? ": " + error.message : null}
+          </div>
+          {!disableReset && (
+            <div>
+              <span title={"Reset"} onClick={handleReset}>
+                <Clear />
+              </span>
+            </div>
+          )}
+        </div>
+        {messages.map(({ message, content }, i) => (
+          <div key={i} className={style.content}>
+            <div className={style.contentHeading}>
+              {message ? message : null}
+            </div>
+            {content && (
+              <CodeBlock
+                text={content.trim().replace(/\n+/g, "\n")}
+                language="javascript"
+              />
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const ErrorsDisplayWithSideEffects = (
+  onReset?: () => void,
+  disableReset?: boolean
+) => {
   const FallbackComponent = <T extends AppError>({
     error,
     resetErrorBoundary,
@@ -44,101 +142,39 @@ const Errors = (onReset?: () => void, disableReset?: boolean) => {
       clearModal();
     }, []);
 
-    if (error instanceof NotFoundError) {
-      return <Loading>{error.message}</Loading>;
-    }
-
-    let messages: { message: string; content: string }[] = [];
-
-    if (error instanceof GraphQLError) {
-      messages = error.errors.map((e) => ({
-        message: e.message,
-        content: "\n\n" + e.extensions.stack.join("\n"),
-      }));
-    } else if (error instanceof NetworkError) {
-      messages = [];
-      if (error.code)
-        messages.push({ message: "Code", content: String(error.code) });
-      if (error.route)
-        messages.push({ message: "Route", content: error.route });
-      if (error.payload)
-        messages.push({
-          message: "Payload",
-          content: JSON.stringify(error.payload, null, 2),
-        });
-    } else if (error instanceof OperatorError) {
-      if (error.operator) {
-        messages.push({ message: "Operator", content: error.operator });
-      }
-      if (error instanceof PanelEventError) {
-        messages.push({ message: "Event", content: error.event });
-      }
-      messages.push({ message: error.message, content: error.stack });
-    }
-    if (error.stack && !(error instanceof OperatorError)) {
-      messages = [...messages, { message: "Trace", content: error.stack }];
-    }
-
-    function handleReset() {
-      if (onReset) {
-        onReset();
-      }
-      resetErrorBoundary();
-    }
-
     return (
-      <div
-        className={classnames(style.wrapper, scrollable)}
-        data-cy={"error-boundary"}
-      >
-        <div className={classnames(style.container, scrollable)}>
-          <div className={style.heading}>
-            <div>
-              {error.name}
-              {error.message ? ": " + error.message : null}
-            </div>
-            {!disableReset && (
-              <div>
-                <span title={"Reset"} onClick={handleReset}>
-                  <Clear />
-                </span>
-              </div>
-            )}
-          </div>
-          {messages.map(({ message, content }, i) => (
-            <div key={i} className={style.content}>
-              <div className={style.contentHeading}>
-                {message ? message : null}
-              </div>
-              {content && (
-                <CodeBlock
-                  text={content.trim().replace(/\n+/g, "\n")}
-                  language="javascript"
-                />
-              )}
-            </div>
-          ))}
-        </div>
-      </div>
+      <ErrorDisplayMarkup
+        error={error}
+        onReset={onReset}
+        disableReset={disableReset}
+        resetErrorBoundary={resetErrorBoundary}
+      />
     );
   };
   return FallbackComponent;
 };
 
-const TrackFallback = (Fallback, onReset, disableReset) => (props) => {
-  Fallback = Fallback || Errors(onReset, disableReset);
-  const trackEvent = useTrackEvent();
+const TrackFallback =
+  (
+    Fallback: ComponentType<any> | undefined,
+    onReset?: () => void,
+    disableReset?: boolean
+  ) =>
+  (props: any) => {
+    const ActualFallback =
+      Fallback || ErrorsDisplayWithSideEffects(onReset, disableReset);
+    const trackEvent = useTrackEvent();
 
-  useEffect(() => {
-    trackEvent("uncaught_app_error", {
-      error: props?.error?.message || props?.error?.name || props?.error,
-      stack: props?.error?.stack,
-      messages: props?.error?.errors?.map((e) => e.message),
-    });
-  }, []);
+    useEffect(() => {
+      trackEvent("uncaught_app_error", {
+        error: props?.error?.message || props?.error?.name || props?.error,
+        stack: props?.error?.stack,
+        messages: props?.error?.errors?.map((e: any) => e.message),
+      });
+    }, []);
 
-  return <Fallback {...props} />;
-};
+    return <ActualFallback {...props} />;
+  };
 
 const ErrorBoundary: React.FC<
   PropsWithChildren<{

--- a/app/packages/components/src/components/ErrorBoundary/index.ts
+++ b/app/packages/components/src/components/ErrorBoundary/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./ErrorBoundary";
+export { default, ErrorDisplayMarkup } from "./ErrorBoundary";

--- a/app/packages/components/src/components/index.ts
+++ b/app/packages/components/src/components/index.ts
@@ -8,7 +8,7 @@ export { default as CodeTabs } from "./CodeTabs";
 export { default as ColoredDot } from "./ColoredDot";
 export { default as CopyButton } from "./CopyButton";
 export { default as Dialog } from "./Dialog";
-export { default as ErrorBoundary } from "./ErrorBoundary";
+export { default as ErrorBoundary, ErrorDisplayMarkup } from "./ErrorBoundary";
 export { default as ExternalLink, useExternalLink } from "./ExternalLink";
 export { default as FilterAndSelectionIndicator } from "./FilterAndSelectionIndicator";
 export { default as Header } from "./Header";


### PR DESCRIPTION
## What changes are proposed in this pull request?

Sometimes we need error boundaries without any side effects (like clearing modal, which might not be relevant, or even throw an error itself).