### PR TITLE
build(actions): AS-898 utilizing trusted publisher workflows

### DIFF
--- a/.github/workflows/build-db.yml
+++ b/.github/workflows/build-db.yml
@@ -109,23 +109,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, test]
     if: startsWith(github.ref, 'refs/tags/db-v')
+    environment: release # For trusted publishing. See below.
+    permissions:
+      id-token: write
     steps:
       - name: Download
         uses: actions/download-artifact@v5
         with:
-          path: downloads
-      - name: Install dependencies
-        run: |
-          pip3 install -U twine packaging
-      - name: Set environment
-        env:
-          RELEASE_TAG: ${{ github.ref }}
-        run: |
-          echo "TWINE_PASSWORD=${{ secrets.FIFTYONE_PYPI_TOKEN }}" >> $GITHUB_ENV
-          echo "TWINE_REPOSITORY=pypi" >> $GITHUB_ENV
-      - name: Upload to pypi
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_NON_INTERACTIVE: 1
-        run: |
-          python3 -m twine upload downloads/dist-*/*
+          pattern: dist-*
+          merge-multiple: true
+          path: dist
+      # Utilize
+      # [trusted publishers](https://docs.pypi.org/trusted-publishers/)
+      # This will use OIDC to publish the dists/ package to pypi.
+      # See
+      # [fiftyone-db](https://pypi.org/manage/project/fiftyone-db/settings/publishing/)
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@v1.13.0

--- a/.github/workflows/build-db.yml
+++ b/.github/workflows/build-db.yml
@@ -111,6 +111,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/db-v')
     environment: release # For trusted publishing. See below.
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: Download

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,7 @@ jobs:
     needs: [build, test]
     environment: release # For trusted publishing. See below.
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: Download dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, test]
     environment: release # For trusted publishing. See below.
+    permissions:
+      id-token: write
     steps:
       - name: Download dist
         uses: actions/download-artifact@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,27 +19,20 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [build, test]
+    environment: release # For trusted publishing. See below.
     steps:
       - name: Download dist
         uses: actions/download-artifact@v5
         with:
           name: dist
           path: dist/
-      - name: Install dependencies
-        run: |
-          pip3 install -U twine packaging
-      - name: Set environment
-        env:
-          RELEASE_TAG: ${{ github.ref }}
-        run: |
-          echo "TWINE_PASSWORD=${{ secrets.FIFTYONE_PYPI_TOKEN }}" >> $GITHUB_ENV
-          echo "TWINE_REPOSITORY=pypi" >> $GITHUB_ENV
-      - name: Upload to pypi
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_NON_INTERACTIVE: 1
-        run: |
-          python3 -m twine upload dist/*
+      # Utilize
+      # [trusted publishers](https://docs.pypi.org/trusted-publishers/)
+      # This will use OIDC to publish the dists/ package to pypi.
+      # See
+      # [fiftyone](https://pypi.org/manage/project/fiftyone/settings/publishing)
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@v1.13.0
 
   publish-docker-images:
     needs: [publish]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Recently, I came across [trusted pypi publishers](https://docs.pypi.org/trusted-publishers/). They utilize OIDC to authenticate with PyPi so that we don't need to keep tokens around for individual users. 

Using short-lived credentials reduces things like attach surface areas and makes maintaining user credentials much easier!

A trusted publisher has also been added to the `fiftyone` and `fiftyone-db` projects.

## How is this patch tested? If it is not, please explain why.

This was tested with a private repository that published to [the PyPi test site](https://test.pypi.org/project/v51-trusted-workflow-package/).

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated PyPI publishing into a single trusted release step for more reliable, maintainable releases.
  * Switched to OIDC-based trusted publishing, removing stored credentials and improving security.
  * Added a dedicated "release" environment for clearer deployment tracking and approvals.
  * Artifact retrieval and Docker publishing remain functionally unchanged; no user-facing feature changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->