### PR TITLE
test(workflows/e2e): change runner from large to standard and add ste…

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,7 +5,7 @@ on: workflow_call
 jobs:
   test-e2e:
     timeout-minutes: 90
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest # the standard runner's 14GB free disk space is not sufficient.  We create more free space with the `jlumbroso/free-disk-space` action as a step (below).
     name: Test e2e (Mongo ${{ matrix.mongodb-version }})
     env:
       FIFTYONE_DO_NOT_TRACK: true
@@ -58,6 +58,10 @@ jobs:
             requirements/github.txt
             requirements/test.txt
             requirements/e2e.txt
+      - name: Free Disk Space (Ubuntu) # standard runner's 14 GB available disk size isn't enough. Need at least 22 GB free.
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          large-packages: false # e2e test failed when `true`
       - name: Install requirements
         if: steps.pip-cache.outputs.cache-hit != true
         run: |


### PR DESCRIPTION
…p with `jlumbroso/free-disk-space` action to create additional free disk space.

## What changes are proposed in this pull request?

In #6687 we tested using a standard action runner but ran out of disk space.  While researching solutions, I discovered the https://github.com/jlumbroso/free-disk-space action.  With the defaults, the e2e test failed.  After configuring this action with `large-packages: false`, the  subsequent run was successful.

This means that we can go back to using the standard runner and eliminate the cost for this action to run on this public/open source repo.  :success_kid:

## How is this patch tested? If it is not, please explain why.

During [the last run](https://github.com/voxel51/fiftyone/actions/runs/20342237649/job/58464997947?pr=6687), I profiled the disk usage (by adding steps to output `df -h`):

| Storage Used | Step(s) |
| ------------ | ------- |
| 15 GB |  Install requirements |
|  0 GB |  Cache Node Modules |
|  4 GB |  Install app |
|  0 GB |  Build app |
|  1 GB |  Install fiftyone |
|  0 GB |  Configure |
|  0 GB |  Setup FFmpeg (with retries) |
|  0 GB |  Cache E2E Node Modules |
|  1 GB |  Install E2E dependencies if not cached, Get Playwright version, Cache playwright browser, Install Playwright browser if not cached |
|  1 GB |  Run playwright tests |

This PR also tests the addition of Sashank to the CODEOWNERS from #6686.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the end-to-end testing workflow to improve disk space availability during test execution, enhancing reliability of the testing process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->