### PR TITLE
test(FileExplorerView): add unit tests for FileTable and utils

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileTable.test.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileTable.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import FileTable from "./FileTable";
+
+// @fiftyone/components imports @fiftyone/utilities transitively via @fiftyone/looker,
+// and utilities has Node.js dependencies that don't work in jsdom.
+// These mocks break that dependency chain.
+vi.mock("@fiftyone/components", () => ({
+  Button: ({ children, onClick }: any) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+  scrollable: "mock-scrollable",
+}));
+
+vi.mock("@fiftyone/utilities", () => ({
+  humanReadableBytes: (bytes: number) => (bytes ? `${bytes} B` : ""),
+}));
+
+const defaultProps = {
+  chooseMode: "file" as const,
+  files: [],
+  selectedFile: null,
+  onSelectFile: vi.fn(),
+  onChoose: vi.fn(),
+  onOpenDir: vi.fn(),
+  nextPage: vi.fn(),
+  hasNextPage: false,
+};
+
+describe("FileTable", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("should render table headers", () => {
+    render(<FileTable {...defaultProps} />);
+
+    expect(screen.getByText("Name")).toBeTruthy();
+    expect(screen.getByText("Modified")).toBeTruthy();
+    expect(screen.getByText("Size")).toBeTruthy();
+  });
+
+  it("should render files", () => {
+    const files = [
+      { name: "test.txt", type: "file", absolute_path: "/test.txt" },
+    ];
+
+    render(<FileTable {...defaultProps} files={files} />);
+
+    expect(screen.getAllByText("test.txt").length).toBeGreaterThan(0);
+  });
+
+  it("should call onSelectFile when row is clicked", () => {
+    const onSelectFile = vi.fn();
+    const files = [
+      { name: "test.txt", type: "file", absolute_path: "/test.txt" },
+    ];
+
+    render(
+      <FileTable {...defaultProps} files={files} onSelectFile={onSelectFile} />
+    );
+
+    fireEvent.click(screen.getAllByText("test.txt")[0]);
+
+    expect(onSelectFile).toHaveBeenCalledWith(files[0]);
+  });
+
+  it("should call onOpenDir when directory is double-clicked", () => {
+    const onOpenDir = vi.fn();
+    const files = [
+      { name: "mydir", type: "directory", absolute_path: "/mydir" },
+    ];
+
+    render(<FileTable {...defaultProps} files={files} onOpenDir={onOpenDir} />);
+
+    fireEvent.doubleClick(screen.getAllByText("mydir")[0]);
+
+    expect(onOpenDir).toHaveBeenCalledWith(files[0]);
+  });
+
+  it("should show Load more button when hasNextPage is true", () => {
+    render(<FileTable {...defaultProps} hasNextPage={true} />);
+
+    expect(screen.getByText("Load more")).toBeTruthy();
+  });
+
+  it("should not show Load more button when hasNextPage is false", () => {
+    render(<FileTable {...defaultProps} hasNextPage={false} />);
+
+    expect(screen.queryByText("Load more")).toBeNull();
+  });
+
+  it("should call nextPage when Load more is clicked", () => {
+    const nextPage = vi.fn();
+
+    render(
+      <FileTable {...defaultProps} hasNextPage={true} nextPage={nextPage} />
+    );
+
+    fireEvent.click(screen.getByText("Load more"));
+
+    expect(nextPage).toHaveBeenCalled();
+  });
+});

--- a/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/utils.test.ts
+++ b/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/utils.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+// utils.ts imports from @fiftyone/utilities at the top level.
+// That module has Node.js dependencies that fail in jsdom.
+// This mock allows the module to load, even though limitFiles doesn't use these functions.
+vi.mock("@fiftyone/utilities", () => ({
+  getBasename: (path: string) => path.split("/").pop() || "",
+  resolveParent: (path: string) => {
+    const parts = path.split("/");
+    parts.pop();
+    return parts.join("/") || null;
+  },
+}));
+
+import { limitFiles } from "./utils";
+
+describe("limitFiles", () => {
+  it("should always include all directories regardless of limit", () => {
+    const files = [
+      { type: "directory", name: "dir1" },
+      { type: "directory", name: "dir2" },
+      { type: "file", name: "file1" },
+    ] as any[];
+
+    const { limitedFiles } = limitFiles(files, 0);
+
+    const dirs = limitedFiles.filter((f) => f.type === "directory");
+    expect(dirs).toHaveLength(2);
+  });
+
+  it("should limit only files", () => {
+    const files = [
+      { type: "directory", name: "dir1" },
+      { type: "file", name: "file1" },
+      { type: "file", name: "file2" },
+      { type: "file", name: "file3" },
+    ] as any[];
+
+    const { limitedFiles } = limitFiles(files, 2);
+
+    expect(limitedFiles).toHaveLength(3); // 1 dir + 2 files
+  });
+
+  it("should return file count (not including directories)", () => {
+    const files = [
+      { type: "directory", name: "dir1" },
+      { type: "file", name: "file1" },
+      { type: "file", name: "file2" },
+    ] as any[];
+
+    const { fileCount } = limitFiles(files, 10);
+
+    expect(fileCount).toBe(2);
+  });
+
+  it("should put directories before files", () => {
+    const files = [
+      { type: "file", name: "file1" },
+      { type: "directory", name: "dir1" },
+    ] as any[];
+
+    const { limitedFiles } = limitFiles(files, 10);
+
+    expect(limitedFiles[0].type).toBe("directory");
+    expect(limitedFiles[1].type).toBe("file");
+  });
+});


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add unit tests for the FileExplorerView component:

- `utils.test.ts` - Tests for `limitFiles` utility function (directory prioritization, file limiting, count calculation)
- `FileTable.test.tsx` - Tests for FileTable component (rendering, row selection, directory navigation, "Load more" button behavior)

## How is this patch tested? If it is not, please explain why.

This PR adds the tests themselves. Run with:

```
yarn test packages/core/src/plugins/SchemaIO/components/FileExplorerView/
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for FileTable component to verify file selection, directory navigation, and pagination functionality.
  * Added unit tests for file utilities to validate filtering and file organization behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->