### PR TITLE
Fix RGB segmentation rendering for MongoDB masks

### DIFF
--- a/app/packages/looker/src/worker/painter.ts
+++ b/app/packages/looker/src/worker/painter.ts
@@ -294,8 +294,10 @@ export const PainterFactory = (requestColor) => ({
     // performance reasons
     // For subsequent mask updates, the maskData.buffer is already a single channel
     if (
-      maskData.channels === 4 &&
-      targets.length === label.mask.image.byteLength
+      (maskData.channels === 4 &&
+        targets.length === label.mask.image.byteLength) ||
+      (maskData.channels === 3 &&
+        targets.length === overlay.length * maskData.channels)
     ) {
       for (let i = 0; i < overlay.length; i++) {
         const [r, g, b] = getRgbFromMaskData(targets, maskData.channels, i);


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR fixes an issue where RGB segmentation masks stored in MongoDB as 3-channel arrays do not render correctly in the FiftyOne App.

After this change, the App correctly renders RGB segmentation masks regardless of how they are stored:

* In MongoDB as 3-channel `(H, W, 3)` arrays
* On disk as 3-channel RGB images
* On disk as 4-channel RGBA images (alpha channel ignored)

This aligns the behavior of in-database masks with the already-working disk-based cases.

## How is this patch tested? If it is not, please explain why.

This patch was tested using three explicit reproduction scenarios:

### Case 1: MongoDB-stored 3-channel RGB masks (bug repro + fix validation)

```python
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.labels as foul

mask_targets = {"#ff6d04": "person", "#499cef": "cat", "#6d04ff": "dog"}

dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    label_types=["segmentations"],
    classes=["person", "cat", "dog"],
    label_field="instances",
    max_samples=25,
    only_matching=True,
)

foul.objects_to_segmentations(
    dataset,
    "instances",
    "segmentations",
    mask_targets=mask_targets,
)

dataset.default_mask_targets = mask_targets

print(dataset.first().segmentations.mask.shape)
# (612, 612, 3)

# BUG (before fix): masks do not render correctly
session = fo.launch_app(dataset)
```

**Before fix:** RGB masks stored in MongoDB do not render correctly in the App
<img width="2712" height="1547" alt="wrong_mongo" src="https://github.com/user-attachments/assets/b3b7e295-7125-452c-aa97-61cdb689d53b" />

**After fix:** RGB masks render correctly
<img width="2712" height="1547" alt="mongo" src="https://github.com/user-attachments/assets/482a8dbb-2390-4044-9501-d29db7cd32b4" />


### Case 2: Disk-based 3-channel RGB masks (regression test)

```python
import os
import tempfile
import cv2
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.labels as foul

mask_targets = {"#ff6d04": "person", "#499cef": "cat", "#6d04ff": "dog"}

dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    label_types=["segmentations"],
    classes=["person", "cat", "dog"],
    label_field="instances",
    max_samples=25,
    only_matching=True,
    dataset_name="coco-2017-validation-disk-3ch",
)

foul.objects_to_segmentations(
    dataset,
    "instances",
    "segmentations",
    mask_targets=mask_targets,
)

temp_dir = tempfile.mkdtemp()
for sample in dataset.iter_samples(autosave=True):
    if sample.segmentations is None or sample.segmentations.mask is None:
        continue
    mask = sample.segmentations.mask
    if len(mask.shape) == 2:
        continue
    mask_path = os.path.join(temp_dir, f"{sample.id}_mask.png")
    cv2.imwrite(mask_path, cv2.cvtColor(mask, cv2.COLOR_RGB2BGR))
    sample.segmentations = fo.Segmentation(mask_path=mask_path)

dataset.default_mask_targets = mask_targets
session = fo.launch_app(dataset)
```

**Result:** Works correctly before and after this fix



### Case 3: Disk-based 4-channel RGBA masks

```python
import os
import tempfile
import cv2
import numpy as np
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.labels as foul

mask_targets = {"#ff6d04": "person", "#499cef": "cat", "#6d04ff": "dog"}

dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    label_types=["segmentations"],
    classes=["person", "cat", "dog"],
    label_field="instances",
    max_samples=25,
    only_matching=True,
    dataset_name="coco-2017-validation-disk-4ch",
)

foul.objects_to_segmentations(
    dataset,
    "instances",
    "segmentations",
    mask_targets=mask_targets,
)

temp_dir = tempfile.mkdtemp()
for sample in dataset.iter_samples(autosave=True):
    if sample.segmentations is None or sample.segmentations.mask is None:
        continue
    mask = sample.segmentations.mask
    if len(mask.shape) == 2:
        continue
    alpha = np.where(mask.sum(axis=2) > 0, 255, 0).astype(np.uint8)
    mask_rgba = np.dstack([mask, alpha])
    mask_path = os.path.join(temp_dir, f"{sample.id}_mask.png")
    cv2.imwrite(mask_path, cv2.cvtColor(mask_rgba, cv2.COLOR_RGBA2BGRA))
    sample.segmentations = fo.Segmentation(mask_path=mask_path)

dataset.default_mask_targets = mask_targets
session = fo.launch_app(dataset)
```

 **Result:** Works correctly before and after this fix

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [ ] No. You can skip the rest of this section.
* [x] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

**Release note description (1–2 sentences):**
The FiftyOne App now correctly renders RGB segmentation masks stored directly in MongoDB as 3-channel arrays, matching the behavior of disk-based RGB and RGBA segmentation masks.

### What areas of FiftyOne does this PR affect?

* [x] App: FiftyOne application changes
* [ ] Build: Build and test infrastructure changes
* [ ] Core: Core `fiftyone` Python library changes
* [ ] Documentation: FiftyOne documentation changes
* [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended overlay mask validation to support additional image mask formats, improving compatibility with different types of image overlays in segmentation workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->