### PR TITLE
fix CORS issue in lighter's canvas

### DIFF
--- a/app/packages/lighter/src/resource/PixiResourceLoader.ts
+++ b/app/packages/lighter/src/resource/PixiResourceLoader.ts
@@ -62,6 +62,9 @@ export class PixiResourceLoader implements ResourceLoader {
 
     await Assets.init({
       preferences: {
+        // Note: having these on will incur a `fetch` request
+        // that requires a CORS preflight request.
+        // Keep these off.
         preferCreateImageBitmap: false,
         preferWorkers: false,
       },


### PR DESCRIPTION
## What changes are proposed in this pull request?

To verify, go to Network tab on Chrome and "Fetch/XHR" and filter for `media`. With this PR, you shouldn't see any fetch request for the image (it should show in `Img` tab)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
