### PR TITLE
kaputt and coffee tutorials

### DIFF
--- a/docs/source/tutorials/coffee_leaves_rocole_original.ipynb
+++ b/docs/source/tutorials/coffee_leaves_rocole_original.ipynb
@@ -118,16 +118,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1b43add8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fo.delete_dataset(\"coffee_rocole\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "13f62929",
    "metadata": {},
    "outputs": [],
@@ -1972,38 +1962,6 @@
     "from fiftyone.utils.huggingface import push_to_hub\n",
     "\n",
     "push_to_hub(tiled_dataset, \"tiled_dataset\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "a4e5de9a",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Session launched. Run `session.show()` to open the App in a cell output.\n",
-      "Session launched. Run `session.show()` to open the App in a cell output.\n",
-      "Session launched. Run `session.show()` to open the App in a cell output.\n"
-     ]
-    }
-   ],
-   "source": [
-    "session = fo.launch_app(dataset, port=5191, auto=False)\n",
-    "session1 = fo.launch_app(dataset2, port=5192, auto=False)\n",
-    "session2= fo.launch_app(tiled_dataset, port=5193, auto=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "9f2568e0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dataset2.delete_sample_field(\"mask_and_sam2_padim\")"
    ]
   }
  ],

--- a/docs/source/tutorials/kaputt_dataset.ipynb
+++ b/docs/source/tutorials/kaputt_dataset.ipynb
@@ -1035,6 +1035,7 @@
    ],
    "source": [
     "import cv2\n",
+    "import numpy as np\n",
     "\n",
     "# Delete and recreate the grouped dataset\n",
     "grouped_dataset_name = \"kaputt_grouped\"\n",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Kaputt Dataset Exploration Tutorial
Coffee Leaves - Practical Solution -Tutorial

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive tutorial demonstrating end-to-end anomaly detection on the RoCoLe coffee-leaf dataset, including data exploration, patch- and embedding-based analysis, model training/inference, leaf masking, spatial heatmaps, tiling, and visualization workflows in FiftyOne.
  * Added an end-to-end Kaputt dataset tutorial covering ingestion, metadata handling, embeddings and similarity indexing, grouped/crop dataset workflows, app integration, indexing, and example model inference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->