### PR TITLE
Set use_fast=false for monet-zero-torch

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -9304,6 +9304,9 @@
                 "type": "fiftyone.utils.transformers.FiftyOneZeroShotTransformerForImageClassification",
                 "config": {
                     "name_or_path": "suinleelab/monet",
+                    "transforms_args": {
+                        "use_fast": false
+                    },
                     "transformers_processor_kwargs": {
                         "padding": true
                     },


### PR DESCRIPTION
## What changes are proposed in this pull request?

This patch fixes `monet-zero-torch` in the Torch model zoo by adding `transforms_args: { "use_fast": false }` to its manifest entry.

`suinleelab/monet` currently loads through `CLIPProcessor`, but with the fast image processor path it resolves to `CLIPImageProcessorFast`, which fails at runtime with:

`AttributeError: 'CLIPImageProcessorFast' object has no attribute '_valid_processor_keys'`

This change makes the MONET entry use the non-fast processor path, which is already how similar CLIP-family manifest entries are configured.

## How is this patch tested? If it is not, please explain why.

Local validation on current `develop` in a GPU-capable benchmark venv:

- Loaded `monet-zero-torch` on CPU and GPU
- Verified the processor switches from `CLIPImageProcessorFast` to `CLIPImageProcessor`
- Ran:
  - `predict()`
  - `predict_all()`
  - `embed()`
  - `embed_all()`
  - `embed_prompts()`
- Confirmed all of the above succeed on both CPU and GPU after the manifest change

Before this patch, the same calls failed with:
`AttributeError: 'CLIPImageProcessorFast' object has no attribute '_valid_processor_keys'`

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

Fixed `monet-zero-torch` so it uses the compatible non-fast processor configuration and no longer fails at inference/embedding time.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [x] Other