### PR TITLE
[HA] Handle null primitives in undo redo

### DIFF
--- a/app/packages/annotation/src/deltas.ts
+++ b/app/packages/annotation/src/deltas.ts
@@ -279,7 +279,7 @@ const buildPrimitiveMutationDelta = (
   // convert any undefined values to null so they are serialized
   // as null for the server
   const newValue = data ?? null;
-  const existingValue = get(sample, path) ?? (null as Primitive);
+  const existingValue = get(sample, path) ?? null;
 
   // If the value hasn't changed, return empty deltas
   if (arePrimitivesEqual(existingValue, newValue)) {


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Handles case where null values cannot be undone/redone
- Fixes typing issue


[primitive_null.webm](https://github.com/user-attachments/assets/772dee52-f3fe-416c-a458-571971aa2c9c)



## How is this patch tested? If it is not, please explain why.

locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistently treat undefined values as null in annotation deltas to ensure accurate comparisons and reliable add/replace/delete behavior.
  * Fixes edge cases in deletion and addition so mutations apply predictably.

* **Refactor**
  * Simplified delta generation logic for annotations, streamlining how mutation instructions are produced and applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->