### PR TITLE
fixes bug with windows file paths

### DIFF
--- a/app/packages/utilities/package.json
+++ b/app/packages/utilities/package.json
@@ -24,6 +24,7 @@
         "vite": "^5.4.21"
     },
     "dependencies": {
+        "@chainner/node-path": "^0.1.1",
         "@microsoft/fetch-event-source": "^2.0.1",
         "fetch-retry": "^5.0.3",
         "lodash": "^4.17.21",

--- a/app/packages/utilities/src/paths.ts
+++ b/app/packages/utilities/src/paths.ts
@@ -3,6 +3,7 @@ export enum PathType {
   LINUX,
   WINDOWS,
 }
+import { win32 } from "@chainner/node-path";
 import pathUtils from "path";
 
 export function determinePathType(path: string): PathType {
@@ -59,9 +60,7 @@ export function resolveParent(path: string): string {
     return url.toString();
   }
   const parsed =
-    pathType === PathType.WINDOWS
-      ? pathUtils.win32.parse(path)
-      : pathUtils.parse(path);
+    pathType === PathType.WINDOWS ? win32.parse(path) : pathUtils.parse(path);
 
   if (parsed.dir && parsed.dir !== path) {
     return parsed.dir;
@@ -101,7 +100,7 @@ export function getBasename(path: string) {
     else if (url.hostname) result = url.hostname;
     else result = null;
   } else if (pathType === PathType.WINDOWS) {
-    result = pathUtils.win32.basename(path);
+    result = win32.basename(path);
   } else {
     result = pathUtils.basename(path);
   }
@@ -116,7 +115,7 @@ export function getRootOrProtocol(path: string) {
     return protocol + "://";
   }
   if (pathType === PathType.WINDOWS) {
-    const parsed = pathUtils.win32.parse(path);
+    const parsed = win32.parse(path);
     return parsed.root;
   }
   return "/";

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1516,6 +1516,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@chainner/node-path@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "@chainner/node-path@npm:0.1.1"
+  checksum: 10/2f71d598c730daf6d833aadb50c8773a24e0bc9f567c67e855ee0e9a2b6c4c0230de1f654ffc2a34936fb82f548b080025d3134ea381709e59999473296d3965
+  languageName: node
+  linkType: hard
+
 "@choojs/findup@npm:^0.2.0":
   version: 0.2.1
   resolution: "@choojs/findup@npm:0.2.1"
@@ -2855,6 +2862,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fiftyone/utilities@workspace:packages/utilities"
   dependencies:
+    "@chainner/node-path": "npm:^0.1.1"
     "@microsoft/fetch-event-source": "npm:^2.0.1"
     fetch-retry: "npm:^5.0.3"
     lodash: "npm:^4.17.21"


### PR DESCRIPTION
## What changes are proposed in this pull request?

We previously added path-browserify in the app to polyfill node.js path operations. However this package does not include win32 so windows paths are failing to operate. 

Adding @chainner/node-path directly applies the node.js win32 methods for us to be avilable to use. https://www.npmjs.com/package/@chainner/node-path.

## How is this patch tested? If it is not, please explain why.

Previous state: Pasting a Windows path into the File Explorer raised an exception due to `win32.parse` being null, and required manually editing the path to be in POSIX format. This exception also interfered with other actions (selecting directory, etc.).

After change: UI proceeds, allows "execute" to be pressed and successfully exports to selected path:
<img width="554" height="690" alt="image" src="https://github.com/user-attachments/assets/a523ec94-1001-481a-8e4b-9b6af11e9de9" />


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fix bug where interactions with Windows file paths would fail

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal path utility dependencies for improved code maintainability while preserving all existing functionality for Windows, Linux, and URL path handling.

* **Style**
  * Minor formatting improvements to code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->