### PR TITLE
[FOEPD-3189] Pin strawberry-graphql to >=0.262.,<0.292.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ INSTALL_REQUIRES = [
     "sseclient-py>=1.7.2,<2",
     "sse-starlette>=0.10.3,<1",
     "starlette>=0.24.0",
-    "strawberry-graphql>=0.262.,<0.292.0",
+    "strawberry-graphql>=0.262.4,<0.292.0",
     "tabulate",
     "tqdm",
     "xmltodict",


### PR DESCRIPTION
## What changes are proposed in this pull request?

0.292.0 released a breaking change and it's safest for now to pin the max version

## How is this patch tested? If it is not, please explain why.

Run app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?


-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixes error launching the app due to strawberry-graphql breaking updates 

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an upper bound to the Strawberry GraphQL dependency, restricting compatible versions to 0.262.4 through 0.291.x. This clarifies supported releases and helps avoid incompatibilities with newer, untested Strawberry GraphQL versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->