### PR TITLE
Remove Beta Note from API Connections

### DIFF
--- a/docs/source/enterprise/api_connection.rst
+++ b/docs/source/enterprise/api_connection.rst
@@ -13,11 +13,6 @@ All actions taken via API connections are authenticated based on the user
 associated with the API key, which means that concepts like user roles and
 dataset permissions *are enforced*.
 
-.. note::
-
-   The recommended stable solution is to use your Enterprise deployment's
-   :ref:`MongoDB connection <configuring-mongodb-connection>`.
-
 .. _configuring-an-api-connection:
 
 Configuring an API connection


### PR DESCRIPTION
## What changes are proposed in this pull request?

Removed the beta note from API Connections since it’s no longer needed, as @sherpan suggested :muscle: 

## How is this patch tested? If it is not, please explain why.

N/A

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [X] No. You can skip the rest of this section.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [X] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed the beta designation and related MongoDB reference from the API connection guidance for Enterprise deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->