### PR TITLE
Don't create indexes by default in view stages

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -2200,6 +2200,8 @@ class SampleCollection(object):
 
         if has_frame_fields:
             frame_numbers = results.pop(0)
+        else:
+            frame_numbers = None
 
         sample_ids = results[0]
         all_label_ids = results[1:]
@@ -5791,7 +5793,7 @@ class SampleCollection(object):
         min_distance=None,
         max_distance=None,
         query=None,
-        create_index=True,
+        create_index=False,
     ):
         """Sorts the samples in the collection by their proximity to a
         specified geolocation.
@@ -5799,7 +5801,8 @@ class SampleCollection(object):
         .. note::
 
             This stage must be the **first stage** in any
-            :class:`fiftyone.core.view.DatasetView` in which it appears.
+            :class:`fiftyone.core.view.DatasetView` in which it appears, and it
+            **requires** a spherical index on the specified location field.
 
         Examples::
 
@@ -5814,14 +5817,18 @@ class SampleCollection(object):
             # Sort the samples by their proximity to Times Square
             #
 
-            view = dataset.geo_near(TIMES_SQUARE)
+            view = dataset.geo_near(TIMES_SQUARE, create_index=True)
 
             #
             # Sort the samples by their proximity to Times Square, and only
             # include samples within 5km
             #
 
-            view = dataset.geo_near(TIMES_SQUARE, max_distance=5000)
+            view = dataset.geo_near(
+                TIMES_SQUARE,
+                max_distance=5000,
+                create_index=True,
+            )
 
             #
             # Sort the samples by their proximity to Times Square, and only
@@ -5844,7 +5851,10 @@ class SampleCollection(object):
             )
 
             view = dataset.geo_near(
-                TIMES_SQUARE, location_field="location", query=in_manhattan
+                TIMES_SQUARE,
+                location_field="location",
+                query=in_manhattan,
+                create_index=True,
             )
 
         Args:
@@ -5874,7 +5884,7 @@ class SampleCollection(object):
             query (None): an optional dict defining a
                 `MongoDB read query <https://docs.mongodb.com/manual/tutorial/query-documents/#read-operations-query-argument>`_
                 that samples must match in order to be included in this view
-            create_index (True): whether to create the required spherical
+            create_index (False): whether to create the required spherical
                 index, if necessary
 
         Returns:
@@ -5897,7 +5907,7 @@ class SampleCollection(object):
         boundary,
         location_field=None,
         strict=True,
-        create_index=True,
+        create_index=False,
     ):
         """Filters the samples in this collection to only include samples whose
         geolocation is within a specified boundary.
@@ -5944,8 +5954,8 @@ class SampleCollection(object):
             strict (True): whether a sample's location data must strictly fall
                 within boundary (True) in order to match, or whether any
                 intersection suffices (False)
-            create_index (True): whether to create the required spherical
-                index, if necessary
+            create_index (False): whether to create a spherical index, if
+                necessary, to optimize the query
 
         Returns:
             a :class:`fiftyone.core.view.DatasetView`
@@ -5968,7 +5978,7 @@ class SampleCollection(object):
         flat=False,
         match_expr=None,
         sort_expr=None,
-        create_index=True,
+        create_index=False,
         order_by_key=None,
     ):
         """Creates a view that groups the samples in the collection by a
@@ -6034,7 +6044,7 @@ class SampleCollection(object):
                 that defines how to sort the groups in the output view. If
                 provided, this expression will be evaluated on the list of
                 samples in each group. Only applicable when ``flat=True``
-            create_index (True): whether to create an index, if necessary, to
+            create_index (False): whether to create an index, if necessary, to
                 optimize the grouping. Only applicable when grouping by
                 field(s), not expressions
             order_by_key (None): an optional fixed ``order_by`` value
@@ -7518,7 +7528,7 @@ class SampleCollection(object):
         return self._add_view_stage(fos.Skip(skip))
 
     @view_stage
-    def sort_by(self, field_or_expr, reverse=False, create_index=True):
+    def sort_by(self, field_or_expr, reverse=False, create_index=False):
         """Sorts the samples in the collection by the given field(s) or
         expression(s).
 
@@ -7582,7 +7592,7 @@ class SampleCollection(object):
                     any string starting with "a" for ascending order, or -1 or
                     any string starting with "d" for descending order
             reverse (False): whether to return the results in descending order
-            create_index (True): whether to create an index, if necessary, to
+            create_index (False): whether to create an index, if necessary, to
                 optimize the sort. Only applicable when sorting by field(s),
                 not expressions
 

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -5080,12 +5080,12 @@ class ViewStageTests(unittest.TestCase):
             ]
         )
 
-        view1 = dataset.sort_by("field")
+        view1 = dataset.sort_by("field", create_index=True)
 
         self.assertListEqual(view1.values("field"), [1, 2, 3])
         self.assertIn("field", dataset.list_indexes())
 
-        view2 = dataset.sort_by([("foo", 1), ("field", 1)])
+        view2 = dataset.sort_by([("foo", 1), ("field", 1)], create_index=True)
 
         self.assertListEqual(view2.values("foo"), ["bar", "spam", "spam"])
         self.assertListEqual(view2.values("field"), [3, 1, 2])
@@ -5101,12 +5101,14 @@ class ViewStageTests(unittest.TestCase):
         self.assertIn("field", dataset2.list_indexes())
         self.assertIn("foo_1_field_1", dataset2.list_indexes())
 
-        view3 = dataset2.sort_by(F("field"))
+        view3 = dataset2.sort_by(F("field"), create_index=True)
 
         self.assertListEqual(view3.values("field"), [1, 2, 3])
         self.assertIn("field", dataset2.list_indexes())
 
-        view4 = dataset2.sort_by([(F("foo"), 1), (F("field"), 1)])
+        view4 = dataset2.sort_by(
+            [(F("foo"), 1), (F("field"), 1)], create_index=True
+        )
 
         self.assertListEqual(view4.values("foo"), ["bar", "spam", "spam"])
         self.assertListEqual(view4.values("field"), [3, 1, 2])


### PR DESCRIPTION
## Change log

Updates the default behavior of the `sort_by()`, `group_by()`, `geo_within()`, and `geo_near()` view stages to **NOT** automatically create an index when used.

Index creation can be quite expensive on large datasets, so it was bad manners of us to be silently performing expensive computation without the user's explicit direction, as instantiating view stages is supposed to be fast (excluding *generated views*).

**Note:** this is technically a breaking change as `geo_near()` **requires** an index in order to work. However, I believe a breaking change is worth it to encourage best practices of separating index creation from view stage instantiation. Also, `geo_near()` has limited utility (it can only be the *first* stage in a view).

## Tested by

```py
import random

import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-geo")
```

### `sort_by()`

```py
classes = ["cat", "dog", "rabbit"]
predictions = [
    fo.Classification(label=random.choice(classes))
    for _ in range(len(dataset))
]
dataset.set_values("predictions", predictions)

view = dataset.sort_by("predictions.label")
_ = len(view)

assert "predictions.label" not in dataset.list_indexes()

view = dataset.sort_by("predictions.label", create_index=True)
_ = len(view)

assert "predictions.label" in dataset.list_indexes()
dataset.drop_index("predictions.label")
```

### `group_by()`

```py
view = dataset.group_by("predictions.label")
_ = len(view)

assert "predictions.label" not in dataset.list_indexes()

view = dataset.group_by("predictions.label", create_index=True)
_ = len(view)

assert "predictions.label" in dataset.list_indexes()
dataset.drop_index("predictions.label")
```

### `geo_within()`

```py
MANHATTAN = [
    [
        [-73.949701, 40.834487],
        [-73.896611, 40.815076],
        [-73.998083, 40.696534],
        [-74.031751, 40.715273],
        [-73.949701, 40.834487],
    ]
]

view = dataset.geo_within(MANHATTAN)
_ = len(view)

assert "location.point" not in dataset.list_indexes()

view = dataset.geo_within(MANHATTAN, create_index=True)
_ = len(view)

assert "location.point" in dataset.list_indexes()
dataset.drop_index("location.point")
```

### `geo_near()`

```py
try:
    view = dataset.geo_near([-73.9855, 40.7580])
    _ = len(view)
    assert False
except:
    assert "location.point" not in dataset.list_indexes()

view = dataset.geo_near([-73.9855, 40.7580], create_index=True)
_ = len(view)

assert "location.point" in dataset.list_indexes()
dataset.drop_index("location.point")
```
