### PR TITLE
populate dataset information for all tensorflow models

### DIFF
--- a/fiftyone/zoo/models/manifest-tf.json
+++ b/fiftyone/zoo/models/manifest-tf.json
@@ -40,7 +40,7 @@
                 }
             },
             "tags": ["segmentation", "cityscapes", "tf", "deeplabv3", "legacy"],
-            "training_data": [],
+            "training_data": [{"name": "Cityscapes", "url": "https://www.cityscapes-dataset.com/"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -83,7 +83,7 @@
                 }
             },
             "tags": ["segmentation", "cityscapes", "tf", "deeplabv3", "legacy"],
-            "training_data": [],
+            "training_data": [{"name": "Cityscapes", "url": "https://www.cityscapes-dataset.com/"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -125,7 +125,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf1", "efficientdet", "legacy"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -167,7 +167,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf1", "efficientdet", "legacy"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -209,7 +209,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf1", "efficientdet", "legacy"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -251,7 +251,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf1", "efficientdet", "legacy"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -293,7 +293,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf1", "efficientdet", "legacy"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -335,7 +335,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf1", "efficientdet", "legacy"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -377,7 +377,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf1", "efficientdet", "legacy"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -425,7 +425,7 @@
                 "inception",
                 "resnet"
             ],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -474,7 +474,7 @@
                 "resnet",
                 "legacy"
             ],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -515,7 +515,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf", "faster-rcnn", "inception"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -556,7 +556,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf", "faster-rcnn"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -597,7 +597,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf", "faster-rcnn", "legacy"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -638,7 +638,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf", "faster-rcnn", "resnet", "legacy"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -679,7 +679,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf", "faster-rcnn", "resnet", "legacy"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -720,7 +720,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf", "faster-rcnn", "resnet"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -761,7 +761,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf", "faster-rcnn", "resnet", "legacy"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -810,7 +810,7 @@
                 "inception",
                 "resnet"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -859,7 +859,7 @@
                 "inception",
                 "legacy"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -907,7 +907,7 @@
                 "inception",
                 "resnet"
             ],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -948,7 +948,7 @@
                 }
             },
             "tags": ["instances", "coco", "tf", "mask-rcnn", "inception"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -989,7 +989,7 @@
                 }
             },
             "tags": ["instances", "coco", "tf", "mask-rcnn", "resnet", "legacy"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1030,7 +1030,7 @@
                 }
             },
             "tags": ["instances", "coco", "tf", "mask-rcnn", "resnet", "legacy"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1078,7 +1078,7 @@
                 "tf1",
                 "mobilenet"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1127,7 +1127,7 @@
                 "resnet",
                 "legacy"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1176,7 +1176,7 @@
                 "resnet",
                 "legacy"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1217,7 +1217,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf", "rfcn", "resnet", "legacy"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1258,7 +1258,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf", "ssd", "inception"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1299,7 +1299,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf", "ssd", "mobilenet", "legacy"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1340,7 +1340,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf", "ssd", "mobilenet", "legacy"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1381,7 +1381,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf", "ssd", "resnet", "legacy"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1429,7 +1429,7 @@
                 "vgg",
                 "legacy"
             ],
-            "training_data": [],
+            "training_data": [{"name": "ImageNet-1K", "url": "https://www.image-net.org/download.php"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1469,7 +1469,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf1", "yolo", "legacy"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2020-12-11 13:45:51"
         },
         {
@@ -1512,7 +1512,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf2", "centernet"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2021-01-6 11:01:34"
         },
         {
@@ -1555,7 +1555,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf2", "centernet"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2021-12-26 07:04:23"
         },
         {
@@ -1598,7 +1598,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf2", "centernet", "resnet"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2021-12-27 14:45:23"
         },
         {
@@ -1641,7 +1641,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf2", "centernet", "resnet"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2021-12-27 14:55:13"
         },
         {
@@ -1684,7 +1684,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf2", "centernet", "resnet"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2021-12-27 14:59:23"
         },
         {
@@ -1727,7 +1727,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf2", "centernet", "mobilenet"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2021-12-27 17:05:20"
         },
         {
@@ -1770,7 +1770,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf2", "efficientdet"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2021-12-27 18:25:10"
         },
         {
@@ -1813,7 +1813,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf2", "efficientdet"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2021-12-27 18:25:10"
         },
         {
@@ -1856,7 +1856,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf2", "efficientdet"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2021-12-27 18:40:20"
         },
         {
@@ -1899,7 +1899,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf2", "efficientdet"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2021-12-27 18:42:30"
         },
         {
@@ -1942,7 +1942,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf2", "efficientdet"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2021-12-27 18:42:30"
         },
         {
@@ -1985,7 +1985,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf2", "efficientdet"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2021-12-27 18:50:20"
         },
         {
@@ -2028,7 +2028,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf2", "efficientdet"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2021-12-27 19:00:20"
         },
         {
@@ -2071,7 +2071,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf2", "efficientdet"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2021-12-27 19:05:20"
         },
         {
@@ -2114,7 +2114,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf2", "ssd", "mobilenet"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2021-12-27 20:01:40"
         },
         {
@@ -2157,7 +2157,7 @@
                 }
             },
             "tags": ["detection", "coco", "tf2", "ssd", "mobilenet"],
-            "training_data": [],
+            "training_data": [{"name": "MS COCO 2017", "url": "https://cocodataset.org"}],
             "date_added": "2021-12-27 20:05:20"
         }
     ]


### PR DESCRIPTION
This commit populates the `training_data` field established in the previous pull request with verified dataset information for TensorFlow model zoo entries. Each entry contains structured dataset references including canonical names and authoritative URLs. 

## What changes are proposed in this pull request?

The `training_data` field in `manifest-tf.json` has been populated with dataset metadata for all TF models. Each populated field contains an array of dataset objects with `name` and `url` properties. Original JSON formatting has been preserved with modifications limited to `training_data` fields. 

## How is this patch tested? If it is not, please explain why.

- JSON schema validation ensures the manifest remains valid  
- Manual diff review confirms only `training_data` fields were modified  
- FiftyOne builds successfully with the populated manifest  
- Model zoo retrieval tested successfully (loaded models from the zoo to verify functionality)  

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.  
-   [x] Yes. Give a description of this change to be included in the release notes for FiftyOne users.  

TensorFlow model zoo entries now include training dataset metadata, providing users with information about the datasets used to train each model.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes  
-   [ ] Build: Build and test infrastructure changes  
-   [ ] Core: Core `fiftyone` Python library changes  
-   [x] Documentation: FiftyOne documentation changes  
-   [ ] Other