### PR TITLE
FOEPD-2166: Increment generated filenames to avoid overwriting existing files

### DIFF
--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -2142,6 +2142,19 @@ class UniqueFilenameMaker(object):
 
         count = self._filename_counts[key]
         if count > 1:
+            # Handle existing filenames that use `-%d` suffix
+            if not self.ignore_existing:
+                while True:
+                    _key = name + ("-%d" % count)
+                    if not self.ignore_exts:
+                        _key += ext
+
+                    if _key in self._filename_counts:
+                        self._filename_counts[key] += 1
+                        count += 1
+                    else:
+                        break
+
             filename = name + ("-%d" % count) + ext
 
         if self.chunk_size is not None:

--- a/fiftyone/utils/labels.py
+++ b/fiftyone/utils/labels.py
@@ -67,8 +67,8 @@ def objects_to_segmentations(
             ``output_dir`` that match the shape of the input paths. The path is
             converted to an absolute path (if necessary) via
             :func:`fiftyone.core.storage.normalize_path`
-        overwrite (False): whether to delete ``output_dir`` prior to exporting
-            if it exists
+        overwrite (False): whether to overwrite any existing files in
+            ``output_dir``
         save_mask_targets (False): whether to store the ``mask_targets`` on the
             dataset
         progress (None): whether to render a progress bar (True/False), use the
@@ -99,12 +99,12 @@ def objects_to_segmentations(
 
     samples = sample_collection.select_fields(in_field)
 
-    if overwrite and output_dir is not None:
-        etau.delete_dir(output_dir)
-
     if output_dir is not None:
         filename_maker = fou.UniqueFilenameMaker(
-            output_dir=output_dir, rel_dir=rel_dir, idempotent=False
+            output_dir=output_dir,
+            rel_dir=rel_dir,
+            ignore_existing=overwrite,
+            idempotent=False,
         )
 
     for sample in samples.iter_samples(autosave=True, progress=progress):
@@ -195,8 +195,8 @@ def export_segmentations(
             converted to an absolute path (if necessary) via
             :func:`fiftyone.core.storage.normalize_path`
         update (True): whether to delete the arrays from the database
-        overwrite (False): whether to delete ``output_dir`` prior to exporting
-            if it exists
+        overwrite (False): whether to overwrite any existing files in
+            ``output_dir``
         progress (None): whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
@@ -217,11 +217,11 @@ def export_segmentations(
 
     samples = sample_collection.select_fields(select_fields)
 
-    if overwrite:
-        etau.delete_dir(output_dir)
-
     filename_maker = fou.UniqueFilenameMaker(
-        output_dir=output_dir, rel_dir=rel_dir, idempotent=False
+        output_dir=output_dir,
+        rel_dir=rel_dir,
+        ignore_existing=overwrite,
+        idempotent=False,
     )
 
     for sample in samples.iter_samples(autosave=True, progress=progress):
@@ -379,8 +379,8 @@ def transform_segmentations(
         update (True): whether to update the mask paths on the instances
         update_mask_targets (False): whether to update the mask targets on the
             dataset to reflect the transformed targets
-        overwrite (False): whether to delete ``output_dir`` prior to exporting
-            if it exists
+        overwrite (False): whether to overwrite any existing files in
+            ``output_dir``
         progress (None): whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
@@ -404,11 +404,11 @@ def transform_segmentations(
     samples = sample_collection.select_fields(select_fields)
 
     if output_dir is not None:
-        if overwrite:
-            etau.delete_dir(output_dir)
-
         filename_maker = fou.UniqueFilenameMaker(
-            output_dir=output_dir, rel_dir=rel_dir, idempotent=False
+            output_dir=output_dir,
+            rel_dir=rel_dir,
+            ignore_existing=overwrite,
+            idempotent=False,
         )
 
     for sample in samples.iter_samples(autosave=True, progress=progress):
@@ -508,8 +508,8 @@ def segmentations_to_detections(
             subdirectories in ``output_dir`` that match the shape of the input
             paths. The path is converted to an absolute path (if necessary) via
             :func:`fiftyone.core.storage.normalize_path`
-        overwrite (False): whether to delete ``output_dir`` prior to exporting
-            if it exists
+        overwrite (False): whether to overwrite any existing files in
+            ``output_dir``
         progress (None): whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
@@ -535,12 +535,12 @@ def segmentations_to_detections(
 
     samples = sample_collection.select_fields(select_fields)
 
-    if overwrite and output_dir is not None:
-        etau.delete_dir(output_dir)
-
     if output_dir is not None:
         filename_maker = fou.UniqueFilenameMaker(
-            output_dir=output_dir, rel_dir=rel_dir, idempotent=False
+            output_dir=output_dir,
+            rel_dir=rel_dir,
+            ignore_existing=overwrite,
+            idempotent=False,
         )
 
     for sample in samples.iter_samples(autosave=True, progress=progress):
@@ -600,8 +600,8 @@ def binarize_instances(
             subdirectories in ``output_dir`` that match the shape of the input
             paths. The path is converted to an absolute path (if necessary) via
             :func:`fiftyone.core.storage.normalize_path`
-        overwrite (False): whether to delete ``output_dir`` prior to exporting
-            if it exists
+        overwrite (False): whether to overwrite any existing files in
+            ``output_dir``
         progress (None): whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
@@ -626,12 +626,12 @@ def binarize_instances(
 
     samples = sample_collection.select_fields(in_field)
 
-    if overwrite and output_dir is not None:
-        etau.delete_dir(output_dir)
-
     if output_dir is not None:
         filename_maker = fou.UniqueFilenameMaker(
-            output_dir=output_dir, rel_dir=rel_dir, idempotent=False
+            output_dir=output_dir,
+            rel_dir=rel_dir,
+            ignore_existing=overwrite,
+            idempotent=False,
         )
 
     for sample in samples.iter_samples(autosave=True, progress=progress):


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/6346

## Change log

- Fixes a bug where `fiftyone.utils.labels` utilities with `overwrite=False` options would erroneously start overwriting existing files if repeatedly executed more than 2 times
- Updates the `fiftyone.utils.labels` utilities with `overwrite=True` options so that they now only overwrite the specific files being exported (rather than deleting the entire directory)

## Tested by

Exporting to the same directory multiple times with `overwrite=False` now continually increments the `-%d` suffix:

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.labels as foul
import fiftyone.core.storage as fos

dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    label_types="segmentations",
    classes=["person", "cat", "dog"],
    label_field="instances",
    max_samples=10,
    only_matching=True,
)

mask_targets = {"#ff6d04": "person", "#499cef": "cat", "#6d04ff": "dog"}
output_dir = "/tmp/segmentations"

fos.delete_dir(output_dir)

for _ in range(3):
    foul.objects_to_segmentations(
        dataset,
        "instances",
        "segmentations",
        mask_targets=mask_targets,
        output_dir=output_dir,
        overwrite=False,
    )

    fo.pprint(dataset.values("segmentations.mask_path"))
```

```
[
    '/tmp/segmentations/000000169076.png',
    '/tmp/segmentations/000000375278.png',
    '/tmp/segmentations/000000000139.png',
    '/tmp/segmentations/000000000785.png',
    '/tmp/segmentations/000000000872.png',
    '/tmp/segmentations/000000000885.png',
    '/tmp/segmentations/000000001000.png',
    '/tmp/segmentations/000000001268.png',
    '/tmp/segmentations/000000001296.png',
    '/tmp/segmentations/000000001353.png',
]
[
    '/tmp/segmentations/000000169076-2.png',
    '/tmp/segmentations/000000375278-2.png',
    '/tmp/segmentations/000000000139-2.png',
    '/tmp/segmentations/000000000785-2.png',
    '/tmp/segmentations/000000000872-2.png',
    '/tmp/segmentations/000000000885-2.png',
    '/tmp/segmentations/000000001000-2.png',
    '/tmp/segmentations/000000001268-2.png',
    '/tmp/segmentations/000000001296-2.png',
    '/tmp/segmentations/000000001353-2.png',
]
[
    '/tmp/segmentations/000000169076-3.png',
    '/tmp/segmentations/000000375278-3.png',
    '/tmp/segmentations/000000000139-3.png',
    '/tmp/segmentations/000000000785-3.png',
    '/tmp/segmentations/000000000872-3.png',
    '/tmp/segmentations/000000000885-3.png',
    '/tmp/segmentations/000000001000-3.png',
    '/tmp/segmentations/000000001268-3.png',
    '/tmp/segmentations/000000001296-3.png',
    '/tmp/segmentations/000000001353-3.png',
]
```

Exporting to an existing directory with `overwrite=True` now only overwrites the specific files being exported (rather than deleting the entire directory):

```py
foul.objects_to_segmentations(
    dataset,
    "instances",
    "segmentations",
    mask_targets=mask_targets,
    output_dir=output_dir,  # already contains files from previous exports
    overwrite=True,
)

fo.pprint(dataset.values("segmentations.mask_path"))

assert len(fos.list_files(output_dir)) == 30
```

```
[
    '/tmp/segmentations/000000169076.png',
    '/tmp/segmentations/000000375278.png',
    '/tmp/segmentations/000000000139.png',
    '/tmp/segmentations/000000000785.png',
    '/tmp/segmentations/000000000872.png',
    '/tmp/segmentations/000000000885.png',
    '/tmp/segmentations/000000001000.png',
    '/tmp/segmentations/000000001268.png',
    '/tmp/segmentations/000000001296.png',
    '/tmp/segmentations/000000001353.png',
]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic filename de-duplication: exports and transforms now append “-N” to resolve name conflicts across 2D/3D segmentation workflows.

- Bug Fixes
  - Overwrite no longer deletes the entire output directory; existing files are preserved and new outputs get unique names.
  - Improved handling of filename collisions to avoid accidental overwrites.

- Documentation
  - Clarified overwrite behavior: the output directory is not removed; conflicts result in uniquely suffixed filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->