### PR TITLE
chore(fiftyone-db): AS-1210 bump fiftyone-db to latest patches

### DIFF
--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -21,20 +21,20 @@ from wheel.bdist_wheel import bdist_wheel
 
 DARWIN = "Darwin"
 DARWIN_DOWNLOADS = {
-    "arm64": "https://fastdl.mongodb.org/osx/mongodb-macos-arm64-7.0.25.tgz",
-    "x86_64": "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-7.0.25.tgz",
+    "arm64": "https://fastdl.mongodb.org/osx/mongodb-macos-arm64-7.0.28.tgz",
+    "x86_64": "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-7.0.28.tgz",
 }
 
 LINUX = "Linux"
 LINUX_DOWNLOADS = {
     "amzn": {
         "2": {
-            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-amazon2-7.0.25.tgz",
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-amazon2-7.0.25.tgz",
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-amazon2-7.0.28.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-amazon2-7.0.28.tgz",
         },
         "2023": {
-            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-amazon2023-7.0.25.tgz",
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-amazon2023-7.0.25.tgz",
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-amazon2023-7.0.28.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-amazon2023-7.0.28.tgz",
         },
     },
     "centos": {
@@ -42,18 +42,18 @@ LINUX_DOWNLOADS = {
             # Supported by Mongo, EOL in
             # [June 2024](https://www.redhat.com/en/topics/linux/centos-linux-eol)
             # Consider removing.
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel70-7.0.25.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel70-7.0.28.tgz",
         },
         "8": {
             # Supported by Mongo, EOL in
             # [December 2021](https://www.redhat.com/en/topics/linux/centos-linux-eol)
             # Consider removing.
-            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-rhel8-7.0.25.tgz",
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel8-7.0.25.tgz",
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-rhel8-7.0.28.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel8-7.0.28.tgz",
         },
         "9": {
-            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-rhel90-7.0.25.tgz",
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel90-7.0.25.tgz",
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-rhel90-7.0.28.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel90-7.0.28.tgz",
         },
     },
     "debian": {
@@ -61,20 +61,20 @@ LINUX_DOWNLOADS = {
             # Supported by Mongo, EOL in
             # [June 2024](https://wiki.debian.org/DebianReleases)
             # Consider removing.
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian10-6.0.24.tgz"
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian10-6.0.27.tgz"
         },
         "11": {
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian11-7.0.25.tgz"
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian11-7.0.28.tgz"
         },
         "12": {
-            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-7.0.25.tgz",
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian12-7.0.25.tgz",
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-7.0.28.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian12-7.0.28.tgz",
         },
     },
     "fedora": {
         "4": {
-            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-rhel90-7.0.25.tgz",
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel90-7.0.25.tgz",
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-rhel90-7.0.28.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel90-7.0.28.tgz",
         },
     },
     "pop": {
@@ -82,24 +82,24 @@ LINUX_DOWNLOADS = {
             # Supported by Mongo, EOL in
             # [May 2023](https://ubuntu.com/blog/ubuntu-18-04-eol-for-devices)
             # Consider removing.
-            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu1804-6.0.24.tgz",
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-6.0.24.tgz",
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu1804-6.0.27.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-6.0.27.tgz",
         },
         "20": {
-            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2004-7.0.25.tgz",
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-7.0.25.tgz",
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2004-7.0.28.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-7.0.28.tgz",
         },
         "22": {
-            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-7.0.25.tgz",
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.25.tgz",
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-7.0.28.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.28.tgz",
         },
         "23": {
-            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-7.0.25.tgz",
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.25.tgz",
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-7.0.28.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.28.tgz",
         },
         "24": {
-            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-7.0.4.tgz",
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.4.tgz",
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-7.0.28.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.28.tgz",
         },
     },
     "rhel": {
@@ -107,15 +107,15 @@ LINUX_DOWNLOADS = {
             # Supported by Mongo, EOL in
             # [June 2024](https://www.redhat.com/en/topics/linux/centos-linux-eol)
             # Consider removing.
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel70-7.0.25.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel70-7.0.28.tgz",
         },
         "8": {
-            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-rhel8-7.0.25.tgz",
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel8-7.0.25.tgz",
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-rhel8-7.0.28.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel8-7.0.28.tgz",
         },
         "9": {
-            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-rhel90-7.0.25.tgz",
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel90-7.0.25.tgz",
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-rhel90-7.0.28.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel90-7.0.28.tgz",
         },
     },
     "ubuntu": {
@@ -123,32 +123,32 @@ LINUX_DOWNLOADS = {
             # Supported by Mongo, EOL in
             # [May 2023](https://ubuntu.com/blog/ubuntu-18-04-eol-for-devices)
             # Consider removing.
-            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu1804-6.0.24.tgz",
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-6.0.24.tgz",
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu1804-6.0.27.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-6.0.27.tgz",
         },
         "20": {
-            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2004-7.0.25.tgz",
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-7.0.25.tgz",
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2004-7.0.28.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-7.0.28.tgz",
         },
         "22": {
-            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-7.0.25.tgz",
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.25.tgz",
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-7.0.28.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.28.tgz",
         },
         "23": {
-            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-7.0.25.tgz",
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.25.tgz",
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-7.0.28.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.28.tgz",
         },
         "24": {
-            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2404-8.0.4.tgz",
-            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2404-8.0.4.tgz",
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2404-8.0.17.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2404-8.0.17.tgz",
         },
     },
 }
 
 WINDOWS = "Windows"
 WINDOWS_DOWNLOADS = {
-    "x86_64": "https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-7.0.25.zip",
-    "amd64": "https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-7.0.25.zip",
+    "x86_64": "https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-7.0.28.zip",
+    "amd64": "https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-7.0.28.zip",
 }
 
 
@@ -190,7 +190,7 @@ def _get_download():
 MONGODB_BINARIES = ["mongod"]
 
 
-VERSION = "1.4.0"
+VERSION = "1.4.1"
 
 
 def get_version():


### PR DESCRIPTION
## What changes are proposed in this pull request?


A [CVE](https://nvd.nist.gov/vuln/detail/CVE-2025-14847) was found in MongoDB. We use mongo internally in a few places for CI. To stay secure, we should update a few versions.

MongoDB recommends upgrading to 8.2.3, 8.0.17, 7.0.28, 6.0.27, 5.0.32, or 4.4.30 to resolve [CVE-2025-14847](https://www.cve.org/CVERecord?id=CVE-2025-14847). For details see https://jira.mongodb.org/browse/SERVER-115508 .

We should update the versions our `fiftyone-db` package uses so that OSS users benefit.

## How is this patch tested? If it is not, please explain why.

Test script is below to verify all packages are downloadable:

```shell
% mkdir -p /tmp/mongo-check

% for pkg in $(cat package/db/setup.py | grep https | grep -v '#' | awk '{ print $2 }' | tr -d '"' | tr -d ',' | tail -n+2 | sort | uniq); do 
  wget --directory-prefix /tmp/mongo-check $pkg
done

--2025-12-30 09:39:46--  https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-amazon2-7.0.28.tgz
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.18, 18.238.80.129, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 80899089 (77M) [application/gzip]
Saving to: ‘/tmp/mongo-check/mongodb-linux-aarch64-amazon2-7.0.28.tgz’

mongodb-linux-aarch64-amazon2-7.0.28.tgz                                                                   100%[=======================================================================================================================================================================================================================================================================================>]  77.15M  22.8MB/s    in 3.5s    

2025-12-30 09:39:50 (21.9 MB/s) - ‘/tmp/mongo-check/mongodb-linux-aarch64-amazon2-7.0.28.tgz’ saved [80899089/80899089]

--2025-12-30 09:39:50--  https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-amazon2023-7.0.28.tgz
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.18, 18.238.80.129, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 80783207 (77M) [application/gzip]
Saving to: ‘/tmp/mongo-check/mongodb-linux-aarch64-amazon2023-7.0.28.tgz’

mongodb-linux-aarch64-amazon2023-7.0.28.tgz                                                                100%[=======================================================================================================================================================================================================================================================================================>]  77.04M  23.6MB/s    in 3.4s    

2025-12-30 09:39:54 (22.9 MB/s) - ‘/tmp/mongo-check/mongodb-linux-aarch64-amazon2023-7.0.28.tgz’ saved [80783207/80783207]

--2025-12-30 09:39:54--  https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-rhel8-7.0.28.tgz
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.18, 18.238.80.129, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 80905065 (77M) [application/gzip]
Saving to: ‘/tmp/mongo-check/mongodb-linux-aarch64-rhel8-7.0.28.tgz’

mongodb-linux-aarch64-rhel8-7.0.28.tgz                                                                     100%[=======================================================================================================================================================================================================================================================================================>]  77.16M  21.6MB/s    in 3.6s    

2025-12-30 09:39:57 (21.2 MB/s) - ‘/tmp/mongo-check/mongodb-linux-aarch64-rhel8-7.0.28.tgz’ saved [80905065/80905065]

--2025-12-30 09:39:57--  https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-rhel90-7.0.28.tgz
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.18, 18.238.80.129, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 80783812 (77M) [application/gzip]
Saving to: ‘/tmp/mongo-check/mongodb-linux-aarch64-rhel90-7.0.28.tgz’

mongodb-linux-aarch64-rhel90-7.0.28.tgz                                                                    100%[=======================================================================================================================================================================================================================================================================================>]  77.04M  21.6MB/s    in 3.7s    

2025-12-30 09:40:01 (21.0 MB/s) - ‘/tmp/mongo-check/mongodb-linux-aarch64-rhel90-7.0.28.tgz’ saved [80783812/80783812]

--2025-12-30 09:40:01--  https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu1804-6.0.27.tgz
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.18, 18.238.80.129, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 69577197 (66M) [application/gzip]
Saving to: ‘/tmp/mongo-check/mongodb-linux-aarch64-ubuntu1804-6.0.27.tgz’

mongodb-linux-aarch64-ubuntu1804-6.0.27.tgz                                                                100%[=======================================================================================================================================================================================================================================================================================>]  66.35M  23.0MB/s    in 2.9s    

2025-12-30 09:40:04 (23.0 MB/s) - ‘/tmp/mongo-check/mongodb-linux-aarch64-ubuntu1804-6.0.27.tgz’ saved [69577197/69577197]

--2025-12-30 09:40:04--  https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2004-7.0.28.tgz
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.18, 18.238.80.129, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 80895572 (77M) [application/gzip]
Saving to: ‘/tmp/mongo-check/mongodb-linux-aarch64-ubuntu2004-7.0.28.tgz’

mongodb-linux-aarch64-ubuntu2004-7.0.28.tgz                                                                100%[=======================================================================================================================================================================================================================================================================================>]  77.15M  21.5MB/s    in 3.7s    

2025-12-30 09:40:09 (21.0 MB/s) - ‘/tmp/mongo-check/mongodb-linux-aarch64-ubuntu2004-7.0.28.tgz’ saved [80895572/80895572]

--2025-12-30 09:40:09--  https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-7.0.28.tgz
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.18, 18.238.80.129, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 80778934 (77M) [application/gzip]
Saving to: ‘/tmp/mongo-check/mongodb-linux-aarch64-ubuntu2204-7.0.28.tgz’

mongodb-linux-aarch64-ubuntu2204-7.0.28.tgz                                                                100%[=======================================================================================================================================================================================================================================================================================>]  77.04M  22.5MB/s    in 3.4s    

2025-12-30 09:40:12 (22.5 MB/s) - ‘/tmp/mongo-check/mongodb-linux-aarch64-ubuntu2204-7.0.28.tgz’ saved [80778934/80778934]

--2025-12-30 09:40:12--  https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2404-8.0.17.tgz
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.18, 18.238.80.129, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 97559909 (93M) [application/gzip]
Saving to: ‘/tmp/mongo-check/mongodb-linux-aarch64-ubuntu2404-8.0.17.tgz’

mongodb-linux-aarch64-ubuntu2404-8.0.17.tgz                                                                100%[=======================================================================================================================================================================================================================================================================================>]  93.04M  21.8MB/s    in 4.3s    

2025-12-30 09:40:17 (21.8 MB/s) - ‘/tmp/mongo-check/mongodb-linux-aarch64-ubuntu2404-8.0.17.tgz’ saved [97559909/97559909]

--2025-12-30 09:40:17--  https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-amazon2-7.0.28.tgz
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.18, 18.238.80.129, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 85982663 (82M) [application/gzip]
Saving to: ‘/tmp/mongo-check/mongodb-linux-x86_64-amazon2-7.0.28.tgz’

mongodb-linux-x86_64-amazon2-7.0.28.tgz                                                                    100%[=======================================================================================================================================================================================================================================================================================>]  82.00M  24.1MB/s    in 3.4s    

2025-12-30 09:40:20 (24.1 MB/s) - ‘/tmp/mongo-check/mongodb-linux-x86_64-amazon2-7.0.28.tgz’ saved [85982663/85982663]

--2025-12-30 09:40:20--  https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-amazon2023-7.0.28.tgz
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.18, 18.238.80.129, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 85838897 (82M) [application/gzip]
Saving to: ‘/tmp/mongo-check/mongodb-linux-x86_64-amazon2023-7.0.28.tgz’

mongodb-linux-x86_64-amazon2023-7.0.28.tgz                                                                 100%[=======================================================================================================================================================================================================================================================================================>]  81.86M  22.0MB/s    in 3.7s    

2025-12-30 09:40:24 (22.0 MB/s) - ‘/tmp/mongo-check/mongodb-linux-x86_64-amazon2023-7.0.28.tgz’ saved [85838897/85838897]

--2025-12-30 09:40:24--  https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian10-6.0.27.tgz
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.18, 18.238.80.129, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 73128315 (70M) [application/gzip]
Saving to: ‘/tmp/mongo-check/mongodb-linux-x86_64-debian10-6.0.27.tgz’

mongodb-linux-x86_64-debian10-6.0.27.tgz                                                                   100%[=======================================================================================================================================================================================================================================================================================>]  69.74M  25.2MB/s    in 2.8s    

2025-12-30 09:40:27 (25.2 MB/s) - ‘/tmp/mongo-check/mongodb-linux-x86_64-debian10-6.0.27.tgz’ saved [73128315/73128315]

--2025-12-30 09:40:27--  https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian11-7.0.28.tgz
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.18, 18.238.80.129, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 85980308 (82M) [application/gzip]
Saving to: ‘/tmp/mongo-check/mongodb-linux-x86_64-debian11-7.0.28.tgz’

mongodb-linux-x86_64-debian11-7.0.28.tgz                                                                   100%[=======================================================================================================================================================================================================================================================================================>]  82.00M  22.2MB/s    in 3.9s    

2025-12-30 09:40:32 (21.2 MB/s) - ‘/tmp/mongo-check/mongodb-linux-x86_64-debian11-7.0.28.tgz’ saved [85980308/85980308]

--2025-12-30 09:40:32--  https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian12-7.0.28.tgz
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.18, 18.238.80.129, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 85841180 (82M) [application/gzip]
Saving to: ‘/tmp/mongo-check/mongodb-linux-x86_64-debian12-7.0.28.tgz’

mongodb-linux-x86_64-debian12-7.0.28.tgz                                                                   100%[=======================================================================================================================================================================================================================================================================================>]  81.86M  23.6MB/s    in 3.7s    

2025-12-30 09:40:36 (22.4 MB/s) - ‘/tmp/mongo-check/mongodb-linux-x86_64-debian12-7.0.28.tgz’ saved [85841180/85841180]

--2025-12-30 09:40:36--  https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel70-7.0.28.tgz
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.18, 18.238.80.129, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 85981489 (82M) [application/gzip]
Saving to: ‘/tmp/mongo-check/mongodb-linux-x86_64-rhel70-7.0.28.tgz’

mongodb-linux-x86_64-rhel70-7.0.28.tgz                                                                     100%[=======================================================================================================================================================================================================================================================================================>]  82.00M  25.8MB/s    in 3.2s    

2025-12-30 09:40:39 (25.8 MB/s) - ‘/tmp/mongo-check/mongodb-linux-x86_64-rhel70-7.0.28.tgz’ saved [85981489/85981489]

--2025-12-30 09:40:39--  https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel8-7.0.28.tgz
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.18, 18.238.80.129, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 85981883 (82M) [application/gzip]
Saving to: ‘/tmp/mongo-check/mongodb-linux-x86_64-rhel8-7.0.28.tgz’

mongodb-linux-x86_64-rhel8-7.0.28.tgz                                                                      100%[=======================================================================================================================================================================================================================================================================================>]  82.00M  23.6MB/s    in 3.6s    

2025-12-30 09:40:43 (22.5 MB/s) - ‘/tmp/mongo-check/mongodb-linux-x86_64-rhel8-7.0.28.tgz’ saved [85981883/85981883]

--2025-12-30 09:40:43--  https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel90-7.0.28.tgz
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.18, 18.238.80.129, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 85842242 (82M) [application/gzip]
Saving to: ‘/tmp/mongo-check/mongodb-linux-x86_64-rhel90-7.0.28.tgz’

mongodb-linux-x86_64-rhel90-7.0.28.tgz                                                                     100%[=======================================================================================================================================================================================================================================================================================>]  81.87M  22.0MB/s    in 4.1s    

2025-12-30 09:40:47 (20.2 MB/s) - ‘/tmp/mongo-check/mongodb-linux-x86_64-rhel90-7.0.28.tgz’ saved [85842242/85842242]

--2025-12-30 09:40:47--  https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-6.0.27.tgz
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.18, 18.238.80.129, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 73103849 (70M) [application/gzip]
Saving to: ‘/tmp/mongo-check/mongodb-linux-x86_64-ubuntu1804-6.0.27.tgz’

mongodb-linux-x86_64-ubuntu1804-6.0.27.tgz                                                                 100%[=======================================================================================================================================================================================================================================================================================>]  69.72M  23.1MB/s    in 3.0s    

2025-12-30 09:40:50 (23.1 MB/s) - ‘/tmp/mongo-check/mongodb-linux-x86_64-ubuntu1804-6.0.27.tgz’ saved [73103849/73103849]

--2025-12-30 09:40:50--  https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-7.0.28.tgz
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.18, 18.238.80.129, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 85981701 (82M) [application/gzip]
Saving to: ‘/tmp/mongo-check/mongodb-linux-x86_64-ubuntu2004-7.0.28.tgz’

mongodb-linux-x86_64-ubuntu2004-7.0.28.tgz                                                                 100%[=======================================================================================================================================================================================================================================================================================>]  82.00M  22.6MB/s    in 3.7s    

2025-12-30 09:40:54 (22.0 MB/s) - ‘/tmp/mongo-check/mongodb-linux-x86_64-ubuntu2004-7.0.28.tgz’ saved [85981701/85981701]

--2025-12-30 09:40:54--  https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.28.tgz
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.18, 18.238.80.129, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 85841849 (82M) [application/gzip]
Saving to: ‘/tmp/mongo-check/mongodb-linux-x86_64-ubuntu2204-7.0.28.tgz’

mongodb-linux-x86_64-ubuntu2204-7.0.28.tgz                                                                 100%[=======================================================================================================================================================================================================================================================================================>]  81.86M  23.8MB/s    in 3.6s    

2025-12-30 09:40:58 (23.0 MB/s) - ‘/tmp/mongo-check/mongodb-linux-x86_64-ubuntu2204-7.0.28.tgz’ saved [85841849/85841849]

--2025-12-30 09:40:58--  https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2404-8.0.17.tgz
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.18, 18.238.80.129, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 103672951 (99M) [application/gzip]
Saving to: ‘/tmp/mongo-check/mongodb-linux-x86_64-ubuntu2404-8.0.17.tgz’

mongodb-linux-x86_64-ubuntu2404-8.0.17.tgz                                                                 100%[=======================================================================================================================================================================================================================================================================================>]  98.87M  23.9MB/s    in 4.4s    

2025-12-30 09:41:03 (22.5 MB/s) - ‘/tmp/mongo-check/mongodb-linux-x86_64-ubuntu2404-8.0.17.tgz’ saved [103672951/103672951]

--2025-12-30 09:41:03--  https://fastdl.mongodb.org/osx/mongodb-macos-arm64-7.0.28.tgz
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.18, 18.238.80.129, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 69532134 (66M) [application/gzip]
Saving to: ‘/tmp/mongo-check/mongodb-macos-arm64-7.0.28.tgz’

mongodb-macos-arm64-7.0.28.tgz                                                                             100%[=======================================================================================================================================================================================================================================================================================>]  66.31M  23.2MB/s    in 2.9s    

2025-12-30 09:41:06 (23.2 MB/s) - ‘/tmp/mongo-check/mongodb-macos-arm64-7.0.28.tgz’ saved [69532134/69532134]

--2025-12-30 09:41:06--  https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-7.0.28.tgz
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.129, 18.238.80.18, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 75044858 (72M) [application/gzip]
Saving to: ‘/tmp/mongo-check/mongodb-macos-x86_64-7.0.28.tgz’

mongodb-macos-x86_64-7.0.28.tgz                                                                            100%[=======================================================================================================================================================================================================================================================================================>]  71.57M  22.8MB/s    in 3.1s    

2025-12-30 09:41:09 (22.8 MB/s) - ‘/tmp/mongo-check/mongodb-macos-x86_64-7.0.28.tgz’ saved [75044858/75044858]

--2025-12-30 09:41:09--  https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-7.0.28.zip
Resolving fastdl.mongodb.org (fastdl.mongodb.org)... 18.238.80.85, 18.238.80.129, 18.238.80.18, ...
Connecting to fastdl.mongodb.org (fastdl.mongodb.org)|18.238.80.85|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 629395200 (600M) [application/zip]
Saving to: ‘/tmp/mongo-check/mongodb-windows-x86_64-7.0.28.zip’

mongodb-windows-x86_64-7.0.28.zip                                                                          100%[=======================================================================================================================================================================================================================================================================================>] 600.24M  24.4MB/s    in 26s     

2025-12-30 09:41:35 (23.1 MB/s) - ‘/tmp/mongo-check/mongodb-windows-x86_64-7.0.28.zip’ saved [629395200/629395200]

% ls -larth /tmp/mongo-check 
total 5266248
-rw-r--r--@  1 alexanderfoley  wheel    99M Dec 15 20:47 mongodb-linux-x86_64-ubuntu2404-8.0.17.tgz
-rw-r--r--@  1 alexanderfoley  wheel    93M Dec 15 21:34 mongodb-linux-aarch64-ubuntu2404-8.0.17.tgz
-rw-r--r--@  1 alexanderfoley  wheel    82M Dec 15 21:41 mongodb-linux-x86_64-rhel8-7.0.28.tgz
-rw-r--r--@  1 alexanderfoley  wheel    66M Dec 15 21:44 mongodb-macos-arm64-7.0.28.tgz
-rw-r--r--@  1 alexanderfoley  wheel    82M Dec 15 21:45 mongodb-linux-x86_64-rhel90-7.0.28.tgz
-rw-r--r--@  1 alexanderfoley  wheel    77M Dec 15 21:47 mongodb-linux-aarch64-rhel8-7.0.28.tgz
-rw-r--r--@  1 alexanderfoley  wheel    77M Dec 15 21:53 mongodb-linux-aarch64-ubuntu2204-7.0.28.tgz
-rw-r--r--@  1 alexanderfoley  wheel    82M Dec 15 21:53 mongodb-linux-x86_64-debian11-7.0.28.tgz
-rw-r--r--@  1 alexanderfoley  wheel    77M Dec 15 21:55 mongodb-linux-aarch64-amazon2-7.0.28.tgz
-rw-r--r--@  1 alexanderfoley  wheel    72M Dec 15 22:00 mongodb-macos-x86_64-7.0.28.tgz
-rw-r--r--@  1 alexanderfoley  wheel    77M Dec 15 22:02 mongodb-linux-aarch64-rhel90-7.0.28.tgz
-rw-r--r--@  1 alexanderfoley  wheel    77M Dec 15 22:07 mongodb-linux-aarch64-ubuntu2004-7.0.28.tgz
-rw-r--r--@  1 alexanderfoley  wheel    77M Dec 15 22:07 mongodb-linux-aarch64-amazon2023-7.0.28.tgz
-rw-r--r--@  1 alexanderfoley  wheel    82M Dec 15 22:08 mongodb-linux-x86_64-amazon2023-7.0.28.tgz
-rw-r--r--@  1 alexanderfoley  wheel    82M Dec 15 22:11 mongodb-linux-x86_64-rhel70-7.0.28.tgz
-rw-r--r--@  1 alexanderfoley  wheel    82M Dec 15 22:16 mongodb-linux-x86_64-ubuntu2204-7.0.28.tgz
-rw-r--r--@  1 alexanderfoley  wheel    82M Dec 15 22:17 mongodb-linux-x86_64-amazon2-7.0.28.tgz
-rw-r--r--@  1 alexanderfoley  wheel    82M Dec 15 22:25 mongodb-linux-x86_64-debian12-7.0.28.tgz
-rw-r--r--@  1 alexanderfoley  wheel    82M Dec 15 22:28 mongodb-linux-x86_64-ubuntu2004-7.0.28.tgz
-rw-r--r--@  1 alexanderfoley  wheel   600M Dec 15 23:08 mongodb-windows-x86_64-7.0.28.zip
-rw-r--r--@  1 alexanderfoley  wheel    70M Dec 17 20:32 mongodb-linux-x86_64-debian10-6.0.27.tgz
-rw-r--r--@  1 alexanderfoley  wheel    70M Dec 17 20:49 mongodb-linux-x86_64-ubuntu1804-6.0.27.tgz
-rw-r--r--@  1 alexanderfoley  wheel    66M Dec 17 21:24 mongodb-linux-aarch64-ubuntu1804-6.0.27.tgz
```

And checking the installed version

```shell
(.venv) fiftyone % pip install ./package/db 
Processing ./package/db
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: fiftyone_db
  Building wheel for fiftyone_db (pyproject.toml) ... done
  Created wheel for fiftyone_db: filename=fiftyone_db-1.4.1-py3-none-macosx_11_0_arm64.whl size=41061502 sha256=8172a7944c30248622bced81b5881c78e699250403a618bcf6ca7fec7e218f10
  Stored in directory: /private/var/folders/yl/39xc_xhx2sz1zxlfg9_h5v7h0000gn/T/pip-ephem-wheel-cache-k7myknl3/wheels/bd/25/50/f9cead6d17eda1118001e5930d117d3bfd63a8494e018f1164
Successfully built fiftyone_db
Installing collected packages: fiftyone_db
Successfully installed fiftyone_db-1.4.1

[notice] A new release of pip is available: 23.0.1 -> 25.3
[notice] To update, run: pip install --upgrade pip
(.venv) fiftyone % ls .venv/lib/python3.10/site-packages/fiftyone/db/bin/mongod 
.venv/lib/python3.10/site-packages/fiftyone/db/bin/mongod
(.venv) fiftyone % .venv/lib/python3.10/site-packages/fiftyone/db/bin/mongod --version
db version v7.0.28
Build Info: {
    "version": "7.0.28",
    "gitVersion": "cfc346c59d2cc3dbc903507fc642e22e3097f362",
    "modules": [],
    "allocator": "system",
    "environment": {
        "distarch": "aarch64",
        "target_arch": "aarch64"
    }
}
```
## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Addresses [CVE](https://nvd.nist.gov/vuln/detail/CVE-2025-14847) by upgrading the packaged `fiftyone-db` versions to one of the following:  8.2.3, 8.0.17, 7.0.28, 6.0.27, 5.0.32, or 4.4.30.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MongoDB binaries to version 7.0.28 across all supported platforms (Darwin, Linux distributions, Windows)
  * Bumped version to 1.4.1

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->