### PR TITLE
Revert "chore(mongo): AS-1210 bump mongo versions used in actions (#6…

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         mongodb-version:
-          - "6.0.27-ubi8"
+          - "6"
           - "7"
           - "8.0"
           - "latest"
@@ -46,11 +46,6 @@ jobs:
         uses: supercharge/mongodb-github-action@1.12.1
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
-          # mongo:6 will not patch 
-          # https://nvd.nist.gov/vuln/detail/CVE-2025-14847
-          # because it's EOL.
-          # If this is 6.0.27, use the mongodb community edition images
-          mongodb-image: ${{ matrix.mongodb-version == '6.0.27-ubi8' && 'mongodb/mongodb-community-server' || 'mongo' }}
 
       - name: Setup
         uses: actions/setup-python@v6


### PR DESCRIPTION
…699)"

This reverts commit 30521100ea8eab67c09f76a1d3a3564cd69c4941.

## What changes are proposed in this pull request?

Yesterday, it didn't look like `mongo:6` was going to get patched - 7 and 8 both did, but 6 hadn't. They eventually released https://hub.docker.com/layers/library/mongo/6.0.27/images/sha256-a5f94ba728d8b1451a7f3692b965ab62c4d4ad7470306823c650e8bf9032a26a, so let's revert this change.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure to streamline e2e workflow configuration and dependency management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->