### PR TITLE
Fix startup issues for some versions of strawberry-gql for python 3.10+

### DIFF
--- a/fiftyone/server/aggregations.py
+++ b/fiftyone/server/aggregations.py
@@ -101,27 +101,29 @@ class StringAggregation(Aggregation):
     values: t.Optional[t.List[StringAggregationValue]] = None
 
 
+_AGGREGATE_TYPES = (
+    BooleanAggregation,
+    DataAggregation,
+    IntAggregation,
+    FloatAggregation,
+    RootAggregation,
+    StringAggregation,
+)
+
 AggregateResult = t.Annotated[
-    t.Union[
-        BooleanAggregation,
-        DataAggregation,
-        IntAggregation,
-        FloatAggregation,
-        RootAggregation,
-        StringAggregation,
-    ],
+    t.Union[_AGGREGATE_TYPES],
     gql.union("AggregateResult"),
+]
+
+AggregationResponse = t.Annotated[
+    t.Union[(*_AGGREGATE_TYPES, AggregationQueryTimeout)],
+    gql.union("AggregationResponse"),
 ]
 
 
 async def aggregate_resolver(
     form: AggregationForm,
-) -> t.List[
-    t.Annotated[
-        t.Union[AggregateResult, AggregationQueryTimeout],
-        gql.union("AggregationResponse"),
-    ]
-]:
+) -> t.List[AggregationResponse]:
     if not form.dataset:
         raise ValueError("Aggregate form missing dataset")
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Remove [problematic nested unions](https://github.com/strawberry-graphql/strawberry/issues/4207) in the strawberry gql schema that can cause fiftyone service from failing to start and `ServiceListenTimeout Errors such as:

```
  >       raise ServiceListenTimeout(etau.get_class_name(self), port)                                                                                                                                                                                                                 
  E       fiftyone.core.service.ServiceListenTimeout: fiftyone.core.service.ServerService failed to bind to port 5151                                                                                                                                                                 
                                                                                                                                                                                                                                                                                      
  ../fiftyone/core/service.py:169: ServiceListenTimeout                                                                                                                                                                                                                               
                                                             
```



## How is this patch tested? If it is not, please explain why.

Tested running app in oss and teams
<img width="1453" height="1000" alt="image" src="https://github.com/user-attachments/assets/ddccc79d-a2ea-4a5b-a8c5-bc7233d63860" />

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved aggregation type handling and response structure for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->