### PR TITLE
[release] empty classes list for labels fallback to text input

### DIFF
--- a/plugins/operators/annotation.py
+++ b/plugins/operators/annotation.py
@@ -260,10 +260,13 @@ class CreateAndActivateField(foo.Operator):
         classes = label_schema_config.get("classes")
 
         # Determine component based on number of classes
-        if classes and len(classes) > foac.CHECKBOXES_OR_RADIO_THRESHOLD:
-            component = foac.DROPDOWN
+        if classes:
+            if len(classes) > foac.CHECKBOXES_OR_RADIO_THRESHOLD:
+                component = foac.DROPDOWN
+            else:
+                component = foac.RADIO
         else:
-            component = foac.RADIO
+            component = foac.TEXT
 
         # Build label schema
         return {


### PR DESCRIPTION
## What changes are proposed in this pull request?

bug: 

https://github.com/user-attachments/assets/0f5da639-194a-4a11-ba75-50ec12cf564f

fix: 
when classes are empty, fallback on text inputs, to be consistent with quick edit and other experiences. 


https://github.com/user-attachments/assets/6775147b-26d4-4dbd-a047-a6289398df41



## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
