### PR TITLE
Fix notifications in Schema Manager's JSON editor

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditAnnotationFieldSchema.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditAnnotationFieldSchema.tsx
@@ -125,9 +125,6 @@ const EditAnnotationSchema = ({ path }: { path: string }) => {
   }, [data.savingComplete, setCurrentField, setNotification]);
   return (
     <>
-      <Typography color="secondary" padding="1rem 0">
-        Copy goes here
-      </Typography>
       <Container>
         {data.loading && <Loading scanning={data.scanning} />}
         {!data.schema && !data.loading && (


### PR DESCRIPTION
## What changes are proposed in this pull request?

Also remove unwanted `Copy goes here` placeholder text. 

Schema Manager test coverage will be a part of forthcoming reorg

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary placeholder text from the annotation schema editing interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->