### PR TITLE
fix the schema manager not checking media type for group slices

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/hooks.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/hooks.ts
@@ -5,9 +5,12 @@
 import { useOperatorExecutor } from "@fiftyone/operators";
 import {
   datasetSampleCount,
+  groupMediaTypesMap,
+  isGroup,
   mediaType,
   queryPerformanceMaxSearch,
   useNotification,
+  usePreferredGroupAnnotationSlice,
 } from "@fiftyone/state";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { useAtomCallback } from "jotai/utils";
@@ -623,10 +626,20 @@ export const useExitNewFieldMode = () => {
 // =============================================================================
 
 /**
- * Hook to get the current dataset media type
+ * Hook to get the effective media type.
+ * For group datasets, resolves to the preferred annotation slice's media type.
  */
 export const useMediaType = () => {
-  return useRecoilValue(mediaType);
+  const datasetMediaType = useRecoilValue(mediaType);
+  const isGroupDataset = useRecoilValue(isGroup);
+  const sliceMediaTypesMap = useRecoilValue(groupMediaTypesMap);
+  const [preferredSlice] = usePreferredGroupAnnotationSlice();
+
+  if (isGroupDataset && preferredSlice && sliceMediaTypesMap[preferredSlice]) {
+    return sliceMediaTypesMap[preferredSlice];
+  }
+
+  return datasetMediaType;
 };
 
 /**


### PR DESCRIPTION
## What changes are proposed in this pull request?

support group slices in schema manager create a new label field 


## How is this patch tested? If it is not, please explain why.

- go to group dataset - 3d slice
- schema manager - add a new label

user should see a drop down of 3d detection, 3d polyline and classification label types. 

after creating the field, in the annotation side, it is updated. 


https://github.com/user-attachments/assets/4b90cea0-2aae-4bd9-a8f9-436af66cb5ab



## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
