### PR TITLE
[HA] Enforce mutual exclusion of hidden/active fields in schema manager FOEPD-3162

### DIFF
--- a/app/packages/core/package.json
+++ b/app/packages/core/package.json
@@ -23,7 +23,7 @@
         "@mui/material": "^5.9.0",
         "@react-spring/web": "^9.4.3",
         "@use-gesture/react": "^10.3.0",
-        "@voxel51/voodo": "^0.0.19",
+        "@voxel51/voodo": "^0.0.20",
         "@xstate/react": "1.3.3",
         "classnames": "^2.2.6",
         "color": "^4.2.3",

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/ActiveFieldsSection.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/ActiveFieldsSection.tsx
@@ -29,6 +29,7 @@ import {
   useActiveFieldsList,
   useNewFieldMode,
   useSelectedActiveFields,
+  useSelectedHiddenFields,
   useSetCurrentField,
 } from "./hooks";
 import SecondaryText from "./SecondaryText";
@@ -71,7 +72,8 @@ const ActiveFieldsSection = () => {
   }, [setNewFieldMode]);
 
   const { fields, setFields } = useActiveFieldsList();
-  const { setSelected } = useSelectedActiveFields();
+  const { selected, setSelected } = useSelectedActiveFields();
+  const { setSelected: setHiddenSelected } = useSelectedHiddenFields();
 
   // Batch field data fetching
   const fieldTypes = useAtomValue(
@@ -152,9 +154,12 @@ const ActiveFieldsSection = () => {
   const handleSelected = useCallback(
     (selectedIds: string[]) => {
       setSelected(new Set(selectedIds));
+      setHiddenSelected(new Set());
     },
-    [setSelected]
+    [setHiddenSelected, setSelected]
   );
+
+  const selectedList = useMemo(() => Array.from(selected), [selected]);
 
   if (!fields?.length) {
     return (
@@ -232,6 +237,7 @@ const ActiveFieldsSection = () => {
         draggable={true}
         onOrderChange={handleOrderChange}
         onSelected={handleSelected}
+        selected={selectedList}
       />
     </>
   );

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/HiddenFieldsSection.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/HiddenFieldsSection.tsx
@@ -27,6 +27,7 @@ import {
   useFieldIsReadOnly,
   useFieldSchemaData,
   useHiddenFieldsWithMetadata,
+  useSelectedActiveFields,
   useSelectedHiddenFields,
   useSetCurrentField,
 } from "./hooks";
@@ -105,7 +106,8 @@ const HiddenFieldsSection = () => {
     hasSchemaStates: fieldHasSchemaStates,
   } = useHiddenFieldsWithMetadata();
   const [expanded, setExpanded] = useState(true);
-  const { setSelected } = useSelectedHiddenFields();
+  const { selected, setSelected } = useSelectedHiddenFields();
+  const { setSelected: setActiveSelected } = useSelectedActiveFields();
 
   const listItems = useMemo(
     () =>
@@ -138,9 +140,12 @@ const HiddenFieldsSection = () => {
   const handleSelected = useCallback(
     (selectedIds: string[]) => {
       setSelected(new Set(selectedIds));
+      setActiveSelected(new Set());
     },
-    [setSelected]
+    [setActiveSelected, setSelected]
   );
+
+  const selectedList = useMemo(() => Array.from(selected), [selected]);
 
   if (!fields.length) {
     return null;
@@ -185,6 +190,7 @@ const HiddenFieldsSection = () => {
           listItems={listItems}
           draggable={false}
           onSelected={handleSelected}
+          selected={selectedList}
         />
       )}
     </>

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2592,7 +2592,7 @@ __metadata:
     "@types/styled-components": "npm:^5.1.23"
     "@use-gesture/react": "npm:^10.3.0"
     "@vitejs/plugin-react-refresh": "npm:^1.3.3"
-    "@voxel51/voodo": "npm:^0.0.19"
+    "@voxel51/voodo": "npm:^0.0.20"
     "@xstate/react": "npm:1.3.3"
     classnames: "npm:^2.2.6"
     color: "npm:^4.2.3"
@@ -7326,9 +7326,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@voxel51/voodo@npm:^0.0.19":
-  version: 0.0.19
-  resolution: "@voxel51/voodo@npm:0.0.19"
+"@voxel51/voodo@npm:^0.0.20":
+  version: 0.0.20
+  resolution: "@voxel51/voodo@npm:0.0.20"
   dependencies:
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/sortable": "npm:^10.0.0"
@@ -7345,7 +7345,7 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
     react-is: ^18.0.0
-  checksum: 10/215486dfda2b133cdb1758a18b8d0a67ff258fa3b43ed090f2faa005e26834e881eacc6ac9404fce271170449bd2c96239dc0810bb38da7940d24e98692e9e7b
+  checksum: 10/dc0a8e4ad6e25b4a90ffeff174c9d00fe163dc3f54d3e334f7b83845b4445c4f8429772c637ff635071dd2aff2a9fd7ff0a2a86dadc292091d91b171fbfe3b78
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds logic to enforce mutual exclusion between hidden and active fields in the annotation schema manager. Upon selection of one type, selection of the other type is cleared.

## How is this patch tested? If it is not, please explain why.

local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced schema field selection behavior to maintain mutually exclusive states between active and hidden field groups. Selecting fields in one section now automatically clears selections in the other.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->