### PR TITLE
Fix handling multiple in AutocompleteView

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/AutocompleteView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/AutocompleteView.tsx
@@ -23,7 +23,7 @@ export default function AutocompleteView(props) {
         disabled={readOnly}
         autoHighlight
         clearOnBlur={multiple}
-        value={getDefaultValue(data, choices)}
+        value={getDefaultValue(data, choices, multiple)}
         freeSolo={allowUserInput}
         size="small"
         onChange={(e, choice) => {
@@ -92,11 +92,22 @@ export default function AutocompleteView(props) {
 
 // TODO: move these functions to a utils file
 
-function getDefaultValue(defaultValue, choices = []) {
+function getDefaultValue(defaultValue, choices = [], multiple = false) {
+  if (multiple) {
+    // For multiple selection, ensure value is always an array
+    const values = Array.isArray(defaultValue)
+      ? defaultValue
+      : defaultValue != null
+      ? [defaultValue]
+      : [];
+    return values.map((v) => {
+      const choice = choices.find(({ value }) => value === v);
+      return choice || { value: v, label: v };
+    });
+  }
   const choice = choices.find(({ value }) => value === defaultValue);
   return choice || defaultValue;
 }
-
 function getValuesOnlySettingFromSchema(schema) {
   const { view = {} } = schema;
   const isObject = schema.type === "object";


### PR DESCRIPTION
## What changes are proposed in this pull request?

Handle `multiple` in the AutocompleteView.
<img width="1247" height="574" alt="image" src="https://github.com/user-attachments/assets/a49e03fa-1de6-4f1c-829d-0ec2019f9a43" />

Currently, clicking on a boundingbox in the modal of an EvaluationPatches view with annotation enabled, the page throws an error with this stacktrace in the console: 
```
pages-dev-overlay-setup.js:77 The above error occurred in the <ForwardRef(Autocomplete)> component:

    at Autocomplete (webpack-internal:///(pages-dir-browser)/../../node_modules/@mui/material/Autocomplete/Autocomplete.js:400:86)
    at div
    at eval (webpack-internal:///(pages-dir-browser)/../../node_modules/@emotion/react/dist/emotion-element-489459f2.browser.development.esm.js:55:66)
    at Box (webpack-internal:///(pages-dir-browser)/../../node_modules/@mui/system/esm/createBox.js:37:72)
    at FieldWrapper (webpack-internal:///(pages-dir-browser)/../../../app/packages/core/src/plugins/SchemaIO/components/FieldWrapper.tsx:25:22)
    at AutocompleteView (webpack-internal:///(pages-dir-browser)/../../../app/packages/core/src/plugins/SchemaIO/components/AutocompleteView.tsx:29:25)
    at AutoComplete (webpack-internal:///(pages-dir-browser)/../../../app/packages/components/src/components/SmartForm/RJSF/widgets/AutoComplete.tsx:23:21)
    at MergedWidget (webpack-internal:///(pages-dir-browser)/../../../app/node_modules/@rjsf/utils/lib/getWidget.js:83:27)
    at ArrayAsCustomWidget (webpack-internal:///(pages-dir-browser)/../../../app/node_modules/@rjsf/core/lib/components/fields/ArrayField.js:151:13)
    at ArrayField (webpack-internal:///(pages-dir-browser)/../../../app/node_modules/@rjsf/core/lib/components/fields/ArrayField.js:475:13)
    at div
    at eval (webpack-internal:///(pages-dir-browser)/../../node_modules/@emotion/react/dist/emotion-element-489459f2.browser.development.esm.js:55:66)
    at Box (webpack-internal:///(pages-dir-browser)/../../node_modules/@mui/system/esm/createBox.js:37:72)
    at FieldTemplate (webpack-internal:///(pages-dir-browser)/../../../app/packages/components/src/components/SmartForm/RJSF/templates/FieldTemplate.tsx:19:26)
    at SchemaFieldRender (webpack-internal:///(pages-dir-browser)/../../../app/node_modules/@rjsf/core/lib/components/fields/SchemaField.js:64:21)
    at SchemaField (webpack-internal:///(pages-dir-browser)/../../../app/node_modules/@rjsf/core/lib/components/fields/SchemaField.js:187:1)
    at ObjectFieldProperty (webpack-internal:///(pages-dir-browser)/../../../app/node_modules/@rjsf/core/lib/components/fields/ObjectField.js:58:13)
    at div
    at eval (webpack-internal:///(pages-dir-browser)/../../node_modules/@emotion/react/dist/emotion-element-489459f2.browser.development.esm.js:55:66)
    at Box (webpack-internal:///(pages-dir-browser)/../../node_modules/@mui/system/esm/createBox.js:37:72)
    at div
    at eval (webpack-internal:///(pages-dir-browser)/../../node_modules/@emotion/react/dist/emotion-element-489459f2.browser.development.esm.js:55:66)
    at Box (webpack-internal:///(pages-dir-browser)/../../node_modules/@mui/system/esm/createBox.js:37:72)
    at div
    at eval (webpack-internal:///(pages-dir-browser)/../../node_modules/@emotion/react/dist/emotion-element-489459f2.browser.development.esm.js:55:66)
    at Box (webpack-internal:///(pages-dir-browser)/../../node_modules/@mui/system/esm/createBox.js:37:72)
    at ObjectFieldTemplate (webpack-internal:///(pages-dir-browser)/../../../app/packages/components/src/components/SmartForm/RJSF/templates/ObjectFieldTemplate.tsx:23:26)
    at ObjectField (webpack-internal:///(pages-dir-browser)/../../../app/node_modules/@rjsf/core/lib/components/fields/ObjectField.js:110:21)
    at div
    at eval (webpack-internal:///(pages-dir-browser)/../../node_modules/@emotion/react/dist/emotion-element-489459f2.browser.development.esm.js:55:66)
    at Box (webpack-internal:///(pages-dir-browser)/../../node_modules/@mui/system/esm/createBox.js:37:72)
    at FieldTemplate (webpack-internal:///(pages-dir-browser)/../../../app/packages/components/src/components/SmartForm/RJSF/templates/FieldTemplate.tsx:19:26)
    at SchemaFieldRender (webpack-internal:///(pages-dir-browser)/../../../app/node_modules/@rjsf/core/lib/components/fields/SchemaField.js:64:21)
    at SchemaField (webpack-internal:///(pages-dir-browser)/../../../app/node_modules/@rjsf/core/lib/components/fields/SchemaField.js:187:1)
    at form
    at Form (webpack-internal:///(pages-dir-browser)/../../../app/node_modules/@rjsf/core/lib/components/Form.js:57:9)
    at eval (webpack-internal:///(pages-dir-browser)/../../../app/node_modules/@rjsf/core/lib/withTheme.js:14:65)
    at RJSF (webpack-internal:///(pages-dir-browser)/../../../app/packages/components/src/components/SmartForm/RJSF/index.tsx:30:14)
    at SmartForm
    at SchemaIOComponent (webpack-internal:///(pages-dir-browser)/../../../app/packages/core/src/plugins/SchemaIO/index.tsx:18:13)
    at div
    at AnnotationSchema (webpack-internal:///(pages-dir-browser)/../../../app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx:222:16)
    at div
    at O (webpack-internal:///(pages-dir-browser)/../../node_modules/styled-components/dist/styled-components.browser.esm.js:30:23678)
    at div
    at O (webpack-internal:///(pages-dir-browser)/../../node_modules/styled-
```

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default value handling for multi-select autocomplete fields, ensuring values are correctly mapped to corresponding choices and displayed as arrays when needed.
  * Single-select autocomplete behavior remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->