### PR TITLE
feat(operators): new download file operators

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -1508,6 +1508,7 @@ class BrowserDownload extends Operator {
     return new OperatorConfig({
       name: "browser_download",
       label: "Download file",
+      unlisted: true,
     });
   }
   async resolveInput(): Promise<types.Property> {

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -1502,6 +1502,109 @@ class ToggleSidebar extends Operator {
   }
 }
 
+class BrowserDownload extends Operator {
+  _builtIn = true;
+  get config(): OperatorConfig {
+    return new OperatorConfig({
+      name: "browser_download",
+      label: "Download file",
+    });
+  }
+  async resolveInput(): Promise<types.Property> {
+    const inputs = new types.Object();
+    inputs.str("url", {
+      label: "URL",
+      description: "The URL of the file to download",
+      required: true,
+    });
+    inputs.str("filename", {
+      label: "Filename",
+      description:
+        "Optional filename for the download (will use URL filename if not provided)",
+      required: false,
+    });
+    return new types.Property(inputs);
+  }
+  async execute({ params }: ExecutionContext) {
+    const url = params.url;
+    const filename = params.filename;
+
+    if (!url) {
+      throw new Error("URL is required");
+    }
+
+    try {
+      // Fetch the file first to ensure it's downloadable
+      const response = await fetch(url, {
+        method: "GET",
+        mode: "cors",
+        cache: "no-cache",
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch file: ${response.status} ${response.statusText}`
+        );
+      }
+
+      // Get the blob data
+      const blob = await response.blob();
+
+      // Determine filename - use provided filename, extract from URL, or use Content-Disposition header
+      let downloadFilename = filename;
+      if (!downloadFilename) {
+        // Try to get filename from Content-Disposition header
+        const contentDisposition = response.headers.get("Content-Disposition");
+        if (contentDisposition) {
+          const filenameMatch = contentDisposition.match(
+            /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/
+          );
+          if (filenameMatch && filenameMatch[1]) {
+            downloadFilename = filenameMatch[1].replace(/['"]/g, "");
+          }
+        }
+
+        // Fallback to URL filename
+        if (!downloadFilename) {
+          downloadFilename = url.split("/").pop() || "download";
+        }
+      }
+
+      // Create object URL for the blob
+      const blobUrl = URL.createObjectURL(blob);
+
+      // Create a temporary anchor element to trigger download
+      const link = document.createElement("a");
+      link.href = blobUrl;
+      link.download = downloadFilename;
+      link.style.display = "none";
+
+      // Add to DOM, click, and remove
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+
+      // Clean up the object URL
+      URL.revokeObjectURL(blobUrl);
+    } catch (error) {
+      // If fetch fails (CORS issues), fall back to direct link approach
+      console.warn("Direct fetch failed, falling back to direct link:", error);
+
+      const downloadFilename = filename || url.split("/").pop() || "download";
+
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = downloadFilename;
+      link.target = "_blank";
+      link.style.display = "none";
+
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    }
+  }
+}
+
 export function registerBuiltInOperators() {
   try {
     _registerBuiltInOperator(CopyViewAsJSON);
@@ -1558,6 +1661,7 @@ export function registerBuiltInOperators() {
     _registerBuiltInOperator(ShowSidebar);
     _registerBuiltInOperator(HideSidebar);
     _registerBuiltInOperator(ToggleSidebar);
+    _registerBuiltInOperator(BrowserDownload);
     _registerBuiltInOperator(ClearActiveFields);
   } catch (e) {
     console.error("Error registering built-in operators");

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -703,6 +703,19 @@ class Operations(object):
         """Toggle the visibility of the App's sidebar."""
         return self._ctx.trigger("toggle_sidebar")
 
+    def browser_download(self, url, filename=None):
+        """Download a file from a URL using the browser's download functionality.
+
+        Args:
+            url: the URL of the file to download
+            filename: optional filename for the download (will use URL filename if not provided)
+        """
+        params = {"url": url}
+        if filename is not None:
+            params["filename"] = filename
+
+        return self._ctx.trigger("browser_download", params=params)
+
 
 def _serialize_view(view):
     return json.loads(json_util.dumps(view._serialize()))

--- a/plugins/operators/__init__.py
+++ b/plugins/operators/__init__.py
@@ -2701,6 +2701,29 @@ def _get_non_default_frame_fields(dataset):
     return schema
 
 
+class DownloadFileOperator(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="download_file",
+            label="Download file",
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+        inputs.str(
+            "url",
+            required=True,
+            label="URL",
+            description="The URL of the file to download",
+        )
+        return types.Property(inputs, view=types.View(label="Download file"))
+
+    def execute(self, ctx):
+        url = ctx.params["url"]
+        ctx.ops.browser_download(url)
+
+
 def _parse_spaces(ctx, spaces):
     if isinstance(spaces, str):
         spaces = json.loads(spaces)
@@ -2742,6 +2765,7 @@ def register(p):
     p.register(DeleteWorkspace)
     p.register(SyncLastModifiedAt)
     p.register(ListFiles)
+    p.register(DownloadFileOperator)
     p.register(ConfigureScenario)
 
     # view stages

--- a/plugins/operators/__init__.py
+++ b/plugins/operators/__init__.py
@@ -2707,6 +2707,7 @@ class DownloadFileOperator(foo.Operator):
         return foo.OperatorConfig(
             name="download_file",
             label="Download file",
+            unlisted=True,
         )
 
     def resolve_input(self, ctx):
@@ -2720,6 +2721,8 @@ class DownloadFileOperator(foo.Operator):
         return types.Property(inputs, view=types.View(label="Download file"))
 
     def execute(self, ctx):
+        # NOTE: this only calls the browser_download operator
+        # in OSS, in teams it resolves cloud bucket urls
         url = ctx.params["url"]
         ctx.ops.browser_download(url)
 

--- a/plugins/operators/fiftyone.yml
+++ b/plugins/operators/fiftyone.yml
@@ -38,5 +38,6 @@ operators:
   - delete_workspace
   - sync_last_modified_at
   - list_files
+  - download_file
   - model_evaluation_configure_scenario
   - load_group_by


### PR DESCRIPTION
New download_file operators

[Example Operators PR](https://github.com/voxel51/fiftyone-plugins/pull/261)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Download file” operator to download files in-browser from a URL, with optional custom filename.
  * Automatically determines filename from provided input, response headers, or URL; falls back to direct link download on fetch failure or CORS issues.
  * Operator available in the operators palette and can be triggered programmatically via a new Python method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->