### PR TITLE
[HA] Resolve loading state when quick edit lacks management permissions

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useAnnotationContextManager.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useAnnotationContextManager.ts
@@ -110,6 +110,7 @@ export const useAnnotationContextManager = (): AnnotationContextManager => {
         // if it doesn't exist, create it
         if (!listSchemaResponse.label_schemas[field]?.label_schema) {
           if (!canManageSchema) {
+            setLabelSchema(listSchemaResponse.label_schemas);
             return {
               status: InitializationStatus.InsufficientPermissions,
             };


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR fixes a bug where the annotation loading state does not resolve when (a) a user enters annotation mode through the quick edit affordance, (b) a schema does not yet exist for the desired field, and (c) the user lacks schema management permissions.

With this fix, the annotation panel correctly displays a "only schema managers..." error state.

## How is this patch tested? If it is not, please explain why.

local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of annotation schema display when users lack management permissions, ensuring existing schemas remain visible in the UI even when insufficient permissions are encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->