### PR TITLE
Fix docs generation for interface methods

### DIFF
--- a/app/gen-docs.js
+++ b/app/gen-docs.js
@@ -1031,6 +1031,19 @@ class DocConstructor extends DocFunction {
 }
 class DocMethod extends DocFragment {
   static kind = () => "Method";
+  signatures() {
+    return this.mapArray("signatures", DocSignature);
+  }
+  addToDescription(desc, parentName = null) {
+    const label = this.label();
+    const name = parentName ? `${parentName}.${label}` : label;
+    const signatures = this.signatures();
+    if (signatures.length > 0) {
+      const sig = signatures[0];
+      const sigText = sig.toTextSignatureWithReturnType();
+      desc.addTypeRow(name, sig.returnType(), sig.shortText() || sigText);
+    }
+  }
 }
 class DocEnumeration extends DocFragment {
   static kind = () => "Enumeration";


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR fixes a crash in `gen-docs.js` that occurred when generating TypeScript API documentation.
The issue was caused by methods (introduced via the `IActivityToast` interface in PR #6830) being treated like properties during documentation generation. When these methods were converted into `DocMethod` objects, the process failed because `DocMethod` did not implement `addToDescription()`.

This change adds `signatures()` and `addToDescription()` methods to the `DocMethod` class, following the same patterns used by `DocProperty`, so methods can be rendered correctly in the generated docs.

## How is this patch tested? If it is not, please explain why.

* Built the documentation locally and verified that generation completes without errors
* Deployed the changes to the dev environment and validated that the affected documentation renders correctly [here](https://docs.dev.voxel51.com/plugins/api/plugins.fiftyone.state.html#useactivitytoast)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [x] No. You can skip the rest of this section.
* [ ] Yes. Give a description of this change to be included in the release
  notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

* [ ] App: FiftyOne application changes
* [ ] Build: Build and test infrastructure changes
* [ ] Core: Core `fiftyone` Python library changes
* [x] Documentation: FiftyOne documentation changes
* [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced method documentation generation to include signatures and return type information in generated documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->