### PR TITLE
release notes for 1.13.3 and 2.16.3

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -19,9 +19,9 @@ Cloud Media
 
 - Optimized cloud media access checks in order to reduce the number of requests
   being made.
-- Updated SDK precendence for cloud credentials. When running the SDK locally
+- Updated SDK precedence for cloud credentials. When running the SDK locally
   the system will default to using local credentials when they are available.
-  This precendence can be overridden by setting
+  This precedence can be overridden by setting
   `FIFTYONE_CLOUD_CRED_ORIGIN_PREFERENCE` to `remote` (or `local`).
 
 Models


### PR DESCRIPTION
## What changes are proposed in this pull request?

Release notes for 1.13.3 and 2.16.3



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * FiftyOne Enterprise 2.16.3 release notes published (dated March 2, 2026), aligned with FiftyOne 1.13.3 and linked to prior notes.

* **New Features**
  * In-App Annotation: expanded permission levels to support all annotation workflows with enhanced can_tag access controls.

* **Improvements**
  * Cloud Media: refined credential handling with improved origin precedence and local/remote defaults.
  * Models: improved omdet model support in enterprise Docker environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->