### PR TITLE
Recompute custom metrics per scenario subset in model evaluation panel

### DIFF
--- a/plugins/panels/model_evaluation/__init__.py
+++ b/plugins/panels/model_evaluation/__init__.py
@@ -880,8 +880,22 @@ class EvaluationPanel(Panel):
                     metrics["incorrect"],
                 ) = self.get_correct_incorrect(results)
 
+            # Recompute custom metrics for this subset
+            original_custom_metrics = results.custom_metrics
+            try:
+                results.custom_metrics = None
+                results.backend.compute_custom_metrics(
+                    results.samples, results.key, results
+                )
+                custom_metrics = self.get_custom_metrics(results)
+            except Exception:
+                custom_metrics = None
+            finally:
+                results.custom_metrics = original_custom_metrics
+
             return {
                 "metrics": metrics,
+                "custom_metrics": custom_metrics,
                 "distribution": len(results.ytrue_ids),
                 "confusion_matrix": self.get_confusion_matrix(results),
                 "confidences": confidences,


### PR DESCRIPTION
## What changes are proposed in this pull request?

When the App builds Scenario Analysis data, `get_subset_def_data` computes standard metrics (precision, recall, F1, IoU, etc.) by calling `results.metrics()` inside a `use_subset()` context manager. However, custom `EvaluationMetric `plugin aggregates were never recomputed for each scenario subset — the panel returned `results.custom_metrics` from the original full-dataset evaluation run, so the values never changed across scenarios.

This fix invokes `compute_custom_metrics()` against the subset view (`results.samples` within the context) inside `get_subset_def_data`, so each scenario subset gets its own custom metric aggregate. The original custom metrics are saved and restored after computation to avoid side effects.

## How is this patch tested? If it is not, please explain why.

It is tested with a custom plugin (with pixel-distance measure) and works with:

```python
dataset = fo.load_dataset("fiftyone_fix")
results = dataset.load_evaluation_results("test_eval")

# Define your scenario subsets (same format the panel uses)
scenario_def = {"type": "field", "field": "cam_type", "value": "iOS"}

with results.use_subset(scenario_def):
    # Standard metrics work out of the box
    print(results.metrics())

    # Recompute custom metrics for this subset
    results.custom_metrics = None
    results.backend.compute_custom_metrics(
        results.samples, results.key, results
    )
    print(results.custom_metrics)
```

NB: This is still not showing in the GUI app - a feature that I believe should be added?

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Custom `EvaluationMetric` plugin values are now recomputed per scenario subset in the Model Evaluation panel, instead of showing the same full-dataset aggregate for every subset.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom metrics are now computed and included in subset evaluation data within the model evaluation panel, providing metrics tailored to each specific subset.
  * Improved error resilience ensures metric computation failures gracefully degrade without disrupting evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->