### PR TITLE
[HA] ensure server-provided fields are preserved in delta calculation

### DIFF
--- a/app/packages/annotation/src/deltas.test.ts
+++ b/app/packages/annotation/src/deltas.test.ts
@@ -1,69 +1,177 @@
 import { describe, expect, it } from "vitest";
-import { buildAnnotationPath, buildJsonPath, type LabelProxy } from "./deltas";
+import {
+  buildAnnotationPath,
+  buildJsonPath,
+  buildSingleMutationDelta,
+  type LabelProxy,
+} from "./deltas";
+import type { AnnotationLabel } from "@fiftyone/state";
 
-describe("buildAnnotationPath", () => {
-  describe("patches views (isGenerated=true)", () => {
-    it("appends '.detections' for Detection labels in generated views", () => {
-      const label: LabelProxy = {
-        type: "Detection",
-        path: "predictions",
-        data: { _id: "label-1", label: "cat" },
-        boundingBox: [0.1, 0.2, 0.3, 0.4],
-      };
-      expect(buildAnnotationPath(label, true)).toBe("predictions.detections");
+type LabelData = AnnotationLabel["data"];
+
+describe("delta calculation utilities", () => {
+  describe("buildAnnotationPath", () => {
+    describe("patches views (isGenerated=true)", () => {
+      it("appends '.detections' for Detection labels in generated views", () => {
+        const label: LabelProxy = {
+          type: "Detection",
+          path: "predictions",
+          data: { _id: "label-1", label: "cat" } as LabelData,
+          boundingBox: [0.1, 0.2, 0.3, 0.4],
+        };
+        expect(buildAnnotationPath(label, true)).toBe("predictions.detections");
+      });
+
+      it("does not append '.detections' for Classification labels in generated views", () => {
+        const label: LabelProxy = {
+          type: "Classification",
+          path: "classifications",
+          data: { _id: "label-1", label: "cat" } as LabelData,
+        };
+        expect(buildAnnotationPath(label, true)).toBe("classifications");
+      });
     });
 
-    it("does not append '.detections' for Classification labels in generated views", () => {
-      const label: LabelProxy = {
-        type: "Classification",
-        path: "classifications",
-        data: { _id: "label-1", label: "cat" },
-      };
-      expect(buildAnnotationPath(label, true)).toBe("classifications");
+    describe("normal views (isGenerated=false)", () => {
+      it("returns path unchanged for Detection labels", () => {
+        const label: LabelProxy = {
+          type: "Detection",
+          path: "predictions",
+          data: { _id: "label-1", label: "cat" } as LabelData,
+          boundingBox: [0.1, 0.2, 0.3, 0.4],
+        };
+        expect(buildAnnotationPath(label, false)).toBe("predictions");
+      });
+
+      it("returns path unchanged for Classification labels", () => {
+        const label: LabelProxy = {
+          type: "Classification",
+          path: "classifications",
+          data: { _id: "label-1", label: "cat" } as LabelData,
+        };
+        expect(buildAnnotationPath(label, false)).toBe("classifications");
+      });
     });
   });
 
-  describe("normal views (isGenerated=false)", () => {
-    it("returns path unchanged for Detection labels", () => {
-      const label: LabelProxy = {
-        type: "Detection",
-        path: "predictions",
-        data: { _id: "label-1", label: "cat" },
-        boundingBox: [0.1, 0.2, 0.3, 0.4],
-      };
-      expect(buildAnnotationPath(label, false)).toBe("predictions");
+  describe("buildJsonPath", () => {
+    it("builds path from labelPath and operationPath", () => {
+      expect(buildJsonPath("predictions.detections", "label")).toBe(
+        "/predictions/detections/label"
+      );
     });
 
-    it("returns path unchanged for Classification labels", () => {
-      const label: LabelProxy = {
-        type: "Classification",
-        path: "classifications",
-        data: { _id: "label-1", label: "cat" },
-      };
-      expect(buildAnnotationPath(label, false)).toBe("classifications");
+    it("builds path with null labelPath (generated/patches views)", () => {
+      // In generated views, labelPath is null because deltas are relative to the label
+      expect(buildJsonPath(null, "label")).toBe("/label");
+    });
+
+    it("handles nested operation paths", () => {
+      expect(buildJsonPath("predictions.detections", "bounding_box/0")).toBe(
+        "/predictions/detections/bounding_box/0"
+      );
+    });
+
+    it("handles deeply nested labelPath", () => {
+      expect(buildJsonPath("a.b.c", "field")).toBe("/a/b/c/field");
     });
   });
-});
 
-describe("buildJsonPath", () => {
-  it("builds path from labelPath and operationPath", () => {
-    expect(buildJsonPath("predictions.detections", "label")).toBe(
-      "/predictions/detections/label"
-    );
-  });
+  describe("buildSingleMutationDelta", () => {
+    const path = "somePath";
+    const fullSampleLabel = {
+      _cls: "Classification",
+      _id: "abc123",
+      tags: ["reviewed"],
+      label: "positive",
+      confidence: 0.95,
+    };
+    const sampleData = {
+      [path]: fullSampleLabel,
+    };
 
-  it("builds path with null labelPath (generated/patches views)", () => {
-    // In generated views, labelPath is null because deltas are relative to the label
-    expect(buildJsonPath(null, "label")).toBe("/label");
-  });
+    it("should preserve server fields (_cls, _id, tags) when new data is missing them", () => {
+      const newData = { label: "negative" } as LabelData;
 
-  it("handles nested operation paths", () => {
-    expect(buildJsonPath("predictions.detections", "bounding_box/0")).toBe(
-      "/predictions/detections/bounding_box/0"
-    );
-  });
+      const deltas = buildSingleMutationDelta(sampleData, path, newData);
 
-  it("handles deeply nested labelPath", () => {
-    expect(buildJsonPath("a.b.c", "field")).toBe("/a/b/c/field");
+      expect(deltas).toEqual([
+        { op: "replace", path: "/label", value: "negative" },
+      ]);
+    });
+
+    it("should generate correct deltas when new data has all fields", () => {
+      const newData = { ...fullSampleLabel, label: "negative" } as LabelData;
+
+      const deltas = buildSingleMutationDelta(sampleData, path, newData);
+
+      expect(deltas).toEqual([
+        { op: "replace", path: "/label", value: "negative" },
+      ]);
+    });
+
+    it("should return empty deltas when nothing changed", () => {
+      const deltas = buildSingleMutationDelta(sampleData, path, {
+        ...fullSampleLabel,
+      } as LabelData);
+
+      expect(deltas).toEqual([]);
+    });
+
+    it("should allow new fields not in existing label", () => {
+      const newData = {
+        label: "positive",
+        custom_attr: "new_value",
+      } as unknown as LabelData;
+
+      const deltas = buildSingleMutationDelta(sampleData, path, newData);
+
+      expect(deltas).toEqual([
+        { op: "add", path: "/custom_attr", value: "new_value" },
+      ]);
+    });
+
+    it("should handle empty existing label (new field)", () => {
+      const newData = {
+        _cls: "Classification",
+        _id: "new123",
+        label: "positive",
+      } as LabelData;
+
+      const deltas = buildSingleMutationDelta({}, path, newData);
+
+      // All fields should be "add" operations
+      expect(deltas.every((d) => d.op === "add")).toBe(true);
+      expect(deltas.find((d) => d.op === "remove")).toBeUndefined();
+    });
+
+    it("should allow new data to explicitly replace field values", () => {
+      const newData = {
+        _cls: "Classification",
+        _id: "abc123",
+        tags: ["reviewed", "updated"],
+        label: "negative",
+        confidence: 0.99,
+      } as LabelData;
+
+      const deltas = buildSingleMutationDelta(sampleData, path, newData);
+
+      expect(deltas).toHaveLength(3);
+      expect(deltas).toContainEqual({
+        op: "replace",
+        path: "/label",
+        value: "negative",
+      });
+      expect(deltas).toContainEqual({
+        op: "replace",
+        path: "/confidence",
+        value: 0.99,
+      });
+      expect(deltas).toContainEqual({
+        op: "add",
+        path: "/tags/1",
+        value: "updated",
+      });
+    });
   });
 });

--- a/app/packages/annotation/src/deltas.ts
+++ b/app/packages/annotation/src/deltas.ts
@@ -13,7 +13,7 @@ import type {
   PrimitiveValue,
   Sample,
 } from "@fiftyone/state";
-import type { Field, Primitive } from "@fiftyone/utilities";
+import { Field, isObject, Primitive } from "@fiftyone/utilities";
 import { get } from "lodash";
 import type { OpType } from "./types";
 import { arePrimitivesEqual, isPrimitiveFieldType } from "./util";
@@ -318,11 +318,7 @@ export const buildSingleMutationDelta = <
   //  (`_cls`, `_id`, `tags`) are preserved when the overlay only has a
   //  subset of fields
   const merged =
-    typeof data === "object" &&
-    data !== null &&
-    !Array.isArray(data) &&
-    typeof existingLabel === "object" &&
-    !Array.isArray(existingLabel)
+    isObject(data) && isObject(existingLabel)
       ? { ...existingLabel, ...data }
       : data;
 

--- a/app/packages/annotation/src/deltas.ts
+++ b/app/packages/annotation/src/deltas.ts
@@ -1,19 +1,19 @@
-import { isDetection3d } from "@fiftyone/core";
-import { JSONDeltas } from "@fiftyone/core/src/client";
+import { isDetection3d } from "@fiftyone/core/src/utils/labels";
+import type { JSONDeltas } from "@fiftyone/core/src/client";
 import {
   extractNestedField,
   generateJsonPatch,
 } from "@fiftyone/core/src/utils/json";
-import { ClassificationLabel } from "@fiftyone/looker/src/overlays/classifications";
-import { DetectionLabel } from "@fiftyone/looker/src/overlays/detection";
-import { PolylineLabel } from "@fiftyone/looker/src/overlays/polyline";
-import {
+import type { ClassificationLabel } from "@fiftyone/looker/src/overlays/classifications";
+import type { DetectionLabel } from "@fiftyone/looker/src/overlays/detection";
+import type { PolylineLabel } from "@fiftyone/looker/src/overlays/polyline";
+import type {
   AnnotationLabel,
   DetectionAnnotationLabel,
   PrimitiveValue,
   Sample,
 } from "@fiftyone/state";
-import { Field, Primitive } from "@fiftyone/utilities";
+import type { Field, Primitive } from "@fiftyone/utilities";
 import { get } from "lodash";
 import type { OpType } from "./types";
 import { arePrimitivesEqual, isPrimitiveFieldType } from "./util";
@@ -305,7 +305,7 @@ export const buildDeletionDeltas = (
  * @param path Label path
  * @param data Label data
  */
-const buildSingleMutationDelta = <
+export const buildSingleMutationDelta = <
   T extends AnnotationLabel["data"] | Primitive
 >(
   sample: Sample,
@@ -313,7 +313,20 @@ const buildSingleMutationDelta = <
   data: T
 ): JSONDeltas => {
   const existingLabel = <T>extractNestedField(sample, path) ?? {};
-  return generateJsonPatch(existingLabel, data);
+
+  // Merge with existing data so server-enriched properties
+  //  (`_cls`, `_id`, `tags`) are preserved when the overlay only has a
+  //  subset of fields
+  const merged =
+    typeof data === "object" &&
+    data !== null &&
+    !Array.isArray(data) &&
+    typeof existingLabel === "object" &&
+    !Array.isArray(existingLabel)
+      ? { ...existingLabel, ...data }
+      : data;
+
+  return generateJsonPatch(existingLabel, merged);
 };
 
 const buildPrimitiveMutationDelta = (

--- a/app/packages/core/src/client/transformer.ts
+++ b/app/packages/core/src/client/transformer.ts
@@ -2,8 +2,8 @@
  * Copyright 2017-2026, Voxel51, Inc.
  */
 
-import * as _ from "lodash";
-import { isObject } from "./util";
+import { cloneDeep } from "lodash";
+import { isObject } from "@fiftyone/utilities";
 
 /**
  * DataTransformer implementations offer conversion from one record type to another.
@@ -26,7 +26,7 @@ export type FieldTransformer = {
  */
 const DateTimeTransformer: FieldTransformer = {
   canTransform: (data: unknown): boolean => {
-    return isObject(data) && "$date" in (data as object);
+    return isObject(data) && "$date" in data;
   },
   transform: (data: unknown): { _cls: "DateTime"; datetime: number } => {
     const date = new Date((data as { $date: string }).$date);
@@ -39,7 +39,7 @@ const DateTimeTransformer: FieldTransformer = {
  */
 const ObjectIdTransformer: FieldTransformer = {
   canTransform: (data: unknown): boolean => {
-    return isObject(data) && "$oid" in (data as object);
+    return isObject(data) && "$oid" in data;
   },
   transform: (data: unknown): string => {
     return (data as { $oid: string }).$oid;
@@ -76,7 +76,7 @@ const SampleTransformer: DataTransformer = {
     };
 
     // transformation happens in-place, so create a new copy of the data first
-    const result = _.cloneDeep(data);
+    const result = cloneDeep(data);
     transformInner(result);
     return result;
   },

--- a/app/packages/core/src/client/util.ts
+++ b/app/packages/core/src/client/util.ts
@@ -80,12 +80,3 @@ export const parseETag = (headerValue?: string): string | null => {
 
   return cleanedValue;
 };
-
-/**
- * Return true if the provided data is an object.
- *
- * @param data Data to check
- */
-export const isObject = (data: unknown): boolean => {
-  return data && typeof data === "object" && !Array.isArray(data);
-};

--- a/app/packages/utilities/src/type-check.ts
+++ b/app/packages/utilities/src/type-check.ts
@@ -47,5 +47,5 @@ const PRIMITIVE_TYPES = ["string", "number", "boolean"];
  * @param data Data to check
  */
 export const isObject = (data: unknown): data is object => {
-  return data && typeof data === "object" && !Array.isArray(data);
+  return data !== null && typeof data === "object" && !Array.isArray(data);
 };

--- a/app/packages/utilities/src/type-check.ts
+++ b/app/packages/utilities/src/type-check.ts
@@ -40,3 +40,12 @@ export type NumberKeyObjectType<V = unknown> = {
 };
 
 const PRIMITIVE_TYPES = ["string", "number", "boolean"];
+
+/**
+ * Return true if the provided data is an object.
+ *
+ * @param data Data to check
+ */
+export const isObject = (data: unknown): data is object => {
+  return data && typeof data === "object" && !Array.isArray(data);
+};


### PR DESCRIPTION
## What changes are proposed in this pull request?

This fixes a bug where server-provided data could be omitted on client-side labels, resulting in erroneous patch requests. Labels are now properly merged during delta calculations.

## How is this patch tested? If it is not, please explain why.

local, unit tests

Specific steps to repro:
* Create a new `Classification` field on a dataset
* Use the `edit_field_values` operator to init `<new_field>.label` to some value for all samples
* Edit the classification label in the annotate tab

Previous behavior:
* Persistence gets into a bad state due to missing local data

New behavior:
* Persistence works as expected

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixed a bug which could cause erroneous patch requests while annotating samples

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Delta/patch generation for annotations updated to preserve existing server-enriched fields during partial updates.

* **Tests**
  * Expanded delta calculation test suite with broader edge-case coverage for nested, empty and mixed updates.

* **Chores**
  * Reorganized imports and utilities; added a shared object-check helper and cleaned up client-side imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->