### PR TITLE
Preserve unlabeled samples in exports

### DIFF
--- a/fiftyone/utils/bdd.py
+++ b/fiftyone/utils/bdd.py
@@ -334,26 +334,30 @@ class BDDDatasetExporter(
     def export_sample(self, image_or_path, labels, metadata=None):
         out_image_path, uuid = self._media_exporter.export(image_or_path)
 
-        if labels is None:
-            return  # unlabeled
-
-        if not isinstance(labels, dict):
-            labels = {"labels": labels}
-
-        if all(v is None for v in labels.values()):
-            return  # unlabeled
-
-        if metadata is None:
-            metadata = fom.ImageMetadata.build_for(image_or_path)
-
         if self.abs_paths:
             name = out_image_path
         else:
             name = uuid
 
-        annotation = _make_bdd_annotation(
-            labels, metadata, name, self.extra_attrs
+        if labels is not None and not isinstance(labels, dict):
+            labels = {"labels": labels}
+
+        has_labels = (
+            labels is not None
+            and labels
+            and not all(v is None for v in labels.values())
         )
+
+        if has_labels:
+            if metadata is None:
+                metadata = fom.ImageMetadata.build_for(image_or_path)
+
+            annotation = _make_bdd_annotation(
+                labels, metadata, name, self.extra_attrs
+            )
+        else:
+            annotation = {"name": name, "attributes": {}, "labels": []}
+
         self._annotations.append(annotation)
 
     def close(self, *args):


### PR DESCRIPTION
## What changes are proposed in this pull request?

While reviewing issue #6454 involving CVAT exports, I confirmed the reported behavior: when you export and re-import a dataset multiple times, one sample disappears.

Here’s what happens:

* The quickstart dataset has **200 samples**, but one of them (`004170.jpg`) contains an **empty `Detections` object** (no bounding boxes).
* On the first export, this sample **is included** because `Detections([])` is not `None`.
* After the first import, that field becomes **`None` instead of an empty `Detections`**, so on the next export the exporter runs this check:

```python
if all(v is None for v in labels.values()):
    return
```

Since the label is now `None`, the XML entry is skipped. The image file is exported, but the annotation is not, so on the **second import the sample is lost**.

I checked the BDD exporter as well (same structure) and confirmed it has the same issue. I updated both exporters so that they **always write an entry for every image**, even when there are no annotations. This aligns with the behavior of the COCO exporter, which already handles empty labels correctly.

## How is this patch tested?
Manually tested with the quickstart dataset (200 samples, 1 with empty/None `ground_truth`) via CVAT:
  * After 1 export/import: 200 samples
  * After 2 export/import cycles: 200 samples
* Confirmed the same behavior and fix for the BDD exporter.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [ ] No. You can skip the rest of this section.
* [x] Yes. Give a description of this change to be included in the release
  notes for FiftyOne users.

**Description (1–2 sentences):**
Fix an issue in the CVAT and BDD exporters where images with no annotations could be dropped after multiple export/import cycles. Exporters now always include all images in the output, even when they have no labels.

### What areas of FiftyOne does this PR affect?

* [ ] App: FiftyOne application changes
* [ ] Build: Build and test infrastructure changes
* [x] Core: Core `fiftyone` Python library changes
* [ ] Documentation: FiftyOne documentation changes
* [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for exporting unlabeled images in CVAT format with proper metadata
  * Optimized BDD export logic to efficiently handle samples with and without labels

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->