### PR TITLE
check that audience matches [FOEPD-2266]

### DIFF
--- a/app/packages/looker-3d/src/hooks/use-fo-loaders.ts
+++ b/app/packages/looker-3d/src/hooks/use-fo-loaders.ts
@@ -1,5 +1,13 @@
 import { useLoader } from "@react-three/fiber";
 
+function ensureArray(value) {
+  if (Array.isArray(value)) {
+    return value;
+  } else {
+    return [value];
+  }
+}
+
 /**
  * Decorates useLoader() to support credentials forwarding
  */
@@ -12,8 +20,17 @@ export function useFoLoader<
   loaderFunction?: Parameters<typeof useLoader>[2]
 ) {
   return useLoader(loader, urls, (loaderInstance) => {
-    if (sessionStorage.getItem("customCredentialsAudience")?.length) {
-      loaderInstance.setWithCredentials(true);
+    const customCredentialsAudience = sessionStorage.getItem(
+      "customCredentialsAudience"
+    );
+    if (customCredentialsAudience) {
+      // The types say that `urls` is string | string[]
+      // But! Our code also sometimes passes in string[][]
+      // So, we're both calling ensureArray() and flat()
+      const urlArray = ensureArray(urls).flat();
+      if (urlArray.some((url) => url.includes(customCredentialsAudience))) {
+        loaderInstance.setWithCredentials(true);
+      }
     }
     if (loaderFunction) {
       loaderFunction(loaderInstance);


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixed a bug where, when `useFoLoader` was deciding whether to include the credentials header, it was not properly checking that the per-user cloud creds audience matched the urls being loaded.

Note: This code needs to call `flat()` because [this line](https://github.com/voxel51/fiftyone-teams/blob/46d9485fdafffd8b8570f8a5f1dfc329a03320a6/app/packages/looker-3d/src/fo3d/Background.tsx#L28) passes `[imageUrls]` in instead of `imageUrls`

## How is this patch tested? If it is not, please explain why.

Not tested at all.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixed a bug in rare situations where an incorrect header was set that resulted in a CORS error.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Credentials are now forwarded only when target URLs match a session-defined audience, reducing unintended credential sharing.
  * Improved handling of multiple and nested URL inputs for more reliable loading behavior.
  * No changes to the user-facing API or workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->