### PR TITLE
Fix convnext sizes

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -244,7 +244,8 @@
                 "sa-1b",
                 "torch",
                 "zero-shot",
-                "transformer"
+                "transformer",
+                "official"
             ],
             "training_data": [
                 {
@@ -286,7 +287,7 @@
                     "support": true
                 }
             },
-            "tags": ["segment-anything", "torch", "zero-shot"],
+            "tags": ["segment-anything", "torch", "zero-shot", "official"],
             "training_data": [
                 {
                     "name": "SA-V",
@@ -644,7 +645,8 @@
                 "torch",
                 "zero-shot",
                 "video",
-                "transformer"
+                "transformer",
+                "official"
             ],
             "training_data": [
                 {
@@ -744,7 +746,7 @@
                     "support": true
                 }
             },
-            "tags": ["segment-anything", "torch", "zero-shot", "transformer"],
+            "tags": ["segment-anything", "torch", "zero-shot", "transformer", "official"],
             "training_data": [
                 {
                     "name": "SA-V",
@@ -954,7 +956,8 @@
                 "torch",
                 "zero-shot",
                 "video",
-                "transformer"
+                "transformer",
+                "official"
             ],
             "training_data": [
                 {
@@ -1287,7 +1290,8 @@
                 "logits",
                 "imagenet",
                 "torch",
-                "densenet"
+                "densenet",
+                "official"
             ],
             "training_data": [
                 {
@@ -2363,7 +2367,8 @@
                 "logits",
                 "imagenet",
                 "torch",
-                "resnext"
+                "resnext",
+                "official"
             ],
             "training_data": [
                 {
@@ -2409,7 +2414,7 @@
                     "support": true
                 }
             },
-            "tags": ["detection", "coco", "torch", "retinanet", "resnet"],
+            "tags": ["detection", "coco", "torch", "retinanet", "resnet", "official"],
             "training_data": [
                 { "name": "MS COCO 2017", "url": "https://cocodataset.org" }
             ],
@@ -2568,7 +2573,7 @@
                     "support": true
                 }
             },
-            "tags": ["classification", "imagenet", "torch", "squeezenet"],
+            "tags": ["classification", "imagenet", "torch", "squeezenet", "official"],
             "training_data": [
                 {
                     "name": "ImageNet-1K",
@@ -6810,7 +6815,7 @@
             "source": "https://huggingface.co/facebook/convnext-tiny-224",
             "author": "Zhuang Liu, et al.",
             "license": "Apache 2.0",
-            "size_bytes": 457742046,
+            "size_bytes": 228984557,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForImageClassification",
                 "config": {
@@ -6836,7 +6841,8 @@
                 "torch",
                 "transformers",
                 "convnext",
-                "embeddings"
+                "embeddings",
+                "official"
             ],
             "training_data": [
                 {
@@ -6899,7 +6905,7 @@
             "source": "https://huggingface.co/facebook/convnext-base-224",
             "author": "Zhuang Liu, et al.",
             "license": "Apache 2.0",
-            "size_bytes": 1417939660,
+            "size_bytes": 709242057,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForImageClassification",
                 "config": {
@@ -6944,7 +6950,7 @@
             "source": "https://huggingface.co/facebook/convnext-large-224",
             "author": "Zhuang Liu, et al.",
             "license": "Apache 2.0",
-            "size_bytes": 3164754044,
+            "size_bytes": 1582656553,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForImageClassification",
                 "config": {
@@ -6970,7 +6976,8 @@
                 "torch",
                 "transformers",
                 "convnext",
-                "embeddings"
+                "embeddings",
+                "official"
             ],
             "training_data": [
                 {
@@ -7598,7 +7605,8 @@
                 "embeddings",
                 "torch",
                 "transformers",
-                "rtdetr"
+                "rtdetr",
+                "official"
             ],
             "training_data": [
                 { "name": "MS COCO 2017", "url": "https://cocodataset.org" }
@@ -8236,7 +8244,8 @@
                 "coco",
                 "torch",
                 "transformers",
-                "pose-estimation"
+                "pose-estimation",
+                "official"
             ],
             "training_data": [
                 { "name": "MS COCO 2017", "url": "https://cocodataset.org" }
@@ -8275,7 +8284,8 @@
                 "coco",
                 "torch",
                 "transformers",
-                "pose-estimation"
+                "pose-estimation",
+                "official"
             ],
             "training_data": [
                 { "name": "MS COCO 2017", "url": "https://cocodataset.org" }
@@ -8314,7 +8324,8 @@
                 "coco",
                 "torch",
                 "transformers",
-                "pose-estimation"
+                "pose-estimation",
+                "official"
             ],
             "training_data": [
                 { "name": "MS COCO 2017", "url": "https://cocodataset.org" }
@@ -8353,7 +8364,8 @@
                 "coco",
                 "torch",
                 "transformers",
-                "pose-estimation"
+                "pose-estimation",
+                "official"
             ],
             "training_data": [
                 { "name": "MS COCO 2017", "url": "https://cocodataset.org" }
@@ -8392,7 +8404,8 @@
                 "coco",
                 "torch",
                 "transformers",
-                "pose-estimation"
+                "pose-estimation",
+                "official"
             ],
             "training_data": [
                 { "name": "MS COCO 2017", "url": "https://cocodataset.org" }
@@ -8431,7 +8444,8 @@
                 "coco",
                 "torch",
                 "transformers",
-                "pose-estimation"
+                "pose-estimation",
+                "official"
             ],
             "training_data": [
                 { "name": "MS COCO 2017", "url": "https://cocodataset.org" }


### PR DESCRIPTION
Corrected size_bytes values for three ConvNeXt models in manifest-torch.json that were incorrectly doubled:

  - convnext-tiny-224-torch: 457,742,046 → 228,984,557 bytes (437 → 218 MB)
  - convnext-base-224-torch: 1,417,939,660 → 709,242,057 bytes (1352 → 676 MB)
  - convnext-large-224-torch: 3,164,754,044 → 1,582,656,553 bytes (3018 → 1509 MB)

  - Add official tag to 18 models: segment-anything variants, densenet161,
  resnext50-32x4d, retinanet-resnet50-fpn, squeezenet-1.1, convnext-tiny/large,
  rtdetr-v2-s, and vitpose models