### PR TITLE
Doc: Fix wrong examples for match stage

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -6901,14 +6901,14 @@ class SampleCollection(object):
             # Only include samples whose `weather` field is "sunny"
             #
 
-            view = dataset.match(F("weather").label == "sunny")
+            view = dataset.match(F("weather.label") == "sunny")
 
             #
             # Only include samples with at least 2 objects in their
             # `predictions` field
             #
 
-            view = dataset.match(F("predictions").detections.length() >= 2)
+            view = dataset.match(F("predictions.detections").length() >= 2)
 
             #
             # Only include samples whose `predictions` field contains at least

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -4766,7 +4766,7 @@ class Match(ViewStage):
         # Only include samples whose `weather` field is "sunny"
         #
 
-        stage = fo.Match(F("weather").label == "sunny")
+        stage = fo.Match(F("weather.label") == "sunny")
         view = dataset.add_stage(stage)
 
         #
@@ -4774,7 +4774,7 @@ class Match(ViewStage):
         # field
         #
 
-        stage = fo.Match(F("predictions").detections.length() >= 2)
+        stage = fo.Match(F("predictions.detections").length() >= 2)
         view = dataset.add_stage(stage)
 
         #


### PR DESCRIPTION
The function docs and hence the published docs for the `match` function contained wrong examples, i.e. the presented examples, when run as written would produce the error:

```py
AttributeError: 'ViewField' object has no attribute 'label' 
AttributeError: 'ViewField' object has no attribute 'detections'
```

This PR fixes this to the correct usage of the ViewFilter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed field path handling in sample filtering operations to properly reference nested document fields. Filters now accurately evaluate complex nested data structures, ensuring correct sample matching based on nested field criteria and hierarchical properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->