### PR TITLE
add cors configuration for pixi asset loader

### DIFF
--- a/app/packages/lighter/src/resource/PixiResourceLoader.ts
+++ b/app/packages/lighter/src/resource/PixiResourceLoader.ts
@@ -64,6 +64,7 @@ export class PixiResourceLoader implements ResourceLoader {
       preferences: {
         preferCreateImageBitmap: true,
         preferWorkers: true,
+        crossOrigin: "anonymous",
       },
       texturePreference: {
         resolution,


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds `crossOrigin: "anonymous"` to the PixiJS asset loader to support fetching cross-origin image assets.

## How is this patch tested? If it is not, please explain why.

local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource loading to support cross-origin requests for textures and assets, enabling better compatibility with external resource sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->