### PR TITLE
try lazily recomputing bounds again if it failed at scene load

### DIFF
--- a/app/packages/looker-3d/src/fo3d/MediaTypeFo3d.tsx
+++ b/app/packages/looker-3d/src/fo3d/MediaTypeFo3d.tsx
@@ -341,7 +341,8 @@ export const MediaTypeFo3dComponent = () => {
 
   const topCameraPosition = useMemo(() => {
     if (
-      Math.abs(effectiveSceneBoundingBox.max.x) === Number.POSITIVE_INFINITY
+      Math.abs(effectiveSceneBoundingBox.max.x) === Number.POSITIVE_INFINITY ||
+      !upVector
     ) {
       return DEFAULT_CAMERA_POSITION();
     }
@@ -423,7 +424,9 @@ export const MediaTypeFo3dComponent = () => {
       }
 
       if (
-        Math.abs(effectiveSceneBoundingBox.max.x) !== Number.POSITIVE_INFINITY
+        Math.abs(effectiveSceneBoundingBox.max.x) !==
+          Number.POSITIVE_INFINITY &&
+        upVector
       ) {
         const size = effectiveSceneBoundingBox.getSize(new Vector3());
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable camera initialization and positioning using improved scene bounds handling.
  * View transitions (top/ego) now retry when scene bounds aren’t ready, reducing failed or jarring switches.
  * Camera framing calculations refined for more consistent, accurate scene navigation and handling of complex geometries.
  * Falls back to sensible defaults when scene bounds are unavailable to avoid broken or unexpected camera behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->