### PR TITLE
Added GitHub token in the docs build workflow

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -43,6 +43,7 @@ jobs:
     env:
       FIFTYONE_DO_NOT_TRACK: true
       DOCSEARCH_API_KEY: ${{ secrets.DOCSEARCH_API_KEY }}
+      GITHUB_TOKEN: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
     steps:
       - name: Clone fiftyone for tag builds
         if: github.ref_type == 'tag'


### PR DESCRIPTION
Added GitHub token support in the docs build workflow to enable fetching all plugins directly from the repository. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the documentation build pipeline by configuring authenticated access within the workflow. This enhances reliability for operations that require permissions (such as fetching or publishing docs) and reduces intermittent failures during documentation generation and deployment. No changes to product features or user experience; this update strictly affects automation infrastructure and should result in more consistent documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->