### PR TITLE
Use `ctx.view` by default in `ctx.target_view()` when the execution context has a view

### DIFF
--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -632,12 +632,8 @@ class ExecutionContext(object):
 
         return self._view
 
-    def target_view(
-        self,
-        param_name="view_target",
-    ):
-        """The target :class:`fiftyone.core.view.DatasetView` for the operator
-        being executed.
+    def target_view(self, param_name="view_target"):
+        """The target view for the operator being executed.
 
         Args:
             param_name ("view_target"): the name of the enum parameter defining
@@ -648,8 +644,6 @@ class ExecutionContext(object):
         """
         target = self.params.get(param_name)
 
-        if not target:
-            return self.view
         if target == constants.ViewTarget.CURRENT_VIEW:
             return self.view
         if target == constants.ViewTarget.DATASET:
@@ -663,7 +657,7 @@ class ExecutionContext(object):
         if target == constants.ViewTarget.DATASET_VIEW:
             return self.dataset.view()
 
-        return self.dataset
+        return self.view if self.has_custom_view else self.dataset
 
     # Alias for common word reversal
     view_target = target_view

--- a/tests/unittests/operators/executor_tests.py
+++ b/tests/unittests/operators/executor_tests.py
@@ -1,3 +1,11 @@
+"""
+FiftyOne operation execution tests.
+
+| Copyright 2017-2025, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
 import unittest
 
 import bson
@@ -81,7 +89,7 @@ class TestOperatorExecutionContext(unittest.TestCase):
         self.assertIsNone(delegated_ctx.num_distributed_tasks)
 
     def test_target_view(self):
-        ds = fo.Dataset(persistent=True)
+        ds = fo.Dataset()
         view = ds.limit(3)
         selected = bson.ObjectId()
         selected_label = bson.ObjectId()
@@ -94,8 +102,8 @@ class TestOperatorExecutionContext(unittest.TestCase):
                     constants.ViewTarget.SELECTED_SAMPLES,
                     view.select([selected]),
                 ),
-                ("TESTING_DEFAULT", ds),
-                (None, ds),
+                ("TESTING_INVALID", view),
+                (None, view),
             ]
             for target_view, expected_view in tests:
                 request_params = {

--- a/tests/unittests/operators/target_view_tests.py
+++ b/tests/unittests/operators/target_view_tests.py
@@ -17,7 +17,7 @@ from fiftyone.operators import types
 
 class TestResolveOperatorTargetViewInputs(unittest.TestCase):
     def test_all_options(self):
-        ds = fo.Dataset(persistent=True)
+        ds = fo.Dataset()
         try:
             request_params = {
                 "dataset_name": ds.name,
@@ -94,7 +94,7 @@ class TestResolveOperatorTargetViewInputs(unittest.TestCase):
             ds.delete()
 
     def test_no_options(self):
-        ds = fo.Dataset(persistent=True)
+        ds = fo.Dataset()
         try:
             request_params = {
                 "dataset_name": ds.name,
@@ -120,7 +120,7 @@ class TestResolveOperatorTargetViewInputs(unittest.TestCase):
             ds.delete()
 
     def test_label_description_override(self):
-        ds = fo.Dataset(persistent=True)
+        ds = fo.Dataset()
         try:
             request_params = {
                 "dataset_name": ds.name,


### PR DESCRIPTION
## Change log

- `ctx.target_view()` now uses `ctx.view` rather than `ctx.dataset` by default if no target view is specified and the execution context has a (non-trivial) view

## Motivation

When implementing operators that are designed to be executed via the SDK, it is natural to allow the user to pass either a `Dataset` or `DatasetView` as input.

For example, here's how [`@voxel51/utils/compute_metadata`](https://github.com/voxel51/fiftyone-plugins/blob/d64a24deaf6ced77cb35ad368d66a3c16ddbd377/plugins/utils/__init__.py#L1643-L1693) implements this:

```py
    def __call__(
        self,
        sample_collection,
        overwrite=False,
        num_workers=None,
        delegate=False,
        delegation_target=None,
    ):
        if isinstance(sample_collection, fo.DatasetView):
            ctx = dict(view=sample_collection)
        else:
            ctx = dict(dataset=sample_collection)

        params = dict(
            overwrite=overwrite,
            num_workers=num_workers,
        )

        return foo.execute_operator(
            self.uri,
            ctx,
            params=params,
            request_delegation=delegate,
            delegation_target=delegation_target,
        )
```

In order for this `__call__()` pattern to continue to work for operators that use `ctx.target_view()` (which we [recently adopted](https://github.com/voxel51/fiftyone-plugins/commit/01e879b60b47836ebd6ec942ae24b7d921669790) for `compute_metadata`), we need `ctx.target_view()` to use `ctx.view` by default, not `ctx.dataset`, when a `view` is provided

With the proposed change, the following code once again processes the input `view` as intended (it used to before [this change](https://github.com/voxel51/fiftyone-plugins/commit/01e879b60b47836ebd6ec942ae24b7d921669790) was made):

```py
import fiftyone as fo
import fiftyone.operators as foo
import fiftyone.zoo as foz

compute_metadata = foo.get_operator("@voxel51/utils/compute_metadata")

dataset = foz.load_zoo_dataset("quickstart")
view = dataset.limit(100)

# Now correctly processes the `view`, not the full `dataset`
compute_metadata(view)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Operators now honor the active view when one is set, instead of silently falling back to the full dataset.
  - Invalid or missing targets now resolve to the active view, leading to more predictable behavior with filtered or selected samples.
  - Improved detection of when a custom view is active for more consistent results.

- Tests
  - Updated unit tests to reflect the new view-resolution behavior and to use non-persistent datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->