### PR TITLE
Merge pull request #6813 from voxel51/afoley/unpin-numpy-in-tests

### DIFF
--- a/requirements/github.txt
+++ b/requirements/github.txt
@@ -1,7 +1,6 @@
 -r test.txt
-# fiftyone doesn't work successfully with numpy>2.0
-# constrain it so that tests are successful.
-numpy<2
+
+numpy
 pydicom>=2.2.0
 shapely>=1.7.1
 tensorflow


### PR DESCRIPTION
chore(requirements): Unpin numpy in github tests

Cherry-picks https://github.com/voxel51/fiftyone/pull/6813 into `develop`

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated numpy dependency constraints to support broader version compatibility, removing upper-bound restrictions to work with newer numpy releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->