### PR TITLE
FOEPD-2342 PipelineExecutionContext added to exec ctx

### DIFF
--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -819,16 +819,20 @@ class DelegatedOperationService(object):
                 if parent_doc.pipeline and parent_doc.pipeline_run_info:
                     stage_index = parent_doc.pipeline_run_info.stage_index
                     pipeline_ctx = PipelineExecutionContext(
-                        parent_doc.pipeline_run_info.active,
-                        stage_index,
-                        len(parent_doc.pipeline.stages),
-                        num_distributed_tasks=parent_doc.pipeline.stages[
-                            stage_index
-                        ].get("num_distributed_tasks")
-                        or 0,
+                        active=parent_doc.pipeline_run_info.active,
+                        curr_stage_index=stage_index,
+                        total_stages=len(parent_doc.pipeline.stages),
+                        num_distributed_tasks=(
+                            parent_doc.pipeline.stages[
+                                stage_index
+                            ].num_distributed_tasks
+                            or 0
+                        ),
                     )
-        except:
-            pass
+        except Exception:
+            logger.debug(
+                "Failed to build PipelineExecutionContext", exc_info=True
+            )
 
         prepared = await prepare_operator_executor(
             operator_uri=operator_uri,

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -8,9 +8,11 @@ FiftyOne operator execution.
 
 import asyncio
 import collections
+import dataclasses
 import inspect
 import logging
 import traceback
+from typing import Optional
 
 import fiftyone as fo
 import fiftyone.core.dataset as fod
@@ -1104,6 +1106,7 @@ class ExecutionResult(object):
         }
 
 
+@dataclasses.dataclass
 class PipelineExecutionContext(object):
     """Represents the execution context of a pipeline.
 
@@ -1122,6 +1125,13 @@ class PipelineExecutionContext(object):
             current stage
     """
 
+    active: bool
+    curr_stage_index: int
+    total_stages: int
+    num_distributed_tasks: int = 0
+    error: Optional[str] = None
+
+    # Overriding default init so we swallow extra kwargs
     def __init__(
         self,
         active,
@@ -1134,7 +1144,6 @@ class PipelineExecutionContext(object):
         self.active = active
         self.curr_stage_index = curr_stage_index
         self.total_stages = total_stages
-
         self.error = error
         self.num_distributed_tasks = num_distributed_tasks
 

--- a/tests/unittests/operators/delegated_tests.py
+++ b/tests/unittests/operators/delegated_tests.py
@@ -5,6 +5,7 @@ FiftyOne delegated operator related unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import asyncio
 import copy
 import time
 import unittest
@@ -22,11 +23,14 @@ from fiftyone.factory import (
     SortDirection,
     SortByField,
 )
+from fiftyone.operators.types import PipelineRunInfo
+from fiftyone.operators import delegated
 from fiftyone.operators.delegated import DelegatedOperationService
 from fiftyone.operators.executor import (
     ExecutionContext,
     ExecutionResult,
     ExecutionRunState,
+    PipelineExecutionContext,
 )
 from fiftyone.operators.types import Pipeline, PipelineStage
 from fiftyone.factory.repos import (
@@ -1222,6 +1226,73 @@ class DelegatedOperationServiceTests(unittest.TestCase):
             )
         finally:
             dataset.delete()
+
+    @patch.object(delegated, "do_execute_operator")
+    @patch.object(delegated, "prepare_operator_executor")
+    def test_execute_with_pipeline_context(
+        self, prepare_operator_mock, do_execute_mock, mock_get_operator
+    ):
+        with patch.object(self.svc, "get") as do_get_mock:
+            parent_run_info = PipelineRunInfo(
+                active=False, expected_children=[1, 1, 5], stage_index=2
+            )
+            parent_id = ObjectId()
+            pipeline = Pipeline(
+                [
+                    PipelineStage(operator_uri="@test/op1", name="one"),
+                    PipelineStage(name="two", operator_uri="@test/op2"),
+                    PipelineStage(
+                        name="three",
+                        operator_uri="@test/op3",
+                        num_distributed_tasks=5,
+                    ),
+                ]
+            )
+
+            parent_do = DelegatedOperationDocument()
+            parent_do.id = parent_id
+            parent_do.pipeline = pipeline
+            parent_do.pipeline_run_info = parent_run_info
+            do_get_mock.return_value = parent_do
+
+            child_do = DelegatedOperationDocument()
+            child_do.id = bson.ObjectId()
+            child_do.operator = "@test/op3"
+            child_do.parent_id = parent_id
+            ctx = ExecutionContext(
+                request_params={"foo": "bar", "dataset_name": "dataset"},
+            )
+            child_do.context = ctx
+            prepare_operator_mock.return_value = (
+                mock_get_operator.return_value,
+                None,
+                ctx,
+                None,
+            )
+
+            #####
+            asyncio.run(self.svc._execute_operator(child_do))
+            #####
+
+            do_get_mock.assert_called_once_with(parent_id)
+            pipeline_ctx = PipelineExecutionContext(
+                parent_run_info.active,
+                parent_run_info.stage_index,
+                total_stages=len(pipeline.stages),
+                num_distributed_tasks=pipeline.stages[
+                    parent_run_info.stage_index
+                ].num_distributed_tasks,
+            )
+            prepare_operator_mock.assert_called_once_with(
+                operator_uri=child_do.operator,
+                request_params=ctx.request_params,
+                delegated_operation_id=child_do.id,
+                set_progress=mock.ANY,
+                pipeline_ctx=pipeline_ctx,
+            )
+            do_execute_mock.assert_called_once_with(
+                mock_get_operator.return_value, ctx, exhaust=True
+            )
 
     def test_paging_sorting(self, mock_get_operator):
         dataset_name = f"test_dataset_{ObjectId()}"

--- a/tests/unittests/operators/executor_tests.py
+++ b/tests/unittests/operators/executor_tests.py
@@ -60,6 +60,7 @@ class TestOperatorExecutionContext(unittest.TestCase):
                 "params": request_params["params"],
                 "request_params": request_params,
                 "user": None,
+                "pipeline": None,
             },
         )
         self.assertDictEqual(ctx.params, request_params["params"])


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add `PipelineExecutionContext` which is a part of the regular `ExecutionContext`.
That way a child operator can access this in their execute function, like `ctx.pipeline.active`.

## How is this patch tested? If it is not, please explain why.

Simulated delegated execution of a child DO from a pipeline and asserted `ctx.pipeline` contained the correct info.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Added `PipelineExecutionContext` object to delegated operator context, accessible via `ctx.pipeline`

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operators running inside a pipeline now receive pipeline execution context (state, current stage, total stages, error status, distributed task count) during preparation and execution.
* **Tests**
  * Added unit tests validating pipeline context creation and that operator preparation/execution receive the computed pipeline context.
* **Other**
  * Execution context serialization now includes pipeline information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->