### PR TITLE
FOEPD-2117 bump max slug len

### DIFF
--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -3077,7 +3077,7 @@ class ResponseStream(object):
 
 _SAFE_CHARS = set(string.ascii_letters) | set(string.digits)
 _HYPHEN_CHARS = set(string.whitespace) | set("+_.-")
-_NAME_LENGTH_RANGE = (1, 100)
+_NAME_LENGTH_RANGE = (1, 1551)
 
 
 def _sanitize_char(c):
@@ -3100,7 +3100,7 @@ def to_slug(name):
         -   All other characters are omitted
         -   All consecutive ``-`` characters are reduced to a single ``-``
         -   All leading and trailing ``-`` are stripped
-        -   Both the input name and the resulting string must be ``[1, 100]``
+        -   Both the input name and the resulting string must be ``[1, 1551]``
             characters in length
 
     Examples::

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -492,7 +492,7 @@ class CoreUtilsTests(unittest.TestCase):
             fou.to_slug("------")  # too short
 
         with self.assertRaises(ValueError):
-            fou.to_slug("a" * 101)  # too long
+            fou.to_slug("a" * 1552)  # too long
 
     def test_get_module_name(self):
         if sys.platform.startswith("win"):


### PR DESCRIPTION
## What changes are proposed in this pull request?

There's been requests to increase dataset / view name size limit.
It was 100 for no particularly sound reason I believe.
New limit is just as arbitrary but 10x greater yet still below the conservative 2000 char URL limit recommendation

## How is this patch tested? If it is not, please explain why.

```python
import fiftyone as fo
s="a" * 1551
ds=fo.Dataset(s)
ds.save_view(s, ds.view())
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Increased maximum resource (dataset, view, snapshot) name size from 100 to 1551

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the maximum character limit for slug-friendly names from 100 to 1551 characters. Users can now create substantially longer, more descriptive identifiers for datasets, projects, and resources while maintaining slug compatibility.

* **Documentation**
  * Updated validation guidelines to reflect the expanded maximum character limits for slug-friendly naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->