### PR TITLE
FOEPD-2553 - Fix mixed views response for video tagging

### DIFF
--- a/fiftyone/server/routes/tag.py
+++ b/fiftyone/server/routes/tag.py
@@ -80,7 +80,7 @@ class Tag(HTTPEndpoint):
         )
 
         view, is_video = fosu.attach_frame_if_necessary(
-            view, current_frame, modal, slice=slice
+            view, current_frame, modal, group_slice=slice
         )
 
         samples = []

--- a/fiftyone/server/utils/__init__.py
+++ b/fiftyone/server/utils/__init__.py
@@ -154,21 +154,21 @@ def meets_type(field: fof.Field, type_or_types):
     )
 
 
-def attach_frame_if_necessary(view, frame_number, modal, slice=None):
+def attach_frame_if_necessary(view, frame_number, modal, group_slice=None):
     """Attaches a frame to view when applicable
 
     Args:
         view: the dataset view
         frame_number: a frame number
         modal: whether this is an App modal request
-        slice (None): the group slice
+        group_slice (None): the group slice
 
     Returns:
         a new view and whether the attachment is true
     """
     is_video = view.media_type == fom.VIDEO
     if view.media_type == fom.MIXED:
-        is_video = view._dataset.group_media_types[slice] == fom.VIDEO
+        is_video = view._dataset.group_media_types[group_slice] == fom.VIDEO
 
     if is_video and frame_number is not None:
         default_filter = F("frame_number") == 1

--- a/tests/unittests/server_utils_tests.py
+++ b/tests/unittests/server_utils_tests.py
@@ -8,13 +8,9 @@ FiftyOne Server utils tests.
 
 import unittest
 
-import strawberry as gql
-from strawberry.schema.config import StrawberryConfig
-
 import fiftyone as fo
 
 from fiftyone.server.utils import attach_frame_if_necessary
-from fiftyone.server.query import Dataset
 
 from decorators import drop_datasets
 
@@ -42,7 +38,7 @@ class TestServerUtils(unittest.TestCase):
             video_group.select_group_slices(media_type="video"),
             1,
             False,
-            slice="video",
+            group_slice="video",
         )
         serialized = view._serialize(include_uuids=False)
         self.assertEqual(is_video, True)
@@ -108,7 +104,7 @@ class TestServerUtils(unittest.TestCase):
             video_group.select_group_slices(_allow_mixed=True),
             1,
             False,
-            slice="video",
+            group_slice="video",
         )
         serialized = view._serialize(include_uuids=False)
         self.assertEqual(is_video, True)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix video slice tagging in the modal on group datasets

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = fo.Dataset("video-group")
dataset.add_group_field("group", default="video")
video = foz.load_zoo_dataset("quickstart-video")

first = video.first()
first["group"] = fo.Group().element("video")

dataset.add_sample(first)
``` 

### Before


https://github.com/user-attachments/assets/c2c7a7d0-0996-4174-85fd-1cddc9677f15



### After
https://github.com/user-attachments/assets/16408924-236c-469e-8a86-55b58d4a6cb9


## How is this patch tested? If it is not, please explain why.

Server tests

## Release Notes

* Fixed video sample tagging in the App for group datasets
*
### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined video frame filtering and selection across image, video, and mixed-media datasets, improving consistency and reliability when viewing specific frames.

* **Tests**
  * Added unit tests covering frame-attachment behavior for images, videos, and mixed media to ensure correct frame selection and grouping behavior across scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->