### PR TITLE
add explicit handling for ul, ol, li markdown elements

### DIFF
--- a/app/packages/components/src/components/Markdown/index.tsx
+++ b/app/packages/components/src/components/Markdown/index.tsx
@@ -169,21 +169,62 @@ const componentsMap = {
       {children}
     </Typography>
   ),
-  ul: ({ children, ...props }) => (
-    <Box component="ul" sx={{ listStyle: "disc", pl: 5, my: 2 }} {...props}>
-      {children}
-    </Box>
-  ),
-  ol: ({ children, ...props }) => (
-    <Box component="ol" sx={{ listStyle: "decimal", pl: 5, my: 2 }} {...props}>
-      {children}
-    </Box>
-  ),
-  li: ({ children, ...props }) => (
-    <Box component="li" sx={{ display: "list-item" }} {...props}>
-      {children}
-    </Box>
-  ),
+  ul: ({ children, className, ...props }) => {
+    // using checkboxes instead of bullets
+    const isTaskList = className?.includes("contains-task-list");
+
+    return (
+      <Box
+        component="ul"
+        sx={{
+          listStyle: isTaskList ? "none" : "disc",
+          pl: isTaskList ? 0 : 5,
+          my: 2,
+          color: "inherit",
+        }}
+        {...props}
+      >
+        {children}
+      </Box>
+    );
+  },
+  ol: ({ children, className, ...props }) => {
+    // using checkboxes instead of numbers
+    const isTaskList = className?.includes("contains-task-list");
+
+    return (
+      <Box
+        component="ol"
+        sx={{
+          listStyle: isTaskList ? "none" : "decimal",
+          pl: isTaskList ? 0 : 5,
+          my: 2,
+          color: "inherit",
+        }}
+        {...props}
+      >
+        {children}
+      </Box>
+    );
+  },
+  li: ({ children, className, ...props }) => {
+    // using checkboxes instead of bullets
+    const isTaskItem = className?.includes("task-list-item");
+
+    return (
+      <Box
+        component="li"
+        sx={{
+          display: isTaskItem ? "flex" : "list-item",
+          alignItems: isTaskItem ? "center" : undefined,
+          color: "inherit",
+        }}
+        {...props}
+      >
+        {children}
+      </Box>
+    );
+  },
 };
 
 export default function Markdown(props: ReactMarkdownOptions) {

--- a/app/packages/components/src/components/Markdown/index.tsx
+++ b/app/packages/components/src/components/Markdown/index.tsx
@@ -176,6 +176,7 @@ const componentsMap = {
     return (
       <Box
         component="ul"
+        className={className}
         sx={{
           listStyle: isTaskList ? "none" : "disc",
           pl: isTaskList ? 0 : 5,
@@ -200,6 +201,7 @@ const componentsMap = {
     return (
       <Box
         component="ol"
+        className={className}
         sx={{
           listStyle: isTaskList ? "none" : "decimal",
           pl: isTaskList ? 0 : 5,
@@ -224,6 +226,7 @@ const componentsMap = {
     return (
       <Box
         component="li"
+        className={className}
         sx={{
           display: "list-item",
           color: "inherit",

--- a/app/packages/components/src/components/Markdown/index.tsx
+++ b/app/packages/components/src/components/Markdown/index.tsx
@@ -181,6 +181,11 @@ const componentsMap = {
           pl: isTaskList ? 0 : 5,
           my: 2,
           color: "inherit",
+          // further indent nested lists
+          "& ul, & ol": {
+            my: 0.5,
+            pl: 3,
+          },
         }}
         {...props}
       >
@@ -200,6 +205,11 @@ const componentsMap = {
           pl: isTaskList ? 0 : 5,
           my: 2,
           color: "inherit",
+          // further indent nested lists
+          "& ul, & ol": {
+            my: 0.5,
+            pl: 3,
+          },
         }}
         {...props}
       >
@@ -215,9 +225,15 @@ const componentsMap = {
       <Box
         component="li"
         sx={{
-          display: isTaskItem ? "flex" : "list-item",
-          alignItems: isTaskItem ? "center" : undefined,
+          display: "list-item",
           color: "inherit",
+          ...(isTaskItem && {
+            listStyle: "none",
+            "& > input[type='checkbox']": {
+              mr: 1,
+              verticalAlign: "middle",
+            },
+          }),
         }}
         {...props}
       >

--- a/app/packages/components/src/components/Markdown/index.tsx
+++ b/app/packages/components/src/components/Markdown/index.tsx
@@ -169,6 +169,21 @@ const componentsMap = {
       {children}
     </Typography>
   ),
+  ul: ({ children, ...props }) => (
+    <Box component="ul" sx={{ listStyle: "disc", pl: 5, my: 2 }} {...props}>
+      {children}
+    </Box>
+  ),
+  ol: ({ children, ...props }) => (
+    <Box component="ol" sx={{ listStyle: "decimal", pl: 5, my: 2 }} {...props}>
+      {children}
+    </Box>
+  ),
+  li: ({ children, ...props }) => (
+    <Box component="li" sx={{ display: "list-item" }} {...props}>
+      {children}
+    </Box>
+  ),
 };
 
 export default function Markdown(props: ReactMarkdownOptions) {


### PR DESCRIPTION
## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

Add explicit handling for `ul`, `ol`, and `li` elements within rendered `Markdown`. This was previously using implicit browser behavior, which can be inconsistent and affected by broad CSS rules.

<!--
Provide a clear, concise description of what this PR does and why.
-->

## 🧪 How is this patch tested? If it is not, please explain why.

local

before:
<img width="942" height="202" alt="Screenshot 2026-03-30 at 12 50 16 PM" src="https://github.com/user-attachments/assets/7e99fbba-8a04-463a-9b4e-c899ec3088c4" />

after:
<img width="927" height="135" alt="Screenshot 2026-03-30 at 12 48 51 PM" src="https://github.com/user-attachments/assets/cfad9f53-5b9c-4950-8f04-055e9fa5ce29" />



<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved Markdown list rendering: unordered and ordered lists now use consistent markers, spacing, nested indentation, and inherit text color for better readability.
  * Better task-list support: task-list markers are suppressed, indentation is adjusted, and checkbox inputs are aligned with tightened spacing for clearer, more consistent visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->