### PR TITLE
Avoid infinite error loop caused by ErrorBoundary throwing error

### DIFF
--- a/app/packages/state/src/session.ts
+++ b/app/packages/state/src/session.ts
@@ -215,8 +215,12 @@ export function sessionAtom<K extends keyof Session>(
       }
 
       if (!isTest) {
-        setterRef(options.key, newValue);
-        sessionRef[options.key] = newValue;
+        if (setterRef) {
+          setterRef(options.key, newValue);
+        }
+        if (sessionRef) {
+          sessionRef[options.key] = newValue;
+        }
       }
 
       set(value, newValue);


### PR DESCRIPTION

## What changes are proposed in this pull request?

Don't use `setterRef` or `sessionRef` when they're not set. This can happen when the error boundary clears the modal, but if there is no modal it causes an error in the error boundary and creates a cascade of errors that hangs the browser tab.

## How is this patch tested? If it is not, please explain why.

Tested manually locally by throwing an error in a component. Without this change, there would rapidly be thousands of console errors that caused the tab to hang. With this change, there are only a few errors and the UI shows the source of the error.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

### Does this area need RPC Testing?

- [ ] Yes
  - [ ] I added the `test-rpc` label to this PR
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session state management reliability through enhanced error handling during state updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->