### PR TITLE
Add pubmed-clip-vit32

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -7608,6 +7608,34 @@
             }
           ],
           "date_added": "2025-09-04 12:45:00"
+        },
+        {
+          "base_name": "pubmed-clip-vit-base-patch32",
+          "base_filename": null,
+          "version": null,
+          "description": "Zero-shot medical image classifier trained on biomedical image–text pairs.",
+          "source": "https://huggingface.co/flaviagiammarino/pubmed-clip-vit-base-patch32",
+          "author": "Sedigheh Eslami et al.",
+          "license": "MIT",
+          "size_bytes": 634388480,
+          "default_deployment_config_dict": {
+            "type": "fiftyone.utils.transformers.FiftyOneZeroShotTransformerForImageClassification",
+            "config": {
+              "name_or_path": "flaviagiammarino/pubmed-clip-vit-base-patch32",
+              "transforms_args": { "use_fast": false },
+              "transformers_processor_kwargs": { "padding": true }
+            }
+          },
+          "requirements": {
+            "packages": ["torch", "torchvision", "transformers"],
+            "cpu": { "support": true },
+            "gpu": { "support": true }
+          },
+          "tags": ["classification", "torch", "official", "medical", "zero-shot"],
+          "training_data": [
+            { "name": "ROCO (Radiology Objects in Context)", "url": "https://github.com/razorx89/roco-dataset" }
+          ],
+          "date_added": "2025-09-05 11:56:00"
         }
     ]
 }


### PR DESCRIPTION
Add PubMedCLIP zero‑shot image classification model: **pubmed-clip-vit32-zero-shot-torch**

* Uses existing `FiftyOneZeroShotTransformerForImageClassification` wrapper (no new wrappers)
* CPU/GPU inference
* Zero‑shot classification + **512‑D** embeddings
* Public on Hugging Face (MIT license)

## What changes are proposed in this pull request?

* Add `pubmed-clip-vit32-zero-shot-torch` entry to the Torch model zoo (`manifest-torch.json`)

## How is this patch tested? If it is not, please explain why.

* Local validation: loaded via zoo alias, ran predictions on demo images, confirmed **512‑D** embeddings
* Confirmed model appears in `foz.list_zoo_models()` and loads with zero‑shot prompts

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [ ] No. You can skip the rest of this section.
* [x] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

Added **PubMedCLIP (ViT‑B/32)** zero‑shot medical image classifier to the Torch model zoo (public, MIT).

### What areas of FiftyOne does this PR affect?

* [ ] App: FiftyOne application changes
* [ ] Build: Build and test infrastructure changes
* [ ] Core: Core `fiftyone` Python library changes
* [ ] Documentation: FiftyOne documentation changes
* [x] Other