### PR TITLE
Update docs banner with visual AI survey

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,12 +4,12 @@ FiftyOne
 .. raw:: html
 
   <div class="responsive-banner">
-    <a href="https://link.voxel51.com/docs-search-sales" target="_blank" aria-label="Get enterprise features for team collaboration and production workflows">
+    <a href="https://link.voxel51.com/visual-ai-survey-5" target="_blank" aria-label="Share how you build, deploy, and scale visual AI">
       <video class="banner-mobile" autoplay loop muted playsinline aria-hidden="true">
-        <source src="https://cdn.voxel51.com/banner/cta_sales_1200x200.webm" type="video/webm">
+        <source src="https://cdn.voxel51.com/banner/survey_2026_january_1200x200.webm" type="video/webm">
       </video>
       <video class="banner-desktop" autoplay loop muted playsinline aria-hidden="true">
-        <source src="https://cdn.voxel51.com/banner/cta_sales_2400x400.webm" type="video/webm">
+        <source src="https://cdn.voxel51.com/banner/survey_2026_january_2400x400.webm" type="video/webm">
       </video>
     </a>
   </div>


### PR DESCRIPTION
## What changes are proposed in this pull request?

Replace homepage sales banner with January 2026 visual AI survey banner

## How is this patch tested? If it is not, please explain why.

Built local, looks good! 

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [X] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [X] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the primary website banner to guide users toward participation in an AI survey, refreshing both the link target and accompanying descriptive text labels
  * Replaced banner video sources with new survey-focused visual content, delivering updated media assets specifically designed for optimal display on both mobile and desktop platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->