### PR TITLE
disable drag gates to mitigate usability issues

### DIFF
--- a/app/packages/lighter/src/interaction/InteractionManager.ts
+++ b/app/packages/lighter/src/interaction/InteractionManager.ts
@@ -372,10 +372,14 @@ export class InteractionManager {
     //  By combining both spatial and temporal drags, we can prevent accidental
     //  dragging behavior when clicking (via spatial gate), while still
     //  allowing for pixel-level drag precision (via temporal gate).
-    const isDrag = this.isTemporalDrag() || this.isSpatialDragEvent(event);
+    // const isDrag = this.isTemporalDrag() || this.isSpatialDragEvent(event);
+    //
+    // todo - update handlers to be "sticky" - if a drag starts from a handler,
+    //  that handler should continue to process events even if the pointer
+    //  moves beyond its bounds.
 
     // Apply drag gate to prevent accidental overlay dragging on click
-    if (handler && isDrag) {
+    if (handler) {
       // Handle drag move
       if (!interactiveHandler) {
         handler.onMove?.(


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR disables the spatial and temporal drag gates which were previously added.

The current resizing behavior for overlays depends on the pointer remaining on the overlay's edge. The drag gates allow for the cursor to drift from its initial point before enacting the drag behavior. In this case, the overlay no longer registers the pointer movement as resizing behavior, and instead ignores the pointer events. This results in a poor resizing experience and requires some broader refactoring to fix properly.

## How is this patch tested? If it is not, please explain why.

local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag and move event handling responsiveness by allowing move events to be processed whenever a handler is available, rather than requiring specific drag conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->