### PR TITLE
[FOEPD-3382] BBox coords from canvas -> media coords

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Position.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Position.tsx
@@ -9,6 +9,10 @@ import { useAtom, useAtomValue } from "jotai";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { SchemaIOComponent } from "../../../../../plugins/SchemaIO";
 import { SchemaType } from "../../../../../plugins/SchemaIO/utils/types";
+import {
+  imagePixelsToCanvasPixels,
+  relativeToImagePixels,
+} from "./coordinateConversion";
 import { currentData, currentOverlay } from "./state";
 
 const createInput = (name: string, readOnly?: boolean) => {
@@ -60,18 +64,38 @@ export default function Position({ readOnly = false }: PositionProps) {
     scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
   );
 
+  const toImagePixels = useCallback(
+    (relative: Parameters<typeof relativeToImagePixels>[0]) => {
+      const dims = scene
+        ?.getCanonicalMedia()
+        ?.getOriginalDimensions() ?? { width: 1, height: 1 };
+      return relativeToImagePixels(relative, dims);
+    },
+    [scene]
+  );
+
+  const toCanvasPixels = useCallback(
+    (imageRect: Parameters<typeof imagePixelsToCanvasPixels>[0]) => {
+      const canonicalMedia = scene?.getCanonicalMedia();
+      const dims = canonicalMedia?.getOriginalDimensions() ?? { width: 1, height: 1 };
+      const rendered = canonicalMedia?.getRenderedBounds() ?? { x: 0, y: 0, width: 1, height: 1 };
+      return imagePixelsToCanvasPixels(imageRect, dims, rendered);
+    },
+    [scene]
+  );
+
   useEffect(() => {
     if (!(overlay instanceof BoundingBoxOverlay) || !overlay.hasValidBounds()) {
       return;
     }
 
-    const rect = overlay.bounds;
+    const rect = toImagePixels(overlay.relativeBounds);
 
     setState({
       position: { x: rect.x, y: rect.y },
       dimensions: { width: rect.width, height: rect.height },
     });
-  }, [overlay]);
+  }, [overlay, toImagePixels]);
 
   const handleBoundsChange = useCallback(
     (payload: { id: string }) => {
@@ -83,7 +107,7 @@ export default function Position({ readOnly = false }: PositionProps) {
         return;
       }
 
-      const rect = overlay.bounds;
+      const rect = toImagePixels(overlay.relativeBounds);
 
       setState({
         position: { x: rect.x, y: rect.y },
@@ -95,7 +119,7 @@ export default function Position({ readOnly = false }: PositionProps) {
         bounding_box: [relative.x, relative.y, relative.width, relative.height],
       });
     },
-    [data?._id, overlay, setData]
+    [data?._id, overlay, toImagePixels, setData]
   );
 
   useEventHandler("lighter:overlay-bounds-changed", handleBoundsChange);
@@ -147,12 +171,15 @@ export default function Position({ readOnly = false }: PositionProps) {
           }
 
           const oldBounds = overlay.bounds;
+          const currentImagePixels = toImagePixels(overlay.relativeBounds);
+          const newImagePixels = {
+            ...currentImagePixels,
+            ...data.dimensions,
+            ...data.position,
+          };
+          const newCanvasBounds = toCanvasPixels(newImagePixels);
           scene?.executeCommand(
-            new TransformOverlayCommand(overlay, overlay.id, oldBounds, {
-              ...oldBounds,
-              ...data.dimensions,
-              ...data.position,
-            })
+            new TransformOverlayCommand(overlay, overlay.id, oldBounds, newCanvasBounds)
           );
         }}
       />

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/coordinateConversion.test.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/coordinateConversion.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  imagePixelsToCanvasPixels,
+  relativeToImagePixels,
+} from "./coordinateConversion";
+
+describe("relativeToImagePixels", () => {
+  it("converts normalized coords to image pixel coords", () => {
+    const result = relativeToImagePixels(
+      { x: 0.1, y: 0.2, width: 0.5, height: 0.4 },
+      { width: 1920, height: 1080 }
+    );
+
+    expect(result.x).toBeCloseTo(192);
+    expect(result.y).toBeCloseTo(216);
+    expect(result.width).toBeCloseTo(960);
+    expect(result.height).toBeCloseTo(432);
+  });
+
+  it("maps (0, 0) origin to image top-left", () => {
+    const result = relativeToImagePixels(
+      { x: 0, y: 0, width: 1, height: 1 },
+      { width: 800, height: 600 }
+    );
+
+    expect(result.x).toBe(0);
+    expect(result.y).toBe(0);
+    expect(result.width).toBe(800);
+    expect(result.height).toBe(600);
+  });
+
+  it("supports negative x/y for boxes that extend beyond the image edge", () => {
+    const result = relativeToImagePixels(
+      { x: -0.1, y: 0, width: 0.5, height: 0.5 },
+      { width: 1000, height: 1000 }
+    );
+
+    expect(result.x).toBeCloseTo(-100);
+    expect(result.y).toBe(0);
+  });
+
+  it("supports width/height > 1 for boxes that extend beyond the image edge", () => {
+    const result = relativeToImagePixels(
+      { x: 0, y: 0, width: 1.2, height: 1.1 },
+      { width: 500, height: 400 }
+    );
+
+    expect(result.width).toBeCloseTo(600);
+    expect(result.height).toBeCloseTo(440);
+  });
+
+  it("uses image width for x/width and image height for y/height independently", () => {
+    // Non-square image: 2000 wide, 500 tall
+    const result = relativeToImagePixels(
+      { x: 0.5, y: 0.5, width: 0.5, height: 0.5 },
+      { width: 2000, height: 500 }
+    );
+
+    expect(result.x).toBeCloseTo(1000);
+    expect(result.y).toBeCloseTo(250);
+    expect(result.width).toBeCloseTo(1000);
+    expect(result.height).toBeCloseTo(250);
+  });
+});
+
+describe("imagePixelsToCanvasPixels", () => {
+  it("converts image pixel coords to canvas pixel coords when canvas matches image size", () => {
+    // When rendered size == original size, image pixels === canvas pixels
+    const dims = { width: 800, height: 600 };
+    const rendered = { x: 0, y: 0, width: 800, height: 600 };
+
+    const result = imagePixelsToCanvasPixels(
+      { x: 100, y: 50, width: 200, height: 150 },
+      dims,
+      rendered
+    );
+
+    expect(result.x).toBeCloseTo(100);
+    expect(result.y).toBeCloseTo(50);
+    expect(result.width).toBeCloseTo(200);
+    expect(result.height).toBeCloseTo(150);
+  });
+
+  it("scales down when image is rendered smaller than its original size", () => {
+    // 1920x1080 image rendered at 960x540 (half size, no letterboxing)
+    const dims = { width: 1920, height: 1080 };
+    const rendered = { x: 0, y: 0, width: 960, height: 540 };
+
+    const result = imagePixelsToCanvasPixels(
+      { x: 480, y: 270, width: 960, height: 540 },
+      dims,
+      rendered
+    );
+
+    expect(result.x).toBeCloseTo(240);
+    expect(result.y).toBeCloseTo(135);
+    expect(result.width).toBeCloseTo(480);
+    expect(result.height).toBeCloseTo(270);
+  });
+
+  it("accounts for canvas offset when image is letterboxed", () => {
+    // 800x400 image (2:1 aspect) rendered letterboxed inside an 800x600 canvas.
+    // Rendered area: x=0, y=100, width=800, height=400
+    const dims = { width: 800, height: 400 };
+    const rendered = { x: 0, y: 100, width: 800, height: 400 };
+
+    const result = imagePixelsToCanvasPixels(
+      { x: 0, y: 0, width: 800, height: 400 },
+      dims,
+      rendered
+    );
+
+    expect(result.x).toBeCloseTo(0);
+    expect(result.y).toBeCloseTo(100); // offset from letterbox
+    expect(result.width).toBeCloseTo(800);
+    expect(result.height).toBeCloseTo(400);
+  });
+
+  it("accounts for canvas offset when image is pillarboxed", () => {
+    // 400x600 image (2:3 aspect) rendered pillarboxed inside an 800x600 canvas.
+    // Rendered area: x=200, y=0, width=400, height=600
+    const dims = { width: 400, height: 600 };
+    const rendered = { x: 200, y: 0, width: 400, height: 600 };
+
+    const result = imagePixelsToCanvasPixels(
+      { x: 0, y: 0, width: 400, height: 600 },
+      dims,
+      rendered
+    );
+
+    expect(result.x).toBeCloseTo(200); // offset from pillarbox
+    expect(result.y).toBeCloseTo(0);
+    expect(result.width).toBeCloseTo(400);
+    expect(result.height).toBeCloseTo(600);
+  });
+
+  it("is the inverse of relativeToImagePixels", () => {
+    const dims = { width: 1920, height: 1080 };
+    const rendered = { x: 50, y: 30, width: 960, height: 540 };
+    const relative = { x: 0.1, y: 0.2, width: 0.4, height: 0.3 };
+
+    // relative → image pixels → canvas pixels should equal relativeToAbsolute
+    const imagePixels = relativeToImagePixels(relative, dims);
+    const canvasPixels = imagePixelsToCanvasPixels(imagePixels, dims, rendered);
+
+    // Manually compute expected canvas pixels from relative coords
+    const expectedX = rendered.x + relative.x * rendered.width;
+    const expectedY = rendered.y + relative.y * rendered.height;
+    const expectedW = relative.width * rendered.width;
+    const expectedH = relative.height * rendered.height;
+
+    expect(canvasPixels.x).toBeCloseTo(expectedX);
+    expect(canvasPixels.y).toBeCloseTo(expectedY);
+    expect(canvasPixels.width).toBeCloseTo(expectedW);
+    expect(canvasPixels.height).toBeCloseTo(expectedH);
+  });
+
+  it("handles boxes that extend beyond the image (negative x/y)", () => {
+    const dims = { width: 1000, height: 1000 };
+    const rendered = { x: 0, y: 0, width: 500, height: 500 };
+
+    const result = imagePixelsToCanvasPixels(
+      { x: -100, y: 0, width: 600, height: 500 },
+      dims,
+      rendered
+    );
+
+    expect(result.x).toBeCloseTo(-50);
+    expect(result.width).toBeCloseTo(300);
+  });
+});
+
+describe("round-trip: relativeToImagePixels → imagePixelsToCanvasPixels", () => {
+  it("preserves the relative position after a full round-trip via image pixels", () => {
+    const dims = { width: 3840, height: 2160 }; // 4K image
+    const rendered = { x: 10, y: 20, width: 1280, height: 720 }; // HD canvas with offset
+    const original = { x: 0.25, y: 0.1, width: 0.5, height: 0.8 };
+
+    const imagePixels = relativeToImagePixels(original, dims);
+    const canvasPixels = imagePixelsToCanvasPixels(imagePixels, dims, rendered);
+
+    // Back to relative via the canvas coordinate system
+    const backToRelativeX = (canvasPixels.x - rendered.x) / rendered.width;
+    const backToRelativeY = (canvasPixels.y - rendered.y) / rendered.height;
+    const backToRelativeW = canvasPixels.width / rendered.width;
+    const backToRelativeH = canvasPixels.height / rendered.height;
+
+    expect(backToRelativeX).toBeCloseTo(original.x);
+    expect(backToRelativeY).toBeCloseTo(original.y);
+    expect(backToRelativeW).toBeCloseTo(original.width);
+    expect(backToRelativeH).toBeCloseTo(original.height);
+  });
+});

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/coordinateConversion.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/coordinateConversion.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import type { Dimensions, Rect } from "@fiftyone/lighter";
+
+/**
+ * Converts normalized [0,1] bounding box coordinates to pixel coordinates
+ * relative to the original image dimensions.
+ *
+ * This is the correct coordinate space for display in the sidebar — values
+ * match what a user would see if they inspected the actual image file.
+ */
+export function relativeToImagePixels(
+  relative: Rect,
+  originalDimensions: Dimensions
+): Rect {
+  return {
+    x: relative.x * originalDimensions.width,
+    y: relative.y * originalDimensions.height,
+    width: relative.width * originalDimensions.width,
+    height: relative.height * originalDimensions.height,
+  };
+}
+
+/**
+ * Converts image-pixel coordinates back to canvas pixel coordinates.
+ *
+ * The canvas renders the image at `renderedBounds` size (letterboxed/pillarboxed
+ * inside the container). To position an overlay on the canvas we need canvas
+ * pixels, not image pixels.
+ */
+export function imagePixelsToCanvasPixels(
+  imageRect: Rect,
+  originalDimensions: Dimensions,
+  renderedBounds: Rect
+): Rect {
+  return {
+    x: renderedBounds.x + (imageRect.x / originalDimensions.width) * renderedBounds.width,
+    y: renderedBounds.y + (imageRect.y / originalDimensions.height) * renderedBounds.height,
+    width: (imageRect.width / originalDimensions.width) * renderedBounds.width,
+    height: (imageRect.height / originalDimensions.height) * renderedBounds.height,
+  };
+}


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

The bounding box position editor in the annotation sidebar was displaying
and applying coordinates in canvas pixel space rather than image pixel
space. This meant the values shown to the user were relative to where the
image happened to be rendered on screen (affected by letterboxing,
pillarboxing, and canvas size), rather than the actual pixel dimensions of
the source image.

This PR introduces two coordinate conversion utilities and wires them into
the position editor:

- `relativeToImagePixels` — converts normalized [0,1] bounding box
  coordinates to pixel coordinates relative to the original image
  dimensions. This is the correct space for display in the sidebar.
- `imagePixelsToCanvasPixels` — converts image pixel coordinates back to
  canvas pixel coordinates (accounting for rendered bounds and letterbox/
  pillarbox offsets) when writing a transform command back to the scene.

The position editor now reads from `overlay.relativeBounds` converted to
image pixels, and converts back to canvas pixels when applying a user
edit.

Notice how the x/y coords are VERY close to 0 and the box starts very close to the media's origin, not the entire canvas
<img width="3554" height="1385" alt="Screenshot from 2026-04-07 10-13-37" src="https://github.com/user-attachments/assets/2095e09b-5a08-4465-b662-e26bf56829cc" />


## 🧪 How is this patch tested? If it is not, please explain why.

A unit test file covers both conversion functions across a range of
scenarios including: standard conversion, identity cases, letterboxed and
pillarboxed images, boxes that extend beyond image edges, and a full
round-trip from relative → image pixels → canvas pixels → back to
relative. Manually verified in the app by editing bounding box coordinates
in the annotation sidebar and confirming the values match the source image
dimensions.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixes a bug in the annotation editor where bounding box coordinates
displayed in the sidebar were in canvas pixel space rather than image
pixel space, causing incorrect values when the image was letterboxed or
rendered at a different size.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of annotation positioning during editing.

* **Tests**
  * Added comprehensive test coverage for coordinate conversion utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->