### PR TITLE
Add multiline support to TextFieldView

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/TextFieldView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TextFieldView.tsx
@@ -8,7 +8,8 @@ import FieldWrapper from "./FieldWrapper";
 export default function TextFieldView(props: ViewPropsType<NumberSchemaType>) {
   const { schema, onChange, path, data } = props;
   const { type, view = {}, min, max, multipleOf = 1 } = schema;
-  const { readOnly, placeholder, compact, label, color, variant } = view;
+  const { readOnly, placeholder, compact, label, color, variant, multiline, rows } =
+    view;
 
   const { inputProps = {}, ...fieldProps } = getComponentProps(props, "field", {
     sx: getFieldSx({ color, variant }),
@@ -27,6 +28,8 @@ export default function TextFieldView(props: ViewPropsType<NumberSchemaType>) {
         fullWidth
         placeholder={compact ? placeholder || label : placeholder}
         type={type}
+        multiline={multiline}
+        rows={rows}
         onChange={(e) => {
           const value = e.target.value;
           onChange(path, type === "number" ? parseFloat(value) : value);

--- a/fiftyone/operators/_types/types.py
+++ b/fiftyone/operators/_types/types.py
@@ -2533,10 +2533,24 @@ class TextFieldView(View):
     .. note::
 
         Must be used with :class:`String` or :class:`Number` properties.
+
+    Args:
+        multiline (False): whether to render a multiline text area
+        rows (None): optional number of visible text rows when ``multiline``
+            is enabled
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, multiline=False, rows=None, **kwargs):
         super().__init__(**kwargs)
+        self.multiline = multiline
+        self.rows = rows
+
+    def to_json(self):
+        return {
+            **super().to_json(),
+            "multiline": self.multiline,
+            "rows": self.rows,
+        }
 
 
 class FieldView(View):

--- a/fiftyone/operators/_types/types.py
+++ b/fiftyone/operators/_types/types.py
@@ -2541,7 +2541,7 @@ class TextFieldView(View):
     """
 
     def __init__(self, multiline=False, rows=None, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(multiline=multiline, rows=rows, **kwargs)
         self.multiline = multiline
         self.rows = rows
 

--- a/tests/unittests/operators/types_tests.py
+++ b/tests/unittests/operators/types_tests.py
@@ -142,3 +142,12 @@ class TestTextFieldViewType(unittest.TestCase):
 
         self.assertTrue(dict_rep["multiline"])
         self.assertEqual(dict_rep["rows"], 5)
+
+    def test_serialize_multiline_after_define_property_clone(self):
+        obj = types.Object()
+        obj.str("notes", view=types.TextFieldView(multiline=True, rows=5))
+
+        view_json = obj.to_json()["properties"]["notes"]["view"]
+
+        self.assertTrue(view_json["multiline"])
+        self.assertEqual(view_json["rows"], 5)

--- a/tests/unittests/operators/types_tests.py
+++ b/tests/unittests/operators/types_tests.py
@@ -132,3 +132,13 @@ class TestPipelineType(unittest.TestCase):
         )
         new_obj = types.PipelineRunInfo.from_json(dict_rep)
         self.assertEqual(new_obj, run_info)
+
+
+class TestTextFieldViewType(unittest.TestCase):
+    def test_serialize_multiline(self):
+        view = types.TextFieldView(multiline=True, rows=5)
+
+        dict_rep = view.to_json()
+
+        self.assertTrue(dict_rep["multiline"])
+        self.assertEqual(dict_rep["rows"], 5)


### PR DESCRIPTION
## Summary
- extend `types.TextFieldView` with `multiline` and `rows` options and include them in JSON serialization
- wire the new view options through the SchemaIO `TextFieldView` React component
- add a unit test validating serialization of multiline settings

Closes #7280

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Text field inputs now support multiline mode with configurable row count, allowing expanded text areas for longer input.
* **Tests**
  * Added unit tests validating multiline behavior and row configuration are preserved when serialized and embedded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->