### PR TITLE
FOEPD-3147 Resolve Stacking Issue With HA Label Tooltip and Schema Manager

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/styled.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/styled.ts
@@ -186,7 +186,7 @@ export const ModalBackground = styled.div`
   background: rgba(0, 0, 0, 0.8);
   top: 0;
   left: 0;
-  z-index: 20001;
+  z-index: 2000;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/app/packages/core/src/components/Modal/TooltipInfo.tsx
+++ b/app/packages/core/src/components/Modal/TooltipInfo.tsx
@@ -29,12 +29,12 @@ import { QuickEditEntry } from "./Sidebar/Annotate";
 
 const TOOLTIP_HEADER_ID = "fo-tooltip-header";
 
-const TooltipDiv = animated(styled(ContentDiv)<{ $isTooltipLocked: boolean }>`
+const TooltipDiv = animated(styled(ContentDiv) <{ $isTooltipLocked: boolean }>`
   position: absolute;
   margin-top: 0;
   left: -1000;
   top: -1000;
-  z-index: 20000;
+  z-index: 1500;
   min-width: 15rem;
   pointer-events: ${(props) => (props.$isTooltipLocked ? "auto" : "none")};
 `);
@@ -583,9 +583,8 @@ const Border = ({ color, id }) => {
   return (
     <BorderDiv
       style={{
-        borderTop: `2px ${
-          selectedLabels.has(id) ? "dashed" : "solid"
-        } ${color}`,
+        borderTop: `2px ${selectedLabels.has(id) ? "dashed" : "solid"
+          } ${color}`,
       }}
     />
   );
@@ -631,23 +630,23 @@ const AttrInfo = ({ label, field, labelType, children = null }) => {
   const attributes =
     typeof label.attributes === "object"
       ? Object.entries(
-          label.attributes as { [key: string]: { value: string | number } }
-        ).map<[string, string | number]>(([k, v]) => [
-          "attributes." + k,
-          v.value,
-        ])
+        label.attributes as { [key: string]: { value: string | number } }
+      ).map<[string, string | number]>(([k, v]) => [
+        "attributes." + k,
+        v.value,
+      ])
       : null;
 
   // we're prettifying the instance config attributes here
   const instanceAttributes = label.instance
     ? Object.entries(label.instance)
-        .filter(
-          ([k, v]) =>
-            typeof v === "string" &&
-            v.length > 0 &&
-            (k === "_id" || !k.startsWith("_"))
-        )
-        .map(([k, v]) => ["instance " + (k === "_id" ? "id" : k), v])
+      .filter(
+        ([k, v]) =>
+          typeof v === "string" &&
+          v.length > 0 &&
+          (k === "_id" || !k.startsWith("_"))
+      )
+      .map(([k, v]) => ["instance " + (k === "_id" ? "id" : k), v])
     : null;
 
   return (


### PR DESCRIPTION
## What changes are proposed in this pull request?
- Updated the `z-index` of `ModalBackground` to be higher than the `Tooltip`'s `z-index`

## How is this patch tested? If it is not, please explain why.
1. Open a sample with object detections in Annotate
2. Hover over a label instance, and click `ctrl` to persist the tooltip
3. Open the schema manager and verify the tooltip is **behind** the resulting modal

Before:

https://github.com/user-attachments/assets/94c5f7ad-5de5-48a3-a1f0-7208f0b7fc33


After:

https://github.com/user-attachments/assets/e97c84c5-efad-405d-b996-414ede4824c9

## Release Notes
- Fixed bug where tooltips would improperly render above Schema Manager

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

- Fixed bug where tooltips would improperly render above Schema Manager

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed modal dialog stacking so modals consistently appear above other page elements.

* **Style**
  * Minor formatting and whitespace improvements in tooltip-related UI code with no user-visible behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->