### PR TITLE
clear annotation selection on label deletion

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Footer.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Footer.tsx
@@ -15,6 +15,7 @@ import { LIGHTER_EVENTS, useLighter } from "@fiftyone/lighter";
 const SaveFooter = () => {
   const { scene } = useLighter();
   const annotationLabel = useAtomValue(currentLabelAtom);
+  const setEditing = useSetAtom(editing);
   const showCancel = useAtomValue(isNew);
 
   const onSave = useCallback(() => {
@@ -30,10 +31,13 @@ const SaveFooter = () => {
     if (scene) {
       scene.dispatchSafely({
         type: LIGHTER_EVENTS.DO_REMOVE_OVERLAY,
-        detail: { ...annotationLabel },
+        detail: {
+          label: { ...annotationLabel },
+          onSuccess: () => setEditing(null),
+        },
       });
     }
-  }, [annotationLabel, scene]);
+  }, [annotationLabel, scene, setEditing]);
 
   return (
     <>

--- a/app/packages/lighter/src/event/EventBus.ts
+++ b/app/packages/lighter/src/event/EventBus.ts
@@ -307,7 +307,11 @@ export type DoLighterEvent =
     }
   | {
       type: typeof LIGHTER_EVENTS.DO_REMOVE_OVERLAY;
-      detail: AnnotationLabel;
+      detail: {
+        onSuccess?: () => void;
+        onError?: (error?: Error | string) => void;
+        label: AnnotationLabel;
+      };
     };
 
 /**


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR updates the annotation persistence logic to clear the sidebar selection state when a label is deleted

## How is this patch tested? If it is not, please explain why.

local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and reporting for overlay removal operations with improved callback execution
  * Improved state management for modal interactions ensuring reliable success and error status feedback
  * Refined control flow for data operations to ensure consistent status propagation throughout the system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->