### PR TITLE
Add 'once' convenience method to EventDispatcher

### DIFF
--- a/app/packages/events/src/dispatch/dispatcher.test.ts
+++ b/app/packages/events/src/dispatch/dispatcher.test.ts
@@ -165,6 +165,150 @@ describe("EventDispatcher", () => {
     });
   });
 
+  describe("once", () => {
+    test("should register a handler that fires only once", () => {
+      const handler = vi.fn();
+      dispatcher.once("test:eventA", handler);
+
+      dispatcher.dispatch("test:eventA", { id: "1", name: "test" });
+      dispatcher.dispatch("test:eventA", { id: "2", name: "test2" });
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith({ id: "1", name: "test" });
+    });
+
+    test("should pass the correct payload to the handler", () => {
+      const handler = vi.fn();
+      dispatcher.once("test:eventA", handler);
+
+      dispatcher.dispatch("test:eventA", { id: "42", name: "hello" });
+
+      expect(handler).toHaveBeenCalledWith({ id: "42", name: "hello" });
+    });
+
+    test("should not affect other handlers registered with on", () => {
+      const onceHandler = vi.fn();
+      const onHandler = vi.fn();
+
+      dispatcher.once("test:eventA", onceHandler);
+      dispatcher.on("test:eventA", onHandler);
+
+      dispatcher.dispatch("test:eventA", { id: "1", name: "test" });
+      dispatcher.dispatch("test:eventA", { id: "2", name: "test2" });
+
+      expect(onceHandler).toHaveBeenCalledTimes(1);
+      expect(onHandler).toHaveBeenCalledTimes(2);
+    });
+
+    test("should work with events with no payload", () => {
+      const handler = vi.fn();
+      dispatcher.once("test:eventC", handler);
+
+      dispatcher.dispatch("test:eventC");
+      dispatcher.dispatch("test:eventC");
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith(undefined);
+    });
+
+    test("should work with events with null payload", () => {
+      const handler = vi.fn();
+      dispatcher.once("test:eventD", handler);
+
+      dispatcher.dispatch("test:eventD", null);
+      dispatcher.dispatch("test:eventD", null);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith(null);
+    });
+
+    test("should return an unregister function", () => {
+      const handler = vi.fn();
+      const unregister = dispatcher.once("test:eventA", handler);
+
+      expect(typeof unregister).toBe("function");
+    });
+
+    test("should not fire if unregistered before the event is dispatched", () => {
+      const handler = vi.fn();
+      const unregister = dispatcher.once("test:eventA", handler);
+
+      unregister();
+      dispatcher.dispatch("test:eventA", { id: "1", name: "test" });
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    test("should be safe to call unregister after handler has already fired", () => {
+      const handler = vi.fn();
+      const unregister = dispatcher.once("test:eventA", handler);
+
+      dispatcher.dispatch("test:eventA", { id: "1", name: "test" });
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      // Should not throw even though the handler already removed itself
+      expect(() => unregister()).not.toThrow();
+
+      dispatcher.dispatch("test:eventA", { id: "2", name: "test2" });
+      expect(handler).toHaveBeenCalledTimes(1); // Still 1
+    });
+
+    test("should allow re-registering the same handler after it has fired", () => {
+      const handler = vi.fn();
+
+      dispatcher.once("test:eventA", handler);
+      dispatcher.dispatch("test:eventA", { id: "1", name: "test" });
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      dispatcher.once("test:eventA", handler);
+      dispatcher.dispatch("test:eventA", { id: "2", name: "test2" });
+      expect(handler).toHaveBeenCalledTimes(2);
+    });
+
+    test("should handle async handlers and fire only once", async () => {
+      vi.useFakeTimers();
+      const handler = vi.fn(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+
+      dispatcher.once("test:eventA", handler);
+
+      dispatcher.dispatch("test:eventA", { id: "1", name: "test" });
+      dispatcher.dispatch("test:eventA", { id: "2", name: "test2" });
+
+      await vi.runAllTimersAsync();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
+    });
+
+    test("should handle errors without preventing removal", async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+      const handler = vi.fn(() => {
+        throw new Error("once handler error");
+      });
+
+      dispatcher.once("test:eventA", handler);
+
+      expect(() =>
+        dispatcher.dispatch("test:eventA", { id: "1", name: "test" })
+      ).not.toThrow();
+
+      // Wait for async error logging
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(consoleErrorSpy).toHaveBeenCalled();
+
+      // Handler should not fire again even though it threw
+      dispatcher.dispatch("test:eventA", { id: "2", name: "test2" });
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
   describe("off", () => {
     test("should unregister a specific handler", () => {
       const handler1 = vi.fn();

--- a/app/packages/events/src/dispatch/dispatcher.ts
+++ b/app/packages/events/src/dispatch/dispatcher.ts
@@ -1,4 +1,4 @@
-import { EventGroup, EventHandler } from "../types";
+import type { EventGroup, EventHandler } from "../types";
 
 type DispatchData<T> = T extends undefined | null ? [data?: T] : [data: T];
 
@@ -86,6 +86,41 @@ export class EventDispatcher<T extends EventGroup> {
   }
 
   /**
+   * Registers a one-time event handler that automatically unregisters itself after firing once.
+   *
+   * @template E - Event type key
+   * @param event - Event type name
+   * @param handler - Handler function (sync or async)
+   *
+   * @returns A function to unregister the handler before it fires
+   *
+   * @example
+   * ```typescript
+   * // Fires once, then removes itself
+   * eventBus.once("demo:eventA", (data) => console.log(data.id));
+   *
+   * // Cancel before it fires
+   * const unregister = eventBus.once("demo:eventA", (data) => console.log(data.id));
+   * unregister();
+   *
+   * // No payload
+   * eventBus.once("demo:eventD", () => console.log("fires once"));
+   * ```
+   */
+  public once<E extends keyof T>(
+    event: E,
+    handler: EventHandler<T[E]>
+  ): () => void {
+    const handlerFn = handler as (data?: T[E]) => void | Promise<void>;
+    const wrapper: EventHandler<T[E]> = ((data?: T[E]) => {
+      this.off(event, wrapper);
+      return handlerFn(data);
+    }) as EventHandler<T[E]>;
+
+    return this.on(event, wrapper);
+  }
+
+  /**
    * Unregisters an event handler.
    *
    * @template E - Event type key
@@ -166,10 +201,11 @@ export class EventDispatcher<T extends EventGroup> {
     ...args: DispatchData<T[E]>
   ): void {
     const data = args[0] as T[E];
-    const typeHandlers = this.handlers[event];
-    if (!typeHandlers || typeHandlers.length === 0) {
+    if (!this.handlers[event]?.length) {
       return;
     }
+    // Make a copy of the handlers at the time of dispatch
+    const typeHandlers = [...this.handlers[event]];
 
     // Collect all handler results (sync handlers return void, async return Promise<void>)
     const promises = typeHandlers.map((handler) => {

--- a/app/packages/events/src/dispatch/dispatcher.ts
+++ b/app/packages/events/src/dispatch/dispatcher.ts
@@ -94,6 +94,22 @@ export class EventDispatcher<T extends EventGroup> {
    *
    * @returns A function to unregister the handler before it fires
    *
+   * @remarks
+   * The handler passed to `once` is wrapped internally, so the original handler reference
+   * is not compatible with `off`. To unregister before the handler fires, use the
+   * returned unregister function instead.
+   *
+   * ```typescript
+   * // ❌ Will not work — `off` cannot match the internal wrapper
+   * const handler = (data) => console.log(data.id);
+   * eventBus.once("demo:eventA", handler);
+   * eventBus.off("demo:eventA", handler);
+   *
+   * // ✅ Use the returned unregister function instead
+   * const unregister = eventBus.once("demo:eventA", handler);
+   * unregister();
+   * ```
+   *
    * @example
    * ```typescript
    * // Fires once, then removes itself

--- a/app/packages/events/src/hooks/createUseEventHandler.ts
+++ b/app/packages/events/src/hooks/createUseEventHandler.ts
@@ -4,6 +4,18 @@ import { EventGroup, EventHandler } from "../types";
 import { useEventBus } from "./useEventBus";
 
 /**
+ * Options for configuring event handler behavior.
+ */
+type UseEventHandlerOptions = {
+  /**
+   * If true, the handler will unregister itself after firing once.
+   * If the component unmounts before the event fires, the handler is still cleaned up.
+   * @default false
+   */
+  once?: boolean;
+};
+
+/**
  * Factory function that creates a type-safe event handler hook.
  * The returned hook automatically registers/unregisters handlers on mount/unmount.
  *
@@ -29,6 +41,11 @@ import { useEventBus } from "./useEventBus";
  *     console.log("Event D received");
  *   }, []));
  *
+ *   // One-time handler — automatically unregisters after the first event
+ *   useDemoEventHandler("demo:eventA", useCallback((data) => {
+ *     console.log("fires once:", data.id);
+ *   }, []), { once: true });
+ *
  *   return <div>...</div>;
  * }
  * ```
@@ -47,13 +64,18 @@ export function createUseEventHandler<T extends EventGroup>(
 ) {
   return function useEventHandler<K extends keyof T>(
     event: K,
-    handler: EventHandler<T[K]>
+    handler: EventHandler<T[K]>,
+    { once = false }: UseEventHandlerOptions = {}
   ) {
     const bus = useEventBus<T>(channelId);
 
     useEffect(() => {
+      if (once) {
+        return bus.once(event, handler);
+      }
+
       bus.on(event, handler);
       return () => bus.off(event, handler);
-    }, [bus, event, handler, channelId]);
+    }, [bus, event, handler, once]);
   };
 }

--- a/app/packages/lighter/src/react/useLighterEventHandler.ts
+++ b/app/packages/lighter/src/react/useLighterEventHandler.ts
@@ -13,9 +13,16 @@ export const UNDEFINED_LIGHTER_SCENE_ID = "UNDEFINED_LIGHTER_SCENE";
  * @example
  * ```typescript
  * const useEventHandler = useLighterEventHandler(eventChannel);
+ *
+ * // Standard handler
  * useEventHandler("lighter:overlay-select", useCallback((payload) => {
  *   console.log(payload.id);
  * }, []));
+ *
+ * // One-time handler
+ * useEventHandler("lighter:overlay-select", useCallback((payload) => {
+ *   console.log(payload.id);
+ * }, []), { once: true });
  * ```
  */
 export const useLighterEventHandler = (eventChannel: string) =>


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Add a convenience method for listening to an event once and only once

## 🧪 How is this patch tested? If it is not, please explain why.

Unit tests

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-time event handlers: register via an options parameter to fire once and self-unregister; can be re-registered later.

* **Bug Fixes**
  * Unregistering before or after firing is safe; thrown errors in handlers are logged without breaking dispatch; async handlers still fire only once.

* **Documentation**
  * Hook examples updated to show one-time handler usage.

* **Tests**
  * Added comprehensive tests covering once behavior, payloads, unregistering, re-registration, async and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->