### PR TITLE
fix overlay initialization on scene recreation

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
@@ -157,7 +157,7 @@ export default function useLabels() {
     } else {
       setLoading(true);
     }
-  }, [modalSampleData, sceneId, schemaMap]);
+  }, [modalSampleData, scene, schemaMap]);
 
   useHover();
   useFocus();


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR fixes a bug in which overlays are not redrawn under specific conditions when the scene is recreated. Simple fix--update hook logic to run on the right condition 🙃.

## How is this patch tested? If it is not, please explain why.

local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization applied to annotation label handling.

**Note:** This release includes internal improvements with no visible changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->