### PR TITLE
hackathon: Enterprise sync for pull requests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -73,7 +73,8 @@ jobs:
     uses: ./.github/workflows/lint-app.yml
 
   enterprise-sync:
-    needs: modified-files
+    enterprise-sync:
+      if: github.event.action == 'closed' || github.event.pull_request.draft != true
     if: github.event.action == 'closed' || github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,7 @@ name: Pull Request
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened, closed, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -72,7 +72,9 @@ jobs:
 
   enterprise-sync:
     needs: modified-files
-    if: needs.modified-files.outputs.docs-only != 'true'
+    if: |
+      github.event.action == 'closed' ||
+      (needs.modified-files.outputs.docs-only != 'true' && github.event.pull_request.draft != true)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       app-changes: ${{ steps.filter.outputs.app }}
-      docs-only: ${{ steps.docs-filter.outputs.docs-only }}
       e2e-changes: ${{ steps.filter.outputs.e2e-pw }}
       fiftyone-changes: ${{ steps.filter.outputs.fiftyone }}
     steps:
@@ -44,13 +43,6 @@ jobs:
               - '.github/workflows/build.yml'
               - '.github/workflows/test.yml'
               - 'plugins/**'
-      - uses: dorny/paths-filter@v4
-        id: docs-filter
-        with:
-          predicate-quantifier: "every"
-          filters: |
-            docs-only:
-              - 'docs/**'
 
   build:
     needs: modified-files
@@ -72,9 +64,7 @@ jobs:
 
   enterprise-sync:
     needs: modified-files
-    if: |
-      github.event.action == 'closed' ||
-      (needs.modified-files.outputs.docs-only != 'true' && github.event.pull_request.draft != true)
+    if: github.event.action == 'closed' || github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -73,8 +73,9 @@ jobs:
     uses: ./.github/workflows/lint-app.yml
 
   enterprise-sync:
-    if: github.event.action == 'closed' || github.event.pull_request.draft != true
-    runs-on: ubuntu-latest
+    if: >-
+      (github.event.action == 'closed' || github.event.pull_request.draft != true) &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       app-changes: ${{ steps.filter.outputs.app }}
+      docs-only: ${{ steps.docs-filter.outputs.docs-only }}
       e2e-changes: ${{ steps.filter.outputs.e2e-pw }}
       fiftyone-changes: ${{ steps.filter.outputs.fiftyone }}
-      docs-only: ${{ steps.docs-filter.outputs.docs-only }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -73,9 +73,8 @@ jobs:
     uses: ./.github/workflows/lint-app.yml
 
   enterprise-sync:
-    enterprise-sync:
-      if: github.event.action == 'closed' || github.event.pull_request.draft != true
     if: github.event.action == 'closed' || github.event.pull_request.draft != true
+    runs-on: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,12 +46,19 @@ jobs:
 
   build:
     needs: modified-files
-    if: ${{ github.event.action != 'closed' && (needs.modified-files.outputs.app-changes == 'true' || needs.modified-files.outputs.fiftyone-changes == 'true') }}
+    if: >-
+      github.event.action != 'closed' && (
+      needs.modified-files.outputs.app-changes == 'true' ||
+      needs.modified-files.outputs.fiftyone-changes == 'true')
     uses: ./.github/workflows/build.yml
 
   e2e:
     needs: modified-files
-    if: ${{ github.event.action != 'closed' && (needs.modified-files.outputs.app-changes == 'true' || needs.modified-files.outputs.e2e-changes == 'true' || needs.modified-files.outputs.fiftyone-changes == 'true') }}
+    if: >-
+      github.event.action != 'closed' && (
+      needs.modified-files.outputs.app-changes == 'true' ||
+      needs.modified-files.outputs.e2e-changes == 'true' ||
+      needs.modified-files.outputs.fiftyone-changes == 'true')
     uses: ./.github/workflows/e2e.yml
     secrets:
       docker-username: ${{ secrets.RO_DOCKERHUB_USERNAME }}
@@ -59,7 +66,10 @@ jobs:
 
   lint:
     needs: modified-files
-    if: ${{ github.event.action != 'closed' && (needs.modified-files.outputs.app-changes == 'true' || needs.modified-files.outputs.fiftyone-changes == 'true') }}
+    if: >-
+      github.event.action != 'closed' && (
+      needs.modified-files.outputs.app-changes == 'true' ||
+      needs.modified-files.outputs.fiftyone-changes == 'true')
     uses: ./.github/workflows/lint-app.yml
 
   enterprise-sync:
@@ -88,12 +98,17 @@ jobs:
 
   test:
     needs: modified-files
-    if: ${{ github.event.action != 'closed' && (needs.modified-files.outputs.app-changes == 'true' || needs.modified-files.outputs.fiftyone-changes == 'true') }}
+    if: >-
+      github.event.action != 'closed' && (
+      needs.modified-files.outputs.app-changes == 'true' ||
+      needs.modified-files.outputs.fiftyone-changes == 'true')
     uses: ./.github/workflows/test.yml
 
   test-windows:
     needs: modified-files
-    if: ${{ github.event.action != 'closed' && needs.modified-files.outputs.fiftyone-changes == 'true' }}
+    if: >-
+      github.event.action != 'closed' &&
+      needs.modified-files.outputs.fiftyone-changes == 'true'
     uses: ./.github/workflows/windows-test.yml
 
   all-tests:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -74,8 +74,9 @@ jobs:
 
   enterprise-sync:
     if: >-
-      (github.event.action == 'closed' || github.event.pull_request.draft != true) &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository && (
+      github.event.action == 'closed' ||
+      github.event.pull_request.draft != true)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,7 @@ name: Pull Request
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened, closed]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,6 +15,7 @@ jobs:
       app-changes: ${{ steps.filter.outputs.app }}
       e2e-changes: ${{ steps.filter.outputs.e2e-pw }}
       fiftyone-changes: ${{ steps.filter.outputs.fiftyone }}
+      docs-only: ${{ steps.docs-filter.outputs.docs-only }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -43,15 +44,22 @@ jobs:
               - '.github/workflows/build.yml'
               - '.github/workflows/test.yml'
               - 'plugins/**'
+      - uses: dorny/paths-filter@v4
+        id: docs-filter
+        with:
+          predicate-quantifier: "every"
+          filters: |
+            docs-only:
+              - 'docs/**'
 
   build:
     needs: modified-files
-    if: ${{ needs.modified-files.outputs.app-changes == 'true' || needs.modified-files.outputs.fiftyone-changes == 'true' }}
+    if: ${{ github.event.action != 'closed' && (needs.modified-files.outputs.app-changes == 'true' || needs.modified-files.outputs.fiftyone-changes == 'true') }}
     uses: ./.github/workflows/build.yml
 
   e2e:
     needs: modified-files
-    if: ${{ needs.modified-files.outputs.app-changes == 'true' || needs.modified-files.outputs.e2e-changes == 'true' || needs.modified-files.outputs.fiftyone-changes == 'true' }}
+    if: ${{ github.event.action != 'closed' && (needs.modified-files.outputs.app-changes == 'true' || needs.modified-files.outputs.e2e-changes == 'true' || needs.modified-files.outputs.fiftyone-changes == 'true') }}
     uses: ./.github/workflows/e2e.yml
     secrets:
       docker-username: ${{ secrets.RO_DOCKERHUB_USERNAME }}
@@ -59,40 +67,41 @@ jobs:
 
   lint:
     needs: modified-files
-    if: ${{ needs.modified-files.outputs.app-changes == 'true' || needs.modified-files.outputs.fiftyone-changes == 'true' }}
+    if: ${{ github.event.action != 'closed' && (needs.modified-files.outputs.app-changes == 'true' || needs.modified-files.outputs.fiftyone-changes == 'true') }}
     uses: ./.github/workflows/lint-app.yml
 
-  teams:
+  enterprise-sync:
+    needs: modified-files
+    if: needs.modified-files.outputs.docs-only != 'true'
     runs-on: ubuntu-latest
-    if: false && github.base_ref == 'develop' # temporarily disabled
     steps:
-      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+      - uses: actions/github-script@v7
         with:
-          owner: voxel51
-          repo: fiftyone-teams
-          github_token: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
-          github_user: voxel51-bot
-          workflow_file_name: merge-oss.yml
-          ref: develop
-          wait_interval: 20
-          client_payload: |
-            {
-              "author": "${{ github.event.pull_request.user.login }}",
-              "branch": "${{ github.head_ref || github.ref_name }}",
-              "pr": ${{ github.event.pull_request.number }}
-            }
-          propagate_failure: true
-          trigger_workflow: true
-          wait_workflow: true
+          github-token: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'voxel51',
+              repo: 'fiftyone-teams',
+              event_type: 'oss-pr-sync',
+              client_payload: {
+                action: context.payload.action,
+                branch: context.payload.pull_request.head.ref,
+                author: context.payload.pull_request.user.login,
+                pr_number: context.payload.pull_request.number,
+                commit_sha: context.payload.pull_request.head.sha,
+                base: context.payload.pull_request.base.ref,
+                merged: context.payload.pull_request.merged ?? false,
+              }
+            });
 
   test:
     needs: modified-files
-    if: ${{ needs.modified-files.outputs.app-changes == 'true' || needs.modified-files.outputs.fiftyone-changes == 'true' }}
+    if: ${{ github.event.action != 'closed' && (needs.modified-files.outputs.app-changes == 'true' || needs.modified-files.outputs.fiftyone-changes == 'true') }}
     uses: ./.github/workflows/test.yml
 
   test-windows:
     needs: modified-files
-    if: ${{ needs.modified-files.outputs.fiftyone-changes == 'true' }}
+    if: ${{ github.event.action != 'closed' && needs.modified-files.outputs.fiftyone-changes == 'true' }}
     uses: ./.github/workflows/windows-test.yml
 
   all-tests:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -75,7 +75,6 @@ jobs:
   enterprise-sync:
     if: github.event.action == 'closed' || github.event.pull_request.draft != true
     runs-on: ubuntu-latest
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7
         with:


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

A new `enterprise / ci` status check will appear on all PRs. The check runs automatically and your PR cannot be merged until it passes. Contributors without access to the downstream repository will see the check pass immediately.

If the check fails due to a merge conflict, a comment will be added to the PR with resolution instructions. If it fails due to a CI failure, update your branch to fix the failure and the check will re-run automatically.
                                                                                                                                                                                      
  ## 🧪 How is this patch tested? If it is not, please explain why.

Tested via `workflow_dispatch` on the downstream workflow files. Full end-to-end testing will be completed before the `enterprise / ci` status check is added as a required check in branch protection.
                                                                                                                                                                                      
  ## 📝 Release Notes

  N/A

  ### What areas of FiftyOne does this PR affect?                                                                                                                                     
   
  -   [ ] App: FiftyOne application changes                                                                                                                                           
  -   [x] Build: Build and test infrastructure changes
  -   [ ] Core: Core `fiftyone` Python library changes
  -   [ ] Documentation: FiftyOne documentation changes
  -   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now responds to additional pull-request actions (e.g., reopened, closed, ready-for-review) and will skip selected jobs when a PR is closed.
  * Replaced an internal notification job with a consolidated sync job that runs for closed or non-draft PRs and dispatches a standardized sync payload with PR metadata.

* **Note**
  * No user-facing changes; updates affect internal CI/sync behavior only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7294)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->