### PR TITLE
Release notes for OSS 1.10.0 / Enterprise 2.13.0

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -26,12 +26,12 @@ App
 
 - Increased maximum length for the name of a dataset or view to over 1000
   characters.
-- Fixed a bug where the UI would allow exporting media greater than 100MB, even
+- Fixed a bug where the UI would allow exporting media greater than 100 MB, even
   though that is not supported, resulting in the download hanging.
 
 Core
-- Optimized
-  :func:`instances_to_polylines() <fiftyone.utils.labels.instances_to_polylines>`
+
+- Optimized :func:`instances_to_polylines() <fiftyone.utils.labels.instances_to_polylines>`
   conversion of instance segmentations whose masks are stored in the cloud.
 
 Compliance
@@ -39,7 +39,7 @@ Compliance
 - Fixed a bug where a license compliance error could be raised even after the
   compliance issue had been resolved.
 - Modified our builds to remove lock files that were causing some scanners
-  (e.g. AWS inspector) to eroneously report vulnerabilities for dependencies
+  (e.g. AWS Inspector) to erroneously report vulnerabilities for dependencies
   not included in our build.
 
 


### PR DESCRIPTION
Release notes for OSS 1.10.0 / Enterprise 2.13.0

## TODO
- [x] Add more detailed notes for PipelineOperator with docs links
- [x] Add additional docs links

## Release Notes

-   [x] No. You can skip the rest of this section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Published FiftyOne Enterprise 2.13.0 release notes with date and summary
  * Added sections: Plugins, App, Core, and Compliance
  * Documented new pipeline operator and pipeline/execution improvements
  * App: longer dataset/view names and UI export fixes
  * Core: optimized handling of cloud-stored instance segmentation data and distributed operation fixes
  * Compliance: license-related fixes and build-cleanliness adjustments
  * Included and referenced FiftyOne 1.10.0 release notes under 2.13.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->