### PR TITLE
[HA] update tooltip to use prevent clipping

### DIFF
--- a/app/packages/looker-3d/src/annotation/annotation-toolbar/AnnotationToolbar.tsx
+++ b/app/packages/looker-3d/src/annotation/annotation-toolbar/AnnotationToolbar.tsx
@@ -1,13 +1,14 @@
 import useCanAnnotate from "@fiftyone/core/src/components/Modal/Sidebar/Annotate/useCanAnnotate";
 import * as fos from "@fiftyone/state";
 import { DragIndicator } from "@mui/icons-material";
-import { Box, IconButton, Tooltip, Typography, styled } from "@mui/material";
+import { Box, IconButton, Typography, styled } from "@mui/material";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import ReactDOM from "react-dom";
 import { useRecoilState, useRecoilValue } from "recoil";
 import { annotationToolbarPositionAtom } from "../../state";
 import type { AnnotationToolbarProps } from "../types";
 import { useAnnotationActions } from "./useAnnotationActions";
+import { Anchor, Tooltip } from "@voxel51/voodo";
 
 const Z_INDEX_MAX_ARBITRARY = 10005;
 
@@ -267,11 +268,9 @@ export const AnnotationToolbar = ({ className }: AnnotationToolbarProps) => {
                   // Render regular action button if no custom component is provided
                   return (
                     <Tooltip
+                      portal
                       key={action.id}
-                      sx={{
-                        zIndex: Z_INDEX_MAX_ARBITRARY,
-                      }}
-                      title={
+                      content={
                         <Box sx={{ zIndex: Z_INDEX_MAX_ARBITRARY + 1 }}>
                           {typeof action.tooltip === "string" ? (
                             <Typography variant="body2">
@@ -287,9 +286,7 @@ export const AnnotationToolbar = ({ className }: AnnotationToolbarProps) => {
                           )}
                         </Box>
                       }
-                      placement="left"
-                      arrow
-                      disableHoverListener={false}
+                      anchor={Anchor.Right}
                     >
                       <ActionButton
                         onClick={() =>


### PR DESCRIPTION
## What changes are proposed in this pull request?

This fixes a styling issue with tooltips sometimes being clipped by other content. Leverages VOODO tooltips rather than MUI for more consistent styling.

## How is this patch tested? If it is not, please explain why.

local

<img width="1526" height="682" alt="image" src="https://github.com/user-attachments/assets/59d8d344-f8b4-44bb-9a94-e9f8e2aac8b2" />

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved annotation toolbar tooltip component rendering for better maintainability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->