### PR TITLE
chore(codeowners): add Sashank as owner on the e2e.yml workflow.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,5 +30,8 @@ setup.py                     @voxel51/aloha-shirts
 requirements.txt             @voxel51/aloha-shirts
 requirements/                @voxel51/aloha-shirts
 
+# e2e test workflow has shared ownership
+.github/workflows/e2e.yml    @voxel51/aloha-shirts sashank@voxel51.com  # implementer of e2e workflow
+
 # Exclusions ('!' syntax not supported by github)
 /fiftyone/internal/features/  @voxel51/developers


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adding Sashank as code owner for the e2e test that he implemented.

## How is this patch tested? If it is not, please explain why.

n/a GitHub shows that the CODEWONER file is valid. After merge, I'll create a PR updating `.github/workflows/e2e.yml` to validate that Sashank is added as reviewer.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code ownership metadata for workflow management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->