### PR TITLE
Fix selecting dynamic embedded doc fields in the sidebar

### DIFF
--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -339,7 +339,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           continue;
         }
 
-        const field = getField([...path.split("."), k], fieldSchema);
+        const field = getField([...pathParts, k], fieldSchema);
 
         // Handle dynamic embedded document fields that don't define an explicit ftype
         if (!field) {


### PR DESCRIPTION
## What changes are proposed in this pull request?

- [FOEPD-2579] Fix `TypeError: Cannot read properties of undefined (reading 'ftype')` when selecting a dynamic embedded doc in the sidebar

https://github.com/user-attachments/assets/465d23c4-134b-40a6-9c9a-f183b237d3a6



## How is this patch tested? If it is not, please explain why.

- add a custom dynamic embedded field
- create sidebar group with a field on the dynamic embedded doc
- load dataset in the app and select the field
- no longer errors out


https://github.com/user-attachments/assets/fbd9045f-5e9e-44fb-8016-bff95f9163b6


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fix ability to select dynamic embedded doc fields in the sidebar.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of embedded document fields: internal/meta fields are skipped, targeted embedded fields render alone, primitive values render directly when no type is defined, and dynamic embedded fields with primitive values are now displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[FOEPD-2579]: https://voxel51.atlassian.net/browse/FOEPD-2579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ