### PR TITLE
[HA] add notification when persistence request is in-flight

### DIFF
--- a/app/packages/annotation/src/events.ts
+++ b/app/packages/annotation/src/events.ts
@@ -20,6 +20,10 @@ export type AnnotationEventGroup = {
    */
   "annotation:persistenceRequested": void;
   /**
+   * Notification event emitted when a persistence request is in flight.
+   */
+  "annotation:persistenceInFlight": void;
+  /**
    * Notification event emitted when aggregate annotation persistence is successful.
    */
   "annotation:persistenceSuccess": void;

--- a/app/packages/annotation/src/hooks/useRegisterAnnotationEventHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterAnnotationEventHandlers.ts
@@ -21,6 +21,17 @@ export const useRegisterAnnotationEventHandlers = () => {
   );
 
   useAnnotationEventHandler(
+    "annotation:persistenceInFlight",
+    useCallback(() => {
+      setConfig({
+        iconName: IconName.Spinner,
+        message: "Saving changes...",
+        variant: Variant.Secondary,
+      });
+    }, [setConfig])
+  );
+
+  useAnnotationEventHandler(
     "annotation:persistenceSuccess",
     useCallback(() => {
       setConfig({

--- a/app/packages/annotation/src/persistence/usePersistAnnotationDeltas.ts
+++ b/app/packages/annotation/src/persistence/usePersistAnnotationDeltas.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { useAnnotationDeltaSupplier } from "./useAnnotationDeltaSupplier";
-import { usePatchSample } from "../hooks";
+import { useAnnotationEventBus, usePatchSample } from "../hooks";
 
 /**
  * @returns `true` if persistence was successful
@@ -21,14 +21,16 @@ export const usePersistAnnotationDeltas =
   (): (() => Promise<PersistenceResult>) => {
     const supplyAnnotationDeltas = useAnnotationDeltaSupplier();
     const patchSample = usePatchSample();
+    const eventBus = useAnnotationEventBus();
 
     return useCallback(async () => {
       const sampleDeltas = supplyAnnotationDeltas();
 
       if (sampleDeltas.length > 0) {
+        eventBus.dispatch("annotation:persistenceInFlight");
         return await patchSample(sampleDeltas);
       }
 
       return null;
-    }, [patchSample, supplyAnnotationDeltas]);
+    }, [eventBus, patchSample, supplyAnnotationDeltas]);
   };

--- a/app/packages/core/package.json
+++ b/app/packages/core/package.json
@@ -23,7 +23,7 @@
         "@mui/material": "^5.9.0",
         "@react-spring/web": "^9.4.3",
         "@use-gesture/react": "^10.3.0",
-        "@voxel51/voodo": "0.0.10",
+        "@voxel51/voodo": "0.0.11",
         "@xstate/react": "1.3.3",
         "classnames": "^2.2.6",
         "color": "^4.2.3",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2592,7 +2592,7 @@ __metadata:
     "@types/styled-components": "npm:^5.1.23"
     "@use-gesture/react": "npm:^10.3.0"
     "@vitejs/plugin-react-refresh": "npm:^1.3.3"
-    "@voxel51/voodo": "npm:0.0.10"
+    "@voxel51/voodo": "npm:0.0.11"
     "@xstate/react": "npm:1.3.3"
     classnames: "npm:^2.2.6"
     color: "npm:^4.2.3"
@@ -7323,9 +7323,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@voxel51/voodo@npm:0.0.10":
-  version: 0.0.10
-  resolution: "@voxel51/voodo@npm:0.0.10"
+"@voxel51/voodo@npm:0.0.11":
+  version: 0.0.11
+  resolution: "@voxel51/voodo@npm:0.0.11"
   dependencies:
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/sortable": "npm:^10.0.0"
@@ -7341,7 +7341,7 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
     react-is: ^18.0.0
-  checksum: 10/04fd38127061de5d9e4786b19ca218ed4a6015cc364a2edc4fd501ea226bab02246df7578ae2035c5a43f1859c05979c95c5e9952266e665fb8ed5fe8e6e82bd
+  checksum: 10/1b2925a43e2f10987f06f46105650ad75e642a275201a3b17e294d8c6964550eb32c2ab91331485ecd399a23ef7050e6768a60df6808edcf20d5c4d4824cc164
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds a notification while request to backend is in-flight.

## How is this patch tested? If it is not, please explain why.

local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual feedback during the save process with a spinner and "Saving changes..." message displayed to users while annotations are being persisted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->