### PR TITLE
add feature flag for human annotation

### DIFF
--- a/app/packages/core/package.json
+++ b/app/packages/core/package.json
@@ -10,6 +10,7 @@
     },
     "dependencies": {
         "@fiftyone/components": "*",
+        "@fiftyone/feature-flags": "*",
         "@fiftyone/flashlight": "*",
         "@fiftyone/looker": "*",
         "@fiftyone/map": "*",

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useCanAnnotate.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useCanAnnotate.ts
@@ -1,6 +1,11 @@
 import { readOnly } from "@fiftyone/state";
 import { useRecoilValue } from "recoil";
+import { FeatureFlag, useFeature } from "@fiftyone/feature-flags";
 
 export default function useCanAnnotate() {
-  return !useRecoilValue(readOnly);
+  const isReadOnly = useRecoilValue(readOnly);
+  const isAnnotationEnabled = useFeature({
+    feature: FeatureFlag.EXPERIMENTAL_ANNOTATION,
+  });
+  return !isReadOnly && isAnnotationEnabled;
 }

--- a/app/packages/feature-flags/src/client/flags.ts
+++ b/app/packages/feature-flags/src/client/flags.ts
@@ -1,4 +1,7 @@
 /**
  * Enumeration of active feature flags.
  */
-export enum FeatureFlag {}
+export enum FeatureFlag {
+  // experimental sample annotation features
+  EXPERIMENTAL_ANNOTATION = "VFF_EXP_ANNOTATION",
+}

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2450,6 +2450,7 @@ __metadata:
   resolution: "@fiftyone/core@workspace:packages/core"
   dependencies:
     "@fiftyone/components": "npm:*"
+    "@fiftyone/feature-flags": "npm:*"
     "@fiftyone/flashlight": "npm:*"
     "@fiftyone/looker": "npm:*"
     "@fiftyone/map": "npm:*"
@@ -2546,7 +2547,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fiftyone/feature-flags@workspace:packages/feature-flags":
+"@fiftyone/feature-flags@npm:*, @fiftyone/feature-flags@workspace:packages/feature-flags":
   version: 0.0.0-use.local
   resolution: "@fiftyone/feature-flags@workspace:packages/feature-flags"
   dependencies:

--- a/fiftyone/internal/features/flags.py
+++ b/fiftyone/internal/features/flags.py
@@ -8,5 +8,8 @@ FiftyOne feature flags.
 
 from typing import Literal
 
-FeatureFlag = Literal["placeholder"]
+FeatureFlag = Literal[
+    # experimental sample annotation features
+    "VFF_EXP_ANNOTATION",
+]
 """Enumeration of active feature flags."""


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds a feature flag to disable experimental annotation features by default.

## How is this patch tested? If it is not, please explain why.

local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced experimental annotation capability, controllable via a new feature flag for gradual rollout and testing.
  * Annotation controls are now shown only when the app is editable (not read-only) and the annotation feature flag is enabled, preventing accidental access in read-only contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->