### PR TITLE
move save only place in attribute card

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/AttributeFormContent.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/AttributeFormContent.tsx
@@ -136,6 +136,25 @@ const AttributeFormContent = ({
         </div>
       )}
 
+      {/* Read-only toggle */}
+      <div>
+        <Stack
+          orientation={Orientation.Row}
+          spacing={Spacing.Sm}
+          style={{ alignItems: "center", marginBottom: 4 }}
+        >
+          <Text variant={TextVariant.Md}>Read-only</Text>
+          <Toggle
+            checked={formState.read_only}
+            onChange={handleReadOnlyChange}
+            size={Size.Sm}
+          />
+        </Stack>
+        <Text variant={TextVariant.Sm} color={TextColor.Secondary}>
+          When enabled, annotators can view but cannot edit values.
+        </Text>
+      </div>
+
       {/* Component type buttons */}
       <div>
         <Text
@@ -218,25 +237,6 @@ const AttributeFormContent = ({
           )}
         </div>
       )}
-
-      {/* Read-only toggle */}
-      <div>
-        <Stack
-          orientation={Orientation.Row}
-          spacing={Spacing.Sm}
-          style={{ alignItems: "center", marginBottom: 4 }}
-        >
-          <Text variant={TextVariant.Md}>Read-only</Text>
-          <Toggle
-            checked={formState.read_only}
-            onChange={handleReadOnlyChange}
-            size={Size.Sm}
-          />
-        </Stack>
-        <Text variant={TextVariant.Sm} color={TextColor.Secondary}>
-          When enabled, annotators can view but cannot edit values.
-        </Text>
-      </div>
     </Stack>
   );
 };


### PR DESCRIPTION
## What changes are proposed in this pull request?

In the edit field schema view, 

as a user, click a label field, the save only option in the attribute card should not be at the bottom but above the component type control. 

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed duplicate read-only toggle in annotation schema form.

* **Improvements**
  * Repositioned read-only toggle for improved form workflow, allowing annotators to control whether fields can be edited or viewed only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->