### PR TITLE
Fix TOC sidebar highlighting wrong active section

### DIFF
--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -747,13 +747,9 @@ function initScrollSpyFix() {
 
   const sections = [];
   tocLinks.forEach((link) => {
-    try {
-      const id = decodeURIComponent(link.getAttribute("href").slice(1));
-      const el = document.getElementById(id);
-      if (el) sections.push({ el, link });
-    } catch (e) {
-      /* malformed href, skip */
-    }
+    const id = decodeURIComponent(link.getAttribute("href").slice(1));
+    const el = document.getElementById(id);
+    if (el) sections.push({ el, link });
   });
   if (!sections.length) return;
 

--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -738,6 +738,83 @@ function initAIChatButtons() {
   });
 }
 
+function initScrollSpyFix() {
+  const tocNav = document.querySelector(".bd-toc-nav");
+  if (!tocNav) return;
+
+  const tocLinks = tocNav.querySelectorAll("a[href^='#']");
+  if (!tocLinks.length) return;
+
+  const sections = [];
+  tocLinks.forEach((link) => {
+    try {
+      const id = decodeURIComponent(link.getAttribute("href").slice(1));
+      const el = document.getElementById(id);
+      if (el) sections.push({ el, link });
+    } catch (e) {
+      /* malformed href, skip */
+    }
+  });
+  if (!sections.length) return;
+
+  const headerOffset =
+    parseInt(getComputedStyle(document.documentElement).scrollPaddingTop, 10) ||
+    80;
+
+  let ticking = false;
+
+  const updateActiveSection = () => {
+    const scrollPos = window.scrollY + headerOffset + 10;
+    let active = null;
+
+    for (let i = 0; i < sections.length; i++) {
+      if (sections[i].el.offsetTop <= scrollPos) {
+        active = sections[i];
+      } else {
+        break;
+      }
+    }
+
+    if (!active || active.link.classList.contains("active")) {
+      ticking = false;
+      return;
+    }
+
+    tocLinks.forEach((link) => {
+      link.classList.remove("active");
+      link.parentElement.classList.remove("active");
+    });
+
+    active.link.classList.add("active");
+    active.link.parentElement.classList.add("active");
+
+    let parent = active.link.parentElement.parentElement;
+    while (parent && parent !== tocNav) {
+      if (parent.tagName === "LI") parent.classList.add("active");
+      parent = parent.parentElement;
+    }
+
+    ticking = false;
+  };
+
+  if (typeof bootstrap !== "undefined" && bootstrap.ScrollSpy) {
+    const spy = bootstrap.ScrollSpy.getInstance(document.body);
+    if (spy) spy.dispose();
+  }
+
+  window.addEventListener(
+    "scroll",
+    () => {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(updateActiveSection);
+    },
+    { passive: true }
+  );
+
+  updateActiveSection();
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   initSidebarToggle();
   initSlidingNavBar();
@@ -750,4 +827,9 @@ document.addEventListener("DOMContentLoaded", () => {
   initDynamicCTAs();
   initDirectAgentAccess();
   initAIChatButtons();
+});
+
+/* ScrollSpy initializes on window.load, so we must run after it */
+window.addEventListener("load", () => {
+  initScrollSpyFix();
 });


### PR DESCRIPTION
## What changes are proposed in this pull request?

This is coming from changes in Bootstrap 5.2 ScrollSpy. Bootstrap replaced the old scroll-event listener with an IntersectionObserver, which introduces a couple of known issues:

1. The observer can emit multiple section updates at once, and the logic sometimes picks the wrong section as active
   * [https://github.com/twbs/bootstrap/issues/41900](https://github.com/twbs/bootstrap/issues/41900)
   * [https://github.com/twbs/bootstrap/issues/36431](https://github.com/twbs/bootstrap/issues/36431)

2. `_activateParents` relies on sibling traversal, which doesn’t work well with nested `<ul>` TOC structures
   * As a result, parent `<li>` elements don’t get the `.active` class
   * This breaks subsection expand/collapse behavior

3. These issues are known upstream but not fully resolved yet
   * [https://github.com/twbs/bootstrap/pull/41016](https://github.com/twbs/bootstrap/pull/41016)

Instead of relying on Bootstrap’s ScrollSpy, I dispose it on `window.load` and replace it with a simple scroll-position listener.

The new approach:

* Determines the active section based on `offsetTop`
* Updates the active state in a deterministic way
* Handles parent activation by walking up the DOM tree, instead of relying on Bootstrap’s sibling traversal

## How is this patch tested? If it is not, please explain why.

Built in local and validate the issue  (video with after and before)

https://github.com/user-attachments/assets/d23835ac-af9a-4126-944b-19406ece1687

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [X] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [X] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the Table of Contents navigation to more accurately track and highlight the active section as users scroll through documentation pages. The active link now reliably reflects the currently viewed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->