### PR TITLE
Add BulkWriteContext to support saving without sample iteration

### DIFF
--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -14,7 +14,7 @@ from packaging.version import Version
 from importlib.metadata import metadata
 
 
-CLIENT_TYPE = "fiftyone"
+CLIENT_TYPE = "fiftyone-teams"
 
 FIFTYONE_DIR = os.path.dirname(os.path.abspath(__file__))
 FIFTYONE_CONFIG_DIR = os.path.join(os.path.expanduser("~"), ".fiftyone")

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -201,8 +201,7 @@ class SaveContext(_AsyncBatchWriter):
         batching_strategy=None,
         async_writes=False,
     ):
-        # Using more than one worker may introduce race conditions in the
-        # state preserved between DB writes
+        # Conservatively default to 1 until we have more testing data
         super().__init__(max_workers=1, async_writes=async_writes)
 
         batch_size, batching_strategy = fou.parse_batching_strategy(


### PR DESCRIPTION
## What changes are proposed in this pull request?

  - Extract the async batch-writing machinery (executor management, futures draining, batch submission) from SaveContext into a reusable _AsyncBatchWriter base class                                                                                                 
  - Adds a new BulkWriteContext that inherits from _AsyncBatchWriter and batches arbitrary pymongo write operations via bulk_write
- This unblocks future performance optimizations by being able to save without needing to introduce the overhead of fo.Sample and having the flexibility to save not at the sample level

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal batch-writing architecture to improve asynchronous operation processing efficiency and error handling for database write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->