### PR TITLE
Add k8s orch to on-demand docs

### DIFF
--- a/docs/source/enterprise/plugins.rst
+++ b/docs/source/enterprise/plugins.rst
@@ -510,8 +510,8 @@ FiftyOne Enterprise supports executing delegated operations on-demand in
 your connected external compute platform. With on-demand compute, resources are
 only provisioned and used when they're actually needed, minimizing idle times.
 
-On-demand compute is currently supported on
-`Databricks <https://www.databricks.com/>`_ and
+On-demand compute is currently supported on FiftyOne's Kubernetes Orchestrator,
+`Databricks <https://www.databricks.com/>`_, and
 `Anyscale <https://www.anyscale.com/>`_.
 
 Administrators can refer to the


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add k8s orch to on-demand docs

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced on-demand compute documentation to reflect FiftyOne's Kubernetes Orchestrator as an additional supported external orchestrator, providing expanded deployment options alongside existing supported platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->