### PR TITLE
Align Windows installer Python version checks

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -38,6 +38,30 @@ SHIFT
 GOTO parse
 :endparse
 
+set MINOR_MIN=9
+set MINOR_MAX=12
+
+where python >nul 2>&1
+IF NOT ERRORLEVEL 1 (
+  set PYTHON_CMD=python
+) else (
+  where py >nul 2>&1
+  IF ERRORLEVEL 1 (
+    echo ERROR: Neither 'python' nor 'py' found in PATH.
+    exit /b 1
+  )
+  set PYTHON_CMD=py
+)
+
+for /f %%v in ('%PYTHON_CMD% -c "import sys; print(""{}.{}"".format(sys.version_info[0], sys.version_info[1]))"') do set PY_VER=%%v
+%PYTHON_CMD% -c "import sys; raise SystemExit(0 if sys.version_info[0] == 3 and %MINOR_MIN% <= sys.version_info[1] <= %MINOR_MAX% else 1)"
+IF ERRORLEVEL 1 (
+  echo Python %PY_VER% is NOT supported. Please use Python 3.%MINOR_MIN% - 3.%MINOR_MAX%.
+  exit /b 1
+)
+
+echo Python %PY_VER% is supported.
+
 :: Resolve pip backend
 where uv >nul 2>&1
 IF NOT ERRORLEVEL 1 (

--- a/setup.py
+++ b/setup.py
@@ -121,5 +121,5 @@ setup(
         "Programming Language :: Python :: 3.12",
     ],
     entry_points={"console_scripts": ["fiftyone=fiftyone.core.cli:main"]},
-    python_requires=">=3.9",
+    python_requires=">=3.9,<3.13",
 )


### PR DESCRIPTION
## Summary
- add Python version validation in `install.bat` to enforce the same supported range as the Unix installer
- make `setup.py` explicitly match that support window via `python_requires=\">=3.9,<3.13\"`
- improve installation consistency across platforms and avoid confusing mismatches for source installs

Closes #7153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported Python versions to 3.9–3.12. The installation process now detects and validates Python compatibility, providing clear error messaging if an unsupported version is encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->