### PR TITLE
[HA] Select 3d label when entering annotation via label quick edit

### DIFF
--- a/app/packages/annotation/src/hooks/useRegisterRendererEventHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterRendererEventHandlers.ts
@@ -14,7 +14,8 @@ export const useRegisterRendererEventHandlers = () => {
   const handleLighterEvent = useLighterEventHandler(scene?.getEventChannel());
 
   const select3DLabel = useSelect3DLabelForAnnotation();
-  const labels3D = [...useWorkingDetections(), ...useWorkingPolylines()];
+  const detections3D = useWorkingDetections();
+  const polylines3D = useWorkingPolylines();
 
   const { entranceLabelId, clearEntranceLabelId } =
     useAnnotationContextManager();
@@ -43,7 +44,8 @@ export const useRegisterRendererEventHandlers = () => {
   // For 3D, we can listen to changes in the working label set and select
   // the label once it's available.
   useEffect(() => {
-    if (entranceLabelId && labels3D) {
+    if (entranceLabelId) {
+      const labels3D = [...detections3D, ...polylines3D];
       const targetLabel = labels3D.find(
         (label) => label._id === entranceLabelId
       );
@@ -54,5 +56,5 @@ export const useRegisterRendererEventHandlers = () => {
         clearEntranceLabelId();
       }
     }
-  }, [entranceLabelId, labels3D]);
+  }, [detections3D, entranceLabelId, polylines3D]);
 };


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds logic to select the relevant 3D label for editing when entering annotation mode through a label tooltip's "quick edit" affordance

## How is this patch tested? If it is not, please explain why.

local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced 3D label selection and synchronization: entering annotation mode now automatically syncs 3D labels with 2D selections and overlay events, reducing manual adjustments.
  * Improved cross-view responsiveness: changes that target a specific label now trigger matching reactions in both 2D overlays and 3D views for a smoother annotation workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->