### PR TITLE
Fix App similarity for group datasets

### DIFF
--- a/app/packages/state/src/recoil/selectors.ts
+++ b/app/packages/state/src/recoil/selectors.ts
@@ -8,19 +8,14 @@ import {
   datasetFragment$key,
   graphQLSyncFragmentAtom,
 } from "@fiftyone/relay";
-import {
-  currentSlice,
-  fieldVisibilityStage,
-  gridSortBy,
-  isGroup,
-} from "@fiftyone/state";
+import { fieldVisibilityStage, gridSortBy } from "@fiftyone/state";
 import { is3d } from "@fiftyone/utilities";
 import { DefaultValue, atomFamily, selector, selectorFamily } from "recoil";
 import { v4 as uuid } from "uuid";
 import * as atoms from "./atoms";
 import { config } from "./config";
 import { dataset as datasetAtom } from "./dataset";
-import { isModalActive, modalSample, modalSelector } from "./modal";
+import { modalSample, modalSelector } from "./modal";
 import { pathFilter } from "./pathFilters";
 import { State } from "./types";
 import { isPatchesView } from "./view";
@@ -408,24 +403,7 @@ export const similarityMethods = selector<{
 }>({
   key: "similarityMethods",
   get: ({ get }) => {
-    let methods = get(datasetAtom)?.brainMethods || [];
-    const isGroupDataset = get(isGroup);
-    const activeSlice = get(currentSlice(get(isModalActive)));
-
-    if (isGroupDataset && activeSlice) {
-      methods = methods.filter(({ viewStages }) => {
-        return viewStages.some((vs) => {
-          const { _cls, kwargs } = JSON.parse(vs);
-          if (_cls === "fiftyone.core.stages.SelectGroupSlices") {
-            const sliceValue = kwargs.filter(
-              (kwarg: string[]) => kwarg[0] === "slices"
-            )?.[0]?.[1];
-            if (sliceValue && sliceValue !== activeSlice) return false;
-          }
-          return true;
-        });
-      });
-    }
+    const methods = get(datasetAtom)?.brainMethods || [];
 
     return methods
       .filter(

--- a/app/packages/state/src/recoil/types.ts
+++ b/app/packages/state/src/recoil/types.ts
@@ -79,7 +79,7 @@ export namespace State {
     version: string;
     timestamp: string;
     config: {};
-    viewStages: readonly string[];
+    viewStages?: readonly string[];
   }
 
   export interface BrainRun extends Run {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Similarity runs no longer store view stages in their run info. Don't filter by them in the App
* https://github.com/voxel51/fiftyone-brain/commit/058e50217fa34875e81acbdbff0e71f297469c4f

<img width="1470" height="875" alt="Screenshot 2025-11-11 at 10 36 35 AM" src="https://github.com/user-attachments/assets/34848561-def6-4937-a866-9fc4697d06f4" />

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

* Fixed sorting by similarity for group datasets in the App

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal logic for computing similarity methods by removing conditional filtering.
  * Made view stages configuration optional in the data model.
  * Removed unused dependencies to improve code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->