### PR TITLE
allow editing nested primitive field with unset parent

### DIFF
--- a/app/packages/annotation/src/persistence/useSidebarDeltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/useSidebarDeltaSupplier.ts
@@ -4,6 +4,7 @@ import { useSampleMutationManager } from "./useSampleMutationManager";
 import { Primitive } from "@fiftyone/utilities";
 import { LabelProxy } from "../deltas";
 import { useGetLabelDelta } from "./useGetLabelDelta";
+import { OpType } from "../types";
 
 /**
  * Method for constructing a {@link LabelProxy} from a primitive value.
@@ -14,13 +15,16 @@ import { useGetLabelDelta } from "./useGetLabelDelta";
 const buildLabelProxy = ({
   data,
   path,
+  op,
 }: {
   data: Primitive;
   path: string;
+  op?: OpType;
 }): LabelProxy => ({
   data,
   path,
   type: "Primitive",
+  op,
 });
 
 /**
@@ -33,7 +37,9 @@ export const useSidebarDeltaSupplier = (): DeltaSupplier => {
 
   return useCallback(() => {
     return Object.entries(stagedMutations)
-      .map(([path, data]) => getLabelDelta({ data, path }, path))
+      .map(([path, mutation]) =>
+        getLabelDelta({ data: mutation.data, path, op: mutation.op }, path)
+      )
       .flat();
   }, [getLabelDelta, stagedMutations]);
 };

--- a/app/packages/annotation/src/types.ts
+++ b/app/packages/annotation/src/types.ts
@@ -1,0 +1,11 @@
+import { Primitive } from "@fiftyone/utilities";
+
+/**
+ * Operation type.
+ */
+export type OpType = "mutate" | "delete" | "add";
+
+export type Mutation = {
+  data: Primitive;
+  op?: OpType;
+};

--- a/app/packages/annotation/src/util/labelPersistence.test.ts
+++ b/app/packages/annotation/src/util/labelPersistence.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { handleLabelPersistence } from "./labelPersistence";
 import type { Sample } from "@fiftyone/looker";
-import type { Field } from "@fiftyone/utilities";
 import type { AnnotationLabel } from "@fiftyone/state";
-import type { OpType } from "../deltas";
+import type { Field } from "@fiftyone/utilities";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpType } from "../types";
+import { handleLabelPersistence } from "./labelPersistence";
 
 vi.mock("../deltas", () => ({
   buildJsonPath: vi.fn(),

--- a/app/packages/annotation/src/util/labelPersistence.ts
+++ b/app/packages/annotation/src/util/labelPersistence.ts
@@ -1,18 +1,14 @@
-import type { Sample } from "@fiftyone/looker";
-import type { Field } from "@fiftyone/utilities";
 import {
   type JSONDeltas,
   patchSample,
   transformSampleData,
   VersionMismatchError,
 } from "@fiftyone/core/src/client";
-import {
-  buildJsonPath,
-  buildLabelDeltas,
-  LabelProxy,
-  type OpType,
-} from "../deltas";
+import type { Sample } from "@fiftyone/looker";
 import { isSampleIsh } from "@fiftyone/looker/src/util";
+import type { Field } from "@fiftyone/utilities";
+import { buildJsonPath, buildLabelDeltas, LabelProxy } from "../deltas";
+import type { OpType } from "../types";
 
 export type DoPatchSampleArgs = {
   sample: Sample | null;

--- a/app/packages/components/src/components/SmartForm/RJSF/index.tsx
+++ b/app/packages/components/src/components/SmartForm/RJSF/index.tsx
@@ -1,6 +1,6 @@
 import Form from "@rjsf/mui";
 import validator from "@rjsf/validator-ajv8";
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { translateSchema } from "./translators";
 import { filterEmptyArrays } from "./utils";
@@ -13,12 +13,21 @@ export { isJSONSchema, isSchemaIOSchema } from "./translators";
 import type { IChangeEvent } from "@rjsf/core";
 import { isObject, type RJSFSchema } from "@rjsf/utils";
 import { SmartFormProps } from "../types";
+import { isNullish } from "@fiftyone/utilities";
 
 export default function RJSF(props: SmartFormProps) {
   const { formProps } = props;
   const formRef = useRef<{ validateForm: () => boolean } | null>(null);
+  const [revision, setRevision] = useState(0);
 
+  const data = props.data;
   const { liveValidate } = formProps || {};
+
+  useEffect(() => {
+    if (isNullish(data)) {
+      setRevision((r) => r + 1);
+    }
+  }, [data]);
 
   useEffect(() => {
     if (formRef.current && liveValidate) {
@@ -68,13 +77,14 @@ export default function RJSF(props: SmartFormProps) {
 
   return (
     <Form
+      key={revision}
       ref={formRef}
       schema={schema as RJSFSchema}
       uiSchema={uiSchema}
       validator={validator}
       widgets={widgets}
       templates={templates}
-      formData={props.data}
+      formData={data}
       onChange={handleChange}
       onSubmit={handleSubmit}
       showErrorList={false}

--- a/app/packages/components/src/components/SmartForm/RJSF/widgets/TextWidget.tsx
+++ b/app/packages/components/src/components/SmartForm/RJSF/widgets/TextWidget.tsx
@@ -16,7 +16,6 @@ export default function TextWidget(props: WidgetProps) {
     onChange = () => {},
     placeholder,
     schema,
-    rawErrors = [],
   } = props;
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/PrimitiveEdit.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/PrimitiveEdit.tsx
@@ -1,10 +1,13 @@
-import { useSampleMutationManager } from "@fiftyone/annotation";
+import {
+  SampleMutationManager,
+  useSampleMutationManager,
+} from "@fiftyone/annotation";
 import {
   DelegatingUndoable,
   KnownContexts,
   useCreateCommand,
 } from "@fiftyone/commands";
-import { Primitive } from "@fiftyone/utilities";
+import { isNullish, Primitive } from "@fiftyone/utilities";
 import { Orientation, Stack } from "@voxel51/voodo";
 import { useCallback, useEffect, useRef, useState } from "react";
 import PrimitiveRenderer from "./PrimitiveRenderer";
@@ -48,6 +51,7 @@ export default function PrimitiveEdit({
     useCallback(() => {
       const oldValue = value;
       const newValue = transientFieldValue.current;
+      const isAddOperation = isAdd(path, sampleMutationManager);
 
       return new DelegatingUndoable(
         `primitive-edit-${path}-action`,
@@ -55,14 +59,27 @@ export default function PrimitiveEdit({
         () => {
           try {
             const serializedValue = serializeFieldValue(newValue, type);
-            sampleMutationManager.stageMutation(path, serializedValue);
+            let op = "mutate";
+            if (isAddOperation) {
+              op = "add";
+            } else if (isNullish(serializedValue) || serializedValue === "") {
+              op = "delete";
+            }
+            sampleMutationManager.stageMutation(path, {
+              data: serializedValue,
+              op,
+            });
           } catch (err) {
             console.warn("unparseable value", newValue);
           }
         },
         // restore original value on undo
         () => {
-          sampleMutationManager.stageMutation(path, oldValue);
+          const hasOldValue = !isNullish(oldValue);
+          sampleMutationManager.stageMutation(path, {
+            data: oldValue,
+            op: isAddOperation && !hasOldValue ? "delete" : "mutate",
+          });
         }
       );
     }, [path, sampleMutationManager, type, value]),
@@ -91,4 +108,11 @@ export default function PrimitiveEdit({
       />
     </Stack>
   );
+}
+
+function isAdd(path: string, sampleMutationManager: SampleMutationManager) {
+  if (!path.includes(".")) return false;
+  const parentPath = path.split(".").slice(0, -1).join(".");
+  const parentValue = sampleMutationManager.getPathValue(parentPath);
+  return isNullish(parentValue);
 }

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/usePrimitiveEntries.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/usePrimitiveEntries.ts
@@ -1,13 +1,11 @@
-import { EntryKind, modalSample, type SidebarEntry } from "@fiftyone/state";
+import { EntryKind, type SidebarEntry } from "@fiftyone/state";
 import { useAtomValue } from "jotai";
 import { useMemo } from "react";
-import { useRecoilValue } from "recoil";
 import { primitivesExpanded } from "./GroupEntry";
 import useSamplePrimitives from "./useSamplePrimitives";
 
 const usePrimitiveEntries = (activeFields: string[]): SidebarEntry[] => {
-  const currentSample = useRecoilValue(modalSample).sample;
-  const samplePrimitives = useSamplePrimitives(currentSample);
+  const samplePrimitives = useSamplePrimitives();
   const primitivesExpandedState = useAtomValue(primitivesExpanded);
 
   const primitiveEntries: SidebarEntry[] = useMemo(() => {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/usePrimitivesCount.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/usePrimitivesCount.ts
@@ -7,7 +7,7 @@ import useSamplePrimitives from "./useSamplePrimitives";
 
 export const usePrimitivesCount = () => {
   const currentSample = useRecoilValue(modalSample).sample;
-  const samplePrimitives = useSamplePrimitives(currentSample);
+  const samplePrimitives = useSamplePrimitives();
   const setPrimitivesCount = useSetAtom(primitivesCount);
 
   useEffect(() => {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useSamplePrimitives.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useSamplePrimitives.ts
@@ -1,11 +1,10 @@
-import { Sample, State, fieldPaths } from "@fiftyone/state";
+import { State, fieldPaths } from "@fiftyone/state";
 import { DICT_FIELD, VALID_PRIMITIVE_TYPES } from "@fiftyone/utilities";
 import { useAtomValue } from "jotai";
-import { get } from "lodash";
 import { useRecoilValue } from "recoil";
 import { activeLabelSchemas } from "./state";
 
-const useSamplePrimitives = (currentSample: Sample): string[] => {
+const useSamplePrimitives = (): string[] => {
   const activeFields = useAtomValue(activeLabelSchemas);
   const primitivePaths = useRecoilValue(
     fieldPaths({
@@ -18,11 +17,9 @@ const useSamplePrimitives = (currentSample: Sample): string[] => {
     return [];
   }
 
-  // only top level primitives that exist - we want to keep null
-  // values it just means the value has not been set yet
-  const validPrimitivePaths = primitivePaths
-    .filter((path) => get(currentSample, path) !== undefined)
-    .filter((path) => activeFields.includes(path));
+  const validPrimitivePaths = primitivePaths.filter((path) =>
+    activeFields.includes(path)
+  );
 
   return validPrimitivePaths;
 };

--- a/app/packages/state/src/recoil/sidebar.ts
+++ b/app/packages/state/src/recoil/sidebar.ts
@@ -84,6 +84,7 @@ import {
   unsupportedMatcher,
 } from "./utils";
 import * as viewAtoms from "./view";
+import { OpType } from "@fiftyone/annotation/src/types";
 
 export enum EntryKind {
   EMPTY = "EMPTY",
@@ -167,6 +168,7 @@ export interface PrimitiveValue {
   type: "Primitive";
   data: Primitive;
   path: string;
+  op?: OpType;
 }
 
 export interface LabelEntry {


### PR DESCRIPTION
## What changes are proposed in this pull request?

allow editing nested primitive field with unset parent

## How is this patch tested? If it is not, please explain why.

Using annotate and quick edit

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Primitive edits now support explicit operations: add, mutate, delete — deltas reflect the actual operation.

* **Refactor**
  * Staged mutations and label proxies now carry full mutation metadata (value + operation) for accurate persistence and delta generation.
  * Internal hooks simplified to derive primitives without external sample arguments.

* **Bug Fixes**
  * Undo/redo for adds and deletes produces correct deltas.

* **UX**
  * Smart form remounts when data is cleared to reset form state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->