### PR TITLE
add support for event state + require event load to be serializable

### DIFF
--- a/app/packages/events/src/demo-state.tsx
+++ b/app/packages/events/src/demo-state.tsx
@@ -1,0 +1,106 @@
+import { Fragment, useState } from "react";
+import {
+  createUseSynchronizedEventState,
+  createUseEventHandler,
+  useEventBus,
+  useEventState,
+} from "./hooks";
+
+/**
+ * Demo showing the difference between useEventHandler (side effects)
+ * and useEventState (state derivation with tearing prevention).
+ */
+
+type CounterEventGroup = {
+  "counter:updated": { count: number };
+  "counter:reset": undefined;
+};
+
+const useCounterState = createUseSynchronizedEventState<CounterEventGroup>();
+const useCounterHandler = createUseEventHandler<CounterEventGroup>();
+
+/**
+ * Component that dispatches counter events.
+ */
+const CounterSource = () => {
+  const [count, setCount] = useState(0);
+  const bus = useEventBus<CounterEventGroup>();
+
+  return (
+    <>
+      <button
+        onClick={() => {
+          const newCount = count + 1;
+          setCount(newCount);
+          bus.dispatch("counter:updated", { count: newCount });
+        }}
+      >
+        Increment and Dispatch
+      </button>
+      <button
+        onClick={() => {
+          setCount(0);
+          bus.dispatch("counter:reset");
+        }}
+      >
+        Reset
+      </button>
+    </>
+  );
+};
+
+/**
+ * Component using useEventState - reads state during render.
+ * Multiple instances will always see the same value (no tearing).
+ */
+const CounterDisplay = ({ label }: { label: string }) => {
+  // Read latest count from events - safe from tearing
+  const latestEvent = useCounterState("counter:updated");
+  const count = latestEvent?.count ?? 0;
+
+  return (
+    <div>
+      {label}: {count}
+    </div>
+  );
+};
+
+/**
+ * Component using useEventHandler - reacts with side effects.
+ * This is for side effects, not for displaying state.
+ */
+const CounterLogger = () => {
+  // Side effects - use createUseEventHandler
+  useCounterHandler("counter:updated", (data) => {
+    console.log("Counter updated to:", data.count);
+  });
+
+  useCounterHandler("counter:reset", () => {
+    console.log("Counter reset");
+  });
+
+  return <Fragment />;
+};
+
+/**
+ * Component using useEventState directly (without factory).
+ */
+const DirectCounterDisplay = () => {
+  const count =
+    useEventState<CounterEventGroup, "counter:updated">("counter:updated")
+      ?.count ?? 0;
+
+  return <div>Direct: {count}</div>;
+};
+
+export const StateDemo = () => {
+  return (
+    <>
+      <CounterSource />
+      <CounterDisplay label="Display 1" />
+      <CounterDisplay label="Display 2" />
+      <DirectCounterDisplay />
+      <CounterLogger />
+    </>
+  );
+};

--- a/app/packages/events/src/hooks/createUseEventHandler.ts
+++ b/app/packages/events/src/hooks/createUseEventHandler.ts
@@ -6,6 +6,18 @@ import { useEventBus } from "./useEventBus";
  * Factory function that creates a type-safe event handler hook.
  * The returned hook automatically registers/unregisters handlers on mount/unmount.
  *
+ * **When to use this vs createUseSynchronizedEventState:**
+ * - Use `createUseEventHandler` when you need to **react to events with side effects**
+ *   (e.g., logging, API calls, navigation, updating local component state via setState)
+ * - Use `createUseSynchronizedEventState` when you need to **read and display** the latest event payload
+ *   in your component's render (prevents tearing in concurrent React rendering)
+ *
+ * **Key differences:**
+ * - `createUseEventHandler`: Registers callbacks that run when events occur. Useful for
+ *   side effects but doesn't provide synchronized state reading across components.
+ * - `createUseSynchronizedEventState`: Returns the latest event payload synchronously during render.
+ *   Multiple components reading the same event will always see the same synchronized value.
+ *
  * @template T - EventGroup type defining event types and payloads
  * @returns A hook function that registers event handlers with automatic cleanup
  *
@@ -18,7 +30,12 @@ import { useEventBus } from "./useEventBus";
  * const useDemoEventHandler = createUseEventHandler<DemoEventGroup>();
  *
  * function Component() {
- *   useDemoEventHandler("demo:eventA", (data) => console.log(data.id, data.name));
+ *   // Side effects - use createUseEventHandler
+ *   useDemoEventHandler("demo:eventA", (data) => {
+ *     console.log(data.id, data.name);
+ *     // Could also call setState here, but for state derivation,
+ *     // prefer createUseSynchronizedEventState to prevent tearing
+ *   });
  *   useDemoEventHandler("demo:eventD", () => console.log("Event D received"));
  *   return <div>...</div>;
  * }

--- a/app/packages/events/src/hooks/createUseSynchronizedEventState.test.tsx
+++ b/app/packages/events/src/hooks/createUseSynchronizedEventState.test.tsx
@@ -1,0 +1,273 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  createUseSynchronizedEventState,
+  createUseSynchronizedEventStateWithDefaults,
+} from "./createUseSynchronizedEventState";
+import { useEventBus } from "./useEventBus";
+import { __test__ } from "../state/EventStateStore";
+
+type TestEventGroup = {
+  "test:eventA": { id: string; name: string };
+  "test:eventB": { value: number };
+  "test:eventC": undefined;
+};
+
+describe("createUseSynchronizedEventState", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __test__.registry.clear();
+  });
+
+  test("should create a hook that returns undefined initially", () => {
+    const useTestEventState = createUseSynchronizedEventState<TestEventGroup>();
+    const { result } = renderHook(() => useTestEventState("test:eventA"));
+
+    expect(result.current).toBeUndefined();
+  });
+
+  test("should return latest event payload after dispatch", async () => {
+    const useTestEventState = createUseSynchronizedEventState<TestEventGroup>();
+    const { result: busResult } = renderHook(() =>
+      useEventBus<TestEventGroup>()
+    );
+    const { result } = renderHook(() => useTestEventState("test:eventA"));
+
+    act(() => {
+      busResult.current.dispatch("test:eventA", { id: "1", name: "test" });
+    });
+    await waitFor(() => {
+      expect(result.current).toEqual({ id: "1", name: "test" });
+    });
+  });
+
+  test("should update when new event is dispatched", async () => {
+    const useTestEventState = createUseSynchronizedEventState<TestEventGroup>();
+    const { result: busResult } = renderHook(() =>
+      useEventBus<TestEventGroup>()
+    );
+    const { result } = renderHook(() => useTestEventState("test:eventA"));
+
+    act(() => {
+      busResult.current.dispatch("test:eventA", { id: "1", name: "test1" });
+    });
+    await waitFor(() => {
+      expect(result.current).toEqual({ id: "1", name: "test1" });
+    });
+
+    act(() => {
+      busResult.current.dispatch("test:eventA", { id: "2", name: "test2" });
+    });
+    await waitFor(() => {
+      expect(result.current).toEqual({ id: "2", name: "test2" });
+    });
+  });
+
+  test("should prevent tearing across multiple components", async () => {
+    const useTestEventState = createUseSynchronizedEventState<TestEventGroup>();
+    const { result: busResult } = renderHook(() =>
+      useEventBus<TestEventGroup>()
+    );
+
+    const { result: result1 } = renderHook(() =>
+      useTestEventState("test:eventA")
+    );
+    const { result: result2 } = renderHook(() =>
+      useTestEventState("test:eventA")
+    );
+    const { result: result3 } = renderHook(() =>
+      useTestEventState("test:eventA")
+    );
+
+    act(() => {
+      busResult.current.dispatch("test:eventA", { id: "1", name: "test" });
+    });
+
+    await waitFor(() => {
+      expect(result1.current).toEqual({ id: "1", name: "test" });
+      expect(result2.current).toEqual({ id: "1", name: "test" });
+      expect(result3.current).toEqual({ id: "1", name: "test" });
+    });
+  });
+
+  test("should handle different event types independently", async () => {
+    const useTestEventState = createUseSynchronizedEventState<TestEventGroup>();
+    const { result: busResult } = renderHook(() =>
+      useEventBus<TestEventGroup>()
+    );
+
+    const { result: resultA } = renderHook(() =>
+      useTestEventState("test:eventA")
+    );
+    const { result: resultB } = renderHook(() =>
+      useTestEventState("test:eventB")
+    );
+
+    act(() => {
+      busResult.current.dispatch("test:eventA", { id: "1", name: "test" });
+      busResult.current.dispatch("test:eventB", { value: 42 });
+    });
+
+    await waitFor(() => {
+      expect(resultA.current).toEqual({ id: "1", name: "test" });
+      expect(resultB.current).toEqual({ value: 42 });
+    });
+  });
+
+  test("should maintain state across re-renders", async () => {
+    const useTestEventState = createUseSynchronizedEventState<TestEventGroup>();
+    const { result: busResult } = renderHook(() =>
+      useEventBus<TestEventGroup>()
+    );
+
+    const { result, rerender } = renderHook(() =>
+      useTestEventState("test:eventA")
+    );
+
+    act(() => {
+      busResult.current.dispatch("test:eventA", { id: "1", name: "test" });
+    });
+    await waitFor(() => {
+      expect(result.current).toEqual({ id: "1", name: "test" });
+    });
+
+    rerender();
+    expect(result.current).toEqual({ id: "1", name: "test" });
+  });
+
+  test("should handle events with no payload", () => {
+    const useTestEventState = createUseSynchronizedEventState<TestEventGroup>();
+    const { result: busResult } = renderHook(() =>
+      useEventBus<TestEventGroup>()
+    );
+
+    const { result } = renderHook(() => useTestEventState("test:eventC"));
+
+    expect(result.current).toBeUndefined();
+    busResult.current.dispatch("test:eventC");
+    expect(result.current).toBeUndefined();
+  });
+});
+
+describe("createUseSynchronizedEventStateWithDefaults", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __test__.registry.clear();
+  });
+
+  test("should return default value initially", () => {
+    const defaults = {
+      "test:eventA": { id: "default", name: "default" },
+      "test:eventB": { value: 0 },
+    };
+    const useTestEventState =
+      createUseSynchronizedEventStateWithDefaults<TestEventGroup>(defaults);
+
+    const { result: resultA } = renderHook(() =>
+      useTestEventState("test:eventA")
+    );
+    const { result: resultB } = renderHook(() =>
+      useTestEventState("test:eventB")
+    );
+
+    expect(resultA.current).toEqual({ id: "default", name: "default" });
+    expect(resultB.current).toEqual({ value: 0 });
+  });
+
+  test("should return latest event payload after dispatch", async () => {
+    const defaults = {
+      "test:eventA": { id: "default", name: "default" },
+    };
+    const useTestEventState =
+      createUseSynchronizedEventStateWithDefaults<TestEventGroup>(defaults);
+    const { result: busResult } = renderHook(() =>
+      useEventBus<TestEventGroup>()
+    );
+
+    const { result } = renderHook(() => useTestEventState("test:eventA"));
+
+    expect(result.current).toEqual({ id: "default", name: "default" });
+
+    act(() => {
+      busResult.current.dispatch("test:eventA", { id: "1", name: "test" });
+    });
+    await waitFor(() => {
+      expect(result.current).toEqual({ id: "1", name: "test" });
+    });
+  });
+
+  test("should allow overriding default per call", () => {
+    const defaults = {
+      "test:eventA": { id: "default", name: "default" },
+    };
+    const useTestEventState =
+      createUseSynchronizedEventStateWithDefaults<TestEventGroup>(defaults);
+
+    const overrideDefault = { id: "override", name: "override" };
+    const { result } = renderHook(() =>
+      useTestEventState("test:eventA", overrideDefault)
+    );
+
+    expect(result.current).toEqual(overrideDefault);
+  });
+
+  test("should return undefined for events without defaults when no override provided", () => {
+    const defaults = {
+      "test:eventA": { id: "default", name: "default" },
+    };
+    const useTestEventState =
+      createUseSynchronizedEventStateWithDefaults<TestEventGroup>(defaults);
+
+    const { result } = renderHook(() => useTestEventState("test:eventB"));
+
+    // Should fall back to useEventState behavior (undefined)
+    expect(result.current).toBeUndefined();
+  });
+
+  test("should prevent tearing with defaults", async () => {
+    const defaults = {
+      "test:eventA": { id: "default", name: "default" },
+    };
+    const useTestEventState =
+      createUseSynchronizedEventStateWithDefaults<TestEventGroup>(defaults);
+    const { result: busResult } = renderHook(() =>
+      useEventBus<TestEventGroup>()
+    );
+
+    const { result: result1 } = renderHook(() =>
+      useTestEventState("test:eventA")
+    );
+    const { result: result2 } = renderHook(() =>
+      useTestEventState("test:eventA")
+    );
+
+    expect(result1.current).toEqual({ id: "default", name: "default" });
+    expect(result2.current).toEqual({ id: "default", name: "default" });
+
+    act(() => {
+      busResult.current.dispatch("test:eventA", { id: "1", name: "test" });
+    });
+
+    await waitFor(() => {
+      expect(result1.current).toEqual({ id: "1", name: "test" });
+      expect(result2.current).toEqual({ id: "1", name: "test" });
+    });
+  });
+
+  test("should handle events with no payload and defaults", () => {
+    const defaults: { "test:eventC"?: undefined } = {
+      "test:eventC": undefined,
+    };
+    const useTestEventState =
+      createUseSynchronizedEventStateWithDefaults<TestEventGroup>(defaults);
+    const { result: busResult } = renderHook(() =>
+      useEventBus<TestEventGroup>()
+    );
+
+    const { result } = renderHook(() => useTestEventState("test:eventC"));
+
+    expect(result.current).toBeUndefined();
+    busResult.current.dispatch("test:eventC");
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/app/packages/events/src/hooks/createUseSynchronizedEventState.ts
+++ b/app/packages/events/src/hooks/createUseSynchronizedEventState.ts
@@ -1,0 +1,97 @@
+import { EventGroup } from "../types";
+import { useEventState } from "./useEventState";
+
+/**
+ * Factory function that creates a type-safe synchronized event state hook.
+ * Similar to `createUseEventHandler`, but for synchronized state derivation instead of side effects.
+ *
+ * **When to use this vs createUseEventHandler:**
+ * - Use `createUseSynchronizedEventState` when multiple components need to **read and display**
+ *   the same event payload in their render. This prevents tearing (visual inconsistencies)
+ *   during concurrent React rendering by ensuring all components see the same synchronized state.
+ * - Use `createUseEventHandler` when components only need to **react** to events
+ *   with side effects (logging, API calls, navigation, etc.)
+ *
+ * **Key differences:**
+ * - `createUseSynchronizedEventState`: Returns a hook that reads the latest event payload synchronously
+ *   during render. All components using the same event will see the same synchronized value,
+ *   preventing tearing in concurrent React rendering.
+ * - `createUseEventHandler`: Returns a hook that registers a callback for side effects.
+ *   Components don't read state from it.
+ *
+ * **Important:** Event payloads must be plain data (serializable). Functions, classes,
+ * and other non-serializable values are not allowed. See {@link PlainData} for details.
+ *
+ * @template T - EventGroup type defining event types and payloads (must use PlainData)
+ * @returns A hook function that reads the latest synchronized event state
+ *
+ * @example
+ * ```typescript
+ * type CounterEventGroup = {
+ *   "counter:updated": { count: number };
+ *   "counter:reset": undefined;
+ * };
+ *
+ * const useCounterState = createUseSynchronizedEventState<CounterEventGroup>();
+ *
+ * function CounterDisplay() {
+ *   // Read latest count - safe from tearing, synchronized across all components
+ *   const latestEvent = useCounterState("counter:updated");
+ *   const count = latestEvent?.count ?? 0;
+ *
+ *   return <div>Count: {count}</div>;
+ * }
+ *
+ * function AnotherCounterDisplay() {
+ *   // This component will always see the same count as CounterDisplay
+ *   // because useSyncExternalStore ensures synchronization
+ *   const latestEvent = useCounterState("counter:updated");
+ *   const count = latestEvent?.count ?? 0;
+ *
+ *   return <div>Also showing: {count}</div>;
+ * }
+ * ```
+ */
+export function createUseSynchronizedEventState<T extends EventGroup>() {
+  return function useEventStateHook<K extends keyof T>(
+    event: K
+  ): T[K] | undefined {
+    return useEventState<T, K>(event);
+  };
+}
+
+/**
+ * Factory function that creates a type-safe synchronized event state hook with default values.
+ * Similar to `createUseSynchronizedEventState`, but allows specifying a default value per event type.
+ *
+ * @template T - EventGroup type defining event types and payloads
+ * @returns A hook function that reads the latest synchronized event state with defaults
+ *
+ * @example
+ * ```typescript
+ * const useCounterState = createUseSynchronizedEventStateWithDefaults<CounterEventGroup>({
+ *   "counter:updated": { count: 0 },
+ * });
+ *
+ * function CounterDisplay() {
+ *   // Always returns a value (never undefined), synchronized across all components
+ *   const latestEvent = useCounterState("counter:updated");
+ *   return <div>Count: {latestEvent.count}</div>;
+ * }
+ * ```
+ */
+export function createUseSynchronizedEventStateWithDefaults<
+  T extends EventGroup
+>(defaults: { [K in keyof T]?: T[K] }) {
+  return function useEventStateHook<K extends keyof T>(
+    event: K,
+    defaultValue?: T[K]
+  ): T[K] {
+    const defaultVal = defaultValue ?? defaults[event];
+    if (defaultVal === undefined) {
+      // No default provided - return undefined (cast to T[K] for type compatibility)
+      return useEventState<T, K>(event) as T[K];
+    }
+    return useEventState<T, K>(event, defaultVal);
+  };
+}

--- a/app/packages/events/src/hooks/createUseSynchronizedEventState.ts
+++ b/app/packages/events/src/hooks/createUseSynchronizedEventState.ts
@@ -86,11 +86,11 @@ export function createUseSynchronizedEventStateWithDefaults<
   return function useEventStateHook<K extends keyof T>(
     event: K,
     defaultValue?: T[K]
-  ): T[K] {
+  ): T[K] | undefined {
     const defaultVal = defaultValue ?? defaults[event];
     if (defaultVal === undefined) {
-      // No default provided - return undefined (cast to T[K] for type compatibility)
-      return useEventState<T, K>(event) as T[K];
+      // No default provided - return undefined
+      return useEventState<T, K>(event);
     }
     return useEventState<T, K>(event, defaultVal);
   };

--- a/app/packages/events/src/hooks/index.ts
+++ b/app/packages/events/src/hooks/index.ts
@@ -1,2 +1,4 @@
-export * from "./useEventBus";
 export * from "./createUseEventHandler";
+export * from "./createUseSynchronizedEventState";
+export * from "./useEventBus";
+export * from "./useEventState";

--- a/app/packages/events/src/hooks/useEventBus.ts
+++ b/app/packages/events/src/hooks/useEventBus.ts
@@ -6,6 +6,11 @@ import { EventGroup } from "../types";
  * Hook that provides access to the default event bus.
  * The dispatcher is shared across all components.
  *
+ * **When to use this:**
+ * - Use `useEventBus` when you need to dispatch events or manually manage subscriptions
+ * - For subscribing to events with side effects, prefer `createUseEventHandler`
+ * - For reading event state in render, use `useEventState` or `createUseSynchronizedEventState`
+ *
  * @template T - EventGroup type defining event types and payloads
  * @returns Event dispatcher with on, off, and dispatch methods
  */

--- a/app/packages/events/src/hooks/useEventState.test.tsx
+++ b/app/packages/events/src/hooks/useEventState.test.tsx
@@ -1,0 +1,300 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { useEventBus } from "./useEventBus";
+import { useEventState } from "./useEventState";
+import { __test__ } from "../state/EventStateStore";
+
+type TestEventGroup = {
+  "test:eventA": { id: string; name: string };
+  "test:eventB": { value: number };
+  "test:eventC": undefined;
+};
+
+describe("useEventState", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Clear state store between tests
+    __test__.registry.clear();
+  });
+
+  test("should return undefined initially when no event has been dispatched", () => {
+    const { result } = renderHook(() =>
+      useEventState<TestEventGroup, "test:eventA">("test:eventA")
+    );
+
+    expect(result.current).toBeUndefined();
+  });
+
+  test("should return the latest event payload after dispatch", async () => {
+    const { result: busResult } = renderHook(() =>
+      useEventBus<TestEventGroup>()
+    );
+    const { result } = renderHook(() =>
+      useEventState<TestEventGroup, "test:eventA">("test:eventA")
+    );
+
+    // Initially undefined
+    expect(result.current).toBeUndefined();
+
+    // Dispatch event
+    act(() => {
+      busResult.current.dispatch("test:eventA", { id: "1", name: "test" });
+    });
+
+    // Should now have the payload
+    await waitFor(() => {
+      expect(result.current).toEqual({ id: "1", name: "test" });
+    });
+  });
+
+  test("should update when a new event is dispatched", async () => {
+    const { result: busResult } = renderHook(() =>
+      useEventBus<TestEventGroup>()
+    );
+    const { result } = renderHook(() =>
+      useEventState<TestEventGroup, "test:eventA">("test:eventA")
+    );
+
+    act(() => {
+      busResult.current.dispatch("test:eventA", { id: "1", name: "test1" });
+    });
+    await waitFor(() => {
+      expect(result.current).toEqual({ id: "1", name: "test1" });
+    });
+
+    act(() => {
+      busResult.current.dispatch("test:eventA", { id: "2", name: "test2" });
+    });
+    await waitFor(() => {
+      expect(result.current).toEqual({ id: "2", name: "test2" });
+    });
+  });
+
+  test("should handle events with no payload", () => {
+    const { result: busResult } = renderHook(() =>
+      useEventBus<TestEventGroup>()
+    );
+    const { result } = renderHook(() =>
+      useEventState<TestEventGroup, "test:eventC">("test:eventC")
+    );
+
+    expect(result.current).toBeUndefined();
+
+    busResult.current.dispatch("test:eventC");
+    expect(result.current).toBeUndefined();
+  });
+
+  test("should prevent tearing - multiple components see same value", async () => {
+    const { result: busResult } = renderHook(() =>
+      useEventBus<TestEventGroup>()
+    );
+
+    const { result: result1 } = renderHook(() =>
+      useEventState<TestEventGroup, "test:eventA">("test:eventA")
+    );
+    const { result: result2 } = renderHook(() =>
+      useEventState<TestEventGroup, "test:eventA">("test:eventA")
+    );
+    const { result: result3 } = renderHook(() =>
+      useEventState<TestEventGroup, "test:eventA">("test:eventA")
+    );
+
+    // All should be undefined initially
+    expect(result1.current).toBeUndefined();
+    expect(result2.current).toBeUndefined();
+    expect(result3.current).toBeUndefined();
+
+    // Dispatch event
+    act(() => {
+      busResult.current.dispatch("test:eventA", { id: "1", name: "test" });
+    });
+
+    // All should see the same value (no tearing)
+    await waitFor(() => {
+      expect(result1.current).toEqual({ id: "1", name: "test" });
+      expect(result2.current).toEqual({ id: "1", name: "test" });
+      expect(result3.current).toEqual({ id: "1", name: "test" });
+    });
+
+    // Dispatch another event
+    act(() => {
+      busResult.current.dispatch("test:eventA", { id: "2", name: "test2" });
+    });
+
+    // All should still see the same value
+    await waitFor(() => {
+      expect(result1.current).toEqual({ id: "2", name: "test2" });
+      expect(result2.current).toEqual({ id: "2", name: "test2" });
+      expect(result3.current).toEqual({ id: "2", name: "test2" });
+    });
+  });
+
+  test("should handle different event types independently", async () => {
+    const { result: busResult } = renderHook(() =>
+      useEventBus<TestEventGroup>()
+    );
+
+    const { result: resultA } = renderHook(() =>
+      useEventState<TestEventGroup, "test:eventA">("test:eventA")
+    );
+    const { result: resultB } = renderHook(() =>
+      useEventState<TestEventGroup, "test:eventB">("test:eventB")
+    );
+
+    act(() => {
+      busResult.current.dispatch("test:eventA", { id: "1", name: "test" });
+      busResult.current.dispatch("test:eventB", { value: 42 });
+    });
+
+    await waitFor(() => {
+      expect(resultA.current).toEqual({ id: "1", name: "test" });
+      expect(resultB.current).toEqual({ value: 42 });
+    });
+  });
+
+  test("should maintain state across re-renders", async () => {
+    const { result: busResult } = renderHook(() =>
+      useEventBus<TestEventGroup>()
+    );
+
+    const { result, rerender } = renderHook(() =>
+      useEventState<TestEventGroup, "test:eventA">("test:eventA")
+    );
+
+    act(() => {
+      busResult.current.dispatch("test:eventA", { id: "1", name: "test" });
+    });
+    await waitFor(() => {
+      expect(result.current).toEqual({ id: "1", name: "test" });
+    });
+
+    // Re-render
+    rerender();
+
+    // State should still be there
+    expect(result.current).toEqual({ id: "1", name: "test" });
+  });
+
+  test("should unsubscribe when component unmounts", async () => {
+    const { result: busResult } = renderHook(() =>
+      useEventBus<TestEventGroup>()
+    );
+
+    const { result, unmount } = renderHook(() =>
+      useEventState<TestEventGroup, "test:eventA">("test:eventA")
+    );
+
+    act(() => {
+      busResult.current.dispatch("test:eventA", { id: "1", name: "test" });
+    });
+    await waitFor(() => {
+      expect(result.current).toEqual({ id: "1", name: "test" });
+    });
+
+    unmount();
+
+    // State should still be tracked (other components might be using it)
+    // But the component should be unsubscribed
+    act(() => {
+      busResult.current.dispatch("test:eventA", { id: "2", name: "test2" });
+    });
+    // The unmounted component's result shouldn't update, but we can't test that directly
+    // The important thing is that the subscription is cleaned up
+  });
+
+  test("should return default value when provided", () => {
+    const defaultValue = { id: "default", name: "default" };
+    const { result } = renderHook(() =>
+      useEventState<TestEventGroup, "test:eventA">("test:eventA", defaultValue)
+    );
+
+    expect(result.current).toEqual(defaultValue);
+  });
+
+  test("should return latest event payload after dispatch with default", async () => {
+    const { result: busResult } = renderHook(() =>
+      useEventBus<TestEventGroup>()
+    );
+    const defaultValue = { id: "default", name: "default" };
+    const { result } = renderHook(() =>
+      useEventState<TestEventGroup, "test:eventA">("test:eventA", defaultValue)
+    );
+
+    expect(result.current).toEqual(defaultValue);
+
+    act(() => {
+      busResult.current.dispatch("test:eventA", { id: "1", name: "test" });
+    });
+    await waitFor(() => {
+      expect(result.current).toEqual({ id: "1", name: "test" });
+    });
+  });
+
+  test("should update when new event is dispatched with default", async () => {
+    const { result: busResult } = renderHook(() =>
+      useEventBus<TestEventGroup>()
+    );
+    const defaultValue = { id: "default", name: "default" };
+    const { result } = renderHook(() =>
+      useEventState<TestEventGroup, "test:eventA">("test:eventA", defaultValue)
+    );
+
+    act(() => {
+      busResult.current.dispatch("test:eventA", { id: "1", name: "test1" });
+    });
+    await waitFor(() => {
+      expect(result.current).toEqual({ id: "1", name: "test1" });
+    });
+
+    act(() => {
+      busResult.current.dispatch("test:eventA", { id: "2", name: "test2" });
+    });
+    await waitFor(() => {
+      expect(result.current).toEqual({ id: "2", name: "test2" });
+    });
+  });
+
+  test("should prevent tearing with default values", async () => {
+    const { result: busResult } = renderHook(() =>
+      useEventBus<TestEventGroup>()
+    );
+    const defaultValue = { id: "default", name: "default" };
+
+    const { result: result1 } = renderHook(() =>
+      useEventState<TestEventGroup, "test:eventA">("test:eventA", defaultValue)
+    );
+    const { result: result2 } = renderHook(() =>
+      useEventState<TestEventGroup, "test:eventA">("test:eventA", defaultValue)
+    );
+
+    // Both should see default initially
+    expect(result1.current).toEqual(defaultValue);
+    expect(result2.current).toEqual(defaultValue);
+
+    act(() => {
+      busResult.current.dispatch("test:eventA", { id: "1", name: "test" });
+    });
+
+    // Both should see the same value
+    await waitFor(() => {
+      expect(result1.current).toEqual({ id: "1", name: "test" });
+      expect(result2.current).toEqual({ id: "1", name: "test" });
+    });
+  });
+
+  test("should handle events with no payload and default", () => {
+    const { result: busResult } = renderHook(() =>
+      useEventBus<TestEventGroup>()
+    );
+    const defaultValue: undefined = undefined;
+
+    const { result } = renderHook(() =>
+      useEventState<TestEventGroup, "test:eventC">("test:eventC", defaultValue)
+    );
+
+    expect(result.current).toBeUndefined();
+
+    busResult.current.dispatch("test:eventC");
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/app/packages/events/src/hooks/useEventState.ts
+++ b/app/packages/events/src/hooks/useEventState.ts
@@ -1,0 +1,71 @@
+import { useSyncExternalStore } from "react";
+import { getEventStateStore } from "../state/EventStateStore";
+import { EventGroup } from "../types";
+
+/**
+ * Hook that reads the latest state from an event using useSyncExternalStore.
+ * This prevents tearing in concurrent React rendering when multiple components
+ * derive state from the same event.
+ *
+ * **When to use this vs useEventHandler:**
+ * - Use `useEventState` when you need to **read and display** the latest event payload
+ *   in your component's render (e.g., showing the current count, latest message, etc.)
+ * - Use `useEventHandler` (or `createUseEventHandler`) when you only need to **react**
+ *   to events with side effects (e.g., logging, API calls, navigation)
+ *
+ * **Key differences:**
+ * - `useEventState`: Returns the latest event payload synchronously during render.
+ *   Multiple components reading the same event will always see the same value,
+ *   preventing visual inconsistencies (tearing). If no default is provided, returns undefined
+ *   when no event has been dispatched yet.
+ * - `useEventHandler`: Registers a callback that runs when events occur. Useful
+ *   for side effects but doesn't provide synchronized state reading.
+ *
+ * **Important:** Event payloads must be plain data (serializable). Functions, classes,
+ * and other non-serializable values are not allowed. See {@link PlainData} for details.
+ *
+ * @template T - EventGroup type defining event types and payloads (must use PlainData)
+ * @template K - Specific event type key
+ * @param event - The event type to track
+ * @param defaultValue - Optional default value to return if no event has been dispatched yet.
+ *   If not provided, returns undefined when no event has been dispatched.
+ * @returns The latest payload for the event, or the default value (or undefined if no default)
+ *
+ * @example
+ * ```typescript
+ * type CounterEventGroup = {
+ *   "counter:updated": { count: number };
+ * };
+ *
+ * // Without default - returns undefined initially
+ * function CounterDisplay() {
+ *   const latestEvent = useEventState<CounterEventGroup, "counter:updated">(
+ *     "counter:updated"
+ *   );
+ *   const count = latestEvent?.count ?? 0;
+ *   return <div>Count: {count}</div>;
+ * }
+ *
+ * // With default - always returns a value
+ * function CounterDisplayWithDefault() {
+ *   const latestEvent = useEventState<CounterEventGroup, "counter:updated">(
+ *     "counter:updated",
+ *     { count: 0 } // Default value
+ *   );
+ *   return <div>Count: {latestEvent.count}</div>;
+ * }
+ * ```
+ */
+export function useEventState<T extends EventGroup, K extends keyof T>(
+  event: K,
+  defaultValue?: T[K]
+): T[K] | undefined {
+  const store = getEventStateStore<T>();
+  const subscription = store.createSubscription(event);
+
+  return useSyncExternalStore(subscription.subscribe, () =>
+    defaultValue === undefined
+      ? subscription.getSnapshot()
+      : subscription.getSnapshotWithDefault(defaultValue)
+  );
+}

--- a/app/packages/events/src/index.ts
+++ b/app/packages/events/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./dispatch";
 export * from "./hooks";
+export * from "./state";
 export * from "./types";

--- a/app/packages/events/src/state/EventStateStore.test.ts
+++ b/app/packages/events/src/state/EventStateStore.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { getEventBus } from "../dispatch";
+import { __test__, getEventStateStore } from "./EventStateStore";
+
+type TestEventGroup = {
+  "test:eventA": { id: string; name: string };
+  "test:eventB": { value: number };
+  "test:eventC": undefined;
+};
+
+describe("EventStateStore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __test__.registry.clear();
+  });
+
+  test("should create a subscription for an event", () => {
+    const store = getEventStateStore<TestEventGroup>();
+    const subscription = store.createSubscription("test:eventA");
+
+    expect(subscription).toBeDefined();
+    expect(typeof subscription.subscribe).toBe("function");
+    expect(typeof subscription.getSnapshot).toBe("function");
+    expect(typeof subscription.getSnapshotWithDefault).toBe("function");
+  });
+
+  test("should return undefined initially", () => {
+    const store = getEventStateStore<TestEventGroup>();
+    const subscription = store.createSubscription("test:eventA");
+
+    expect(subscription.getSnapshot()).toBeUndefined();
+  });
+
+  test("should track latest event payload", () => {
+    const store = getEventStateStore<TestEventGroup>();
+    const bus = getEventBus<TestEventGroup>();
+    const subscription = store.createSubscription("test:eventA");
+
+    expect(subscription.getSnapshot()).toBeUndefined();
+
+    // Subscribe to start tracking events
+    const listener = vi.fn();
+    subscription.subscribe(listener);
+
+    bus.dispatch("test:eventA", { id: "1", name: "test" });
+    expect(subscription.getSnapshot()).toEqual({ id: "1", name: "test" });
+
+    bus.dispatch("test:eventA", { id: "2", name: "test2" });
+    expect(subscription.getSnapshot()).toEqual({ id: "2", name: "test2" });
+  });
+
+  test("should notify subscribers when state changes", () => {
+    const store = getEventStateStore<TestEventGroup>();
+    const bus = getEventBus<TestEventGroup>();
+    const subscription = store.createSubscription("test:eventA");
+
+    const listener1 = vi.fn();
+    const listener2 = vi.fn();
+
+    const unsubscribe1 = subscription.subscribe(listener1);
+    const unsubscribe2 = subscription.subscribe(listener2);
+
+    // Initial state
+    expect(listener1).not.toHaveBeenCalled();
+    expect(listener2).not.toHaveBeenCalled();
+
+    // Dispatch event
+    bus.dispatch("test:eventA", { id: "1", name: "test" });
+
+    // Both listeners should be notified
+    expect(listener1).toHaveBeenCalledTimes(1);
+    expect(listener2).toHaveBeenCalledTimes(1);
+
+    // Dispatch another event
+    bus.dispatch("test:eventA", { id: "2", name: "test2" });
+
+    expect(listener1).toHaveBeenCalledTimes(2);
+    expect(listener2).toHaveBeenCalledTimes(2);
+
+    // Unsubscribe one listener
+    unsubscribe1();
+
+    // Dispatch another event
+    bus.dispatch("test:eventA", { id: "3", name: "test3" });
+
+    // Only listener2 should be notified
+    expect(listener1).toHaveBeenCalledTimes(2);
+    expect(listener2).toHaveBeenCalledTimes(3);
+
+    unsubscribe2();
+  });
+
+  test("should return memoized subscription for same event", () => {
+    const store = getEventStateStore<TestEventGroup>();
+    const subscription1 = store.createSubscription("test:eventA");
+    const subscription2 = store.createSubscription("test:eventA");
+
+    expect(subscription1).toBe(subscription2);
+  });
+
+  test("should handle different events independently", () => {
+    const store = getEventStateStore<TestEventGroup>();
+    const bus = getEventBus<TestEventGroup>();
+
+    const subscriptionA = store.createSubscription("test:eventA");
+    const subscriptionB = store.createSubscription("test:eventB");
+
+    // Subscribe to start tracking events
+    const listenerA = vi.fn();
+    const listenerB = vi.fn();
+    subscriptionA.subscribe(listenerA);
+    subscriptionB.subscribe(listenerB);
+
+    bus.dispatch("test:eventA", { id: "1", name: "test" });
+    bus.dispatch("test:eventB", { value: 42 });
+
+    expect(subscriptionA.getSnapshot()).toEqual({ id: "1", name: "test" });
+    expect(subscriptionB.getSnapshot()).toEqual({ value: 42 });
+  });
+
+  test("should return default value when provided", () => {
+    const store = getEventStateStore<TestEventGroup>();
+    const subscription = store.createSubscription("test:eventA");
+    const defaultValue = { id: "default", name: "default" };
+
+    expect(subscription.getSnapshotWithDefault(defaultValue)).toEqual(
+      defaultValue
+    );
+
+    // Subscribe to start tracking events
+    const listener = vi.fn();
+    subscription.subscribe(listener);
+
+    const bus = getEventBus<TestEventGroup>();
+    bus.dispatch("test:eventA", { id: "1", name: "test" });
+
+    expect(subscription.getSnapshotWithDefault(defaultValue)).toEqual({
+      id: "1",
+      name: "test",
+    });
+  });
+
+  test("should cleanup all trackers", () => {
+    const store = getEventStateStore<TestEventGroup>();
+    const subscription = store.createSubscription("test:eventA");
+    const listener = vi.fn();
+
+    subscription.subscribe(listener);
+
+    const bus = getEventBus<TestEventGroup>();
+    bus.dispatch("test:eventA", { id: "1", name: "test" });
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(subscription.getSnapshot()).toEqual({ id: "1", name: "test" });
+
+    store.cleanup();
+
+    // After cleanup, trackers map is cleared, but existing subscription objects
+    // still hold references to their trackers. The cleanup is mainly for testing
+    // purposes. In practice, subscriptions are managed by React components.
+    // The subscription still works because it has a reference to the tracker.
+    // To fully test cleanup, we'd need to create a new subscription after cleanup.
+    const newSubscription = store.createSubscription("test:eventA");
+    expect(newSubscription.getSnapshot()).toBeUndefined();
+  });
+
+  test("should unsubscribe from event bus when no listeners remain", () => {
+    const store = getEventStateStore<TestEventGroup>();
+    const bus = getEventBus<TestEventGroup>();
+    const subscription = store.createSubscription("test:eventA");
+
+    const handler = vi.fn();
+    bus.on("test:eventA", handler);
+
+    const listener1 = vi.fn();
+    const listener2 = vi.fn();
+
+    const unsubscribe1 = subscription.subscribe(listener1);
+    const unsubscribe2 = subscription.subscribe(listener2);
+
+    // Dispatch should trigger both listeners and the handler
+    bus.dispatch("test:eventA", { id: "1", name: "test" });
+    expect(listener1).toHaveBeenCalledTimes(1);
+    expect(listener2).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // Unsubscribe both listeners
+    unsubscribe1();
+    unsubscribe2();
+
+    // The store should have unsubscribed from the event bus
+    // But the handler we registered directly should still work
+    bus.dispatch("test:eventA", { id: "2", name: "test2" });
+    expect(handler).toHaveBeenCalledTimes(2);
+    // Listeners should not be called
+    expect(listener1).toHaveBeenCalledTimes(1);
+    expect(listener2).toHaveBeenCalledTimes(1);
+  });
+
+  test("should handle events with no payload", () => {
+    const store = getEventStateStore<TestEventGroup>();
+    const bus = getEventBus<TestEventGroup>();
+    const subscription = store.createSubscription("test:eventC");
+
+    expect(subscription.getSnapshot()).toBeUndefined();
+
+    bus.dispatch("test:eventC");
+    expect(subscription.getSnapshot()).toBeUndefined();
+  });
+
+  test("should return same store instance for same channel", () => {
+    const store1 = getEventStateStore<TestEventGroup>();
+    const store2 = getEventStateStore<TestEventGroup>();
+
+    expect(store1).toBe(store2);
+  });
+});

--- a/app/packages/events/src/state/EventStateStore.ts
+++ b/app/packages/events/src/state/EventStateStore.ts
@@ -1,0 +1,167 @@
+import { getEventBus } from "../dispatch";
+import { EventGroup } from "../types";
+
+/**
+ * Per-event state tracking. Each event type has its own state and listeners.
+ */
+class EventStateTracker<K> {
+  private state: K | undefined = undefined;
+  private listeners: Set<() => void> = new Set();
+  private unsubscribeCallback: (() => void) | null = null;
+  private refCount = 0;
+
+  /**
+   * Subscribe to event updates. Returns unsubscribe function.
+   */
+  subscribe(
+    callback: () => void,
+    bus: any,
+    event: string | number | symbol
+  ): () => void {
+    this.listeners.add(callback);
+    this.refCount++;
+
+    // Subscribe to the event bus if this is the first listener
+    if (this.refCount === 1 && !this.unsubscribeCallback) {
+      const handler = (data: K) => {
+        this.state = data;
+        // Notify all listeners
+        this.listeners.forEach((listener) => listener());
+      };
+
+      bus.on(event, handler);
+      this.unsubscribeCallback = () => {
+        bus.off(event, handler);
+      };
+    }
+
+    // Return unsubscribe function
+    return () => {
+      this.listeners.delete(callback);
+      this.refCount--;
+
+      // Unsubscribe from event bus if no listeners remain
+      if (this.refCount === 0 && this.unsubscribeCallback) {
+        this.unsubscribeCallback();
+        this.unsubscribeCallback = null;
+        this.state = undefined;
+      }
+    };
+  }
+
+  /**
+   * Get the current snapshot of state.
+   */
+  getSnapshot(): K | undefined {
+    return this.state;
+  }
+
+  /**
+   * Get the current snapshot with a default value.
+   */
+  getSnapshotWithDefault(defaultValue: K): K {
+    return this.state ?? defaultValue;
+  }
+}
+
+/**
+ * Store that tracks the latest payload for each event type.
+ * This enables state derivation from events using useSyncExternalStore,
+ * preventing tearing in concurrent React rendering.
+ *
+ * @template T - EventGroup type defining event types and payloads
+ */
+export class EventStateStore<T extends EventGroup> {
+  private trackers: Map<keyof T, EventStateTracker<T[keyof T]>> = new Map();
+  private subscriptions: Map<
+    keyof T,
+    {
+      subscribe: (callback: () => void) => () => void;
+      getSnapshot: () => T[keyof T] | undefined;
+      getSnapshotWithDefault: (defaultValue: T[keyof T]) => T[keyof T];
+    }
+  > = new Map();
+
+  /**
+   * Get or create a tracker for a specific event type.
+   */
+  private getTracker<K extends keyof T>(event: K): EventStateTracker<T[K]> {
+    if (!this.trackers.has(event)) {
+      this.trackers.set(event, new EventStateTracker<T[K]>());
+    }
+    return this.trackers.get(event) as EventStateTracker<T[K]>;
+  }
+
+  /**
+   * Create a subscribe/getSnapshot pair for a specific event.
+   * This is used by useSyncExternalStore to track state for a single event.
+   * The subscription object is memoized per event to prevent unnecessary re-subscriptions.
+   */
+  createSubscription<K extends keyof T>(
+    event: K
+  ): {
+    subscribe: (callback: () => void) => () => void;
+    getSnapshot: () => T[K] | undefined;
+    getSnapshotWithDefault: (defaultValue: T[K]) => T[K];
+  } {
+    // Return memoized subscription if it exists
+    const existing = this.subscriptions.get(event);
+    if (existing) {
+      return existing as {
+        subscribe: (callback: () => void) => () => void;
+        getSnapshot: () => T[K] | undefined;
+        getSnapshotWithDefault: (defaultValue: T[K]) => T[K];
+      };
+    }
+
+    const tracker = this.getTracker(event);
+    const bus = getEventBus<T>();
+
+    const subscription = {
+      subscribe: (callback: () => void) => {
+        return tracker.subscribe(callback, bus, event);
+      },
+      getSnapshot: (): T[K] | undefined => tracker.getSnapshot(),
+      getSnapshotWithDefault: (defaultValue: T[K]): T[K] =>
+        tracker.getSnapshotWithDefault(defaultValue),
+    };
+
+    this.subscriptions.set(event, subscription);
+    return subscription;
+  }
+
+  /**
+   * Cleanup: clear all trackers and subscriptions.
+   * Useful for testing or when the store is no longer needed.
+   */
+  cleanup(): void {
+    this.trackers.clear();
+    this.subscriptions.clear();
+  }
+}
+
+/**
+ * Registry of EventStateStore instances by channel ID.
+ * Similar to the dispatcher registry, but for state stores.
+ */
+const stateStoreRegistry = new Map<string, EventStateStore<any>>();
+
+/**
+ * Gets or creates an EventStateStore for the given channel ID.
+ * By default, uses "default" channel to match the event bus.
+ */
+export function getEventStateStore<T extends EventGroup>(
+  channelId: string = "default"
+): EventStateStore<T> {
+  if (!stateStoreRegistry.has(channelId)) {
+    stateStoreRegistry.set(channelId, new EventStateStore<T>());
+  }
+  return stateStoreRegistry.get(channelId) as EventStateStore<T>;
+}
+
+/**
+ * Exports the registry for testing purposes.
+ */
+export const __test__ = {
+  registry: stateStoreRegistry,
+};

--- a/app/packages/events/src/state/index.ts
+++ b/app/packages/events/src/state/index.ts
@@ -1,0 +1,1 @@
+export * from "./EventStateStore";

--- a/app/packages/events/src/types/event.ts
+++ b/app/packages/events/src/types/event.ts
@@ -1,17 +1,65 @@
 /**
+ * Type that represents plain data (no functions, classes, or complex objects).
+ * This ensures event payloads are serializable and safe for state derivation.
+ *
+ * Plain data includes:
+ * - Primitives: string, number, boolean, null, undefined
+ * - Arrays of plain data
+ * - Objects with plain data values (no functions, classes, or circular references)
+ *
+ * @example
+ * ```typescript
+ * // ✅ Valid plain data
+ * const valid: PlainData = {
+ *   id: "123",
+ *   count: 42,
+ *   tags: ["a", "b", "c"],
+ *   metadata: { key: "value" }
+ * };
+ *
+ * // ❌ Invalid (contains function)
+ * const invalid: PlainData = {
+ *   id: "123",
+ *   // Error: function not allowed
+ *   callback: () => {}
+ * };
+ * ```
+ */
+export type PlainData =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | PlainData[]
+  | { [key: string]: PlainData };
+
+/**
  * A type representing a group of events, where each key is an event type name
  * and each value is the payload type for that event. If the payload is `undefined` or `null`,
  * the event is considered to have no payload.
  *
+ * **Important:** Event payloads must be plain data (serializable).
  * @example
  * ```typescript
  * type DomainEventGroup = {
  *   "domainFoo:login": { id: string; timestamp: number };
  *   "domainFoo:logout": undefined;
  * };
+ *
+ * // ✅ Valid
+ * const bus = useEventBus<DomainEventGroup>();
+ * bus.dispatch("domainFoo:login", { id: "123", timestamp: Date.now() });
+ *
+ * // ❌ Invalid (TypeScript will error)
+ * bus.dispatch("domainFoo:login", {
+ *   id: "123",
+ *    // Error: function not allowed in payload
+ *   callback: () => {}
+ * });
  * ```
  */
-export type EventGroup = Record<string, unknown>;
+export type EventGroup = Record<string, PlainData | undefined | null>;
 
 /**
  * A handler function for a specific event type.


### PR DESCRIPTION
## What changes are proposed in this pull request?

In our current setup, if event payload is used as React state, multiple components might get a different read during React's concurrent rendering. This PR introduces the concept of "event state" which uses [useSyncExternalStore](https://react.dev/reference/react/useSyncExternalStore) to make sure no [tearing](https://github.com/reactwg/react-18/discussions/69) occurs.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added synchronized event state hooks to prevent rendering inconsistencies across components
  * Introduced centralized per-event state store for event-driven state management
  * Added a demo component showcasing event-driven state patterns and best practices
  * Strengthened type safety by constraining event payloads to plain-data shapes

* **Documentation**
  * Enhanced docs with guidance comparing synchronized reads vs. side-effect handlers and usage examples

* **Tests**
  * Added comprehensive test coverage for event state store and related hooks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->