### PR TITLE
Add `fiftyone app debug` command

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -2085,7 +2085,7 @@ Tools for working with the FiftyOne App.
 
 .. code-block:: text
 
-    fiftyone app [-h] [--all-help] {config,launch,view,connect} ...
+    fiftyone app [-h] [--all-help] {config,launch,debug,view,connect} ...
 
 **Arguments**
 
@@ -2099,6 +2099,7 @@ Tools for working with the FiftyOne App.
       {config,launch,view,connect}
         config              Tools for working with your App config.
         launch              Launch the FiftyOne App.
+        debug               Launch the FiftyOne App in debug mode.
         view                View datasets in the App without persisting them to the database.
         connect             Connect to a remote FiftyOne App.
 
@@ -2193,6 +2194,43 @@ Launch the FiftyOne App.
 
     # Launch an App session with a specific browser
     fiftyone app launch ... --browser <name>
+
+.. _cli-fiftyone-app-debug:
+
+Launch the App (debug mode)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Launch the FiftyOne App in debug mode.
+
+.. code-block:: text
+
+    fiftyone app debug [-h] [-p PORT] [-A ADDRESS]  [--headless] [NAME]
+
+**Arguments**
+
+.. code-block:: text
+
+    positional arguments:
+      NAME                  the name of a dataset to open
+
+    options:
+      -h, --help            show this help message and exit
+      -p PORT, --port PORT  the port number to use
+      -A ADDRESS, --address ADDRESS
+                            the address (server name) to use
+      --headless            don't open the browser
+
+**Examples**
+
+.. code-block:: shell
+
+    # Launch the App in debug mode
+    fiftyone app debug
+
+.. code-block:: shell
+
+    # Launch the App in debug mode with a given dataset loaded
+    fiftyone app debug <name>
 
 .. _cli-fiftyone-app-view:
 

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -1087,6 +1087,7 @@ class AppCommand(Command):
         subparsers = parser.add_subparsers(title="available commands")
         _register_command(subparsers, "config", AppConfigCommand)
         _register_command(subparsers, "launch", AppLaunchCommand)
+        _register_command(subparsers, "debug", AppDebugCommand)
         _register_command(subparsers, "view", AppViewCommand)
         _register_command(subparsers, "connect", AppConnectCommand)
 
@@ -1249,6 +1250,66 @@ def _wait():
             time.sleep(10)
     except KeyboardInterrupt:
         pass
+
+
+class AppDebugCommand(Command):
+    """Launch the FiftyOne App in debug mode.
+
+    Examples::
+
+        # Launch the App in debug mode
+        fiftyone app debug
+
+        # Launch the App in debug mode with a given dataset loaded
+        fiftyone app debug <name>
+    """
+
+    @staticmethod
+    def setup(parser):
+        parser.add_argument(
+            "name",
+            metavar="NAME",
+            nargs="?",
+            help="the name of a dataset to open",
+        )
+        parser.add_argument(
+            "-p",
+            "--port",
+            metavar="PORT",
+            default=None,
+            type=int,
+            help="the port number to use",
+        )
+        parser.add_argument(
+            "-A",
+            "--address",
+            metavar="ADDRESS",
+            default=None,
+            type=str,
+            help="the address (server name) to use",
+        )
+        parser.add_argument(
+            "--headless",
+            action="store_true",
+            help="don't open the browser",
+        )
+
+    @staticmethod
+    def execute(parser, args):
+        import fiftyone.server.main as fsm
+
+        # TODO: remove when https://voxel51.atlassian.net/browse/FOEPD-2418
+        # is resolved
+        os.environ[
+            "FIFTYONE_EXECUTION_STORE_NOTIFICATION_SERVICE_DISABLED"
+        ] = "true"
+
+        fsm.start_server(
+            port=args.port,
+            address=args.address,
+            dataset=args.name,
+            open_browser=not args.headless,
+        )
 
 
 class AppViewCommand(Command):

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -13,6 +13,7 @@ import asyncio
 from hypercorn.asyncio import serve
 from hypercorn.config import Config
 import logging
+import webbrowser
 
 if os.environ.get("FIFTYONE_DISABLE_SERVICES", False):
     del os.environ["FIFTYONE_DISABLE_SERVICES"]
@@ -30,21 +31,50 @@ DEBUG_LOGGING = fo.config.logging_level == "DEBUG"
 if DEBUG_LOGGING:
     logging.getLogger("asyncio").setLevel(logging.DEBUG)
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--port", type=int, default=fo.config.default_app_port)
-    parser.add_argument(
-        "--address", type=str, default=fo.config.default_app_address
-    )
-    parser.add_argument("--clean_start", action="store_true")
-    args = parser.parse_args()
+
+def start_server(
+    port=None,
+    address=None,
+    dataset=None,
+    clean_start=False,
+    open_browser=False,
+):
+    if port is None:
+        port = fo.config.default_app_port
+
+    if address is None:
+        address = fo.config.default_app_address
+
+    if clean_start:
+        fo.delete_datasets("*")
+
     config = Config()
-    config.bind = [f"{args.address}:{args.port}"]
-    set_port(args.port)
+    config.bind = [f"{address}:{port}"]
+    set_port(port)
 
     config.use_reloader = foc.DEV_INSTALL
 
-    if args.clean_start:
-        fo.delete_datasets("*")
+    if open_browser:
+        url = f"http://{address}:{port}"
+        if dataset is not None:
+            url += f"/datasets/{dataset}"
+
+        webbrowser.open(url, new=2)
 
     asyncio.run(serve(app, config), debug=DEBUG_LOGGING)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=None)
+    parser.add_argument("--address", type=str, default=None)
+    parser.add_argument("--clean_start", action="store_true")
+    parser.add_argument("--open_browser", action="store_true")
+    args = parser.parse_args()
+
+    start_server(
+        port=args.port,
+        address=args.address,
+        clean_start=args.clean_start,
+        open_browser=args.open_browser,
+    )


### PR DESCRIPTION
## Release notes

- Adds a `fiftyone app debug` command that launches the App in debug mode. In debug mode, server logs are printed to the shell, which is useful, eg, when developing plugins

## Example usages

```
$ fiftyone app debug

$ fiftyone zoo datasets load quickstart 
$ fiftyone app debug quickstart
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added a debug mode command for the FiftyOne App CLI, enabling users to launch the application with configurable server options including port, address, headless mode, and automatic browser opening.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->