### PR TITLE
Bump eta to 0.15.1

### DIFF
--- a/fiftyone/zoo/models/__init__.py
+++ b/fiftyone/zoo/models/__init__.py
@@ -502,6 +502,7 @@ class ZooModel(etam.Model):
         default_deployment_config_dict (None): a
             :class:`fiftyone.core.models.ModelConfig` dict describing the
             recommended settings for deploying the model
+        training_data (None): the training data information for the model, if applicable
     """
 
     _REQUIREMENT_ERROR_SUFFIX = (

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ INSTALL_REQUIRES = [
     # internal packages
     "fiftyone-brain>=0.21.2,<0.22",
     "fiftyone-db>=0.4,<2.0",
-    "voxel51-eta>=0.14.4,<0.16",
+    "voxel51-eta>=0.14.5",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ INSTALL_REQUIRES = [
     # internal packages
     "fiftyone-brain>=0.21.2,<0.22",
     "fiftyone-db>=0.4,<2.0",
-    "voxel51-eta>=0.14.5",
+    "voxel51-eta>=0.15.1,<0.16",
 ]
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

To support new `training_data` key from ML

## How is this patch tested? If it is not, please explain why.

See thread context from bMoore: https://github.com/voxel51/fiftyone/pull/6299#pullrequestreview-3162462713

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented an optional training_data parameter in the Model Zoo API, clarifying available configuration without altering behavior.
* **Chores**
  * Updated dependency requirements to require voxel51-eta >= 0.15.1 and < 0.16, improving compatibility and alignment with upstream changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->