### PR TITLE
[FOEPD-3169] Fix 400 bad request

### DIFF
--- a/app/packages/utilities/src/fetch.test.ts
+++ b/app/packages/utilities/src/fetch.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { setFetchFunction, getFetchFunction } from "./fetch";
+
+describe("fetch", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("Content-Type header", () => {
+    it("should set Content-Type to application/json when body is provided", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+        headers: new Headers(),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      setFetchFunction("http://localhost");
+      await getFetchFunction()("POST", "/test", { data: "value" }, "json", 0);
+
+      const [, init] = mockFetch.mock.calls[0];
+      expect(init.headers["Content-Type"]).toBe("application/json");
+    });
+
+    it("should not set Content-Type when body is not provided", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+        headers: new Headers(),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      setFetchFunction("http://localhost");
+      await getFetchFunction()("DELETE", "/test", null, "json", 0);
+
+      const [, init] = mockFetch.mock.calls[0];
+      expect(init.headers["Content-Type"]).toBeUndefined();
+    });
+  });
+});

--- a/app/packages/utilities/src/fetch.ts
+++ b/app/packages/utilities/src/fetch.ts
@@ -337,8 +337,10 @@ export const setFetchFunction = (
       }${path}`;
     }
 
+    // set content type only if body is present, otherwise it can cause Bad Request
+    // errors for endpoints that don't expect a body
     headers = mergeHeaders(
-      { "Content-Type": "application/json" },
+      body ? { "Content-Type": "application/json" } : {},
       defaultHeaders,
       headers
     );


### PR DESCRIPTION
## What changes are proposed in this pull request?

Only set content-type if there is a body, else automatically doing this to methods like DELETE that do not contain a body, will trigger a Bad Request error

## How is this patch tested? If it is not, please explain why.

- Add tests
- verified running in teams locally that there is no 400 Bad Request for lock Delete

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP request header handling to conditionally include the Content-Type header only when a request body is present.

* **Tests**
  * Added tests to verify correct Content-Type header behavior in HTTP requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->