### PR TITLE
fix: replace 7 bare except clauses with except Exception in server/query.py

### DIFF
--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -119,7 +119,7 @@ class BrainRunConfig(RunConfig):
 
             if issubclass(fob.VisualizationConfig, etau.get_class(self.cls)):
                 return BrainRunType.visualization
-        except:
+        except Exception:
             pass
 
         return None
@@ -141,7 +141,7 @@ class BrainRunConfig(RunConfig):
                 embeddings_field=self.embeddings_field,
                 patches_field=self.patches_field,
             )
-        except:
+        except Exception:
             return None
 
 
@@ -517,7 +517,7 @@ class Query(fosa.AggregateQuery):
                 SavedView.from_doc(view_doc)
                 for view_doc in ds._doc.saved_views
             ]
-        except:
+        except Exception:
             return None
 
     @gql.field
@@ -618,7 +618,7 @@ async def serialize_dataset(
             if serialized_view:
                 for stage in serialized_view:
                     view = view.add_stage(fosg.ViewStage._from_dict(stage))
-        except:
+        except Exception:
             view: fov.DatasetView = fov.DatasetView._build(
                 dataset, serialized_view or []
             )
@@ -674,19 +674,19 @@ async def serialize_dataset(
         for brain_method in data.brain_methods:
             try:
                 type = brain_method.config.type().value
-            except:
+            except Exception:
                 type = None
 
             try:
                 max_k = brain_method.config.max_k()
-            except:
+            except Exception:
                 max_k = None
 
             try:
                 supports_least_similarity = (
                     brain_method.config.supports_least_similarity()
                 )
-            except:
+            except Exception:
                 supports_least_similarity = None
 
             setattr(brain_method.config, "type", type)


### PR DESCRIPTION
## Summary

Replace 7 bare `except:` clauses with `except Exception:` in `fiftyone/server/query.py`.

Bare `except:` catches **all** exceptions including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`. In a server query module these broad catches can silently swallow signals that should terminate the process. `except Exception:` is the correct form for "catch any non-fatal error."

**All 7 changes follow this pattern:**
```python
# Before
    except:
        pass   # or return None / return BrainRunType / fallback

# After
    except Exception:
        pass   # or return None / return BrainRunType / fallback
```

Affected lines: 122, 144, 520, 621 (and 3 more)

## Testing
No behavior change — correctness/style fix only. All exception-swallowing blocks continue to catch non-fatal errors as intended while allowing `KeyboardInterrupt` to propagate correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal exception handling robustness to better capture and manage specific error conditions during query processing and dataset operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->