### PR TITLE
Add Google Tag Manager integration to Docs

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,6 +1,14 @@
 {% extends "!layout.html" %} {% block extrahead %}
 <meta property="og:image" content="{{og_image}}" />
 
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-NLDVC93R');</script>
+<!-- End Google Tag Manager -->
+
 <link
   href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css"
   rel="stylesheet"
@@ -102,8 +110,11 @@
 </script>
 {% endblock %}
 
-
 {%- block content %}
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NLDVC93R"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
   {# A tiny helper pixel to detect if we've scrolled #}
   <div id="pst-scroll-pixel-helper"></div>
   <div id="pst-search-dialog"></div>


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds **Google Tag Manager (GTM) integration** into the Sphinx documentation by extending `layout.html`.

## How is this patch tested? If it is not, please explain why.

Confirmed via browser dev tools that the GTM script loads correctly.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.

### What areas of FiftyOne does this PR affect?

* [ ] App: FiftyOne application changes
* [ ] Build: Build and test infrastructure changes
* [ ] Core: Core `fiftyone` Python library changes
* [x] Documentation: FiftyOne documentation changes
* [ ] Other