### PR TITLE
fix plugin icon styling when using img FOEPD-3114

### DIFF
--- a/app/packages/operators/src/OperatorIcon.tsx
+++ b/app/packages/operators/src/OperatorIcon.tsx
@@ -52,7 +52,7 @@ function ImageIcon(props: ImageIconPropsType) {
       src={src}
       height={21}
       width={21}
-      style={{ maxWidth: "none" }}
+      style={{ ...iconProps?.style, maxWidth: "none" }}
     />
   );
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add override for `max-width` styling for `<ImageIcon />` to override new voodo base css.

Note: `<ImageIcon />` is only used in `<OperatorIcon />`

## How is this patch tested? If it is not, please explain why.

Unable to test. I don't have a local plugin with an `img` icon

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixed bug where image icons for some plugins were not sized correctly.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved image icon rendering by adjusting width display behavior to ensure proper visualization of image elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->