### PR TITLE
fix label being duplicated when changing field of a label

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Field.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Field.tsx
@@ -1,11 +1,23 @@
+import { DeleteAnnotationCommand, getFieldSchema } from "@fiftyone/annotation";
+import { useCommandBus } from "@fiftyone/command-bus";
+import {
+  DelegatingUndoable,
+  KnownContexts,
+  useCreateCommand,
+} from "@fiftyone/commands";
 import { useIsWorkingInitialized } from "@fiftyone/looker-3d";
-import { isPatchesView } from "@fiftyone/state";
+import {
+  isPatchesView,
+  useModalSampleSchema,
+  useUnboundStateRef,
+} from "@fiftyone/state";
 import { useAtom, useAtomValue } from "jotai";
-import { useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { useRecoilValue } from "recoil";
 import { SchemaIOComponent } from "../../../../../plugins/SchemaIO";
 import AddSchema from "./AddSchema";
 import {
+  current,
   currentDisabledFields,
   currentField,
   currentFields,
@@ -47,15 +59,61 @@ const Field = () => {
   const disabled = useAtomValue(currentDisabledFields);
   const [currentFieldValue, setCurrentField] = useAtom(currentField);
   const isPatches = useRecoilValue(isPatchesView);
-  const schema = useMemo(() => createSchema(fields, disabled, isPatches), [
-    disabled,
-    fields,
-    isPatches,
-  ]);
+  const currentLabel = useAtomValue(current);
+  const schema = useMemo(
+    () => createSchema(fields, disabled, isPatches),
+    [disabled, fields, isPatches]
+  );
   const type = useAtomValue(currentType);
   const state = useAtomValue(editing);
+  const modalSampleSchema = useModalSampleSchema();
+  const commandBus = useCommandBus();
+  const nextFieldValue = useRef(currentFieldValue);
+  const labelId = currentLabel?.overlay?.id;
+  const currentLabelRef = useUnboundStateRef(currentLabel);
 
   const is3DAnnotationStagingInitialized = useIsWorkingInitialized();
+
+  const updateField = useCreateCommand(
+    KnownContexts.ModalAnnotate,
+    `update-${labelId}-field`,
+    useCallback(() => {
+      const currentField = currentFieldValue as string;
+      const newField = nextFieldValue.current as string;
+
+      return new DelegatingUndoable(
+        `update-${labelId}-field-action`,
+        // stage mutation on execute
+        async () => {
+          const currentLabel = currentLabelRef.current;
+          const fieldSchema = getFieldSchema(modalSampleSchema, currentField);
+          if (!currentLabel || !fieldSchema) return;
+          await commandBus.execute(
+            new DeleteAnnotationCommand(currentLabel, fieldSchema)
+          );
+          setCurrentField(newField);
+        },
+        // restore original value on undo
+        async () => {
+          const currentLabel = currentLabelRef.current;
+          const fieldSchema = getFieldSchema(modalSampleSchema, newField);
+          if (!currentLabel || !fieldSchema) return;
+          await commandBus.execute(
+            new DeleteAnnotationCommand(currentLabel, fieldSchema)
+          );
+          setCurrentField(currentField);
+        }
+      );
+    }, [
+      modalSampleSchema,
+      currentLabelRef,
+      commandBus,
+      setCurrentField,
+      labelId,
+      currentFieldValue,
+    ]),
+    () => true
+  );
 
   return (
     <>
@@ -67,7 +125,8 @@ const Field = () => {
             smartForm={true}
             data={{ field: currentFieldValue }}
             onChange={({ field }) => {
-              setCurrentField(field);
+              nextFieldValue.current = field;
+              updateField.callback();
             }}
           />
         </div>

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/state.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/state.ts
@@ -1,4 +1,4 @@
-import { type AnnotationLabel } from "@fiftyone/state";
+import type { AnnotationLabel } from "@fiftyone/state";
 import {
   CLASSIFICATION,
   CLASSIFICATIONS,
@@ -18,6 +18,7 @@ import {
 } from "../state";
 import { addLabel, labels, labelsByPath } from "../useLabels";
 import { activePrimitiveAtom } from "./useActivePrimitive";
+import { buildNewLabelData } from "./useCreate";
 
 export const savedLabel = atom<AnnotationLabel["data"] | null>(null);
 
@@ -107,16 +108,21 @@ export const currentField = atom(
     return get(current)?.path;
   },
   (get, set, path: string) => {
-    const label = get(current);
+    const currentLabel = get(current);
 
     // no label or label is already set to this field
-    if (!label || label.path === path) {
+    if (!currentLabel || currentLabel.path === path) {
       return;
     }
 
-    label.overlay?.updateField(path);
-    label.overlay?.updateLabel({ _id: label.data._id });
-    set(current, { ...label, path, data: { _id: label.data._id } });
+    const currentData = currentLabel.data;
+    const data = buildNewLabelData(path, currentData._cls, currentData?._id);
+    data.bounding_box = currentData?.bounding_box;
+
+    currentLabel.overlay?.updateField(path);
+    currentLabel.overlay?.updateLabel(data);
+
+    set(current, { ...currentLabel, path, data });
   }
 );
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useCreate.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useCreate.ts
@@ -45,32 +45,11 @@ const useCreateAnnotationLabel = () => {
 
       // Extract default values from the label schema for new annotations
       const fieldSchema = store.get(labelSchemaData(field));
-      const labelSchema = fieldSchema?.label_schema;
-      const defaults: Record<string, unknown> = {};
 
-      // Top-level default applies to the "label" value (e.g., default class)
-      if (labelSchema?.default !== undefined) {
-        defaults.label = labelSchema.default;
-      }
-
-      // Attribute-level defaults
-      if (Array.isArray(labelSchema?.attributes)) {
-        for (const attr of labelSchema.attributes) {
-          if (attr.name && attr.default !== undefined) {
-            defaults[attr.name] = attr.default;
-          }
-        }
-      }
-
-      const data = {
-        _id: id,
-        ...defaults,
-        ...(labelValue && { label: labelValue }),
-      };
+      // Build label data with defaults and quick draw values (if applicable)
+      const data = buildNewLabelData(field, type, id, labelValue);
 
       if (type === CLASSIFICATION) {
-        data["_cls"] = "Classification";
-
         const overlay = overlayFactory.create<
           ClassificationOptions,
           ClassificationOverlay
@@ -87,8 +66,6 @@ const useCreateAnnotationLabel = () => {
       }
 
       if (type === DETECTION) {
-        data["_cls"] = "Detection";
-
         const readOnly = isFieldReadOnly(fieldSchema);
 
         const overlay = overlayFactory.create<
@@ -107,10 +84,6 @@ const useCreateAnnotationLabel = () => {
         scene?.enterInteractiveMode(handler);
         store.set(savedLabel, data);
         return { data, overlay, path: field, type };
-      }
-
-      if (type === POLYLINE) {
-        throw new Error("todo");
       }
 
       return undefined;
@@ -150,4 +123,52 @@ export default function useCreate(type: LabelType) {
     },
     [createAnnotationLabel, setEditing, type]
   );
+}
+
+export function buildNewLabelData(
+  field: string,
+  type: LabelType,
+  id?: string,
+  label?: string
+) {
+  const labelId = id || objectId();
+  const store = getDefaultStore();
+
+  // Extract default values from the label schema for new annotations
+  const fieldSchema = store.get(labelSchemaData(field));
+  const labelSchema = fieldSchema?.label_schema;
+  const defaults: Record<string, unknown> = {};
+  const labelValue = label || labelSchema?.classes?.[0];
+
+  // Top-level default applies to the "label" value (e.g., default class)
+  if (labelSchema?.default !== undefined) {
+    defaults.label = labelSchema.default;
+  }
+
+  // Attribute-level defaults
+  if (Array.isArray(labelSchema?.attributes)) {
+    for (const attr of labelSchema.attributes) {
+      if (attr.name && attr.default !== undefined) {
+        defaults[attr.name] = attr.default;
+      }
+    }
+  }
+
+  const data = {
+    _cls:
+      type === CLASSIFICATION
+        ? "Classification"
+        : type === DETECTION
+        ? "Detection"
+        : undefined,
+    _id: labelId,
+    ...defaults,
+    ...(labelValue && { label: labelValue }),
+  };
+
+  if (type === POLYLINE) {
+    throw new Error("todo");
+  }
+
+  return data;
 }

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useSchemaManager.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useSchemaManager.ts
@@ -43,6 +43,8 @@ type FieldSchema = {
   range?: [number, number];
   values?: (string | number)[];
   classes?: string[];
+  default?: unknown;
+  attributes?: Record<string, unknown>;
 };
 
 /**


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently, when changing the field of a label, it creates a new label with the new field and also keeps the previous label with previous field causing various issues.

## How is this patch tested? If it is not, please explain why.

Using Annotation sidebar

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

fix label being duplicated when changing field of a label

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Field edits in modal annotations are now staged and fully undoable/redoable via a managed update flow.
  * Quick editing paths now funnel through the staged update flow so all field changes are captured.

* **Bug Fixes**
  * Prevents rendering and update actions before the modal is fully initialized.

* **Refactor**
  * Centralized label data construction and extended schema fields to support defaults and additional attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->