### PR TITLE
Remove embeddings tag from owlvit models

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -3603,7 +3603,6 @@
             "tags": [
                 "detection",
                 "logits",
-                "embeddings",
                 "torch",
                 "transformers",
                 "zero-shot",
@@ -3641,7 +3640,6 @@
             "tags": [
                 "detection",
                 "logits",
-                "embeddings",
                 "torch",
                 "transformers",
                 "zero-shot",
@@ -3679,7 +3677,6 @@
             "tags": [
                 "detection",
                 "logits",
-                "embeddings",
                 "torch",
                 "transformers",
                 "zero-shot",


### PR DESCRIPTION
## What changes are proposed in this pull request?

remove "embeddings" tag from owl vit models.

## How is this patch tested? If it is not, please explain why.

Model doesn't appear in compute vis operator anymore.

