### PR TITLE
prevent pan and zoom

### DIFF
--- a/app/packages/lighter/src/interaction/InteractionManager.ts
+++ b/app/packages/lighter/src/interaction/InteractionManager.ts
@@ -271,6 +271,8 @@ export class InteractionManager {
 
       // If this is a movable overlay, track move state
       if (TypeGuards.isMovable(handler) && TypeGuards.isSpatial(handler)) {
+        this.renderer.disableZoomPan();
+
         const type = handler.isDragging?.()
           ? LIGHTER_EVENTS.OVERLAY_DRAG_START
           : LIGHTER_EVENTS.OVERLAY_RESIZE_START;
@@ -329,8 +331,6 @@ export class InteractionManager {
       }
 
       if (handler.isMoving?.()) {
-        this.renderer.disableZoomPan();
-
         // Emit move event with bounds information
         if (TypeGuards.isSpatial(handler)) {
           const type = handler.isDragging?.()


### PR DESCRIPTION
## What changes are proposed in this pull request?

Sometimes the canvas is dragged slightly while moving an overlay

## How is this patch tested? If it is not, please explain why.

Manually

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overlay dragging interaction. When you start dragging an overlay, zoom and pan functions are now automatically disabled to prevent unintended viewport changes during repositioning. These viewport control functions are restored when the drag operation completes or is cancelled, providing a smoother and more predictable interaction experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->