### PR TITLE
select first orc as default when default is delegated

### DIFF
--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -323,11 +323,15 @@ const useOperatorPromptSubmitOptions = (
     hasAvailableOrchestrators &&
     executionOptions.orchestratorRegistrationEnabled
   ) {
-    for (let orc of execDetails.executionOptions.availableOrchestrators) {
+    for (let [
+      index,
+      orc,
+    ] of execDetails.executionOptions.availableOrchestrators.entries()) {
       options.push({
         label: "Schedule",
         choiceLabel: `Schedule on ${orc.instanceID}`,
         id: orc.id,
+        default: defaultToSchedule && index === 0,
         description: `Run this operation on ${orc.instanceID}`,
         onSelect() {
           setSelectedID(orc.id);


### PR DESCRIPTION
## 🔗 Related Issues


## 📋 What changes are proposed in this pull request?

If we have multiple orcs, immediate execution, and default to delegated we don't currently select an orc as the default instead it goes to "execute". This fixes that by defaulting to the first orc listed

## 🧪 How is this patch tested? If it is not, please explain why.

deployed in teams here: https://camron.ephem.fiftyone.ai/datasets/quickstart/samples

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

If your operator defines "default_choice_to_delegated" as true and allows immediate execution now the UI will automatically select an orc to schedule on instead of "execute immediately".

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scheduling options to correctly default to the first available orchestrator when scheduling is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->