### PR TITLE
FOEPD-2813: explicitly use node 22 in remaining workflows

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -123,6 +123,11 @@ jobs:
           echo "Installing fiftyone"
           pip install .
 
+      - name: Setup node 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
       - name: Enable corepack
         run: corepack enable
       - name: Prepare yarn 4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,11 @@ jobs:
         run: |
           pip install --upgrade pip setuptools wheel build
 
+      - name: Setup node 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
       - name: Enable corepack
         run: corepack enable
       - name: Prepare yarn 4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup node 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
       - name: Enable corepack
         run: corepack enable
       - name: Prepare yarn 4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development workflows to use Node.js 22 across build, test, and documentation processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->