### PR TITLE
Optimize performance of `bool(view)`

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -253,10 +253,13 @@ class SampleCollection(object):
         return self.summary()
 
     def __bool__(self):
-        return len(self) > 0
+        if self._is_full_collection():
+            return self.count() > 0
+        else:
+            return self.limit(1).count() > 0
 
     def __len__(self):
-        raise NotImplementedError("Subclass must implement __len__()")
+        return self.count()
 
     def __contains__(self, sample_id):
         try:

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -358,9 +358,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     def __deepcopy__(self, memo):
         return self  # datasets are singletons
 
-    def __len__(self):
-        return self.count()
-
     def _estimated_count(self, frames=False):
         if frames:
             if self._frame_collection is None:

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -99,9 +99,6 @@ class DatasetView(foc.SampleCollection):
         other_d = other._serialize(include_uuids=False)
         return d == other_d
 
-    def __len__(self):
-        return self.count()
-
     def __getitem__(self, id_filepath_slice):
         if isinstance(id_filepath_slice, numbers.Integral):
             raise KeyError(


### PR DESCRIPTION
## Release Notes

- optimized the performance of `bool(view)`

## Tested by

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = fo.Dataset()
assert len(dataset) == 0
assert bool(dataset) == False

dataset = foz.load_zoo_dataset("quickstart")
assert len(dataset) == 200
assert bool(dataset) == True

view = dataset.match(F("uniqueness") > 0.5)
assert len(view) == 100
assert bool(view) == True

view = dataset.exists("metadata")
assert len(view) == 0
assert bool(view) == False

patches = dataset.to_patches("ground_truth")
assert len(patches) == 1232
assert bool(patches) == True

view = patches.exists("metadata")
assert len(view) == 0
assert bool(view) == False
```
