### PR TITLE
Refactor toolbar.  Add undo/redo to non-edit annotation sidebar.

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Actions.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Actions.tsx
@@ -25,14 +25,12 @@ import { editing } from "./Edit";
 import useCreate from "./Edit/useCreate";
 import useCanManageSchema from "./useCanManageSchema";
 import useShowModal from "./useShowModal";
-import { Typography } from "@mui/material";
 
 const ActionsDiv = styled.div`
   align-items: center;
   color: ${({ theme }) => theme.text.secondary};
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
   padding: 0.25rem 1rem;
   width: 100%;
   max-width: 100%;
@@ -42,8 +40,6 @@ const Row = styled.div`
   display: flex;
   justify-content: space-between;
   width: 100%;
-  align-items: center;
-  padding: 0 0;
 `;
 
 const Container = styled.div<{ $active?: boolean }>`

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Edit.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Edit.tsx
@@ -29,7 +29,6 @@ import {
 import { useConfirmDelete } from "../Confirmation/useConfirmDelete";
 import useDelete from "./useDelete";
 import { current } from "../Edit/state";
-import Actions from "../Actions";
 
 const ContentContainer = styled.div`
   margin: 0.25rem 1rem;


### PR DESCRIPTION
## What changes are proposed in this pull request?
With autosave, the undo redo buttons need to be available even when not editing an annotation.
I added them to the non edit panel and adopted the UX from the design figma for the rest of the buttons.

Figma:
https://www.figma.com/design/dzn9zA7BvFKQJKgbnQxYzv/Human-Annotation-GA?node-id=447-1030&p=f&t=Kvb2QwyfL6lqzn1N-0

Screenshot:
<img width="304" height="352" alt="Screenshot 2026-01-26 at 4 43 08 PM" src="https://github.com/user-attachments/assets/5ee6ab71-ef35-4d1c-975a-07f602277bb4" />

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.
Manually
(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Undo and Redo controls to the annotation sidebar for improved workflow efficiency.
  * Reorganized the annotation panel layout for better visual organization of editing tools and controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->