### PR TITLE
Bug fix: `to_torch()` on empty collections

### DIFF
--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -2524,7 +2524,11 @@ class NumpySerializedList:
         self._lst = [_serialize(x) for x in lst]
         self._addr = np.asarray([len(x) for x in self._lst], dtype=np.int64)
         self._addr = np.cumsum(self._addr)
-        self._lst = np.concatenate(self._lst)
+        self._lst = (
+            np.concatenate(self._lst)
+            if self._lst
+            else np.empty(0, dtype=np.uint8)
+        )
 
         logger.debug(
             "Serialized dataset takes {:.2f} MiB".format(


### PR DESCRIPTION
## Change log

- fixes a bug where `apply_model()` and `compute_embeddings()` would raise an error when applied to empty collections. now they will successfully complete as no-ops

## Tested by

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
model = foz.load_zoo_model("clip-vit-base32-torch")

view = dataset.limit(0)

# these previously raised errors; now they succeed as no-ops
view.apply_model(model, label_field="clip_predictions")
view.compute_embeddings(model, embeddings_field="clip_embeddings")
```
