### PR TITLE
Fix saving with stale version

### DIFF
--- a/app/packages/annotation/src/persistence/usePersistenceEventHandler.ts
+++ b/app/packages/annotation/src/persistence/usePersistenceEventHandler.ts
@@ -2,7 +2,7 @@ import {
   ConcurrencyLimitBehavior,
   useConcurrentCallback,
 } from "@fiftyone/utilities/src/useConcurrentCallback";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback } from "react";
 import { useAnnotationEventBus } from "../hooks";
 import { usePersistAnnotationDeltas } from "./usePersistAnnotationDeltas";
 
@@ -14,39 +14,21 @@ export const usePersistenceEventHandler = () => {
   const eventBus = useAnnotationEventBus();
   const persistAnnotationDeltas = usePersistAnnotationDeltas();
 
-  // After a PATCH response, `refreshSample` queues React state updates but
-  // closures (version token, delta base sample) remain stale until the next
-  // render. This ref gates the next save attempt so it cannot fire until
-  // React has re-rendered and all hooks hold up-to-date values.
-  const awaitingRenderRef = useRef(false);
-  useEffect(() => {
-    awaitingRenderRef.current = false;
-  });
-
   return useConcurrentCallback(
     useCallback(async () => {
-      // Skip until React has re-rendered with the latest sample data;
-      // the next auto-save tick will pick up pending changes.
-      if (awaitingRenderRef.current) {
-        return;
-      }
-
       try {
         const success = await persistAnnotationDeltas();
 
         if (success === null) {
-          // no-op — no pending changes, no render gate needed
+          // no-op
         } else if (success) {
-          awaitingRenderRef.current = true;
           eventBus.dispatch("annotation:persistenceSuccess");
         } else {
-          awaitingRenderRef.current = true;
           eventBus.dispatch("annotation:persistenceError", {
             error: new Error("Server rejected changes"),
           });
         }
       } catch (error) {
-        awaitingRenderRef.current = true;
         eventBus.dispatch("annotation:persistenceError", { error });
       }
     }, [eventBus, persistAnnotationDeltas]),

--- a/app/packages/core/src/components/Modal/Lighter/LighterSampleRenderer.tsx
+++ b/app/packages/core/src/components/Modal/Lighter/LighterSampleRenderer.tsx
@@ -92,12 +92,14 @@ export const LighterSampleRenderer = ({
   }, [isReady, addOverlay, scene, sample.sample._id]);
 
   useEffect(() => {
-    // sceneId should be deterministic, but unique for a given sample snapshot
+    // sceneId should be deterministic and unique per sample. It must NOT
+    // include last_modified_at — every successful annotation PATCH changes
+    // that timestamp, which would destroy/recreate the entire scene (wiping
+    // all overlays, including in-progress bounding boxes). Overlay data
+    // updates are handled incrementally by useLabels instead.
     const sample = sampleRef.current;
-    setSceneId(
-      `${sample?.sample?._id}-${sample?.sample?.last_modified_at?.datetime}`
-    );
-  }, [sample.sample._id, sample.sample.last_modified_at?.datetime]);
+    setSceneId(`${sample?.sample?._id}`);
+  }, [sample.sample._id]);
 
   return (
     <div


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add a gate to avoid  Version Mismatch Error due to save fired with stale version 
<img width="694" height="95" alt="image" src="https://github.com/user-attachments/assets/4e711785-6968-4ac4-b666-0056bb794a2b" />


## How is this patch tested? If it is not, please explain why.

Run app and create multiple detection annotations.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved annotation persistence handling to prevent duplicate or conflicting save operations.
  * Enhanced error and success state management during annotation persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->