### PR TITLE
Release Notes for OSS 1.12.0 and Enterprise 1.15.0

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -48,11 +48,6 @@ Plugins, Operators, and Orchestrators
 
 Authorization
 
-- Credentials for access to cloud media can now be assigned at the global
-  scope, per each user group, and per each user -- in addition to allowing
-  different credentials for different cloud buckets.
-- New environment variable `NO_CREDENTIALS` can be set to prevent local use of
-  server-provided cloud credentials (allowed by default).
 - The restriction on role re-upgrades is no longer based on "role" but now
   "license tier". For example, Admin and Member are considered the same tier
   since they both use up the same seat type, so users are free to switch
@@ -152,6 +147,11 @@ Brain
 - Fixed: When subselecting samples from the lancedb table, ensure the samples
   being selected exist in the table. 
   `#272 <https://github.com/voxel51/fiftyone-brain/pull/272>`_
+
+ETA
+
+- Fixed an incompatibility with `numpy>=2` and the `FFmpegVideoReader`.
+  `#686 <https://github.com/voxel51/eta/pull/686>`_
 
 Docs
 


### PR DESCRIPTION
## TODO
- [x] Release notes for new `compute_mistakenness` operator @PeterOttoMoeller 
- [x] Reference any docs on RPC, particularly about env vars, if those exist. @Anddraca 
- [x] Add additional docs references when possible @jleven @AdonaiVera 

## What changes are proposed in this pull request?

Release Notes for OSS 1.12.0 and Enterprise 1.15.0

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added FiftyOne Enterprise 2.15.0 release notes, introducing an Enterprise section with subsections (Core, Plugins, Authorization, App, Security) summarizing new operators, reliability and credential handling improvements, UI and policy updates, and other enhancements.
  * Clarifies that all FiftyOne 1.12.0 updates are included and preserves the existing FiftyOne 1.12.0 notes below for reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->