### PR TITLE
FOEPD-3047 - Clean up the undo stack when leaving the annotation panel or current sample

### DIFF
--- a/app/packages/commands/src/hooks/useUndoRedo.ts
+++ b/app/packages/commands/src/hooks/useUndoRedo.ts
@@ -12,7 +12,7 @@ import { useCommandContext } from "./useCommandContext";
  * and the undo/redo functions.  clear method to clear the undo/redo stack.
  */
 export const useUndoRedo = (
-  context?: CommandContext
+  context?: CommandContext | string
 ): {
   undoEnabled: boolean;
   redoEnabled: boolean;

--- a/app/packages/core/src/components/Modal/ModalNavigation.tsx
+++ b/app/packages/core/src/components/Modal/ModalNavigation.tsx
@@ -14,6 +14,7 @@ import {
   KnownCommands,
   KnownContexts,
   useKeyBindings,
+  useUndoRedo,
 } from "@fiftyone/commands";
 
 const Arrow = styled.span<{
@@ -60,7 +61,7 @@ const ModalNavigation = ({ closePanels }: { closePanels: () => void }) => {
   const showModalNavigationControls = useRecoilValue(
     fos.showModalNavigationControls
   );
-
+  const clearUndo = useUndoRedo(KnownContexts.ModalAnnotate).clear;
   const sidebarwidth = useRecoilValue(fos.sidebarWidth(true));
   const isSidebarVisible = useRecoilValue(fos.sidebarVisible(true));
 
@@ -88,6 +89,7 @@ const ModalNavigation = ({ closePanels }: { closePanels: () => void }) => {
         navigateFn: async (offset) => {
           const navigation = fos.modalNavigation.get();
           if (navigation) {
+            clearUndo();
             return await navigation.next(offset).then((s) => {
               selectiveRenderingEventBus.removeAllListeners();
               setModal(s);
@@ -97,7 +99,7 @@ const ModalNavigation = ({ closePanels }: { closePanels: () => void }) => {
         onNavigationStart: closePanels,
         debounceTime: 150,
       }),
-    [closePanels, setModal]
+    [closePanels, setModal, clearUndo]
   );
 
   const previousNavigator = useMemo(
@@ -107,6 +109,7 @@ const ModalNavigation = ({ closePanels }: { closePanels: () => void }) => {
         navigateFn: async (offset) => {
           const navigation = fos.modalNavigation.get();
           if (navigation) {
+            clearUndo();
             return await navigation.previous(offset).then((s) => {
               selectiveRenderingEventBus.removeAllListeners();
               setModal(s);
@@ -116,7 +119,7 @@ const ModalNavigation = ({ closePanels }: { closePanels: () => void }) => {
         onNavigationStart: closePanels,
         debounceTime: 150,
       }),
-    [closePanels, setModal]
+    [closePanels, setModal, clearUndo]
   );
 
   useEffect(() => {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Annotate.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Annotate.tsx
@@ -20,6 +20,7 @@ import useLabels from "./useLabels";
 import { usePrimitivesCount } from "./usePrimitivesCount";
 import { useAnnotationContextManager } from "./useAnnotationContextManager";
 import useDelete from "./Edit/useDelete";
+import { KnownContexts, useUndoRedo } from "@fiftyone/commands";
 
 const showImportPage = atom((get) => !get(activeLabelSchemas)?.length);
 
@@ -120,6 +121,7 @@ const Annotate = ({ disabledReason }: AnnotateProps) => {
   const loading = useAtomValue(labelSchemasData) === null;
   const editing = useAtomValue(isEditing);
   const contextManager = useAnnotationContextManager();
+  const { clear: clearUndo } = useUndoRedo(KnownContexts.ModalAnnotate);
   useDelete();
 
   useEffect(() => {
@@ -127,6 +129,7 @@ const Annotate = ({ disabledReason }: AnnotateProps) => {
 
     return () => {
       contextManager.exit();
+      clearUndo();
     };
   }, []);
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR clears the undo stack when the user leaves the annotation panel or navigates to another sample.

## How is this patch tested? If it is not, please explain why.
Manually locally.


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Undo/redo history is now cleared during modal navigation and when exiting annotation mode to prevent unintended behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->