### PR TITLE
Fix leaking file descriptors in _load_image

### DIFF
--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -2630,21 +2630,6 @@ def from_image_classification_dir_tree(dataset_dir):
 
 
 def _load_image(image_path, use_numpy, force_rgb):
-    # Load image from disk
-    if force_rgb:
-        img = cv2.imread(image_path, cv2.IMREAD_COLOR)
-        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-    else:
-        img = cv2.imread(image_path, cv2.IMREAD_UNCHANGED)
-
-    if not use_numpy:
-        # convert to PIL Image for torchvision compatibility
-        img = Image.fromarray(img)
-
-    return img
-
-
-def _load_image(image_path, use_numpy, force_rgb):
     if use_numpy:
         if force_rgb:
             img = cv2.imread(image_path, cv2.IMREAD_COLOR)


### PR DESCRIPTION
## What changes are proposed in this pull request?
                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                 
  - Fix file descriptor leak in _load_image() by properly managing file handles                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                      
#### Rationale                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                      
  The previous implementation leaked file descriptors when using PIL. Calling Image.open() holds a file handle, and when .convert("RGB") creates a new Image object, the original is orphaned with its handle still open. In a DataLoader processing many images, this can exhaust the OS file descriptor limit.                                      
                                                                                                                                                                                                                                                                                                                                                      
  The fix follows torchvision's established pattern from ImageFolder: place the context manager on the file handle rather than the Image object. This cleanly separates file lifecycle from image lifecycle.                                                                                                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                      
  For force_rgb=False, img.load() is called to ensure pixels are loaded before the file closes. This adds no practical overhead since transforms access pixels immediately anyway.                                                                                                                                                                    
                      

## How is this patch tested? If it is not, please explain why.

Run inference and verify that resource warning no longer logged.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More consistent image loading behavior across array and non‑array paths, with clearer handling of RGB vs non‑RGB outputs.
  * Non‑array loading now uses a managed file-access approach to ensure predictable resource handling.
* **Bug Fixes**
  * Prevented file-handle leaks during non‑array image loading for more reliable resource management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->