### PR TITLE
Run e2e against mongo:latest only

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,9 +28,6 @@ jobs:
       fail-fast: false
       matrix:
         mongodb-version:
-          - "6"
-          - "7"
-          - "8.0"
           - "latest"
     steps:
       - name: Checkout


### PR DESCRIPTION
We're seeing frequent e2e errors in CI because of timeouts in downloading zoo datasets. It happens because our zoo datasets are hosted on google drive which has a relatively low rate limit. For now - let's only run e2e on mongo:latest until we have a better strategy.
