### PR TITLE
Enforce client_type 

### DIFF
--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -226,6 +226,7 @@ def establish_db_conn(config):
 
     db_config = get_db_config()
     if db_config.type != foc.CLIENT_TYPE:
+        _disconnect()
         raise ConnectionError(
             "Cannot connect to database type '%s' with client type '%s'"
             % (db_config.type, foc.CLIENT_TYPE)


### PR DESCRIPTION
## What changes are proposed in this pull request?

- FOEPD-2604
- enforce client type requirement 

## How is this patch tested? If it is not, please explain why.

- try to connect to fiftyone-teams db with fiftyone and vice versa. Currently after the first error, it allows accessing the data. Now, it doesn't.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection error handling to ensure proper resource cleanup when connection configuration mismatches occur, preventing potential resource leakage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->