### PR TITLE
Bugfix for yolo classification models

### DIFF
--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -666,10 +666,12 @@ class FiftyOneYOLOClassificationModel(FiftyOneYOLOModel):
 
     def _ultralytics_preprocess(self, img):
         # Taken from ultralytics.models.yolo.classify.predict.
-        is_legacy_transform = any(
-            self._model.predictor._legacy_transform_name in str(transform)
-            for transform in self.transforms.transforms
-        )
+        is_legacy_transform = False
+        if hasattr(self._model.predictor, "_legacy_transform_name"):
+            is_legacy_transform = any(
+                self._model.predictor._legacy_transform_name in str(transform)
+                for transform in self.transforms.transforms
+            )
         if is_legacy_transform:
             img = torch.stack(
                 [self._model.predictor.transforms(im) for im in img], dim=0


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix for https://github.com/voxel51/fiftyone/issues/6069 where YOLO classification models were failing for ultralytics>=8.3.158

## How is this patch tested? If it is not, please explain why.

```
# Add config for a yolo classifcation model
        {
            "base_name": "yolov8n-classify",
            "base_filename": "yolov8n-cls.pt",
            "version": null,
            "description": "A YOLO classification model",
            "manager": {
                  "type": "fiftyone.core.models.ModelManager",
                  "config": {
                      "url": "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolov8n-cls.pt"
                  }
              },
            "default_deployment_config_dict": {
                "type": "fiftyone.utils.ultralytics.FiftyOneYOLOClassificationModel",
                "config": {
                  "entrypoint_fcn": "ultralytics.YOLO",
                  "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsClassificationOutputProcessor"
                }
            },
            "requirements": {
               "packages": [
                      "torch>=1.7.0",
                      "torchvision>=0.8.1",
                      "ultralytics>=8.2.0"
                  ],
                  "cpu": {
                      "support": true
                  },
                  "gpu": {
                      "support": true
                  }
            }
        }
```

```
# Load model, run inference and evaluation

import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

# Tested on ultralytics==8.3.203
model = foz.load_zoo_model("yolov8n-classify")
dataset.apply_model(model, label_field="classify_v8n_latest", num_workers=8, batch_size=32)

# Evaluation done against ultralytics==8.3.99
eval_res = dataset.evaluate_classifications("classify_v8n_latest", gt_field="classify_v8n_old", eval_key="test_classify")
eval_res.print_metrics() 
```
Similar test done for direct inference using yolo model and converting via `fiftyone.utils.ultralytics.convert_ultralytics_model`.

```
from ultralytics import YOLO
yolo_model = YOLO( "yolov8n-cls.pt")

# Run direct inference and add results to dataset
yolo_results = yolo_model(filepaths, ...)

for result in yolo_results:
    sample = dataset[result.path]
    sample["classify_v8n_direct_latest"] = fou.to_classifications(result)
    sample.save()

# Convert yolo model and run inference
dataset.apply_model(yolo_model, label_field="classify_v8n_conv_latest", num_workers=8, batch_size=32)

# Evalute using dataset.evaluate_classifications
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved preprocessing errors in YOLO Classification when legacy transforms aren’t available, preventing crashes.
  * Ensures a safe fallback path for image handling, improving stability during inference.
  * Enhances compatibility across different Ultralytics versions by conditionally using legacy behavior only when supported.
  * Reduces unexpected failures in classification workflows, resulting in more reliable predictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->