### PR TITLE
[HA] Integrate BrowserAnnotationProvider with annotation framework

### DIFF
--- a/app/packages/annotation/src/agents/SAM2BrowserAnnotationAgent.test.ts
+++ b/app/packages/annotation/src/agents/SAM2BrowserAnnotationAgent.test.ts
@@ -1,13 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { BrowserAnnotationProvider } from "../providers";
+import { BrowserAnnotationProvider, PointLabel } from "../providers";
 import { SAM2BrowserAnnotationAgent } from "./SAM2BrowserAnnotationAgent";
 import {
   AgentTaskType,
   type AnnotationContext,
   InferenceCapability,
 } from "./types";
-
-const PointLabel = { NEGATIVE: 0, POSITIVE: 1 } as const;
 
 const makeContext = (
   overrides: Partial<AnnotationContext> = {}

--- a/app/packages/annotation/src/agents/SAM2BrowserAnnotationAgent.test.ts
+++ b/app/packages/annotation/src/agents/SAM2BrowserAnnotationAgent.test.ts
@@ -1,0 +1,265 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BrowserAnnotationProvider } from "../providers";
+import { SAM2BrowserAnnotationAgent } from "./SAM2BrowserAnnotationAgent";
+import {
+  AgentTaskType,
+  type AnnotationContext,
+  InferenceCapability,
+} from "./types";
+
+const PointLabel = { NEGATIVE: 0, POSITIVE: 1 } as const;
+
+const makeContext = (
+  overrides: Partial<AnnotationContext> = {}
+): AnnotationContext => {
+  return {
+    sampleDescriptor: { datasetId: "ds-1", sampleId: "s-1" },
+    taskType: AgentTaskType.SEGMENT,
+    ...overrides,
+  };
+};
+
+const makeProviderResult = (overrides: Record<string, unknown> = {}) => {
+  return {
+    mask: new Float32Array([0.1, 0.9, 0.8, 0.2]),
+    maskWidth: 2,
+    maskHeight: 2,
+    bbox: { x: 0.1, y: 0.2, w: 0.3, h: 0.4 },
+    ...overrides,
+  };
+};
+
+const makeProvider = () => {
+  return {
+    initialize: vi.fn().mockResolvedValue(undefined),
+    infer: vi.fn(),
+    abort: vi.fn(),
+    dispose: vi.fn(),
+  } as unknown as BrowserAnnotationProvider & {
+    initialize: ReturnType<typeof vi.fn>;
+    infer: ReturnType<typeof vi.fn>;
+    abort: ReturnType<typeof vi.fn>;
+    dispose: ReturnType<typeof vi.fn>;
+  };
+};
+
+describe("SAM2BrowserAnnotationAgent", () => {
+  let agent: SAM2BrowserAnnotationAgent;
+  let provider: ReturnType<typeof makeProvider>;
+  const imageUrl = "https://media.test/sample.jpg";
+
+  beforeEach(() => {
+    provider = makeProvider();
+    agent = new SAM2BrowserAnnotationAgent(provider);
+    agent.setImageUrl(imageUrl);
+  });
+
+  describe("infer", () => {
+    it("should initialize the provider on the first call", async () => {
+      provider.infer.mockResolvedValue(makeProviderResult());
+
+      await agent.infer(makeContext());
+
+      expect(provider.initialize).toHaveBeenCalledOnce();
+    });
+
+    it("should not re-initialize on subsequent calls", async () => {
+      provider.infer.mockResolvedValue(makeProviderResult());
+
+      await agent.infer(makeContext());
+      await agent.infer(makeContext());
+
+      expect(provider.initialize).toHaveBeenCalledOnce();
+    });
+
+    it("should throw if imageUrl has not been set", async () => {
+      const freshAgent = new SAM2BrowserAnnotationAgent(makeProvider());
+
+      await expect(freshAgent.infer(makeContext())).rejects.toThrow(
+        "Must set imageUrl before calling infer()"
+      );
+    });
+
+    it("should pass the imageUrl set via setImageUrl", async () => {
+      provider.infer.mockResolvedValue(makeProviderResult());
+
+      const newImageUrl = "https://media.test/other.jpg";
+      agent.setImageUrl(newImageUrl);
+
+      await agent.infer(makeContext());
+
+      expect(provider.infer).toHaveBeenCalledWith(
+        expect.objectContaining({ imageUrl: newImageUrl })
+      );
+    });
+
+    it("should convert positive and negative points to PromptPoints", async () => {
+      provider.infer.mockResolvedValue(makeProviderResult());
+
+      await agent.infer(
+        makeContext({
+          positivePoints: [
+            [0.5, 0.3],
+            [0.7, 0.1],
+          ],
+          negativePoints: [[0.2, 0.8]],
+        })
+      );
+
+      expect(provider.infer).toHaveBeenCalledWith({
+        imageUrl,
+        points: [
+          { x: 0.5, y: 0.3, label: PointLabel.POSITIVE },
+          { x: 0.7, y: 0.1, label: PointLabel.POSITIVE },
+          { x: 0.2, y: 0.8, label: PointLabel.NEGATIVE },
+        ],
+      });
+    });
+
+    it("should send an empty points array when no prompts are provided", async () => {
+      provider.infer.mockResolvedValue(makeProviderResult());
+
+      await agent.infer(makeContext());
+
+      expect(provider.infer).toHaveBeenCalledWith({
+        imageUrl,
+        points: [],
+      });
+    });
+
+    it("should return a sync segmentation result", async () => {
+      const providerResult = makeProviderResult();
+      provider.infer.mockResolvedValue(providerResult);
+
+      const result = await agent.infer(makeContext());
+
+      expect(result).toEqual({
+        type: "sync",
+        taskType: AgentTaskType.SEGMENT,
+        response: {
+          detections: [
+            {
+              mask: providerResult.mask,
+              mask_width: 2,
+              mask_height: 2,
+              bounding_box: [0.1, 0.2, 0.3, 0.4],
+            },
+          ],
+        },
+      });
+    });
+
+    it("should propagate provider initialization errors", async () => {
+      provider.initialize.mockRejectedValue(
+        new Error("Missing browser APIs: WASM SIMD")
+      );
+
+      await expect(agent.infer(makeContext())).rejects.toThrow(
+        "Missing browser APIs: WASM SIMD"
+      );
+    });
+
+    it("should allow retry after initialization failure", async () => {
+      provider.initialize
+        .mockRejectedValueOnce(new Error("init failed"))
+        .mockResolvedValueOnce(undefined);
+      provider.infer.mockResolvedValue(makeProviderResult());
+
+      await expect(agent.infer(makeContext())).rejects.toThrow("init failed");
+
+      const result = await agent.infer(makeContext());
+      expect(result.type).toBe("sync");
+      expect(provider.initialize).toHaveBeenCalledTimes(2);
+    });
+
+    it("should propagate provider inference errors", async () => {
+      provider.infer.mockRejectedValue(new Error("Worker error"));
+
+      await expect(agent.infer(makeContext())).rejects.toThrow("Worker error");
+    });
+  });
+
+  describe("listSupportedTasks", () => {
+    it("should return only SEGMENT", async () => {
+      const tasks = await agent.listSupportedTasks();
+      expect(tasks).toEqual([AgentTaskType.SEGMENT]);
+    });
+  });
+
+  describe("listInferenceCapabilities", () => {
+    it("should return point capabilities for SEGMENT", async () => {
+      const caps = await agent.listInferenceCapabilities(AgentTaskType.SEGMENT);
+      expect(caps).toEqual([
+        InferenceCapability.POSITIVE_POINT,
+        InferenceCapability.NEGATIVE_POINT,
+      ]);
+    });
+
+    it("should return empty for non-SEGMENT tasks", async () => {
+      expect(
+        await agent.listInferenceCapabilities(AgentTaskType.DETECT)
+      ).toEqual([]);
+      expect(
+        await agent.listInferenceCapabilities(AgentTaskType.CLASSIFY)
+      ).toEqual([]);
+      expect(
+        await agent.listInferenceCapabilities(AgentTaskType.INFER)
+      ).toEqual([]);
+    });
+  });
+
+  describe("getModelMetadata", () => {
+    it("should return SAM2 metadata for SEGMENT", async () => {
+      const meta = await agent.getModelMetadata(AgentTaskType.SEGMENT);
+      expect(meta).toEqual({ name: "SAM2 Tiny", version: "hiera-tiny-onnx" });
+    });
+
+    it("should return null for non-SEGMENT tasks", async () => {
+      expect(await agent.getModelMetadata(AgentTaskType.DETECT)).toBeNull();
+    });
+  });
+
+  describe("abort", () => {
+    it("should forward to the provider", async () => {
+      await agent.abort();
+      expect(provider.abort).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("dispose", () => {
+    it("should dispose the provider", () => {
+      agent.dispose();
+      expect(provider.dispose).toHaveBeenCalledOnce();
+    });
+
+    it("should allow re-initialization after dispose", async () => {
+      provider.infer.mockResolvedValue(makeProviderResult());
+
+      await agent.infer(makeContext());
+      agent.dispose();
+      await agent.infer(makeContext());
+
+      expect(provider.initialize).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("concurrent initialization", () => {
+    it("should coalesce concurrent infer calls into a single init", async () => {
+      let resolveInit: () => void;
+      provider.initialize.mockReturnValue(
+        new Promise<void>((r) => {
+          resolveInit = r;
+        })
+      );
+      provider.infer.mockResolvedValue(makeProviderResult());
+
+      const p1 = agent.infer(makeContext());
+      const p2 = agent.infer(makeContext());
+
+      resolveInit!();
+      await Promise.all([p1, p2]);
+
+      expect(provider.initialize).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/app/packages/annotation/src/agents/SAM2BrowserAnnotationAgent.test.ts
+++ b/app/packages/annotation/src/agents/SAM2BrowserAnnotationAgent.test.ts
@@ -37,16 +37,31 @@ const makeProviderResult = (overrides: Record<string, unknown> = {}) => {
 };
 
 const makeProvider = () => {
-  return {
+  const mock = {
     initialize: vi.fn().mockResolvedValue(undefined),
     infer: vi.fn(),
     abort: vi.fn(),
     dispose: vi.fn(),
-  } as unknown as BrowserAnnotationProvider & {
+    isInitialized: vi.fn().mockReturnValue(false),
+  };
+
+  // wire up interactions between initialize/isInitialized
+  mock.initialize.mockImplementation(() => {
+    mock.isInitialized.mockReturnValue(true);
+    return Promise.resolve();
+  });
+
+  // wire up interactions between dispose/isInitialized
+  mock.dispose.mockImplementation(() => {
+    mock.isInitialized.mockReturnValue(false);
+  });
+
+  return mock as unknown as BrowserAnnotationProvider & {
     initialize: ReturnType<typeof vi.fn>;
     infer: ReturnType<typeof vi.fn>;
     abort: ReturnType<typeof vi.fn>;
     dispose: ReturnType<typeof vi.fn>;
+    isInitialized: ReturnType<typeof vi.fn>;
   };
 };
 
@@ -245,6 +260,60 @@ describe("SAM2BrowserAnnotationAgent", () => {
 
       await agent.infer(makeContext());
       agent.dispose();
+      await agent.infer(makeContext());
+
+      expect(provider.initialize).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("dispose during initialization", () => {
+    it("should not mark as initialized if disposed before init resolves", async () => {
+      let resolveInit: () => void;
+      provider.initialize.mockReturnValue(
+        new Promise<void>((r) => {
+          resolveInit = r;
+        })
+      );
+      // Mirror real provider: infer throws when worker is gone
+      provider.infer.mockImplementation(() => {
+        if (!provider.isInitialized()) {
+          throw new Error("Provider is not initialized");
+        }
+        return Promise.resolve(makeProviderResult());
+      });
+
+      const inferPromise = agent.infer(makeContext());
+
+      // dispose while initialize() is still pending
+      agent.dispose();
+
+      // now let initialize resolve — provider is already disposed
+      resolveInit!();
+
+      // infer should fail because provider is disposed
+      await expect(inferPromise).rejects.toThrow("Provider is not initialized");
+    });
+
+    it("should re-initialize on next infer after dispose during init", async () => {
+      let resolveInit: () => void;
+      provider.initialize.mockReturnValueOnce(
+        new Promise<void>((r) => {
+          resolveInit = r;
+        })
+      );
+      provider.infer.mockResolvedValue(makeProviderResult());
+
+      const firstInfer = agent.infer(makeContext());
+
+      // dispose mid-init
+      agent.dispose();
+      resolveInit!();
+      await firstInfer.catch(() => {});
+
+      // restore provider to working state
+      provider.isInitialized.mockReturnValue(true);
+      provider.initialize.mockResolvedValue(undefined);
+
       await agent.infer(makeContext());
 
       expect(provider.initialize).toHaveBeenCalledTimes(2);

--- a/app/packages/annotation/src/agents/SAM2BrowserAnnotationAgent.test.ts
+++ b/app/packages/annotation/src/agents/SAM2BrowserAnnotationAgent.test.ts
@@ -5,13 +5,22 @@ import {
   AgentTaskType,
   type AnnotationContext,
   InferenceCapability,
+  SampleDescriptor,
 } from "./types";
+
+const _DATASET_ID = "dataset-id";
+const _SAMPLE_ID = "sample-id";
+const _MEDIA_URL = "media-url";
 
 const makeContext = (
   overrides: Partial<AnnotationContext> = {}
 ): AnnotationContext => {
   return {
-    sampleDescriptor: { datasetId: "ds-1", sampleId: "s-1" },
+    sampleDescriptor: {
+      datasetId: _DATASET_ID,
+      sampleId: _SAMPLE_ID,
+      mediaUrl: _MEDIA_URL,
+    },
     taskType: AgentTaskType.SEGMENT,
     ...overrides,
   };
@@ -44,12 +53,10 @@ const makeProvider = () => {
 describe("SAM2BrowserAnnotationAgent", () => {
   let agent: SAM2BrowserAnnotationAgent;
   let provider: ReturnType<typeof makeProvider>;
-  const imageUrl = "https://media.test/sample.jpg";
 
   beforeEach(() => {
     provider = makeProvider();
     agent = new SAM2BrowserAnnotationAgent(provider);
-    agent.setImageUrl(imageUrl);
   });
 
   describe("infer", () => {
@@ -70,24 +77,27 @@ describe("SAM2BrowserAnnotationAgent", () => {
       expect(provider.initialize).toHaveBeenCalledOnce();
     });
 
-    it("should throw if imageUrl has not been set", async () => {
+    it("should throw if mediaUrl has not been set", async () => {
       const freshAgent = new SAM2BrowserAnnotationAgent(makeProvider());
 
-      await expect(freshAgent.infer(makeContext())).rejects.toThrow(
-        "Must set imageUrl before calling infer()"
-      );
+      await expect(
+        freshAgent.infer({
+          ...makeContext(),
+          sampleDescriptor: {
+            datasetId: _DATASET_ID,
+            sampleId: _SAMPLE_ID,
+          } as SampleDescriptor,
+        })
+      ).rejects.toThrow("Missing media url");
     });
 
-    it("should pass the imageUrl set via setImageUrl", async () => {
+    it("should pass the mediaUrl provided in the context", async () => {
       provider.infer.mockResolvedValue(makeProviderResult());
-
-      const newImageUrl = "https://media.test/other.jpg";
-      agent.setImageUrl(newImageUrl);
 
       await agent.infer(makeContext());
 
       expect(provider.infer).toHaveBeenCalledWith(
-        expect.objectContaining({ imageUrl: newImageUrl })
+        expect.objectContaining({ imageUrl: _MEDIA_URL })
       );
     });
 
@@ -105,7 +115,7 @@ describe("SAM2BrowserAnnotationAgent", () => {
       );
 
       expect(provider.infer).toHaveBeenCalledWith({
-        imageUrl,
+        imageUrl: _MEDIA_URL,
         points: [
           { x: 0.5, y: 0.3, label: PointLabel.POSITIVE },
           { x: 0.7, y: 0.1, label: PointLabel.POSITIVE },
@@ -120,7 +130,7 @@ describe("SAM2BrowserAnnotationAgent", () => {
       await agent.infer(makeContext());
 
       expect(provider.infer).toHaveBeenCalledWith({
-        imageUrl,
+        imageUrl: _MEDIA_URL,
         points: [],
       });
     });

--- a/app/packages/annotation/src/agents/SAM2BrowserAnnotationAgent.ts
+++ b/app/packages/annotation/src/agents/SAM2BrowserAnnotationAgent.ts
@@ -1,0 +1,177 @@
+import type {
+  AnnotationAgent,
+  AnnotationContext,
+  InferenceResult,
+  ModelMetadata,
+  SegmentationInferenceResult,
+  SyncInferenceResult,
+  Vec2,
+} from "./types";
+import { AgentTaskType, InferenceCapability } from "./types";
+import {
+  BrowserAnnotationProvider,
+  PointLabel,
+  type PromptPoint,
+} from "../providers";
+
+/**
+ * Browser-side annotation agent backed by SAM2 Tiny (ONNX, runs in a web
+ * worker via {@link BrowserAnnotationProvider}).
+ *
+ * Supports the {@link AgentTaskType.SEGMENT} task type with positive and
+ * negative point prompts.
+ *
+ * The provider is lazily initialized on the first {@link infer} call and
+ * reused for subsequent calls.
+ */
+export class SAM2BrowserAnnotationAgent
+  implements AnnotationAgent<SegmentationInferenceResult>
+{
+  private readonly provider: BrowserAnnotationProvider;
+  private imageUrl: string | null = null;
+  private initialized = false;
+  private initializing$: Promise<void> | null = null;
+
+  constructor(provider: BrowserAnnotationProvider) {
+    this.provider = provider;
+  }
+
+  /**
+   * Set the image URL.
+   *
+   * @param url Image URL
+   */
+  setImageUrl(url: string) {
+    this.imageUrl = url;
+  }
+
+  async infer(
+    context: AnnotationContext
+  ): Promise<InferenceResult<SegmentationInferenceResult>> {
+    if (!this.imageUrl) {
+      throw new Error("Must set imageUrl before calling infer()");
+    }
+
+    // lazily initialize on first inference call
+    await this.ensureInitialized();
+
+    const points = this.buildPromptPoints(context);
+
+    const result = await this.provider.infer({
+      imageUrl: this.imageUrl,
+      points,
+    });
+
+    return {
+      type: "sync",
+      taskType: AgentTaskType.SEGMENT,
+      response: {
+        detections: [
+          {
+            mask: result.mask,
+            mask_width: result.maskWidth,
+            mask_height: result.maskHeight,
+            bounding_box: [
+              result.bbox.x,
+              result.bbox.y,
+              result.bbox.w,
+              result.bbox.h,
+            ],
+          },
+        ],
+      },
+    } as SyncInferenceResult<SegmentationInferenceResult>;
+  }
+
+  async listSupportedTasks(): Promise<AgentTaskType[]> {
+    return [AgentTaskType.SEGMENT];
+  }
+
+  async listInferenceCapabilities(
+    task: AgentTaskType
+  ): Promise<InferenceCapability[]> {
+    if (task === AgentTaskType.SEGMENT) {
+      return [
+        InferenceCapability.POSITIVE_POINT,
+        InferenceCapability.NEGATIVE_POINT,
+      ];
+    }
+
+    return [];
+  }
+
+  async getModelMetadata(task: AgentTaskType): Promise<ModelMetadata | null> {
+    if (task === AgentTaskType.SEGMENT) {
+      return { name: "SAM2 Tiny", version: "hiera-tiny-onnx" };
+    }
+
+    return null;
+  }
+
+  async subscribe(): Promise<void> {
+    // no-op; only supports synchronous inference
+  }
+
+  async unsubscribe(): Promise<void> {
+    // no-op; only supports synchronous inference
+  }
+
+  async abort(): Promise<void> {
+    this.provider.abort();
+  }
+
+  /**
+   * Release the web worker and all provider resources.
+   */
+  dispose(): void {
+    this.provider.dispose();
+    this.initialized = false;
+    this.initializing$ = null;
+  }
+
+  /**
+   * Concurrency-safe method to await provider initialization.
+   *
+   * @private
+   */
+  private async ensureInitialized(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+
+    if (!this.initializing$) {
+      this.initializing$ = this.provider
+        .initialize()
+        .then(() => {
+          this.initialized = true;
+        })
+        .catch((err) => {
+          this.initializing$ = null;
+          throw err;
+        });
+    }
+
+    await this.initializing$;
+  }
+
+  /**
+   * Build a list of positive and negative prompt points from the provided
+   * {@link AnnotationContext}.
+   *
+   * @param context Annotation context containing positive and negative points
+   * @private
+   */
+  private buildPromptPoints(context: AnnotationContext): PromptPoint[] {
+    return (context.positivePoints ?? [])
+      .map((point) => this.vec2ToPoint(point, PointLabel.POSITIVE))
+      .concat(
+        (context.negativePoints ?? []).map((point) =>
+          this.vec2ToPoint(point, PointLabel.NEGATIVE)
+        )
+      );
+  }
+
+  private vec2ToPoint(vec: Vec2, label: PointLabel): PromptPoint {
+    return { x: vec[0], y: vec[1], label };
+  }
+}

--- a/app/packages/annotation/src/agents/SAM2BrowserAnnotationAgent.ts
+++ b/app/packages/annotation/src/agents/SAM2BrowserAnnotationAgent.ts
@@ -28,7 +28,6 @@ export class SAM2BrowserAnnotationAgent
   implements AnnotationAgent<SegmentationInferenceResult>
 {
   private readonly provider: BrowserAnnotationProvider;
-  private imageUrl: string | null = null;
   private initialized = false;
   private initializing$: Promise<void> | null = null;
 
@@ -36,20 +35,11 @@ export class SAM2BrowserAnnotationAgent
     this.provider = provider;
   }
 
-  /**
-   * Set the image URL.
-   *
-   * @param url Image URL
-   */
-  setImageUrl(url: string) {
-    this.imageUrl = url;
-  }
-
   async infer(
     context: AnnotationContext
   ): Promise<InferenceResult<SegmentationInferenceResult>> {
-    if (!this.imageUrl) {
-      throw new Error("Must set imageUrl before calling infer()");
+    if (!context.sampleDescriptor.mediaUrl) {
+      throw new Error("Missing media url");
     }
 
     // lazily initialize on first inference call
@@ -58,7 +48,7 @@ export class SAM2BrowserAnnotationAgent
     const points = this.buildPromptPoints(context);
 
     const result = await this.provider.infer({
-      imageUrl: this.imageUrl,
+      imageUrl: context.sampleDescriptor.mediaUrl,
       points,
     });
 

--- a/app/packages/annotation/src/agents/SAM2BrowserAnnotationAgent.ts
+++ b/app/packages/annotation/src/agents/SAM2BrowserAnnotationAgent.ts
@@ -133,7 +133,14 @@ export class SAM2BrowserAnnotationAgent
       this.initializing$ = this.provider
         .initialize()
         .then(() => {
-          this.initialized = true;
+          // Defer initialization state to the provider.
+          // This handles potential race conditions with initialize/dispose and
+          //  any silent initialization failures.
+          this.initialized = this.provider.isInitialized();
+
+          if (!this.initialized) {
+            this.initializing$ = null;
+          }
         })
         .catch((err) => {
           this.initializing$ = null;

--- a/app/packages/annotation/src/agents/hooks/index.ts
+++ b/app/packages/annotation/src/agents/hooks/index.ts
@@ -4,4 +4,5 @@ export * from "./useAgentRegistry";
 export * from "./useAgentSelector";
 export * from "./useAnnotationAgent";
 export * from "./useApplyInferenceResult";
+export * from "./useSampleDescriptor";
 export * from "./useToolsContext";

--- a/app/packages/annotation/src/agents/hooks/useAgentRegistry.ts
+++ b/app/packages/annotation/src/agents/hooks/useAgentRegistry.ts
@@ -2,12 +2,19 @@ import { AgentDescriptor, AgentRegistry } from "../registry";
 import { atom, useAtom } from "jotai";
 import { useCallback, useMemo } from "react";
 import { AnnotationAgent, InferenceResultProxy } from "../types";
+import { SAM2BrowserAnnotationAgent } from "../SAM2BrowserAnnotationAgent";
+import { BrowserAnnotationProvider } from "../../providers";
 
 /** Maps agent IDs to their {@link AgentDescriptor} entries. */
 type RegistryMap = Record<string, AgentDescriptor<InferenceResultProxy>>;
 
 const registryAtom = atom<RegistryMap>({
   // built-in agents defined statically
+  "sam2-tiny-onnx": {
+    id: "sam2-tiny-onnx",
+    label: "SAM2",
+    agent: new SAM2BrowserAnnotationAgent(new BrowserAnnotationProvider()),
+  },
 });
 
 /**

--- a/app/packages/annotation/src/agents/hooks/useAnnotationAgent.ts
+++ b/app/packages/annotation/src/agents/hooks/useAnnotationAgent.ts
@@ -1,8 +1,4 @@
-import {
-  DetectionAnnotationLabel,
-  useCurrentDatasetName,
-  useCurrentSampleId,
-} from "@fiftyone/state";
+import { DetectionAnnotationLabel } from "@fiftyone/state";
 import {
   AgentTaskType,
   AnnotationAgent,
@@ -18,6 +14,7 @@ import { atom, useAtom } from "jotai";
 import { useToolsContext } from "./useToolsContext";
 import { useActiveTask } from "./useActiveTask";
 import { useActiveCapabilities } from "./useActiveCapabilities";
+import { useSampleDescriptor } from "./useSampleDescriptor";
 
 /**
  * Converts an `[x, y, w, h]` bounding box to a four-corner {@link ROI}
@@ -116,16 +113,14 @@ export const useAnnotationAgent = <T extends InferenceResultProxy>(
  * In all cases, this context includes the current {@link SampleDescriptor}.
  */
 const useAgentContext = (): AnnotationContext | null => {
-  const datasetId = useCurrentDatasetName();
-  const sampleId = useCurrentSampleId();
   const { selectedLabel } = useAnnotationContext();
+  const sampleDescriptor = useSampleDescriptor();
   const toolsContext = useToolsContext();
 
   return useMemo(() => {
     const labelOverride =
       selectedLabel && "bounding_box" in selectedLabel.data
         ? {
-            taskType: AgentTaskType.SEGMENT,
             textPrompt: selectedLabel.data.label,
             regionsOfInterest: [
               bboxToRoi(
@@ -135,22 +130,13 @@ const useAgentContext = (): AnnotationContext | null => {
           }
         : {};
 
-    const taskType =
-      "taskType" in labelOverride
-        ? labelOverride.taskType
-        : toolsContext.taskType;
-
     // No valid context until a task is selected
-    if (!taskType) return null;
+    if (!toolsContext.taskType) return null;
 
     return {
       ...toolsContext,
       ...labelOverride,
-      taskType,
-      sampleDescriptor: {
-        datasetId,
-        sampleId,
-      },
+      sampleDescriptor,
     };
-  }, [datasetId, sampleId, selectedLabel, toolsContext]);
+  }, [sampleDescriptor, selectedLabel, toolsContext]);
 };

--- a/app/packages/annotation/src/agents/hooks/useSampleDescriptor.ts
+++ b/app/packages/annotation/src/agents/hooks/useSampleDescriptor.ts
@@ -1,0 +1,25 @@
+import { SampleDescriptor } from "../types";
+import { useMemo } from "react";
+import {
+  useCurrentDatasetName,
+  useCurrentSampleId,
+  useModalMediaPath,
+} from "@fiftyone/state";
+
+/**
+ * Hook which returns a {@link SampleDescriptor} for the active modal media.
+ */
+export const useSampleDescriptor = (): SampleDescriptor => {
+  const datasetId = useCurrentDatasetName();
+  const sampleId = useCurrentSampleId();
+  const mediaUrl = useModalMediaPath();
+
+  return useMemo(
+    () => ({
+      datasetId,
+      sampleId,
+      mediaUrl,
+    }),
+    [datasetId, mediaUrl, sampleId]
+  );
+};

--- a/app/packages/annotation/src/agents/index.ts
+++ b/app/packages/annotation/src/agents/index.ts
@@ -1,5 +1,6 @@
 export * from "./hooks";
 export * from "./AgentSelect";
 export * from "./OperatorAnnotationAgent";
+export * from "./SAM2BrowserAnnotationAgent";
 export * from "./registry";
 export * from "./types";

--- a/app/packages/annotation/src/agents/types.ts
+++ b/app/packages/annotation/src/agents/types.ts
@@ -56,6 +56,8 @@ export type SampleDescriptor = {
   datasetId: string;
   /** The ID of the sample within the dataset. */
   sampleId: string;
+  /** The URL of the media being annotated. */
+  mediaUrl: string;
 };
 
 /**

--- a/app/packages/annotation/src/providers/index.ts
+++ b/app/packages/annotation/src/providers/index.ts
@@ -1,2 +1,2 @@
 export * from "./types";
-export { BrowserAnnotationProvider } from "./BrowserAnnotationProvider";
+export * from "./BrowserAnnotationProvider";

--- a/app/packages/state/src/accessors/modal.ts
+++ b/app/packages/state/src/accessors/modal.ts
@@ -10,6 +10,7 @@ import {
   fieldSchema,
   ModalSample,
   modalSample,
+  selectedMediaField,
   State,
 } from "../recoil";
 
@@ -97,4 +98,21 @@ export const useCurrentSampleId = () => {
   const loadable = useRecoilValueLoadable(currentSampleId);
 
   return loadable.state === "hasValue" ? loadable.contents : null;
+};
+
+/**
+ * Returns the current media path in the modal.
+ */
+export const useModalMediaPath = (): string | null => {
+  const sample = useModalSample();
+  const mediaField = useRecoilValue(selectedMediaField(true));
+
+  if (!sample) {
+    return null;
+  }
+
+  return Array.isArray(sample.urls)
+    ? sample.urls.find((u) => u.field === mediaField)?.url ??
+        sample.urls[0]?.url
+    : sample.urls[mediaField];
 };


### PR DESCRIPTION
## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

Integrates the interfaces set up in #7213 with the browser-based inference added in #7192 and subsequent PRs.

<!--
Provide a clear, concise description of what this PR does and why.
-->

## 🧪 How is this patch tested? If it is not, please explain why.

unit tests

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser-based SAM2 segmentation agent with positive/negative point prompts and model metadata; registered by default.

* **Improvements**
  * Robust lazy initialization with retry and concurrent-infer handling; proper abort/dispose semantics.
  * Unified sample descriptor exposing media URL so annotation tools reliably receive current media.

* **Tests**
  * Comprehensive test coverage for agent behavior, prompt handling, lifecycle, error propagation, and capability listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->