### PR TITLE
Add HuggingFace custom tags support

### DIFF
--- a/docs/scripts/make_hf_dataset_docs.py
+++ b/docs/scripts/make_hf_dataset_docs.py
@@ -246,8 +246,8 @@ This is a **Hugging Face dataset**. For large datasets, ensure `huggingface_hub>
                 if dataset.downloads > 0
                 else display_name
             )
-            all_tags = ["huggingface"] + tasks + custom_tags
-            tags = sorted(set(t.replace("_", "-").lower() for t in all_tags))
+            all_tags = ["huggingface", *tasks, *custom_tags]
+            tags = sorted({t.replace("_", "-").lower() for t in all_tags if t})
 
             hf_badge = '<span class="card-subtitle text-muted" style="background-color: #FFC107; color: black !important; padding: 2px 6px; border-radius: 4px; font-size: 0.8em; font-weight: 500;">Hugging Face</span><br/>'
             base_description = self._make_description(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add custom tags from HuggingFace datasets. Thanks to @allenleetc  for noticing that custom tags like 3D, LIDAR, and  point-cloud from HuggingFace dataset metadata weren't appearing in the docs.

## How is this patch tested? If it is not, please explain why.

Built the Docs in local and validate tags. 

<img width="2713" height="1550" alt="Screenshot from 2025-12-26 18-15-25" src="https://github.com/user-attachments/assets/86387daa-c94b-48be-a034-eb3868607526" />

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [X] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.



### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [X] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dataset docs now extract custom tags from dataset metadata (defaults to empty list when absent).

* **Improvements**
  * Tagging consolidated: adds a base "huggingface" tag and combines task + custom tags.
  * Tags are normalized (underscores→hyphens, lowercase), deduplicated and sorted for consistent display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->