### PR TITLE
FOEPD-3140: reflect explore sidebar settings in label visibility in annotate

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Annotate.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Annotate.tsx
@@ -13,7 +13,7 @@ import LabelEntry from "./LabelEntry";
 import LoadingEntry from "./LoadingEntry";
 import PrimitiveEntry from "./PrimitiveEntry";
 import SchemaManager from "./SchemaManager";
-import { activeLabelSchemas, labelSchemasData, showModal } from "./state";
+import { labelSchemasData, showModal, visibleLabelSchemas } from "./state";
 import type { AnnotationDisabledReason } from "./useCanAnnotate";
 import useEntries from "./useEntries";
 import useLabels from "./useLabels";
@@ -22,7 +22,7 @@ import { useAnnotationContextManager } from "./useAnnotationContextManager";
 import useDelete from "./Edit/useDelete";
 import { KnownContexts, useUndoRedo } from "@fiftyone/commands";
 
-const showImportPage = atom((get) => !get(activeLabelSchemas)?.length);
+const showImportPage = atom((get) => !get(visibleLabelSchemas)?.length);
 
 const DISABLED_MESSAGES: Record<
   Exclude<AnnotationDisabledReason, null>,

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/state.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/state.ts
@@ -11,10 +11,10 @@ import { atom, PrimitiveAtom, useAtomValue } from "jotai";
 import { atomFamily, atomWithReset } from "jotai/utils";
 import { capitalize } from "lodash";
 import {
-  activeLabelSchemas,
   fieldType,
   isFieldReadOnly,
   labelSchemaData,
+  visibleLabelSchemas,
 } from "../state";
 import { addLabel, labels, labelsByPath } from "../useLabels";
 import { activePrimitiveAtom } from "./useActivePrimitive";
@@ -202,7 +202,7 @@ const fieldsOfType = atomFamily((type: LabelType) =>
   atom((get) => {
     const fields = new Array<string>();
 
-    for (const field of get(activeLabelSchemas) ?? []) {
+    for (const field of get(visibleLabelSchemas) ?? []) {
       if (type && IS[type].has(get(fieldType(field)))) {
         const fieldSchema = get(labelSchemaData(field));
         const fieldReadOnly = isFieldReadOnly(fieldSchema);

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/state.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/state.ts
@@ -24,6 +24,29 @@ export const labelSchemaData = atomFamily((field: string) => {
 
 export const activeLabelSchemas = atom<string[] | null>(null);
 
+/**
+ * Mirror of Recoil activeFields({ modal: true }), written by Sidebar.tsx.
+ * Can't read Recoil from inside a Jotai atom's getter, so we need the data
+ * bridged into a Jotai atom. null means not yet active (falls through to
+ * activeLabelSchemas).
+ */
+export const exploreActiveFields = atom<string[] | null>(null);
+
+/**
+ * Intersection of activeLabelSchemas and exploreActiveFields.
+ * Display consumers should read this instead of activeLabelSchemas so that
+ * hiding a field in the Explore sidebar also hides it in Annotate.
+ */
+export const visibleLabelSchemas = atom((get) => {
+  const active = get(activeLabelSchemas);
+  const explore = get(exploreActiveFields);
+
+  if (!active || !explore) return [];
+
+  const exploreSet = new Set(explore);
+  return active.filter((field) => exploreSet.has(field));
+});
+
 export const inactiveLabelSchemas = atom((get) =>
   Object.keys(get(labelSchemasData) ?? {})
     .sort()
@@ -109,9 +132,7 @@ export const showModal = atom(false);
  * User-set schema `read_only` (from Schema Manager) takes precedence,
  * then falls back to field-level `read_only` (from Python backend).
  */
-export const isFieldReadOnly = (
-  data: LabelSchemaMeta | undefined
-): boolean => {
+export const isFieldReadOnly = (data: LabelSchemaMeta | undefined): boolean => {
   return !!data?.label_schema?.read_only || !!data?.read_only;
 };
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useEntries.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useEntries.ts
@@ -2,14 +2,14 @@ import { EntryKind, type SidebarEntry } from "@fiftyone/state";
 import { getDefaultStore, useAtomValue } from "jotai";
 import { useMemo } from "react";
 import { LABELS_GROUP_NAME, labelsExpanded } from "./GroupEntry";
-import { activeLabelSchemas } from "./state";
+import { visibleLabelSchemas } from "./state";
 import { LabelsState, labelAtoms, labelsState } from "./useLabels";
 import usePrimitiveEntries from "./usePrimitiveEntries";
 const store = getDefaultStore();
 
 const useEntries = (): [SidebarEntry[], (entries: SidebarEntry[]) => void] => {
   const atoms = useAtomValue(labelAtoms);
-  const activeFields = useAtomValue(activeLabelSchemas);
+  const activeFields = useAtomValue(visibleLabelSchemas);
   const state = useAtomValue(labelsState);
   const primitiveEntries = usePrimitiveEntries(activeFields || []);
   const expanded = useAtomValue(labelsExpanded);

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
@@ -16,9 +16,9 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { selector, useRecoilCallback, useRecoilValue } from "recoil";
 import type { LabelType } from "./Edit/state";
 import {
-  activeLabelSchemas,
   isFieldReadOnly,
   labelSchemasData,
+  visibleLabelSchemas,
 } from "./state";
 import { useAddAnnotationLabelToRenderer } from "./useAddAnnotationLabelToRenderer";
 import useFocus from "./useFocus";
@@ -283,7 +283,7 @@ export default function useLabels() {
   const modalSample = useModalSample();
   const setLabels = useSetAtom(labels);
   const setLoading = useSetAtom(labelsState);
-  const active = useAtomValue(activeLabelSchemas);
+  const active = useAtomValue(visibleLabelSchemas);
   const addLabelToRenderer = useAddAnnotationLabelToRenderer();
   const addLabelToStore = useSetAtom(addLabel);
   const createLabel = useCreateAnnotationLabel();
@@ -300,19 +300,20 @@ export default function useLabels() {
   const loadingRef = useRef(LabelsState.UNSET);
 
   const getFieldType = useRecoilCallback(
-    ({ snapshot }) => async (path: string) => {
-      const loadable = await snapshot.getLoadable(field(path));
-      const type = loadable
-        .getValue()
-        ?.embeddedDocType?.split(".")
-        .slice(-1)[0];
+    ({ snapshot }) =>
+      async (path: string) => {
+        const loadable = await snapshot.getLoadable(field(path));
+        const type = loadable
+          .getValue()
+          ?.embeddedDocType?.split(".")
+          .slice(-1)[0];
 
-      if (!type) {
-        throw new Error("no type");
-      }
+        if (!type) {
+          throw new Error("no type");
+        }
 
-      return type as LabelType;
-    },
+        return type as LabelType;
+      },
     []
   );
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useSamplePrimitives.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useSamplePrimitives.ts
@@ -2,10 +2,10 @@ import { State, fieldPaths } from "@fiftyone/state";
 import { DICT_FIELD, VALID_PRIMITIVE_TYPES } from "@fiftyone/utilities";
 import { useAtomValue } from "jotai";
 import { useRecoilValue } from "recoil";
-import { activeLabelSchemas } from "./state";
+import { visibleLabelSchemas } from "./state";
 
 const useSamplePrimitives = (): string[] => {
-  const activeFields = useAtomValue(activeLabelSchemas);
+  const activeFields = useAtomValue(visibleLabelSchemas);
   const primitivePaths = useRecoilValue(
     fieldPaths({
       space: State.SPACE.SAMPLE,

--- a/app/packages/core/src/components/Modal/Sidebar/Sidebar.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Sidebar.tsx
@@ -1,11 +1,12 @@
 import {
+  activeFields,
   ANNOTATE,
   EXPLORE,
   datasetName,
   modalMode,
   useModalExplorEntries,
 } from "@fiftyone/state";
-import { useAtomValue } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import { useEffect } from "react";
 import { useRecoilValue } from "recoil";
 import ExploreSidebar from "../../Sidebar";
@@ -13,6 +14,7 @@ import SidebarContainer from "../../Sidebar/SidebarContainer";
 import Annotate from "./Annotate";
 import { AnnotationSliceSelector } from "./Annotate/AnnotationSliceSelector";
 import { GroupModeTransitionManager } from "./Annotate/GroupModeTransitionManager";
+import { exploreActiveFields } from "./Annotate/state";
 import useCanAnnotate from "./Annotate/useCanAnnotate";
 import useLoadSchemas from "./Annotate/useLoadSchemas";
 import Mode from "./Mode";
@@ -36,6 +38,15 @@ const Sidebar = () => {
   const { showAnnotationTab, disabledReason, isGroupedDataset } =
     useCanAnnotate();
   const datasetNameValue = useRecoilValue(datasetName);
+  const exploreFields = useRecoilValue(
+    activeFields({ modal: true, expanded: false })
+  );
+  const setExploreFields = useSetAtom(exploreActiveFields);
+
+  useEffect(() => {
+    setExploreFields(exploreFields);
+    return () => setExploreFields(null);
+  }, [exploreFields, setExploreFields]);
 
   const loadSchemas = useLoadSchemas();
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

annotation sidebar field visibility should also reflect explore sidebar settings

## How is this patch tested? If it is not, please explain why.

Both dropdown options and labels in the annotation sidebar should also reflect the explore sidebar's visibility settings


https://github.com/user-attachments/assets/51bf4984-7482-45ac-957a-eae275b237b7


https://github.com/user-attachments/assets/692d66ee-b6e4-4eb2-9435-87134faf5100




## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved label schema filtering in the annotation modal. Label availability is now determined by active field visibility, providing a more contextual and accurate presentation of available labels based on the current annotation context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->