### PR TITLE
Update download links for HMDB51 dataset

### DIFF
--- a/fiftyone/utils/hmdb51.py
+++ b/fiftyone/utils/hmdb51.py
@@ -79,12 +79,11 @@ def download_hmdb51_dataset(
 
 
 _VIDEOS_DOWNLOAD_LINK = (
-    "http://serre-lab.clps.brown.edu/wp-content/uploads/2013/10/hmdb51_org.rar"
+    "https://drive.usercontent.google.com/download?id=17anw5Oxp7lmp9cMwXPOyOpL5olDLmPpj&export=download&confirm=t"
 )
 
 _SPLITS_DOWNLOAD_LINK = (
-    "http://serre-lab.clps.brown.edu/wp-content/uploads/2013/10/"
-    "test_train_splits.rar"
+    "https://drive.usercontent.google.com/download?id=1NQxJWJSYWefyNS-LFYCenFih4gRDUPCX&export=download&confirm=t"
 )
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Updates HMDB51 dataset download links from defunct Brown University server to working Google Drive mirrors.

## How is this patch tested? If it is not, please explain why.

Verified downloads complete successfully and produce valid archives. Confirmed integration with FiftyOne's download infrastructure.

## Release Notes

Updated HMDB51 dataset delivery infrastructure.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated HMDB51 dataset download sources for improved accessibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->