### PR TITLE
[HA] Fix infinite save loop for primitive date edits FOEPD-3163

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/PrimitiveRenderer.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/PrimitiveRenderer.tsx
@@ -45,7 +45,11 @@ export default function PrimitiveRenderer({
         selected={fieldValue as Date}
         showTimeSelect={type === "datetime"}
         onChange={(date: Date | null) => {
-          handleChange(date);
+          if (date && !Number.isNaN(date.getTime())) {
+            handleChange(date.toISOString());
+          } else {
+            handleChange(undefined);
+          }
         }}
       />
     );


### PR DESCRIPTION
## What changes are proposed in this pull request?

Update `onChange` emission to use ISO string dates rather than raw `Date` objects, consistent with handling in #6978. This prevents the current infinite save loop behavior.

## How is this patch tested? If it is not, please explain why.

local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced date validation in the date picker component to prevent invalid or malformed dates from being processed. Valid dates are now properly formatted before being handled, while null or invalid entries are appropriately skipped, ensuring data consistency and improving the reliability of date input operations throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->