### PR TITLE
add datePicker and jsonEditor views and register as smartform widgets

### DIFF
--- a/app/packages/components/src/components/SmartForm/RJSF/translators/ui.ts
+++ b/app/packages/components/src/components/SmartForm/RJSF/translators/ui.ts
@@ -82,6 +82,17 @@ export function translateToUISchema(
       };
       break;
 
+    case SmartFormComponents.DatePickerView:
+      uiSchema["ui:widget"] = "DatePickerWidget";
+      uiSchema["ui:options"] = {
+        dateOnly: view.date_only,
+      };
+      break;
+
+    case SmartFormComponents.JsonEditorView:
+      uiSchema["ui:widget"] = "JsonEditorWidget";
+      break;
+
     case SmartFormComponents.ColorView:
       uiSchema["ui:widget"] = "color";
       break;

--- a/app/packages/components/src/components/SmartForm/RJSF/widgets/DatePickerWidget.tsx
+++ b/app/packages/components/src/components/SmartForm/RJSF/widgets/DatePickerWidget.tsx
@@ -1,0 +1,38 @@
+/**
+ * Date/datetime input widget using native HTML5 date inputs
+ */
+
+import { WidgetProps } from "@rjsf/utils";
+import { FormField, Input } from "@voxel51/voodo";
+import React from "react";
+
+export default function DatePickerWidget(props: WidgetProps) {
+  const {
+    label,
+    value,
+    disabled,
+    readonly,
+    autofocus,
+    onChange = () => {},
+    options,
+  } = props;
+
+  const dateOnly = options?.dateOnly ?? false;
+  const inputType = dateOnly ? "date" : "datetime-local";
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(event.target.value || undefined);
+  };
+
+  const inputComponent = (
+    <Input
+      disabled={disabled || readonly}
+      autoFocus={autofocus}
+      type={inputType}
+      value={value ?? ""}
+      onChange={handleChange}
+    />
+  );
+
+  return <FormField control={inputComponent} label={label} />;
+}

--- a/app/packages/components/src/components/SmartForm/RJSF/widgets/JsonEditorWidget.tsx
+++ b/app/packages/components/src/components/SmartForm/RJSF/widgets/JsonEditorWidget.tsx
@@ -1,0 +1,48 @@
+/**
+ * JSON editor widget using a textarea for dict/object values
+ */
+
+import { WidgetProps } from "@rjsf/utils";
+import { FormField } from "@voxel51/voodo";
+import React from "react";
+
+export default function JsonEditorWidget(props: WidgetProps) {
+  const {
+    label,
+    value,
+    disabled,
+    readonly,
+    autofocus,
+    onChange = () => {},
+    placeholder,
+  } = props;
+
+  const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    onChange(event.target.value);
+  };
+
+  const inputComponent = (
+    <textarea
+      disabled={disabled || readonly}
+      autoFocus={autofocus}
+      value={value ?? ""}
+      placeholder={placeholder || "{}"}
+      onChange={handleChange}
+      rows={4}
+      style={{
+        width: "100%",
+        fontFamily: "monospace",
+        fontSize: "0.875rem",
+        padding: "8px",
+        borderRadius: "4px",
+        border: "1px solid var(--fo-palette-divider)",
+        backgroundColor: "var(--fo-palette-background-field)",
+        color: "var(--fo-palette-text-primary)",
+        resize: "vertical",
+        boxSizing: "border-box",
+      }}
+    />
+  );
+
+  return <FormField control={inputComponent} label={label} />;
+}

--- a/app/packages/components/src/components/SmartForm/RJSF/widgets/index.tsx
+++ b/app/packages/components/src/components/SmartForm/RJSF/widgets/index.tsx
@@ -1,6 +1,8 @@
 import AutoComplete from "./AutoComplete";
 import CheckboxWidget from "./CheckboxWidget";
+import DatePickerWidget from "./DatePickerWidget";
 import Dropdown from "./Dropdown";
+import JsonEditorWidget from "./JsonEditorWidget";
 import LabelValueWidget from "./LabelValueWidget";
 import RadioWidget from "./RadioWidget";
 import SelectWidget from "./SelectWidget";
@@ -10,7 +12,9 @@ import ToggleWidget from "./ToggleWidget";
 
 export default {
   AutoComplete,
+  DatePickerWidget,
   Dropdown,
+  JsonEditorWidget,
   LabelValueWidget,
   SelectWidget,
   RangeWidget: SliderWidget,

--- a/app/packages/components/src/components/SmartForm/types.ts
+++ b/app/packages/components/src/components/SmartForm/types.ts
@@ -46,6 +46,8 @@ export enum SmartFormComponents {
   SliderView = "SliderView",
   ToggleView = "ToggleView",
   LabelValueView = "LabelValueView",
+  DatePickerView = "DatePickerView",
+  JsonEditorView = "JsonEditorView",
 }
 
 export interface SmartFormProps {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/schemaHelpers.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/schemaHelpers.ts
@@ -191,6 +191,32 @@ export const createText = (name: string, type: string): SchemaType => {
   };
 };
 
+export const createDatePicker = (
+  name: string,
+  dateOnly: boolean
+): SchemaType => {
+  return {
+    type: "string",
+    view: {
+      name: "DatePickerView",
+      component: "DatePickerView",
+      label: name,
+      date_only: dateOnly,
+    },
+  };
+};
+
+export const createJsonInput = (name: string): SchemaType => {
+  return {
+    type: "string",
+    view: {
+      name: "JsonEditorView",
+      component: "JsonEditorView",
+      label: name,
+    },
+  };
+};
+
 /**
  * Creates an array schema for numeric lists: list<float> and list<int>
  */
@@ -258,6 +284,18 @@ export function generatePrimitiveSchema(
       return createRadio(name, schema.values || [], "number");
     }
     return createText(name, "number");
+  }
+
+  if (schema.type === "date") {
+    return createDatePicker(name, true);
+  }
+
+  if (schema.type === "datetime") {
+    return createDatePicker(name, false);
+  }
+
+  if (schema.type === "dict") {
+    return createJsonInput(name);
   }
 
   console.warn(`Unknown schema type: ${schema.type}, ${schema.component}`);


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add date picker and json editor as smart form widgets so that `date` `datetime` and `json` type input can show

## How is this patch tested? If it is not, please explain why.

bug: 

<img width="336" height="659" alt="Screenshot 2026-02-11 at 6 57 43 PM" src="https://github.com/user-attachments/assets/bb121424-a677-4879-855e-e956d9cf3654" />

fix: 
<img width="248" height="467" alt="Screenshot 2026-02-11 at 7 08 17 PM" src="https://github.com/user-attachments/assets/656365ec-37e0-45b6-b8e9-d81f1b27820c" />

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added date picker widget with support for date-only and datetime input fields
  * Added JSON editor widget for editing object and dictionary fields
  * Both widgets are now integrated into the SmartForm system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->