### PR TITLE
[HA] add keybinding to reset zoom/pan in lighter

### DIFF
--- a/app/packages/annotation/src/hooks/index.ts
+++ b/app/packages/annotation/src/hooks/index.ts
@@ -6,4 +6,5 @@ export * from "./useLabelPersistence";
 export * from "./usePatchSample";
 export * from "./useRegisterAnnotationCommandHandlers";
 export * from "./useRegisterAnnotationEventHandlers";
+export * from "./useRegisterAnnotationKeyBindings";
 export * from "./useRegisterRendererEventHandlers";

--- a/app/packages/annotation/src/hooks/useRegisterAnnotationKeyBindings.ts
+++ b/app/packages/annotation/src/hooks/useRegisterAnnotationKeyBindings.ts
@@ -1,0 +1,19 @@
+import { KnownContexts, useKeyBindings } from "@fiftyone/commands";
+import { useLighter } from "@fiftyone/lighter";
+
+export const useRegisterAnnotationKeybindings = () => {
+  const { scene } = useLighter();
+
+  useKeyBindings(
+    KnownContexts.ModalAnnotate,
+    [
+      {
+        commandId: "lighter-reset-zoom-pan",
+        sequence: "r",
+        handler: () => scene.resetZoomPan(),
+        label: "Reset zoom and pan",
+      },
+    ],
+    [scene]
+  );
+};

--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -2,6 +2,7 @@ import {
   useAutoSave,
   useRegisterAnnotationCommandHandlers,
   useRegisterAnnotationEventHandlers,
+  useRegisterAnnotationKeybindings,
   useRegisterRendererEventHandlers,
 } from "@fiftyone/annotation";
 import {
@@ -67,6 +68,7 @@ const SpacesContainer = styled.div`
 const AnnotationHandlerRegistration = () => {
   useRegisterAnnotationCommandHandlers();
   useRegisterAnnotationEventHandlers();
+  useRegisterAnnotationKeybindings();
   useRegisterRendererEventHandlers();
   useAnnotationTracking();
 

--- a/app/packages/lighter/src/core/Scene2D.ts
+++ b/app/packages/lighter/src/core/Scene2D.ts
@@ -643,6 +643,13 @@ export class Scene2D {
   }
 
   /**
+   * Reset the scene's zoom level to 100% and clears pan translation.
+   */
+  resetZoomPan(): void {
+    this.config.renderer.resetZoomPan();
+  }
+
+  /**
    * Gets the canvas bounding rectangle for coordinate conversion.
    * This is a safer alternative to getCanvas() when you only need the bounds.
    * @returns The DOMRect of the canvas element.

--- a/app/packages/lighter/src/renderer/PixiRenderer2D.ts
+++ b/app/packages/lighter/src/renderer/PixiRenderer2D.ts
@@ -91,12 +91,8 @@ export class PixiRenderer2D implements Renderer2D {
     // to re-render the scene with updated scaling
     // TODO: throttle?
     this.viewport.on("zoomed", (_data) => {
-      if (this.viewport) {
-        this.eventBus.dispatch("lighter:zoomed", {
-          scale: this.viewport.scaled,
-        });
-        this.emitViewportMoved();
-      }
+      this.emitViewportZoomed();
+      this.emitViewportMoved();
     });
 
     this.viewport.on("moved", () => {
@@ -663,6 +659,17 @@ export class PixiRenderer2D implements Renderer2D {
   }
 
   /**
+   * Reset the viewport's zoom to 100% and clears any pan translation.
+   */
+  resetZoomPan(): void {
+    this.viewport?.setZoom(1);
+    this.viewport?.moveCorner(0, 0);
+
+    this.emitViewportZoomed();
+    this.emitViewportMoved();
+  }
+
+  /**
    * Disables zoom and pan interactions (e.g., during overlay dragging).
    * This prevents viewport plugins from interfering with overlay interactions.
    */
@@ -725,6 +732,18 @@ export class PixiRenderer2D implements Renderer2D {
       x: this.viewport.x,
       y: this.viewport.y,
     };
+  }
+
+  /**
+   * Emits a zoomed event with the current scale.
+   * @private
+   */
+  private emitViewportZoomed(): void {
+    if (this.viewport) {
+      this.eventBus.dispatch("lighter:zoomed", {
+        scale: this.viewport.scaled,
+      });
+    }
   }
 
   /**

--- a/app/packages/lighter/src/renderer/Renderer2D.ts
+++ b/app/packages/lighter/src/renderer/Renderer2D.ts
@@ -127,6 +127,11 @@ export interface Renderer2D {
   getCanvas(): HTMLCanvasElement;
 
   /**
+   * Reset the renderer's zoom level to 100% and clear any pan translation.
+   */
+  resetZoomPan(): void;
+
+  /**
    * Disables zoom and pan interactions (e.g., during overlay dragging).
    */
   disableZoomPan(): void;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds a keybinding for `r` to reset scene's pan/zoom.

## How is this patch tested? If it is not, please explain why.

local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Added keybinding to reset pan/zoom in annotation mode.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard shortcut to reset zoom and pan in annotation mode. Press "r" to return to the default zoom level and pan position while annotating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->