### PR TITLE
Fix/read only

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/state.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/state.ts
@@ -10,7 +10,12 @@ import {
 import { atom, PrimitiveAtom, useAtomValue } from "jotai";
 import { atomFamily, atomWithReset } from "jotai/utils";
 import { capitalize } from "lodash";
-import { activeLabelSchemas, fieldType, labelSchemaData } from "../state";
+import {
+  activeLabelSchemas,
+  fieldType,
+  isFieldReadOnly,
+  labelSchemaData,
+} from "../state";
 import { addLabel, labels, labelsByPath } from "../useLabels";
 import { activePrimitiveAtom } from "./useActivePrimitive";
 
@@ -124,7 +129,7 @@ export const currentFieldIsReadOnlyAtom = atom((get) => {
   }
 
   const fieldSchema = get(labelSchemaData(field));
-  return !!fieldSchema?.read_only;
+  return isFieldReadOnly(fieldSchema);
 });
 
 export const currentOverlay = atom((get) => {
@@ -200,9 +205,9 @@ const fieldsOfType = atomFamily((type: LabelType) =>
     for (const field of get(activeLabelSchemas) ?? []) {
       if (type && IS[type].has(get(fieldType(field)))) {
         const fieldSchema = get(labelSchemaData(field));
-        const isFieldReadOnly = fieldSchema?.read_only || false;
+        const fieldReadOnly = isFieldReadOnly(fieldSchema);
 
-        if (!isFieldReadOnly) {
+        if (!fieldReadOnly) {
           fields.push(field);
         }
       }

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useCreate.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useCreate.ts
@@ -16,7 +16,7 @@ import { atom, getDefaultStore, useSetAtom } from "jotai";
 import { useCallback } from "react";
 import type { LabelType } from "./state";
 import { defaultField, editing, savedLabel } from "./state";
-import { labelSchemaData } from "../state";
+import { isFieldReadOnly, labelSchemaData } from "../state";
 import { useQuickDraw } from "./useQuickDraw";
 import { ClassificationLabel, DetectionLabel } from "@fiftyone/looker";
 
@@ -78,7 +78,7 @@ const useCreateAnnotationLabel = () => {
         data["_cls"] = "Detection";
 
         const fieldSchema = store.get(labelSchemaData(field));
-        const isReadOnly = !!fieldSchema?.read_only;
+        const readOnly = isFieldReadOnly(fieldSchema);
 
         const overlay = overlayFactory.create<
           BoundingBoxOptions,
@@ -87,8 +87,8 @@ const useCreateAnnotationLabel = () => {
           field,
           id,
           label: data as DetectionLabel,
-          draggable: !isReadOnly,
-          resizeable: !isReadOnly,
+          draggable: !readOnly,
+          resizeable: !readOnly,
         });
         addOverlay(overlay);
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useQuickDraw.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useQuickDraw.ts
@@ -3,7 +3,7 @@ import { atom, useAtom, useAtomValue } from "jotai";
 import { atomFamily, useAtomCallback } from "jotai/utils";
 import { countBy, maxBy } from "lodash";
 import { useCallback, useMemo } from "react";
-import { fieldType, labelSchemaData } from "../state";
+import { fieldType, isFieldReadOnly, labelSchemaData } from "../state";
 import { labelsByPath } from "../useLabels";
 import { defaultField, useAnnotationContext } from "./state";
 import { BaseOverlay, useLighter } from "@fiftyone/lighter";
@@ -118,7 +118,7 @@ export const useQuickDraw = () => {
 
         if (lastField) {
           const schema = get(labelSchemaData(lastField));
-          if (!schema?.read_only) {
+          if (!isFieldReadOnly(schema)) {
             return lastField;
           }
         }
@@ -132,7 +132,7 @@ export const useQuickDraw = () => {
 
           if (
             detectionTypes.has(typeStr || "") &&
-            !schema?.read_only &&
+            !isFieldReadOnly(schema) &&
             fieldLabels.length > maxCount
           ) {
             maxCount = fieldLabels.length;

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/state.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/state.ts
@@ -10,6 +10,7 @@ import {
   fieldAttributeCount,
   fieldType,
   inactiveLabelSchemas,
+  isFieldReadOnly,
   labelSchemaData,
 } from "../state";
 import { isSystemReadOnlyField } from "./constants";
@@ -100,8 +101,7 @@ export const fieldHasSchema = atomFamily((path: string) =>
 export const fieldIsReadOnly = atomFamily((path: string) =>
   atom((get) => {
     const data = get(labelSchemaData(path));
-    // Check schema-level read_only first (user-configured), then field-level (system)
-    return data?.label_schema?.read_only || data?.read_only || false;
+    return isFieldReadOnly(data);
   })
 );
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/state.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/state.ts
@@ -104,6 +104,18 @@ export const removeFromActiveSchemas = atom(
 export const showModal = atom(false);
 
 /**
+ * Check if a field is read-only.
+ *
+ * User-set schema `read_only` (from Schema Manager) takes precedence,
+ * then falls back to field-level `read_only` (from Python backend).
+ */
+export const isFieldReadOnly = (
+  data: LabelSchemaMeta | undefined
+): boolean => {
+  return !!data?.label_schema?.read_only || !!data?.read_only;
+};
+
+/**
  * Public API for the current annotation schema context.
  */
 export interface AnnotationSchemaContext {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useCreateAnnotationLabel.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useCreateAnnotationLabel.ts
@@ -11,7 +11,7 @@ import {
 import { PolylineLabel } from "@fiftyone/looker/src/overlays/polyline";
 import { AnnotationLabel } from "@fiftyone/state";
 import { getDefaultStore } from "jotai";
-import { labelSchemaData } from "./state";
+import { isFieldReadOnly, labelSchemaData } from "./state";
 
 /**
  * Hook which provides a method for creating an {@link AnnotationLabel}.
@@ -45,7 +45,7 @@ export const useCreateAnnotationLabel = () => {
         // Check if field is read-only
         const store = getDefaultStore();
         const fieldSchema = store.get(labelSchemaData(field));
-        const isReadOnly = !!fieldSchema?.read_only;
+        const isReadOnly = isFieldReadOnly(fieldSchema);
 
         const overlay = overlayFactory.create<
           BoundingBoxOptions,

--- a/app/packages/lighter/src/overlay/BoundingBoxOverlay.ts
+++ b/app/packages/lighter/src/overlay/BoundingBoxOverlay.ts
@@ -653,7 +653,10 @@ export class BoundingBoxOverlay
    * @param draggable - Whether the overlay should be draggable.
    */
   setDraggable(draggable: boolean): void {
-    this.isDraggable = draggable;
+    if (this.isDraggable !== draggable) {
+      this.isDraggable = draggable;
+      this.markDirty();
+    }
   }
 
   /**
@@ -669,7 +672,10 @@ export class BoundingBoxOverlay
    * @param resizeable - Whether the overlay should be resizeable.
    */
   setResizeable(resizeable: boolean): void {
-    this.isResizeable = resizeable;
+    if (this.isResizeable !== resizeable) {
+      this.isResizeable = resizeable;
+      this.markDirty();
+    }
   }
 
   /**


### PR DESCRIPTION
## What changes are proposed in this pull request?

Make read-only read-only again.

## How is this patch tested? If it is not, please explain why.

https://github.com/user-attachments/assets/1135580a-0253-4308-914b-dcd3af37c284

https://github.com/user-attachments/assets/cf440e63-b3c2-4e02-aaa3-7c810cd79f8b

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed read-only field handling to properly prevent editing of detection overlays and annotations when associated fields are marked as read-only.
  * Detection boxes and quick-draw selections now respect read-only status, preventing unwanted modifications to protected field data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->