### PR TITLE
Fix FIW dataset download by migrating to Kaggle

### DIFF
--- a/fiftyone/utils/fiw.py
+++ b/fiftyone/utils/fiw.py
@@ -286,13 +286,12 @@ def _parse_identifier(identifier):
     return "/".join(id_parts[:2])
 
 
-def parse_fiw_dataset(source_dir, dataset_dir, scratch_dir, split):
+def parse_fiw_dataset(source_dir, dataset_dir, split):
     """Parses the manually downloaded FIW dataset.
 
     Args:
         source_dir: the directory containing the manually downloaded FIW files
         dataset_dir: the directory to output the final dataset
-        scratch_dir: a scratch directory for temporary files
         split: the split to prepare
 
     Returns:
@@ -304,7 +303,7 @@ def parse_fiw_dataset(source_dir, dataset_dir, scratch_dir, split):
     return _get_dataset_info(dataset_dir, split)
 
 
-def download_fiw_dataset(dataset_dir, split, source_dir=None, scratch_dir=None, cleanup=False):
+def download_fiw_dataset(dataset_dir, split, source_dir=None):
     """Downloads and extracts the Families in the Wild dataset.
 
     Note:
@@ -317,14 +316,11 @@ def download_fiw_dataset(dataset_dir, split, source_dir=None, scratch_dir=None, 
         split: the split being loaded
         source_dir (None): the directory containing the manually downloaded
             FIW files
-        scratch_dir (None): a scratch directory to use to store temporary files
-        cleanup (True): whether to cleanup the scratch directory after
-            extraction
 
     Returns:
         a tuple of (num_samples, classes)
     """
-    return parse_fiw_dataset(source_dir, dataset_dir, scratch_dir, split)
+    return parse_fiw_dataset(source_dir, dataset_dir, split)
 
 
 def _validate_source_dir(source_dir):
@@ -348,6 +344,24 @@ def _validate_source_dir(source_dir):
     if "train_relationships.csv" not in contents:
         _raise_fiw_error(
             "Required file 'train_relationships.csv' not found in '%s'." % source_dir
+        )
+
+    test_faces_found = (
+        "test-public-faces" in contents
+        or os.path.isdir(os.path.join(source_dir, "test-public-faces", "test-public-faces"))
+    )
+    if not test_faces_found:
+        _raise_fiw_error(
+            "Required directory 'test-public-faces' not found in '%s'." % source_dir
+        )
+
+    test_lists_found = (
+        "test-public-lists" in contents
+        or os.path.isdir(os.path.join(source_dir, "test-public-lists", "test-public-lists"))
+    )
+    if not test_lists_found:
+        _raise_fiw_error(
+            "Required directory 'test-public-lists' not found in '%s'." % source_dir
         )
 
 
@@ -536,7 +550,7 @@ def _generate_mid_csv(family_dir, family_id, member_gender, member_rels):
     mids.sort()
 
     rows = []
-    for row_idx, mid in enumerate(mids):
+    for mid in mids:
         identifier = "%s/MID%d" % (family_id, mid)
         gender = member_gender.get(identifier, "U")
         row = {"MID": mid}

--- a/fiftyone/utils/fiw.py
+++ b/fiftyone/utils/fiw.py
@@ -2,15 +2,15 @@
 Utilities for working with the
 `Families in the Wild dataset <https://web.northeastern.edu/smilelab/fiw/>`_.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
 import logging
 import os
-import shutil
 import random
-from collections import Counter, defaultdict
+import shutil
+from collections import defaultdict
 
 import eta.core.utils as etau
 import pandas as pd
@@ -54,8 +54,8 @@ class FIWDatasetImporter(foud.BatchDatasetImporter):
         data_path = os.path.join(self.dataset_dir, "data")
 
         logger.info("Parsing relationships and adding samples...")
-        samples = _load_split(data_path, tags, labels_path)
-        dataset.add_samples(samples)
+        samples = _load_split(data_path, tags, labels_path, progress=progress)
+        dataset.add_samples(samples, progress=progress)
 
         return sorted(set(dataset.values("id")) - prev_ids)
 
@@ -133,16 +133,20 @@ def get_identifier_filepaths_map(samples):
     return dict(id_map)
 
 
-def _load_split(split_dir, tags, labels_path):
+def _load_split(split_dir, tags, labels_path, progress=None):
     samples = []
     face_indices = defaultdict(lambda: 0)
     kinship_map = _parse_kinship_map(labels_path)
 
     subdirs = etau.list_subdirs(split_dir)
-    with fou.ProgressBar(subdirs) as pb:
+    with fou.ProgressBar(subdirs, progress=progress) as pb:
         for family in pb(subdirs):
             family_dir = os.path.join(split_dir, family)
-            labels = pd.read_csv(os.path.join(split_dir, family, "mid.csv"))
+            mid_csv_path = os.path.join(split_dir, family, "mid.csv")
+            if not os.path.isfile(mid_csv_path):
+                continue
+
+            labels = pd.read_csv(mid_csv_path)
             for member in etau.list_subdirs(family_dir):
                 imgs_dir = os.path.join(family_dir, member)
                 if "MID" in member:
@@ -169,10 +173,17 @@ def _load_member(
     member_id_int = _get_mid(member_id)
     name = _get_name(labels, member_id_int)
     gender = _get_gender(labels, member_id_int)
+
+    if not os.path.isdir(dir_images):
+        return samples
+
     imgs_list = os.listdir(dir_images)
     rels = _get_relationships(labels, member_id_int, num_members, family_id)
 
     for img in imgs_list:
+        if not img.lower().endswith(('.jpg', '.jpeg', '.png')):
+            continue
+
         sample = fo.Sample(filepath=os.path.join(dir_images, img), tags=tags)
         picture, face = _get_picture_face(img)
         sample["family"] = family_id
@@ -237,7 +248,10 @@ def _get_relationships(labels, member_id_int, num_members, family_id):
 
 def _get_picture_face(img_path):
     filename = os.path.splitext(os.path.basename(img_path))[0]
-    return filename.split("_")
+    parts = filename.split("_")
+    if len(parts) >= 2:
+        return parts[0], parts[1]
+    return filename, "face0"
 
 
 def _get_mid(member_id):
@@ -249,29 +263,44 @@ def _format_mid(member_id_int):
 
 
 def _get_name(labels, member_id):
+    if "Name" not in labels.columns:
+        return None
+
     names = labels["Name"]
-    if len(names) >= member_id:
-        return names[member_id - 1]
+    row = labels.loc[labels["MID"] == member_id]
+    if len(row) > 0:
+        return row["Name"].values[0]
 
     return None
 
 
 def _get_gender(labels, member_id):
-    genders = labels["Gender"]
-    if len(genders) >= member_id:
-        return genders[member_id - 1]
+    if "Gender" not in labels.columns:
+        return None
+
+    row = labels.loc[labels["MID"] == member_id]
+    if len(row) > 0:
+        return row["Gender"].values[0]
 
     return None
 
 
 def _parse_kinship_map(labels_path):
+    if not os.path.isfile(labels_path):
+        return {}
+
     split_list = pd.read_csv(labels_path)
     kinship_map = defaultdict(lambda: defaultdict(set))
 
-    pairs = split_list[["p1", "p2", "ptype"]].value_counts().keys()
-    for p1, p2, ptype in pairs:
-        p1 = _parse_identifier(p1)
-        p2 = _parse_identifier(p2)
+    if "p1" not in split_list.columns or "p2" not in split_list.columns:
+        return {}
+
+    ptype_col = "ptype" if "ptype" in split_list.columns else None
+
+    for _, row in split_list.iterrows():
+        p1 = _parse_identifier(row["p1"])
+        p2 = _parse_identifier(row["p2"])
+        ptype = row[ptype_col] if ptype_col else "kin"
         kinship_map[p1][ptype].add(p2)
         kinship_map[p2][ptype].add(p1)
 
@@ -279,6 +308,7 @@ def _parse_kinship_map(labels_path):
 
 
 def _parse_identifier(identifier):
+    identifier = str(identifier).rstrip("/")
     id_parts = identifier.split("/")
     if len(id_parts) not in [2, 3]:
         raise ValueError("Invalid identifier found: '%s'" % identifier)
@@ -289,10 +319,16 @@ def _parse_identifier(identifier):
 def parse_fiw_dataset(source_dir, dataset_dir, split):
     """Parses the manually downloaded FIW dataset.
 
+    This function accepts the official FIW download structure with a ``FIDs/``
+    directory containing all families, and organizes it into the FiftyOne
+    expected format with train/val/test splits.
+
     Args:
-        source_dir: the directory containing the manually downloaded FIW files
+        source_dir: the directory containing the manually downloaded FIW files.
+            Should contain either a ``FIDs/`` directory (official structure) or
+            individual family directories (F0001, F0002, etc.)
         dataset_dir: the directory to output the final dataset
-        split: the split to prepare
+        split: the split to prepare ("train", "val", or "test")
 
     Returns:
         a tuple of (num_samples, classes)
@@ -324,6 +360,7 @@ def download_fiw_dataset(dataset_dir, split, source_dir=None):
 
 
 def _validate_source_dir(source_dir):
+    """Validates the source directory contains FIW data."""
     if source_dir is None:
         _raise_fiw_error(
             "You must provide a `source_dir` in order to load the FIW dataset."
@@ -336,208 +373,222 @@ def _validate_source_dir(source_dir):
 
     contents = os.listdir(source_dir)
 
-    if "train-faces" not in contents:
-        _raise_fiw_error(
-            "Required directory 'train-faces' not found in '%s'." % source_dir
-        )
+    fids_dir = os.path.join(source_dir, "FIDs")
+    has_fids = os.path.isdir(fids_dir)
 
-    if "train_relationships.csv" not in contents:
-        _raise_fiw_error(
-            "Required file 'train_relationships.csv' not found in '%s'." % source_dir
-        )
+    family_dirs = [d for d in contents if d.startswith("F") and d[1:].isdigit()]
+    has_family_dirs = len(family_dirs) > 0
 
-    test_faces_found = (
-        "test-public-faces" in contents
-        or os.path.isdir(os.path.join(source_dir, "test-public-faces", "test-public-faces"))
-    )
-    if not test_faces_found:
+    if not has_fids and not has_family_dirs:
         _raise_fiw_error(
-            "Required directory 'test-public-faces' not found in '%s'." % source_dir
-        )
-
-    test_lists_found = (
-        "test-public-lists" in contents
-        or os.path.isdir(os.path.join(source_dir, "test-public-lists", "test-public-lists"))
-    )
-    if not test_lists_found:
-        _raise_fiw_error(
-            "Required directory 'test-public-lists' not found in '%s'." % source_dir
+            "Source directory '%s' does not contain FIW data.\n"
+            "Expected either a 'FIDs/' directory or family directories "
+            "(F0001, F0002, etc.)" % source_dir
         )
 
 
 def _raise_fiw_error(msg):
+    """Raises an error with instructions for obtaining FIW data."""
     raise OSError(
         "\n\n"
         + msg
         + "\n\n"
-        + "You must download the FIW dataset manually from the official source.\n\n"
+        + "The FIW dataset requires manual download from the official source.\n\n"
         + "1. Register at: https://docs.google.com/forms/d/e/1FAIpQLSd5_hbg-7QlrqE9V4MJShgww308yCxHlj6VOLctETX6aYLQgg/viewform\n"
         + "2. Download and extract the dataset\n"
         + "3. Pass the extraction directory as `source_dir`\n\n"
+        + "Expected structure (official format):\n"
+        + "   source_dir/\n"
+        + "       FIDs/\n"
+        + "           F0001/\n"
+        + "               MID1/\n"
+        + "                   *.jpg\n"
+        + "               mid.csv\n"
+        + "           F0002/\n"
+        + "               ...\n"
+        + "       FIW_PIDs.csv (optional)\n"
+        + "       FIW_FIDs.csv (optional)\n"
+        + "       FIW_RIDs.csv (optional)\n\n"
         + "More info: https://fulab.sites.northeastern.edu/fiw-download/\n"
-        + "Run `fiftyone zoo datasets info fiw` for more information"
+        + "Run `fiftyone zoo datasets info fiw` for more information."
     )
 
 
 def _organize_fiw_data(source_dir, dataset_dir):
-    """Organizes FIW source data into fiftyone expected structure."""
+    """Organizes FIW source data into FiftyOne expected structure."""
     if not _is_missing_images(dataset_dir) and not _is_missing_labels(dataset_dir):
+        logger.info("Dataset already organized, skipping...")
         return
 
-    test_public_lists = os.path.join(source_dir, "test-public-lists")
-    if os.path.isdir(os.path.join(test_public_lists, "test-public-lists")):
-        test_public_lists = os.path.join(test_public_lists, "test-public-lists")
+    logger.info("Organizing FIW data...")
 
-    logger.info("Building member metadata from typed pairs...")
-    pair_to_type, member_gender, member_rels = _build_member_metadata(
-        test_public_lists
+    fids_dir = os.path.join(source_dir, "FIDs")
+
+    if os.path.isdir(fids_dir):
+        _organize_fids_structure(fids_dir, dataset_dir)
+    else:
+        _organize_fids_structure(source_dir, dataset_dir)
+
+
+def _organize_fids_structure(families_dir, dataset_dir):
+    """Organizes official FIW FIDs structure."""
+    logger.info("Detected official FIDs structure")
+
+    all_families = sorted([
+        d for d in os.listdir(families_dir)
+        if os.path.isdir(os.path.join(families_dir, d))
+        and d.startswith("F")
+        and (d[1:5].isdigit() if len(d) > 4 else d[1:].isdigit())
+    ])
+
+    if not all_families:
+        _raise_fiw_error(
+            "No family directories found in '%s'." % families_dir
+        )
+
+    logger.info("Found %d families", len(all_families))
+
+    families_with_relationships = []
+    for family in all_families:
+        family_dir = os.path.join(families_dir, family)
+        mid_csv = _find_mid_csv(family_dir, family)
+        if mid_csv and _has_relationships(mid_csv):
+            families_with_relationships.append(family)
+
+    logger.info(
+        "Found %d families with relationship data",
+        len(families_with_relationships)
     )
 
-    relationships_csv = os.path.join(source_dir, "train_relationships.csv")
-    train_rels_df = (
-        pd.read_csv(relationships_csv)
-        if os.path.exists(relationships_csv)
-        else pd.DataFrame()
+    random.seed(42)
+
+    if len(families_with_relationships) >= 10:
+        n_val = max(1, len(families_with_relationships) // 10)
+        n_test = max(1, len(families_with_relationships) // 10)
+
+        shuffled = families_with_relationships.copy()
+        random.shuffle(shuffled)
+
+        val_families = set(shuffled[:n_val])
+        test_families = set(shuffled[n_val:n_val + n_test])
+        train_families = set(all_families) - val_families - test_families
+    else:
+        train_families = set(all_families)
+        val_families = set()
+        test_families = set()
+
+    split_assignments = {
+        "train": train_families,
+        "val": val_families,
+        "test": test_families,
+    }
+
+    logger.info(
+        "Split sizes - train: %d, val: %d, test: %d",
+        len(train_families), len(val_families), len(test_families)
     )
 
-    # Get families with relationship data
-    families_with_rels = set()
-    if len(train_rels_df) > 0:
-        for col in ["p1", "p2"]:
-            for val in train_rels_df[col]:
-                families_with_rels.add(val.split("/")[0])
+    all_pairs = defaultdict(list)
 
-    train_faces_src = os.path.join(source_dir, "train-faces")
-    all_train_families = (
-        set(os.listdir(train_faces_src))
-        if os.path.isdir(train_faces_src)
-        else set()
-    )
-
-    # Split families with relationships 80/20 for train/val
-    complete_families = sorted(families_with_rels & all_train_families)
-    random.seed(42)  # Reproducible split
-    val_count = len(complete_families) // 5
-    val_families = set(random.sample(complete_families, val_count))
-
-    # Families without relationships go to train only
-    train_families = all_train_families - val_families
-
-    # Organize train data
-    if os.path.isdir(train_faces_src):
-        train_data_dest = os.path.join(dataset_dir, "train", "data")
-        etau.ensure_dir(train_data_dest)
-        for family in train_families:
-            src_family = os.path.join(train_faces_src, family)
-            dest_family = os.path.join(train_data_dest, family)
-            if os.path.isdir(src_family) and not os.path.exists(dest_family):
-                shutil.copytree(src_family, dest_family)
-                _generate_mid_csv(
-                    dest_family, family, member_gender, member_rels
-                )
-
-    # Organize val data
-    if os.path.isdir(train_faces_src):
-        val_data_dest = os.path.join(dataset_dir, "val", "data")
-        etau.ensure_dir(val_data_dest)
-        for family in val_families:
-            src_family = os.path.join(train_faces_src, family)
-            dest_family = os.path.join(val_data_dest, family)
-            if os.path.isdir(src_family) and not os.path.exists(dest_family):
-                shutil.copytree(src_family, dest_family)
-                _generate_mid_csv(
-                    dest_family, family, member_gender, member_rels
-                )
-
-    # Generate train labels (excluding val families)
-    if len(train_rels_df) > 0:
-        train_pairs = [
-            (row["p1"].rstrip("/"), row["p2"].rstrip("/"))
-            for _, row in train_rels_df.iterrows()
-            if row["p1"].split("/")[0] not in val_families
-        ]
-        labels_path = os.path.join(dataset_dir, "train", "labels.csv")
-        _generate_labels_csv(train_pairs, labels_path, pair_to_type)
-
-        # Generate val labels
-        val_pairs = [
-            (row["p1"].rstrip("/"), row["p2"].rstrip("/"))
-            for _, row in train_rels_df.iterrows()
-            if row["p1"].split("/")[0] in val_families
-        ]
-        labels_path = os.path.join(dataset_dir, "val", "labels.csv")
-        _generate_labels_csv(val_pairs, labels_path, pair_to_type)
-
-    test_faces_src = os.path.join(source_dir, "test-public-faces")
-    if os.path.isdir(os.path.join(test_faces_src, "test-public-faces")):
-        test_faces_src = os.path.join(test_faces_src, "test-public-faces")
-    if os.path.isdir(test_faces_src):
-        test_data_dest = os.path.join(dataset_dir, "test", "data")
-        etau.ensure_dir(test_data_dest)
-        for family in os.listdir(test_faces_src):
-            src_family = os.path.join(test_faces_src, family)
-            dest_family = os.path.join(test_data_dest, family)
-            if os.path.isdir(src_family) and not os.path.exists(dest_family):
-                shutil.copytree(src_family, dest_family)
-                _generate_mid_csv(
-                    dest_family, family, member_gender, member_rels
-                )
-
-        labels_path = os.path.join(dataset_dir, "test", "labels.csv")
-        _generate_test_labels_csv(test_public_lists, labels_path)
-
-    splits_path = os.path.join(dataset_dir, "splits.csv")
-    _generate_splits_csv(dataset_dir, splits_path)
-
-
-def _build_member_metadata(test_public_dir):
-    """Build gender and relationship info from typed pairs."""
-    member_gender_votes = defaultdict(Counter)
-    member_rels = defaultdict(dict)
-    pair_to_type = {}
-
-    if not os.path.isdir(test_public_dir):
-        return {}, {}, {}
-
-    for f in os.listdir(test_public_dir):
-        if not f.endswith(".csv"):
+    for split_name, families in split_assignments.items():
+        if not families:
             continue
-        rtype = f.replace(".csv", "")
-        df = pd.read_csv(os.path.join(test_public_dir, f))
 
-        g1, g2 = _TYPE_TO_GENDER.get(rtype, (None, None))
-        r1, r2 = _TYPE_TO_REL.get(rtype, (None, None))
+        split_data_dir = os.path.join(dataset_dir, split_name, "data")
+        etau.ensure_dir(split_data_dir)
 
-        for _, row in df.iterrows():
-            p1 = row["p1"].rstrip("/")
-            p2 = row["p2"].rstrip("/")
+        for family in families:
+            src_family = os.path.join(families_dir, family)
+            dest_family = os.path.join(split_data_dir, family)
 
-            key = (min(p1, p2), max(p1, p2))
-            pair_to_type[key] = rtype
+            if os.path.exists(dest_family):
+                continue
 
-            if g1:
-                member_gender_votes[p1][g1] += 1
-            if g2:
-                member_gender_votes[p2][g2] += 1
-            if r1:
-                member_rels[p1][p2] = r1
-            if r2:
-                member_rels[p2][p1] = r2
+            _copy_family(src_family, dest_family, family)
 
-    member_gender = {}
-    for m, votes in member_gender_votes.items():
-        if votes:
-            member_gender[m] = votes.most_common(1)[0][0]
+            pairs = _extract_pairs_from_family(dest_family, family)
+            all_pairs[split_name].extend(pairs)
 
-    return pair_to_type, member_gender, dict(member_rels)
+    _generate_splits_csv(dataset_dir, all_families)
+
+    for split_name in _SPLITS:
+        labels_path = os.path.join(dataset_dir, split_name, "labels.csv")
+        if not os.path.exists(labels_path) or os.path.getsize(labels_path) == 0:
+            _generate_labels_csv(labels_path, all_pairs.get(split_name, []))
 
 
-def _generate_mid_csv(family_dir, family_id, member_gender, member_rels):
-    """Generate mid.csv with gender and relationship matrix."""
+def _find_mid_csv(family_dir, family_id):
+    """Finds the mid.csv file for a family, checking multiple naming conventions."""
+    candidates = [
+        os.path.join(family_dir, "mid.csv"),
+        os.path.join(family_dir, "%s.csv" % family_id),
+        os.path.join(family_dir, "F%s.csv" % family_id[1:] if family_id.startswith("F") else family_id),
+    ]
+
+    for candidate in candidates:
+        if os.path.isfile(candidate):
+            return candidate
+
+    csv_files = [f for f in os.listdir(family_dir) if f.endswith(".csv")]
+    if len(csv_files) == 1:
+        return os.path.join(family_dir, csv_files[0])
+
+    return None
+
+
+def _has_relationships(mid_csv_path):
+    """Checks if a mid.csv file contains relationship data."""
+    try:
+        df = pd.read_csv(mid_csv_path)
+        if "MID" not in df.columns:
+            return False
+
+        numeric_cols = [c for c in df.columns if str(c).isdigit() or c.startswith("MID")]
+        numeric_cols = [c for c in numeric_cols if c != "MID"]
+
+        if not numeric_cols:
+            return False
+
+        for col in numeric_cols:
+            if df[col].dtype in ['int64', 'float64']:
+                if (df[col] > 0).any():
+                    return True
+
+        return False
+    except Exception:
+        return False
+
+
+def _copy_family(src_family, dest_family, family_id):
+    """Copies a family directory, ensuring mid.csv exists."""
+    etau.ensure_dir(dest_family)
+
+    mid_csv_src = _find_mid_csv(src_family, family_id)
+
+    for item in os.listdir(src_family):
+        src_item = os.path.join(src_family, item)
+        dest_item = os.path.join(dest_family, item)
+
+        if os.path.isdir(src_item) and item.startswith("MID"):
+            if not os.path.exists(dest_item):
+                shutil.copytree(src_item, dest_item)
+        elif item.endswith(".csv"):
+            if not os.path.exists(dest_item):
+                shutil.copy2(src_item, dest_item)
+
+    dest_mid_csv = os.path.join(dest_family, "mid.csv")
+    if not os.path.exists(dest_mid_csv):
+        if mid_csv_src:
+            shutil.copy2(mid_csv_src, dest_mid_csv)
+        else:
+            _generate_mid_csv(dest_family, family_id)
+
+
+def _generate_mid_csv(family_dir, family_id):
+    """Generates a minimal mid.csv if none exists."""
     mids = []
     for item in os.listdir(family_dir):
-        item_path = os.path.join(family_dir, item)
-        if os.path.isdir(item_path) and item.startswith("MID"):
+        if os.path.isdir(os.path.join(family_dir, item)) and item.startswith("MID"):
             try:
                 mid_num = int(item.replace("MID", ""))
                 mids.append(mid_num)
@@ -545,147 +596,147 @@ def _generate_mid_csv(family_dir, family_id, member_gender, member_rels):
                 continue
 
     if not mids:
-        return None
+        return
 
     mids.sort()
 
     rows = []
     for mid in mids:
-        identifier = "%s/MID%d" % (family_id, mid)
-        gender = member_gender.get(identifier, "U")
         row = {"MID": mid}
-        rels = member_rels.get(identifier, {})
-        for col_idx, other_mid in enumerate(mids):
-            other_id = "%s/MID%d" % (family_id, other_mid)
-            rel_code = rels.get(other_id, 0)
-            row["MID%d" % col_idx] = rel_code
+        for other_mid in mids:
+            row[str(other_mid)] = 0
         row["Name"] = "Member_%d" % mid
-        row["Gender"] = gender
+        row["Gender"] = "U"
         rows.append(row)
 
     df = pd.DataFrame(rows)
     csv_path = os.path.join(family_dir, "mid.csv")
     df.to_csv(csv_path, index=False)
-    return csv_path
 
 
-def _generate_labels_csv(pairs_source, output_path, pair_to_type):
-    """Generate labels.csv with relationship types."""
-    if isinstance(pairs_source, str):
-        df = pd.read_csv(pairs_source)
-        pairs = [
-            (row["p1"].rstrip("/"), row["p2"].rstrip("/"))
-            for _, row in df.iterrows()
-        ]
+def _extract_pairs_from_family(family_dir, family_id):
+    """Extracts kinship pairs from a family's mid.csv."""
+    pairs = []
+
+    mid_csv = os.path.join(family_dir, "mid.csv")
+    if not os.path.isfile(mid_csv):
+        return pairs
+
+    try:
+        df = pd.read_csv(mid_csv)
+    except Exception:
+        return pairs
+
+    if "MID" not in df.columns:
+        return pairs
+
+    for _, row in df.iterrows():
+        mid1 = row["MID"]
+        p1 = "%s/MID%d" % (family_id, mid1)
+
+        for col in df.columns:
+            if col in ["MID", "Name", "Gender"]:
+                continue
+
+            try:
+                rel_code = int(row[col])
+            except (ValueError, TypeError):
+                continue
+
+            if rel_code <= 0 or rel_code not in _RELATIONSHIP_MAP:
+                continue
+
+            try:
+                mid2 = int(col) if str(col).isdigit() else int(str(col).replace("MID", ""))
+            except ValueError:
+                continue
+
+            if mid1 == mid2:
+                continue
+
+            p2 = "%s/MID%d" % (family_id, mid2)
+            ptype = _RELATIONSHIP_MAP[rel_code]
+            pairs.append((p1, p2, ptype))
+
+    return pairs
+
+
+def _generate_splits_csv(dataset_dir, all_families):
+    """Generates splits.csv listing all family IDs."""
+    splits_path = os.path.join(dataset_dir, "splits.csv")
+    if os.path.exists(splits_path):
+        return
+
+    df = pd.DataFrame({"FID": sorted(all_families)})
+    df.to_csv(splits_path, index=False)
+
+
+def _generate_labels_csv(labels_path, pairs):
+    """Generates labels.csv from extracted pairs."""
+    etau.ensure_dir(os.path.dirname(labels_path))
+
+    if not pairs:
+        df = pd.DataFrame(columns=["p1", "p2", "ptype"])
     else:
-        pairs = pairs_source
+        unique_pairs = list(set(pairs))
+        df = pd.DataFrame(unique_pairs, columns=["p1", "p2", "ptype"])
 
-    rows = []
-    for p1, p2 in pairs:
-        key = (min(p1, p2), max(p1, p2))
-        ptype = pair_to_type.get(key, "kin")
-        rows.append({"p1": p1, "p2": p2, "ptype": ptype})
-
-    df_out = pd.DataFrame(rows)
-    etau.ensure_dir(os.path.dirname(output_path))
-    df_out.to_csv(output_path, index=False)
-    return output_path
-
-
-def _generate_test_labels_csv(test_public_dir, output_path):
-    """Generate test labels.csv from test-public-lists."""
-    rows = []
-    for f in os.listdir(test_public_dir):
-        if not f.endswith(".csv"):
-            continue
-        rtype = f.replace(".csv", "")
-        df = pd.read_csv(os.path.join(test_public_dir, f))
-        for _, row in df.iterrows():
-            p1 = row["p1"].rstrip("/")
-            p2 = row["p2"].rstrip("/")
-            rows.append({"p1": p1, "p2": p2, "ptype": rtype})
-
-    df_out = pd.DataFrame(rows)
-    etau.ensure_dir(os.path.dirname(output_path))
-    df_out.to_csv(output_path, index=False)
-    return len(rows)
-
-
-def _generate_splits_csv(data_dir, output_path):
-    """Generate splits.csv listing all family IDs."""
-    families = set()
-    for split in _SPLITS:
-        split_dir = os.path.join(data_dir, split, "data")
-        if os.path.isdir(split_dir):
-            for item in os.listdir(split_dir):
-                if item.startswith("F") and os.path.isdir(
-                    os.path.join(split_dir, item)
-                ):
-                    families.add(item)
-    df = pd.DataFrame({"FID": sorted(families)})
-    df.to_csv(output_path, index=False)
-    return output_path
+    df.to_csv(labels_path, index=False)
 
 
 def _is_missing_images(dataset_dir):
+    """Checks if any split is missing image data."""
     for split in _SPLITS:
-        if not os.path.isdir(os.path.join(dataset_dir, split, "data")):
-            return True
+        split_data = os.path.join(dataset_dir, split, "data")
+        if os.path.isdir(split_data):
+            families = [d for d in os.listdir(split_data)
+                       if os.path.isdir(os.path.join(split_data, d))]
+            if families:
+                return False
 
-    return False
+    return True
 
 
 def _is_missing_labels(dataset_dir):
-    required_files = [os.path.join(dataset_dir, "splits.csv")]
+    """Checks if required label files are missing."""
+    splits_file = os.path.join(dataset_dir, "splits.csv")
+    if not os.path.isfile(splits_file):
+        return True
 
     for split in _SPLITS:
-        required_files.append(os.path.join(dataset_dir, split, "labels.csv"))
-
-    for f in required_files:
-        if not os.path.isfile(f):
+        labels_file = os.path.join(dataset_dir, split, "labels.csv")
+        if not os.path.isfile(labels_file):
             return True
 
     return False
 
 
 def _get_dataset_info(dataset_dir, split):
+    """Gets dataset info for a split."""
     splits_file = os.path.join(dataset_dir, "splits.csv")
-    splits_df = pd.read_csv(splits_file)
+
+    if os.path.isfile(splits_file):
+        splits_df = pd.read_csv(splits_file)
+        classes = sorted(splits_df["FID"].unique())
+    else:
+        classes = []
+
     split_img_glob = os.path.join(
         dataset_dir, split, "data", "*", "*", "*.jpg"
     )
-    num_samples = len(etau.get_glob_matches(split_img_glob))
-    return num_samples, sorted(splits_df["FID"].unique())
+    jpg_matches = etau.get_glob_matches(split_img_glob)
+
+    split_img_glob_png = os.path.join(
+        dataset_dir, split, "data", "*", "*", "*.png"
+    )
+    png_matches = etau.get_glob_matches(split_img_glob_png)
+
+    num_samples = len(jpg_matches) + len(png_matches)
+
+    return num_samples, classes
 
 
 _SPLITS = ["train", "test", "val"]
-
-_TYPE_TO_GENDER = {
-    "fs": ("M", "M"),
-    "fd": ("M", "F"),
-    "ms": ("F", "M"),
-    "md": ("F", "F"),
-    "bb": ("M", "M"),
-    "ss": ("F", "F"),
-    "gfgs": ("M", "M"),
-    "gfgd": ("M", "F"),
-    "gmgs": ("F", "M"),
-    "gmgd": ("F", "F"),
-}
-
-_TYPE_TO_REL = {
-    "fs": (4, 1),
-    "fd": (4, 1),
-    "ms": (4, 1),
-    "md": (4, 1),
-    "bb": (2, 2),
-    "ss": (2, 2),
-    "sibs": (2, 2),
-    "gfgs": (6, 3),
-    "gfgd": (6, 3),
-    "gmgs": (6, 3),
-    "gmgd": (6, 3),
-}
 
 _RELATIONSHIP_MAP = {
     1: "child",

--- a/fiftyone/utils/fiw.py
+++ b/fiftyone/utils/fiw.py
@@ -144,6 +144,7 @@ def _load_split(split_dir, tags, labels_path, progress=None):
             family_dir = os.path.join(split_dir, family)
             mid_csv_path = os.path.join(split_dir, family, "mid.csv")
             if not os.path.isfile(mid_csv_path):
+                logger.warning("Skipping family %s: mid.csv not found", family)
                 continue
 
             labels = pd.read_csv(mid_csv_path)
@@ -266,7 +267,6 @@ def _get_name(labels, member_id):
     if "Name" not in labels.columns:
         return None
 
-    names = labels["Name"]
     row = labels.loc[labels["MID"] == member_id]
     if len(row) > 0:
         return row["Name"].values[0]
@@ -460,14 +460,14 @@ def _organize_fids_structure(families_dir, dataset_dir):
         len(families_with_relationships)
     )
 
-    random.seed(42)
+    rng = random.Random(42)
 
     if len(families_with_relationships) >= 10:
         n_val = max(1, len(families_with_relationships) // 10)
         n_test = max(1, len(families_with_relationships) // 10)
 
         shuffled = families_with_relationships.copy()
-        random.shuffle(shuffled)
+        rng.shuffle(shuffled)
 
         val_families = set(shuffled[:n_val])
         test_families = set(shuffled[n_val:n_val + n_test])
@@ -726,12 +726,17 @@ def _get_dataset_info(dataset_dir, split):
     )
     jpg_matches = etau.get_glob_matches(split_img_glob)
 
+    split_img_glob_jpeg = os.path.join(
+        dataset_dir, split, "data", "*", "*", "*.jpeg"
+    )
+    jpeg_matches = etau.get_glob_matches(split_img_glob_jpeg)
+
     split_img_glob_png = os.path.join(
         dataset_dir, split, "data", "*", "*", "*.png"
     )
     png_matches = etau.get_glob_matches(split_img_glob_png)
 
-    num_samples = len(jpg_matches) + len(png_matches)
+    num_samples = len(jpg_matches) + len(jpeg_matches) + len(png_matches)
 
     return num_samples, classes
 

--- a/fiftyone/utils/fiw.py
+++ b/fiftyone/utils/fiw.py
@@ -151,7 +151,12 @@ def _read_mid_csv(path):
     """
     try:
         df = pd.read_csv(path)
-    except Exception:
+    except (
+        FileNotFoundError,
+        pd.errors.ParserError,
+        pd.errors.EmptyDataError,
+        UnicodeDecodeError,
+    ):
         return None
 
     if len(df.columns) < 2 or len(df) == 0:

--- a/fiftyone/utils/fiw.py
+++ b/fiftyone/utils/fiw.py
@@ -722,21 +722,14 @@ def _has_relationships(mid_csv_path):
     if df is None or "MID" not in df.columns:
         return False
 
-    try:
-        # Relationship columns are the numeric columns that are not MID
-        for col in df.columns:
-            if col in ("MID", "Name", "Gender"):
-                continue
+    # Relationship columns are the numeric columns that are not MID
+    for col in df.columns:
+        if col in ("MID", "Name", "Gender"):
+            continue
 
-            try:
-                vals = pd.to_numeric(df[col], errors="coerce")
-            except Exception:
-                continue
-
-            if vals.notna().any() and (vals > 0).any():
-                return True
-    except Exception:
-        return False
+        vals = pd.to_numeric(df[col], errors="coerce")
+        if vals.notna().any() and (vals > 0).any():
+            return True
 
     return False
 

--- a/fiftyone/utils/fiw.py
+++ b/fiftyone/utils/fiw.py
@@ -133,6 +133,52 @@ def get_identifier_filepaths_map(samples):
     return dict(id_map)
 
 
+def _read_mid_csv(path):
+    """Reads a mid.csv or F####.csv file and normalizes column format.
+
+    The official FIW mid.csv files may use different column naming
+    conventions. Some have a ``MID`` column header, others use a numeric
+    first column (``0``, ``1``, ...) or leave it unnamed.
+
+    This function normalizes the DataFrame so the member-ID column is
+    always named ``MID``.
+
+    Args:
+        path: path to the CSV file
+
+    Returns:
+        a normalized ``pd.DataFrame``, or None if the file cannot be read
+    """
+    try:
+        df = pd.read_csv(path)
+    except Exception:
+        return None
+
+    if len(df.columns) < 2 or len(df) == 0:
+        return None
+
+    if "MID" in df.columns:
+        return df
+
+    first_col = str(df.columns[0])
+
+    # Official FIW uses "0" as the header for the MID column
+    if first_col in ("0", "Unnamed: 0"):
+        df = df.rename(columns={df.columns[0]: "MID"})
+        return df
+
+    # Check if first column looks like MID values (positive integers)
+    try:
+        vals = pd.to_numeric(df.iloc[:, 0], errors="raise")
+        if (vals > 0).all() and vals.nunique() == len(vals):
+            df = df.rename(columns={df.columns[0]: "MID"})
+            return df
+    except (ValueError, TypeError):
+        pass
+
+    return df
+
+
 def _load_split(split_dir, tags, labels_path, progress=None):
     samples = []
     face_indices = defaultdict(lambda: 0)
@@ -142,12 +188,18 @@ def _load_split(split_dir, tags, labels_path, progress=None):
     with fou.ProgressBar(subdirs, progress=progress) as pb:
         for family in pb(subdirs):
             family_dir = os.path.join(split_dir, family)
-            mid_csv_path = os.path.join(split_dir, family, "mid.csv")
-            if not os.path.isfile(mid_csv_path):
-                logger.warning("Skipping family %s: mid.csv not found", family)
+            mid_csv_path = _find_mid_csv(family_dir, family)
+            if mid_csv_path is None:
+                logger.warning("Skipping family %s: no mid.csv found", family)
                 continue
 
-            labels = pd.read_csv(mid_csv_path)
+            labels = _read_mid_csv(mid_csv_path)
+            if labels is None or "MID" not in labels.columns:
+                logger.warning(
+                    "Skipping family %s: could not parse mid.csv", family
+                )
+                continue
+
             for member in etau.list_subdirs(family_dir):
                 imgs_dir = os.path.join(family_dir, member)
                 if "MID" in member:
@@ -323,12 +375,20 @@ def parse_fiw_dataset(source_dir, dataset_dir, split):
     directory containing all families, and organizes it into the FiftyOne
     expected format with train/val/test splits.
 
+    It also accepts a pre-organized structure where data is already split
+    into ``train/``, ``val/``, and ``test/`` subdirectories.
+
     Args:
         source_dir: the directory containing the manually downloaded FIW files.
-            Should contain either a ``FIDs/`` directory (official structure) or
-            individual family directories (F0001, F0002, etc.)
+            Should contain either:
+
+            -   A ``FIDs/`` directory (official structure from
+                https://fulab.sites.northeastern.edu/fiw-download/)
+            -   Individual family directories (``F0001/``, ``F0002/``, etc.)
+            -   A pre-organized split structure (``train/data/``,
+                ``val/data/``, ``test/data/``)
         dataset_dir: the directory to output the final dataset
-        split: the split to prepare ("train", "val", or "test")
+        split: the split to prepare (``"train"``, ``"val"``, or ``"test"``)
 
     Returns:
         a tuple of (num_samples, classes)
@@ -371,20 +431,58 @@ def _validate_source_dir(source_dir):
             "Source directory '%s' does not exist." % source_dir
         )
 
+    # Accept pre-organized split structure
+    if _is_pre_organized(source_dir):
+        return
+
     contents = os.listdir(source_dir)
 
     fids_dir = os.path.join(source_dir, "FIDs")
     has_fids = os.path.isdir(fids_dir)
 
-    family_dirs = [d for d in contents if d.startswith("F") and d[1:].isdigit()]
+    family_dirs = [
+        d for d in contents
+        if os.path.isdir(os.path.join(source_dir, d))
+        and _is_family_dir_name(d)
+    ]
     has_family_dirs = len(family_dirs) > 0
 
     if not has_fids and not has_family_dirs:
         _raise_fiw_error(
             "Source directory '%s' does not contain FIW data.\n"
-            "Expected either a 'FIDs/' directory or family directories "
-            "(F0001, F0002, etc.)" % source_dir
+            "Expected one of:\n"
+            "  - A 'FIDs/' directory (official FIW download)\n"
+            "  - Family directories (F0001/, F0002/, etc.)\n"
+            "  - Pre-organized splits (train/data/, val/data/, test/data/)"
+            % source_dir
         )
+
+
+def _is_family_dir_name(name):
+    """Checks if a directory name matches FIW family naming conventions.
+
+    Accepts ``F0001``, ``F1000``, ``FID0001``, etc.
+    """
+    if name.startswith("FID") and len(name) > 3:
+        return name[3:].isdigit()
+    if name.startswith("F") and len(name) > 1:
+        return name[1:].isdigit()
+    return False
+
+
+def _is_pre_organized(source_dir):
+    """Checks if source_dir already has train/val/test split structure."""
+    for split in _SPLITS:
+        split_data = os.path.join(source_dir, split, "data")
+        if os.path.isdir(split_data):
+            families = [
+                d for d in os.listdir(split_data)
+                if os.path.isdir(os.path.join(split_data, d))
+            ]
+            if families:
+                return True
+
+    return False
 
 
 def _raise_fiw_error(msg):
@@ -394,21 +492,27 @@ def _raise_fiw_error(msg):
         + msg
         + "\n\n"
         + "The FIW dataset requires manual download from the official source.\n\n"
-        + "1. Register at: https://docs.google.com/forms/d/e/1FAIpQLSd5_hbg-7QlrqE9V4MJShgww308yCxHlj6VOLctETX6aYLQgg/viewform\n"
-        + "2. Download and extract the dataset\n"
-        + "3. Pass the extraction directory as `source_dir`\n\n"
-        + "Expected structure (official format):\n"
-        + "   source_dir/\n"
-        + "       FIDs/\n"
-        + "           F0001/\n"
-        + "               MID1/\n"
-        + "                   *.jpg\n"
-        + "               mid.csv\n"
-        + "           F0002/\n"
-        + "               ...\n"
-        + "       FIW_PIDs.csv (optional)\n"
-        + "       FIW_FIDs.csv (optional)\n"
-        + "       FIW_RIDs.csv (optional)\n\n"
+        + "Steps:\n"
+        + "  1. Register at https://fulab.sites.northeastern.edu/fiw-download/\n"
+        + "  2. Download and extract the dataset\n"
+        + "  3. Pass the extraction directory as `source_dir`\n\n"
+        + "Expected structure (official FIW database)::\n\n"
+        + "    source_dir/\n"
+        + "        FIDs/\n"
+        + "            F0001/\n"
+        + "                MID1/\n"
+        + "                    P00001_face0.jpg\n"
+        + "                    ...\n"
+        + "                MID2/\n"
+        + "                    ...\n"
+        + "                mid.csv\n"
+        + "            F0002/\n"
+        + "                ...\n"
+        + "        FIW_PIDs.csv (optional)\n"
+        + "        FIW_FIDs.csv (optional)\n"
+        + "        FIW_RIDs.csv (optional)\n\n"
+        + "The mid.csv file in each family directory contains the\n"
+        + "relationship matrix, names, and genders for family members.\n\n"
         + "More info: https://fulab.sites.northeastern.edu/fiw-download/\n"
         + "Run `fiftyone zoo datasets info fiw` for more information."
     )
@@ -416,8 +520,16 @@ def _raise_fiw_error(msg):
 
 def _organize_fiw_data(source_dir, dataset_dir):
     """Organizes FIW source data into FiftyOne expected structure."""
-    if not _is_missing_images(dataset_dir) and not _is_missing_labels(dataset_dir):
+    if not _is_missing_images(dataset_dir) and not _is_missing_labels(
+        dataset_dir
+    ):
         logger.info("Dataset already organized, skipping...")
+        return
+
+    # If source is already organized into splits, copy it directly
+    if _is_pre_organized(source_dir):
+        logger.info("Detected pre-organized split structure")
+        _copy_pre_organized(source_dir, dataset_dir)
         return
 
     logger.info("Organizing FIW data...")
@@ -430,15 +542,57 @@ def _organize_fiw_data(source_dir, dataset_dir):
         _organize_fids_structure(source_dir, dataset_dir)
 
 
-def _organize_fids_structure(families_dir, dataset_dir):
-    """Organizes official FIW FIDs structure."""
-    logger.info("Detected official FIDs structure")
+def _copy_pre_organized(source_dir, dataset_dir):
+    """Copies a pre-organized split structure to the dataset directory."""
+    all_families = set()
 
+    for split in _SPLITS:
+        src_split_data = os.path.join(source_dir, split, "data")
+        dest_split_data = os.path.join(dataset_dir, split, "data")
+
+        if os.path.isdir(src_split_data):
+            if not os.path.isdir(dest_split_data):
+                shutil.copytree(src_split_data, dest_split_data)
+
+            families = [
+                d for d in os.listdir(dest_split_data)
+                if os.path.isdir(os.path.join(dest_split_data, d))
+            ]
+            all_families.update(families)
+
+        # Copy existing labels.csv if present
+        src_labels = os.path.join(source_dir, split, "labels.csv")
+        dest_labels = os.path.join(dataset_dir, split, "labels.csv")
+        if os.path.isfile(src_labels) and not os.path.isfile(dest_labels):
+            etau.ensure_dir(os.path.dirname(dest_labels))
+            shutil.copy2(src_labels, dest_labels)
+
+        # Generate labels.csv from mid.csv if not present
+        if not os.path.isfile(dest_labels) and os.path.isdir(dest_split_data):
+            pairs = []
+            for family in os.listdir(dest_split_data):
+                family_dir = os.path.join(dest_split_data, family)
+                if os.path.isdir(family_dir):
+                    pairs.extend(
+                        _extract_pairs_from_family(family_dir, family)
+                    )
+            _generate_labels_csv(dest_labels, pairs)
+
+    # Copy or generate splits.csv
+    src_splits = os.path.join(source_dir, "splits.csv")
+    dest_splits = os.path.join(dataset_dir, "splits.csv")
+    if os.path.isfile(src_splits) and not os.path.isfile(dest_splits):
+        shutil.copy2(src_splits, dest_splits)
+    elif not os.path.isfile(dest_splits):
+        _generate_splits_csv(dataset_dir, sorted(all_families))
+
+
+def _organize_fids_structure(families_dir, dataset_dir):
+    """Organizes official FIW FIDs structure into train/val/test splits."""
     all_families = sorted([
         d for d in os.listdir(families_dir)
         if os.path.isdir(os.path.join(families_dir, d))
-        and d.startswith("F")
-        and (d[1:5].isdigit() if len(d) > 4 else d[1:].isdigit())
+        and _is_family_dir_name(d)
     ])
 
     if not all_families:
@@ -448,6 +602,8 @@ def _organize_fids_structure(families_dir, dataset_dir):
 
     logger.info("Found %d families", len(all_families))
 
+    # Only families with a mid.csv that has relationship data get
+    # preferential placement into val/test so those splits are useful
     families_with_relationships = []
     for family in all_families:
         family_dir = os.path.join(families_dir, family)
@@ -457,7 +613,7 @@ def _organize_fids_structure(families_dir, dataset_dir):
 
     logger.info(
         "Found %d families with relationship data",
-        len(families_with_relationships)
+        len(families_with_relationships),
     )
 
     rng = random.Random(42)
@@ -485,7 +641,9 @@ def _organize_fids_structure(families_dir, dataset_dir):
 
     logger.info(
         "Split sizes - train: %d, val: %d, test: %d",
-        len(train_families), len(val_families), len(test_families)
+        len(train_families),
+        len(val_families),
+        len(test_families),
     )
 
     all_pairs = defaultdict(list)
@@ -513,23 +671,40 @@ def _organize_fids_structure(families_dir, dataset_dir):
 
     for split_name in _SPLITS:
         labels_path = os.path.join(dataset_dir, split_name, "labels.csv")
-        if not os.path.exists(labels_path) or os.path.getsize(labels_path) == 0:
-            _generate_labels_csv(labels_path, all_pairs.get(split_name, []))
+        if not os.path.isfile(labels_path) or os.path.getsize(labels_path) == 0:
+            _generate_labels_csv(
+                labels_path, all_pairs.get(split_name, [])
+            )
 
 
 def _find_mid_csv(family_dir, family_id):
-    """Finds the mid.csv file for a family, checking multiple naming conventions."""
+    """Finds the mid.csv file for a family.
+
+    Checks multiple naming conventions used across different versions of
+    the FIW dataset: ``mid.csv``, ``F####.csv``, ``FID####.csv``, or any
+    lone CSV in the directory.
+    """
     candidates = [
         os.path.join(family_dir, "mid.csv"),
         os.path.join(family_dir, "%s.csv" % family_id),
-        os.path.join(family_dir, "F%s.csv" % family_id[1:] if family_id.startswith("F") else family_id),
     ]
+
+    # Also try the alternate FID prefix form
+    if family_id.startswith("F") and not family_id.startswith("FID"):
+        candidates.append(
+            os.path.join(family_dir, "FID%s.csv" % family_id[1:])
+        )
 
     for candidate in candidates:
         if os.path.isfile(candidate):
             return candidate
 
-    csv_files = [f for f in os.listdir(family_dir) if f.endswith(".csv")]
+    # Fall back to lone CSV
+    try:
+        csv_files = [f for f in os.listdir(family_dir) if f.endswith(".csv")]
+    except OSError:
+        return None
+
     if len(csv_files) == 1:
         return os.path.join(family_dir, csv_files[0])
 
@@ -537,30 +712,37 @@ def _find_mid_csv(family_dir, family_id):
 
 
 def _has_relationships(mid_csv_path):
-    """Checks if a mid.csv file contains relationship data."""
-    try:
-        df = pd.read_csv(mid_csv_path)
-        if "MID" not in df.columns:
-            return False
-
-        numeric_cols = [c for c in df.columns if str(c).isdigit() or c.startswith("MID")]
-        numeric_cols = [c for c in numeric_cols if c != "MID"]
-
-        if not numeric_cols:
-            return False
-
-        for col in numeric_cols:
-            if df[col].dtype in ['int64', 'float64']:
-                if (df[col] > 0).any():
-                    return True
-
+    """Checks if a mid.csv file contains non-zero relationship data."""
+    df = _read_mid_csv(mid_csv_path)
+    if df is None or "MID" not in df.columns:
         return False
+
+    try:
+        # Relationship columns are the numeric columns that are not MID
+        for col in df.columns:
+            if col in ("MID", "Name", "Gender"):
+                continue
+
+            try:
+                vals = pd.to_numeric(df[col], errors="coerce")
+            except Exception:
+                continue
+
+            if vals.notna().any() and (vals > 0).any():
+                return True
     except Exception:
         return False
 
+    return False
+
 
 def _copy_family(src_family, dest_family, family_id):
-    """Copies a family directory, ensuring mid.csv exists."""
+    """Copies a family directory to the dataset structure.
+
+    Copies MID subdirectories and CSV files. If the source has a CSV under
+    a non-standard name, it is also copied as ``mid.csv`` so the importer
+    can find it.
+    """
     etau.ensure_dir(dest_family)
 
     mid_csv_src = _find_mid_csv(src_family, family_id)
@@ -569,73 +751,48 @@ def _copy_family(src_family, dest_family, family_id):
         src_item = os.path.join(src_family, item)
         dest_item = os.path.join(dest_family, item)
 
-        if os.path.isdir(src_item) and item.startswith("MID"):
+        if os.path.isdir(src_item) and item.upper().startswith("MID"):
             if not os.path.exists(dest_item):
                 shutil.copytree(src_item, dest_item)
         elif item.endswith(".csv"):
             if not os.path.exists(dest_item):
                 shutil.copy2(src_item, dest_item)
 
+    # Ensure mid.csv exists under that name (the importer looks for it)
     dest_mid_csv = os.path.join(dest_family, "mid.csv")
     if not os.path.exists(dest_mid_csv):
-        if mid_csv_src:
+        if mid_csv_src is not None:
             shutil.copy2(mid_csv_src, dest_mid_csv)
         else:
-            _generate_mid_csv(dest_family, family_id)
-
-
-def _generate_mid_csv(family_dir, family_id):
-    """Generates a minimal mid.csv if none exists."""
-    mids = []
-    for item in os.listdir(family_dir):
-        if os.path.isdir(os.path.join(family_dir, item)) and item.startswith("MID"):
-            try:
-                mid_num = int(item.replace("MID", ""))
-                mids.append(mid_num)
-            except ValueError:
-                continue
-
-    if not mids:
-        return
-
-    mids.sort()
-
-    rows = []
-    for mid in mids:
-        row = {"MID": mid}
-        for other_mid in mids:
-            row[str(other_mid)] = 0
-        row["Name"] = "Member_%d" % mid
-        row["Gender"] = "U"
-        rows.append(row)
-
-    df = pd.DataFrame(rows)
-    csv_path = os.path.join(family_dir, "mid.csv")
-    df.to_csv(csv_path, index=False)
+            logger.warning(
+                "Family %s has no mid.csv; relationship data will be "
+                "unavailable for this family",
+                family_id,
+            )
 
 
 def _extract_pairs_from_family(family_dir, family_id):
-    """Extracts kinship pairs from a family's mid.csv."""
+    """Extracts kinship pairs from a family's mid.csv relationship matrix."""
     pairs = []
 
-    mid_csv = os.path.join(family_dir, "mid.csv")
-    if not os.path.isfile(mid_csv):
+    mid_csv_path = _find_mid_csv(family_dir, family_id)
+    if mid_csv_path is None:
         return pairs
 
-    try:
-        df = pd.read_csv(mid_csv)
-    except Exception:
-        return pairs
-
-    if "MID" not in df.columns:
+    df = _read_mid_csv(mid_csv_path)
+    if df is None or "MID" not in df.columns:
         return pairs
 
     for _, row in df.iterrows():
-        mid1 = row["MID"]
+        try:
+            mid1 = int(row["MID"])
+        except (ValueError, TypeError):
+            continue
+
         p1 = "%s/MID%d" % (family_id, mid1)
 
         for col in df.columns:
-            if col in ["MID", "Name", "Gender"]:
+            if col in ("MID", "Name", "Gender"):
                 continue
 
             try:
@@ -646,8 +803,15 @@ def _extract_pairs_from_family(family_dir, family_id):
             if rel_code <= 0 or rel_code not in _RELATIONSHIP_MAP:
                 continue
 
+            # Column name is the target MID number
+            col_str = str(col)
             try:
-                mid2 = int(col) if str(col).isdigit() else int(str(col).replace("MID", ""))
+                if col_str.isdigit():
+                    mid2 = int(col_str)
+                elif col_str.upper().startswith("MID"):
+                    mid2 = int(col_str.upper().replace("MID", ""))
+                else:
+                    continue
             except ValueError:
                 continue
 
@@ -685,12 +849,14 @@ def _generate_labels_csv(labels_path, pairs):
 
 
 def _is_missing_images(dataset_dir):
-    """Checks if any split is missing image data."""
+    """Checks if any split has image data in the dataset directory."""
     for split in _SPLITS:
         split_data = os.path.join(dataset_dir, split, "data")
         if os.path.isdir(split_data):
-            families = [d for d in os.listdir(split_data)
-                       if os.path.isdir(os.path.join(split_data, d))]
+            families = [
+                d for d in os.listdir(split_data)
+                if os.path.isdir(os.path.join(split_data, d))
+            ]
             if families:
                 return False
 
@@ -721,22 +887,12 @@ def _get_dataset_info(dataset_dir, split):
     else:
         classes = []
 
-    split_img_glob = os.path.join(
-        dataset_dir, split, "data", "*", "*", "*.jpg"
-    )
-    jpg_matches = etau.get_glob_matches(split_img_glob)
-
-    split_img_glob_jpeg = os.path.join(
-        dataset_dir, split, "data", "*", "*", "*.jpeg"
-    )
-    jpeg_matches = etau.get_glob_matches(split_img_glob_jpeg)
-
-    split_img_glob_png = os.path.join(
-        dataset_dir, split, "data", "*", "*", "*.png"
-    )
-    png_matches = etau.get_glob_matches(split_img_glob_png)
-
-    num_samples = len(jpg_matches) + len(jpeg_matches) + len(png_matches)
+    num_samples = 0
+    for ext in ("*.jpg", "*.jpeg", "*.png"):
+        glob_pattern = os.path.join(
+            dataset_dir, split, "data", "*", "*", ext
+        )
+        num_samples += len(etau.get_glob_matches(glob_pattern))
 
     return num_samples, classes
 

--- a/fiftyone/zoo/datasets/base.py
+++ b/fiftyone/zoo/datasets/base.py
@@ -1513,7 +1513,6 @@ class FIWDataset(FiftyOneDataset):
         num_samples, classes = fouf.parse_fiw_dataset(
             self.source_dir,
             dataset_dir,
-            scratch_dir,
             split,
         )
 

--- a/fiftyone/zoo/datasets/base.py
+++ b/fiftyone/zoo/datasets/base.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Zoo Datasets provided natively by the library.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
@@ -1435,17 +1435,19 @@ class FIWDataset(FiftyOneDataset):
         utilities for FIW.
 
     In order to load the FIW dataset, you must download the source data
-    manually. The directory should be organized in the following format::
+    manually. The directory should contain the official FIW structure::
 
         source_dir/
-            train-faces/
+            FIDs/
                 F0001/
                     MID1/
-                    MID2/
-                ...
-            test-public-faces/
-            test-public-lists/
-            train_relationships.csv
+                        *.jpg
+                    mid.csv
+                F0002/
+                    ...
+            FIW_PIDs.csv (optional)
+            FIW_FIDs.csv (optional)
+            FIW_RIDs.csv (optional)
 
     You can register at
     https://docs.google.com/forms/d/e/1FAIpQLSd5_hbg-7QlrqE9V4MJShgww308yCxHlj6VOLctETX6aYLQgg/viewform
@@ -1460,7 +1462,7 @@ class FIWDataset(FiftyOneDataset):
 
         dataset = foz.load_zoo_dataset(
             "fiw",
-            split="test",
+            split="train",
             source_dir=source_dir,
         )
 

--- a/fiftyone/zoo/datasets/base.py
+++ b/fiftyone/zoo/datasets/base.py
@@ -1435,13 +1435,16 @@ class FIWDataset(FiftyOneDataset):
         utilities for FIW.
 
     In order to load the FIW dataset, you must download the source data
-    manually. The directory should contain the official FIW structure::
+    manually. The expected structure is the official FIW database layout::
 
         source_dir/
             FIDs/
                 F0001/
                     MID1/
-                        *.jpg
+                        P00001_face0.jpg
+                        ...
+                    MID2/
+                        ...
                     mid.csv
                 F0002/
                     ...
@@ -1449,9 +1452,17 @@ class FIWDataset(FiftyOneDataset):
             FIW_FIDs.csv (optional)
             FIW_RIDs.csv (optional)
 
-    You can register at
-    https://docs.google.com/forms/d/e/1FAIpQLSd5_hbg-7QlrqE9V4MJShgww308yCxHlj6VOLctETX6aYLQgg/viewform
-    in order to get access to download the data.
+    The ``mid.csv`` file in each family directory contains the relationship
+    matrix, member names, and genders. These files are included in the
+    official FIW download and should not need to be created manually.
+
+    Alternatively, you can provide a directory containing family
+    directories directly (``F0001/``, ``F0002/``, etc.) without the
+    ``FIDs/`` wrapper, or a pre-organized split structure with
+    ``train/data/``, ``val/data/``, ``test/data/`` subdirectories.
+
+    Register at https://fulab.sites.northeastern.edu/fiw-download/ to
+    get access to the official data.
 
     Example usage::
 


### PR DESCRIPTION
## Summary

- Replaces dead Google Drive links with Kaggle download (thesistime/fiwdata)
- Generates metadata files (mid.csv, labels.csv, splits.csv) dynamically
- Infers gender and relationship matrix from typed pair data
- Creates proper train/val/test splits at family level

## Split Statistics

| Split | Families | Samples | Pairs |
|-------|----------|---------|-------|
| train | 704 | 18,253 | 3,012 |
| val | 72 | 1,827 | 586 |
| test | 786 | 20,726 | 6,433 |

## Test plan

- [x] Verify Kaggle download works
- [x] Verify train split loads with relationships and kinships
- [x] Verify val split loads with relationships and kinships
- [x] Verify test split loads with relationships and kinships
- [x] CI tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FIW import can use a user-provided source directory, generate train/val/test splits and labels, and report progress during ingestion. Dataset instances retain the provided source path and indicate manual provisioning is required.

* **Refactor**
  * Loading flow now normalizes diverse FIW layouts into a standardized structure before ingesting.

* **Bug Fixes**
  * Better handling of missing/malformed files, skipped non-image files, and clearer, actionable error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->