### PR TITLE
fix image scaling on zoom

### DIFF
--- a/app/packages/lighter/src/overlay/ImageOverlay.ts
+++ b/app/packages/lighter/src/overlay/ImageOverlay.ts
@@ -217,15 +217,16 @@ export class ImageOverlay
     const bounds = this.currentBounds;
     if (!bounds) return;
 
+    // Set the base width/height (at scale = 1)
+    this.imgElement.style.width = `${bounds.width}px`;
+    this.imgElement.style.height = `${bounds.height}px`;
+
     // Calculate the transformed position based on viewport
     const transformedX = bounds.x * scale + viewportX;
     const transformedY = bounds.y * scale + viewportY;
-    const transformedWidth = bounds.width * scale;
-    const transformedHeight = bounds.height * scale;
 
-    this.imgElement.style.transform = `translate(${transformedX}px, ${transformedY}px)`;
-    this.imgElement.style.width = `${transformedWidth}px`;
-    this.imgElement.style.height = `${transformedHeight}px`;
+    // Use CSS transform for both translation and scaling
+    this.imgElement.style.transform = `translate(${transformedX}px, ${transformedY}px) scale(${scale})`;
   }
 
   /**


### PR DESCRIPTION
## What changes are proposed in this pull request?

Zooming in Lighter broke when scaling the image.

## How is this patch tested? If it is not, please explain why.

https://github.com/user-attachments/assets/1dbd339f-b44a-475c-8df6-3c5c16bcd086

https://github.com/user-attachments/assets/55653a2d-fd9f-426b-9dff-031f3a0c8112

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined image overlay rendering by consolidating positioning and scaling operations into a single, more efficient transform approach.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->