### PR TITLE
Fix tsc errors in the analytics package.

### DIFF
--- a/app/packages/analytics/src/analytics.test.ts
+++ b/app/packages/analytics/src/analytics.test.ts
@@ -23,11 +23,11 @@ describe("Analytics", () => {
     page: vi.fn(),
     identify: vi.fn(),
     group: vi.fn(),
-  };
+  } as unknown as AnalyticsBrowser;
 
   beforeEach(() => {
     // Mock return value of AnalyticsBrowser.load
-    AnalyticsBrowser.load.mockReturnValue(mockSegment);
+    vi.mocked(AnalyticsBrowser.load).mockReturnValue(mockSegment);
     analytics = new Analytics({
       debounceInterval: 5000,
     });
@@ -125,7 +125,8 @@ describe("Analytics", () => {
 
   it("should not log debug information when debug mode is disabled", () => {
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    analytics = new Analytics({
+    analytics = new Analytics();
+    analytics.load({
       writeKey: "test",
       userId: "user",
       userGroup: "group",
@@ -151,7 +152,7 @@ describe("Analytics", () => {
     // segment should be called with context.page.url = undefined
     expect(mockSegment.track).toHaveBeenCalledWith("custom_event", undefined, {
       context: {
-        page: { url: null, path: null, title: null },
+        page: { url: undefined, path: undefined, title: undefined },
       },
     });
   });

--- a/app/packages/analytics/src/state.ts
+++ b/app/packages/analytics/src/state.ts
@@ -1,7 +1,7 @@
 import { atom } from "recoil";
 import type { AnalyticsInfo } from "./usingAnalytics";
 
-export const analyticsInfo = atom<AnalyticsInfo>({
+export const analyticsInfo = atom<AnalyticsInfo | null>({
   key: "analyticsInfo",
   default: null,
 });

--- a/app/packages/analytics/src/useAnalyticsInfo.ts
+++ b/app/packages/analytics/src/useAnalyticsInfo.ts
@@ -3,8 +3,8 @@ import { analyticsInfo } from "./state";
 import type { AnalyticsInfo } from "./usingAnalytics";
 
 export default function useAnalyticsInfo(): [
-  AnalyticsInfo,
+  AnalyticsInfo | null,
   (info: AnalyticsInfo) => void
 ] {
-  return useRecoilState<AnalyticsInfo>(analyticsInfo);
+  return useRecoilState<AnalyticsInfo | null>(analyticsInfo);
 }

--- a/app/packages/analytics/src/useTrackEvent.ts
+++ b/app/packages/analytics/src/useTrackEvent.ts
@@ -10,11 +10,11 @@ import usingAnalytics from "./usingAnalytics";
  * service.
  */
 export default function useTrackEvent() {
-  const info = useRecoilValue<AnalyticsInfo>(analyticsInfo);
+  const info = useRecoilValue<AnalyticsInfo | null>(analyticsInfo);
   return useCallback(
-    (eventName: string, properties?: Record<string, any>) => {
+    (eventName: string, properties?: Record<string, unknown>) => {
       try {
-        const analytics = usingAnalytics(info);
+        const analytics = usingAnalytics(info!);
         analytics.trackEvent(eventName, properties);
       } catch (err) {
         console.warn("Failed to track event", err);

--- a/app/packages/analytics/src/useTrackEvent.ts
+++ b/app/packages/analytics/src/useTrackEvent.ts
@@ -13,8 +13,12 @@ export default function useTrackEvent() {
   const info = useRecoilValue<AnalyticsInfo | null>(analyticsInfo);
   return useCallback(
     (eventName: string, properties?: Record<string, unknown>) => {
+      if (!info) {
+        console.warn("Analytics not initialized");
+        return;
+      }
       try {
-        const analytics = usingAnalytics(info!);
+        const analytics = usingAnalytics(info);
         analytics.trackEvent(eventName, properties);
       } catch (err) {
         console.warn("Failed to track event", err);

--- a/app/packages/analytics/src/usingAnalytics.ts
+++ b/app/packages/analytics/src/usingAnalytics.ts
@@ -1,4 +1,4 @@
-import { AnalyticsBrowser } from "@segment/analytics-next";
+import { AnalyticsBrowser, Options } from "@segment/analytics-next";
 
 export type AnalyticsInfo = {
   writeKey: string;
@@ -15,7 +15,7 @@ export type AnalyticsConfig = {
   debounceInterval: number;
 };
 
-let _analytics: Analytics = null;
+let _analytics: Analytics | null = null;
 
 export default function usingAnalytics(info: AnalyticsInfo): Analytics {
   if (!_analytics) {
@@ -28,7 +28,7 @@ export default function usingAnalytics(info: AnalyticsInfo): Analytics {
 }
 
 export class Analytics {
-  private _segment?: AnalyticsBrowser;
+  private _segment: AnalyticsBrowser | null = null;
   private _debug = false;
   private _lastEventTimestamps: Record<string, number> = {}; // Tracks last event times
   private _debounceInterval = 1000; // Default debounce interval in milliseconds (5 seconds)
@@ -42,7 +42,7 @@ export class Analytics {
     }
   }
 
-  redact(properties: Record<string, any>) {
+  redact(properties?: Record<string, unknown>) {
     if (!properties) return properties;
     return Object.keys(properties).reduce((acc, key) => {
       if (this._redactedProperties.includes(key)) {
@@ -66,7 +66,7 @@ export class Analytics {
     if (info.redact) {
       this._redactedProperties = info.redact;
     }
-    this._disableUrlTracking = info.disableUrlTracking;
+    this._disableUrlTracking = Boolean(info.disableUrlTracking);
     if (!info.writeKey) {
       if (this._debug) {
         console.warn("Analytics disabled (no write key)");
@@ -96,16 +96,20 @@ export class Analytics {
     this._segment = null;
   }
 
-  page(name?: string, properties?: {}) {
+  page(name?: string, properties?: Record<string, unknown>) {
     if (!this._segment || this._disableUrlTracking) return;
-    properties = this.redact(properties);
+    if (properties) {
+      properties = this.redact(properties);
+    }
     this._segment.page(name, properties);
   }
 
-  track(name: string, properties?: {}) {
+  track(name: string, properties?: Record<string, unknown>) {
     const now = Date.now();
     const lastTimestamp = this._lastEventTimestamps[name] || 0;
-    properties = this.redact(properties);
+    if (properties) {
+      properties = this.redact(properties);
+    }
 
     if (now - lastTimestamp < this._debounceInterval) {
       if (this._debug) {
@@ -117,9 +121,9 @@ export class Analytics {
     this._lastEventTimestamps[name] = now;
 
     if (!this._segment) return;
-    let opts;
+    let opts: Options | undefined;
     if (this._disableUrlTracking) {
-      opts = { context: { page: { url: null, path: null, title: null } } };
+      opts = { context: { page: {} } };
     }
     if (this._version) {
       opts = { ...opts, version: this._version };
@@ -130,22 +134,26 @@ export class Analytics {
     this._segment.track(name, properties, opts);
   }
 
-  trackEvent(name: string, properties?: {}) {
+  trackEvent(name: string, properties?: Record<string, unknown>) {
     this.track(name, properties);
   }
 
-  identify(userId: string, traits?: {}) {
+  identify(userId: string, traits?: Record<string, unknown>) {
     if (!this._segment) return;
-    traits = this.redact(traits);
+    if (traits) {
+      traits = this.redact(traits);
+    }
     if (this._debug) {
       console.log("identify", userId, traits);
     }
     this._segment.identify(userId, traits);
   }
 
-  group(groupId: string, traits?: {}) {
+  group(groupId: string, traits?: Record<string, unknown>) {
     if (!this._segment) return;
-    traits = this.redact(traits);
+    if (traits) {
+      traits = this.redact(traits);
+    }
     this._segment.group(groupId, traits);
   }
 }

--- a/app/packages/analytics/vite.config.ts
+++ b/app/packages/analytics/vite.config.ts
@@ -1,7 +1,7 @@
-import { UserConfig } from "vite";
+import { ESBuildOptions, UserConfig } from "vite";
 
 export default <UserConfig>{
-  esbuild: true,
+  esbuild: {} as ESBuildOptions,
   build: {
     lib: {
       entry: "src/index.ts",

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -17,7 +17,6 @@
         "node_modules",
         "dist",
         "packages/aggregations/**/*",
-        "packages/analytics/**/*",
         "packages/annotation/**/*",
         "packages/app/**/*",
         "packages/command-bus/**/*",

--- a/app/tsconfig.spec.json
+++ b/app/tsconfig.spec.json
@@ -14,7 +14,6 @@
         "node_modules",
         "dist",
         "packages/aggregations/**/*",
-        "packages/analytics/**/*",
         "packages/annotation/**/*",
         "packages/app/**/*",
         "packages/command-bus/**/*",


### PR DESCRIPTION
## What changes are proposed in this pull request?
Enabled compilation of the analytics package.  Fixed type errors.

## How is this patch tested? If it is not, please explain why.
Local compiles and unit tests.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analytics initialization can now be deferred—instantiate the service first, then load configuration separately.
  * Added support for configurable debounce intervals in analytics tracking.

* **Bug Fixes**
  * Enhanced null-safety handling; users now receive warning logs when event tracking is attempted before analytics initialization is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->