### PR TITLE
Fix quick edit perms causing operator not found errors.

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/QuickEditEntry.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/QuickEditEntry.tsx
@@ -3,11 +3,32 @@ import { Stack } from "@mui/material";
 import { Clickable, Icon, IconName, Size } from "@voxel51/voodo";
 import { FC, ReactNode } from "react";
 import { useCanAnnotateField } from "./useCanAnnotateField";
+import useCanAnnotate from "./useCanAnnotate";
 
 type QuickEditEntryProps = {
   children: ReactNode;
   enabled: boolean;
   path: string;
+};
+
+/**
+ * Inner component that uses annotation-dependent hooks.
+ * Only mounted when the user has base annotation permission,
+ * avoiding lookups of operators that are not enabled.
+ */
+const QuickEditAction: FC<{ path: string }> = ({ path }) => {
+  const canAnnotateField = useCanAnnotateField(path);
+  const { enterAnnotationMode } = useAnnotationController();
+
+  if (!canAnnotateField) {
+    return null;
+  }
+
+  return (
+    <Clickable onClick={() => enterAnnotationMode(path)}>
+      <Icon name={IconName.Edit} size={Size.Sm} />
+    </Clickable>
+  );
 };
 
 /**
@@ -22,8 +43,7 @@ export const QuickEditEntry: FC<QuickEditEntryProps> = ({
   enabled,
   path,
 }) => {
-  const canAnnotate = useCanAnnotateField(path);
-  const { enterAnnotationMode } = useAnnotationController();
+  const { showAnnotationTab: canAnnotate } = useCanAnnotate();
 
   return (
     <Stack
@@ -33,11 +53,7 @@ export const QuickEditEntry: FC<QuickEditEntryProps> = ({
       gap={2}
     >
       {children}
-      {enabled && canAnnotate && (
-        <Clickable onClick={() => enterAnnotationMode(path)}>
-          <Icon name={IconName.Edit} size={Size.Sm} />
-        </Clickable>
-      )}
+      {enabled && canAnnotate && <QuickEditAction path={path} />}
     </Stack>
   );
 };

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useCanAnnotate.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useCanAnnotate.ts
@@ -1,4 +1,3 @@
-import { FeatureFlag, useFeature } from "@fiftyone/feature-flags";
 import {
   canAnnotate,
   isGeneratedView,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix `Operator "@voxel51/operators/activate_label_schemas" not found error when annotation is not enabled due to QuickEdit component

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved annotation permission handling in edit functionality with more efficient component organization.

* **Chores**
  * Removed unused dependencies to streamline codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->