### PR TITLE
fix missing schema when editing a label in annotate

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/state.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/state.ts
@@ -104,7 +104,7 @@ export const currentSchema = atom((get) => {
     throw new Error("no current field");
   }
 
-  return get(labelSchemaData(field))?.labelSchema;
+  return get(labelSchemaData(field))?.label_schema;
 });
 
 export const currentDisabledFields = atom((get) => {


### PR DESCRIPTION
## What changes are proposed in this pull request?

fix missing schema when editing a label in annotate

## How is this patch tested? If it is not, please explain why.

Using annotate tab in the app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed field reference handling in the annotation editing component to ensure correct data retrieval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->