### PR TITLE
Refactor computing embeddings with dataloader for patches

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -81,49 +81,6 @@ view_stage = _make_registrar()
 aggregation = _make_registrar()
 
 
-def _compute_id_partitions(samples, num_buckets):
-    """Partitions a sample collection's ``_id`` space into ranges using
-    MongoDB's ``$bucketAuto``.
-
-    Args:
-        samples: a :class:`SampleCollection`
-        num_buckets: the number of partitions to create
-
-    Returns:
-        a list of ``(min_id, max_id)`` :class:`bson.ObjectId` pairs, or
-        ``None`` if ``num_buckets <= 0``
-    """
-    if num_buckets <= 0:
-        return None
-
-    pipeline = samples._pipeline(
-        pipeline=[{"$bucketAuto": {"groupBy": "$_id", "buckets": num_buckets}}]
-    )
-    coll = samples._dataset._sample_collection
-    return [
-        (r["_id"]["min"], r["_id"]["max"])
-        for r in coll.aggregate(pipeline, hint={"_id": 1})
-    ]
-
-
-def _id_partition_match(partitions, worker_id):
-    """Returns a ``$match`` stage that filters to a single partition range.
-
-    Args:
-        partitions: the list from :func:`_compute_id_partitions`
-        worker_id: the zero-based worker index
-
-    Returns:
-        a ``$match`` dict, or ``None`` if the worker_id is out of range
-    """
-    if worker_id >= len(partitions):
-        return None
-
-    min_id, max_id = partitions[worker_id]
-    op = "$lte" if worker_id == len(partitions) - 1 else "$lt"
-    return {"$match": {"_id": {"$gte": min_id, op: max_id}}}
-
-
 class _DummyFuture:
     def __init__(self, *, value=None):
         self.value = value


### PR DESCRIPTION
## What changes are proposed in this pull request?

Refactor the patch embeddings data loader (TorchImagePatchesDataset) from a map-style Dataset to a streaming IterableDataset that reads detection metadata and resolves corresponding media in the dataloader worker, bypassing the need to materialize all bounding boxes and file paths into memory upfront. 

Retains a list-based path (_iter_list_detections) for callers that pass explicit image_paths/patches rather than a samples view

Benefits:
- memory efficient multi-worker Dataloaders
- enable batch_size > 1
-  Decode images from bytes (used by the prefetcher) instead of always reading from a file path to avoid additional file checks
- remove need to iterate over both samples and dataloader


## How is this patch tested? If it is not, please explain why.

Manual testing with compute_patch_embeddings with 'clip-vit-base32-torch` on detections field.
- [x] improved performance
- [x] output embeddings are the same

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
