### PR TITLE
fix: correct training_data for all SAM 2 Hiera models

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -265,7 +265,16 @@
                 }
             },
             "tags": ["segment-anything", "torch", "zero-shot"],
-            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
+            "training_data": [
+                            {
+                                            "name": "SA-V",
+                                            "url": "https://ai.meta.com/datasets/segment-anything-video/"
+                            },
+                            {
+                                            "name": "SA-1B",
+                                            "url": "https://segment-anything.com/dataset/index.html"
+                            }
+            ],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -307,7 +316,16 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
+            "training_data": [
+                            {
+                                            "name": "SA-V",
+                                            "url": "https://ai.meta.com/datasets/segment-anything-video/"
+                            },
+                            {
+                                            "name": "SA-1B",
+                                            "url": "https://segment-anything.com/dataset/index.html"
+                            }
+            ],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -349,7 +367,16 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
+            "training_data": [
+                            {
+                                            "name": "SA-V",
+                                            "url": "https://ai.meta.com/datasets/segment-anything-video/"
+                            },
+                            {
+                                            "name": "SA-1B",
+                                            "url": "https://segment-anything.com/dataset/index.html"
+                            }
+            ],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -391,7 +418,16 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
+            "training_data": [
+                            {
+                                            "name": "SA-V",
+                                            "url": "https://ai.meta.com/datasets/segment-anything-video/"
+                            },
+                            {
+                                            "name": "SA-1B",
+                                            "url": "https://segment-anything.com/dataset/index.html"
+                            }
+            ],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -433,7 +469,16 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
+            "training_data": [
+                            {
+                                            "name": "SA-V",
+                                            "url": "https://ai.meta.com/datasets/segment-anything-video/"
+                            },
+                            {
+                                            "name": "SA-1B",
+                                            "url": "https://segment-anything.com/dataset/index.html"
+                            }
+            ],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -476,7 +521,16 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
+            "training_data": [
+                            {
+                                            "name": "SA-V",
+                                            "url": "https://ai.meta.com/datasets/segment-anything-video/"
+                            },
+                            {
+                                            "name": "SA-1B",
+                                            "url": "https://segment-anything.com/dataset/index.html"
+                            }
+            ],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -519,7 +573,16 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
+            "training_data": [
+                            {
+                                            "name": "SA-V",
+                                            "url": "https://ai.meta.com/datasets/segment-anything-video/"
+                            },
+                            {
+                                            "name": "SA-1B",
+                                            "url": "https://segment-anything.com/dataset/index.html"
+                            }
+            ],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -561,7 +624,16 @@
                 "video",
                 "transformer"
             ],
-            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
+            "training_data": [
+                            {
+                                            "name": "SA-V",
+                                            "url": "https://ai.meta.com/datasets/segment-anything-video/"
+                            },
+                            {
+                                            "name": "SA-1B",
+                                            "url": "https://segment-anything.com/dataset/index.html"
+                            }
+            ],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -651,7 +723,16 @@
                 }
             },
             "tags": ["segment-anything", "torch", "zero-shot", "transformer"],
-            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
+            "training_data": [
+                            {
+                                            "name": "SA-V",
+                                            "url": "https://ai.meta.com/datasets/segment-anything-video/"
+                            },
+                            {
+                                            "name": "SA-1B",
+                                            "url": "https://segment-anything.com/dataset/index.html"
+                            }
+            ],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -695,7 +776,16 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
+            "training_data": [
+                            {
+                                            "name": "SA-V",
+                                            "url": "https://ai.meta.com/datasets/segment-anything-video/"
+                            },
+                            {
+                                            "name": "SA-1B",
+                                            "url": "https://segment-anything.com/dataset/index.html"
+                            }
+            ],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -739,7 +829,16 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
+            "training_data": [
+                            {
+                                            "name": "SA-V",
+                                            "url": "https://ai.meta.com/datasets/segment-anything-video/"
+                            },
+                            {
+                                            "name": "SA-1B",
+                                            "url": "https://segment-anything.com/dataset/index.html"
+                            }
+            ],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -783,7 +882,16 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
+            "training_data": [
+                            {
+                                            "name": "SA-V",
+                                            "url": "https://ai.meta.com/datasets/segment-anything-video/"
+                            },
+                            {
+                                            "name": "SA-1B",
+                                            "url": "https://segment-anything.com/dataset/index.html"
+                            }
+            ],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -826,7 +934,16 @@
                 "video",
                 "transformer"
             ],
-            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
+            "training_data": [
+                            {
+                                            "name": "SA-V",
+                                            "url": "https://ai.meta.com/datasets/segment-anything-video/"
+                            },
+                            {
+                                            "name": "SA-1B",
+                                            "url": "https://segment-anything.com/dataset/index.html"
+                            }
+            ],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -871,7 +988,16 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
+            "training_data": [
+                            {
+                                            "name": "SA-V",
+                                            "url": "https://ai.meta.com/datasets/segment-anything-video/"
+                            },
+                            {
+                                            "name": "SA-1B",
+                                            "url": "https://segment-anything.com/dataset/index.html"
+                            }
+            ],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -916,7 +1042,16 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
+            "training_data": [
+                            {
+                                            "name": "SA-V",
+                                            "url": "https://ai.meta.com/datasets/segment-anything-video/"
+                            },
+                            {
+                                            "name": "SA-1B",
+                                            "url": "https://segment-anything.com/dataset/index.html"
+                            }
+            ],
             "date_added": "2024-08-05 14:38:20"
         },
         {
@@ -961,7 +1096,16 @@
                 "transformer",
                 "official"
             ],
-            "training_data": [{"name": "SA-1B", "url": "https://segment-anything.com/dataset/index.html"}],
+            "training_data": [
+                            {
+                                            "name": "SA-V",
+                                            "url": "https://ai.meta.com/datasets/segment-anything-video/"
+                            },
+                            {
+                                            "name": "SA-1B",
+                                            "url": "https://segment-anything.com/dataset/index.html"
+                            }
+            ],
             "date_added": "2024-08-05 14:38:20"
         },
         {


### PR DESCRIPTION
* Set training_data to SA-V and SA-1B for every checkpoint across SAM 2 and SAM 2.1

* Added SA-V dataset URL

Models touched:

* segment-anything-2-hiera-tiny-image-torch
* segment-anything-2-hiera-small-image-torch
* segment-anything-2-hiera-base-plus-image-torch
* segment-anything-2-hiera-large-image-torch
* segment-anything-2-hiera-tiny-video-torch
* segment-anything-2-hiera-small-video-torch
* segment-anything-2-hiera-base-plus-video-torch
* segment-anything-2-hiera-large-video-torch
* segment-anything-2.1-hiera-tiny-image-torch
* segment-anything-2.1-hiera-small-image-torch
* segment-anything-2.1-hiera-base-plus-image-torch
* segment-anything-2.1-hiera-large-image-torch
* segment-anything-2.1-hiera-tiny-video-torch
* segment-anything-2.1-hiera-small-video-torch
* segment-anything-2.1-hiera-base-plus-video-torch
* segment-anything-2.1-hiera-large-video-torch

## What changes are proposed in this pull request?

Update the training\_data field for all SAM 2 Hiera models to list SA-V and SA-1B with official dataset links. No other fields are modified.

## How is this patch tested? If it is not, please explain why.

* Link check to confirm the dataset URLs resolve
* Smoke load models

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [x] No. You can skip the rest of this section.
* [ ] Yes. Give a description of this change to be included in the release
  notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

* [ ] App: FiftyOne application changes
* [ ] Build: Build and test infrastructure changes
* [ ] Core: Core `fiftyone` Python library changes
* [ ] Documentation: FiftyOne documentation changes
* [x] Other