### PR TITLE
Remove serverside JS usages

### DIFF
--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -2663,82 +2663,6 @@ class ViewExpression(object):
         """
         return ViewExpression({"$reverseArray": self})
 
-    def sort(self, key=None, numeric=False, reverse=False):
-        """Sorts this expression, which must resolve to an array.
-
-        If no ``key`` is provided, this array must contain elements whose
-        BSON representation can be sorted by JavaScript's ``.sort()`` method.
-
-        If a ``key`` is provided, the array must contain documents, which are
-        sorted by ``key``, which must be a field or embedded field.
-
-        Examples::
-
-            #
-            # Sort the tags of each sample in a dataset
-            #
-
-            import fiftyone as fo
-            from fiftyone import ViewField as F
-
-            dataset = fo.Dataset()
-            dataset.add_samples(
-                [
-                    fo.Sample(filepath="im1.jpg", tags=["z", "f", "p", "a"]),
-                    fo.Sample(filepath="im2.jpg", tags=["y", "q", "h", "d"]),
-                    fo.Sample(filepath="im3.jpg", tags=["w", "c", "v", "l"]),
-                ]
-            )
-
-            # Sort the `tags` of each sample
-            view = dataset.set_field("tags", F("tags").sort())
-
-            print(view.first().tags)
-
-            #
-            # Sort the predictions in each sample of a dataset by `confidence`
-            #
-
-            import fiftyone as fo
-            import fiftyone.zoo as foz
-            from fiftyone import ViewField as F
-
-            dataset = foz.load_zoo_dataset("quickstart")
-
-            view = dataset.set_field(
-                "predictions.detections",
-                F("detections").sort(key="confidence", numeric=True, reverse=True)
-            )
-
-            sample = view.first()
-            print(sample.predictions.detections[0].confidence)
-            print(sample.predictions.detections[-1].confidence)
-
-        Args:
-            key (None): an optional field or ``embedded.field.name`` to sort by
-            numeric (False): whether the array contains numeric values. By
-                default, the values will be sorted alphabetically by their
-                string representations
-            reverse (False): whether to sort in descending order
-
-        Returns:
-            a :class:`ViewExpression`
-        """
-        sort_order = pymongo.DESCENDING if reverse else pymongo.ASCENDING
-
-        if key is not None:
-            sort_by = {key: sort_order}
-        else:
-            sort_by = sort_order
-
-        sort_stage = {
-            "$sortArray": {
-                "input": self,
-                "sortBy": sort_by,
-            }
-        }
-        return ViewExpression(sort_stage)
-
     def filter(self, expr):
         """Applies the given filter to the elements of this expression, which
         must resolve to an array.
@@ -4562,14 +4486,6 @@ class ViewExpression(object):
             zip_expr["defaults"] = defaults
 
         return ViewExpression({"$zip": zip_expr})
-
-    # Experimental expressions ###############################################
-
-    def _function(self, function):
-        function = " ".join(function.split())
-        return ViewExpression(
-            {"$function": {"body": function, "args": [self], "lang": "js"}}
-        )
 
 
 class ViewField(ViewExpression):

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -963,7 +963,12 @@ def _count_list_items(path, view):
                                         "$add": [
                                             {
                                                 "$ifNull": [
-                                                    {"$getField": "$$this"},
+                                                    {
+                                                        "$getField": {
+                                                            "input": "$$value",
+                                                            "field": "$$this",
+                                                        }
+                                                    },
                                                     0,
                                                 ]
                                             },

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -948,39 +948,23 @@ def _add_label_tags(path, field, view):
 
 def _count_list_items(path, view):
     expr = {
-        "$reduce": {
-            "input": F(path),  # The field to be processed
-            "initialValue": {},
-            "in": {
-                "$mergeObjects": [
-                    "$$value",
-                    {
-                        "$arrayToObject": [
-                            [
-                                {
-                                    "k": "$$this",
-                                    "v": {
-                                        "$add": [
-                                            {
-                                                "$ifNull": [
-                                                    {
-                                                        "$getField": {
-                                                            "input": "$$value",
-                                                            "field": "$$this",
-                                                        }
-                                                    },
-                                                    0,
-                                                ]
-                                            },
-                                            1,
-                                        ]
-                                    },
-                                }
-                            ]
-                        ]
+        "$arrayToObject": {
+            "$map": {
+                "input": {"$setUnion": "$_label_tags"},
+                "as": "tag",
+                "in": {
+                    "k": "$$tag",
+                    "v": {
+                        "$size": {
+                            "$filter": {
+                                "input": "$_label_tags",
+                                "as": "t",
+                                "cond": {"$eq": ["$$t", "$$tag"]},
+                            }
+                        }
                     },
-                ]
-            },
+                },
+            }
         }
     }
     return view.set_field(path, expr, _allow_missing=True)


### PR DESCRIPTION
[$function](https://www.mongodb.com/docs/manual/reference/operator/aggregation/function/) is deprecated. It's also slow and bad security (which is why it's deprecated).

## What changes are proposed in this pull request?

1. Translate `ViewExpression.sort` to mongo native `$sortArray`. This was added in 5.2 which wouldn't have been OK originally but is fine now since we require >=6.0.
2. In server count list items, replace the JS function with a fairly complicated mongo expression that also makes a histogram of values. Unfortunately it is not nearly as succinct as the JS function, but it will probably be faster since it's mongo native

NOTE: `ViewExpression.sort` docstring examples do not work in any configuration I've tried, with code going back 4+ years. I've tried mongodb versions back to 4.2. Both local (Mac) and some deployed (Linux). Either the docstrings have been totally wrong forever, the function has been broken forever, or I'm doing something silly. Would love to know in any case.

## How is this patch tested? If it is not, please explain why.

App runs if you disable serverside JS 🤷🏼
Gemini says they're logically equivalent 🤷🏼 🤖 
Letting unit tests run to see results of that.
I'm open to more tests to run? I don't really know what the server function populates (2)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Remove usage of deprecated $function MongoDB stage

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Array sorting now uses database-side sorting for deterministic results; the previous client-side function-based sorter was removed. Reversing arrays remains supported.
  * List-item counting now uses a database aggregation to produce item-count maps for lists, deriving counts from centralized label data for improved consistency.

* **Chores**
  * Updated internal dependencies to support the new aggregation-based approaches.

* **Documentation**
  * Updated docs to reflect the sorting removal and new counting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->