### PR TITLE
Enable connecting to established DatabaseService

### DIFF
--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -255,7 +255,6 @@ def _is_client_closed(client):
 
 
 def _connect():
-    print("_connect()")
     global _client
     if _is_client_closed(_client):
         _client = None


### PR DESCRIPTION
## What changes are proposed in this pull request?

- enable connecting to mongodb in child processes without needing to start up a DatabaseService in every process when FIFTYONE_DATABASE_URI is not set (eg using the FO managed mongo) [FOEPD-2554]

- currently if you attempt to disable extra services in child processes you get this error:
```
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/Users/kacey/Dev/voxel51/fiftyone/fiftyone/core/dataset.py", line 9012, in _load_dataset
    version = fomi.get_dataset_revision(name)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kacey/Dev/voxel51/fiftyone/fiftyone/migrations/runner.py", line 61, in get_dataset_revision
    conn = foo.get_db_conn()
           ^^^^^^^^^^^^^^^^^
  File "/Users/kacey/Dev/voxel51/fiftyone/fiftyone/core/odm/database.py", line 501, in get_db_conn
    db = _client[fo.config.database_name]
         ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable

"""
```

## How is this patch tested? If it is not, please explain why.

This minimal example now completes without error. 
```
# unset FIFTYONE_DATABASE_URI in the environment

from multiprocessing import Pool
import os
import fiftyone as fo
import fiftyone.zoo as foz

def worker_init():
    """Called once when each worker process starts"""
    os.environ["FIFTYONE_DISABLE_SERVICES"] = "1"


def worker_task(data):
    dataset = fo.load_dataset(data[0])
    print(f"Worker {data[1]} loaded dataset '{data[0]}' with {len(dataset)} samples")
    return

if __name__ == "__main__":

    dataset = foz.load_zoo_dataset('quickstart')
    assert dataset.first() is not None
    with Pool(processes=2, initializer=worker_init) as pool:
        results = pool.map(worker_task, [(dataset.name, i) for i in range(2)])
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Improve database connection logic so child processes can connect to mongo when no explicit connection string set.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


[FOEPD-2554]: https://voxel51.atlassian.net/browse/FOEPD-2554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection logic so an explicit database port (via environment) prevents starting the local database service, avoiding unintended service startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->