### PR TITLE
bugfix: cannot save colorscheme as default due to missing import

### DIFF
--- a/app/packages/core/src/components/ColorModal/ColorFooter.tsx
+++ b/app/packages/core/src/components/ColorModal/ColorFooter.tsx
@@ -3,7 +3,7 @@ import * as foq from "@fiftyone/relay";
 import * as fos from "@fiftyone/state";
 import React, { useEffect } from "react";
 import { useMutation } from "react-relay";
-import { useRecoilValue } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import { ButtonGroup, ModalActionButtonContainer } from "./ShareStyledDiv";
 import { activeColorEntry } from "./state";
 
@@ -15,6 +15,7 @@ const ColorFooter: React.FC = () => {
     : "Save to dataset app config";
   const setColorScheme = fos.useSetSessionColorScheme();
   const activeColorModalField = useRecoilValue(activeColorEntry);
+  const setActiveColorModalField = useSetRecoilState(activeColorEntry);
   const [setDatasetColorScheme] =
     useMutation<foq.setDatasetColorSchemeMutation>(foq.setDatasetColorScheme);
   const colorScheme = useRecoilValue(fos.colorScheme);


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes a regression: cannot save colorscheme to dataset.app_config.colorscheme in the APP due to a missing import

Currently: 

https://github.com/user-attachments/assets/5e221edd-0c72-4a9f-b426-214b294cc6f3

Looks like an import has been removed by mistake.

## How is this patch tested? If it is not, please explain why.

locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

Fixes a bug that cannot save colorscheme as a dataset default in the UI

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixes a regression: cannot save colorscheme to dataset.app_config.colorscheme in the APP due to a missing import

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal state management for the color modal component to ensure proper cleanup of selection state when saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->