### PR TITLE
Adds try-except for GraphQL init

### DIFF
--- a/fiftyone/server/app.py
+++ b/fiftyone/server/app.py
@@ -107,6 +107,13 @@ schema = gql.Schema(
     scalar_overrides=SCALAR_OVERRIDES,
 )
 
+try:  # strawberry-graphql<0.292.0
+    gqlc = GraphQL(schema, graphiql=foc.DEV_INSTALL)
+except TypeError:  # strawberry-graphql>=0.292.0
+    gqlc = GraphQL(
+        schema,
+        graphql_ide="graphiql" if foc.DEV_INSTALL else None
+    )
 
 app = Starlette(
     middleware=[
@@ -125,13 +132,11 @@ app = Starlette(
     ],
     debug=True,
     routes=[Route(route, endpoint) for route, endpoint in routes]
+
     + [
         Route(
             "/graphql",
-            GraphQL(
-                schema,
-                graphiql=foc.DEV_INSTALL,
-            ),
+            gqlc,
         ),
         Mount(
             "/plugins",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Related to #7014 but makes attempt to correct for new `strawberry-graphql` init keyword with backwards compatibility. Not the best/cleanest fix, but wanted to have CI run on it to see if it would pass. Likely better to pin the dependency for now, but if CI passes, perhaps this could suffice until another solution is found.

## How is this patch tested? If it is not, please explain why.

Untested, hence leaving as draft PR. Allows CI tests to run against changes to see if it will work. 

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
