### PR TITLE
chore(deps): bump fiftyone-brain and eta to newest versions (#6809)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,9 +77,9 @@ INSTALL_REQUIRES = [
     "universal-analytics-python3>=1.0.1,<2",
     "pydash",
     # internal packages
-    "fiftyone-brain>=0.21.4,<0.22",
+    "fiftyone-brain>=0.21.5,<0.22",
     "fiftyone-db>=0.4,<2.0",
-    "voxel51-eta>=0.15.2,<0.16",
+    "voxel51-eta>=0.15.3,<0.16",
 ]
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Cherry-picks https://github.com/voxel51/fiftyone/pull/6809 into `develop` to benefit from the numpy fixes.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to latest patch versions to improve stability and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->