### PR TITLE
Add sam2 predict_interactive and parity tests

### DIFF
--- a/fiftyone/utils/sam2.py
+++ b/fiftyone/utils/sam2.py
@@ -51,12 +51,12 @@ class _SAM2Predictor(fosam._SAMPredictor):
 
     def __init__(self, model):
         self.processor = smip.SAM2ImagePredictor(model)
-        self._image_id = None
         self.sam_transforms = (
             self.processor._transforms
             if hasattr(self.processor, "_transforms")
             else smip.SAM2Transforms(model.image_size, mask_threshold=0)
         )
+        self.image_id = None
 
     def image_transform(self, img):
         """Transforms image for SAM2 model input.
@@ -109,6 +109,44 @@ class _SAM2Predictor(fosam._SAMPredictor):
         unnorm_points = self.sam_transforms.transform_coords(norm_points)
         return torch.tensor(unnorm_points, dtype=torch.float64), torch.tensor(
             labels, dtype=torch.int
+        )
+
+    def valid_image(self, curr_id):
+        if self.processor._is_image_set:
+            return curr_id == self.image_id
+        return False
+
+    @property
+    def original_size(self):
+        return self.processor._orig_hw[0]
+
+    def predict(
+        self,
+        boxes=None,
+        point_coords=None,
+        point_labels=None,
+        multimask_output=False,
+    ):
+        """Wrapper for ``sam2.sam2_image_predictor.Sam2ImagePredictor._predict``
+
+        Args:
+          point_coords (None): a BxNx2 array of point prompts in (X,Y) pixels
+          point_labels (None): a BxN array of labels for the
+            point prompts. 1 indicates a foreground point and 0 indicates a
+            background point.
+          boxes (None): a Bx4 array of box prompts in XYXY format.
+          multimask_output (False): if true, the model will return three masks.
+
+        Returns:
+          the output masks in BxCxHxW format where C is the number of masks
+          model's prediction in BxC
+          low resolution logits in BxCxHxW where H=W=256
+        """
+        return self.processor._predict(
+            point_coords=point_coords,
+            point_labels=point_labels,
+            boxes=boxes,
+            multimask_output=multimask_output,
         )
 
 
@@ -220,18 +258,12 @@ class SegmentAnything2ImageModel(fosam.SegmentAnythingModel):
         point_labels = imgs.get("point_labels")
         boxes = imgs.get("boxes")
         mask_inputs = imgs.get("mask_inputs")  # Not used currently
-        multimask_output = (
-            True if (boxes is None and point_coords is not None) else False
-        )
+        multimask_output = True if (boxes is None and point_coords is not None) else False
         outputs = []
         for img_idx in range(len(images)):
             out_masks, iou_pred, _ = self._sam_predictor.processor._predict(
-                point_coords=point_coords[img_idx]
-                if point_coords is not None
-                else None,
-                point_labels=point_labels[img_idx]
-                if point_labels is not None
-                else None,
+                point_coords=point_coords[img_idx] if point_coords is not None else None,
+                point_labels=point_labels[img_idx] if point_labels is not None else None,
                 boxes=boxes[img_idx] if boxes is not None else None,
                 mask_input=mask_inputs[img_idx] if mask_inputs else None,
                 multimask_output=multimask_output,
@@ -246,9 +278,7 @@ class SegmentAnything2ImageModel(fosam.SegmentAnythingModel):
 
 
 # TODO: Refactor SAM2 Video Model to use GetItem
-class SegmentAnything2VideoModelConfig(
-    fout.TorchImageModelConfig, fozm.HasZooModel
-):
+class SegmentAnything2VideoModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
     """Configuration for running a :class:`SegmentAnything2VideoModel`.
 
     See :class:`fiftyone.utils.torch.TorchImageModelConfig` for additional
@@ -416,10 +446,7 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
         kp_idx_obj_id_map = {}
         current_obj_idx = 0
         for frame_idx, frame_detections in enumerate(self._curr_prompts):
-            if (
-                len(frame_detections) == 0
-                or len(frame_detections.detections) == 0
-            ):
+            if len(frame_detections) == 0 or len(frame_detections.detections) == 0:
                 continue
             for detection in frame_detections.detections:
                 if detection.index is not None:
@@ -455,9 +482,7 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
         ) in self.model.propagate_in_video(inference_state):
             detections = []
             for i, out_obj_id in enumerate(out_obj_ids):
-                mask = np.squeeze(
-                    (out_mask_logits[i] > 0.0).cpu().numpy(), axis=0
-                )
+                mask = np.squeeze((out_mask_logits[i] > 0.0).cpu().numpy(), axis=0)
 
                 box = fosam._mask_to_box(mask)
                 if box is None:
@@ -495,10 +520,7 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
         kp_idx_obj_id_map = {}
         current_obj_idx = 0
         for frame_idx, frame_keypoints in enumerate(self._curr_prompts):
-            if (
-                len(frame_keypoints) == 0
-                or len(frame_keypoints.keypoints) == 0
-            ):
+            if len(frame_keypoints) == 0 or len(frame_keypoints.keypoints) == 0:
                 continue
             for keypoint in frame_keypoints.keypoints:
                 if keypoint.index is not None:
@@ -535,9 +557,7 @@ class SegmentAnything2VideoModel(fom.SamplesMixin, fom.Model):
         ) in self.model.propagate_in_video(inference_state):
             detections = []
             for i, out_obj_id in enumerate(out_obj_ids):
-                mask = np.squeeze(
-                    (out_mask_logits[i] > 0.0).cpu().numpy(), axis=0
-                )
+                mask = np.squeeze((out_mask_logits[i] > 0.0).cpu().numpy(), axis=0)
                 box = fosam._mask_to_box(mask)
                 if box is None:
                     continue
@@ -582,16 +602,12 @@ def load_fiftyone_video_frames(
 
     num_frames = len(sample.frames)
     try:
-        images = torch.zeros(
-            num_frames, 3, image_size, image_size, dtype=torch.float32
-        )
+        images = torch.zeros(num_frames, 3, image_size, image_size, dtype=torch.float32)
     except Exception as e:
         raise (e)
     for frame_number in range(num_frames):
         current_frame = video_reader.read()
-        resized_frame = (
-            cv2.resize(current_frame, (image_size, image_size)) / 255.0
-        )
+        resized_frame = cv2.resize(current_frame, (image_size, image_size)) / 255.0
         img = torch.from_numpy(resized_frame).permute(2, 0, 1)
         images[frame_number] = img
 

--- a/tests/intensive/sam_parity_tests.py
+++ b/tests/intensive/sam_parity_tests.py
@@ -1029,6 +1029,7 @@ class TestSAM2InteractiveParity(unittest.TestCase):
                 boxes,
                 boxes_xyxy,
                 box_classes,
+                _,
             ) = fo.utils.sam.preprocess_detections_to_sam(
                 gt, (h, w), self.fo_model._sam_predictor.box_transform
             )
@@ -1192,6 +1193,7 @@ class TestSAM2InteractiveParity(unittest.TestCase):
                 boxes,
                 boxes_xyxy,
                 box_classes,
+                _,
             ) = fo.utils.sam.preprocess_detections_to_sam(
                 gt, (h, w), self.fo_model._sam_predictor.box_transform
             )

--- a/tests/intensive/sam_parity_tests.py
+++ b/tests/intensive/sam_parity_tests.py
@@ -962,5 +962,308 @@ class TestSAMInteractiveParity(unittest.TestCase):
         )
 
 
+class TestSAM2InteractiveParity(unittest.TestCase):
+    """Compare predict_interactive outputs against direct
+    segment_anything inference using evaluate_detections."""
+
+    MODEL_NAME = "segment-anything-2-hiera-tiny-image-torch"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.fo_model = foz.load_zoo_model(cls.MODEL_NAME)
+
+        from sam2.build_sam import build_sam2
+        from sam2.sam2_image_predictor import SAM2ImagePredictor
+        from sam2.automatic_mask_generator import SAM2AutomaticMaskGenerator
+
+        checkpoint_path = cls.fo_model.config.model_path
+        model_cfg = cls.fo_model.config.entrypoint_args["config_file"]
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+
+        sam2 = build_sam2(model_cfg, checkpoint_path, device=device)
+
+        cls.predictor = SAM2ImagePredictor(sam2)
+        cls.auto_gen = SAM2AutomaticMaskGenerator(sam2)
+        cls.device = device
+        cls.dataset = _create_test_dataset(num_samples=2, seed=7)
+        cls.output_processor = fo.utils.sam.SAMSegmenterOutputProcessor()
+
+    def test_interactive_auto_parity(self):
+        interactive_field = "sam2_inter_auto"
+        direct_field = "sam2_direct_auto"
+
+        for sample in self.dataset.iter_samples(progress=False, autosave=True):
+            # predict_interactive auto mode
+            sample[interactive_field] = self.fo_model.predict_interactive(
+                sample=sample
+            )
+
+            # Direct SAM auto
+            image = _get_image_as_numpy(sample.filepath)
+            masks = self.auto_gen.generate(image)
+            sample[direct_field] = _auto_masks_to_detections(masks)
+
+        self.dataset.set_field(
+            f"{interactive_field}.detections.label",
+            F("label").if_else(F("label"), PLACEHOLDER_LABEL),
+        ).save()
+
+        _assert_parity(
+            self,
+            self.dataset,
+            interactive_field,
+            direct_field,
+            eval_key="eval_sam2_inter_auto",
+        )
+
+    def test_interactive_box_prompt_parity(self):
+        interactive_field = "sam2_inter_box"
+        direct_field = "sam2_direct_box"
+
+        for sample in self.dataset.iter_samples(progress=False, autosave=True):
+            gt = sample.get_field("ground_truth")
+            image = _get_image_as_numpy(sample.filepath)
+            h, w = image.shape[:2]
+
+            (
+                boxes,
+                boxes_xyxy,
+                box_classes,
+            ) = fo.utils.sam.preprocess_detections_to_sam(
+                gt, (h, w), self.fo_model._sam_predictor.box_transform
+            )
+            sample[interactive_field] = self.fo_model.predict_interactive(
+                sample=sample,
+                boxes=boxes,
+                boxes_xyxy=boxes_xyxy,
+                prompt_classes=box_classes,
+            )
+
+            self.predictor.set_image(image)
+            masks = []
+            scores = []
+            box_prompts = []
+            labels = []
+            for gt_det in gt.detections:
+                box_abs = _box_to_sam_abs(gt_det.bounding_box, w, h)
+                _masks, _scores, _ = self.predictor.predict(
+                    box=box_abs,
+                    multimask_output=False,
+                )
+                masks.append(_masks[None, ...])
+                scores.append(_scores[None, ...])
+                box_prompts.append(box_abs)
+                labels.append(gt_det.label)
+
+            outputs = {
+                "masks": torch.as_tensor(np.concatenate(masks, axis=0)),
+                "iou_predictions": torch.as_tensor(
+                    np.concatenate(scores, axis=0)
+                ),
+            }
+            sample[direct_field] = self.output_processor(
+                output=[outputs],
+                frame_size=[(h, w)],
+                box_prompts=[box_prompts],
+                labels=[labels],
+            )[0]
+
+        _assert_parity(
+            self,
+            self.dataset,
+            interactive_field,
+            direct_field,
+            eval_key="eval_sam2_inter_box",
+        )
+
+    def test_interactive_keypoint_prompt_parity(self):
+        kp_field = "sam2_inter_test_kps"
+        interactive_field = "sam2_inter_kp"
+        direct_field = "sam2_direct_kp"
+
+        kp_model = foz.load_zoo_model("vitpose-base-simple-torch")
+        self.dataset.apply_model(
+            kp_model, prompt_field="ground_truth", label_field=kp_field
+        )
+
+        for sample in self.dataset.iter_samples(progress=False, autosave=True):
+            kps_label = sample.get_field(kp_field)
+            if kps_label is None or not kps_label.keypoints:
+                sample[interactive_field] = Detections()
+                sample[direct_field] = Detections()
+                continue
+
+            image = _get_image_as_numpy(sample.filepath)
+            h, w = image.shape[:2]
+
+            (
+                points,
+                points_labels,
+                points_classes,
+            ) = fo.utils.sam.preprocess_keypoints_to_sam(
+                kps_label,
+                (h, w),
+                self.fo_model._sam_predictor.point_transform,
+            )
+
+            sample[interactive_field] = self.fo_model.predict_interactive(
+                sample=sample,
+                points=points,
+                point_labels=points_labels,
+                prompt_classes=points_classes,
+            )
+
+            self.predictor.set_image(image)
+            masks = []
+            scores = []
+            labels = []
+            for kp in kps_label.keypoints:
+                pts = np.array(kp.points)
+                valid = (pts[:, 0] > 0) & (pts[:, 1] > 0)
+                if not valid.any():
+                    continue
+
+                pts_abs = pts[valid] * np.array([w, h])
+                pts_labels = np.ones(len(pts_abs), dtype=np.int32)
+
+                _masks, _scores, _ = self.predictor.predict(
+                    point_coords=pts_abs,
+                    point_labels=pts_labels,
+                    multimask_output=True,
+                )
+                masks.append(_masks[None, ...])
+                scores.append(_scores[None, ...])
+                labels.append(PLACEHOLDER_LABEL)
+
+            outputs = {
+                "masks": torch.as_tensor(np.concatenate(masks, axis=0)),
+                "iou_predictions": torch.as_tensor(
+                    np.concatenate(scores, axis=0)
+                ),
+            }
+            sample[direct_field] = self.output_processor(
+                output=[outputs],
+                frame_size=[(h, w)],
+                labels=[labels],
+                mask_index=self.fo_model.config.points_mask_index,
+            )[0]
+
+        self.dataset.set_field(
+            f"{interactive_field}.detections.label",
+            F("label").if_else(F("label"), PLACEHOLDER_LABEL),
+        ).save()
+
+        _assert_parity(
+            self,
+            self.dataset,
+            interactive_field,
+            direct_field,
+            eval_key="eval_sam2_inter_kp",
+        )
+
+    def test_interactive_box_point_combo_parity(self):
+        interactive_field = "sam2_inter_combo"
+        direct_field = "sam2_direct_combo"
+
+        # Build center-point keypoints from ground_truth boxes
+        for sample in self.dataset.iter_samples(progress=False, autosave=True):
+            gt = sample.get_field("ground_truth")
+            if gt is None:
+                continue
+            kps = []
+            for det in gt.detections:
+                bx, by, bw, bh = det.bounding_box
+                cx, cy = bx + bw / 2, by + bh / 2
+                kps.append(Keypoint(points=[(cx, cy)], label=det.label))
+            sample["combo_points"] = Keypoints(keypoints=kps)
+
+        for sample in self.dataset.iter_samples(progress=False, autosave=True):
+            gt = sample.get_field("ground_truth")
+            combo_kps = sample.get_field("combo_points")
+            if gt is None or not gt.detections:
+                sample[interactive_field] = Detections()
+                sample[direct_field] = Detections()
+                continue
+
+            image = _get_image_as_numpy(sample.filepath)
+            h, w = image.shape[:2]
+
+            (
+                boxes,
+                boxes_xyxy,
+                box_classes,
+            ) = fo.utils.sam.preprocess_detections_to_sam(
+                gt, (h, w), self.fo_model._sam_predictor.box_transform
+            )
+
+            (
+                points,
+                points_labels,
+                _,
+            ) = fo.utils.sam.preprocess_keypoints_to_sam(
+                combo_kps,
+                (h, w),
+                self.fo_model._sam_predictor.point_transform,
+            )
+
+            sample[interactive_field] = self.fo_model.predict_interactive(
+                sample=sample,
+                boxes=boxes,
+                points=points,
+                point_labels=points_labels,
+                prompt_classes=box_classes,
+                boxes_xyxy=boxes_xyxy,
+            )
+
+            self.predictor.set_image(image)
+            masks = []
+            scores = []
+            box_prompts = []
+            labels = []
+            for i, gt_det in enumerate(gt.detections):
+                box_abs = _box_to_sam_abs(gt_det.bounding_box, w, h)
+
+                point_coords = None
+                point_labels_arr = None
+                if combo_kps is not None and i < len(combo_kps.keypoints):
+                    pts = combo_kps.keypoints[i].points
+                    if pts:
+                        px, py = pts[0]
+                        point_coords = np.array([[px * w, py * h]])
+                        point_labels_arr = np.array([1])
+
+                _masks, _scores, _ = self.predictor.predict(
+                    point_coords=point_coords,
+                    point_labels=point_labels_arr,
+                    box=box_abs,
+                    multimask_output=False,
+                )
+                masks.append(_masks[None, ...])
+                scores.append(_scores[None, ...])
+                box_prompts.append(box_abs)
+                labels.append(gt_det.label)
+
+            outputs = {
+                "masks": torch.as_tensor(np.concatenate(masks, axis=0)),
+                "iou_predictions": torch.as_tensor(
+                    np.concatenate(scores, axis=0)
+                ),
+            }
+            sample[direct_field] = self.output_processor(
+                output=[outputs],
+                frame_size=[(h, w)],
+                box_prompts=[box_prompts],
+                labels=[labels],
+            )[0]
+
+        _assert_parity(
+            self,
+            self.dataset,
+            interactive_field,
+            direct_field,
+            eval_key="eval_sam2_inter_combo",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 🔗 Related Issues
No related issues to link

## 📋 What changes are proposed in this pull request?

This PR  adds `predict_interactive` in SAM2 and related parity tests.

## 🧪 How is this patch tested? If it is not, please explain why.

Added parity tests which compare outputs from `predict_interactive` against direct SAM2 inference.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Adds `SegmentAnything2ImageModel.predict_interactive`  which caches image embeddings.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive parity test suite for SAM2 interactive functionality covering automatic segmentation, box prompting, keypoint prompting, and combined prompting scenarios.

* **Refactor**
  * Improved SAM2 image predictor wrapper implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->