### PR TITLE
fiftyone/operators requires plugin pros or backend

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@
 /e2e-pw/                     @voxel51/frontend-devs
 /fiftyone/server/            @voxel51/frontend-devs
 /plugins/panels/             @voxel51/plugin-pros
-/fiftyone/operators/         @voxel51/plugin-pros
+/fiftyone/operators/         @voxel51/plugin-pros @voxel51/backend-squad
 
 # Backend
 /fiftyone/api/               @voxel51/backend-squad


### PR DESCRIPTION
## What changes are proposed in this pull request?

Plugin Pros should be notified of PRs that may involve them, but not necessarily required for merging. Most of the work in there nowadays is done by backend squad.

So I have made it such that `fiftyone/operators` changes will invite both plugin pros and backend squad to approve, but either fulfills the requirement.

## How is this patch tested? If it is not, please explain why.

Not

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership rules to assign two teams as owners for a specific directory, replacing the previous single owner.
  * Pull requests touching that area will now request reviews from both teams by default, improving coverage and responsiveness.
  * No product behavior or user-facing functionality is affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->