### PR TITLE
Add option to monitor DOs for manual termination

### DIFF
--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -3185,6 +3185,14 @@ class DelegatedLaunchCommand(Command):
             help="the type of service to launch. The default is 'local'",
         )
 
+        parser.add_argument(
+            "-m",
+            "--no-monitor",
+            action="store_false",
+            dest="monitor",
+            help="whether to monitor the state of the operation with a parent process",
+        )
+
     @staticmethod
     def execute(parser, args):
         supported_types = ("local",)
@@ -3195,10 +3203,10 @@ class DelegatedLaunchCommand(Command):
             )
 
         if args.type == "local":
-            _launch_delegated_local()
+            _launch_delegated_local(monitor=args.monitor)
 
 
-def _launch_delegated_local():
+def _launch_delegated_local(monitor=False):
     from fiftyone.core.session.session import _WELCOME_MESSAGE
 
     try:
@@ -3208,7 +3216,7 @@ def _launch_delegated_local():
         print("Delegated operation service running")
         print("\nTo exit, press ctrl + c")
         while True:
-            dos.execute_queued_operations(limit=1, log=True)
+            dos.execute_queued_operations(limit=1, log=True, monitor=monitor)
             time.sleep(0.5)
     except KeyboardInterrupt:
         pass

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -8,7 +8,11 @@ FiftyOne delegated operations.
 
 import asyncio
 import logging
+import logging.handlers
+import multiprocessing
+import os
 import traceback
+import psutil
 
 from fiftyone.factory.repo_factory import RepositoryFactory
 from fiftyone.factory import DelegatedOperationPagingParams
@@ -22,6 +26,76 @@ from fiftyone.operators.executor import (
 
 
 logger = logging.getLogger(__name__)
+
+
+def _configure_child_logging(queue):
+    """Configures logging in a child process to send logs to a queue.
+
+    This function should be called at the start of the target function
+    for any new process. It clears all existing handlers from the root
+    logger and adds a QueueHandler.
+    """
+    root_logger = logging.getLogger("fiftyone")
+    root_logger.handlers.clear()
+    queue_handler = logging.handlers.QueueHandler(queue)
+    root_logger.addHandler(queue_handler)
+
+
+def _execute_operator_in_child_process(
+    operation_id, log=False, log_queue=None
+):
+    """Worker function to be run in a separate 'spawned' process.
+
+    This function receives a simple ID, not a complex object, to avoid
+    serialization (pickling) errors. It instantiates its own service to create
+    fresh resources and then fetches the operation document from the database.
+
+    Args:
+        operation_id: the string ID of the operation to execute
+        log (False): the optional boolean flag to log the execution
+        log_queue (None): a multiprocessing queue to send log records to
+    """
+    # On POSIX systems, become the session leader to take control of any
+    # subprocesses. This allows the parent to terminate the entire process
+    # group reliably.
+    if hasattr(os, "setsid"):
+        try:
+            os.setsid()
+        except Exception:
+            pass
+
+    if log_queue:
+        _configure_child_logging(log_queue)
+
+    logger = logging.getLogger(__name__)
+    service = DelegatedOperationService()
+    result = None
+
+    try:
+        operation = service.get(operation_id)
+        if not operation:
+            logger.error(
+                "Operation %s not found in child process. Aborting.",
+                operation_id,
+            )
+            return
+        if log:
+            logger.info(
+                "\nRunning operation %s (%s) in child process",
+                operation.id,
+                operation.operator,
+            )
+
+        result = asyncio.run(service._execute_operator(operation))
+
+        service.set_completed(doc_id=operation.id, result=result)
+        if log:
+            logger.info("Operation %s complete", operation.id)
+    except Exception:
+        result = ExecutionResult(error=traceback.format_exc())
+        service.set_failed(doc_id=operation_id, result=result)
+        if log:
+            logger.error("Operation %s failed\n%s", operation_id, result.error)
 
 
 class DelegatedOperationService(object):
@@ -427,6 +501,8 @@ class DelegatedOperationService(object):
         dataset_name=None,
         limit=None,
         log=False,
+        monitor=True,
+        check_interval_seconds=300,
         **kwargs,
     ):
         """Executes queued delegated operations matching the given criteria.
@@ -442,6 +518,8 @@ class DelegatedOperationService(object):
                 operations to execute
             log (False): the optional boolean flag to log the execution of the
                 delegated operations
+            monitor (True): if we should monitor the state of the operator in a subprocess.
+            check_interval_seconds (300): how many seconds to wait between polling operator status.
         """
         results = []
         if limit is not None:
@@ -459,7 +537,14 @@ class DelegatedOperationService(object):
         )
 
         for op in queued_ops:
-            results.append(self.execute_operation(operation=op, log=log))
+            results.append(
+                self.execute_operation(
+                    operation=op,
+                    log=log,
+                    monitor=monitor,
+                    check_interval_seconds=check_interval_seconds,
+                )
+            )
         return results
 
     def count(self, filters=None, search=None):
@@ -475,7 +560,13 @@ class DelegatedOperationService(object):
         return self._repo.count(filters=filters, search=search)
 
     def execute_operation(
-        self, operation, log=False, run_link=None, log_path=None
+        self,
+        operation,
+        log=False,
+        run_link=None,
+        log_path=None,
+        monitor=True,
+        check_interval_seconds=300,
     ):
         """Executes the given delegated operation.
 
@@ -487,8 +578,9 @@ class DelegatedOperationService(object):
             run_link (None): an optional link to orchestrator-specific
                 information about the operation
             log_path (None): an optional path to the log file for the operation
+            monitor (True): if we should monitor the state of the operator in a subprocess.
+            check_interval_seconds (300): how many seconds to wait between polling operator status.
         """
-        result = None
         try:
             succeeded = (
                 self.set_running(
@@ -507,7 +599,7 @@ class DelegatedOperationService(object):
                         operation.id,
                         operation.operator,
                     )
-                return result
+                return None
 
             if log:
                 logger.info(
@@ -516,19 +608,152 @@ class DelegatedOperationService(object):
                     operation.operator,
                 )
 
-            result = asyncio.run(self._execute_operator(operation))
+            if monitor:
+                return self._execute_operation_multi_proc(
+                    operation, log, check_interval_seconds
+                )
+            else:
+                return self._execute_operation_sync(operation, log)
+        except Exception as e:
+            logger.debug(
+                "Uncaught exception when executing operator. Error=%s",
+                e,
+                exc_info=True,
+            )
+        return None
 
+    def _execute_operation_sync(self, operation, log=False):
+        """Executes an operation synchronously in the current process."""
+        try:
+            result = asyncio.run(self._execute_operator(operation))
             self.set_completed(doc_id=operation.id, result=result)
             if log:
                 logger.info("Operation %s complete", operation.id)
-        except:
+        except Exception as e:
+            logger.debug(
+                "Uncaught exception when executing operator. Error=%s",
+                e,
+                exc_info=True,
+            )
             result = ExecutionResult(error=traceback.format_exc())
-
             self.set_failed(doc_id=operation.id, result=result)
             if log:
                 logger.info(
                     "Operation %s failed\n%s", operation.id, result.error
                 )
+        return result
+
+    def _terminate_child_process(self, child_process, operation_id, reason):
+        """
+        Terminates a child process and its descendants using psutil.
+        """
+        pid = child_process.pid
+        logger.warning(
+            "Terminating process tree (PID: %d) for operation %s. Reason: %s",
+            pid,
+            operation_id,
+            reason,
+        )
+
+        try:
+            parent = psutil.Process(pid)
+            children = parent.children(recursive=True)
+
+            for child in children:
+                try:
+                    child.terminate()
+                except psutil.NoSuchProcess:
+                    pass
+
+            _, alive = psutil.wait_procs(children, timeout=10)
+
+            for p in alive:
+                try:
+                    p.kill()
+                except psutil.NoSuchProcess:
+                    pass
+            try:
+                parent.terminate()
+                parent.wait(timeout=10)
+                if parent.is_running():
+                    parent.kill()
+                    parent.wait(timeout=5)
+            except psutil.NoSuchProcess:
+                pass
+        except psutil.NoSuchProcess:
+            logger.info(
+                "Process %d for op %s already terminated.", pid, operation_id
+            )
+        except Exception as e:
+            logger.error(
+                "Error during process tree termination for PID %d: %s", pid, e
+            )
+
+    def _execute_operation_multi_proc(
+        self, operation, log=False, check_interval_seconds=300
+    ):
+        """Executes an operation in a separate process and monitors it."""
+        ctx = multiprocessing.get_context("spawn")
+        log_queue = ctx.Queue()
+
+        root_logger = logging.getLogger("fiftyone")
+        listener = logging.handlers.QueueListener(
+            log_queue, *root_logger.handlers
+        )
+        listener.start()
+
+        result = None
+        child_process = None
+        try:
+            child_process = ctx.Process(
+                target=_execute_operator_in_child_process,
+                args=(operation.id, log, log_queue),
+            )
+            child_process.start()
+
+            while child_process.is_alive():
+                child_process.join(timeout=check_interval_seconds)
+
+                if not child_process.is_alive():
+                    break
+
+                try:
+                    op_doc = self.get(operation.id)
+                    if (
+                        op_doc
+                        and op_doc.run_state == ExecutionRunState.FAILED
+                        and op_doc.result.error
+                        and "marked as failed by" in op_doc.result.error
+                    ):
+                        reason = "Operation marked as FAILED externally"
+                        self._terminate_child_process(
+                            child_process, operation.id, reason
+                        )
+                        break
+                except Exception as e:
+                    reason = f"Error in monitoring loop: {e}"
+                    logger.error(
+                        "Error in monitoring loop for operation %s: %s",
+                        operation.id,
+                        e,
+                    )
+                    self._terminate_child_process(
+                        child_process, operation.id, reason
+                    )
+                    raise
+            final_doc = self.get(operation.id)
+            result = (
+                final_doc.result
+                if final_doc and final_doc.result
+                else ExecutionResult()
+            )
+        finally:
+            listener.stop()
+            if child_process and child_process.is_alive():
+                self._terminate_child_process(
+                    child_process, operation.id, "Executor shutting down"
+                )
+
         return result
 
     async def _execute_operator(self, doc):

--- a/tests/unittests/operators/delegated_tests.py
+++ b/tests/unittests/operators/delegated_tests.py
@@ -6,12 +6,15 @@ FiftyOne delegated operator related unit tests.
 |
 """
 import copy
+import signal
+import threading
 import time
 import unittest
 from unittest import mock
 from unittest.mock import patch
 
 import bson
+import psutil
 import pytest
 
 import fiftyone
@@ -470,7 +473,8 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.assertEqual(doc.run_state, ExecutionRunState.QUEUED)
 
         results = self.svc.execute_queued_operations(
-            delegation_target="test_target"
+            delegation_target="test_target",
+            monitor=False,
         )
         self.assertEqual(len(results), 1)
         self.assertIsNone(results[0].error)
@@ -501,7 +505,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.assertEqual(doc.run_state, ExecutionRunState.QUEUED)
 
         results = self.svc.execute_queued_operations(
-            delegation_target="test_target"
+            delegation_target="test_target", monitor=False
         )
         self.assertEqual(len(results), 1)
         self.assertIsNone(results[0].error)
@@ -538,7 +542,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.assertEqual(doc.run_state, ExecutionRunState.QUEUED)
 
         results = self.svc.execute_queued_operations(
-            delegation_target="test_target_generator"
+            delegation_target="test_target_generator", monitor=False
         )
         self.assertEqual(len(results), 1)
         self.assertIsNone(results[0].error)
@@ -572,7 +576,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.assertEqual(doc.run_state, ExecutionRunState.QUEUED)
 
         results = self.svc.execute_queued_operations(
-            delegation_target="test_target"
+            delegation_target="test_target", monitor=False
         )
         self.assertEqual(len(results), 1)
         self.assertIsNone(results[0].error)
@@ -609,7 +613,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
             DelegatedOperationService, "set_progress"
         ) as set_progress:
             self.svc.execute_operation(
-                operation=doc, run_link="http://run.info"
+                operation=doc, run_link="http://run.info", monitor=False
             )
             self.assertEqual(set_progress.call_count, 10)
             for x in range(10):
@@ -644,7 +648,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         #   it's running elsewhere.
         self.svc.set_running(doc.id)
 
-        self.svc.execute_operation(doc)
+        self.svc.execute_operation(doc, monitor=False)
         operator.execute.assert_not_called()
 
         doc = self.svc.get(doc_id=doc.id)
@@ -673,7 +677,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.assertEqual(doc.run_state, ExecutionRunState.QUEUED)
 
         results = self.svc.execute_queued_operations(
-            delegation_target="test_target"
+            delegation_target="test_target", monitor=False
         )
         self.assertEqual(len(results), 1)
         self.assertIsNotNone(results[0].error)
@@ -713,7 +717,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.assertEqual(doc.run_state, ExecutionRunState.QUEUED)
 
         results = self.svc.execute_queued_operations(
-            delegation_target="test_target"
+            delegation_target="test_target", monitor=False
         )
         self.assertEqual(len(results), 1)
         self.assertIsNotNone(results[0].error)
@@ -737,7 +741,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.assertIsNone(rerun_doc.result)
 
         results = self.svc.execute_queued_operations(
-            delegation_target="test_target"
+            delegation_target="test_target", monitor=False
         )
         self.assertEqual(len(results), 1)
         self.assertIsNone(results[0].error)
@@ -774,7 +778,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
 
         # Execute once with original dataset name
         results = self.svc.execute_queued_operations(
-            delegation_target="test_target"
+            delegation_target="test_target", monitor=False
         )
         self.assertEqual(len(results), 1)
         self.assertIsNotNone(results[0].error)
@@ -806,7 +810,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
             self.assertIsNone(rerun_doc.result)
 
             results = self.svc.execute_queued_operations(
-                delegation_target="test_target"
+                delegation_target="test_target", monitor=False
             )
             self.assertEqual(len(results), 1)
             self.assertIsNone(results[0].error)
@@ -850,10 +854,145 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         )
         self.docs_to_delete.append(doc)
         doc = self.svc.set_running(doc.id)
-        result = self.svc.execute_operation(doc)
+        result = self.svc.execute_operation(doc, monitor=False)
         changed_doc = self.svc.get(doc_id=doc.id)
         self.assertEqual(changed_doc.status, doc.status)
         self.assertIsNone(result)
+
+    @patch("logging.handlers.QueueListener")
+    @patch("multiprocessing.get_context")
+    def test_execute_operation_monitor_success(
+        self,
+        mock_get_context,
+        mock_listener,
+        mock_get_operator,
+    ):
+        mock_process = mock.MagicMock()
+        mock_process.is_alive.side_effect = [True, False, False]
+
+        mock_context = mock.MagicMock()
+        mock_context.Process.return_value = mock_process
+        mock_context.Queue.return_value = mock.MagicMock()
+        mock_get_context.return_value = mock_context
+
+        doc = self.svc.queue_operation(
+            operator=f"{TEST_DO_PREFIX}/operator/monitor_success",
+            context=ExecutionContext(
+                request_params={"dataset_id": str(ObjectId())}
+            ),
+        )
+        self.docs_to_delete.append(doc)
+
+        completed_doc = copy.deepcopy(doc)
+        completed_doc.run_state = ExecutionRunState.COMPLETED
+        completed_doc.result = ExecutionResult(result={"executed": True})
+
+        with patch.object(self.svc, "get", return_value=completed_doc), patch(
+            "fiftyone.operators.delegated._execute_operator_in_child_process"
+        ):
+            result = self.svc.execute_operation(
+                operation=doc,
+                log=False,
+                monitor=True,
+            )
+
+        self.assertIsNotNone(result)
+        self.assertIsNone(result.error)
+        self.assertEqual(result.result, {"executed": True})
+
+    @patch("logging.handlers.QueueListener")
+    @patch("multiprocessing.get_context")
+    def test_execute_operation_monitor_internal_fail(
+        self,
+        mock_get_context,
+        mock_listener,
+        mock_get_operator,
+    ):
+        mock_process = mock.MagicMock()
+        mock_process.is_alive.side_effect = [True, False, False]
+
+        mock_context = mock.MagicMock()
+        mock_context.Process.return_value = mock_process
+        mock_context.Queue.return_value = mock.MagicMock()
+        mock_get_context.return_value = mock_context
+
+        doc = self.svc.queue_operation(
+            operator=f"{TEST_DO_PREFIX}/operator/monitor_fail",
+            context=ExecutionContext(
+                request_params={"dataset_id": str(ObjectId())}
+            ),
+        )
+        self.docs_to_delete.append(doc)
+
+        failed_doc = copy.deepcopy(doc)
+        failed_doc.run_state = ExecutionRunState.FAILED
+        failed_doc.result = ExecutionResult(
+            error="MockOperator failed internally"
+        )
+
+        with patch.object(self.svc, "get", return_value=failed_doc), patch(
+            "fiftyone.operators.delegated._execute_operator_in_child_process"
+        ):
+            result = self.svc.execute_operation(
+                operation=doc,
+                log=False,
+                monitor=True,
+            )
+
+        self.assertIsNotNone(result)
+        self.assertIsNotNone(result.error)
+        self.assertIn("MockOperator failed internally", result.error)
+
+    @patch("psutil.Process")
+    @patch("logging.handlers.QueueListener")
+    @patch("multiprocessing.get_context")
+    def test_execute_operation_monitor_external_fail(
+        self,
+        mock_get_context,
+        mock_listener,
+        mock_psutil_process,
+        mock_get_operator,
+    ):
+        mock_process = mock.MagicMock()
+        mock_process.pid = 12345
+        mock_process.is_alive.side_effect = [True, True, False]
+
+        mock_context = mock.MagicMock()
+        mock_context.Process.return_value = mock_process
+        mock_context.Queue.return_value = mock.MagicMock()
+        mock_get_context.return_value = mock_context
+
+        mock_psutil_parent = mock.MagicMock()
+        mock_psutil_process.return_value = mock_psutil_parent
+
+        doc = self.svc.queue_operation(
+            operator=f"{TEST_DO_PREFIX}/operator/monitor_external_fail",
+            context=ExecutionContext(
+                request_params={"dataset_id": str(ObjectId())}
+            ),
+        )
+        self.docs_to_delete.append(doc)
+
+        failed_doc = copy.deepcopy(doc)
+        failed_doc.run_state = ExecutionRunState.FAILED
+        failed_doc.result = ExecutionResult(error="marked as failed by test")
+
+        with patch.object(self.svc, "get", return_value=failed_doc), patch(
+            "time.sleep", return_value=None
+        ):
+            result = self.svc.execute_operation(
+                operation=doc, log=False, monitor=True
+            )
+
+        mock_psutil_process.assert_called_once_with(mock_process.pid)
+        mock_psutil_parent.children.assert_called_once_with(recursive=True)
+        mock_psutil_parent.terminate.assert_called_once()
+
+        self.assertIsNotNone(result)
+        self.assertIn("marked as failed by test", result.error)
+
+        mock_process.start.assert_called_once()
+        mock_process.join.assert_called()
 
     def test_execute_with_renamed_dataset(self, get_op_mock):
         # setup
@@ -888,7 +1027,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         # Execute queued operation after saving the new dataset name
         try:
             results = self.svc.execute_queued_operations(
-                delegation_target="test_target"
+                delegation_target="test_target", monitor=False
             )
             self.assertEqual(len(results), 1)
             self.assertIsNone(results[0].error)


### PR DESCRIPTION
## What changes are proposed in this pull request?

By default running DOs using the CLI will now occasionally check if the DO has been manually marked as failed and terminate the execution process if it has been.

## How is this patch tested? If it is not, please explain why.

Used `fiftyone delegated launch` without the -m command and ran a simple DO I created that will spawn a bunch of child processes. Verified before execution the number of processes, then started executing and manually failed it during execution. The output is here:

Processes before execution
```
(TEAMS) ➜  cam_test git:(main) ✗ ps aux | grep python
camronstaley     30267   8.7  0.3 410947504  55616 s019  S+   10Sep25  87:17.86 /Users/camronstaley/Workplace/envs/HUB/bin/python -c from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=7, pipe_handle=20) --multiprocessing-fork
camronstaley     30232   0.5  0.0 411080496   8720 s019  S+   10Sep25  14:20.90 python dev.py
camronstaley     30265   0.3  0.0 410451888   7136 s019  S+   10Sep25  10:32.22 /Users/camronstaley/Workplace/envs/HUB/bin/python -c from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=7, pipe_handle=9) --multiprocessing-fork
camronstaley     69915   0.1  1.8 411374416 332560 s034  S     4:02PM   0:01.94 /Users/camronstaley/Workplace/envs/TEAMS/bin/python /Users/camronstaley/Workplace/fiftyone-teams/fiftyone/service/cache.py
camronstaley     50243   0.0  0.2 1604671104  37536   ??  S     1:36PM   1:03.78 /private/var/folders/vy/jdncjrdx3q35qtw0rmnpfy980000gn/T/AppTranslocation/CDA2CADD-5C5D-4EC8-8F98-D162218E24B3/d/Visual Studio Code.app/Contents/Frameworks/Code Helper (Plugin).app/Contents/MacOS/Code Helper (Plugin) /Users/camronstaley/.vscode/extensions/ms-python.vscode-pylance-2025.4.1/dist/server.bundle.js --cancellationReceive=file:16f30dc9e148632d8104fe091a01ed9787ce8f9d4a --node-ipc --clientProcessId=49799
camronstaley     49866   0.0  0.0 411091616   1632   ??  S     1:36PM   0:00.17 /Users/camronstaley/.vscode/extensions/ms-python.python-2024.14.1-darwin-arm64/python-env-tools/bin/pet server
camronstaley     99204   0.0  0.1 411897696  18144 s019  S+   12Sep25   2:17.59 /Users/camronstaley/Workplace/envs/HUB/bin/python -c from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=7, pipe_handle=20) --multiprocessing-fork
camronstaley     30264   0.0  0.0 410301552   2816 s019  S+   10Sep25   0:00.03 /Users/camronstaley/Workplace/envs/HUB/bin/python -c from multiprocessing.resource_tracker import main;main(6)
camronstaley     44282   0.0  0.1 1604685344  23200   ??  S    10Sep25   2:31.12 /private/var/folders/vy/jdncjrdx3q35qtw0rmnpfy980000gn/T/AppTranslocation/CDA2CADD-5C5D-4EC8-8F98-D162218E24B3/d/Visual Studio Code.app/Contents/Frameworks/Code Helper (Plugin).app/Contents/MacOS/Code Helper (Plugin) /Users/camronstaley/.vscode/extensions/ms-python.vscode-pylance-2025.4.1/dist/server.bundle.js --cancellationReceive=file:2607b54abc3379396af0899478a6317a432f933d2b --node-ipc --clientProcessId=44170
camronstaley     44171   0.0  0.0 410829472    400   ??  S    10Sep25   0:00.24 /Users/camronstaley/.vscode/extensions/ms-python.python-2024.14.1-darwin-arm64/python-env-tools/bin/pet server
camronstaley     11858   0.0  0.2 1604635200  30336   ??  S     9Sep25   2:54.60 /private/var/folders/vy/jdncjrdx3q35qtw0rmnpfy980000gn/T/AppTranslocation/CDA2CADD-5C5D-4EC8-8F98-D162218E24B3/d/Visual Studio Code.app/Contents/Frameworks/Code Helper (Plugin).app/Contents/MacOS/Code Helper (Plugin) /Users/camronstaley/.vscode/extensions/ms-python.vscode-pylance-2025.4.1/dist/server.bundle.js --cancellationReceive=file:b1b8acd820b5b0e4f8771a9fcd2a449901f51830a2 --node-ipc --clientProcessId=11610
camronstaley     11618   0.0  0.0 411091616   1872   ??  S     9Sep25   0:00.24 /Users/camronstaley/.vscode/extensions/ms-python.python-2024.14.1-darwin-arm64/python-env-tools/bin/pet server
camronstaley     69958   0.0  0.0 410209344   1344 s036  S+    4:02PM   0:00.00 grep --color=auto --exclude-dir=.bzr --exclude-dir=CVS --exclude-dir=.git --exclude-dir=.hg --exclude-dir=.svn --exclude-dir=.idea --exclude-dir=.tox python
camronstaley     69882   0.0  1.6 411410912 295408 s034  S     4:02PM   0:02.06 /Users/camronstaley/Workplace/envs/TEAMS/bin/python /Users/camronstaley/Workplace/fiftyone-teams/fiftyone/service/main.py --51-service media-cache --multi --cache-dir /Users/camronstaley/fiftyone/__cache__ /Users/camronstaley/Workplace/envs/TEAMS/bin/python /Users/camronstaley/Workplace/fiftyone-teams/fiftyone/service/cache.py
camronstaley     69852   0.0  1.7 411482816 313632 s034  S+    4:02PM   0:02.41 /Users/camronstaley/Workplace/envs/TEAMS/bin/python /Users/camronstaley/Workplace/envs/TEAMS/bin/fiftyone delegated launch -t remote --no-validate
```

Processes during execution:
```
(TEAMS) ➜  cam_test git:(main) ✗ ps aux | grep python
camronstaley     30267   0.2  0.3 410947504  55600 s019  S+   10Sep25  87:19.70 /Users/camronstaley/Workplace/envs/HUB/bin/python -c from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=7, pipe_handle=20) --multiprocessing-fork
camronstaley     30265   0.1  0.0 410451888   7072 s019  S+   10Sep25  10:32.43 /Users/camronstaley/Workplace/envs/HUB/bin/python -c from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=7, pipe_handle=9) --multiprocessing-fork
camronstaley     30232   0.1  0.0 411080496   8720 s019  S+   10Sep25  14:21.19 python dev.py
camronstaley     50243   0.0  0.2 1604671104  37808   ??  S     1:36PM   1:03.80 /private/var/folders/vy/jdncjrdx3q35qtw0rmnpfy980000gn/T/AppTranslocation/CDA2CADD-5C5D-4EC8-8F98-D162218E24B3/d/Visual Studio Code.app/Contents/Frameworks/Code Helper (Plugin).app/Contents/MacOS/Code Helper (Plugin) /Users/camronstaley/.vscode/extensions/ms-python.vscode-pylance-2025.4.1/dist/server.bundle.js --cancellationReceive=file:16f30dc9e148632d8104fe091a01ed9787ce8f9d4a --node-ipc --clientProcessId=49799
camronstaley     49866   0.0  0.0 411091616   1632   ??  S     1:36PM   0:00.17 /Users/camronstaley/.vscode/extensions/ms-python.python-2024.14.1-darwin-arm64/python-env-tools/bin/pet server
camronstaley     99204   0.0  0.1 411897696  26144 s019  S+   12Sep25   2:17.71 /Users/camronstaley/Workplace/envs/HUB/bin/python -c from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=7, pipe_handle=20) --multiprocessing-fork
camronstaley     30264   0.0  0.0 410301552   2816 s019  S+   10Sep25   0:00.03 /Users/camronstaley/Workplace/envs/HUB/bin/python -c from multiprocessing.resource_tracker import main;main(6)
camronstaley     44282   0.0  0.1 1604685344  23712   ??  S    10Sep25   2:31.14 /private/var/folders/vy/jdncjrdx3q35qtw0rmnpfy980000gn/T/AppTranslocation/CDA2CADD-5C5D-4EC8-8F98-D162218E24B3/d/Visual Studio Code.app/Contents/Frameworks/Code Helper (Plugin).app/Contents/MacOS/Code Helper (Plugin) /Users/camronstaley/.vscode/extensions/ms-python.vscode-pylance-2025.4.1/dist/server.bundle.js --cancellationReceive=file:2607b54abc3379396af0899478a6317a432f933d2b --node-ipc --clientProcessId=44170
camronstaley     44171   0.0  0.0 410829472    400   ??  S    10Sep25   0:00.24 /Users/camronstaley/.vscode/extensions/ms-python.python-2024.14.1-darwin-arm64/python-env-tools/bin/pet server
camronstaley     11858   0.0  0.3 1604635200  52880   ??  S     9Sep25   2:59.37 /private/var/folders/vy/jdncjrdx3q35qtw0rmnpfy980000gn/T/AppTranslocation/CDA2CADD-5C5D-4EC8-8F98-D162218E24B3/d/Visual Studio Code.app/Contents/Frameworks/Code Helper (Plugin).app/Contents/MacOS/Code Helper (Plugin) /Users/camronstaley/.vscode/extensions/ms-python.vscode-pylance-2025.4.1/dist/server.bundle.js --cancellationReceive=file:b1b8acd820b5b0e4f8771a9fcd2a449901f51830a2 --node-ipc --clientProcessId=11610
camronstaley     11618   0.0  0.0 411091616   1680   ??  S     9Sep25   0:00.24 /Users/camronstaley/.vscode/extensions/ms-python.python-2024.14.1-darwin-arm64/python-env-tools/bin/pet server
camronstaley     71067   0.0  0.0 410059408    224 s036  R+    4:03PM   0:00.00 grep --color=auto --exclude-dir=.bzr --exclude-dir=CVS --exclude-dir=.git --exclude-dir=.hg --exclude-dir=.svn --exclude-dir=.idea --exclude-dir=.tox python
camronstaley     70855   0.0  0.1 411487696  18464   ??  S     4:03PM   0:00.00 /Users/camronstaley/Workplace/envs/TEAMS/bin/python -c from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=16, pipe_handle=20) --multiprocessing-fork
camronstaley     70854   0.0  0.1 411487696  18576   ??  S     4:03PM   0:00.00 /Users/camronstaley/Workplace/envs/TEAMS/bin/python -c from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=16, pipe_handle=20) --multiprocessing-fork
camronstaley     70853   0.0  0.1 411487696  18784   ??  S     4:03PM   0:00.00 /Users/camronstaley/Workplace/envs/TEAMS/bin/python -c from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=16, pipe_handle=20) --multiprocessing-fork
camronstaley     70852   0.0  0.1 411487696  18416   ??  S     4:03PM   0:00.00 /Users/camronstaley/Workplace/envs/TEAMS/bin/python -c from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=16, pipe_handle=20) --multiprocessing-fork
camronstaley     70851   0.0  0.1 411487696  18752   ??  S     4:03PM   0:00.00 /Users/camronstaley/Workplace/envs/TEAMS/bin/python -c from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=16, pipe_handle=20) --multiprocessing-fork
camronstaley     70819   0.0  1.8 411490080 334672   ??  Ss    4:03PM   0:02.21 /Users/camronstaley/Workplace/envs/TEAMS/bin/python -c from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=16, pipe_handle=20) --multiprocessing-fork
camronstaley     70818   0.0  0.0 410722416   6624 s034  S+    4:03PM   0:00.04 /Users/camronstaley/Workplace/envs/TEAMS/bin/python -c from multiprocessing.resource_tracker import main;main(15)
camronstaley     70671   0.0  1.6 411382592 294384 s034  S     4:03PM   0:01.92 /Users/camronstaley/Workplace/envs/TEAMS/bin/python /Users/camronstaley/Workplace/fiftyone-teams/fiftyone/service/cache.py
camronstaley     70639   0.0  1.6 411454992 297024 s034  S     4:03PM   0:02.13 /Users/camronstaley/Workplace/envs/TEAMS/bin/python /Users/camronstaley/Workplace/fiftyone-teams/fiftyone/service/main.py --51-service media-cache --multi --cache-dir /Users/camronstaley/fiftyone/__cache__ /Users/camronstaley/Workplace/envs/TEAMS/bin/python /Users/camronstaley/Workplace/fiftyone-teams/fiftyone/service/cache.py
camronstaley     70636   0.0  1.6 411519904 306048 s034  S+    4:03PM   0:02.50 /Users/camronstaley/Workplace/envs/TEAMS/bin/python /Users/camronstaley/Workplace/envs/TEAMS/bin/fiftyone delegated launch -t remote --no-validate
```


Processes after termination:
```
(TEAMS) ➜  cam_test git:(main) ✗ ps aux | grep python
camronstaley     30232   0.4  0.0 411080496   8720 s019  S+   10Sep25  14:21.36 python dev.py
camronstaley     30267   0.3  0.3 410947504  55792 s019  S+   10Sep25  87:20.70 /Users/camronstaley/Workplace/envs/HUB/bin/python -c from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=7, pipe_handle=20) --multiprocessing-fork
camronstaley     30265   0.3  0.0 410451888   7136 s019  S+   10Sep25  10:32.55 /Users/camronstaley/Workplace/envs/HUB/bin/python -c from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=7, pipe_handle=9) --multiprocessing-fork
camronstaley     50243   0.0  0.2 1604671104  37808   ??  S     1:36PM   1:03.80 /private/var/folders/vy/jdncjrdx3q35qtw0rmnpfy980000gn/T/AppTranslocation/CDA2CADD-5C5D-4EC8-8F98-D162218E24B3/d/Visual Studio Code.app/Contents/Frameworks/Code Helper (Plugin).app/Contents/MacOS/Code Helper (Plugin) /Users/camronstaley/.vscode/extensions/ms-python.vscode-pylance-2025.4.1/dist/server.bundle.js --cancellationReceive=file:16f30dc9e148632d8104fe091a01ed9787ce8f9d4a --node-ipc --clientProcessId=49799
camronstaley     49866   0.0  0.0 411091616   1632   ??  S     1:36PM   0:00.17 /Users/camronstaley/.vscode/extensions/ms-python.python-2024.14.1-darwin-arm64/python-env-tools/bin/pet server
camronstaley     99204   0.0  0.1 411897696  26464 s019  S+   12Sep25   2:17.77 /Users/camronstaley/Workplace/envs/HUB/bin/python -c from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=7, pipe_handle=20) --multiprocessing-fork
camronstaley     30264   0.0  0.0 410301552   2816 s019  S+   10Sep25   0:00.03 /Users/camronstaley/Workplace/envs/HUB/bin/python -c from multiprocessing.resource_tracker import main;main(6)
camronstaley     44282   0.0  0.1 1604685344  23808   ??  S    10Sep25   2:31.14 /private/var/folders/vy/jdncjrdx3q35qtw0rmnpfy980000gn/T/AppTranslocation/CDA2CADD-5C5D-4EC8-8F98-D162218E24B3/d/Visual Studio Code.app/Contents/Frameworks/Code Helper (Plugin).app/Contents/MacOS/Code Helper (Plugin) /Users/camronstaley/.vscode/extensions/ms-python.vscode-pylance-2025.4.1/dist/server.bundle.js --cancellationReceive=file:2607b54abc3379396af0899478a6317a432f933d2b --node-ipc --clientProcessId=44170
camronstaley     44171   0.0  0.0 410829472    400   ??  S    10Sep25   0:00.24 /Users/camronstaley/.vscode/extensions/ms-python.python-2024.14.1-darwin-arm64/python-env-tools/bin/pet server
camronstaley     11858   0.0  0.2 1604635200  38928   ??  S     9Sep25   2:59.38 /private/var/folders/vy/jdncjrdx3q35qtw0rmnpfy980000gn/T/AppTranslocation/CDA2CADD-5C5D-4EC8-8F98-D162218E24B3/d/Visual Studio Code.app/Contents/Frameworks/Code Helper (Plugin).app/Contents/MacOS/Code Helper (Plugin) /Users/camronstaley/.vscode/extensions/ms-python.vscode-pylance-2025.4.1/dist/server.bundle.js --cancellationReceive=file:b1b8acd820b5b0e4f8771a9fcd2a449901f51830a2 --node-ipc --clientProcessId=11610
camronstaley     11618   0.0  0.0 411091616   1680   ??  S     9Sep25   0:00.24 /Users/camronstaley/.vscode/extensions/ms-python.python-2024.14.1-darwin-arm64/python-env-tools/bin/pet server
camronstaley     71538   0.0  0.0 410200128   1232 s036  S+    4:04PM   0:00.00 grep --color=auto --exclude-dir=.bzr --exclude-dir=CVS --exclude-dir=.git --exclude-dir=.hg --exclude-dir=.svn --exclude-dir=.idea --exclude-dir=.tox python
camronstaley     70818   0.0  0.0 410722416   7152 s034  S+    4:03PM   0:00.04 /Users/camronstaley/Workplace/envs/TEAMS/bin/python -c from multiprocessing.resource_tracker import main;main(15)
camronstaley     70671   0.0  1.6 411382592 294400 s034  S     4:03PM   0:01.93 /Users/camronstaley/Workplace/envs/TEAMS/bin/python /Users/camronstaley/Workplace/fiftyone-teams/fiftyone/service/cache.py
camronstaley     70639   0.0  1.4 411438544 271088 s034  S     4:03PM   0:02.17 /Users/camronstaley/Workplace/envs/TEAMS/bin/python /Users/camronstaley/Workplace/fiftyone-teams/fiftyone/service/main.py --51-service media-cache --multi --cache-dir /Users/camronstaley/fiftyone/__cache__ /Users/camronstaley/Workplace/envs/TEAMS/bin/python /Users/camronstaley/Workplace/fiftyone-teams/fiftyone/service/cache.py
camronstaley     70636   0.0  1.2 411634528 224656 s034  S+    4:03PM   0:02.56 /Users/camronstaley/Workplace/envs/TEAMS/bin/python /Users/camronstaley/Workplace/envs/TEAMS/bin/fiftyone delegated launch -t remote --no-validate
```

Here are the execution console outputs:
```

(TEAMS) ➜  fiftyone-teams git:(feat/cancel-do) fiftyone delegated launch -t remote --no-validate
Continual Executor started
Registering executor builtin
SecretsManager can only access secrets from the database when initialized from within an environment with set internal service ID and encryption key. 

Running operation 68cdc2e07da656d6f4722cdb (@voxel51/camstale_test/test_wait_multi)
SecretsManager can only access secrets from the database when initialized from within an environment with set internal service ID and encryption key. 

Running operation 68cdc2e07da656d6f4722cdb (@voxel51/camstale_test/test_wait_multi) in child process
[test_wait_multi] Main operator process started.
[test_wait_multi] Spawning 5 worker processes...
[test_wait_multi] Started worker process 1 with PID 70851.
[test_wait_multi] Started worker process 2 with PID 70852.
[test_wait_multi] Started worker process 3 with PID 70853.
[test_wait_multi] Started worker process 4 with PID 70854.
[test_wait_multi] Started worker process 5 with PID 70855.
[test_wait_multi] All worker processes have been spawned.
[test_wait_multi] Now waiting for them to complete...
Terminating process tree (PID: 70819) for operation 68cdc2e07da656d6f4722cdb. Reason: Operation marked as FAILED externally
Terminating process tree (PID: 70819) for operation 68cdc2e07da656d6f4722cdb. Reason: Executor shutting down
Process 70819 for op 68cdc2e07da656d6f4722cdb already terminated.
Flushing logs to /Users/camronstaley/Workplace/logs/do_logs/2025/9/19/68cdc2e07da656d6f4722cdb.log

Running operation 68cdc59f7da656d6f4722cdc (@voxel51/camstale_test/test_wait)
SecretsManager can only access secrets from the database when initialized from within an environment with set internal service ID and encryption key. 

Running operation 68cdc59f7da656d6f4722cdc (@voxel51/camstale_test/test_wait) in child process
[test_wait] Starting operator at 2025-09-19T16:05:45.776068. Will wait for 1800 seconds until 2025-09-19T16:35:45.776068.
Terminating process tree (PID: 72623) for operation 68cdc59f7da656d6f4722cdc. Reason: Operation marked as FAILED externally
Terminating process tree (PID: 72623) for operation 68cdc59f7da656d6f4722cdc. Reason: Executor shutting down
Process 72623 for op 68cdc59f7da656d6f4722cdc already terminated.
Flushing logs to /Users/camronstaley/Workplace/logs/do_logs/2025/9/19/68cdc59f7da656d6f4722cdc.log
^CReceived termination signal, stopping executor...
stopping daemon
(TEAMS) ➜  fiftyone-teams git:(feat/cancel-do) ✗ fiftyone delegated launch -t remote --no-validate
Continual Executor started
Registering executor builtin
SecretsManager can only access secrets from the database when initialized from within an environment with set internal service ID and encryption key. 

Running operation 68cdc59f7da656d6f4722cdc (@voxel51/camstale_test/test_wait)
SecretsManager can only access secrets from the database when initialized from within an environment with set internal service ID and encryption key. 

Running operation 68cdc59f7da656d6f4722cdc (@voxel51/camstale_test/test_wait) in child process
[test_wait] Starting operator at 2025-09-19T16:07:37.564364. Will wait for 1800 seconds until 2025-09-19T16:37:37.564364.
Error in monitoring loop for operation 68cdc59f7da656d6f4722cdc: 'NoneType' object has no attribute 'get'
Terminating process tree (PID: 74189) for operation 68cdc59f7da656d6f4722cdc. Reason: Error in monitoring loop: 'NoneType' object has no attribute 'get'
Terminating process tree (PID: 74189) for operation 68cdc59f7da656d6f4722cdc. Reason: Executor shutting down
Process 74189 for op 68cdc59f7da656d6f4722cdc already terminated.
```

Here are my simple test operators:
```
"""
A FiftyOne plugin with two test operators for process management.

1.  test_wait: A simple delegated operator that waits for 30 minutes.
2.  test_wait_multi: A delegated operator that spawns 5 child processes,
    each of which waits for 30 minutes.

These are designed to test how killing the main operator process affects
any child processes it has spawned.
"""
import time
import datetime
import multiprocessing

import fiftyone.operators as foo
import fiftyone.operators.types as types
from fiftyone.core.logging import logger

# Define the worker function at the top level of the module.
# This is a requirement for the `multiprocessing` module, which needs to be
# able to pickle the function to send it to the child process.
def worker_wait(process_id, wait_seconds):
    """A simple function that a child process will execute."""
    start_time = datetime.datetime.now()
    end_time = start_time + datetime.timedelta(seconds=wait_seconds)
    
    logger.info(
        f"[Worker {process_id}] Starting wait at {start_time.isoformat()}. "
        f"Will wait until {end_time.isoformat()}."
    )
    
    time.sleep(wait_seconds)
    
    logger.info(f"[Worker {process_id}] Finished waiting at {datetime.datetime.now().isoformat()}.")


class TestWait(foo.Operator):
    """
    A simple delegated operator that waits for a fixed duration.
    """

    @property
    def name(self):
        return "test_wait"

    @property
    def config(self):
        return foo.OperatorConfig(
            name=self.name,
            label="Test Wait (Single Process)",
            description="Waits for 30 minutes in a single process",
            delegated=True, # This is crucial for running as a separate process
        )

    def resolve_input(self, ctx):
        # No inputs are needed for this operator
        inputs = types.Object()
        return types.Property(inputs)

    def execute(self, ctx):
        wait_seconds = 30 * 60  # 30 minutes
        start_time = datetime.datetime.now()
        end_time = start_time + datetime.timedelta(seconds=wait_seconds)

        logger.info(
            f"[{self.name}] Starting operator at {start_time.isoformat()}. "
            f"Will wait for {wait_seconds} seconds until {end_time.isoformat()}."
        )

        time.sleep(wait_seconds)

        logger.info(f"[{self.name}] Finished waiting at {datetime.datetime.now().isoformat()}.")
        
        return {"status": "completed"}


class TestWaitMulti(foo.Operator):
    """
    A delegated operator that spawns multiple child processes, each of which
    waits for a fixed duration.
    """

    @property
    def name(self):
        return "test_wait_multi"

    @property
    def config(self):
        return foo.OperatorConfig(
            name=self.name,
            label="Test Wait (Multi-Process)",
            description="Spawns 5 child processes that each wait for 30 minutes",
            delegated=True, # This is crucial for running as a separate process
        )

    def resolve_input(self, ctx):
        # No inputs are needed for this operator
        inputs = types.Object()
        return types.Property(inputs)

    def execute(self, ctx):
        num_processes = 5
        wait_seconds = 30 * 60  # 30 minutes
        processes = []

        logger.info(f"[{self.name}] Main operator process started.")
        logger.info(f"[{self.name}] Spawning {num_processes} worker processes...")
        mp_fork = multiprocessing.get_context("fork")
        for i in range(num_processes):
            process_id = i + 1
            # Create a Process object
            p = mp_fork.Process(
                target=worker_wait, args=(process_id, wait_seconds)
            )
            processes.append(p)
            # Start the process
            p.start()
            logger.info(f"[{self.name}] Started worker process {process_id} with PID {p.pid}.")

        logger.info(f"[{self.name}] All worker processes have been spawned.")
        logger.info(f"[{self.name}] Now waiting for them to complete...")

        # Wait for all processes to finish
        for p in processes:
            p.join()

        logger.info(f"[{self.name}] All worker processes have completed. Operator finished.")
        
        return {"status": "completed"}


def register(p):
    """Registers the plugins in this module with FiftyOne."""
    p.register(TestWait)
    p.register(TestWaitMulti)
```
## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

If you run `fiftyone delegated launch` any DOs executed will run in a child process. If that DO is manually marked as failed during execution, then the execution process will be terminated early.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
