### PR TITLE
HA: Fix labels in focus

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useFocus.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useFocus.ts
@@ -33,7 +33,7 @@ export default function useFocus() {
 
   useEffect(() => {
     const handler = (event) => {
-      if (event.detail.isBridgeLogicHandled) {
+      if (event.detail.ignoreSideEffects) {
         return;
       }
 
@@ -42,11 +42,12 @@ export default function useFocus() {
       if (!current || !STORE.get(hasChanges)) {
         // no unsaved changes, allow the exit
         onExit();
+
         return;
       }
 
       // there are unsaved changes, ask for confirmation
-      scene?.selectOverlay(event.detail.id, { isBridgeLogicHandled: true });
+      scene?.selectOverlay(event.detail.id, { ignoreSideEffects: true });
       confirmExit(() => {
         scene?.deselectOverlay(current, {
           isBridgeLogicHandled: true,
@@ -64,7 +65,7 @@ export default function useFocus() {
 
   useEffect(() => {
     const handler = (event) => {
-      if (event.detail.isBridgeLogicHandled) {
+      if (event.detail.ignoreSideEffects) {
         return;
       }
       selectId.current = event.detail.id;
@@ -74,7 +75,7 @@ export default function useFocus() {
         if (STORE.get(current)?.isNew) return;
 
         // a label is already being edited, let the DESELECT event handle it
-        scene?.deselectOverlay(event.detail.id, { isBridgeLogicHandled: true });
+        scene?.deselectOverlay(event.detail.id, { ignoreSideEffects: true });
         return;
       }
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
@@ -157,7 +157,23 @@ export default function useLabels() {
     } else {
       setLoading(true);
     }
-  }, [modalSampleData, scene, schemaMap]);
+    return () => {
+      // clear the scene on unmount
+      setLoading(true);
+      setLabels([]);
+      scene?.clear();
+    };
+  }, [
+    addLabel,
+    filter,
+    getFieldType,
+    modalSampleData,
+    paths,
+    schemaMap,
+    scene,
+    setLabels,
+    setLoading,
+  ]);
 
   useHover();
   useFocus();

--- a/app/packages/lighter/src/selection/SelectionManager.ts
+++ b/app/packages/lighter/src/selection/SelectionManager.ts
@@ -20,6 +20,11 @@ export interface SelectionOptions {
    * by lighter's bridge.
    */
   isBridgeLogicHandled?: boolean;
+
+  /**
+   * Flag for ignoring side effects
+   */
+  ignoreSideEffects?: boolean;
 }
 
 /**


### PR DESCRIPTION
## What changes are proposed in this pull request?

* Fixes selecting a label from the sidebar and then de-selecting it from the canvas
* Fixes label interactions after closing and then reopening a sample
  * The scene must be cleared so new overlays are properly initialized

## How is this patch tested? If it is not, please explain why.

### Before

https://github.com/user-attachments/assets/025f40da-2c65-4067-aa1f-ea1925fc259b


### After

https://github.com/user-attachments/assets/773915e0-c4ef-474b-98dd-6fed260f2005


## Release Notes

N/A

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of annotation-related state when components unmount, preventing potential unexpected behavior from persisting into subsequent operations.
  * Enhanced side effects management in selection and overlay event handling for more consistent and reliable interactions.

* **Chores**
  * Refined internal event handling and management for improved code clarity and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->