### PR TITLE
chore(e2e): tempoarily reduce mongodb matrix versions to latest for t…

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,7 +5,8 @@ on: workflow_call
 jobs:
   test-e2e:
     timeout-minutes: 90
-    runs-on: ubuntu-latest-m
+    # runs-on: ubuntu-latest-m  # large runner
+    runs-on: ubuntu-latest # standard runner
     name: Test e2e (Mongo ${{ matrix.mongodb-version }})
     env:
       FIFTYONE_DO_NOT_TRACK: true
@@ -22,9 +23,9 @@ jobs:
       fail-fast: false
       matrix:
         mongodb-version:
-          - "6"
-          - "7"
-          - "8.0"
+          # - "6"
+          # - "7"
+          # - "8.0"
           - "latest"
     steps:
       - name: Checkout

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -82,6 +82,8 @@ jobs:
           df -h
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          large-packages: false
       - name: Get free space
         run: |
           df -h
@@ -89,7 +91,9 @@ jobs:
         if: steps.pip-cache.outputs.cache-hit != true
         run: |
           pip install -r requirements/e2e.txt
-
+      - name: Get free space
+        run: |
+          df -h
       - name: Cache Node Modules
         id: app-node-cache
         uses: actions/cache@v5
@@ -98,25 +102,35 @@ jobs:
             app/node_modules
             app/.yarn/cache
           key: node-modules-${{ hashFiles('app/yarn.lock') }}
-
+      - name: Get free space
+        run: |
+          df -h
       - name: Install app
         if: steps.app-node-cache.outputs.cache-hit != 'true'
         run: yarn install
         working-directory: app
-
+      - name: Get free space
+        run: |
+          df -h
       - name: Build app
         run: make app
-
+      - name: Get free space
+        run: |
+          df -h
       - name: Install fiftyone
         run: |
           pip install .
-
+      - name: Get free space
+        run: |
+          df -h
       - name: Configure
         id: test_config
         run: |
           python tests/utils/setup_config.py
           python tests/utils/github_actions_flags.py
-
+      - name: Get free space
+        run: |
+          df -h
       # - name: Setup FFmpeg (with retries)
       #   uses: FedericoCarboni/setup-ffmpeg@v3
 
@@ -124,7 +138,9 @@ jobs:
       # is merged or the maintainer addresses the root issue.
       - name: Setup FFmpeg (with retries)
         uses: afoley587/setup-ffmpeg@main
-
+      - name: Get free space
+        run: |
+          df -h
       - name: Cache E2E Node Modules
         id: e2e-node-cache
         uses: actions/cache@v5
@@ -132,7 +148,9 @@ jobs:
           path: |
             e2e-pw/node_modules
           key: node-modules-${{ hashFiles('e2e-pw/yarn.lock') }}
-
+      - name: Get free space
+        run: |
+          df -h
       - name: Install E2E dependencies if not cached
         run: yarn install
         if: steps.e2e-node-cache.outputs.cache-hit != 'true'
@@ -155,11 +173,15 @@ jobs:
         run: yarn playwright install
         if: steps.playwright-browser-cache.outputs.cache-hit != 'true'
         working-directory: e2e-pw
-
+      - name: Get free space
+        run: |
+          df -h
       - name: Run Playwright tests
         run: yarn e2e
         working-directory: e2e-pw
-
+      - name: Get free space
+        run: |
+          df -h
       - name: Lint Playwright tests
         run: yarn lint
         working-directory: e2e-pw

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,26 +28,44 @@ jobs:
           # - "8.0"
           - "latest"
     steps:
+      - name: Get free space
+        run: |
+          df -h
       - name: Checkout
         uses: actions/checkout@v6
         with:
           submodules: true
 
+      - name: Get free space
+        run: |
+          df -h
       - name: Setup node 22
         uses: actions/setup-node@v6
         with:
           node-version: 22
 
+      - name: Get free space
+        run: |
+          df -h
       - name: Enable corepack
         run: corepack enable
+      - name: Get free space
+        run: |
+          df -h
       - name: Prepare yarn 4
         run: corepack prepare yarn@4.9.1 --activate
 
+      - name: Get free space
+        run: |
+          df -h
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.12.1
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
 
+      - name: Get free space
+        run: |
+          df -h
       - name: Setup
         uses: actions/setup-python@v6
         id: pip-cache
@@ -59,6 +77,14 @@ jobs:
             requirements/github.txt
             requirements/test.txt
             requirements/e2e.txt
+      - name: Get free space
+        run: |
+          df -h
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+      - name: Get free space
+        run: |
+          df -h
       - name: Install requirements
         if: steps.pip-cache.outputs.cache-hit != true
         run: |


### PR DESCRIPTION
…esting a standard runner (with less disk space) to see if we encounter out of disk error.

## What changes are proposed in this pull request?

Test to see if we need more disk space than the standard runner provides (14 GB).  Our `ubuntu-latest-m` runner provides 150GB disk, but has the same CPU and Memory as a standard runner.

For testing, let's reduce the mongodb matrix version from 4 to 1 for testing.  Once the testing is complete, I'll restore the matrix'd versions.

## How is this patch tested? If it is not, please explain why.

This PR tests that.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI updated to use the standard runner and a simplified MongoDB matrix (only "latest").
  * Added many disk-space checks and dedicated free-space steps across CI stages to monitor available space and improve reliability during builds and tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->