### PR TITLE
bumping to `fiftyone-brain>=0.21.4`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ INSTALL_REQUIRES = [
     "universal-analytics-python3>=1.0.1,<2",
     "pydash",
     # internal packages
-    "fiftyone-brain>=0.21.3,<0.22",
+    "fiftyone-brain>=0.21.4,<0.22",
     "fiftyone-db>=0.4,<2.0",
     "voxel51-eta>=0.15.1,<0.16",
 ]


### PR DESCRIPTION
to be merged once `fiftyone-brain==0.21.4` is published. cf https://github.com/voxel51/fiftyone-brain/pull/265

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to the latest compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->