### PR TITLE
Align manifest embeddings tags with model has_embeddings attribute

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -7592,7 +7592,14 @@
                     "support": true
                 }
             },
-            "tags": ["detection", "coco", "torch", "transformers", "rtdetr"],
+            "tags": [
+                "detection",
+                "coco",
+                "embeddings",
+                "torch",
+                "transformers",
+                "rtdetr"
+            ],
             "training_data": [
                 { "name": "MS COCO 2017", "url": "https://cocodataset.org" }
             ],
@@ -7628,6 +7635,7 @@
             "tags": [
                 "detection",
                 "coco",
+                "embeddings",
                 "torch",
                 "transformers",
                 "rtdetr",
@@ -7665,6 +7673,7 @@
             "tags": [
                 "detection",
                 "coco",
+                "embeddings",
                 "torch",
                 "transformers",
                 "detr",
@@ -7702,6 +7711,7 @@
             "tags": [
                 "detection",
                 "coco",
+                "embeddings",
                 "torch",
                 "transformers",
                 "detr",
@@ -7739,6 +7749,7 @@
             "tags": [
                 "detection",
                 "coco",
+                "embeddings",
                 "torch",
                 "transformers",
                 "detr",
@@ -7776,6 +7787,7 @@
             "tags": [
                 "detection",
                 "coco",
+                "embeddings",
                 "torch",
                 "transformers",
                 "detr",
@@ -7813,6 +7825,7 @@
             "tags": [
                 "detection",
                 "coco",
+                "embeddings",
                 "torch",
                 "transformers",
                 "detr",


### PR DESCRIPTION
Fixed 28 discrepancies between the manifest "embeddings" tag and the actual `has_embeddings` attribute returned by torch models.

**Added "embeddings" tag to 27 models:**
- All ConvNeXt models (5 variants)
- All EfficientNet models (8 variants)
- All Swin-v2 models (4 variants)
- All SegFormer models (6 variants)
- Medical models: medsiglip-448-zero-torch, monet-zero-torch, pubmed-clip-vit-base-patch32
- segmentation-transformer-torch

**Removed "embeddings" tag from 1 model:**
- zero-shot-detection-transformer-torch

## Context

The embeddings tag is used in the app to determine if a model can compute embeddings without loading the model (see the compute_visualization operator). This PR ensures the manifest accurately reflects each model's actual capabilities by aligning tags with the `has_embeddings` property.

This builds on #6575 which fixed the OWLViT models.