### PR TITLE
[HA] Implement auto-save functionality for 2D labels

### DIFF
--- a/app/packages/annotation/src/commands.ts
+++ b/app/packages/annotation/src/commands.ts
@@ -29,3 +29,12 @@ export class DeleteAnnotationCommand extends Command<boolean> {
     super();
   }
 }
+
+/**
+ * Command to persist aggregate annotation changes.
+ */
+export class PersistAnnotationChanges extends Command<boolean | null> {
+  constructor() {
+    super();
+  }
+}

--- a/app/packages/annotation/src/events.ts
+++ b/app/packages/annotation/src/events.ts
@@ -16,6 +16,18 @@ type MutationSuccess<T> = {
 
 export type AnnotationEventGroup = {
   /**
+   * Notification event emitted when aggregate annotation persistence is requested.
+   */
+  "annotation:persistenceRequested": void;
+  /**
+   * Notification event emitted when aggregate annotation persistence is successful.
+   */
+  "annotation:persistenceSuccess": void;
+  /**
+   * Notification event emitted when aggregate annotation persistence is unsuccessful.
+   */
+  "annotation:persistenceError": { error?: Error };
+  /**
    * Notification event emitted when a label is upserted successfully.
    */
   "annotation:upsertSuccess": MutationSuccess<"upsert">;

--- a/app/packages/annotation/src/hooks/index.ts
+++ b/app/packages/annotation/src/hooks/index.ts
@@ -4,3 +4,4 @@ export * from "./useGetVersionToken";
 export * from "./useLabelPersistence";
 export * from "./usePatchSample";
 export * from "./useRegisterAnnotationCommandHandlers";
+export * from "./useRegisterAnnotationEventHandlers";

--- a/app/packages/annotation/src/hooks/useRegisterAnnotationEventHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterAnnotationEventHandlers.ts
@@ -1,0 +1,44 @@
+import { useAnnotationEventHandler } from "./useAnnotationEventHandler";
+import { useCommandBus } from "@fiftyone/commands";
+import { PersistAnnotationChanges } from "../commands";
+import { useNotification } from "@fiftyone/state";
+import { useCallback } from "react";
+
+/**
+ * Hook which registers global annotation event handlers.
+ * This should be called once in the composition root.
+ */
+export const useRegisterAnnotationEventHandlers = () => {
+  const commandBus = useCommandBus();
+  const setNotification = useNotification();
+
+  useAnnotationEventHandler(
+    "annotation:persistenceRequested",
+    useCallback(() => {
+      commandBus.execute(new PersistAnnotationChanges());
+    }, [commandBus])
+  );
+
+  useAnnotationEventHandler(
+    "annotation:persistenceSuccess",
+    useCallback(() => {
+      setNotification({
+        msg: "Changes saved successfully",
+        variant: "success",
+      });
+    }, [setNotification])
+  );
+
+  useAnnotationEventHandler(
+    "annotation:persistenceError",
+    useCallback(
+      ({ error }) => {
+        setNotification({
+          msg: `Error saving changes: ${error}`,
+          variant: "error",
+        });
+      },
+      [setNotification]
+    )
+  );
+};

--- a/app/packages/annotation/src/index.ts
+++ b/app/packages/annotation/src/index.ts
@@ -2,3 +2,4 @@ export * from "./commands";
 export * from "./deltas";
 export * from "./events";
 export * from "./hooks";
+export * from "./persistence";

--- a/app/packages/annotation/src/persistence/deltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/deltaSupplier.ts
@@ -1,0 +1,6 @@
+import type { JSONDeltas } from "@fiftyone/core";
+
+/**
+ * A function which provides a list of JSON-patch operations when called.
+ */
+export type DeltaSupplier = () => JSONDeltas;

--- a/app/packages/annotation/src/persistence/index.ts
+++ b/app/packages/annotation/src/persistence/index.ts
@@ -1,0 +1,7 @@
+export * from "./deltaSupplier";
+export * from "./use3dDeltaSupplier";
+export * from "./useAnnotationDeltaSupplier";
+export * from "./useAutoSave";
+export * from "./useLighterDeltaSupplier";
+export * from "./usePersistAnnotationDeltas";
+export * from "./useSidebarDeltaSupplier";

--- a/app/packages/annotation/src/persistence/use3dDeltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/use3dDeltaSupplier.ts
@@ -1,0 +1,13 @@
+import { DeltaSupplier } from "./deltaSupplier";
+import { useCallback } from "react";
+
+/**
+ * Hook which provides a {@link DeltaSupplier} which captures changes isolated
+ * to the 3D annotation context.
+ */
+export const use3dDeltaSupplier = (): DeltaSupplier => {
+  // todo
+  return useCallback(() => {
+    return [];
+  }, []);
+};

--- a/app/packages/annotation/src/persistence/useAnnotationDeltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/useAnnotationDeltaSupplier.ts
@@ -1,0 +1,23 @@
+import { DeltaSupplier } from "./deltaSupplier";
+import { useLighterDeltaSupplier } from "./useLighterDeltaSupplier";
+import { useCallback } from "react";
+import { useSidebarDeltaSupplier } from "./useSidebarDeltaSupplier";
+import { use3dDeltaSupplier } from "./use3dDeltaSupplier";
+
+/**
+ * Hook which provides a {@link DeltaSupplier} containing an aggregation of
+ * deltas from all annotation sources.
+ */
+export const useAnnotationDeltaSupplier = (): DeltaSupplier => {
+  const supply3dDeltas = use3dDeltaSupplier();
+  const supplyLighterDeltas = useLighterDeltaSupplier();
+  const supplySidebarDeltas = useSidebarDeltaSupplier();
+
+  return useCallback(() => {
+    return [
+      ...supply3dDeltas(),
+      ...supplyLighterDeltas(),
+      ...supplySidebarDeltas(),
+    ];
+  }, [supply3dDeltas, supplyLighterDeltas, supplySidebarDeltas]);
+};

--- a/app/packages/annotation/src/persistence/useAutoSave.ts
+++ b/app/packages/annotation/src/persistence/useAutoSave.ts
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+import { useAnnotationEventBus } from "../hooks";
+
+/**
+ * Hook which emits a persistence request at the specified interval.
+ *
+ * @param enabled If true, enables auto-save functionality
+ * @param autoSaveInterval Interval in milliseconds to trigger persistence
+ */
+export const useAutoSave = (enabled = false, autoSaveInterval = 3_000) => {
+  const eventBus = useAnnotationEventBus();
+
+  useEffect(() => {
+    if (enabled) {
+      const intervalHandle = setInterval(() => {
+        eventBus.dispatch("annotation:persistenceRequested");
+      }, autoSaveInterval);
+
+      return () => clearInterval(intervalHandle);
+    }
+  }, [autoSaveInterval, enabled, eventBus]);
+};

--- a/app/packages/annotation/src/persistence/useLighterDeltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/useLighterDeltaSupplier.ts
@@ -1,0 +1,81 @@
+import { DeltaSupplier } from "./deltaSupplier";
+import { buildJsonPath, buildLabelDeltas, getFieldSchema } from "../deltas";
+import {
+  BaseOverlay,
+  BoundingBoxOverlay,
+  ClassificationOverlay,
+  useLighter,
+} from "@fiftyone/lighter";
+import { useCallback } from "react";
+import type { JSONDeltas } from "@fiftyone/core";
+import {
+  AnnotationLabel,
+  useModalSample,
+  useModalSampleSchema,
+} from "@fiftyone/state";
+import { DetectionLabel } from "@fiftyone/looker";
+import { ClassificationLabel } from "@fiftyone/looker/src/overlays/classifications";
+
+const buildAnnotationLabel = (
+  overlay: BaseOverlay
+): AnnotationLabel | undefined => {
+  if (
+    overlay instanceof BoundingBoxOverlay &&
+    (overlay as BoundingBoxOverlay).label.label
+  ) {
+    return {
+      type: "Detection",
+      data: overlay.label as DetectionLabel,
+      overlay,
+      path: overlay.field,
+    };
+  } else if (
+    overlay instanceof ClassificationOverlay &&
+    (overlay as ClassificationOverlay).label.label
+  ) {
+    return {
+      type: "Classification",
+      data: overlay.label as ClassificationLabel,
+      overlay,
+      path: overlay.field,
+    };
+  }
+};
+
+/**
+ * Hook which provides a {@link DeltaSupplier} which captures changes isolated
+ * to the Lighter annotation context.
+ */
+export const useLighterDeltaSupplier = (): DeltaSupplier => {
+  const { scene } = useLighter();
+  const modalSample = useModalSample();
+  const modalSampleSchema = useModalSampleSchema();
+
+  return useCallback(() => {
+    const sampleDeltas: JSONDeltas = [];
+
+    scene?.getAllOverlays().forEach((overlay) => {
+      const annotationLabel = buildAnnotationLabel(overlay);
+      if (annotationLabel) {
+        const labelDeltas = buildLabelDeltas(
+          modalSample.sample,
+          buildAnnotationLabel(overlay),
+          getFieldSchema(modalSampleSchema, overlay.field),
+          "mutate"
+        );
+
+        if (labelDeltas?.length > 0) {
+          sampleDeltas.push(
+            ...labelDeltas.map((delta) => ({
+              ...delta,
+              // convert label delta to sample delta
+              path: buildJsonPath(overlay.field, delta.path),
+            }))
+          );
+        }
+      }
+    });
+
+    return sampleDeltas;
+  }, [modalSample.sample, modalSampleSchema, scene]);
+};

--- a/app/packages/annotation/src/persistence/usePersistAnnotationDeltas.ts
+++ b/app/packages/annotation/src/persistence/usePersistAnnotationDeltas.ts
@@ -1,0 +1,34 @@
+import { useCallback } from "react";
+import { useAnnotationDeltaSupplier } from "./useAnnotationDeltaSupplier";
+import { usePatchSample } from "../hooks";
+
+/**
+ * @returns `true` if persistence was successful
+ * @returns `false` if persistence was unsuccessful
+ * @returns `null` if no changes were pending
+ */
+type PersistenceResult = boolean | null;
+
+/**
+ * Hook which provides a callback to persist all pending annotation deltas.
+ *
+ * @returns A callback that persists annotation deltas and returns:
+ *   - `true` if persistence was successful
+ *   - `false` if persistence was unsuccessful
+ *   - `null` if no changes were pending
+ */
+export const usePersistAnnotationDeltas =
+  (): (() => Promise<PersistenceResult>) => {
+    const supplyAnnotationDeltas = useAnnotationDeltaSupplier();
+    const patchSample = usePatchSample();
+
+    return useCallback(async () => {
+      const sampleDeltas = supplyAnnotationDeltas();
+
+      if (sampleDeltas.length > 0) {
+        return await patchSample(sampleDeltas);
+      }
+
+      return null;
+    }, [patchSample, supplyAnnotationDeltas]);
+  };

--- a/app/packages/annotation/src/persistence/useSidebarDeltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/useSidebarDeltaSupplier.ts
@@ -1,0 +1,13 @@
+import { DeltaSupplier } from "./deltaSupplier";
+import { useCallback } from "react";
+
+/**
+ * Hook which provides a {@link DeltaSupplier} which captures changes isolated
+ * to the annotation sidebar.
+ */
+export const useSidebarDeltaSupplier = (): DeltaSupplier => {
+  // todo
+  return useCallback(() => {
+    return [];
+  }, []);
+};

--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -1,4 +1,8 @@
-import { useRegisterAnnotationCommandHandlers } from "@fiftyone/annotation";
+import {
+  useAutoSave,
+  useRegisterAnnotationCommandHandlers,
+  useRegisterAnnotationEventHandlers,
+} from "@fiftyone/annotation";
 import { HelpPanel, JSONPanel } from "@fiftyone/components";
 import { selectiveRenderingEventBus } from "@fiftyone/looker";
 import { OPERATOR_PROMPT_AREAS, OperatorPromptArea } from "@fiftyone/operators";
@@ -7,7 +11,7 @@ import {
   currentModalUniqueIdJotaiAtom,
   jotaiStore,
 } from "@fiftyone/state/src/jotai";
-import React, { useCallback, useMemo, useRef } from "react";
+import React, { Fragment, useCallback, useMemo, useRef } from "react";
 import ReactDOM from "react-dom";
 import { useRecoilCallback, useRecoilValue } from "recoil";
 import styled from "styled-components";
@@ -18,6 +22,7 @@ import { Sidebar } from "./Sidebar";
 import { TooltipInfo } from "./TooltipInfo";
 import { useLookerHelpers, useTooltipEventHandler } from "./hooks";
 import { modalContext } from "./modal-context";
+import { FeatureFlag, useFeature } from "@fiftyone/feature-flags";
 
 const ModalWrapper = styled.div`
   position: fixed;
@@ -54,7 +59,14 @@ const SpacesContainer = styled.div`
 
 const ModalCommandHandlersRegistration = () => {
   useRegisterAnnotationCommandHandlers();
-  return null;
+  useRegisterAnnotationEventHandlers();
+
+  const { isEnabled: enableAutoSave } = useFeature({
+    feature: FeatureFlag.ANNOTATION_AUTO_SAVE,
+  });
+  useAutoSave(enableAutoSave);
+
+  return <Fragment />;
 };
 
 const Modal = () => {

--- a/app/packages/feature-flags/src/client/flags.ts
+++ b/app/packages/feature-flags/src/client/flags.ts
@@ -6,4 +6,6 @@ export enum FeatureFlag {
   EXPERIMENTAL_ANNOTATION = "VFF_EXP_ANNOTATION",
   // annotation milestone 4 features
   VFF_ANNOTATION_M4 = "VFF_ANNOTATION_M4",
+  // annotation auto-save features
+  ANNOTATION_AUTO_SAVE = "VFF_ANNOTATION_AUTO_SAVE",
 }

--- a/fiftyone/internal/features/flags.py
+++ b/fiftyone/internal/features/flags.py
@@ -13,5 +13,7 @@ FeatureFlag = Literal[
     "VFF_EXP_ANNOTATION",
     # annotation milestone 4 features
     "VFF_ANNOTATION_M4",
+    # annotation auto-save features
+    "VFF_ANNOTATION_AUTO_SAVE",
 ]
 """Enumeration of active feature flags."""


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR builds on #6754 to add auto-save functionality (behind a feature flag) for 2D label editing. It also includes placeholders for 3D labels and primitive sample attributes.

## How is this patch tested? If it is not, please explain why.

local app, unit tests

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added annotation persistence with automatic saving capabilities
  * Introduced success and error notifications for save operations
  * Enabled configurable auto-save feature for annotations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->