### PR TITLE
Fix COCO export instance segmentation coordinates out of bounds

### DIFF
--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -1316,7 +1316,7 @@ class COCOObject(object):
             bbox = [x * width, y * height, w * width, h * height]
 
             segmentation = _polyline_to_coco_segmentation(
-                label, frame_size, iscrowd=iscrowd
+                label, frame_size, iscrowd=iscrowd, bbox=bbox
             )
         elif isinstance(label, fol.Keypoint):
             keypoints = _make_coco_keypoints(label, frame_size)
@@ -2250,7 +2250,9 @@ def _normalize_coco_segmentation(segmentation):
     return _segmentation
 
 
-def _polyline_to_coco_segmentation(polyline, frame_size, iscrowd="iscrowd"):
+def _polyline_to_coco_segmentation(
+    polyline, frame_size, iscrowd="iscrowd", bbox=None
+):
     if polyline.get_attribute_value(iscrowd, None):
         seg = polyline.to_segmentation(frame_size=frame_size, target=1)
         return _mask_to_rle(seg.mask)
@@ -2260,8 +2262,19 @@ def _polyline_to_coco_segmentation(polyline, frame_size, iscrowd="iscrowd"):
     for points in polyline.points:
         polygon = []
         for x, y in points:
-            polygon.append(int(x * width))
-            polygon.append(int(y * height))
+            x_abs = int(x * width)
+            y_abs = int(y * height)
+
+            # Clip segmentation points to bbox if provided
+            if bbox is not None:
+                x_min, y_min, w, h = bbox
+                x_max = x_min + w
+                y_max = y_min + h
+                x_abs = max(int(x_min), min(x_abs, int(x_max)))
+                y_abs = max(int(y_min), min(y_abs, int(y_max)))
+
+            polygon.append(x_abs)
+            polygon.append(y_abs)
 
         polygons.append(polygon)
 


### PR DESCRIPTION
## Problem

When exporting datasets to COCO format, instance segmentation masks have coordinates that exceed the bounds of their bounding boxes. This causes data integrity issues in exported annotations.

## Solution

Added clipping logic to ensure segmentation polygon coordinates are clipped to their corresponding bounding box bounds before export.

## Validation

```python
# Export COCO dataset
ds.export(export_dir=PATH, dataset_type=fo.types.COCODetectionDataset)

# All segmentation coordinates now within bbox bounds
# No OOB coordinates in exported labels.json
```

Fixes #2847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved COCO format exports to correctly handle polyline segmentations by clipping segmentation points to their corresponding bounding box regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->