### PR TITLE
Allow delegated execution of potentially expensive builtin operators

### DIFF
--- a/plugins/operators/__init__.py
+++ b/plugins/operators/__init__.py
@@ -154,6 +154,9 @@ class EditFieldValues(foo.Operator):
         return foo.OperatorConfig(
             name="edit_field_values",
             label="Edit field values",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=False,
             dynamic=True,
         )
 
@@ -398,6 +401,9 @@ class CloneSampleField(foo.Operator):
         return foo.OperatorConfig(
             name="clone_sample_field",
             label="Clone sample field",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=False,
             dynamic=True,
         )
 
@@ -507,6 +513,9 @@ class CloneFrameField(foo.Operator):
         return foo.OperatorConfig(
             name="clone_frame_field",
             label="Clone frame field",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=False,
             dynamic=True,
         )
 
@@ -625,6 +634,9 @@ class RenameSampleField(foo.Operator):
         return foo.OperatorConfig(
             name="rename_sample_field",
             label="Rename sample field",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=False,
             dynamic=True,
         )
 
@@ -708,6 +720,9 @@ class RenameFrameField(foo.Operator):
         return foo.OperatorConfig(
             name="rename_frame_field",
             label="Rename frame field",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=False,
             dynamic=True,
         )
 
@@ -800,6 +815,9 @@ class ClearSampleField(foo.Operator):
         return foo.OperatorConfig(
             name="clear_sample_field",
             label="Clear sample field",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=False,
             dynamic=True,
         )
 
@@ -899,6 +917,9 @@ class ClearFrameField(foo.Operator):
         return foo.OperatorConfig(
             name="clear_frame_field",
             label="Clear frame field",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=False,
             dynamic=True,
         )
 
@@ -1189,6 +1210,9 @@ class DeleteSampleField(foo.Operator):
         return foo.OperatorConfig(
             name="delete_sample_field",
             label="Delete sample field",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=False,
             dynamic=True,
         )
 
@@ -1255,6 +1279,9 @@ class DeleteFrameField(foo.Operator):
         return foo.OperatorConfig(
             name="delete_frame_field",
             label="Delete frame field",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=False,
             dynamic=True,
         )
 
@@ -1996,6 +2023,9 @@ class CreateSummaryField(foo.Operator):
         return foo.OperatorConfig(
             name="create_summary_field",
             label="Create summary field",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=False,
             dynamic=True,
         )
 
@@ -2193,6 +2223,9 @@ class UpdateSummaryField(foo.Operator):
         return foo.OperatorConfig(
             name="update_summary_field",
             label="Update summary field",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=False,
             dynamic=True,
         )
 
@@ -2257,6 +2290,9 @@ class DeleteSummaryField(foo.Operator):
         return foo.OperatorConfig(
             name="delete_summary_field",
             label="Delete summary field",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=False,
             dynamic=True,
         )
 
@@ -2368,6 +2404,9 @@ class RenameGroupSlice(foo.Operator):
         return foo.OperatorConfig(
             name="rename_group_slice",
             label="Rename group slice",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=False,
             dynamic=True,
         )
 
@@ -2433,6 +2472,9 @@ class DeleteGroupSlice(foo.Operator):
         return foo.OperatorConfig(
             name="delete_group_slice",
             label="Delete group slice",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=False,
             dynamic=True,
         )
 
@@ -3190,6 +3232,9 @@ class SyncLastModifiedAt(foo.Operator):
         return foo.OperatorConfig(
             name="sync_last_modified_at",
             label="Sync last modified at",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=False,
             dynamic=True,
         )
 


### PR DESCRIPTION
## Release notes

- Allow delegated execution for builtin operations that could take sufficiently long to justify delegation on large datasets



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Field management operations—including editing, cloning, renaming, clearing, and deleting fields, as well as summary field and group management features—now support both delegated and immediate execution modes, providing users with greater flexibility and control over how these operations are performed based on their specific workflow requirements and preferences.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->