### PR TITLE
undo latest 3d commit

### DIFF
--- a/app/packages/looker-3d/src/annotation/types.ts
+++ b/app/packages/looker-3d/src/annotation/types.ts
@@ -1,11 +1,5 @@
 import { ReactNode } from "react";
-import * as THREE from "three";
 
-/**
- * Represents an action item in the annotation toolbar.
- * Actions can be buttons, toggles, or custom components that perform
- * annotation-related operations in the 3D viewer.
- */
 export interface AnnotationAction {
   id: string;
   label: string;
@@ -19,10 +13,6 @@ export interface AnnotationAction {
   customComponent?: ReactNode;
 }
 
-/**
- * Groups can be shown or hidden, and are used to organize
- * annotation tools by functionality.
- */
 export interface AnnotationActionGroup {
   id: string;
   label?: string;
@@ -30,60 +20,41 @@ export interface AnnotationActionGroup {
   actions: AnnotationAction[];
 }
 
-/**
- * Props for the annotation toolbar component that displays
- * available annotation actions and their groups.
- */
 export interface AnnotationToolbarProps {
   className?: string;
 }
 
-/**
- * Transform mode for manipulating 3D objects.
- * Controls which type of transformation is active (translation, rotation, or scaling).
- */
-export type TransformMode = "translate" | "rotate" | "scale";
+// Hover state for specific polyline points/segments
+export interface HoveredPolylineInfo {
+  labelId: string;
+  segmentIndex: number;
+  // undefined means hovering over the segment, not a specific point
+  pointIndex?: number;
+}
 
-/**
- * Coordinate space for transformations.
- * Determines whether transformations are applied in world space or local object space.
- */
+// Transform control state
+export type TransformMode = "translate" | "rotate" | "scale";
 export type TransformSpace = "world" | "local";
 
-/**
- * Spatial positioning data for 3D objects.
- * Contains position and optional rotation (quaternion) information.
- */
 export interface Spatial {
   position: [number, number, number];
   quaternion?: [number, number, number, number];
 }
 
-/**
- * Identifies a specific point within a polyline annotation.
- * Used to track which point in which segment of which label is currently selected.
- */
 export interface SelectedPoint {
   labelId: string;
   segmentIndex: number;
   pointIndex: number;
 }
 
-/**
- * Stores the transformed vertices for a single polyline segment.
- * Polyline segments are lists of connected vertices. Segments are stored
- * in an array where the array index corresponds to the segmentIndex.
- */
+// Polyline segment transformations - stores modified segments for each label
+// Each segment is a list of connected vertices
+// Segments are stored in an array where the index IS the segmentIndex
 export interface PolylineSegmentTransform {
-  /** All vertices in this segment (connected) */
+  // All vertices in this segment (connected)
   points: [number, number, number][];
 }
 
-/**
- * Complete transformation data for polyline point annotations.
- * Stores all segments of a polyline along with metadata such as
- * the file path, sample ID, label name, and additional custom properties.
- */
 export interface PolylinePointTransformData {
   segments: PolylineSegmentTransform[];
   path?: string;
@@ -92,11 +63,6 @@ export interface PolylinePointTransformData {
   misc?: Record<string, unknown>;
 }
 
-/**
- * State information for an active polyline segment being edited.
- * Tracks whether the segment is currently active, if it's closed,
- * the current mouse position in 3D space, and all vertices in the segment.
- */
 export interface SegmentState {
   isActive: boolean;
   isClosed: boolean;
@@ -104,11 +70,6 @@ export interface SegmentState {
   vertices: [number, number, number][];
 }
 
-/**
- * State for annotation plane visualization and interaction.
- * Controls the visibility and orientation of annotation planes in the 3D viewer,
- * including which axes (X, Y, Z) are displayed.
- */
 export interface AnnotationPlaneState {
   enabled: boolean;
   position: [number, number, number];
@@ -117,24 +78,3 @@ export interface AnnotationPlaneState {
   showY: boolean;
   showZ: boolean;
 }
-
-/**
- * Subscription payload for canvas interaction callbacks.
- * Each subscription defines a plane and callbacks for pointer events on that plane.
- */
-export type CanvasInteractionSubscriptionPayload = {
-  /** Unique identifier for this subscription */
-  id: string;
-  /** Normal vector of the plane in 3D space (defines the plane's orientation) */
-  planeNormal: THREE.Vector3;
-  /** Constant term in the plane equation (defines the plane's position) */
-  planeConstant: number;
-  /** Mouse button number to listen for (0=left, 1=middle, 2=right). If undefined, listens to all buttons */
-  button?: number;
-  /** Callback invoked when pointer is released on the plane. Receives the 3D intersection point and the pointer event */
-  onPointerUp?: (pt: THREE.Vector3, ev: PointerEvent) => void;
-  /** Callback invoked when pointer is pressed down on the plane */
-  onPointerDown?: () => void;
-  /** Callback invoked when pointer moves while over the plane. Receives the 3D intersection point and the pointer event */
-  onPointerMove?: (pt: THREE.Vector3, ev: PointerEvent) => void;
-};

--- a/app/packages/looker-3d/src/fo3d/Fo3dCanvas.tsx
+++ b/app/packages/looker-3d/src/fo3d/Fo3dCanvas.tsx
@@ -8,8 +8,6 @@ import {
   PerspectiveCamera as PerspectiveCameraDrei,
 } from "@react-three/drei";
 import { useAtomValue } from "jotai";
-import { useEffect } from "react";
-import { useResetRecoilState } from "recoil";
 import * as THREE from "three";
 import { Vector3 } from "three";
 import { SpinningCube } from "../SpinningCube";
@@ -17,12 +15,9 @@ import { StatusTunnel } from "../StatusBar";
 import { AnnotationPlane } from "../annotation/AnnotationPlane";
 import { SegmentPolylineRenderer } from "../annotation/SegmentPolylineRenderer";
 import { useCameraViews } from "../hooks/use-camera-views";
-import { useEmptyCanvasInteractionListener } from "../hooks/use-empty-canvas-interaction";
 import { ThreeDLabels } from "../labels";
-import { emptyCanvasInteractionSubscriptionsAtom } from "../state";
 import { FoSceneComponent } from "./FoScene";
 import { Gizmos } from "./Gizmos";
-import { useFo3dContext } from "./context";
 import { SceneControls } from "./scene-controls/SceneControls";
 
 interface Fo3dSceneContentProps {
@@ -169,20 +164,6 @@ export const Fo3dSceneContent = ({
 };
 
 const AnnotationControls = () => {
-  const { fo3dRoot } = useFo3dContext();
-
-  const resetEmptyCanvasInteractionSubscriptions = useResetRecoilState(
-    emptyCanvasInteractionSubscriptionsAtom
-  );
-
-  useEmptyCanvasInteractionListener();
-
-  useEffect(() => {
-    return () => {
-      resetEmptyCanvasInteractionSubscriptions();
-    };
-  }, [fo3dRoot]);
-
   return (
     <>
       <AnnotationPlane panelType="main" viewType="top" />

--- a/app/packages/looker-3d/src/hooks/use-empty-canvas-interaction.ts
+++ b/app/packages/looker-3d/src/hooks/use-empty-canvas-interaction.ts
@@ -1,8 +1,6 @@
 import { useThree } from "@react-three/fiber";
-import { useCallback, useEffect, useRef } from "react";
-import { useRecoilValue, useSetRecoilState } from "recoil";
-import { CanvasInteractionSubscriptionPayload } from "../annotation/types";
-import { emptyCanvasInteractionSubscriptionsAtom } from "../state";
+import { useEffect, useMemo, useRef } from "react";
+import * as THREE from "three";
 import {
   createPlane,
   getPlaneIntersection,
@@ -10,135 +8,95 @@ import {
   toNDC,
 } from "../utils";
 
-/**
- * Sets up event listeners for empty canvas interactions.
- * This hook should be called once in the Canvas tree (e.g., in AnnotationControls).
- * It reads subscriptions from Recoil state and invokes callbacks for each subscription.
- */
-export function useEmptyCanvasInteractionListener() {
-  const { gl, camera, raycaster, events } = useThree();
-  const subscriptions = useRecoilValue(emptyCanvasInteractionSubscriptionsAtom);
+type Options = {
+  onPointerUp?: (pt: THREE.Vector3, ev: PointerEvent) => void;
+  onPointerDown?: () => void;
+  onPointerMove?: (
+    pt: THREE.Vector3,
+    ptPerpendicular: THREE.Vector3 | null,
+    ev: PointerEvent
+  ) => void;
+  planeNormal?: THREE.Vector3;
+  planeConstant?: number;
+  button?: number;
+  doubleRaycast?: boolean;
+};
+
+export function useEmptyCanvasInteraction({
+  onPointerUp,
+  onPointerDown,
+  onPointerMove,
+  planeNormal = new THREE.Vector3(0, 1, 0),
+  planeConstant = 0,
+  button = 0,
+  doubleRaycast = false,
+}: Options = {}) {
+  // Refs to avoid re-rendering
+  const onPointerUpRef = useRef(onPointerUp);
+  const onPointerDownRef = useRef(onPointerDown);
+  const onPointerMoveRef = useRef(onPointerMove);
+
+  onPointerUpRef.current = onPointerUp;
+  onPointerDownRef.current = onPointerDown;
+  onPointerMoveRef.current = onPointerMove;
+
+  const { gl, camera, scene, raycaster, events } = useThree();
+
+  const plane = useMemo(
+    () => createPlane(planeNormal, planeConstant),
+    [planeNormal, planeConstant]
+  );
+
+  // Create perpendicular plane for cursor position
+  const perpendicularPlane = useMemo(() => {
+    const normalizedNormal = planeNormal.clone().normalize();
+
+    // If z-axis is the plane normal, use y-axis for perpendicular plane
+    if (Math.abs(normalizedNormal.z) > 0.9) {
+      return createPlane(new THREE.Vector3(0, 1, 0), planeConstant);
+    }
+    // If y-axis is the plane normal, use z-axis for perpendicular plane
+    if (Math.abs(normalizedNormal.y) > 0.9) {
+      return createPlane(new THREE.Vector3(0, 0, 1), planeConstant);
+    }
+
+    // Default fallback - use z-axis
+    return createPlane(new THREE.Vector3(0, 0, 1), planeConstant);
+  }, [planeNormal, planeConstant]);
 
   useEffect(() => {
     const el = (events.connected ?? gl.domElement) as HTMLCanvasElement;
 
     const handlePointerMove = (ev: PointerEvent) => {
+      if (!onPointerMoveRef.current) return;
       const ndc = toNDC(ev, el);
-      subscriptions.forEach((subscription) => {
-        if (!subscription.onPointerMove) return;
-        const plane = createPlane(
-          subscription.planeNormal,
-          subscription.planeConstant
-        );
-        const pt = getPlaneIntersection(raycaster, camera, ndc, plane);
-        if (pt) {
-          subscription.onPointerMove(pt, ev);
-        }
-      });
+      const pt = getPlaneIntersection(raycaster, camera, ndc, plane);
+      const ptPerpendicular = doubleRaycast
+        ? getPlaneIntersection(raycaster, camera, ndc, perpendicularPlane)
+        : null;
+      onPointerMoveRef.current?.(pt, ptPerpendicular, ev);
     };
 
-    const handlePointerDown = (ev: PointerEvent) => {
-      subscriptions.forEach((subscription) => {
-        if (!subscription.onPointerDown) return;
-        if (!isButtonMatch(ev, subscription.button)) return;
-        subscription.onPointerDown();
-      });
+    const handleDown = (ev: PointerEvent) => {
+      if (!isButtonMatch(ev, button)) return;
+      onPointerDownRef.current?.();
     };
 
-    const handlePointerUp = (ev: PointerEvent) => {
+    const handleUp = (ev: PointerEvent) => {
+      if (!isButtonMatch(ev, button)) return;
       const ndc = toNDC(ev, el);
-      subscriptions.forEach((subscription) => {
-        if (!subscription.onPointerUp) return;
-        if (!isButtonMatch(ev, subscription.button)) return;
-        const plane = createPlane(
-          subscription.planeNormal,
-          subscription.planeConstant
-        );
-        const pt = getPlaneIntersection(raycaster, camera, ndc, plane);
-        if (pt) {
-          subscription.onPointerUp(pt, ev);
-        }
-      });
+      const pt = getPlaneIntersection(raycaster, camera, ndc, plane);
+      if (pt) onPointerUpRef.current?.(pt, ev);
     };
 
     el.addEventListener("pointermove", handlePointerMove, { passive: true });
-    el.addEventListener("pointerdown", handlePointerDown, { passive: true });
-    el.addEventListener("pointerup", handlePointerUp, { passive: true });
+    el.addEventListener("pointerdown", handleDown, { passive: true });
+    el.addEventListener("pointerup", handleUp, { passive: true });
 
     return () => {
       el.removeEventListener("pointermove", handlePointerMove);
-      el.removeEventListener("pointerdown", handlePointerDown);
-      el.removeEventListener("pointerup", handlePointerUp);
+      el.removeEventListener("pointerdown", handleDown);
+      el.removeEventListener("pointerup", handleUp);
     };
-  }, [gl, camera, raycaster, events, subscriptions]);
-}
-
-/**
- * Registers a subscription for empty canvas interactions.
- * Returns an unsubscribe function to remove the subscription.
- *
- * @param payload - Subscription payload with plane parameters and callbacks
- * @returns Unsubscribe function
- */
-export function useEmptyCanvasInteraction(
-  payload: CanvasInteractionSubscriptionPayload
-) {
-  const setSubscriptions = useSetRecoilState(
-    emptyCanvasInteractionSubscriptionsAtom
-  );
-
-  // Refs to avoid re-registering on callback changes
-  const onPointerUpRef = useRef(payload.onPointerUp);
-  const onPointerDownRef = useRef(payload.onPointerDown);
-  const onPointerMoveRef = useRef(payload.onPointerMove);
-
-  onPointerUpRef.current = payload.onPointerUp;
-  onPointerDownRef.current = payload.onPointerDown;
-  onPointerMoveRef.current = payload.onPointerMove;
-
-  const planeNormalX = payload.planeNormal.x;
-  const planeNormalY = payload.planeNormal.y;
-  const planeNormalZ = payload.planeNormal.z;
-
-  useEffect(() => {
-    const subscription: CanvasInteractionSubscriptionPayload = {
-      id: payload.id,
-      planeNormal: payload.planeNormal.clone(),
-      planeConstant: payload.planeConstant,
-      button: payload.button ?? 0,
-      onPointerUp: (pt, ev) => onPointerUpRef.current?.(pt, ev),
-      onPointerDown: () => onPointerDownRef.current?.(),
-      onPointerMove: (pt, ev) => onPointerMoveRef.current?.(pt, ev),
-    };
-
-    setSubscriptions((prev) => {
-      const next = new Map(prev);
-      next.set(payload.id, subscription);
-      return next;
-    });
-
-    return () => {
-      setSubscriptions((prev) => {
-        const next = new Map(prev);
-        next.delete(payload.id);
-        return next;
-      });
-    };
-  }, [
-    payload.id,
-    planeNormalX,
-    planeNormalY,
-    planeNormalZ,
-    payload.planeConstant,
-    payload.button,
-    setSubscriptions,
-  ]);
-
-  return useCallback(() => {
-    setSubscriptions((prev) => {
-      const next = new Map(prev);
-      next.delete(payload.id);
-      return next;
-    });
-  }, [payload.id, setSubscriptions]);
+  }, [gl, camera, scene, raycaster, events, plane, perpendicularPlane, button]);
 }

--- a/app/packages/looker-3d/src/state.ts
+++ b/app/packages/looker-3d/src/state.ts
@@ -9,7 +9,6 @@ import { atom, atomFamily, DefaultValue, selector } from "recoil";
 import { Vector3 } from "three";
 import type {
   AnnotationPlaneState,
-  CanvasInteractionSubscriptionPayload,
   PolylinePointTransformData,
   SegmentState,
   SelectedPoint,
@@ -546,18 +545,6 @@ export const annotationPlaneAtom = selector<AnnotationPlaneState>({
       set(annotationPlaneAtomImpl(name), newValue as AnnotationPlaneState);
     }
   },
-});
-
-/**
- * Stores active subscriptions for empty canvas interactions.
- * Multiple components can register callbacks for plane intersections,
- * all handled by a single event listener system.
- */
-export const emptyCanvasInteractionSubscriptionsAtom = atom<
-  Map<string, CanvasInteractionSubscriptionPayload>
->({
-  key: "fo3d-emptyCanvasInteractionSubscriptions",
-  default: new Map(),
 });
 
 /**


### PR DESCRIPTION
undoes vertex deletion bug (shouldn't take three Delete hits to undo a vertex) + fix regression where you couldn't annotate in side panels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Double-click support for committing polyline segments and closing loops via vertex proximity.
  * Shared cursor display that projects perpendicularly during segmentation for improved aiming.

* **Refactor**
  * Consolidated canvas interaction handling into a single hook; simplified event lifecycle and enabled optional double-raycast.
  * Annotation plane state extended to include quaternion; polyline point payloads adjusted (some fields removed) — may affect integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->