### PR TITLE
improve background compute onboarding

### DIFF
--- a/app/packages/core/package.json
+++ b/app/packages/core/package.json
@@ -23,7 +23,7 @@
         "@mui/material": "^5.9.0",
         "@react-spring/web": "^9.4.3",
         "@use-gesture/react": "^10.3.0",
-        "@voxel51/voodo": "^0.0.20",
+        "@voxel51/voodo": "^0.0.21",
         "@xstate/react": "1.3.3",
         "classnames": "^2.2.6",
         "color": "^4.2.3",

--- a/app/packages/operators/src/components/OperatorPromptBody.tsx
+++ b/app/packages/operators/src/components/OperatorPromptBody.tsx
@@ -1,4 +1,3 @@
-import { Alert, AlertTitle } from "@mui/material";
 import { useOperatorPrompt } from "../state";
 import { BaseStylesProvider } from "../styled-components";
 import { getOperatorPromptConfigs } from "../utils";
@@ -10,22 +9,10 @@ export default function OperatorPromptBody(props: {
   operatorPrompt: OperatorPromptType;
 }) {
   const { operatorPrompt } = props;
-  const {
-    showWarning,
-    // warningTitle,
-    warningMessage,
-    showResultOrError,
-  } = getOperatorPromptConfigs(operatorPrompt);
-  const warningTitle = null; // todo
+  const { showResultOrError } = getOperatorPromptConfigs(operatorPrompt);
 
   return (
     <BaseStylesProvider>
-      {showWarning && (
-        <Alert severity="warning">
-          <AlertTitle>{warningTitle}</AlertTitle>
-          {warningMessage}
-        </Alert>
-      )}
       {operatorPrompt.showPrompt && (
         <OperatorPromptForm operatorPrompt={operatorPrompt} />
       )}

--- a/app/packages/operators/src/components/OperatorPromptFooter.tsx
+++ b/app/packages/operators/src/components/OperatorPromptFooter.tsx
@@ -1,10 +1,16 @@
 import { Button } from "@fiftyone/components";
-import { CircularProgress, Button as MUIButton } from "@mui/material";
+import { CircularProgress, Link, Stack } from "@mui/material";
+import {
+  IconName,
+  RichCard,
+  Variant,
+  Button as VoodoButton,
+} from "@voxel51/voodo";
 import { useCallback } from "react";
+import { SubmitButtonOption } from "../OperatorPalette";
 import SplitButton from "../SplitButton";
 import { BaseStylesProvider } from "../styled-components";
 import { onEnter } from "../utils";
-import { SubmitButtonOption } from "../OperatorPalette";
 
 export default function OperatorPromptFooter(props: OperatorFooterProps) {
   const {
@@ -18,7 +24,7 @@ export default function OperatorPromptFooter(props: OperatorFooterProps) {
     submitButtonOptions,
     submitOptionsLoading,
     hasSubmitButtonOptions,
-    showWarning,
+    requiresOrchestratorSetup,
   } = props;
 
   const handleSubmit = useCallback(() => {
@@ -26,62 +32,72 @@ export default function OperatorPromptFooter(props: OperatorFooterProps) {
     onSubmit();
   }, [disableSubmit, onSubmit]);
 
-  if (showWarning) {
+  if (requiresOrchestratorSetup) {
     return (
-      <MUIButton
-        sx={{ textTransform: "none" }}
-        onClick={onCancel}
-        onKeyDown={onEnter(onCancel)}
-      >
-        OK
-      </MUIButton>
-    );
-  }
-
-  if (!showWarning) {
-    return (
-      <>
-        {loading && (
-          <CircularProgress
-            size={20}
-            sx={{ mr: 1, color: (theme) => theme.palette.text.secondary }}
-          />
-        )}
-        {onCancel && (
-          <BaseStylesProvider>
-            <Button onClick={onCancel} onKeyDown={onEnter(onCancel)}>
-              {cancelButtonText}
-            </Button>
-          </BaseStylesProvider>
-        )}
-        {onSubmit && !hasSubmitButtonOptions && !submitOptionsLoading && (
-          <BaseStylesProvider>
-            <Button
-              onClick={handleSubmit}
-              onKeyDown={onEnter(handleSubmit)}
-              disabled={disableSubmit}
-              title={disableSubmit && disabledReason}
+      <Stack sx={{ width: "100%", gap: 2 }}>
+        <RichCard
+          title="Background compute is not yet configured"
+          description="Production workflows require dedicated compute resources."
+          icon={IconName.Orchestrator}
+          compact
+          action={
+            <Link
+              href="https://docs.voxel51.com/plugins/using_plugins.html#delegated-operations"
+              target="_blank"
             >
-              {submitButtonText}
-            </Button>
-          </BaseStylesProvider>
-        )}
-        {onSubmit && hasSubmitButtonOptions && !submitOptionsLoading && (
-          <BaseStylesProvider>
-            <SplitButton
-              disabled={disableSubmit}
-              disabledReason={disabledReason}
-              options={submitButtonOptions}
-              submitOnEnter
-              onSubmit={onSubmit}
-            />
-          </BaseStylesProvider>
-        )}
-      </>
+              <VoodoButton variant={Variant.Secondary}>Set up now</VoodoButton>
+            </Link>
+          }
+        />
+        <Stack justifyContent="flex-end" direction="row">
+          <Button onClick={onCancel} onKeyDown={onEnter(onCancel)}>
+            Close
+          </Button>
+        </Stack>
+      </Stack>
     );
   }
 
-  return null;
+  return (
+    <>
+      {loading && (
+        <CircularProgress
+          size={20}
+          sx={{ mr: 1, color: (theme) => theme.palette.text.secondary }}
+        />
+      )}
+      {onCancel && (
+        <BaseStylesProvider>
+          <Button onClick={onCancel} onKeyDown={onEnter(onCancel)}>
+            {cancelButtonText}
+          </Button>
+        </BaseStylesProvider>
+      )}
+      {onSubmit && !hasSubmitButtonOptions && !submitOptionsLoading && (
+        <BaseStylesProvider>
+          <Button
+            onClick={handleSubmit}
+            onKeyDown={onEnter(handleSubmit)}
+            disabled={disableSubmit}
+            title={disableSubmit && disabledReason}
+          >
+            {submitButtonText}
+          </Button>
+        </BaseStylesProvider>
+      )}
+      {onSubmit && hasSubmitButtonOptions && !submitOptionsLoading && (
+        <BaseStylesProvider>
+          <SplitButton
+            disabled={disableSubmit}
+            disabledReason={disabledReason}
+            options={submitButtonOptions}
+            submitOnEnter
+            onSubmit={onSubmit}
+          />
+        </BaseStylesProvider>
+      )}
+    </>
+  );
 }
 
 type OperatorFooterProps = {
@@ -92,8 +108,8 @@ type OperatorFooterProps = {
   disableSubmit?: boolean;
   disabledReason?: string;
   loading?: boolean;
-  submitButtonOptions: SubmitButtonOption[];
-  hasSubmitButtonOptions: boolean;
-  submitOptionsLoading: boolean;
-  showWarning?: boolean;
+  submitButtonOptions?: SubmitButtonOption[];
+  hasSubmitButtonOptions?: boolean;
+  submitOptionsLoading?: boolean;
+  requiresOrchestratorSetup?: boolean;
 };

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -404,22 +404,17 @@ const useOperatorPromptSubmitOptions = (
   }, [options, selectedID]);
 
   if (selectedOption) selectedOption.selected = true;
-  const showWarning =
+  const requiresOrchestratorSetup =
     executionOptions.orchestratorRegistrationEnabled &&
     !hasAvailableOrchestrators &&
     !executionOptions.allowImmediateExecution;
-  const warningStr =
-    "This operation requires [delegated execution](https://docs.voxel51.com/plugins/using_plugins.html#delegated-operations)";
-  const warningMessage = React.createElement(Markdown, null, warningStr);
 
   return {
-    showWarning,
-    warningTitle: "No available orchestrators",
-    warningMessage,
-    options,
+    handleSubmit,
     hasOptions: options.length > 0,
     isLoading: execDetails.isLoading,
-    handleSubmit,
+    options,
+    requiresOrchestratorSetup,
   };
 };
 

--- a/app/packages/operators/src/utils.ts
+++ b/app/packages/operators/src/utils.ts
@@ -60,8 +60,8 @@ export function getOperatorPromptConfigs(operatorPrompt: OperatorPromptType) {
   const submitButtonOptions = operatorPrompt.submitOptions.options;
   const submitButtonLoading = operatorPrompt.submitOptions.isLoading;
   const hasSubmitButtonOptions = operatorPrompt.submitOptions.hasOptions;
-  const showWarning = operatorPrompt.submitOptions.showWarning;
-  const warningMessage = operatorPrompt.submitOptions.warningMessage;
+  const requiresOrchestratorSetup =
+    operatorPrompt.submitOptions.requiresOrchestratorSetup;
   let cancelButtonText = "Cancel";
   let onSubmit, onCancel;
 
@@ -106,8 +106,7 @@ export function getOperatorPromptConfigs(operatorPrompt: OperatorPromptType) {
     submitButtonOptions,
     submitButtonLoading,
     hasSubmitButtonOptions,
-    showWarning,
-    warningMessage,
+    requiresOrchestratorSetup,
     cancelButtonText,
     onSubmit,
     onCancel,

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2594,7 +2594,7 @@ __metadata:
     "@types/styled-components": "npm:^5.1.23"
     "@use-gesture/react": "npm:^10.3.0"
     "@vitejs/plugin-react-refresh": "npm:^1.3.3"
-    "@voxel51/voodo": "npm:^0.0.20"
+    "@voxel51/voodo": "npm:^0.0.21"
     "@xstate/react": "npm:1.3.3"
     classnames: "npm:^2.2.6"
     color: "npm:^4.2.3"
@@ -7311,9 +7311,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@voxel51/voodo@npm:^0.0.20":
-  version: 0.0.20
-  resolution: "@voxel51/voodo@npm:0.0.20"
+"@voxel51/voodo@npm:^0.0.21":
+  version: 0.0.21
+  resolution: "@voxel51/voodo@npm:0.0.21"
   dependencies:
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/sortable": "npm:^10.0.0"
@@ -7330,7 +7330,7 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
     react-is: ^18.0.0
-  checksum: 10/dc0a8e4ad6e25b4a90ffeff174c9d00fe163dc3f54d3e334f7b83845b4445c4f8429772c637ff635071dd2aff2a9fd7ff0a2a86dadc292091d91b171fbfe3b78
+  checksum: 10/129cd91c80f47ebb9372c15dc018bdb8d3391ae959043ebab3c6338851f79aba40f0146d478e248f46f6603ae9d9fbc5cd30079cf9a42b38f385884041a16b94
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

improve background compute onboarding

## How is this patch tested? If it is not, please explain why.

Using an operator which required background compute

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved orchestrator setup requirement handling by removing generic warning alerts and replacing them with a dedicated setup flow.

* **Style**
  * Updated footer UI to display a "Set up now" link and documentation guidance when orchestrator setup is required, providing clearer guidance to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->