### PR TITLE
FOEPD-2856: Add docs for new camera model / intrinsics / extrinsics

### DIFF
--- a/docs/source/_includes/substitutions.rst
+++ b/docs/source/_includes/substitutions.rst
@@ -69,6 +69,15 @@
 .. |KeypointSkeleton| replace:: :class:`KeypointSkeleton <fiftyone.core.odm.dataset.KeypointSkeleton>`
 .. |ColorScheme| replace:: :class:`ColorScheme <fiftyone.core.odm.dataset.ColorScheme>`
 
+.. |CameraIntrinsics| replace:: :class:`CameraIntrinsics <fiftyone.core.camera.CameraIntrinsics>`
+.. |PinholeCameraIntrinsics| replace:: :class:`PinholeCameraIntrinsics <fiftyone.core.camera.PinholeCameraIntrinsics>`
+.. |OpenCVCameraIntrinsics| replace:: :class:`OpenCVCameraIntrinsics <fiftyone.core.camera.OpenCVCameraIntrinsics>`
+.. |OpenCVFisheyeCameraIntrinsics| replace:: :class:`OpenCVFisheyeCameraIntrinsics <fiftyone.core.camera.OpenCVFisheyeCameraIntrinsics>`
+.. |CameraIntrinsicsRef| replace:: :class:`CameraIntrinsicsRef <fiftyone.core.camera.CameraIntrinsicsRef>`
+.. |SensorExtrinsics| replace:: :class:`SensorExtrinsics <fiftyone.core.camera.SensorExtrinsics>`
+.. |CameraExtrinsics| replace:: :class:`CameraExtrinsics <fiftyone.core.camera.CameraExtrinsics>`
+.. |CameraProjector| replace:: :class:`CameraProjector <fiftyone.core.camera.CameraProjector>`
+
 .. |tags| replace:: :class:`tags <fiftyone.core.sample.Sample>`
 .. |Tags| replace:: :class:`Tags <fiftyone.core.sample.Sample>`
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Documentation for intrinsics / extrinsics. Main PR is https://github.com/voxel51/fiftyone/pull/6700

## How is this patch tested? If it is not, please explain why.

Local docs build

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded user guide with comprehensive camera calibration coverage: storing/resolving camera intrinsics and sensor extrinsics, intrinsics models, 3D projection/transform workflows, and practical dataset/sample examples.
  * Added new substitutions and cross-reference entries for camera-related terms to improve readability and linking.
  * Note: content-only changes; no API or runtime behavior changes. Some sections were inadvertently duplicated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->