### PR TITLE
release notes for 1.13.2 / 2.16.2

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -6,7 +6,7 @@ FiftyOne Release Notes
 
 FiftyOne Enterprise 2.16.2
 --------------------------
-*Released February 19, 2026*
+*Released February 20, 2026*
 
 Includes all updates from :ref:`FiftyOne 1.13.2 <release-notes-v1.13.2>`, plus:
 
@@ -17,7 +17,7 @@ Includes all updates from :ref:`FiftyOne 1.13.2 <release-notes-v1.13.2>`, plus:
 
 FiftyOne 1.13.2
 ---------------
-*Released February 19, 2026*
+*Released February 20, 2026*
 
 :ref:`In-App Annotation <in-app-annotation>`
 


### PR DESCRIPTION
release notes for 1.13.2 / 2.16.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added FiftyOne Enterprise 2.16.2 release notes and retained FiftyOne 1.13.2 notes for continuity
  * Clarified cross-version linkage: 1.13.2 content included alongside Enterprise 2.16.2 updates
  * Renamed "Human Annotation" to "In-App Annotation" and updated wording in release docs
* **Bug Fixes**
  * Fixed issue allowing guest users to load datasets
<!-- end of auto-generated comment: release notes by coderabbit.ai -->