### PR TITLE
Allow `compute_embeddings()` to write to embedded fields

### DIFF
--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -1025,13 +1025,6 @@ def compute_embeddings(
             embeddings_field
         )
 
-        if "." in embeddings_field:
-            ftype = "frame" if _is_frame_field else "sample"
-            raise ValueError(
-                "Invalid `embeddings_field=%s`. Expected a top-level %s field "
-                "name that contains no '.'" % (embeddings_field, ftype)
-            )
-
         if dataset.media_type == fom.VIDEO and model.media_type == "image":
             if not dataset.has_frame_field(embeddings_field):
                 dataset.add_frame_field(embeddings_field, fof.VectorField)
@@ -1097,7 +1090,11 @@ def compute_embeddings(
 def _compute_image_embeddings_single(
     samples, model, embeddings_field, skip_failures, progress
 ):
-    samples = samples.select_fields()
+    if embeddings_field is not None and "." in embeddings_field:
+        root_field = embeddings_field.split(".", 1)[0]
+        samples = samples.select_fields(root_field)
+    else:
+        samples = samples.select_fields()
 
     embeddings = []
     errors = False
@@ -1141,7 +1138,11 @@ def _compute_image_embeddings_single(
 def _compute_image_embeddings_batch(
     samples, model, embeddings_field, batch_size, skip_failures, progress
 ):
-    samples = samples.select_fields()
+    if embeddings_field is not None and "." in embeddings_field:
+        root_field = embeddings_field.split(".", 1)[0]
+        samples = samples.select_fields(root_field)
+    else:
+        samples = samples.select_fields()
 
     embeddings = []
     errors = False
@@ -1209,7 +1210,11 @@ def _compute_image_embeddings_data_loader(
         field_mapping,
     )
 
-    samples = samples.select_fields()
+    if embeddings_field is not None and "." in embeddings_field:
+        root_field = embeddings_field.split(".", 1)[0]
+        samples = samples.select_fields(root_field)
+    else:
+        samples = samples.select_fields()
 
     embeddings = []
     errors = False
@@ -1284,7 +1289,11 @@ def _compute_frame_embeddings_single(
     frame_counts, total_frame_count = _get_frame_counts(samples)
     is_clips = samples._dataset._is_clips
 
-    samples = samples.select_fields()
+    if embeddings_field is not None and "." in embeddings_field:
+        root_field = embeddings_field.split(".", 1)[0]
+        samples = samples.select_fields(root_field)
+    else:
+        samples = samples.select_fields()
 
     embeddings_dict = {}
 
@@ -1350,7 +1359,11 @@ def _compute_frame_embeddings_batch(
     frame_counts, total_frame_count = _get_frame_counts(samples)
     is_clips = samples._dataset._is_clips
 
-    samples = samples.select_fields()
+    if embeddings_field is not None and "." in embeddings_field:
+        root_field = embeddings_field.split(".", 1)[0]
+        samples = samples.select_fields(root_field)
+    else:
+        samples = samples.select_fields()
 
     embeddings_dict = {}
 
@@ -1420,7 +1433,11 @@ def _compute_video_embeddings(
 ):
     is_clips = samples._dataset._is_clips
 
-    samples = samples.select_fields()
+    if embeddings_field is not None and "." in embeddings_field:
+        root_field = embeddings_field.split(".", 1)[0]
+        samples = samples.select_fields(root_field)
+    else:
+        samples = samples.select_fields()
 
     embeddings = []
     errors = False

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -353,11 +353,7 @@ def _apply_image_model_single(
 ):
     needs_samples = isinstance(model, SamplesMixin)
 
-    if needs_samples:
-        fields = list(model.needs_fields.values())
-        samples = samples.select_fields(fields)
-    else:
-        samples = samples.select_fields()
+    samples = _select_fields_for_inference(samples, model)
 
     with contextlib.ExitStack() as context:
         pb = context.enter_context(fou.ProgressBar(progress=progress))
@@ -400,11 +396,7 @@ def _apply_image_model_batch(
 ):
     needs_samples = isinstance(model, SamplesMixin)
 
-    if needs_samples:
-        fields = list(model.needs_fields.values())
-        samples = samples.select_fields(fields)
-    else:
-        samples = samples.select_fields()
+    samples = _select_fields_for_inference(samples, model)
 
     with contextlib.ExitStack() as context:
         pb = context.enter_context(fou.ProgressBar(samples, progress=progress))
@@ -469,11 +461,7 @@ def _apply_image_model_data_loader(
         field_mapping,
     )
 
-    if needs_samples:
-        fields = list(model.needs_fields.values())
-        samples = samples.select_fields(fields)
-    else:
-        samples = samples.select_fields()
+    samples = _select_fields_for_inference(samples, model)
 
     with contextlib.ExitStack() as context:
         pb = context.enter_context(fou.ProgressBar(samples, progress=progress))
@@ -532,11 +520,7 @@ def _apply_image_model_to_frames_single(
     frame_counts, total_frame_count = _get_frame_counts(samples)
     is_clips = samples._dataset._is_clips
 
-    if needs_samples:
-        fields = list(model.needs_fields.values())
-        samples = samples.select_fields(fields)
-    else:
-        samples = samples.select_fields()
+    samples = _select_fields_for_inference(samples, model)
 
     with contextlib.ExitStack() as context:
         pb = context.enter_context(
@@ -599,11 +583,7 @@ def _apply_image_model_to_frames_batch(
     frame_counts, total_frame_count = _get_frame_counts(samples)
     is_clips = samples._dataset._is_clips
 
-    if needs_samples:
-        fields = list(model.needs_fields.values())
-        samples = samples.select_fields(fields)
-    else:
-        samples = samples.select_fields()
+    samples = _select_fields_for_inference(samples, model)
 
     with contextlib.ExitStack() as context:
         pb = context.enter_context(
@@ -670,11 +650,7 @@ def _apply_video_model(
     needs_samples = isinstance(model, SamplesMixin)
     is_clips = samples._dataset._is_clips
 
-    if needs_samples:
-        fields = list(model.needs_fields.values())
-        samples = samples.select_fields(fields)
-    else:
-        samples = samples.select_fields()
+    samples = _select_fields_for_inference(samples, model)
 
     with contextlib.ExitStack() as context:
         pb = context.enter_context(fou.ProgressBar(progress=progress))
@@ -709,6 +685,14 @@ def _apply_video_model(
                     raise e
 
                 logger.warning("Sample: %s\nError: %s\n", sample.id, e)
+
+
+def _select_fields_for_inference(samples, model):
+    if isinstance(model, SamplesMixin):
+        fields = list(model.needs_fields.values())
+        return samples.select_fields(fields)
+    else:
+        return samples.select_fields()
 
 
 def _export_arrays(label, input_path, filename_maker):
@@ -1090,11 +1074,7 @@ def compute_embeddings(
 def _compute_image_embeddings_single(
     samples, model, embeddings_field, skip_failures, progress
 ):
-    if embeddings_field is not None and "." in embeddings_field:
-        root_field = embeddings_field.split(".", 1)[0]
-        samples = samples.select_fields(root_field)
-    else:
-        samples = samples.select_fields()
+    samples = _select_fields_for_embeddings(samples, embeddings_field)
 
     embeddings = []
     errors = False
@@ -1138,11 +1118,7 @@ def _compute_image_embeddings_single(
 def _compute_image_embeddings_batch(
     samples, model, embeddings_field, batch_size, skip_failures, progress
 ):
-    if embeddings_field is not None and "." in embeddings_field:
-        root_field = embeddings_field.split(".", 1)[0]
-        samples = samples.select_fields(root_field)
-    else:
-        samples = samples.select_fields()
+    samples = _select_fields_for_embeddings(samples, embeddings_field)
 
     embeddings = []
     errors = False
@@ -1210,11 +1186,7 @@ def _compute_image_embeddings_data_loader(
         field_mapping,
     )
 
-    if embeddings_field is not None and "." in embeddings_field:
-        root_field = embeddings_field.split(".", 1)[0]
-        samples = samples.select_fields(root_field)
-    else:
-        samples = samples.select_fields()
+    samples = _select_fields_for_embeddings(samples, embeddings_field)
 
     embeddings = []
     errors = False
@@ -1289,11 +1261,7 @@ def _compute_frame_embeddings_single(
     frame_counts, total_frame_count = _get_frame_counts(samples)
     is_clips = samples._dataset._is_clips
 
-    if embeddings_field is not None and "." in embeddings_field:
-        root_field = embeddings_field.split(".", 1)[0]
-        samples = samples.select_fields(root_field)
-    else:
-        samples = samples.select_fields()
+    samples = _select_fields_for_embeddings(samples, embeddings_field)
 
     embeddings_dict = {}
 
@@ -1359,11 +1327,7 @@ def _compute_frame_embeddings_batch(
     frame_counts, total_frame_count = _get_frame_counts(samples)
     is_clips = samples._dataset._is_clips
 
-    if embeddings_field is not None and "." in embeddings_field:
-        root_field = embeddings_field.split(".", 1)[0]
-        samples = samples.select_fields(root_field)
-    else:
-        samples = samples.select_fields()
+    samples = _select_fields_for_embeddings(samples, embeddings_field)
 
     embeddings_dict = {}
 
@@ -1433,11 +1397,7 @@ def _compute_video_embeddings(
 ):
     is_clips = samples._dataset._is_clips
 
-    if embeddings_field is not None and "." in embeddings_field:
-        root_field = embeddings_field.split(".", 1)[0]
-        samples = samples.select_fields(root_field)
-    else:
-        samples = samples.select_fields()
+    samples = _select_fields_for_embeddings(samples, embeddings_field)
 
     embeddings = []
     errors = False
@@ -1482,6 +1442,14 @@ def _compute_video_embeddings(
         return np.empty((0, 0), dtype=float)
 
     return np.stack(embeddings)
+
+
+def _select_fields_for_embeddings(samples, embeddings_field):
+    if embeddings_field is not None and "." in embeddings_field:
+        root_field = embeddings_field.split(".", 1)[0]
+        return samples.select_fields(root_field)
+    else:
+        return samples.select_fields()
 
 
 def compute_patch_embeddings(
@@ -1706,7 +1674,7 @@ def _embed_patches(
     skip_failures,
     progress,
 ):
-    samples = samples.select_fields(patches_field)
+    samples = _select_fields_for_patch_embeddings(samples, patches_field)
 
     if embeddings_field is not None:
         label_parser = _make_label_parser(samples, patches_field)
@@ -1821,7 +1789,7 @@ def _embed_patches_data_loader(
         skip_failures,
     )
 
-    samples = samples.select_fields(patches_field)
+    samples = _select_fields_for_patch_embeddings(samples, patches_field)
 
     if embeddings_field is not None:
         label_parser = _make_label_parser(samples, patches_field)
@@ -1884,9 +1852,9 @@ def _embed_frame_patches(
 ):
     frame_counts, total_frame_count = _get_frame_counts(samples)
     is_clips = samples._dataset._is_clips
-
     _patches_field = samples._FRAMES_PREFIX + patches_field
-    samples = samples.select_fields(_patches_field)
+
+    samples = _select_fields_for_patch_embeddings(samples, _patches_field)
 
     if embeddings_field is not None:
         label_parser = _make_label_parser(samples, _patches_field)
@@ -2023,6 +1991,10 @@ def _parse_batch_size(batch_size, model, use_data_loader):
         batch_size = 1
 
     return batch_size
+
+
+def _select_fields_for_patch_embeddings(samples, patches_field):
+    return samples.select_fields(patches_field)
 
 
 def _make_label_parser(samples, patches_field):


### PR DESCRIPTION
## Change log

- Allow `compute_embeddings()` to write to embedded fields

## Tested by

```py
import fiftyone as fo
import fiftyone.zoo as foz

model = foz.load_zoo_model("clip-vit-base32-torch")
dataset = foz.load_zoo_dataset("quickstart", max_samples=10)

dataset.add_sample_field(
    "data",
    fo.EmbeddedDocumentField,
    embedded_doc_type=fo.DynamicEmbeddedDocument,
)

# this already works
dataset.apply_model(model, label_field="data.predictions")

# this didn't, but now it does!
dataset.compute_embeddings(model, embeddings_field="data.embeddings")
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support nested (dot-qualified) embedding fields across images, frames, videos, and patches, writing results to the correct location.

- Performance
  - Faster inference and embedding workflows by loading only the fields required for each operation, reducing I/O and memory use.

- Bug Fixes
  - Resolved errors when using nested embedding fields and ensured valid field constraints during processing.

- Refactor
  - Consolidated field-loading logic across inference and embedding paths for more consistent behavior without changing the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->