### PR TITLE
feat(plugins): enable caching by default

### DIFF
--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -118,7 +118,7 @@ class FiftyOneConfig(EnvConfig):
             d,
             "plugins_cache_enabled",
             env_var="FIFTYONE_PLUGINS_CACHE_ENABLED",
-            default=False,
+            default=True,
         )
         self.operator_timeout = self.parse_int(
             d,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Make the plugin cache enabled by default.

## How is this patch tested? If it is not, please explain why.

The cache has been tested thoroughly in fiftyone-teams.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

The plugin cache will now be enabled by default. Plugin developers should disable this by setting the corresponding config to false, which maintains hot reload support of operators and panels.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Plugins cache is now enabled by default, improving plugin loading efficiency and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->