### PR TITLE
FOEPD-2894: Use DynamicEmbeddedDocument as fallback when new loading newer datasets with legacy clients

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -9160,6 +9160,33 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     def _sample_dict_to_doc(self, d, *, _reload_backing_docs=True):
         try:
             return self._sample_doc_cls.from_dict(d)
+        except moe.NotRegistered as e:
+            # Handle unknown embedded document types by sanitizing the document
+            # and retrying. This enables backward compatibility when loading
+            # datasets created with newer FiftyOne versions that have types not
+            # available in this version.
+            from fiftyone.core.odm.utils import sanitize_unknown_embedded_docs
+
+            logger.warning(
+                "Detected unknown embedded document class while loading sample with "
+                "ID %s. Attempting to replace unknown types with DynamicEmbeddedDocument. "
+                "Original error: %s",
+                (d or {}).get("_id", "None"),
+                str(e),
+            )
+
+            # Sanitize the document to remove unknown embedded document types
+            d_sanitized = sanitize_unknown_embedded_docs(d)
+
+            try:
+                return self._sample_doc_cls.from_dict(d_sanitized)
+            except Exception as retry_error:
+                logger.debug(
+                    "Even after sanitizing, failed to load sample with ID %s: %s",
+                    (d or {}).get("_id", "None"),
+                    str(retry_error),
+                )
+                raise retry_error
         except Exception as e:
             logger.debug(
                 f'Error loading sample with ID {(d or {}).get("_id", "None")}. Error: {e}'

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -88,11 +88,42 @@ class SampleFieldDocument(EmbeddedDocument):
 
         embedded_doc_type = self.embedded_doc_type
         if embedded_doc_type is not None:
-            embedded_doc_type = etau.get_class(embedded_doc_type)
+            try:
+                embedded_doc_type = etau.get_class(embedded_doc_type)
+            except (ImportError, ModuleNotFoundError):
+                # Fall back to generic embedded document for unknown types
+                # This enables backward compatibility when loading datasets
+                # created with newer FiftyOne versions that have types not
+                # available in this version
+                from fiftyone.core.odm.embedded_document import (
+                    DynamicEmbeddedDocument,
+                )
+
+                logger.warning(
+                    "Unknown embedded document type '%s' for field '%s'. "
+                    "Using DynamicEmbeddedDocument as fallback. "
+                    "Some functionality may be limited.",
+                    self.embedded_doc_type,
+                    self.name,
+                )
+                embedded_doc_type = DynamicEmbeddedDocument
 
         subfield = self.subfield
         if subfield is not None:
-            subfield = etau.get_class(subfield)
+            try:
+                subfield = etau.get_class(subfield)
+            except (ImportError, ModuleNotFoundError):
+                from fiftyone.core.odm.embedded_document import (
+                    DynamicEmbeddedDocument,
+                )
+
+                logger.warning(
+                    "Unknown subfield type '%s' for field '%s'. "
+                    "Using DynamicEmbeddedDocument as fallback.",
+                    self.subfield,
+                    self.name,
+                )
+                subfield = DynamicEmbeddedDocument
 
         fields = None
         if self.fields is not None:

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -113,17 +113,14 @@ class SampleFieldDocument(EmbeddedDocument):
             try:
                 subfield = etau.get_class(subfield)
             except (ImportError, ModuleNotFoundError):
-                from fiftyone.core.odm.embedded_document import (
-                    DynamicEmbeddedDocument,
-                )
-
                 logger.warning(
                     "Unknown subfield type '%s' for field '%s'. "
-                    "Using DynamicEmbeddedDocument as fallback.",
+                    "Setting subfield to None. "
+                    "Some functionality may be limited.",
                     self.subfield,
                     self.name,
                 )
-                subfield = DynamicEmbeddedDocument
+                subfield = None
 
         fields = None
         if self.fields is not None:

--- a/fiftyone/core/odm/utils.py
+++ b/fiftyone/core/odm/utils.py
@@ -9,6 +9,7 @@ Utilities for documents.
 from datetime import date, datetime
 import inspect
 import json
+import logging
 import numbers
 import sys
 import warnings
@@ -16,6 +17,7 @@ import warnings
 from bson import Binary, json_util, ObjectId, SON
 import numpy as np
 import pytz
+from mongoengine.errors import NotRegistered
 
 import eta.core.utils as etau
 
@@ -27,6 +29,8 @@ import fiftyone.core.utils as fou
 fol = fou.lazy_import("fiftyone.core.labels")
 food = fou.lazy_import("fiftyone.core.odm.document")
 fooe = fou.lazy_import("fiftyone.core.odm.embedded_document")
+
+logger = logging.getLogger(__name__)
 
 
 def serialize_value(value, extended=False):
@@ -121,6 +125,58 @@ def deserialize_value(value):
         return [deserialize_value(v) for v in value]
 
     return value
+
+
+def sanitize_unknown_embedded_docs(d):
+    """Recursively replaces unknown embedded document types with DynamicEmbeddedDocument,
+    removing unresolvable _cls fields so MongoEngine doesn't try to resolve them.
+
+    This enables backward compatibility when loading datasets created with newer
+    FiftyOne versions that contain embedded document types not available in the
+    current version.
+
+    Args:
+        d: a dictionary potentially containing embedded documents
+
+    Returns:
+        the sanitized dictionary
+    """
+    if not isinstance(d, dict):
+        return d
+
+    result = {}
+    for k, v in d.items():
+        if isinstance(v, dict):
+            if "_cls" in v:
+                try:
+                    result[k] = deserialize_value(v)
+                except DocumentRegistryError:
+                    # Just keep the dict as-is without _cls
+                    v_copy = v.copy()
+                    unknown_cls = v_copy.pop("_cls", None)
+                    if unknown_cls:
+                        logger.warning(
+                            "Removing unknown embedded document type '%s' from field '%s'",
+                            unknown_cls,
+                            k,
+                        )
+                    result[k] = sanitize_unknown_embedded_docs(v_copy)
+            else:
+                # Recursively sanitize nested dicts
+                result[k] = sanitize_unknown_embedded_docs(v)
+        elif isinstance(v, list):
+            result[k] = [
+                (
+                    sanitize_unknown_embedded_docs(item)
+                    if isinstance(item, dict)
+                    else item
+                )
+                for item in v
+            ]
+        else:
+            result[k] = v
+
+    return result
 
 
 def validate_field_name(field_name, media_type=None, is_frame_field=False):

--- a/tests/unittests/odm_tests.py
+++ b/tests/unittests/odm_tests.py
@@ -188,3 +188,86 @@ class GetIndexedValuesTests(unittest.TestCase):
 
         finally:
             dataset.delete()
+
+
+class SanitizeUnknownEmbeddedDocsTests(unittest.TestCase):
+    """Tests for graceful handling of unknown embedded document types."""
+
+    def test_sanitize_simple_unknown_document(self):
+        """Test sanitizing a simple unknown embedded document."""
+        import fiftyone.core.odm.utils as foou
+
+        data = {
+            "field1": "value1",
+            "unknown_field": {
+                "_cls": "UnknownDocumentType",
+                "data": "some_data",
+            },
+        }
+
+        result = foou.sanitize_unknown_embedded_docs(data)
+
+        # The unknown document should be converted to DynamicEmbeddedDocument
+        self.assertEqual(result["field1"], "value1")
+        self.assertIn("unknown_field", result)
+        # DynamicEmbeddedDocument keeps the data
+        self.assertEqual(result["unknown_field"]["data"], "some_data")
+        self.assertNotIn("_cls", result["unknown_field"])
+
+    def test_sanitize_nested_unknown_documents(self):
+        """Test sanitizing nested unknown embedded documents."""
+        import fiftyone.core.odm.utils as foou
+
+        data = {
+            "level1": {
+                "_cls": "UnknownType1",
+                "level2": {
+                    "_cls": "UnknownType2",
+                    "value": "nested_value",
+                },
+            },
+        }
+
+        result = foou.sanitize_unknown_embedded_docs(data)
+
+        # Both levels should be preserved
+        self.assertIn("level1", result)
+        self.assertEqual(result["level1"]["level2"]["value"], "nested_value")
+
+    def test_sanitize_list_of_documents(self):
+        """Test sanitizing lists containing unknown documents."""
+        import fiftyone.core.odm.utils as foou
+
+        data = {
+            "items": [
+                {"_cls": "UnknownType", "name": "item1"},
+                "string_item",
+                {"normal_dict": "value"},
+            ],
+        }
+
+        result = foou.sanitize_unknown_embedded_docs(data)
+
+        self.assertEqual(len(result["items"]), 3)
+        self.assertEqual(result["items"][0]["name"], "item1")
+        self.assertEqual(result["items"][1], "string_item")
+        self.assertEqual(result["items"][2]["normal_dict"], "value")
+
+    def test_sanitize_preserves_known_documents(self):
+        """Test that known documents are preserved as-is."""
+        import fiftyone.core.odm.utils as foou
+
+        # Create a dict that looks like a FiftyOne document (has _cls but it's known)
+        data = {
+            "field": "value",
+            "nested": {
+                "_cls": "fiftyone.core.odm.embedded_document.DynamicEmbeddedDocument",
+                "data": "preserved",
+            },
+        }
+
+        result = foou.sanitize_unknown_embedded_docs(data)
+
+        # Should not raise an error and should preserve structure
+        self.assertEqual(result["field"], "value")
+        self.assertIn("nested", result)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Use `DynamicEmbeddedDocument` as fallback when new cls is not found. This makes legacy clients of FO more resilient when loading datasets created by newer SDKs.

Tested loading example dataset from https://github.com/voxel51/fiftyone/pull/6700 in older version of FO.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when loading datasets containing unknown embedded field types.
  * Unknown types now generate warnings and fall back to safe dynamic representations instead of preventing dataset loading.
  * Nested and list-based embedded documents are handled more reliably during deserialization.

* **Tests**
  * Added coverage for unknown embedded documents, including nested documents, lists, and preservation of recognized document types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->