### PR TITLE
Allow config operator execution menu z-index and menu position

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/OperatorExecutionButtonView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/OperatorExecutionButtonView.tsx
@@ -28,6 +28,9 @@ export default function OperatorExecutionButtonView(props: ViewPropsType) {
     on_error,
     on_success,
     on_option_selected,
+    inside_modal = false,
+    menu_anchor_origin,
+    menu_transform_origin,
   } = view;
   const panelId = usePanelId();
   const variant = getVariant(props);
@@ -95,6 +98,9 @@ export default function OperatorExecutionButtonView(props: ViewPropsType) {
           executionParams={computedParams}
           variant={variant}
           disabled={disabled}
+          insideModal={inside_modal}
+          menuAnchorOrigin={menu_anchor_origin}
+          menuTransformOrigin={menu_transform_origin}
           startIcon={icon_position === "left" ? Icon : undefined}
           endIcon={icon_position === "right" ? Icon : undefined}
           title={description}

--- a/app/packages/operators/src/components/OperatorExecutionButton/index.tsx
+++ b/app/packages/operators/src/components/OperatorExecutionButton/index.tsx
@@ -16,6 +16,9 @@ import { OperatorExecutionOption } from "../../state";
  * @param executionParams Parameters to provide to the operator's execute call
  * @param onOptionSelected Callback for execution option selection
  * @param disabled If true, disables the button and context menu
+ * @param insideModal If true, elevate menu z-index to appear above modals
+ * @param menuAnchorOrigin Controls where the menu attaches to the button
+ * @param menuTransformOrigin Controls which point of the menu aligns with button
  */
 export const OperatorExecutionButton = ({
   operatorUri,
@@ -25,6 +28,9 @@ export const OperatorExecutionButton = ({
   executionParams,
   onOptionSelected,
   disabled,
+  insideModal,
+  menuAnchorOrigin,
+  menuTransformOrigin,
   children,
   ...props
 }: {
@@ -35,6 +41,15 @@ export const OperatorExecutionButton = ({
   executionParams?: object;
   onOptionSelected?: (option: OperatorExecutionOption) => void;
   disabled?: boolean;
+  insideModal?: boolean;
+  menuAnchorOrigin?: {
+    vertical: "top" | "bottom" | "center";
+    horizontal: "left" | "right" | "center";
+  };
+  menuTransformOrigin?: {
+    vertical: "top" | "bottom" | "center";
+    horizontal: "left" | "right" | "center";
+  };
   children: React.ReactNode;
 }) => {
   return (
@@ -46,6 +61,9 @@ export const OperatorExecutionButton = ({
       executionParams={executionParams}
       onOptionSelected={onOptionSelected}
       disabled={disabled}
+      insideModal={insideModal}
+      menuAnchorOrigin={menuAnchorOrigin}
+      menuTransformOrigin={menuTransformOrigin}
     >
       <Button disabled={disabled} {...props}>
         {children}

--- a/app/packages/operators/src/components/OperatorExecutionMenu/index.tsx
+++ b/app/packages/operators/src/components/OperatorExecutionMenu/index.tsx
@@ -11,6 +11,9 @@ import ExecutionOptionItem from "../../ExecutionOptionItem";
  * @param onClose Callback for context menu close events
  * @param executionOptions List of operator execution options
  * @param onClick Callback for an option being clicked
+ * @param insideModal If true, elevate z-index to appear above modals
+ * @param anchorOrigin Controls where the menu attaches to the anchor element
+ * @param transformOrigin Controls which point of the menu aligns with the anchor
  */
 export const OperatorExecutionMenu = ({
   anchor,
@@ -18,15 +21,37 @@ export const OperatorExecutionMenu = ({
   onClose,
   executionOptions,
   onOptionClick,
+  insideModal = false,
+  anchorOrigin,
+  transformOrigin,
 }: {
   anchor?: Element | null;
   open: boolean;
   onClose: () => void;
   executionOptions: OperatorExecutionOption[];
   onOptionClick?: (option: OperatorExecutionOption) => void;
+  insideModal?: boolean;
+  anchorOrigin?: {
+    vertical: "top" | "bottom" | "center";
+    horizontal: "left" | "right" | "center";
+  };
+  transformOrigin?: {
+    vertical: "top" | "bottom" | "center";
+    horizontal: "left" | "right" | "center";
+  };
 }) => {
   return (
-    <Menu anchorEl={anchor} open={open} onClose={onClose}>
+    <Menu
+      anchorEl={anchor}
+      open={open}
+      onClose={onClose}
+      anchorOrigin={anchorOrigin}
+      transformOrigin={transformOrigin}
+      sx={{
+        // Elevate z-index above dialogs (1300) when inside a modal
+        zIndex: insideModal ? 1800 : undefined,
+      }}
+    >
       {executionOptions.map((target) => (
         <Item
           key={target.id}

--- a/app/packages/operators/src/components/OperatorExecutionTrigger/index.tsx
+++ b/app/packages/operators/src/components/OperatorExecutionTrigger/index.tsx
@@ -36,6 +36,9 @@ import {
  * @param executorOptions Operator executor options
  * @param onOptionSelected Callback for execution option selection
  * @param disabled If true, context menu will never open
+ * @param insideModal If true, elevate menu z-index to appear above modals
+ * @param menuAnchorOrigin Controls where the menu attaches to the anchor
+ * @param menuTransformOrigin Controls which point of the menu aligns with anchor
  */
 export const OperatorExecutionTrigger = ({
   operatorUri,
@@ -46,6 +49,9 @@ export const OperatorExecutionTrigger = ({
   executorOptions,
   onOptionSelected,
   disabled,
+  insideModal,
+  menuAnchorOrigin,
+  menuTransformOrigin,
   children,
   ...props
 }: {
@@ -58,6 +64,15 @@ export const OperatorExecutionTrigger = ({
   executorOptions?: OperatorExecutorOptions;
   onOptionSelected?: (option: OperatorExecutionOption) => void;
   disabled?: boolean;
+  insideModal?: boolean;
+  menuAnchorOrigin?: {
+    vertical: "top" | "bottom" | "center";
+    horizontal: "left" | "right" | "center";
+  };
+  menuTransformOrigin?: {
+    vertical: "top" | "bottom" | "center";
+    horizontal: "left" | "right" | "center";
+  };
 }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   // Anchor to use for context menu
@@ -110,6 +125,9 @@ export const OperatorExecutionTrigger = ({
         onClose={() => setIsMenuOpen(false)}
         onOptionClick={onOptionSelected}
         executionOptions={executionOptions}
+        insideModal={insideModal}
+        anchorOrigin={menuAnchorOrigin}
+        transformOrigin={menuTransformOrigin}
       />
     </>
   );


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Fixes the issue that import dataset (data lens) DO dropdown falls behind the modal. 
- Added props to allow users to config the operator execution menu in css style

## Summary by CodeRabbit

## Release Notes

**New Features**
- Operator execution buttons now support customizable menu positioning through configurable anchor and transform origin settings
- Added modal-aware mode for operator execution buttons with automatic z-index elevation to ensure menus display properly above modal dialogs
- View-level configuration options enable flexible operator execution UI layouts with enhanced positioning control

## How is this patch tested? If it is not, please explain why.

https://github.com/user-attachments/assets/c55aacfa-a72e-4508-8f0d-652adfc7980b

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Added props to allow users to config the operator execution menu in css style

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Operator execution buttons now support customizable menu positioning through configurable anchor and transform origin settings
- Added modal-aware mode for operator execution buttons with automatic z-index elevation to ensure menus display properly above modal dialogs
- View-level configuration options enable flexible operator execution UI layouts with enhanced positioning control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->