### PR TITLE
Ensure new release of starlette 1.0 will not break FO

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ INSTALL_REQUIRES = [
     "setuptools",
     "sseclient-py>=1.7.2,<2",
     "sse-starlette>=0.10.3,<1",
-    "starlette>=0.24.0",
+    "starlette>=0.24.0,<0.53",
     "strawberry-graphql>=0.262.4,<0.292.0",
     "tabulate",
     "tqdm",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Restrict starlette to the current minor version. The 1.0 version [is imminent](https://starlette.dev/release-notes/).

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Ensure fiftyone will not break when `starlette 1.0` is released.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
