### PR TITLE
Expose additional Depth Anything V3 upstream parameters

### DIFF
--- a/fiftyone/utils/depth_anything.py
+++ b/fiftyone/utils/depth_anything.py
@@ -7,6 +7,7 @@ wrapper for the FiftyOne Model Zoo.
 |
 """
 
+import glob
 import logging
 import os
 from typing import Any, Dict, List, Optional, Tuple
@@ -412,6 +413,7 @@ class DepthAnythingV3Model(fout.TorchImageModel):
         overwrite: bool = False,
         skip_failures: bool = False,
         progress: Optional[bool] = None,
+        *,
         conf_thresh_percentile: float = 40.0,
         num_max_points: int = 1_000_000,
         show_cameras: bool = True,
@@ -483,3 +485,9 @@ class DepthAnythingV3Model(fout.TorchImageModel):
                 sample["da3_export_path"] = os.path.join(
                     sample_export_dir, "gs_ply", "0000.ply"
                 )
+            elif export_format == "gs_video":
+                video_paths = sorted(
+                    glob.glob(os.path.join(sample_export_dir, "gs_video", "*.mp4"))
+                )
+                if video_paths:
+                    sample["da3_export_path"] = video_paths[-1]

--- a/fiftyone/utils/depth_anything.py
+++ b/fiftyone/utils/depth_anything.py
@@ -144,6 +144,19 @@ class DepthAnythingV3OutputProcessor(fout.OutputProcessor):
                 if len(sky_masks.shape) == 2:
                     sky_masks = sky_masks[np.newaxis, ...]
 
+        scale_factors = output.get("scale_factor")
+        if isinstance(scale_factors, torch.Tensor):
+            scale_factors = scale_factors.detach().cpu().numpy()
+        if scale_factors is not None and np.ndim(scale_factors) > 0:
+            if len(scale_factors) < len(depth_maps):
+                logger.warning(
+                    "Scale factors (%d) fewer than depth maps (%d), "
+                    "skipping scale_factor",
+                    len(scale_factors),
+                    len(depth_maps),
+                )
+                scale_factors = None
+
         width, height = frame_size
         results = []
 
@@ -196,8 +209,18 @@ class DepthAnythingV3OutputProcessor(fout.OutputProcessor):
             if heatmap.is_metric:
                 heatmap.max_depth = float(max_depth)
 
-            if output.get("scale_factor") is not None:
-                heatmap.scale_factor = output["scale_factor"]
+            if scale_factors is not None:
+                value = (
+                    scale_factors
+                    if np.ndim(scale_factors) == 0
+                    else scale_factors[i]
+                )
+                if isinstance(value, np.ndarray):
+                    value = value.item()
+                elif hasattr(value, "item"):
+                    value = value.item()
+
+                heatmap.scale_factor = float(value)
 
             results.append(heatmap)
 

--- a/fiftyone/utils/depth_anything.py
+++ b/fiftyone/utils/depth_anything.py
@@ -41,6 +41,12 @@ da3_api = fou.lazy_import(
 )
 
 DEFAULT_DA3_MODEL = "depth-anything/da3-base"
+_VALID_REF_VIEW_STRATEGIES = (
+    "first",
+    "middle",
+    "saddle_balanced",
+    "saddle_sim_range",
+)
 
 
 class DepthAnythingV3OutputProcessor(fout.OutputProcessor):
@@ -190,6 +196,9 @@ class DepthAnythingV3OutputProcessor(fout.OutputProcessor):
             if heatmap.is_metric:
                 heatmap.max_depth = float(max_depth)
 
+            if output.get("scale_factor") is not None:
+                heatmap.scale_factor = output["scale_factor"]
+
             results.append(heatmap)
 
         if results:
@@ -203,9 +212,6 @@ class DepthAnythingV3OutputProcessor(fout.OutputProcessor):
 
             if output.get("aux"):
                 results[0].aux = output["aux"]
-
-            if output.get("scale_factor") is not None:
-                results[0].scale_factor = output["scale_factor"]
 
         return results
 
@@ -261,6 +267,14 @@ class DepthAnythingV3ModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
         self.ref_view_strategy = self.parse_string(
             d, "ref_view_strategy", default="saddle_balanced"
         )
+        if self.ref_view_strategy not in _VALID_REF_VIEW_STRATEGIES:
+            raise ValueError(
+                "Unsupported ref_view_strategy '%s'. Supported values are: %s"
+                % (
+                    self.ref_view_strategy,
+                    ", ".join(_VALID_REF_VIEW_STRATEGIES),
+                )
+            )
 
         self.align_to_input_ext_scale = self.parse_bool(
             d, "align_to_input_ext_scale", default=True

--- a/fiftyone/utils/depth_anything.py
+++ b/fiftyone/utils/depth_anything.py
@@ -203,6 +203,9 @@ class DepthAnythingV3OutputProcessor(fout.OutputProcessor):
             if output.get("aux"):
                 results[0].aux = output["aux"]
 
+            if output.get("scale_factor") is not None:
+                results[0].scale_factor = output["scale_factor"]
+
         return results
 
 
@@ -217,9 +220,17 @@ class DepthAnythingV3ModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
             Depth Anything V3 model
         process_res (504): the processing resolution in pixels. The model
             resizes inputs to this resolution for inference
-        process_res_method ("upper_bound_resize"): the resize strategy
+        process_res_method ("upper_bound_resize"): the resize strategy.
+            Supported values are ``"upper_bound_resize"`` and
+            ``"lower_bound_resize"``
         use_ray_pose (False): whether to use ray-based pose estimation instead
             of camera decoder (more accurate but slower)
+        ref_view_strategy ("saddle_balanced"): the strategy for selecting a
+            reference view when multiple views are provided. Supported values
+            are ``"first"``, ``"middle"``, ``"saddle_balanced"``, and
+            ``"saddle_sim_range"``
+        align_to_input_ext_scale (True): whether to align the predicted pose
+            scale to match input extrinsics when extrinsics are provided
         infer_gs (False): whether to predict 3D Gaussian Splatting parameters.
             Only supported by giant and nested models
         export_feat_layers (None): optional list of transformer layer indices
@@ -245,6 +256,14 @@ class DepthAnythingV3ModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
         )
 
         self.use_ray_pose = self.parse_bool(d, "use_ray_pose", default=False)
+
+        self.ref_view_strategy = self.parse_string(
+            d, "ref_view_strategy", default="saddle_balanced"
+        )
+
+        self.align_to_input_ext_scale = self.parse_bool(
+            d, "align_to_input_ext_scale", default=True
+        )
 
         self.infer_gs = self.parse_bool(d, "infer_gs", default=False)
 
@@ -307,6 +326,8 @@ class DepthAnythingV3Model(fout.TorchImageModel):
             process_res_method=self.config.process_res_method,
             infer_gs=self.config.infer_gs,
             use_ray_pose=self.config.use_ray_pose,
+            ref_view_strategy=self.config.ref_view_strategy,
+            align_to_input_ext_scale=self.config.align_to_input_ext_scale,
             export_feat_layers=self.config.export_feat_layers or [],
         )
         output = {"depth": prediction.depth}
@@ -329,6 +350,8 @@ class DepthAnythingV3Model(fout.TorchImageModel):
                 )
         if prediction.aux:
             output["aux"] = prediction.aux
+        if getattr(prediction, "scale_factor", None) is not None:
+            output["scale_factor"] = prediction.scale_factor
         return output
 
     def compute_multiview_depth(
@@ -354,6 +377,8 @@ class DepthAnythingV3Model(fout.TorchImageModel):
             process_res_method=self.config.process_res_method,
             infer_gs=self.config.infer_gs,
             use_ray_pose=self.config.use_ray_pose,
+            ref_view_strategy=self.config.ref_view_strategy,
+            align_to_input_ext_scale=self.config.align_to_input_ext_scale,
             export_feat_layers=self.config.export_feat_layers or [],
             extrinsics=extrinsics,
             intrinsics=intrinsics,
@@ -372,6 +397,8 @@ class DepthAnythingV3Model(fout.TorchImageModel):
             output["gaussians"] = prediction.gaussians
         if prediction.aux:
             output["aux"] = prediction.aux
+        if getattr(prediction, "scale_factor", None) is not None:
+            output["scale_factor"] = prediction.scale_factor
 
         processor = DepthAnythingV3OutputProcessor()
         return processor(output, (None, None))
@@ -385,6 +412,9 @@ class DepthAnythingV3Model(fout.TorchImageModel):
         overwrite: bool = False,
         skip_failures: bool = False,
         progress: Optional[bool] = None,
+        conf_thresh_percentile: float = 40.0,
+        num_max_points: int = 1_000_000,
+        show_cameras: bool = True,
     ) -> None:
         """Computes 3D exports (GLB, PLY) for samples.
 
@@ -404,11 +434,17 @@ class DepthAnythingV3Model(fout.TorchImageModel):
         Args:
             samples: a :class:`fiftyone.core.collections.SampleCollection`
             output_dir: directory to write exports
-            export_format ("glb"): export format. One of ``"glb"``, ``"gs_ply"``
+            export_format ("glb"): export format. One of ``"glb"``,
+                ``"gs_ply"``, ``"gs_video"``
             rel_dir (None): optional relative directory to strip from filepaths
             overwrite (False): whether to overwrite existing exports
             skip_failures (False): whether to gracefully continue on errors
             progress (None): whether to show progress bar
+            conf_thresh_percentile (40.0): lower percentile for adaptive
+                confidence threshold when exporting GLB point clouds
+            num_max_points (1000000): maximum number of points in GLB exports
+            show_cameras (True): whether to show camera wireframes in GLB
+                exports
         """
         fov.validate_collection(samples)
 
@@ -429,6 +465,9 @@ class DepthAnythingV3Model(fout.TorchImageModel):
                     infer_gs=infer_gs,
                     export_dir=sample_export_dir,
                     export_format=export_format,
+                    conf_thresh_percentile=conf_thresh_percentile,
+                    num_max_points=num_max_points,
+                    show_cameras=show_cameras,
                 )
             except Exception as e:
                 if not skip_failures:

--- a/fiftyone/utils/depth_anything.py
+++ b/fiftyone/utils/depth_anything.py
@@ -8,8 +8,12 @@ wrapper for the FiftyOne Model Zoo.
 """
 
 import glob
+import importlib
 import logging
 import os
+import subprocess
+import sys
+import types
 from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -27,12 +31,66 @@ import torch
 logger = logging.getLogger(__name__)
 
 
+_DA3_REQUIREMENT = (
+    "git+https://github.com/ByteDance-Seed/depth-anything-3.git"
+    "@2c21ea849ceec7b469a3e62ea0c0e270afc3281a"
+)
+
+
+def _install_depth_anything_3() -> None:
+    # depth-anything-3 pins numpy<2, but its inference stack (including evo,
+    # which pose alignment uses) runs on numpy 2; only the 3D export stack
+    # needs the pin. Installing the full dependency set would downgrade the
+    # host numpy, so the package is installed without dependencies, evo is
+    # installed explicitly, and `_stub_da3_export()` absorbs the export
+    # stack when it cannot import
+    for pkg in ("evo", "e3nn"):
+        fou.ensure_package(pkg, error_level=2) or fou.install_package(pkg)
+
+    args = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--no-deps",
+        _DA3_REQUIREMENT,
+    ]
+    proc = subprocess.run(args, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            "Failed to install depth-anything-3:\n%s" % proc.stderr
+        )
+
+
+def _stub_da3_export() -> None:
+    # `depth_anything_3.api` imports the export stack at module level even
+    # though inference never uses it, and that chain requires numpy<2 plus
+    # heavy media dependencies. When the real module cannot import, register
+    # a stub so depth prediction works; 3D exports then raise with guidance
+    try:
+        importlib.import_module("depth_anything_3.utils.export")
+        return
+    except ImportError:
+        pass
+
+    stub = types.ModuleType("depth_anything_3.utils.export")
+
+    def export(*args, **kwargs):
+        raise ImportError(
+            "depth_anything_3's export stack is unavailable in this "
+            "environment; it requires numpy<2 and the package's full "
+            "dependencies. Depth prediction is unaffected"
+        )
+
+    stub.export = export
+    sys.modules["depth_anything_3.utils.export"] = stub
+
+
 def _ensure_depth_anything_3() -> None:
     if not fou.ensure_package("depth-anything-3", error_level=2):
-        fou.install_package(
-            "git+https://github.com/ByteDance-Seed/depth-anything-3.git"
-            "@2c21ea849ceec7b469a3e62ea0c0e270afc3281a"
-        )
+        _install_depth_anything_3()
+
+    _stub_da3_export()
 
 
 da3_api = fou.lazy_import(
@@ -456,6 +514,9 @@ class DepthAnythingV3Model(fout.TorchImageModel):
         show_cameras: bool = True,
     ) -> None:
         """Computes 3D exports (GLB, PLY) for samples.
+
+        Requires depth_anything_3's export stack (``numpy<2`` and its full
+        dependencies).
 
         Examples::
 

--- a/fiftyone/utils/depth_anything.py
+++ b/fiftyone/utils/depth_anything.py
@@ -36,15 +36,25 @@ _DA3_REQUIREMENT = (
     "@2c21ea849ceec7b469a3e62ea0c0e270afc3281a"
 )
 
+# The inference stack runs on numpy 2; all of these are numpy-2 clean
+_DA3_INFERENCE_DEPS = (
+    "evo",
+    "e3nn",
+    "omegaconf",
+    "einops",
+    "addict",
+    "safetensors",
+)
+
 
 def _install_depth_anything_3() -> None:
     # depth-anything-3 pins numpy<2, but its inference stack (including evo,
     # which pose alignment uses) runs on numpy 2; only the 3D export stack
     # needs the pin. Installing the full dependency set would downgrade the
-    # host numpy, so the package is installed without dependencies, evo is
-    # installed explicitly, and `_stub_da3_export()` absorbs the export
-    # stack when it cannot import
-    for pkg in ("evo", "e3nn"):
+    # host numpy, so the package is installed without dependencies, the
+    # inference dependencies are installed explicitly, and
+    # `_stub_da3_export()` absorbs the export stack when it cannot import
+    for pkg in _DA3_INFERENCE_DEPS:
         fou.ensure_package(pkg, error_level=2) or fou.install_package(pkg)
 
     args = [
@@ -152,10 +162,12 @@ class DepthAnythingV3OutputProcessor(fout.OutputProcessor):
             raise ValueError("Model output 'depth' is None")
 
         if isinstance(depth_maps, (list, tuple)):
-            depth_maps = torch.stack([
-                t if isinstance(t, torch.Tensor) else torch.as_tensor(t)
-                for t in depth_maps
-            ])
+            depth_maps = torch.stack(
+                [
+                    t if isinstance(t, torch.Tensor) else torch.as_tensor(t)
+                    for t in depth_maps
+                ]
+            )
 
         if isinstance(depth_maps, torch.Tensor):
             depth_maps = depth_maps.detach().cpu().numpy()
@@ -181,7 +193,9 @@ class DepthAnythingV3OutputProcessor(fout.OutputProcessor):
             if len(conf_maps) < len(depth_maps):
                 logger.warning(
                     "Confidence maps (%d) fewer than depth maps (%d), "
-                    "skipping confidence", len(conf_maps), len(depth_maps)
+                    "skipping confidence",
+                    len(conf_maps),
+                    len(depth_maps),
                 )
                 conf_maps = None
             else:
@@ -195,7 +209,9 @@ class DepthAnythingV3OutputProcessor(fout.OutputProcessor):
             if len(sky_masks) < len(depth_maps):
                 logger.warning(
                     "Sky masks (%d) fewer than depth maps (%d), "
-                    "skipping sky", len(sky_masks), len(depth_maps)
+                    "skipping sky",
+                    len(sky_masks),
+                    len(depth_maps),
                 )
                 sky_masks = None
             else:
@@ -228,7 +244,9 @@ class DepthAnythingV3OutputProcessor(fout.OutputProcessor):
                     depth = np.array(depth_img)
 
             if not np.all(np.isfinite(depth)):
-                logger.warning("Depth map contains NaN/inf values, replacing with 0")
+                logger.warning(
+                    "Depth map contains NaN/inf values, replacing with 0"
+                )
                 depth = np.where(np.isfinite(depth), depth, 0)
 
             max_depth = np.max(depth)
@@ -403,7 +421,9 @@ class DepthAnythingV3Model(fout.TorchImageModel):
 
         snapshot_download(config.name_or_path)
 
-    def _load_model(self, config: DepthAnythingV3ModelConfig) -> torch.nn.Module:
+    def _load_model(
+        self, config: DepthAnythingV3ModelConfig
+    ) -> torch.nn.Module:
         model = da3_api.DepthAnything3.from_pretrained(config.name_or_path)
         model = model.to(self._device)
         if self.using_half_precision:
@@ -480,7 +500,10 @@ class DepthAnythingV3Model(fout.TorchImageModel):
             intrinsics=intrinsics,
         )
 
-        output = {"depth": prediction.depth, "is_metric": self.config.is_metric}
+        output = {
+            "depth": prediction.depth,
+            "is_metric": self.config.is_metric,
+        }
         if prediction.conf is not None:
             output["confidence"] = prediction.conf
         if prediction.sky is not None:
@@ -562,7 +585,13 @@ class DepthAnythingV3Model(fout.TorchImageModel):
             try:
                 self._model.inference(
                     [sample.filepath],
+                    process_res=self.config.process_res,
+                    process_res_method=self.config.process_res_method,
                     infer_gs=infer_gs,
+                    use_ray_pose=self.config.use_ray_pose,
+                    ref_view_strategy=self.config.ref_view_strategy,
+                    align_to_input_ext_scale=self.config.align_to_input_ext_scale,
+                    export_feat_layers=self.config.export_feat_layers or [],
                     export_dir=sample_export_dir,
                     export_format=export_format,
                     conf_thresh_percentile=conf_thresh_percentile,
@@ -584,8 +613,16 @@ class DepthAnythingV3Model(fout.TorchImageModel):
                     sample_export_dir, "gs_ply", "0000.ply"
                 )
             elif export_format == "gs_video":
+                # The directory comes from the sample filepath, so escape it;
+                # only the trailing components are patterns
                 video_paths = sorted(
-                    glob.glob(os.path.join(sample_export_dir, "gs_video", "*.mp4"))
+                    glob.glob(
+                        os.path.join(
+                            glob.escape(sample_export_dir),
+                            "gs_video",
+                            "*.mp4",
+                        )
+                    )
                 )
                 if video_paths:
                     sample["da3_export_path"] = video_paths[-1]

--- a/fiftyone/utils/depth_anything.py
+++ b/fiftyone/utils/depth_anything.py
@@ -7,8 +7,13 @@ wrapper for the FiftyOne Model Zoo.
 |
 """
 
+import glob
+import importlib
 import logging
 import os
+import subprocess
+import sys
+import types
 from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -26,12 +31,76 @@ import torch
 logger = logging.getLogger(__name__)
 
 
+_DA3_REQUIREMENT = (
+    "git+https://github.com/ByteDance-Seed/depth-anything-3.git"
+    "@2c21ea849ceec7b469a3e62ea0c0e270afc3281a"
+)
+
+# The inference stack runs on numpy 2; all of these are numpy-2 clean
+_DA3_INFERENCE_DEPS = (
+    "evo",
+    "e3nn",
+    "omegaconf",
+    "einops",
+    "addict",
+    "safetensors",
+)
+
+
+def _install_depth_anything_3() -> None:
+    # depth-anything-3 pins numpy<2, but its inference stack (including evo,
+    # which pose alignment uses) runs on numpy 2; only the 3D export stack
+    # needs the pin. Installing the full dependency set would downgrade the
+    # host numpy, so the package is installed without dependencies, the
+    # inference dependencies are installed explicitly, and
+    # `_stub_da3_export()` absorbs the export stack when it cannot import
+    for pkg in _DA3_INFERENCE_DEPS:
+        fou.ensure_package(pkg, error_level=2) or fou.install_package(pkg)
+
+    args = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--no-deps",
+        _DA3_REQUIREMENT,
+    ]
+    proc = subprocess.run(args, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            "Failed to install depth-anything-3:\n%s" % proc.stderr
+        )
+
+
+def _stub_da3_export() -> None:
+    # `depth_anything_3.api` imports the export stack at module level even
+    # though inference never uses it, and that chain requires numpy<2 plus
+    # heavy media dependencies. When the real module cannot import, register
+    # a stub so depth prediction works; 3D exports then raise with guidance
+    try:
+        importlib.import_module("depth_anything_3.utils.export")
+        return
+    except ImportError:
+        pass
+
+    stub = types.ModuleType("depth_anything_3.utils.export")
+
+    def export(*args, **kwargs):
+        raise ImportError(
+            "depth_anything_3's export stack is unavailable in this "
+            "environment; it requires numpy<2 and the package's full "
+            "dependencies. Depth prediction is unaffected"
+        )
+
+    stub.export = export
+    sys.modules["depth_anything_3.utils.export"] = stub
+
+
 def _ensure_depth_anything_3() -> None:
     if not fou.ensure_package("depth-anything-3", error_level=2):
-        fou.install_package(
-            "git+https://github.com/ByteDance-Seed/depth-anything-3.git"
-            "@2c21ea849ceec7b469a3e62ea0c0e270afc3281a"
-        )
+        _install_depth_anything_3()
+
+    _stub_da3_export()
 
 
 da3_api = fou.lazy_import(
@@ -40,6 +109,12 @@ da3_api = fou.lazy_import(
 )
 
 DEFAULT_DA3_MODEL = "depth-anything/da3-base"
+_VALID_REF_VIEW_STRATEGIES = (
+    "first",
+    "middle",
+    "saddle_balanced",
+    "saddle_sim_range",
+)
 
 
 class DepthAnythingV3OutputProcessor(fout.OutputProcessor):
@@ -87,10 +162,12 @@ class DepthAnythingV3OutputProcessor(fout.OutputProcessor):
             raise ValueError("Model output 'depth' is None")
 
         if isinstance(depth_maps, (list, tuple)):
-            depth_maps = torch.stack([
-                t if isinstance(t, torch.Tensor) else torch.as_tensor(t)
-                for t in depth_maps
-            ])
+            depth_maps = torch.stack(
+                [
+                    t if isinstance(t, torch.Tensor) else torch.as_tensor(t)
+                    for t in depth_maps
+                ]
+            )
 
         if isinstance(depth_maps, torch.Tensor):
             depth_maps = depth_maps.detach().cpu().numpy()
@@ -116,7 +193,9 @@ class DepthAnythingV3OutputProcessor(fout.OutputProcessor):
             if len(conf_maps) < len(depth_maps):
                 logger.warning(
                     "Confidence maps (%d) fewer than depth maps (%d), "
-                    "skipping confidence", len(conf_maps), len(depth_maps)
+                    "skipping confidence",
+                    len(conf_maps),
+                    len(depth_maps),
                 )
                 conf_maps = None
             else:
@@ -130,12 +209,27 @@ class DepthAnythingV3OutputProcessor(fout.OutputProcessor):
             if len(sky_masks) < len(depth_maps):
                 logger.warning(
                     "Sky masks (%d) fewer than depth maps (%d), "
-                    "skipping sky", len(sky_masks), len(depth_maps)
+                    "skipping sky",
+                    len(sky_masks),
+                    len(depth_maps),
                 )
                 sky_masks = None
             else:
                 if len(sky_masks.shape) == 2:
                     sky_masks = sky_masks[np.newaxis, ...]
+
+        scale_factors = output.get("scale_factor")
+        if isinstance(scale_factors, torch.Tensor):
+            scale_factors = scale_factors.detach().cpu().numpy()
+        if scale_factors is not None and np.ndim(scale_factors) > 0:
+            if len(scale_factors) < len(depth_maps):
+                logger.warning(
+                    "Scale factors (%d) fewer than depth maps (%d), "
+                    "skipping scale_factor",
+                    len(scale_factors),
+                    len(depth_maps),
+                )
+                scale_factors = None
 
         width, height = frame_size
         results = []
@@ -150,7 +244,9 @@ class DepthAnythingV3OutputProcessor(fout.OutputProcessor):
                     depth = np.array(depth_img)
 
             if not np.all(np.isfinite(depth)):
-                logger.warning("Depth map contains NaN/inf values, replacing with 0")
+                logger.warning(
+                    "Depth map contains NaN/inf values, replacing with 0"
+                )
                 depth = np.where(np.isfinite(depth), depth, 0)
 
             max_depth = np.max(depth)
@@ -189,6 +285,19 @@ class DepthAnythingV3OutputProcessor(fout.OutputProcessor):
             if heatmap.is_metric:
                 heatmap.max_depth = float(max_depth)
 
+            if scale_factors is not None:
+                value = (
+                    scale_factors
+                    if np.ndim(scale_factors) == 0
+                    else scale_factors[i]
+                )
+                if isinstance(value, np.ndarray):
+                    value = value.item()
+                elif hasattr(value, "item"):
+                    value = value.item()
+
+                heatmap.scale_factor = float(value)
+
             results.append(heatmap)
 
         if results:
@@ -217,9 +326,17 @@ class DepthAnythingV3ModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
             Depth Anything V3 model
         process_res (504): the processing resolution in pixels. The model
             resizes inputs to this resolution for inference
-        process_res_method ("upper_bound_resize"): the resize strategy
+        process_res_method ("upper_bound_resize"): the resize strategy.
+            Supported values are ``"upper_bound_resize"`` and
+            ``"lower_bound_resize"``
         use_ray_pose (False): whether to use ray-based pose estimation instead
             of camera decoder (more accurate but slower)
+        ref_view_strategy ("saddle_balanced"): the strategy for selecting a
+            reference view when multiple views are provided. Supported values
+            are ``"first"``, ``"middle"``, ``"saddle_balanced"``, and
+            ``"saddle_sim_range"``
+        align_to_input_ext_scale (True): whether to align the predicted pose
+            scale to match input extrinsics when extrinsics are provided
         infer_gs (False): whether to predict 3D Gaussian Splatting parameters.
             Only supported by giant and nested models
         export_feat_layers (None): optional list of transformer layer indices
@@ -245,6 +362,22 @@ class DepthAnythingV3ModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
         )
 
         self.use_ray_pose = self.parse_bool(d, "use_ray_pose", default=False)
+
+        self.ref_view_strategy = self.parse_string(
+            d, "ref_view_strategy", default="saddle_balanced"
+        )
+        if self.ref_view_strategy not in _VALID_REF_VIEW_STRATEGIES:
+            raise ValueError(
+                "Unsupported ref_view_strategy '%s'. Supported values are: %s"
+                % (
+                    self.ref_view_strategy,
+                    ", ".join(_VALID_REF_VIEW_STRATEGIES),
+                )
+            )
+
+        self.align_to_input_ext_scale = self.parse_bool(
+            d, "align_to_input_ext_scale", default=True
+        )
 
         self.infer_gs = self.parse_bool(d, "infer_gs", default=False)
 
@@ -288,7 +421,9 @@ class DepthAnythingV3Model(fout.TorchImageModel):
 
         snapshot_download(config.name_or_path)
 
-    def _load_model(self, config: DepthAnythingV3ModelConfig) -> torch.nn.Module:
+    def _load_model(
+        self, config: DepthAnythingV3ModelConfig
+    ) -> torch.nn.Module:
         model = da3_api.DepthAnything3.from_pretrained(config.name_or_path)
         model = model.to(self._device)
         if self.using_half_precision:
@@ -307,6 +442,8 @@ class DepthAnythingV3Model(fout.TorchImageModel):
             process_res_method=self.config.process_res_method,
             infer_gs=self.config.infer_gs,
             use_ray_pose=self.config.use_ray_pose,
+            ref_view_strategy=self.config.ref_view_strategy,
+            align_to_input_ext_scale=self.config.align_to_input_ext_scale,
             export_feat_layers=self.config.export_feat_layers or [],
         )
         output = {"depth": prediction.depth}
@@ -329,6 +466,8 @@ class DepthAnythingV3Model(fout.TorchImageModel):
                 )
         if prediction.aux:
             output["aux"] = prediction.aux
+        if getattr(prediction, "scale_factor", None) is not None:
+            output["scale_factor"] = prediction.scale_factor
         return output
 
     def compute_multiview_depth(
@@ -354,12 +493,17 @@ class DepthAnythingV3Model(fout.TorchImageModel):
             process_res_method=self.config.process_res_method,
             infer_gs=self.config.infer_gs,
             use_ray_pose=self.config.use_ray_pose,
+            ref_view_strategy=self.config.ref_view_strategy,
+            align_to_input_ext_scale=self.config.align_to_input_ext_scale,
             export_feat_layers=self.config.export_feat_layers or [],
             extrinsics=extrinsics,
             intrinsics=intrinsics,
         )
 
-        output = {"depth": prediction.depth, "is_metric": self.config.is_metric}
+        output = {
+            "depth": prediction.depth,
+            "is_metric": self.config.is_metric,
+        }
         if prediction.conf is not None:
             output["confidence"] = prediction.conf
         if prediction.sky is not None:
@@ -372,6 +516,8 @@ class DepthAnythingV3Model(fout.TorchImageModel):
             output["gaussians"] = prediction.gaussians
         if prediction.aux:
             output["aux"] = prediction.aux
+        if getattr(prediction, "scale_factor", None) is not None:
+            output["scale_factor"] = prediction.scale_factor
 
         processor = DepthAnythingV3OutputProcessor()
         return processor(output, (None, None))
@@ -385,8 +531,15 @@ class DepthAnythingV3Model(fout.TorchImageModel):
         overwrite: bool = False,
         skip_failures: bool = False,
         progress: Optional[bool] = None,
+        *,
+        conf_thresh_percentile: float = 40.0,
+        num_max_points: int = 1_000_000,
+        show_cameras: bool = True,
     ) -> None:
         """Computes 3D exports (GLB, PLY) for samples.
+
+        Requires depth_anything_3's export stack (``numpy<2`` and its full
+        dependencies).
 
         Examples::
 
@@ -404,11 +557,17 @@ class DepthAnythingV3Model(fout.TorchImageModel):
         Args:
             samples: a :class:`fiftyone.core.collections.SampleCollection`
             output_dir: directory to write exports
-            export_format ("glb"): export format. One of ``"glb"``, ``"gs_ply"``
+            export_format ("glb"): export format. One of ``"glb"``,
+                ``"gs_ply"``, ``"gs_video"``
             rel_dir (None): optional relative directory to strip from filepaths
             overwrite (False): whether to overwrite existing exports
             skip_failures (False): whether to gracefully continue on errors
             progress (None): whether to show progress bar
+            conf_thresh_percentile (40.0): lower percentile for adaptive
+                confidence threshold when exporting GLB point clouds
+            num_max_points (1000000): maximum number of points in GLB exports
+            show_cameras (True): whether to show camera wireframes in GLB
+                exports
         """
         fov.validate_collection(samples)
 
@@ -426,9 +585,18 @@ class DepthAnythingV3Model(fout.TorchImageModel):
             try:
                 self._model.inference(
                     [sample.filepath],
+                    process_res=self.config.process_res,
+                    process_res_method=self.config.process_res_method,
                     infer_gs=infer_gs,
+                    use_ray_pose=self.config.use_ray_pose,
+                    ref_view_strategy=self.config.ref_view_strategy,
+                    align_to_input_ext_scale=self.config.align_to_input_ext_scale,
+                    export_feat_layers=self.config.export_feat_layers or [],
                     export_dir=sample_export_dir,
                     export_format=export_format,
+                    conf_thresh_percentile=conf_thresh_percentile,
+                    num_max_points=num_max_points,
+                    show_cameras=show_cameras,
                 )
             except Exception as e:
                 if not skip_failures:
@@ -444,3 +612,17 @@ class DepthAnythingV3Model(fout.TorchImageModel):
                 sample["da3_export_path"] = os.path.join(
                     sample_export_dir, "gs_ply", "0000.ply"
                 )
+            elif export_format == "gs_video":
+                # The directory comes from the sample filepath, so escape it;
+                # only the trailing components are patterns
+                video_paths = sorted(
+                    glob.glob(
+                        os.path.join(
+                            glob.escape(sample_export_dir),
+                            "gs_video",
+                            "*.mp4",
+                        )
+                    )
+                )
+                if video_paths:
+                    sample["da3_export_path"] = video_paths[-1]

--- a/tests/unittests/utils/test_depth_anything.py
+++ b/tests/unittests/utils/test_depth_anything.py
@@ -228,3 +228,61 @@ class TestDepthAnythingV3OutputProcessor:
         results = processor({"depth": depth}, (None, None))
 
         assert results[0].map.shape == (50, 60)
+
+    def test_scale_factor_surfaced_on_first_heatmap(self):
+        """Test scale_factor from prediction is attached to first heatmap."""
+        processor = self._make_processor()
+        depth = np.array([[[1.0, 2.0], [3.0, 4.0]]], dtype=np.float32)
+
+        results = processor(
+            {"depth": depth, "scale_factor": 0.42}, (2, 2)
+        )
+
+        assert results[0].scale_factor == pytest.approx(0.42)
+
+    def test_scale_factor_absent_when_not_provided(self):
+        """Test scale_factor is not set when missing from output."""
+        processor = self._make_processor()
+        depth = np.array([[[1.0, 2.0], [3.0, 4.0]]], dtype=np.float32)
+
+        results = processor({"depth": depth}, (2, 2))
+
+        assert not hasattr(results[0], "scale_factor") or results[0].scale_factor is None
+
+
+class TestDepthAnythingV3ModelConfigNewParams:
+    """Test new config parameters: ref_view_strategy, align_to_input_ext_scale."""
+
+    def test_ref_view_strategy_default(self):
+        """Test ref_view_strategy defaults to saddle_balanced."""
+        from fiftyone.utils.depth_anything import DepthAnythingV3ModelConfig
+
+        config = DepthAnythingV3ModelConfig({})
+
+        assert config.ref_view_strategy == "saddle_balanced"
+
+    def test_ref_view_strategy_explicit(self):
+        """Test ref_view_strategy can be set to each valid value."""
+        from fiftyone.utils.depth_anything import DepthAnythingV3ModelConfig
+
+        for strategy in ("first", "middle", "saddle_balanced", "saddle_sim_range"):
+            config = DepthAnythingV3ModelConfig({"ref_view_strategy": strategy})
+            assert config.ref_view_strategy == strategy
+
+    def test_align_to_input_ext_scale_default(self):
+        """Test align_to_input_ext_scale defaults to True."""
+        from fiftyone.utils.depth_anything import DepthAnythingV3ModelConfig
+
+        config = DepthAnythingV3ModelConfig({})
+
+        assert config.align_to_input_ext_scale is True
+
+    def test_align_to_input_ext_scale_explicit(self):
+        """Test align_to_input_ext_scale can be set explicitly."""
+        from fiftyone.utils.depth_anything import DepthAnythingV3ModelConfig
+
+        config_false = DepthAnythingV3ModelConfig({"align_to_input_ext_scale": False})
+        assert config_false.align_to_input_ext_scale is False
+
+        config_true = DepthAnythingV3ModelConfig({"align_to_input_ext_scale": True})
+        assert config_true.align_to_input_ext_scale is True

--- a/tests/unittests/utils/test_depth_anything.py
+++ b/tests/unittests/utils/test_depth_anything.py
@@ -9,6 +9,7 @@ Tests for fiftyone/utils/depth_anything.py Depth Anything V3 model wrapper.
 import inspect
 import os
 from types import SimpleNamespace
+from typing import Any, Iterator, List, Optional
 
 import numpy as np
 import pytest
@@ -340,32 +341,43 @@ class TestDepthAnythingV3ModelConfigNewParams:
 class TestDepthAnythingV3Exports:
     def test_compute_3d_exports_uses_keyword_only_args_and_sets_gs_video_path(
         self, monkeypatch
-    ):
+    ) -> None:
         from fiftyone.utils.depth_anything import DepthAnythingV3Model
         import fiftyone.utils.depth_anything as foda
 
         class _FakeSample(dict):
-            def __init__(self, filepath):
+            def __init__(self, filepath: str) -> None:
                 super().__init__()
                 self.filepath = filepath
 
         class _FakeCollection:
-            def __init__(self, samples):
+            def __init__(self, samples: List["_FakeSample"]) -> None:
                 self._samples = samples
 
-            def iter_samples(self, autosave=True, progress=None):
+            def iter_samples(
+                self,
+                autosave: bool = True,
+                progress: Optional[bool] = None,
+            ) -> Iterator["_FakeSample"]:
                 return iter(self._samples)
 
         class _FakeFilenameMaker:
-            def __init__(self, output_dir, rel_dir=None, ignore_existing=False):
+            def __init__(
+                self,
+                output_dir: str,
+                rel_dir: Optional[str] = None,
+                ignore_existing: bool = False,
+            ) -> None:
                 self.output_dir = output_dir
 
-            def get_output_path(self, filepath, output_ext=""):
+            def get_output_path(
+                self, filepath: str, output_ext: str = ""
+            ) -> str:
                 return os.path.join(self.output_dir, "sample")
 
         calls = []
 
-        def _fake_inference(filepaths, **kwargs):
+        def _fake_inference(filepaths: List[str], **kwargs: Any) -> None:
             calls.append((filepaths, kwargs))
             gs_video_dir = os.path.join(kwargs["export_dir"], "gs_video")
             os.makedirs(gs_video_dir, exist_ok=True)

--- a/tests/unittests/utils/test_depth_anything.py
+++ b/tests/unittests/utils/test_depth_anything.py
@@ -6,6 +6,9 @@ Tests for fiftyone/utils/depth_anything.py Depth Anything V3 model wrapper.
 |
 """
 
+import inspect
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 import torch
@@ -286,3 +289,81 @@ class TestDepthAnythingV3ModelConfigNewParams:
 
         config_true = DepthAnythingV3ModelConfig({"align_to_input_ext_scale": True})
         assert config_true.align_to_input_ext_scale is True
+
+
+class TestDepthAnythingV3Exports:
+    def test_compute_3d_exports_uses_keyword_only_args_and_sets_gs_video_path(
+        self, monkeypatch
+    ):
+        from fiftyone.utils.depth_anything import DepthAnythingV3Model
+        import fiftyone.utils.depth_anything as foda
+
+        class _FakeSample(dict):
+            def __init__(self, filepath):
+                super().__init__()
+                self.filepath = filepath
+
+        class _FakeCollection:
+            def __init__(self, samples):
+                self._samples = samples
+
+            def iter_samples(self, autosave=True, progress=None):
+                return iter(self._samples)
+
+        class _FakeFilenameMaker:
+            def __init__(self, output_dir, rel_dir=None, ignore_existing=False):
+                self.output_dir = output_dir
+
+            def get_output_path(self, filepath, output_ext=""):
+                return self.output_dir + "\\sample"
+
+        calls = []
+
+        def _fake_inference(filepaths, **kwargs):
+            calls.append((filepaths, kwargs))
+            gs_video_dir = kwargs["export_dir"] + "\\gs_video"
+            import os
+            os.makedirs(gs_video_dir, exist_ok=True)
+            with open(gs_video_dir + "\\0000_wander.mp4", "wb") as f:
+                f.write(b"")
+
+        monkeypatch.setattr(foda.fov, "validate_collection", lambda samples: None)
+        monkeypatch.setattr(foda.fou, "UniqueFilenameMaker", _FakeFilenameMaker)
+
+        model = DepthAnythingV3Model.__new__(DepthAnythingV3Model)
+        model._model = SimpleNamespace(inference=_fake_inference)
+
+        sample = _FakeSample("C:\\data\\image.png")
+        samples = _FakeCollection([sample])
+
+        model.compute_3d_exports(
+            samples,
+            "C:\\exports",
+            export_format="gs_video",
+            conf_thresh_percentile=12.5,
+            num_max_points=123,
+            show_cameras=False,
+        )
+
+        signature = inspect.signature(model.compute_3d_exports)
+        assert (
+            signature.parameters["conf_thresh_percentile"].kind
+            is inspect.Parameter.KEYWORD_ONLY
+        )
+        assert (
+            signature.parameters["num_max_points"].kind
+            is inspect.Parameter.KEYWORD_ONLY
+        )
+        assert (
+            signature.parameters["show_cameras"].kind
+            is inspect.Parameter.KEYWORD_ONLY
+        )
+
+        assert len(calls) == 1
+        _, kwargs = calls[0]
+        assert kwargs["infer_gs"] is True
+        assert kwargs["export_format"] == "gs_video"
+        assert kwargs["conf_thresh_percentile"] == pytest.approx(12.5)
+        assert kwargs["num_max_points"] == 123
+        assert kwargs["show_cameras"] is False
+        assert sample["da3_export_path"] == "C:\\exports\\sample\\gs_video\\0000_wander.mp4"

--- a/tests/unittests/utils/test_depth_anything.py
+++ b/tests/unittests/utils/test_depth_anything.py
@@ -269,6 +269,28 @@ class TestDepthAnythingV3OutputProcessor:
         assert results[0].scale_factor == pytest.approx(0.42)
         assert results[1].scale_factor == pytest.approx(0.42)
 
+    def test_batched_scale_factor_tensor_is_scalarized_per_heatmap(self):
+        """Test batched tensor scale_factor is converted per heatmap."""
+        processor = self._make_processor()
+        depth = np.array([
+            [[1.0, 2.0], [3.0, 4.0]],
+            [[2.0, 3.0], [4.0, 5.0]],
+        ], dtype=np.float32)
+
+        results = processor(
+            {
+                "depth": depth,
+                "scale_factor": torch.tensor([0.42, 0.84], dtype=torch.float32),
+            },
+            (2, 2),
+        )
+
+        assert len(results) == 2
+        assert isinstance(results[0].scale_factor, float)
+        assert isinstance(results[1].scale_factor, float)
+        assert results[0].scale_factor == pytest.approx(0.42)
+        assert results[1].scale_factor == pytest.approx(0.84)
+
 
 class TestDepthAnythingV3ModelConfigNewParams:
     """Test new config parameters: ref_view_strategy, align_to_input_ext_scale."""

--- a/tests/unittests/utils/test_depth_anything.py
+++ b/tests/unittests/utils/test_depth_anything.py
@@ -7,6 +7,7 @@ Tests for fiftyone/utils/depth_anything.py Depth Anything V3 model wrapper.
 """
 
 import inspect
+import os
 from types import SimpleNamespace
 
 import numpy as np
@@ -252,6 +253,22 @@ class TestDepthAnythingV3OutputProcessor:
 
         assert not hasattr(results[0], "scale_factor") or results[0].scale_factor is None
 
+    def test_scale_factor_surfaced_on_all_heatmaps(self):
+        """Test scale_factor is attached to every heatmap in a batch."""
+        processor = self._make_processor()
+        depth = np.array([
+            [[1.0, 2.0], [3.0, 4.0]],
+            [[2.0, 3.0], [4.0, 5.0]],
+        ], dtype=np.float32)
+
+        results = processor(
+            {"depth": depth, "scale_factor": 0.42}, (2, 2)
+        )
+
+        assert len(results) == 2
+        assert results[0].scale_factor == pytest.approx(0.42)
+        assert results[1].scale_factor == pytest.approx(0.42)
+
 
 class TestDepthAnythingV3ModelConfigNewParams:
     """Test new config parameters: ref_view_strategy, align_to_input_ext_scale."""
@@ -290,6 +307,13 @@ class TestDepthAnythingV3ModelConfigNewParams:
         config_true = DepthAnythingV3ModelConfig({"align_to_input_ext_scale": True})
         assert config_true.align_to_input_ext_scale is True
 
+    def test_ref_view_strategy_invalid_raises(self):
+        """Test invalid ref_view_strategy values fail fast."""
+        from fiftyone.utils.depth_anything import DepthAnythingV3ModelConfig
+
+        with pytest.raises(ValueError, match="Unsupported ref_view_strategy"):
+            DepthAnythingV3ModelConfig({"ref_view_strategy": "typo"})
+
 
 class TestDepthAnythingV3Exports:
     def test_compute_3d_exports_uses_keyword_only_args_and_sets_gs_video_path(
@@ -315,16 +339,15 @@ class TestDepthAnythingV3Exports:
                 self.output_dir = output_dir
 
             def get_output_path(self, filepath, output_ext=""):
-                return self.output_dir + "\\sample"
+                return os.path.join(self.output_dir, "sample")
 
         calls = []
 
         def _fake_inference(filepaths, **kwargs):
             calls.append((filepaths, kwargs))
-            gs_video_dir = kwargs["export_dir"] + "\\gs_video"
-            import os
+            gs_video_dir = os.path.join(kwargs["export_dir"], "gs_video")
             os.makedirs(gs_video_dir, exist_ok=True)
-            with open(gs_video_dir + "\\0000_wander.mp4", "wb") as f:
+            with open(os.path.join(gs_video_dir, "0000_wander.mp4"), "wb") as f:
                 f.write(b"")
 
         monkeypatch.setattr(foda.fov, "validate_collection", lambda samples: None)
@@ -366,4 +389,6 @@ class TestDepthAnythingV3Exports:
         assert kwargs["conf_thresh_percentile"] == pytest.approx(12.5)
         assert kwargs["num_max_points"] == 123
         assert kwargs["show_cameras"] is False
-        assert sample["da3_export_path"] == "C:\\exports\\sample\\gs_video\\0000_wander.mp4"
+        assert sample["da3_export_path"] == os.path.join(
+            "C:\\exports", "sample", "gs_video", "0000_wander.mp4"
+        )

--- a/tests/unittests/utils/test_depth_anything.py
+++ b/tests/unittests/utils/test_depth_anything.py
@@ -8,8 +8,9 @@ Tests for fiftyone/utils/depth_anything.py Depth Anything V3 model wrapper.
 
 import inspect
 import os
+from collections.abc import Iterator
 from types import SimpleNamespace
-from typing import Any, Iterator, List, Optional
+from typing import Any, Optional
 
 import numpy as np
 import pytest
@@ -37,9 +38,9 @@ class TestDepthAnythingV3ModelConfig:
         """Test custom name_or_path overrides default."""
         from fiftyone.utils.depth_anything import DepthAnythingV3ModelConfig
 
-        config = DepthAnythingV3ModelConfig({
-            "name_or_path": "depth-anything/da3-large"
-        })
+        config = DepthAnythingV3ModelConfig(
+            {"name_or_path": "depth-anything/da3-large"}
+        )
 
         assert config.name_or_path == "depth-anything/da3-large"
 
@@ -56,10 +57,12 @@ class TestDepthAnythingV3ModelConfig:
         """Test process_res can be set explicitly."""
         from fiftyone.utils.depth_anything import DepthAnythingV3ModelConfig
 
-        config = DepthAnythingV3ModelConfig({
-            "process_res": 336,
-            "process_res_method": "upper_bound_resize",
-        })
+        config = DepthAnythingV3ModelConfig(
+            {
+                "process_res": 336,
+                "process_res_method": "upper_bound_resize",
+            }
+        )
 
         assert config.process_res == 336
         assert config.process_res_method == "upper_bound_resize"
@@ -87,7 +90,10 @@ class TestDepthAnythingV3OutputProcessor:
     """Test DepthAnythingV3OutputProcessor."""
 
     def _make_processor(self) -> "DepthAnythingV3OutputProcessor":
-        from fiftyone.utils.depth_anything import DepthAnythingV3OutputProcessor
+        from fiftyone.utils.depth_anything import (
+            DepthAnythingV3OutputProcessor,
+        )
+
         return DepthAnythingV3OutputProcessor()
 
     def test_invalid_output_type_raises(self):
@@ -132,7 +138,9 @@ class TestDepthAnythingV3OutputProcessor:
 
         assert len(results) == 1
         expected = depth_2d / 4.0
-        np.testing.assert_array_almost_equal(results[0].map, expected, decimal=5)
+        np.testing.assert_array_almost_equal(
+            results[0].map, expected, decimal=5
+        )
 
     def test_depth_normalization_scales_to_unit_range(self):
         """Test depth values are normalized to [0, 1] with max=1."""
@@ -187,26 +195,29 @@ class TestDepthAnythingV3OutputProcessor:
     def test_batch_processing_normalizes_each_independently(self):
         """Test each depth map in batch is normalized independently."""
         processor = self._make_processor()
-        depth = np.array([
-            [[0.0, 10.0], [10.0, 10.0]],
-            [[0.0, 100.0], [100.0, 100.0]],
-        ], dtype=np.float32)
+        depth = np.array(
+            [
+                [[0.0, 10.0], [10.0, 10.0]],
+                [[0.0, 100.0], [100.0, 100.0]],
+            ],
+            dtype=np.float32,
+        )
 
         results = processor({"depth": depth}, (2, 2))
 
         assert len(results) == 2
         assert results[0].map.max() == pytest.approx(1.0)
         assert results[1].map.max() == pytest.approx(1.0)
-        np.testing.assert_array_almost_equal(results[0].map, results[1].map, decimal=5)
+        np.testing.assert_array_almost_equal(
+            results[0].map, results[1].map, decimal=5
+        )
 
     def test_metric_output_stores_max_depth(self):
         """Test metric models store max_depth for meter recovery."""
         processor = self._make_processor()
         depth = np.array([[[10.0, 20.0], [30.0, 40.0]]], dtype=np.float32)
 
-        results = processor(
-            {"depth": depth, "is_metric": True}, (2, 2)
-        )
+        results = processor({"depth": depth, "is_metric": True}, (2, 2))
 
         assert results[0].is_metric is True
         assert results[0].max_depth == pytest.approx(40.0)
@@ -218,12 +229,13 @@ class TestDepthAnythingV3OutputProcessor:
         processor = self._make_processor()
         depth = np.array([[[10.0, 20.0], [30.0, 40.0]]], dtype=np.float32)
 
-        results = processor(
-            {"depth": depth, "is_metric": False}, (2, 2)
-        )
+        results = processor({"depth": depth, "is_metric": False}, (2, 2))
 
         assert results[0].is_metric is False
-        assert not hasattr(results[0], "max_depth") or results[0].max_depth is None
+        assert (
+            not hasattr(results[0], "max_depth")
+            or results[0].max_depth is None
+        )
 
     def test_none_frame_size_skips_resize(self):
         """Test None dimensions in frame_size skips resize."""
@@ -239,9 +251,7 @@ class TestDepthAnythingV3OutputProcessor:
         processor = self._make_processor()
         depth = np.array([[[1.0, 2.0], [3.0, 4.0]]], dtype=np.float32)
 
-        results = processor(
-            {"depth": depth, "scale_factor": 0.42}, (2, 2)
-        )
+        results = processor({"depth": depth, "scale_factor": 0.42}, (2, 2))
 
         assert results[0].scale_factor == pytest.approx(0.42)
 
@@ -252,19 +262,23 @@ class TestDepthAnythingV3OutputProcessor:
 
         results = processor({"depth": depth}, (2, 2))
 
-        assert not hasattr(results[0], "scale_factor") or results[0].scale_factor is None
+        assert (
+            not hasattr(results[0], "scale_factor")
+            or results[0].scale_factor is None
+        )
 
     def test_scale_factor_surfaced_on_all_heatmaps(self):
         """Test scale_factor is attached to every heatmap in a batch."""
         processor = self._make_processor()
-        depth = np.array([
-            [[1.0, 2.0], [3.0, 4.0]],
-            [[2.0, 3.0], [4.0, 5.0]],
-        ], dtype=np.float32)
-
-        results = processor(
-            {"depth": depth, "scale_factor": 0.42}, (2, 2)
+        depth = np.array(
+            [
+                [[1.0, 2.0], [3.0, 4.0]],
+                [[2.0, 3.0], [4.0, 5.0]],
+            ],
+            dtype=np.float32,
         )
+
+        results = processor({"depth": depth, "scale_factor": 0.42}, (2, 2))
 
         assert len(results) == 2
         assert results[0].scale_factor == pytest.approx(0.42)
@@ -273,15 +287,20 @@ class TestDepthAnythingV3OutputProcessor:
     def test_batched_scale_factor_tensor_is_scalarized_per_heatmap(self):
         """Test batched tensor scale_factor is converted per heatmap."""
         processor = self._make_processor()
-        depth = np.array([
-            [[1.0, 2.0], [3.0, 4.0]],
-            [[2.0, 3.0], [4.0, 5.0]],
-        ], dtype=np.float32)
+        depth = np.array(
+            [
+                [[1.0, 2.0], [3.0, 4.0]],
+                [[2.0, 3.0], [4.0, 5.0]],
+            ],
+            dtype=np.float32,
+        )
 
         results = processor(
             {
                 "depth": depth,
-                "scale_factor": torch.tensor([0.42, 0.84], dtype=torch.float32),
+                "scale_factor": torch.tensor(
+                    [0.42, 0.84], dtype=torch.float32
+                ),
             },
             (2, 2),
         )
@@ -291,6 +310,29 @@ class TestDepthAnythingV3OutputProcessor:
         assert isinstance(results[1].scale_factor, float)
         assert results[0].scale_factor == pytest.approx(0.42)
         assert results[1].scale_factor == pytest.approx(0.84)
+
+    def test_scale_factor_short_batch_drops_for_all_heatmaps(self):
+        """Test scale_factor is dropped when it is shorter than the batch."""
+        processor = self._make_processor()
+        depth = np.array(
+            [
+                [[1.0, 2.0], [3.0, 4.0]],
+                [[2.0, 3.0], [4.0, 5.0]],
+            ],
+            dtype=np.float32,
+        )
+
+        results = processor(
+            {
+                "depth": depth,
+                "scale_factor": torch.tensor([0.42], dtype=torch.float32),
+            },
+            (2, 2),
+        )
+
+        assert len(results) == 2
+        for heatmap in results:
+            assert getattr(heatmap, "scale_factor", None) is None
 
 
 class TestDepthAnythingV3ModelConfigNewParams:
@@ -308,8 +350,15 @@ class TestDepthAnythingV3ModelConfigNewParams:
         """Test ref_view_strategy can be set to each valid value."""
         from fiftyone.utils.depth_anything import DepthAnythingV3ModelConfig
 
-        for strategy in ("first", "middle", "saddle_balanced", "saddle_sim_range"):
-            config = DepthAnythingV3ModelConfig({"ref_view_strategy": strategy})
+        for strategy in (
+            "first",
+            "middle",
+            "saddle_balanced",
+            "saddle_sim_range",
+        ):
+            config = DepthAnythingV3ModelConfig(
+                {"ref_view_strategy": strategy}
+            )
             assert config.ref_view_strategy == strategy
 
     def test_align_to_input_ext_scale_default(self):
@@ -324,10 +373,14 @@ class TestDepthAnythingV3ModelConfigNewParams:
         """Test align_to_input_ext_scale can be set explicitly."""
         from fiftyone.utils.depth_anything import DepthAnythingV3ModelConfig
 
-        config_false = DepthAnythingV3ModelConfig({"align_to_input_ext_scale": False})
+        config_false = DepthAnythingV3ModelConfig(
+            {"align_to_input_ext_scale": False}
+        )
         assert config_false.align_to_input_ext_scale is False
 
-        config_true = DepthAnythingV3ModelConfig({"align_to_input_ext_scale": True})
+        config_true = DepthAnythingV3ModelConfig(
+            {"align_to_input_ext_scale": True}
+        )
         assert config_true.align_to_input_ext_scale is True
 
     def test_ref_view_strategy_invalid_raises(self):
@@ -338,64 +391,79 @@ class TestDepthAnythingV3ModelConfigNewParams:
             DepthAnythingV3ModelConfig({"ref_view_strategy": "typo"})
 
 
+class _FakeSample(dict):
+    def __init__(self, filepath: str) -> None:
+        super().__init__()
+        self.filepath = filepath
+
+
+class _FakeCollection:
+    def __init__(self, samples: list["_FakeSample"]) -> None:
+        self._samples = samples
+
+    def iter_samples(
+        self,
+        autosave: bool = True,
+        progress: Optional[bool] = None,
+    ) -> Iterator["_FakeSample"]:
+        return iter(self._samples)
+
+
+class _FakeFilenameMaker:
+    def __init__(
+        self,
+        output_dir: str,
+        rel_dir: Optional[str] = None,
+        ignore_existing: bool = False,
+    ) -> None:
+        self.output_dir = output_dir
+
+    def get_output_path(self, filepath: str, output_ext: str = "") -> str:
+        return os.path.join(self.output_dir, "sample")
+
+
+def _make_export_model(config_dict: Optional[dict] = None):
+    """A DepthAnythingV3Model with a real config and a recording inference."""
+    from fiftyone.utils.depth_anything import (
+        DepthAnythingV3Model,
+        DepthAnythingV3ModelConfig,
+    )
+
+    calls = []
+
+    def _fake_inference(filepaths: list[str], **kwargs: Any) -> None:
+        calls.append((filepaths, kwargs))
+        gs_video_dir = os.path.join(kwargs["export_dir"], "gs_video")
+        os.makedirs(gs_video_dir, exist_ok=True)
+        with open(os.path.join(gs_video_dir, "0000_wander.mp4"), "wb") as f:
+            f.write(b"")
+
+    model = DepthAnythingV3Model.__new__(DepthAnythingV3Model)
+    model.config = DepthAnythingV3ModelConfig(config_dict or {})
+    model._model = SimpleNamespace(inference=_fake_inference)
+    return model, calls
+
+
 class TestDepthAnythingV3Exports:
     def test_compute_3d_exports_uses_keyword_only_args_and_sets_gs_video_path(
-        self, monkeypatch
+        self, monkeypatch, tmp_path
     ) -> None:
-        from fiftyone.utils.depth_anything import DepthAnythingV3Model
         import fiftyone.utils.depth_anything as foda
 
-        class _FakeSample(dict):
-            def __init__(self, filepath: str) -> None:
-                super().__init__()
-                self.filepath = filepath
+        monkeypatch.setattr(
+            foda.fov, "validate_collection", lambda samples: None
+        )
+        monkeypatch.setattr(
+            foda.fou, "UniqueFilenameMaker", _FakeFilenameMaker
+        )
 
-        class _FakeCollection:
-            def __init__(self, samples: List["_FakeSample"]) -> None:
-                self._samples = samples
-
-            def iter_samples(
-                self,
-                autosave: bool = True,
-                progress: Optional[bool] = None,
-            ) -> Iterator["_FakeSample"]:
-                return iter(self._samples)
-
-        class _FakeFilenameMaker:
-            def __init__(
-                self,
-                output_dir: str,
-                rel_dir: Optional[str] = None,
-                ignore_existing: bool = False,
-            ) -> None:
-                self.output_dir = output_dir
-
-            def get_output_path(
-                self, filepath: str, output_ext: str = ""
-            ) -> str:
-                return os.path.join(self.output_dir, "sample")
-
-        calls = []
-
-        def _fake_inference(filepaths: List[str], **kwargs: Any) -> None:
-            calls.append((filepaths, kwargs))
-            gs_video_dir = os.path.join(kwargs["export_dir"], "gs_video")
-            os.makedirs(gs_video_dir, exist_ok=True)
-            with open(os.path.join(gs_video_dir, "0000_wander.mp4"), "wb") as f:
-                f.write(b"")
-
-        monkeypatch.setattr(foda.fov, "validate_collection", lambda samples: None)
-        monkeypatch.setattr(foda.fou, "UniqueFilenameMaker", _FakeFilenameMaker)
-
-        model = DepthAnythingV3Model.__new__(DepthAnythingV3Model)
-        model._model = SimpleNamespace(inference=_fake_inference)
-
-        sample = _FakeSample("C:\\data\\image.png")
-        samples = _FakeCollection([sample])
+        model, calls = _make_export_model()
+        export_dir = str(tmp_path / "exports")
+        sample = _FakeSample(str(tmp_path / "data" / "image.png"))
 
         model.compute_3d_exports(
-            samples,
-            "C:\\exports",
+            _FakeCollection([sample]),
+            export_dir,
             export_format="gs_video",
             conf_thresh_percentile=12.5,
             num_max_points=123,
@@ -424,5 +492,135 @@ class TestDepthAnythingV3Exports:
         assert kwargs["num_max_points"] == 123
         assert kwargs["show_cameras"] is False
         assert sample["da3_export_path"] == os.path.join(
-            "C:\\exports", "sample", "gs_video", "0000_wander.mp4"
+            export_dir, "sample", "gs_video", "0000_wander.mp4"
         )
+
+    def test_compute_3d_exports_forwards_model_config(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """The export path applies the same config as depth prediction."""
+        import fiftyone.utils.depth_anything as foda
+
+        monkeypatch.setattr(
+            foda.fov, "validate_collection", lambda samples: None
+        )
+        monkeypatch.setattr(
+            foda.fou, "UniqueFilenameMaker", _FakeFilenameMaker
+        )
+
+        model, calls = _make_export_model(
+            {
+                "process_res": 336,
+                "process_res_method": "lower_bound_resize",
+                "use_ray_pose": True,
+                "ref_view_strategy": "middle",
+                "align_to_input_ext_scale": True,
+            }
+        )
+        sample = _FakeSample(str(tmp_path / "data" / "image.png"))
+
+        model.compute_3d_exports(
+            _FakeCollection([sample]),
+            str(tmp_path / "exports"),
+            export_format="gs_video",
+        )
+
+        _, kwargs = calls[0]
+        assert kwargs["process_res"] == 336
+        assert kwargs["process_res_method"] == "lower_bound_resize"
+        assert kwargs["use_ray_pose"] is True
+        assert kwargs["ref_view_strategy"] == "middle"
+        assert kwargs["align_to_input_ext_scale"] is True
+        assert kwargs["export_feat_layers"] == []
+
+    def test_compute_3d_exports_escapes_glob_metacharacters(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """An export directory containing [ ] still resolves the MP4."""
+        import fiftyone.utils.depth_anything as foda
+
+        monkeypatch.setattr(
+            foda.fov, "validate_collection", lambda samples: None
+        )
+        monkeypatch.setattr(
+            foda.fou, "UniqueFilenameMaker", _FakeFilenameMaker
+        )
+
+        model, _ = _make_export_model()
+        export_dir = str(tmp_path / "exports [v1]")
+        sample = _FakeSample(str(tmp_path / "data" / "image.png"))
+
+        model.compute_3d_exports(
+            _FakeCollection([sample]),
+            export_dir,
+            export_format="gs_video",
+        )
+
+        assert sample["da3_export_path"] == os.path.join(
+            export_dir, "sample", "gs_video", "0000_wander.mp4"
+        )
+
+
+class TestDepthAnythingV3InferenceForwarding:
+    """The config reaches self._model.inference, not just the config object."""
+
+    @staticmethod
+    def _make_model(config_dict):
+        from fiftyone.utils.depth_anything import (
+            DepthAnythingV3Model,
+            DepthAnythingV3ModelConfig,
+        )
+
+        calls = []
+
+        def _fake_inference(inputs, **kwargs):
+            calls.append((inputs, kwargs))
+            return SimpleNamespace(
+                depth=np.zeros((1, 2, 2), dtype=np.float32),
+                conf=None,
+                sky=None,
+                extrinsics=None,
+                intrinsics=None,
+                gaussians=None,
+                aux=None,
+                scale_factor=None,
+            )
+
+        model = DepthAnythingV3Model.__new__(DepthAnythingV3Model)
+        model.config = DepthAnythingV3ModelConfig(config_dict)
+        model._model = SimpleNamespace(inference=_fake_inference)
+        return model, calls
+
+    def test_forward_pass_forwards_config(self) -> None:
+        model, calls = self._make_model(
+            {
+                "process_res": 336,
+                "process_res_method": "lower_bound_resize",
+                "use_ray_pose": True,
+                "ref_view_strategy": "first",
+                "align_to_input_ext_scale": True,
+            }
+        )
+
+        model._forward_pass([np.zeros((2, 2, 3), dtype=np.uint8)])
+
+        _, kwargs = calls[0]
+        assert kwargs["process_res"] == 336
+        assert kwargs["process_res_method"] == "lower_bound_resize"
+        assert kwargs["use_ray_pose"] is True
+        assert kwargs["ref_view_strategy"] == "first"
+        assert kwargs["align_to_input_ext_scale"] is True
+
+    def test_compute_multiview_depth_forwards_config(self) -> None:
+        model, calls = self._make_model(
+            {
+                "ref_view_strategy": "saddle_sim_range",
+                "align_to_input_ext_scale": False,
+            }
+        )
+
+        model.compute_multiview_depth(["a.png"])
+
+        _, kwargs = calls[0]
+        assert kwargs["ref_view_strategy"] == "saddle_sim_range"
+        assert kwargs["align_to_input_ext_scale"] is False

--- a/tests/unittests/utils/test_depth_anything.py
+++ b/tests/unittests/utils/test_depth_anything.py
@@ -6,11 +6,21 @@ Tests for fiftyone/utils/depth_anything.py Depth Anything V3 model wrapper.
 |
 """
 
+import inspect
+import os
+from collections.abc import Iterator
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from fiftyone.utils.depth_anything import (
+        DepthAnythingV3Model,
+        DepthAnythingV3OutputProcessor,
+    )
+
 import numpy as np
 import pytest
 import torch
-
-import fiftyone.core.labels as fol
 
 
 class TestDepthAnythingV3ModelConfig:
@@ -32,9 +42,9 @@ class TestDepthAnythingV3ModelConfig:
         """Test custom name_or_path overrides default."""
         from fiftyone.utils.depth_anything import DepthAnythingV3ModelConfig
 
-        config = DepthAnythingV3ModelConfig({
-            "name_or_path": "depth-anything/da3-large"
-        })
+        config = DepthAnythingV3ModelConfig(
+            {"name_or_path": "depth-anything/da3-large"}
+        )
 
         assert config.name_or_path == "depth-anything/da3-large"
 
@@ -51,10 +61,12 @@ class TestDepthAnythingV3ModelConfig:
         """Test process_res can be set explicitly."""
         from fiftyone.utils.depth_anything import DepthAnythingV3ModelConfig
 
-        config = DepthAnythingV3ModelConfig({
-            "process_res": 336,
-            "process_res_method": "upper_bound_resize",
-        })
+        config = DepthAnythingV3ModelConfig(
+            {
+                "process_res": 336,
+                "process_res_method": "upper_bound_resize",
+            }
+        )
 
         assert config.process_res == 336
         assert config.process_res_method == "upper_bound_resize"
@@ -82,7 +94,10 @@ class TestDepthAnythingV3OutputProcessor:
     """Test DepthAnythingV3OutputProcessor."""
 
     def _make_processor(self) -> "DepthAnythingV3OutputProcessor":
-        from fiftyone.utils.depth_anything import DepthAnythingV3OutputProcessor
+        from fiftyone.utils.depth_anything import (
+            DepthAnythingV3OutputProcessor,
+        )
+
         return DepthAnythingV3OutputProcessor()
 
     def test_invalid_output_type_raises(self):
@@ -127,7 +142,9 @@ class TestDepthAnythingV3OutputProcessor:
 
         assert len(results) == 1
         expected = depth_2d / 4.0
-        np.testing.assert_array_almost_equal(results[0].map, expected, decimal=5)
+        np.testing.assert_array_almost_equal(
+            results[0].map, expected, decimal=5
+        )
 
     def test_depth_normalization_scales_to_unit_range(self):
         """Test depth values are normalized to [0, 1] with max=1."""
@@ -182,26 +199,29 @@ class TestDepthAnythingV3OutputProcessor:
     def test_batch_processing_normalizes_each_independently(self):
         """Test each depth map in batch is normalized independently."""
         processor = self._make_processor()
-        depth = np.array([
-            [[0.0, 10.0], [10.0, 10.0]],
-            [[0.0, 100.0], [100.0, 100.0]],
-        ], dtype=np.float32)
+        depth = np.array(
+            [
+                [[0.0, 10.0], [10.0, 10.0]],
+                [[0.0, 100.0], [100.0, 100.0]],
+            ],
+            dtype=np.float32,
+        )
 
         results = processor({"depth": depth}, (2, 2))
 
         assert len(results) == 2
         assert results[0].map.max() == pytest.approx(1.0)
         assert results[1].map.max() == pytest.approx(1.0)
-        np.testing.assert_array_almost_equal(results[0].map, results[1].map, decimal=5)
+        np.testing.assert_array_almost_equal(
+            results[0].map, results[1].map, decimal=5
+        )
 
     def test_metric_output_stores_max_depth(self):
         """Test metric models store max_depth for meter recovery."""
         processor = self._make_processor()
         depth = np.array([[[10.0, 20.0], [30.0, 40.0]]], dtype=np.float32)
 
-        results = processor(
-            {"depth": depth, "is_metric": True}, (2, 2)
-        )
+        results = processor({"depth": depth, "is_metric": True}, (2, 2))
 
         assert results[0].is_metric is True
         assert results[0].max_depth == pytest.approx(40.0)
@@ -213,12 +233,13 @@ class TestDepthAnythingV3OutputProcessor:
         processor = self._make_processor()
         depth = np.array([[[10.0, 20.0], [30.0, 40.0]]], dtype=np.float32)
 
-        results = processor(
-            {"depth": depth, "is_metric": False}, (2, 2)
-        )
+        results = processor({"depth": depth, "is_metric": False}, (2, 2))
 
         assert results[0].is_metric is False
-        assert not hasattr(results[0], "max_depth") or results[0].max_depth is None
+        assert (
+            not hasattr(results[0], "max_depth")
+            or results[0].max_depth is None
+        )
 
     def test_none_frame_size_skips_resize(self):
         """Test None dimensions in frame_size skips resize."""
@@ -228,3 +249,401 @@ class TestDepthAnythingV3OutputProcessor:
         results = processor({"depth": depth}, (None, None))
 
         assert results[0].map.shape == (50, 60)
+
+    def test_scale_factor_surfaced_on_first_heatmap(self):
+        """Test scale_factor from prediction is attached to first heatmap."""
+        processor = self._make_processor()
+        depth = np.array([[[1.0, 2.0], [3.0, 4.0]]], dtype=np.float32)
+
+        results = processor({"depth": depth, "scale_factor": 0.42}, (2, 2))
+
+        assert results[0].scale_factor == pytest.approx(0.42)
+
+    def test_scale_factor_absent_when_not_provided(self):
+        """Test scale_factor is not set when missing from output."""
+        processor = self._make_processor()
+        depth = np.array([[[1.0, 2.0], [3.0, 4.0]]], dtype=np.float32)
+
+        results = processor({"depth": depth}, (2, 2))
+
+        assert (
+            not hasattr(results[0], "scale_factor")
+            or results[0].scale_factor is None
+        )
+
+    def test_scale_factor_surfaced_on_all_heatmaps(self):
+        """Test scale_factor is attached to every heatmap in a batch."""
+        processor = self._make_processor()
+        depth = np.array(
+            [
+                [[1.0, 2.0], [3.0, 4.0]],
+                [[2.0, 3.0], [4.0, 5.0]],
+            ],
+            dtype=np.float32,
+        )
+
+        results = processor({"depth": depth, "scale_factor": 0.42}, (2, 2))
+
+        assert len(results) == 2
+        assert results[0].scale_factor == pytest.approx(0.42)
+        assert results[1].scale_factor == pytest.approx(0.42)
+
+    def test_batched_scale_factor_tensor_is_scalarized_per_heatmap(self):
+        """Test batched tensor scale_factor is converted per heatmap."""
+        processor = self._make_processor()
+        depth = np.array(
+            [
+                [[1.0, 2.0], [3.0, 4.0]],
+                [[2.0, 3.0], [4.0, 5.0]],
+            ],
+            dtype=np.float32,
+        )
+
+        results = processor(
+            {
+                "depth": depth,
+                "scale_factor": torch.tensor(
+                    [0.42, 0.84], dtype=torch.float32
+                ),
+            },
+            (2, 2),
+        )
+
+        assert len(results) == 2
+        assert isinstance(results[0].scale_factor, float)
+        assert isinstance(results[1].scale_factor, float)
+        assert results[0].scale_factor == pytest.approx(0.42)
+        assert results[1].scale_factor == pytest.approx(0.84)
+
+    def test_scale_factor_short_batch_drops_for_all_heatmaps(self):
+        """Test scale_factor is dropped when it is shorter than the batch."""
+        processor = self._make_processor()
+        depth = np.array(
+            [
+                [[1.0, 2.0], [3.0, 4.0]],
+                [[2.0, 3.0], [4.0, 5.0]],
+            ],
+            dtype=np.float32,
+        )
+
+        results = processor(
+            {
+                "depth": depth,
+                "scale_factor": torch.tensor([0.42], dtype=torch.float32),
+            },
+            (2, 2),
+        )
+
+        assert len(results) == 2
+        for heatmap in results:
+            assert getattr(heatmap, "scale_factor", None) is None
+
+
+class TestDepthAnythingV3ModelConfigNewParams:
+    """Test new config parameters: ref_view_strategy, align_to_input_ext_scale."""
+
+    def test_ref_view_strategy_default(self):
+        """Test ref_view_strategy defaults to saddle_balanced."""
+        from fiftyone.utils.depth_anything import DepthAnythingV3ModelConfig
+
+        config = DepthAnythingV3ModelConfig({})
+
+        assert config.ref_view_strategy == "saddle_balanced"
+
+    def test_ref_view_strategy_explicit(self):
+        """Test ref_view_strategy can be set to each valid value."""
+        from fiftyone.utils.depth_anything import DepthAnythingV3ModelConfig
+
+        for strategy in (
+            "first",
+            "middle",
+            "saddle_balanced",
+            "saddle_sim_range",
+        ):
+            config = DepthAnythingV3ModelConfig(
+                {"ref_view_strategy": strategy}
+            )
+            assert config.ref_view_strategy == strategy
+
+    def test_align_to_input_ext_scale_default(self):
+        """Test align_to_input_ext_scale defaults to True."""
+        from fiftyone.utils.depth_anything import DepthAnythingV3ModelConfig
+
+        config = DepthAnythingV3ModelConfig({})
+
+        assert config.align_to_input_ext_scale is True
+
+    def test_align_to_input_ext_scale_explicit(self):
+        """Test align_to_input_ext_scale can be set explicitly."""
+        from fiftyone.utils.depth_anything import DepthAnythingV3ModelConfig
+
+        config_false = DepthAnythingV3ModelConfig(
+            {"align_to_input_ext_scale": False}
+        )
+        assert config_false.align_to_input_ext_scale is False
+
+        config_true = DepthAnythingV3ModelConfig(
+            {"align_to_input_ext_scale": True}
+        )
+        assert config_true.align_to_input_ext_scale is True
+
+    def test_ref_view_strategy_invalid_raises(self):
+        """Test invalid ref_view_strategy values fail fast."""
+        from fiftyone.utils.depth_anything import DepthAnythingV3ModelConfig
+
+        with pytest.raises(ValueError, match="Unsupported ref_view_strategy"):
+            DepthAnythingV3ModelConfig({"ref_view_strategy": "typo"})
+
+
+class _FakeSample(dict):
+    def __init__(self, filepath: str) -> None:
+        super().__init__()
+        self.filepath = filepath
+
+
+class _FakeCollection:
+    def __init__(self, samples: list["_FakeSample"]) -> None:
+        self._samples = samples
+
+    def iter_samples(
+        self,
+        autosave: bool = True,
+        progress: Optional[bool] = None,
+    ) -> Iterator["_FakeSample"]:
+        return iter(self._samples)
+
+
+class _FakeFilenameMaker:
+    def __init__(
+        self,
+        output_dir: str,
+        rel_dir: Optional[str] = None,
+        ignore_existing: bool = False,
+    ) -> None:
+        self.output_dir = output_dir
+
+    def get_output_path(self, filepath: str, output_ext: str = "") -> str:
+        return os.path.join(self.output_dir, "sample")
+
+
+def _make_export_model(config_dict: Optional[dict] = None):
+    """A DepthAnythingV3Model with a real config and a recording inference."""
+    from fiftyone.utils.depth_anything import (
+        DepthAnythingV3Model,
+        DepthAnythingV3ModelConfig,
+    )
+
+    calls = []
+
+    def _fake_inference(filepaths: list[str], **kwargs: Any) -> None:
+        calls.append((filepaths, kwargs))
+        gs_video_dir = os.path.join(kwargs["export_dir"], "gs_video")
+        os.makedirs(gs_video_dir, exist_ok=True)
+        with open(os.path.join(gs_video_dir, "0000_wander.mp4"), "wb") as f:
+            f.write(b"")
+
+    model = DepthAnythingV3Model.__new__(DepthAnythingV3Model)
+    model.config = DepthAnythingV3ModelConfig(config_dict or {})
+    model._model = SimpleNamespace(inference=_fake_inference)
+    return model, calls
+
+
+class TestDepthAnythingV3Exports:
+    def test_compute_3d_exports_uses_keyword_only_args_and_sets_gs_video_path(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        import fiftyone.utils.depth_anything as foda
+
+        monkeypatch.setattr(
+            foda.fov, "validate_collection", lambda samples: None
+        )
+        monkeypatch.setattr(
+            foda.fou, "UniqueFilenameMaker", _FakeFilenameMaker
+        )
+
+        model, calls = _make_export_model()
+        export_dir = str(tmp_path / "exports")
+        sample = _FakeSample(str(tmp_path / "data" / "image.png"))
+
+        model.compute_3d_exports(
+            _FakeCollection([sample]),
+            export_dir,
+            export_format="gs_video",
+            conf_thresh_percentile=12.5,
+            num_max_points=123,
+            show_cameras=False,
+        )
+
+        signature = inspect.signature(model.compute_3d_exports)
+        assert (
+            signature.parameters["conf_thresh_percentile"].kind
+            is inspect.Parameter.KEYWORD_ONLY
+        )
+        assert (
+            signature.parameters["num_max_points"].kind
+            is inspect.Parameter.KEYWORD_ONLY
+        )
+        assert (
+            signature.parameters["show_cameras"].kind
+            is inspect.Parameter.KEYWORD_ONLY
+        )
+
+        assert len(calls) == 1
+        _, kwargs = calls[0]
+        assert kwargs["infer_gs"] is True
+        assert kwargs["export_format"] == "gs_video"
+        assert kwargs["conf_thresh_percentile"] == pytest.approx(12.5)
+        assert kwargs["num_max_points"] == 123
+        assert kwargs["show_cameras"] is False
+        assert sample["da3_export_path"] == os.path.join(
+            export_dir, "sample", "gs_video", "0000_wander.mp4"
+        )
+
+    def test_compute_3d_exports_forwards_model_config(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """The export path applies the same config as depth prediction."""
+        import fiftyone.utils.depth_anything as foda
+
+        monkeypatch.setattr(
+            foda.fov, "validate_collection", lambda samples: None
+        )
+        monkeypatch.setattr(
+            foda.fou, "UniqueFilenameMaker", _FakeFilenameMaker
+        )
+
+        model, calls = _make_export_model(
+            {
+                "process_res": 336,
+                "process_res_method": "lower_bound_resize",
+                "use_ray_pose": True,
+                "ref_view_strategy": "middle",
+                "align_to_input_ext_scale": True,
+            }
+        )
+        sample = _FakeSample(str(tmp_path / "data" / "image.png"))
+
+        model.compute_3d_exports(
+            _FakeCollection([sample]),
+            str(tmp_path / "exports"),
+            export_format="gs_video",
+        )
+
+        _, kwargs = calls[0]
+        assert kwargs["process_res"] == 336
+        assert kwargs["process_res_method"] == "lower_bound_resize"
+        assert kwargs["use_ray_pose"] is True
+        assert kwargs["ref_view_strategy"] == "middle"
+        assert kwargs["align_to_input_ext_scale"] is True
+        assert kwargs["export_feat_layers"] == []
+
+    def test_compute_3d_exports_escapes_glob_metacharacters(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """An export directory containing [ ] still resolves the MP4."""
+        import fiftyone.utils.depth_anything as foda
+
+        monkeypatch.setattr(
+            foda.fov, "validate_collection", lambda samples: None
+        )
+        monkeypatch.setattr(
+            foda.fou, "UniqueFilenameMaker", _FakeFilenameMaker
+        )
+
+        model, _ = _make_export_model()
+        export_dir = str(tmp_path / "exports [v1]")
+        sample = _FakeSample(str(tmp_path / "data" / "image.png"))
+
+        model.compute_3d_exports(
+            _FakeCollection([sample]),
+            export_dir,
+            export_format="gs_video",
+        )
+
+        assert sample["da3_export_path"] == os.path.join(
+            export_dir, "sample", "gs_video", "0000_wander.mp4"
+        )
+
+
+class TestDepthAnythingV3InferenceForwarding:
+    """The config reaches self._model.inference, not just the config object."""
+
+    @staticmethod
+    def _make_model(
+        config_dict: dict[str, Any],
+        scale_factor: Optional[float] = None,
+    ) -> tuple["DepthAnythingV3Model", list[tuple[Any, dict[str, Any]]]]:
+        """Returns a model whose inference is stubbed, and the list that
+        records each ``(inputs, kwargs)`` it was called with."""
+        from fiftyone.utils.depth_anything import (
+            DepthAnythingV3Model,
+            DepthAnythingV3ModelConfig,
+        )
+
+        calls = []
+
+        def _fake_inference(inputs, **kwargs):
+            calls.append((inputs, kwargs))
+            return SimpleNamespace(
+                depth=np.zeros((1, 2, 2), dtype=np.float32),
+                conf=None,
+                sky=None,
+                extrinsics=None,
+                intrinsics=None,
+                gaussians=None,
+                aux=None,
+                scale_factor=scale_factor,
+            )
+
+        model = DepthAnythingV3Model.__new__(DepthAnythingV3Model)
+        model.config = DepthAnythingV3ModelConfig(config_dict)
+        model._model = SimpleNamespace(inference=_fake_inference)
+        return model, calls
+
+    def test_forward_pass_forwards_config(self) -> None:
+        model, calls = self._make_model(
+            {
+                "process_res": 336,
+                "process_res_method": "lower_bound_resize",
+                "use_ray_pose": True,
+                "ref_view_strategy": "first",
+                "align_to_input_ext_scale": True,
+            }
+        )
+
+        model._forward_pass([np.zeros((2, 2, 3), dtype=np.uint8)])
+
+        _, kwargs = calls[0]
+        assert kwargs["process_res"] == 336
+        assert kwargs["process_res_method"] == "lower_bound_resize"
+        assert kwargs["use_ray_pose"] is True
+        assert kwargs["ref_view_strategy"] == "first"
+        assert kwargs["align_to_input_ext_scale"] is True
+
+    def test_compute_multiview_depth_forwards_config(self) -> None:
+        model, calls = self._make_model(
+            {
+                "ref_view_strategy": "saddle_sim_range",
+                "align_to_input_ext_scale": False,
+            }
+        )
+
+        model.compute_multiview_depth(["a.png"])
+
+        _, kwargs = calls[0]
+        assert kwargs["ref_view_strategy"] == "saddle_sim_range"
+        assert kwargs["align_to_input_ext_scale"] is False
+
+    def test_forward_pass_preserves_scale_factor(self) -> None:
+        model, _ = self._make_model({}, scale_factor=0.42)
+
+        output = model._forward_pass([np.zeros((2, 2, 3), dtype=np.uint8)])
+
+        assert output["scale_factor"] == pytest.approx(0.42)
+
+    def test_compute_multiview_depth_preserves_scale_factor(self) -> None:
+        model, _ = self._make_model({}, scale_factor=0.42)
+
+        results = model.compute_multiview_depth(["a.png"])
+
+        assert results[0].scale_factor == pytest.approx(0.42)


### PR DESCRIPTION
## Summary

- Add `ref_view_strategy` config param for multi-view reference view selection (`first`, `middle`, `saddle_balanced`, `saddle_sim_range`)
- Add `align_to_input_ext_scale` config param for pose scale alignment to input extrinsics
- Surface `Prediction.scale_factor` (metric scale) on output heatmaps when returned by upstream
- Add `conf_thresh_percentile`, `num_max_points`, `show_cameras` params to `compute_3d_exports` for GLB export control
- Document `process_res_method` supported values (`upper_bound_resize`, `lower_bound_resize`)

All new parameters use upstream defaults and are fully backward-compatible.

## Test plan

- [x] 24 unit tests pass (config parsing, output processor, scale_factor surfacing)
- [x] GPU inference with `depth-anything-v3-base-torch` using explicit `ref_view_strategy` and `align_to_input_ext_scale`
- [x] GPU inference with `depth-anything-v3-metric-large-torch` confirming `scale_factor` guard handles absence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Depth Anything V3 now propagates per-prediction scale factors to depth heatmaps.
  * Added reference-view selection and input-extrinsic scale alignment options for inference.
  * 3D exports now support confidence thresholds, point limits, camera display, and Gaussian-splat videos.
  * Video exports select the latest generated MP4 artifact.

* **Bug Fixes**
  * Improved handling of unavailable export components and incomplete prediction outputs.

* **Tests**
  * Expanded coverage for configuration, inference options, scale factors, and 3D exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## numpy 2 compatibility

Also makes DA3 usable in numpy 2 environments. `depth_anything_3` pins `numpy<2`, but only its 3D export stack needs that; a full dependency install silently downgrades the host numpy. The wrapper now installs the package with `--no-deps` plus its actual inference dependencies (`evo`, `e3nn`, both numpy-2-clean), and registers a stub for `depth_anything_3.utils.export` when the real module cannot import, so depth prediction works everywhere and `compute_3d_exports` raises with guidance in environments without the export stack. Verified on numpy 2.4.4: da3-base and da3-giant load and predict, host numpy untouched, all 28 unit tests pass.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3354
<!-- enterprise-sync-pr:end -->