### PR TITLE
Implement basic annotation client

### DIFF
--- a/app/packages/core/src/client/annotationClient.ts
+++ b/app/packages/core/src/client/annotationClient.ts
@@ -1,4 +1,10 @@
 import { encodeURIPath } from "./util";
+import { Sample } from "@fiftyone/looker";
+import {
+  MalformedRequestError,
+  NetworkError,
+  NotFoundError,
+} from "@fiftyone/utilities";
 
 /**
  * Label types which currently support mutation via {@link patchSample}.
@@ -12,25 +18,71 @@ export type MutableLabelTypes =
   | "Polylines";
 
 /**
- * A field specification can either be
- *  - `null` indicating the field should be deleted, OR
- *  - an object containing at least the `_cls` field to specify the label type
+ * Specification for a field which should be removed.
  */
-export type FieldSpecification = null | {
+export type NullField = null;
+
+/**
+ * Specification for a label field.
+ */
+export type LabelField = {
   _cls: MutableLabelTypes;
   [key: string]: unknown;
 };
 
+/**
+ * Specification for a top-level attribute field.
+ */
+export type AttributeField = Record<string, unknown>;
+
+/**
+ * A field specification can either be
+ *  - `null` indicating the field should be deleted, OR
+ *  - an object containing at least the `_cls` field to specify the label type, OR
+ *  - an arbitrary mapping to primitives or objects
+ */
+export type FieldSpecification = NullField | LabelField | AttributeField;
+
 export type PatchSampleRequest = {
   datasetId: string;
   sampleId: string;
-  deltas: Record<string, FieldSpecification>[];
+  delta: Record<string, FieldSpecification>;
 };
 
-export type PatchSampleResponse = {
-  status: string;
-  patched_sample_id: string;
+export type ErrorResponse = {
   errors: string[];
+};
+
+export type PatchSampleResponse = ErrorResponse | Sample;
+
+/**
+ * Error resulting from a failed update operation.
+ */
+export class PatchApplicationError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = "Patch Application Error";
+  }
+}
+
+const handleErrorResponse = async (response: Response) => {
+  if (response.status === 400) {
+    let body: ErrorResponse;
+    try {
+      body = await response.json();
+    } catch (err) {
+      body = {} as ErrorResponse;
+    }
+    if (body.errors) {
+      throw new PatchApplicationError(body.errors.join(", "));
+    }
+
+    throw new MalformedRequestError();
+  } else if (response.status === 404) {
+    throw new NotFoundError({ path: "sample" });
+  }
+
+  throw new Error(`http error: ${response.status} ${response.statusText}`);
 };
 
 /**
@@ -45,7 +97,7 @@ export const patchSample = async (
     encodeURIPath(["dataset", request.datasetId, "sample", request.sampleId]),
     {
       method: "PATCH",
-      body: JSON.stringify(request.deltas),
+      body: JSON.stringify(request.delta),
       headers: {
         "content-type": "application/json",
       },
@@ -55,6 +107,6 @@ export const patchSample = async (
   if (httpResponse.ok) {
     return httpResponse.json();
   } else {
-    throw new Error(`http error: ${httpResponse.status}`);
+    await handleErrorResponse(httpResponse);
   }
 };

--- a/app/packages/core/src/client/annotationClient.ts
+++ b/app/packages/core/src/client/annotationClient.ts
@@ -1,10 +1,6 @@
 import { encodeURIPath } from "./util";
 import { Sample } from "@fiftyone/looker";
-import {
-  MalformedRequestError,
-  NetworkError,
-  NotFoundError,
-} from "@fiftyone/utilities";
+import { MalformedRequestError, NotFoundError } from "@fiftyone/utilities";
 
 /**
  * Label types which currently support mutation via {@link patchSample}.

--- a/app/packages/core/src/client/annotationClient.ts
+++ b/app/packages/core/src/client/annotationClient.ts
@@ -1,0 +1,59 @@
+import { encodeURIPath } from "./util";
+
+/**
+ * Label types which currently support mutation via {@link patchSample}.
+ */
+type MutableLabelTypes =
+  | "Classification"
+  | "Classifications"
+  | "Detection"
+  | "Detections"
+  | "Polyline"
+  | "Polylines";
+
+/**
+ * A field specification can either be
+ *  - `null` indicating the field should be deleted, OR
+ *  - an object containing at least the `_cls` field to specify the label type
+ */
+type FieldSpecification =
+  | null
+  | ({ _cls: MutableLabelTypes } & Record<string, never>);
+
+export type PatchSampleRequest = {
+  datasetId: string;
+  sampleId: string;
+  deltas: Record<string, FieldSpecification>[];
+};
+
+export type PatchSampleResponse = {
+  status: string;
+  patched_sample_id: string;
+  errors: string[];
+};
+
+/**
+ * Patch a sample, applying the specified updates to its fields.
+ *
+ * @param request Patch sample request
+ */
+export const patchSample = async (
+  request: PatchSampleRequest
+): Promise<PatchSampleResponse> => {
+  const httpResponse = await fetch(
+    encodeURIPath(["dataset", request.datasetId, "sample", request.sampleId]),
+    {
+      method: "PATCH",
+      body: JSON.stringify(request.deltas),
+      headers: {
+        "content-type": "application/json",
+      },
+    }
+  );
+
+  if (httpResponse.ok) {
+    return httpResponse.json();
+  } else {
+    throw new Error(`http error: ${httpResponse.status}`);
+  }
+};

--- a/app/packages/core/src/client/annotationClient.ts
+++ b/app/packages/core/src/client/annotationClient.ts
@@ -108,7 +108,7 @@ export const patchSample = (
       request.sampleId,
     ]),
     method: "PATCH",
-    body: request,
+    body: request.delta,
     errorHandler: handleErrorResponse,
   });
 };

--- a/app/packages/core/src/client/annotationClient.ts
+++ b/app/packages/core/src/client/annotationClient.ts
@@ -68,19 +68,18 @@ export class PatchApplicationError extends Error {
 const handleErrorResponse = async (response: Response) => {
   if (response.status === 400) {
     // either a malformed request, or a list of errors from applying the patch
-    let errorResponse: ErrorResponse;
+    let errorResponse: ErrorResponse | undefined;
     try {
       // expected error response: '["error 1","error 2"]'
       const body = await response.text();
       const errorList = JSON.parse(body);
-      if (errorList && typeof errorList === typeof []) {
+      if (Array.isArray(errorList)) {
         errorResponse = { errors: errorList };
       }
     } catch (err) {
       // doesn't look like a list of errors
-      errorResponse = {} as ErrorResponse;
     }
-    if (errorResponse.errors) {
+    if (errorResponse?.errors) {
       throw new PatchApplicationError(errorResponse.errors.join(", "));
     }
 

--- a/app/packages/core/src/client/annotationClient.ts
+++ b/app/packages/core/src/client/annotationClient.ts
@@ -3,7 +3,7 @@ import { encodeURIPath } from "./util";
 /**
  * Label types which currently support mutation via {@link patchSample}.
  */
-type MutableLabelTypes =
+export type MutableLabelTypes =
   | "Classification"
   | "Classifications"
   | "Detection"
@@ -16,9 +16,10 @@ type MutableLabelTypes =
  *  - `null` indicating the field should be deleted, OR
  *  - an object containing at least the `_cls` field to specify the label type
  */
-type FieldSpecification =
-  | null
-  | ({ _cls: MutableLabelTypes } & Record<string, never>);
+export type FieldSpecification = null | {
+  _cls: MutableLabelTypes;
+  [key: string]: unknown;
+};
 
 export type PatchSampleRequest = {
   datasetId: string;

--- a/app/packages/core/src/client/annotationClient.ts
+++ b/app/packages/core/src/client/annotationClient.ts
@@ -53,7 +53,7 @@ export type ErrorResponse = {
   errors: string[];
 };
 
-export type PatchSampleResponse = ErrorResponse | Sample;
+export type PatchSampleResponse = Sample;
 
 /**
  * Error resulting from a failed update operation.
@@ -87,8 +87,6 @@ const handleErrorResponse = async (response: Response) => {
   } else if (response.status === 404) {
     throw new NotFoundError({ path: "sample" });
   }
-
-  throw new Error(`http error: ${response.status} ${response.statusText}`);
 };
 
 /**

--- a/app/packages/core/src/client/index.ts
+++ b/app/packages/core/src/client/index.ts
@@ -1,0 +1,1 @@
+export * from "./annotationClient";

--- a/app/packages/core/src/client/util.ts
+++ b/app/packages/core/src/client/util.ts
@@ -1,0 +1,9 @@
+/**
+ * Generate a URI from the path parts using URL-safe encoding.
+ *
+ * @param parts Path parts
+ */
+export const encodeURIPath = (parts: string[]): string => {
+  const encoded = parts.map((part) => encodeURIComponent(part)).join("/");
+  return `/${encoded}`;
+};

--- a/app/packages/core/src/index.ts
+++ b/app/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./client";
 export * from "./components";
 export * from "./hooks";
 export * from "./plugins";

--- a/app/packages/utilities/src/errors.ts
+++ b/app/packages/utilities/src/errors.ts
@@ -96,6 +96,12 @@ export class NetworkError extends AppError {
   }
 }
 
+export class MalformedRequestError extends AppError {
+  constructor(message?: string) {
+    super({ name: "Malformed Request Error" }, message);
+  }
+}
+
 export class NotFoundError extends AppError {
   readonly path: string;
 

--- a/app/packages/utilities/src/fetch.ts
+++ b/app/packages/utilities/src/fetch.ts
@@ -31,7 +31,7 @@ export type FetchFunctionConfig<T> = {
   result?: FetchResultType;
   retries?: number;
   retryCodes?: number[];
-  errorHandler?: (response: Response) => void;
+  errorHandler?: (response: Response) => void | Promise<void>;
 };
 
 export interface FetchFunction {
@@ -42,7 +42,7 @@ export interface FetchFunction {
     result?: FetchResultType,
     retries?: number,
     retryCodes?: number[],
-    errorHandler?: (response: Response) => void
+    errorHandler?: (response: Response) => void | Promise<void>
   ): Promise<R>;
 }
 
@@ -176,7 +176,7 @@ export const setFetchFunction = (
 
     if (!response.ok) {
       if (errorHandler) {
-        errorHandler(response);
+        await errorHandler(response);
       }
       // if custom error handler doesn't throw, use default error handling
 

--- a/app/packages/utilities/src/fetch.ts
+++ b/app/packages/utilities/src/fetch.ts
@@ -11,6 +11,9 @@ let fetchFunctionSingleton: FetchFunction;
 let fetchHeaders: HeadersInit;
 let fetchPathPrefix = "";
 
+/**
+ * Supported methods for accessing response data.
+ */
 export type FetchResultType =
   | "json"
   | "blob"
@@ -18,6 +21,9 @@ export type FetchResultType =
   | "arrayBuffer"
   | "json-stream";
 
+/**
+ * Configuration for a `fetch` call.
+ */
 export type FetchFunctionConfig<T> = {
   method: string;
   path: string;
@@ -44,6 +50,10 @@ export const getFetchFunction = () => {
   return fetchFunctionSingleton;
 };
 
+/**
+ * Wrapper for {@link getFetchFunction} which provides configration via
+ * {@link FetchFunctionConfig}.
+ */
 export const getFetchFunctionConfigurable =
   (): (<A, R>(config: FetchFunctionConfig<A>) => Promise<R>) =>
   <A>(config: FetchFunctionConfig<A>) =>

--- a/app/packages/utilities/src/fetch.ts
+++ b/app/packages/utilities/src/fetch.ts
@@ -51,7 +51,7 @@ export const getFetchFunction = () => {
 };
 
 /**
- * Wrapper for {@link getFetchFunction} which provides configration via
+ * Wrapper for {@link getFetchFunction} which provides configuration via
  * {@link FetchFunctionConfig}.
  */
 export const getFetchFunctionConfigurable =


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR implements a basic frontend client for interacting with the endpoint added in #6368.

## How is this patch tested? If it is not, please explain why.

local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client-side sample patching with structured per-field updates and a dedicated patch request/response flow.
  * Configurable fetch behavior with richer result types and optional per-request error handlers.

* **Bug Fixes / Error Handling**
  * Improved mapping of HTTP error responses to specific error types for clearer diagnostics.

* **Chores**
  * Utility to build encoded API paths.
  * Broadened public exports to make client and link utilities more accessible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->