### PR TITLE
docs(deprecation): AS-1111 add python 3.9 deprecation docs

### DIFF
--- a/docs/source/deprecation.rst
+++ b/docs/source/deprecation.rst
@@ -17,9 +17,8 @@ Python 3.9
 *Support ending June 1, 2026*
 
 `Python 3.9 <https://devguide.python.org/versions/>`_
-transitions to `end-of-life` effective October of 2025. FiftyOne releases after
-September June, 2026 might no longer be compatible with Python 3.9.
-
+transitioned to `end-of-life` effective October of 2025. FiftyOne releases after
+June 1, 2026 might no longer be compatible with Python 3.9.
 
 .. _deprecation-mongodb-6.0:
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

We are planning to deprecation python 3.9 at the end of May 2026. It went EOL October 2025 and other packages are beginning to drop its support. As a first step, we should add a notice to https://docs.voxel51.com/deprecation.html about the impending drop.

This also fixes some of the rst links.

## How is this patch tested? If it is not, please explain why.

Docs-only PR.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Python 3.9 deprecation notice with end-of-life timing details
  * Added MongoDB 6.0 deprecation wording update ("Support ending")
  * Reordered deprecation docs and added a dedicated Kubernetes 1.30 section for clarity and accessibility
  * Minor formatting adjustments to anchors and section headers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->