### PR TITLE
WorkspaceEditor is a modal, so its Selection needs to adjust its z-index

### DIFF
--- a/app/packages/spaces/src/components/Workspaces/WorkspaceEditor.tsx
+++ b/app/packages/spaces/src/components/Workspaces/WorkspaceEditor.tsx
@@ -93,6 +93,7 @@ export default function WorkspaceEditor() {
               hideActions
               readonly
               noBorder
+              insideModal={true}
             />
           </Stack>
         </Stack>


### PR DESCRIPTION
## What changes are proposed in this pull request?

The Selection in WorkspaceEditor adjusts its z-index because its in a modal.

## How is this patch tested? If it is not, please explain why.

Ran the app:
<img width="593" height="819" alt="image" src="https://github.com/user-attachments/assets/88c34bf3-97b2-46fc-a7ed-8471d3d260ce" />


Before:
<img width="505" height="607" alt="image" src="https://github.com/user-attachments/assets/bd09bc82-03cf-4da7-84a6-944724a05823" />


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Color selection UI now renders within the modal dialog for improved layout and interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->