### PR TITLE
[HA] add discard action to annotation footer

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Footer.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Footer.tsx
@@ -8,26 +8,39 @@ import { Row } from "./Components";
 import { currentField, hasChanges, isNew } from "./state";
 import useExit from "./useExit";
 import useSave, { isSaving } from "./useSave";
+import { Stack } from "@mui/material";
 
 const SaveFooter = () => {
   const { onDelete, onExit: onExitConfirm } = useContext(ConfirmationContext);
   const onSave = useSave();
+  const onDiscard = useExit();
   const showCancel = useAtomValue(isNew);
   const changes = useAtomValue(hasChanges);
   const saving = useAtomValue(isSaving);
 
   return (
     <>
-      <MuiButton
-        disabled={!changes || saving}
-        onClick={() => {
-          onSave();
-        }}
-        variant="contained"
-        color="primary"
-      >
-        {saving ? <LoadingDots text={"Saving"} /> : "Save"}
-      </MuiButton>
+      <Stack direction="row" spacing={1}>
+        <MuiButton
+          disabled={!changes || saving}
+          onClick={onDiscard}
+          variant="outlined"
+        >
+          Discard
+        </MuiButton>
+
+        <MuiButton
+          disabled={!changes || saving}
+          onClick={() => {
+            onSave();
+          }}
+          variant="contained"
+          color="primary"
+        >
+          {saving ? <LoadingDots text={"Saving"} /> : "Save"}
+        </MuiButton>
+      </Stack>
+
       <RoundButton
         className={saving ? "disabled" : ""}
         onClick={saving ? undefined : showCancel ? onExitConfirm : onDelete}


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds a discard button to the annotation footer, which discards all pending changes to the label.

## How is this patch tested? If it is not, please explain why.

local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Discard button in the annotation edit modal, allowing users to cancel changes alongside the Save option.
  * Improved button layout with Save and Discard actions now displayed side-by-side for better accessibility and clarity.
  * Enhanced visual distinction between actions with differentiated button styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->