### PR TITLE
FOEPD-2576: fix camera position resolution bug

### DIFF
--- a/app/packages/looker-3d/src/fo3d/MediaTypeFo3d.tsx
+++ b/app/packages/looker-3d/src/fo3d/MediaTypeFo3d.tsx
@@ -354,6 +354,16 @@ export const MediaTypeFo3dComponent = () => {
         );
       }
 
+      const defaultCameraPosition = foScene?.cameraProps.position;
+
+      if (defaultCameraPosition) {
+        return new Vector3(
+          defaultCameraPosition[0],
+          defaultCameraPosition[1],
+          defaultCameraPosition[2]
+        );
+      }
+
       if (
         !ignoreLastSavedCameraPosition &&
         lastSavedCameraPosition &&
@@ -363,16 +373,6 @@ export const MediaTypeFo3dComponent = () => {
           lastSavedCameraPosition[0],
           lastSavedCameraPosition[1],
           lastSavedCameraPosition[2]
-        );
-      }
-
-      const defaultCameraPosition = foScene?.cameraProps.position;
-
-      if (defaultCameraPosition) {
-        return new Vector3(
-          defaultCameraPosition[0],
-          defaultCameraPosition[1],
-          defaultCameraPosition[2]
         );
       }
 


### PR DESCRIPTION
There's an expected precedence order which has a bug. See "Files changed" tab for reference + fix.

Expected behavior = user defined camera position in fo3d file should take precedence over browser saved camera position