### PR TITLE
Bump fiftyone-db to 7 where possible

### DIFF
--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -94,8 +94,8 @@ LINUX_DOWNLOADS = {
             "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.25.tgz",
         },
         "23": {
-            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-7.0.4.tgz",
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.4.tgz",
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-7.0.25.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.25.tgz",
         },
         "24": {
             "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-7.0.4.tgz",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Bump default installed DB from 6 to 7 for many platforms. Bump to latest patch version when it was already at 7.
Some do not have a version 7 binary so we have to stay with 6.
We do not want to go directly to 8 because if users had 6 they will get an error from Mongo saying they cannot upgrade directly from 6 to 8. We will likely need a better upgrade solution in the future.

Copied links directly from MongoDB page to avoid find-replace issues

## How is this patch tested? If it is not, please explain why.

Not

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Update default fiftyone-DB to MongoDB 7

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
