### PR TITLE
change mode switch to use voodo

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Mode.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Mode.tsx
@@ -27,7 +27,7 @@ const Mode = () => {
   const { enterAnnotationMode, exitAnnotationMode } = useAnnotationController();
   const editing = useAtomValue(isEditing);
 
-  const defaultIndex = mode === ModalMode.ANNOTATE ? 1 : 0;
+  const defaultIndex = MODE_TABS.findIndex((tab) => tab.id === mode);
 
   const handleChange = useCallback(
     (index: number) => {

--- a/e2e-pw/src/oss/poms/modal/modal-sidebar.ts
+++ b/e2e-pw/src/oss/poms/modal/modal-sidebar.ts
@@ -72,7 +72,8 @@ export class ModalSidebarPom {
   }
 
   async switchMode(mode: "annotate" | "explore") {
-    await this.locator.getByTestId(mode).click();
+    const label = mode === "annotate" ? "Annotate" : "Explore";
+    await this.locator.getByRole("button", { name: label }).click();
   }
 
   async toggleLabelCheckbox(field: string) {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Changes mode switch to use voodo toggle

[mode-toggle.webm](https://github.com/user-attachments/assets/33d9cad1-fc4b-48e4-822b-8034725f4d59)



## How is this patch tested? If it is not, please explain why.

locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned the mode selector as a tab-style toggle for Explore and Annotate, improving layout and usability and adding top spacing to accommodate the control.
* **Accessibility / Bug Fixes**
  * Mode buttons now use clear accessible labels, ensuring consistent keyboard/assistive navigation and more reliable selection in automated tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->