### PR TITLE
CVAT integration: support >10 projects

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -4932,8 +4932,8 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         self, search_url_fcn, target, target_key, value_key
     ):
         search_url = search_url_fcn(target)
-        resp = self.get(search_url).json()
-        for info in resp["results"]:
+        results = self._get_paginated_results(search_url)
+        for info in results:
             if info[target_key] == target:
                 return info[value_key]
 


### PR DESCRIPTION
Resolves #7024

## Release Notes

- Fixes a bug in the [CVAT integration](https://docs.voxel51.com/integrations/cvat.html) where annotations could fail to load when calling `load_annotations()` if there are >10 CVAT projects

## Description

In reference to #7024 , this PR extends `_get_value_from_search()` to support paginated results (by delegating to `_get_paginated_results()`).

## How is this patch tested? If it is not, please explain why.

Not familiar with how your automated CVAT tests are set up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CVAT integration to properly handle paginated API responses, ensuring all results are retrieved across multiple pages instead of only processing the first page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->