### PR TITLE
[HA] Disable samples scan for quick edit

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useSchemaManager.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useSchemaManager.ts
@@ -1,5 +1,5 @@
-import { useCallback, useMemo } from "react";
 import { useOperatorExecutor } from "@fiftyone/operators";
+import { useCallback, useMemo } from "react";
 
 /**
  * Schema field types.
@@ -354,7 +354,10 @@ export const useSchemaManager = (): SchemaManager => {
     async (
       request: InitializeSchemaRequest
     ): Promise<InitializeSchemaResponse> => {
-      const createResponse = await createSchemas({ field: request.field });
+      const createResponse = await createSchemas({
+        field: request.field,
+        scan_samples: false,
+      });
       const updateResponse = await updateSchema({
         field: request.field,
         label_schema: createResponse.label_schema,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Quick edit is should likely not scan samples for when initializing a label schema

## How is this patch tested? If it is not, please explain why.

Separate E2E PR

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated schema initialization process in the annotation interface to prevent sample scanning during setup, optimizing the initialization workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->