### PR TITLE
improve error details for when an operator returns non-serializable value

### DIFF
--- a/app/packages/components/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/app/packages/components/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -73,13 +73,16 @@ export const ErrorDisplayMarkup = <T extends AppError>({
         content: JSON.stringify(error.payload, null, 2),
       });
   } else if (error instanceof OperatorError) {
+    if (error.message) {
+      messages.push({ message: "Message", content: error.message });
+    }
     if (error.operator) {
       messages.push({ message: "Operator", content: error.operator });
     }
     if (error instanceof PanelEventError) {
       messages.push({ message: "Event", content: error.event });
     }
-    messages.push({ message: error.message, content: error.stack });
+    messages.push({ message: "Trace", content: error.stack });
   }
   if (error.stack && !(error instanceof OperatorError)) {
     messages = [...messages, { message: "Trace", content: error.stack }];

--- a/app/packages/operators/src/components/OperatorPromptOutput.tsx
+++ b/app/packages/operators/src/components/OperatorPromptOutput.tsx
@@ -7,8 +7,13 @@ export default function OperatorPromptOutput({ operatorPrompt, outputFields }) {
   const executorError = operatorPrompt?.executorError;
   const resolveError = operatorPrompt?.resolveError;
   const error = resolveError || executorError;
+
   if (!outputFields && !executorError && !resolveError) return null;
+
   const { result } = operatorPrompt.executor;
+  const defaultMsg = "Error occurred during operator execution";
+  const message = error?.bodyResponse?.error;
+  const reason = message ? defaultMsg + ". " + message : defaultMsg;
 
   return (
     <Box p={2}>
@@ -24,7 +29,7 @@ export default function OperatorPromptOutput({ operatorPrompt, outputFields }) {
           schema={{ view: { detailed: true } }}
           data={[
             {
-              reason: "Error occurred during operator execution",
+              reason,
               details: stringifyError(error),
             },
           ]}

--- a/fiftyone/operators/server.py
+++ b/fiftyone/operators/server.py
@@ -22,7 +22,7 @@ from .executor import (
 )
 from .message import GeneratedMessage
 from .permissions import PermissionedOperatorRegistry
-from .utils import is_method_overridden
+from .utils import is_method_overridden, create_operator_response
 from .operator import Operator
 
 
@@ -107,7 +107,7 @@ class ExecuteOperator(HTTPEndpoint):
             raise HTTPException(status_code=404, detail=error_detail)
 
         result = await execute_or_delegate_operator(operator_uri, data)
-        return result.to_json()
+        return await create_operator_response(result)
 
 
 def create_response_generator(generator):

--- a/fiftyone/server/decorators.py
+++ b/fiftyone/server/decorators.py
@@ -6,40 +6,17 @@ FiftyOne Server decorators
 |
 """
 
-from json import JSONEncoder
 import traceback
 import typing as t
 import logging
 
 from bson import json_util
-import numpy as np
 from starlette.endpoints import HTTPEndpoint
 from starlette.exceptions import HTTPException
 from starlette.responses import JSONResponse, Response
 from starlette.requests import Request
 
-from fiftyone.core.utils import run_sync_task
-
-
-class Encoder(JSONEncoder):
-    """Custom JSON encoder that handles numpy types."""
-
-    def default(self, o):
-        if isinstance(o, np.floating):
-            return float(o)
-
-        if isinstance(o, np.integer):
-            return int(o)
-
-        return JSONEncoder.default(self, o)
-
-
-async def create_response(response: dict):
-    """Creates a JSON response from the given dictionary."""
-    return Response(
-        await run_sync_task(lambda: json_util.dumps(response, cls=Encoder)),
-        headers={"Content-Type": "application/json"},
-    )
+from fiftyone.core.utils import create_response
 
 
 def route(func):


### PR DESCRIPTION
## What changes are proposed in this pull request?

improve error details for when an operator returns non-serializable value

## How is this patch tested? If it is not, please explain why.

Using a test operator and python panel event

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

improve error details for when an operator returns non-serializable value

#### Todo
Update docs to note the rule that operator, python-panel lifecycle methods, and python-panel events must return JSON-serializable values. If a complex value to be returned (i.e. DatasetView), it must be serialized or parsed into serialiazble object


### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Bug Fixes
  * Error panel now shows a distinct "Trace" section and includes explicit message entries for operator errors.
  * Operator output displays more informative, context-aware error reasons.
  * Prevented empty output views from being rendered when there are no results.

* Refactor
  * Unified JSON response creation for more consistent API responses.
  * Improved numeric-type serialization for reliability.
  * Enhanced server error responses to include structured messages and stack traces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->