### PR TITLE
Add custom 404 page for docs site

### DIFF
--- a/docs/source/404.html
+++ b/docs/source/404.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>404 - Page not found</title>
+    <link rel="icon" href="/_static/favicon/favicon-32.png">
+    <style>@font-face{font-display:swap;font-family:Geist;src:url("/_static/fonts/geist-v3-latin-500.woff2") format("woff2")}</style>
+</head>
+<body style="margin:0;height:100vh;display:flex;flex-direction:column;align-items:center;justify-content:center;font-family:Geist,system-ui,sans-serif;background:#fff;">
+    <h1 style="font-size:48px;font-weight:500;margin:0 0 8px;">404</h1>
+    <p style="margin:0 0 32px;color:#333;">Page not found</p>
+    <a href="https://docs.voxel51.com/" style="background:#1a1a1a;color:#fff;padding:14px 28px;border-radius:40px;text-decoration:none;font-size:14px;">Back to Home</a>
+</body>
+</html>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -202,6 +202,7 @@ html_favicon = "_static/favicon/favicon.ico"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+html_extra_path = ["404.html"]
 
 # These paths are either relative to html_static_path
 # or fully qualified paths (eg. https://...)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Added a simple 404 error page that matches FO docs styling. The page shows a "404 - Page not found" message with a button to return home. Deployed to dev and configured GCS to serve the custom 404 page. After this PR is merged, I'll apply the same config to prod.

## How is this patch tested? If it is not, please explain why.

Build in local, and deploy to dev to validate that is working property 

http://docs.dev.voxel51.com/thispagedoesntexist
<img width="2739" height="1650" alt="image" src="https://github.com/user-attachments/assets/e17212e3-7782-43f6-b928-c7543d8e39ec" />

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [X] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [X] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a custom 404 error page for the documentation site with a helpful message and navigation link back to the home page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->