### PR TITLE
Weak ETags should not double quote the value

### DIFF
--- a/fiftyone/server/utils/http.py
+++ b/fiftyone/server/utils/http.py
@@ -21,7 +21,7 @@ class ETag:
 
         # Add weak prefix if necessary
         if is_weak:
-            return f'W/"{value}"'
+            return f"W/{value}"
 
         return value
 

--- a/fiftyone/server/utils/http.py
+++ b/fiftyone/server/utils/http.py
@@ -15,6 +15,8 @@ class ETag:
     @staticmethod
     def create(value: Any, is_weak: bool = False) -> str:
         """Creates an ETag string from the given value."""
+        value = str(value)
+
         # Wrap in quotes if not already quoted
         if not (value.startswith('"') and value.endswith('"')):
             value = f'"{value}"'


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix a typo that would cause a bug. 

## How is this patch tested? If it is not, please explain why.

n/a

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed weak ETag formatting to conform with HTTP expectations (removes extra surrounding quotes).
  * Ensures ETag values are consistently interpreted as strings.
  * Maintains existing public API and leaves strong/quoted ETag behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->