### PR TITLE
[FOEPD-3392] Implement image embedding caching in IndexedDB

### DIFF
--- a/app/packages/annotation/src/providers/embeddingCache.test.ts
+++ b/app/packages/annotation/src/providers/embeddingCache.test.ts
@@ -109,11 +109,14 @@ describe("embeddingCache", () => {
     expect(closeSpy).toHaveBeenCalledTimes(1);
 
     const result = await getEmbedding(TEST_URL);
-
     expect(result).toBe(embedding);
-    // Memory hit. IDB not opened again.
-    expect(openSpy).toHaveBeenCalledTimes(1);
-    expect(closeSpy).toHaveBeenCalledTimes(1);
+
+    // Let fire-and-forget IDB timestamp write settle
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Memory hit opens IDB once to persist lastAccessed
+    expect(openSpy).toHaveBeenCalledTimes(2);
+    expect(closeSpy).toHaveBeenCalledTimes(2);
   });
 
   it("Falls back to IndexedDB when memory is empty", async () => {
@@ -168,6 +171,28 @@ describe("embeddingCache", () => {
 
     const newEntry = await getEmbedding("https://example.com/new.jpg");
     expect(newEntry).toBeDefined();
+  });
+
+  it("Memory hit updates IDB timestamp so hot entries survive eviction", async () => {
+    // Fill cache
+    for (let i = 0; i < MAX_CACHE_ENTRIES; i++)
+      await putEmbedding(`https://example.com/${i}.jpg`, createTestEmbedding(i));
+
+    // Touch entry 0 from memory (updates its IDB lastAccessed)
+    await getEmbedding("https://example.com/0.jpg");
+  
+    // Let the fire-and-forget IDB write settle
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Add a new entry which should evict entry 1 (oldest untouched), not entry 0
+    await putEmbedding("https://example.com/new.jpg", createTestEmbedding(99));
+
+    _resetMemoryCache();
+    const hot = await getEmbedding("https://example.com/0.jpg");
+    const evicted = await getEmbedding("https://example.com/1.jpg");
+
+    expect(hot).toBeDefined();
+    expect(evicted).toBeUndefined();
   });
 
   it.each([

--- a/app/packages/annotation/src/providers/embeddingCache.test.ts
+++ b/app/packages/annotation/src/providers/embeddingCache.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getEmbedding,
+  putEmbedding,
+  _resetMemoryCache,
+  MAX_CACHE_ENTRIES,
+  type CachedEmbedding,
+} from "./embeddingCache";
+
+function createMockIDB(options?: { failOn?: "get" | "put" }) {
+  const { failOn } = options ?? {};
+  const store = new Map<string, CachedEmbedding>();
+  const closeSpy = vi.fn();
+
+  const mockObjectStore = () => ({
+    get: (key: string) => {
+      const req = {
+        result: undefined as CachedEmbedding | undefined,
+        onsuccess: null as any,
+        onerror: null as any,
+        error: failOn === "get" ? new Error("read failed") : null,
+      };
+      setTimeout(() => {
+        if (failOn === "get") { req.onerror?.(); }
+        else { req.result = store.get(key); req.onsuccess?.(); }
+      });
+      return req;
+    },
+    put: (value: CachedEmbedding, key: string) => { if (failOn !== "put") store.set(key, value); },
+    delete: (key: string) => { store.delete(key); },
+    getAllKeys: () => {
+      const req = { result: [] as string[], onsuccess: null as any, onerror: null as any };
+      setTimeout(() => { req.result = [...store.keys()]; req.onsuccess?.(); });
+      return req;
+    },
+  });
+
+  const mockDB = {
+    transaction: (_store?: string, mode?: string) => {
+      const os = mockObjectStore();
+      const shouldFailPut = failOn === "put" && mode === "readwrite";
+      const tx = {
+        objectStore: () => os,
+        onerror: null as any,
+        error: shouldFailPut ? new Error("write failed") : null,
+        set oncomplete(fn: any) {
+          if (!shouldFailPut)
+            setTimeout(() => fn?.());
+        },
+      };
+
+      if (shouldFailPut)
+        setTimeout(() => tx.onerror?.());
+
+      return tx;
+    },
+    createObjectStore: () => {},
+    close: closeSpy,
+  };
+
+  const openSpy = vi.fn(() => {
+    const req = { result: mockDB, onupgradeneeded: null as any, onsuccess: null as any, onerror: null as any };
+    setTimeout(() => { req.onupgradeneeded?.(); req.onsuccess?.(); });
+    return req;
+  });
+
+  const mockIndexedDB = { open: openSpy };
+
+  return { store, mockIndexedDB, closeSpy, openSpy };
+}
+
+function createTestEmbedding(seed = 51): CachedEmbedding {
+  return {
+    imageEmbed: { data: new Float32Array([seed, seed + 1]), dims: [1, 2] },
+    highResFeats0: { data: new Float32Array([seed + 2]), dims: [1, 1] },
+    highResFeats1: { data: new Float32Array([seed + 3]), dims: [1, 1] },
+    processedImage: { originalWidth: 640, originalHeight: 480, scale: 1.6, padX: 12, padY: 56 },
+  };
+}
+
+const TEST_URL = "https://example.com/image.jpg";
+
+describe("embeddingCache", () => {
+  let closeSpy: ReturnType<typeof vi.fn>;
+  let openSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetMemoryCache();
+    const idb = createMockIDB();
+    closeSpy = idb.closeSpy;
+    openSpy = idb.openSpy;
+    vi.stubGlobal("indexedDB", idb.mockIndexedDB);
+  });
+
+  it("Returns undefined on cache miss", async () => {
+    const result = await getEmbedding(TEST_URL);
+
+    expect(result).toBeUndefined();
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("Returns embedding from memory on cache hit", async () => {
+    const embedding = createTestEmbedding();
+    await putEmbedding(TEST_URL, embedding);
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+
+    const result = await getEmbedding(TEST_URL);
+
+    expect(result).toBe(embedding);
+    // Memory hit. IDB not opened again.
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("Falls back to IndexedDB when memory is empty", async () => {
+    const embedding = createTestEmbedding();
+    await putEmbedding(TEST_URL, embedding);
+    _resetMemoryCache();
+
+    const result = await getEmbedding(TEST_URL);
+
+    expect(result?.processedImage).toEqual(embedding.processedImage);
+    // put opened IDB once + get opened IDB once
+    expect(openSpy).toHaveBeenCalledTimes(2);
+    expect(closeSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("Evicts oldest entry when over MAX_CACHE_ENTRIES", async () => {
+    for (let i = 0; i <= MAX_CACHE_ENTRIES; i++)
+      await putEmbedding(`https://example.com/${i}.jpg`, createTestEmbedding(i));
+
+    // Clear memory so gets fall through to IDB, where entry 0 was also evicted
+    _resetMemoryCache();
+    const evicted = await getEmbedding("https://example.com/0.jpg");
+    const kept = await getEmbedding("https://example.com/1.jpg");
+
+    expect(evicted).toBeUndefined();
+    expect(kept).toBeDefined();
+    expect(openSpy).toHaveBeenCalledTimes(MAX_CACHE_ENTRIES + 1 + 2);
+    expect(closeSpy).toHaveBeenCalledTimes(MAX_CACHE_ENTRIES + 1 + 2);
+  });
+
+  it.each([
+    { name: "open fails on get", failOn: undefined, op: "get" as const, warning: "Embedding cache open failed: Error: blocked" },
+    { name: "open fails on put", failOn: undefined, op: "put" as const, warning: "Embedding cache open failed: Error: blocked" },
+    { name: "idbGet fails", failOn: "get" as const, op: "get" as const, warning: "Embedding cache read failed: Error: read failed" },
+    { name: "idbPut fails", failOn: "put" as const, op: "put" as const, warning: "Embedding cache write failed: Error: write failed" },
+  ])("Warns and falls through when $name", async ({ failOn, op, warning }) => {
+    if (failOn) {
+      const idb = createMockIDB({ failOn });
+      vi.stubGlobal("indexedDB", idb.mockIndexedDB);
+    } else {
+      vi.stubGlobal("indexedDB", { open: () => { throw new Error("blocked"); } });
+    }
+    const onWarning = vi.fn();
+
+    if (op === "get") {
+      const result = await getEmbedding(TEST_URL, onWarning);
+      expect(result).toBeUndefined();
+    } else {
+      await putEmbedding(TEST_URL, createTestEmbedding(), onWarning);
+    }
+
+    expect(onWarning).toHaveBeenCalledWith(warning);
+  });
+
+  it("IDB handle is closed on all paths", async () => {
+    await putEmbedding(TEST_URL, createTestEmbedding());
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+
+    await getEmbedding("https://example.com/miss.jpg");
+    expect(openSpy).toHaveBeenCalledTimes(2);
+    expect(closeSpy).toHaveBeenCalledTimes(2);
+
+    _resetMemoryCache();
+    await getEmbedding(TEST_URL);
+    expect(openSpy).toHaveBeenCalledTimes(3);
+    expect(closeSpy).toHaveBeenCalledTimes(3);
+  });
+});

--- a/app/packages/annotation/src/providers/embeddingCache.test.ts
+++ b/app/packages/annotation/src/providers/embeddingCache.test.ts
@@ -10,34 +10,40 @@ import {
 function createMockIDB(options?: { failOn?: "get" | "put" }) {
   const { failOn } = options ?? {};
   const store = new Map<string, CachedEmbedding>();
+  const metaStore = new Map<string, number>();
   const closeSpy = vi.fn();
 
-  const mockObjectStore = () => ({
+  const makeMockObjectStore = (backing: Map<string, any>) => () => ({
     get: (key: string) => {
       const req = {
-        result: undefined as CachedEmbedding | undefined,
+        result: undefined as any,
         onsuccess: null as any,
         onerror: null as any,
         error: failOn === "get" ? new Error("read failed") : null,
       };
       setTimeout(() => {
         if (failOn === "get") { req.onerror?.(); }
-        else { req.result = store.get(key); req.onsuccess?.(); }
+        else { req.result = backing.get(key); req.onsuccess?.(); }
       });
       return req;
     },
-    put: (value: CachedEmbedding, key: string) => { if (failOn !== "put") store.set(key, value); },
-    delete: (key: string) => { store.delete(key); },
+    put: (value: any, key: string) => { if (failOn !== "put") backing.set(key, value); },
+    delete: (key: string) => { backing.delete(key); },
     getAllKeys: () => {
       const req = { result: [] as string[], onsuccess: null as any, onerror: null as any };
-      setTimeout(() => { req.result = [...store.keys()]; req.onsuccess?.(); });
+      setTimeout(() => { req.result = [...backing.keys()]; req.onsuccess?.(); });
       return req;
     },
   });
 
+  const stores: Record<string, ReturnType<typeof makeMockObjectStore>> = {
+    embeddings: makeMockObjectStore(store),
+    metadata: makeMockObjectStore(metaStore),
+  };
+
   const mockDB = {
-    transaction: (_store?: string, mode?: string) => {
-      const os = mockObjectStore();
+    transaction: (storeName?: string, mode?: string) => {
+      const os = (stores[storeName ?? "embeddings"] ?? stores["embeddings"])();
       const shouldFailPut = failOn === "put" && mode === "readwrite";
       const tx = {
         objectStore: () => os,
@@ -75,7 +81,6 @@ function createTestEmbedding(seed = 51): CachedEmbedding {
     highResFeats0: { data: new Float32Array([seed + 2]), dims: [1, 1] },
     highResFeats1: { data: new Float32Array([seed + 3]), dims: [1, 1] },
     processedImage: { originalWidth: 640, originalHeight: 480, scale: 1.6, padX: 12, padY: 56 },
-    lastAccessed: 0,
   };
 }
 

--- a/app/packages/annotation/src/providers/embeddingCache.test.ts
+++ b/app/packages/annotation/src/providers/embeddingCache.test.ts
@@ -75,6 +75,7 @@ function createTestEmbedding(seed = 51): CachedEmbedding {
     highResFeats0: { data: new Float32Array([seed + 2]), dims: [1, 1] },
     highResFeats1: { data: new Float32Array([seed + 3]), dims: [1, 1] },
     processedImage: { originalWidth: 640, originalHeight: 480, scale: 1.6, padX: 12, padY: 56 },
+    lastAccessed: 0,
   };
 }
 
@@ -141,6 +142,32 @@ describe("embeddingCache", () => {
     expect(kept).toBeDefined();
     expect(openSpy).toHaveBeenCalledTimes(MAX_CACHE_ENTRIES + 1 + 2);
     expect(closeSpy).toHaveBeenCalledTimes(MAX_CACHE_ENTRIES + 1 + 2);
+  });
+
+  it("Preserves prior-session IDB entries after reload and new write", async () => {
+    // Seed MAX_CACHE_ENTRIES entries (simulates a prior session)
+    for (let i = 0; i < MAX_CACHE_ENTRIES; i++)
+      await putEmbedding(`https://example.com/${i}.jpg`, createTestEmbedding(i));
+
+    // Simulate page reload: memory is empty, IDB still has all entries
+    _resetMemoryCache();
+
+    // Write one new entry: it should evict only the oldest, not all prior entries
+    await putEmbedding("https://example.com/new.jpg", createTestEmbedding(99));
+
+    // Entry 0 is oldest, gets evicted. Entries 1-4 + new should survive.
+    _resetMemoryCache();
+
+    const evicted = await getEmbedding("https://example.com/0.jpg");
+    expect(evicted).toBeUndefined();
+
+    for (let i = 1; i < MAX_CACHE_ENTRIES; i++) {
+      const kept = await getEmbedding(`https://example.com/${i}.jpg`);
+      expect(kept).toBeDefined();
+    }
+
+    const newEntry = await getEmbedding("https://example.com/new.jpg");
+    expect(newEntry).toBeDefined();
   });
 
   it.each([

--- a/app/packages/annotation/src/providers/embeddingCache.ts
+++ b/app/packages/annotation/src/providers/embeddingCache.ts
@@ -2,6 +2,7 @@ import type { ImageGeometry } from "./math";
 
 const DB_NAME = "fiftyone-embeddings";
 const STORE_NAME = "embeddings";
+const META_STORE = "metadata";
 export const MAX_CACHE_ENTRIES = 5;
 
 interface StoredTensor {
@@ -14,7 +15,6 @@ export interface CachedEmbedding {
   highResFeats0: StoredTensor;
   highResFeats1: StoredTensor;
   processedImage: ImageGeometry;
-  lastAccessed: number;
 }
 
 /**
@@ -32,7 +32,10 @@ function openDB(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const req = indexedDB.open(DB_NAME, 1);
 
-    req.onupgradeneeded = () => req.result.createObjectStore(STORE_NAME);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore(STORE_NAME);
+      req.result.createObjectStore(META_STORE);
+    };
     req.onsuccess = () => resolve(req.result);
     req.onerror = () => reject(req.error);
   });
@@ -81,6 +84,36 @@ function idbGetAllKeys(db: IDBDatabase): Promise<string[]> {
   });
 }
 
+/** Write a lightweight timestamp to the metadata store. */
+function idbPutMeta(db: IDBDatabase, key: string, lastAccessed: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(META_STORE, "readwrite");
+    tx.objectStore(META_STORE).put(lastAccessed, key);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+/** Read a timestamp from the metadata store. */
+function idbGetMeta(db: IDBDatabase, key: string): Promise<number | undefined> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(META_STORE, "readonly");
+    const req = tx.objectStore(META_STORE).get(key);
+    req.onsuccess = () => resolve(req.result as number | undefined);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/** Delete a metadata entry by key. */
+function idbDeleteMeta(db: IDBDatabase, key: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(META_STORE, "readwrite");
+    tx.objectStore(META_STORE).delete(key);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
 /** Move a key to the end of the Map (= most recently used). */
 function touch(key: string, value: CachedEmbedding): void {
   cache.delete(key);
@@ -105,18 +138,19 @@ async function evictIDB(db: IDBDatabase): Promise<void> {
   if (keys.length <= MAX_CACHE_ENTRIES)
     return;
 
-  // Read timestamps for all entries
+  // Read timestamps from lightweight metadata store
   const entries: { key: string; lastAccessed: number }[] = [];
   for (const key of keys) {
-    const record = await idbGet(db, key).catch((): undefined => undefined);
-    entries.push({ key, lastAccessed: record?.lastAccessed ?? 0 });
+    const ts = await idbGetMeta(db, key).catch((): undefined => undefined);
+    entries.push({ key, lastAccessed: ts ?? 0 });
   }
 
-  // Sort oldest first, delete excess
+  // Sort oldest first, delete excess from both stores
   entries.sort((a, b) => a.lastAccessed - b.lastAccessed);
   const toDelete = entries.length - MAX_CACHE_ENTRIES;
   for (let i = 0; i < toDelete; i++) {
     await idbDelete(db, entries[i].key).catch(() => {});
+    await idbDeleteMeta(db, entries[i].key).catch(() => {});
   }
 }
 
@@ -130,12 +164,11 @@ export async function getEmbedding(
 ): Promise<CachedEmbedding | undefined> {
   const mem = cache.get(url);
   if (mem) {
-    mem.lastAccessed = Date.now();
     touch(url, mem);
 
-    // Persist updated timestamp to IDB (fire-and-forget)
+    // Persist updated timestamp to lightweight metadata store (fire-and-forget)
     openDB()
-      .then((db) => idbPut(db, url, mem).finally(() => db.close()))
+      .then((db) => idbPutMeta(db, url, Date.now()).finally(() => db.close()))
       .catch((err) => onWarning?.(`Embedding cache timestamp update failed: ${err}`));
 
     return mem;
@@ -154,12 +187,11 @@ export async function getEmbedding(
     if (!record)
       return undefined;
 
-    record.lastAccessed = Date.now();
     touch(url, record);
     evictMemory();
 
-    // Update lastAccessed in IDB (fire-and-forget: close() will wait for pending txn)
-    idbPut(db, url, record).catch((err) => onWarning?.(`Embedding cache timestamp update failed: ${err}`));
+    // Update timestamp in lightweight metadata store (fire-and-forget: close() waits for pending txn)
+    idbPutMeta(db, url, Date.now()).catch((err) => onWarning?.(`Embedding cache timestamp update failed: ${err}`));
 
     return record;
   } catch (err) {
@@ -179,7 +211,6 @@ export async function putEmbedding(
   embedding: CachedEmbedding,
   onWarning?: (message: string) => void
 ): Promise<void> {
-  embedding.lastAccessed = Date.now();
   touch(url, embedding);
   evictMemory();
 
@@ -193,6 +224,7 @@ export async function putEmbedding(
 
   try {
     await idbPut(db, url, embedding);
+    await idbPutMeta(db, url, Date.now());
     await evictIDB(db);
   } catch (err) {
     onWarning?.(`Embedding cache write failed: ${err}`);

--- a/app/packages/annotation/src/providers/embeddingCache.ts
+++ b/app/packages/annotation/src/providers/embeddingCache.ts
@@ -14,6 +14,7 @@ export interface CachedEmbedding {
   highResFeats0: StoredTensor;
   highResFeats1: StoredTensor;
   processedImage: ImageGeometry;
+  lastAccessed: number;
 }
 
 /**
@@ -86,12 +87,32 @@ function touch(key: string, value: CachedEmbedding): void {
   cache.set(key, value);
 }
 
-/** Remove IDB entries that aren't in the current memory LRU. */
+/** Evict oldest entries from memory when over limit. */
+function evictMemory(): void {
+  while (cache.size > MAX_CACHE_ENTRIES) {
+    const [oldest] = cache.keys();
+    cache.delete(oldest);
+  }
+}
+
+/** Evict oldest IDB entries by lastAccessed timestamp when over limit. */
 async function evictIDB(db: IDBDatabase): Promise<void> {
   const keys = await idbGetAllKeys(db);
+  if (keys.length <= MAX_CACHE_ENTRIES)
+    return;
+
+  // Read timestamps for all entries
+  const entries: { key: string; lastAccessed: number }[] = [];
   for (const key of keys) {
-    if (!cache.has(key))
-      await idbDelete(db, key).catch(() => {});
+    const record = await idbGet(db, key).catch((): undefined => undefined);
+    entries.push({ key, lastAccessed: record?.lastAccessed ?? 0 });
+  }
+
+  // Sort oldest first, delete excess
+  entries.sort((a, b) => a.lastAccessed - b.lastAccessed);
+  const toDelete = entries.length - MAX_CACHE_ENTRIES;
+  for (let i = 0; i < toDelete; i++) {
+    await idbDelete(db, entries[i].key).catch(() => {});
   }
 }
 
@@ -122,7 +143,13 @@ export async function getEmbedding(
     if (!record)
       return undefined;
 
+    record.lastAccessed = Date.now();
     touch(url, record);
+    evictMemory();
+
+    // Update lastAccessed in IDB (fire-and-forget)
+    idbPut(db, url, record).catch(() => {});
+
     return record;
   } catch (err) {
     onWarning?.(`Embedding cache read failed: ${err}`);
@@ -141,13 +168,9 @@ export async function putEmbedding(
   embedding: CachedEmbedding,
   onWarning?: (message: string) => void
 ): Promise<void> {
+  embedding.lastAccessed = Date.now();
   touch(url, embedding);
-
-/** Evict oldest from memory (Map iteration order = insertion order) */
-  while (cache.size > MAX_CACHE_ENTRIES) {
-    const [oldest] = cache.keys();
-    cache.delete(oldest);
-  }
+  evictMemory();
 
   let db: IDBDatabase;
   try {

--- a/app/packages/annotation/src/providers/embeddingCache.ts
+++ b/app/packages/annotation/src/providers/embeddingCache.ts
@@ -1,0 +1,168 @@
+import type { ImageGeometry } from "./math";
+
+const DB_NAME = "fiftyone-embeddings";
+const STORE_NAME = "embeddings";
+export const MAX_CACHE_ENTRIES = 5;
+
+interface StoredTensor {
+  data: Float32Array;
+  dims: number[];
+}
+
+export interface CachedEmbedding {
+  imageEmbed: StoredTensor;
+  highResFeats0: StoredTensor;
+  highResFeats1: StoredTensor;
+  processedImage: ImageGeometry;
+}
+
+/**
+ * In-memory LRU. Map iteration order = insertion order; newest at end.
+ * Each entry holds three Float32Array tensors (encoder outputs); size depends on the model.
+ */
+const cache = new Map<string, CachedEmbedding>();
+
+/** Reset in-memory cache. Exported for testing only. */
+export function _resetMemoryCache(): void {
+  cache.clear();
+}
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+
+    req.onupgradeneeded = () => req.result.createObjectStore(STORE_NAME);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/** Read a cached embedding by key, or undefined on miss. */
+function idbGet(db: IDBDatabase, key: string): Promise<CachedEmbedding | undefined> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readonly");
+
+    const req = tx.objectStore(STORE_NAME).get(key);
+    req.onsuccess = () => resolve(req.result as CachedEmbedding | undefined);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/** Write an embedding to the cache, keyed by URL. */
+function idbPut(db: IDBDatabase, key: string, value: CachedEmbedding): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readwrite");
+
+    tx.objectStore(STORE_NAME).put(value, key);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+/** Delete a single cache entry by key. */
+function idbDelete(db: IDBDatabase, key: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readwrite");
+    tx.objectStore(STORE_NAME).delete(key);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+/** Return all keys in the object store. */
+function idbGetAllKeys(db: IDBDatabase): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readonly");
+    const req = tx.objectStore(STORE_NAME).getAllKeys();
+    // Keys are always URL strings
+    req.onsuccess = () => resolve(req.result as string[]);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/** Move a key to the end of the Map (= most recently used). */
+function touch(key: string, value: CachedEmbedding): void {
+  cache.delete(key);
+  cache.set(key, value);
+}
+
+/** Remove IDB entries that aren't in the current memory LRU. */
+async function evictIDB(db: IDBDatabase): Promise<void> {
+  const keys = await idbGetAllKeys(db);
+  for (const key of keys) {
+    if (!cache.has(key))
+      await idbDelete(db, key).catch(() => {});
+  }
+}
+
+/**
+ * Get a cached embedding by image URL.
+ * Checks in-memory LRU first, falls back to IndexedDB.
+ */
+export async function getEmbedding(
+  url: string,
+  onWarning?: (message: string) => void
+): Promise<CachedEmbedding | undefined> {
+  const mem = cache.get(url);
+  if (mem) {
+    touch(url, mem);
+    return mem;
+  }
+
+  let db: IDBDatabase;
+  try {
+    db = await openDB();
+  } catch (err) {
+    onWarning?.(`Embedding cache open failed: ${err}`);
+    return undefined;
+  }
+
+  try {
+    const record = await idbGet(db, url);
+    if (!record)
+      return undefined;
+
+    touch(url, record);
+    return record;
+  } catch (err) {
+    onWarning?.(`Embedding cache read failed: ${err}`);
+    return undefined;
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Store an embedding in the cache, evicting the LRU entry if over limit.
+ * Memory updates are synchronous; IDB write is async (safe to fire-and-forget).
+ */
+export async function putEmbedding(
+  url: string,
+  embedding: CachedEmbedding,
+  onWarning?: (message: string) => void
+): Promise<void> {
+  touch(url, embedding);
+
+/** Evict oldest from memory (Map iteration order = insertion order) */
+  while (cache.size > MAX_CACHE_ENTRIES) {
+    const [oldest] = cache.keys();
+    cache.delete(oldest);
+  }
+
+  let db: IDBDatabase;
+  try {
+    db = await openDB();
+  } catch (err) {
+    onWarning?.(`Embedding cache open failed: ${err}`);
+    return;
+  }
+
+  try {
+    await idbPut(db, url, embedding);
+    await evictIDB(db);
+  } catch (err) {
+    onWarning?.(`Embedding cache write failed: ${err}`);
+  } finally {
+    db.close();
+  }
+}

--- a/app/packages/annotation/src/providers/embeddingCache.ts
+++ b/app/packages/annotation/src/providers/embeddingCache.ts
@@ -126,7 +126,14 @@ export async function getEmbedding(
 ): Promise<CachedEmbedding | undefined> {
   const mem = cache.get(url);
   if (mem) {
+    mem.lastAccessed = Date.now();
     touch(url, mem);
+
+    // Persist updated timestamp to IDB (fire-and-forget)
+    openDB()
+      .then((db) => idbPut(db, url, mem).finally(() => db.close()))
+      .catch((err) => onWarning?.(`Embedding cache timestamp update failed: ${err}`));
+
     return mem;
   }
 

--- a/app/packages/annotation/src/providers/embeddingCache.ts
+++ b/app/packages/annotation/src/providers/embeddingCache.ts
@@ -95,7 +95,11 @@ function evictMemory(): void {
   }
 }
 
-/** Evict oldest IDB entries by lastAccessed timestamp when over limit. */
+/**
+ * Evict oldest IDB entries by lastAccessed timestamp when over limit.
+ * Read failures treat entries as oldest (lastAccessed=0), which may
+ * cause premature eviction. This is Acceptable since cache is an
+ * optimization, not a source of truth. */
 async function evictIDB(db: IDBDatabase): Promise<void> {
   const keys = await idbGetAllKeys(db);
   if (keys.length <= MAX_CACHE_ENTRIES)
@@ -154,8 +158,8 @@ export async function getEmbedding(
     touch(url, record);
     evictMemory();
 
-    // Update lastAccessed in IDB (fire-and-forget)
-    idbPut(db, url, record).catch(() => {});
+    // Update lastAccessed in IDB (fire-and-forget: close() will wait for pending txn)
+    idbPut(db, url, record).catch((err) => onWarning?.(`Embedding cache timestamp update failed: ${err}`));
 
     return record;
   } catch (err) {

--- a/app/packages/annotation/src/providers/math.ts
+++ b/app/packages/annotation/src/providers/math.ts
@@ -4,13 +4,17 @@ export const SAM2_INPUT_SIZE = 1024;
 // Fixed output mask resolution from the SAM2 decoder (model constraint).
 export const SAM2_OUTPUT_SIZE = 256;
 
-export interface ProcessedImage {
-  tensor: Float32Array;
+// Geometric metadata from preprocessing (shared by encoder, decoder, and cache).
+export interface ImageGeometry {
   originalWidth: number;
   originalHeight: number;
   scale: number;
   padX: number;
   padY: number;
+}
+
+export interface ProcessedImage extends ImageGeometry {
+  tensor: Float32Array;
 }
 
 /**
@@ -25,7 +29,7 @@ export interface ProcessedImage {
 export function transformPoint(
   x: number,
   y: number,
-  img: ProcessedImage
+  img: ImageGeometry
 ): [number, number] {
   return [
     x * img.originalWidth * img.scale + img.padX,
@@ -42,7 +46,7 @@ export function transformPoint(
  */
 export function normalizeBbox(
   bbox: { x: number; y: number; w: number; h: number },
-  img: ProcessedImage
+  img: ImageGeometry
 ): { x: number; y: number; w: number; h: number } {
   return {
     x: bbox.x / img.originalWidth,
@@ -64,7 +68,7 @@ export function normalizeBbox(
  */
 export function computeMaskBbox(
   maskData: Float32Array,
-  img: ProcessedImage,
+  img: ImageGeometry,
   maskH = SAM2_OUTPUT_SIZE,
   maskW = SAM2_OUTPUT_SIZE
 ): { x: number; y: number; w: number; h: number } | null {
@@ -115,7 +119,7 @@ export function computeMaskBbox(
  */
 export function postprocessMask(
   maskData: Float32Array,
-  img: ProcessedImage,
+  img: ImageGeometry,
   bbox: { x: number; y: number; w: number; h: number },
   maskH = SAM2_OUTPUT_SIZE,
   maskW = SAM2_OUTPUT_SIZE

--- a/app/packages/annotation/src/providers/types.ts
+++ b/app/packages/annotation/src/providers/types.ts
@@ -24,9 +24,13 @@ export interface BoundingBox {
 }
 
 export interface InferenceResult {
+  /** Row-major mask values in [0,1], length = maskWidth * maskHeight. */
   mask: Float32Array;
+  /** Pixel width of the cropped mask region. */
   maskWidth: number;
+  /** Pixel height of the cropped mask region. */
   maskHeight: number;
+  /** Bounding box in normalized [0,1] coordinates. */
   bbox: BoundingBox;
 }
 

--- a/app/packages/annotation/src/providers/types.ts
+++ b/app/packages/annotation/src/providers/types.ts
@@ -25,6 +25,8 @@ export interface BoundingBox {
 
 export interface InferenceResult {
   mask: Float32Array;
+  maskWidth: number;
+  maskHeight: number;
   bbox: BoundingBox;
 }
 

--- a/app/packages/annotation/src/providers/worker.ts
+++ b/app/packages/annotation/src/providers/worker.ts
@@ -46,6 +46,12 @@ const HF_BASE = "https://huggingface.co/SharpAI/sam2-hiera-tiny-onnx/resolve/mai
 const ENCODER_URL = `${HF_BASE}/encoder.with_runtime_opt.ort`;
 const DECODER_URL = `${HF_BASE}/decoder.onnx`;
 
+/**
+ * Prefix embedding cache keys with the encoder contract so stale entries
+ * are ignored if/when the model or preprocessing changes.
+ */
+const CACHE_PREFIX = `${ENCODER_URL}:${SAM2_INPUT_SIZE}:`;
+
 const isCOI = typeof crossOriginIsolated !== "undefined" && crossOriginIsolated;
 ort.env.wasm.numThreads = isCOI ? 4 : 1;
 ort.env.wasm.simd = true;
@@ -180,7 +186,8 @@ async function embedAndDecode(
 
   const postWarning = (message: string) => postNotification("warning", message);
 
-  const cached = await getEmbedding(imageUrl, postWarning);
+  const cacheKey = CACHE_PREFIX + imageUrl;
+  const cached = await getEmbedding(cacheKey, postWarning);
   if (cached) {
     encResults = {
       image_embed: new ort.Tensor("float32", cached.imageEmbed.data, cached.imageEmbed.dims),
@@ -199,7 +206,7 @@ async function embedAndDecode(
 
     // Fire-and-forget: IDB write runs in background while decoder proceeds.
     // Memory LRU is updated synchronously inside putEmbedding before the first await.
-    putEmbedding(imageUrl, {
+    putEmbedding(cacheKey, {
       // Key names are defined by the ONNX model and must match exactly.
       // Encode — input: "image"; outputs: "image_embed", "high_res_feats_0", "high_res_feats_1"
       imageEmbed: { data: encResults["image_embed"].data as Float32Array, dims: [...encResults["image_embed"].dims] },

--- a/app/packages/annotation/src/providers/worker.ts
+++ b/app/packages/annotation/src/providers/worker.ts
@@ -212,6 +212,7 @@ async function embedAndDecode(
         padX: geometry.padX,
         padY: geometry.padY,
       },
+      lastAccessed: 0,
     }, postWarning);
   }
 

--- a/app/packages/annotation/src/providers/worker.ts
+++ b/app/packages/annotation/src/providers/worker.ts
@@ -188,14 +188,23 @@ async function embedAndDecode(
 
   const cacheKey = CACHE_PREFIX + imageUrl;
   const cached = await getEmbedding(cacheKey, postWarning);
+  let cacheHit = false;
+
   if (cached) {
-    encResults = {
-      image_embed: new ort.Tensor("float32", cached.imageEmbed.data, cached.imageEmbed.dims),
-      high_res_feats_0: new ort.Tensor("float32", cached.highResFeats0.data, cached.highResFeats0.dims),
-      high_res_feats_1: new ort.Tensor("float32", cached.highResFeats1.data, cached.highResFeats1.dims),
-    };
-    geometry = cached.processedImage;
-  } else {
+    try {
+      encResults = {
+        image_embed: new ort.Tensor("float32", cached.imageEmbed.data, cached.imageEmbed.dims),
+        high_res_feats_0: new ort.Tensor("float32", cached.highResFeats0.data, cached.highResFeats0.dims),
+        high_res_feats_1: new ort.Tensor("float32", cached.highResFeats1.data, cached.highResFeats1.dims),
+      };
+      geometry = cached.processedImage;
+      cacheHit = true;
+    } catch {
+      postWarning("Corrupt embedding cache entry, re-encoding");
+    }
+  }
+
+  if (!cacheHit) {
     const imageData = await loadImageData(imageUrl);
     const processed = preprocessImage(imageData);
     geometry = processed;

--- a/app/packages/annotation/src/providers/worker.ts
+++ b/app/packages/annotation/src/providers/worker.ts
@@ -219,7 +219,6 @@ async function embedAndDecode(
         padX: geometry.padX,
         padY: geometry.padY,
       },
-      lastAccessed: 0,
     }, postWarning);
   }
 

--- a/app/packages/annotation/src/providers/worker.ts
+++ b/app/packages/annotation/src/providers/worker.ts
@@ -1,5 +1,5 @@
 import * as ort from "onnxruntime-web";
-import type { PromptPoint, WorkerMessageType, WorkerNotifications, WorkerResponse } from "./types";
+import type { InferenceResult, PromptPoint, WorkerMessageType, WorkerNotifications, WorkerResponse } from "./types";
 import {
   SAM2_INPUT_SIZE,
   SAM2_OUTPUT_SIZE,
@@ -7,9 +7,11 @@ import {
   computeMaskBbox,
   normalizeBbox,
   postprocessMask,
+  type ImageGeometry,
   type ProcessedImage,
 } from "./math";
 import { loadModelWeights } from "./modelCache";
+import { getEmbedding, putEmbedding } from "./embeddingCache";
 
 // Typed postMessage helpers to enforce message shapes at compile time.
 
@@ -166,28 +168,59 @@ async function loadModel(): Promise<void> {
 async function embedAndDecode(
   imageUrl: string,
   points: PromptPoint[]
-): Promise<{ mask: Float32Array; bbox: { x: number; y: number; w: number; h: number } }> {
+): Promise<InferenceResult> {
   if (!encoderSession || !decoderSession)
     throw new Error("Model not loaded");
 
   if (points.length === 0)
     throw new Error("At least one prompt point is required");
 
-  const imageData = await loadImageData(imageUrl);
-  const processedImageData = preprocessImage(imageData);
+  let encResults: Record<string, ort.Tensor>;
+  let geometry: ImageGeometry;
 
-  // Key names are defined by the ONNX model and must match exactly.
-  // Encode — input: "image"; outputs: "image_embed", "high_res_feats_0", "high_res_feats_1"
-  const encResults = await encoderSession.run({
-    image: new ort.Tensor("float32", processedImageData.tensor, [1, 3, SAM2_INPUT_SIZE, SAM2_INPUT_SIZE]),
-  });
+  const postWarning = (message: string) => postNotification("warning", message);
+
+  const cached = await getEmbedding(imageUrl, postWarning);
+  if (cached) {
+    encResults = {
+      image_embed: new ort.Tensor("float32", cached.imageEmbed.data, cached.imageEmbed.dims),
+      high_res_feats_0: new ort.Tensor("float32", cached.highResFeats0.data, cached.highResFeats0.dims),
+      high_res_feats_1: new ort.Tensor("float32", cached.highResFeats1.data, cached.highResFeats1.dims),
+    };
+    geometry = cached.processedImage;
+  } else {
+    const imageData = await loadImageData(imageUrl);
+    const processed = preprocessImage(imageData);
+    geometry = processed;
+
+    encResults = await encoderSession.run({
+      image: new ort.Tensor("float32", processed.tensor, [1, 3, SAM2_INPUT_SIZE, SAM2_INPUT_SIZE]),
+    });
+
+    // Fire-and-forget: IDB write runs in background while decoder proceeds.
+    // Memory LRU is updated synchronously inside putEmbedding before the first await.
+    putEmbedding(imageUrl, {
+      // Key names are defined by the ONNX model and must match exactly.
+      // Encode — input: "image"; outputs: "image_embed", "high_res_feats_0", "high_res_feats_1"
+      imageEmbed: { data: encResults["image_embed"].data as Float32Array, dims: [...encResults["image_embed"].dims] },
+      highResFeats0: { data: encResults["high_res_feats_0"].data as Float32Array, dims: [...encResults["high_res_feats_0"].dims] },
+      highResFeats1: { data: encResults["high_res_feats_1"].data as Float32Array, dims: [...encResults["high_res_feats_1"].dims] },
+      processedImage: {
+        originalWidth: geometry.originalWidth,
+        originalHeight: geometry.originalHeight,
+        scale: geometry.scale,
+        padX: geometry.padX,
+        padY: geometry.padY,
+      },
+    }, postWarning);
+  }
 
   // Build decoder inputs
   const n = points.length;
   const coords = new Float32Array(n * 2);
   const labels = new Float32Array(n);
   for (let i = 0; i < n; i++) {
-    const [sx, sy] = transformPoint(points[i].x, points[i].y, processedImageData);
+    const [sx, sy] = transformPoint(points[i].x, points[i].y, geometry);
     coords[i * 2] = sx;
     coords[i * 2 + 1] = sy;
     labels[i] = points[i].label;
@@ -216,14 +249,14 @@ async function embedAndDecode(
   }
 
   const bestMask = masks.slice(bestIdx * sz, (bestIdx + 1) * sz);
-  const bbox = computeMaskBbox(bestMask, processedImageData);
+  const bbox = computeMaskBbox(bestMask, geometry);
 
   if (!bbox)
     throw new Error("Model returned an empty mask");
 
-  const finalMask = postprocessMask(bestMask, processedImageData, bbox);
+  const finalMask = postprocessMask(bestMask, geometry, bbox);
 
-  return { mask: finalMask, bbox: normalizeBbox(bbox, processedImageData) };
+  return { mask: finalMask, maskWidth: bbox.w, maskHeight: bbox.h, bbox: normalizeBbox(bbox, geometry) };
 }
 
 // Worker message handler
@@ -235,8 +268,8 @@ self.onmessage = async (e: MessageEvent) => {
       await loadModel();
       postResponse(id, "loadModel", undefined as void);
     } else if (type === "embedAndDecode") {
-      const { mask, bbox } = await embedAndDecode(payload.imageUrl, payload.points);
-      postResponse(id, "embedAndDecode", { mask, bbox }, [mask.buffer as ArrayBuffer]);
+      const result = await embedAndDecode(payload.imageUrl, payload.points);
+      postResponse(id, "embedAndDecode", result, [result.mask.buffer as ArrayBuffer]);
     } else {
       postError(id, type, `Unknown message type: ${type}`);
     }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Caches SAM2 encoder embeddings in IndexedDB with in-memory LRU eviction so repeated prompts on the same image skip encoding and run decoder only (~150ms vs ~1-3s)

## How is this patch tested? If it is not, please explain why.

- Unit tests
- In-app (local uncommitted UI changes for testing)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an embedding cache with in-memory LRU and persistent backing for faster repeated-image processing and eviction of oldest entries.
  * Separated image geometry from tensor data so geometry is reused across processing.
  * Inference now returns full results including explicit maskWidth and maskHeight.

* **Tests**
  * Added comprehensive tests for cache reads/writes, eviction, timestamp updates, persistence across sessions, warning/error paths, and resource open/close behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->