### PR TITLE
add static typing for lighter event handlers

### DIFF
--- a/app/packages/core/src/components/Modal/Lighter/useOverlayPersistence.ts
+++ b/app/packages/core/src/components/Modal/Lighter/useOverlayPersistence.ts
@@ -10,7 +10,7 @@ import { useOperatorExecutor } from "@fiftyone/operators";
 import { DETECTION } from "@fiftyone/utilities";
 import { useSetAtom } from "jotai";
 import { useCallback, useEffect } from "react";
-import { LIGHTER_EVENTS, Scene2D } from "@fiftyone/lighter";
+import { LIGHTER_EVENTS, OverlayEventDetail, Scene2D } from "@fiftyone/lighter";
 
 /**
  * Hook that handles overlay persistence events.
@@ -23,7 +23,11 @@ export const useOverlayPersistence = (scene: Scene2D | null) => {
   const removeLabelEffect = useSetAtom(removeLabel);
 
   const handlePersistOverlay = useCallback(
-    (event: CustomEvent) => {
+    (
+      event: CustomEvent<
+        OverlayEventDetail<typeof LIGHTER_EVENTS.DO_PERSIST_OVERLAY>
+      >
+    ) => {
       const overlay = event.detail;
 
       if (overlay) {
@@ -60,11 +64,15 @@ export const useOverlayPersistence = (scene: Scene2D | null) => {
         );
       }
     },
-    [addBoundingBox]
+    [addBoundingBox, addLabelEffect]
   );
 
   const handleRemoveOverlay = useCallback(
-    (event: CustomEvent) => {
+    (
+      event: CustomEvent<
+        OverlayEventDetail<typeof LIGHTER_EVENTS.DO_REMOVE_OVERLAY>
+      >
+    ) => {
       const { id, sampleId, path } = event.detail;
       try {
         console.log("removing bounding box", id, sampleId, path);
@@ -79,7 +87,7 @@ export const useOverlayPersistence = (scene: Scene2D | null) => {
         console.error("Error removing bounding box", error);
       }
     },
-    [removeBoundingBox]
+    [removeBoundingBox, removeLabelEffect]
   );
 
   useEffect(() => {

--- a/app/packages/lighter/src/core/Scene2D.ts
+++ b/app/packages/lighter/src/core/Scene2D.ts
@@ -19,6 +19,7 @@ import {
   DoLighterEvent,
   LIGHTER_EVENTS,
   type LighterEvent,
+  LighterEventDetail,
 } from "../event/EventBus";
 import type { InteractionHandler } from "../interaction/InteractionManager";
 import { InteractionManager } from "../interaction/InteractionManager";
@@ -1064,7 +1065,10 @@ export class Scene2D {
    * @param type - The event type to listen for.
    * @param listener - The event listener function.
    */
-  on(type: LighterEvent["type"], listener: (e: CustomEvent) => void): void {
+  on<T extends LighterEvent["type"]>(
+    type: T,
+    listener: (e: CustomEvent<LighterEventDetail<T>>) => void
+  ): void {
     this.config.eventBus.on(type, listener);
   }
 
@@ -1074,7 +1078,10 @@ export class Scene2D {
    * @param type - The event type.
    * @param listener - The event listener function.
    */
-  off(type: LighterEvent["type"], listener: (e: CustomEvent) => void): void {
+  off<T extends LighterEvent["type"]>(
+    type: T,
+    listener: (e: CustomEvent<LighterEventDetail<T>>) => void
+  ): void {
     this.config.eventBus.off(type, listener);
   }
 

--- a/app/packages/lighter/src/event/EventBus.ts
+++ b/app/packages/lighter/src/event/EventBus.ts
@@ -291,6 +291,14 @@ export type LighterEvent =
   | DoLighterEvent;
 
 /**
+ * Type for Lighter event payloads.
+ */
+export type LighterEventDetail<T extends LighterEvent["type"]> = Extract<
+  LighterEvent,
+  { type: T }
+>["detail"];
+
+/**
  * Event bus for communication between components.
  */
 export class EventBus extends EventTarget {
@@ -310,9 +318,9 @@ export class EventBus extends EventTarget {
    * @param abortController - The abort controller to use for the event listener.
    * Calling `abort` on this will remove the event listener.
    */
-  on(
-    type: LighterEvent["type"],
-    listener: (e: CustomEvent) => void,
+  on<T extends LighterEvent["type"]>(
+    type: T,
+    listener: (e: CustomEvent<LighterEventDetail<T>>) => void,
     abortController?: AbortController
   ): void {
     if (abortController) {
@@ -329,7 +337,10 @@ export class EventBus extends EventTarget {
    * @param type - The event type.
    * @param listener - The event listener function.
    */
-  off(type: LighterEvent["type"], listener: (e: CustomEvent) => void): void {
+  off<T extends LighterEvent["type"]>(
+    type: T,
+    listener: (e: CustomEvent<LighterEventDetail<T>>) => void
+  ): void {
     this.removeEventListener(type, listener as EventListener);
   }
 }

--- a/app/packages/lighter/src/index.ts
+++ b/app/packages/lighter/src/index.ts
@@ -34,7 +34,10 @@ export type { ResourceLoader } from "./resource/ResourceLoader";
 
 // Event exports
 export { EventBus, LIGHTER_EVENTS } from "./event/EventBus";
-export type { LighterEvent as OverlayEvent } from "./event/EventBus";
+export type {
+  LighterEvent as OverlayEvent,
+  LighterEventDetail as OverlayEventDetail,
+} from "./event/EventBus";
 
 // Interaction exports
 export { InteractionManager } from "./interaction/InteractionManager";


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR updates the Lighter event types to provide support for static type inference. This allows event handlers to use concrete types and provide compile-time safety.

Example type inference:
<img width="575" height="280" alt="image" src="https://github.com/user-attachments/assets/e608d798-5e3b-436f-a1f0-1f1a3b757099" />


## How is this patch tested? If it is not, please explain why.

local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Strengthened event handling type safety in 2D scenes and overlay persistence, improving reliability when adding/removing overlays and reducing edge-case errors. No UI changes.
- Chores
  - Expanded public type exports to include event detail types, offering improved TypeScript support for integrators without affecting runtime behavior.
- Documentation
  - Clarified event typing across the overlay/scene layers through more precise types, aiding developer understanding and reducing misuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->