### PR TITLE
Updating segmentation conf mat mapping [FOEPD-2363]

### DIFF
--- a/plugins/panels/model_evaluation/__init__.py
+++ b/plugins/panels/model_evaluation/__init__.py
@@ -1278,8 +1278,8 @@ def _init_segmentation_results(dataset, results, gt_field):
     for ytrue, ypred, ytrue_id, ypred_id in zip(
         results.ytrue, results.ypred, results.ytrue_ids, results.ypred_ids
     ):
-        i = classes_map[ytrue]
-        j = classes_map[ypred]
+        j = classes_map[ytrue]
+        i = classes_map[ypred]
         index = (i, j)
 
         if index not in ytrue_ids_dict:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Updating the confusion matrix map for segmentations- the x and y values were inverted previously.

## How is this patch tested? If it is not, please explain why.

Tested locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other
Built-in panel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect class indexing in segmentation model evaluation results, ensuring proper alignment of predicted and ground truth class mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->