### PR TITLE
[Release] HA styling updates

### DIFF
--- a/app/packages/core/package.json
+++ b/app/packages/core/package.json
@@ -23,7 +23,7 @@
         "@mui/material": "^5.9.0",
         "@react-spring/web": "^9.4.3",
         "@use-gesture/react": "^10.3.0",
-        "@voxel51/voodo": "0.0.14",
+        "@voxel51/voodo": "0.0.15",
         "@xstate/react": "1.3.3",
         "classnames": "^2.2.6",
         "color": "^4.2.3",

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Actions.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Actions.tsx
@@ -20,7 +20,14 @@ import {
 } from "@fiftyone/utilities";
 import PolylineIcon from "@mui/icons-material/Timeline";
 import CuboidIcon from "@mui/icons-material/ViewInAr";
-import { Text, TextColor, TextVariant } from "@voxel51/voodo";
+import {
+  Button,
+  Size,
+  Text,
+  TextColor,
+  TextVariant,
+  Variant,
+} from "@voxel51/voodo";
 import { useSetAtom } from "jotai";
 import { useCallback } from "react";
 import { useRecoilValue } from "recoil";
@@ -336,9 +343,9 @@ const Schema = () => {
   const showModal = useShowModal();
 
   return (
-    <RoundButton onClick={showModal}>
-      <Text variant={TextVariant.Lg}>Schema</Text>
-    </RoundButton>
+    <Button variant={Variant.Borderless} size={Size.Sm} onClick={showModal}>
+      Schema
+    </Button>
   );
 };
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/ActiveFieldsSection.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/ActiveFieldsSection.tsx
@@ -52,7 +52,11 @@ const FieldActions = ({ path }: { path: string }) => {
         data-cy="edit"
         onClick={() => setField(path)}
       >
-        <Icon name={IconName.Edit} size={Size.Md} />
+        <Icon
+          name={IconName.Edit}
+          size={Size.Md}
+          color="var(--color-content-text-secondary)"
+        />
       </Button>
     </Tooltip>
   );

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/CardActions.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/CardActions.tsx
@@ -4,13 +4,14 @@
  */
 
 import {
-  Clickable,
+  Button,
   Icon,
   IconName,
   Orientation,
   Size,
   Spacing,
   Stack,
+  Variant,
 } from "@voxel51/voodo";
 
 interface CardActionsProps {
@@ -31,24 +32,34 @@ const CardActions = ({
   onDelete,
 }: CardActionsProps) => (
   <Stack orientation={Orientation.Row} spacing={Spacing.Sm}>
-    <Clickable onClick={onCancel} style={{ padding: 4 }}>
-      <Icon name={IconName.Close} size={Size.Md} />
-    </Clickable>
+    <Button variant={Variant.Icon} borderless onClick={onCancel}>
+      <Icon
+        name={IconName.Close}
+        size={Size.Md}
+        color="var(--color-content-text-secondary)"
+      />
+    </Button>
     {onDelete && (
-      <Clickable onClick={onDelete} style={{ padding: 4 }}>
-        <Icon name={IconName.Delete} size={Size.Md} />
-      </Clickable>
+      <Button variant={Variant.Icon} borderless onClick={onDelete}>
+        <Icon
+          name={IconName.Delete}
+          size={Size.Md}
+          color="var(--color-content-text-secondary)"
+        />
+      </Button>
     )}
-    <Clickable
+    <Button
+      variant={Variant.Icon}
+      borderless
       onClick={canSave ? onSave : undefined}
-      style={{
-        padding: 4,
-        opacity: canSave ? 1 : 0.5,
-        cursor: canSave ? "pointer" : "not-allowed",
-      }}
+      disabled={!canSave}
     >
-      <Icon name={IconName.Check} size={Size.Md} />
-    </Clickable>
+      <Icon
+        name={IconName.Check}
+        size={Size.Md}
+        color="var(--color-content-text-secondary)"
+      />
+    </Button>
   </Stack>
 );
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/ComponentTypeButton.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/ComponentTypeButton.tsx
@@ -36,7 +36,7 @@ const ComponentTypeButton = ({
           style={{
             display: "flex",
             alignItems: "center",
-            justifyContent: "center",
+            justifyContent: "flex-start",
             gap: 8,
             padding: "8px 12px",
             borderRadius: "var(--radius-md)",

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/EditAction.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/EditAction.tsx
@@ -2,16 +2,20 @@
  * Edit action button component.
  */
 
-import { Clickable, Icon, IconName, Size } from "@voxel51/voodo";
+import { Button, Icon, IconName, Size, Variant } from "@voxel51/voodo";
 
 interface EditActionProps {
   onEdit: () => void;
 }
 
 const EditAction = ({ onEdit }: EditActionProps) => (
-  <Clickable onClick={onEdit}>
-    <Icon name={IconName.Edit} size={Size.Md} />
-  </Clickable>
+  <Button variant={Variant.Icon} borderless onClick={onEdit}>
+    <Icon
+      name={IconName.Edit}
+      size={Size.Md}
+      color="var(--color-content-text-secondary)"
+    />
+  </Button>
 );
 
 export default EditAction;

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/PrimitiveFieldContent.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/PrimitiveFieldContent.tsx
@@ -4,6 +4,7 @@
  */
 
 import {
+  FormFieldGroup,
   Orientation,
   Spacing,
   Stack,
@@ -202,11 +203,10 @@ const PrimitiveFieldContent = ({
     <Stack orientation={Orientation.Column} spacing={Spacing.Lg}>
       {/* Component type buttons */}
       {componentOptions.length > 0 && (
-        <div>
+        <FormFieldGroup orientation={Orientation.Column} spacing={Spacing.Sm}>
           <Text
             variant={largeLabels ? TextVariant.Lg : TextVariant.Md}
             color={largeLabels ? TextColor.Primary : TextColor.Secondary}
-            style={{ marginBottom: "0.5rem" }}
           >
             Input type
           </Text>
@@ -222,7 +222,7 @@ const PrimitiveFieldContent = ({
               />
             ))}
           </div>
-        </div>
+        </FormFieldGroup>
       )}
 
       {/* Values list */}

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/ValuesList.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/ValuesList.tsx
@@ -3,18 +3,16 @@
  */
 
 import {
-  Clickable,
+  Button,
   Icon,
   IconName,
   Input,
-  Orientation,
   RichList,
   Size,
-  Spacing,
-  Stack,
   Text,
   TextColor,
   TextVariant,
+  Variant,
 } from "@voxel51/voodo";
 import React, { useState } from "react";
 import {
@@ -86,9 +84,17 @@ const ValuesList = ({
       canDrag: true,
       primaryContent: value,
       actions: (
-        <Clickable onClick={() => handleDeleteValue(index)}>
-          <Icon name={IconName.Delete} size={Size.Md} />
-        </Clickable>
+        <Button
+          variant={Variant.Icon}
+          borderless
+          onClick={() => handleDeleteValue(index)}
+        >
+          <Icon
+            name={IconName.Delete}
+            size={Size.Md}
+            color="var(--color-content-text-secondary)"
+          />
+        </Button>
       ),
     })
   );
@@ -116,16 +122,10 @@ const ValuesList = ({
         >
           Values
         </Text>
-        <Clickable onClick={handleAddValue}>
-          <Stack
-            orientation={Orientation.Row}
-            spacing={Spacing.Xs}
-            style={{ alignItems: "center" }}
-          >
-            <Icon name={IconName.Add} size={Size.Sm} />
-            <Text variant={TextVariant.Sm}>Add</Text>
-          </Stack>
-        </Clickable>
+        <Button variant={Variant.Borderless} onClick={handleAddValue}>
+          <Icon name={IconName.Add} size={Size.Sm} className="size-5" />
+          <span>Add</span>
+        </Button>
       </div>
       <Input
         type={isNumeric ? "number" : "text"}

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/HiddenFieldsSection.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/HiddenFieldsSection.tsx
@@ -72,7 +72,11 @@ const HiddenFieldActions = ({
                 data-cy={"edit"}
                 onClick={() => setField(path)}
               >
-                <Icon name={IconName.Edit} size={Size.Md} />
+                <Icon
+                  name={IconName.Edit}
+                  size={Size.Md}
+                  color="var(--color-content-text-secondary)"
+                />
               </Button>
             </Tooltip>
           ) : (

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/Modal.tsx
@@ -207,7 +207,7 @@ const Modal = () => {
             <Icon
               name={IconName.Close}
               size={Size.Lg}
-              color={TextColor.Secondary}
+              color="var(--color-content-text-secondary)"
             />
           </Button>
         </ModalHeader>

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/NewFieldSchema/NewFieldSchema.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/NewFieldSchema/NewFieldSchema.tsx
@@ -9,15 +9,13 @@
 import { useOperatorExecutor } from "@fiftyone/operators";
 import { is3d } from "@fiftyone/utilities";
 import {
+  FormField,
   Input,
   Orientation,
   Select,
   Size,
   Spacing,
   Stack,
-  Text,
-  TextColor,
-  TextVariant,
   ToggleSwitch,
 } from "@voxel51/voodo";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -29,12 +27,10 @@ import {
   getDefaultComponent,
   toFieldType,
 } from "../constants";
-import {
-  getLabelTypeOptions,
-  validateFieldName,
-  type AttributeConfig,
-  type SchemaConfigType,
-} from "../utils";
+import AttributesSection from "../EditFieldLabelSchema/GUIContent/AttributesSection";
+import ClassesSection from "../EditFieldLabelSchema/GUIContent/ClassesSection";
+import PrimitiveFieldContent from "../EditFieldLabelSchema/GUIContent/PrimitiveFieldContent";
+import Footer from "../Footer";
 import {
   useExitNewFieldMode,
   useLabelSchemasData,
@@ -42,11 +38,13 @@ import {
   useSetActiveLabelSchemas,
   useSetLabelSchemasData,
 } from "../hooks";
-import AttributesSection from "../EditFieldLabelSchema/GUIContent/AttributesSection";
-import ClassesSection from "../EditFieldLabelSchema/GUIContent/ClassesSection";
-import PrimitiveFieldContent from "../EditFieldLabelSchema/GUIContent/PrimitiveFieldContent";
-import Footer from "../Footer";
 import { ListContainer } from "../styled";
+import {
+  getLabelTypeOptions,
+  validateFieldName,
+  type AttributeConfig,
+  type SchemaConfigType,
+} from "../utils";
 
 type FieldCategory = "label" | "primitive";
 
@@ -277,80 +275,65 @@ const NewFieldSchema = () => {
           style={{ width: "100%" }}
         >
           {/* Field name input */}
-          <div>
-            <Text
-              variant={TextVariant.Md}
-              color={TextColor.Secondary}
-              style={{ marginBottom: "0.5rem" }}
-            >
-              Field name
-            </Text>
-            <Input
-              value={fieldName}
-              onChange={(e) => setFieldName(e.target.value)}
-              placeholder="Enter field name"
-              error={!!fieldNameError}
-              autoFocus
-            />
-            {fieldNameError && (
-              <Text
-                variant={TextVariant.Sm}
-                color={TextColor.Destructive}
-                style={{ marginTop: "0.2rem" }}
-              >
-                {fieldNameError}
-              </Text>
-            )}
-          </div>
+          <FormField
+            label="Field name"
+            control={
+              <Input
+                value={fieldName}
+                onChange={(e) => setFieldName(e.target.value)}
+                placeholder="Enter field name"
+                error={!!fieldNameError}
+                autoFocus
+              />
+            }
+            error={fieldNameError || undefined}
+          />
 
           {/* Category toggle */}
-          <div style={{ width: "100%" }}>
-            <Text
-              variant={TextVariant.Md}
-              color={TextColor.Secondary}
-              style={{ marginBottom: "0.5rem" }}
-            >
-              Field category
-            </Text>
-            <ToggleSwitch
-              size={Size.Md}
-              defaultIndex={CATEGORY_LABEL}
-              onChange={handleCategoryChange}
-              fullWidth
-              tabs={[
-                { id: "label", data: { label: "Label" } },
-                { id: "primitive", data: { label: "Primitive" } },
-              ]}
-            />
-          </div>
+          <FormField
+            label="Field category"
+            control={
+              <ToggleSwitch
+                size={Size.Md}
+                defaultIndex={CATEGORY_LABEL}
+                onChange={handleCategoryChange}
+                fullWidth
+                tabs={[
+                  { id: "label", data: { label: "Label", content: null } },
+                  {
+                    id: "primitive",
+                    data: { label: "Primitive", content: null },
+                  },
+                ]}
+              />
+            }
+          />
 
           {/* Type dropdown */}
-          <div>
-            <Text
-              variant={TextVariant.Md}
-              color={TextColor.Secondary}
-              style={{ marginBottom: "0.5rem" }}
-            >
-              {category === "label" ? "Label type" : "Primitive type"}
-            </Text>
-            <Select
-              exclusive
-              portal
-              value={category === "label" ? labelType : primitiveType}
-              onChange={(value) => {
-                if (typeof value === "string") {
-                  if (category === "label") {
-                    handleLabelTypeChange(value);
-                  } else {
-                    handlePrimitiveTypeChange(value);
+          <FormField
+            label={category === "label" ? "Label type" : "Primitive type"}
+            control={
+              <Select
+                exclusive
+                portal
+                value={category === "label" ? labelType : primitiveType}
+                onChange={(value) => {
+                  if (typeof value === "string") {
+                    if (category === "label") {
+                      handleLabelTypeChange(value);
+                    } else {
+                      handlePrimitiveTypeChange(value);
+                    }
                   }
+                }}
+                options={
+                  category === "label"
+                    ? labelTypeOptions
+                    : ATTRIBUTE_TYPE_OPTIONS
                 }
-              }}
-              options={
-                category === "label" ? labelTypeOptions : ATTRIBUTE_TYPE_OPTIONS
-              }
-            />
-          </div>
+              />
+            }
+          />
 
           {/* Primitive field config */}
           {category === "primitive" && (

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2592,7 +2592,7 @@ __metadata:
     "@types/styled-components": "npm:^5.1.23"
     "@use-gesture/react": "npm:^10.3.0"
     "@vitejs/plugin-react-refresh": "npm:^1.3.3"
-    "@voxel51/voodo": "npm:0.0.14"
+    "@voxel51/voodo": "npm:0.0.15"
     "@xstate/react": "npm:1.3.3"
     classnames: "npm:^2.2.6"
     color: "npm:^4.2.3"
@@ -7324,9 +7324,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@voxel51/voodo@npm:0.0.14":
-  version: 0.0.14
-  resolution: "@voxel51/voodo@npm:0.0.14"
+"@voxel51/voodo@npm:0.0.15":
+  version: 0.0.15
+  resolution: "@voxel51/voodo@npm:0.0.15"
   dependencies:
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/sortable": "npm:^10.0.0"
@@ -7342,7 +7342,7 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
     react-is: ^18.0.0
-  checksum: 10/8c66adbd0c6068d3dfe89ce1cef3ec353f665dc17e57bcbf9ed73ae4d1a1f1a6ce3e5f724e6c73cb014e05c0c8879b9be813f53e5c510d70412cd9c3e8c96ca9
+  checksum: 10/235852067e0e77f12a163e170b270327f4a8a34e39e83b833101cceed88e6eca6aa574bd63ee3aed7cfd2b43bbb138038fefb2839a36112f51fb907d6fef48ed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- updates voodo to 0.0.15
- updates button/icon usages
- icons in secondary color
- Text/Input groups to form groups

## How is this patch tested? If it is not, please explain why.

Tested locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated icon colors for consistency throughout the interface.
  * Adjusted button and layout alignments for improved visual presentation.

* **Refactor**
  * Modernized UI components with current implementations for improved consistency.
  * Enhanced form structure using standardized field wrappers for better organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->