### PR TITLE
[Proposal] trigger client side panel event from python

### DIFF
--- a/app/packages/operators/src/Panel/hooks/index.ts
+++ b/app/packages/operators/src/Panel/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as usePanelClientEvent } from "./usePanelClientEvent";

--- a/app/packages/operators/src/Panel/hooks/usePanelClientEvent.tsx
+++ b/app/packages/operators/src/Panel/hooks/usePanelClientEvent.tsx
@@ -1,0 +1,55 @@
+import { usePanelId } from "@fiftyone/spaces";
+
+const events: PanelsEvents = {};
+
+export default function usePanelEvents(panelId?: string) {
+  const id = usePanelId();
+  const computedPanelId = panelId ?? id;
+
+  function register(
+    event: string,
+    callback: PanelEventHandler,
+    panelId?: string
+  ) {
+    const registerPanelId = panelId ?? computedPanelId;
+    assertPanelId(registerPanelId);
+    if (!events[registerPanelId]) {
+      events[registerPanelId] = {};
+    }
+    events[registerPanelId][event] = callback;
+  }
+
+  function trigger(event: string, params: unknown, panelId?: string) {
+    const triggerPanelId = panelId ?? computedPanelId;
+    assertPanelId(triggerPanelId);
+    const callback = events[triggerPanelId]?.[event];
+    if (callback) {
+      callback(params);
+    }
+  }
+
+  function unregister(event: string, panelId?: string) {
+    const unregisterPanelId = panelId ?? computedPanelId;
+    assertPanelId(unregisterPanelId);
+    if (events[unregisterPanelId]) {
+      delete events[unregisterPanelId][event];
+    }
+  }
+
+  return { register, trigger, unregister };
+}
+
+function assertPanelId(panelId?: string) {
+  if (!panelId) {
+    throw new Error("Panel ID is required");
+  }
+  return panelId;
+}
+
+type PanelEventHandler = (params: unknown) => void;
+type PanelEvents = {
+  [key: string]: PanelEventHandler;
+};
+type PanelsEvents = {
+  [key: string]: PanelEvents;
+};

--- a/app/packages/operators/src/index.ts
+++ b/app/packages/operators/src/index.ts
@@ -33,3 +33,4 @@ export {
   useTriggerPanelEvent,
 } from "./usePanelEvent";
 export { validate } from "./validation";
+export * from "./Panel/hooks";

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -716,6 +716,19 @@ class Operations(object):
 
         return self._ctx.trigger("browser_download", params=params)
 
+    def trigger_panel_client_event(self, id, event, params=None):
+        """Triggers a panel client-side event.
+
+        Args:
+            id: the ID of the panel
+            event: the event to trigger
+            params: the parameters to pass to the event
+        """
+        return self._ctx.trigger(
+            "trigger_panel_client_event",
+            {"panel_id": id, "event": event, "params": params},
+        )
+
 
 def _serialize_view(view):
     return json.loads(json_util.dumps(view._serialize()))

--- a/fiftyone/operators/panel.py
+++ b/fiftyone/operators/panel.py
@@ -373,3 +373,14 @@ class PanelRef(object):
         if title is None:
             raise ValueError("title cannot be None")
         self._ctx.ops.set_panel_title(id=self.id, title=title)
+
+    def trigger(self, event, params=None):
+        """Triggers a client-side event of a panel.
+
+        Args:
+            event: name of client-side event to trigger
+            params: parameters to pass to the event
+        """
+        self._ctx.ops.trigger_panel_client_event(
+            id=self.id, event=event, params=params
+        )


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add a utility to easily register and trigger JS panel events from Python panel events 

## How is this patch tested? If it is not, please explain why.

Using a hybrid python panel

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Add a utility to easily register and trigger JS panel events from Python panel events. See usage for more details 

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

## Usage

```py
# Python
class PanelOne(Panel):
    @property
    def config(self):
        return PanelConfig(
            name="panel_one",
            label="Panel One",
            icon="looks_one",
        )

    def set_samples_count(self, ctx):
        params = {"count":  ctx.view.count()}
        ctx.panel.trigger("set_samples_count", params)

    def render(self, ctx):
        panel = types.Object()
        return types.Property(
            panel,
            view=types.View(
                component="CustomViewOne",
                composite_view=True,
                set_samples_count=self.set_samples_count,
            ),
        )
```

```js
// JavaScript
export default function Four(props) {
  const { set_samples_count } = props.schema.view;

  const handleEvent = usePanelEvent();
  const panelId = usePanelId();
  const { register } = usePanelClientEvent();
  const [count, setCount] = useState()

  register("set_samples_count", (params) => {
    setCount(params.count)
  });

  return (
    <Box>
      <Button
        onClick={() => {
          handleEvent(panelId, { operator: my_py_event });
        }}
      >
        Set samples count
      </Button>
      <Typography>Samples count: {count}</Typography>
    </Box>
  );
}
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add a hook to register, trigger, and unregister client-side panel events.
  * Introduce a built-in operator to trigger panel client events.
  * Expose panel hooks through the package public API for simpler importing.
  * Add Python SDK methods to trigger panel client events, including from panel references.

* **Chores**
  * Remove an unused icon import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->