### PR TITLE
[FOEPD-3388] Add ESC functionality to opt of of annotation flow

### DIFF
--- a/app/packages/commands/src/context/CommandContextManager.ts
+++ b/app/packages/commands/src/context/CommandContextManager.ts
@@ -25,6 +25,7 @@ export enum KnownCommands {
   ModalNextSample = "fo.modal.next.sample",
   ModalPreviousSample = "fo.modal.previous.sample",
   ModalDeleteAnnotation = "fo.modal.delete.annotation",
+  ModalAnnotateDeselect = "fo.modal.annotate.deselect",
 }
 //callback for context changes
 export type CommandContextListener = (newId: string) => void;

--- a/app/packages/commands/src/context/context.manager.test.ts
+++ b/app/packages/commands/src/context/context.manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, vi, expect, beforeEach } from "vitest";
-import { CommandContextManager, KnownContexts } from "./CommandContextManager";
+import { CommandContextManager, KnownCommands, KnownContexts } from "./CommandContextManager";
 import { DelegatingUndoable } from "../actions";
 
 describe("CommandContextManager", () => {
@@ -133,6 +133,141 @@ describe("CommandContextManager", () => {
       new KeyboardEvent("keydown", { ctrlKey: true, key: "x" })
     );
     expect(execFn).toBeCalledTimes(0);
+  });
+
+  describe("Escape key priority: ModalAnnotate overrides Modal", () => {
+    // Simulates the annotate-tab Escape behavior:
+    // When a label is selected (Header mounted), ModalAnnotate's Escape binding
+    // should fire instead of Modal's close handler.
+    // When the label is deselected (Header unmounted / binding unregistered),
+    // Modal's Escape should fire again.
+
+    const escapeEvent = () =>
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true });
+
+    it("ModalAnnotate Escape fires instead of Modal Escape when both are bound", async () => {
+      const modalClose = vi.fn();
+      const annotateDeselect = vi.fn();
+
+      const manager = CommandContextManager.instance();
+
+      const modalCtx = manager.getCommandContext(KnownContexts.Modal)!;
+      const annotateCtx = manager.getCommandContext(KnownContexts.ModalAnnotate)!;
+
+      const modalCmd = modalCtx.registerCommand("fo.modal.close.test", modalClose, () => true);
+      modalCtx.bindKey("Escape", modalCmd.id);
+
+      const annotateCmd = annotateCtx.registerCommand(
+        KnownCommands.ModalAnnotateDeselect,
+        annotateDeselect,
+        () => true
+      );
+      annotateCtx.bindKey("Escape", annotateCmd.id);
+
+      await manager.handleKeyDown(escapeEvent());
+
+      expect(annotateDeselect).toHaveBeenCalledOnce();
+      expect(modalClose).not.toHaveBeenCalled();
+    });
+
+    it("Modal Escape fires when ModalAnnotate has no Escape binding", async () => {
+      const modalClose = vi.fn();
+
+      const manager = CommandContextManager.instance();
+      const modalCtx = manager.getCommandContext(KnownContexts.Modal)!;
+
+      const modalCmd = modalCtx.registerCommand("fo.modal.close.test", modalClose, () => true);
+      modalCtx.bindKey("Escape", modalCmd.id);
+
+      await manager.handleKeyDown(escapeEvent());
+
+      expect(modalClose).toHaveBeenCalledOnce();
+    });
+
+    it("Modal Escape fires again after ModalAnnotate Escape binding is unregistered", async () => {
+      const modalClose = vi.fn();
+      const annotateDeselect = vi.fn();
+
+      const manager = CommandContextManager.instance();
+      const modalCtx = manager.getCommandContext(KnownContexts.Modal)!;
+      const annotateCtx = manager.getCommandContext(KnownContexts.ModalAnnotate)!;
+
+      const modalCmd = modalCtx.registerCommand("fo.modal.close.test", modalClose, () => true);
+      modalCtx.bindKey("Escape", modalCmd.id);
+
+      const annotateCmd = annotateCtx.registerCommand(
+        KnownCommands.ModalAnnotateDeselect,
+        annotateDeselect,
+        () => true
+      );
+      annotateCtx.bindKey("Escape", annotateCmd.id);
+
+      // Simulate Header mounting: annotate Escape fires
+      await manager.handleKeyDown(escapeEvent());
+      expect(annotateDeselect).toHaveBeenCalledOnce();
+      expect(modalClose).not.toHaveBeenCalled();
+
+      // Simulate Header unmounting: unregister the ModalAnnotate binding
+      annotateCtx.unbindKey("Escape");
+      annotateCtx.unregisterCommand(annotateCmd.id);
+
+      vi.clearAllMocks();
+
+      // Now Modal Escape takes over
+      await manager.handleKeyDown(escapeEvent());
+      expect(modalClose).toHaveBeenCalledOnce();
+      expect(annotateDeselect).not.toHaveBeenCalled();
+    });
+
+    it("Escape is blocked when an input element is focused", async () => {
+      const annotateDeselect = vi.fn();
+
+      const manager = CommandContextManager.instance();
+      const annotateCtx = manager.getCommandContext(KnownContexts.ModalAnnotate)!;
+
+      const annotateCmd = annotateCtx.registerCommand(
+        KnownCommands.ModalAnnotateDeselect,
+        annotateDeselect,
+        () => true
+      );
+      annotateCtx.bindKey("Escape", annotateCmd.id);
+
+      // Simulate focus on an input field
+      const input = document.createElement("input");
+      document.body.appendChild(input);
+      input.focus();
+
+      await manager.handleKeyDown(escapeEvent());
+
+      expect(annotateDeselect).not.toHaveBeenCalled();
+
+      input.remove();
+    });
+
+    it("ModalAnnotate Escape is skipped when its command is disabled", async () => {
+      const modalClose = vi.fn();
+      const annotateDeselect = vi.fn();
+
+      const manager = CommandContextManager.instance();
+      const modalCtx = manager.getCommandContext(KnownContexts.Modal)!;
+      const annotateCtx = manager.getCommandContext(KnownContexts.ModalAnnotate)!;
+
+      const modalCmd = modalCtx.registerCommand("fo.modal.close.test", modalClose, () => true);
+      modalCtx.bindKey("Escape", modalCmd.id);
+
+      // Register with enablement returning false
+      const annotateCmd = annotateCtx.registerCommand(
+        KnownCommands.ModalAnnotateDeselect,
+        annotateDeselect,
+        () => false
+      );
+      annotateCtx.bindKey("Escape", annotateCmd.id);
+
+      await manager.handleKeyDown(escapeEvent());
+
+      expect(annotateDeselect).not.toHaveBeenCalled();
+      expect(modalClose).toHaveBeenCalledOnce();
+    });
   });
 
   it("can perform undo/redo on an inherited context", async () => {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Header.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Header.tsx
@@ -22,7 +22,7 @@ import {
   useAnnotationContext,
 } from "./state";
 
-import { KnownCommands, KnownContexts, useCommand } from "@fiftyone/commands";
+import { KnownCommands, KnownContexts, useCommand, useKeyBindings } from "@fiftyone/commands";
 import useColor from "./useColor";
 import useExit from "./useExit";
 import { useQuickDraw } from "./useQuickDraw";
@@ -118,6 +118,16 @@ const Header = () => {
     onExit,
     disableQuickDraw,
     scene,
+  ]);
+
+  useKeyBindings(KnownContexts.ModalAnnotate, [
+    {
+      commandId: KnownCommands.ModalAnnotateDeselect,
+      sequence: "Escape",
+      handler: handleExit,
+      label: "Deselect",
+      description: "Deselect the current label and return to the label list.",
+    },
   ]);
 
   return (


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

When a label was selected in the annotation editor, pressing ESC had no
effect — the only way to return to the label list was to click the Back
button. This PR wires ESC to deselect the current label and return to the
label list when the annotation edit header is mounted.

The implementation uses the existing command context priority system so
that the annotation-level ESC binding takes precedence over the modal-level
ESC close handler while a label is selected. When the header unmounts
(label deselected), the binding is unregistered and the modal's ESC
behavior resumes normally. A new `ModalAnnotateDeselect` known command is
added to the command registry to represent this action.

## 🧪 How is this patch tested? If it is not, please explain why.

Unit tests cover the full range of Escape key priority scenarios via the
`CommandContextManager`:

- `ModalAnnotate` ESC fires instead of `Modal` ESC when both are bound
- `Modal` ESC fires when `ModalAnnotate` has no ESC binding
- `Modal` ESC resumes after the `ModalAnnotate` binding is unregistered
- ESC is blocked when an input element is focused
- `ModalAnnotate` ESC is skipped when its command's enablement returns false

Manually verified in the app by selecting a label, pressing ESC, and
confirming the editor returns to the label list without closing the modal.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Pressing ESC while editing a label in the annotation panel now deselects
the label and returns to the label list, rather than doing nothing.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Escape key support to close and deselect the annotation modal, providing a quick keyboard shortcut for users.

* **Tests**
  * Added comprehensive test coverage for Escape key behavior across modal contexts, including scenarios with focus states and command predicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->