### PR TITLE
Fix numpy output serialization in KeypointOutputProcessor and embed_all

### DIFF
--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -1617,7 +1617,7 @@ class KeypointOutputProcessor(OutputProcessor):
                     # Low confidence
                     points.append((float("nan"), float("nan")))
                 else:
-                    points.append((p[0] / width, p[1] / height))
+                    points.append((float(p[0] / width), float(p[1] / height)))
             _keypoints.append(
                 fol.Keypoint(
                     points=points,

--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -532,7 +532,12 @@ class ZeroShotTransformerEmbeddingsMixin(EmbeddingsMixin):
                 args[k] = v.to(self.device)
             features = self._model.get_image_features(**args)
             if not isinstance(features, torch.Tensor):
-                features = features.pooler_output
+                features = getattr(features, "pooler_output", None)
+                if features is None:
+                    raise ValueError(
+                        "get_image_features() returned a non-tensor "
+                        "output without a pooler_output attribute"
+                    )
             return features.detach().cpu().numpy()
 
 

--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -530,9 +530,10 @@ class ZeroShotTransformerEmbeddingsMixin(EmbeddingsMixin):
         with torch.no_grad():
             for k, v in args.items():
                 args[k] = v.to(self.device)
-            return (
-                self._model.get_image_features(**args).detach().cpu().numpy()
-            )
+            features = self._model.get_image_features(**args)
+            if not isinstance(features, torch.Tensor):
+                features = features.pooler_output
+            return features.detach().cpu().numpy()
 
 
 class ZeroShotTransformerPromptMixin(PromptMixin):

--- a/tests/unittests/utils/test_keypoint_output.py
+++ b/tests/unittests/utils/test_keypoint_output.py
@@ -1,0 +1,27 @@
+"""
+Tests for KeypointOutputProcessor numpy serialization.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import torch
+
+from fiftyone.utils.torch import KeypointOutputProcessor
+
+
+class TestKeypointOutputProcessorSerialization:
+    """Ensure _parse_output returns native Python floats, not numpy scalars."""
+
+    def test_points_are_native_floats(self):
+        output = {
+            "keypoints": torch.tensor([[[320.0, 240.0]]]),
+            "keypoints_scores": torch.tensor([[5.0]]),  # high logit
+        }
+        processor = KeypointOutputProcessor()
+        result = processor._parse_output(output, (640, 480), None)
+
+        x, y = result.keypoints[0].points[0]
+        assert type(x) is float, f"x is {type(x)}, expected float"
+        assert type(y) is float, f"y is {type(y)}, expected float"

--- a/tests/unittests/utils/test_keypoint_output.py
+++ b/tests/unittests/utils/test_keypoint_output.py
@@ -25,3 +25,5 @@ class TestKeypointOutputProcessorSerialization:
         x, y = result.keypoints[0].points[0]
         assert type(x) is float, f"x is {type(x)}, expected float"
         assert type(y) is float, f"y is {type(y)}, expected float"
+        assert x == 0.5, f"x is {x}, expected 0.5"
+        assert y == 0.5, f"y is {y}, expected 0.5"


### PR DESCRIPTION
## Summary

- Wrap numpy scalar division in `float()` in `KeypointOutputProcessor._parse_output`
  (same fix as #6407 for the parent class)
- Handle `ModelOutput` return type from `get_image_features()` in
  `ZeroShotTransformerEmbeddingsMixin.embed_all`

## What changes are proposed in this pull request?

`KeypointOutputProcessor._parse_output` divides numpy arrays by Python ints, producing
`np.float32` values that pymongo rejects. #6407 fixed the same issue in the child class
`KeypointDetectorOutputProcessor` but the parent class was missed. This crashes all vitpose
and pose-estimation-transformer models on `dataset.apply_model()`.

`ZeroShotTransformerEmbeddingsMixin.embed_all` calls
`self._model.get_image_features(**args).detach()`, assuming the return value is always a
tensor. For siglip, monet-zero, pubmed-clip, and zero-shot-classification-transformer,
`get_image_features()` returns a `BaseModelOutputWithPooling` which doesn't have `.detach()`.
The fix extracts `.pooler_output` when the return is not a tensor.

## How is this patch tested? If it is not, please explain why.

Reproduced all 11 affected failures with numpy 2.3.5. Applied both patches and verified
all 11 models pass. Ran a full 216-model zoo sweep with patches applied to confirm zero
regressions (203 pass vs 192 without patches — the 11 difference is exactly these fixes).

## Release Notes

- [x] Yes.

Fixed `InvalidDocument` error when running vitpose models and `AttributeError` when
calling `embed()` on siglip/clip-based models with numpy >= 2.0.

### What areas of FiftyOne does this PR affect?

- [x] Core: Core fiftyone Python library changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure keypoint coordinates are produced as native Python floats for consistent numeric formatting.
  * Improve transformer embedding extraction to handle varied model output shapes and raise a clear error when expected features are missing.

* **Tests**
  * Added unit tests validating keypoint coordinate serialization as native floats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->