### PR TITLE
[HA] Clear stale primitive mutations on annotation context exit

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useAnnotationContextManager.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useAnnotationContextManager.ts
@@ -12,6 +12,7 @@ import { atom, useAtom, useAtomValue } from "jotai";
 import { KnownContexts, useCommandContext } from "@fiftyone/commands";
 import useSave from "./Edit/useSave";
 import { usePrimitiveController } from "./Edit/useActivePrimitive";
+import { useSampleMutationManager } from "@fiftyone/annotation";
 
 /**
  * Status code when attempting to initialize annotation schema.
@@ -98,6 +99,7 @@ export const useAnnotationContextManager = (): AnnotationContextManager => {
   const sampleScanLimit = useQueryPerformanceSampleLimit();
   const canManageSchema = useCanManageSchema();
   const { isPrimitive, setActivePrimitive } = usePrimitiveController();
+  const { reset: clearStaleMutations } = useSampleMutationManager();
 
   const initializeFieldSchema = useCallback(
     async (field: string) => {
@@ -218,9 +220,15 @@ export const useAnnotationContextManager = (): AnnotationContextManager => {
     if (contextManager.isActive()) {
       saveChanges();
       deactivateCommandContext();
+      clearStaleMutations();
       contextManager.exit();
     }
-  }, [contextManager, deactivateCommandContext, saveChanges]);
+  }, [
+    clearStaleMutations,
+    contextManager,
+    deactivateCommandContext,
+    saveChanges,
+  ]);
 
   return useMemo(
     () => ({


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds cleanup logic for an edge case where stale primitive edits may persist in memory. In certain cases, this could cause unnecessary save cycles. This is now cleared upon leaving annotation mode.

## How is this patch tested? If it is not, please explain why.

local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of annotation state when exiting annotation mode, ensuring stale changes are cleared and do not affect subsequent annotation sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->