### PR TITLE
Add YOLO26 detection, segmentation, and classification models to zoo

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -6087,6 +6087,221 @@
             "date_added": "2026-01-15 12:00:00"
         },
         {
+            "base_name": "yolo26n-pose-coco-torch",
+            "base_filename": "yolo26n-pose-coco.pt",
+            "description": "Ultra-fast NMS-free pose estimation for edge devices",
+            "source": "https://docs.ultralytics.com/models/yolo26/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
+            "size_bytes": 7878574,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26n-pose.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLOModel",
+                "config": {
+                    "entrypoint_fcn": "ultralytics.YOLO",
+                    "entrypoint_args": {
+                        "model": "yolo26n-pose.pt"
+                    },
+                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsPoseOutputProcessor"
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.4.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["keypoints", "coco", "torch", "yolo", "official"],
+            "training_data": [
+                { "name": "MS COCO 2017", "url": "https://cocodataset.org" }
+            ],
+            "date_added": "2026-01-15 12:00:00"
+        },
+        {
+            "base_name": "yolo26s-pose-coco-torch",
+            "base_filename": "yolo26s-pose-coco.pt",
+            "description": "Fast NMS-free pose estimation balancing speed and accuracy",
+            "source": "https://docs.ultralytics.com/models/yolo26/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
+            "size_bytes": 24151790,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26s-pose.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLOModel",
+                "config": {
+                    "entrypoint_fcn": "ultralytics.YOLO",
+                    "entrypoint_args": {
+                        "model": "yolo26s-pose.pt"
+                    },
+                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsPoseOutputProcessor"
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.4.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["keypoints", "coco", "torch", "yolo", "official"],
+            "training_data": [
+                { "name": "MS COCO 2017", "url": "https://cocodataset.org" }
+            ],
+            "date_added": "2026-01-15 12:00:00"
+        },
+        {
+            "base_name": "yolo26m-pose-coco-torch",
+            "base_filename": "yolo26m-pose-coco.pt",
+            "description": "NMS-free pose estimation with improved keypoint accuracy",
+            "source": "https://docs.ultralytics.com/models/yolo26/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
+            "size_bytes": 49036866,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26m-pose.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLOModel",
+                "config": {
+                    "entrypoint_fcn": "ultralytics.YOLO",
+                    "entrypoint_args": {
+                        "model": "yolo26m-pose.pt"
+                    },
+                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsPoseOutputProcessor"
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.4.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["keypoints", "coco", "torch", "yolo", "official"],
+            "training_data": [
+                { "name": "MS COCO 2017", "url": "https://cocodataset.org" }
+            ],
+            "date_added": "2026-01-15 12:00:00"
+        },
+        {
+            "base_name": "yolo26l-pose-coco-torch",
+            "base_filename": "yolo26l-pose-coco.pt",
+            "description": "High-accuracy NMS-free pose estimation",
+            "source": "https://docs.ultralytics.com/models/yolo26/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
+            "size_bytes": 57995961,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26l-pose.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLOModel",
+                "config": {
+                    "entrypoint_fcn": "ultralytics.YOLO",
+                    "entrypoint_args": {
+                        "model": "yolo26l-pose.pt"
+                    },
+                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsPoseOutputProcessor"
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.4.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["keypoints", "coco", "torch", "yolo", "official"],
+            "training_data": [
+                { "name": "MS COCO 2017", "url": "https://cocodataset.org" }
+            ],
+            "date_added": "2026-01-15 12:00:00"
+        },
+        {
+            "base_name": "yolo26x-pose-coco-torch",
+            "base_filename": "yolo26x-pose-coco.pt",
+            "description": "Maximum accuracy NMS-free pose estimation",
+            "source": "https://docs.ultralytics.com/models/yolo26/",
+            "author": "Glenn Jocher, et al.",
+            "license": "AGPL-3.0",
+            "size_bytes": 126242553,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26x-pose.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLOModel",
+                "config": {
+                    "entrypoint_fcn": "ultralytics.YOLO",
+                    "entrypoint_args": {
+                        "model": "yolo26x-pose.pt"
+                    },
+                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsPoseOutputProcessor"
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.4.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["keypoints", "coco", "torch", "yolo", "official"],
+            "training_data": [
+                { "name": "MS COCO 2017", "url": "https://cocodataset.org" }
+            ],
+            "date_added": "2026-01-15 12:00:00"
+        },
+        {
             "base_name": "yolo11n-seg-coco-torch",
             "base_filename": "yolo11n-seg-coco.pt",
             "description": "Edge model producing object outlines directly on phones and edge devices",


### PR DESCRIPTION
## Summary
- Add YOLO26 model family to the model zoo (latest Ultralytics release, Jan 2026)

## Models Added

### Detection
| Model | Size | Description |
|-------|------|-------------|
| `yolo26n-coco-torch` | 5.5 MB | Ultra-fast, edge devices |
| `yolo26s-coco-torch` | 20 MB | Fast, balanced |
| `yolo26m-coco-torch` | 44 MB | Medium, general use |
| `yolo26l-coco-torch` | 53 MB | High accuracy |
| `yolo26x-coco-torch` | 119 MB | Maximum accuracy |

### Instance Segmentation
| Model | Size | Description |
|-------|------|-------------|
| `yolo26n-seg-coco-torch` | 6.7 MB | Ultra-fast, edge devices |
| `yolo26s-seg-coco-torch` | 23 MB | Fast, balanced |
| `yolo26m-seg-coco-torch` | 55 MB | Medium, general use |
| `yolo26l-seg-coco-torch` | 64 MB | High accuracy |
| `yolo26x-seg-coco-torch` | 142 MB | Maximum accuracy |

### Classification
| Model | Size | Description |
|-------|------|-------------|
| `yolo26n-cls-imagenet-torch` | 5.5 MB | Ultra-fast, edge devices |
| `yolo26s-cls-imagenet-torch` | 13 MB | Fast, balanced |
| `yolo26m-cls-imagenet-torch` | 22 MB | Medium, general use |
| `yolo26l-cls-imagenet-torch` | 27 MB | High accuracy |
| `yolo26x-cls-imagenet-torch` | 57 MB | Maximum accuracy |

## Usage
```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=5)

# Detection
model = foz.load_zoo_model("yolo26m-coco-torch")
dataset.apply_model(model, label_field="yolo26_det")

# Instance segmentation
seg_model = foz.load_zoo_model("yolo26m-seg-coco-torch")
dataset.apply_model(seg_model, label_field="yolo26_seg")

# Classification
cls_model = foz.load_zoo_model("yolo26m-cls-imagenet-torch")
dataset.apply_model(cls_model, label_field="yolo26_cls")

session = fo.launch_app(dataset)
```

## Test plan
- [x] Model loading via `foz.load_zoo_model()`
- [x] Detection models produce `Detections`
- [x] Segmentation models produce instance masks
- [x] Classification models produce `Classification`
- [x] All 15 variants load successfully
- [x] App and dataset launch successfully