### PR TITLE
Cleanup awaits/async after making execute synchronous

### DIFF
--- a/app/packages/commands/src/context/CommandContext.ts
+++ b/app/packages/commands/src/context/CommandContext.ts
@@ -101,8 +101,8 @@ export class CommandContext {
    * @see Undoable
    * @param action an action to execute
    */
-  public async executeAction(action: Action) {
-    await this.actions.execute(action);
+  public executeAction(action: Action) {
+    this.actions.execute(action);
   }
 
   /**

--- a/app/packages/commands/src/context/context.manager.test.ts
+++ b/app/packages/commands/src/context/context.manager.test.ts
@@ -68,7 +68,7 @@ describe("CommandContextManager", () => {
     );
   });
 
-  it("can invoke a key binding", async () => {
+  it("can invoke a key binding", () => {
     const execFn = vi.fn(() => {
       return;
     });
@@ -86,7 +86,7 @@ describe("CommandContextManager", () => {
     expect(execFn).toBeCalledTimes(1);
   });
 
-  it("can invoke an inherited binding", async () => {
+  it("can invoke an inherited binding", () => {
     const execFn = vi.fn(() => {
       return;
     });
@@ -109,7 +109,7 @@ describe("CommandContextManager", () => {
     expect(execFn).toBeCalledTimes(1);
   });
 
-  it("does not invoke a non-inherited default binding", async () => {
+  it("does not invoke a non-inherited default binding", () => {
     const execFn = vi.fn(() => {
       return;
     });
@@ -132,7 +132,7 @@ describe("CommandContextManager", () => {
     expect(execFn).toBeCalledTimes(0);
   });
 
-  it("can perform undo/redo on an inherited context", async () => {
+  it("can perform undo/redo on an inherited context", () => {
     const undoFn = vi.fn(() => {
       return;
     });

--- a/app/packages/commands/src/context/context.test.ts
+++ b/app/packages/commands/src/context/context.test.ts
@@ -29,7 +29,7 @@ describe("CommandContext", () => {
     expect(
       context.registerCommand(
         "fo.test",
-        async () => {
+        () => {
           return;
         },
         () => {
@@ -44,7 +44,7 @@ describe("CommandContext", () => {
     expect(
       context.registerCommand(
         "fo.test",
-        async () => {
+        () => {
           return;
         },
         () => {
@@ -55,7 +55,7 @@ describe("CommandContext", () => {
     expect(() => {
       context.registerCommand(
         "fo.test",
-        async () => {
+        () => {
           return;
         },
         () => {
@@ -65,66 +65,66 @@ describe("CommandContext", () => {
     }).toThrowError();
   });
 
-  it("can execute and undo/redo", async () => {
-    await context.executeAction(testUndoable);
+  it("can execute and undo/redo", () => {
+    context.executeAction(testUndoable);
     expect(testExec).toBeCalledTimes(1);
     expect(testUndo).toBeCalledTimes(0);
     expect(context.canUndo()).toBe(true);
     expect(context.canRedo()).toBe(false);
-    await context.undo();
+    context.undo();
     expect(testExec).toBeCalledTimes(1);
     expect(testUndo).toBeCalledTimes(1);
     expect(context.canUndo()).toBe(false);
     expect(context.canRedo()).toBe(true);
-    await context.redo();
+    context.redo();
     expect(testExec).toBeCalledTimes(2);
     expect(testUndo).toBeCalledTimes(1);
     expect(context.canUndo()).toBe(true);
   });
 
-  it("fires updates on undo redo state changes", async () => {
+  it("fires updates on undo redo state changes", () => {
     const listener = vi.fn((_undoEnabled, _redoEnabled) => {
       return;
     });
     const unsub = context.subscribeUndoState(listener);
-    await context.executeAction(testUndoable);
+    context.executeAction(testUndoable);
     expect(listener).toBeCalledTimes(1);
     //expect undo=true, redo=false
     expect(listener.mock.calls[0][0]).toBe(true);
     expect(listener.mock.calls[0][1]).toBe(false);
 
-    await context.undo();
+    context.undo();
     expect(listener).toBeCalledTimes(2);
     //expect undo=false, redo-true
     expect(listener.mock.calls[1][0]).toBe(false);
     expect(listener.mock.calls[1][1]).toBe(true);
     unsub();
-    await context.executeAction(testUndoable);
+    context.executeAction(testUndoable);
     //should no longer be called after unsubscribe
     expect(listener).toBeCalledTimes(2);
-    await context.undo();
+    context.undo();
     expect(listener).toBeCalledTimes(2);
   });
 
-  it("fires action events on execute/undo/redo", async () => {
+  it("fires action events on execute/undo/redo", () => {
     const listener = vi.fn((_id, _isUndo) => {
       return;
     });
     const unsub = context.subscribeActions(listener);
-    await context.executeAction(testUndoable);
+    context.executeAction(testUndoable);
     expect(listener).toBeCalledTimes(1);
     expect(listener.mock.calls[0][0]).toBe(testUndoable.id);
     expect(listener.mock.calls[0][1]).toBe(false);
-    await context.undo();
+    context.undo();
     expect(listener).toBeCalledTimes(2);
     expect(listener.mock.calls[1][0]).toBe(testUndoable.id);
     expect(listener.mock.calls[1][1]).toBe(true);
-    await context.redo();
+    context.redo();
     expect(listener).toBeCalledTimes(3);
     expect(listener.mock.calls[2][0]).toBe(testUndoable.id);
     expect(listener.mock.calls[2][1]).toBe(false);
     unsub();
-    await context.undo();
+    context.undo();
     //not called after unsub
     expect(listener).toBeCalledTimes(3);
   });

--- a/app/packages/commands/src/registry/CommandRegistry.ts
+++ b/app/packages/commands/src/registry/CommandRegistry.ts
@@ -58,10 +58,10 @@ export class CommandRegistry {
    * @param id The command id
    * @returns true if the command was registered and enabled and executed.
    */
-  public async executeCommand(id: string): Promise<boolean> {
+  public executeCommand(id: string): boolean {
     const command = this.getCommand(id);
     if (command && command.isEnabled()) {
-      const result = await command.execute();
+      const result = command.execute();
       if (result && isUndoable(result)) {
         //enable undo/redo
         this.actionManager.push(result as Undoable);

--- a/app/packages/commands/src/registry/registry.test.ts
+++ b/app/packages/commands/src/registry/registry.test.ts
@@ -17,7 +17,7 @@ describe("CommandRegistry", () => {
   it("can register commands", () => {
     let command = registry.registerCommand(
       cmdOne,
-      async () => {
+      () => {
         return;
       },
       () => {
@@ -27,7 +27,7 @@ describe("CommandRegistry", () => {
     expect(command).toBeDefined();
     command = registry.registerCommand(
       cmdTwo,
-      async () => {
+      () => {
         return;
       },
       () => {
@@ -44,7 +44,7 @@ describe("CommandRegistry", () => {
   it("can unregister commands", () => {
     let command = registry.registerCommand(
       cmdOne,
-      async () => {
+      () => {
         return;
       },
       () => {
@@ -54,7 +54,7 @@ describe("CommandRegistry", () => {
     expect(command).toBeDefined();
     command = registry.registerCommand(
       cmdTwo,
-      async () => {
+      () => {
         return;
       },
       () => {
@@ -82,7 +82,7 @@ describe("CommandRegistry", () => {
 
     registry.registerCommand(
       cmdOne,
-      async () => {
+      () => {
         testFunc();
       },
       () => {
@@ -102,7 +102,7 @@ describe("CommandRegistry", () => {
 
     registry.registerCommand(
       cmdOne,
-      async () => {
+      () => {
         testFunc();
       },
       () => {
@@ -123,7 +123,7 @@ describe("CommandRegistry", () => {
     registry.addListener(listener);
     registry.registerCommand(
       cmdOne,
-      async () => {
+      () => {
         return;
       },
       () => {
@@ -139,7 +139,7 @@ describe("CommandRegistry", () => {
     registry.removeListener(listener);
     registry.registerCommand(
       cmdOne,
-      async () => {
+      () => {
         return;
       },
       () => {


### PR DESCRIPTION
## What changes are proposed in this pull request?

The command API was once async.  Just cleaning up some leftover awaits and asyncs.

## How is this patch tested? If it is not, please explain why.

Unit tests

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated command execution to operate synchronously instead of asynchronously, changing how commands process and complete.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->