### PR TITLE
Fix behavior change with sklearn>=1.8

### DIFF
--- a/fiftyone/utils/eval/base.py
+++ b/fiftyone/utils/eval/base.py
@@ -900,6 +900,17 @@ class BaseClassificationResults(BaseEvaluationResults):
         #   Handle this case here now to maintain consistent functionality with
         #   sklearn < 1.8
         if self.ytrue.size == 0:
+            # If average is None, return arrays of zeros. From function
+            # docstring:
+            # precision : float (if average is not None) or array of float,
+            #         shape =\
+            #         [n_unique_labels]
+            #         Precision score.
+            if average is None:
+                num_labels = 0 if labels is None else len(labels)
+                zeros = np.zeros(num_labels, dtype=float)
+                return zeros, zeros, zeros
+
             return 0.0, 0.0, 0.0
 
         precision, recall, fscore, _ = skm.precision_recall_fscore_support(


### PR DESCRIPTION
## What changes are proposed in this pull request?

In sklearn 1.8 and later, passing empty arrays raises an error instead of returning zeros.
https://github.com/scikit-learn/scikit-learn/pull/32549
Handle this case here now to maintain consistent functionality with sklearn < 1.8

## How is this patch tested? If it is not, please explain why.

Unit tests now pass with both scikit-learn 1.7.x and 1.8.0

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixes error raised with classification evaluation results on an empty view, with scikit-learn>=1.8

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reporting now detects when there are no samples and displays "No samples to analyze".
  * Precision, recall, and F1-score computations return zeros for empty inputs, ensuring stable, consistent evaluation metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->