### PR TITLE
FOEPD-3291: Fix Broken Hover Styling in Nav

### DIFF
--- a/app/packages/app/src/components/Nav.tsx
+++ b/app/packages/app/src/components/Nav.tsx
@@ -95,8 +95,10 @@ const Nav: React.FC<
           </Suspense>
         )}
         {!hasDataset && <div style={{ flex: 1 }} />}
-        <div className={iconContainer}>
+        <div style={{ padding: '0.5rem' }}>
           <Teams />
+        </div>
+        <div className={iconContainer}>
           <IconButton
             title={mode === "dark" ? "Light mode" : "Dark mode"}
             onClick={() => {
@@ -107,8 +109,7 @@ const Nav: React.FC<
             sx={{
               color: (theme) => theme.palette.text.secondary,
               m: 0,
-              height: "32px",
-              width: "32px",
+              p: "0.5rem",
             }}
           >
             {mode === "dark" ? <LightMode color="inherit" /> : <DarkMode />}

--- a/app/packages/components/src/components/Icons/Icons.module.css
+++ b/app/packages/components/src/components/Icons/Icons.module.css
@@ -3,8 +3,7 @@ div.iconContainer {
   justify-content: flex-end;
   height: 100%;
   align-items: center;
-  column-gap: 2px;
-  padding: 1rem;
+  padding-right: 1rem;
 }
 
 a.iconLink {
@@ -12,10 +11,8 @@ a.iconLink {
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  width: 32px;
-  height: 32px;
   border-radius: 50%;
-  padding: 4px;
+  padding: 0.5rem;
 }
 
 a.iconLink:hover {


### PR DESCRIPTION
## What changes are proposed in this pull request?
- Fix broken hover styling for the Theme Toggle button in the Nav Bar
- Add hover styling for the rest of the similarly styled buttons in the Nav Bar (Discord, GitHub, Documentation)

## How is this patch tested? If it is not, please explain why.

1. Open the OSS app
2. Hover your cursor over the `Theme Toggle` button in the top right of the `Nav Bar`
3. Verify the resulting hover interaction shows a circular hover shadow interaction and **not** an oval.
4. Hover your cursor over the Discord, GitHub, and Documentation buttons and verify each has a circular shadow that appears on the hover interaction.

Before:

https://github.com/user-attachments/assets/78def26f-328e-45a2-9bbb-34d964cf69af

After:

https://github.com/user-attachments/assets/b16e7dd9-63da-4b19-9eeb-d375669a2e27


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

- Improved hover styling for buttons in the Nav Bar.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted spacing and padding around the navigation icons and Teams area to improve layout balance.
  * Standardized icon button sizing and added explicit padding/margin for consistent touch targets.
  * Rounded icon link appearance and introduced a hover background for clearer interactive feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->