### PR TITLE
Fix plugin docs crash on empty headings

### DIFF
--- a/docs/scripts/generate_plugin_docs.py
+++ b/docs/scripts/generate_plugin_docs.py
@@ -129,10 +129,10 @@ class PluginDocGenerator:
         )
         self.load_dataset_pattern = re.compile(r"\bdef\s+load_dataset\s*\(")
         self.empty_heading_pattern = re.compile(
-            r"^[ \t]{0,3}#{1,6}[ \t]*$",
+            r"^\s*#{1,6}\s*$",
             flags=re.MULTILINE,
         )
-        self.heading_pattern = re.compile(r"^[ \t]{0,3}#{1,6}[ \t]+\S")
+        self.heading_pattern = re.compile(r"^\s*#{1,6}\s+\S")
 
     def _remove_emojis(self, text: str) -> str:
         """Remove emoji and miscellaneous symbols from a string.


### PR DESCRIPTION
## What changes are proposed in this pull request?

The doc build was failing with `AssertionError: Empty title` during both the HTML and Markdown build steps when processing plugin pages generated by `generate_plugin_docs.py`.

I fixed applying two conditions
- After `_remove_emojis`, strip heading lines whose text is empty (`re.sub(r"^#+\s*$", "", ...)`) so ghost headings don't reach either builder.
- Check whether any heading with actual text content remains. If not, prepend `# {display_name}` as a guaranteed fallback title

## How is this patch tested? If it is not, please explain why.

Built in local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [X] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [X] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved plugin documentation generation: removes stray/standalone heading lines and normalizes headings in README files.
  * If a plugin README lacks any headings, a top-level title is automatically added using the plugin display name.
  * Preserves existing behavior for community plugin notes so original content remains intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->