### PR TITLE
Ensure recoil mock values in App tests

### DIFF
--- a/app/__mocks__/recoil.ts
+++ b/app/__mocks__/recoil.ts
@@ -20,6 +20,35 @@ export const getValue = (atom) => {
     }
   }
 
+  // Sometimes, code will use the original version of selectorFamily instead of the mock
+  // When that happens, there is no `params`. Instead, the `key` is a string of the form:
+  // <key>__selectorFamily/<params as json>/#
+  if (atom.key.includes("__selectorFamily")) {
+    const [key, rest] = atom.key.split("__selectorFamily");
+    if (mockValues[key]) {
+      const [_, params, _number] = rest.split("/");
+      if (params) {
+        if (mockValues[key] instanceof Function) {
+          let realParams = params;
+          try {
+            realParams = JSON.parse(params);
+          } catch {
+            // must not be json
+          }
+          return mockValues[key](realParams);
+        } else {
+          return mockValues[key][params];
+        }
+      } else {
+        if (mockValues[key] instanceof Function) {
+          return mockValues[key]();
+        } else {
+          return mockValues[key];
+        }
+      }
+    }
+  }
+
   if (atom.params !== undefined) {
     return mockValues[atom.key](atom.params);
   }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Ensure recoil mock value store contains set values even when mock import issues arise

## How is this patch tested? If it is not, please explain why.

Existing coverage

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved mock value handling for selector functionality to support more flexible test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->