### PR TITLE
[DO NOT MERGE] build(actions): Testing windows-2025 runners

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,6 +41,7 @@ jobs:
               - 'setup.py'
               - '.github/workflows/build.yml'
               - '.github/workflows/test.yml'
+              - '.github/workflows/windows-test.yml'
               - 'plugins/**'
 
   build:

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-latest
+          - windows-2025
         python:
           - "3.9"
           - "3.10"


### PR DESCRIPTION
## What changes are proposed in this pull request?

@coderabbit ignore

GitHub is changing the `windows-latest` floating tag from `windows-2022` to `windows-2025` this month. This PR is solely to trigger tests to make sure that `windows-2025` doesn't break our existing workflows. And, if so, gives some time to remediate BEFORE the final cut over.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
