### PR TITLE
fix label attribute name

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
@@ -29,20 +29,23 @@ const useSchema = () => {
     properties.label = createSelect("label", config?.classes ?? []);
 
     for (const attr in attributes) {
-      if (attr === "id") {
+      const attribute = attributes[attr];
+      const name = attribute.name;
+
+      if (name === "id") {
         continue;
       }
 
-      if (attributes[attr].component === "text") {
-        properties[attr] = createInput(attr, attributes[attr]);
+      if (attribute.component === "text") {
+        properties[name] = createInput(name, attribute);
       }
 
-      if (attributes[attr].component === "radio") {
-        properties[attr] = createRadio(attr, attributes[attr].values);
+      if (attribute.component === "radio") {
+        properties[name] = createRadio(name, attribute.values);
       }
 
-      if (attributes[attr].component === "dropdown") {
-        properties[attr] = createTags(attr, attributes[attr].values);
+      if (attribute.component === "dropdown") {
+        properties[name] = createTags(name, attribute.values);
       }
     }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Use name property for attribute name as attributes are not list instead of dict since https://github.com/voxel51/fiftyone/pull/6779

## How is this patch tested? If it is not, please explain why.

Using label editing form

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected field mapping in the annotation editor so form fields use attribute names, ensuring values display and save correctly.
  * Consistently hides the system “id” field from the sidebar.
  * Resolves mismatches between displayed labels and underlying data for text, radio, and dropdown fields.

* **Refactor**
  * Streamlined form generation for annotation attributes to improve reliability and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->