### PR TITLE
bumping brain version for `fiftyone==1.8.0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ INSTALL_REQUIRES = [
     "universal-analytics-python3>=1.0.1,<2",
     "pydash",
     # internal packages
-    "fiftyone-brain>=0.21.2,<0.22",
+    "fiftyone-brain>=0.21.3,<0.22",
     "fiftyone-db>=0.4,<2.0",
     "voxel51-eta>=0.14.4,<0.16",
 ]


### PR DESCRIPTION
I'm proposing that we release `fiftyone-brain==0.21.3` (https://github.com/voxel51/fiftyone-brain/pull/260) and ensure that all `fiftyone==1.8.0` users will get this patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a core dependency to the latest patch version to improve stability and compatibility.
  * No user-facing changes expected; routine maintenance to keep the app up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->