### PR TITLE
FOEPD-3181: toggle field annotation visibility also active on save or disgard

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/useLabelSchema.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/useLabelSchema.ts
@@ -17,7 +17,10 @@ import {
   labelSchemaData,
   removeFromActiveSchemas,
 } from "../../state";
-import { useSchemaManager } from "../../useSchemaManager";
+import {
+  useSchemaManager,
+  type UpdateSchemaRequest,
+} from "../../useSchemaManager";
 import { currentLabelSchema } from "../state";
 import { reconcileComponent } from "../utils";
 
@@ -154,7 +157,10 @@ const useSave = (field: string, visibilityChanged: boolean) => {
       const labelSchema = current ? reconcileComponent(current) : current;
 
       try {
-        await updateSchema({ field, label_schema: labelSchema });
+        await updateSchema({
+          field,
+          label_schema: labelSchema,
+        } as UpdateSchemaRequest);
       } catch (error) {
         console.error("Failed to save label schema:", error);
         setIsSaving(false);
@@ -313,12 +319,11 @@ export default function useLabelSchema(field: string) {
   // this view). Visibility is local state so it resets automatically on unmount.
   // After a successful save, savedLabelSchema is already updated before unmount,
   // so re-opening the field will show the saved state correctly.
-  const setCurrentSchema = useSetAtom(currentLabelSchema(field));
   useEffect(() => {
     return () => {
-      setCurrentSchema(undefined);
+      currentLabelSchema.remove(field);
     };
-  }, [setCurrentSchema]);
+  }, [field]);
 
   // Wrap discard to also revert visibility
   const originalDiscard = validate.discard;

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/hooks.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/hooks.ts
@@ -37,7 +37,6 @@ import {
   hiddenFieldTypes,
   isNewFieldMode,
   jsonValidationErrors,
-  pendingActiveSchemas,
   selectedActiveFields,
   selectedHiddenFields,
   sortedInactivePaths,
@@ -650,14 +649,11 @@ export const useIsLargeDataset = () => {
  */
 export const useSchemaManagerCleanup = () => {
   const setCurrentFieldAtom = useSetAtom(currentField);
-  const setPendingActiveSchemas = useSetAtom(pendingActiveSchemas);
 
   useEffect(() => {
     return () => {
       // Reset field editing state
       setCurrentFieldAtom(null);
-      // Reset pending visibility state
-      setPendingActiveSchemas(null);
     };
   }, []);
 };

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/state.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/state.ts
@@ -186,16 +186,6 @@ export const hasJsonChanges = atom((get) => {
 });
 
 // =============================================================================
-// Pending Visibility State
-// =============================================================================
-
-/**
- * Pending active schemas list. Mirrors activeLabelSchemas but only persisted
- * on save via set_active_label_schemas. null means not yet initialized.
- */
-export const pendingActiveSchemas = atom<string[] | null>(null);
-
-// =============================================================================
 // Edit Field Label Schema State
 // =============================================================================
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

In the “Edit field schema” part of the Schema Manager, the “Visible field” toggle takes immediate effect: When the user changes the state of the toggle, the field is immediately moved to/from the annotation schema and either “Active fields” or “Hidden fields” section of the Schema Manager UI.

Desired Behavior
Changing the state of the toggle doesn’t take immediate effect. The user must click the “Save” button in “Edit field schema” for it to take effect.

## How is this patch tested? If it is not, please explain why.

changed visibility of multiple fields, then save: the field visibility would not move until user clicks "save"

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Changing the state of the toggle doesn’t take immediate effect. The user must click the “Save” button in “Edit field schema” for it to take effect.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced per-field visibility management with automatic persistence when saving schema changes.

* **Improvements**
  * Streamlined field visibility logic in schema editing workflow for enhanced schema manager integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->