### PR TITLE
Add PE Core Base

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -8532,7 +8532,7 @@
             "source": "https://github.com/facebookresearch/perception_models/",
             "author": "Daniel Bolya, et al.",
             "license": "Apache 2.0",
-            "size_bytes": 2684747432,
+            "size_bytes": 1794747432,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.pe.PEVisionEncoder",
                 "config": {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Added PE Core Base

## How is this patch tested? If it is not, please explain why.

Ran `compute_emeddings`.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Added `PE-Core-B16-224-Vision-Encoder`, the base variant of the PE Core line of models.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other
