### PR TITLE
[HA] Migrate annotation notifications to use voodo's activity toast

### DIFF
--- a/app/packages/annotation/src/hooks/useRegisterAnnotationEventHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterAnnotationEventHandlers.ts
@@ -1,8 +1,9 @@
 import { useAnnotationEventHandler } from "./useAnnotationEventHandler";
 import { useCommandBus } from "@fiftyone/command-bus";
 import { PersistAnnotationChanges } from "../commands";
-import { useNotification } from "@fiftyone/state";
+import { useActivityToast } from "@fiftyone/state";
 import { useCallback } from "react";
+import { IconName, Variant } from "@voxel51/voodo";
 
 /**
  * Hook which registers global annotation event handlers.
@@ -10,7 +11,7 @@ import { useCallback } from "react";
  */
 export const useRegisterAnnotationEventHandlers = () => {
   const commandBus = useCommandBus();
-  const setNotification = useNotification();
+  const { setConfig } = useActivityToast();
 
   useAnnotationEventHandler(
     "annotation:persistenceRequested",
@@ -22,11 +23,12 @@ export const useRegisterAnnotationEventHandlers = () => {
   useAnnotationEventHandler(
     "annotation:persistenceSuccess",
     useCallback(() => {
-      setNotification({
-        msg: "Changes saved successfully",
-        variant: "success",
+      setConfig({
+        iconName: IconName.Check,
+        message: "Changes saved successfully",
+        variant: Variant.Success,
       });
-    }, [setNotification])
+    }, [setConfig])
   );
 
   useAnnotationEventHandler(
@@ -35,12 +37,13 @@ export const useRegisterAnnotationEventHandlers = () => {
       ({ error }) => {
         console.error(error);
 
-        setNotification({
-          msg: `Error saving changes: ${error}`,
-          variant: "error",
+        setConfig({
+          iconName: IconName.Error,
+          message: `Error saving changes: ${error}`,
+          variant: Variant.Danger,
         });
       },
-      [setNotification]
+      [setConfig]
     )
   );
 };

--- a/app/packages/app/src/pages/datasets/DatasetPage.tsx
+++ b/app/packages/app/src/pages/datasets/DatasetPage.tsx
@@ -1,4 +1,5 @@
 import {
+  ActivityToast,
   Dataset,
   QueryPerformanceToast,
   Snackbar,
@@ -121,6 +122,7 @@ const DatasetPage: Route<DatasetPageQuery> = ({ prepared }) => {
       </div>
       <Snackbar />
       <QueryPerformanceToast />
+      <ActivityToast />
     </Nav>
   );
 };

--- a/app/packages/core/package.json
+++ b/app/packages/core/package.json
@@ -23,7 +23,7 @@
         "@mui/material": "^5.9.0",
         "@react-spring/web": "^9.4.3",
         "@use-gesture/react": "^10.3.0",
-        "@voxel51/voodo": "0.0.8",
+        "@voxel51/voodo": "0.0.10",
         "@xstate/react": "1.3.3",
         "classnames": "^2.2.6",
         "color": "^4.2.3",

--- a/app/packages/core/src/components/ActivityToast.tsx
+++ b/app/packages/core/src/components/ActivityToast.tsx
@@ -1,0 +1,19 @@
+import { ActivityToast as VoodoActivityToast, Icon } from "@voxel51/voodo";
+import { useActivityToast } from "@fiftyone/state";
+import React from "react";
+
+/**
+ * Wrapper for VOODO's ActivityToast which manages toast state.
+ */
+export const ActivityToast = () => {
+  const { config, open } = useActivityToast();
+
+  return (
+    <VoodoActivityToast
+      open={open}
+      icon={({ ...props }) => <Icon name={config.iconName} {...props} />}
+      message={config.message}
+      variant={config.variant}
+    />
+  );
+};

--- a/app/packages/core/src/components/index.ts
+++ b/app/packages/core/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from "./ActivityToast";
 export { default as Checkbox } from "./Common/Checkbox";
 export { default as Dataset } from "./Dataset";
 export { default as EmptySamples } from "./EmptySamples";

--- a/app/packages/state/package.json
+++ b/app/packages/state/package.json
@@ -18,6 +18,7 @@
         "README.md"
     ],
     "peerDependencies": {
+        "@voxel51/voodo": "*",
         "react": "*",
         "react-error-boundary": "*",
         "react-relay": "*",

--- a/app/packages/state/src/hooks/index.ts
+++ b/app/packages/state/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from "./hooks-utils";
+export * from "./useActivityToast";
 export { default as useSearchSchemaFields } from "./schema/useSearchSchemaFields";
 export { default as useSetSelectedFieldsStage } from "./schema/useSetSelectedFieldsStage";
 export { default as useSimilarityType } from "./similaritySearch/useSimilarityType";

--- a/app/packages/state/src/hooks/useActivityToast.ts
+++ b/app/packages/state/src/hooks/useActivityToast.ts
@@ -1,0 +1,125 @@
+import { useEffect, useMemo, useState } from "react";
+import { atom, useAtom } from "jotai";
+import { IconName, Variant } from "@voxel51/voodo";
+
+/**
+ * Configuration data which drives ActivityToast behavior.
+ */
+export type ActivityToastConfig = {
+  /**
+   * Name of the icon to display in the toast.
+   */
+  iconName: IconName;
+
+  /**
+   * Message to display in the toast.
+   */
+  message: string;
+
+  /**
+   * Toast variant.
+   */
+  variant: Variant;
+
+  /**
+   * Visibility timeout in milliseconds;
+   * the toast will disappear after this time has elapsed.
+   *
+   * This timeout is reset any time the toast configuration is modified.
+   */
+  timeout?: number;
+};
+
+/**
+ * Activity toast interface.
+ */
+export interface IActivityToast {
+  /**
+   * Current toast configuration.
+   */
+  config: ActivityToastConfig;
+
+  /**
+   * `true` if the toast is open, else `false`.
+   */
+  open: boolean;
+
+  /**
+   * Set the toast configuration.
+   *
+   * @param config {@link ActivityToastConfig} data.
+   */
+  setConfig(config: ActivityToastConfig): void;
+
+  /**
+   * Set the icon for the toast.
+   *
+   * @param iconName Icon name
+   */
+  setIconName(iconName: IconName): void;
+
+  /**
+   * Set the message for the toast.
+   *
+   * @param message Message
+   */
+  setMessage(message: string): void;
+
+  /**
+   * Set the timeout for the toast.
+   *
+   * @param timeout Visibility timeout in milliseconds
+   */
+  setTimeout(timeout: number): void;
+
+  /**
+   * Set the toast variant.
+   *
+   * @param variant Variant
+   */
+  setVariant(variant: Variant): void;
+}
+
+const DEFAULT_VISIBILITY_TIMEOUT = 2000;
+
+const toastConfigAtom = atom<ActivityToastConfig>({
+  iconName: IconName.Check,
+  message: "",
+  variant: Variant.Success,
+  timeout: DEFAULT_VISIBILITY_TIMEOUT,
+});
+
+/**
+ * Hook which provides read and write access to the application's ActivityToast
+ * through the {@link IActivityToast} interface.
+ */
+export const useActivityToast = (): IActivityToast => {
+  const [config, setConfig] = useAtom<ActivityToastConfig>(toastConfigAtom);
+  const [open, setOpen] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (config.message) {
+      setOpen(true);
+    }
+
+    const timeout = setTimeout(
+      () => setOpen(false),
+      config.timeout ?? DEFAULT_VISIBILITY_TIMEOUT
+    );
+
+    return () => clearTimeout(timeout);
+  }, [config]);
+
+  return useMemo(
+    () => ({
+      config,
+      open,
+      setConfig,
+      setIconName: (iconName) => setConfig((prev) => ({ ...prev, iconName })),
+      setMessage: (message) => setConfig((prev) => ({ ...prev, message })),
+      setTimeout: (timeout) => setConfig((prev) => ({ ...prev, timeout })),
+      setVariant: (variant) => setConfig((prev) => ({ ...prev, variant })),
+    }),
+    [config, open, setConfig]
+  );
+};

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2592,7 +2592,7 @@ __metadata:
     "@types/styled-components": "npm:^5.1.23"
     "@use-gesture/react": "npm:^10.3.0"
     "@vitejs/plugin-react-refresh": "npm:^1.3.3"
-    "@voxel51/voodo": "npm:0.0.8"
+    "@voxel51/voodo": "npm:0.0.10"
     "@xstate/react": "npm:1.3.3"
     classnames: "npm:^2.2.6"
     color: "npm:^4.2.3"
@@ -2989,6 +2989,7 @@ __metadata:
     typescript: "npm:^4.7.4"
     vite: "npm:^5.4.21"
   peerDependencies:
+    "@voxel51/voodo": "*"
     react: "*"
     react-error-boundary: "*"
     react-relay: "*"
@@ -7322,9 +7323,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@voxel51/voodo@npm:0.0.8":
-  version: 0.0.8
-  resolution: "@voxel51/voodo@npm:0.0.8"
+"@voxel51/voodo@npm:0.0.10":
+  version: 0.0.10
+  resolution: "@voxel51/voodo@npm:0.0.10"
   dependencies:
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/sortable": "npm:^10.0.0"
@@ -7340,7 +7341,7 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
     react-is: ^18.0.0
-  checksum: 10/2ef5630169f90377e8cf9c8f410f754b1745e414010b3addb037676b5987543c2af36fafdeab55fd90cfee3acc0d0e5b388bd423413ff80dd8dd7e5d352a5958
+  checksum: 10/04fd38127061de5d9e4786b19ca218ed4a6015cc364a2edc4fd501ea226bab02246df7578ae2035c5a43f1859c05979c95c5e9952266e665fb8ed5fe8e6e82bd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

* Add support for using VOODO's `ActivityToast` component
* Integrate annotation notifications with `ActivityToast`

## How is this patch tested? If it is not, please explain why.

local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced activity toast notifications for improved user feedback. Success messages confirm when changes are saved, while error toasts alert users to issues. Toasts automatically dismiss after a brief duration for a streamlined experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->