### PR TITLE
Fix label and primitive collapsing

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useEntries.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useEntries.ts
@@ -57,7 +57,7 @@ const useEntries = (): [SidebarEntry[], (entries: SidebarEntry[]) => void] => {
     }
 
     return result as SidebarEntry[];
-  }, [atoms, activeFields, state, primitiveEntries]);
+  }, [atoms, activeFields, state, expanded]);
 
   return [
     [


### PR DESCRIPTION
## What changes are proposed in this pull request?

- only hide labels on collapse, not both labels and primitives

[label-minimizing.webm](https://github.com/user-attachments/assets/31b905e1-44f9-4a2b-97b8-239311eb5a0b)

## How is this patch tested? If it is not, please explain why.

tested locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sidebar annotation behavior so collapsed state no longer builds entry list and shows no entries.
  * Ensured the annotation list consistently includes primitive items alongside computed entries when expanded, preventing missing items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->