### PR TITLE
[FOEPD-3393] Implement browser compatibility detection and error reporting

### DIFF
--- a/app/packages/annotation/src/providers/BrowserAnnotationProvider.test.ts
+++ b/app/packages/annotation/src/providers/BrowserAnnotationProvider.test.ts
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BrowserAnnotationProvider } from "./BrowserAnnotationProvider";
+
+// Mock Worker
+class MockWorker {
+  onmessage: any = null;
+  onerror: any = null;
+  terminate = vi.fn();
+  postMessage = vi.fn((msg: any) => {
+    if (msg.type === "loadModel") {
+      setTimeout(() => {
+        this.onmessage?.({ data: { id: msg.id, type: "loadModel", success: true } });
+      });
+    }
+  });
+}
+
+// Stub API for compatibility check
+function stubBrowserAPIs() {
+  if (typeof globalThis.OffscreenCanvas === "undefined")
+    vi.stubGlobal("OffscreenCanvas", class OffscreenCanvas {});
+}
+
+describe("BrowserAnnotationProvider", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    stubBrowserAPIs();
+  });
+
+  it("Calls onStatus with loading then ready on successful init", async () => {
+    vi.stubGlobal("Worker", MockWorker);
+
+    const onStatus = vi.fn();
+    const provider = new BrowserAnnotationProvider({ onStatus });
+    await provider.initialize();
+
+    expect(onStatus).toHaveBeenCalledTimes(2);
+    expect(onStatus).toHaveBeenNthCalledWith(1, "loading");
+    expect(onStatus).toHaveBeenNthCalledWith(2, "ready");
+  });
+
+  it("Calls onStatus with failure when worker loadModel rejects", async () => {
+    class MockWorker {
+      onmessage: any = null;
+      onerror: any = null;
+      terminate = vi.fn();
+      postMessage = vi.fn((msg: any) => {
+        setTimeout(() => {
+          this.onmessage?.({ data: { id: msg.id, type: "loadModel", success: false, error: "ONNX init failed" } });
+        });
+      });
+    }
+    vi.stubGlobal("Worker", MockWorker);
+
+    const onStatus = vi.fn();
+    const provider = new BrowserAnnotationProvider({ onStatus });
+
+    await expect(provider.initialize()).rejects.toThrow("ONNX init failed");
+    expect(onStatus).toHaveBeenCalledTimes(2);
+    expect(onStatus).toHaveBeenNthCalledWith(1, "loading");
+    expect(onStatus).toHaveBeenNthCalledWith(2, "failure");
+  });
+
+  it("Throws unsupported and calls onError when OffscreenCanvas is missing", async () => {
+    const original = globalThis.OffscreenCanvas;
+    delete globalThis.OffscreenCanvas;
+
+    try {
+      const onError = vi.fn();
+      const onStatus = vi.fn();
+      const provider = new BrowserAnnotationProvider({ onError, onStatus });
+
+      await expect(provider.initialize()).rejects.toThrow("Missing browser APIs");
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith({
+        kind: "unsupported",
+        message: expect.stringContaining("OffscreenCanvas"),
+      });
+      expect(onStatus).toHaveBeenCalledWith("failure");
+    } finally {
+      globalThis.OffscreenCanvas = original;
+    }
+  });
+
+  it("Warns but does not block when SharedArrayBuffer is missing", async () => {
+    const original = globalThis.SharedArrayBuffer;
+    delete globalThis.SharedArrayBuffer;
+    vi.stubGlobal("Worker", MockWorker);
+
+    try {
+      const onWarning = vi.fn();
+      const provider = new BrowserAnnotationProvider({ onWarning });
+      await provider.initialize();
+
+      expect(onWarning).toHaveBeenCalledWith(expect.stringContaining("SharedArrayBuffer"));
+    } finally {
+      globalThis.SharedArrayBuffer = original;
+    }
+  });
+
+  it("Throws unsupported when both WASM SIMD and OffscreenCanvas are missing", async () => {
+    const originalOC = globalThis.OffscreenCanvas;
+    const originalWA = globalThis.WebAssembly;
+    delete globalThis.OffscreenCanvas;
+    delete globalThis.WebAssembly;
+
+    try {
+      const onError = vi.fn();
+      const provider = new BrowserAnnotationProvider({ onError });
+
+      await expect(provider.initialize()).rejects.toThrow("Missing browser APIs");
+      const msg = onError.mock.calls[0][0].message;
+      expect(msg).toContain("WASM SIMD");
+      expect(msg).toContain("OffscreenCanvas");
+    } finally {
+      globalThis.OffscreenCanvas = originalOC;
+      globalThis.WebAssembly = originalWA;
+    }
+  });
+
+  it("Forwards all worker notification types to callbacks", async () => {
+    class MockWorker {
+      onmessage: any = null;
+      onerror: any = null;
+      terminate = vi.fn();
+      postMessage = vi.fn((msg: any) => {
+        if (msg.type === "loadModel") {
+          setTimeout(() => {
+            this.onmessage?.({ data: { type: "status", result: "loading" } });
+            this.onmessage?.({ data: { type: "progress", result: { file: "encoder", loaded: 50, total: 100 } } });
+            this.onmessage?.({ data: { type: "warning", result: "IDB unavailable" } });
+            this.onmessage?.({ data: { type: "error", result: { kind: "download_failure", message: "cdn down" } } });
+            this.onmessage?.({ data: { id: msg.id, type: "loadModel", success: true } });
+          });
+        }
+      });
+    }
+    vi.stubGlobal("Worker", MockWorker);
+
+    const onStatus = vi.fn();
+    const onProgress = vi.fn();
+    const onWarning = vi.fn();
+    const onError = vi.fn();
+    const provider = new BrowserAnnotationProvider({ onStatus, onProgress, onWarning, onError });
+    await provider.initialize();
+
+    // Worker-emitted notifications forwarded
+    expect(onStatus).toHaveBeenCalledWith("loading");
+    expect(onProgress).toHaveBeenCalledWith({ file: "encoder", loaded: 50, total: 100 });
+    expect(onWarning).toHaveBeenCalledWith("IDB unavailable");
+    expect(onError).toHaveBeenCalledWith({ kind: "download_failure", message: "cdn down" });
+  });
+
+  it("Does not spawn worker when APIs are unsupported", async () => {
+    const original = globalThis.OffscreenCanvas;
+    delete globalThis.OffscreenCanvas;
+    const WorkerSpy = vi.fn();
+    vi.stubGlobal("Worker", WorkerSpy);
+
+    try {
+      const provider = new BrowserAnnotationProvider();
+      await provider.initialize().catch(() => {});
+      expect(WorkerSpy).not.toHaveBeenCalled();
+    } finally {
+      globalThis.OffscreenCanvas = original;
+    }
+  });
+
+  it("Throws if initialize is called twice", async () => {
+    vi.stubGlobal("Worker", MockWorker);
+
+    const provider = new BrowserAnnotationProvider();
+    await provider.initialize();
+
+    await expect(provider.initialize()).rejects.toThrow("Already initialized");
+  });
+
+  it("Dispose rejects pending promises and clears state", async () => {
+    vi.stubGlobal("Worker", MockWorker);
+
+    const provider = new BrowserAnnotationProvider();
+    await provider.initialize();
+
+    // Start an inference that will never resolve
+    const inferPromise = provider.infer({ imageUrl: "test.jpg", points: [{ x: 0.5, y: 0.5, label: 1 }] }).catch((e: Error) => e);
+    provider.dispose();
+
+    const err = await inferPromise;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe("Provider disposed");
+  });
+
+  it("Worker onerror rejects all pending promises and emits failure", async () => {
+    class MockWorker {
+      onmessage: any = null;
+      onerror: any = null;
+      terminate = vi.fn();
+      postMessage = vi.fn((msg: any) => {
+        if (msg.type === "loadModel") {
+          setTimeout(() => {
+            this.onmessage?.({ data: { id: msg.id, type: "loadModel", success: true } });
+          });
+        }
+        // embedAndDecode triggers a worker error instead of resolving
+        if (msg.type === "embedAndDecode") {
+          setTimeout(() => {
+            this.onerror?.({ message: "Worker crashed" });
+          });
+        }
+      });
+    }
+    vi.stubGlobal("Worker", MockWorker);
+
+    const onStatus = vi.fn();
+    const provider = new BrowserAnnotationProvider({ onStatus });
+    await provider.initialize();
+
+    const err = await provider.infer({ imageUrl: "test.jpg", points: [{ x: 0.5, y: 0.5, label: 1 }] }).catch((e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe("Worker crashed");
+    expect(onStatus).toHaveBeenCalledWith("failure");
+  });
+
+  it("Abort rejects the most recent inference", async () => {
+    vi.stubGlobal("Worker", MockWorker);
+
+    const provider = new BrowserAnnotationProvider();
+    await provider.initialize();
+
+    const inferPromise = provider.infer({ imageUrl: "test.jpg", points: [{ x: 0.5, y: 0.5, label: 1 }] }).catch((e: Error) => e);
+    provider.abort();
+
+    const err = await inferPromise;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe("Inference aborted");
+  });
+
+  it("Abort is a no-op when no inference is pending", async () => {
+    vi.stubGlobal("Worker", MockWorker);
+
+    const provider = new BrowserAnnotationProvider();
+    await provider.initialize();
+
+    expect(() => provider.abort()).not.toThrow();
+  });
+
+  it("Infer rejects when provider is not initialized", async () => {
+    const provider = new BrowserAnnotationProvider();
+
+    const err = await provider.infer({ imageUrl: "test.jpg", points: [{ x: 0.5, y: 0.5, label: 1 }] }).catch((e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe("Worker not initialized");
+  });
+});

--- a/app/packages/annotation/src/providers/BrowserAnnotationProvider.ts
+++ b/app/packages/annotation/src/providers/BrowserAnnotationProvider.ts
@@ -139,6 +139,8 @@ export class BrowserAnnotationProvider implements AnnotationProvider {
       await this.send("loadModel", {}).promise;
       this.onStatus?.("ready");
     } catch (err) {
+      this.worker?.terminate();
+      this.worker = null;
       this.onStatus?.("failure");
       throw err;
     }
@@ -170,10 +172,6 @@ export class BrowserAnnotationProvider implements AnnotationProvider {
     this.pending.clear();
     this.worker?.terminate();
     this.worker = null;
-    this.onStatus = null;
-    this.onProgress = null;
-    this.onWarning = null;
-    this.onError = null;
   }
 
   private send<T extends WorkerMessageType>(

--- a/app/packages/annotation/src/providers/BrowserAnnotationProvider.ts
+++ b/app/packages/annotation/src/providers/BrowserAnnotationProvider.ts
@@ -1,11 +1,15 @@
 import type {
   AnnotationProvider,
+  DownloadProgress,
   DownloadProgressCallback,
+  ErrorCallback,
   InferenceRequest,
   InferenceResult,
+  ProviderError,
+  ProviderStatus,
+  StatusCallback,
   WarningCallback,
   WorkerMessageType,
-  WorkerNotifications,
   WorkerRequest,
   WorkerResponse,
 } from "./types";
@@ -15,24 +19,78 @@ type Pending<T> = {
   reject: (reason: unknown) => void;
 };
 
+// Check that the browser supports the APIs required for ONNX inference.
+function checkBrowserCompatibility(): { errors: string[]; warnings: string[] } {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // WASM SIMD: same byte sequence used by onnxruntime-web to detect SIMD support.
+  // Source: https://github.com/microsoft/onnxruntime/blob/main/js/web/lib/wasm/wasm-factory.ts
+  try {
+    if (!WebAssembly.validate(new Uint8Array([
+      0, 97, 115, 109, 1, 0, 0, 0, 1, 4, 1, 96, 0, 0, 3, 2, 1, 0, 10, 30, 1, 28, 0, 65, 0, 253, 15, 253, 12, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 253, 186, 1, 26, 11,
+    ])))
+      errors.push("WASM SIMD");
+  } catch {
+    errors.push("WASM SIMD");
+  }
+
+  if (typeof OffscreenCanvas === "undefined")
+    errors.push("OffscreenCanvas");
+
+  // SharedArrayBuffer: enables multi-threaded WASM. Without it, falls back to single-threaded.
+  if (typeof SharedArrayBuffer === "undefined")
+    warnings.push("SharedArrayBuffer unavailable. Falling back to single-threaded WASM");
+
+  return { errors, warnings };
+}
+
+export interface BrowserAnnotationProviderOptions {
+  onStatus?: StatusCallback;
+  onProgress?: DownloadProgressCallback;
+  onWarning?: WarningCallback;
+  onError?: ErrorCallback;
+}
+
 export class BrowserAnnotationProvider implements AnnotationProvider {
   private worker: Worker | null = null;
   private nextId = 0;
   private pending = new Map<number, Pending<unknown>>();
   private lastInferenceId: number | null = null;
-  private onProgress: DownloadProgressCallback | null = null;
-  private onWarning: WarningCallback | null = null;
+  private onStatus: StatusCallback | null;
+  private onProgress: DownloadProgressCallback | null;
+  private onWarning: WarningCallback | null;
+  private onError: ErrorCallback | null;
 
-  async initialize(onProgress?: DownloadProgressCallback, onWarning?: WarningCallback): Promise<void> {
+  constructor(options?: BrowserAnnotationProviderOptions) {
+    this.onStatus = options?.onStatus ?? null;
+    this.onProgress = options?.onProgress ?? null;
+    this.onWarning = options?.onWarning ?? null;
+    this.onError = options?.onError ?? null;
+  }
+
+  async initialize(): Promise<void> {
     if (this.worker)
       throw new Error("Already initialized. Call dispose() first.");
+
+    const { errors, warnings } = checkBrowserCompatibility();
+
+    if (errors.length > 0) {
+      const err: ProviderError = { kind: "unsupported", message: `Missing browser APIs: ${errors.join(", ")}` };
+      this.onError?.(err);
+      this.onStatus?.("failure");
+      throw new Error(err.message);
+    }
+
+    for (const w of warnings)
+      this.onWarning?.(w);
+
+    this.onStatus?.("loading");
 
     this.worker = new Worker(new URL("./worker.ts", import.meta.url), {
       type: "module",
     });
-
-    this.onProgress = onProgress ?? null;
-    this.onWarning = onWarning ?? null;
 
     this.worker.onmessage = (e: MessageEvent) => {
       const { id, type, success, result, error } = e.data;
@@ -40,13 +98,23 @@ export class BrowserAnnotationProvider implements AnnotationProvider {
       if (type === "ready")
         return;
 
+      if (type === "status") {
+        this.onStatus?.(result as ProviderStatus);
+        return;
+      }
+
       if (type === "progress") {
-        this.onProgress?.(result as WorkerNotifications["progress"]);
+        this.onProgress?.(result as DownloadProgress);
         return;
       }
 
       if (type === "warning") {
-        this.onWarning?.(result as WorkerNotifications["warning"]);
+        this.onWarning?.(result as string);
+        return;
+      }
+
+      if (type === "error") {
+        this.onError?.(result as ProviderError);
         return;
       }
 
@@ -61,12 +129,19 @@ export class BrowserAnnotationProvider implements AnnotationProvider {
 
     this.worker.onerror = (e: ErrorEvent) => {
       const msg = e.message || "Worker error";
+      this.onStatus?.("failure");
       for (const entry of this.pending.values())
         entry.reject(new Error(msg));
       this.pending.clear();
     };
 
-    await this.send("loadModel", {}).promise;
+    try {
+      await this.send("loadModel", {}).promise;
+      this.onStatus?.("ready");
+    } catch (err) {
+      this.onStatus?.("failure");
+      throw err;
+    }
   }
 
   async infer(request: InferenceRequest): Promise<InferenceResult> {
@@ -95,8 +170,10 @@ export class BrowserAnnotationProvider implements AnnotationProvider {
     this.pending.clear();
     this.worker?.terminate();
     this.worker = null;
+    this.onStatus = null;
     this.onProgress = null;
     this.onWarning = null;
+    this.onError = null;
   }
 
   private send<T extends WorkerMessageType>(

--- a/app/packages/annotation/src/providers/BrowserAnnotationProvider.ts
+++ b/app/packages/annotation/src/providers/BrowserAnnotationProvider.ts
@@ -88,9 +88,14 @@ export class BrowserAnnotationProvider implements AnnotationProvider {
 
     this.onStatus?.("loading");
 
-    this.worker = new Worker(new URL("./worker.ts", import.meta.url), {
-      type: "module",
-    });
+    try {
+      this.worker = new Worker(new URL("./worker.ts", import.meta.url), {
+        type: "module",
+      });
+    } catch (err) {
+      this.onStatus?.("failure");
+      throw err;
+    }
 
     this.worker.onmessage = (e: MessageEvent) => {
       const { id, type, success, result, error } = e.data;
@@ -133,6 +138,8 @@ export class BrowserAnnotationProvider implements AnnotationProvider {
       for (const entry of this.pending.values())
         entry.reject(new Error(msg));
       this.pending.clear();
+      this.worker?.terminate();
+      this.worker = null;
     };
 
     try {

--- a/app/packages/annotation/src/providers/types.ts
+++ b/app/packages/annotation/src/providers/types.ts
@@ -53,16 +53,35 @@ export type WorkerMessages = {
 
 /** One-way worker-to-main-thread notification payloads. */
 export type WorkerNotifications = {
+  status: ProviderStatus;
   progress: DownloadProgress;
   warning: string;
+  error: ProviderError;
 };
 
 export type WorkerMessageType = keyof WorkerMessages;
 export type WorkerRequest<T extends WorkerMessageType> = WorkerMessages[T]["request"];
 export type WorkerResponse<T extends WorkerMessageType> = WorkerMessages[T]["response"];
 
+/** Status events emitted during the provider lifecycle. */
+export type ProviderStatus = "loading" | "encoding" | "ready" | "failure";
+
+/** Typed error categories for structured error reporting. */
+export type ProviderErrorKind =
+  | "unsupported"
+  | "download_failure"
+  | "encoder_failure"
+  | "decoder_failure";
+
+export interface ProviderError {
+  kind: ProviderErrorKind;
+  message: string;
+}
+
+export type StatusCallback = (status: ProviderStatus) => void;
 export type DownloadProgressCallback = (progress: DownloadProgress) => void;
 export type WarningCallback = (message: string) => void;
+export type ErrorCallback = (error: ProviderError) => void;
 
 export interface AnnotationProvider {
   initialize(): Promise<void>;

--- a/app/packages/annotation/src/providers/types.ts
+++ b/app/packages/annotation/src/providers/types.ts
@@ -71,7 +71,8 @@ export type ProviderErrorKind =
   | "unsupported"
   | "download_failure"
   | "encoder_failure"
-  | "decoder_failure";
+  | "decoder_failure"
+  | "inference_failure";
 
 export interface ProviderError {
   kind: ProviderErrorKind;

--- a/app/packages/annotation/src/providers/worker.ts
+++ b/app/packages/annotation/src/providers/worker.ts
@@ -217,8 +217,6 @@ async function embedAndDecode(
   let encResults: Record<string, ort.Tensor>;
   let geometry: ImageGeometry;
 
-  postStatusNotification("encoding");
-
   const cacheKey = CACHE_PREFIX + imageUrl;
   const cached = await getEmbedding(cacheKey, postWarningNotification);
   let cacheHit = false;
@@ -238,6 +236,7 @@ async function embedAndDecode(
   }
 
   if (!cacheHit) {
+    postStatusNotification("encoding");
     const imageData = await loadImageData(imageUrl);
     const processed = preprocessImage(imageData);
     geometry = processed;
@@ -324,6 +323,8 @@ self.onmessage = async (e: MessageEvent) => {
       postError(id, type, `Unknown message type: ${type}`);
     }
   } catch (err) {
+    if (type === "embedAndDecode")
+      postErrorNotification({ kind: "inference_failure", message: err instanceof Error ? err.message : String(err) });
     postError(id, type, err instanceof Error ? err.message : String(err));
   }
 };

--- a/app/packages/annotation/src/providers/worker.ts
+++ b/app/packages/annotation/src/providers/worker.ts
@@ -1,5 +1,14 @@
 import * as ort from "onnxruntime-web";
-import type { InferenceResult, PromptPoint, WorkerMessageType, WorkerNotifications, WorkerResponse } from "./types";
+import type {
+  DownloadProgress,
+  InferenceResult,
+  ProviderError,
+  ProviderStatus,
+  PromptPoint,
+  WorkerMessageType,
+  WorkerNotifications,
+  WorkerResponse,
+} from "./types";
 import {
   SAM2_INPUT_SIZE,
   SAM2_OUTPUT_SIZE,
@@ -13,13 +22,29 @@ import {
 import { loadModelWeights } from "./modelCache";
 import { getEmbedding, putEmbedding } from "./embeddingCache";
 
-// Typed postMessage helpers to enforce message shapes at compile time.
+// Typed helpers to enforce message shapes at compile time.
 
 function postNotification<T extends keyof WorkerNotifications>(
   type: T,
   result: WorkerNotifications[T]
 ): void {
   self.postMessage({ type, result });
+}
+
+function postStatusNotification(status: ProviderStatus): void {
+  postNotification("status", status);
+}
+
+function postProgressNotification(progress: DownloadProgress): void {
+  postNotification("progress", progress);
+}
+
+function postWarningNotification(message: string): void {
+  postNotification("warning", message);
+}
+
+function postErrorNotification(error: ProviderError): void {
+  postNotification("error", error);
 }
 
 function postResponse<T extends WorkerMessageType>(
@@ -139,29 +164,39 @@ function preprocessImage(imageData: ImageData): ProcessedImage {
 async function loadModel(): Promise<void> {
   const opts: ort.InferenceSession.SessionOptions = { executionProviders: ["wasm"] };
 
-  const postProgress = (file: "encoder" | "decoder", loaded: number, total: number) =>
-    postNotification("progress", { file, loaded, total });
+  postStatusNotification("loading");
 
-  const postWarning = (message: string) =>
-    postNotification("warning", message);
-
-  if (!encoderSession) {
-    const encoderBuf = await loadModelWeights(
-      ENCODER_URL,
-      (loaded, total) => postProgress("encoder", loaded, total),
-      postWarning
-    );
-    encoderSession = await ort.InferenceSession.create(encoderBuf, opts);
+  async function loadSession(
+    url: string,
+    name: "encoder" | "decoder",
+    failureKind: "encoder_failure" | "decoder_failure",
+  ): Promise<ort.InferenceSession> {
+    let buf: ArrayBuffer;
+    try {
+      buf = await loadModelWeights(
+        url,
+        (loaded, total) => postProgressNotification({ file: name, loaded, total }),
+        postWarningNotification
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      postErrorNotification({ kind: "download_failure", message: `${name} download failed: ${msg}` });
+      throw err;
+    }
+    try {
+      return await ort.InferenceSession.create(buf, opts);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      postErrorNotification({ kind: failureKind, message: `${name} init failed: ${msg}` });
+      throw err;
+    }
   }
 
-  if (!decoderSession) {
-    const decoderBuf = await loadModelWeights(
-      DECODER_URL,
-      (loaded, total) => postProgress("decoder", loaded, total),
-      postWarning
-    );
-    decoderSession = await ort.InferenceSession.create(decoderBuf, opts);
-  }
+  if (!encoderSession)
+    encoderSession = await loadSession(ENCODER_URL, "encoder", "encoder_failure");
+
+  if (!decoderSession)
+    decoderSession = await loadSession(DECODER_URL, "decoder", "decoder_failure");
 }
 
 /**
@@ -184,10 +219,10 @@ async function embedAndDecode(
   let encResults: Record<string, ort.Tensor>;
   let geometry: ImageGeometry;
 
-  const postWarning = (message: string) => postNotification("warning", message);
+  postStatusNotification("encoding");
 
   const cacheKey = CACHE_PREFIX + imageUrl;
-  const cached = await getEmbedding(cacheKey, postWarning);
+  const cached = await getEmbedding(cacheKey, postWarningNotification);
   let cacheHit = false;
 
   if (cached) {
@@ -200,7 +235,7 @@ async function embedAndDecode(
       geometry = cached.processedImage;
       cacheHit = true;
     } catch {
-      postWarning("Corrupt embedding cache entry, re-encoding");
+      postWarningNotification("Corrupt embedding cache entry, re-encoding");
     }
   }
 
@@ -228,7 +263,7 @@ async function embedAndDecode(
         padX: geometry.padX,
         padY: geometry.padY,
       },
-    }, postWarning);
+    }, postWarningNotification);
   }
 
   // Build decoder inputs
@@ -285,12 +320,15 @@ self.onmessage = async (e: MessageEvent) => {
       postResponse(id, "loadModel", undefined as void);
     } else if (type === "embedAndDecode") {
       const result = await embedAndDecode(payload.imageUrl, payload.points);
+      postStatusNotification("ready");
       postResponse(id, "embedAndDecode", result, [result.mask.buffer as ArrayBuffer]);
     } else {
       postError(id, type, `Unknown message type: ${type}`);
     }
   } catch (err) {
-    postError(id, type, err instanceof Error ? err.message : String(err));
+    const msg = err instanceof Error ? err.message : String(err);
+    postStatusNotification("failure");
+    postError(id, type, msg);
   }
 };
 

--- a/app/packages/annotation/src/providers/worker.ts
+++ b/app/packages/annotation/src/providers/worker.ts
@@ -323,7 +323,7 @@ self.onmessage = async (e: MessageEvent) => {
       postError(id, type, `Unknown message type: ${type}`);
     }
   } catch (err) {
-    if (type === "embedAndDecode")
+      postStatusNotification("failure");
       postErrorNotification({ kind: "inference_failure", message: err instanceof Error ? err.message : String(err) });
     postError(id, type, err instanceof Error ? err.message : String(err));
   }

--- a/app/packages/annotation/src/providers/worker.ts
+++ b/app/packages/annotation/src/providers/worker.ts
@@ -323,8 +323,10 @@ self.onmessage = async (e: MessageEvent) => {
       postError(id, type, `Unknown message type: ${type}`);
     }
   } catch (err) {
+    if (type === "embedAndDecode") {
       postStatusNotification("failure");
       postErrorNotification({ kind: "inference_failure", message: err instanceof Error ? err.message : String(err) });
+    }
     postError(id, type, err instanceof Error ? err.message : String(err));
   }
 };

--- a/app/packages/annotation/src/providers/worker.ts
+++ b/app/packages/annotation/src/providers/worker.ts
@@ -164,8 +164,6 @@ function preprocessImage(imageData: ImageData): ProcessedImage {
 async function loadModel(): Promise<void> {
   const opts: ort.InferenceSession.SessionOptions = { executionProviders: ["wasm"] };
 
-  postStatusNotification("loading");
-
   async function loadSession(
     url: string,
     name: "encoder" | "decoder",
@@ -326,9 +324,7 @@ self.onmessage = async (e: MessageEvent) => {
       postError(id, type, `Unknown message type: ${type}`);
     }
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    postStatusNotification("failure");
-    postError(id, type, msg);
+    postError(id, type, err instanceof Error ? err.message : String(err));
   }
 };
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Detect WASM SIMD and OffscreenCanvas on initialization, blocking with a typed "unsupported" error if missing. SharedArrayBuffer is detected but treated as a warning, falling back to single-threaded WASM gracefully.

Adds typed error events (download_failure, encoder_failure, decoder_failure) and status events (loading, encoding, ready, failure) emitted through constructor-provided callbacks on BrowserAnnotationProvider.

## How is this patch tested? If it is not, please explain why.

Unit tests

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added browser compatibility validation system with typed error reporting
  * Implemented provider status lifecycle tracking through callback-based notifications
  * Introduced structured error types for categorized failure handling

* **Tests**
  * Added comprehensive test suite covering initialization, browser compatibility detection, worker message routing, and error/disposal scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->