### PR TITLE
hide channel impl detail for now

### DIFF
--- a/app/packages/events/src/demo.tsx
+++ b/app/packages/events/src/demo.tsx
@@ -21,7 +21,7 @@ const useDemoEventHandler = createUseEventHandler<DemoEventGroup>();
 
 const Source = () => {
   const [count, setCount] = useState(0);
-  const eventBus = useEventBus<DemoEventGroup>({ channelId: "default" });
+  const eventBus = useEventBus<DemoEventGroup>();
 
   // compile-time error; "foo" is not a key of DemoEventGroup
   // eventBus.dispatch("foo", {bar: "baz"});
@@ -69,7 +69,7 @@ const Source = () => {
 };
 
 const Sink = () => {
-  const eventBus = useEventBus<DemoEventGroup>({ channelId: "default" });
+  const eventBus = useEventBus<DemoEventGroup>();
 
   useEffect(() => {
     const eventAHandler: EventHandler<DemoEventGroup["demo:eventA"]> = (

--- a/app/packages/events/src/dispatch/registry.ts
+++ b/app/packages/events/src/dispatch/registry.ts
@@ -27,13 +27,12 @@ function getDispatcher<T extends EventGroup>(
  * part of the React component tree.
  *
  * @template T - EventGroup type defining event types and payloads
- * @param channelId - Channel identifier (defaults to "default")
  * @returns Event dispatcher with on, off, and dispatch methods
  *
  * @example
  * ```typescript
  * // ✅ Good: Non-React usage
- * const bus = getEventBus<MyEventGroup>("my-channel");
+ * const bus = getEventBus<MyEventGroup>();
  * bus.on("my:event", (data) => console.log(data));
  * bus.dispatch("my:event", { value: 42 });
  *
@@ -44,10 +43,8 @@ function getDispatcher<T extends EventGroup>(
  * }
  * ```
  */
-export function getEventBus<T extends EventGroup>(
-  channelId = "default"
-): EventDispatcher<T> {
-  return getDispatcher<T>(channelId);
+export function getEventBus<T extends EventGroup>(): EventDispatcher<T> {
+  return getDispatcher<T>("default");
 }
 
 /**

--- a/app/packages/events/src/hooks/createUseEventHandler.test.tsx
+++ b/app/packages/events/src/hooks/createUseEventHandler.test.tsx
@@ -143,7 +143,7 @@ describe("createUseEventHandler", () => {
     expect(handler).toHaveBeenCalledWith(undefined);
   });
 
-  test("should use default channel when no channelId is provided", () => {
+  test("should use shared event bus", () => {
     const useTestEventHandler = createUseEventHandler<TestEventGroup>();
     const handler = vi.fn();
 
@@ -158,39 +158,6 @@ describe("createUseEventHandler", () => {
     busResult.current.dispatch("test:eventA", { id: "1", name: "test" });
 
     expect(handler).toHaveBeenCalledTimes(1);
-  });
-
-  test("should use specified channelId", () => {
-    const useTestEventHandlerChannel1 =
-      createUseEventHandler<TestEventGroup>("channel1");
-    const useTestEventHandlerChannel2 =
-      createUseEventHandler<TestEventGroup>("channel2");
-    const handler1 = vi.fn();
-    const handler2 = vi.fn();
-
-    const { result: busResult1 } = renderHook(() =>
-      useEventBus<TestEventGroup>({ channelId: "channel1" })
-    );
-
-    const { result: busResult2 } = renderHook(() =>
-      useEventBus<TestEventGroup>({ channelId: "channel2" })
-    );
-
-    renderHook(() => {
-      useTestEventHandlerChannel1("test:eventA", handler1);
-    });
-
-    renderHook(() => {
-      useTestEventHandlerChannel2("test:eventA", handler2);
-    });
-
-    busResult1.current.dispatch("test:eventA", { id: "1", name: "test1" });
-    busResult2.current.dispatch("test:eventA", { id: "2", name: "test2" });
-
-    expect(handler1).toHaveBeenCalledTimes(1);
-    expect(handler1).toHaveBeenCalledWith({ id: "1", name: "test1" });
-    expect(handler2).toHaveBeenCalledTimes(1);
-    expect(handler2).toHaveBeenCalledWith({ id: "2", name: "test2" });
   });
 
   test("should handle multiple handlers for the same event", () => {

--- a/app/packages/events/src/hooks/createUseEventHandler.ts
+++ b/app/packages/events/src/hooks/createUseEventHandler.ts
@@ -3,11 +3,10 @@ import { EventGroup, EventHandler } from "../types";
 import { useEventBus } from "./useEventBus";
 
 /**
- * Factory function that creates a type-safe event handler hook for a specific channel.
+ * Factory function that creates a type-safe event handler hook.
  * The returned hook automatically registers/unregisters handlers on mount/unmount.
  *
  * @template T - EventGroup type defining event types and payloads
- * @param channelId - Optional channel identifier (defaults to "default")
  * @returns A hook function that registers event handlers with automatic cleanup
  *
  * @example
@@ -25,14 +24,12 @@ import { useEventBus } from "./useEventBus";
  * }
  * ```
  */
-export function createUseEventHandler<T extends EventGroup>(
-  channelId = "default"
-) {
+export function createUseEventHandler<T extends EventGroup>() {
   return function useEventHandler<K extends keyof T>(
     event: K,
     handler: EventHandler<T[K]>
   ) {
-    const bus = useEventBus<T>({ channelId });
+    const bus = useEventBus<T>();
 
     useEffect(() => {
       bus.on(event, handler);

--- a/app/packages/events/src/hooks/useEventBus.ts
+++ b/app/packages/events/src/hooks/useEventBus.ts
@@ -3,19 +3,15 @@ import { EventDispatcher, getEventBus } from "../dispatch";
 import { EventGroup } from "../types";
 
 /**
- * Hook that provides access to an event bus for a specific channel.
- * The dispatcher is shared across all components using the same channel ID.
+ * Hook that provides access to the default event bus.
+ * The dispatcher is shared across all components.
  *
  * @template T - EventGroup type defining event types and payloads
- * @param options - Configuration options
- * @param options.channelId - Channel identifier (defaults to "default")
  * @returns Event dispatcher with on, off, and dispatch methods
  */
-export const useEventBus = <T extends EventGroup>(
-  { channelId } = { channelId: "default" }
-) => {
+export const useEventBus = <T extends EventGroup>() => {
   return useMemo(() => {
-    const dispatcher = getEventBus<T>(channelId);
+    const dispatcher = getEventBus<T>();
     // Return bound methods to allow destructuring while maintaining 'this' context
     // This also gives us flexibility to e.g. inject a global observer here
     return {
@@ -23,5 +19,5 @@ export const useEventBus = <T extends EventGroup>(
       off: dispatcher.off.bind(dispatcher),
       dispatch: dispatcher.dispatch.bind(dispatcher),
     } as EventDispatcher<T>;
-  }, [channelId]);
+  }, []);
 };


### PR DESCRIPTION
## What changes are proposed in this pull request?

use `default` channel by default and don't expose it to public APIs

## How is this patch tested? If it is not, please explain why.

Unit tests.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified event bus system to use a single shared default channel instead of per-channel isolation
  * Removed channelId parameter from useEventBus, getEventBus, and createUseEventHandler hooks
  * All components now access the same global event dispatcher without channel scoping
  * Updated test suite to validate shared instance behavior and cross-component event dispatch

<!-- end of auto-generated comment: release notes by coderabbit.ai -->