### PR TITLE
Various typos

### DIFF
--- a/ISSUE_POLICY.md
+++ b/ISSUE_POLICY.md
@@ -92,7 +92,7 @@ Documentation issues typically go through the following lifecycle:
 Installation issues typically go through the following lifecycle:
 
 1. An installation GitHub Issue is submitted, which contains a description of
-   the issue and the platforms its affects.
+   the issue and the platforms it affects.
 2. The [issue is triaged](ISSUE_TRIAGE.md) to identify whether more information
    is needed from the author, give an indication of priority, and route the
    issue to appropriate maintainers.
@@ -100,7 +100,6 @@ Installation issues typically go through the following lifecycle:
    about how to implement a fix.
 4. After an approach has been agreed upon, an owner for the fix is identified.
    FiftyOne maintainers may choose to adopt ownership of severe installation
-   issues to ensure a timely fix. FiftyOne maintainers may choose to adopt
-   ownership of severe installation
+   issues to ensure a timely fix.
 5. The fix owner begins implementing the fix and ultimately files associated
    pull requests.

--- a/docs/source/brain.rst
+++ b/docs/source/brain.rst
@@ -68,7 +68,7 @@ workflow:
   "What data should I select to annotate?"
 
 * :ref:`Mistakenness <brain-label-mistakes>`:
-  Annotations mistakes create an artificial ceiling on the performance of your
+  Annotation mistakes create an artificial ceiling on the performance of your
   models. However, finding these mistakes by hand is at least as arduous as the
   original annotation was, especially in cases of larger datasets. The FiftyOne
   Brain provides a quantitative *mistakenness measure* to identify possible
@@ -180,7 +180,7 @@ Applications
 ------------
 
 How can embedding-based visualization of your data be used in practice? These
-visualizations often uncover hidden structure in you data that has important
+visualizations often uncover hidden structure in your data that has important
 semantic meaning depending on the data you use to color/size the points.
 
 Here are a few of the many possible applications:

--- a/docs/source/enterprise/app.rst
+++ b/docs/source/enterprise/app.rst
@@ -43,7 +43,7 @@ Pinned datasets
 You can pin datasets for easy access by hovering over the dataset's name in
 the main table and clicking the pin icon.
 
-The "Your pinned datasets" widget on the right-hand side of the hompage shows
+The "Your pinned datasets" widget on the right-hand side of the homepage shows
 your pinned datasets at a glance and allows you to quickly open one by
 clicking on its name. Pinned datasets are listed in reverse chronological order
 (most recently pinned on top).
@@ -168,7 +168,7 @@ right hand side of a row of the dataset listing table and selecting
 .. note::
 
    Did you know? You can also use the :ref:`Enterprise SDK <enterprise-python-sdk>` to
-   programmatically, create, edit, and delete datasets.
+   programmatically create, edit, and delete datasets.
 
 .. _enterprise-dataset-basic-info:
 

--- a/docs/source/enterprise/data_quality.rst
+++ b/docs/source/enterprise/data_quality.rst
@@ -124,7 +124,7 @@ update to show the corresponding samples:
 
 If you find a better threshold for a dataset, you can save it via the
 "Save Threshold" option under the settings menu. You can use
-"Reset Threshold" to the revert to the default threshold at any time.
+"Reset Threshold" to revert to the default threshold at any time.
 
 Once you've reviewed the potential issues in the grid, you can use the
 "Add Tags" button to take action on them. Clicking the button will display a

--- a/docs/source/enterprise/dataset_versioning.rst
+++ b/docs/source/enterprise/dataset_versioning.rst
@@ -154,7 +154,7 @@ been re-materialized but kept in cold storage also).
 Snapshot archival
 -----------------
 
-Snapshot your datasets easier knowing your database won't be overrun!
+Snapshot your datasets more easily knowing your database won't be overrun!
 
 If your snapshots are important for historical significance but aren't used
 very often, then you can consider archiving snapshots. This is especially

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -158,7 +158,7 @@ _________________
 
 .. customcalloutitem::
     :header: Visualizing embeddings
-    :description: Are you using embeddings to analyze your data and models? Use FiftyOne's embeddings visualization capabilities to reveal hidden structure in you data, mine hard samples, pre-annotate data, recommend new samples for annotation, and more.
+    :description: Are you using embeddings to analyze your data and models? Use FiftyOne's embeddings visualization capabilities to reveal hidden structure in your data, mine hard samples, pre-annotate data, recommend new samples for annotation, and more.
     :button_text: Experience the power of embeddings
     :button_link: tutorials/image_embeddings.html
     :image: _static/images/homepage_embeddings.gif
@@ -172,7 +172,7 @@ _________________
 
 .. customcalloutitem::
     :header: Finding annotation mistakes
-    :description: Annotations mistakes create an artificial ceiling on the performance of your model. However, finding these mistakes by hand is not feasible! Use FiftyOne to automatically identify possible label mistakes in your datasets.
+    :description: Annotation mistakes create an artificial ceiling on the performance of your model. However, finding these mistakes by hand is not feasible! Use FiftyOne to automatically identify possible label mistakes in your datasets.
     :button_text: Check out the label mistakes tutorial
     :button_link: tutorials/classification_mistakes.html
     :image: _static/images/homepage_mistakes.gif
@@ -301,7 +301,7 @@ Dataset Zoo
 The FiftyOne Dataset Zoo provides a powerful interface for downloading datasets
 and loading them into FiftyOne.
 
-It provides native access to dozens of popular benchmark datasets, and it als
+It provides native access to dozens of popular benchmark datasets, and it also
 supports downloading arbitrary public or private datasets whose
 download/preparation methods are provided via GitHub repositories or URLs.
 

--- a/docs/source/installation/troubleshooting.rst
+++ b/docs/source/installation/troubleshooting.rst
@@ -224,7 +224,7 @@ If you have output similar to the below, you may just need to install
   .../site-packages/fiftyone/db/bin/mongod: error while loading shared libraries:
     libcrypto.so.1.1: cannot open shared object file: No such file or directory
 
-On Ubuntu, `libssl` packages can be install with the following command:
+On Ubuntu, `libssl` packages can be installed with the following command:
 
 .. code-block:: shell
 
@@ -240,7 +240,7 @@ FiftyOne to use a MongoDB instance that you have installed yourself.
 Troubleshooting Windows imports
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If your encounter a `psutil.NoSuchProcessExists` exists when importing
+If you encounter a `psutil.NoSuchProcessExists` exists when importing
 `fiftyone`, you are likely missing the C++ libraries MongoDB requires.
 
 .. code-block::

--- a/docs/source/installation/troubleshooting.rst
+++ b/docs/source/installation/troubleshooting.rst
@@ -240,7 +240,7 @@ FiftyOne to use a MongoDB instance that you have installed yourself.
 Troubleshooting Windows imports
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you encounter a `psutil.NoSuchProcessExists` exists when importing
+If you encounter a `psutil.NoSuchProcess` error when importing
 `fiftyone`, you are likely missing the C++ libraries MongoDB requires.
 
 .. code-block::

--- a/docs/source/integrations/milvus.rst
+++ b/docs/source/integrations/milvus.rst
@@ -40,7 +40,7 @@ datasets and use this to query your data is as follows:
     a model to use to generate embeddings
 
 3)  Use the :meth:`compute_similarity() <fiftyone.brain.compute_similarity>`
-    methodto generate a Milvus similarity index for the samples or object
+    method to generate a Milvus similarity index for the samples or object
     patches in a dataset by setting the parameter `backend="milvus"` and
     specifying a `brain_key` of your choice
 
@@ -184,7 +184,7 @@ variety of ways.
 **Environment variables (recommended)**
 
 The recommended way to configure your Milvus credentials is to store them
-in the environment variables shown below, which are  automatically accessed by
+in the environment variables shown below, which are automatically accessed by
 FiftyOne whenever a connection to Milvus is made.
 
 .. code-block:: shell

--- a/docs/source/integrations/mongodb.rst
+++ b/docs/source/integrations/mongodb.rst
@@ -167,7 +167,7 @@ To use the MongoDB backend, simply set the optional `backend` parameter of
 
     fob.compute_similarity(..., backend="mongodb", ...)
 
-Alternatively, you can permanently configure FiftyOne to use the MonogDB
+Alternatively, you can permanently configure FiftyOne to use the MongoDB
 backend by setting the following environment variable:
 
 .. code-block:: shell

--- a/docs/source/integrations/pinecone.rst
+++ b/docs/source/integrations/pinecone.rst
@@ -40,7 +40,7 @@ FiftyOne datasets and use this to query your data is as follows:
     a model to use to generate embeddings
 
 3)  Use the :meth:`compute_similarity() <fiftyone.brain.compute_similarity>`
-    methodto generate a Pinecone similarity index for the samples or object
+    method to generate a Pinecone similarity index for the samples or object
     patches in a dataset by setting the parameter `backend="pinecone"` and
     specifying a `brain_key` of your choice
 

--- a/docs/source/user_guide/app.rst
+++ b/docs/source/user_guide/app.rst
@@ -92,7 +92,7 @@ opened in a new tab of your web browser. See
 
     When working inside a Docker container, FiftyOne should automatically
     detect and appropriately configure networking. However, if you are unable
-    to load the App in your browser, you many need to manually
+    to load the App in your browser, you may need to manually
     :ref:`set the App address <restricting-app-address>` to `0.0.0.0`:
 
     .. code:: python

--- a/docs/source/user_guide/draw_labels.rst
+++ b/docs/source/user_guide/draw_labels.rst
@@ -46,7 +46,7 @@ your datasets that you have identified by constructing a |DatasetView|.
 
   .. group-tab:: CLI
 
-    You can rendered annotated media for an entire FiftyOne dataset
+    You can render annotated media for an entire FiftyOne dataset
     :doc:`via the CLI </cli/index>`:
 
     .. code-block:: shell

--- a/docs/source/user_guide/export_datasets.rst
+++ b/docs/source/user_guide/export_datasets.rst
@@ -128,7 +128,7 @@ a |DatasetView| into any format of your choice via the basic recipe below.
             --label-field $LABEL_FIELD
 
     Note the `LABEL_FIELD` argument in the above example, which specifies the
-    particular label field that you wish to export. This is necessary your
+    particular label field that you wish to export. This is necessary if your
     FiftyOne dataset contains multiple label fields.
 
     You can use the :ref:`kwargs option <cli-fiftyone-datasets-export>` to

--- a/docs/source/user_guide/plots.rst
+++ b/docs/source/user_guide/plots.rst
@@ -46,7 +46,7 @@ Overview
 ________
 
 All |Session| instances provide a
-:meth:`plots attribute <fiftyone.core.session.Session.plots>` attribute that
+:meth:`plots attribute <fiftyone.core.session.Session.plots>` that
 you can use to attach |ResponsivePlot| instances to the FiftyOne App.
 
 When |ResponsivePlot| instances are attached to a |Session|, they are

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -947,7 +947,7 @@ class Polyline(_HasAttributesDict, _HasID, _HasInstance, Label):
 
         Args:
             xc: the x-center coordinate
-            yc: the y-center coorindate
+            yc: the y-center coordinate
             w: the box width
             y: the box height
             theta: the counter-clockwise rotation of the box in radians
@@ -1487,7 +1487,7 @@ class GeoLocation(_HasID, Label):
 
                 [[lon1, lat1], [lon2, lat2], ...]
 
-        polygon (None): a polygon defined by coorindates as shown below::
+        polygon (None): a polygon defined by coordinates as shown below::
 
                 [
                     [[lon1, lat1], [lon2, lat2], ...],


### PR DESCRIPTION
Various typo fixes. The first being:

als -> also in index.rst

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed multiple typos and wording across user and enterprise docs, troubleshooting, integrations, and guides for clearer phrasing (e.g., "you data" → "your data"; "hompage" → "homepage"; "you many" → "you may"; spacing and punctuation fixes).
  * Corrected small wording in policy and docstrings; corrected integration name spelling (MongoDB).
  * Editorial-only changes with no functional, API, or behavioral impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->