### PR TITLE
deps(setup.py): Use ETA version 0.15.2 or higher

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ INSTALL_REQUIRES = [
     # internal packages
     "fiftyone-brain>=0.21.4,<0.22",
     "fiftyone-db>=0.4,<2.0",
-    "voxel51-eta>=0.15.1,<0.16",
+    "voxel51-eta>=0.15.2,<0.16",
 ]
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

In https://github.com/voxel51/eta/pull/683, we bumped the `httplib2` version in ETA so that we weren't bound to a vulnerable version. The result was [eta version 0.15.2](https://pypi.org/project/voxel51-eta/0.15.2/)

Let's also bump the version here so that `fiftyone` can benefit.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency version to ensure stability and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->