### PR TITLE
Fix lfw dataset download

### DIFF
--- a/fiftyone/utils/lfw.py
+++ b/fiftyone/utils/lfw.py
@@ -46,7 +46,8 @@ def download_lfw_dataset(dataset_dir, scratch_dir=None, cleanup=True):
         for test_folder in pb(test_folders):
             indir = os.path.join(images_dir, test_folder)
             outdir = os.path.join(dataset_dir, "test", test_folder)
-            etau.move_dir(indir, outdir)
+            if os.path.exists(indir):
+                etau.move_dir(indir, outdir)
 
     # Train split
     logger.info("Creating train split...")
@@ -55,7 +56,8 @@ def download_lfw_dataset(dataset_dir, scratch_dir=None, cleanup=True):
         for train_folder in pb(train_folders):
             indir = os.path.join(images_dir, train_folder)
             outdir = os.path.join(dataset_dir, "train", train_folder)
-            etau.move_dir(indir, outdir)
+            if os.path.exists(indir):
+                etau.move_dir(indir, outdir)
 
     if cleanup:
         etau.delete_dir(scratch_dir)


### PR DESCRIPTION
Fix LFW download URLs and handle overlapping splits

- Replace broken UMass URLs with working figshare mirrors
- Add existence check before moving directories to handle people
  who appear in both train and test splits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of data organization by adding validation before moving directories.

* **Chores**
  * Updated dataset resource hosting for improved reliability and availability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->