### PR TITLE
FOEPD-1976: Render docstring example correctly

### DIFF
--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -3153,7 +3153,7 @@ def async_executor(
     Context manager that provides a function for submitting tasks to a thread
     pool executor. All tasks are joined when the context is exited.
 
-    Example:
+    Example::
 
         with async_executor(max_workers=4) as submit:
             for item in items:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Render the example usage in a docstring as code.

## How is this patch tested? If it is not, please explain why.

Built docs, checked output:
<img width="651" height="554" alt="Screenshot 2025-08-29 at 11 51 25 AM" src="https://github.com/user-attachments/assets/3cb5d95a-455c-435d-ab5c-edd6c92e8ac4" />

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
