### PR TITLE
Update docs dependencies to latest version

### DIFF
--- a/docs/source/_templates/navbar-links.html
+++ b/docs/source/_templates/navbar-links.html
@@ -2,7 +2,7 @@
   <!-- Products Dropdown -->
   <div class="nav-item dropdown">
     <a class="nav-link dropdown-toggle" href="#" id="productsDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-      Products
+      Product
     </a>
     <ul class="dropdown-menu" aria-labelledby="productsDropdown">
       <li><a class="dropdown-item" href="{{link_annotation}}" target="_blank">Data Annotation</a></li>

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -7,17 +7,17 @@ typing_extensions==4.15.0
 
 # precommit requirements
 pre-commit==4.3.0
-pylint==3.3.8
+pylint==4.0.1
 jupyter-client==8.6.3
 
 # docs requirements
 autodocsumm==0.2.14
 # myst parser does not support docutils 0.22: https://github.com/executablebooks/MyST-Parser/pull/1045
 docutils==0.21.2
-ipykernel==6.30.1
+ipykernel==7.0.1
 ipython_genutils==0.2.0
 Jinja2==3.1.6
-MarkupSafe==3.0.2
+MarkupSafe==3.0.3
 jsx-lexer==2.0.1
 libsass==0.23.0
 myst-parser==4.0.1
@@ -27,7 +27,7 @@ sphinx-autobuild==2025.8.25
 sphinx-tabs==3.4.7
 sphinx-design==0.6.1
 # nbsphinx does not support yet Sphinx > 8.2: https://github.com/spatialaudio/nbsphinx/issues/832
-Sphinx==8.1.3 
+Sphinx==8.1.3
 sphinx-copybutton==0.5.2
 sphinxcontrib-jquery==4.1
 sphinx-pushfeedback==0.1.8


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Updates requirements/docs.txt to latest version.
- Updates header "Products" -> "Product" to match [main webiste](https://voxel51.com/).

## How is this patch tested? If it is not, please explain why.

Docs build runs locally without errors.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated navigation menu label for improved consistency

* **Chores**
  * Updated documentation dependencies including pylint, ipykernel, and MarkupSafe to newer versions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->