### PR TITLE
Bug datetime primitive undo

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/PrimitiveEdit.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/PrimitiveEdit.tsx
@@ -82,9 +82,7 @@ export default function PrimitiveEdit({
           const hasOldValue = !isNullish(oldValue);
           let oldValueSerialized = oldValue;
           if (type === "date" || type === "datetime") {
-            oldValueSerialized = serializeDatabaseDateValue(
-              oldValue as { datetime: number }
-            );
+            oldValueSerialized = serializeDatabaseDateValue(oldValue);
           }
 
           sampleMutationManager.stageMutation(path, {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/serialization.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/serialization.ts
@@ -1,4 +1,4 @@
-import { Primitive } from "@fiftyone/utilities";
+import { isNullish, Primitive } from "@fiftyone/utilities";
 
 /**
  * Problem: user is in EST, server is in UTC. User picks a
@@ -28,10 +28,22 @@ export function serializeDateValue(type: string, date: Date): string {
  * @param value - The value to serialize
  * @returns The serialized value
  */
-export function serializeDatabaseDateValue(value: {
-  datetime: number;
-}): Primitive {
+export function serializeDatabaseDateValue(
+  value: Primitive | { datetime: number }
+): Primitive {
+  if (!isDateInDatabaseFormat(value)) return value;
   return new Date(value.datetime).toISOString();
+}
+
+/**
+ * Is input in format { _cls: "DateTime", datetime: number }?
+ * @param value - The value to check
+ * @returns True if the value is in the format { _cls: "DateTime", datetime: number }, false otherwise
+ */
+export function isDateInDatabaseFormat(
+  value: unknown
+): value is { datetime: number } {
+  return !isNullish(value) && typeof value === "object" && "datetime" in value;
 }
 
 /**


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixing autosave loop with malformed data

[datetime_fix.webm](https://github.com/user-attachments/assets/e7d677fc-941a-42d1-bef3-c7eb69db75cd)


## How is this patch tested? If it is not, please explain why.

Tested locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed undo for date and datetime field edits so reverted values restore correctly, including values stored in database-specific date/datetime formats.
  * Improved reliability when reverting empty or null date values to prevent incorrect deletions or malformed restores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->