### PR TITLE
Pins `strawberry-graphql` version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ INSTALL_REQUIRES = [
     "sseclient-py>=1.7.2,<2",
     "sse-starlette>=0.10.3,<1",
     "starlette>=0.24.0",
-    "strawberry-graphql>=0.262.4,<=0.291.3",
+    "strawberry-graphql>=0.262.4,<0.292.0",
     "tabulate",
     "tqdm",
     "xmltodict",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Pin the upper version for `strawberry-graphql` until proper refactor can be conducted, prevents new installs from breaking due to change in `0.292.0` ([release notes](https://github.com/strawberry-graphql/strawberry/releases/tag/0.292.0))

## How is this patch tested? If it is not, please explain why.

Locally found that launching app would fail on new install with `strawberry-graphql==0.292.0`, downgraded and app launched without issue.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Avoids breaking design change from latest `strawberry-graphql` release.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened version constraints for the strawberry-graphql dependency to a defined supported range. This change reduces the risk of incompatibility with newer, untested releases and helps ensure more stable, predictable behavior across environments. No functional behavior or public interfaces were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->