### PR TITLE
[HA] Unify scroll in schema manager

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/index.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/index.tsx
@@ -2,7 +2,7 @@
  * Main GUI View component for editing field schema.
  */
 
-import { LoadingSpinner, scrollable } from "@fiftyone/components";
+import { LoadingSpinner } from "@fiftyone/components";
 import {
   Button,
   Size,
@@ -14,12 +14,7 @@ import {
 import { useCallback, useMemo } from "react";
 import { PRIMITIVE_FIELD_TYPES } from "../../constants";
 import { useFieldType } from "../../hooks";
-import {
-  EditSectionHeader,
-  EmptyStateBox,
-  ListContainer,
-  Section,
-} from "../../styled";
+import { EditSectionHeader, EmptyStateBox, Section } from "../../styled";
 import type { AttributeConfig, SchemaConfigType } from "../../utils";
 import AttributesSection from "./AttributesSection";
 import ClassesSection from "./ClassesSection";
@@ -132,23 +127,21 @@ const GUIContent = ({
   // Primitive field types show a different UI
   if (isPrimitive && fType) {
     return (
-      <ListContainer className={scrollable}>
-        <Section>
-          <PrimitiveFieldContent
-            field={field}
-            fieldType={fType}
-            config={config}
-            onConfigChange={onConfigChange}
-            largeLabels
-          />
-        </Section>
-      </ListContainer>
+      <Section>
+        <PrimitiveFieldContent
+          field={field}
+          fieldType={fType}
+          config={config}
+          onConfigChange={onConfigChange}
+          largeLabels
+        />
+      </Section>
     );
   }
 
   if (scanning) {
     return (
-      <ListContainer className={scrollable}>
+      <>
         <Section>
           <EditSectionHeader>
             <Text variant={TextVariant.Lg}>Classes</Text>
@@ -181,12 +174,12 @@ const GUIContent = ({
             </Button>
           </EmptyStateBox>
         </Section>
-      </ListContainer>
+      </>
     );
   }
 
   return (
-    <ListContainer className={scrollable}>
+    <>
       <ClassesSection
         classes={classes}
         attributeCount={attributes.length}
@@ -202,7 +195,7 @@ const GUIContent = ({
         onDeleteAttribute={handleDeleteAttribute}
         onOrderChange={handleAttributeOrderChange}
       />
-    </ListContainer>
+    </>
   );
 };
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/styled.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/styled.ts
@@ -33,8 +33,8 @@ export const EditContainer = styled.div`
   flex: 1;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
   margin-bottom: 2rem;
+  padding-right: 1rem;
 `;
 
 export const EditSectionHeader = styled.div`
@@ -63,7 +63,6 @@ export const SchemaSection = styled.div`
   flex: 1;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
 `;
 
 export const TabsRow = styled.div`


### PR DESCRIPTION
## What changes are proposed in this pull request?

uses same container + scroll element for all HA schema pages

[scroll.webm](https://github.com/user-attachments/assets/14d2ed19-5abe-4880-9e2e-98c5072bad35)


## How is this patch tested? If it is not, please explain why.

locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured internal component layout in the annotation schema editor for improved maintainability.

* **Style**
  * Adjusted container spacing and overflow handling in the schema management interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->