### PR TITLE
Add plugin-bundled skills discovery and install CLI

### DIFF
--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -4462,7 +4462,6 @@ class PluginsSkillsCommand(Command):
     def setup(parser):
         subparsers = parser.add_subparsers(title="available commands")
         _register_command(subparsers, "list", PluginsSkillsListCommand)
-        _register_command(subparsers, "install", PluginsSkillsInstallCommand)
 
     @staticmethod
     def execute(parser, args):
@@ -4539,86 +4538,6 @@ def _print_skills_list(plugin=None, category=None, names_only=False):
     records = [tuple(_format_cell(r[key]) for key in headers) for r in rows]
     table_str = tabulate(records, headers=headers, tablefmt=_TABLE_FORMAT)
     print(table_str)
-
-
-class PluginsSkillsInstallCommand(Command):
-    """Install plugin skills to AI agent directories.
-
-    Examples::
-
-        # Install skills for Claude Code
-        fiftyone plugins skills install --claude
-
-        # Install skills for Cursor
-        fiftyone plugins skills install --cursor
-
-        # Install skills for all supported agents
-        fiftyone plugins skills install --claude --cursor --codex --opencode
-
-        # Install skills globally
-        fiftyone plugins skills install --claude --global
-
-        # Install skills from a specific plugin only
-        fiftyone plugins skills install --claude --plugin-names @voxel51/my-plugin
-    """
-
-    @staticmethod
-    def setup(parser):
-        parser.add_argument(
-            "--claude",
-            action="store_true",
-            help="install skills for Claude Code",
-        )
-        parser.add_argument(
-            "--codex",
-            action="store_true",
-            help="install skills for Codex",
-        )
-        parser.add_argument(
-            "--cursor",
-            action="store_true",
-            help="install skills for Cursor",
-        )
-        parser.add_argument(
-            "--opencode",
-            action="store_true",
-            help="install skills for OpenCode",
-        )
-        parser.add_argument(
-            "-g",
-            "--global",
-            dest="global_",
-            action="store_true",
-            help="install to global user-level directories instead of local",
-        )
-        parser.add_argument(
-            "-n",
-            "--plugin-names",
-            nargs="+",
-            default=None,
-            metavar="PLUGIN_NAMES",
-            help="a plugin name or list of plugin names to include",
-        )
-
-    @staticmethod
-    def execute(parser, args):
-        agents = [
-            a
-            for a in ("claude", "codex", "cursor", "opencode")
-            if getattr(args, a)
-        ]
-
-        if not agents:
-            parser.error(
-                "at least one agent flag is required "
-                "(--claude, --codex, --cursor, --opencode)"
-            )
-
-        fop.install_skills(
-            agents=agents,
-            plugin=args.plugin_names,
-            global_=args.global_,
-        )
 
 
 class LabsCommand(Command):

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -3861,6 +3861,7 @@ class PluginsCommand(Command):
         _register_command(subparsers, "enable", PluginsEnableCommand)
         _register_command(subparsers, "disable", PluginsDisableCommand)
         _register_command(subparsers, "delete", PluginsDeleteCommand)
+        _register_command(subparsers, "skills", PluginsSkillsCommand)
 
     @staticmethod
     def execute(parser, args):
@@ -4452,6 +4453,172 @@ class PluginsDeleteCommand(Command):
 
         for name in names:
             fop.delete_plugin(name)
+
+
+class PluginsSkillsCommand(Command):
+    """Tools for working with FiftyOne plugin skills."""
+
+    @staticmethod
+    def setup(parser):
+        subparsers = parser.add_subparsers(title="available commands")
+        _register_command(subparsers, "list", PluginsSkillsListCommand)
+        _register_command(subparsers, "install", PluginsSkillsInstallCommand)
+
+    @staticmethod
+    def execute(parser, args):
+        parser.print_help()
+
+
+class PluginsSkillsListCommand(Command):
+    """List skills provided by installed plugins.
+
+    Examples::
+
+        # List all available skills
+        fiftyone plugins skills list
+
+        # List skills from a specific plugin
+        fiftyone plugins skills list --plugin @voxel51/my-plugin
+
+        # List skills in a specific category
+        fiftyone plugins skills list --category data-ingestion
+
+        # List skill names only
+        fiftyone plugins skills list --names-only
+    """
+
+    @staticmethod
+    def setup(parser):
+        parser.add_argument(
+            "-p",
+            "--plugin",
+            metavar="PLUGIN",
+            help="only show skills from this plugin",
+        )
+        parser.add_argument(
+            "-c",
+            "--category",
+            metavar="CATEGORY",
+            help="only show skills in this category",
+        )
+        parser.add_argument(
+            "-n",
+            "--names-only",
+            action="store_true",
+            help="only show names",
+        )
+
+    @staticmethod
+    def execute(parser, args):
+        _print_skills_list(
+            plugin=args.plugin,
+            category=args.category,
+            names_only=args.names_only,
+        )
+
+
+def _print_skills_list(plugin=None, category=None, names_only=False):
+    skills = fop.list_skills(plugin=plugin, category=category)
+
+    if names_only:
+        for s in skills:
+            print(s.name)
+
+        return
+
+    headers = ["name", "category", "plugin", "path"]
+    rows = [
+        {
+            "name": s.name,
+            "category": s.category or "",
+            "plugin": s.plugin_name,
+            "path": s.path,
+        }
+        for s in skills
+    ]
+    records = [tuple(_format_cell(r[key]) for key in headers) for r in rows]
+    table_str = tabulate(records, headers=headers, tablefmt=_TABLE_FORMAT)
+    print(table_str)
+
+
+class PluginsSkillsInstallCommand(Command):
+    """Install plugin skills to AI agent directories.
+
+    Examples::
+
+        # Install skills for Claude Code
+        fiftyone plugins skills install --claude
+
+        # Install skills for Cursor
+        fiftyone plugins skills install --cursor
+
+        # Install skills for all supported agents
+        fiftyone plugins skills install --claude --cursor --codex --opencode
+
+        # Install skills globally
+        fiftyone plugins skills install --claude --global
+
+        # Install skills from a specific plugin only
+        fiftyone plugins skills install --claude --plugin-names @voxel51/my-plugin
+    """
+
+    @staticmethod
+    def setup(parser):
+        parser.add_argument(
+            "--claude",
+            action="store_true",
+            help="install skills for Claude Code",
+        )
+        parser.add_argument(
+            "--codex",
+            action="store_true",
+            help="install skills for Codex",
+        )
+        parser.add_argument(
+            "--cursor",
+            action="store_true",
+            help="install skills for Cursor",
+        )
+        parser.add_argument(
+            "--opencode",
+            action="store_true",
+            help="install skills for OpenCode",
+        )
+        parser.add_argument(
+            "-g",
+            "--global",
+            dest="global_",
+            action="store_true",
+            help="install to global user-level directories instead of local",
+        )
+        parser.add_argument(
+            "-n",
+            "--plugin-names",
+            nargs="*",
+            default=None,
+            metavar="PLUGIN_NAMES",
+            help="a plugin name or list of plugin names to include",
+        )
+
+    @staticmethod
+    def execute(parser, args):
+        agents = [
+            a
+            for a in ("claude", "codex", "cursor", "opencode")
+            if getattr(args, a)
+        ]
+
+        if not agents:
+            parser.error(
+                "at least one agent flag is required "
+                "(--claude, --codex, --cursor, --opencode)"
+            )
+
+        fop.install_skills(
+            agents=agents,
+            plugin=args.plugin_names,
+            global_=args.global_,
+        )
 
 
 class LabsCommand(Command):

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -4594,7 +4594,7 @@ class PluginsSkillsInstallCommand(Command):
         parser.add_argument(
             "-n",
             "--plugin-names",
-            nargs="*",
+            nargs="+",
             default=None,
             metavar="PLUGIN_NAMES",
             help="a plugin name or list of plugin names to include",

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -4491,14 +4491,16 @@ class PluginsSkillsListCommand(Command):
         parser.add_argument(
             "-p",
             "--plugin",
+            nargs="+",
             metavar="PLUGIN",
-            help="only show skills from this plugin",
+            help="only show skills from this plugin(s)",
         )
         parser.add_argument(
             "-c",
             "--category",
+            nargs="+",
             metavar="CATEGORY",
-            help="only show skills in this category",
+            help="only show skills in this category(s)",
         )
         parser.add_argument(
             "-n",

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -99,6 +99,7 @@ class FiftyOneCommand(Command):
         _register_command(subparsers, "datasets", DatasetsCommand)
         _register_command(subparsers, "migrate", MigrateCommand)
         _register_command(subparsers, "operators", OperatorsCommand)
+        _register_command(subparsers, "skills", SkillsCommand)
         _register_command(subparsers, "delegated", DelegatedCommand)
         _register_command(subparsers, "plugins", PluginsCommand)
         _register_command(subparsers, "utils", UtilsCommand)
@@ -3861,7 +3862,6 @@ class PluginsCommand(Command):
         _register_command(subparsers, "enable", PluginsEnableCommand)
         _register_command(subparsers, "disable", PluginsDisableCommand)
         _register_command(subparsers, "delete", PluginsDeleteCommand)
-        _register_command(subparsers, "skills", PluginsSkillsCommand)
 
     @staticmethod
     def execute(parser, args):
@@ -4455,35 +4455,38 @@ class PluginsDeleteCommand(Command):
             fop.delete_plugin(name)
 
 
-class PluginsSkillsCommand(Command):
-    """Tools for working with FiftyOne plugin skills."""
+class SkillsCommand(Command):
+    """Tools for working with FiftyOne skills."""
 
     @staticmethod
     def setup(parser):
         subparsers = parser.add_subparsers(title="available commands")
-        _register_command(subparsers, "list", PluginsSkillsListCommand)
+        _register_command(subparsers, "list", SkillsListCommand)
 
     @staticmethod
     def execute(parser, args):
         parser.print_help()
 
 
-class PluginsSkillsListCommand(Command):
+class SkillsListCommand(Command):
     """List skills provided by installed plugins.
 
     Examples::
 
         # List all available skills
-        fiftyone plugins skills list
+        fiftyone skills list
 
         # List skills from a specific plugin
-        fiftyone plugins skills list --plugin @voxel51/my-plugin
+        fiftyone skills list --plugin @voxel51/my-plugin
 
         # List skills in a specific category
-        fiftyone plugins skills list --category data-ingestion
+        fiftyone skills list --category data-ingestion
+
+        # List enabled skills
+        fiftyone skills list --enabled
 
         # List skill names only
-        fiftyone plugins skills list --names-only
+        fiftyone skills list --names-only
     """
 
     @staticmethod
@@ -4503,6 +4506,20 @@ class PluginsSkillsListCommand(Command):
             help="only show skills in this category(s)",
         )
         parser.add_argument(
+            "-e",
+            "--enabled",
+            action="store_true",
+            default=None,
+            help="only show skills from enabled plugins",
+        )
+        parser.add_argument(
+            "-d",
+            "--disabled",
+            action="store_true",
+            default=None,
+            help="only show skills from disabled plugins",
+        )
+        parser.add_argument(
             "-n",
             "--names-only",
             action="store_true",
@@ -4511,29 +4528,47 @@ class PluginsSkillsListCommand(Command):
 
     @staticmethod
     def execute(parser, args):
+        if args.enabled:
+            enabled = True
+        elif args.disabled:
+            enabled = False
+        else:
+            enabled = "all"
+
         _print_skills_list(
             plugin=args.plugin,
             category=args.category,
+            enabled=enabled,
             names_only=args.names_only,
         )
 
 
-def _print_skills_list(plugin=None, category=None, names_only=False):
-    skills = fop.list_skills(plugin=plugin, category=category)
+def _print_skills_list(
+    plugin=None, category=None, enabled="all", names_only=False
+):
+    skills = fop.list_skills(plugin=plugin, category=category, enabled=enabled)
 
     if names_only:
+        skills_map = defaultdict(list)
         for s in skills:
-            print(s.name)
+            skills_map[s.plugin_name].append(s)
+
+        for pname, plugin_skills in skills_map.items():
+            print(pname)
+            for s in plugin_skills:
+                print("    " + s.name)
 
         return
 
-    headers = ["name", "category", "plugin", "path"]
+    enabled_plugins = set(fop.list_enabled_plugins())
+
+    headers = ["name", "category", "plugin", "enabled"]
     rows = [
         {
             "name": s.name,
             "category": s.category or "",
             "plugin": s.plugin_name,
-            "path": s.path,
+            "enabled": s.plugin_name in enabled_plugins,
         }
         for s in skills
     ]

--- a/fiftyone/plugins/__init__.py
+++ b/fiftyone/plugins/__init__.py
@@ -27,10 +27,7 @@ from .core import (
 from .definitions import PluginDefinition
 from .context import PluginContext
 from .secrets import PluginSecretsResolver
-from .skills import (
-    install_skills,
-    list_skills,
-)
+from .skills import list_skills
 
 # This enables Sphinx refs to directly use paths imported here
 __all__ = [

--- a/fiftyone/plugins/__init__.py
+++ b/fiftyone/plugins/__init__.py
@@ -27,6 +27,10 @@ from .core import (
 from .definitions import PluginDefinition
 from .context import PluginContext
 from .secrets import PluginSecretsResolver
+from .skills import (
+    install_skills,
+    list_skills,
+)
 
 # This enables Sphinx refs to directly use paths imported here
 __all__ = [

--- a/fiftyone/plugins/definitions.py
+++ b/fiftyone/plugins/definitions.py
@@ -5,6 +5,7 @@ Plugin definitions.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import hashlib
 import os
 
@@ -105,6 +106,11 @@ class PluginDefinition(object):
         return self._metadata.get("operators", []) + self._metadata.get(
             "panels", []
         )
+
+    @property
+    def skills(self):
+        """The skills of the plugin."""
+        return self._metadata.get("skills", [])
 
     @property
     def package_json_path(self):
@@ -221,6 +227,7 @@ class PluginDefinition(object):
             "fiftyone_compatibility": self.fiftyone_compatibility,
             "operators": self._metadata.get("operators", []),
             "panels": self._metadata.get("panels", []),
+            "skills": self._metadata.get("skills", []),
             "js_bundle": self.js_bundle,
             "py_entry": self.py_entry,
             "js_bundle_exists": self.has_js,

--- a/fiftyone/plugins/skills.py
+++ b/fiftyone/plugins/skills.py
@@ -60,7 +60,7 @@ class SkillDefinition(object):
     @property
     def content(self):
         """The full raw content of the skill file."""
-        with open(self._path, "r") as f:
+        with open(self._path, "r", encoding="utf-8") as f:
             return f.read()
 
     def to_dict(self):
@@ -142,7 +142,7 @@ def _iter_plugin_skills(plugin_definition):
 
 
 def _parse_skill_frontmatter(skill_path):
-    with open(skill_path, "r") as f:
+    with open(skill_path, "r", encoding="utf-8") as f:
         content = f.read()
 
     if not content.startswith("---"):

--- a/fiftyone/plugins/skills.py
+++ b/fiftyone/plugins/skills.py
@@ -8,6 +8,7 @@ FiftyOne plugin skills.
 
 import logging
 import os
+import re
 
 import yaml
 
@@ -105,13 +106,13 @@ def list_skills(enabled=True, plugin=None, category=None):
 
     skills = []
     for pd in plugin_defs:
-        try:
-            for skill in _iter_plugin_skills(pd):
+        for skill in _iter_plugin_skills(pd):
+            try:
                 if category is not None and skill.category not in category:
                     continue
                 skills.append(skill)
-        except:
-            logger.info(f"Failed to load skills from plugin '{pd.name}'")
+            except:
+                logger.info(f"Failed to load skill from plugin '{pd.name}'")
 
     return skills
 
@@ -145,10 +146,7 @@ def _parse_skill_frontmatter(skill_path):
     with open(skill_path, "r", encoding="utf-8") as f:
         content = f.read()
 
-    if not content.startswith("---"):
-        return {}
-
-    parts = content.split("---", 2)
+    parts = re.split(r"^---\s*$", content, maxsplit=2, flags=re.MULTILINE)
     if len(parts) < 3:
         return {}
 

--- a/fiftyone/plugins/skills.py
+++ b/fiftyone/plugins/skills.py
@@ -8,26 +8,8 @@ FiftyOne plugin skills.
 
 import logging
 import os
-import shutil
 
 import yaml
-
-_LOCAL_TARGETS = {
-    "claude": os.path.join(".claude", "skills"),
-    "codex": os.path.join(".codex", "skills"),
-    "cursor": os.path.join(".cursor", "skills"),
-    "opencode": os.path.join(".opencode", "skills"),
-}
-
-_GLOBAL_TARGETS = {
-    "claude": os.path.join("~", ".claude", "skills"),
-    "codex": os.path.join("~", ".codex", "skills"),
-    "cursor": os.path.join("~", ".cursor", "skills"),
-    "opencode": os.path.join("~", ".config", "opencode", "skills"),
-}
-
-_CENTRAL_LOCAL = os.path.join(".agents", "skills")
-_CENTRAL_GLOBAL = os.path.join("~", ".agents", "skills")
 
 logger = logging.getLogger(__name__)
 
@@ -134,83 +116,6 @@ def list_skills(enabled=True, plugin=None, category=None):
     return skills
 
 
-def install_skills(agents, plugin=None, global_=False):
-    """Installs skills from installed plugins to AI agent directories.
-
-    A central copy of each skill is written to
-    ``.agents/skills/<skill-name>/`` (or ``~/.agents/skills/<skill-name>/``
-    when ``global_=True``) and a relative symlink is created in each
-    requested agent's skills directory.
-
-    Args:
-        agents: an agent name or list of agent names. Supported agents are
-            ``"claude"``, ``"codex"``, ``"cursor"``, and ``"opencode"``
-        plugin (None): a plugin name or list of plugin names to include.
-            By default, skills from all plugins are installed
-        global_ (False): whether to install to global user-level
-            directories (``~/``) rather than local project-level
-            directories
-
-    Returns:
-        a list of installed skill names
-    """
-    if isinstance(agents, str):
-        agents = [agents]
-
-    targets = _GLOBAL_TARGETS if global_ else _LOCAL_TARGETS
-    unknown = [a for a in agents if a not in targets]
-    if unknown:
-        raise ValueError(
-            f"Unsupported agent(s) {unknown}. Supported agents are: "
-            f"{sorted(targets.keys())}"
-        )
-
-    skills = list_skills(plugin=plugin)
-    if not skills:
-        logger.info("No skills found")
-        return []
-
-    central_base = _CENTRAL_GLOBAL if global_ else _CENTRAL_LOCAL
-    central_dir = os.path.realpath(os.path.expanduser(central_base))
-
-    installed = []
-
-    for skill in skills:
-        if (
-            not skill.name
-            or os.path.basename(skill.name) != skill.name
-            or skill.name in (".", "..")
-        ):
-            raise ValueError(f"Invalid skill name: {skill.name!r}")
-
-        skill_central = os.path.join(central_dir, skill.name)
-        os.makedirs(skill_central, exist_ok=True)
-
-        dest = os.path.join(skill_central, os.path.basename(skill.path))
-        shutil.copy2(skill.path, dest)
-        logger.info(f"Copied skill '{skill.name}' to '{skill_central}'")
-
-        for agent in agents:
-            agent_skills_dir = os.path.realpath(
-                os.path.expanduser(targets[agent])
-            )
-            os.makedirs(agent_skills_dir, exist_ok=True)
-
-            link_path = os.path.join(agent_skills_dir, skill.name)
-            if os.path.islink(link_path):
-                os.unlink(link_path)
-            elif os.path.isdir(link_path):
-                shutil.rmtree(link_path)
-
-            rel_target = os.path.relpath(skill_central, agent_skills_dir)
-            os.symlink(rel_target, link_path)
-            logger.info(f"Created symlink '{link_path}' -> '{rel_target}'")
-
-        installed.append(skill.name)
-
-    return installed
-
-
 def _iter_plugin_skills(plugin_definition):
     plugin_dir = os.path.realpath(plugin_definition.directory)
     for rel_path in plugin_definition.skills:
@@ -248,6 +153,7 @@ def _parse_skill_frontmatter(skill_path):
         return {}
 
     try:
-        return yaml.safe_load(parts[1]) or {}
+        result = yaml.safe_load(parts[1])
+        return result if isinstance(result, dict) else {}
     except yaml.YAMLError:
         return {}

--- a/fiftyone/plugins/skills.py
+++ b/fiftyone/plugins/skills.py
@@ -1,0 +1,232 @@
+"""
+FiftyOne plugin skills.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import logging
+import os
+import shutil
+
+import yaml
+
+_LOCAL_TARGETS = {
+    "claude": os.path.join(".claude", "skills"),
+    "codex": os.path.join(".codex", "skills"),
+    "cursor": os.path.join(".cursor", "skills"),
+    "opencode": os.path.join(".opencode", "skills"),
+}
+
+_GLOBAL_TARGETS = {
+    "claude": os.path.join("~", ".claude", "skills"),
+    "codex": os.path.join("~", ".codex", "skills"),
+    "cursor": os.path.join("~", ".cursor", "skills"),
+    "opencode": os.path.join("~", ".config", "opencode", "skills"),
+}
+
+_CENTRAL_LOCAL = os.path.join(".agents", "skills")
+_CENTRAL_GLOBAL = os.path.join("~", ".agents", "skills")
+
+logger = logging.getLogger(__name__)
+
+
+class SkillDefinition(object):
+    """A skill definition.
+
+    Args:
+        path: the absolute path to the skill's Markdown file
+        metadata: a skill metadata dict parsed from the file's YAML
+            frontmatter
+        plugin_name: the name of the plugin that provides this skill
+    """
+
+    def __init__(self, path, metadata, plugin_name):
+        self._path = path
+        self._metadata = metadata
+        self._plugin_name = plugin_name
+
+    @property
+    def name(self):
+        """The name of the skill."""
+        return self._metadata.get(
+            "name",
+            os.path.splitext(os.path.basename(self._path))[0],
+        )
+
+    @property
+    def description(self):
+        """The description of the skill."""
+        return self._metadata.get("description", "")
+
+    @property
+    def category(self):
+        """The category of the skill."""
+        return self._metadata.get("category", "")
+
+    @property
+    def path(self):
+        """The absolute path to the skill file."""
+        return self._path
+
+    @property
+    def plugin_name(self):
+        """The name of the plugin that provides this skill."""
+        return self._plugin_name
+
+    @property
+    def content(self):
+        """The full raw content of the skill file."""
+        with open(self._path, "r") as f:
+            return f.read()
+
+    def to_dict(self):
+        """Returns a JSON dict representation of the skill.
+
+        Returns:
+            a JSON dict
+        """
+        return {
+            "name": self.name,
+            "description": self.description,
+            "category": self.category,
+            "path": self.path,
+            "plugin": self.plugin_name,
+        }
+
+
+def list_skills(enabled=True, plugin=None, category=None):
+    """Lists available skills from installed plugins.
+
+    Args:
+        enabled (True): whether to include only enabled plugins (True),
+            only disabled plugins (False), or all plugins (``"all"``)
+        plugin (None): a plugin name or list of plugin names to include.
+            By default, skills from all plugins are included
+        category (None): a category or list of categories to filter by.
+            By default, skills of all categories are included
+
+    Returns:
+        a list of :class:`SkillDefinition` instances
+    """
+    import fiftyone.plugins as fop
+
+    plugin_defs = fop.list_plugins(enabled=enabled, builtin="all")
+
+    if plugin is not None:
+        plugin = {plugin} if isinstance(plugin, str) else set(plugin)
+        plugin_defs = [p for p in plugin_defs if p.name in plugin]
+
+    if category is not None:
+        category = {category} if isinstance(category, str) else set(category)
+
+    skills = []
+    for pd in plugin_defs:
+        try:
+            for skill in _iter_plugin_skills(pd):
+                if category is not None and skill.category not in category:
+                    continue
+                skills.append(skill)
+        except:
+            logger.info(f"Failed to load skills from plugin '{pd.name}'")
+
+    return skills
+
+
+def install_skills(agents, plugin=None, global_=False):
+    """Installs skills from installed plugins to AI agent directories.
+
+    A central copy of each skill is written to
+    ``.agents/skills/<skill-name>/`` (or ``~/.agents/skills/<skill-name>/``
+    when ``global_=True``) and a relative symlink is created in each
+    requested agent's skills directory.
+
+    Args:
+        agents: an agent name or list of agent names. Supported agents are
+            ``"claude"``, ``"codex"``, ``"cursor"``, and ``"opencode"``
+        plugin (None): a plugin name or list of plugin names to include.
+            By default, skills from all plugins are installed
+        global_ (False): whether to install to global user-level
+            directories (``~/``) rather than local project-level
+            directories
+
+    Returns:
+        a list of installed skill names
+    """
+    if isinstance(agents, str):
+        agents = [agents]
+
+    targets = _GLOBAL_TARGETS if global_ else _LOCAL_TARGETS
+    unknown = [a for a in agents if a not in targets]
+    if unknown:
+        raise ValueError(
+            f"Unsupported agent(s) {unknown}. Supported agents are: "
+            f"{sorted(targets.keys())}"
+        )
+
+    skills = list_skills(plugin=plugin)
+    if not skills:
+        logger.info("No skills found")
+        return []
+
+    central_base = _CENTRAL_GLOBAL if global_ else _CENTRAL_LOCAL
+    central_dir = os.path.realpath(os.path.expanduser(central_base))
+
+    installed = []
+
+    for skill in skills:
+        skill_central = os.path.join(central_dir, skill.name)
+        os.makedirs(skill_central, exist_ok=True)
+
+        dest = os.path.join(skill_central, os.path.basename(skill.path))
+        shutil.copy2(skill.path, dest)
+        logger.info(f"Copied skill '{skill.name}' to '{skill_central}'")
+
+        for agent in agents:
+            agent_skills_dir = os.path.realpath(
+                os.path.expanduser(targets[agent])
+            )
+            os.makedirs(agent_skills_dir, exist_ok=True)
+
+            link_path = os.path.join(agent_skills_dir, skill.name)
+            if os.path.islink(link_path):
+                os.unlink(link_path)
+            elif os.path.isdir(link_path):
+                shutil.rmtree(link_path)
+
+            rel_target = os.path.relpath(skill_central, agent_skills_dir)
+            os.symlink(rel_target, link_path)
+            logger.info(f"Created symlink '{link_path}' -> '{rel_target}'")
+
+        installed.append(skill.name)
+
+    return installed
+
+
+def _iter_plugin_skills(plugin_definition):
+    for rel_path in plugin_definition.skills:
+        skill_path = os.path.join(plugin_definition.directory, rel_path)
+        if not os.path.isfile(skill_path):
+            logger.debug(f"Skill file not found: '{skill_path}'")
+            continue
+
+        metadata = _parse_skill_frontmatter(skill_path)
+        yield SkillDefinition(skill_path, metadata, plugin_definition.name)
+
+
+def _parse_skill_frontmatter(skill_path):
+    with open(skill_path, "r") as f:
+        content = f.read()
+
+    if not content.startswith("---"):
+        return {}
+
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return {}
+
+    try:
+        return yaml.safe_load(parts[1]) or {}
+    except yaml.YAMLError:
+        return {}

--- a/fiftyone/plugins/skills.py
+++ b/fiftyone/plugins/skills.py
@@ -52,7 +52,7 @@ class SkillDefinition(object):
         """The name of the skill."""
         return self._metadata.get(
             "name",
-            os.path.splitext(os.path.basename(self._path))[0],
+            os.path.basename(os.path.dirname(self._path)),
         )
 
     @property
@@ -176,6 +176,13 @@ def install_skills(agents, plugin=None, global_=False):
     installed = []
 
     for skill in skills:
+        if (
+            not skill.name
+            or os.path.basename(skill.name) != skill.name
+            or skill.name in (".", "..")
+        ):
+            raise ValueError(f"Invalid skill name: {skill.name!r}")
+
         skill_central = os.path.join(central_dir, skill.name)
         os.makedirs(skill_central, exist_ok=True)
 
@@ -205,8 +212,22 @@ def install_skills(agents, plugin=None, global_=False):
 
 
 def _iter_plugin_skills(plugin_definition):
+    plugin_dir = os.path.realpath(plugin_definition.directory)
     for rel_path in plugin_definition.skills:
-        skill_path = os.path.join(plugin_definition.directory, rel_path)
+        skill_path = os.path.realpath(os.path.join(plugin_dir, rel_path))
+        try:
+            outside = (
+                os.path.commonpath([plugin_dir, skill_path]) != plugin_dir
+            )
+        except ValueError:
+            outside = True
+
+        if outside:
+            logger.warning(
+                "Ignoring skill path outside plugin directory: %s", rel_path
+            )
+            continue
+
         if not os.path.isfile(skill_path):
             logger.debug(f"Skill file not found: '{skill_path}'")
             continue

--- a/tests/unittests/plugins/skills_tests.py
+++ b/tests/unittests/plugins/skills_tests.py
@@ -141,69 +141,6 @@ def test_list_skills_missing_file_skipped(mocker, plugins_dir):
     assert fop.list_skills() == []
 
 
-def test_install_skills_unknown_agent(mocker, plugins_dir):
-    _make_plugin(plugins_dir, "plugin-a", "skill-a")
-    mocker.patch("fiftyone.config.plugins_dir", plugins_dir)
-
-    with pytest.raises(ValueError, match="Unsupported agent"):
-        fop.install_skills(agents="gemini")
-
-
-def test_install_skills_creates_central_copy(
-    mocker, plugins_dir, tmp_path_factory
-):
-    _make_plugin(plugins_dir, "plugin-a", "skill-a")
-    mocker.patch("fiftyone.config.plugins_dir", plugins_dir)
-
-    central = str(tmp_path_factory.mktemp("central"))
-    agent_dir = str(tmp_path_factory.mktemp("agent"))
-    mocker.patch("fiftyone.plugins.skills._CENTRAL_LOCAL", central)
-    mocker.patch(
-        "fiftyone.plugins.skills._LOCAL_TARGETS", {"claude": agent_dir}
-    )
-
-    fop.install_skills(agents="claude")
-
-    assert os.path.isfile(os.path.join(central, "skill-a", "SKILL.md"))
-
-
-def test_install_skills_creates_symlink(mocker, plugins_dir, tmp_path_factory):
-    _make_plugin(plugins_dir, "plugin-a", "skill-a")
-    mocker.patch("fiftyone.config.plugins_dir", plugins_dir)
-
-    central = str(tmp_path_factory.mktemp("central"))
-    agent_dir = str(tmp_path_factory.mktemp("agent"))
-    mocker.patch("fiftyone.plugins.skills._CENTRAL_LOCAL", central)
-    mocker.patch(
-        "fiftyone.plugins.skills._LOCAL_TARGETS", {"claude": agent_dir}
-    )
-
-    fop.install_skills(agents="claude")
-
-    link = os.path.join(agent_dir, "skill-a")
-    assert os.path.islink(link)
-    assert os.path.realpath(link) == os.path.realpath(
-        os.path.join(central, "skill-a")
-    )
-
-
-def test_install_skills_returns_names(mocker, plugins_dir, tmp_path_factory):
-    _make_plugin(plugins_dir, "plugin-a", "skill-a")
-    _make_plugin(plugins_dir, "plugin-b", "skill-b")
-    mocker.patch("fiftyone.config.plugins_dir", plugins_dir)
-
-    central = str(tmp_path_factory.mktemp("central"))
-    agent_dir = str(tmp_path_factory.mktemp("agent"))
-    mocker.patch("fiftyone.plugins.skills._CENTRAL_LOCAL", central)
-    mocker.patch(
-        "fiftyone.plugins.skills._LOCAL_TARGETS", {"claude": agent_dir}
-    )
-
-    installed = fop.install_skills(agents="claude")
-
-    assert set(installed) == {"skill-a", "skill-b"}
-
-
 def test_parse_skill_frontmatter_valid(tmp_path_factory):
     tmp = tmp_path_factory.mktemp("skills")
     skill_file = tmp / "SKILL.md"

--- a/tests/unittests/plugins/skills_tests.py
+++ b/tests/unittests/plugins/skills_tests.py
@@ -1,0 +1,223 @@
+"""
+FiftyOne plugin skills tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import json
+import os
+from unittest import mock
+
+import pytest
+
+import fiftyone.plugins as fop
+import fiftyone.plugins.skills as fps
+
+
+_DEFAULT_APP_CONFIG = {}
+
+_SKILL_MD = """\
+---
+name: {name}
+description: A test skill
+category: {category}
+---
+# {name}
+"""
+
+_PLUGIN_YML = """\
+name: {plugin}
+version: 1.0.0
+skills:
+  - skills/{skill}/SKILL.md
+"""
+
+_PLUGIN_YML_NO_SKILLS = """\
+name: {plugin}
+version: 1.0.0
+"""
+
+
+@pytest.fixture(autouse=True, scope="function")
+def app_config_path(tmp_path_factory):
+    fn = tmp_path_factory.mktemp(".fiftyone") / "app_config.json"
+    with open(fn, "w") as f:
+        f.write(json.dumps(_DEFAULT_APP_CONFIG))
+    return str(fn)
+
+
+@pytest.fixture(autouse=True)
+def mock_app_config_env_var(app_config_path):
+    with mock.patch.dict(
+        os.environ, {"FIFTYONE_APP_CONFIG_PATH": app_config_path}
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True, scope="function")
+def plugins_dir(tmp_path_factory):
+    return tmp_path_factory.mktemp("fiftyone-plugins")
+
+
+def _make_plugin(plugins_dir, plugin_name, skill_name, category="general"):
+    skill_dir = os.path.join(plugins_dir, plugin_name, "skills", skill_name)
+    os.makedirs(skill_dir, exist_ok=True)
+
+    with open(
+        os.path.join(plugins_dir, plugin_name, "fiftyone.yml"), "w"
+    ) as f:
+        f.write(_PLUGIN_YML.format(plugin=plugin_name, skill=skill_name))
+
+    with open(os.path.join(skill_dir, "SKILL.md"), "w") as f:
+        f.write(_SKILL_MD.format(name=skill_name, category=category))
+
+
+def _make_plugin_no_skills(plugins_dir, plugin_name):
+    plugin_dir = os.path.join(plugins_dir, plugin_name)
+    os.makedirs(plugin_dir, exist_ok=True)
+
+    with open(os.path.join(plugin_dir, "fiftyone.yml"), "w") as f:
+        f.write(_PLUGIN_YML_NO_SKILLS.format(plugin=plugin_name))
+
+
+def test_list_skills(mocker, plugins_dir):
+    _make_plugin(plugins_dir, "plugin-a", "skill-a")
+    mocker.patch("fiftyone.config.plugins_dir", plugins_dir)
+
+    skills = fop.list_skills()
+
+    assert len(skills) == 1
+    assert skills[0].name == "skill-a"
+    assert skills[0].plugin_name == "plugin-a"
+
+
+def test_list_skills_disabled_plugin(mocker, plugins_dir):
+    _make_plugin(plugins_dir, "plugin-a", "skill-a")
+    mocker.patch("fiftyone.config.plugins_dir", plugins_dir)
+    fop.disable_plugin("plugin-a")
+
+    assert fop.list_skills() == []
+
+
+def test_list_skills_filter_plugin(mocker, plugins_dir):
+    _make_plugin(plugins_dir, "plugin-a", "skill-a")
+    _make_plugin(plugins_dir, "plugin-b", "skill-b")
+    mocker.patch("fiftyone.config.plugins_dir", plugins_dir)
+
+    skills = fop.list_skills(plugin="plugin-a")
+
+    assert len(skills) == 1
+    assert skills[0].plugin_name == "plugin-a"
+
+
+def test_list_skills_filter_category(mocker, plugins_dir):
+    _make_plugin(plugins_dir, "plugin-a", "skill-a", category="qa")
+    _make_plugin(plugins_dir, "plugin-b", "skill-b", category="export")
+    mocker.patch("fiftyone.config.plugins_dir", plugins_dir)
+
+    skills = fop.list_skills(category="qa")
+
+    assert len(skills) == 1
+    assert skills[0].name == "skill-a"
+
+
+def test_list_skills_no_skills_key(mocker, plugins_dir):
+    _make_plugin_no_skills(plugins_dir, "plugin-a")
+    mocker.patch("fiftyone.config.plugins_dir", plugins_dir)
+
+    assert fop.list_skills() == []
+
+
+def test_list_skills_missing_file_skipped(mocker, plugins_dir):
+    plugin_dir = os.path.join(plugins_dir, "plugin-a")
+    os.makedirs(plugin_dir, exist_ok=True)
+    with open(os.path.join(plugin_dir, "fiftyone.yml"), "w") as f:
+        f.write(_PLUGIN_YML.format(plugin="plugin-a", skill="missing"))
+    # intentionally not creating the skill file
+    mocker.patch("fiftyone.config.plugins_dir", plugins_dir)
+
+    assert fop.list_skills() == []
+
+
+def test_install_skills_unknown_agent(mocker, plugins_dir):
+    _make_plugin(plugins_dir, "plugin-a", "skill-a")
+    mocker.patch("fiftyone.config.plugins_dir", plugins_dir)
+
+    with pytest.raises(ValueError, match="Unsupported agent"):
+        fop.install_skills(agents="gemini")
+
+
+def test_install_skills_creates_central_copy(
+    mocker, plugins_dir, tmp_path_factory
+):
+    _make_plugin(plugins_dir, "plugin-a", "skill-a")
+    mocker.patch("fiftyone.config.plugins_dir", plugins_dir)
+
+    central = str(tmp_path_factory.mktemp("central"))
+    agent_dir = str(tmp_path_factory.mktemp("agent"))
+    mocker.patch("fiftyone.plugins.skills._CENTRAL_LOCAL", central)
+    mocker.patch(
+        "fiftyone.plugins.skills._LOCAL_TARGETS", {"claude": agent_dir}
+    )
+
+    fop.install_skills(agents="claude")
+
+    assert os.path.isfile(os.path.join(central, "skill-a", "SKILL.md"))
+
+
+def test_install_skills_creates_symlink(mocker, plugins_dir, tmp_path_factory):
+    _make_plugin(plugins_dir, "plugin-a", "skill-a")
+    mocker.patch("fiftyone.config.plugins_dir", plugins_dir)
+
+    central = str(tmp_path_factory.mktemp("central"))
+    agent_dir = str(tmp_path_factory.mktemp("agent"))
+    mocker.patch("fiftyone.plugins.skills._CENTRAL_LOCAL", central)
+    mocker.patch(
+        "fiftyone.plugins.skills._LOCAL_TARGETS", {"claude": agent_dir}
+    )
+
+    fop.install_skills(agents="claude")
+
+    link = os.path.join(agent_dir, "skill-a")
+    assert os.path.islink(link)
+    assert os.path.realpath(link) == os.path.realpath(
+        os.path.join(central, "skill-a")
+    )
+
+
+def test_install_skills_returns_names(mocker, plugins_dir, tmp_path_factory):
+    _make_plugin(plugins_dir, "plugin-a", "skill-a")
+    _make_plugin(plugins_dir, "plugin-b", "skill-b")
+    mocker.patch("fiftyone.config.plugins_dir", plugins_dir)
+
+    central = str(tmp_path_factory.mktemp("central"))
+    agent_dir = str(tmp_path_factory.mktemp("agent"))
+    mocker.patch("fiftyone.plugins.skills._CENTRAL_LOCAL", central)
+    mocker.patch(
+        "fiftyone.plugins.skills._LOCAL_TARGETS", {"claude": agent_dir}
+    )
+
+    installed = fop.install_skills(agents="claude")
+
+    assert set(installed) == {"skill-a", "skill-b"}
+
+
+def test_parse_skill_frontmatter_valid(tmp_path_factory):
+    tmp = tmp_path_factory.mktemp("skills")
+    skill_file = tmp / "SKILL.md"
+    skill_file.write_text("---\nname: my-skill\ncategory: qa\n---\n# body\n")
+
+    metadata = fps._parse_skill_frontmatter(str(skill_file))
+
+    assert metadata["name"] == "my-skill"
+    assert metadata["category"] == "qa"
+
+
+def test_parse_skill_frontmatter_none(tmp_path_factory):
+    tmp = tmp_path_factory.mktemp("skills")
+    skill_file = tmp / "SKILL.md"
+    skill_file.write_text("# No frontmatter here\n")
+
+    assert fps._parse_skill_frontmatter(str(skill_file)) == {}


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

This PR adds support for skills inside plugins in FiftyOne, aligned with the data agent work.

The idea is pretty simple. Skills are just Markdown files for AI agents, and now you can define them directly in `fiftyone.yml`, the same way we already do with operators and panels. So `fiftyone.yml` becomes the source of truth, and you just list your skills under `skills:` using relative paths. Plugins can even be just skills, no operators needed.

```
name: "@voxel51/fiftyone-internal-skills"
description: Internal FiftyOne skills for data-centric ML workflows
version: 1.0.0
url: https://github.com/voxel51/fiftyone-internal-skills

skills:
  - skills/fiftyone-annotation-qa/SKILL.md
``` 
## 🧪 How is this patch tested? If it is not, please explain why.

* `pre-commit run --files` passes
* Unit tests pass: `pytest tests/unittests/plugins/`
* Manual tests:
  * `fiftyone plugins skills list` shows skills

```
(env) ado@Adonais-MacBook-Pro fiftyone % fiftyone plugins skills list
name                        category    plugin                             path
--------------------------  ----------  ---------------------------------  ---------------------------------------------------------------------------------------------------
fiftyone-annotation-qa      QA          @voxel51/fiftyone-internal-skills  /Users/ado/fiftyone/__plugins__/fiftyone-internal-skills/skills/fiftyone-annotation-qa/SKILL.md
fiftyone-auto-labeling      Annotate    @voxel51/fiftyone-internal-skills  /Users/ado/fiftyone/__plugins__/fiftyone-internal-skills/skills/fiftyone-auto-labeling/SKILL.md
fiftyone-data-distribution  Curate      @voxel51/fiftyone-internal-skills  /Users/ado/fiftyone/__plugins__/fiftyone-internal-skills/skills/fiftyone-data-distribution/SKILL.md
fiftyone-data-enrichment    Curate      @voxel51/fiftyone-internal-skills  /Users/ado/fiftyone/__plugins__/fiftyone-internal-skills/skills/fiftyone-data-enrichment/SKILL.md
fiftyone-data-export        Export      @voxel51/fiftyone-internal-skills  /Users/ado/fiftyone/__plugins__/fiftyone-internal-skills/skills/fiftyone-data-export/SKILL.md
fiftyone-data-import        Import      @voxel51/fiftyone-internal-skills  /Users/ado/fiftyone/__plugins__/fiftyone-internal-skills/skills/fiftyone-data-import/SKILL.md
fiftyone-data-quality       Curate      @voxel51/fiftyone-internal-skills  /Users/ado/fiftyone/__plugins__/fiftyone-internal-skills/skills/fiftyone-data-quality/SKILL.md
fiftyone-dataset-split      Annotate    @voxel51/fiftyone-internal-skills  /Users/ado/fiftyone/__plugins__/fiftyone-internal-skills/skills/fiftyone-dataset-split/SKILL.md
fiftyone-me-panel-config    Evaluate    @voxel51/fiftyone-internal-skills  /Users/ado/fiftyone/__plugins__/fiftyone-internal-skills/skills/fiftyone-me-panel-config/SKILL.md
fiftyone-model-evaluation   Evaluate    @voxel51/fiftyone-internal-skills  /Users/ado/fiftyone/__plugins__/fiftyone-internal-skills/skills/fiftyone-model-evaluation/SKILL.md
fiftyone-nl-dataset-query   Curate      @voxel51/fiftyone-internal-skills  /Users/ado/fiftyone/__plugins__/fiftyone-internal-skills/skills/fiftyone-nl-dataset-query/SKILL.md
```

Some example for testing
```
fiftyone plugins skills list            
fiftyone plugins skills list --plugin "@voxel51/fiftyone-internal-skills"
fiftyone plugins skills list --category qa                                                                      
fiftyone plugins skills list --names-only
```
---

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [x] Yes. Give a description of this change to be included in the release
  notes for FiftyOne users.

Adds support for plugin-based AI agent skills in FiftyOne, including CLI commands to list skills.

---

### What areas of FiftyOne does this PR affect?

* [ ] App: FiftyOne application changes
* [ ] Build: Build and test infrastructure changes
* [x] Core: Core `fiftyone` Python library changes
* [ ] Documentation: FiftyOne documentation changes
* [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "plugins skills" CLI group with a "list" subcommand to discover plugin-provided skills (filter by plugin, category, or names-only).
  * Plugin metadata and public plugin API now expose discovered skills for serialization and querying; skills include name, description, category, path, and provider plugin.

* **Tests**
  * Added tests covering skills discovery, filtering, frontmatter parsing, missing skill files, and behavior with disabled plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->