### PR TITLE
Fix numpy >= 2.0 serialization in KeypointOutputProcessor

### DIFF
--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -1590,7 +1590,7 @@ class KeypointDetectorOutputProcessor(OutputProcessor):
                     # Not visible
                     points.append((float("nan"), float("nan")))
                 else:
-                    points.append((p[0] / width, p[1] / height))
+                    points.append((float(p[0] / width), float(p[1] / height)))
 
             _detections.append(
                 fol.Detection(


### PR DESCRIPTION
Fixes MongoDB BSON error with numpy >= 2.0 by converting numpy scalars to Python floats in KeypointOutputProcessor (line 1565). Wraps p[0]/width and p[1]/height in float().

  ## What changes are proposed in this pull request?

  Changes line 1565 in `fiftyone/utils/torch.py` from `points.append((p[0] / width, p[1] / height))` to `points.append((float(p[0] / width), float(p[1] / height)))` to convert numpy scalar types to Python native floats before MongoDB serialization.

  ## How is this patch tested? If it is not, please explain why.

  Reproduced bug with vitpose and numpy 2.3.3. Verified fix resolves the issue. Confirmed backwards compatibility with numpy 1.26.4. Tested other output processors with numpy 2.3.3 to confirm issue is isolated to KeypointOutputProcessor.

  ## Release Notes

  ### Is this a user-facing change that should be mentioned in the release notes?

  -   [x] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

  Fixed MongoDB serialization error when running keypoint detection with numpy >= 2.0.

  ### What areas of FiftyOne does this PR affect?

  -   [ ] App: FiftyOne application changes
  -   [ ] Build: Build and test infrastructure changes
  -   [x] Core: Core fiftyone Python library changes
  -   [ ] Documentation: FiftyOne documentation changes
  -   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures detector output keypoint coordinates are consistently floats, improving reliability across downstream processing, visualizations, and exports. This prevents occasional type inconsistencies that could cause rounding or compatibility issues when consuming normalized bounding box points, leading to more predictable results and smoother integrations. No changes to workflows or settings required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->