### PR TITLE
Pin timm<1.0.24 for omdet-turbo-swin-tiny-torch

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -3797,7 +3797,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "torchvision", "transformers>=4.51"],
+                "packages": ["torch", "torchvision", "transformers>=4.51", "timm<1.0.24"],
                 "cpu": {
                     "support": true
                 },


### PR DESCRIPTION
## Summary
Pin timm<1.0.24 for omdet-turbo-swin-tiny-torch to fix inference failure.

## Problem
timm 1.0.24 (released Jan 7, 2026) introduced a regression in Swin Transformer's relative position bias handling. This causes:
```
IndexError: index 1841 is out of bounds for dimension 0 with size 169
```

## Verification

**Local testing:**
- timm 1.0.24 + fiftyone 1.11.1: IndexError on inference
- timm 1.0.22 + fiftyone 1.11.1: SUCCESS

**CI history (model-zoo-status):**
| Run Date | timm | omdet-turbo result |
|----------|------|-------------------|
| Dec 31 | 1.0.22 | PASS |
| Jan 5 | 1.0.22 | PASS |
| Jan 12 | 1.0.24 | FAIL |
| Jan 26 | 1.0.24 | FAIL |

**Tested with:**
- Python 3.11
- torch 2.10.0
- transformers 4.57.6
- fiftyone 1.11.1
- quickstart dataset, apply_model with omdet-turbo-swin-tiny-torch

## Related
Upstream issue should be filed with huggingface/pytorch-image-models.