### PR TITLE
[HA e2e] Schema Manager golden paths

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Actions.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Actions.tsx
@@ -343,7 +343,12 @@ const Schema = () => {
   const showModal = useShowModal();
 
   return (
-    <Button variant={Variant.Borderless} size={Size.Sm} onClick={showModal}>
+    <Button
+      variant={Variant.Borderless}
+      size={Size.Sm}
+      onClick={showModal}
+      data-cy="open-schema-manager"
+    >
       Schema
     </Button>
   );

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/ActiveFieldsSection.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/ActiveFieldsSection.tsx
@@ -180,6 +180,7 @@ const ActiveFieldsSection = () => {
             size={Size.Md}
             variant={Variant.Primary}
             onClick={handleNewField}
+            data-cy="new-field-button"
           >
             New field
           </Button>
@@ -214,6 +215,7 @@ const ActiveFieldsSection = () => {
           size={Size.Md}
           variant={Variant.Primary}
           onClick={handleNewField}
+          data-cy="new-field-button"
         >
           New field
         </Button>

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/AddClassCard.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/AddClassCard.tsx
@@ -66,6 +66,7 @@ const AddClassCard = ({
       <Stack orientation={Orientation.Column} spacing={Spacing.Md}>
         <div>
           <Input
+            data-cy="class-name-input"
             value={name}
             onChange={handleChange}
             onKeyDown={handleKeyDown}

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/AttributeFormContent.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/AttributeFormContent.tsx
@@ -85,6 +85,7 @@ const AttributeFormContent = ({
             Name
           </Text>
           <Input
+            data-cy="attribute-name-input"
             value={formState.name}
             onChange={(e) => handleNameChange(e.target.value)}
             placeholder="Attribute name"
@@ -149,6 +150,7 @@ const AttributeFormContent = ({
           {componentOptions.map((opt) => (
             <ComponentTypeButton
               key={opt.id}
+              data-cy={`component-type-${opt.id}`}
               icon={opt.icon}
               label={opt.label}
               isSelected={formState.component === opt.id}

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/AttributesSection.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/AttributesSection.tsx
@@ -188,6 +188,7 @@ const AttributesSection = ({
       <EditSectionHeader>
         <Text variant={TextVariant.Lg}>Attributes</Text>
         <Button
+          data-cy="add-attribute-button"
           size={Size.Md}
           variant={Variant.Secondary}
           onClick={() => setIsAdding(true)}

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/CardActions.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/CardActions.tsx
@@ -51,6 +51,7 @@ const CardActions = ({
       </Button>
     )}
     <Button
+      data-cy="save-card-button"
       variant={Variant.Icon}
       borderless
       onClick={canSave ? onSave : undefined}

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/ClassesSection.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/ClassesSection.tsx
@@ -206,6 +206,7 @@ const ClassesSection = ({
           variant={Variant.Secondary}
           onClick={() => setIsAdding(true)}
           disabled={isAdding || editingClass !== null}
+          data-cy="add-class-button"
         >
           + Add class
         </Button>

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/ComponentTypeButton.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/ComponentTypeButton.tsx
@@ -32,7 +32,11 @@ const ComponentTypeButton = ({
   const theme = useTheme();
 
   return (
-    <div style={{ flex: 1 }} data-cy={dataCy}>
+    <div
+      style={{ flex: 1 }}
+      data-cy={dataCy}
+      data-selected={isSelected || undefined}
+    >
       <Clickable onClick={onClick}>
         <div
           style={{

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/ComponentTypeButton.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/ComponentTypeButton.tsx
@@ -18,6 +18,7 @@ interface ComponentTypeButtonProps {
   isSelected: boolean;
   onClick: () => void;
   largeText?: boolean;
+  "data-cy"?: string;
 }
 
 const ComponentTypeButton = ({
@@ -26,11 +27,12 @@ const ComponentTypeButton = ({
   isSelected,
   onClick,
   largeText = false,
+  "data-cy": dataCy,
 }: ComponentTypeButtonProps) => {
   const theme = useTheme();
 
   return (
-    <div style={{ flex: 1 }}>
+    <div style={{ flex: 1 }} data-cy={dataCy}>
       <Clickable onClick={onClick}>
         <div
           style={{

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/PrimitiveFieldContent.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/PrimitiveFieldContent.tsx
@@ -219,6 +219,7 @@ const PrimitiveFieldContent = ({
                 isSelected={component === opt.id}
                 onClick={() => handleComponentChange(opt.id)}
                 largeText={largeLabels}
+                data-cy={`component-type-${opt.id}`}
               />
             ))}
           </div>

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/RangeInput.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/RangeInput.tsx
@@ -47,6 +47,7 @@ const RangeInput = ({
             Min
           </Text>
           <Input
+            data-cy="range-min"
             type="number"
             value={min}
             onChange={(e) => onRangeChange({ min: e.target.value, max })}
@@ -63,6 +64,7 @@ const RangeInput = ({
             Max
           </Text>
           <Input
+            data-cy="range-max"
             type="number"
             value={max}
             onChange={(e) => onRangeChange({ min, max: e.target.value })}

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/ValuesList.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/ValuesList.tsx
@@ -134,6 +134,7 @@ const ValuesList = ({
         </Button>
       </div>
       <Input
+        data-cy="value-input"
         type={isNumeric ? "number" : "text"}
         value={newValue}
         onChange={handleChange}

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/NewFieldSchema/NewFieldSchema.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/NewFieldSchema/NewFieldSchema.tsx
@@ -340,6 +340,7 @@ const NewFieldSchema = () => {
             label={category === "label" ? "Label type" : "Primitive type"}
             control={
               <Select
+                data-cy="field-type-select"
                 exclusive
                 portal
                 value={category === "label" ? labelType : primitiveType}

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/NewFieldSchema/NewFieldSchema.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/NewFieldSchema/NewFieldSchema.tsx
@@ -304,6 +304,7 @@ const NewFieldSchema = () => {
             label="Field name"
             control={
               <Input
+                data-cy="new-field-name"
                 value={fieldName}
                 onChange={(e) => setFieldName(e.target.value)}
                 placeholder="Enter field name"

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useSamplePrimitives.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useSamplePrimitives.ts
@@ -1,7 +1,6 @@
 import { Sample, State, fieldPaths } from "@fiftyone/state";
 import { DICT_FIELD, VALID_PRIMITIVE_TYPES } from "@fiftyone/utilities";
 import { useAtomValue } from "jotai";
-import { get } from "lodash";
 import { useRecoilValue } from "recoil";
 import { activeLabelSchemas } from "./state";
 
@@ -18,11 +17,11 @@ const useSamplePrimitives = (currentSample: Sample): string[] => {
     return [];
   }
 
-  // only top level primitives that exist - we want to keep null
-  // values it just means the value has not been set yet
-  const validPrimitivePaths = primitivePaths
-    .filter((path) => get(currentSample, path) !== undefined)
-    .filter((path) => activeFields.includes(path));
+  // Show all active primitive fields, even if the sample doesn't
+  // have a value yet (e.g. newly created fields via schema manager)
+  const validPrimitivePaths = primitivePaths.filter((path) =>
+    activeFields.includes(path)
+  );
 
   return validPrimitivePaths;
 };

--- a/app/packages/core/src/plugins/SchemaIO/components/AutocompleteView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/AutocompleteView.tsx
@@ -74,6 +74,7 @@ export default function AutocompleteView(props) {
           return option == value;
         }}
         multiple={multiple}
+        ChipProps={{ "data-cy": "selected-tag" }}
         renderOption={(props, option) => {
           return (
             <MenuItem

--- a/e2e-pw/src/oss/poms/modal/index.ts
+++ b/e2e-pw/src/oss/poms/modal/index.ts
@@ -4,6 +4,7 @@ import { Duration } from "../../utils";
 import { ModalTaggerPom } from "../action-row/tagger/modal-tagger";
 import { ModalPanelPom } from "../panels/modal-panel";
 import { UrlPom } from "../url";
+import { ModalAnnotateSidebarPom } from "./annotate-sidebar";
 import { ModalGroupActionsPom } from "./group-actions";
 import { ModalImaAsVideoControlsPom } from "./imavid-controls";
 import { Looker3DControlsPom } from "./looker-3d-controls";
@@ -18,6 +19,7 @@ export class ModalPom {
   readonly looker: Locator;
   readonly modalContainer: Locator;
 
+  readonly annotateSidebar: ModalAnnotateSidebarPom;
   readonly group: ModalGroupActionsPom;
   readonly imavid: ModalImaAsVideoControlsPom;
   readonly looker3dControls: Looker3DControlsPom;
@@ -38,11 +40,12 @@ export class ModalPom {
     this.looker = this.locator.getByTestId("looker").last();
     this.modalContainer = this.locator.getByTestId("modal-looker-container");
 
+    this.annotateSidebar = new ModalAnnotateSidebarPom(page);
     this.group = new ModalGroupActionsPom(page, this);
     this.imavid = new ModalImaAsVideoControlsPom(page, this);
     this.looker3dControls = new Looker3DControlsPom(page, this);
     this.panel = new ModalPanelPom(page, this);
-    this.sidebar = new ModalSidebarPom(page);
+    this.sidebar = new ModalSidebarPom(page, this.locator);
     this.tagger = new ModalTaggerPom(page, this);
     this.url = new UrlPom(page, eventUtils);
     this.video = new ModalVideoControlsPom(page, this);

--- a/e2e-pw/src/oss/poms/modal/modal-sidebar.ts
+++ b/e2e-pw/src/oss/poms/modal/modal-sidebar.ts
@@ -1,6 +1,8 @@
 import { Locator, Page, expect } from "src/oss/fixtures";
 import { Duration } from "src/oss/utils";
 
+const MODAL_LOCATOR = "[data-cy=modal]";
+
 export class ModalSidebarPom {
   readonly page: Page;
   readonly locator: Locator;
@@ -81,6 +83,67 @@ export class ModalSidebarPom {
 
   async toggleSidebarGroup(name: string) {
     await this.locator.getByTestId(`sidebar-group-entry-${name}`).click();
+  }
+
+  // =========================================================================
+  // Annotation sidebar actions
+  // =========================================================================
+
+  /**
+   * The modal locator (parent of sidebar)
+   */
+  get modal() {
+    return this.page.locator(MODAL_LOCATOR);
+  }
+
+  /**
+   * Click the "Schema" button in the annotation sidebar actions area
+   */
+  async clickSchemaButton() {
+    await this.modal.getByRole("button", { name: "Schema" }).click();
+  }
+
+  /**
+   * Click the Classification create button (SVG with title "Classification")
+   */
+  async clickCreateClassification() {
+    await this.modal.locator('svg:has-text("Classification")').click();
+  }
+
+  /**
+   * Click the Detection create button (SVG with title "Detection")
+   */
+  async clickCreateDetection() {
+    await this.modal.locator('svg:has-text("Detection")').click();
+  }
+
+  /**
+   * Click a primitive entry by its field path name
+   */
+  async clickPrimitiveEntry(path: string) {
+    await this.modal.getByText(path, { exact: true }).click();
+  }
+
+  /**
+   * The field dropdown (MUI Select) in the annotation editing view
+   */
+  get fieldDropdown() {
+    return this.modal.locator('.MuiSelect-select[role="combobox"]');
+  }
+
+  /**
+   * Get a portalled field dropdown option by name
+   */
+  getFieldOption(name: string) {
+    return this.page.getByRole("option", { name });
+  }
+
+  /**
+   * Select a field from the annotation editing field dropdown
+   */
+  async selectField(name: string) {
+    await this.fieldDropdown.click();
+    await this.getFieldOption(name).click();
   }
 }
 
@@ -177,5 +240,48 @@ class SidebarAsserter {
     await expect(
       this.modalSidebarPom.locator.getByText(messageSubstring)
     ).toBeVisible();
+  }
+
+  // =========================================================================
+  // Annotation editing assertions
+  // =========================================================================
+
+  /**
+   * Assert the field dropdown is visible and contains a specific field
+   */
+  async hasFieldOption(name: string) {
+    await expect(this.modalSidebarPom.fieldDropdown).toBeVisible();
+    await this.modalSidebarPom.fieldDropdown.click();
+    await expect(this.modalSidebarPom.getFieldOption(name)).toBeVisible();
+    // close the dropdown by pressing Escape
+    await this.modalSidebarPom.page.keyboard.press("Escape");
+  }
+
+  /**
+   * Assert that a radio option with the given label is visible
+   */
+  async hasRadioOption(label: string) {
+    await expect(
+      this.modalSidebarPom.modal.getByRole("radio", { name: label })
+    ).toBeVisible();
+  }
+
+  /**
+   * Assert that all provided radio options are visible
+   */
+  async hasRadioOptions(labels: string[]) {
+    for (const label of labels) {
+      await this.hasRadioOption(label);
+    }
+  }
+
+  /**
+   * Assert that a slider is visible with the given min and max values
+   */
+  async hasSliderWithRange(min: string, max: string) {
+    const slider = this.modalSidebarPom.modal.locator('[role="slider"]');
+    await expect(slider).toBeVisible();
+    await expect(slider).toHaveAttribute("aria-valuemin", min);
+    await expect(slider).toHaveAttribute("aria-valuemax", max);
   }
 }

--- a/e2e-pw/src/oss/poms/modal/modal-sidebar.ts
+++ b/e2e-pw/src/oss/poms/modal/modal-sidebar.ts
@@ -303,12 +303,12 @@ class SidebarAsserter {
    * Assert that a toggle switch is visible in the modal
    */
   async hasBooleanToggle() {
-    // ToggleSwitch renders as two buttons: "False" and "True"
+    // voodo ToggleSwitch renders Headless UI tabs
     await expect(
-      this.modalSidebarPom.modal.getByRole("button", { name: "False" })
+      this.modalSidebarPom.modal.getByRole("tab", { name: "False" })
     ).toBeVisible();
     await expect(
-      this.modalSidebarPom.modal.getByRole("button", { name: "True" })
+      this.modalSidebarPom.modal.getByRole("tab", { name: "True" })
     ).toBeVisible();
   }
 

--- a/e2e-pw/src/oss/poms/modal/modal-sidebar.ts
+++ b/e2e-pw/src/oss/poms/modal/modal-sidebar.ts
@@ -125,6 +125,13 @@ export class ModalSidebarPom {
   }
 
   /**
+   * Select an option from an MUI Autocomplete dropdown in the modal
+   */
+  async selectAutocompleteOption(label: string) {
+    await this.page.getByRole("option", { name: label }).click();
+  }
+
+  /**
    * The field dropdown (MUI Select) in the annotation editing view
    */
   get fieldDropdown() {
@@ -283,5 +290,34 @@ class SidebarAsserter {
     await expect(slider).toBeVisible();
     await expect(slider).toHaveAttribute("aria-valuemin", min);
     await expect(slider).toHaveAttribute("aria-valuemax", max);
+  }
+
+  /**
+   * Assert that a date picker is visible in the modal
+   */
+  async hasDatePicker() {
+    await expect(
+      this.modalSidebarPom.modal.locator(".react-datepicker-wrapper")
+    ).toBeVisible();
+  }
+
+  /**
+   * Assert that a toggle switch is visible in the modal
+   */
+  async hasToggle() {
+    await expect(this.modalSidebarPom.modal.getByRole("switch")).toBeVisible();
+  }
+
+  /**
+   * Assert that MUI Autocomplete chips/tags with the given labels are visible
+   */
+  async hasSelectedTags(labels: string[]) {
+    for (const label of labels) {
+      await expect(
+        this.modalSidebarPom.modal
+          .locator('[data-cy="selected-tag"]')
+          .filter({ hasText: label })
+      ).toBeVisible();
+    }
   }
 }

--- a/e2e-pw/src/oss/poms/modal/modal-sidebar.ts
+++ b/e2e-pw/src/oss/poms/modal/modal-sidebar.ts
@@ -1,8 +1,6 @@
 import { Locator, Page, expect } from "src/oss/fixtures";
 import { Duration } from "src/oss/utils";
 
-const MODAL_LOCATOR = "[data-cy=modal]";
-
 export class ModalSidebarPom {
   readonly page: Page;
   readonly locator: Locator;
@@ -93,7 +91,7 @@ export class ModalSidebarPom {
    * The modal locator (parent of sidebar)
    */
   get modal() {
-    return this.page.locator(MODAL_LOCATOR);
+    return this.page.getByTestId("modal");
   }
 
   /**

--- a/e2e-pw/src/oss/poms/modal/modal-sidebar.ts
+++ b/e2e-pw/src/oss/poms/modal/modal-sidebar.ts
@@ -123,6 +123,13 @@ export class ModalSidebarPom {
   }
 
   /**
+   * Open the MUI Autocomplete dropdown in the modal by clicking its input
+   */
+  async openAutocomplete() {
+    await this.modal.getByRole("combobox").click();
+  }
+
+  /**
    * Select an option from an MUI Autocomplete dropdown in the modal
    */
   async selectAutocompleteOption(label: string) {

--- a/e2e-pw/src/oss/poms/modal/modal-sidebar.ts
+++ b/e2e-pw/src/oss/poms/modal/modal-sidebar.ts
@@ -302,8 +302,14 @@ class SidebarAsserter {
   /**
    * Assert that a toggle switch is visible in the modal
    */
-  async hasToggle() {
-    await expect(this.modalSidebarPom.modal.getByRole("switch")).toBeVisible();
+  async hasBooleanToggle() {
+    // ToggleSwitch renders as two buttons: "False" and "True"
+    await expect(
+      this.modalSidebarPom.modal.getByRole("button", { name: "False" })
+    ).toBeVisible();
+    await expect(
+      this.modalSidebarPom.modal.getByRole("button", { name: "True" })
+    ).toBeVisible();
   }
 
   /**

--- a/e2e-pw/src/oss/poms/modal/modal-sidebar.ts
+++ b/e2e-pw/src/oss/poms/modal/modal-sidebar.ts
@@ -6,7 +6,7 @@ export class ModalSidebarPom {
   readonly locator: Locator;
   readonly assert: SidebarAsserter;
 
-  constructor(page: Page) {
+  constructor(page: Page, readonly modal: Locator = page.getByTestId("modal")) {
     this.page = page;
 
     this.assert = new SidebarAsserter(this);
@@ -88,13 +88,6 @@ export class ModalSidebarPom {
   // =========================================================================
 
   /**
-   * The modal locator (parent of sidebar)
-   */
-  get modal() {
-    return this.page.getByTestId("modal");
-  }
-
-  /**
    * Click the "Schema" button in the annotation sidebar actions area
    */
   async clickSchemaButton() {
@@ -117,6 +110,8 @@ export class ModalSidebarPom {
 
   /**
    * Click a primitive entry by its field path name
+   *
+   * @param path The field path name
    */
   async clickPrimitiveEntry(path: string) {
     await this.modal.getByText(path, { exact: true }).click();
@@ -131,6 +126,8 @@ export class ModalSidebarPom {
 
   /**
    * Select an option from an MUI Autocomplete dropdown in the modal
+   *
+   * @param label The option label to select
    */
   async selectAutocompleteOption(label: string) {
     await this.page.getByRole("option", { name: label }).click();
@@ -145,6 +142,8 @@ export class ModalSidebarPom {
 
   /**
    * Get a portalled field dropdown option by name
+   *
+   * @param name The option name
    */
   getFieldOption(name: string) {
     return this.page.getByRole("option", { name });
@@ -152,6 +151,8 @@ export class ModalSidebarPom {
 
   /**
    * Select a field from the annotation editing field dropdown
+   *
+   * @param name The field name to select
    */
   async selectField(name: string) {
     await this.fieldDropdown.click();
@@ -247,6 +248,8 @@ class SidebarAsserter {
 
   /**
    * Assert that annotation is disabled with a specific message
+   *
+   * @param messageSubstring The substring to match in the disabled message
    */
   async hasDisabledMessage(messageSubstring: string) {
     await expect(
@@ -260,6 +263,8 @@ class SidebarAsserter {
 
   /**
    * Assert the field dropdown is visible and contains a specific field
+   *
+   * @param name The field name to check for
    */
   async hasFieldOption(name: string) {
     await expect(this.modalSidebarPom.fieldDropdown).toBeVisible();
@@ -271,6 +276,8 @@ class SidebarAsserter {
 
   /**
    * Assert that a radio option with the given label is visible
+   *
+   * @param label The radio option label
    */
   async hasRadioOption(label: string) {
     await expect(
@@ -280,6 +287,8 @@ class SidebarAsserter {
 
   /**
    * Assert that all provided radio options are visible
+   *
+   * @param labels The radio option labels to verify
    */
   async hasRadioOptions(labels: string[]) {
     for (const label of labels) {
@@ -289,6 +298,9 @@ class SidebarAsserter {
 
   /**
    * Assert that a slider is visible with the given min and max values
+   *
+   * @param min The expected minimum value
+   * @param max The expected maximum value
    */
   async hasSliderWithRange(min: string, max: string) {
     const slider = this.modalSidebarPom.modal.locator('[role="slider"]');
@@ -310,7 +322,7 @@ class SidebarAsserter {
    * Assert that a toggle switch is visible in the modal
    */
   async hasBooleanToggle() {
-    // voodo ToggleSwitch renders Headless UI tabs
+    // ToggleSwitch renders Headless UI tabs
     await expect(
       this.modalSidebarPom.modal.getByRole("tab", { name: "False" })
     ).toBeVisible();
@@ -321,6 +333,8 @@ class SidebarAsserter {
 
   /**
    * Assert that MUI Autocomplete chips/tags with the given labels are visible
+   *
+   * @param labels The tag labels to verify
    */
   async hasSelectedTags(labels: string[]) {
     for (const label of labels) {

--- a/e2e-pw/src/oss/poms/schema-manager/editor.ts
+++ b/e2e-pw/src/oss/poms/schema-manager/editor.ts
@@ -1,6 +1,6 @@
 import { expect, Page } from "src/oss/fixtures";
 import type { EventUtils } from "src/shared/event-utils";
-import type { SchemaManagerPom } from ".";
+import type { ComponentType, SchemaManagerPom } from ".";
 
 type JSONValue =
   | string
@@ -11,10 +11,10 @@ type JSONValue =
   | Array<JSONValue>;
 
 /**
- * The JSON editor view for a field in the schema manager
+ * The editor view for a field in the schema manager
  */
-export class JSONEditorPom {
-  readonly assert: JSONEditorAsserter;
+export class EditorPom {
+  readonly assert: EditorAsserter;
 
   constructor(
     readonly page: Page,
@@ -22,7 +22,7 @@ export class JSONEditorPom {
     readonly field: string,
     readonly schemaManager: SchemaManagerPom
   ) {
-    this.assert = new JSONEditorAsserter(this);
+    this.assert = new EditorAsserter(this);
   }
 
   /**
@@ -147,10 +147,10 @@ export class JSONEditorPom {
 }
 
 /**
- * JSON editor view asserter
+ * Editor view asserter
  */
-class JSONEditorAsserter {
-  constructor(private readonly jsonEditorPom: JSONEditorPom) {}
+class EditorAsserter {
+  constructor(private readonly editorPom: EditorPom) {}
 
   /**
    * Does the json match
@@ -158,7 +158,7 @@ class JSONEditorAsserter {
    * @param json The json to compare
    */
   async hasJSON(json: JSONValue) {
-    const current = await this.jsonEditorPom.getJSON();
+    const current = await this.editorPom.getJSON();
     expect(current).toStrictEqual(json);
   }
 
@@ -168,6 +168,25 @@ class JSONEditorAsserter {
    * @param errors The error strings to compare
    */
   async hasErrors(errors: string[]) {
-    expect(await this.jsonEditorPom.getErrors()).toStrictEqual(errors);
+    expect(await this.editorPom.getErrors()).toStrictEqual(errors);
+  }
+
+  /**
+   * Open the field's edit view and verify the range inputs match
+   *
+   * @param min The expected minimum range value
+   * @param max The expected maximum range value
+   */
+  async hasRangeConfig(min: string, max: string) {
+    await this.editorPom.schemaManager.assert.hasRangeValues(min, max);
+  }
+
+  /**
+   * Verify the selected component type in the edit view
+   *
+   * @param id The component type identifier
+   */
+  async hasComponentType(id: ComponentType) {
+    await this.editorPom.schemaManager.assert.hasSelectedComponentType(id);
   }
 }

--- a/e2e-pw/src/oss/poms/schema-manager/field-row.ts
+++ b/e2e-pw/src/oss/poms/schema-manager/field-row.ts
@@ -154,4 +154,12 @@ class FieldRowAsserter {
     const text = await this.fieldRowPom.getType();
     expect(text).toBe(type);
   }
+
+  /**
+   * Open the field's edit view and verify the range inputs match
+   */
+  async hasRangeConfig(min: string, max: string) {
+    await this.fieldRowPom.edit();
+    await this.fieldRowPom.schemaManager.assert.hasRangeValues(min, max);
+  }
 }

--- a/e2e-pw/src/oss/poms/schema-manager/field-row.ts
+++ b/e2e-pw/src/oss/poms/schema-manager/field-row.ts
@@ -162,4 +162,12 @@ class FieldRowAsserter {
     await this.fieldRowPom.edit();
     await this.fieldRowPom.schemaManager.assert.hasRangeValues(min, max);
   }
+
+  /**
+   * Open the field's edit view and verify the selected component type
+   */
+  async hasComponentType(id: string) {
+    await this.fieldRowPom.edit();
+    await this.fieldRowPom.schemaManager.assert.hasSelectedComponentType(id);
+  }
 }

--- a/e2e-pw/src/oss/poms/schema-manager/field-row.ts
+++ b/e2e-pw/src/oss/poms/schema-manager/field-row.ts
@@ -1,7 +1,7 @@
 import { expect, Page } from "src/oss/fixtures";
 import type { EventUtils } from "src/shared/event-utils";
-import type { SchemaManagerPom } from ".";
-import { JSONEditorPom } from "./json-editor";
+import type { ComponentType, SchemaManagerPom } from ".";
+import { EditorPom } from "./editor";
 
 /**
  * A field row of the schema manager. May be active/hidden, checked/unchecked,
@@ -73,7 +73,7 @@ export class FieldRowPom {
     // click must be forced because the field row has an aria-disabled
     // attribute
     await this.pencil.click({ force: true });
-    return new JSONEditorPom(
+    return new EditorPom(
       this.page,
       this.eventUtils,
       this.field,
@@ -88,7 +88,7 @@ export class FieldRowPom {
     // click must be forced because the field row has an aria-disabled
     // attribute
     await this.scanButton.click({ force: true });
-    return new JSONEditorPom(
+    return new EditorPom(
       this.page,
       this.eventUtils,
       this.field,
@@ -157,17 +157,22 @@ class FieldRowAsserter {
 
   /**
    * Open the field's edit view and verify the range inputs match
+   *
+   * @param min The expected minimum range value
+   * @param max The expected maximum range value
    */
   async hasRangeConfig(min: string, max: string) {
-    await this.fieldRowPom.edit();
-    await this.fieldRowPom.schemaManager.assert.hasRangeValues(min, max);
+    const editor = await this.fieldRowPom.edit();
+    await editor.assert.hasRangeConfig(min, max);
   }
 
   /**
    * Open the field's edit view and verify the selected component type
+   *
+   * @param id The component type identifier
    */
-  async hasComponentType(id: string) {
-    await this.fieldRowPom.edit();
-    await this.fieldRowPom.schemaManager.assert.hasSelectedComponentType(id);
+  async hasComponentType(id: ComponentType) {
+    const editor = await this.fieldRowPom.edit();
+    await editor.assert.hasComponentType(id);
   }
 }

--- a/e2e-pw/src/oss/poms/schema-manager/index.ts
+++ b/e2e-pw/src/oss/poms/schema-manager/index.ts
@@ -78,6 +78,200 @@ export class SchemaManagerPom {
   async moveFields() {
     await this.locator.getByTestId("move-fields").click();
   }
+
+  // =========================================================================
+  // New field creation
+  // =========================================================================
+
+  /**
+   * The "New field" button locator
+   */
+  get newFieldButton() {
+    return this.locator.getByTestId("new-field-button");
+  }
+
+  /**
+   * The field name input locator
+   */
+  get fieldNameInput() {
+    return this.locator.getByTestId("new-field-name");
+  }
+
+  /**
+   * The field type combobox locator
+   */
+  get typeSelect() {
+    return this.locator.getByRole("combobox");
+  }
+
+  /**
+   * The "+ Add class" button locator
+   */
+  get addClassButton() {
+    return this.locator.getByTestId("add-class-button");
+  }
+
+  /**
+   * The class name input locator (visible after clicking Add class)
+   */
+  get classNameInput() {
+    return this.locator.getByTestId("class-name-input");
+  }
+
+  /**
+   * The "Create" button locator in the new field footer
+   */
+  get createButton() {
+    return this.locator.getByTestId("primary-button");
+  }
+
+  /**
+   * Get a component type button locator by id (e.g. "slider", "text", "radio")
+   */
+  getComponentTypeButton(id: string) {
+    return this.locator.getByTestId(`component-type-${id}`);
+  }
+
+  /**
+   * The range min input locator
+   */
+  get rangeMinInput() {
+    return this.locator.getByTestId("range-min");
+  }
+
+  /**
+   * The range max input locator
+   */
+  get rangeMaxInput() {
+    return this.locator.getByTestId("range-max");
+  }
+
+  /**
+   * Click the "New field" button to start creating a new field
+   */
+  async clickNewField() {
+    await this.newFieldButton.click();
+  }
+
+  /**
+   * Fill in the field name
+   */
+  async fillFieldName(name: string) {
+    await this.fieldNameInput.fill(name);
+  }
+
+  /**
+   * Select a type from the type dropdown (options are portalled)
+   *
+   * @param typeName the visible label, e.g. "Classification", "Float"
+   */
+  async selectType(typeName: string) {
+    await this.typeSelect.click();
+    await this.page
+      .getByRole("option", { name: typeName, exact: true })
+      .click();
+  }
+
+  /**
+   * Add a class by name. Clicks "+ Add class", types the name, then presses
+   * Enter to confirm.
+   */
+  async addClass(name: string) {
+    await this.addClassButton.click();
+    await this.classNameInput.pressSequentially(name, { delay: 50 });
+    await this.classNameInput.press("Enter");
+  }
+
+  /**
+   * Switch to the "Primitive" field category
+   */
+  async selectPrimitiveCategory() {
+    await this.locator.getByText("Primitive").click();
+  }
+
+  /**
+   * Click a component type button (e.g. "slider", "text", "radio")
+   */
+  async selectComponentType(id: string) {
+    // force: true needed because component may be inside a RichList with aria-disabled
+    await this.getComponentTypeButton(id).click({ force: true });
+  }
+
+  /**
+   * Fill the min/max range inputs
+   */
+  async fillRange(min: string, max: string) {
+    await this.rangeMinInput.fill(min);
+    await this.rangeMaxInput.fill(max);
+  }
+
+  /**
+   * Click the "Create" button in the new field footer
+   */
+  async create() {
+    await this.createButton.click();
+  }
+
+  // =========================================================================
+  // Attribute creation
+  // =========================================================================
+
+  /**
+   * The "+ Add attribute" button locator
+   */
+  get addAttributeButton() {
+    return this.locator.getByTestId("add-attribute-button");
+  }
+
+  /**
+   * The attribute name input locator
+   */
+  get attributeNameInput() {
+    return this.locator.getByTestId("attribute-name-input");
+  }
+
+  /**
+   * The save card button (checkmark) locator
+   */
+  get saveCardButton() {
+    return this.locator.getByTestId("save-card-button");
+  }
+
+  /**
+   * The value input locator
+   */
+  get valueInput() {
+    return this.locator.getByTestId("value-input");
+  }
+
+  /**
+   * Click the "+ Add attribute" button
+   */
+  async clickAddAttribute() {
+    await this.addAttributeButton.click();
+  }
+
+  /**
+   * Fill the attribute name input
+   */
+  async fillAttributeName(name: string) {
+    await this.attributeNameInput.pressSequentially(name, { delay: 50 });
+  }
+
+  /**
+   * Add a value to the attribute values list
+   */
+  async addAttributeValue(value: string) {
+    await this.valueInput.pressSequentially(value, { delay: 50 });
+    await this.valueInput.press("Enter");
+  }
+
+  /**
+   * Click the checkmark to save the attribute card
+   */
+  async saveAttribute() {
+    await this.saveCardButton.click({ force: true });
+  }
 }
 
 /**
@@ -156,6 +350,14 @@ class SchemaManagerAsserter {
     }
 
     await Promise.all(promises);
+  }
+
+  /**
+   * Verify the range min/max inputs have the expected values
+   */
+  async hasRangeValues(min: string, max: string) {
+    await expect(this.schemaManagerPom.rangeMinInput).toHaveValue(min);
+    await expect(this.schemaManagerPom.rangeMaxInput).toHaveValue(max);
   }
 
   /**

--- a/e2e-pw/src/oss/poms/schema-manager/index.ts
+++ b/e2e-pw/src/oss/poms/schema-manager/index.ts
@@ -293,6 +293,15 @@ class SchemaManagerAsserter {
   }
 
   /**
+   * Verify a component type button is selected in the edit view
+   */
+  async hasSelectedComponentType(id: string) {
+    await expect(
+      this.schemaManagerPom.getComponentTypeButton(id)
+    ).toHaveAttribute("data-selected", "true");
+  }
+
+  /**
    * Is the field row in the hidden fields section
    *
    * @param field the field name

--- a/e2e-pw/src/oss/poms/schema-manager/index.ts
+++ b/e2e-pw/src/oss/poms/schema-manager/index.ts
@@ -178,7 +178,8 @@ export class SchemaManagerPom {
    */
   async addClass(name: string) {
     await this.addClassButton.click();
-    await this.classNameInput.pressSequentially(name, { delay: 50 });
+    // force: true needed because input is inside RichList item with aria-disabled
+    await this.classNameInput.fill(name, { force: true });
     await this.classNameInput.press("Enter");
   }
 
@@ -201,8 +202,9 @@ export class SchemaManagerPom {
    * Fill the min/max range inputs
    */
   async fillRange(min: string, max: string) {
-    await this.rangeMinInput.fill(min);
-    await this.rangeMaxInput.fill(max);
+    // force: true needed because voodo Input wraps Headless UI Field
+    await this.rangeMinInput.fill(min, { force: true });
+    await this.rangeMaxInput.fill(max, { force: true });
   }
 
   /**
@@ -255,14 +257,16 @@ export class SchemaManagerPom {
    * Fill the attribute name input
    */
   async fillAttributeName(name: string) {
-    await this.attributeNameInput.pressSequentially(name, { delay: 50 });
+    // force: true needed because input is inside RichList item with aria-disabled
+    await this.attributeNameInput.fill(name, { force: true });
   }
 
   /**
    * Add a value to the attribute values list
    */
   async addAttributeValue(value: string) {
-    await this.valueInput.pressSequentially(value, { delay: 50 });
+    // force: true needed because input is inside RichList item with aria-disabled
+    await this.valueInput.fill(value, { force: true });
     await this.valueInput.press("Enter");
   }
 

--- a/e2e-pw/src/oss/poms/schema-manager/index.ts
+++ b/e2e-pw/src/oss/poms/schema-manager/index.ts
@@ -178,7 +178,7 @@ export class SchemaManagerPom {
    */
   async addClass(name: string) {
     await this.addClassButton.click();
-    await this.classNameInput.pressSequentially(name, { delay: 50 });
+    await this.classNameInput.fill(name);
     await this.classNameInput.press("Enter");
   }
 

--- a/e2e-pw/src/oss/poms/schema-manager/index.ts
+++ b/e2e-pw/src/oss/poms/schema-manager/index.ts
@@ -178,7 +178,7 @@ export class SchemaManagerPom {
    */
   async addClass(name: string) {
     await this.addClassButton.click();
-    await this.classNameInput.fill(name);
+    await this.classNameInput.pressSequentially(name, { delay: 50 });
     await this.classNameInput.press("Enter");
   }
 

--- a/e2e-pw/src/oss/poms/schema-manager/index.ts
+++ b/e2e-pw/src/oss/poms/schema-manager/index.ts
@@ -98,10 +98,10 @@ export class SchemaManagerPom {
   }
 
   /**
-   * The field type combobox locator
+   * The field type select dropdown
    */
   get typeSelect() {
-    return this.locator.getByRole("combobox");
+    return this.locator.getByTestId("field-type-select");
   }
 
   /**

--- a/e2e-pw/src/oss/poms/schema-manager/index.ts
+++ b/e2e-pw/src/oss/poms/schema-manager/index.ts
@@ -2,6 +2,15 @@ import { Page, expect } from "src/oss/fixtures";
 import type { EventUtils } from "src/shared/event-utils";
 import { FieldRowPom } from "./field-row";
 
+export type ComponentType =
+  | "slider"
+  | "text"
+  | "radio"
+  | "json"
+  | "datepicker"
+  | "toggle"
+  | "checkboxes";
+
 /**
  * The schema manager modal accessible via the sample modal's 'Annotate' tab
  */
@@ -126,9 +135,11 @@ export class SchemaManagerPom {
   }
 
   /**
-   * Get a component type button locator by id (e.g. "slider", "text", "radio")
+   * Get a component type button locator by id
+   *
+   * @param id The component type identifier
    */
-  getComponentTypeButton(id: string) {
+  getComponentTypeButton(id: ComponentType) {
     return this.locator.getByTestId(`component-type-${id}`);
   }
 
@@ -175,6 +186,8 @@ export class SchemaManagerPom {
   /**
    * Add a class by name. Clicks "+ Add class", types the name, then presses
    * Enter to confirm.
+   *
+   * @param name The class name to add
    */
   async addClass(name: string) {
     await this.addClassButton.click();
@@ -191,18 +204,23 @@ export class SchemaManagerPom {
   }
 
   /**
-   * Click a component type button (e.g. "slider", "text", "radio")
+   * Click a component type button
+   *
+   * @param id The component type identifier
    */
-  async selectComponentType(id: string) {
+  async selectComponentType(id: ComponentType) {
     // force: true needed because component may be inside a RichList with aria-disabled
     await this.getComponentTypeButton(id).click({ force: true });
   }
 
   /**
    * Fill the min/max range inputs
+   *
+   * @param min The minimum range value
+   * @param max The maximum range value
    */
   async fillRange(min: string, max: string) {
-    // force: true needed because voodo Input wraps Headless UI Field
+    // force: true needed because Input wraps Headless UI Field
     await this.rangeMinInput.fill(min, { force: true });
     await this.rangeMaxInput.fill(max, { force: true });
   }
@@ -255,6 +273,8 @@ export class SchemaManagerPom {
 
   /**
    * Fill the attribute name input
+   *
+   * @param name The attribute name
    */
   async fillAttributeName(name: string) {
     // force: true needed because input is inside RichList item with aria-disabled
@@ -263,6 +283,8 @@ export class SchemaManagerPom {
 
   /**
    * Add a value to the attribute values list
+   *
+   * @param value The value to add
    */
   async addAttributeValue(value: string) {
     // force: true needed because input is inside RichList item with aria-disabled
@@ -298,10 +320,12 @@ class SchemaManagerAsserter {
 
   /**
    * Verify a component type button is selected in the edit view
+   *
+   * @param id The component type identifier
    */
-  async hasSelectedComponentType(id: string) {
+  async hasSelectedComponentType(id: ComponentType | string) {
     await expect(
-      this.schemaManagerPom.getComponentTypeButton(id)
+      this.schemaManagerPom.getComponentTypeButton(id as ComponentType)
     ).toHaveAttribute("data-selected", "true");
   }
 
@@ -367,6 +391,9 @@ class SchemaManagerAsserter {
 
   /**
    * Verify the range min/max inputs have the expected values
+   *
+   * @param min The expected minimum range value
+   * @param max The expected maximum range value
    */
   async hasRangeValues(min: string, max: string) {
     await expect(this.schemaManagerPom.rangeMinInput).toHaveValue(min);

--- a/e2e-pw/src/oss/specs/smoke-tests/schema-manager.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/schema-manager.spec.ts
@@ -638,6 +638,7 @@ test.describe.serial("schema manager", () => {
     // Verify in annotation sidebar — renders as autocomplete with configured choices
     await modal.sidebar.clickPrimitiveEntry(stringListFieldName);
     for (const value of stringListSelections) {
+      await modal.sidebar.openAutocomplete();
       await modal.sidebar.selectAutocompleteOption(value);
     }
     await modal.sidebar.assert.hasSelectedTags(stringListSelections);

--- a/e2e-pw/src/oss/specs/smoke-tests/schema-manager.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/schema-manager.spec.ts
@@ -556,7 +556,7 @@ test.describe.serial("schema manager", () => {
 
     // Verify toggle renders in annotation sidebar
     await modal.sidebar.clickPrimitiveEntry(boolFieldName);
-    await modal.sidebar.assert.hasToggle();
+    await modal.sidebar.assert.hasBooleanToggle();
   });
 
   test("add new dictionary field with json editor", async ({

--- a/e2e-pw/src/oss/specs/smoke-tests/schema-manager.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/schema-manager.spec.ts
@@ -25,6 +25,14 @@ const detectionAttribute = {
   name: "sensor",
   values: ["nikon", "sony", "zeiss"],
 };
+const intRadioFieldName = "test_int_radio_field";
+const intRadioValues = ["0", "1", "2"];
+const dateFieldName = "test_date_field";
+const boolFieldName = "test_bool_field";
+const dictFieldName = "test_dict_field";
+const stringListFieldName = "test_string_list_field";
+const stringListValues = ["a", "b", "c", "d", "e", "f"];
+const stringListSelections = ["a", "c", "e"];
 
 const test = base.extend<{
   grid: GridPom;
@@ -354,8 +362,7 @@ test.describe.serial("schema manager", () => {
     await modal.assert.isOpen();
     await modal.sidebar.switchMode("annotate");
 
-    // Open schema manager via Schema button (active schemas exist from previous test)
-    await modal.sidebar.clickSchemaButton();
+    await schemaManager.open();
     await schemaManager.assert.isOpen();
 
     // Create a new primitive slider field
@@ -393,8 +400,7 @@ test.describe.serial("schema manager", () => {
     await modal.assert.isOpen();
     await modal.sidebar.switchMode("annotate");
 
-    // Open schema manager via Schema button (active schemas exist from previous tests)
-    await modal.sidebar.clickSchemaButton();
+    await schemaManager.open();
     await schemaManager.assert.isOpen();
 
     // Create a new detection field with an attribute
@@ -426,5 +432,214 @@ test.describe.serial("schema manager", () => {
     await modal.sidebar.assert.hasFieldOption(detectionFieldName);
     await modal.sidebar.selectField(detectionFieldName);
     await modal.sidebar.assert.hasRadioOptions(detectionAttribute.values);
+  });
+
+  test("add new integer field with radio values", async ({
+    fiftyoneLoader,
+    page,
+    modal,
+    schemaManager,
+  }) => {
+    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+      searchParams: new URLSearchParams({ id }),
+    });
+    await modal.assert.isOpen();
+    await modal.sidebar.switchMode("annotate");
+
+    await schemaManager.open();
+    await schemaManager.assert.isOpen();
+
+    // Create integer field with radio component and values
+    await schemaManager.clickNewField();
+    await schemaManager.fillFieldName(intRadioFieldName);
+    await schemaManager.selectPrimitiveCategory();
+    await schemaManager.selectType("Integer");
+    await schemaManager.selectComponentType("radio");
+    for (const value of intRadioValues) {
+      await schemaManager.addAttributeValue(value);
+    }
+    await schemaManager.create();
+
+    // Verify field in active fields
+    await schemaManager.assert.hasActiveFieldRows([
+      { name: intRadioFieldName, type: "Int" },
+    ]);
+
+    // Verify radio component type is preserved in edit view
+    const intRow = schemaManager.getFieldRow(intRadioFieldName);
+    await intRow.assert.hasComponentType("radio");
+
+    await schemaManager.close();
+    await schemaManager.assert.isClosed();
+  });
+
+  test("add new date field with datepicker", async ({
+    fiftyoneLoader,
+    page,
+    modal,
+    schemaManager,
+  }) => {
+    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+      searchParams: new URLSearchParams({ id }),
+    });
+    await modal.assert.isOpen();
+    await modal.sidebar.switchMode("annotate");
+
+    await schemaManager.open();
+    await schemaManager.assert.isOpen();
+
+    // Create date field (datepicker is default and only component)
+    await schemaManager.clickNewField();
+    await schemaManager.fillFieldName(dateFieldName);
+    await schemaManager.selectPrimitiveCategory();
+    await schemaManager.selectType("Date");
+    await schemaManager.create();
+
+    // Verify field in active fields
+    await schemaManager.assert.hasActiveFieldRows([
+      { name: dateFieldName, type: "Date" },
+    ]);
+
+    await schemaManager.close();
+    await schemaManager.assert.isClosed();
+
+    // Close and reopen modal to refresh sample data with the new field
+    await modal.close();
+    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+      searchParams: new URLSearchParams({ id }),
+    });
+    await modal.assert.isOpen();
+    await modal.sidebar.switchMode("annotate");
+
+    // Verify date picker renders in annotation sidebar
+    await modal.sidebar.clickPrimitiveEntry(dateFieldName);
+    await modal.sidebar.assert.hasDatePicker();
+  });
+
+  test("add new boolean field with toggle", async ({
+    fiftyoneLoader,
+    page,
+    modal,
+    schemaManager,
+  }) => {
+    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+      searchParams: new URLSearchParams({ id }),
+    });
+    await modal.assert.isOpen();
+    await modal.sidebar.switchMode("annotate");
+
+    await schemaManager.open();
+    await schemaManager.assert.isOpen();
+
+    // Create boolean field (toggle is default component)
+    await schemaManager.clickNewField();
+    await schemaManager.fillFieldName(boolFieldName);
+    await schemaManager.selectPrimitiveCategory();
+    await schemaManager.selectType("Boolean");
+    await schemaManager.create();
+
+    // Verify field in active fields
+    await schemaManager.assert.hasActiveFieldRows([
+      { name: boolFieldName, type: "Bool" },
+    ]);
+
+    await schemaManager.close();
+    await schemaManager.assert.isClosed();
+
+    // Close and reopen modal to refresh sample data with the new field
+    await modal.close();
+    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+      searchParams: new URLSearchParams({ id }),
+    });
+    await modal.assert.isOpen();
+    await modal.sidebar.switchMode("annotate");
+
+    // Verify toggle renders in annotation sidebar
+    await modal.sidebar.clickPrimitiveEntry(boolFieldName);
+    await modal.sidebar.assert.hasToggle();
+  });
+
+  test("add new dictionary field with json editor", async ({
+    fiftyoneLoader,
+    page,
+    modal,
+    schemaManager,
+  }) => {
+    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+      searchParams: new URLSearchParams({ id }),
+    });
+    await modal.assert.isOpen();
+    await modal.sidebar.switchMode("annotate");
+
+    await schemaManager.open();
+    await schemaManager.assert.isOpen();
+
+    // Create dictionary field (json is default and only component)
+    await schemaManager.clickNewField();
+    await schemaManager.fillFieldName(dictFieldName);
+    await schemaManager.selectPrimitiveCategory();
+    await schemaManager.selectType("Dictionary");
+    await schemaManager.create();
+
+    // Verify field in active fields
+    await schemaManager.assert.hasActiveFieldRows([
+      { name: dictFieldName, type: "Dict" },
+    ]);
+
+    // Verify json component type in edit view
+    const dictRow = schemaManager.getFieldRow(dictFieldName);
+    await dictRow.assert.hasComponentType("json");
+
+    await schemaManager.close();
+    await schemaManager.assert.isClosed();
+  });
+
+  test("add new string list field with checkboxes and select values", async ({
+    fiftyoneLoader,
+    page,
+    modal,
+    schemaManager,
+  }) => {
+    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+      searchParams: new URLSearchParams({ id }),
+    });
+    await modal.assert.isOpen();
+    await modal.sidebar.switchMode("annotate");
+
+    await schemaManager.open();
+    await schemaManager.assert.isOpen();
+
+    // Create string list field with checkboxes component and values
+    await schemaManager.clickNewField();
+    await schemaManager.fillFieldName(stringListFieldName);
+    await schemaManager.selectPrimitiveCategory();
+    await schemaManager.selectType("String list");
+    for (const value of stringListValues) {
+      await schemaManager.addAttributeValue(value);
+    }
+    await schemaManager.create();
+
+    // Verify field in active fields
+    await schemaManager.assert.hasActiveFieldRows([
+      { name: stringListFieldName, type: "List<str>" },
+    ]);
+
+    await schemaManager.close();
+    await schemaManager.assert.isClosed();
+
+    // Close and reopen modal to refresh sample data with the new field
+    await modal.close();
+    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+      searchParams: new URLSearchParams({ id }),
+    });
+    await modal.assert.isOpen();
+    await modal.sidebar.switchMode("annotate");
+
+    // Verify in annotation sidebar — renders as autocomplete with configured choices
+    await modal.sidebar.clickPrimitiveEntry(stringListFieldName);
+    for (const value of stringListSelections) {
+      await modal.sidebar.selectAutocompleteOption(value);
+    }
+    await modal.sidebar.assert.hasSelectedTags(stringListSelections);
   });
 });

--- a/e2e-pw/src/oss/specs/smoke-tests/schema-manager.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/schema-manager.spec.ts
@@ -50,6 +50,27 @@ const test = base.extend<{
   },
 });
 
+/**
+ * Navigate to a dataset, open the sample modal, switch to annotate mode,
+ * and open the schema manager.
+ */
+async function openSchemaManager(
+  fiftyoneLoader: Parameters<Parameters<typeof test>[2]>[0]["fiftyoneLoader"],
+  page: Parameters<Parameters<typeof test>[2]>[0]["page"],
+  modal: ModalPom,
+  schemaManager: SchemaManagerPom,
+  dataset: string,
+  sampleId: string
+) {
+  await fiftyoneLoader.waitUntilGridVisible(page, dataset, {
+    searchParams: new URLSearchParams({ id: sampleId }),
+  });
+  await modal.assert.isOpen();
+  await modal.sidebar.switchMode("annotate");
+  await schemaManager.open();
+  await schemaManager.assert.isOpen();
+}
+
 test.afterAll(async ({ foWebServer }) => {
   await foWebServer.stopWebServer();
 });
@@ -161,14 +182,14 @@ test.describe.serial("schema manager", () => {
     modal,
     schemaManager,
   }) => {
-    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
-      searchParams: new URLSearchParams({ id }),
-    });
-    // Init
-    await modal.assert.isOpen();
-    await modal.sidebar.switchMode("annotate");
-    await schemaManager.open();
-    await schemaManager.assert.isOpen();
+    await openSchemaManager(
+      fiftyoneLoader,
+      page,
+      modal,
+      schemaManager,
+      datasetName,
+      id
+    );
 
     // Configure
     const row = schemaManager.getFieldRow("classification");
@@ -322,13 +343,14 @@ test.describe.serial("schema manager", () => {
     modal,
     schemaManager,
   }) => {
-    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
-      searchParams: new URLSearchParams({ id }),
-    });
-    await modal.assert.isOpen();
-    await modal.sidebar.switchMode("annotate");
-    await schemaManager.open();
-    await schemaManager.assert.isOpen();
+    await openSchemaManager(
+      fiftyoneLoader,
+      page,
+      modal,
+      schemaManager,
+      datasetName,
+      id
+    );
 
     // Create a new classification field with classes
     await schemaManager.clickNewField();
@@ -361,14 +383,14 @@ test.describe.serial("schema manager", () => {
     modal,
     schemaManager,
   }) => {
-    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
-      searchParams: new URLSearchParams({ id }),
-    });
-    await modal.assert.isOpen();
-    await modal.sidebar.switchMode("annotate");
-
-    await schemaManager.open();
-    await schemaManager.assert.isOpen();
+    await openSchemaManager(
+      fiftyoneLoader,
+      page,
+      modal,
+      schemaManager,
+      datasetName,
+      id
+    );
 
     // Create a new primitive slider field
     await schemaManager.clickNewField();
@@ -399,14 +421,14 @@ test.describe.serial("schema manager", () => {
     modal,
     schemaManager,
   }) => {
-    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
-      searchParams: new URLSearchParams({ id }),
-    });
-    await modal.assert.isOpen();
-    await modal.sidebar.switchMode("annotate");
-
-    await schemaManager.open();
-    await schemaManager.assert.isOpen();
+    await openSchemaManager(
+      fiftyoneLoader,
+      page,
+      modal,
+      schemaManager,
+      datasetName,
+      id
+    );
 
     // Create a new detection field with an attribute
     // Default label type is already "Detections", no need to select it
@@ -445,14 +467,14 @@ test.describe.serial("schema manager", () => {
     modal,
     schemaManager,
   }) => {
-    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
-      searchParams: new URLSearchParams({ id }),
-    });
-    await modal.assert.isOpen();
-    await modal.sidebar.switchMode("annotate");
-
-    await schemaManager.open();
-    await schemaManager.assert.isOpen();
+    await openSchemaManager(
+      fiftyoneLoader,
+      page,
+      modal,
+      schemaManager,
+      datasetName,
+      id
+    );
 
     // Create integer field with radio component and values
     await schemaManager.clickNewField();
@@ -484,14 +506,14 @@ test.describe.serial("schema manager", () => {
     modal,
     schemaManager,
   }) => {
-    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
-      searchParams: new URLSearchParams({ id }),
-    });
-    await modal.assert.isOpen();
-    await modal.sidebar.switchMode("annotate");
-
-    await schemaManager.open();
-    await schemaManager.assert.isOpen();
+    await openSchemaManager(
+      fiftyoneLoader,
+      page,
+      modal,
+      schemaManager,
+      datasetName,
+      id
+    );
 
     // Create date field (datepicker is default and only component)
     await schemaManager.clickNewField();
@@ -517,7 +539,7 @@ test.describe.serial("schema manager", () => {
     await modal.sidebar.switchMode("annotate");
 
     // Verify date picker renders in annotation sidebar
-    await modal.sidebar.clickPrimitiveEntry(dateFieldName);
+    await modal.annotateSidebar.selectActivePrimitiveField(dateFieldName);
     await modal.sidebar.assert.hasDatePicker();
   });
 
@@ -527,14 +549,14 @@ test.describe.serial("schema manager", () => {
     modal,
     schemaManager,
   }) => {
-    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
-      searchParams: new URLSearchParams({ id }),
-    });
-    await modal.assert.isOpen();
-    await modal.sidebar.switchMode("annotate");
-
-    await schemaManager.open();
-    await schemaManager.assert.isOpen();
+    await openSchemaManager(
+      fiftyoneLoader,
+      page,
+      modal,
+      schemaManager,
+      datasetName,
+      id
+    );
 
     // Create boolean field (toggle is default component)
     await schemaManager.clickNewField();
@@ -560,7 +582,7 @@ test.describe.serial("schema manager", () => {
     await modal.sidebar.switchMode("annotate");
 
     // Verify toggle renders in annotation sidebar
-    await modal.sidebar.clickPrimitiveEntry(boolFieldName);
+    await modal.annotateSidebar.selectActivePrimitiveField(boolFieldName);
     await modal.sidebar.assert.hasBooleanToggle();
   });
 
@@ -570,14 +592,14 @@ test.describe.serial("schema manager", () => {
     modal,
     schemaManager,
   }) => {
-    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
-      searchParams: new URLSearchParams({ id }),
-    });
-    await modal.assert.isOpen();
-    await modal.sidebar.switchMode("annotate");
-
-    await schemaManager.open();
-    await schemaManager.assert.isOpen();
+    await openSchemaManager(
+      fiftyoneLoader,
+      page,
+      modal,
+      schemaManager,
+      datasetName,
+      id
+    );
 
     // Create dictionary field (json is default and only component)
     await schemaManager.clickNewField();
@@ -605,14 +627,14 @@ test.describe.serial("schema manager", () => {
     modal,
     schemaManager,
   }) => {
-    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
-      searchParams: new URLSearchParams({ id }),
-    });
-    await modal.assert.isOpen();
-    await modal.sidebar.switchMode("annotate");
-
-    await schemaManager.open();
-    await schemaManager.assert.isOpen();
+    await openSchemaManager(
+      fiftyoneLoader,
+      page,
+      modal,
+      schemaManager,
+      datasetName,
+      id
+    );
 
     // Create string list field with checkboxes component and values
     await schemaManager.clickNewField();
@@ -641,7 +663,7 @@ test.describe.serial("schema manager", () => {
     await modal.sidebar.switchMode("annotate");
 
     // Verify in annotation sidebar — renders as autocomplete with configured choices
-    await modal.sidebar.clickPrimitiveEntry(stringListFieldName);
+    await modal.annotateSidebar.selectActivePrimitiveField(stringListFieldName);
     for (const value of stringListSelections) {
       await modal.sidebar.openAutocomplete();
       await modal.sidebar.selectAutocompleteOption(value);


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add golden paths e2e tests on schema manager for

1) add a new classification field with classes, verify in sidebar by creating a new cls tag
2) add a new detection field with no classes and one attribute,  verify in sidebar by creating a detection
3) add a new primitive field (float type) with ranges

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Added e2e tests for golden paths for schema manager
- add a new class
- add a new attribute
- add detection field (with no classes)
- add classification field (with classes)
- add different primitive fields

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **User-facing Change**
  * Annotation sidebar now shows all active primitive fields even when the current sample has no value, so newly defined fields appear for annotation.

* **Tests**
  * Added extensive end-to-end scenarios covering schema/field creation and annotation flows.
  * Expanded test helpers, assertions, and UI selectors to improve automation and verification of the schema manager and annotation UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->