### PR TITLE
Omit unlisted operators by default in `fiftyone operators list`

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -843,23 +843,24 @@ List operators and panels that are installed locally.
 
 .. code-block:: text
 
-    fiftyone operators list [-h] [-g PATT] [-e] [-d] [-b] [-c] [-o] [-p] [-n]
+    fiftyone operators list [-h] [-g PATT] [-e] [-d] [-b] [-c] [-o] [-p] [-n] [-u]
 
 **Arguments**
 
 .. code-block:: text
 
     optional arguments:
-      -h, --help            show this help message and exit
+      -h, --help              show this help message and exit
       -g PATT, --glob-patt PATT
-                            only show operators whose URI matches the glob pattern
-      -e, --enabled         only show enabled operators and panels
-      -d, --disabled        only show disabled operators and panels
-      -b, --builtins-only   only show builtin operators and panels
-      -c, --no-builtins     only show non-builtin operators and panels
-      -o, --operators-only  only show operators
-      -p, --panels-only     only show panels
-      -n, --names-only      only show names
+                              only show operators whose URI matches the glob pattern
+      -e, --enabled           only show enabled operators and panels
+      -d, --disabled          only show disabled operators and panels
+      -b, --builtins-only     only show builtin operators and panels
+      -c, --no-builtins       only show non-builtin operators and panels
+      -o, --operators-only    only show operators
+      -p, --panels-only       only show panels
+      -n, --names-only        only show names
+      -u, --include-unlisted  include unlisted operators
 
 **Examples**
 


### PR DESCRIPTION
## Release Notes

N/A

## Description

`fiftyone operators list` will now omit unlisted operators by default, for consistency with the fact that "unlisted" means "not intended for direct usage by end users".

A `fiftyone operators list -u` option is added to opt-in to including unlisted operators, if desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-u/--include-unlisted` flag to the `fiftyone operators list` command. Users can now include unlisted operators in the output, displayed with their unlisted status in an additional column.

* **Documentation**
  * Improved formatting and alignment of help text for the operators list command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->