### PR TITLE
Validate frame numbers passed to `set_values()`

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -34,6 +34,7 @@ import fiftyone.core.evaluation as foev
 import fiftyone.core.expressions as foe
 from fiftyone.core.expressions import ViewField as F
 import fiftyone.core.fields as fof
+import fiftyone.core.frame_utils as fofu
 import fiftyone.core.groups as fog
 import fiftyone.core.labels as fol
 import fiftyone.core.map as focm
@@ -12637,6 +12638,7 @@ def _parse_frame_values_dicts(sample_collection, sample_ids, values):
             id_map[(_id, fn)] = _fid
 
         for fn in set(_vals.keys()) - set(_fns):
+            fofu.validate_frame_number(fn)
             dicts.append(
                 {
                     "_sample_id": ObjectId(_id),

--- a/fiftyone/core/frame_utils.py
+++ b/fiftyone/core/frame_utils.py
@@ -56,7 +56,7 @@ def validate_frame_number(value):
         )
 
 
-class FrameError(Exception):
+class FrameError(ValueError):
     """Exception raised when an invalid frame number is encountered."""
 
     pass


### PR DESCRIPTION
## Release notes

- all frame numbers passed to `set_values()` are now validated for type/value safety

## Tested by

- unit tests added
- example below

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video")

# Frame numbers must be ints, not strings!
naughty_values = {
    dataset.first().filepath: {
        "1": fo.Detections(),
        "2": fo.Detections(),
        "63": fo.Detections()
    },
    dataset[1:].first().filepath: {
        "2": fo.Detections(),
        "63": fo.Detections(),
        "10000": fo.Detections(),
    }
}

# Previously this would cause corruption, but now correctly raises an error
dataset.set_values("frames.new_field", naughty_values, key_field="filepath")
# FrameError: Frame numbers must be integers; found <class 'str'>

# No corruption anyone!
assert all(isinstance(fn, int) for fn in dataset.values("frames[].frame_number"))
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for frame numbers to prevent invalid entries from being inserted during frame value parsing.
  * Updated exception handling for frame-related errors to provide more appropriate error classification.

* **Tests**
  * Added unit test to verify frame number validation and error handling behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->