### PR TITLE
Optimize label tagging for non-list fields

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -2147,30 +2147,24 @@ class SampleCollection(object):
                     )
                 )
         else:
-            _id_path = _root + "._id"
             id_path = root + "._id"
             tags_path = _root + ".tags"
             update = update_fcn(tags_path)
             update["$set"] = {"last_modified_at": now}
 
-            if label_ids is None:
+            if ids is None or label_ids is None:
                 if is_frame_field:
-                    label_ids = self.values(id_path, unwind=True)
+                    ids, label_ids = self.values(["frames._id", id_path])
+                    ids = itertools.chain.from_iterable(ids)
+                    label_ids = itertools.chain.from_iterable(label_ids)
                 else:
-                    label_ids = self.values(id_path)
+                    ids, label_ids = self.values(["_id", id_path])
 
-            batch_size = fou.recommend_batch_size_for_value(
-                ObjectId(), max_size=100000
-            )
-            for _label_ids in fou.iter_batches(label_ids, batch_size):
-                _label_ids = [_id for _id in _label_ids if _id is not None]
-                if _label_ids:
-                    ops.append(
-                        UpdateMany(
-                            {_id_path: {"$in": _label_ids}},
-                            update,
-                        )
-                    )
+            for _id, _label_id in zip(ids, label_ids):
+                if _label_id is None:
+                    continue
+
+                ops.append(UpdateOne({"_id": _id}, update))
 
         if ops:
             self._dataset._bulk_write(ops, ids=ids, frames=is_frame_field)


### PR DESCRIPTION
## Release notes

- optimizes `tag_labels()` and `untag_labels()` when applied to non-list `Label` fields

## Implementation details

The former implementation of `tag_labels()` and `untag_labels()` for non-list `Label` fields used `UpdateMany()`, which optimized for the fewest number of bulk write operations, but at the cost of filtering by label IDs, which is not guaranteed to be an indexed field in general and thus means that even editing a single label's tag requires a full COLLSCAN 👎👎👎 

The new implementation uses `Update()` operations that filter on sample IDs, which will always use indexes. It should also guarantee that the runtime of `tag_labels()` and `untag_labels()` is proportional to the number of labels actually being edited, *independent* of the size of the dataset 👍👍👍 

## Tested by

- unit tests continue to work
- also manually confirmed as follows

```py
import fiftyone as fo
import fiftyone.zoo as foz

# Image dataset

dataset = foz.load_zoo_dataset("cifar10", split="test")

assert dataset.count_label_tags("ground_truth") == {}

dataset.take(100).tag_labels("test", label_fields="ground_truth")
assert dataset.count_label_tags(label_fields="ground_truth") == {"test": 100}

dataset.take(1000).clear_sample_field("ground_truth")
assert len(dataset.exists("ground_truth")) == 9000

# Test untag in presence of None labels
dataset.untag_labels("test", label_fields="ground_truth")
assert dataset.count_label_tags("ground_truth") == {}

# Test tagging in precense of None labels
dataset.tag_labels("test", label_fields="ground_truth")
assert dataset.count_label_tags(label_fields="ground_truth") == {"test": 9000}

# Video dataset

dataset = foz.load_zoo_dataset("quickstart-video")

frame_ids = dataset.values("frames.id", unwind=True)
values = {id: fo.Classification() for id in frame_ids}
dataset.set_values("frames.cls", values, key_field="frames.id")
assert dataset.count_label_tags("frames.cls") == {}

dataset[:5].tag_labels("test", label_fields="frames.cls")
assert dataset.count_label_tags(label_fields="frames.cls") == {"test": 679}

dataset[3:7].clear_sample_field("frames.cls")
assert dataset.count("frames.cls") == 759

# Test untag in presence of None labels
dataset.untag_labels("test", label_fields="frames.cls")
assert dataset.count_label_tags("frames.cls") == {}

# Test tag in presence of None labels
dataset.tag_labels("test", label_fields="frames.cls")
assert dataset.count_label_tags(label_fields="frames.cls") == {"test": 759}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal label update operations for improved consistency and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->