### PR TITLE
Update disabled message for grouped datasets

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Annotate.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Annotate.tsx
@@ -21,6 +21,14 @@ import useLabels from "./useLabels";
 
 const showImportPage = atom((get) => !get(activePaths).length);
 
+const GROUP_UNSUPPORTED = (
+  <p>
+    Annotation isn&rsquo;t supported for grouped datasets. Use{" "}
+    <code>SelectGroupSlices</code> to create a view of the image or 3D slices
+    you want to label.
+  </p>
+);
+
 const Container = styled.div`
   flex: 1;
   display: flex;
@@ -89,6 +97,10 @@ const Annotate = () => {
 
   const mediaType = useRecoilValue(fos.mediaType);
   const annotationSupported = isAnnotationSupported(mediaType);
+  const disabledMsg =
+    !annotationSupported && mediaType === "group"
+      ? GROUP_UNSUPPORTED
+      : undefined;
 
   if (annotationSupported && (loading || !scene)) {
     return <Loading />;
@@ -98,7 +110,11 @@ const Annotate = () => {
     <>
       {editing && <Edit key="edit" />}
       {showImport ? (
-        <ImportSchema key="import" disabled={!annotationSupported} />
+        <ImportSchema
+          key="import"
+          disabled={!annotationSupported}
+          disabledMsg={disabledMsg}
+        />
       ) : (
         <AnnotateSidebar key="annotate" />
       )}

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/ImportSchema.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/ImportSchema.tsx
@@ -6,6 +6,9 @@ import styled from "styled-components";
 import useCanManageSchema from "./useCanManageSchema";
 import useShowModal from "./useShowModal";
 
+const DISABLED_DEFAULT =
+  "Annotation is not yet supported for this type of media or view.";
+
 const Container = styled.div`
   flex: 1;
   display: flex;
@@ -16,8 +19,15 @@ const Container = styled.div`
   position: relative;
 `;
 
+export interface ImportSchemaProps {
+  disabled?: boolean;
+  disabledMsg?: React.ReactNode;
+}
+
 const ImportSchema = (
-  { disabled }: { disabled: boolean } = { disabled: false }
+  { disabled, disabledMsg }: ImportSchemaProps = {
+    disabled: false,
+  }
 ) => {
   const canManage = useCanManageSchema();
   const showModal = useShowModal();
@@ -73,10 +83,11 @@ const ImportSchema = (
             margin: 2,
             background: "#333",
             boxShadow: "0px 1px 2px 0px rgba(16, 24, 40, 0.05)",
+            alignItems: "center",
           }}
         >
           <Typography color="secondary" fontSize={12}>
-            Annotation is not yet supported for this type of media or view.
+            {disabledMsg || DISABLED_DEFAULT}
           </Typography>
         </Alert>
       )}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Updated 'disabled' message for grouped datasets.

## How is this patch tested? If it is not, please explain why.

Manually

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added contextual guidance messages that display when annotation is unavailable for group media, helping users understand feature limitations.
  * Enhanced disabled state messaging to support custom, context-specific messages across annotation workflows for clearer user communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->