### PR TITLE
Metadata primitive editing

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/PrimitiveEntry.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/PrimitiveEntry.tsx
@@ -5,11 +5,9 @@ import {
   type Primitive,
 } from "@fiftyone/utilities";
 import { animated } from "@react-spring/web";
-import { useSetAtom } from "jotai";
 import { useMemo } from "react";
 import { useRecoilValue } from "recoil";
 import styled from "styled-components";
-import { editing } from "./Edit/state";
 import useActivePrimitive from "./Edit/useActivePrimitive";
 import { useReadOnly } from "./SchemaManager/EditFieldLabelSchema/useLabelSchema";
 import { useSampleValue } from "./useSampleValue";
@@ -73,7 +71,6 @@ const PrimitiveEntry = ({ path }: PrimitiveEntryProps) => {
   const timeZone = useRecoilValue(fos.timeZone);
   const [, setActivePrimitive] = useActivePrimitive();
   const { isReadOnly } = useReadOnly(path);
-  const setEditingAtom = useSetAtom(editing);
 
   const formatted = useMemo(() => {
     if (value === undefined || value === null) return null;
@@ -102,7 +99,7 @@ const PrimitiveEntry = ({ path }: PrimitiveEntryProps) => {
       style={{ cursor: isReadOnly ? "default" : "pointer" }}
     >
       <Header>
-        <div>{field.name || path}</div>
+        <div>{path}</div>
         <FormattedValue>{formatted}</FormattedValue>
       </Header>
     </Container>


### PR DESCRIPTION
## What changes are proposed in this pull request?

Use `path` instead of field, so things like `metadata.width` is shown to the user.

## How is this patch tested? If it is not, please explain why.

locally
<img width="548" height="714" alt="Screenshot from 2026-01-23 11-22-13" src="https://github.com/user-attachments/assets/51d86a54-9eaf-4297-8002-ebc7e287128a" />


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

metadata fields will show full path instead of `height`/`width`

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused state management patterns from the internal architecture to reduce processing overhead and streamline component operations without impacting existing functionality

* **UI Changes**
  * Updated label displays to show path information instead of field names, providing clearer identification and improved context when navigating entry fields

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->