### PR TITLE
Support displaying date fields in nested embedded docs 

### DIFF
--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -352,13 +352,21 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           ) {
             // Render the value of the embedded doc field
             results.push(String(v));
-          } else if (typeof v === "object" && v !== null) {
+          } else if (
+            typeof v === "object" &&
+            v !== null &&
+            "_cls" in v &&
+            typeof v["_cls"] === "string"
+          ) {
             // Handle Date and DateTime primitives within the embedded doc
             const ftype = withPath(FIELDS_PATH, v["_cls"] + "Field");
-            if (ftype) {
-              results.push(
-                formatPrimitive({ ftype, timeZone, value: v as Primitive })
-              );
+            const formatted = formatPrimitive({
+              ftype,
+              timeZone,
+              value: v as Primitive,
+            });
+            if (formatted !== null) {
+              results.push(formatted);
             }
           }
           continue;

--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -1,7 +1,7 @@
 /**
  * Copyright 2017-2025, Voxel51, Inc.
  */
-import type { COLOR_BY } from "@fiftyone/utilities";
+import type { COLOR_BY, Primitive } from "@fiftyone/utilities";
 import {
   BOOLEAN_FIELD,
   CLASSIFICATION,
@@ -24,6 +24,8 @@ import {
   formatDateTime,
   getColor,
   withPath,
+  FIELDS_PATH,
+  formatPrimitive,
 } from "@fiftyone/utilities";
 import { isEqual } from "lodash";
 import type {
@@ -350,6 +352,14 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           ) {
             // Render the value of the embedded doc field
             results.push(String(v));
+          } else if (typeof v === "object" && v !== null) {
+            // Handle Date and DateTime primitives within the embedded doc
+            const ftype = withPath(FIELDS_PATH, v["_cls"] + "Field");
+            if (ftype) {
+              results.push(
+                formatPrimitive({ ftype, timeZone, value: v as Primitive })
+              );
+            }
           }
           continue;
         }

--- a/app/packages/utilities/src/index.ts
+++ b/app/packages/utilities/src/index.ts
@@ -390,6 +390,7 @@ export const DYNAMIC_GROUP_FIELDS = [
   STRING_FIELD,
 ];
 
+export const FIELDS_PATH = "fiftyone.core.fields";
 export const LABELS_PATH = "fiftyone.core.labels";
 
 export const PATCHES_FIELDS = withPath(LABELS_PATH, [


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Fix selecting nested date types in the sidebar by rendering them as primitives

## How is this patch tested? If it is not, please explain why.

- add DateTime field via: 
```
from datetime import timedelta, datetime
now = datetime.now()
modified_at=[now -timedelta(days=i) for i in range(len(ds))]
ds.set_values('ground_truth.mistakenness.modified_at', modified_at)

```

https://github.com/user-attachments/assets/6107801c-fabc-4f03-b08c-e51cd0f32c4a




## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and formatting of date/datetime values inside embedded documents so primitive values display correctly.
* **Chores**
  * Added a new public constant for field path wiring to support formatting logic across the app.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->