### PR TITLE
add support for providing actions for notification

### DIFF
--- a/app/packages/state/src/hooks/useNotification.tsx
+++ b/app/packages/state/src/hooks/useNotification.tsx
@@ -1,6 +1,6 @@
 import Close from "@mui/icons-material/Close";
-import { IconButton } from "@mui/material";
-import { enqueueSnackbar, closeSnackbar, OptionsObject } from "notistack";
+import { Button, ButtonProps, IconButton, Stack } from "@mui/material";
+import { closeSnackbar, enqueueSnackbar, OptionsObject } from "notistack";
 import React from "react";
 
 const SNACKBAR_AUTO_HIDE_DURATION = 3000;
@@ -9,7 +9,7 @@ export default function useNotification(): (
   options: NotificationOption
 ) => void {
   return (options: NotificationOption) => {
-    const { msg } = options;
+    const { msg, actions = [], ...otherOptions } = options;
     enqueueSnackbar({
       key: msg,
       message: msg,
@@ -17,19 +17,50 @@ export default function useNotification(): (
       autoHideDuration: SNACKBAR_AUTO_HIDE_DURATION,
       preventDuplicate: true,
       action: (
-        <IconButton
-          onClick={() => {
-            closeSnackbar(msg);
-          }}
-        >
-          <Close fontSize="small" sx={{ color: "white" }} />
-        </IconButton>
+        <Stack direction="row" spacing={1} alignItems="center">
+          {actions.map((action) => {
+            const { label, href, onClick, buttonProps } = action;
+            return (
+              <Button
+                key={label}
+                onClick={onClick}
+                href={href}
+                variant="outlined"
+                sx={{
+                  borderColor: "hsl(0deg 0% 100% / 30%)",
+                  color: (theme) => theme.palette.text.primary,
+                  "&:hover": {
+                    borderColor: "hsl(0deg 0% 100% / 30%)",
+                  },
+                }}
+                {...buttonProps}
+              >
+                {label}
+              </Button>
+            );
+          })}
+          <IconButton
+            onClick={() => {
+              closeSnackbar(msg);
+            }}
+          >
+            <Close fontSize="small" sx={{ color: "white" }} />
+          </IconButton>
+        </Stack>
       ),
-      ...options,
+      ...otherOptions,
     });
   };
 }
 
 type NotificationOption = OptionsObject & {
   msg: string;
+  actions?: ActionType[];
+};
+
+type ActionType = {
+  label: string;
+  href?: string;
+  onClick?: () => void;
+  buttonProps?: ButtonProps;
 };


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add support for providing actions for notification

## How is this patch tested? If it is not, please explain why.

Using an example notification in the app with provided actions

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

In-app notification now allows providing custom actions. See Usage below 

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


### Usage

#### React
```js
import { useNotification } from "@fiftyone/state";

export default function MyComponent() {
  const notify = useNotification();

  return (
    <Box>
      <Button
        onClick={() =>
          notify({
            msg: "This is a notification",
            variant: "success",
            actions: [
              { label: "Show alert", onClick: () => alert("Action clicked") },
              { label: "Navigate to href", href: "https://docs.voxel51.com" },
            ],
          })
        }
      >
        Notify
      </Button>
    </Box>
  );
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notification actions have been expanded to support multiple customizable buttons. Each action button can now include a custom label, optional link destination, and click handler, displayed in a horizontal layout alongside the standard close button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->