### PR TITLE
fix: replace bare except with except Exception in v0_20_0 migration

### DIFF
--- a/fiftyone/migrations/revisions/v0_20_0.py
+++ b/fiftyone/migrations/revisions/v0_20_0.py
@@ -156,7 +156,7 @@ def _update_runs(
     for run_id in runs.values():
         try:
             run_dict = db.runs.find_one({"_id": run_id})
-        except:
+        except Exception:
             continue
 
         config = run_dict.get("config", {})
@@ -173,7 +173,7 @@ def _update_runs(
                     run_dict["results"] = _update_run_results(
                         db, results_id, results_updates
                     )
-                except:
+                except Exception:
                     pass
 
             db.runs.replace_one({"_id": run_id}, run_dict)
@@ -196,7 +196,7 @@ def _update_run_results(db, results_id, updates):
     try:
         # Delete old run results
         fs.delete(results_id)
-    except:
+    except Exception:
         pass
 
     return new_results_id


### PR DESCRIPTION
## Summary

Replace 3 bare `except:` clauses with `except Exception:` in the v0.20 migration revision.

All three follow the same "swallow any error and continue/pass" pattern where `except Exception:` is the correct, precise form — it catches all non-fatal errors without masking `SystemExit` or `KeyboardInterrupt`.

**Changes:**
```python
# Before
    except:
        continue   # or pass

# After
    except Exception:
        continue   # or pass
```

Affected lines: 159, 176, 199

## Testing
No behavior change — correctness/style fix only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved exception handling robustness in migration processes to ensure more predictable behavior during data migration operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->