### PR TITLE
chore(mongo): AS-1210 bump mongo versions used in actions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         mongodb-version:
-          - "6"
+          - "6.0.27-ubi8"
           - "7"
           - "8.0"
           - "latest"
@@ -46,6 +46,11 @@ jobs:
         uses: supercharge/mongodb-github-action@1.12.1
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
+          # mongo:6 will not patch 
+          # https://nvd.nist.gov/vuln/detail/CVE-2025-14847
+          # because it's EOL.
+          # If this is 6.0.27, use the mongodb community edition images
+          mongodb-image: ${{ matrix.mongodb-version == '6.0.27-ubi8' && 'mongodb/mongodb-community-server' || 'mongo' }}
 
       - name: Setup
         uses: actions/setup-python@v6


### PR DESCRIPTION
## What changes are proposed in this pull request?

A [CVE](https://nvd.nist.gov/vuln/detail/CVE-2025-14847) was found in MongoDB. We use mongo internally in a few places for CI. To stay secure, we should update a few versions.

We use the floating `mongo:7` and `mongo:8` for mongo 7 and 8 respectively. Those floating tags are updated to the patched versions of Mongo. `mongo:6`, however, is no longer getting updated because it is EOL. So we need to switch to the `mongodb/mongodb-community-server:6.0.27-ubi8` image and document it.

## How is this patch tested? If it is not, please explain why.

This will be tested via GH actions

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated end-to-end testing infrastructure to use a specific MongoDB version for improved test reliability and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->