### PR TITLE
Add docs for request param overrides

### DIFF
--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -2706,6 +2706,78 @@ performing a cleanup action:
 
         # ... normal stage logic
 
+.. _pipeline-request-params-overrides:
+
+Overriding request parameters per stage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, each stage in a pipeline inherits the same execution context as the
+top-level pipeline operator — including its ``view``, ``view_name``, ``filters``,
+and other request parameters.
+
+Use ``request_params_overrides`` on a :class:`PipelineStage
+<fiftyone.operators.types.PipelineStage>` to give a specific stage a different
+execution context. Any key you include in ``request_params_overrides`` will
+shadow the corresponding value from the top-level request for that stage only;
+all other stages are unaffected.
+
+Overridable parameters include:
+
+- ``view`` — a list of view stages to apply
+- ``view_name`` — the name of a saved view to use
+- ``filters`` — a dictionary of filters to apply
+- any other valid :ref:`execution context <operator-execution-context>` request
+  parameter
+
+.. note::
+
+    Do **not** include ``params`` inside ``request_params_overrides``. Use the
+    ``params`` field of :class:`PipelineStage
+    <fiftyone.operators.types.PipelineStage>` directly for operator parameters.
+
+.. code-block:: python
+
+    import fiftyone.operators as foo
+    import fiftyone.operators.types as types
+
+    class MultiViewPipeline(foo.PipelineOperator):
+        @property
+        def config(self):
+            return foo.OperatorConfig(
+                name="multi_view_pipeline",
+                label="Multi-View Pipeline",
+                allow_delegated_execution=True,
+                allow_immediate_execution=False,
+            )
+
+        def resolve_pipeline(self, ctx):
+            pipeline = types.Pipeline()
+
+            # Stage 1 runs against the view the user has open
+            pipeline.stage(
+                operator_uri="@my-plugin/compute_stats",
+                name="Stats on current view",
+                params={"field": "predictions"},
+            )
+
+            # Stage 2 runs against a different saved view
+            pipeline.stage(
+                operator_uri="@my-plugin/compute_stats",
+                name="Stats on val split",
+                params={"field": "predictions"},
+                request_params_overrides={"view_name": "val_split"},
+            )
+
+            # Stage 3 runs against the full dataset (no view applied)
+            pipeline.stage(
+                operator_uri="@my-plugin/compute_stats",
+                name="Stats on full dataset",
+                params={"field": "predictions"},
+                request_params_overrides={"view": None, "view_name": None},
+            )
+
+            return pipeline
+
 .. _operator-secrets:
 
 Accessing secrets


### PR DESCRIPTION
## 🔗 Related Issues


## 📋 What changes are proposed in this pull request?

Update docs for request param overrides.

## 🧪 How is this patch tested? If it is not, please explain why.

n/a

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Added instructions to docs for how to use request param overrides in pipeline operators.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added comprehensive documentation explaining how pipeline stages can override inherited request parameters, including detailed specifications of which parameters are overridable and how stage-level overrides affect individual stages without impacting other pipeline stages.
* Included practical code examples demonstrating stage-level configuration techniques with multiple pipeline stages.
* Added clarification notes on proper parameter placement within stage configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->