### PR TITLE
route decorator cast to JSON when starlette http exception detail is …

### DIFF
--- a/fiftyone/server/decorators.py
+++ b/fiftyone/server/decorators.py
@@ -60,11 +60,18 @@ def route(func):
             return await create_response(response)
 
         except Exception as e:
-            # Immediately re-raise starlette HTTP exceptions
             if isinstance(e, HTTPException):
+                # Cast to JSON when starlette HTTPException has a dict detail
+                if isinstance(e.detail, dict):
+                    return JSONResponse(
+                        e.detail,
+                        status_code=e.status_code,
+                    )
+
+                # Immediately re-raise starlette HTTPException
                 raise e
 
-            # Cast non-starlette HTTP exceptions as JSON with 500 status code
+            # Cast non-starlette HTTPExceptions as JSON with 500 status code
             logging.exception(e)
             return JSONResponse(
                 {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Cast to starlette HTTP exception to JSON response when `detail` is a dict.  Allows short-circuiting in routes without explicitly returning. This allows fewer lines of code and makes private functions more re-useable.

##### Example
```py
from starlette.endpoints import HTTPEndpoint
from starlette.exceptions import HTTPException
from starlette.requests import Request
from starlette.responses import JSONResponse

from fiftyone.server.decorators import route


def get_foo(request: Request):
    foo = request.path_params["foo"]

    if foo == "42":
        raise HTTPException(
            status_code=400, detail={"message": "Foo can't be 42!"}
        )

    return foo


class Foo(HTTPEndpoint):
    """Does some stuff"""

    @route
    async def get(self, request: Request, _) -> JSONResponse:
        foo = get_foo()
        return JSONResponse({"foo": foo, "bar": "baz"})

    @route
    async def put(self, request: Request, data: dict) -> JSONResponse:
        foo = get_foo()
        # Do some stuff to update foo
        return JSONResponse({"updated": True})

```

Both get and put will now return `400` if foo is "42" without explicitly returning.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other
