### PR TITLE
Support `Concat` stages in `make_optimized_select_view()`

### DIFF
--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -9339,6 +9339,7 @@ _STAGES_THAT_SELECT_OR_REORDER = {
     SortBySimilarity,
     Shuffle,
     # View stages that only select documents
+    Concat,
     Exclude,
     ExcludeBy,
     ExcludeGroupSlices,

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -5220,6 +5220,24 @@ class ViewStageTests(unittest.TestCase):
         self.assertTrue(clips is not also_clips)
         self.assertEqual(clips._dataset.name, also_clips._dataset.name)
 
+    def test_make_optimized_select_view_concat(self):
+        dataset = fo.Dataset()
+        dataset.add_samples(
+            [
+                fo.Sample(filepath="image1.jpg"),
+                fo.Sample(filepath="image2.jpg"),
+                fo.Sample(filepath="image3.jpg"),
+                fo.Sample(filepath="image4.jpg"),
+            ]
+        )
+
+        ids = dataset[1:-1].values("id")
+        view = dataset[:-1] + dataset[1:]
+
+        optimized_view = fov.make_optimized_select_view(view, ids)
+
+        self.assertEqual(optimized_view._stages, [fosg.Select(ids)])
+
     def test_make_optimized_select_view_group_dataset(self):
         dataset, sample_ids = self._make_group_dataset()
 


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/6673

## Release notes

- fixes a bug in `make_optimized_select_view()` that would cause incorrect behavior when applied to views that contain `Concat` stages

## Tested by

- unit tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Concat stage to be properly recognized in view stage registries, improving display in view representations and ensuring correct optimization behavior during view construction.

* **Tests**
  * Added unit test to verify optimized view construction when using concatenated slices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->