### PR TITLE
Fixing `bash` references in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Then run the install script:
 
 ```shell
 # Mac or Linux
-./install.sh
+bash install.sh
 
 # Windows
 .\install.bat
@@ -142,7 +142,7 @@ git checkout develop
 git pull
 
 # Mac or Linux
-bash install.bash
+bash install.sh
 
 # Windows
 .\install.bat
@@ -163,7 +163,7 @@ script:
 
 ```shell
 # Mac or Linux
-bash install.bash -d
+bash install.sh -d
 
 # Windows
 .\install.bat -d
@@ -187,7 +187,7 @@ git clone --depth 1 https://github.com/voxel51/fiftyone.git
 cd fiftyone
 
 # Mac or Linux
-bash install.bash
+bash install.sh
 
 # Windows
 .\install.bat


### PR DESCRIPTION
https://github.com/voxel51/fiftyone/pull/6348 converted FO's install scripts from `bash` to `sh`, but a few references to `install.bash` remained in READMEs. This PR updates those.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Mac and Linux installation instructions to use standardized command syntax for the install script, improving clarity and consistency across all platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->