### PR TITLE
FOEPD-3003 - Sync zoom, pan, rendering of lighter and looker

### DIFF
--- a/app/packages/core/src/components/Modal/Lighter/LighterSampleRenderer.tsx
+++ b/app/packages/core/src/components/Modal/Lighter/LighterSampleRenderer.tsx
@@ -50,9 +50,7 @@ export const LighterSampleRenderer = ({
   const sampleRef = useRef(sample);
   sampleRef.current = sample;
 
-  /**
-   * This effect is responsible for loading the sample and adding the overlays to the scene.
-   */
+  // Load the sample and add overlays when the scene is ready
   useEffect(() => {
     if (!isReady || !scene) return;
 
@@ -70,12 +68,20 @@ export const LighterSampleRenderer = ({
           maintainAspectRatio: true,
         }
       );
-      addOverlay(mediaOverlay, false);
+      addOverlay(mediaOverlay);
 
       // Set the image overlay as canonical media for coordinate transformations
       scene.setCanonicalMedia(mediaOverlay);
+
+      // Apply viewport immediately after adding overlay to prevent initial flash
+      // This only runs once when the overlay is added, not on every viewport change
+      const renderer = scene.getRenderer();
+      const currentViewport = fos.jotaiStore.get(fos.modalViewport);
+      if (currentViewport && renderer.isReady()) {
+        renderer.setViewport(currentViewport.scale, currentViewport.pan);
+      }
     }
-  }, [isReady, addOverlay, scene]);
+  }, [isReady, addOverlay, scene, sample.sample._id]);
 
   useEffect(() => {
     // sceneId should be deterministic, but unique for a given sample snapshot
@@ -83,7 +89,7 @@ export const LighterSampleRenderer = ({
     setSceneId(
       `${sample?.sample?._id}-${sample?.sample?.last_modified_at?.datetime}`
     );
-  }, []);
+  }, [sample.sample._id, sample.sample.last_modified_at?.datetime]);
 
   return (
     <div
@@ -96,6 +102,8 @@ export const LighterSampleRenderer = ({
         height: "100%",
         display: "flex",
         flexDirection: "column",
+        overflow: "hidden",
+        position: "relative",
       }}
     >
       {containerRef.current && sceneId && (
@@ -108,7 +116,7 @@ export const LighterSampleRenderer = ({
 const LighterSetupImpl = (props: {
   containerRef: React.RefObject<HTMLDivElement>;
   sceneId: string;
-}) => {
+}): React.ReactElement | null => {
   const { containerRef, sceneId } = props;
 
   const options = useRecoilValue(

--- a/app/packages/core/src/components/Modal/Lighter/useBridge.ts
+++ b/app/packages/core/src/components/Modal/Lighter/useBridge.ts
@@ -11,8 +11,9 @@ import {
   useLighterEventBus,
   useLighterEventHandler,
 } from "@fiftyone/lighter";
-import { useAtomValue, useSetAtom } from "jotai";
-import { useCallback, useEffect } from "react";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useCallback, useEffect, useRef, useState } from "react";
+import * as fos from "@fiftyone/state";
 import { currentData, currentOverlay } from "../Sidebar/Annotate/Edit/state";
 import { coerceStringBooleans } from "../Sidebar/Annotate/utils";
 import useColorMappingContext from "./useColorMappingContext";
@@ -147,4 +148,97 @@ export const useBridge = (scene: Scene2D | null) => {
       overlay.markDirty();
     }
   }, [scene, context]);
+
+  const [viewport, setViewport] = useAtom(fos.modalViewport);
+  const viewportRef = useRef(viewport);
+  viewportRef.current = viewport;
+
+  const lastLighterViewport = useRef<{
+    scale: number;
+    pan: [number, number];
+  } | null>(null);
+
+  const [readyCount, setReadyCount] = useState(0);
+
+  // Reset lastLighterViewport when scene changes (e.g., switching modes)
+  // This prevents stale viewport data from being used
+  useEffect(() => {
+    lastLighterViewport.current = null;
+  }, [scene]);
+
+  useEventHandler(
+    "lighter:ready",
+    useCallback(() => {
+      setReadyCount((c: number) => c + 1);
+
+      // Apply viewport immediately when ready to prevent flash
+      if (scene && viewport) {
+        const renderer = scene.getRenderer();
+        if (renderer.isReady()) {
+          renderer.setViewport(viewport.scale, viewport.pan);
+        }
+      }
+    }, [scene, viewport])
+  );
+
+  useEventHandler(
+    "lighter:viewport-moved",
+    useCallback(
+      (payload) => {
+        lastLighterViewport.current = {
+          scale: payload.scale,
+          pan: [payload.x, payload.y],
+        };
+
+        // Only update the atom if the user is actively interacting
+        // This prevents initialization/auto-center events from overwriting
+        // the atom with stale data when switching back from Looker
+        if (!scene) return;
+        const renderer = scene.getRenderer();
+        if (!renderer.isReady() || !renderer.isInteracting()) {
+          return;
+        }
+
+        setViewport((prev: { scale: number; pan: [number, number] } | null) => {
+          if (
+            prev?.scale === payload.scale &&
+            prev?.pan[0] === payload.x &&
+            prev?.pan[1] === payload.y
+          ) {
+            return prev;
+          }
+          return { scale: payload.scale, pan: [payload.x, payload.y] };
+        });
+      },
+      [setViewport, scene]
+    )
+  );
+
+  useEffect(() => {
+    if (!scene) return;
+
+    const renderer = scene.getRenderer();
+    if (!renderer.isReady()) return;
+
+    // Don't update if user is currently interacting (to prevent snap-back)
+    if (renderer.isInteracting()) {
+      return;
+    }
+
+    // If we have a viewport in the atom, apply it
+    // This runs whenever Lighter becomes ready (readyCount changes)
+    if (viewport) {
+      const currentScale = renderer.getScale();
+      const currentPos = renderer.getViewportPosition();
+
+      // Apply viewport if it differs from Lighter's current state
+      if (
+        viewport.scale !== currentScale ||
+        viewport.pan[0] !== currentPos.x ||
+        viewport.pan[1] !== currentPos.y
+      ) {
+        renderer.setViewport(viewport.scale, viewport.pan);
+      }
+    }
+  }, [scene, readyCount, viewport]);
 };

--- a/app/packages/core/src/components/Modal/ModalLooker.tsx
+++ b/app/packages/core/src/components/Modal/ModalLooker.tsx
@@ -20,7 +20,9 @@ export const useShowOverlays = () => {
 
 export const useClearSelectedLabels = () => {
   return useRecoilCallback(
-    ({ set }) => async () => set(fos.selectedLabels, []),
+    ({ set }) =>
+      async () =>
+        set(fos.selectedLabels, []),
     []
   );
 };
@@ -48,8 +50,9 @@ const ModalLookerNoTimeline = React.memo((props: LookerProps) => {
       id={id}
       data-cy="modal-looker-container"
       style={{
-        width: props.ghost ? 0 : "100%",
-        height: props.ghost ? 0 : "100%",
+        width: "100%",
+        height: "100%",
+        display: props.ghost ? "none" : "block",
         background: theme.background.level2,
         position: "relative",
       }}

--- a/app/packages/core/src/components/Modal/ModalNavigation.tsx
+++ b/app/packages/core/src/components/Modal/ModalNavigation.tsx
@@ -4,6 +4,7 @@ import {
 } from "@fiftyone/components";
 import { selectiveRenderingEventBus } from "@fiftyone/looker";
 import * as fos from "@fiftyone/state";
+import { useSetAtom } from "jotai";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useRecoilValue, useRecoilValueLoadable } from "recoil";
 import styled from "styled-components";
@@ -81,6 +82,7 @@ const ModalNavigation = ({ closePanels }: { closePanels: () => void }) => {
 
   // important: make sure all dependencies of the navigators are referentially stable,
   // or else the debouncing mechanism won't work
+  const setViewport = useSetAtom(fos.modalViewport as any);
   const nextNavigator = useMemo(
     () =>
       createDebouncedNavigator({
@@ -90,6 +92,7 @@ const ModalNavigation = ({ closePanels }: { closePanels: () => void }) => {
           if (navigation) {
             return await navigation.next(offset).then((s) => {
               selectiveRenderingEventBus.removeAllListeners();
+              setViewport(null);
               setModal(s);
             });
           }
@@ -97,7 +100,7 @@ const ModalNavigation = ({ closePanels }: { closePanels: () => void }) => {
         onNavigationStart: closePanels,
         debounceTime: 150,
       }),
-    [closePanels, setModal]
+    [closePanels, setModal, setViewport]
   );
 
   const previousNavigator = useMemo(
@@ -109,6 +112,7 @@ const ModalNavigation = ({ closePanels }: { closePanels: () => void }) => {
           if (navigation) {
             return await navigation.previous(offset).then((s) => {
               selectiveRenderingEventBus.removeAllListeners();
+              setViewport(null);
               setModal(s);
             });
           }
@@ -116,7 +120,7 @@ const ModalNavigation = ({ closePanels }: { closePanels: () => void }) => {
         onNavigationStart: closePanels,
         debounceTime: 150,
       }),
-    [closePanels, setModal]
+    [closePanels, setModal, setViewport]
   );
 
   useEffect(() => {

--- a/app/packages/core/src/constants/viewport.ts
+++ b/app/packages/core/src/constants/viewport.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+/**
+ * Minimum zoom scale for Looker viewer.
+ * Scale of 1.0 means the image fits within the viewport.
+ * Values less than 1.0 would zoom out beyond the natural fit.
+ */
+export const MIN_ZOOM_SCALE = 1.0;
+
+/**
+ * Minimum zoom scale for Lighter viewer.
+ * This value corresponds to MIN_ZOOM_SCALE (1.0) in Looker's coordinate system.
+ * Lighter uses pixi-viewport which has a different scale interpretation.
+ */
+export const MIN_ZOOM_SCALE_LIGHTER = 0.8;

--- a/app/packages/lighter/src/core/Scene2D.ts
+++ b/app/packages/lighter/src/core/Scene2D.ts
@@ -48,6 +48,7 @@ import {
   OVERLAY_STATUS_PENDING,
   RenderingStateManager,
 } from "./RenderingStateManager";
+import type { Renderer2D } from "../renderer/Renderer2D";
 import type { Scene2DConfig, SceneOptions } from "./SceneConfig";
 import { CommandContextManager, Action } from "@fiftyone/commands";
 
@@ -236,7 +237,9 @@ export class Scene2D {
           absoluteBounds,
           relativeBounds
         );
-        CommandContextManager.instance().getActiveContext().pushUndoable(addCommand);
+        CommandContextManager.instance()
+          .getActiveContext()
+          .pushUndoable(addCommand);
       }
     });
 
@@ -256,7 +259,9 @@ export class Scene2D {
             startBounds,
             endBounds
           );
-          CommandContextManager.instance().getActiveContext().pushUndoable(moveCommand);
+          CommandContextManager.instance()
+            .getActiveContext()
+            .pushUndoable(moveCommand);
         }
       }
     });
@@ -279,7 +284,9 @@ export class Scene2D {
             startBounds,
             endBounds
           );
-          CommandContextManager.instance().getActiveContext().pushUndoable(moveCommand);
+          CommandContextManager.instance()
+            .getActiveContext()
+            .pushUndoable(moveCommand);
         }
       }
     });
@@ -1073,6 +1080,10 @@ export class Scene2D {
     return this.overlays.get(id);
   }
 
+  getRenderer(): Renderer2D {
+    return this.config.renderer;
+  }
+
   /**
    * Checks if an overlay with the given ID exists in the scene.
    * @param id - The overlay ID to check.
@@ -1088,7 +1099,10 @@ export class Scene2D {
    * @param options - The transformation options.
    * @returns True if the transformation was successful, false otherwise.
    */
-  async transformOverlay(id: string, options: TransformOptions): Promise<boolean> {
+  async transformOverlay(
+    id: string,
+    options: TransformOptions
+  ): Promise<boolean> {
     const overlay = this.overlays.get(id);
     if (!overlay) {
       console.warn(`Overlay with id ${id} not found`);
@@ -1185,7 +1199,9 @@ export class Scene2D {
    * @param isUndoable - Whether the command is undoable.
    */
   async executeCommand(command: Action, isUndoable = true): Promise<void> {
-    await CommandContextManager.instance().getActiveContext().executeAction(command);
+    await CommandContextManager.instance()
+      .getActiveContext()
+      .executeAction(command);
     this.eventBus.dispatch("lighter:command-executed", {
       commandId: command.id,
       isUndoable,

--- a/app/packages/lighter/src/events/index.ts
+++ b/app/packages/lighter/src/events/index.ts
@@ -165,6 +165,8 @@ export type LighterEventGroup = {
   "lighter:zoomed": { scale: number };
   /** Emitted when the viewport is panned/moved */
   "lighter:viewport-moved": { x: number; y: number; scale: number };
+  /** Emitted when the renderer is fully initialized and ready */
+  "lighter:ready": undefined;
 
   // ============================================================================
   // "DO" EVENTS USERS CAN EMIT TO FORCE STATE CHANGES OR ACTIONS

--- a/app/packages/lighter/src/renderer/Renderer2D.ts
+++ b/app/packages/lighter/src/renderer/Renderer2D.ts
@@ -152,6 +152,12 @@ export interface Renderer2D {
   getViewportPosition(): { x: number; y: number };
 
   /**
+   * Check if the renderer is currently being interacted with (dragged, pinched, or zoomed)
+   * @returns True if the renderer is being interacted with.
+   */
+  isInteracting(): boolean;
+
+  /**
    * Check if the renderer is initialized and ready to use.
    * @returns True if the renderer is ready.
    */
@@ -161,6 +167,13 @@ export interface Renderer2D {
    * Reset tick handler, and remove all children from the viewport.
    */
   cleanUp(): void;
+
+  /**
+   * Sets the scale and pan of the viewport.
+   * @param scale - The new scale level.
+   * @param pan - The new pan position [x, y].
+   */
+  setViewport(scale: number, pan: [number, number]): void;
 
   /**
    * Destroys the renderer.

--- a/app/packages/looker/src/lookers/abstract.ts
+++ b/app/packages/looker/src/lookers/abstract.ts
@@ -107,7 +107,7 @@ export abstract class AbstractLooker<
   private readonly ctx: CanvasRenderingContext2D;
   private previousState?: Readonly<State>;
   private readonly rootEvents: Events<State>;
-  private isSampleUpdating: boolean = false;
+  private pendingReset = false;
 
   protected readonly abortController: AbortController;
   protected currentOverlays: Overlay<State>[];
@@ -121,6 +121,8 @@ export abstract class AbstractLooker<
 
   /** @internal */
   state: State;
+
+  sample: S;
 
   sampleOverlays: Overlay<State>[];
   pluckedOverlays: Overlay<State>[];
@@ -137,6 +139,7 @@ export abstract class AbstractLooker<
     this.subscriptions = {};
     this.updater = this.makeUpdate();
     this.state = this.getInitialState(config, options);
+    this.sample = sample;
 
     this.loadSample(sample);
     this.state.options.mimetype = getMimeType(sample);
@@ -255,6 +258,7 @@ export abstract class AbstractLooker<
     }
 
     this.subscriptions[field].push(callback);
+    callback(this.state[field]);
 
     // return unsubscribe function
     return () => {
@@ -277,7 +281,7 @@ export abstract class AbstractLooker<
     this.sampleOverlays = loadOverlays(sample, this.state.config.fieldSchema);
   }
 
-  pluckOverlays(state: Readonly<State>): Overlay<State>[] {
+  pluckOverlays(_state: Readonly<State>): Overlay<State>[] {
     return this.sampleOverlays;
   }
 
@@ -417,8 +421,22 @@ export abstract class AbstractLooker<
           return;
         }
 
+        const oldScale = this.state.scale;
+        const oldPan = this.state.pan;
+
         this.pluckedOverlays = this.pluckOverlays(this.state);
         this.state = this.postProcess();
+
+        if (this.state.scale !== oldScale && this.subscriptions["scale"]) {
+          this.subscriptions["scale"].forEach((cb) => cb(this.state.scale));
+        }
+
+        if (
+          this.subscriptions["pan"] &&
+          (this.state.pan[0] !== oldPan[0] || this.state.pan[1] !== oldPan[1])
+        ) {
+          this.subscriptions["pan"].forEach((cb) => cb(this.state.pan));
+        }
 
         [this.currentOverlays, this.state.rotate] = processOverlays(
           this.state,
@@ -619,6 +637,15 @@ export abstract class AbstractLooker<
     });
   }
 
+  setCamera(scale: number, pan: [number, number]): void {
+    this.pendingReset = false;
+    this.updater({
+      scale,
+      pan: [...pan] as Coordinates,
+      setZoom: false,
+    });
+  }
+
   /**
    * Detaches the instance from the DOM
    */
@@ -637,22 +664,17 @@ export abstract class AbstractLooker<
     let timeoutId: ReturnType<typeof setTimeout>;
     return (sample: Sample) => {
       clearTimeout(timeoutId);
+      const resetZoom = this.pendingReset;
+      this.pendingReset = false;
+
       timeoutId = setTimeout(() => {
-        // todo: sometimes instance in spotlight?.updateItems() is defined but has no ref to sample
-        // this crashes the app. this is a bug and should be fixed
-        if (!this.sample) {
-          return;
-        }
-
-        if (this.isSampleUpdating) {
-          return;
-        }
-
-        this.isSampleUpdating = true;
         try {
-          this.loadSample(sample, retrieveTransferables(this.sampleOverlays));
+          this.loadSample(
+            sample,
+            retrieveTransferables(this.sampleOverlays),
+            resetZoom
+          );
         } catch (error) {
-          this.isSampleUpdating = false;
           console.error(error);
         }
       }, UPDATE_SAMPLE_DEBOUNCE_MS);
@@ -660,6 +682,12 @@ export abstract class AbstractLooker<
   })();
 
   updateSample(sample: Sample) {
+    if (
+      this.sample &&
+      (sample._id !== this.sample._id || sample.id !== this.sample.id)
+    ) {
+      this.pendingReset = true;
+    }
     this.updateSampleDebounced(sample);
   }
 
@@ -681,7 +709,7 @@ export abstract class AbstractLooker<
         labels: renderLabels,
       })
       .then(({ sample, coloring }) => {
-        this.sample = sample;
+        this.sample = sample as S;
         this.loadOverlays(sample);
 
         // to run looker reconciliation
@@ -883,12 +911,17 @@ export abstract class AbstractLooker<
   }
 
   protected hasResized(): boolean {
-    return Boolean(
-      !this.previousState?.windowBBox ||
-        !this.state?.windowBBox ||
-        this.previousState.windowBBox.some(
-          (v, i) => v !== this.state.windowBBox[i]
-        )
+    if (!this.previousState?.windowBBox || !this.state?.windowBBox) {
+      return false;
+    }
+
+    const [_, __, pw, ph] = this.previousState.windowBBox;
+    if (pw === 0 || ph === 0) {
+      return false;
+    }
+
+    return this.previousState.windowBBox.some(
+      (v, i) => v !== this.state.windowBBox[i]
     );
   }
 
@@ -898,8 +931,13 @@ export abstract class AbstractLooker<
     }
   }
 
-  private loadSample(sample: Sample, transfer: Transferable[] = []) {
+  private loadSample(
+    sample: Sample,
+    transfer: Transferable[] = [],
+    resetZoom = false
+  ) {
     const messageUUID = uuid();
+    const shouldReset = resetZoom;
 
     const labelsWorker = getLabelsWorker();
 
@@ -907,7 +945,6 @@ export abstract class AbstractLooker<
       if (uuid === messageUUID) {
         if (error) {
           console.warn(error);
-          this.isSampleUpdating = false;
           labelsWorker.removeEventListener("message", listener);
           return;
         }
@@ -915,13 +952,14 @@ export abstract class AbstractLooker<
         // we paint overlays again, so cleanup the old ones
         // this helps prevent memory leaks from, for instance, dangling ImageBitmaps
         this.cleanOverlays();
-        this.sample = sample;
+        this.sample = sample as S;
         this.loadOverlays(sample);
         this.updater((prev) => ({
           ...prev,
           overlaysPrepared: true,
           disabled: false,
           reloading: false,
+          setZoom: shouldReset || prev.setZoom,
           options: {
             ...prev.options,
             coloring,
@@ -929,8 +967,6 @@ export abstract class AbstractLooker<
         }));
 
         labelsWorker.removeEventListener("message", listener);
-
-        this.isSampleUpdating = false;
       }
     };
 

--- a/app/packages/looker/src/util.ts
+++ b/app/packages/looker/src/util.ts
@@ -338,51 +338,12 @@ export const getRenderedScale = (
 };
 
 export const snapBox = (
-  scale: number,
+  _scale: number,
   pan: Coordinates,
-  [ww, wh]: Dimensions,
-  [iw, ih]: Dimensions,
-  pad = true
+  _ww: Dimensions,
+  _iw: Dimensions,
+  _pad = true
 ): Coordinates => {
-  const sww = ww * scale;
-  const swh = wh * scale;
-  const ar = iw / ih;
-  if (ww / wh < ar) {
-    iw = sww * (pad ? 1.1 : 1);
-    ih = iw / ar;
-  } else {
-    ih = swh * (pad ? 1.1 : 1);
-    iw = ih * ar;
-  }
-
-  const tly = (swh - ih) / 2 - Math.max((wh - ih) / 2, 0);
-  if (ih > wh) {
-    if (pan[1] > -tly) {
-      pan[1] = -tly;
-    }
-
-    const bry = -tly - ih;
-    if (pan[1] - wh < bry) {
-      pan[1] -= pan[1] - wh - bry;
-    }
-  } else {
-    pan[1] = -tly;
-  }
-
-  const tlx = (sww - iw) / 2 - Math.max((ww - iw) / 2, 0);
-  if (iw > ww) {
-    if (pan[0] > -tlx) {
-      pan[0] = -tlx;
-    }
-
-    const brx = -tlx - iw;
-    if (pan[0] - ww < brx) {
-      pan[0] -= pan[0] - ww - brx;
-    }
-  } else {
-    pan[0] = -tlx;
-  }
-
   return pan;
 };
 

--- a/app/packages/looker/src/zoom.ts
+++ b/app/packages/looker/src/zoom.ts
@@ -4,6 +4,7 @@ import {
   getCls,
   getFieldInfo,
 } from "@fiftyone/utilities";
+import { MIN_ZOOM_SCALE } from "@fiftyone/core/src/constants/viewport";
 import { MIN_PIXELS } from "./constants";
 import { POINTS_FROM_FO } from "./overlays";
 import { Overlay } from "./overlays/base";
@@ -70,20 +71,20 @@ export const zoomToContent = <
   const squeeze = 1 - state.options.zoomPad;
 
   if (wAR < iAR) {
-    scale = Math.max(1, 1 / bw);
+    scale = Math.max(MIN_ZOOM_SCALE, 1 / bw);
     w = ww * scale;
     h = w / iAR;
     if (!state.config.thumbnail && bh * h > wh) {
-      scale = Math.max(1, (wh * scale) / (bh * h));
+      scale = Math.max(MIN_ZOOM_SCALE, (wh * scale) / (bh * h));
       w = ww * scale;
       h = w / iAR;
     }
   } else {
-    scale = Math.max(1, 1 / bh);
+    scale = Math.max(MIN_ZOOM_SCALE, 1 / bh);
     h = wh * scale;
     w = h * iAR;
     if (!state.config.thumbnail && bw * w > ww) {
-      scale = Math.max(1, (ww * scale) / (bw * w));
+      scale = Math.max(MIN_ZOOM_SCALE, (ww * scale) / (bw * w));
       h = wh * scale;
       w = h * iAR;
     }

--- a/app/packages/state/src/hooks/useClearModal.ts
+++ b/app/packages/state/src/hooks/useClearModal.ts
@@ -1,6 +1,7 @@
-import { useRecoilCallback, useSetRecoilState } from "recoil";
-
+import { useSetAtom } from "jotai";
 import { useCallback } from "react";
+import { useRecoilCallback, useSetRecoilState } from "recoil";
+import { modalViewport } from "../jotai";
 import * as fos from "../recoil";
 
 /**
@@ -21,6 +22,7 @@ import * as fos from "../recoil";
 
 export default () => {
   const setModal = useSetRecoilState(fos.modalSelector);
+  const setViewport = useSetAtom(modalViewport);
   const close = useRecoilCallback(
     ({ reset, set, snapshot }) =>
       async () => {
@@ -41,7 +43,8 @@ export default () => {
   );
 
   return useCallback(() => {
+    setViewport(null);
     close();
     setModal(null);
-  }, [close, setModal]);
+  }, [close, setModal, setViewport]);
 };

--- a/app/packages/state/src/jotai/modal.ts
+++ b/app/packages/state/src/jotai/modal.ts
@@ -1,3 +1,4 @@
+import { atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import { createDatasetKeyedStorage, parseDatasetNameFromUrl } from "./utils";
 
@@ -24,3 +25,8 @@ export const modalMode = atomWithStorage<ModalMode>(
   ModalMode.EXPLORE,
   createDatasetKeyedStorage<ModalMode>(parseDatasetNameFromUrl)
 );
+
+export const modalViewport = atom<{
+  scale: number;
+  pan: [number, number];
+} | null>(null);

--- a/app/packages/state/src/recoil/looker.ts
+++ b/app/packages/state/src/recoil/looker.ts
@@ -19,7 +19,7 @@ import skeletonFilter from "./skeletonFilter";
 import { State } from "./types";
 import * as viewAtoms from "./view";
 
-type Lookers = FrameLooker | ImageLooker | VideoLooker;
+export type Lookers = FrameLooker | ImageLooker | VideoLooker;
 
 export const lookerOptions = selectorFamily<
   Partial<Omit<ReturnType<Lookers["getDefaultOptions"]>, "selected">>,


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR implements bidirectional viewport synchronization between Looker and Lighter, fixes visual flash issues, and ensures consistent rendering across both viewers.  It also fixes a flash of the unscaled sample when Lighter loads.
Looker can now pan arbitrarily.  Lighter is now has a minimum zoom set the the same as lookers.

Key Changes
Viewport State Management - Migrated viewport state to Jotai atom (modalViewport) for shared state between viewers
Bidirectional Sync - Implemented two-way synchronization via useBridge.ts (Lighter) and use-looker.ts (Looker)
Flash Prevention - Hide image element until first viewport transform is applied (Lighter)
Shared Constants - Created MIN_ZOOM_SCALE_LIGHTER/MIN_ZOOM_SCALE_LOOKER) constants to ensure consistent minimum zoom.  These are different values due to library differences.
Consistent Rendering - Added image-rendering: pixelated to Lighter to match Looker's style

Video demo:

https://github.com/user-attachments/assets/9df35e02-1e9e-4975-9fd2-674edce12b84



## How is this patch tested? If it is not, please explain why.
Manually, locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Since looker is already available, this introduces arbitrary panning to it.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added synchronized viewport control between modal viewers and image overlays.
  * Introduced minimum zoom constraints for consistent scaling behavior across viewers.
  * Added ready-state detection for improved viewer initialization.

* **Bug Fixes**
  * Prevented visual flashing of images during initial display.
  * Fixed viewport snapping during user interactions.
  * Improved viewport reset behavior on modal navigation and closure.

* **Refactor**
  * Simplified pan-zoom calculation logic.
  * Enhanced state management for viewer viewport synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->