### PR TITLE
Add redirects for old API URLs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ from custom_directives import (
     CustomGuidesCardDirective,
     CustomAnimatedCTADirective,
 )
-from redirects import generate_redirects
+from redirects import generate_redirects, generate_api_redirects
 
 import fiftyone.constants as foc
 
@@ -281,6 +281,7 @@ def setup(app):
     # Generate page redirects
     app.add_config_value("redirects_file", "redirects", "env")
     app.connect("builder-inited", generate_redirects)
+    app.connect("build-finished", generate_api_redirects)
 
     # Custom directives
     app.add_directive("custombutton", CustomButtonDirective)


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR fixes old API class URLs that were breaking (flagged by **Monica, thanks Monica!** 🙌).

Old links like:
`api/fiftyone.zoo.datasets.base.ActivityNet200Dataset.html`

now correctly redirect to the module page with an anchor, for example:
`fiftyone.zoo.datasets.base.html#fiftyone.zoo.datasets.base.ActivityNet200Dataset`

The redirects are generated at **Sphinx `build-finished` time**, so all HTML files exist before scanning for class IDs.
This fixes **100+ broken links** reported by Google Search Console and improves SEO by preserving link equity.

**Examples (working on dev):**

* [https://docs.dev.voxel51.com/api/fiftyone.core.labels.Detection.html](https://docs.dev.voxel51.com/api/fiftyone.core.labels.Detection.html)
* [https://docs.dev.voxel51.com/api/fiftyone.core.labels.Segmentation.html](https://docs.dev.voxel51.com/api/fiftyone.core.labels.Segmentation.html)
* [https://docs.dev.voxel51.com/api/fiftyone.zoo.datasets.base.ActivityNet100Dataset.html](https://docs.dev.voxel51.com/api/fiftyone.zoo.datasets.base.ActivityNet100Dataset.html)
* [https://docs.dev.voxel51.com/api/fiftyone.zoo.datasets.base.ActivityNet200Dataset.html](https://docs.dev.voxel51.com/api/fiftyone.zoo.datasets.base.ActivityNet200Dataset.html)
* [https://docs.dev.voxel51.com/api/fiftyone.core.view.DatasetView.html](https://docs.dev.voxel51.com/api/fiftyone.core.view.DatasetView.html)

## How is this patch tested? If it is not, please explain why.

- Deployed to **dev** and tested live: [https://docs.dev.voxel51.com/](https://docs.dev.voxel51.com/)
- Manually opened multiple old API URLs and confirmed they redirect to the correct module + anchor
- Verified pages load correctly and anchors jump to the right class

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

* [ ] App: FiftyOne application changes
* [ ] Build: Build and test infrastructure changes
* [ ] Core: Core `fiftyone` Python library changes
* [x] Documentation: FiftyOne documentation changes
* [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved API redirect generation during documentation builds. Redirects are now created at build completion, ensuring they're generated reliably for HTML documentation builds without errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->