### PR TITLE
test: add mongodb-version matrix to e2e workflow to test supported ve…

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -141,6 +141,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v5
         with:
-          name: playwright-report
+          name: playwright-report-mongodb-${{ matrix.mongodb-version }}
           path: e2e-pw/playwright-report/
           retention-days: 30


### PR DESCRIPTION
…rsions of MongoDB (not just latest). Remove invalid parameter `working-directory` from "Cache playwright browser" step.

## What changes are proposed in this pull request?

Fiftyone is supported on multiple MongoDB versions.  Despite that the e2e.yml action has no [recorded runs](https://github.com/voxel51/fiftyone/actions/workflows/e2e.yml), let's add a matrix to test the supported versions.

While here, from the `Cache playwright browser` step, let's remove the `working-directory: e2e-pw` since it isn't supported. 

## How is this patch tested? If it is not, please explain why.

n/a - Since this workflow has never been run. We are just enabling a future capability.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end testing to run across multiple MongoDB versions (6, 7, 8.0, latest).
  * Improved test resilience with fail-fast disabled and per-version test reports for clearer results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->