### PR TITLE
make num writer threads configurable

### DIFF
--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -75,7 +75,7 @@ def apply_model(
     store_logits=False,
     batch_size=None,
     num_workers=None,
-    num_writer_thread_workers=None,
+    num_writer_workers=None,
     skip_failures=True,
     output_dir=None,
     rel_dir=None,
@@ -106,6 +106,8 @@ def apply_model(
             batching
         num_workers (None): the number of workers to use when loading images.
             Only applicable for Torch-based models
+        num_writer_workers (None): the number of thread workers to use when
+            writing predictions. Only applicable for Torch-based models.
         skip_failures (True): whether to gracefully continue without raising an
             error if predictions cannot be generated for a sample. Only
             applicable to :class:`Model` instances
@@ -285,7 +287,7 @@ def apply_model(
                 filename_maker,
                 progress,
                 field_mapping,
-                num_writer_thread_workers,
+                num_writer_workers,
             )
 
         if batch_size is not None:
@@ -459,7 +461,7 @@ def _apply_image_model_data_loader(
     filename_maker,
     progress,
     field_mapping,
-    num_writer_thread_workers,
+    num_writer_workers,
 ):
     needs_samples = isinstance(model, SamplesMixin)
 
@@ -483,7 +485,7 @@ def _apply_image_model_data_loader(
         ctx = context.enter_context(foc.SaveContext(samples))
         submit = context.enter_context(
             fou.async_executor(
-                max_workers=num_writer_thread_workers,
+                max_workers=num_writer_workers,
                 skip_failures=skip_failures,
                 warning="Async failure labeling batches",
             )
@@ -907,7 +909,7 @@ def compute_embeddings(
     embeddings_field=None,
     batch_size=None,
     num_workers=None,
-    num_writer_thread_workers=None,
+    num_writer_workers=None,
     skip_failures=True,
     progress=None,
     **kwargs,
@@ -938,6 +940,8 @@ def compute_embeddings(
             batching
         num_workers (None): the number of workers to use when loading images.
             Only applicable for Torch-based models
+        num_writer_workers (None): the number of thread workers to use when
+            writing embeddings. Only applicable for Torch-based models.
         skip_failures (True): whether to gracefully continue without raising an
             error if embeddings cannot be generated for a sample. Only
             applicable to :class:`Model` instances
@@ -1082,7 +1086,7 @@ def compute_embeddings(
                 skip_failures,
                 progress,
                 field_mapping,
-                num_writer_thread_workers,
+                num_writer_workers,
             )
 
         if batch_size is not None:
@@ -1205,7 +1209,7 @@ def _compute_image_embeddings_data_loader(
     skip_failures,
     progress,
     field_mapping,
-    num_writer_thread_workers,
+    num_writer_workers,
 ):
     data_loader = _make_data_loader(
         samples,
@@ -1230,7 +1234,7 @@ def _compute_image_embeddings_data_loader(
 
         submit = context.enter_context(
             fou.async_executor(
-                max_workers=num_writer_thread_workers,
+                max_workers=num_writer_workers,
                 skip_failures=skip_failures,
                 warning="Async failure saving embeddings",
             )

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -75,6 +75,7 @@ def apply_model(
     store_logits=False,
     batch_size=None,
     num_workers=None,
+    num_writer_thread_workers=None,
     skip_failures=True,
     output_dir=None,
     rel_dir=None,
@@ -284,6 +285,7 @@ def apply_model(
                 filename_maker,
                 progress,
                 field_mapping,
+                num_writer_thread_workers,
             )
 
         if batch_size is not None:
@@ -457,6 +459,7 @@ def _apply_image_model_data_loader(
     filename_maker,
     progress,
     field_mapping,
+    num_writer_thread_workers,
 ):
     needs_samples = isinstance(model, SamplesMixin)
 
@@ -480,7 +483,7 @@ def _apply_image_model_data_loader(
         ctx = context.enter_context(foc.SaveContext(samples))
         submit = context.enter_context(
             fou.async_executor(
-                max_workers=1,
+                max_workers=num_writer_thread_workers,
                 skip_failures=skip_failures,
                 warning="Async failure labeling batches",
             )
@@ -904,6 +907,7 @@ def compute_embeddings(
     embeddings_field=None,
     batch_size=None,
     num_workers=None,
+    num_writer_thread_workers=None,
     skip_failures=True,
     progress=None,
     **kwargs,
@@ -1078,6 +1082,7 @@ def compute_embeddings(
                 skip_failures,
                 progress,
                 field_mapping,
+                num_writer_thread_workers,
             )
 
         if batch_size is not None:
@@ -1200,6 +1205,7 @@ def _compute_image_embeddings_data_loader(
     skip_failures,
     progress,
     field_mapping,
+    num_writer_thread_workers,
 ):
     data_loader = _make_data_loader(
         samples,
@@ -1224,7 +1230,7 @@ def _compute_image_embeddings_data_loader(
 
         submit = context.enter_context(
             fou.async_executor(
-                max_workers=1,
+                max_workers=num_writer_thread_workers,
                 skip_failures=skip_failures,
                 warning="Async failure saving embeddings",
             )

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -2859,11 +2859,15 @@ def recommend_thread_pool_workers(num_workers=None):
     If a ``fo.config.max_thread_pool_workers`` is set, this limit is applied.
 
     Args:
-        num_workers (None): a suggested number of workers
+        num_workers (None): a suggested number of workers. If ``num_workers <= 0``, this
+            function returns 1.
 
     Returns:
         a number of workers
     """
+    if num_workers <= 0:
+        num_workers = 1
+
     if num_workers is None:
         num_workers = multiprocessing.cpu_count()
 
@@ -3160,7 +3164,8 @@ def async_executor(
                 submit(process_item, item)
 
     Args:
-        max_workers: the maximum number of workers to use
+        max_workers (None): the maximum number of workers to use. By default,
+            this is determined by :func:`fiftyone.core.utils.recommend_thread_pool_workers`.
         skip_failures (False): whether to skip exceptions raised by tasks
         warning ("Async failure"): the warning message to log if a task
             raises an exception and ``skip_failures == True``

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -2865,11 +2865,12 @@ def recommend_thread_pool_workers(num_workers=None):
     Returns:
         a number of workers
     """
-    if num_workers <= 0:
-        num_workers = 1
 
     if num_workers is None:
         num_workers = multiprocessing.cpu_count()
+
+    if num_workers <= 0:
+        num_workers = 1
 
     if fo.config.max_thread_pool_workers is not None:
         num_workers = min(num_workers, fo.config.max_thread_pool_workers)

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -3147,7 +3147,7 @@ fos = lazy_import("fiftyone.core.storage")
 
 @contextmanager
 def async_executor(
-    *, max_workers, skip_failures=False, warning="Async failure"
+    *, max_workers=None, skip_failures=False, warning="Async failure"
 ):
     """
     Context manager that provides a function for submitting tasks to a thread
@@ -3168,6 +3168,12 @@ def async_executor(
     Raises:
         Exception: if a task raises an exception and ``skip_failures == False``
     """
+    if max_workers is None:
+        max_workers = (
+            fo.config.default_thread_pool_workers
+            or recommend_thread_pool_workers(max_workers)
+        )
+
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         _futures = []
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Make num writer threads used in `apply_model` and `compute_embeddings` configurable. This has a pretty big effect on runtime (>2.5x in reasonable cases).

Also something weird may be happening with memory usage.

## How is this patch tested? If it is not, please explain why.

Code and data will be shared privately, I don't want to dump it here.

### Performance impact of num threads on I/O heavy jobs

**Task**: Computing dense embeddings with DINO v3
**Variables**:
1. num threads
2. model size
3. embedding size (controlled by image size during inference)

**`compute_embeddings` benchmark time vs num threads**
<img width="859" height="547" alt="image" src="https://github.com/user-attachments/assets/f9fa7931-8438-4b73-9f24-82f9b5efc5cb" />


**analysis**
Without a large enough number of threads, the writing jobs just continue getting queued and pile up. As we exit the async execution, we have to do a blocking wait for them to all finish to complete the `compute_embeddings` operation. This effectively means that rather than saving time in `compute_embeddings`, we are just deferring the wait for I/O till later.

By increasing the number of writer threads, we can avoid this issue. Interestingly, this effect seems to be more pronounced for larger image sizes  and model sizes.

I'm not sure why the speed flatlines so quickly with num threads. The writing still continues after the GPU workload ends even for 16 threads. We may be hitting the limits of mongo throughput. Something to consider for an embeddings rework @brimoor .

### Memory consumption vs num samples

**Task**: Computing dense embeddings with DINO v3
**Variables**:
1. num threads
2. num samples

**`compute_embeddings` memory usage over time**
<img width="2389" height="1180" alt="image" src="https://github.com/user-attachments/assets/a2533edd-c54e-416f-9643-eb0d1addf506" />
<img width="2390" height="1180" alt="image" src="https://github.com/user-attachments/assets/3c18adb1-9ced-48ef-83d6-89f6df02acb7" />

**analysis**
As the writing jobs pile up, we use more and more memory. It is critical that tasks like this don't have memory requirements that scale this quickly with the number of samples. In this case some back pressure and garbage collection will likely do.

Adding more threads should in theory help, because we would clear the job queue faster, thus not allowing it to pile up in the first place. Given that the write throughput scaling we get with threads isn't good, it doesn't resolve the problem. Regardless, we should have the guardrails mentioned above.

### action items
We need some limit on the number of embeddings that can be floating in memory at once.
1. add configurable back pressure to `async_executor`
2. figure out if we should manually garbage collect here or if this will happen naturally.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional num_writer_workers setting to control writer-thread concurrency for asynchronous labeling/saving and embedding computation, improving throughput for heavy workloads.
  * Async executor now accepts an explicit max_workers default derived from user config or a CPU-based recommendation when unset.

* **Bug Fixes / Behavior**
  * Thread recommendation now clamps non-positive inputs to at least 1 worker to avoid zero/negative worker counts.

* **Documentation**
  * Docstrings updated to describe the new parameter and defaulting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->