### PR TITLE
[HA] Add test coverage for JSON-patch data normalization

### DIFF
--- a/app/packages/core/src/utils/json.test.ts
+++ b/app/packages/core/src/utils/json.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { normalizeData } from "./json";
+
+describe("normalizeData", () => {
+  it("should leave primitive values unchanged", () => {
+    const primitives = [
+      "some string",
+      123,
+      123.123,
+      true,
+      false,
+      null,
+      undefined,
+    ];
+
+    primitives.forEach((primitive) =>
+      expect(normalizeData(primitive)).toBe(primitive)
+    );
+  });
+
+  it("should recursively process lists of data", () => {
+    // no fields with special handling
+    const data = ["some string", { property: "value" }];
+
+    expect(normalizeData(data)).toStrictEqual(data);
+  });
+
+  it("should recursively process nested objects", () => {
+    const data = {
+      foo: {
+        bar: "baz",
+      },
+    };
+
+    expect(normalizeData(data)).toStrictEqual(data);
+  });
+
+  /**
+   * Dates are expected to be converted from the server-serialized format
+   * to an ISO string.
+   */
+  describe("dates", () => {
+    const date = new Date();
+    // mimics format of dates serialized by the server
+    const serializedDate = {
+      _cls: "DateTime",
+      datetime: date.getTime(),
+    };
+    const isoString = date.toISOString();
+
+    it("should convert serialized dates to iso strings", () => {
+      expect(normalizeData(serializedDate)).toBe(isoString);
+    });
+
+    it("should process dates in nested objects", () => {
+      const data = {
+        foo: serializedDate,
+        bar: "other data",
+      };
+
+      const normalized = normalizeData(data);
+
+      expect(typeof normalized).toBe("object");
+      expect("foo" in (normalized as object)).toBeTruthy();
+      expect((normalized as { foo: unknown }).foo).toBe(isoString);
+    });
+
+    it("should process dates in lists", () => {
+      const data = [serializedDate];
+
+      const normalized = normalizeData(data);
+
+      expect(Array.isArray(normalized)).toBeTruthy();
+      expect((normalized as unknown[]).length).toBe(data.length);
+      expect((normalized as unknown[])[0]).toBe(isoString);
+    });
+
+    it("should process dates in lists of nested objects", () => {
+      const data = [{ foo: serializedDate }];
+
+      const normalized = normalizeData(data);
+
+      expect(Array.isArray(normalized)).toBeTruthy();
+      expect((normalized as unknown[]).length).toBe(data.length);
+
+      const obj = (normalized as unknown[])[0];
+      expect("foo" in (obj as object)).toBeTruthy();
+      expect((obj as { foo: unknown }).foo).toBe(isoString);
+    });
+
+    it("should not convert partial dates", () => {
+      const data = {
+        _cls: "DateTime",
+        foo: 123,
+      };
+
+      expect(normalizeData(data)).toStrictEqual(data);
+    });
+
+    it("should not convert invalid dates", () => {
+      const invalidTimestamps: number[] = [NaN, 1e20];
+
+      invalidTimestamps.forEach((invalidTimestamp) => {
+        const data = {
+          _cls: "DateTime",
+          datetime: invalidTimestamp,
+        };
+
+        expect(normalizeData(data)).toStrictEqual(data);
+      });
+    });
+  });
+});

--- a/app/packages/core/src/utils/json.ts
+++ b/app/packages/core/src/utils/json.ts
@@ -5,7 +5,7 @@ import * as jsonpatch from "fast-json-patch";
  *
  * @param data Data to normalize
  */
-const normalizeData = (data: unknown): unknown => {
+export const normalizeData = (data: unknown): unknown => {
   if (data && typeof data === "object" && !Array.isArray(data)) {
     const obj = data as Record<string, unknown>;
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds unit tests for expected normalization behavior when computing JSON-patch deltas. No functional change.

## How is this patch tested? If it is not, please explain why.

see tests

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for data normalization utilities, covering edge cases including date serialization, nested structures, and invalid timestamp handling.

* **Infrastructure**
  * Enhanced modularity by exposing a utility function as part of the public API for improved code reusability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->