### PR TITLE
Robust logic for PR Welcome to skip members

### DIFF
--- a/.github/workflows/pr-welcome-comment.yml
+++ b/.github/workflows/pr-welcome-comment.yml
@@ -11,22 +11,48 @@ permissions:
 jobs:
   welcome:
     runs-on: ubuntu-latest
-    if: >-
-      github.event.pull_request.author_association != 'MEMBER' &&
-      github.event.pull_request.author_association != 'OWNER' &&
-      github.event.pull_request.author_association != 'COLLABORATOR'
     steps:
       - name: Comment on PR
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
           script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+
+            const internal = ['MEMBER', 'OWNER', 'COLLABORATOR'];
+            if (internal.includes(pr.author_association)) {
+              console.log(`Skipping: ${pr.user.login} is ${pr.author_association}`);
+              return;
+            }
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
               body: [
-                `Thanks for opening this pull request, @${context.payload.pull_request.user.login}! 🎉`,
+                `Thanks for opening this pull request, @${pr.user.login}! 🎉`,
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+
+            const internal = ['MEMBER', 'OWNER', 'COLLABORATOR'];
+            if (internal.includes(pr.author_association)) {
+              console.log(`Skipping: ${pr.user.login} is ${pr.author_association}`);
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: [
+                `Thanks for opening this pull request, @${pr.user.login}! 🎉`,
                 '',
                 'A maintainer will review your changes soon. In the meantime, please ensure:',
                 '',

--- a/.github/workflows/pr-welcome-comment.yml
+++ b/.github/workflows/pr-welcome-comment.yml
@@ -35,24 +35,6 @@ jobs:
               issue_number: context.payload.pull_request.number,
               body: [
                 `Thanks for opening this pull request, @${pr.user.login}! 🎉`,
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-            });
-
-            const internal = ['MEMBER', 'OWNER', 'COLLABORATOR'];
-            if (internal.includes(pr.author_association)) {
-              console.log(`Skipping: ${pr.user.login} is ${pr.author_association}`);
-              return;
-            }
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body: [
-                `Thanks for opening this pull request, @${pr.user.login}! 🎉`,
                 '',
                 'A maintainer will review your changes soon. In the meantime, please ensure:',
                 '',


### PR DESCRIPTION
## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

N/A

## 📋 What changes are proposed in this pull request?

<!--
Provide a clear, concise description of what this PR does and why.
-->

New logic for skipping members, contributors, and owners. Apparently:
> The `author_association` value in the GitHub webhook payloads respects the PR author's org membership visibility setting. If org membership is set to private (GitHub's default), the payload reports NONE or CONTRIBUTOR instead of MEMBER. All three `!=` checks pass and the job runs. The REST API with a properly-scoped token can see through private membership, which is why `pulls.get()` inside the script works.

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

Changes run on external repo. Action exits without error, no comment post for repo OWNER. https://github.com/Burhan-Q/ex-fo-issues/pull/15 Still untested with an external author PR.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GitHub Actions workflow logic for pull request handling and contributor verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->