### PR TITLE
fix TypeError: config?.attributes.filter is not a function

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
@@ -22,7 +22,10 @@ const useSchema = (readOnly: boolean) => {
   const effectiveReadOnly = readOnly || isLabelReadOnly;
 
   return useMemo(() => {
-    const properties = config?.attributes
+    const attributes = Array.isArray(config?.attributes)
+      ? config.attributes
+      : [];
+    const properties = attributes
       .filter(({ name }) => name && !["id", "attributes"].includes(name))
       .reduce(
         (schema: SchemaType, value: SchemaType) => ({


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently, clicking on a bounding box throws an error:

<img width="1233" height="445" alt="image" src="https://github.com/user-attachments/assets/5ab60bef-ccfe-4a7b-b8b3-bd6e80284106" />


## How is this patch tested? If it is not, please explain why.

Tested locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of annotation attribute handling to prevent potential runtime errors and ensure stable behavior in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->