### PR TITLE
Ontology odm

### DIFF
--- a/fiftyone/core/odm/__init__.py
+++ b/fiftyone/core/odm/__init__.py
@@ -82,6 +82,7 @@ from .frame import (
     NoDatasetFrameDocument,
 )
 from .mixins import get_default_fields
+from .ontology import OntologyDocument, OntologyType
 from .runs import RunDocument
 from .sample import (
     DatasetSampleDocument,

--- a/fiftyone/core/odm/ontology.py
+++ b/fiftyone/core/odm/ontology.py
@@ -7,6 +7,7 @@ Ontology documents.
 """
 
 from enum import Enum
+from datetime import datetime
 
 from mongoengine.fields import DynamicField
 
@@ -56,3 +57,9 @@ class OntologyDocument(Document):
     root = DynamicField()
     created_at = DateTimeField()
     last_modified_at = DateTimeField()
+
+    def save(self, *args, **kwargs):
+        if not self.in_db and self.created_at is None:
+            self.created_at = datetime.utcnow()
+
+        return super().save(*args, **kwargs)

--- a/fiftyone/core/odm/ontology.py
+++ b/fiftyone/core/odm/ontology.py
@@ -66,7 +66,11 @@ class OntologyDocument(Document):
     last_modified_at = DateTimeField()
 
     def save(self, *args, **kwargs):
+        now = datetime.now(timezone.utc)
+
         if not self.in_db and self.created_at is None:
-            self.created_at = datetime.now(timezone.utc)
+            self.created_at = now
+
+        self.last_modified_at = now
 
         return super().save(*args, **kwargs)

--- a/fiftyone/core/odm/ontology.py
+++ b/fiftyone/core/odm/ontology.py
@@ -7,7 +7,7 @@ Ontology documents.
 """
 
 from enum import Enum
-from datetime import datetime
+from datetime import datetime, timezone
 
 from mongoengine.fields import DynamicField
 
@@ -60,6 +60,6 @@ class OntologyDocument(Document):
 
     def save(self, *args, **kwargs):
         if not self.in_db and self.created_at is None:
-            self.created_at = datetime.utcnow()
+            self.created_at = datetime.now(timezone.utc)
 
         return super().save(*args, **kwargs)

--- a/fiftyone/core/odm/ontology.py
+++ b/fiftyone/core/odm/ontology.py
@@ -20,10 +20,18 @@ from .document import Document
 
 
 class OntologyType(str, Enum):  # TODO - update to StrEnum
-    """Allowed values for :attr:`OntologyDocument.type` in storage and APIs."""
+    """Allowed values for :attr:`OntologyDocument.type` in storage and APIs.
+
+    ``TAXONOMY`` — a reusable hierarchical class tree. Multiple annotation
+    ontologies can reference the same taxonomy by name.
+
+    ``ANNOTATION_ONTOLOGY`` — a container that defines classes, attributes
+    (with optional conditional display logic), and references to taxonomies.
+    This is the document that gets connected to a label schema on a field.
+    """
 
     TAXONOMY = "taxonomy"
-    CONDITIONAL_ATTRIBUTES = "conditional_attributes"
+    ANNOTATION_ONTOLOGY = "annotation_ontology"
 
 
 _ONTOLOGY_TYPE_VALUES = tuple(t.value for t in OntologyType)

--- a/fiftyone/core/odm/ontology.py
+++ b/fiftyone/core/odm/ontology.py
@@ -1,0 +1,58 @@
+"""
+Ontology documents.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from enum import Enum
+
+from mongoengine.fields import DynamicField
+
+from fiftyone.core.fields import (
+    DateTimeField,
+    IntField,
+    StringField,
+)
+
+from .document import Document
+
+
+class OntologyType(str, Enum):  # TODO - update to StrEnum
+    """Allowed values for :attr:`OntologyDocument.type` in storage and APIs."""
+
+    TAXONOMY = "taxonomy"
+    CONDITIONAL_ATTRIBUTES = "conditional_attributes"
+
+
+_ONTOLOGY_TYPE_VALUES = tuple(t.value for t in OntologyType)
+
+
+class OntologyDocument(Document):
+    """Backing document for ontologies.
+
+    Ontologies are global resources not scoped to any single dataset.
+    Multiple datasets can reference the same ontology by name. Each
+    save creates a new versioned document; ``(name, version)`` is unique.
+    """
+
+    meta = {
+        "collection": "ontologies",
+        "strict": False,
+        "indexes": [
+            {
+                "fields": ["name", "version"],
+                "unique": True,
+            },
+            "type",
+        ],
+    }
+
+    name = StringField(required=True)
+    version = IntField(required=True, default=1)
+    type = StringField(required=True, choices=_ONTOLOGY_TYPE_VALUES)
+    description = StringField(default=None)
+    root = DynamicField()
+    created_at = DateTimeField()
+    last_modified_at = DateTimeField()

--- a/fiftyone/core/odm/ontology.py
+++ b/fiftyone/core/odm/ontology.py
@@ -9,10 +9,9 @@ Ontology documents.
 from enum import Enum
 from datetime import datetime, timezone
 
-from mongoengine.fields import DynamicField
-
 from fiftyone.core.fields import (
     DateTimeField,
+    DictField,
     IntField,
     StringField,
 )
@@ -54,7 +53,7 @@ class OntologyDocument(Document):
     version = IntField(required=True, default=1)
     type = StringField(required=True, choices=_ONTOLOGY_TYPE_VALUES)
     description = StringField(default=None)
-    root = DynamicField()
+    root = DictField()
     created_at = DateTimeField()
     last_modified_at = DateTimeField()
 

--- a/fiftyone/core/odm/ontology.py
+++ b/fiftyone/core/odm/ontology.py
@@ -9,6 +9,7 @@ Ontology documents.
 from enum import Enum
 from datetime import datetime, timezone
 
+import fiftyone.core.utils as fou
 from fiftyone.core.fields import (
     DateTimeField,
     DictField,
@@ -42,7 +43,8 @@ class OntologyDocument(Document):
 
     Ontologies are global resources not scoped to any single dataset.
     Multiple datasets can reference the same ontology by name. Each
-    save creates a new versioned document; ``(name, version)`` is unique.
+    save creates a new versioned document; ``(slug, version)`` is unique,
+    so names differing only in case or punctuation collide on save.
     """
 
     meta = {
@@ -50,14 +52,16 @@ class OntologyDocument(Document):
         "strict": False,
         "indexes": [
             {
-                "fields": ["name", "version"],
+                "fields": ["slug", "version"],
                 "unique": True,
             },
+            "name",
             "type",
         ],
     }
 
     name = StringField(required=True)
+    slug = StringField(required=True)
     version = IntField(required=True, default=1)
     type = StringField(required=True, choices=_ONTOLOGY_TYPE_VALUES)
     description = StringField(default=None)
@@ -67,6 +71,9 @@ class OntologyDocument(Document):
 
     def save(self, *args, **kwargs):
         now = datetime.now(timezone.utc)
+
+        if self.name is not None:
+            self.slug = fou.to_slug(self.name)
 
         if not self.in_db and self.created_at is None:
             self.created_at = now

--- a/tests/unittests/ontology_tests.py
+++ b/tests/unittests/ontology_tests.py
@@ -55,16 +55,30 @@ class OntologyDocumentTests(unittest.TestCase):
         self.assertEqual(loaded.root["name"], "vehicle_type")
         self.assertEqual(len(loaded.root["values"]), 2)
 
-    def test_create_conditional_attributes(self):
+    def test_create_annotation_ontology(self):
         doc = OntologyDocument(
-            name="vehicle_damage_attributes",
+            name="vehicle_damage_ontology",
             version=1,
-            type=OntologyType.CONDITIONAL_ATTRIBUTES,
-            description="Vehicle damage condition attributes",
+            type=OntologyType.ANNOTATION_ONTOLOGY,
+            description="Vehicle damage annotation ontology",
             root={
+                "classes": ["car", "motorcycle", "truck"],
                 "attributes": [
                     {
+                        "name": "damage_present",
+                        "type": "bool",
+                        "component": "checkbox",
+                    },
+                    {
                         "name": "damage_location",
+                        "type": "str",
+                        "component": "dropdown",
+                        "values": [
+                            "front",
+                            "rear",
+                            "driver_side",
+                            "passenger_side",
+                        ],
                         "when": {
                             "equals": {
                                 "field": "damage_present",
@@ -74,6 +88,9 @@ class OntologyDocumentTests(unittest.TestCase):
                     },
                     {
                         "name": "damage_severity",
+                        "type": "str",
+                        "component": "radio",
+                        "values": ["minor", "moderate", "severe"],
                         "when": {
                             "equals": {
                                 "field": "damage_present",
@@ -82,20 +99,25 @@ class OntologyDocumentTests(unittest.TestCase):
                         },
                     },
                 ],
+                "taxonomies": ["vehicle_classes"],
             },
         )
         doc.save()
 
         loaded = OntologyDocument.objects.get(
-            name="vehicle_damage_attributes", version=1
+            name="vehicle_damage_ontology", version=1
         )
         self.assertIsNotNone(loaded.created_at)
-        self.assertEqual(loaded.type, OntologyType.CONDITIONAL_ATTRIBUTES)
+        self.assertEqual(loaded.type, OntologyType.ANNOTATION_ONTOLOGY)
+        self.assertIsInstance(loaded.root["classes"], list)
+        self.assertEqual(len(loaded.root["classes"]), 3)
         self.assertIsInstance(loaded.root["attributes"], list)
-        self.assertEqual(len(loaded.root["attributes"]), 2)
+        self.assertEqual(len(loaded.root["attributes"]), 3)
         self.assertEqual(
-            loaded.root["attributes"][0]["name"], "damage_location"
+            loaded.root["attributes"][1]["name"], "damage_location"
         )
+        self.assertIn("when", loaded.root["attributes"][1])
+        self.assertEqual(loaded.root["taxonomies"], ["vehicle_classes"])
 
     def test_name_version_uniqueness(self):
         OntologyDocument(
@@ -139,6 +161,16 @@ class OntologyDocumentTests(unittest.TestCase):
             name="bad_type",
             version=1,
             type="invalid_type",
+            root={},
+        )
+        with self.assertRaises(ValidationError):
+            doc.save()
+
+    def test_old_conditional_attributes_type_rejected(self):
+        doc = OntologyDocument(
+            name="old_type",
+            version=1,
+            type="conditional_attributes",
             root={},
         )
         with self.assertRaises(ValidationError):
@@ -196,8 +228,8 @@ class OntologyDocumentTests(unittest.TestCase):
         OntologyDocument(
             name="shared_name",
             version=2,
-            type=OntologyType.CONDITIONAL_ATTRIBUTES,
-            root={"attributes": [{"name": "attr"}]},
+            type=OntologyType.ANNOTATION_ONTOLOGY,
+            root={"classes": [], "attributes": [], "taxonomies": []},
         ).save()
 
         docs = OntologyDocument.objects(name="shared_name")
@@ -217,19 +249,19 @@ class OntologyDocumentTests(unittest.TestCase):
             root={"name": "root"},
         ).save()
         OntologyDocument(
-            name="ca1",
+            name="ao1",
             version=1,
-            type=OntologyType.CONDITIONAL_ATTRIBUTES,
-            root={"attributes": []},
+            type=OntologyType.ANNOTATION_ONTOLOGY,
+            root={"classes": [], "attributes": [], "taxonomies": []},
         ).save()
 
         taxonomies = OntologyDocument.objects(type=OntologyType.TAXONOMY)
         self.assertEqual(taxonomies.count(), 2)
 
-        conditionals = OntologyDocument.objects(
-            type=OntologyType.CONDITIONAL_ATTRIBUTES
+        annotation_ontologies = OntologyDocument.objects(
+            type=OntologyType.ANNOTATION_ONTOLOGY
         )
-        self.assertEqual(conditionals.count(), 1)
+        self.assertEqual(annotation_ontologies.count(), 1)
 
     def test_delete(self):
         doc = OntologyDocument(

--- a/tests/unittests/ontology_tests.py
+++ b/tests/unittests/ontology_tests.py
@@ -9,7 +9,7 @@ FiftyOne ontology ODM unit tests.
 # pylint: disable=no-member
 
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 from mongoengine.errors import ValidationError
 from pymongo.errors import DuplicateKeyError
@@ -141,7 +141,7 @@ class OntologyDocumentTests(unittest.TestCase):
             doc.save()
 
     def test_serialization(self):
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         doc = OntologyDocument(
             name="serialize_test",
             version=1,

--- a/tests/unittests/ontology_tests.py
+++ b/tests/unittests/ontology_tests.py
@@ -6,6 +6,8 @@ FiftyOne ontology ODM unit tests.
 |
 """
 
+# pylint: disable=no-member
+
 import unittest
 from datetime import datetime
 
@@ -39,13 +41,13 @@ class OntologyDocumentTests(unittest.TestCase):
                     {"name": "motorcycle"},
                 ],
             },
-            created_at=datetime.utcnow(),
         )
         doc.save()
 
         loaded = OntologyDocument.objects.get(
             name="vehicle_classes", version=1
         )
+        self.assertIsNotNone(loaded.created_at)
         self.assertEqual(loaded.name, "vehicle_classes")
         self.assertEqual(loaded.version, 1)
         self.assertEqual(loaded.type, OntologyType.TAXONOMY)
@@ -79,13 +81,13 @@ class OntologyDocumentTests(unittest.TestCase):
                     },
                 },
             ],
-            created_at=datetime.utcnow(),
         )
         doc.save()
 
         loaded = OntologyDocument.objects.get(
             name="vehicle_damage_attributes", version=1
         )
+        self.assertIsNotNone(loaded.created_at)
         self.assertEqual(loaded.type, OntologyType.CONDITIONAL_ATTRIBUTES)
         self.assertIsInstance(loaded.root, list)
         self.assertEqual(len(loaded.root), 2)
@@ -97,7 +99,6 @@ class OntologyDocumentTests(unittest.TestCase):
             version=1,
             type=OntologyType.TAXONOMY,
             root={"name": "root"},
-            created_at=datetime.utcnow(),
         ).save()
 
         with self.assertRaises(DuplicateKeyError):
@@ -106,7 +107,6 @@ class OntologyDocumentTests(unittest.TestCase):
                 version=1,
                 type=OntologyType.TAXONOMY,
                 root={"name": "root"},
-                created_at=datetime.utcnow(),
             ).save()
 
     def test_multiple_versions(self):
@@ -117,7 +117,6 @@ class OntologyDocumentTests(unittest.TestCase):
                 type=OntologyType.TAXONOMY,
                 description=f"Version {v}",
                 root={"name": "root", "version_data": v},
-                created_at=datetime.utcnow(),
             ).save()
 
         all_versions = OntologyDocument.objects(name="versioned")
@@ -137,7 +136,6 @@ class OntologyDocumentTests(unittest.TestCase):
             version=1,
             type="invalid_type",
             root={},
-            created_at=datetime.utcnow(),
         )
         with self.assertRaises(ValidationError):
             doc.save()
@@ -170,9 +168,9 @@ class OntologyDocumentTests(unittest.TestCase):
             version=1,
             type="taxonomy",
             root={"name": "root"},
-            created_at=datetime.utcnow(),
         )
         doc.save()
+        self.assertIsNotNone(doc.created_at)
 
         original_modified = doc.last_modified_at
 
@@ -181,8 +179,7 @@ class OntologyDocumentTests(unittest.TestCase):
         doc.reload()
 
         self.assertIsNotNone(doc.last_modified_at)
-        if original_modified is not None:
-            self.assertGreaterEqual(doc.last_modified_at, original_modified)
+        self.assertNotEqual(doc.last_modified_at, original_modified)
 
     def test_same_name_different_types(self):
         OntologyDocument(
@@ -190,7 +187,6 @@ class OntologyDocumentTests(unittest.TestCase):
             version=1,
             type=OntologyType.TAXONOMY,
             root={"name": "root"},
-            created_at=datetime.utcnow(),
         ).save()
 
         OntologyDocument(
@@ -198,7 +194,6 @@ class OntologyDocumentTests(unittest.TestCase):
             version=2,
             type=OntologyType.CONDITIONAL_ATTRIBUTES,
             root=[{"name": "attr"}],
-            created_at=datetime.utcnow(),
         ).save()
 
         docs = OntologyDocument.objects(name="shared_name")
@@ -210,21 +205,18 @@ class OntologyDocumentTests(unittest.TestCase):
             version=1,
             type=OntologyType.TAXONOMY,
             root={"name": "root"},
-            created_at=datetime.utcnow(),
         ).save()
         OntologyDocument(
             name="tax2",
             version=1,
             type=OntologyType.TAXONOMY,
             root={"name": "root"},
-            created_at=datetime.utcnow(),
         ).save()
         OntologyDocument(
             name="ca1",
             version=1,
             type=OntologyType.CONDITIONAL_ATTRIBUTES,
             root=[],
-            created_at=datetime.utcnow(),
         ).save()
 
         taxonomies = OntologyDocument.objects(type=OntologyType.TAXONOMY)
@@ -241,7 +233,6 @@ class OntologyDocumentTests(unittest.TestCase):
             version=1,
             type=OntologyType.TAXONOMY,
             root={"name": "root"},
-            created_at=datetime.utcnow(),
         ).save()
 
         self.assertEqual(OntologyDocument.objects(name="to_delete").count(), 1)

--- a/tests/unittests/ontology_tests.py
+++ b/tests/unittests/ontology_tests.py
@@ -1,0 +1,258 @@
+"""
+FiftyOne ontology ODM unit tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+from datetime import datetime
+
+from mongoengine.errors import ValidationError
+from pymongo.errors import DuplicateKeyError
+
+import fiftyone.core.odm as foo
+from fiftyone.core.odm.ontology import OntologyDocument, OntologyType
+
+
+class OntologyDocumentTests(unittest.TestCase):
+    def setUp(self):
+        db = foo.get_db_conn()
+        db.drop_collection("ontologies")
+        OntologyDocument.ensure_indexes()
+
+    def tearDown(self):
+        db = foo.get_db_conn()
+        db.drop_collection("ontologies")
+
+    def test_create_taxonomy(self):
+        doc = OntologyDocument(
+            name="vehicle_classes",
+            version=1,
+            type=OntologyType.TAXONOMY,
+            description="Vehicle type hierarchy",
+            root={
+                "name": "vehicle_type",
+                "values": [
+                    {"name": "car"},
+                    {"name": "motorcycle"},
+                ],
+            },
+            created_at=datetime.utcnow(),
+        )
+        doc.save()
+
+        loaded = OntologyDocument.objects.get(
+            name="vehicle_classes", version=1
+        )
+        self.assertEqual(loaded.name, "vehicle_classes")
+        self.assertEqual(loaded.version, 1)
+        self.assertEqual(loaded.type, OntologyType.TAXONOMY)
+        self.assertEqual(loaded.description, "Vehicle type hierarchy")
+        self.assertEqual(loaded.root["name"], "vehicle_type")
+        self.assertEqual(len(loaded.root["values"]), 2)
+
+    def test_create_conditional_attributes(self):
+        doc = OntologyDocument(
+            name="vehicle_damage_attributes",
+            version=1,
+            type=OntologyType.CONDITIONAL_ATTRIBUTES,
+            description="Vehicle damage condition attributes",
+            root=[
+                {
+                    "name": "damage_location",
+                    "when": {
+                        "equals": {
+                            "field": "damage_present",
+                            "value": True,
+                        }
+                    },
+                },
+                {
+                    "name": "damage_severity",
+                    "when": {
+                        "equals": {
+                            "field": "damage_present",
+                            "value": True,
+                        }
+                    },
+                },
+            ],
+            created_at=datetime.utcnow(),
+        )
+        doc.save()
+
+        loaded = OntologyDocument.objects.get(
+            name="vehicle_damage_attributes", version=1
+        )
+        self.assertEqual(loaded.type, OntologyType.CONDITIONAL_ATTRIBUTES)
+        self.assertIsInstance(loaded.root, list)
+        self.assertEqual(len(loaded.root), 2)
+        self.assertEqual(loaded.root[0]["name"], "damage_location")
+
+    def test_name_version_uniqueness(self):
+        OntologyDocument(
+            name="test_ontology",
+            version=1,
+            type=OntologyType.TAXONOMY,
+            root={"name": "root"},
+            created_at=datetime.utcnow(),
+        ).save()
+
+        with self.assertRaises(DuplicateKeyError):
+            OntologyDocument(
+                name="test_ontology",
+                version=1,
+                type=OntologyType.TAXONOMY,
+                root={"name": "root"},
+                created_at=datetime.utcnow(),
+            ).save()
+
+    def test_multiple_versions(self):
+        for v in range(1, 4):
+            OntologyDocument(
+                name="versioned",
+                version=v,
+                type=OntologyType.TAXONOMY,
+                description=f"Version {v}",
+                root={"name": "root", "version_data": v},
+                created_at=datetime.utcnow(),
+            ).save()
+
+        all_versions = OntologyDocument.objects(name="versioned")
+        self.assertEqual(all_versions.count(), 3)
+
+        latest = (
+            OntologyDocument.objects(name="versioned")
+            .order_by("-version")
+            .first()
+        )
+        self.assertEqual(latest.version, 3)
+        self.assertEqual(latest.root["version_data"], 3)
+
+    def test_invalid_type_rejected(self):
+        doc = OntologyDocument(
+            name="bad_type",
+            version=1,
+            type="invalid_type",
+            root={},
+            created_at=datetime.utcnow(),
+        )
+        with self.assertRaises(ValidationError):
+            doc.save()
+
+    def test_serialization(self):
+        now = datetime.utcnow()
+        doc = OntologyDocument(
+            name="serialize_test",
+            version=1,
+            type="taxonomy",
+            description="test",
+            root={"name": "root", "values": [{"name": "child"}]},
+            created_at=now,
+        )
+        doc.save()
+
+        d = doc.to_dict()
+        self.assertEqual(d["name"], "serialize_test")
+        self.assertEqual(d["version"], 1)
+        self.assertEqual(d["type"], OntologyType.TAXONOMY)
+
+        restored = OntologyDocument.from_dict(d)
+        self.assertEqual(restored.name, doc.name)
+        self.assertEqual(restored.version, doc.version)
+        self.assertEqual(restored.root, doc.root)
+
+    def test_last_modified_at_auto_updates(self):
+        doc = OntologyDocument(
+            name="timestamp_test",
+            version=1,
+            type="taxonomy",
+            root={"name": "root"},
+            created_at=datetime.utcnow(),
+        )
+        doc.save()
+
+        original_modified = doc.last_modified_at
+
+        doc.description = "updated"
+        doc.save()
+        doc.reload()
+
+        self.assertIsNotNone(doc.last_modified_at)
+        if original_modified is not None:
+            self.assertGreaterEqual(doc.last_modified_at, original_modified)
+
+    def test_same_name_different_types(self):
+        OntologyDocument(
+            name="shared_name",
+            version=1,
+            type=OntologyType.TAXONOMY,
+            root={"name": "root"},
+            created_at=datetime.utcnow(),
+        ).save()
+
+        OntologyDocument(
+            name="shared_name",
+            version=2,
+            type=OntologyType.CONDITIONAL_ATTRIBUTES,
+            root=[{"name": "attr"}],
+            created_at=datetime.utcnow(),
+        ).save()
+
+        docs = OntologyDocument.objects(name="shared_name")
+        self.assertEqual(docs.count(), 2)
+
+    def test_query_by_type(self):
+        OntologyDocument(
+            name="tax1",
+            version=1,
+            type=OntologyType.TAXONOMY,
+            root={"name": "root"},
+            created_at=datetime.utcnow(),
+        ).save()
+        OntologyDocument(
+            name="tax2",
+            version=1,
+            type=OntologyType.TAXONOMY,
+            root={"name": "root"},
+            created_at=datetime.utcnow(),
+        ).save()
+        OntologyDocument(
+            name="ca1",
+            version=1,
+            type=OntologyType.CONDITIONAL_ATTRIBUTES,
+            root=[],
+            created_at=datetime.utcnow(),
+        ).save()
+
+        taxonomies = OntologyDocument.objects(type=OntologyType.TAXONOMY)
+        self.assertEqual(taxonomies.count(), 2)
+
+        conditionals = OntologyDocument.objects(
+            type=OntologyType.CONDITIONAL_ATTRIBUTES
+        )
+        self.assertEqual(conditionals.count(), 1)
+
+    def test_delete(self):
+        doc = OntologyDocument(
+            name="to_delete",
+            version=1,
+            type=OntologyType.TAXONOMY,
+            root={"name": "root"},
+            created_at=datetime.utcnow(),
+        ).save()
+
+        self.assertEqual(OntologyDocument.objects(name="to_delete").count(), 1)
+
+        doc.delete()
+
+        self.assertEqual(OntologyDocument.objects(name="to_delete").count(), 0)
+
+
+if __name__ == "__main__":
+    fo_unittest = unittest.TestLoader().loadTestsFromTestCase(
+        OntologyDocumentTests
+    )
+    unittest.TextTestRunner(verbosity=2).run(fo_unittest)

--- a/tests/unittests/ontology_tests.py
+++ b/tests/unittests/ontology_tests.py
@@ -263,6 +263,70 @@ class OntologyDocumentTests(unittest.TestCase):
         )
         self.assertEqual(annotation_ontologies.count(), 1)
 
+    def test_slug_populated_on_save(self):
+        doc = OntologyDocument(
+            name="Vehicle Classes",
+            version=1,
+            type=OntologyType.TAXONOMY,
+            root={"name": "root"},
+        )
+        doc.save()
+
+        self.assertEqual(doc.slug, "vehicle-classes")
+
+        loaded = OntologyDocument.objects.get(
+            slug="vehicle-classes", version=1
+        )
+        self.assertEqual(loaded.name, "Vehicle Classes")
+
+    def test_slug_sanitizes_name(self):
+        doc = OntologyDocument(
+            name="My_Ontology.v1!",
+            version=1,
+            type=OntologyType.TAXONOMY,
+            root={"name": "root"},
+        ).save()
+
+        self.assertEqual(doc.slug, "my-ontology-v1")
+
+    def test_case_insensitive_uniqueness(self):
+        OntologyDocument(
+            name="Cars",
+            version=1,
+            type=OntologyType.TAXONOMY,
+            root={"name": "root"},
+        ).save()
+
+        with self.assertRaises(DuplicateKeyError):
+            OntologyDocument(
+                name="CARS",
+                version=1,
+                type=OntologyType.TAXONOMY,
+                root={"name": "root"},
+            ).save()
+
+    def test_slug_differs_across_versions(self):
+        for v in range(1, 4):
+            OntologyDocument(
+                name="My Ontology",
+                version=v,
+                type=OntologyType.TAXONOMY,
+                root={"name": "root"},
+            ).save()
+
+        docs = OntologyDocument.objects(slug="my-ontology")
+        self.assertEqual(docs.count(), 3)
+
+    def test_invalid_name_rejected(self):
+        doc = OntologyDocument(
+            name="!!!",
+            version=1,
+            type=OntologyType.TAXONOMY,
+            root={"name": "root"},
+        )
+        with self.assertRaises(ValueError):
+            doc.save()
+
     def test_delete(self):
         doc = OntologyDocument(
             name="to_delete",

--- a/tests/unittests/ontology_tests.py
+++ b/tests/unittests/ontology_tests.py
@@ -61,26 +61,28 @@ class OntologyDocumentTests(unittest.TestCase):
             version=1,
             type=OntologyType.CONDITIONAL_ATTRIBUTES,
             description="Vehicle damage condition attributes",
-            root=[
-                {
-                    "name": "damage_location",
-                    "when": {
-                        "equals": {
-                            "field": "damage_present",
-                            "value": True,
-                        }
+            root={
+                "attributes": [
+                    {
+                        "name": "damage_location",
+                        "when": {
+                            "equals": {
+                                "field": "damage_present",
+                                "value": True,
+                            }
+                        },
                     },
-                },
-                {
-                    "name": "damage_severity",
-                    "when": {
-                        "equals": {
-                            "field": "damage_present",
-                            "value": True,
-                        }
+                    {
+                        "name": "damage_severity",
+                        "when": {
+                            "equals": {
+                                "field": "damage_present",
+                                "value": True,
+                            }
+                        },
                     },
-                },
-            ],
+                ],
+            },
         )
         doc.save()
 
@@ -89,9 +91,11 @@ class OntologyDocumentTests(unittest.TestCase):
         )
         self.assertIsNotNone(loaded.created_at)
         self.assertEqual(loaded.type, OntologyType.CONDITIONAL_ATTRIBUTES)
-        self.assertIsInstance(loaded.root, list)
-        self.assertEqual(len(loaded.root), 2)
-        self.assertEqual(loaded.root[0]["name"], "damage_location")
+        self.assertIsInstance(loaded.root["attributes"], list)
+        self.assertEqual(len(loaded.root["attributes"]), 2)
+        self.assertEqual(
+            loaded.root["attributes"][0]["name"], "damage_location"
+        )
 
     def test_name_version_uniqueness(self):
         OntologyDocument(
@@ -193,7 +197,7 @@ class OntologyDocumentTests(unittest.TestCase):
             name="shared_name",
             version=2,
             type=OntologyType.CONDITIONAL_ATTRIBUTES,
-            root=[{"name": "attr"}],
+            root={"attributes": [{"name": "attr"}]},
         ).save()
 
         docs = OntologyDocument.objects(name="shared_name")
@@ -216,7 +220,7 @@ class OntologyDocumentTests(unittest.TestCase):
             name="ca1",
             version=1,
             type=OntologyType.CONDITIONAL_ATTRIBUTES,
-            root=[],
+            root={"attributes": []},
         ).save()
 
         taxonomies = OntologyDocument.objects(type=OntologyType.TAXONOMY)


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

This pull request adds a new top-level document to support the ontology proposal. Please see 3543 for full details on this proposal and the implementations it will contain.

- new ODM
- auto managed created at and last modified at
- unit tests that also contain some of the taxonomy and conditional attribute document structure.

## 🧪 How is this patch tested? If it is not, please explain why.

- new unit tests around this document
- working in a Python shell to import and create documents in local database.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ontology persistence for storing and managing taxonomies and annotation ontologies with name/version uniqueness, automatic created/last-modified timestamps, slug generation/sanitization, and version-aware retrieval.
  * Validation enforces allowed ontology types and rejects invalid legacy or malformed values.

* **Tests**
  * Added comprehensive tests covering creation, versioning, uniqueness (case-insensitive), slug behavior, validation, serialization round-trips, timestamps, querying by type, and deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->