### PR TITLE
clarify PipelineStage.params and relax some errors into coercion

### DIFF
--- a/fiftyone/operators/_types/pipeline.py
+++ b/fiftyone/operators/_types/pipeline.py
@@ -18,8 +18,7 @@ class PipelineStage:
         name: the name of the stage
         num_distributed_tasks: the number of distributed tasks to use
             for the stage, optional
-        params: optional parameters to pass to the operator, overwriting
-            any existing parameters
+        params: optional parameters to pass to the operator
     """
 
     # Required
@@ -62,7 +61,7 @@ class PipelineStage:
             self.num_distributed_tasks is not None
             and self.num_distributed_tasks < 1
         ):
-            raise ValueError("num_distributed_tasks must be >= 1")
+            self.num_distributed_tasks = None
 
     def to_json(self):
         """Converts the object definition to JSON / python dict.
@@ -111,8 +110,7 @@ class Pipeline:
             name: the name of the stage
             num_distributed_tasks: the number of distributed tasks to use
                 for the stage, optional
-            params: optional parameters to pass to the operator, overwriting
-                any existing parameters
+            params: optional parameters to pass to the operator
             **kwargs: reserved for future use
 
         Returns:

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -300,9 +300,9 @@ async def execute_or_delegate_operator(
                 ctx.num_distributed_tasks
                 or "num_distributed_tasks" in ctx.request_params
             ):
-                raise ValueError(
-                    "Distributed execution is only supported in FiftyOne Enterprise"
-                )
+                # Distributed execution is only supported in FiftyOne Enterprise
+                ctx.request_params.pop("num_distributed_tasks", None)
+
             if isinstance(operator, PipelineOperator):
                 raise ValueError(
                     "Pipeline operators require a distributed executor, "

--- a/tests/unittests/operators/types_tests.py
+++ b/tests/unittests/operators/types_tests.py
@@ -87,17 +87,19 @@ class TestPipelineType(unittest.TestCase):
         with self.assertRaises(ValueError):
             types.PipelineStage(operator_uri=None)
 
-        with self.assertRaises(ValueError):
-            types.PipelineStage(operator_uri="my/uri", num_distributed_tasks=0)
+        pipe = types.PipelineStage(
+            operator_uri="my/uri", num_distributed_tasks=0
+        )
+        self.assertIsNone(pipe.num_distributed_tasks)
 
-        with self.assertRaises(ValueError):
-            types.PipelineStage(
-                operator_uri="my/uri", num_distributed_tasks=-5
-            )
+        pipe = types.PipelineStage(
+            operator_uri="my/uri", num_distributed_tasks=-5
+        )
+        self.assertIsNone(pipe.num_distributed_tasks)
 
         pipe = types.Pipeline()
-        with self.assertRaises(ValueError):
-            pipe.stage("my/uri", num_distributed_tasks=-5)
+        pipe.stage("my/uri", num_distributed_tasks=-5)
+        self.assertIsNone(pipe.stages[0].num_distributed_tasks)
 
     def test_none(self):
         self.assertIsNone(types.Pipeline.from_json(None))


### PR DESCRIPTION
## What changes are proposed in this pull request?

Clarifying docstring for `PipelineStage.params`. Params must be explicit now, they are not overriding.
Relaxed some errors into just coercion to the right thing. For example num_distributed_tasks for a DO that doesn't support it doesn't error. (Product discussion)

## How is this patch tested? If it is not, please explain why.

N/A

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for distributed task configuration; invalid values now coerce gracefully instead of raising errors.
  
* **Improvements**
  * Enhanced forward compatibility for pipeline operators and executor to accept future parameter variations without disruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->