### PR TITLE
bump voodo to version 0.0.14 and some general styling updates

### DIFF
--- a/app/packages/core/package.json
+++ b/app/packages/core/package.json
@@ -23,7 +23,7 @@
         "@mui/material": "^5.9.0",
         "@react-spring/web": "^9.4.3",
         "@use-gesture/react": "^10.3.0",
-        "@voxel51/voodo": "0.0.11",
+        "@voxel51/voodo": "0.0.14",
         "@xstate/react": "1.3.3",
         "classnames": "^2.2.6",
         "color": "^4.2.3",

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/LabelEntry.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/LabelEntry.tsx
@@ -108,7 +108,7 @@ const LabelEntry = ({ atom }: { atom: PrimitiveAtom<AnnotationLabel> }) => {
       <Header>
         <Column>
           <Icon fill={color} />
-          <div style={!label.data.label ? { color } : {}}>
+          <div style={!label.data.label ? { color } : { paddingLeft: "8px" }}>
             {label.data.label ?? "None"}
           </div>
         </Column>

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/ActiveFieldsSection.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/ActiveFieldsSection.tsx
@@ -10,7 +10,6 @@ import type { ListItemProps } from "@voxel51/voodo";
 import {
   Anchor,
   Button,
-  Clickable,
   Icon,
   IconName,
   Pill,
@@ -48,9 +47,14 @@ const FieldActions = ({ path }: { path: string }) => {
       anchor={Anchor.Bottom}
       portal
     >
-      <Clickable data-cy="edit" onClick={() => setField(path)}>
+      <Button
+        variant={Variant.Icon}
+        borderless
+        data-cy="edit"
+        onClick={() => setField(path)}
+      >
         <Icon name={IconName.Edit} size={Size.Md} />
-      </Clickable>
+      </Button>
     </Tooltip>
   );
 };

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/HiddenFieldsSection.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/HiddenFieldsSection.tsx
@@ -5,10 +5,10 @@
  */
 
 import { FeatureFlag, useFeature } from "@fiftyone/feature-flags";
+import type { ListItemProps } from "@voxel51/voodo";
 import {
   Anchor,
   Button,
-  Clickable,
   Icon,
   IconName,
   Pill,
@@ -19,7 +19,6 @@ import {
   Tooltip,
   Variant,
 } from "@voxel51/voodo";
-import type { ListItemProps } from "@voxel51/voodo";
 import { useCallback, useMemo, useState } from "react";
 import SecondaryText from "./SecondaryText";
 import { isSystemReadOnlyField } from "./constants";
@@ -71,9 +70,14 @@ const HiddenFieldActions = ({
               anchor={Anchor.Bottom}
               portal
             >
-              <Clickable data-cy={"edit"} onClick={() => setField(path)}>
+              <Button
+                variant={Variant.Icon}
+                borderless
+                data-cy={"edit"}
+                onClick={() => setField(path)}
+              >
                 <Icon name={IconName.Edit} size={Size.Md} />
-              </Clickable>
+              </Button>
             </Tooltip>
           ) : (
             <Button

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/Modal.tsx
@@ -28,7 +28,6 @@ import {
 import NewFieldSchema from "./NewFieldSchema";
 import {
   BackButton,
-  CloseButton,
   ModalBackground,
   ModalContainer,
   ModalFooter,
@@ -183,11 +182,20 @@ const Modal = () => {
       >
         <ModalHeader>
           <Heading />
-          <CloseButton
+          <Button
+            variant={Variant.Icon}
+            borderless
+            size={Size.Sm}
             data-cy="close-schema-manager"
-            color="secondary"
             onClick={() => setShowModal(false)}
-          />
+            style={{ marginRight: "14px" }}
+          >
+            <Icon
+              name={IconName.Close}
+              size={Size.Lg}
+              color={TextColor.Secondary}
+            />
+          </Button>
         </ModalHeader>
 
         <Subheading />

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2592,7 +2592,7 @@ __metadata:
     "@types/styled-components": "npm:^5.1.23"
     "@use-gesture/react": "npm:^10.3.0"
     "@vitejs/plugin-react-refresh": "npm:^1.3.3"
-    "@voxel51/voodo": "npm:0.0.11"
+    "@voxel51/voodo": "npm:0.0.14"
     "@xstate/react": "npm:1.3.3"
     classnames: "npm:^2.2.6"
     color: "npm:^4.2.3"
@@ -7323,9 +7323,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@voxel51/voodo@npm:0.0.11":
-  version: 0.0.11
-  resolution: "@voxel51/voodo@npm:0.0.11"
+"@voxel51/voodo@npm:0.0.14":
+  version: 0.0.14
+  resolution: "@voxel51/voodo@npm:0.0.14"
   dependencies:
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/sortable": "npm:^10.0.0"
@@ -7341,7 +7341,7 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
     react-is: ^18.0.0
-  checksum: 10/1b2925a43e2f10987f06f46105650ad75e642a275201a3b17e294d8c6964550eb32c2ab91331485ecd399a23ef7050e6768a60df6808edcf20d5c4d4824cc164
+  checksum: 10/8c66adbd0c6068d3dfe89ce1cef3ec353f665dc17e57bcbf9ed73ae4d1a1f1a6ce3e5f724e6c73cb014e05c0c8879b9be813f53e5c510d70412cd9c3e8c96ca9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- bumps voodo to latest
- some small padding fixes
- button updates

<img width="770" height="690" alt="image" src="https://github.com/user-attachments/assets/336cfacf-15a8-4ea7-906e-37c479e5e595" />


## How is this patch tested? If it is not, please explain why.

Tested locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined label spacing in annotation interface; adjusted padding in label containers when content is absent.

* **Refactor**
  * Transitioned edit action controls from Clickable wrappers to Button icon variants throughout annotation modal sections.
  * Standardized modal header close button with icon button component, maintaining functionality with updated component structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->