### PR TITLE
Allow add_samples to insert unordered

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -3446,7 +3446,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         dicts = [doc for _, doc in samples_and_docs]
         try:
             # adds `_id` to each dict
-            res = self._sample_collection.insert_many(dicts)
+            res = self._sample_collection.insert_many(dicts, ordered=False)
         except BulkWriteError as bwe:
             msg = bwe.details["writeErrors"][0]["errmsg"]
             raise ValueError(msg) from bwe


### PR DESCRIPTION
## What changes are proposed in this pull request?

The underlying call to `insert_many` has been updated to include `ordered=False`. In some cases, this will increase performance, particularly for large quantities of docs being inserted.

@brimoor for visibility, I believe this was the change discussed

## How is this patch tested? If it is not, please explain why.

Existing automated tests

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

When calling `Dataset.add_samples()`, the returned list of sample id's will no longer be in the order in which they were provided, and the order of the docs in the collection are no longer guaranteed to be in a specific order. The trade-off is the opportunity for increased throughput when adding many samples at a time. 

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized bulk sample insertion in datasets for improved write efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->