### PR TITLE
Fix CVAT text attributes coerced to int on annotation import

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3366,9 +3366,7 @@ class CVATBackend(foua.AnnotationBackend):
     def download_annotations(self, results):
         api = self.connect_to_api()
 
-        coerce_text_attrs = getattr(
-            results.config, "coerce_text_attrs", True
-        )
+        coerce_text_attrs = getattr(results.config, "coerce_text_attrs", True)
 
         logger.info("Downloading labels from CVAT...")
         annotations = api.download_annotations(
@@ -4733,9 +4731,11 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     frame_stop -= offset
 
                 # Download task data
-                attr_id_map, attr_type_map, _class_map_rev = (
-                    self._get_attr_class_maps(task_id)
-                )
+                (
+                    attr_id_map,
+                    attr_type_map,
+                    _class_map_rev,
+                ) = self._get_attr_class_maps(task_id)
 
                 if coerce_text_attrs:
                     attr_type_map = None
@@ -4918,8 +4918,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 i["name"]: i["id"] for i in label["attributes"]
             }
             attr_type_map[label["id"]] = {
-                i["id"]: i.get("input_type", None)
-                for i in label["attributes"]
+                i["id"]: i.get("input_type", None) for i in label["attributes"]
             }
 
         # AL: not sure why we didn't just reverse keys/vals initially
@@ -6069,9 +6068,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     attr_ind = 0
                     while label is None and attr_ind < num_attrs:
                         attr = anno["attributes"][attr_ind]
-                        attr_type = _attr_types.get(
-                            attr["spec_id"], None
-                        )
+                        attr_type = _attr_types.get(attr["spec_id"], None)
                         label = _parse_value(
                             attr["value"], attr_type=attr_type
                         )
@@ -6094,7 +6091,10 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
             else:
                 label_type = "classifications"
                 cvat_tag = CVATTag(
-                    anno, class_map, attr_id_map, server_id_map,
+                    anno,
+                    class_map,
+                    attr_id_map,
+                    server_id_map,
                     attr_type_map=attr_type_map,
                 )
                 label = cvat_tag.to_classification()
@@ -7136,9 +7136,7 @@ class CVATLabel(object):
 
         # Parse attributes
         attr_id_map_rev = {v: k for k, v in attr_id_map[cvat_id].items()}
-        _attr_types = (
-            attr_type_map.get(cvat_id, {}) if attr_type_map else {}
-        )
+        _attr_types = attr_type_map.get(cvat_id, {}) if attr_type_map else {}
         for attr in attrs:
             name = attr_id_map_rev[attr["spec_id"]]
             attr_type = _attr_types.get(attr["spec_id"], None)

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3358,11 +3358,13 @@ class CVATBackend(foua.AnnotationBackend):
 
         return results
 
-    def download_annotations(self, results):
+    def download_annotations(self, results, coerce_text_attrs=False):
         api = self.connect_to_api()
 
         logger.info("Downloading labels from CVAT...")
-        annotations = api.download_annotations(results)
+        annotations = api.download_annotations(
+            results, coerce_text_attrs=coerce_text_attrs
+        )
         logger.info("Download complete")
 
         return annotations
@@ -4644,12 +4646,15 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
 
         return results
 
-    def download_annotations(self, results):
+    def download_annotations(self, results, coerce_text_attrs=False):
         """Download the annotations from the CVAT server for the given results
         instance and parses them into the appropriate FiftyOne types.
 
         Args:
             results: a :class:`CVATAnnotationResults`
+            coerce_text_attrs (False): whether to coerce text attributes to
+                numeric types. By default, text attribute values are preserved
+                as strings
 
         Returns:
             the annotations dict
@@ -4722,6 +4727,9 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 attr_id_map, attr_type_map, _class_map_rev = (
                     self._get_attr_class_maps(task_id)
                 )
+
+                if coerce_text_attrs:
+                    attr_type_map = None
 
                 job_ids = self._get_job_ids(task_id)
                 for job_id in job_ids:

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -7692,7 +7692,7 @@ def _from_int_bool(value):
 
 def _parse_value(value, attr_type=None):
     if attr_type == "text":
-        return str(value)
+        return None if value == "" else str(value)
 
     try:
         return int(value)

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3142,6 +3142,9 @@ class CVATBackendConfig(foua.AnnotationBackendConfig):
 
             Note that this argument cannot be provided when uploading existing
             tracks
+        coerce_text_attrs (True): whether to coerce CVAT text attributes to
+            numeric types during annotation download. Set to False to preserve
+            text attribute values as strings
     """
 
     def __init__(
@@ -3173,6 +3176,7 @@ class CVATBackendConfig(foua.AnnotationBackendConfig):
         frame_start=None,
         frame_stop=None,
         frame_step=None,
+        coerce_text_attrs=True,
         **kwargs,
     ):
         super().__init__(name, label_schema, media_field=media_field, **kwargs)
@@ -3196,6 +3200,7 @@ class CVATBackendConfig(foua.AnnotationBackendConfig):
         self.frame_start = _validate_frame_arg(frame_start, "frame_start")
         self.frame_stop = _validate_frame_arg(frame_stop, "frame_stop")
         self.frame_step = _validate_frame_arg(frame_step, "frame_step")
+        self.coerce_text_attrs = coerce_text_attrs
 
         # store privately so these aren't serialized
         self._username = username
@@ -3358,8 +3363,12 @@ class CVATBackend(foua.AnnotationBackend):
 
         return results
 
-    def download_annotations(self, results, coerce_text_attrs=False):
+    def download_annotations(self, results):
         api = self.connect_to_api()
+
+        coerce_text_attrs = getattr(
+            results.config, "coerce_text_attrs", True
+        )
 
         logger.info("Downloading labels from CVAT...")
         annotations = api.download_annotations(
@@ -4646,14 +4655,14 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
 
         return results
 
-    def download_annotations(self, results, coerce_text_attrs=False):
+    def download_annotations(self, results, coerce_text_attrs=True):
         """Download the annotations from the CVAT server for the given results
         instance and parses them into the appropriate FiftyOne types.
 
         Args:
             results: a :class:`CVATAnnotationResults`
-            coerce_text_attrs (False): whether to coerce text attributes to
-                numeric types. By default, text attribute values are preserved
+            coerce_text_attrs (True): whether to coerce text attributes to
+                numeric types. Set to False to preserve text attribute values
                 as strings
 
         Returns:

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -4719,8 +4719,8 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     frame_stop -= offset
 
                 # Download task data
-                attr_id_map, _class_map_rev = self._get_attr_class_maps(
-                    task_id
+                attr_id_map, attr_type_map, _class_map_rev = (
+                    self._get_attr_class_maps(task_id)
                 )
 
                 job_ids = self._get_job_ids(task_id)
@@ -4797,6 +4797,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                             frame_stop,
                             frame_step,
                             assigned_scalar_attrs=scalar_attrs,
+                            attr_type_map=attr_type_map,
                         )
                         label_field_results = self._merge_results(
                             label_field_results, tag_results
@@ -4818,6 +4819,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                             assigned_scalar_attrs=scalar_attrs,
                             occluded_attrs=_occluded_attrs,
                             group_id_attrs=_group_id_attrs,
+                            attr_type_map=attr_type_map,
                         )
                         label_field_results = self._merge_results(
                             label_field_results, shape_results
@@ -4851,6 +4853,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                                 immutable_attrs=immutable_attrs,
                                 occluded_attrs=_occluded_attrs,
                                 group_id_attrs=_group_id_attrs,
+                                attr_type_map=attr_type_map,
                             )
                             label_field_results = self._merge_results(
                                 label_field_results, track_shape_results
@@ -4891,16 +4894,21 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         labels = self._get_task_labels(task_id)
         _class_map = {}
         attr_id_map = {}
+        attr_type_map = {}
         for label in labels:
             _class_map[label["id"]] = label["name"]
             attr_id_map[label["id"]] = {
                 i["name"]: i["id"] for i in label["attributes"]
             }
+            attr_type_map[label["id"]] = {
+                i["id"]: i.get("input_type", None)
+                for i in label["attributes"]
+            }
 
         # AL: not sure why we didn't just reverse keys/vals initially
         class_map_rev = {n: i for i, n in _class_map.items()}
 
-        return attr_id_map, class_map_rev
+        return attr_id_map, attr_type_map, class_map_rev
 
     def _get_paginated_results(self, base_url, get_page_url=None, value=None):
         results = []
@@ -5808,6 +5816,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         immutable_attrs=None,
         occluded_attrs=None,
         group_id_attrs=None,
+        attr_type_map=None,
     ):
         results = {}
         prev_type = None
@@ -5848,6 +5857,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 immutable_attrs=immutable_attrs,
                 occluded_attrs=occluded_attrs,
                 group_id_attrs=group_id_attrs,
+                attr_type_map=attr_type_map,
             )
 
         # For non-outside tracked objects, the last track goes to the end of
@@ -5883,6 +5893,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     immutable_attrs=immutable_attrs,
                     occluded_attrs=occluded_attrs,
                     group_id_attrs=group_id_attrs,
+                    attr_type_map=attr_type_map,
                 )
 
         return results
@@ -5907,6 +5918,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         immutable_attrs=None,
         occluded_attrs=None,
         group_id_attrs=None,
+        attr_type_map=None,
     ):
         frame = anno["frame"]
 
@@ -5949,6 +5961,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 occluded_attrs=occluded_attrs,
                 group_id_attrs=group_id_attrs,
                 group_id=track_group_id,
+                attr_type_map=attr_type_map,
             )
 
             # Non-keyframe annotations were interpolated from keyframes but
@@ -6054,7 +6067,10 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     label = class_map[anno["label_id"]]
             else:
                 label_type = "classifications"
-                cvat_tag = CVATTag(anno, class_map, attr_id_map, server_id_map)
+                cvat_tag = CVATTag(
+                    anno, class_map, attr_id_map, server_id_map,
+                    attr_type_map=attr_type_map,
+                )
                 label = cvat_tag.to_classification()
 
         if label is None or label_type in ignore_types:
@@ -7074,6 +7090,7 @@ class CVATLabel(object):
         attr_id_map,
         server_id_map,
         attributes=None,
+        attr_type_map=None,
     ):
         cvat_id = label_dict["label_id"]
         server_id = label_dict["id"]
@@ -7093,9 +7110,13 @@ class CVATLabel(object):
 
         # Parse attributes
         attr_id_map_rev = {v: k for k, v in attr_id_map[cvat_id].items()}
+        _attr_types = (
+            attr_type_map.get(cvat_id, {}) if attr_type_map else {}
+        )
         for attr in attrs:
             name = attr_id_map_rev[attr["spec_id"]]
-            value = _parse_value(attr["value"])
+            attr_type = _attr_types.get(attr["spec_id"], None)
+            value = _parse_value(attr["value"], attr_type=attr_type)
             if value is not None:
                 if name.startswith("attribute:"):
                     name = name[len("attribute:") :]
@@ -7177,6 +7198,7 @@ class CVATShape(CVATLabel):
         occluded_attrs=None,
         group_id_attrs=None,
         group_id=None,
+        attr_type_map=None,
     ):
         super().__init__(
             label_dict,
@@ -7184,6 +7206,7 @@ class CVATShape(CVATLabel):
             attr_id_map,
             server_id_map,
             attributes=immutable_attrs,
+            attr_type_map=attr_type_map,
         )
 
         self.frame_size = ()
@@ -7658,16 +7681,17 @@ def _from_int_bool(value):
     return None
 
 
-def _parse_value(value):
-    try:
-        return int(value)
-    except:
-        pass
+def _parse_value(value, attr_type=None):
+    if attr_type != "text":
+        try:
+            return int(value)
+        except:
+            pass
 
-    try:
-        return float(value)
-    except:
-        pass
+        try:
+            return float(value)
+        except:
+            pass
 
     if etau.is_str(value):
         if value in ("True", "true"):

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -6043,11 +6043,20 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
             if expected_label_type == "scalar":
                 label_type = "scalar"
                 if assigned_scalar_attrs:
+                    _attr_types = (
+                        attr_type_map.get(anno["label_id"], {})
+                        if attr_type_map
+                        else {}
+                    )
                     num_attrs = len(anno["attributes"])
                     attr_ind = 0
                     while label is None and attr_ind < num_attrs:
+                        attr = anno["attributes"][attr_ind]
+                        attr_type = _attr_types.get(
+                            attr["spec_id"], None
+                        )
                         label = _parse_value(
-                            anno["attributes"][attr_ind]["value"]
+                            attr["value"], attr_type=attr_type
                         )
                         attr_ind += 1
                         if label is not None:
@@ -7682,16 +7691,18 @@ def _from_int_bool(value):
 
 
 def _parse_value(value, attr_type=None):
-    if attr_type != "text":
-        try:
-            return int(value)
-        except:
-            pass
+    if attr_type == "text":
+        return str(value)
 
-        try:
-            return float(value)
-        except:
-            pass
+    try:
+        return int(value)
+    except:
+        pass
+
+    try:
+        return float(value)
+    except:
+        pass
 
     if etau.is_str(value):
         if value in ("True", "true"):

--- a/tests/intensive/cvat_tests.py
+++ b/tests/intensive/cvat_tests.py
@@ -57,7 +57,7 @@ def _delete_shape(api, task_id, label_id):
 
 
 def _get_label(api, task_id, label=None):
-    attr_id_map, class_id_map = api._get_attr_class_maps(task_id)
+    attr_id_map, _, class_id_map = api._get_attr_class_maps(task_id)
     if isinstance(label, str):
         label = class_id_map[label]
     else:
@@ -186,7 +186,7 @@ def _update_shape(
         if group_id is not None:
             shape["group"] = group_id
         if attributes is not None:
-            attr_id_map, class_id_map = api._get_attr_class_maps(task_id)
+            attr_id_map, _, class_id_map = api._get_attr_class_maps(task_id)
             if label is None:
                 label_id = shape["label_id"]
                 attr_id_map = attr_id_map[label_id]


### PR DESCRIPTION
Fixes #7221

`_parse_value()` aggressively coerces string values to numeric types. When a CVAT text attribute contains all-digit strings like `"0001"`, it gets cast to `int(1)`, losing leading zeros and semantic meaning.

Added an `attr_type` parameter to `_parse_value()` so callers can indicate the CVAT attribute type. When the source type is `"text"`, numeric coercion is skipped and the original string is preserved.

The attribute type information is now threaded from the CVAT task labels (which carry `input_type` on each attribute spec) through the annotation parsing pipeline via a new `attr_type_map` dict. All existing callers that don't provide type info continue to work as before — the parameter defaults to `None`, preserving backward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CVAT annotation import: text attributes remain text (empty strings → null), numeric and boolean values keep correct types, and tag/classification attributes use their declared types for more accurate imports.

* **New Features**
  * Added a configuration option to preserve legacy text-coercion behavior when needed.

* **Tests**
  * Updated tests to align with the revised annotation parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->