### PR TITLE
FOEPD-2219: Disable async DB writes in `apply_model` and `compute_embeddings`

### DIFF
--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -478,13 +478,6 @@ def _apply_image_model_data_loader(
     with contextlib.ExitStack() as context:
         pb = context.enter_context(fou.ProgressBar(samples, progress=progress))
         ctx = context.enter_context(foc.SaveContext(samples))
-        submit = context.enter_context(
-            fou.async_executor(
-                max_workers=1,
-                skip_failures=skip_failures,
-                warning="Async failure labeling batches",
-            )
-        )
 
         def save_batch(sample_batch, labels_batch):
             with _handle_batch_error(skip_failures, sample_batch):
@@ -514,7 +507,7 @@ def _apply_image_model_data_loader(
                 else:
                     labels_batch = model.predict_all(imgs)
 
-                submit(save_batch, sample_batch, labels_batch)
+                save_batch(sample_batch, labels_batch)
 
             pb.update(len(sample_batch))
 
@@ -1221,14 +1214,6 @@ def _compute_image_embeddings_data_loader(
         else:
             ctx = None
 
-        submit = context.enter_context(
-            fou.async_executor(
-                max_workers=1,
-                skip_failures=skip_failures,
-                warning="Async failure saving embeddings",
-            )
-        )
-
         def save_batch(sample_batch, embeddings_batch):
             with _handle_batch_error(skip_failures, sample_batch):
                 for sample, embedding in zip(sample_batch, embeddings_batch):
@@ -1260,7 +1245,7 @@ def _compute_image_embeddings_data_loader(
                 )
 
             if embeddings_field is not None:
-                submit(save_batch, sample_batch, embeddings_batch)
+                save_batch(sample_batch, embeddings_batch)
             else:
                 embeddings.extend(embeddings_batch)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Reverts DB writes in `apply_model` and `compute_embeddings` to happening on the main thread, rather than running on a background thread (introduced in #6288) because it can result in unbounded memory usage as tasks back up in the queue under DB pressure.

## How is this patch tested? If it is not, please explain why.

Ran a benchmarking script and compared memory usage from before #6288, the latest develop, and with these changes. Memory usage with these changes returns to being flat:
![visualization(12)](https://github.com/user-attachments/assets/333fb578-363b-45b0-bc69-50ef0cde282c)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
