### PR TITLE
Parallelize docs build to reduce CI execution time

### DIFF
--- a/docs/generate_docs.bash
+++ b/docs/generate_docs.bash
@@ -108,11 +108,13 @@ sphinx-apidoc --force --no-toc --separate --follow-links \
         fiftyone/server \
         fiftyone/service \
         fiftyone/management \
-        fiftyone/api
+        fiftyone/api &
 
 sphinx-apidoc --force --no-toc --separate --follow-links \
     --templatedir=docs/templates/apidoc \
-    -o docs/source/plugins/api plugins
+    -o docs/source/plugins/api plugins &
+
+wait
 
 # Remove symlink
 unlink fiftyone/brain
@@ -121,23 +123,25 @@ cd docs
 
 if [[ ${FAST_BUILD} = false ]]; then
     echo "Generating model zoo listing page"
-    python scripts/make_model_zoo_docs.py
+    python scripts/make_model_zoo_docs.py &
 
     echo "Generating Hugging Face dataset documentation"
-    python scripts/make_hf_dataset_docs.py
+    python scripts/make_hf_dataset_docs.py &
 
     echo "Generating plugin documentation"
-    python scripts/generate_plugin_docs.py
+    python scripts/generate_plugin_docs.py &
 
     echo "Generating TypeScript API docs"
     cd ../app
     yarn doc
     cd ../docs
+
+    wait
 fi
 
 echo "Building docs"
 # sphinx-build [OPTIONS] SOURCEDIR OUTPUTDIR [FILENAMES...]
-sphinx-build -M html source build $SPHINXOPTS
+sphinx-build -M html source build --jobs auto $SPHINXOPTS
 
 # Remove symlink to fiftyone-teams
 if [[ -n "${PATH_TO_TEAMS}" ]]; then


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR optimizes the documentation build process by parallelizing independent tasks:
- sphinx-apidoc commands now run concurrently using background jobs
- Python documentation generation scripts execute in parallel
- Sphinx build uses `--jobs auto` for multi-core processing
- Added `wait` commands to ensure proper synchronization

**Performance improvement:** Build time reduced from **50m 55s to 23m 48s** (53% faster) when using `--jobs 4` locally.

Credit to @afoley587  for this optimization.


## How is this patch tested? If it is not, please explain why.

Tested by running `bash docs/generate_docs.bash` locally and verifying:
- All documentation builds successfully
- Build time is reduced compared to sequential execution
- Output documentation is identical to previous builds

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Optimized documentation generation pipeline by parallelizing API documentation and plugin documentation generation tasks for improved build performance.
* Enhanced Sphinx HTML builds with multi-job support to enable faster concurrent compilation.
* Added automated post-processing phase to improve documentation output quality and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->