### PR TITLE
chore(deps): bump fiftyone-brain and eta to newest versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,9 +77,9 @@ INSTALL_REQUIRES = [
     "universal-analytics-python3>=1.0.1,<2",
     "pydash",
     # internal packages
-    "fiftyone-brain>=0.21.4,<0.22",
+    "fiftyone-brain>=0.21.5,<0.22",
     "fiftyone-db>=0.4,<2.0",
-    "voxel51-eta>=0.15.2,<0.16",
+    "voxel51-eta>=0.15.3,<0.16",
 ]
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This bumps ETA and fiftyone-brain in this repository to pick up some `numpy` fixes. See https://github.com/voxel51/eta/pull/686.

> [!NOTE]
> `fiftyone-brain==0.21.5` has not been published yet. The tests will fail at first. That is OK!

> [!NOTE]
> This will be `cherry-picked` into `develop` after merging.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Bumps `fiftyone-brain` and `voxel51-eta` versions to next patch release. These releases fix a `numpy>2.0` incompatibility by using V2's `frombuffer` as opposed to V1's `fromstring`. See https://github.com/voxel51/eta/pull/686.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency versions to latest patches for improved stability and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->