### PR TITLE
Model Eval bugfix related to disable preview in creating scenario

### DIFF
--- a/plugins/operators/model_evaluation/__init__.py
+++ b/plugins/operators/model_evaluation/__init__.py
@@ -304,7 +304,7 @@ class ConfigureScenario(foo.Operator):
         return True
 
     def render_empty_sample_distribution(
-        self, ctx, inputs, params, description=None
+        self, ctx, inputs, params, description=None, is_invalid=True
     ):
         self.render_plot_preview_toggle(ctx, inputs)
 
@@ -336,8 +336,8 @@ class ConfigureScenario(foo.Operator):
                     },
                 },
             ),
-            invalid=True,
-            error_message="No values selected",
+            invalid=is_invalid,
+            error_message="No values selected" if is_invalid else None,
         )
 
     def get_label_attribute_path(self, params):
@@ -392,6 +392,7 @@ class ConfigureScenario(foo.Operator):
                     inputs,
                     ctx.params,
                     description="You can toggle the 'View sample distribution' to see the preview.",
+                    is_invalid=False,
                 )
             else:
                 # NOTE: values for custom_code is the parsed custom code expression
@@ -423,6 +424,7 @@ class ConfigureScenario(foo.Operator):
                 ctx.params,
                 description="Distribution preview is not enabled. Turn on distribution preview"
                 + " to visualize the subset breakdown.",
+                is_invalid=False,
             )
 
         plot_data, error = self.get_sample_distribution(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Previous bug: With Distribution preview disabled, I am still seeing that I cannot submit the scenario eval plot as it says its waiting on the sample distribution plot.

## How is this patch tested? If it is not, please explain why.

Tested on FOE:

https://github.com/user-attachments/assets/c2542235-2520-416c-ac58-6829e831389a


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Bugfix: disable preview when creating scenarios should allow user to submit scenario w/t preview

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined error state handling in model evaluation displays to provide more accurate feedback when sample distributions cannot be rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->