### PR TITLE
[DOCS] Fix word wrapping of 'Required?' column

### DIFF
--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -193,7 +193,7 @@ exposes, and declare any :ref:`secrets <plugins-secrets>` that it may require.
 The following fields are available:
 
 .. table::
-    :widths: 20,10,70
+    :widths: 20,11,69
 
     +------------------------------+-----------+-----------------------------------------------------------------------------+
     | Field                        | Required? | Description                                                                 |


### PR DESCRIPTION
## What changes are proposed in this pull request?

Make "Required?" column on [this docs page](https://docs.voxel51.com/plugins/developing_plugins.html#developing-plugins) slightly wider so question mark doesn't wrap to next line:
<img width="918" height="301" alt="Screenshot 2025-09-10 at 11 09 09 AM" src="https://github.com/user-attachments/assets/f8704e15-c394-4bdd-85ee-fe389a9553e8" />

## How is this patch tested? If it is not, please explain why.

Built docs locally and checked page:
<img width="923" height="284" alt="Screenshot 2025-09-10 at 11 06 46 AM" src="https://github.com/user-attachments/assets/1d15d1ec-a396-4138-ab7a-aaaa92197d13" />

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
