### PR TITLE
Fix bug when reloading temporal detection (activitynet style) evaluation results

### DIFF
--- a/fiftyone/utils/eval/activitynet.py
+++ b/fiftyone/utils/eval/activitynet.py
@@ -368,9 +368,12 @@ class ActivityNetDetectionResults(DetectionResults):
         self.thresholds = (
             np.asarray(thresholds) if thresholds is not None else None
         )
-        self.classwise_AP = np.array(classwise_AP)
-
-        self._classwise_AP = self.classwise_AP.mean(0)
+        self.classwise_AP = (
+            np.array(classwise_AP) if classwise_AP is not None else None
+        )
+        self._classwise_AP = (
+            self.classwise_AP.mean(0) if classwise_AP is not None else None
+        )
 
     def plot_pr_curves(
         self, classes=None, iou_thresh=None, backend="plotly", **kwargs
@@ -400,7 +403,9 @@ class ActivityNetDetectionResults(DetectionResults):
                 used
             -   a plotly or matplotlib figure, otherwise
         """
-        if classes is None:
+        if classes is None and self._classwise_AP is None:
+            classes = self.classes
+        elif classes is None:
             inds = np.argsort(self._classwise_AP)[::-1][:3]
             classes = self.classes[inds]
 
@@ -443,6 +448,9 @@ class ActivityNetDetectionResults(DetectionResults):
         Returns:
             the mAP in ``[0, 1]``
         """
+        if self._classwise_AP is None:
+            return None
+
         if classes is not None:
             class_inds = np.array([self._get_class_index(c) for c in classes])
             classwise_AP = self._classwise_AP[class_inds]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes long standing error when reloading ActivityNet-style temporal detection evaluation results

## How is this patch tested? If it is not, please explain why.

```python
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video")[:1].clone()
dataset.name = "an-test"
dataset.persistent = True

sample = dataset.first()
sample["tempdet"] = fo.TemporalDetections(detections=[fo.TemporalDetection(label="activation", support=[7,27])])
sample["tempdet2"] = fo.TemporalDetections(detections=[fo.TemporalDetection(label="activation", support=[8,29], confidence=0.8412)])
sample.save()

results = dataset.evaluate_detections("tempdet2", gt_field="tempdet", eval_key="eval", compute_mAP=True)
```
Close and restart python
```python
import fiftyone as fo

dataset = fo.load_dataset("an-test")
results = dataset.load_evaluation_results("eval")
```

Previously:
```
In [4]: results = dataset.load_evaluation_results("evaluation")
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[4], line 1
----> 1 results = dataset.load_evaluation_results("evaluation")

File ~/work/fiftyone/fiftyone-teams/fiftyone/core/collections.py:5093, in SampleCollection.load_evaluation_results(self, eval_key, cache, **kwargs)
   5079 def load_evaluation_results(self, eval_key, cache=True, **kwargs):
   5080     """Loads the results for the evaluation with the given key on this
   5081     collection.
   5082 
   (...)
   5091         a :class:`fiftyone.core.evaluation.EvaluationResults`
   5092     """
-> 5093     return foev.EvaluationMethod.load_run_results(
   5094         self, eval_key, cache=cache, **kwargs
   5095     )

File ~/work/fiftyone/fiftyone-teams/fiftyone/core/runs.py:729, in BaseRun.load_run_results(cls, samples, key, cache, load_view, **kwargs)
    727 except Exception as e:
    728     if run_doc.version == foc.VERSION:
--> 729         raise e
    731     raise ValueError(
    732         "Failed to load results for %s with key '%s'. The %s used "
    733         "fiftyone==%s but you are currently using fiftyone==%s. We "
   (...)
    742         )
    743     ) from e
    745 # Cache the results for future use in this session

File ~/work/fiftyone/fiftyone-teams/fiftyone/core/runs.py:726, in BaseRun.load_run_results(cls, samples, key, cache, load_view, **kwargs)
    723 d = json_util.loads(run_doc.results.read().decode())
    725 try:
--> 726     run_results = BaseRunResults.from_dict(d, run_samples, config, key)
    727 except Exception as e:
    728     if run_doc.version == foc.VERSION:

File ~/work/fiftyone/fiftyone-teams/fiftyone/core/runs.py:1023, in BaseRunResults.from_dict(cls, d, samples, config, key)
   1017     logger.debug(
   1018         "Unable to load '%s'; falling back to base class",
   1019         run_results_cls,
   1020     )
   1021     run_results_cls = cls.base_results_cls(config.type)
-> 1023 return run_results_cls._from_dict(d, samples, config, key)

File ~/work/fiftyone/fiftyone-teams/fiftyone/utils/eval/activitynet.py:492, in ActivityNetDetectionResults._from_dict(cls, d, samples, config, eval_key, **kwargs)
    490 iou_threshs = d["iou_threshs"]
    491 thresholds = d.get("thresholds", None)
--> 492 return super()._from_dict(
    493     d,
    494     samples,
    495     config,
    496     eval_key,
    497     precision=precision,
    498     recall=recall,
    499     iou_threshs=iou_threshs,
    500     thresholds=thresholds,
    501     **kwargs,
    502 )

File ~/work/fiftyone/fiftyone-teams/fiftyone/utils/eval/detection.py:644, in DetectionResults._from_dict(cls, d, samples, config, eval_key, **kwargs)
    640 custom_metrics = d.get("custom_metrics", None)
    642 matches = list(zip(ytrue, ypred, ious, confs, ytrue_ids, ypred_ids))
--> 644 return cls(
    645     samples,
    646     config,
    647     eval_key,
    648     matches,
    649     classes=classes,
    650     missing=missing,
    651     custom_metrics=custom_metrics,
    652     **kwargs,
    653 )

TypeError: ActivityNetDetectionResults.__init__() missing 1 required positional argument: 'classwise_AP'
```

After fix the results load

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fix bug when reloading temporal detection evaluation results.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-class average precision (AP) metrics are now exposed for ActivityNet detection results for easier inspection and selection.

* **Bug Fixes**
  * Plotting now selects representative classes by default when detailed class metrics are available.
  * Overall mAP handling now returns empty when class-level data is absent and computes correctly when present.
  * Per-class metrics are preserved across result serialization and loading.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->