### PR TITLE
chore(setup.py): Constrain numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ INSTALL_REQUIRES = [
     "matplotlib",
     "mongoengine~=0.29.1",
     "motor~=3.6.0",
-    "numpy",
+    "numpy<2.4",
     "packaging",
     "pandas",
     # Pillow 11.2.0 introduced CVE 2025-48379 that is fixed in 11.3.0


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fiftyone doesn't work with numpy>2 in all cases. We should fix this so that customers can successfully run/install fiftyone.


## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

constraints numpy to versions 2.4 or lower.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraints to ensure compatibility with current and upcoming releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->