### PR TITLE
Fix annotation documentation link in release notes

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -86,7 +86,7 @@ FiftyOne 1.13.0
 
 App
 
-- New Feature: :ref:`Human Annotation! <fiftyone-annotation>` Create, edit, and
+- New Feature: :ref:`In-App Annotation <in-app-annotation>` Create, edit, and
   delete classification and detection labels on images, as well as cuboid and
   3d polylines on 3d datasets. :ref:`Dataset Managers <enterprise-can-edit>`
   can define an annotation schema to constrain all metadata edits, either


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixed broken documentation link in release notes (v1.13.0) that was pointing to a dead webpage.

- Updated reference from fiftyone-annotation to in-app-annotation
- Changed link text from "Human Annotation!" to "In-App Annotation"
- Link now correctly points to 
https://docs.voxel51.com/user_guide/annotation.html
instead of 
https://docs.voxel51.com/integrations/annotation.html#fiftyone-annotation

## How is this patch tested? If it is not, please explain why.

✅ Verified the target reference in-app-annotation exists in [annotation.rst:1](vscode-file://vscode-app/c:/Users/o00887230/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
✅ Pre-commit hooks passed (prettier validation)
Can be tested by building documentation locally and verifying the link resolves correctly

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(This is a documentation fix for previously released content, no user-facing change in functionality)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology in release notes for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->