### PR TITLE
Query param to auto-open agent modal

### DIFF
--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -597,6 +597,19 @@ const initKapaAI = () => {
   });
 };
 
+/* Direct Agent Modal Access via URL Parameter */
+function initDirectAgentAccess() {
+  const openAgent = new URLSearchParams(window.location.search).get("agent");
+  if (openAgent === "true") {
+    setTimeout(() => {
+      const floatingButton = document.querySelector(".kapa-ai-button");
+      if (floatingButton) {
+        floatingButton.click();
+      }
+    }, 2000);
+  }
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   initSidebarToggle();
   initSlidingNavBar();
@@ -605,4 +618,5 @@ document.addEventListener("DOMContentLoaded", () => {
   initTabsSlidingIndicator();
   initMobileNavDropdown();
   initKapaAI();
+  initDirectAgentAccess();
 });


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds support for opening the agent modal automatically in the docs via a query parameter. By appending `?agent=true` to any docs URL, the agent modal will open as the first view.

This was suggested by @ehofesmann to make it easier to share links where the agent appears immediately when opening the page.

## How is this patch tested? If it is not, please explain why.

- Manually tested by appending `?agent=true` to docs URLs and confirming the
  agent modal opens automatically.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Added support for `?agent=true` query param in the docs to automatically open the agent modal when a page loads.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * You can now open the Direct Agent modal via a URL parameter (?agent=true). When included, the modal opens automatically shortly after the page loads, enabling deep links and smoother onboarding flows. Works on initial load without user interaction.
* Documentation
  * The documentation site supports direct links that immediately open the Direct Agent modal, improving shareability for demos and support. Users without the parameter see no change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->