### PR TITLE
doc update external orchestrators

### DIFF
--- a/docs/source/enterprise/plugins.rst
+++ b/docs/source/enterprise/plugins.rst
@@ -510,11 +510,10 @@ External orchestrators
 ----------------------
 
 It is also possible to connect your FiftyOne Enterprise deployment to other
-externally managed workflow orchestration tools such as:
+externally-managed workflow orchestration tools such as:
 `Airflow <https://airflow.apache.org>`_, `Flyte <https://flyte.org>`_,
-`Spark <https://spark.apache.org/>`_, etc. These platforms will have less
-builtin support and must have a continually running worker pool that can accept
-tasks from your deployment (i.e., not on-demand).
+`Spark <https://spark.apache.org/>`_, etc. Please contact your Voxel51 Customer
+Success representative for further details.
 
 .. _enterprise-managing-delegated-operations:
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Small doc update for External Orchestrators

## How is this patch tested? If it is not, please explain why.
Built doc and reviewed

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Standardized terminology by hyphenating “externally-managed.”
  * Updated External orchestrators guidance: removed the prescriptive requirement for continuously running worker pools.
  * Users are now directed to contact Voxel51 Customer Success for specifics on external orchestration, including Spark.
  * Clarifies guidance and provides a clear support contact for enterprise deployments.
  * No functional changes to product behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->