### PR TITLE
Fix stale sample model after patches view edits

### DIFF
--- a/app/packages/state/src/hooks/useUpdateSamples.test.ts
+++ b/app/packages/state/src/hooks/useUpdateSamples.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("react", () => ({
+  useCallback: (fn: any) => fn,
+}));
+
+vi.mock("react-relay", () => ({
+  useRelayEnvironment: () => ({}),
+  commitLocalUpdate: (_env: any, updater: (store: any) => void) => {
+    updater(mockStore);
+  },
+}));
+
+vi.mock("./useLookerStore", () => ({
+  stores: new Set(),
+}));
+
+import { useUpdateSamples } from "./useUpdateSamples";
+import { stores } from "./useLookerStore";
+
+let storeRecords: Record<string, any>;
+let deletedIds: string[];
+
+const mockStore = {
+  get: (id: string) => storeRecords[id] ?? null,
+  delete: (id: string) => {
+    deletedIds.push(id);
+    delete storeRecords[id];
+  },
+};
+
+const createMockRecord = () => ({
+  setValue: vi.fn(),
+});
+
+describe("useUpdateSamples", () => {
+  beforeEach(() => {
+    storeRecords = {};
+    deletedIds = [];
+    stores.clear();
+  });
+
+  it("updates Relay store records for the sample and its modal variant", () => {
+    const record = createMockRecord();
+    const modalRecord = createMockRecord();
+    storeRecords["sample-1"] = record;
+    storeRecords["sample-1-modal"] = modalRecord;
+
+    const updateSamples = useUpdateSamples();
+    const sample = { _id: "sample-1", filepath: "/img.png" };
+    updateSamples([["sample-1", sample as any]]);
+
+    expect(record.setValue).toHaveBeenCalledWith(
+      JSON.stringify(sample),
+      "sample"
+    );
+    expect(modalRecord.setValue).toHaveBeenCalledWith(
+      JSON.stringify(sample),
+      "sample"
+    );
+  });
+
+  it("deletes the source sample modal record for generated view samples", () => {
+    const patchRecord = createMockRecord();
+    storeRecords["patch-label-id"] = patchRecord;
+    storeRecords["source-1-modal"] = createMockRecord();
+
+    const updateSamples = useUpdateSamples();
+    const patchSample = {
+      _id: "patch-label-id",
+      _sample_id: "source-1",
+      filepath: "/patch.png",
+    };
+    updateSamples([["patch-label-id", patchSample as any]]);
+
+    expect(deletedIds).toContain("source-1-modal");
+    expect(storeRecords["source-1-modal"]).toBeUndefined();
+  });
+
+  it("does not delete any records for non-generated samples", () => {
+    storeRecords["sample-1"] = createMockRecord();
+
+    const updateSamples = useUpdateSamples();
+    const sample = { _id: "sample-1", filepath: "/img.png" };
+    updateSamples([["sample-1", sample as any]]);
+
+    expect(deletedIds).toHaveLength(0);
+  });
+
+  it("updates looker stores when the sample exists", () => {
+    const mockLooker = { updateSample: vi.fn() };
+    const sampleData = { sample: { _id: "s1" }, urls: {} };
+    const lookers = { get: vi.fn(() => mockLooker) } as any;
+    const samples = new Map<string, any>([["s1", sampleData]]);
+    stores.add({ samples, lookers });
+
+    const updateSamples = useUpdateSamples();
+    const newSample = { _id: "s1", filepath: "/new.png" };
+    updateSamples([["s1", newSample as any]]);
+
+    expect(samples.get("s1")).toEqual({ ...sampleData, sample: newSample });
+    expect(mockLooker.updateSample).toHaveBeenCalledWith(newSample);
+  });
+});

--- a/app/packages/state/src/hooks/useUpdateSamples.ts
+++ b/app/packages/state/src/hooks/useUpdateSamples.ts
@@ -3,77 +3,6 @@ import { commitLocalUpdate, useRelayEnvironment } from "react-relay";
 import type { ModalSample } from "../recoil";
 import { stores } from "./useLookerStore";
 
-/**
- * For generated view samples (patches/clips/frames), update the source
- * sample's cached label data in the Relay store so the modal shows fresh
- * data when the user returns to the source dataset view.
- *
- * The patch sample's `_id` is the label's `_id` within the source sample.
- * We find that label in the source sample's fields and replace it with the
- * updated data from the patch sample.
- */
-function updateSourceSampleLabel(
-  store: Parameters<Parameters<typeof commitLocalUpdate>[1]>[0],
-  patchSample: Record<string, unknown>
-): void {
-  const sourceSampleId = patchSample._sample_id;
-  if (typeof sourceSampleId !== "string") return;
-
-  const patchLabelId = patchSample._id;
-
-  const sourceIds = [sourceSampleId, `${sourceSampleId}-modal`];
-  for (const sourceId of sourceIds) {
-    const sourceRecord = store.get(sourceId);
-    if (!sourceRecord) continue;
-
-    const raw = sourceRecord.getValue("sample");
-    if (typeof raw !== "string") continue;
-
-    let sourceSample: Record<string, unknown>;
-    try {
-      sourceSample = JSON.parse(raw);
-    } catch {
-      continue;
-    }
-
-    let updated = false;
-    for (const [fieldName, fieldValue] of Object.entries(sourceSample)) {
-      if (
-        !fieldValue ||
-        typeof fieldValue !== "object" ||
-        Array.isArray(fieldValue)
-      ) {
-        continue;
-      }
-
-      // Look for array sub-fields (e.g. detections, classifications, polylines)
-      for (const [listKey, listValue] of Object.entries(
-        fieldValue as Record<string, unknown>
-      )) {
-        if (!Array.isArray(listValue)) continue;
-
-        const idx = listValue.findIndex(
-          (item: Record<string, unknown>) => item?._id === patchLabelId
-        );
-
-        if (idx !== -1 && patchSample[fieldName]) {
-          listValue[idx] = {
-            ...(listValue[idx] as Record<string, unknown>),
-            ...(patchSample[fieldName] as Record<string, unknown>),
-          };
-          updated = true;
-          break;
-        }
-      }
-      if (updated) break;
-    }
-
-    if (updated) {
-      sourceRecord.setValue(JSON.stringify(sourceSample), "sample");
-    }
-  }
-}
-
 export const useUpdateSamples = () => {
   const environment = useRelayEnvironment();
 
@@ -108,10 +37,12 @@ export const useUpdateSamples = () => {
             }
           }
 
-          updateSourceSampleLabel(
-            store,
-            sample as unknown as Record<string, unknown>
-          );
+          // For generated views (patches/clips/frames), delete the source
+          // sample's cached modal record so the next modal open fetches fresh data
+          const sourceSampleId = (sample as Record<string, unknown>)._sample_id;
+          if (typeof sourceSampleId === "string") {
+            store.delete(`${sourceSampleId}-modal`);
+          }
         }
       });
     },


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix cache issue when returning to the full dataset view after making annotation edits in the patches view and opening up the sample modal. 

## How is this patch tested? If it is not, please explain why.

- test locally
- added unit tests

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where modal views for generated samples could display stale cached data. Modal records are now properly cleaned up during updates to ensure fresh data is fetched on reopening.

* **Tests**
  * Added comprehensive test suite for sample update functionality, covering store record updates, cleanup operations, and integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->