### PR TITLE
add open source migration steps to Enterprise getting started guide

### DIFF
--- a/docs/source/enterprise/getting_started.rst
+++ b/docs/source/enterprise/getting_started.rst
@@ -150,8 +150,11 @@ interacting with cloud-backed media in FiftyOne Enterprise.
 Import your data
 ~~~~~~~~~~~~~~~~
 
+Importing directly from cloud bucket
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 The example code below shows the basic pattern for creating new datasets and
-populating them via the FiftyOne Enterprise Python SDK:
+populating them directly from cloud storage via the FiftyOne Enterprise Python SDK:
 
 .. tabs::
 
@@ -222,7 +225,7 @@ populating them via the FiftyOne Enterprise Python SDK:
          dataset.add_samples(samples)
 
          # You must mark the dataset as persistent to access it in the UI
-         dataset.persistent = True     
+         dataset.persistent = True
 
   .. group-tab:: MinIO
 
@@ -249,8 +252,17 @@ populating them via the FiftyOne Enterprise Python SDK:
          # You must mark the dataset as persistent to access it in the UI
          dataset.persistent = True
 
-Refer to :ref:`this page <importing-datasets>` for more information about
-importing your media and labels into FiftyOne via Python.
+Refer to :ref:`this page <importing-datasets>` for more
+information about importing your media and labels into FiftyOne via Python.
+
+Migrate from FiftyOne open-source
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you have an existing FiftyOne open-source dataset with locally stored media,
+you can migrate it to FiftyOne Enterprise and upload your media to cloud storage.
+
+Refer to :ref:`this page <enterprise-migrating-datasets>` for detailed instructions on
+migrating datasets from FiftyOne open-source to FiftyOne Enterprise.
 
 Compute metadata
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## What changes are proposed in this pull request?

adds a link to the open source to enterprise migration guide in the enterprise getting started guide

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added guidance for importing datasets directly from cloud storage buckets (AWS, GCP, Azure, MinIO) using the FiftyOne Enterprise Python SDK, including patterns for creating new datasets and populating them from cloud storage.
* Added migration guidance section with detailed instructions for upgrading datasets from FiftyOne open-source to FiftyOne Enterprise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->