### PR TITLE
fix: replace bare except with except Exception in v0_19_0 migration

### DIFF
--- a/fiftyone/migrations/revisions/v0_19_0.py
+++ b/fiftyone/migrations/revisions/v0_19_0.py
@@ -91,7 +91,7 @@ def _down_runs(db, dataset_dict, runs_field):
         if isinstance(_id, ObjectId):
             try:
                 run_doc = db.runs.find_one({"_id": _id})
-            except:
+            except Exception:
                 continue
 
             db.runs.delete_one({"_id": _id})
@@ -108,24 +108,24 @@ def _down_runs(db, dataset_dict, runs_field):
 def _warn_legacy_3d_config(dataset_dict):
     try:
         config = dataset_dict["app_config"]["plugins"]["3d"]
-    except:
+    except Exception:
         return
 
     is_legacy = False
 
     try:
         is_legacy |= "itemRotation" in config["overlay"]
-    except:
+    except Exception:
         pass
 
     try:
         is_legacy |= "rotation" in config["overlay"]
-    except:
+    except Exception:
         pass
 
     try:
         is_legacy |= "rotation" in config["pointCloud"]
-    except:
+    except Exception:
         pass
 
     if is_legacy:


### PR DESCRIPTION
## Summary

Replace 5 bare `except:` clauses with `except Exception:` in the v0.19 migration revision.

Bare `except:` catches **all** exceptions including `SystemExit` and `KeyboardInterrupt`. In migration scripts these are used as "swallow any error and continue/return/pass" patterns — `except Exception:` is the correct, precise form for this intent.

**Changes (all 5 follow this pattern):**
```python
# Before
    except:
        continue   # or return / pass

# After
    except Exception:
        continue   # or return / pass
```

Affected lines: 94, 111, 118, 123, 128

## Testing
No behavior change — correctness/style fix only. Migration logic is identical; non-fatal exceptions are still swallowed as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved exception handling patterns in the migration system for better code quality and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->