### PR TITLE
FOEPD-3057 Add a hook to sync the sidebar

### DIFF
--- a/app/packages/core/src/components/Modal/Lighter/LighterSampleRenderer.tsx
+++ b/app/packages/core/src/components/Modal/Lighter/LighterSampleRenderer.tsx
@@ -15,6 +15,7 @@ import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useRecoilValue } from "recoil";
 import { singletonCanvas } from "./SharedCanvas";
 import { useBridge } from "./useBridge";
+import { useSyncOverlayToSidebar } from "./useSyncOverlayToSidebar";
 
 export interface LighterSampleRendererProps {
   /** Custom CSS class name */
@@ -121,6 +122,7 @@ const LighterSetupImpl = (props: {
 
   // This is the bridge between FiftyOne state management system and Lighter
   useBridge(scene);
+  useSyncOverlayToSidebar(scene);
 
   return null;
 };

--- a/app/packages/core/src/components/Modal/Lighter/useSyncOverlayToSidebar.ts
+++ b/app/packages/core/src/components/Modal/Lighter/useSyncOverlayToSidebar.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { KnownContexts, useCommandContext } from "@fiftyone/commands";
+import {
+  UNDEFINED_LIGHTER_SCENE_ID,
+  useLighterEventHandler,
+  type Scene2D,
+} from "@fiftyone/lighter";
+import { type AnnotationLabel } from "@fiftyone/state";
+import { getDefaultStore, useAtomValue } from "jotai";
+import { isEqual } from "lodash";
+import { useCallback, useEffect, useRef } from "react";
+import { editing as editingAtom } from "../Sidebar/Annotate/Edit/state";
+import { coerceStringBooleans } from "../Sidebar/Annotate/utils";
+
+/**
+ * Hook that synchronizes changes from Lighter overlays to the sidebar editing atoms.
+ * It ensures that the sidebar remains the authoritative UI for editing, but
+ * pulls data from the renderer when it changes (e.g. via commands, undo/redo).
+ */
+export function useSyncOverlayToSidebar(scene: Scene2D | null) {
+  const useEventHandler = useLighterEventHandler(
+    scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
+  );
+  const store = getDefaultStore();
+  const editingValue = useAtomValue(editingAtom);
+
+  // Track the last synced label data to prevent unnecessary updates (and focus loss)
+  const lastSyncedDataRef = useRef<AnnotationLabel["data"] | null>(null);
+
+  const { context } = useCommandContext(KnownContexts.ModalAnnotate);
+
+  const sync = useCallback(() => {
+    // Only sync if we are actually editing a label atom
+    if (!editingValue || typeof editingValue === "string") {
+      return;
+    }
+
+    const currentEditing = store.get(editingValue);
+    if (!currentEditing?.overlay) {
+      return;
+    }
+
+    const overlayLabel = currentEditing.overlay.label;
+    if (!overlayLabel) {
+      return;
+    }
+
+    // Coerce data to match Sidebar expectations (e.g. string booleans)
+    const coercedLabel = coerceStringBooleans(
+      overlayLabel as Record<string, unknown>
+    ) as AnnotationLabel["data"];
+
+    if (isEqual(coercedLabel, lastSyncedDataRef.current)) {
+      return;
+    }
+
+    // Update the atom with the latest authoritative data from the overlay
+    // We perform a full replacement to ensure fields are cleared correctly on undo
+    store.set(editingValue, {
+      ...currentEditing,
+      data: coercedLabel,
+    } as AnnotationLabel);
+
+    lastSyncedDataRef.current = coercedLabel;
+  }, [editingValue, store]);
+
+  const handleEvent = useCallback(() => {
+    sync();
+  }, [sync]);
+
+  // Comprehensive action subscription (catches global undo/redo/execute)
+  useEffect(() => {
+    return context.subscribeActions(() => sync());
+  }, [context, sync]);
+
+  // Lighter-specific event fallbacks (e.g. for commands not handled by global context)
+  useEventHandler("lighter:command-executed", handleEvent);
+
+  // Sync when the editing atom changes (e.g. new label selected or mount)
+  useEffect(() => {
+    sync();
+  }, [sync]);
+}

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
@@ -1,5 +1,5 @@
 import { useAnnotationEventBus } from "@fiftyone/annotation";
-import { expandPath, field } from "@fiftyone/state";
+import { expandPath, field, type AnnotationLabel } from "@fiftyone/state";
 import { FLOAT_FIELD, INT_FIELD } from "@fiftyone/utilities";
 import { useAtom, useAtomValue } from "jotai";
 import { isEqual } from "lodash";
@@ -144,9 +144,11 @@ const AnnotationSchema = ({ readOnly = false }: AnnotationSchemaProps) => {
             return;
           }
 
+          _save(value);
+
           eventBus.dispatch("annotation:sidebarValueUpdated", {
             overlayId: overlay.id,
-            currentLabel: overlay.label as any,
+            currentLabel: overlay.label as unknown as AnnotationLabel["data"],
             value,
           });
         }}

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Position.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Position.tsx
@@ -5,7 +5,7 @@ import {
   useLighter,
   useLighterEventHandler,
 } from "@fiftyone/lighter";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { SchemaIOComponent } from "../../../../../plugins/SchemaIO";
 import { currentData, currentOverlay } from "./state";
 import { useAtom, useAtomValue } from "jotai";
@@ -146,12 +146,19 @@ export default function Position({ readOnly = false }: PositionProps) {
           }
 
           const oldBounds = overlay.getAbsoluteBounds();
+          const newBounds = {
+            ...oldBounds,
+            ...data.dimensions,
+            ...data.position,
+          };
+
           scene?.executeCommand(
-            new TransformOverlayCommand(overlay, overlay.id, oldBounds, {
-              ...oldBounds,
-              ...data.dimensions,
-              ...data.position,
-            })
+            new TransformOverlayCommand(
+              overlay,
+              overlay.id,
+              oldBounds,
+              newBounds
+            )
           );
         }}
       />

--- a/app/packages/lighter/src/index.ts
+++ b/app/packages/lighter/src/index.ts
@@ -70,6 +70,7 @@ export type {
   Dimensions,
   DrawStyle,
   Point,
+  RawLookerLabel,
   Rect,
   Spatial,
   TextOptions,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Uses a hook based approach to sync the sidebar.

## How is this patch tested? If it is not, please explain why.

Locally, manually

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced synchronization between Lighter overlays and the sidebar editing interface to ensure real-time data consistency.

* **Refactor**
  * Improved internal synchronization mechanism for overlay state management.
  * Updated annotation editing workflow to streamline data updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->