### PR TITLE
add support for custom view target in ctx.target_view

### DIFF
--- a/fiftyone/operators/constants.py
+++ b/fiftyone/operators/constants.py
@@ -43,3 +43,10 @@ class ViewTarget:
 
     SELECTED_SAMPLES = "SELECTED_SAMPLES"
     """Selected samples in the app view, if any."""
+
+    CUSTOM_VIEW_TARGET = "CUSTOM_VIEW_TARGET"
+    """Custom view target specified by the caller.
+
+    When using this option, specify 'custom_view_target' in the
+    operator parameters with a list of JSON-serialized view stages to apply.
+    """

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -717,6 +717,12 @@ class ExecutionContext(contextlib.AbstractContextManager):
             return self.view.select_labels(self.selected_labels)
         if target == constants.ViewTarget.DATASET_VIEW:
             return self.dataset.view()
+        if target == constants.ViewTarget.CUSTOM_VIEW_TARGET:
+            if (
+                view_stages := self.params.get("custom_view_target")
+            ) is not None:
+                # pylint: disable-next-line=protected-access
+                return fov.DatasetView._build(self.dataset, view_stages)
 
         return self.view if self.has_custom_view else self.dataset
 

--- a/tests/unittests/operators/executor_tests.py
+++ b/tests/unittests/operators/executor_tests.py
@@ -103,6 +103,7 @@ class TestOperatorExecutionContext(unittest.TestCase):
                     constants.ViewTarget.SELECTED_SAMPLES,
                     view.select([selected]),
                 ),
+                (constants.ViewTarget.CUSTOM_VIEW_TARGET, ds.limit(5)),
                 ("TESTING_INVALID", view),
                 (None, view),
             ]
@@ -113,6 +114,12 @@ class TestOperatorExecutionContext(unittest.TestCase):
                     "params": {
                         "name": "Jon",
                         "view_target": target_view,
+                        "custom_view_target": [
+                            {
+                                "_cls": "fiftyone.core.stages.Limit",
+                                "kwargs": [["limit", 5]],
+                            }
+                        ],
                     },
                     "view": [
                         {


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds support for specifying a custom view target which can be resolved via `ctx.target_view()`.

This option adds flexibility to operators in cases where the desired view is known, but distinct from the session's _current_ view.

## How is this patch tested? If it is not, please explain why.

local, unit

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Added option to provide a custom view via context parameters when invoking an operator programmatically.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Operators now support custom view targets, enabling flexible view configuration control. Users can define custom view behaviors by passing JSON-serialized view stage definitions through the custom_view_target parameter when invoking operators. This enables caller-specified custom viewing options and dynamic view modification at runtime without requiring changes to operator code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->