### PR TITLE
Fix DO logs for builtin plugins and add extensibility hooks

### DIFF
--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -918,7 +918,14 @@ class DelegatedOperationService(object):
                     logger.debug("Pinging operation %s", operation_id)
                     self._repo.ping(operation_id)
                     if on_monitor_ping:
-                        on_monitor_ping(child_process.pid)
+                        try:
+                            on_monitor_ping(child_process.pid)
+                        except Exception as e:
+                            logger.debug(
+                                "Error in on_monitor_ping callback for operation %s: %s",
+                                operation_id,
+                                e,
+                            )
             except Exception as e:
                 reason = f"Error in monitoring loop: {e}"
                 logger.error(


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Fix `_configure_child_logging` to configure all FiftyOne loggers (`fiftyone`, `eta`, `plugins`, debug targets) instead of only the root `fiftyone` logger (FOEPD-3342)
  - Add optional `stdout_capture` kwarg to capture stdout/stderr into logging for delegated operations (both in-process and multi-process execution)
  - Add optional `on_monitor_ping` callback invoked on each monitor ping with the child process PID

## How is this patch tested? If it is not, please explain why.

- Existing tests pass

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional stdout/stderr capture for operators running in background processes, with a safe no‑op fallback.
  * Monitoring callbacks invoked during operation pings for real‑time progress tracking (callbacks receive child process IDs).

* **Improvements**
  * Consolidated child‑process logging to prevent duplicate entries and ensure consistent log propagation.
  * Stdout capture and monitor callbacks now reliably propagate through delegated execution paths; monitor callbacks are executed safely (exceptions handled).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->