### PR TITLE
clean up use of jotai store

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/bridgeQuickDraw.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/bridgeQuickDraw.ts
@@ -3,7 +3,7 @@
  */
 
 import { getDefaultStore } from "jotai";
-import { quickDrawActiveAtom } from "./useQuickDraw";
+import { _dangerousQuickDrawActiveAtom } from "./useQuickDraw";
 
 /**
  * Quick draw bridge for non-React code.
@@ -16,6 +16,6 @@ export const quickDrawBridge = {
    */
   isQuickDrawActive(): boolean {
     const store = getDefaultStore();
-    return store.get(quickDrawActiveAtom);
+    return store.get(_dangerousQuickDrawActiveAtom);
   },
 };

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
@@ -82,7 +82,7 @@ export const addLabel = atom(
 export const labels = atom<Array<AnnotationLabel>>([]);
 export const labelAtoms = splitAtom(labels, ({ overlay }) => overlay.id);
 export const labelsByPath = atom((get) => {
-  const map = {};
+  const map: Record<string, AnnotationLabel[]> = {};
   for (const label of get(labels)) {
     if (!label.path) {
       continue;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Refactor hooks to remove direct use of jotai's store.

## How is this patch tested? If it is not, please explain why.

local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal state management architecture for quick draw functionality.
  * Improved type safety for annotation data structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->