### PR TITLE
Fix #7153: [INSTALL] Inconsistent supported Python Versions for Linux...

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -51,6 +51,30 @@ IF NOT ERRORLEVEL 1 (
   set PIP=pip
 )
 
+:: Check Python version (3.9 - 3.12 supported)
+for /f "tokens=*" %%v in ('python -c "import sys; print(f\"{sys.version_info.major}.{sys.version_info.minor}\")" 2^>nul') do set PY_VER=%%v
+if "%PY_VER%"=="" (
+  echo ERROR: Python not found in PATH.
+  exit /b 1
+)
+for /f "tokens=1,2 delims=." %%a in ("%PY_VER%") do (
+  set PY_MAJOR=%%a
+  set PY_MINOR=%%b
+)
+if %PY_MAJOR% NEQ 3 (
+  echo Python %PY_VER% is NOT supported. Please use Python 3.9 - 3.12.
+  exit /b 1
+)
+if %PY_MINOR% LSS 9 (
+  echo Python %PY_VER% is NOT supported. Please use Python 3.9 - 3.12.
+  exit /b 1
+)
+if %PY_MINOR% GTR 12 (
+  echo Python %PY_VER% is NOT supported. Please use Python 3.9 - 3.12.
+  exit /b 1
+)
+echo Python %PY_VER% is supported.
+
 :: Do this first so pip installs with a built app
 if %BUILD_APP%==true (
   echo ***** INSTALLING FIFTYONE-APP *****

--- a/setup.py
+++ b/setup.py
@@ -121,5 +121,5 @@ setup(
         "Programming Language :: Python :: 3.12",
     ],
     entry_points={"console_scripts": ["fiftyone=fiftyone.core.cli:main"]},
-    python_requires=">=3.9",
+    python_requires=">=3.9,<3.13",
 )


### PR DESCRIPTION
Closes #7153

## 🔗 Related Issues

Fixes #7153

## 📋 What changes are proposed in this pull request?

Two changes to enforce consistent Python version constraints (3.9–3.12) across all install paths:

1. **`install.bat`**: Added a Python version check block (after the `pip` detection logic, before `BUILD_APP`) that:
   - Retrieves the running Python's major/minor version via `python -c "import sys; print(...)"`.
   - Exits with an error if Python is not found in `PATH`.
   - Exits with an error if the major version is not 3, or the minor version is below 9 or above 12.
   - Mirrors the equivalent version gate already present in `install.sh`.

2. **`setup.py`**: Tightened `python_requires` from `">=3.9"` to `">=3.9,<3.13"`, so `pip` will refuse to install FiftyOne on Python 3.13+ rather than silently proceeding with an unsupported interpreter.

## 🧪 How is this patch tested? If it is not, please explain why.

Manually tested `install.bat` on Windows by temporarily setting the environment to simulate Python 3.8, 3.9, 3.12, and 3.13:
- Python 3.8 → prints error and exits with code 1.
- Python 3.9 and 3.12 → prints "Python X.Y is supported." and continues.
- Python 3.13 → prints error and exits with code 1.

The `setup.py` change is verified by inspecting the metadata produced by `python setup.py egg_info` and confirming `Requires-Python: >=3.9,<3.13` appears in the generated `.egg-info/PKG-INFO`.

No automated tests added; the install scripts are not covered by the unit test suite.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

`install.bat` now enforces the same Python 3.9–3.12 version requirement that `install.sh` already checked, and `setup.py` has been updated to declare `python_requires=">=3.9,<3.13"` so that package installers correctly reject unsupported Python versions.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Python version validation during installation to ensure Python 3.9–3.12 is available on the system
  * Updated package metadata to explicitly restrict support to Python 3.9–3.12, preventing installation on unsupported versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->