### PR TITLE
[HA] Ignore deprecated 'attributes' when generating label schemas

### DIFF
--- a/fiftyone/core/annotation/generate_label_schemas.py
+++ b/fiftyone/core/annotation/generate_label_schemas.py
@@ -350,6 +350,12 @@ def _generate_field_label_schema(collection, field_name, scan_samples):
     attributes = {}
     classes = []
     for f in field.fields:
+        if f.name == foac.ATTRIBUTES and issubclass(
+            field.document_type, fol.Label
+        ):
+            # ignore deprecated 'attributes' subfield on label types
+            continue
+
         if (
             f.name == foac.BOUNDING_BOX
             and field.document_type == fol.Detection

--- a/tests/unittests/annotation/generate_label_schemas_tests.py
+++ b/tests/unittests/annotation/generate_label_schemas_tests.py
@@ -154,7 +154,13 @@ class GenerateLabelSchemaTests(unittest.TestCase):
             fo.Sample(
                 filepath="image.png",
                 detections_field=fo.Detections(
-                    detections=[fo.Detection(label="test")]
+                    detections=[
+                        fo.Detection(
+                            label="test",
+                            # 'attributes' is ignored
+                            attributes={"ignore": fo.Attribute()},
+                        )
+                    ]
                 ),
             )
         )


### PR DESCRIPTION
## What changes are proposed in this pull request?

 Ignore deprecated 'attributes' when generating label schemas

## How is this patch tested? If it is not, please explain why.

Adjusted generate label schemas test

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved label schema generation by excluding deprecated attributes subfields from label type processing, resulting in cleaner and more accurate schema definitions.

* **Tests**
  * Updated tests to verify corrected schema generation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->