### PR TITLE
lighter canvas zoom should prevent default zoom behavior

### DIFF
--- a/app/packages/lighter/src/interaction/InteractionManager.ts
+++ b/app/packages/lighter/src/interaction/InteractionManager.ts
@@ -240,6 +240,7 @@ export class InteractionManager {
     this.canvas.addEventListener("pointerup", this.handlePointerUp);
     this.canvas.addEventListener("pointercancel", this.handlePointerCancel);
     this.canvas.addEventListener("pointerleave", this.handlePointerLeave);
+    this.canvas.addEventListener("wheel", this.handleWheel, { passive: false });
     document.addEventListener("keydown", this.handleKeyDown);
     document.addEventListener("keyup", this.handleKeyUp);
     this.eventBus.on(LIGHTER_EVENTS.ZOOMED, this.handleZoomed);
@@ -456,6 +457,14 @@ export class InteractionManager {
       const point = this.getCanvasPoint(event);
       this.hoveredHandler.onHoverLeave?.(point, event);
       this.hoveredHandler = undefined;
+    }
+  };
+
+  private handleWheel = (event: WheelEvent): void => {
+    // If we are zooming in with mouse and target is canvas, prevent default
+    // because we want zoom to be handled by canvas only
+    if (event.target === this.canvas) {
+      event.preventDefault();
     }
   };
 
@@ -809,6 +818,7 @@ export class InteractionManager {
     this.canvas.removeEventListener("pointerup", this.handlePointerUp);
     this.canvas.removeEventListener("pointercancel", this.handlePointerCancel);
     this.canvas.removeEventListener("pointerleave", this.handlePointerLeave);
+    this.canvas.removeEventListener("wheel", this.handleWheel);
     document.removeEventListener("keydown", this.handleKeyDown);
     document.removeEventListener("keyup", this.handleKeyUp);
     this.eventBus.off(LIGHTER_EVENTS.ZOOMED, this.handleZoomed);


### PR DESCRIPTION
## What changes are proposed in this pull request?

This fixes the annoying issue when you're zooming in using mouse wheel on a lighter canvas and it sometimes zooms in the whole document.

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced canvas interaction by implementing improved wheel event handling. Scroll wheel events on the canvas are now properly captured and managed, preventing unintended page scrolling while allowing zoom functionality to work as intended. Event listeners are properly cleaned up during system shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->