### PR TITLE
[HA] Add hamburger menu to label edit header to support deletion

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Header.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Header.tsx
@@ -7,15 +7,50 @@ import { current3dAnnotationModeAtom } from "@fiftyone/looker-3d/src/state";
 import { useRecoilValue } from "recoil";
 import { ICONS } from "../Icons";
 import { Row } from "./Components";
-import { currentOverlay, currentType } from "./state";
+import { currentOverlay, currentType, useAnnotationContext } from "./state";
 import useColor from "./useColor";
 import useExit from "./useExit";
+import useDelete from "./useDelete";
+import { useRef, useState } from "react";
+import { Box, Menu, MenuItem, Stack } from "@mui/material";
+import { Clickable, Icon, IconName, Size, Text } from "@voxel51/voodo";
+
+const LabelHamburgerMenu = () => {
+  const [open, setOpen] = useState<boolean>(false);
+  const anchor = useRef<HTMLElement | null>(null);
+  const onDelete = useDelete();
+
+  return (
+    <>
+      <Clickable onClick={() => setOpen(true)}>
+        <Box ref={anchor} sx={{ p: 0.5 }}>
+          <Icon name={IconName.MoreVertical} size={Size.Md} />
+        </Box>
+      </Clickable>
+
+      <Menu
+        anchorEl={anchor.current}
+        open={open}
+        onClose={() => setOpen(false)}
+        sx={{ zIndex: 9999 }}
+      >
+        <MenuItem onClick={onDelete}>
+          <Stack direction="row" gap={1} alignItems="center">
+            <Icon name={IconName.Delete} size={Size.Md} />
+            <Text>Delete label</Text>
+          </Stack>
+        </MenuItem>
+      </Menu>
+    </>
+  );
+};
 
 const Header = () => {
   const type = useAtomValue(currentType);
   const Icon = ICONS[type?.toLowerCase() ?? ""];
   const color = useColor(useAtomValue(currentOverlay) ?? undefined);
   const onExit = useExit();
+  const annotationContext = useAnnotationContext();
 
   const current3dAnnotationMode = useRecoilValue(current3dAnnotationModeAtom);
   const isAnnotatingPolyline = current3dAnnotationMode === "polyline";
@@ -30,12 +65,17 @@ const Header = () => {
         {Icon && <Icon fill={color} />}
         <div>Edit {type}</div>
       </ItemLeft>
-      {!isAnnotatingPolyline && !isAnnotatingCuboid && (
-        <ItemRight>
-          <Undo />
-          <Redo />
-        </ItemRight>
-      )}
+      <ItemRight>
+        <Stack direction="row" alignItems="center">
+          {!isAnnotatingPolyline && !isAnnotatingCuboid && (
+            <>
+              <Undo />
+              <Redo />
+            </>
+          )}
+          {annotationContext.selectedLabel !== null && <LabelHamburgerMenu />}
+        </Stack>
+      </ItemRight>
     </Row>
   );
 };

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/state.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/state.ts
@@ -7,7 +7,7 @@ import {
   POLYLINE,
   POLYLINES,
 } from "@fiftyone/utilities";
-import type { PrimitiveAtom } from "jotai";
+import { PrimitiveAtom, useAtomValue } from "jotai";
 import { atom } from "jotai";
 import { atomFamily, atomWithReset } from "jotai/utils";
 import { capitalize } from "lodash";
@@ -234,3 +234,22 @@ export const deleteValue = atom(null, (get, set) => {
   );
   set(editing, null);
 });
+
+/**
+ * Public API for interacting with the active annotation context.
+ */
+export interface AnnotationContext {
+  /**
+   * Currently-selected annotation label.
+   */
+  selectedLabel: AnnotationLabel | null;
+}
+
+/**
+ * Hook which returns the current {@link AnnotationContext}.
+ */
+export const useAnnotationContext = (): AnnotationContext => {
+  return {
+    selectedLabel: useAtomValue(current),
+  };
+};


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds a hamburger menu to the active label header, which currently offers a single option for deleting the label.

## How is this patch tested? If it is not, please explain why.

local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a menu option to delete labels during annotation workflow.
  * Introduced a context menu accessible from the annotation header for label management.

* **UI/UX Improvements**
  * Reorganized annotation header layout to accommodate new label management options while preserving existing undo/redo controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->