### PR TITLE
[HA] Prevent incorrect bookkeeping of persistence attempts

### DIFF
--- a/app/packages/annotation/src/hooks/useRegisterAnnotationEventHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterAnnotationEventHandlers.ts
@@ -24,14 +24,15 @@ export const useRegisterAnnotationEventHandlers = () => {
     useCallback(async () => {
       if (retryController.canAttempt) {
         await handlePersistenceRequest();
-        retryController.recordAttempt();
       }
-    }, [handlePersistenceRequest, retryController])
+    }, [handlePersistenceRequest, retryController.canAttempt])
   );
 
   useAnnotationEventHandler(
     "annotation:persistenceInFlight",
     useCallback(() => {
+      retryController.recordAttempt();
+
       // silence notifications when unhealthy
       if (!retryController.isUnhealthy) {
         setConfig({
@@ -41,7 +42,7 @@ export const useRegisterAnnotationEventHandlers = () => {
           timeout: INDEFINITE_TOAST_TIMEOUT,
         });
       }
-    }, [retryController.isUnhealthy, setConfig])
+    }, [retryController, setConfig])
   );
 
   useAnnotationEventHandler(


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR fixes a bug where persistence attempts were being recorded when no deltas were detected. This manifested as no-op requests being interpreted as failures.

## How is this patch tested? If it is not, please explain why.

local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of annotation persistence operations by optimizing retry attempt tracking during persistence workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->