### PR TITLE
Account for scaling when zoomed

### DIFF
--- a/app/packages/lighter/src/overlay/BaseOverlay.ts
+++ b/app/packages/lighter/src/overlay/BaseOverlay.ts
@@ -261,19 +261,33 @@ export abstract class BaseOverlay implements InteractionHandler {
    * Handle pointer down event.
    * Override in subclasses to implement custom behavior.
    * @param point - The point where the event occurred.
+   * @param worldPoint - Screen point translated to viewport point.
    * @param event - The original pointer event.
+   * @param scale - The current scaling factor of the viewport.
    * @returns True if the event was handled.
    */
-  onPointerDown?(point: Point, event: PointerEvent): boolean;
+  onPointerDown?(
+    point: Point,
+    worldPoint: Point,
+    event: PointerEvent,
+    scale: number
+  ): boolean;
 
   /**
    * Handle drag event.
    * Override in subclasses to implement custom behavior.
    * @param point - The point where the event occurred.
+   * @param worldPoint - Screen point translated to viewport point.
    * @param event - The original pointer event.
+   * @param scale - The current scaling factor of the viewport.
    * @returns True if the event was handled.
    */
-  onMove?(point: Point, event: PointerEvent): boolean;
+  onMove?(
+    point: Point,
+    worldPoint: Point,
+    event: PointerEvent,
+    scale: number
+  ): boolean;
 
   /**
    * Handle pointer up event.

--- a/app/packages/lighter/src/renderer/PixiRenderer2D.ts
+++ b/app/packages/lighter/src/renderer/PixiRenderer2D.ts
@@ -441,6 +441,14 @@ export class PixiRenderer2D implements Renderer2D {
   }
 
   /**
+   * Returns current scaling factor of the viewport.
+   * @returns Current scaling factor.
+   */
+  getScale(): number {
+    return this.viewport?.scaled ?? 1;
+  }
+
+  /**
    * Check if the renderer is initialized
    */
   isReady(): boolean {

--- a/app/packages/lighter/src/renderer/Renderer2D.ts
+++ b/app/packages/lighter/src/renderer/Renderer2D.ts
@@ -143,6 +143,12 @@ export interface Renderer2D {
   screenToWorld(screenPoint: Point): Point;
 
   /**
+   * Returns current scaling factor of the viewport.
+   * @returns Current scaling factor.
+   */
+  getScale(): number;
+
+  /**
    * Reset tick handler, and remove all children from the viewport.
    */
   cleanUp(): void;


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Zoom-aware interactions: cursor, clicks, drags, and resizes now adapt to world coordinates and current zoom level for more precise control.
  - Renderer now exposes current zoom, enabling scale-aware tools and overlays.

- Bug Fixes
  - More accurate hit detection and resize handles across different zoom levels.
  - Consistent drag/resize sensitivity regardless of zoom.
  - More reliable hover/drag state transitions when zooming in or out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->