### PR TITLE
add warning for return value of panel event

### DIFF
--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -2884,6 +2884,19 @@ and programmatically modify the current state.
     via their `ctx` argument and can use it to get/update panel state and
     trigger other operations.
 
+.. warning::
+
+    The return value of all panel events—including builtin events (such as 
+    `on_load`, `on_unload`, `on_change_ctx`, etc.) and custom events (such as
+    `on_change_brain_key`, `on_click_start`, etc.)—must be JSON-serializable.
+
+    If your panel event returns a value of a custom type (for example, a NumPy
+    array or a FiftyOne Sample or custom class), you must first convert it to a
+    JSON-serializable format (such as a Python list or dictionary).
+
+    Returning non-serializable objects will cause errors and prevent your panel
+    from functioning correctly.
+
 .. code-block:: python
     :linenos:
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Docs update to add a warning for the return value of a panel event

## How is this patch tested? If it is not, please explain why.

Building docs and previwing it

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on ensuring panel events return JSON-serializable values, with recommendations for converting non-serializable types such as NumPy arrays to compatible formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->