### PR TITLE
Fix ±1px shift in _render_instance for objects_to_segmentations

### DIFF
--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -1776,25 +1776,39 @@ def _parse_segmentation_mask_targets(mask, frame_size, mask_targets):
 
 def _render_instance(mask, detection, target):
     dobj = foue.to_detected_object(detection, extra_attrs=False)
-    obj_mask, offset = etai.render_instance_mask(
-        dobj.mask, dobj.bounding_box, img=mask
-    )
+    bbox = dobj.bounding_box
+    img_h, img_w = mask.shape[:2]
 
-    x0, y0 = offset
+    # Use round() instead of int() for the start position to avoid a ±1px
+    # shift caused by independently flooring both the start and end
+    # coordinates. The mask is placed at its actual dimensions with no
+    # resize, and clipped to image bounds.
+    x0 = int(round(bbox.top_left.x * img_w))
+    y0 = int(round(bbox.top_left.y * img_h))
+
+    obj_mask = np.asarray(dobj.mask, dtype=bool)
     dh, dw = obj_mask.shape
+
+    # Clip to image bounds
+    x1 = min(x0 + dw, img_w)
+    y1 = min(y0 + dh, img_h)
+    x0 = max(x0, 0)
+    y0 = max(y0, 0)
+    obj_mask = obj_mask[: (y1 - y0), : (x1 - x0)]
+
     target = np.asarray(target)
 
     if mask.ndim == 3:
-        patch = mask[y0 : (y0 + dh), x0 : (x0 + dw), :]
+        patch = mask[y0:y1, x0:x1, :]
         if target.size == 3:
             patch[obj_mask, :] = np.reshape(target, (1, 1, 3))
         else:
             patch[obj_mask, :] = target
-        mask[y0 : (y0 + dh), x0 : (x0 + dw), :] = patch
+        mask[y0:y1, x0:x1, :] = patch
     else:
-        patch = mask[y0 : (y0 + dh), x0 : (x0 + dw)]
+        patch = mask[y0:y1, x0:x1]
         patch[obj_mask] = target
-        mask[y0 : (y0 + dh), x0 : (x0 + dw)] = patch
+        mask[y0:y1, x0:x1] = patch
 
 
 def _render_polyline(mask, polyline, target, thickness):

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -1783,8 +1783,8 @@ def _render_instance(mask, detection, target):
     # shift caused by independently flooring both the start and end
     # coordinates. The mask is placed at its actual dimensions with no
     # resize, and clipped to image bounds.
-    x0 = int(round(bbox.top_left.x * img_w))
-    y0 = int(round(bbox.top_left.y * img_h))
+    x0 = round(bbox.top_left.x * img_w)
+    y0 = round(bbox.top_left.y * img_h)
 
     obj_mask = np.asarray(dobj.mask, dtype=bool)
     dh, dw = obj_mask.shape


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix `±1px` pixel shift in `objects_to_segmentations()` caused by `_render_instance` independently flooring both start and end bounding box coordinates via `int()`.

When converting normalized bbox coordinates to pixel positions, the previous implementation delegated to `etai.render_instance_mask`, which calls `BoundingBox.coords_in()`. This independently floors both corners:

```python
x_start = int(bbox_x * image_width)              # floor
x_end   = int((bbox_x + bbox_w) * image_width)   # floor independently
target_width = x_end - x_start                    # can be ±1 vs mask.shape[1]
```
Due to floating-point arithmetic, `floor(a + b) != floor(a) + floor(b)`. When the computed target size differs from the actual mask dimensions, the mask is resized using interpolation, shifting pixels by 1-2px. The shift is intermittent — it only affects detections with fractional pixel coordinates.

**Fix:** Replace `_render_instance` to bypass `etai.render_instance_mask` entirely:
1. Compute start position using `round()` instead of `int()`
2. Place the mask at its actual dimensions — no resize needed
3. Clip to image bounds for edge cases

## How is this patch tested? If it is not, please explain why.

Tested with 10 synthetic cases covering:
- Fractional coords that trigger `floor(a+b) != floor(a) + floor(b)` on both axes
- Exact integer coords (no-op, confirms backward compatibility)
- Masks near all image boundaries (top-left, bottom-right, corners)
- Masks extending to image edges (right overflow, bottom overflow, corner overflow)
- Zero origin and full image width span

**9 out of 10** synthetic cases had `±1px` mismatch with the old `int()` approach. **All `10` pass with the fix**. 

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixed `±1px` pixel shift in `objects_to_segmentations()`.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection mask rendering and placement across images. Masks now align more accurately with detections, handle image edges and boundaries robustly, and correctly apply to both color and grayscale patches—reducing visual artifacts and misaligned segmentations near image borders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->