### PR TITLE
[FOEPD-3394] Add Cross-Origin Isolation and CORS headers to server routes

### DIFF
--- a/app/packages/annotation/src/providers/worker.ts
+++ b/app/packages/annotation/src/providers/worker.ts
@@ -78,8 +78,14 @@ const DECODER_URL = `${HF_BASE}/decoder.onnx`;
 const CACHE_PREFIX = `${ENCODER_URL}:${SAM2_INPUT_SIZE}:`;
 
 const isCOI = typeof crossOriginIsolated !== "undefined" && crossOriginIsolated;
-ort.env.wasm.numThreads = isCOI ? 4 : 1;
+ort.env.wasm.numThreads = isCOI ? navigator.hardwareConcurrency || 4 : 1;
 ort.env.wasm.simd = true;
+
+// Dev: optimizeDeps.exclude lets ort use its embedded WASM bundle.
+// Prod: worker bundling strips the embedded WASM, so point to the emitted files.
+if (!import.meta.env?.DEV) {
+  ort.env.wasm.wasmPaths = import.meta.env.ORT_WASM_PATH;
+}
 
 let encoderSession: ort.InferenceSession | null = null;
 let decoderSession: ort.InferenceSession | null = null;

--- a/app/packages/annotation/src/providers/worker.ts
+++ b/app/packages/annotation/src/providers/worker.ts
@@ -83,7 +83,7 @@ ort.env.wasm.simd = true;
 
 // Dev: optimizeDeps.exclude lets ort use its embedded WASM bundle.
 // Prod: worker bundling strips the embedded WASM, so point to the emitted files.
-if (!import.meta.env?.DEV) {
+if (!import.meta.env?.DEV && import.meta.env?.ORT_WASM_PATH) {
   ort.env.wasm.wasmPaths = import.meta.env.ORT_WASM_PATH;
 }
 

--- a/app/packages/annotation/src/providers/worker.ts
+++ b/app/packages/annotation/src/providers/worker.ts
@@ -64,10 +64,8 @@ function postError(id: number, type: string, error: string): void {
 const IMAGE_MEAN = [0.485, 0.456, 0.406];
 const IMAGE_STD = [0.229, 0.224, 0.225];
 
-// SAM2 Tiny model weights (HuggingFace-hosted, pre-optimized ONNX)
-// Meta (Apache 2.0, https://huggingface.co/facebook/sam2-hiera-tiny)
-// SharpAI (Apache 2.0, ONNX conversion + ORT optimization, https://huggingface.co/SharpAI/sam2-hiera-tiny-onnx)
-const HF_BASE = "https://huggingface.co/SharpAI/sam2-hiera-tiny-onnx/resolve/main";
+// SAM2 Tiny model weights (pre-optimized ONNX)
+const HF_BASE = "https://models-cdn.voxel51.com/sam2";
 const ENCODER_URL = `${HF_BASE}/encoder.with_runtime_opt.ort`;
 const DECODER_URL = `${HF_BASE}/decoder.onnx`;
 

--- a/app/packages/app/package.json
+++ b/app/packages/app/package.json
@@ -58,7 +58,8 @@
         "vite": "^5.4.21",
         "vite-plugin-relay": "^1.0.7",
         "vite-plugin-rewrite-all": "^1.0.2",
-        "vite-plugin-svgr": "^4.2.0"
+        "vite-plugin-svgr": "^4.2.0",
+        "onnxruntime-web": "^1.24.3"
     },
     "peerDependencies": {
         "@mui/icons-material": "*",

--- a/app/packages/app/package.json
+++ b/app/packages/app/package.json
@@ -51,6 +51,7 @@
         "@types/react-router": "^5.1.20",
         "@types/styled-components": "^5.1.23",
         "@vitejs/plugin-react-refresh": "^1.3.3",
+        "onnxruntime-web": "^1.24.3",
         "relay-compiler": "^14.1.0",
         "rollup-plugin-polyfill-node": "^0.6.2",
         "typescript": "^5.3.2",
@@ -58,8 +59,7 @@
         "vite": "^5.4.21",
         "vite-plugin-relay": "^1.0.7",
         "vite-plugin-rewrite-all": "^1.0.2",
-        "vite-plugin-svgr": "^4.2.0",
-        "onnxruntime-web": "^1.24.3"
+        "vite-plugin-svgr": "^4.2.0"
     },
     "peerDependencies": {
         "@mui/icons-material": "*",

--- a/app/packages/app/vite.config.ts
+++ b/app/packages/app/vite.config.ts
@@ -36,6 +36,8 @@ async function loadConfig() {
           },
           closeBundle() {
             const distAssets = path.resolve(__dirname, "dist/assets");
+            if (!fs.existsSync(distAssets))
+              return;
             const keep = new Set(ortWasmFiles);
             for (const f of fs.readdirSync(distAssets)) {
               if (f.includes("ort-wasm") && !keep.has(f)) {

--- a/app/packages/app/vite.config.ts
+++ b/app/packages/app/vite.config.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 import reactRefresh from "@vitejs/plugin-react-refresh";
 import nodePolyfills from "rollup-plugin-polyfill-node";
 import { defineConfig } from "vite";

--- a/app/packages/app/vite.config.ts
+++ b/app/packages/app/vite.config.ts
@@ -1,3 +1,5 @@
+import fs from "fs";
+import path from "path";
 import reactRefresh from "@vitejs/plugin-react-refresh";
 import nodePolyfills from "rollup-plugin-polyfill-node";
 import { defineConfig } from "vite";
@@ -20,7 +22,26 @@ async function loadConfig() {
       nodePolyfills(),
       // pluginRewriteAll to address this vite bug: https://github.com/vitejs/vite/issues/2415
       pluginRewriteAll(),
+      // In production, the worker bundle strips ort's embedded WASM.
+      // Emit the WASM runtime files so ort can load them at runtime.
+      {
+        name: "copy-ort-wasm",
+        apply: "build",
+        buildStart() {
+          const ortDist = path.dirname(require.resolve("onnxruntime-web"));
+          for (const f of ["ort-wasm-simd-threaded.jsep.wasm", "ort-wasm-simd-threaded.jsep.mjs"]) {
+            this.emitFile({ type: "asset", fileName: `assets/${f}`, source: fs.readFileSync(path.join(ortDist, f)) });
+          }
+        },
+      },
     ],
+    assetsInclude: ["**/*.onnx"],
+    define: {
+      "import.meta.env.ORT_WASM_PATH": JSON.stringify("/assets/"),
+    },
+    optimizeDeps: {
+      exclude: ["onnxruntime-web"],
+    },
     resolve: {
       alias: {
         path: "path-browserify",
@@ -41,6 +62,10 @@ async function loadConfig() {
       allowedHosts: true,
       host: true,
       port: Number.parseInt(process.env.FIFTYONE_DEFAULT_APP_PORT || "5173"),
+      headers: {
+        "Cross-Origin-Opener-Policy": "same-origin",
+        "Cross-Origin-Embedder-Policy": "credentialless",
+      },
       proxy: {
         "/plugins": {
           target: `http://127.0.0.1:${

--- a/app/packages/app/vite.config.ts
+++ b/app/packages/app/vite.config.ts
@@ -22,18 +22,29 @@ async function loadConfig() {
       nodePolyfills(),
       // pluginRewriteAll to address this vite bug: https://github.com/vitejs/vite/issues/2415
       pluginRewriteAll(),
-      // In production, the worker bundle strips ort's embedded WASM.
-      // Emit the WASM runtime files so ort can load them at runtime.
-      {
-        name: "copy-ort-wasm",
-        apply: "build",
-        buildStart() {
-          const ortDist = path.dirname(require.resolve("onnxruntime-web"));
-          for (const f of ["ort-wasm-simd-threaded.jsep.wasm", "ort-wasm-simd-threaded.jsep.mjs"]) {
-            this.emitFile({ type: "asset", fileName: `assets/${f}`, source: fs.readFileSync(path.join(ortDist, f)) });
-          }
-        },
-      },
+      // Vite's worker bundling breaks ort's WASM resolution and emits hashed
+      // copies that ort can't find by name. Emit unhashed copies and clean up.
+      (() => {
+        const ortWasmFiles = ["ort-wasm-simd-threaded.jsep.wasm", "ort-wasm-simd-threaded.jsep.mjs"];
+        return {
+          name: "copy-ort-wasm",
+          buildStart() {
+            const ortDist = path.dirname(require.resolve("onnxruntime-web"));
+            for (const f of ortWasmFiles) {
+              this.emitFile({ type: "asset", fileName: `assets/${f}`, source: fs.readFileSync(path.join(ortDist, f)) });
+            }
+          },
+          closeBundle() {
+            const distAssets = path.resolve(__dirname, "dist/assets");
+            const keep = new Set(ortWasmFiles);
+            for (const f of fs.readdirSync(distAssets)) {
+              if (f.includes("ort-wasm") && !keep.has(f)) {
+                fs.unlinkSync(path.join(distAssets, f));
+              }
+            }
+          },
+        };
+      })(),
     ],
     assetsInclude: ["**/*.onnx"],
     define: {

--- a/app/packages/app/vite.config.ts
+++ b/app/packages/app/vite.config.ts
@@ -28,6 +28,7 @@ async function loadConfig() {
         const ortWasmFiles = ["ort-wasm-simd-threaded.jsep.wasm", "ort-wasm-simd-threaded.jsep.mjs"];
         return {
           name: "copy-ort-wasm",
+          apply: "build",
           buildStart() {
             const ortDist = path.dirname(require.resolve("onnxruntime-web"));
             for (const f of ortWasmFiles) {

--- a/app/packages/app/vite.config.ts
+++ b/app/packages/app/vite.config.ts
@@ -26,9 +26,13 @@ async function loadConfig() {
       // copies that ort can't find by name. Emit unhashed copies and clean up.
       (() => {
         const ortWasmFiles = ["ort-wasm-simd-threaded.jsep.wasm", "ort-wasm-simd-threaded.jsep.mjs"];
+        let assetsDir = "";
         return {
           name: "copy-ort-wasm",
           apply: "build",
+          configResolved(config) {
+            assetsDir = path.resolve(config.root, config.build.outDir, "assets");
+          },
           buildStart() {
             const ortDist = path.dirname(require.resolve("onnxruntime-web"));
             for (const f of ortWasmFiles) {
@@ -36,13 +40,12 @@ async function loadConfig() {
             }
           },
           closeBundle() {
-            const distAssets = path.resolve(__dirname, "dist/assets");
-            if (!fs.existsSync(distAssets))
+            if (!fs.existsSync(assetsDir))
               return;
             const keep = new Set(ortWasmFiles);
-            for (const f of fs.readdirSync(distAssets)) {
+            for (const f of fs.readdirSync(assetsDir)) {
               if (f.includes("ort-wasm") && !keep.has(f)) {
-                fs.unlinkSync(path.join(distAssets, f));
+                fs.unlinkSync(path.join(assetsDir, f));
               }
             }
           },

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2460,6 +2460,7 @@ __metadata:
     lodash: "npm:^4.17.23"
     notistack: "npm:^3.0.1"
     numeral: "npm:^2.0.6"
+    onnxruntime-web: "npm:^1.24.3"
     path-to-regexp: "npm:^8.0.0"
     react: "npm:18.2.0"
     react-dom: "npm:18.2.0"

--- a/fiftyone/server/app.py
+++ b/fiftyone/server/app.py
@@ -30,6 +30,7 @@ from starlette.types import Scope
 
 import fiftyone as fo
 import fiftyone.constants as foc
+import fiftyone.core.context as focx
 from fiftyone.operators.store.notification_service import (
     MongoChangeStreamNotificationServiceLifecycleManager,
     default_notification_service,
@@ -97,8 +98,14 @@ class HeadersMiddleware(BaseHTTPMiddleware):
     ) -> Response:
         response = await call_next(request)
         response.headers["x-colab-notebook-cache-control"] = "no-cache"
-        response.headers["Cross-Origin-Opener-Policy"] = "same-origin"
-        response.headers["Cross-Origin-Embedder-Policy"] = "credentialless"
+        # Enable cross-origin isolation for multi-threaded WASM
+        # (SharedArrayBuffer).
+        # Skipped in notebook/iframe contexts (Jupyter, Colab) where
+        # COOP: same-origin would prevent the app from loading inside
+        # the iframe.
+        if not focx.is_notebook_context():
+            response.headers["Cross-Origin-Opener-Policy"] = "same-origin"
+            response.headers["Cross-Origin-Embedder-Policy"] = "credentialless"
         return response
 
 

--- a/fiftyone/server/app.py
+++ b/fiftyone/server/app.py
@@ -97,6 +97,8 @@ class HeadersMiddleware(BaseHTTPMiddleware):
     ) -> Response:
         response = await call_next(request)
         response.headers["x-colab-notebook-cache-control"] = "no-cache"
+        response.headers["Cross-Origin-Opener-Policy"] = "same-origin"
+        response.headers["Cross-Origin-Embedder-Policy"] = "credentialless"
         return response
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add Cross-Origin Isolation headers (COOP: same-origin, COEP: credentialless) to both the Python server and Vite dev server config, enabling SharedArrayBuffer for multi-threaded WASM inference.

Use credentialless instead of require-corp for COEP to avoid breaking cross-origin media loading.

Configure Vite to properly resolve runtime files with optimizeDeps.exclude for dev and a build plugin for prod.

Drtive-by: set weights URL to Voxel51-hosted.

## How is this patch tested? If it is not, please explain why.

- yarn build, check the fiftyone/server/static/assets/ dir for wasm files. Run fiftyone app launch and check segmentation works at localhost:5151 (with mutlithreading)
- python fiftyone/server/main.py with yarn dev and check segmentation works at localhost:5153 (with mutlithreading)
- Ephem deployment (multi threading needs a nextjs config change in the teams repo though)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Worker thread allocation now scales to available CPU cores when cross-origin isolation is enabled, improving parallelism.

* **Configuration**
  * Model asset base URL switched to a CDN, updating model download sources.
  * WASM and model assets can be served from a configurable assets path in production; build emits fixed asset filenames and includes .onnx models as assets.
  * In non-development builds, a custom WASM path override is applied when specified.

* **Infrastructure**
  * Cross-origin isolation headers added to dev and production servers to enable secure features that rely on isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->