### PR TITLE
Adding one additional default operator that should be delegated

### DIFF
--- a/plugins/operators/__init__.py
+++ b/plugins/operators/__init__.py
@@ -2345,6 +2345,9 @@ class AddGroupSlice(foo.Operator):
         return foo.OperatorConfig(
             name="add_group_slice",
             label="Add group slice",
+            allow_delegated_execution=True,
+            allow_immediate_execution=True,
+            default_choice_to_delegated=False,
             dynamic=True,
         )
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adding one additional operator to [this](https://github.com/voxel51/fiftyone/pull/6843) pull request which also should have the option to be delegated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced operator execution with flexible modes, now supporting both delegated and immediate execution options for improved control over operation processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->