### PR TITLE
[HA] Skip schema activation for users without manage permissions

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useAnnotationContextManager.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useAnnotationContextManager.ts
@@ -127,7 +127,9 @@ export const useAnnotationContextManager = (): AnnotationContextManager => {
           });
         }
 
-        await schemaManager.activateSchemas({ fields: [field] });
+        if (canManageSchema) {
+          await schemaManager.activateSchemas({ fields: [field] });
+        }
 
         // refresh annotation state
         listSchemaResponse = await schemaManager.listSchemas({});


### PR DESCRIPTION
## What changes are proposed in this pull request?

When entering annotation mode via the quick-edit flow, this change skips schema activation if the user does not have manage permissions.

## How is this patch tested? If it is not, please explain why.

local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schema activation to respect user permissions. Schema activation now only proceeds when users have the appropriate authorization, preventing unauthorized activation attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->