### PR TITLE
Run CI on all PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,11 +3,6 @@ name: Pull Request
 on:
   pull_request:
     types: [opened, synchronize]
-    branches:
-      - develop
-      - feat/*
-      - main
-      - release/v[0-9]+.[0-9]+.[0-9]+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This would ensure that every PR triggers a run of the test suite.

Right now, the test suite only runs when the base branch is one of:
```
    branches:
      - develop
      - feat/*
      - main
      - release/v[0-9]+.[0-9]+.[0-9]+
```

That has left open an edge case where a PR can sneak by without running CI -- specifically, if the base branch is changed to (e.g.) `develop` right before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded pull request workflow to run on all branches, ensuring consistent CI checks across all contributions, including hotfixes and experimental branches.
  * Improves visibility and reliability of automated validation prior to merges, without altering build outputs.
  * No user-facing functionality, performance, or UI changes; application behavior remains unchanged.
  * Documentation, tests, and features are unaffected by this change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->