### PR TITLE
fix typing cursor jumping to end in code editor

### DIFF
--- a/app/packages/components/src/components/Code/index.tsx
+++ b/app/packages/components/src/components/Code/index.tsx
@@ -1,0 +1,26 @@
+import Editor, { EditorProps } from "@monaco-editor/react";
+import { useColorScheme } from "@mui/material";
+import React, { useEffect, useState } from "react";
+
+export default function Code(props: CodeProps) {
+  const { readOnly, options = {}, defaultValue, value, ...editorProps } = props;
+  const { mode } = useColorScheme();
+  const [revision, setRevision] = useState(0);
+
+  useEffect(() => {
+    setRevision((revision) => revision + 1);
+  }, []);
+
+  return (
+    <Editor
+      key={`revision-${revision}`}
+      theme={mode === "dark" ? "vs-dark" : "light"}
+      options={{ readOnly, lineNumbers: "on", ...options }}
+      defaultValue={defaultValue}
+      value={value}
+      {...editorProps}
+    />
+  );
+}
+
+type CodeProps = EditorProps & { readOnly?: boolean };

--- a/app/packages/components/src/components/index.ts
+++ b/app/packages/components/src/components/index.ts
@@ -3,6 +3,7 @@ export { default as Arrow } from "./Arrow";
 export { default as Bar } from "./Bar";
 export { default as Button } from "./Button";
 export { default as CenteredStack } from "./CenteredStack";
+export { default as Code } from "./Code";
 export { default as CodeBlock } from "./CodeBlock";
 export { default as CodeTabs } from "./CodeTabs";
 export { default as ColoredDot } from "./ColoredDot";

--- a/app/packages/core/src/components/ColorModal/JSONViewer.tsx
+++ b/app/packages/core/src/components/ColorModal/JSONViewer.tsx
@@ -1,8 +1,7 @@
-import { useTheme } from "@fiftyone/components";
+import { useTheme, Code } from "@fiftyone/components";
 import { isValidColor } from "@fiftyone/looker/src/overlays/util";
 import { ColorSchemeInput } from "@fiftyone/relay";
 import * as fos from "@fiftyone/state";
-import Editor from "@monaco-editor/react";
 import { Link } from "@mui/material";
 import colorString from "color-string";
 import React, { useLayoutEffect, useMemo, useRef, useState } from "react";
@@ -171,9 +170,8 @@ const JSONViewer: React.FC = () => {
           about custom color schemes.
         </p>
       </SectionWrapper>
-      <Editor
+      <Code
         defaultLanguage="json"
-        theme={themeMode == "dark" ? "vs-dark" : "vs-light"}
         value={JSON.stringify(data, null, 4)}
         width={"100%"}
         height={"calc(100% - 90px)"}

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/JSONEditor.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/JSONEditor.tsx
@@ -1,11 +1,11 @@
 import {
   CenteredStack,
+  Code,
   LoadingSpinner,
   scrollable,
 } from "@fiftyone/components";
 import { Text, TextColor } from "@voxel51/voodo";
 import { useEffect, useState } from "react";
-import { CodeView } from "../../../../../../plugins/SchemaIO/components";
 import { ContentArea } from "../styled";
 
 type JSONValue =
@@ -55,25 +55,16 @@ const JSONEditor = ({
           : {}
       }
     >
-      <CodeView
-        data={value}
-        onChange={(_, value) => {
-          onChange(value);
-          setValue(value);
+      <Code
+        defaultValue={value}
+        onChange={(value) => {
+          const strValue = value as string;
+          onChange(strValue);
+          setValue(strValue);
         }}
-        schema={{
-          view: {
-            language: "json",
-            readOnly: false,
-            width: "100%",
-            height: "100%",
-            componentsProps: {
-              container: {
-                style: { height: "100%" },
-              },
-            },
-          },
-        }}
+        language="json"
+        height={"100%"}
+        width={"100%"}
       />
     </ContentArea>
   );

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/GUIView.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/GUIView.tsx
@@ -4,11 +4,10 @@
  * Main view for the Schema Manager with GUI and JSON tabs.
  */
 
-import { scrollable } from "@fiftyone/components";
+import { Code, scrollable } from "@fiftyone/components";
 import { FeatureFlag, useFeature } from "@fiftyone/feature-flags";
 import { Size, Text, TextColor, ToggleSwitch } from "@voxel51/voodo";
 import { useCallback } from "react";
-import { CodeView } from "../../../../../plugins/SchemaIO/components";
 import ActiveFieldsSection from "./ActiveFieldsSection";
 import { Container, Item } from "./Components";
 import { TAB_GUI, TAB_IDS, TAB_JSON } from "./constants";
@@ -69,22 +68,12 @@ const JSONContent = () => {
         bottom: 0,
       }}
     >
-      <CodeView
-        data={currentJson}
-        path="schemas"
-        schema={{
-          view: {
-            language: "json",
-            readOnly: true,
-            width: "100%",
-            height: "100%",
-            componentsProps: {
-              container: {
-                style: { height: "100%" },
-              },
-            },
-          },
-        }}
+      <Code
+        value={currentJson}
+        language="json"
+        height="100%"
+        width="100%"
+        readOnly
       />
     </ContentArea>
   );

--- a/app/packages/core/src/plugins/SchemaIO/components/CodeView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/CodeView.tsx
@@ -1,12 +1,11 @@
-import Editor from "@monaco-editor/react";
-import { Box, useColorScheme } from "@mui/material";
+import { Code } from "@fiftyone/components";
+import { Box } from "@mui/material";
 import { useKey } from "../hooks";
 import { getComponentProps } from "../utils";
 import autoFocus from "../utils/auto-focus";
 import HeaderView from "./HeaderView";
 
 export default function CodeView(props) {
-  const { mode } = useColorScheme();
   const { onChange, path, schema, data } = props;
   const { view = {} } = schema;
   const { language, readOnly } = view;
@@ -35,10 +34,9 @@ export default function CodeView(props) {
       {...getComponentProps(props, "container")}
     >
       <HeaderView {...props} nested />
-      <Editor
+      <Code
         key={key}
         height={height}
-        theme={mode === "dark" ? "vs-dark" : "light"}
         value={data}
         defaultValue={src}
         onChange={(value) => {
@@ -46,7 +44,7 @@ export default function CodeView(props) {
           setUserChanged();
         }}
         language={language}
-        options={{ readOnly, lineNumbers: "on" }}
+        readOnly={readOnly}
         onMount={(editor) => {
           if (autoFocus(props)) {
             editor.focus();

--- a/e2e-pw/src/oss/poms/schema-manager/json-editor.ts
+++ b/e2e-pw/src/oss/poms/schema-manager/json-editor.ts
@@ -29,9 +29,7 @@ export class JSONEditorPom {
    * The code editor's locator
    */
   get locator() {
-    return this.schemaManager.locator
-      .getByTestId("json-editor")
-      .locator(".monaco-editor");
+    return this.schemaManager.locator.locator(".monaco-editor");
   }
 
   /**


### PR DESCRIPTION
## What changes are proposed in this pull request?

fix typing cursor jumping to end in code editor

## How is this patch tested? If it is not, please explain why.

Using label schema JSON editor in annotate tab

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable Code editor with light/dark theme and read-only/edit modes.
  * Added application-level fetch caching with a way to clear the cache.

* **Refactor**
  * Replaced scattered JSON/code editors with the centralized Code component for consistent UI.
  * Clear fetch cache automatically when switching datasets to avoid stale data.

* **Behavior**
  * Adjusted label-loading timing to centralize when labels are initialized.

* **Tests**
  * Updated end-to-end JSON editor locator for the new editor integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->