### PR TITLE
[Proposal] Surface bulk write result to tag_labels

### DIFF
--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -191,7 +191,7 @@ class ClipsView(fov.DatasetView):
 
         if label_field == self._classification_field:
             ids, label_ids = self._to_source_ids(label_field, _ids, label_ids)
-            self._source_collection._tag_labels(
+            return self._source_collection._tag_labels(
                 tags, label_field, ids=ids, label_ids=label_ids
             )
 
@@ -205,7 +205,7 @@ class ClipsView(fov.DatasetView):
 
         if label_field == self._classification_field:
             ids, label_ids = self._to_source_ids(label_field, _ids, label_ids)
-            self._source_collection._untag_labels(
+            return self._source_collection._untag_labels(
                 tags, label_field, ids=ids, label_ids=label_ids
             )
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -2016,6 +2016,9 @@ class SampleCollection(object):
             label_fields (None): an optional name or iterable of names of
                 :class:`fiftyone.core.labels.Label` fields. By default, all
                 label fields are used
+
+        Returns:
+            AggregatedBulkWriteResult: A summary of the updates that were applied.
         """
         agg_result = AggregatedBulkWriteResult()
 
@@ -2083,6 +2086,9 @@ class SampleCollection(object):
             label_fields (None): an optional name or iterable of names of
                 :class:`fiftyone.core.labels.Label` fields. By default, all
                 label fields are used
+
+        Returns:
+            AggregatedBulkWriteResult: A summary of the updates that were applied.
         """
         agg_result = AggregatedBulkWriteResult()
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -45,7 +45,7 @@ import fiftyone.core.runs as fors
 import fiftyone.core.sample as fosa
 import fiftyone.core.storage as fost
 import fiftyone.core.utils as fou
-from fiftyone.core.types import AggregatedBulkWriteResult, EditLabelTagsResult
+from fiftyone.core.types import AggregatedBulkWriteResult, _EditLabelTagsResult
 
 fod = fou.lazy_import("fiftyone.core.dataset")
 fos = fou.lazy_import("fiftyone.core.stages")
@@ -2189,7 +2189,7 @@ class SampleCollection(object):
                 ops, ids=ids, frames=is_frame_field
             )
 
-        return EditLabelTagsResult(
+        return _EditLabelTagsResult(
             ids=ids, label_ids=label_ids, bulk_write_result=bulk_write_result
         )
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -2041,7 +2041,8 @@ class SampleCollection(object):
             # We only need to process labels that are missing a tag of interest
             view = self.filter_labels(label_field, match_expr)
             res = view._tag_labels(tags, label_field)
-            agg_result.add(res.bulk_write_result)
+            if res and hasattr(res, "bulk_write_result"):
+                agg_result.add(res.bulk_write_result)
         return agg_result
 
     def _tag_labels(self, tags, label_field, ids=None, label_ids=None):
@@ -2108,7 +2109,8 @@ class SampleCollection(object):
             # We only need to process labels that have a tag of interest
             view = self.select_labels(tags=tags, fields=label_field)
             res = view._untag_labels(tags, label_field)
-            agg_result.add(res.bulk_write_result)
+            if res and hasattr(res, "bulk_write_result"):
+                agg_result.add(res.bulk_write_result)
         return agg_result
 
     def _untag_labels(self, tags, label_field, ids=None, label_ids=None):

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -2039,7 +2039,6 @@ class SampleCollection(object):
             view = self.filter_labels(label_field, match_expr)
             res = view._tag_labels(tags, label_field)
             agg_result.add(res.bulk_write_result)
-        print(agg_result)
         return agg_result
 
     def _tag_labels(self, tags, label_field, ids=None, label_ids=None):

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -54,6 +54,7 @@ import fiftyone.core.storage as fost
 from fiftyone.core.singletons import DatasetSingleton
 import fiftyone.core.utils as fou
 import fiftyone.core.view as fov
+from fiftyone.core.types import AggregatedBulkWriteResult
 
 fot = fou.lazy_import("fiftyone.core.stages")
 foud = fou.lazy_import("fiftyone.utils.data")
@@ -3624,7 +3625,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         else:
             coll = self._sample_collection
 
-        foo.bulk_write(ops, coll, ordered=ordered, progress=progress)
+        bulk_write_results = foo.bulk_write(
+            ops, coll, ordered=ordered, progress=progress
+        )
 
         if frames:
             fofr.Frame._reload_docs(self._frame_collection_name, frame_ids=ids)
@@ -3632,6 +3635,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             fos.Sample._reload_docs(
                 self._sample_collection_name, sample_ids=ids
             )
+
+        return AggregatedBulkWriteResult.from_results(bulk_write_results)
 
     def _merge_doc(
         self,

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -194,7 +194,7 @@ class _PatchesView(fov.DatasetView):
 
         if label_field in self._label_fields:
             ids, label_ids = self._to_source_ids(label_field, _ids, label_ids)
-            self._source_collection._tag_labels(
+            return self._source_collection._tag_labels(
                 tags, label_field, ids=ids, label_ids=label_ids
             )
 
@@ -208,7 +208,7 @@ class _PatchesView(fov.DatasetView):
 
         if label_field in self._label_fields:
             ids, label_ids = self._to_source_ids(label_field, _ids, label_ids)
-            self._source_collection._untag_labels(
+            return self._source_collection._untag_labels(
                 tags, label_field, ids=ids, label_ids=label_ids
             )
 

--- a/fiftyone/core/types.py
+++ b/fiftyone/core/types.py
@@ -9,6 +9,8 @@ Core type definitions and result containers.
 from typing import Optional, Union
 from pymongo.results import BulkWriteResult
 
+from fiftyone.core.expressions import ObjectId
+
 
 class AggregatedBulkWriteResult:
     """Aggregated result from multiple bulk write operations."""
@@ -50,21 +52,24 @@ class AggregatedBulkWriteResult:
         return self
 
 
-class EditLabelTagsResult:
-    """Result of label tag edit operations."""
+class _EditLabelTagsResult:
+    """Internal result of label tag edit operations used to pass state."""
 
     def __init__(
         self,
         *,
-        ids: Optional[list[str]] = None,
-        label_ids: Optional[list[str]] = None,
+        ids: Optional[list[ObjectId]] = None,
+        label_ids: Optional[list[Union[list[ObjectId], ObjectId]]] = None,
         bulk_write_result: Optional[
             Union[BulkWriteResult, AggregatedBulkWriteResult]
         ] = None,
     ):
+        # ids and label_ids are parallel arrays used primarily to propagate
+        # tag operations from generated views to their source collections.
         self.ids = ids
         self.label_ids = label_ids
         self.bulk_write_result = bulk_write_result
 
     def __iter__(self):
+        """Allows unpacking: ids, label_ids = result"""
         return iter((self.ids, self.label_ids))

--- a/fiftyone/core/types.py
+++ b/fiftyone/core/types.py
@@ -1,0 +1,70 @@
+"""
+Core type definitions and result containers.
+
+| Copyright 2017-2025, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from typing import Optional, Union
+from pymongo.results import BulkWriteResult
+
+
+class AggregatedBulkWriteResult:
+    """Aggregated result from multiple bulk write operations."""
+
+    def __init__(self):
+        self.inserted_count = 0
+        self.matched_count = 0
+        self.modified_count = 0
+        self.deleted_count = 0
+        self.upserted_count = 0
+
+    def __repr__(self):
+        return (
+            f"AggregatedBulkWriteResult("
+            f"matched={self.matched_count}, "
+            f"modified={self.modified_count}, "
+            f"inserted={self.inserted_count}, "
+            f"upserted={self.upserted_count}, "
+            f"deleted={self.deleted_count})"
+        )
+
+    @classmethod
+    def from_results(cls, results: list[BulkWriteResult]):
+        agg = cls()
+        for result in results:
+            agg.add(result)
+        return agg
+
+    def add(
+        self, result: Optional[BulkWriteResult]
+    ) -> "AggregatedBulkWriteResult":
+        if result is None:
+            return self
+        self.inserted_count += result.inserted_count
+        self.matched_count += result.matched_count
+        self.modified_count += result.modified_count
+        self.deleted_count += result.deleted_count
+        self.upserted_count += result.upserted_count
+        return self
+
+
+class EditLabelTagsResult:
+    """Result of label tag edit operations."""
+
+    def __init__(
+        self,
+        *,
+        ids: Optional[list[str]] = None,
+        label_ids: Optional[list[str]] = None,
+        bulk_write_result: Optional[
+            Union[BulkWriteResult, AggregatedBulkWriteResult]
+        ] = None,
+    ):
+        self.ids = ids
+        self.label_ids = label_ids
+        self.bulk_write_result = bulk_write_result
+
+    def __iter__(self):
+        return iter((self.ids, self.label_ids))

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -196,7 +196,7 @@ class FramesView(fov.DatasetView):
         )
 
         frame_field = self._source_collection._FRAMES_PREFIX + label_field
-        self._source_collection._tag_labels(
+        return self._source_collection._tag_labels(
             tags, frame_field, ids=ids, label_ids=label_ids
         )
 
@@ -206,7 +206,7 @@ class FramesView(fov.DatasetView):
         )
 
         frame_field = self._source_collection._FRAMES_PREFIX + label_field
-        self._source_collection._untag_labels(
+        return self._source_collection._untag_labels(
             tags, frame_field, ids=ids, label_ids=label_ids
         )
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Enable surfacing bulk write results to get the modified count and avoid making potentially expensive queries.
For example, notifying how many labels were actually tagged with no additional overhead:

<img width="653" height="136" alt="image" src="https://github.com/user-attachments/assets/0e185226-be82-4618-84d7-03aee54cf97a" />


## How is this patch tested? If it is not, please explain why.

```
import fiftyone as fo
ds=fo.load_dataset('quickstart')
res=ds.limit(1).tag_labels('test-bwr')
# prints AggregatedBulkWriteResult(matched=14, modified=14, inserted=0, upserted=0, deleted=0)

res=ds.limit(1).tag_labels('test-bwr')
# AggregatedBulkWriteResult(matched=0, modified=0, inserted=0, upserted=0, deleted=0)
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced bulk operation result tracking: Tag, untag, and bulk write operations now return detailed aggregated results, providing visibility into operation outcomes with counts of inserted, matched, modified, deleted, and upserted items across multiple label fields.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->