### PR TITLE
Remove MAP calculations in scenario analysis

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/Scenarios.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/NativeModelEvaluationView/evaluation/scenario/Scenarios.tsx
@@ -1063,7 +1063,6 @@ const MODEL_PERFORMANCE_METRICS = [
   { label: "Precision", key: "precision" },
   { label: "Recall", key: "recall" },
   { label: "IoU", key: "iou" },
-  { label: "mAP", key: "mAP" },
 ];
 
 function PredictionStatisticsChart(props) {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Removes mAP from Scenario Analysis ([FOEPD-2227](https://voxel51.atlassian.net/browse/FOEPD-2227))

<img width="1728" height="967" alt="Screenshot 2025-11-03 at 7 12 46 AM" src="https://github.com/user-attachments/assets/20e61edd-35e9-405c-b94c-21b145457888" />
<img width="1728" height="964" alt="Screenshot 2025-11-03 at 7 12 24 AM" src="https://github.com/user-attachments/assets/a50a6673-4119-460a-808a-4eb3232b0703" />
<img width="1728" height="962" alt="Screenshot 2025-11-03 at 7 12 11 AM" src="https://github.com/user-attachments/assets/7b4f09af-6444-4bd0-8d84-ecfedd9c669d" />


## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


[FOEPD-2227]: https://voxel51.atlassian.net/browse/FOEPD-2227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed mAP metric from available model performance metrics options in evaluation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->