### PR TITLE
remove unnecessary returns from me panel events

### DIFF
--- a/plugins/panels/model_evaluation/__init__.py
+++ b/plugins/panels/model_evaluation/__init__.py
@@ -704,10 +704,11 @@ class EvaluationPanel(Panel):
             subset_def = subsets.get(subset, None)
 
             if error:
-                return ctx.ops.notify(
+                ctx.ops.notify(
                     f"Failed to load custom code subsets: {error}",
                     variant="error",
                 )
+                return
 
         if subset_def is not None:
             eval_view = foue.get_subset_view(eval_view, gt_field, subset_def)
@@ -1195,10 +1196,11 @@ class EvaluationPanel(Panel):
 
     def delete_scenario(self, ctx):
         if not self.can_delete_scenario(ctx):
-            return ctx.ops.notify(
+            ctx.ops.notify(
                 "You do not have permission to delete scenarios",
                 variant="error",
             )
+            return
         scenario_id = ctx.params.get("id", None)
         scenarios = get_scenarios(ctx)
         scenarios.pop(scenario_id, None)


### PR DESCRIPTION
## What changes are proposed in this pull request?

remove unnecessary returns from me panel events

## How is this patch tested? If it is not, please explain why.

Using ME panel

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model Evaluation view now immediately notifies you and halts processing if generating subsets from custom code fails, preventing partial or misleading results.
  * Deleting a scenario without sufficient permissions now shows a clear notification and cancels the action, avoiding unintended behavior and confusion.
  * Overall error handling in these flows is more robust, with faster feedback and safer defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->