### PR TITLE
[FOEPD-2613] Add flag to inform backend that a given DO is being monitored

### DIFF
--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -15,9 +15,9 @@ from bson import ObjectId
 from pymongo import IndexModel
 from pymongo.collection import Collection
 
-from fiftyone.internal.util import is_remote_service
 from fiftyone.factory import DelegatedOperationPagingParams
 from fiftyone.factory.repos import DelegatedOperationDocument
+from fiftyone.internal.util import is_remote_service
 from fiftyone.operators.executor import (
     ExecutionContext,
     ExecutionProgress,
@@ -56,6 +56,7 @@ class DelegatedOperationRepo(object):
         log_path: Optional[str] = None,
         progress: Optional[ExecutionProgress] = None,
         required_state: Optional[ExecutionRunState] = None,
+        monitored: bool = False,
     ) -> DelegatedOperationDocument:
         """Update the run state of an operation."""
         raise NotImplementedError("subclass must implement update_run_state()")
@@ -320,6 +321,7 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
         log_path: Optional[str] = None,
         progress: Optional[ExecutionProgress] = None,
         required_state: Optional[ExecutionRunState] = None,
+        monitored: bool = False,
     ) -> DelegatedOperationDocument:
         update = None
 
@@ -367,6 +369,7 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
                     "run_state": run_state,
                     "started_at": datetime.utcnow(),
                     "updated_at": datetime.utcnow(),
+                    "monitored": monitored,
                 }
             }
         elif run_state == ExecutionRunState.SCHEDULED:

--- a/fiftyone/factory/repos/delegated_operation_doc.py
+++ b/fiftyone/factory/repos/delegated_operation_doc.py
@@ -60,6 +60,7 @@ class DelegatedOperationDocument(object):
         self.log_upload_error = None
         self.log_size = None
         self.log_path = None
+        self.monitored = False
 
         # distributed task fields
         self.parent_id = None  # Only on children
@@ -93,6 +94,7 @@ class DelegatedOperationDocument(object):
         self.metadata = doc.get("metadata", None)
         self.label = doc.get("label", None)
         self.updated_at = doc.get("updated_at", None)
+        self.monitored = doc.get("monitored", False)
 
         # grouped fields
         self.parent_id = doc.get("parent_id", None)

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -13,19 +13,19 @@ import logging.handlers
 import multiprocessing
 import os
 import traceback
+
 import psutil
 
-from fiftyone.factory.repo_factory import RepositoryFactory
 from fiftyone.factory import DelegatedOperationPagingParams
+from fiftyone.factory.repo_factory import RepositoryFactory
 from fiftyone.operators.executor import (
-    prepare_operator_executor,
-    do_execute_operator,
     ExecutionResult,
     ExecutionRunState,
-    resolve_type_with_context,
     PipelineExecutionContext,
+    do_execute_operator,
+    prepare_operator_executor,
+    resolve_type_with_context,
 )
-
 
 logger = logging.getLogger(__name__)
 
@@ -180,6 +180,7 @@ class DelegatedOperationService(object):
         run_link=None,
         log_path=None,
         required_state=None,
+        monitored=False,
     ):
         """Sets the given delegated operation to running state.
 
@@ -195,6 +196,8 @@ class DelegatedOperationService(object):
                 :class:`fiftyone.operators.executor.ExecutionRunState` required
                 state of the operation. If provided, the update will only be
                 performed if the referenced operation matches this state.
+            monitored (False): whether the operation is being monitored by
+                an external process
 
         Returns:
             a :class:`fiftyone.factory.repos.DelegatedOperationDocument` if the
@@ -207,6 +210,7 @@ class DelegatedOperationService(object):
             log_path=log_path,
             progress=progress,
             required_state=required_state,
+            monitored=monitored,
         )
 
     def set_scheduled(self, doc_id, required_state=None):
@@ -627,6 +631,7 @@ class DelegatedOperationService(object):
                         run_link=run_link,
                         log_path=log_path,
                         required_state=ExecutionRunState.QUEUED,
+                        monitored=monitor,
                     )
                     is not None
                 )


### PR DESCRIPTION
## What changes are proposed in this pull request?

https://voxel51.atlassian.net/browse/FOEPD-2613

Add flag to inform backend that a given DO is being monitored. This will allow us to set more aggressive automatic termination for DOs that are being monitored.

## How is this patch tested? If it is not, please explain why.

Created a DO then ran:

```
fiftyone delegated launch
```

Saw that the monitored flag = false

Did it again but this time added the -m flag:

```
fiftyone delegated launch -m
```

Saw that the monitored flag = true

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
