### PR TITLE
Fixing NVIDIA URLs - Cosmos Transfer Tutorial

### DIFF
--- a/docs/source/tutorials/cosmos-transfer-integration.ipynb
+++ b/docs/source/tutorials/cosmos-transfer-integration.ipynb
@@ -42,7 +42,7 @@
     "\n",
     "### 2. Install Cosmos-Transfer 2.5 and Dependencies\n",
     "\n",
-    "Clone the [official repository](https://github.com/nvidia-cosmos/cosmos-transfer2.5) and set up the environment. You can also follow the instructions on this [Cosmos Transfer 2.5 Recipe](https://github.com/nvidia-cosmos/cosmos-cookbook/blob/main/docs/recipes/inference/transfer2_5/inference-biotrove-augmentation_w_FiftyOne/inference.md) and the [Setup Process](https://github.com/nvidia-cosmos/cosmos-cookbook/blob/main/docs/recipes/inference/transfer2_5/inference-biotrove-augmentation_w_FiftyOne/setup.md)\n",
+    "Clone the [official repository](https://github.com/nvidia-cosmos/cosmos-transfer2.5) and set up the environment. You can also follow the instructions on this [Cosmos Transfer 2.5 Recipe](https://github.com/nvidia-cosmos/cosmos-cookbook/blob/main/docs/recipes/inference/transfer2_5/biotrove_augmentation/inference.md) and the [Setup Process](https://github.com/nvidia-cosmos/cosmos-cookbook/blob/main/docs/recipes/inference/transfer2_5/biotrove_augmentation/setup.md)\n",
     "\n",
     "### System requirements\n",
     "\n",


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR updates two outdated documentation URLs related to the Cosmos Transfer workflow.
Specifically, it updates the links to the Cosmos Transfer Recipe and Setup pages in the NVIDIA repository to point to the latest, accurate reference materials. No functional or code-level changes are included—this PR strictly improves documentation accuracy and clarity.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [X] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [X] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tutorial references to point to new Cosmos-Transfer recipe paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->