### PR TITLE
use ResolvableProperty for scenario preview plot

### DIFF
--- a/plugins/operators/__init__.py
+++ b/plugins/operators/__init__.py
@@ -22,7 +22,7 @@ import fiftyone.utils.data as foud
 from fiftyone.core.odm.workspace import default_workspace_factory
 
 from .group_by import GroupBy
-from .model_evaluation import ConfigureScenario
+from .model_evaluation import ConfigureScenario, ConfigureScenarioPlotResolver
 from .annotation import (
     ActivateAnnotationSchemas,
     AddBoundingBox,
@@ -3291,6 +3291,7 @@ def register(p):
     p.register(ListFiles)
     p.register(DownloadFileOperator)
     p.register(ConfigureScenario)
+    p.register(ConfigureScenarioPlotResolver)
 
     # view stages
     p.register(GroupBy)

--- a/plugins/operators/fiftyone.yml
+++ b/plugins/operators/fiftyone.yml
@@ -44,6 +44,7 @@ operators:
   - list_files
   - download_file
   - model_evaluation_configure_scenario
+  - model_evaluation_configure_scenario_plot_resolver
   - activate_annotation_schemas
   - compute_annotation_schema
   - deactivate_annotation_schemas

--- a/plugins/operators/model_evaluation/__init__.py
+++ b/plugins/operators/model_evaluation/__init__.py
@@ -50,14 +50,6 @@ class ConfigureScenario(foo.Operator):
             unlisted=True,
         )
 
-    # we use `fosu.cache_dataset()` rather than `@execution_cache` here so that
-    # the cached dataset can be reused outside of the current prompt session
-    def get_dataset(self, ctx):
-        """
-        Returns the dataset for the current context.
-        """
-        return fosu.cache_dataset(ctx.dataset)
-
     @execution_cache(
         prompt_scoped=True, residency="ephemeral", ttl=PROMPT_SCOPED_CACHE_TTL
     )
@@ -65,7 +57,7 @@ class ConfigureScenario(foo.Operator):
         """
         Returns the number of samples in the dataset for the current context.
         """
-        dataset = self.get_dataset(ctx)
+        dataset = get_dataset(ctx)
         return dataset.count()
 
     def get_default_for_distribution_preview(self, ctx):
@@ -141,137 +133,8 @@ class ConfigureScenario(foo.Operator):
             view=radio_view,
         )
 
-    def extract_evaluation_keys(self, ctx):
-        key = ctx.params.get("key", None)
-        compare_key = ctx.params.get("compare_key", None)
-        return key, compare_key
-
     def extract_evaluation_id(self, ctx):
         return ctx.params.get("eval_id")
-
-    def get_subset_def_data_for_eval_key(
-        self, ctx, eval_key, _, name, subset_def
-    ):
-        """
-        Builds and returns an execution cache key for each type of scenario.
-        - eval key + name + type + subset definition
-        """
-        scenario_type = self.get_scenario_type(ctx.params)
-
-        if scenario_type == ScenarioType.CUSTOM_CODE:
-            key = [
-                "sample-distribution-data",
-                eval_key,
-                name,
-                scenario_type,
-                str(subset_def),
-            ]
-        elif scenario_type == ScenarioType.VIEW:
-            key = [
-                "sample-distribution-data",
-                eval_key,
-                name,
-                scenario_type,
-                subset_def.get("view", ""),
-            ]
-        else:
-            if isinstance(subset_def, list):
-                subset_def = subset_def[0]
-
-            key = [
-                "sample-distribution-data",
-                eval_key,
-                name,
-                scenario_type,
-                str(subset_def),
-            ]
-
-        return key
-
-    # there is no need to use `@execution_cache` here because evaluation
-    # results are cached on the dataset, which is cached by `get_dataset()`
-    def get_evaluations_results(self, ctx):
-        """
-        Returns the evaluation results for the current context.
-        """
-        dataset = self.get_dataset(ctx)
-        eval_key, compare_key = self.extract_evaluation_keys(ctx)
-        eval_results = dataset.load_evaluation_results(eval_key)
-        compare_eval_results = None
-        if compare_key:
-            compare_eval_results = dataset.load_evaluation_results(compare_key)
-
-        return eval_results, compare_eval_results
-
-    @execution_cache(
-        key_fn=get_subset_def_data_for_eval_key,
-        prompt_scoped=True,
-        ttl=PROMPT_SCOPED_CACHE_TTL,
-    )
-    def get_subset_def_data_for_eval(
-        self, ctx, _, eval_result, name, subset_def
-    ):
-        x, y = [], []
-        with eval_result.use_subset(subset_def):
-            x.append(name)
-            y.append(len(eval_result.ytrue_ids))
-        return x, y
-
-    def get_sample_distribution(self, ctx, subset_expressions):
-        try:
-            eval_key, compare_eval_key = self.extract_evaluation_keys(ctx)
-            eval_results, compare_eval_results = self.get_evaluations_results(
-                ctx
-            )
-
-            plot_data = []
-            x = []
-            y = []
-            for name, subset_def in subset_expressions.items():
-                more_x, more_y = self.get_subset_def_data_for_eval(
-                    ctx, eval_key, eval_results, name, subset_def
-                )
-                x += more_x
-                y += more_y
-
-            plot_data.append(
-                {
-                    "x": x,
-                    "y": y,
-                    "type": "bar",
-                    "name": eval_key,
-                    "marker": {"color": KEY_COLOR},
-                }
-            )
-
-            if compare_eval_key and compare_eval_results:
-                compare_x = []
-                compare_y = []
-
-                for name, subset_def in subset_expressions.items():
-                    more_x, more_y = self.get_subset_def_data_for_eval(
-                        ctx,
-                        compare_eval_key,
-                        compare_eval_results,
-                        name,
-                        subset_def,
-                    )
-                    compare_x += more_x
-                    compare_y += more_y
-
-                plot_data.append(
-                    {
-                        "x": compare_x,
-                        "y": compare_y,
-                        "type": "bar",
-                        "name": compare_eval_key,
-                        "marker": {"color": COMPARE_KEY_COLOR},
-                    }
-                )
-
-            return plot_data, None
-        except Exception as e:
-            return None, e
 
     def convert_to_plotly_data(self, preview_data):
         if preview_data is None or len(preview_data) == 0:
@@ -427,47 +290,22 @@ class ConfigureScenario(foo.Operator):
                 is_invalid=False,
             )
 
-        plot_data, error = self.get_sample_distribution(
-            ctx, subset_expressions
-        )
-
-        if error:
-            inputs.view(
-                "plot_preview_error",
-                view=types.HeaderView(label=""),
-                invalid=True,
-                error_message="Custom scenario definition is invalid",
-            )
-            return
-
-        preview_container = inputs.grid("grid", height="400px", width="100%")
-        preview_height = "300px"
-        scenario_type = ctx.params.get("scenario_type", None)
-        x_axis_title = "Subset"
-        if scenario_type == ScenarioType.LABEL_ATTRIBUTE:
-            x_axis_title = "Attribute value"
-        elif scenario_type == ScenarioType.SAMPLE_FIELD:
-            x_axis_title = "Field value"
-        elif scenario_type == ScenarioType.VIEW:
-            x_axis_title = "Saved view"
-
-        preview_container.plot(
-            "plot_preview",
-            label="Sample distribution preview",
-            config=dict(
-                scrollZoom=False,  # Disable zoom on scroll
+        inputs.define_property(
+            "scenario_preview",
+            types.ResolvableProperty(
+                resolver="@voxel51/operators/model_evaluation_configure_scenario_plot_resolver",
+                # debounce=True,
+                # throttle=True,
+                # dependencies=["address"],
+                # wait=1000,
+                auto_update=False,
+                params={"subset_expressions": subset_expressions},
             ),
-            data=plot_data,
-            height=preview_height,
-            width="100%",
-            layout={
-                "xaxis": {"title": {"text": x_axis_title}},
-                "yaxis": {"title": {"text": "Label Instances"}},
-            },
+            label="Plot",
         )
 
     def get_custom_code_key(self, params):
-        scenario_type = self.get_scenario_type(params)
+        scenario_type = get_scenario_type(params)
 
         if scenario_type in [
             ScenarioType.LABEL_ATTRIBUTE,
@@ -588,7 +426,7 @@ class ConfigureScenario(foo.Operator):
         """
         Returns the view mode for saved views based on the number of available saved views.
         """
-        dataset = self.get_dataset(ctx)
+        dataset = get_dataset(ctx)
         view_names = dataset.list_saved_views()
         if not view_names:
             return ShowOptionsMethod.EMPTY, []
@@ -637,7 +475,7 @@ class ConfigureScenario(foo.Operator):
         - certain scenario type. has to be one of type ScenarioType
         - certain scenario field (ex: "tags", "labels")
         """
-        scenario_type = self.get_scenario_type(params)
+        scenario_type = get_scenario_type(params)
         if scenario_type == ScenarioType.VIEW:
             return f"{scenario_type}_values"
 
@@ -675,7 +513,7 @@ class ConfigureScenario(foo.Operator):
         return key, [key for key, val in selected_values.items() if val]
 
     def render_checkbox_view(self, ctx, values, inputs, with_description=None):
-        scenario_type = self.get_scenario_type(ctx.params)
+        scenario_type = get_scenario_type(ctx.params)
         key, selected_values = self.get_selected_values(ctx.params)
 
         stack = inputs.v_stack(
@@ -764,9 +602,9 @@ class ConfigureScenario(foo.Operator):
             Tuple[str, Any]: Picker type and corresponding values.
         """
         # Validate field name
-        eval_key, _ = self.extract_evaluation_keys(ctx)
+        eval_key, _ = extract_evaluation_keys(ctx)
 
-        dataset = self.get_dataset(ctx)
+        dataset = get_dataset(ctx)
         schema = dataset.get_field_schema(flat=True)
         dataset_or_view = dataset
         try:
@@ -834,7 +672,7 @@ class ConfigureScenario(foo.Operator):
         """
         values = values or []
 
-        scenario_type = self.get_scenario_type(ctx.params)
+        scenario_type = get_scenario_type(ctx.params)
         scenario_type_display = (
             "saved views"
             if scenario_type == "view"
@@ -942,7 +780,7 @@ class ConfigureScenario(foo.Operator):
         ]
 
     def render_label_attribute(self, ctx, inputs, gt_field, label_attr=None):
-        dataset = self.get_dataset(ctx)
+        dataset = get_dataset(ctx)
         schema = dataset.get_field_schema(flat=True)
         valid_options = self.get_valid_label_attribute_path_options(
             schema, gt_field
@@ -1009,7 +847,7 @@ class ConfigureScenario(foo.Operator):
         return options
 
     def render_sample_fields(self, ctx, inputs, field_name=None):
-        dataset = self.get_dataset(ctx)
+        dataset = get_dataset(ctx)
         schema = dataset.get_field_schema(flat=True)
         valid_options = self.get_valid_sample_field_path_options(schema)
 
@@ -1038,19 +876,6 @@ class ConfigureScenario(foo.Operator):
                 description=f"Select a field to view sample distribution",
             )
 
-    def get_scenario_type(self, params):
-        scenario_type = params.get("scenario_type", None)
-
-        if scenario_type not in [
-            ScenarioType.VIEW,
-            ScenarioType.CUSTOM_CODE,
-            ScenarioType.LABEL_ATTRIBUTE,
-            ScenarioType.SAMPLE_FIELD,
-        ]:
-            return ScenarioType.CUSTOM_CODE
-
-        return scenario_type
-
     def get_modal_title(self, ctx):
         scenario_id = ctx.params.get("scenario_id", None)
         label = "Edit scenario" if scenario_id else "Create scenario"
@@ -1062,7 +887,7 @@ class ConfigureScenario(foo.Operator):
 
     def resolve_input(self, ctx):
         # force `ctx.dataset` to be cached
-        _ = self.get_dataset(ctx)
+        _ = get_dataset(ctx)
 
         inputs = types.Object()
 
@@ -1072,7 +897,7 @@ class ConfigureScenario(foo.Operator):
             view=types.HiddenView(),
         )
 
-        scenario_type = self.get_scenario_type(ctx.params)
+        scenario_type = get_scenario_type(ctx.params)
         self.render_scenario_types(inputs, scenario_type)
 
         scenario_id = ctx.params.get("scenario_id", None)
@@ -1195,7 +1020,7 @@ class ConfigureScenario(foo.Operator):
         return stack
 
     def execute(self, ctx):
-        scenario_type = self.get_scenario_type(ctx.params)
+        scenario_type = get_scenario_type(ctx.params)
         if scenario_type is None:
             raise ValueError("Scenario type must be selected")
 
@@ -1287,3 +1112,211 @@ class ConfigureScenario(foo.Operator):
             "name": scenario_name,
             "id": scenario_id_str,
         }
+
+
+class ConfigureScenarioPlotResolver(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="model_evaluation_configure_scenario_plot_resolver",
+            label="Configure scenario plot resolver",
+            dynamic=True,
+            unlisted=True,
+        )
+
+    def execute(self, ctx):
+        subset_expressions = ctx.params.get("subset_expressions", {})
+        plot_data, error = self.get_sample_distribution(
+            ctx, subset_expressions
+        )
+
+        inputs = types.Object()
+
+        if error:
+            inputs.view(
+                "plot_preview_error",
+                view=types.HeaderView(label=""),
+                invalid=True,
+                error_message="Custom scenario definition is invalid",
+            )
+            return
+
+        preview_container = inputs.grid("grid", height="400px", width="100%")
+        preview_height = "300px"
+        scenario_type = ctx.params.get("scenario_type", None)
+        x_axis_title = "Subset"
+        if scenario_type == ScenarioType.LABEL_ATTRIBUTE:
+            x_axis_title = "Attribute value"
+        elif scenario_type == ScenarioType.SAMPLE_FIELD:
+            x_axis_title = "Field value"
+        elif scenario_type == ScenarioType.VIEW:
+            x_axis_title = "Saved view"
+
+        preview_container.plot(
+            "plot_preview",
+            label="Sample distribution preview",
+            config=dict(
+                scrollZoom=False,  # Disable zoom on scroll
+            ),
+            data=plot_data,
+            height=preview_height,
+            width="100%",
+            layout={
+                "xaxis": {"title": {"text": x_axis_title}},
+                "yaxis": {"title": {"text": "Label Instances"}},
+            },
+        )
+
+        return types.Property(preview_container).to_json()
+
+    def get_subset_def_data_for_eval_key(
+        self, ctx, eval_key, _, name, subset_def
+    ):
+        """
+        Builds and returns an execution cache key for each type of scenario.
+        - eval key + name + type + subset definition
+        """
+        scenario_type = get_scenario_type(ctx.params)
+
+        if scenario_type == ScenarioType.CUSTOM_CODE:
+            key = [
+                "sample-distribution-data",
+                eval_key,
+                name,
+                scenario_type,
+                str(subset_def),
+            ]
+        elif scenario_type == ScenarioType.VIEW:
+            key = [
+                "sample-distribution-data",
+                eval_key,
+                name,
+                scenario_type,
+                subset_def.get("view", ""),
+            ]
+        else:
+            if isinstance(subset_def, list):
+                subset_def = subset_def[0]
+
+            key = [
+                "sample-distribution-data",
+                eval_key,
+                name,
+                scenario_type,
+                str(subset_def),
+            ]
+
+        return key
+
+    @execution_cache(
+        key_fn=get_subset_def_data_for_eval_key,
+        prompt_scoped=True,
+        ttl=PROMPT_SCOPED_CACHE_TTL,
+    )
+    def get_subset_def_data_for_eval(
+        self, ctx, _, eval_result, name, subset_def
+    ):
+        x, y = [], []
+        with eval_result.use_subset(subset_def):
+            x.append(name)
+            y.append(len(eval_result.ytrue_ids))
+        return x, y
+
+    def get_sample_distribution(self, ctx, subset_expressions):
+        try:
+            eval_key, compare_eval_key = extract_evaluation_keys(ctx)
+            eval_results, compare_eval_results = get_evaluations_results(ctx)
+
+            plot_data = []
+            x = []
+            y = []
+            for name, subset_def in subset_expressions.items():
+                more_x, more_y = self.get_subset_def_data_for_eval(
+                    ctx, eval_key, eval_results, name, subset_def
+                )
+                x += more_x
+                y += more_y
+
+            plot_data.append(
+                {
+                    "x": x,
+                    "y": y,
+                    "type": "bar",
+                    "name": eval_key,
+                    "marker": {"color": KEY_COLOR},
+                }
+            )
+
+            if compare_eval_key and compare_eval_results:
+                compare_x = []
+                compare_y = []
+
+                for name, subset_def in subset_expressions.items():
+                    more_x, more_y = self.get_subset_def_data_for_eval(
+                        ctx,
+                        compare_eval_key,
+                        compare_eval_results,
+                        name,
+                        subset_def,
+                    )
+                    compare_x += more_x
+                    compare_y += more_y
+
+                plot_data.append(
+                    {
+                        "x": compare_x,
+                        "y": compare_y,
+                        "type": "bar",
+                        "name": compare_eval_key,
+                        "marker": {"color": COMPARE_KEY_COLOR},
+                    }
+                )
+
+            return plot_data, None
+        except Exception as e:
+            return None, e
+
+
+# we use `fosu.cache_dataset()` rather than `@execution_cache` here so that
+# the cached dataset can be reused outside of the current prompt session
+def get_dataset(ctx):
+    """
+    Returns the dataset for the current context.
+    """
+    return fosu.cache_dataset(ctx.dataset)
+
+
+def extract_evaluation_keys(ctx):
+    key = ctx.params.get("key", None)
+    compare_key = ctx.params.get("compare_key", None)
+    return key, compare_key
+
+
+# there is no need to use `@execution_cache` here because evaluation
+# results are cached on the dataset, which is cached by `get_dataset()`
+def get_evaluations_results(ctx):
+    """
+    Returns the evaluation results for the current context.
+    """
+    dataset = get_dataset(ctx)
+    eval_key, compare_key = extract_evaluation_keys(ctx)
+    eval_results = dataset.load_evaluation_results(eval_key)
+    compare_eval_results = None
+    if compare_key:
+        compare_eval_results = dataset.load_evaluation_results(compare_key)
+
+    return eval_results, compare_eval_results
+
+
+def get_scenario_type(params):
+    scenario_type = params.get("scenario_type", None)
+
+    if scenario_type not in [
+        ScenarioType.VIEW,
+        ScenarioType.CUSTOM_CODE,
+        ScenarioType.LABEL_ATTRIBUTE,
+        ScenarioType.SAMPLE_FIELD,
+    ]:
+        return ScenarioType.CUSTOM_CODE
+
+    return scenario_type


### PR DESCRIPTION
## What changes are proposed in this pull request?

use ResolvableProperty for scenario preview plot so that plot can load independently withot blocking the create flow

## How is this patch tested? If it is not, please explain why.

Using create scenario flow

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scenario plot resolver operator to improve scenario-based plotting and interactive model-evaluation visualizations.

* **Refactor**
  * Centralized evaluation and dataset utilities into shared module-level helpers, simplifying plotting flows and making scenario plotting more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->