### PR TITLE
chore(workflow/lint-app): remove duplicate checkout step.

### DIFF
--- a/.github/workflows/lint-app.yml
+++ b/.github/workflows/lint-app.yml
@@ -9,7 +9,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: changes
         with:


### PR DESCRIPTION
## What changes are proposed in this pull request?

https://github.com/voxel51/fiftyone/pull/6641 shows that we are attempting to add a duplicate checkout step in the lint-app.yaml.  Let's remove this duplicate entry.

## How is this patch tested? If it is not, please explain why.

n/a.  Removing the duplicate step shouldn't affect anything.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow by removing redundant validation steps, improving build efficiency with no impact to functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->