### PR TITLE
[HA] Remove click threshold to prevent dropped clicks; disable pan/zoom in quick-draw

### DIFF
--- a/app/packages/lighter/src/interaction/InteractionManager.ts
+++ b/app/packages/lighter/src/interaction/InteractionManager.ts
@@ -351,6 +351,15 @@ export class InteractionManager {
       this.handleHover(this.currentPixelCoordinates, event);
     }
 
+    // To determine drag behavior, we allow for two cases:
+    //  1. A spatial drag indicates that the pointer has moved a sufficient
+    //    distance from its starting point. We allow for some epsilon of
+    //    movement to allow for normal clicks to move a few pixels.
+    //  2. A temporal drag indicates that the pointer has been pressed for a
+    //    sufficient period of time.
+    //  By combining both spatial and temporal drags, we can prevent accidental
+    //  dragging behavior when clicking (via spatial gate), while still
+    //  allowing for pixel-level drag precision (via temporal gate).
     const isDrag = this.isTemporalDrag() || this.isSpatialDragEvent(event);
 
     // Apply drag gate to prevent accidental overlay dragging on click
@@ -810,9 +819,7 @@ export class InteractionManager {
    */
   private isTemporalDrag(): boolean {
     if (this.clickStartTime) {
-      const now = new Date().getTime();
-
-      return now - this.clickStartTime > this.DRAG_TIME_THRESHOLD;
+      return Date.now() - this.clickStartTime > this.DRAG_TIME_THRESHOLD;
     }
 
     return false;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Note: this should target `v1.13.2`

* Removes a temporal click threshold, which was preventing some clicks from being handled
* Increases the drag threshold, which allows for small movements during a click without considering it a drag action
* Disables pan/zoom when drawing bounding boxes
* Disables pan/zoom which clicking an unselected overlay

## How is this patch tested? If it is not, please explain why.

local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Improved canvas interactions in annotation mode

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Improvements**
  * Click vs. drag distinction improved with combined spatial and temporal gating (movement + 500 ms) for more reliable interactions.
  * Pan/zoom now correctly disabled during overlay interactions; clicking unselected overlays auto-selects them and prevents unintended viewport gestures.
  * Drag handling refined to only start when gated conditions pass, ensuring correct emission of overlay drag/resize events and reliable selection/clearing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->