### PR TITLE
Fix pymongo connect after close

### DIFF
--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -240,6 +240,8 @@ def establish_db_conn(config):
 
 def _connect():
     global _client
+    if _client and getattr(_client, "_closed", False):
+        _client = None
     if _client is None:
         global _connection_kwargs
 

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -275,6 +275,8 @@ def _async_connect(use_global=False):
     _connect()
 
     global _async_client
+    if _async_client and getattr(_async_client, "_closed", False):
+        _async_client = None
     if not use_global or _async_client is None:
         global _connection_kwargs
         client = mtr.AsyncIOMotorClient(

--- a/tests/unittests/odm_tests.py
+++ b/tests/unittests/odm_tests.py
@@ -109,3 +109,14 @@ class GetIndexedValuesTests(unittest.TestCase):
 
         finally:
             dataset.delete()
+
+
+class GetDbConnTests(unittest.TestCase):
+    def test_get_db_conn(self):
+        conn = foo.get_db_conn()
+        self.assertIsNotNone(conn)
+        conn.client.close()
+        assert conn.client._closed == True
+        # should be able to reconnect
+        conn = foo.get_db_conn()
+        assert conn.client._closed == False


### PR DESCRIPTION
## What changes are proposed in this pull request?

- enable re-establishing a connection if the client has been closed 

## How is this patch tested? If it is not, please explain why.

- added automated test and tested locally
```


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
