### PR TITLE
fix: replace bare except with except Exception in useragent.py

### DIFF
--- a/fiftyone/utils/useragent.py
+++ b/fiftyone/utils/useragent.py
@@ -14,5 +14,5 @@ def with_fiftyone_useragent():
 
         useragent.with_partner("voxel51")
         useragent.with_product("fiftyone", foc.VERSION)
-    except:
+    except Exception:
         pass


### PR DESCRIPTION
## Summary

Replace bare `except:` with `except Exception:` in `fiftyone/utils/useragent.py`.

Bare `except:` silently catches **all** exceptions — including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit` — which can suppress critical signals and make programs impossible to interrupt. `except Exception:` is the correct, Pythonic choice when the intent is to swallow non-fatal errors.

**Change:**
```python
# Before
    except:
        pass

# After
    except Exception:
        pass
```

## Testing
No behavior change — style/correctness fix only. The `pass` block continues to swallow non-fatal exceptions while correctly allowing `SystemExit` and `KeyboardInterrupt` to propagate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved exception handling robustness in user-agent utilities to prevent unintended suppression of critical system errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->