### PR TITLE
Add request param overrides for pipeline operators

### DIFF
--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -2739,8 +2739,9 @@ Commonly overridden parameters include:
 
 .. note::
 
-    The ``dataset_name``, ``delegated``, and ``request_delegation`` parameters
-    cannot be overridden per stage.
+    The following parameters cannot be overridden per stage and will be ignored
+    if included: ``dataset_id``, ``dataset_name``, ``delegated``,
+    ``delegation_target``, ``request_delegation``, ``results``.
 
 .. code-block:: python
 

--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -2714,8 +2714,8 @@ Overriding request parameters per stage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, each stage in a pipeline inherits the same execution context as the
-top-level pipeline operator — including its ``view``, ``view_name``, ``filters``,
-and other request parameters.
+top-level pipeline operator — including its ``view``, ``view_name``, and other
+request parameters.
 
 Use ``request_params_overrides`` on a :class:`PipelineStage
 <fiftyone.operators.types.PipelineStage>` to give a specific stage a different
@@ -2723,19 +2723,24 @@ execution context. Any key you include in ``request_params_overrides`` will
 shadow the corresponding value from the top-level request for that stage only;
 all other stages are unaffected.
 
-Overridable parameters include:
+Commonly overridden parameters include:
 
-- ``view`` — a list of view stages to apply
+- ``view`` — a :class:`DatasetView <fiftyone.core.view.DatasetView>` to apply
+  (serialized automatically), or ``None`` to clear any active view
 - ``view_name`` — the name of a saved view to use
-- ``filters`` — a dictionary of filters to apply
-- any other valid :ref:`execution context <operator-execution-context>` request
-  parameter
+- ``selected`` — a list of selected sample IDs
+- ``group_slice`` — the group slice to use
 
 .. note::
 
     Do **not** include ``params`` inside ``request_params_overrides``. Use the
     ``params`` field of :class:`PipelineStage
     <fiftyone.operators.types.PipelineStage>` directly for operator parameters.
+
+.. note::
+
+    The ``dataset_name``, ``delegated``, and ``request_delegation`` parameters
+    cannot be overridden per stage.
 
 .. code-block:: python
 
@@ -2776,6 +2781,16 @@ Overridable parameters include:
                 name="Stats on full dataset",
                 params={"field": "predictions"},
                 request_params_overrides={"view": None, "view_name": None},
+            )
+
+            # Stage 4 runs against a programmatic slice of the current view,
+            # useful for manual batching
+            batch = ctx.view[:100]
+            pipeline.stage(
+                operator_uri="@my-plugin/compute_stats",
+                name="Stats on first 100 samples",
+                params={"field": "predictions"},
+                request_params_overrides={"view": batch},
             )
 
             return pipeline

--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -2708,6 +2708,78 @@ performing a cleanup action:
 
         # ... normal stage logic
 
+.. _pipeline-request-params-overrides:
+
+Overriding request parameters per stage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, each stage in a pipeline inherits the same execution context as the
+top-level pipeline operator — including its ``view``, ``view_name``, ``filters``,
+and other request parameters.
+
+Use ``request_params_overrides`` on a :class:`PipelineStage
+<fiftyone.operators.types.PipelineStage>` to give a specific stage a different
+execution context. Any key you include in ``request_params_overrides`` will
+shadow the corresponding value from the top-level request for that stage only;
+all other stages are unaffected.
+
+Overridable parameters include:
+
+- ``view`` — a list of view stages to apply
+- ``view_name`` — the name of a saved view to use
+- ``filters`` — a dictionary of filters to apply
+- any other valid :ref:`execution context <operator-execution-context>` request
+  parameter
+
+.. note::
+
+    Do **not** include ``params`` inside ``request_params_overrides``. Use the
+    ``params`` field of :class:`PipelineStage
+    <fiftyone.operators.types.PipelineStage>` directly for operator parameters.
+
+.. code-block:: python
+
+    import fiftyone.operators as foo
+    import fiftyone.operators.types as types
+
+    class MultiViewPipeline(foo.PipelineOperator):
+        @property
+        def config(self):
+            return foo.OperatorConfig(
+                name="multi_view_pipeline",
+                label="Multi-View Pipeline",
+                allow_delegated_execution=True,
+                allow_immediate_execution=False,
+            )
+
+        def resolve_pipeline(self, ctx):
+            pipeline = types.Pipeline()
+
+            # Stage 1 runs against the view the user has open
+            pipeline.stage(
+                operator_uri="@my-plugin/compute_stats",
+                name="Stats on current view",
+                params={"field": "predictions"},
+            )
+
+            # Stage 2 runs against a different saved view
+            pipeline.stage(
+                operator_uri="@my-plugin/compute_stats",
+                name="Stats on val split",
+                params={"field": "predictions"},
+                request_params_overrides={"view_name": "val_split"},
+            )
+
+            # Stage 3 runs against the full dataset (no view applied)
+            pipeline.stage(
+                operator_uri="@my-plugin/compute_stats",
+                name="Stats on full dataset",
+                params={"field": "predictions"},
+                request_params_overrides={"view": None, "view_name": None},
+            )
+
+            return pipeline
+
 .. _operator-secrets:
 
 Accessing secrets

--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -2617,6 +2617,78 @@ performing a cleanup action:
 
         # ... normal stage logic
 
+.. _pipeline-request-params-overrides:
+
+Overriding request parameters per stage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, each stage in a pipeline inherits the same execution context as the
+top-level pipeline operator — including its ``view``, ``view_name``, ``filters``,
+and other request parameters.
+
+Use ``request_params_overrides`` on a :class:`PipelineStage
+<fiftyone.operators.types.PipelineStage>` to give a specific stage a different
+execution context. Any key you include in ``request_params_overrides`` will
+shadow the corresponding value from the top-level request for that stage only;
+all other stages are unaffected.
+
+Overridable parameters include:
+
+- ``view`` — a list of view stages to apply
+- ``view_name`` — the name of a saved view to use
+- ``filters`` — a dictionary of filters to apply
+- any other valid :ref:`execution context <operator-execution-context>` request
+  parameter
+
+.. note::
+
+    Do **not** include ``params`` inside ``request_params_overrides``. Use the
+    ``params`` field of :class:`PipelineStage
+    <fiftyone.operators.types.PipelineStage>` directly for operator parameters.
+
+.. code-block:: python
+
+    import fiftyone.operators as foo
+    import fiftyone.operators.types as types
+
+    class MultiViewPipeline(foo.PipelineOperator):
+        @property
+        def config(self):
+            return foo.OperatorConfig(
+                name="multi_view_pipeline",
+                label="Multi-View Pipeline",
+                allow_delegated_execution=True,
+                allow_immediate_execution=False,
+            )
+
+        def resolve_pipeline(self, ctx):
+            pipeline = types.Pipeline()
+
+            # Stage 1 runs against the view the user has open
+            pipeline.stage(
+                operator_uri="@my-plugin/compute_stats",
+                name="Stats on current view",
+                params={"field": "predictions"},
+            )
+
+            # Stage 2 runs against a different saved view
+            pipeline.stage(
+                operator_uri="@my-plugin/compute_stats",
+                name="Stats on val split",
+                params={"field": "predictions"},
+                request_params_overrides={"view_name": "val_split"},
+            )
+
+            # Stage 3 runs against the full dataset (no view applied)
+            pipeline.stage(
+                operator_uri="@my-plugin/compute_stats",
+                name="Stats on full dataset",
+                params={"field": "predictions"},
+                request_params_overrides={"view": None, "view_name": None},
+            )
+
+            return pipeline
+
 .. _operator-secrets:
 
 Accessing secrets

--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -2623,27 +2623,27 @@ Overriding request parameters per stage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, each stage in a pipeline inherits the same execution context as the
-top-level pipeline operator — including its ``view``, ``view_name``, ``filters``,
+top-level pipeline operator — including its `view`, `view_name`, `filters`,
 and other request parameters.
 
-Use ``request_params_overrides`` on a :class:`PipelineStage
+Use `request_params_overrides` on a :class:`PipelineStage
 <fiftyone.operators.types.PipelineStage>` to give a specific stage a different
-execution context. Any key you include in ``request_params_overrides`` will
+execution context. Any key you include in `request_params_overrides` will
 shadow the corresponding value from the top-level request for that stage only;
 all other stages are unaffected.
 
 Overridable parameters include:
 
-- ``view`` — a list of view stages to apply
-- ``view_name`` — the name of a saved view to use
-- ``filters`` — a dictionary of filters to apply
-- any other valid :ref:`execution context <operator-execution-context>` request
-  parameter
+-   `view` — a list of view stages to apply
+-   `view_name` — the name of a saved view to use
+-   `filters` — a dictionary of filters to apply
+-   any other valid
+    :ref:`execution context <operator-execution-context>` request parameter
 
 .. note::
 
-    Do **not** include ``params`` inside ``request_params_overrides``. Use the
-    ``params`` field of :class:`PipelineStage
+    Do **not** include `params` inside `request_params_overrides`. Use the
+    `params` field of :class:`PipelineStage
     <fiftyone.operators.types.PipelineStage>` directly for operator parameters.
 
 .. code-block:: python

--- a/fiftyone/operators/_types/pipeline.py
+++ b/fiftyone/operators/_types/pipeline.py
@@ -7,9 +7,23 @@ FiftyOne pipeline operator types.
 """
 
 import dataclasses
+import logging
 from typing import Any, List, Mapping, Optional
 
 import fiftyone.core.view as fov
+
+logger = logging.getLogger(__name__)
+
+_DISALLOWED_REQUEST_PARAM_OVERRIDES = frozenset(
+    {
+        "dataset_id",
+        "dataset_name",
+        "delegated",
+        "delegation_target",
+        "request_delegation",
+        "results",
+    }
+)
 
 
 @dataclasses.dataclass
@@ -41,15 +55,19 @@ class PipelineStage:
     request_params_overrides: Optional[Mapping[str, Any]] = None
     """Optional dict of request parameter overrides for the execution context.
 
-    This allows stages to override any ExecutionContext request parameter such as:
-    - `view`: a :class:`fiftyone.core.view.DatasetView` or serialized list of
-        view stages to apply (DatasetView instances are serialized automatically)
-    - `view_name`: Name of a saved view to use
-    - `filters`: Dictionary of filters to apply
-    - Any other valid ExecutionContext request parameter
+    Commonly overridden parameters include:
+    - `view`: a :class:`fiftyone.core.view.DatasetView` (serialized
+        automatically) or ``None`` to clear any active view
+    - `view_name`: name of a saved view to use
+    - `selected`: list of selected sample IDs
+    - `group_slice`: group slice to use
 
-    Note: The `params` field should not be included in `request_params_overrides`.
-    Use the `params` field directly for operator parameters.
+    The keys ``dataset_id``, ``dataset_name``, ``delegated``,
+    ``delegation_target``, ``request_delegation``, and ``results`` are not
+    allowed and will be removed with a logged error.
+
+    Note: The `params` field should not be included here; use the `params`
+    field of :class:`PipelineStage` directly for operator parameters.
     """
 
     # ADD A CUSTOM __init__ METHOD TO ACCEPT AND DISCARD UNUSED KWARGS
@@ -90,6 +108,23 @@ class PipelineStage:
             self.num_distributed_tasks = None
 
         if self.request_params_overrides is not None:
+            disallowed = (
+                _DISALLOWED_REQUEST_PARAM_OVERRIDES
+                & self.request_params_overrides.keys()
+            )
+            if disallowed:
+                logger.error(
+                    "request_params_overrides contains disallowed keys %s "
+                    "for stage '%s'; they will be ignored",
+                    sorted(disallowed),
+                    self.operator_uri,
+                )
+                self.request_params_overrides = {
+                    k: v
+                    for k, v in self.request_params_overrides.items()
+                    if k not in disallowed
+                }
+
             view = self.request_params_overrides.get("view", None)
             if isinstance(view, fov.DatasetView):
                 self.request_params_overrides = {

--- a/fiftyone/operators/_types/pipeline.py
+++ b/fiftyone/operators/_types/pipeline.py
@@ -9,6 +9,8 @@ FiftyOne pipeline operator types.
 import dataclasses
 from typing import Any, List, Mapping, Optional
 
+import fiftyone.core.view as fov
+
 
 @dataclasses.dataclass
 class PipelineStage:
@@ -38,13 +40,14 @@ class PipelineStage:
 
     request_params_overrides: Optional[Mapping[str, Any]] = None
     """Optional dict of request parameter overrides for the execution context.
-    
+
     This allows stages to override any ExecutionContext request parameter such as:
-    - `view`: List of view stages to apply
+    - `view`: a :class:`fiftyone.core.view.DatasetView` or serialized list of
+        view stages to apply (DatasetView instances are serialized automatically)
     - `view_name`: Name of a saved view to use
     - `filters`: Dictionary of filters to apply
     - Any other valid ExecutionContext request parameter
-    
+
     Note: The `params` field should not be included in `request_params_overrides`.
     Use the `params` field directly for operator parameters.
     """
@@ -85,6 +88,14 @@ class PipelineStage:
             and self.num_distributed_tasks < 1
         ):
             self.num_distributed_tasks = None
+
+        if self.request_params_overrides is not None:
+            view = self.request_params_overrides.get("view", None)
+            if isinstance(view, fov.DatasetView):
+                self.request_params_overrides = {
+                    **self.request_params_overrides,
+                    "view": view._serialize(),
+                }
 
     def to_json(self):
         """Converts the object definition to JSON / python dict.
@@ -137,7 +148,8 @@ class Pipeline:
             rerunnable: whether the stage is rerunnable
             request_params_overrides: optional dict of request parameter
                 overrides for the execution context. Allows overriding fields
-                like `view`, `filters`, etc.
+                like `view` (accepts a DatasetView or serialized stages),
+                `filters`, etc.
             **kwargs: reserved for future use
 
         Returns:

--- a/tests/unittests/operators/delegated_tests.py
+++ b/tests/unittests/operators/delegated_tests.py
@@ -2478,9 +2478,7 @@ class TestPipelineRequestParamsOverrides(unittest.TestCase):
                     name="export_stage",
                     operator_uri="@test/export_op",
                     params={"format": "json"},
-                    request_params_overrides={
-                        "dataset_name": "export_dataset"
-                    },
+                    request_params_overrides={"view_name": "export_view"},
                 ),
             ]
         )
@@ -2508,5 +2506,5 @@ class TestPipelineRequestParamsOverrides(unittest.TestCase):
         # Verify second stage overrides
         self.assertEqual(
             doc.pipeline.stages[1].request_params_overrides,
-            {"dataset_name": "export_dataset"},
+            {"view_name": "export_view"},
         )

--- a/tests/unittests/operators/types_tests.py
+++ b/tests/unittests/operators/types_tests.py
@@ -7,6 +7,7 @@ FiftyOne operator type tests.
 """
 
 import unittest
+from unittest.mock import MagicMock, patch
 
 import bson
 
@@ -108,6 +109,59 @@ class TestPipelineType(unittest.TestCase):
         pipe = types.Pipeline()
         pipe.stage("my/uri", num_distributed_tasks=-5)
         self.assertIsNone(pipe.stages[0].num_distributed_tasks)
+
+    def test_disallowed_keys_stripped(self):
+        with self.assertLogs(
+            "fiftyone.operators._types.pipeline", level="ERROR"
+        ) as log:
+            stage = types.PipelineStage(
+                operator_uri="my/uri",
+                request_params_overrides={
+                    "dataset_id": "some_id",
+                    "dataset_name": "should_be_stripped",
+                    "delegated": True,
+                    "delegation_target": "some_target",
+                    "request_delegation": True,
+                    "results": {},
+                    "view_name": "should_be_kept",
+                },
+            )
+
+        overrides = stage.request_params_overrides
+        self.assertNotIn("dataset_id", overrides)
+        self.assertNotIn("dataset_name", overrides)
+        self.assertNotIn("delegated", overrides)
+        self.assertNotIn("delegation_target", overrides)
+        self.assertNotIn("request_delegation", overrides)
+        self.assertNotIn("results", overrides)
+        self.assertEqual(overrides.get("view_name"), "should_be_kept")
+        self.assertTrue(any("disallowed" in msg for msg in log.output))
+
+    def test_view_datasetview_auto_serialized(self):
+        serialized_stages = [{"_cls": "Limit", "kwargs": [["limit", 10]]}]
+        mock_view = MagicMock()
+        mock_view._serialize.return_value = serialized_stages
+
+        MockDatasetView = type("DatasetView", (), {})
+        mock_view.__class__ = MockDatasetView
+
+        with patch("fiftyone.operators._types.pipeline.fov") as mock_fov:
+            mock_fov.DatasetView = MockDatasetView
+            stage = types.PipelineStage(
+                operator_uri="my/uri",
+                request_params_overrides={
+                    "view": mock_view,
+                    "view_name": "also_kept",
+                },
+            )
+
+        mock_view._serialize.assert_called_once()
+        self.assertEqual(
+            stage.request_params_overrides["view"], serialized_stages
+        )
+        self.assertEqual(
+            stage.request_params_overrides["view_name"], "also_kept"
+        )
 
     def test_none(self):
         self.assertIsNone(types.Pipeline.from_json(None))


### PR DESCRIPTION
## 🔗 Related Issues


## 📋 What changes are proposed in this pull request?

Update docs for request param overrides.

## 🧪 How is this patch tested? If it is not, please explain why.

n/a

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Added instructions to docs for how to use request param overrides in pipeline operators.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on overriding pipeline stage-level request parameters using `request_params_overrides`.
  * Documented parameter inheritance and shadowing behavior for pipeline stages.
  * Included code example demonstrating multi-view pipeline configuration with different execution contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->