### PR TITLE
Add medsiglip-448-torch

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -7542,6 +7542,37 @@
             "tags": ["segmentation", "torch", "segformer", "official"],
             "training_data": [{"name": "ADE20K", "url": "https://github.com/CSAILVision/ADE20K"}],
             "date_added": "2025-08-04 12:34:27"
+        },
+        {
+          "base_name": "medsiglip-448-zero-torch",
+          "base_filename": null,
+          "version": null,
+          "description": "Medical SigLIP for zero-shot image classification and embeddings",
+          "source": "https://huggingface.co/google/medsiglip-448",
+          "author": "Google Research",
+          "license": "Custom (HAI-DEF gated on Hugging Face)",
+          "size_bytes": null,
+          "default_deployment_config_dict": {
+            "type": "fiftyone.utils.transformers.FiftyOneZeroShotTransformerForImageClassification",
+            "config": {
+              "name_or_path": "google/medsiglip-448",
+              "transformers_processor_kwargs": {
+                "padding": true
+              },
+              "output_processor_args": {
+                "store_logits": true,
+                "logits_key": "logits_per_image"
+              }
+            }
+          },
+          "requirements": {
+            "packages": ["torch", "torchvision", "transformers", "huggingface_hub"],
+            "cpu": { "support": true },
+            "gpu": { "support": true }
+          },
+          "tags": ["classification", "torch", "official", "medical", "zero-shot"],
+          "training_data": [],
+          "date_added": "2025-09-03 15:09:00"
         }
     ]
 }


### PR DESCRIPTION
Add MedSigLIP zero‑shot image classification model from Google: **medsiglip-448-torch**

* Uses existing `FiftyOneZeroShotTransformerForImageClassification` wrapper
* CPU/GPU inference
* Zero‑shot classification + 1152‑D embeddings
* Gated on Hugging Face (HAI‑DEF)

## What changes are proposed in this pull request?

* Add `medsiglip-448-torch` entry to Torch model zoo (`manifest-torch.json`)

## How is this patch tested? If it is not, please explain why.

* Local validation and via build: loaded via zoo alias, ran SCIN demo images from the model card, confirmed predictions and **1152‑D** embeddings
* Confirmed model appears in `foz.list_zoo_models()` and loads without additional wrappers

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [ ] No. You can skip the rest of this section.
* [x] Yes. Give a description of this change to be included in the release
  notes for FiftyOne users.

Added **MedSigLIP (google/medsiglip‑448)** zero‑shot medical image classifier to the Torch model zoo (Hugging Face gated access required).

### What areas of FiftyOne does this PR affect?

* [ ] App: FiftyOne application changes
* [ ] Build: Build and test infrastructure changes
* [ ] Core: Core `fiftyone` Python library changes
* [ ] Documentation: FiftyOne documentation changes
* [x] Other
