### PR TITLE
fix batcher having an element of none ending iteration

### DIFF
--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1652,6 +1652,8 @@ class ContentSizeBatcher(Batcher):
             ``len(iterable)``, if possible
     """
 
+    _SENTINEL = object()
+
     def __init__(
         self,
         iterable,
@@ -1676,8 +1678,7 @@ class ContentSizeBatcher(Batcher):
         self.target_size = target_size
         self.max_batch_size = max_batch_size
         self.size_calc_fn = size_calc_fn
-        self._sentinel = object()  # used to terminate iteration
-        self._next_element = self._sentinel
+        self._next_element = self._SENTINEL
         self._last_batch_content_size = None
         self._encoding_ratio = 1.0
 
@@ -1688,14 +1689,14 @@ class ContentSizeBatcher(Batcher):
         except StopIteration:
             # If iterable is empty, we want to throw StopIteration at the first
             #   call to next(), not here.
-            self._next_element = self._sentinel
+            self._next_element = self._SENTINEL
         return self
 
     def __next__(self):
         if self._render_progress and self._last_batch_size:
             self._pb.update(count=self._last_batch_size)
 
-        if self._next_element is self._sentinel:
+        if self._next_element is self._SENTINEL:
             raise StopIteration
 
         # Must have at least 1 element in a batch
@@ -1727,7 +1728,7 @@ class ContentSizeBatcher(Batcher):
                 # If we get StopIteration, it just means we are done and can
                 #   end this batch. On the following call to __next__(), we'll
                 #   raise our StopIteration
-                self._next_element = self._sentinel
+                self._next_element = self._SENTINEL
                 break
 
         self._last_batch_size = len(curr_batch)

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -353,6 +353,18 @@ class BatcherTests(unittest.TestCase):
             for batch in batcher:
                 self.assertEqual(len(batch), n // 2)
 
+        samples_with_none = [None] + samples
+        count = 0
+        batcher = fou.ContentSizeBatcher(
+            iter(samples_with_none), target_size=1
+        )
+        with batcher:
+            for batch in batcher:
+                if count == 0:
+                    self.assertIsNone(batch[0])
+                count += len(batch)
+        self.assertEqual(count, len(samples_with_none))
+
     def test_static_batcher_perfect_boundary(self):
         iterable = list(range(200))
         batcher = fou.StaticBatcher(iterable, batch_size=100, progress=False)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixing a bug where if your iterable contained `None` and you were using the ContentSizeBatcher it would exit prematurely.

## How is this patch tested? If it is not, please explain why.

Unit tests / running set values with a values input of [None]

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Batch processing now correctly handles leading None values without treating them as iteration termination, improving reliability of batch operations.
* **Tests**
  * Added a unit test that verifies correct batching when input sequences include leading None elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->