### PR TITLE
feat: allow for using the SAM2 video predictor on flattened image datasets

### DIFF
--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -411,6 +411,38 @@ def _to_abs_boxes(boxes, img_width, img_height, chunk_size=1e6):
     return boxes_xyxy
 
 
+def _to_abs_mask(mask, abs_box, img_width, img_height):
+    """
+    Args:
+        mask: numpy array relative to box
+        abs_box: [x1, y1, x2, y2]
+        img_width: width of the image
+        img_height: height of the image
+    Returns:
+        numpy array relative to the image
+    """
+    x1, y1, x2, y2 = abs_box
+    box_width = x2 - x1
+    box_height = y2 - y1
+    mask_fitted = np.pad(
+        mask,
+        [
+            (0, max(0, box_height - mask.shape[0])),
+            (0, max(0, box_width - mask.shape[1])),
+        ],
+    )[:box_height, :box_width]
+    mask_framed = np.zeros(
+        (
+            img_height,
+            img_width,
+        ),
+        bool,
+    )
+    mask_framed[y1:y2, x1:x2] = mask_fitted
+    mask_framed = mask_framed.astype(np.uint8)
+    return mask_framed
+
+
 def _mask_to_box(mask):
     pos_indices = np.where(mask)
     if all(arr.size == 0 for arr in pos_indices):

--- a/fiftyone/utils/sam2.py
+++ b/fiftyone/utils/sam2.py
@@ -522,7 +522,25 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
 
         # The existing video path will handle
         # prompt extraction, registration, propagation, and detection construction
-        sample_detections = self.predict(mock_reader, mock_video_sample)
+        try:
+            sample_detections = self.predict(mock_reader, mock_video_sample)
+        except Exception as e:
+            if "mat1 and mat2 must have the same dtype" in str(e):
+                """
+                ------------------------------------------------------------
+                This error typically occurs due to a mixed-precision dtype mismatch in SAM2's
+                internal transformer layers. This is a known issue in SAM2's implementation
+                that is more likely to occur when propagating across
+                multiple sequences with different label sets, as this triggers
+                more complex memory attention paths in SAM2's tracking stack.
+                ------------------------------------------------------------
+                """
+                raise RuntimeError(
+                    f"Error propagating to all frames; \
+                please try with a shorter sequence with continuous frames and consistent labels."
+                )
+            else:
+                raise e
 
         return [
             sample_detections.get(i + 1, fol.Detections())

--- a/fiftyone/utils/sam2.py
+++ b/fiftyone/utils/sam2.py
@@ -851,7 +851,7 @@ def load_fiftyone_video_frames(
     img_mean=(0.485, 0.456, 0.406),
     img_std=(0.229, 0.224, 0.225),
     async_loading_frames=False,
-    compute_device=torch.device("cuda"),
+    compute_device=None,
 ):
     """
     The signature of this function matches
@@ -875,7 +875,7 @@ def load_fiftyone_video_frames(
             image_size=image_size,
             img_mean=img_mean,
             img_std=img_std,
-            async_loading_frames=async_loading_frames,
+            async_loading_frames=False,
         )
     else:
         raise NotImplementedError("Unsupported media type")
@@ -888,8 +888,11 @@ def load_fiftyone_video_frames_from_video_file(
     offload_video_to_cpu,
     img_mean=(0.485, 0.456, 0.406),
     img_std=(0.229, 0.224, 0.225),
-    compute_device=torch.device("cuda"),
+    compute_device=None,
 ):
+    if compute_device is None:
+        compute_device = "cuda:0" if torch.cuda.is_available() else "cpu"
+
     img_mean = torch.tensor(img_mean, dtype=torch.float32)[:, None, None]
     img_std = torch.tensor(img_std, dtype=torch.float32)[:, None, None]
 

--- a/fiftyone/utils/sam2.py
+++ b/fiftyone/utils/sam2.py
@@ -8,9 +8,7 @@ wrapper for the FiftyOne Model Zoo.
 """
 
 import logging
-import contextlib
 import os
-import shutil
 import tempfile
 from typing import List, Optional
 
@@ -473,12 +471,6 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
     def predict_all(
         self, imgs: List[np.ndarray], samples: Optional[List] = None
     ) -> List[fol.Detections]:
-        batch_size = self.config.batch_size
-        if (batch_size is None) or (batch_size == len(imgs)):
-            logger.warning(
-                f"Batch size {batch_size} may be insufficient for the sequence of frames"
-            )
-
         # Get the prompt field name from needs_fields (sample-level in this path)
         if "prompt_field" in self.needs_fields:
             prompt_field = self.needs_fields["prompt_field"]
@@ -615,8 +607,6 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
             return self._forward_pass_boxes(video_reader, sample)
         elif self._curr_prompt_type == "points":
             return self._forward_pass_points(video_reader, sample)
-        elif self._curr_prompt_type == "masks":
-            return self._forward_pass_boxes(video_reader, sample)
 
     def _forward_pass_boxes(self, video_reader, sample):
         image_folder = getattr(video_reader, "image_folder", None)
@@ -886,12 +876,9 @@ def load_fiftyone_video_frames_from_video_file(
     img_std = torch.tensor(img_std, dtype=torch.float32)[:, None, None]
 
     num_frames = len(sample.frames)
-    try:
-        images = torch.zeros(
-            num_frames, 3, image_size, image_size, dtype=torch.float32
-        )
-    except Exception as e:
-        raise (e)
+    images = torch.zeros(
+        num_frames, 3, image_size, image_size, dtype=torch.float32
+    )
     for frame_number in range(num_frames):
         current_frame = video_reader.read()
         resized_frame = (

--- a/fiftyone/utils/sam2.py
+++ b/fiftyone/utils/sam2.py
@@ -247,7 +247,7 @@ class SegmentAnything2ImageModel(fosam.SegmentAnythingModel):
         if "negative_prompt_field" in self.needs_fields:
             negative_field = self.needs_fields["negative_prompt_field"]
             if negative_field.startswith("frames."):
-                negative_field = negative_field[len("frames."):]
+                negative_field = negative_field[len("frames.") :]
 
         if negative_field and samples is not None:
             negative_prompts = []
@@ -256,7 +256,9 @@ class SegmentAnything2ImageModel(fosam.SegmentAnythingModel):
                     value = sample.get_field(negative_field)
                 except AttributeError:
                     logger.warning(
-                        "Sample %s has no field '%s'", sample.id, negative_field
+                        "Sample %s has no field '%s'",
+                        sample.id,
+                        negative_field,
                     )
                     value = None
                 negative_prompts.append(value)
@@ -307,7 +309,9 @@ class SegmentAnything2ImageModel(fosam.SegmentAnythingModel):
                 multimask_output=False,
             )
 
-            if self._curr_negative_prompts and idx < len(self._curr_negative_prompts):
+            if self._curr_negative_prompts and idx < len(
+                self._curr_negative_prompts
+            ):
                 masks = _subtract_negative_box_regions(
                     masks, self._curr_negative_prompts[idx], w, h
                 )
@@ -441,7 +445,9 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
         self._curr_prompts = self._get_prompts(sample, field_name)
         self._curr_prompt_type = self._get_prompt_type(sample, field_name)
         if negative_field_name:
-            self._curr_negative_prompts = self._get_prompts(sample, negative_field_name)
+            self._curr_negative_prompts = self._get_prompts(
+                sample, negative_field_name
+            )
         else:
             self._curr_negative_prompts = None
 
@@ -484,7 +490,13 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
                 continue
 
             if isinstance(value, fol.Detections):
-                return "boxes"
+                if any(
+                    detection.mask is not None
+                    for detection in value.detections
+                ):
+                    return "masks"
+                else:
+                    return "boxes"
 
             if isinstance(value, fol.Keypoints):
                 return "points"
@@ -509,7 +521,7 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
         return prompts
 
     def _forward_pass(self, video_reader, sample):
-        if self._curr_prompt_type == "boxes":
+        if self._curr_prompt_type in ["boxes", "masks"]:
             return self._forward_pass_boxes(video_reader, sample)
         elif self._curr_prompt_type == "points":
             return self._forward_pass_points(video_reader, sample)
@@ -546,12 +558,29 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
                     chunk_size=1,
                 )
                 box = np.round(box_xyxy.squeeze(axis=0)).astype(int)
-                _, _, _ = self.model.add_new_points_or_box(
-                    inference_state=inference_state,
-                    frame_idx=frame_idx,
-                    obj_id=ann_obj_id,
-                    box=box,
-                )
+
+                if detection.mask is not None:
+                    # prevent SAM2 from running a segmentation inside the box
+                    # instead, use the prompted mask directly
+                    mask_array = fosam._to_abs_mask(
+                        detection.mask,
+                        box,
+                        self._curr_frame_width,
+                        self._curr_frame_height,
+                    )
+                    _, _, _ = self.model.add_new_mask(
+                        inference_state=inference_state,
+                        frame_idx=frame_idx,
+                        obj_id=ann_obj_id,
+                        mask=mask_array,
+                    )
+                else:
+                    _, _, _ = self.model.add_new_points_or_box(
+                        inference_state=inference_state,
+                        frame_idx=frame_idx,
+                        obj_id=ann_obj_id,
+                        box=box,
+                    )
 
         sample_detections = {}
         for (
@@ -565,7 +594,9 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
                     (out_mask_logits[i] > 0.0).cpu().numpy(), axis=0
                 )
 
-                if self._curr_negative_prompts and out_frame_idx < len(self._curr_negative_prompts):
+                if self._curr_negative_prompts and out_frame_idx < len(
+                    self._curr_negative_prompts
+                ):
                     mask = _subtract_negative_box_regions(
                         mask,
                         self._curr_negative_prompts[out_frame_idx],
@@ -592,7 +623,9 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
                     fol.Detection(
                         label=label,
                         bounding_box=bounding_box,
-                        mask=mask,
+                        mask=mask
+                        if self._curr_prompt_type == "masks"
+                        else None,
                         index=out_obj_id,
                     )
                 )
@@ -633,9 +666,17 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
                     keypoint,
                 )
 
-                if self._curr_negative_prompts and frame_idx < len(self._curr_negative_prompts):
-                    neg_frame_keypoints = self._curr_negative_prompts[frame_idx]
-                    if neg_frame_keypoints and isinstance(neg_frame_keypoints, fol.Keypoints) and len(neg_frame_keypoints.keypoints) > 0:
+                if self._curr_negative_prompts and frame_idx < len(
+                    self._curr_negative_prompts
+                ):
+                    neg_frame_keypoints = self._curr_negative_prompts[
+                        frame_idx
+                    ]
+                    if (
+                        neg_frame_keypoints
+                        and isinstance(neg_frame_keypoints, fol.Keypoints)
+                        and len(neg_frame_keypoints.keypoints) > 0
+                    ):
                         for neg_keypoint in neg_frame_keypoints.keypoints:
                             neg_points, _ = fosam._to_sam_points(
                                 neg_keypoint.points,

--- a/fiftyone/utils/sam2.py
+++ b/fiftyone/utils/sam2.py
@@ -412,7 +412,7 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
         try:
             self.ctx = _load_video_frames_monkey_patches()
         except Exception as e:
-            logger.warning(
+            logger.error(
                 "Failed to monkey patch sam2.utils.misc.load_video_frames: %s",
                 e,
             )
@@ -918,8 +918,7 @@ def load_fiftyone_video_frames_from_image_files(
     with tempfile.TemporaryDirectory(prefix="fo_sam2_frames_") as tmpdir:
         for idx, frame_filepath in enumerate(sample.values("filepath")):
             src = frame_filepath
-            ext = os.path.splitext(src)[1].lower()
-            dest = os.path.join(tmpdir, "%05d%s" % (idx, ext))
+            dest = os.path.join(tmpdir, "%05d.jpg" % idx)
             os.symlink(os.path.abspath(src), dest)
 
         return smutil.load_video_frames_from_jpg_images(

--- a/fiftyone/utils/sam2.py
+++ b/fiftyone/utils/sam2.py
@@ -114,14 +114,18 @@ class SegmentAnything2VideoModelConfig(
 
     See :class:`fiftyone.utils.torch.TorchImageModelConfig` for additional
     arguments.
+
+    Args:
+        media_mode (None): the media mode to use for the model (only "video" and "image" are supported). If None, defaults to "video"
     """
 
     def __init__(self, d):
         d = self.init(d)
         super().__init__(d)
 
-        self.batch_size = self.parse_int(d, "batch_size", default=None)
         self.media_mode = self.parse_string(d, "media_mode", default="video")
+        if self.media_mode not in ["video", "image"]:
+            raise ValueError("media_mode must be one of 'video' or 'image'")
 
 
 class SegmentAnything2ImageModel(fosam.SegmentAnythingModel):
@@ -397,7 +401,7 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
         config: a :class:`SegmentAnything2VideoModelConfig`
     """
 
-    def __init__(self, config, media_mode="video"):
+    def __init__(self, config):
         dir(sam2)  # ensure package is installed
         self._fields = {}
 
@@ -418,9 +422,7 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
             )
 
         self.model = self._load_model(config)
-        self.media_mode = (
-            getattr(config, "media_mode", None) or media_mode or "video"
-        )
+        self.media_mode = getattr(config, "media_mode", "video")
 
         self._curr_prompt_type = None
         self._curr_prompts = None
@@ -451,7 +453,7 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
             )
         return model
 
-    def predict(self, video_reader, sample=None):
+    def predict(self, video_reader, sample):
         field_name, negative_field_name = self._get_field()
         (
             self._curr_frame_width,
@@ -465,7 +467,6 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
             )
         else:
             self._curr_negative_prompts = None
-
         return self._forward_pass(video_reader, sample)
 
     def predict_all(
@@ -493,10 +494,9 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
         if not has_prompt:
             return [fol.Detections() for _ in samples]
 
-        # We construct a lightweight container that mimics a video sample for flattened frames
-        # The sample has a `frames` dict and delegates to
-        # the existing video path via `_forward_pass_boxes`.
-        class _MockVideoSample(object):
+        class _ImageSamplesAsVideoFrames:
+            """Adapts a list of image samples to the video sample interface."""
+
             media_type = focm.IMAGE
 
             def __init__(self, frames):
@@ -506,14 +506,7 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
             def frames(self):
                 return {ii + 1: ff for ii, ff in enumerate(self._frames)}
 
-            def values(self, field_name):
-                if field_name == "filepath":
-                    return [f.filepath for f in self._frames]
-                raise AttributeError(
-                    "No field '%s' on mock video sample" % field_name
-                )
-
-        mock_video_sample = _MockVideoSample(samples)
+        mock_video_sample = _ImageSamplesAsVideoFrames(samples)
 
         hh, ww = 0, 0
         if len(imgs) > 0:
@@ -937,7 +930,10 @@ def load_fiftyone_video_frames_from_image_files(
     """
 
     with tempfile.TemporaryDirectory(prefix="fo_sam2_frames_") as tmpdir:
-        for idx, frame_filepath in enumerate(sample.values("filepath")):
+        frame_filepaths = [
+            sample.frames[ii].filepath for ii in sorted(sample.frames.keys())
+        ]
+        for idx, frame_filepath in enumerate(frame_filepaths):
             src = frame_filepath
             dest = os.path.join(tmpdir, "%05d.jpg" % idx)
             os.symlink(os.path.abspath(src), dest)

--- a/fiftyone/utils/sam2.py
+++ b/fiftyone/utils/sam2.py
@@ -8,6 +8,11 @@ wrapper for the FiftyOne Model Zoo.
 """
 
 import logging
+import contextlib
+import os
+import shutil
+import tempfile
+from typing import List, Optional
 
 import cv2
 import eta.core.utils as etau
@@ -19,6 +24,7 @@ import fiftyone.core.utils as fou
 import fiftyone.utils.sam as fosam
 import fiftyone.utils.torch as fout
 import fiftyone.zoo.models as fozm
+import fiftyone.core.media as focm
 
 fou.ensure_torch()
 import torch
@@ -115,6 +121,9 @@ class SegmentAnything2VideoModelConfig(
     def __init__(self, d):
         d = self.init(d)
         super().__init__(d)
+
+        self.batch_size = self.parse_int(d, "batch_size", default=None)
+        self.media_mode = self.parse_string(d, "media_mode", default="video")
 
 
 class SegmentAnything2ImageModel(fosam.SegmentAnythingModel):
@@ -390,7 +399,7 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
         config: a :class:`SegmentAnything2VideoModelConfig`
     """
 
-    def __init__(self, config):
+    def __init__(self, config, media_mode="video"):
         dir(sam2)  # ensure package is installed
         self._fields = {}
 
@@ -403,14 +412,17 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
         self._download_model(config)
 
         try:
-            self.ctx = _load_video_frames_monkey_patch()
+            self.ctx = _load_video_frames_monkey_patches()
         except Exception as e:
             logger.warning(
-                "Failed to monkey patch sam2.utils.misc.load_vide_frames: %s",
+                "Failed to monkey patch sam2.utils.misc.load_video_frames: %s",
                 e,
             )
 
         self.model = self._load_model(config)
+        self.media_mode = (
+            getattr(config, "media_mode", None) or media_mode or "video"
+        )
 
         self._curr_prompt_type = None
         self._curr_prompts = None
@@ -421,7 +433,12 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
 
     @property
     def media_type(self):
-        return "video"
+        return self.media_mode
+
+    @property
+    def ragged_batches(self):
+        # Frames are resized to a fixed size, so batching is safe
+        return False
 
     def _download_model(self, config):
         config.download_model_if_necessary()
@@ -436,7 +453,7 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
             )
         return model
 
-    def predict(self, video_reader, sample):
+    def predict(self, video_reader, sample=None):
         field_name, negative_field_name = self._get_field()
         (
             self._curr_frame_width,
@@ -453,33 +470,106 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
 
         return self._forward_pass(video_reader, sample)
 
-    def _get_field(self):
+    def predict_all(
+        self, imgs: List[np.ndarray], samples: Optional[List] = None
+    ) -> List[fol.Detections]:
+        batch_size = self.config.batch_size
+        if (batch_size is None) or (batch_size == len(imgs)):
+            logger.warning(
+                f"Batch size {batch_size} may be insufficient for the sequence of frames"
+            )
+
+        # Get the prompt field name from needs_fields (sample-level in this path)
         if "prompt_field" in self.needs_fields:
             prompt_field = self.needs_fields["prompt_field"]
         else:
             prompt_field = next(iter(self.needs_fields.values()), None)
-
-        if not prompt_field.startswith("frames."):
-            raise ValueError(
-                "'prompt_field' should be a frame field for segment anything 2 video model"
-            )
 
         if prompt_field is None:
             raise AttributeError(
                 "Missing required argument 'prompt_field' for segment anything 2 video model"
             )
 
-        prompt_field = prompt_field[len("frames.") :]
+        # If there are no prompts anywhere in this sequence, do not call SAM2
+        has_prompt = False
+        for s in samples:
+            val = s.get_field(prompt_field)
+            if isinstance(val, fol.Detections) and len(val.detections) > 0:
+                has_prompt = True
+                break
+
+        if not has_prompt:
+            return [fol.Detections() for _ in samples]
+
+        # We construct a lightweight container that mimics a video sample for flattened frames
+        # The sample has a `frames` dict and delegates to
+        # the existing video path via `_forward_pass_boxes`.
+        class _MockVideoSample(object):
+            media_type = focm.IMAGE
+
+            def __init__(self, frames):
+                self._frames = list(frames)
+
+            @property
+            def frames(self):
+                return {ii + 1: ff for ii, ff in enumerate(self._frames)}
+
+            def values(self, field_name):
+                if field_name == "filepath":
+                    return [f.filepath for f in self._frames]
+                raise AttributeError(
+                    "No field '%s' on mock video sample" % field_name
+                )
+
+        mock_video_sample = _MockVideoSample(samples)
+
+        hh, ww = 0, 0
+        if len(imgs) > 0:
+            hh, ww = imgs[0].shape[0], imgs[0].shape[1]
+        mock_reader = type("_Reader", (), {"frame_size": (ww, hh)})()
+
+        # The existing video path will handle
+        # prompt extraction, registration, propagation, and detection construction
+        sample_detections = self.predict(mock_reader, mock_video_sample)
+
+        return [
+            sample_detections.get(i + 1, fol.Detections())
+            for i in range(len(samples))
+        ]
+
+    def _get_field(self):
+        if "prompt_field" in self.needs_fields:
+            prompt_field = self.needs_fields["prompt_field"]
+        else:
+            prompt_field = next(iter(self.needs_fields.values()), None)
+
+        if prompt_field is None:
+            raise AttributeError(
+                "Missing required argument 'prompt_field' for segment anything 2 video model"
+            )
+
+        # sample-level prompt_field for flattened frames
+        if getattr(self, "media_mode", "video") == "video":
+            if prompt_field.startswith("frames."):
+                prompt_field = prompt_field[len("frames.") :]
+            else:
+                raise ValueError(
+                    "'prompt_field' should be a frame field for segment anything 2 video model"
+                )
 
         # Get negative_prompt_field if provided
         negative_prompt_field = None
         if "negative_prompt_field" in self.needs_fields:
             negative_prompt_field = self.needs_fields["negative_prompt_field"]
-            if not negative_prompt_field.startswith("frames."):
-                raise ValueError(
-                    "'negative_prompt_field' should be a frame field for segment anything 2 video model"
-                )
-            negative_prompt_field = negative_prompt_field[len("frames.") :]
+            if getattr(self, "media_mode", "video") == "video":
+                if negative_prompt_field.startswith("frames."):
+                    negative_prompt_field = negative_prompt_field[
+                        len("frames.") :
+                    ]
+                else:
+                    raise ValueError(
+                        "'negative_prompt_field' should be a frame field for segment anything 2 video model"
+                    )
 
         return prompt_field, negative_prompt_field
 
@@ -525,10 +615,16 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
             return self._forward_pass_boxes(video_reader, sample)
         elif self._curr_prompt_type == "points":
             return self._forward_pass_points(video_reader, sample)
+        elif self._curr_prompt_type == "masks":
+            return self._forward_pass_boxes(video_reader, sample)
 
     def _forward_pass_boxes(self, video_reader, sample):
-        video_path = (sample, video_reader)
-        inference_state = self.model.init_state(video_path)
+        image_folder = getattr(video_reader, "image_folder", None)
+        if image_folder is not None:
+            inference_state = self.model.init_state(image_folder)
+        else:
+            video_path = (sample, video_reader)
+            inference_state = self.model.init_state(video_path)
 
         classes_obj_id_map = {}
         kp_idx_obj_id_map = {}
@@ -635,8 +731,12 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
         return sample_detections
 
     def _forward_pass_points(self, video_reader, sample):
-        video_path = (sample, video_reader)
-        inference_state = self.model.init_state(video_path)
+        image_folder = getattr(video_reader, "image_folder", None)
+        if image_folder is not None:
+            inference_state = self.model.init_state(image_folder)
+        else:
+            video_path = (sample, video_reader)
+            inference_state = self.model.init_state(video_path)
 
         classes_obj_id_map = {}
         kp_idx_obj_id_map = {}
@@ -745,7 +845,43 @@ def load_fiftyone_video_frames(
     async_loading_frames=False,
     compute_device=torch.device("cuda"),
 ):
-    sample, video_reader = video_path
+    """
+    The signature of this function matches
+    sam2.utils.misc.load_video_frames;
+    The argument `video_path` is a misnomer; we pass a tuple of (sample, reader) instead.
+    """
+    sample, reader = video_path
+    if sample.media_type == focm.VIDEO:
+        return load_fiftyone_video_frames_from_video_file(
+            sample=sample,
+            video_reader=reader,
+            image_size=image_size,
+            offload_video_to_cpu=offload_video_to_cpu,
+            img_mean=img_mean,
+            img_std=img_std,
+            compute_device=compute_device,
+        )
+    elif sample.media_type == focm.IMAGE:
+        return load_fiftyone_video_frames_from_image_files(
+            sample=sample,
+            image_size=image_size,
+            img_mean=img_mean,
+            img_std=img_std,
+            async_loading_frames=async_loading_frames,
+        )
+    else:
+        raise NotImplementedError("Unsupported media type")
+
+
+def load_fiftyone_video_frames_from_video_file(
+    sample,
+    video_reader,
+    image_size,
+    offload_video_to_cpu,
+    img_mean=(0.485, 0.456, 0.406),
+    img_std=(0.229, 0.224, 0.225),
+    compute_device=torch.device("cuda"),
+):
     img_mean = torch.tensor(img_mean, dtype=torch.float32)[:, None, None]
     img_std = torch.tensor(img_std, dtype=torch.float32)[:, None, None]
 
@@ -778,10 +914,39 @@ def load_fiftyone_video_frames(
     return images, video_height, video_width
 
 
-def _load_video_frames_monkey_patch():
-    entrypoint_module = smutil.load_video_frames
+def load_fiftyone_video_frames_from_image_files(
+    sample,
+    image_size,
+    img_mean=(0.485, 0.456, 0.406),
+    img_std=(0.229, 0.224, 0.225),
+    async_loading_frames=False,
+):
+    """Load video frames from FiftyOne frame samples via a temp dir of symlinks.
 
+    Creates a temp dir, symlinks each frame filepath as 00000.jpg, 00001.jpg, ...
+    (sorted by frame number), then calls the original SAM2 load_video_frames_from_jpg_images on
+    that path. Temp dir is removed on return.
+    """
+
+    with tempfile.TemporaryDirectory(prefix="fo_sam2_frames_") as tmpdir:
+        for idx, frame_filepath in enumerate(sample.values("filepath")):
+            src = frame_filepath
+            ext = os.path.splitext(src)[1].lower()
+            dest = os.path.join(tmpdir, "%05d%s" % (idx, ext))
+            os.symlink(os.path.abspath(src), dest)
+
+        return smutil.load_video_frames_from_jpg_images(
+            tmpdir,
+            image_size=image_size,
+            offload_video_to_cpu=True,
+            img_mean=img_mean,
+            img_std=img_std,
+            async_loading_frames=async_loading_frames,
+        )
+
+
+def _load_video_frames_monkey_patches():
     return fou.MonkeyPatchFunction(
-        entrypoint_module,
+        smutil.load_video_frames,
         load_fiftyone_video_frames,
     )

--- a/tests/intensive/model_zoo_tests.py
+++ b/tests/intensive/model_zoo_tests.py
@@ -276,8 +276,9 @@ def _apply_video_models(
     dataset.match_frames(F("frame_number") <= max_frames).keep_frames()
 
     if _SAM_PROMPT_FIELD in kwargs:
+        prompt_field = kwargs[_SAM_PROMPT_FIELD]
         dataset.match_frames(F("frame_number") > 1).set_field(
-            kwargs[_SAM_PROMPT_FIELD], None
+            prompt_field, None
         ).save()
 
     for idx, model_name in enumerate(model_names, 1):
@@ -301,11 +302,11 @@ def _apply_video_models(
                 assert len(last_frame[label_field].detections) > 0
                 # if our prompt field does not have a mask,
                 # the label field shouldn't have a mask either
+                if prompt_field.startswith("frames."):
+                    prompt_field = prompt_field[len("frames.") :]
                 assert (
-                    first_frame[kwargs[_SAM_PROMPT_FIELD]].detections[0].mask is None
-                ) == (
-                    last_frame[label_field].detections[0].mask is None
-                )
+                    first_frame[prompt_field].detections[0].mask is None
+                ) == (last_frame[label_field].detections[0].mask is None)
 
     session = fo.launch_app(dataset)
     session.wait()

--- a/tests/intensive/model_zoo_tests.py
+++ b/tests/intensive/model_zoo_tests.py
@@ -116,6 +116,17 @@ def test_sam2_video():
     )
 
 
+def test_sam2_video_flattened():
+    models = ["segment-anything-2-hiera-tiny-video-torch"]
+    _apply_video_models_on_flattened_dataset(
+        models,
+        max_samples=1,
+        max_frames=3,
+        batch_size=8,  # must be >= the number of frames
+        apply_kwargs={_SAM_PROMPT_FIELD: "detections"},
+    )
+
+
 def test_keypoint_models():
     models = _get_models_with_tag("keypoints")
     _apply_person_keypoint_models(models)
@@ -295,6 +306,65 @@ def _apply_video_models(
                 ) == (
                     last_frame[label_field].detections[0].mask is None
                 )
+
+    session = fo.launch_app(dataset)
+    session.wait()
+
+
+def _apply_video_models_on_flattened_dataset(
+    model_names,
+    batch_size=None,
+    confidence_thresh=None,
+    pass_confidence_thresh=False,
+    max_samples=1,
+    max_frames=3,
+    model_kwargs=None,
+    apply_kwargs=None,
+):
+    if pass_confidence_thresh:
+        kwargs = {"confidence_thresh": confidence_thresh}
+    else:
+        kwargs = {}
+
+    if apply_kwargs:
+        kwargs.update(apply_kwargs)
+
+    dataset = foz.load_zoo_dataset(
+        "quickstart-video",
+        dataset_name=fo.get_default_dataset_name(),
+        max_samples=max_samples,
+    )
+    dataset.match_frames(F("frame_number") <= max_frames).keep_frames()
+
+    # convert to image dataset
+    dataset = dataset.to_frames(sample_frames=True, sparse=True)
+    model_kwargs = {
+        "media_mode": "image",
+        "batch_size": batch_size,
+    }
+
+    if _SAM_PROMPT_FIELD in kwargs:
+        dataset.match(F("frame_number") > 1).set_field(
+            kwargs[_SAM_PROMPT_FIELD], None
+        ).save()
+
+    for idx, model_name in enumerate(model_names, 1):
+        print(
+            "Running model %d/%d: '%s'" % (idx, len(model_names), model_name)
+        )
+
+        model = foz.load_zoo_model(model_name, **(model_kwargs or {}))
+        assert model.media_mode == "image"
+
+        label_field = model_name.lower().replace("-", "_").replace(".", "_")
+
+        dataset.apply_model(
+            model, label_field=label_field, batch_size=batch_size, **kwargs
+        )
+
+        sample = dataset.last()
+        assert sample[label_field] is not None
+        assert len(sample[label_field].detections) > 0
 
     session = fo.launch_app(dataset)
     session.wait()

--- a/tests/intensive/model_zoo_tests.py
+++ b/tests/intensive/model_zoo_tests.py
@@ -276,9 +276,8 @@ def _apply_video_models(
     dataset.match_frames(F("frame_number") <= max_frames).keep_frames()
 
     if _SAM_PROMPT_FIELD in kwargs:
-        prompt_field = kwargs[_SAM_PROMPT_FIELD]
         dataset.match_frames(F("frame_number") > 1).set_field(
-            prompt_field, None
+            kwargs[_SAM_PROMPT_FIELD], None
         ).save()
 
     for idx, model_name in enumerate(model_names, 1):
@@ -302,6 +301,7 @@ def _apply_video_models(
                 assert len(last_frame[label_field].detections) > 0
                 # if our prompt field does not have a mask,
                 # the label field shouldn't have a mask either
+                prompt_field = kwargs[_SAM_PROMPT_FIELD]
                 if prompt_field.startswith("frames."):
                     prompt_field = prompt_field[len("frames.") :]
                 assert (

--- a/tests/intensive/model_zoo_tests.py
+++ b/tests/intensive/model_zoo_tests.py
@@ -284,9 +284,17 @@ def _apply_video_models(
 
         for sample in dataset:
             if len(sample.frames) > 0:
+                first_frame = sample.frames[1]
                 last_frame = sample.frames[len(sample.frames)]
                 assert last_frame[label_field] is not None
                 assert len(last_frame[label_field].detections) > 0
+                # if our prompt field does not have a mask,
+                # the label field shouldn't have a mask either
+                assert (
+                    first_frame[kwargs[_SAM_PROMPT_FIELD]].detections[0].mask is None
+                ) == (
+                    last_frame[label_field].detections[0].mask is None
+                )
 
     session = fo.launch_app(dataset)
     session.wait()

--- a/tests/intensive/model_zoo_tests.py
+++ b/tests/intensive/model_zoo_tests.py
@@ -338,10 +338,8 @@ def _apply_video_models_on_flattened_dataset(
 
     # convert to image dataset
     dataset = dataset.to_frames(sample_frames=True, sparse=True)
-    model_kwargs = {
-        "media_mode": "image",
-        "batch_size": batch_size,
-    }
+    model_kwargs = model_kwargs or {}
+    model_kwargs.update({"media_mode": "image"})
 
     if _SAM_PROMPT_FIELD in kwargs:
         dataset.match(F("frame_number") > 1).set_field(


### PR DESCRIPTION
## What changes are proposed in this pull request?

1. [minor] Ability to handle mask prompts. Currently, when the prompt field has detections, only bounding boxes are read. SAM2 uses its own segmentation to find masks within it. With this commit, it also takes the mask from the detection into consideration via the `add_new_mask` API call.
2. [related to the above; changes existing behavior] In the video propagator, if only bounding box prompts are provided, only bounding boxes are returned. Masks are only returned if prompts contain them.
3. [major] Ability to pass a flattened image dataset into the `SegmentAnything2VideoModel`. This is [supported by the original SAM2 code already](https://github.com/facebookresearch/sam2/blob/2b90b9f5ceec907a1c18123530e92e794ad901a4/sam2/utils/misc.py#L172).

## JIRA

https://voxel51.atlassian.net/browse/ML-356

## How is this patch tested? If it is not, please explain why.

- https://github.com/voxel51/fiftyone/pull/7143 for videos
- Added a new test `test_sam2_video_flattened` for images

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

SAM2 models now support flattened image datasets for propagating labels across video frames. Users can specify `media_mode="image"` while loading the video model from the zoo. An adequate batch size -- larger than the set of images to propagate to -- must be passed when applying the model.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SegmentAnything2 gains configurable media mode (video or image), frame-based batching, batch-size support, and improved handling for per-frame prompts and masks.
  * New helpers to load video frames from video files or image-sequence folders and automatic dispatch based on media type.
  * Support for converting box-relative masks into full-image masks.

* **Tests**
  * Added tests for flattened video workflows and frame-based processing to validate image/video inference paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->