### PR TITLE
normalize data prior to comparison

### DIFF
--- a/app/packages/core/src/utils/json.ts
+++ b/app/packages/core/src/utils/json.ts
@@ -1,6 +1,41 @@
 import * as jsonpatch from "fast-json-patch";
 
 /**
+ * Normalize data for accurate comparison.
+ *
+ * @param data Data to normalize
+ */
+const normalizeData = (data: unknown): unknown => {
+  if (data && typeof data === "object" && !Array.isArray(data)) {
+    const obj = data as Record<string, unknown>;
+
+    // convert dates from {_cls: "DateTime": datetime: 12345...} to iso strings
+    if (obj._cls === "DateTime" && typeof obj.datetime === "number") {
+      try {
+        const date = new Date(obj.datetime);
+        if (!Number.isNaN(date.getTime())) {
+          return date.toISOString();
+        }
+      } catch (err) {
+        console.warn("failed to parse date", err);
+      }
+    }
+
+    // recursively normalize objects
+    return Object.fromEntries(
+      Object.entries(obj).map(([k, v]) => [k, normalizeData(v)])
+    );
+  }
+
+  // recursively normalize lists
+  if (Array.isArray(data)) {
+    return data.map(normalizeData);
+  }
+
+  return data;
+};
+
+/**
  * Create an array of patches from the differences between two objects.
  *
  * @param from From object
@@ -12,7 +47,7 @@ export const generateJsonPatch = <
   from: T,
   to: T
 ): jsonpatch.Operation[] => {
-  return jsonpatch.compare(from, to);
+  return jsonpatch.compare(normalizeData(from), normalizeData(to));
 };
 
 /**


### PR DESCRIPTION
## What changes are proposed in this pull request?

Normalize data prior to computing JSON-patch deltas. This specifically handles date/date-time comparisons where serialization formats are causing discrepancies

## How is this patch tested? If it is not, please explain why.

local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of data comparison and JSON patching by enhancing DateTime object handling and standardizing data structure normalization for more reliable data synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->