### PR TITLE
update httplib2 version to fix security vulnerability [FOEPD-2771]

### DIFF
--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,6 +1,6 @@
-google-api-python-client>=1.6.5
+google-api-python-client>=1.7.12
 google-cloud-storage>=1.36
-httplib2==0.19
+httplib2>=0.19
 ipywidgets>=7.5
 notebook>=5.3
 pydicom>=2.2.0


### PR DESCRIPTION
## What changes are proposed in this pull request?

bump `httplib2` version to `0.19`

Running `pip` resulted in the following:

```
Successfully installed botocore-1.36.2 httplib2-0.19.0 pyparsing-2.4.7 s3transfer-0.11.3
```

## How is this patch tested? If it is not, please explain why.

Read through [CHANGELOG](https://github.com/httplib2/httplib2/blob/master/CHANGELOG) and I don't see any breaking changes.

I have not thoroughly testing running the application.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Security fix for httplib2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated google-api-python-client minimum to >=1.7.12 to ensure compatibility with newer API fixes.
  * Relaxed httplib2 constraint to require >=0.19 by removing the previous upper bound, improving compatibility with recent transports.
  * Added shapely (>=1.7.1) to support geometry operations required by newer features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->