### PR TITLE
swap default behavior for ENABLE_CREDS_LOCAL_USE

### DIFF
--- a/docs/source/enterprise/installation.rst
+++ b/docs/source/enterprise/installation.rst
@@ -677,8 +677,10 @@ credentials from the other source will be attempted before giving up.
 Cloud Credentials Local Download
 ___________________________________
 
-By default, when using the Enterprise SDK with an API connection, any
-credential for a given user may be fetched to the local machine. This behavior
-may not be desirable. To disable downloading of credentials to machines, set
-the environment variable `ENABLE_CREDS_LOCAL_USE` to `false` on the Voxel-Hub
-API server.
+By default, users must set up local credentials when using the Enterprise SDK
+with an API connection. This is to prevent downloading credentials from the
+Enterprise server to that user's local machine. However, you can change this
+default, so that local SDK usage will access credentials from the Enterprise
+server. To enable downloading of credentials to machines, set the environment
+variable `FEATURE_FLAG_ENABLE_CREDS_LOCAL_USE` to `True` on the Voxel-Hub API
+server.


### PR DESCRIPTION
## What changes are proposed in this pull request?

Swap description of the default behavior of `ENABLE_CREDS_LOCAL_USE`

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Enterprise installation guidance: local credential setup is now required by default; downloading credentials from the server is available by enabling a feature flag. Updated the environment variable used to enable server-side credential downloads (name changed to FEATURE_FLAG_ENABLE_CREDS_LOCAL_USE).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->