### PR TITLE
Add sam3 image model to the model zoo

### DIFF
--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -1329,5 +1329,5 @@ def _get_sam_box_labels(detection):
     if "sam_label" in detection and detection.sam_label is not None:
         return detection.sam_label
     if "sam3_label" in detection and detection.sam3_label is not None:
-        return detection.sam3_labels
+        return detection.sam3_label
     return True

--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -624,7 +624,7 @@ class SAMSegmenterOutputProcessor(fout.OutputProcessor):
         mask_thresh (0.5): Threshold for converting float masks to boolean masks
     """
 
-    def __init__(self, classes=None, mask_thresh=0.5, **kwargs):
+    def __init__(self, classes=None, mask_thresh=0.5):
         self.classes = None
         self.mask_thresh = mask_thresh
 

--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -285,7 +285,6 @@ class SegmentAnythingImageGetItem(fout.GetItem):
             raise ValueError(
                 "Field mapping contains prompt_field which is not a required key. Use type specific prompt key(s) -- box_prompt_field, point_prompt_field."
             )
-
         self.mode = self._set_mode(field_mapping)
         self.box_transform_kwargs = kwargs.pop("box_transform_kwargs", {})
         self.point_transform_kwargs = kwargs.pop("point_transform_kwargs", {})
@@ -354,7 +353,7 @@ class SegmentAnythingImageGetItem(fout.GetItem):
                 )
             img, img_hw = self.transform(img)
         else:
-            img_hw = img.shape[:2]
+            img_hw = img.shape[:2] if self.use_numpy else img.size[::-1]
         item_dict["image"] = img
         item_dict["original_size"] = img_hw
         item_dict["id"] = d["id"]
@@ -621,15 +620,11 @@ class SAMSegmenterOutputProcessor(fout.OutputProcessor):
     """Converts SAM model outputs to FiftyOne format.
 
     Args:
-        classes (None): the list of class labels for the model
+        classes (None): the list of class labels for the model. Not used in SAM output processor.
         mask_thresh (0.5): Threshold for converting float masks to boolean masks
     """
 
     def __init__(self, classes=None, mask_thresh=0.5, **kwargs):
-        if classes is not None:
-            logger.warning(
-                "SAM doesn't generate classes. Input prompt classes will be preserved when available. Setting classes to None."
-            )
         self.classes = None
         self.mask_thresh = mask_thresh
 
@@ -857,7 +852,7 @@ class SegmentAnythingModel(fout.TorchImageModelWithPrompts):
         if "checkpoint" not in config.entrypoint_args:
             config.entrypoint_args["checkpoint"] = config.model_path
 
-        fout.TorchImageModel.__init__(self, config)
+        fout.TorchImageModelWithPrompts.__init__(self, config)
         self._sam_auto_generator = self._load_auto_generator()
         self._sam_predictor = self._load_predictor()
 

--- a/fiftyone/utils/sam2.py
+++ b/fiftyone/utils/sam2.py
@@ -111,16 +111,6 @@ class SegmentAnything2ImageModelConfig(fosam.SegmentAnythingModelConfig):
         )
 
 
-class SegmentAnything2ImageGetItem(fosam.SegmentAnythingImageGetItem):
-    pass
-
-
-class SegmentAnything2ImageGetItemForVideo(
-    fosam.SegmentAnythingImageGetItemForVideo
-):
-    pass
-
-
 class _SAM2Predictor(fosam._SAMPredictor):
     """Wrapper for ``sam2.sam2_image_predictor.SAM2ImagePredictor``.
 
@@ -220,6 +210,16 @@ class _SAM2Predictor(fosam._SAMPredictor):
             boxes=boxes,
             multimask_output=multimask_output,
         )
+
+
+class SegmentAnything2ImageGetItem(fosam.SegmentAnythingImageGetItem):
+    pass
+
+
+class SegmentAnything2ImageGetItemForVideo(
+    fosam.SegmentAnythingImageGetItemForVideo
+):
+    pass
 
 
 class SegmentAnything2ImageModel(fosam.SegmentAnythingModel):

--- a/fiftyone/utils/sam2.py
+++ b/fiftyone/utils/sam2.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 
 def _sam2_image_transform(img):
-    """Transforms image for SAM3 model input.
+    """Transforms image for SAM2 model input.
 
     Args:
         img: a PIL or a uint8 numpy array containing image in HWC format

--- a/fiftyone/utils/sam2.py
+++ b/fiftyone/utils/sam2.py
@@ -33,16 +33,18 @@ logger = logging.getLogger(__name__)
 
 
 def _sam2_image_transform(img):
-    """Transforms image for SAM2 model input.
+    """Transforms image for SAM3 model input.
 
     Args:
-        img: a uint8 numpy array containing image in HWC format
+        img: a PIL or a uint8 numpy array containing image in HWC format
 
     Returns:
-        a uint8 numpy array containing image in HWC format
+        a PIL image or a uint8 numpy array containing image in HWC format
         a tuple containing original image dimensions
     """
-    return img, img.shape[:2]
+    if isinstance(img, np.ndarray):
+        return img, img.shape[:2]
+    return img, img.size[::-1]
 
 
 def _sam2_box_transform(boxes_xyxy, orig_hw, resolution):

--- a/fiftyone/utils/sam3.py
+++ b/fiftyone/utils/sam3.py
@@ -275,7 +275,7 @@ class SAM3ConceptSegmenterOutputProcessor(fout.OutputProcessor):
         return proc_output
 
 
-class SegmentAnything3ImageModel(fosam.SegmentAnythingModel):
+class SegmentAnything3ImageModel(fosam2.SegmentAnything2ImageModel):
     """Wrapper for running `Segment Anything 3 <https://ai.meta.com/research/sam3>`_
     inference.
 

--- a/fiftyone/utils/sam3.py
+++ b/fiftyone/utils/sam3.py
@@ -93,20 +93,7 @@ class _SAM3Predictor(fosam2._SAM2Predictor):
             if hasattr(self.processor, "_transforms")
             else sam2ip.SAM2Transforms(model.image_size, mask_threshold=0)
         )
-
-    def image_transform(self, img):
-        """Transforms image for SAM3 model input.
-
-        Args:
-            img: a PIL or a uint8 numpy array containing image in HWC format
-
-        Returns:
-            a PIL image or a uint8 numpy array containing image in HWC format
-            a tuple containing original image dimensions
-        """
-        if isinstance(img, np.ndarray):
-            return super().image_transform(img)
-        return img, img.size[::-1]
+        self.resolution = float(self.sam_transforms.resolution)
 
 
 class SegmentAnything3ImageGetItem(fosam.SegmentAnythingImageGetItem):
@@ -137,15 +124,16 @@ class SegmentAnything3ImageGetItem(fosam.SegmentAnythingImageGetItem):
         operation_mode="concept",
         **kwargs,
     ):
+        self.text_prompts = text_prompts
+        self.operation_mode = operation_mode
         super().__init__(
             field_mapping=field_mapping,
             transform=transform,
             use_numpy=use_numpy,
             box_transform=box_transform,
             point_transform=point_transform,
+            **kwargs,
         )
-        self.text_prompts = text_prompts
-        self.operation_mode = operation_mode
 
     def __call__(self, d):
         """Prepares the model input for a given sample's data.
@@ -337,12 +325,12 @@ class SegmentAnything3ImageModel(fosam.SegmentAnythingModel):
             repo_id="facebook/sam3",
             filename=os.path.basename(config.model_path),
             local_dir=os.path.dirname(config.model_path),
-            local_dir_use_symlinks=False,
         )
 
     def _build_concept_output_processor(self, config):
         kwargs = config.output_processor_args or {}
-        # NOTE: Add new config params for concept output processor, if needed for more configurability.
+        # NOTE: Add params for concept output processor to SegmentAnything3ImageModelConfig
+        # if needed for more configurability.
         return SAM3ConceptSegmenterOutputProcessor(
             classes=None, mask_thresh=kwargs.get("mask_thresh", 0.5)
         )
@@ -354,6 +342,10 @@ class SegmentAnything3ImageModel(fosam.SegmentAnythingModel):
 
     @operation_mode.setter
     def operation_mode(self, value):
+        if value not in ["visual", "concept"]:
+            raise ValueError(
+                f"Operation mode can be either visual or concept. {value} is not supported."
+            )
         self._operation_mode = value
 
     @staticmethod
@@ -437,7 +429,9 @@ class SegmentAnything3ImageModel(fosam.SegmentAnythingModel):
                         ),
                         inference_metadata=sam3ds.InferenceMetadata(
                             original_image_id=img_idx,
-                            original_size=results["original_size"][::-1],
+                            original_size=results["original_size"][img_idx][
+                                ::-1
+                            ],
                             # dummy values
                             coco_image_id=img_idx,
                             original_category_id=1,

--- a/fiftyone/utils/sam3.py
+++ b/fiftyone/utils/sam3.py
@@ -1,0 +1,539 @@
+"""
+`Segment Anything 3 <https://github.com/facebookresearch/sam3>`_
+wrapper for the FiftyOne Model Zoo.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import logging
+import numpy as np
+import os
+from PIL import Image
+from enum import Enum
+
+import fiftyone.core.labels as fol
+import fiftyone.core.utils as fou
+import fiftyone.utils.torch as fout
+import fiftyone.utils.sam as fosam
+import fiftyone.utils.sam2 as fosam2
+
+fou.ensure_torch()
+import torch
+
+sam3 = fou.lazy_import("sam3")
+sam3tr = fou.lazy_import("sam3.train.transforms.basic_for_api")
+sam3ds = fou.lazy_import("sam3.train.data.sam3_image_dataset")
+sam2ip = fou.lazy_import("sam2.sam2_image_predictor")
+
+logger = logging.getLogger(__name__)
+
+
+class SegmentAnything3ImageModelConfig(fosam.SegmentAnythingModelConfig):
+    """Configuration for running a :class:`SegmentAnything3ImageModel`.
+
+    See :class:`fiftyone.utils.torch.TorchImageModelConfig` for additional
+    arguments.
+
+    Args:
+        classes (None): a list of custom classes for use as SAM3 text prompts
+    """
+
+    def __init__(self, cfg_dict):
+        """Initializes :class:`SegmentAnythingModelConfig`
+
+        Args:
+            cfg_dict: a dictionary with config parameters
+        """
+        d = self.init(cfg_dict)
+        super().__init__(d)
+        self.get_item_cls = self.parse_string(
+            d,
+            "get_item_cls",
+            default="fiftyone.utils.sam3.SegmentAnything3ImageGetItem",
+        )
+        self.classes = self.parse_array(d, "classes", default=None)
+        self.operation_mode = self.parse_string(
+            d, "operation_mode", default="concept"
+        )
+        self.image_id = None
+
+
+class _SAM3Predictor(fosam2._SAM2Predictor):
+    def __init__(self, model):
+        if model.inst_interactive_predictor is None:
+            raise AttributeError(
+                "Sam3Image.inst_interactive_predictor must be initialized."
+            )
+
+        self.processor = model.inst_interactive_predictor
+        self.image_id = None
+        self.sam_transforms = (
+            self.processor._transforms
+            if hasattr(self.processor, "_transforms")
+            else sam2ip.SAM2Transforms(model.image_size, mask_threshold=0)
+        )
+
+    def image_transform(self, img):
+        """Transforms image for SAM3 model input.
+
+        Args:
+            img: a PIL or a uint8 numpy array containing image in HWC format
+
+        Returns:
+            a PIL image or a uint8 numpy array containing image in HWC format
+            a tuple containing original image dimensions
+        """
+        # SAM2 does image pre-processing when it calls SAM2ImagePredictor.set_image.
+        # No straight-forward way to decouple them other than extracting the functionality.
+        if isinstance(img, np.ndarray):
+            return super().image_transform(img)
+        return img, img.size[::-1]
+
+
+class SegmentAnything3ImageGetItem(fosam.SegmentAnythingImageGetItem):
+    """A :class:`GetItem` that loads images, bounding boxes and/or keypoints to feed to
+    :class:`SegmentAnythingModel` instances.
+
+    Args:
+        field_mapping (None): the user-supplied dict mapping keys in
+            :attr:`required_keys` to field names of their dataset that contain
+            the required values
+        transform (None): SAM specific image transform function to apply
+        use_numpy (False): whether to use numpy arrays rather than PIL images
+            and Torch tensors when loading data
+        box_transform (None): SAM specific box transform function to apply
+        point_transform (None): SAM specific point transform function to apply
+        text_prompts (None): Text prompts for concept prompting the model
+        operation_mode ("concept"): Operation mode of the model (required for collate_fn)
+    """
+
+    def __init__(
+        self,
+        field_mapping=None,
+        transform=None,
+        use_numpy=False,
+        box_transform=None,
+        point_transform=None,
+        text_prompts=None,
+        operation_mode="concept",
+        **kwargs,
+    ):
+        super().__init__(
+            field_mapping=field_mapping,
+            transform=transform,
+            use_numpy=use_numpy,
+            box_transform=box_transform,
+            point_transform=point_transform,
+        )
+        self.text_prompts = text_prompts
+        self.operation_mode = operation_mode
+
+    def __call__(self, d):
+        """Prepares the model input for a given sample's data.
+
+        Args:
+            d: a dict mapping the :meth:`required_keys` to values from the
+                sample being processed
+
+        Returns:
+            the model input
+        """
+        item_dict = super().__call__(d=d)
+        item_dict["operation_mode"] = self.operation_mode
+        if self.operation_mode == "concept":
+            item_dict["text_prompts"] = self.text_prompts
+        return item_dict
+
+
+class SegmentAnything3ImageGetItemForVideo(SegmentAnything3ImageGetItem):
+    """Workaround for applying image model to video reader frames.
+
+    Frames are not stored on disk and therefore cannot be loaded.
+    """
+
+    def __call__(self, d):
+        """Prepares the model input for a given sample's data.
+
+        Args:
+            d: a dict mapping the :meth:`required_keys` to values from the
+                sample being processed
+
+        Returns:
+            the model input
+        """
+        item_dict = fosam.SegmentAnythingImageGetItemForVideo.__call__(
+            self, d=d
+        )
+        item_dict["operation_mode"] = self.operation_mode
+        if self.operation_mode == "concept":
+            item_dict["image"] = Image.fromarray(item_dict["image"], "RGB")
+            item_dict["text_prompts"] = self.text_prompts
+        return item_dict
+
+    @property
+    def required_keys(self):
+        """The list of keys that must exist on the dicts provided to the
+        :meth:`__call__` method at runtime."""
+
+        common_keys = ["image"]
+        box_keys = ["box_prompt_field"]
+        point_keys = ["point_prompt_field"]
+
+        if self.mode == fosam.SAMPromptMode.auto:
+            return common_keys
+        elif self.mode == fosam.SAMPromptMode.box_only:
+            return common_keys + box_keys
+        elif self.mode == fosam.SAMPromptMode.point_only:
+            return common_keys + point_keys
+        elif self.mode == fosam.SAMPromptMode.box_point_combo:
+            return common_keys + box_keys + point_keys
+        else:
+            raise ValueError(f"Undefined required keys for {self.mode.name}")
+
+
+def build_sam_datapoint_transform():
+    transform = sam3tr.ComposeAPI(
+        transforms=[
+            sam3tr.RandomResizeAPI(
+                sizes=1008,
+                max_size=1008,
+                square=True,
+                consistent_transform=False,
+            ),
+            sam3tr.ToTensorAPI(),
+            sam3tr.NormalizeAPI(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
+        ]
+    )
+    return transform
+
+
+class SegmentAnything3ImageModel(fosam.SegmentAnythingModel):
+    """Wrapper for running `Segment Anything 3 <https://ai.meta.com/research/sam3>`_
+    inference.
+
+    Args:
+        config: a :class:`SegmentAnything3ModelConfig`
+    """
+
+    def __init__(self, config):
+        if config.output_processor_cls is None:
+            config.output_processor_cls = (
+                "fiftyone.utils.sam.SAMSegmenterOutputProcessor"
+            )
+
+        if config.entrypoint_args is None:
+            config.entrypoint_args = {}
+        if "enable_inst_interactivity" not in config.entrypoint_args:
+            # Sam3Image.inst_interactive_predictor is only needed for "visual" operation mode.
+            # Always set to True for easy switching of operation modes in a loaded zoo model.
+            config.entrypoint_args["enable_inst_interactivity"] = True
+
+        fout.TorchImageModelWithPrompts.__init__(self, config)
+        self._sam_auto_generator = None
+        self._sam_predictor = self._load_predictor()
+        self._operation_mode = self.config.operation_mode
+
+    def _load_predictor(self):
+        predictor = _SAM3Predictor(model=self._model)
+        tracker_model = predictor.processor.model
+        if getattr(tracker_model, "backbone", None) is None:
+            tracker_model.backbone = self._model.backbone
+        return predictor
+
+    def _load_model(self, config):
+        if "device" not in config.entrypoint_args:
+            config.entrypoint_args["device"] = self._device
+        return super()._load_model(config)
+
+    def _download_model(self, config):
+        # Download sam3 to fo.config.model_zoo_dir from HF hub.
+        from huggingface_hub import hf_hub_download
+
+        hf_hub_download(
+            repo_id="facebook/sam3",
+            filename=os.path.basename(config.model_path),
+            local_dir=os.path.dirname(config.model_path),
+            local_dir_use_symlinks=False,
+        )
+
+    @property
+    def operation_mode(self):
+        """Whether to use the model in visual or concept segmentation mode"""
+        return self._operation_mode
+
+    @operation_mode.setter
+    def operation_mode(self, value):
+        self._operation_mode = value
+
+    @staticmethod
+    def collate_fn(batch):
+        """Collates a batch of inputs where each input is generated from :class:`SegmentAnything3ImageGetItem`.
+
+        Args:
+            batch: a list of dict containing model input from :class:`SegmentAnything3ImageGetItem`
+
+        Returns:
+            a collated dictionary of model input for the batch.
+        """
+        results = fosam.SegmentAnythingModel.collate_fn(batch)
+
+        operation_modes = results["operation_mode"]
+        if not all(op == operation_modes[0] for op in operation_modes):
+            raise ValueError(
+                "All samples in a batch must have the same operation_mode"
+            )
+        results["operation_mode"] = results["operation_mode"][0]
+
+        if results["operation_mode"] == "visual":
+            return results
+
+        # For "concept" mode, the collated output needs to be in Datapoint.
+        transform = build_sam_datapoint_transform()
+        datapoints = []
+        for img_idx in range(len(results["image"])):
+            datapoint = sam3ds.Datapoint(find_queries=[], images=[])
+            datapoint.images = [
+                sam3ds.Image(
+                    data=results["image"][img_idx],
+                    objects=[],
+                    size=results["original_size"][img_idx],
+                )
+            ]
+            text_prompts = (
+                results["text_prompts"][img_idx]
+                if "text_prompts" in results
+                else []
+            )
+            for tx in text_prompts:
+                datapoint.find_queries.append(
+                    sam3ds.FindQueryLoaded(
+                        query_text=tx,
+                        image_id=0,
+                        object_ids_output=[],  # unused for inference
+                        is_exhaustive=True,  # unused for inference
+                        query_processing_order=0,
+                        inference_metadata=sam3ds.InferenceMetadata(
+                            original_image_id=img_idx,
+                            original_size=results["original_size"][::-1],
+                            # dummy values
+                            coco_image_id=img_idx,
+                            original_category_id=1,
+                            object_id=0,
+                            frame_index=0,
+                        ),
+                    )
+                )
+            box_prompts = (
+                results["boxes_xyxy"][img_idx]
+                if "boxes_xyxy" in results
+                else None
+            )
+            if box_prompts is not None:
+                datapoint.find_queries.append(
+                    sam3ds.FindQueryLoaded(
+                        query_text="visual",
+                        image_id=0,
+                        object_ids_output=[],  # unused for inference
+                        is_exhaustive=True,  # unused for inference
+                        query_processing_order=0,
+                        input_bbox=torch.tensor(
+                            box_prompts, dtype=torch.float
+                        ),
+                        input_bbox_label=torch.tensor(
+                            results["boxes_labels"][img_idx], dtype=torch.bool
+                        ),
+                        inference_metadata=sam3ds.InferenceMetadata(
+                            original_image_id=img_idx,
+                            original_size=results["original_size"][::-1],
+                            # dummy values
+                            coco_image_id=img_idx,
+                            original_category_id=1,
+                            object_id=0,
+                            frame_index=0,
+                        ),
+                    )
+                )
+            datapoints.append(transform(datapoint))
+        batched_dps = sam3.train.data.collator.collate_fn_api(
+            datapoints, dict_key="datapoints"
+        )
+        results["datapoints"] = batched_dps["datapoints"]
+        return results
+
+    def build_get_item(self, field_mapping=None):
+        """Builds a :class:`SegmentAnything3ImageGetItem` for loading model input from samples.
+
+        Args:
+            field_mapping (None): a dict mapping required keys to sample fields
+
+        Returns:
+            a :class:`SegmentAnything3ImageGetItem` instance
+        """
+        rm_text_prompts, rm_op_mode = False, False
+        if self.config.get_item_args is None:
+            self.config.get_item_args = {}
+        if (
+            "text_prompts" not in self.config.get_item_args
+            and self.config.classes is not None
+        ):
+            self.config.get_item_args["text_prompts"] = self.config.classes
+            rm_text_prompts = True
+        if "operation_mode" not in self.config.get_item_args:
+            self.config.get_item_args[
+                "operation_mode"
+            ] = self.config.operation_mode
+            rm_op_mode = True
+        self.config.get_item_args["use_numpy"] = (
+            self.config.operation_mode == "visual"
+        )
+        get_item = super().build_get_item(field_mapping=field_mapping)
+        if rm_text_prompts:
+            _ = self.config.get_item_args.pop("text_prompts")
+        if rm_op_mode:
+            _ = self.config.get_item_args.pop("operation_mode")
+        return get_item
+
+    def _predict_all(self, args):
+        if self._preprocess and self.has_collate_fn:
+            # Pre-processing only applies collate. Args are expected to have the model transformations applied.
+            if isinstance(args, dict):
+                args = [args]
+            args = self.collate_fn(args)
+
+        prompt_type = args["prompt_type"]
+
+        orig_image_sizes = args.get("original_size")
+        # Only preserve boxes when using prompts with boxes.
+        boxes_xyxy = (
+            args.get("boxes_xyxy")
+            if prompt_type in ["box_only", "box_point_combo"]
+            else None
+        )
+        labels = args.get("classes") if "datapoints" not in args else None
+
+        if "datapoints" in args:
+            # Concept mode
+            args["datapoints"] = sam3.model.utils.misc.copy_data_to_device(
+                args["datapoints"], self.device, non_blocking=True
+            )
+            orig_image_sizes = args.get("original_size")
+
+            output = self._forward_pass_concept(args)
+        elif prompt_type == "auto":
+            return self._forward_pass_auto(args)
+        else:
+            for key in args:
+                if isinstance(args[key], torch.Tensor):
+                    args[key] = args[key].to(self.device)
+                elif (
+                    isinstance(args[key], list)
+                    and args[key]
+                    and isinstance(args[key][0], torch.Tensor)
+                ):
+                    args[key] = [v.to(self.device) for v in args[key]]
+
+            output = self._forward_pass(args)
+
+        if self._output_processor is not None:
+            return self._output_processor(
+                output,
+                orig_image_sizes,
+                confidence_thresh=self.config.confidence_thresh,
+                box_prompts=boxes_xyxy,
+                labels=labels,
+                mask_index=self.config.points_mask_index,
+                classes=self.config.filter_classes,
+            )
+        return output
+
+    def _forward_pass_concept(self, imgs):
+        with torch.inference_mode():
+            _output = self._model(imgs["datapoints"])
+
+        output = []
+        orig_image_sizes = imgs.get("original_size")
+        for idx, out in enumerate(_output):
+            out_bbox = out["pred_boxes"]
+            out_logits = out["pred_logits"]
+            out_masks = out["pred_masks"]
+            out_probs = out_logits.sigmoid()
+            presence_score = out["presence_logit_dec"].sigmoid().unsqueeze(1)
+            out_probs = (out_probs * presence_score).squeeze(-1)
+
+            keep = out_probs > 0.5
+            out_probs = out_probs[keep]
+            out_masks = out_masks[keep]
+            out_bbox = out_bbox[keep]
+
+            boxes = sam3.model.box_ops.box_cxcywh_to_xyxy(out_bbox)
+
+            img_h = orig_image_sizes[idx][0]
+            img_w = orig_image_sizes[idx][1]
+            scale_fct = torch.tensor([img_w, img_h, img_w, img_h]).to(
+                self.device
+            )
+            boxes = boxes * scale_fct[None, :]
+
+            out_masks = sam3.model.data_misc.interpolate(
+                out_masks.unsqueeze(1),
+                (img_h, img_w),
+                mode="bilinear",
+                align_corners=False,
+            ).sigmoid()
+            output.append(
+                {
+                    "masks": (out_masks > 0.5).float(),
+                    "iou_predictions": out_probs.unsqueeze(1).float(),
+                }
+            )
+
+        return output
+
+    def _forward_pass(self, imgs):
+        """Forward pass with prompts
+
+        Args:
+            imgs: a dict containing model input
+
+        Returns:
+            a dict containing model output
+        """
+        # TODO: FIX THIS! Using sam3 predict_inst_batch
+        images = imgs.pop("image")
+
+        self._sam_predictor.processor.set_image_batch(images)
+
+        point_coords = imgs.get("point_coords")
+        point_labels = imgs.get("point_labels")
+        boxes = imgs.get("boxes")
+        mask_inputs = imgs.get("mask_inputs")  # Not used currently
+        multimask_output = (
+            True if (boxes is None and point_coords is not None) else False
+        )
+        outputs = []
+        for img_idx in range(len(images)):
+            out_masks, iou_pred, _ = self._sam_predictor.processor._predict(
+                point_coords=point_coords[img_idx]
+                if point_coords is not None
+                else None,
+                point_labels=point_labels[img_idx]
+                if point_labels is not None
+                else None,
+                boxes=boxes[img_idx] if boxes is not None else None,
+                mask_input=mask_inputs[img_idx] if mask_inputs else None,
+                multimask_output=multimask_output,
+            )
+            outputs.append(
+                {
+                    "masks": out_masks.float(),
+                    "iou_predictions": iou_pred.float(),
+                }
+            )
+        return outputs
+
+    def _forward_pass_auto(self, imgs):
+        raise RuntimeError(
+            "sam3.model.sam3_image.Sam3Image doesn't support auto segmentation. You may use one of the SAM/SAM2 zoo models for auto segmentation."
+        )

--- a/fiftyone/utils/sam3.py
+++ b/fiftyone/utils/sam3.py
@@ -8,12 +8,9 @@ wrapper for the FiftyOne Model Zoo.
 """
 
 import logging
-import numpy as np
 import os
 from PIL import Image
-from enum import Enum
 
-import fiftyone.core.labels as fol
 import fiftyone.core.utils as fou
 import fiftyone.utils.torch as fout
 import fiftyone.utils.sam as fosam
@@ -488,6 +485,7 @@ class SegmentAnything3ImageModel(fosam2.SegmentAnything2ImageModel):
             if prompt_type in ["box_only", "box_point_combo"]
             else None
         )
+        # TODO: Add classes to concept mode by adding tracking for which detection came from which prompt.
         labels = args.get("classes") if "datapoints" not in args else None
 
         if "datapoints" in args:

--- a/fiftyone/utils/sam3.py
+++ b/fiftyone/utils/sam3.py
@@ -18,6 +18,7 @@ import fiftyone.core.utils as fou
 import fiftyone.utils.torch as fout
 import fiftyone.utils.sam as fosam
 import fiftyone.utils.sam2 as fosam2
+import fiftyone.zoo.models as fozm
 
 fou.ensure_torch()
 import torch
@@ -25,39 +26,57 @@ import torch
 sam3 = fou.lazy_import("sam3")
 sam3tr = fou.lazy_import("sam3.train.transforms.basic_for_api")
 sam3ds = fou.lazy_import("sam3.train.data.sam3_image_dataset")
+sam3coll = fou.lazy_import("sam3.train.data.collator")
+sam3misc = fou.lazy_import("sam3.model.utils.misc")
 sam2ip = fou.lazy_import("sam2.sam2_image_predictor")
 
 logger = logging.getLogger(__name__)
 
 
-class SegmentAnything3ImageModelConfig(fosam.SegmentAnythingModelConfig):
+class SegmentAnything3ImageModelConfig(
+    fout.TorchImageModelConfig, fozm.HasZooModel
+):
     """Configuration for running a :class:`SegmentAnything3ImageModel`.
 
     See :class:`fiftyone.utils.torch.TorchImageModelConfig` for additional
     arguments.
 
     Args:
-        classes (None): a list of custom classes for use as SAM3 text prompts
+        points_mask_index (None): an optional mask index to use for each
+            keypoint output
+        get_item_cls (None): a string like
+            ``"fiftyone.utils.sam.SegmentAnythingImageGetItem"`` specifying the
+            :class:`GetItem` to use for SAM
+        get_item_args (None): a dictionary of arguments for
+            ``get_item_cls(field_mapping=field_mapping, **kwargs)``
+        operation_mode ("concept"): concept or visual mode of operation for inference
     """
 
     def __init__(self, cfg_dict):
-        """Initializes :class:`SegmentAnythingModelConfig`
+        """Initializes :class:`SegmentAnything3ImageModelConfig`
 
         Args:
             cfg_dict: a dictionary with config parameters
         """
         d = self.init(cfg_dict)
         super().__init__(d)
+
+        self.points_mask_index = self.parse_int(
+            d, "points_mask_index", default=None
+        )
+        if self.points_mask_index and not 0 <= self.points_mask_index <= 2:
+            raise ValueError("mask_index must be 0, 1, or 2")
+
         self.get_item_cls = self.parse_string(
             d,
             "get_item_cls",
             default="fiftyone.utils.sam3.SegmentAnything3ImageGetItem",
         )
-        self.classes = self.parse_array(d, "classes", default=None)
+        self.get_item_args = self.parse_dict(d, "get_item_args", default=None)
+
         self.operation_mode = self.parse_string(
             d, "operation_mode", default="concept"
         )
-        self.image_id = None
 
 
 class _SAM3Predictor(fosam2._SAM2Predictor):
@@ -85,8 +104,6 @@ class _SAM3Predictor(fosam2._SAM2Predictor):
             a PIL image or a uint8 numpy array containing image in HWC format
             a tuple containing original image dimensions
         """
-        # SAM2 does image pre-processing when it calls SAM2ImagePredictor.set_image.
-        # No straight-forward way to decouple them other than extracting the functionality.
         if isinstance(img, np.ndarray):
             return super().image_transform(img)
         return img, img.size[::-1]
@@ -94,7 +111,7 @@ class _SAM3Predictor(fosam2._SAM2Predictor):
 
 class SegmentAnything3ImageGetItem(fosam.SegmentAnythingImageGetItem):
     """A :class:`GetItem` that loads images, bounding boxes and/or keypoints to feed to
-    :class:`SegmentAnythingModel` instances.
+    :class:`SegmentAnything3ImageModel` instances.
 
     Args:
         field_mapping (None): the user-supplied dict mapping keys in
@@ -194,6 +211,11 @@ class SegmentAnything3ImageGetItemForVideo(SegmentAnything3ImageGetItem):
 
 
 def build_sam_datapoint_transform():
+    """Builds transforms for SAM3 datapoints.
+
+    Returns:
+        composed transforms
+    """
     transform = sam3tr.ComposeAPI(
         transforms=[
             sam3tr.RandomResizeAPI(
@@ -207,6 +229,62 @@ def build_sam_datapoint_transform():
         ]
     )
     return transform
+
+
+class SAM3ConceptSegmenterOutputProcessor(fout.OutputProcessor):
+    """Converts SAM model outputs to FiftyOne format.
+
+    Args:
+        classes (None): the list of class labels for the model. Not used in SAM output processor.
+        mask_thresh (0.5): Threshold for converting float masks to boolean masks
+    """
+
+    def __init__(self, classes=None, mask_thresh=0.5):
+        self.classes = None
+        self.mask_thresh = mask_thresh
+
+    def __call__(
+        self,
+        output,
+        frame_size,
+    ):
+        """Returns processed model output in FiftyOne format.
+
+        Args:
+            output: a list of model output per sample
+            frame_size: a list of tuple containing original image height and width
+
+        Returns:
+            a list of :class:`fiftyone.core.labels.Detections` instances
+        """
+        proc_output = []
+        for idx, out in enumerate(output):
+            out_logits = out["pred_logits"]
+            out_masks = out["pred_masks"]
+            out_probs = out_logits.sigmoid()
+            presence_score = out["presence_logit_dec"].sigmoid().unsqueeze(1)
+            out_probs = (out_probs * presence_score).squeeze(-1)
+
+            keep = out_probs > self.mask_thresh
+            out_probs = out_probs[keep]
+            out_masks = out_masks[keep]
+
+            img_h = frame_size[idx][0]
+            img_w = frame_size[idx][1]
+
+            out_masks = sam3.model.data_misc.interpolate(
+                out_masks.unsqueeze(1),
+                (img_h, img_w),
+                mode="bilinear",
+                align_corners=False,
+            ).sigmoid()
+            proc_output.append(
+                {
+                    "masks": out_masks.float(),
+                    "iou_predictions": out_probs.unsqueeze(1).float(),
+                }
+            )
+        return proc_output
 
 
 class SegmentAnything3ImageModel(fosam.SegmentAnythingModel):
@@ -234,6 +312,9 @@ class SegmentAnything3ImageModel(fosam.SegmentAnythingModel):
         self._sam_auto_generator = None
         self._sam_predictor = self._load_predictor()
         self._operation_mode = self.config.operation_mode
+        self._concept_output_processor = self._build_concept_output_processor(
+            config
+        )
 
     def _load_predictor(self):
         predictor = _SAM3Predictor(model=self._model)
@@ -244,8 +325,9 @@ class SegmentAnything3ImageModel(fosam.SegmentAnythingModel):
 
     def _load_model(self, config):
         if "device" not in config.entrypoint_args:
-            config.entrypoint_args["device"] = self._device
-        return super()._load_model(config)
+            config.entrypoint_args["device"] = str(self._device)
+        model = super()._load_model(config)
+        return model
 
     def _download_model(self, config):
         # Download sam3 to fo.config.model_zoo_dir from HF hub.
@@ -256,6 +338,13 @@ class SegmentAnything3ImageModel(fosam.SegmentAnythingModel):
             filename=os.path.basename(config.model_path),
             local_dir=os.path.dirname(config.model_path),
             local_dir_use_symlinks=False,
+        )
+
+    def _build_concept_output_processor(self, config):
+        kwargs = config.output_processor_args or {}
+        # NOTE: Add new config params for concept output processor, if needed for more configurability.
+        return SAM3ConceptSegmenterOutputProcessor(
+            classes=None, mask_thresh=kwargs.get("mask_thresh", 0.5)
         )
 
     @property
@@ -316,7 +405,9 @@ class SegmentAnything3ImageModel(fosam.SegmentAnythingModel):
                         query_processing_order=0,
                         inference_metadata=sam3ds.InferenceMetadata(
                             original_image_id=img_idx,
-                            original_size=results["original_size"][::-1],
+                            original_size=results["original_size"][img_idx][
+                                ::-1
+                            ],
                             # dummy values
                             coco_image_id=img_idx,
                             original_category_id=1,
@@ -356,7 +447,7 @@ class SegmentAnything3ImageModel(fosam.SegmentAnythingModel):
                     )
                 )
             datapoints.append(transform(datapoint))
-        batched_dps = sam3.train.data.collator.collate_fn_api(
+        batched_dps = sam3coll.collate_fn_api(
             datapoints, dict_key="datapoints"
         )
         results["datapoints"] = batched_dps["datapoints"]
@@ -371,29 +462,21 @@ class SegmentAnything3ImageModel(fosam.SegmentAnythingModel):
         Returns:
             a :class:`SegmentAnything3ImageGetItem` instance
         """
-        rm_text_prompts, rm_op_mode = False, False
-        if self.config.get_item_args is None:
-            self.config.get_item_args = {}
-        if (
-            "text_prompts" not in self.config.get_item_args
-            and self.config.classes is not None
-        ):
-            self.config.get_item_args["text_prompts"] = self.config.classes
-            rm_text_prompts = True
-        if "operation_mode" not in self.config.get_item_args:
-            self.config.get_item_args[
-                "operation_mode"
-            ] = self.config.operation_mode
-            rm_op_mode = True
-        self.config.get_item_args["use_numpy"] = (
-            self.config.operation_mode == "visual"
-        )
-        get_item = super().build_get_item(field_mapping=field_mapping)
-        if rm_text_prompts:
-            _ = self.config.get_item_args.pop("text_prompts")
-        if rm_op_mode:
-            _ = self.config.get_item_args.pop("operation_mode")
-        return get_item
+        base_args = self.config.get_item_args or {}
+        overrides = {
+            "operation_mode": base_args.get(
+                "operation_mode", self.config.operation_mode
+            ),
+            "use_numpy": self.config.operation_mode == "visual",
+        }
+        if "text_prompts" not in base_args and self.config.classes is not None:
+            overrides["text_prompts"] = self.config.classes
+        original = self.config.get_item_args
+        self.config.get_item_args = {**base_args, **overrides}
+        try:
+            return super().build_get_item(field_mapping=field_mapping)
+        finally:
+            self.config.get_item_args = original
 
     def _predict_all(self, args):
         if self._preprocess and self.has_collate_fn:
@@ -415,12 +498,15 @@ class SegmentAnything3ImageModel(fosam.SegmentAnythingModel):
 
         if "datapoints" in args:
             # Concept mode
-            args["datapoints"] = sam3.model.utils.misc.copy_data_to_device(
+            args["datapoints"] = sam3misc.copy_data_to_device(
                 args["datapoints"], self.device, non_blocking=True
             )
-            orig_image_sizes = args.get("original_size")
 
             output = self._forward_pass_concept(args)
+            if self._concept_output_processor is not None:
+                output = self._concept_output_processor(
+                    output, orig_image_sizes
+                )
         elif prompt_type == "auto":
             return self._forward_pass_auto(args)
         else:
@@ -450,46 +536,7 @@ class SegmentAnything3ImageModel(fosam.SegmentAnythingModel):
 
     def _forward_pass_concept(self, imgs):
         with torch.inference_mode():
-            _output = self._model(imgs["datapoints"])
-
-        output = []
-        orig_image_sizes = imgs.get("original_size")
-        for idx, out in enumerate(_output):
-            out_bbox = out["pred_boxes"]
-            out_logits = out["pred_logits"]
-            out_masks = out["pred_masks"]
-            out_probs = out_logits.sigmoid()
-            presence_score = out["presence_logit_dec"].sigmoid().unsqueeze(1)
-            out_probs = (out_probs * presence_score).squeeze(-1)
-
-            keep = out_probs > 0.5
-            out_probs = out_probs[keep]
-            out_masks = out_masks[keep]
-            out_bbox = out_bbox[keep]
-
-            boxes = sam3.model.box_ops.box_cxcywh_to_xyxy(out_bbox)
-
-            img_h = orig_image_sizes[idx][0]
-            img_w = orig_image_sizes[idx][1]
-            scale_fct = torch.tensor([img_w, img_h, img_w, img_h]).to(
-                self.device
-            )
-            boxes = boxes * scale_fct[None, :]
-
-            out_masks = sam3.model.data_misc.interpolate(
-                out_masks.unsqueeze(1),
-                (img_h, img_w),
-                mode="bilinear",
-                align_corners=False,
-            ).sigmoid()
-            output.append(
-                {
-                    "masks": (out_masks > 0.5).float(),
-                    "iou_predictions": out_probs.unsqueeze(1).float(),
-                }
-            )
-
-        return output
+            return self._model(imgs["datapoints"])
 
     def _forward_pass(self, imgs):
         """Forward pass with prompts
@@ -500,38 +547,7 @@ class SegmentAnything3ImageModel(fosam.SegmentAnythingModel):
         Returns:
             a dict containing model output
         """
-        # TODO: FIX THIS! Using sam3 predict_inst_batch
-        images = imgs.pop("image")
-
-        self._sam_predictor.processor.set_image_batch(images)
-
-        point_coords = imgs.get("point_coords")
-        point_labels = imgs.get("point_labels")
-        boxes = imgs.get("boxes")
-        mask_inputs = imgs.get("mask_inputs")  # Not used currently
-        multimask_output = (
-            True if (boxes is None and point_coords is not None) else False
-        )
-        outputs = []
-        for img_idx in range(len(images)):
-            out_masks, iou_pred, _ = self._sam_predictor.processor._predict(
-                point_coords=point_coords[img_idx]
-                if point_coords is not None
-                else None,
-                point_labels=point_labels[img_idx]
-                if point_labels is not None
-                else None,
-                boxes=boxes[img_idx] if boxes is not None else None,
-                mask_input=mask_inputs[img_idx] if mask_inputs else None,
-                multimask_output=multimask_output,
-            )
-            outputs.append(
-                {
-                    "masks": out_masks.float(),
-                    "iou_predictions": iou_pred.float(),
-                }
-            )
-        return outputs
+        return fosam2.SegmentAnything2ImageModel._forward_pass(self, imgs)
 
     def _forward_pass_auto(self, imgs):
         raise RuntimeError(

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -651,6 +651,56 @@
             "date_added": "2024-08-05 14:38:20"
         },
         {
+            "base_name": "segment-anything-3-image-torch",
+            "base_filename": "sam3.pt",
+            "version": null,
+            "description": "Open-vocabulary instance segmentation that finds and segments all objects matching a text concept like 'person' or 'yellow school bus'",
+            "source": "https://github.com/facebookresearch/sam3",
+            "author": "Nicolas Carion, Laura Gustafson, Yuan-Ting Hu, et al.",
+            "license": "SAM License",
+            "size_bytes": 3704365056,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {}
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.sam3.SegmentAnything3ImageModel",
+                "config": {
+                    "entrypoint_fcn": "sam3.model_builder.build_sam3_image_model",
+                    "entrypoint_args": {}
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "sam3"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": [
+                "segmentation",
+                "instance-segmentation",
+                "zero-shot",
+                "open-vocabulary",
+                "text-prompted",
+                "transformer",
+                "official"
+            ],
+            "training_data": [
+                {
+                    "name": "SA-1B",
+                    "url": "https://ai.meta.com/datasets/segment-anything/"
+                },
+                {
+                    "name": "SA-Co",
+                    "url": "https://github.com/facebookresearch/sam3"
+                }
+            ],
+            "date_added": "2026-01-30"
+        },
+        {
             "base_name": "med-sam-2-video-torch",
             "base_filename": "med-sam-2_pretrain.pth",
             "version": null,

--- a/tests/intensive/sam_image_model_tests.py
+++ b/tests/intensive/sam_image_model_tests.py
@@ -13,6 +13,7 @@ Usage:
 
 import unittest
 import numpy as np
+import torch
 
 import fiftyone as fo
 import fiftyone.zoo as foz
@@ -22,6 +23,8 @@ from fiftyone.core.labels import Detections
 PLACEHOLDER_LABEL = "mask"
 SAM_MODEL_NAME = "segment-anything-vitb-torch"
 SAM2_MODEL_NAME = "segment-anything-2-hiera-tiny-image-torch"
+SAM3_MODEL_NAME = "segment-anything-3-image-torch"
+TEXT_PROMPTS = ["person"]
 
 
 def _create_image_dataset(num_samples=5, seed=51):
@@ -414,6 +417,268 @@ class TestSamplesMixinDeprecation(unittest.TestCase):
         self.assertEqual(
             len(result.detections), len(sample["ground_truth"].detections)
         )
+
+
+class TestSAM3ConceptApplyModel(unittest.TestCase):
+    """Verify ``apply_model`` works for SAM3 concept mode on image
+    datasets."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = foz.load_zoo_model(
+            SAM3_MODEL_NAME,
+            classes=TEXT_PROMPTS,
+            operation_mode="concept",
+        )
+        cls.dataset = _create_image_dataset(num_samples=5, seed=80)
+
+    @classmethod
+    def tearDownClass(cls):
+        fo.delete_dataset(cls.dataset.name)
+
+    def test_concept_single_prompt(self):
+        field = "sam3_concept_single"
+        self.dataset.apply_model(self.model, label_field=field)
+        _assert_field_populated(self, self.dataset, field, min_dets=0)
+
+        self.dataset.delete_sample_field(field)
+
+    def test_concept_multi_prompt(self):
+        """Multiple text prompts produce detections labeled per prompt."""
+        multi_prompts = ["person", "car"]
+        model = foz.load_zoo_model(
+            SAM3_MODEL_NAME,
+            classes=multi_prompts,
+            operation_mode="concept",
+        )
+
+        field = "sam3_concept_multi"
+        self.dataset.apply_model(model, label_field=field)
+        _assert_field_populated(self, self.dataset, field, min_dets=0)
+
+        self.dataset.delete_sample_field(field)
+
+
+class TestSAM3VisualApplyModel(unittest.TestCase):
+    """Verify ``apply_model`` works for SAM3 visual mode on image
+    datasets."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = foz.load_zoo_model(
+            SAM3_MODEL_NAME,
+            operation_mode="visual",
+        )
+        cls.dataset = _create_image_dataset(num_samples=5, seed=81)
+
+    @classmethod
+    def tearDownClass(cls):
+        fo.delete_dataset(cls.dataset.name)
+
+    def test_box_prompt(self):
+        """Box prompts from ground_truth produce detections."""
+        field = "sam3_visual_box"
+        self.dataset.apply_model(
+            self.model,
+            label_field=field,
+            prompt_field="ground_truth",
+        )
+        _assert_field_populated(
+            self, self.dataset, field, prompt_field="ground_truth"
+        )
+
+        # Labels should come from the ground truth detections
+        for sample in self.dataset.iter_samples(progress=False):
+            gt = sample.get_field("ground_truth")
+            preds = sample.get_field(field)
+            if gt is None or preds is None:
+                continue
+
+            gt_labels = {d.label for d in gt.detections}
+            for det in preds.detections:
+                self.assertIn(
+                    det.label,
+                    gt_labels,
+                    f"Visual box label '{det.label}' not in GT labels",
+                )
+
+        self.dataset.delete_sample_field(field)
+
+    def test_keypoint_prompt(self):
+        """Keypoint prompts produce detections."""
+        kp_field = "sam3_test_kps"
+        kp_model = foz.load_zoo_model("vitpose-base-simple-torch")
+        with torch.amp.autocast("cuda", enabled=False):
+            self.dataset.apply_model(
+                kp_model,
+                prompt_field="ground_truth",
+                label_field=kp_field,
+            )
+
+        field = "sam3_visual_kp"
+        self.dataset.apply_model(
+            self.model,
+            label_field=field,
+            prompt_field=kp_field,
+        )
+        _assert_field_populated(
+            self, self.dataset, field, prompt_field=kp_field
+        )
+
+        self.dataset.delete_sample_field(field)
+        self.dataset.delete_sample_field(kp_field)
+
+
+class TestSAM3ConceptApplyModelVideo(unittest.TestCase):
+    """Verify apply_model works for SAM3 concept-mode image model on video
+    datasets (frame-level inference)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = foz.load_zoo_model(
+            SAM3_MODEL_NAME,
+            classes=TEXT_PROMPTS,
+            operation_mode="concept",
+        )
+        cls.dataset = _create_video_dataset(num_samples=2)
+
+    @classmethod
+    def tearDownClass(cls):
+        fo.delete_dataset(cls.dataset.name)
+
+    def test_concept_segmentation_video(self):
+        """apply_model with text prompts on a video dataset should produce
+        per-frame concept segmentations."""
+        field = "frames.sam3_vid_concept"
+        self.dataset.apply_model(self.model, label_field=field)
+
+        for sample in self.dataset.iter_samples(progress=False):
+            for frame_number, frame in sample.frames.items():
+                value = frame.get_field("sam3_vid_concept")
+                self.assertIsNotNone(
+                    value,
+                    f"Frame {frame_number} of sample {sample.id} "
+                    f"has no concept segmentations",
+                )
+                self.assertIsInstance(value, Detections)
+
+        self.dataset.delete_frame_field("sam3_vid_concept")
+
+    def test_concept_multi_prompt_video(self):
+        """Multiple text prompts on video frames should produce correctly
+        labeled per-frame detections."""
+        multi_prompts = ["person", "car"]
+        model = foz.load_zoo_model(
+            SAM3_MODEL_NAME,
+            classes=multi_prompts,
+            operation_mode="concept",
+        )
+
+        field = "frames.sam3_vid_multi"
+        self.dataset.apply_model(model, label_field=field)
+
+        for sample in self.dataset.iter_samples(progress=False):
+            for frame_number, frame in sample.frames.items():
+                value = frame.get_field("sam3_vid_multi")
+                self.assertIsNotNone(
+                    value,
+                    f"Frame {frame_number} of sample {sample.id} "
+                    f"has no multi-prompt segmentations",
+                )
+                self.assertIsInstance(value, Detections)
+
+        self.dataset.delete_frame_field("sam3_vid_multi")
+
+
+class TestSAM3VisualApplyModelVideo(unittest.TestCase):
+    """Verify apply_model works for SAM3 visual-mode image model on video
+    datasets (frame-level inference with box prompts)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = foz.load_zoo_model(
+            SAM3_MODEL_NAME,
+            operation_mode="visual",
+        )
+        cls.dataset = _create_video_dataset(num_samples=2)
+
+    @classmethod
+    def tearDownClass(cls):
+        fo.delete_dataset(cls.dataset.name)
+
+    def test_box_prompt_video(self):
+        """apply_model with box prompts on video frames should produce
+        per-frame segmentations. The number of predicted masks on each
+        frame must match the number of prompt boxes."""
+        field = "frames.sam3_vid_box"
+        self.dataset.apply_model(
+            self.model,
+            label_field=field,
+            prompt_field="frames.detections",
+        )
+
+        for sample in self.dataset.iter_samples(progress=False):
+            for frame_number, frame in sample.frames.items():
+                dets = frame.get_field("detections")
+                preds = frame.get_field("sam3_vid_box")
+
+                n_gt = (
+                    len(dets.detections)
+                    if dets is not None and dets.detections
+                    else 0
+                )
+                n_pred = (
+                    len(preds.detections)
+                    if preds is not None and preds.detections
+                    else 0
+                )
+
+                self.assertEqual(
+                    n_pred,
+                    n_gt,
+                    f"Frame {frame_number} of sample {sample.id}: "
+                    f"expected {n_gt} predictions, got {n_pred}",
+                )
+
+                # Each prediction should have a mask
+                if preds is not None:
+                    for det in preds.detections:
+                        self.assertIsNotNone(det.mask)
+                        self.assertIsNotNone(det.confidence)
+
+        self.dataset.delete_frame_field("sam3_vid_box")
+
+    def test_box_prompt_video_labels_match_gt(self):
+        """Box-prompted predictions on video frames should inherit labels
+        from the prompt field's detections."""
+        field = "frames.sam3_vid_box_lbl"
+        self.dataset.apply_model(
+            self.model,
+            label_field=field,
+            prompt_field="frames.detections",
+        )
+
+        for sample in self.dataset.iter_samples(progress=False):
+            for frame_number, frame in sample.frames.items():
+                dets = frame.get_field("detections")
+                preds = frame.get_field("sam3_vid_box_lbl")
+
+                if dets is None or not dets.detections:
+                    continue
+                if preds is None or not preds.detections:
+                    continue
+
+                gt_labels = [d.label for d in dets.detections]
+                pred_labels = [d.label for d in preds.detections]
+
+                self.assertEqual(
+                    pred_labels,
+                    gt_labels,
+                    f"Frame {frame_number} of sample {sample.id}: "
+                    f"label mismatch: {pred_labels} != {gt_labels}",
+                )
+
+        self.dataset.delete_frame_field("sam3_vid_box_lbl")
 
 
 if __name__ == "__main__":

--- a/tests/intensive/sam_parity_tests.py
+++ b/tests/intensive/sam_parity_tests.py
@@ -12,9 +12,10 @@ Usage:
     pytest sam_parity_tests.py -v --timeout=500
 """
 
-import unittest
+import cv2
 import numpy as np
 import torch
+import unittest
 
 import fiftyone as fo
 import fiftyone.zoo as foz
@@ -1308,8 +1309,6 @@ def _concept_output_to_detections(output, img_h, img_w, label="mask"):
         # Resize to original image size if needed
         mh, mw = mask_i.shape
         if mh != img_h or mw != img_w:
-            import cv2
-
             mask_i = cv2.resize(
                 mask_i.astype(np.uint8),
                 (img_w, img_h),
@@ -1452,7 +1451,6 @@ class TestSAM3VisualParity(unittest.TestCase):
         )
 
         from sam3.model_builder import build_sam3_image_model
-        from sam3.model.sam3_image_processor import Sam3Processor
 
         sam3_model = build_sam3_image_model(
             enable_inst_interactivity=True,

--- a/tests/intensive/sam_parity_tests.py
+++ b/tests/intensive/sam_parity_tests.py
@@ -21,10 +21,13 @@ import fiftyone.zoo as foz
 from fiftyone.core.labels import Detection, Detections, Keypoint, Keypoints
 from fiftyone import ViewField as F
 
-MASK_IOU = 0.99
+MASK_IOU = 0.95  # change for more/less aggressive mask parity testing
 MASK_THRESH = 0.5
 PLACEHOLDER_LABEL = "mask"
 MIN_METRIC = 1.0
+
+# Default text prompts for concept-mode tests
+TEXT_PROMPTS = ["person"]
 
 
 def _create_test_dataset(num_samples=5, seed=51):
@@ -47,6 +50,12 @@ def _get_image_as_numpy(filepath):
     from PIL import Image
 
     return np.array(Image.open(filepath).convert("RGB"))
+
+
+def _get_image_as_pil(filepath):
+    from PIL import Image
+
+    return Image.open(filepath).convert("RGB")
 
 
 def _auto_masks_to_detections(masks_list):
@@ -1264,6 +1273,426 @@ class TestSAM2InteractiveParity(unittest.TestCase):
             interactive_field,
             direct_field,
             eval_key="eval_sam2_inter_combo",
+        )
+
+
+def _concept_output_to_detections(output, img_h, img_w, label="mask"):
+    """Convert ``Sam3Processor.set_text_prompt()`` output to
+    ``fo.Detections``.
+
+    Args:
+        output: dict with keys ``masks`` ([N, H, W] bool/uint8),
+            ``boxes`` ([N, 4] xyxy absolute), ``scores`` ([N] float).
+        img_h: original image height.
+        img_w: original image width.
+        label: label string to assign to each detection.
+
+    Returns:
+        a :class:`fiftyone.core.labels.Detections` instance.
+    """
+    masks = output["masks"]
+    scores = output["scores"]
+
+    if isinstance(masks, torch.Tensor):
+        masks = masks.cpu().float().numpy()
+    if isinstance(scores, torch.Tensor):
+        scores = scores.cpu().float().numpy()
+
+    if masks.ndim > 3:
+        masks = masks.squeeze(1)
+
+    dets = []
+    for i in range(len(masks)):
+        mask_i = masks[i].astype(bool) if masks[i].dtype != bool else masks[i]
+
+        # Resize to original image size if needed
+        mh, mw = mask_i.shape
+        if mh != img_h or mw != img_w:
+            import cv2
+
+            mask_i = cv2.resize(
+                mask_i.astype(np.uint8),
+                (img_w, img_h),
+                interpolation=cv2.INTER_NEAREST,
+            ).astype(bool)
+
+        if not mask_i.any():
+            continue
+
+        det = Detection.from_mask(
+            mask=mask_i,
+            label=label,
+            confidence=float(scores[i]),
+        )
+        dets.append(det)
+
+    return Detections(detections=dets)
+
+
+class TestSAM3ConceptParity(unittest.TestCase):
+    """Compare FiftyOne SAM3 concept-mode integration outputs against
+    direct ``Sam3Processor.set_text_prompt()`` inference."""
+
+    MODEL_NAME = "segment-anything-3-image-torch"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.fo_model = foz.load_zoo_model(
+            cls.MODEL_NAME,
+            classes=TEXT_PROMPTS,
+            operation_mode="concept",
+        )
+
+        from sam3.model_builder import build_sam3_image_model
+        from sam3.model.sam3_image_processor import Sam3Processor
+
+        cls.sam3_model = build_sam3_image_model()
+        cls.processor = Sam3Processor(cls.sam3_model)
+
+        cls.device = "cuda" if torch.cuda.is_available() else "cpu"
+        cls.dataset = _create_test_dataset(num_samples=4, seed=31)
+
+    def test_concept_text_prompt_parity(self):
+        fo_field = "sam3_concept_fo"
+        direct_field = "sam3_concept_direct"
+
+        self.dataset.apply_model(self.fo_model, label_field=fo_field)
+        self.dataset.set_field(
+            f"{fo_field}.detections.label",
+            F("label").if_else(F("label"), PLACEHOLDER_LABEL),
+        ).save()
+
+        for sample in self.dataset.iter_samples(progress=False, autosave=True):
+            image = _get_image_as_pil(sample.filepath)
+            img_np = np.array(image)
+            img_h, img_w = img_np.shape[:2]
+
+            inference_state = self.processor.set_image(image)
+
+            all_dets = []
+            for prompt_text in TEXT_PROMPTS:
+                output = self.processor.set_text_prompt(
+                    state=inference_state,
+                    prompt=prompt_text,
+                )
+                dets = _concept_output_to_detections(
+                    output, img_h, img_w, label=PLACEHOLDER_LABEL
+                )
+                all_dets.extend(dets.detections)
+
+            sample[direct_field] = Detections(detections=all_dets)
+
+        _assert_parity(
+            self,
+            self.dataset,
+            fo_field,
+            direct_field,
+            eval_key="eval_sam3_concept",
+        )
+
+    def test_concept_multi_prompt_parity(self):
+        """Multiple text prompts: verify each prompt's detections match."""
+        multi_prompts = ["person", "car"]
+
+        fo_model_multi = foz.load_zoo_model(
+            self.MODEL_NAME,
+            classes=multi_prompts,
+            operation_mode="concept",
+        )
+
+        fo_field = "sam3_multi_fo"
+        direct_field = "sam3_multi_direct"
+
+        self.dataset.apply_model(fo_model_multi, label_field=fo_field)
+        self.dataset.set_field(
+            f"{fo_field}.detections.label",
+            F("label").if_else(F("label"), PLACEHOLDER_LABEL),
+        ).save()
+
+        for sample in self.dataset.iter_samples(progress=False, autosave=True):
+            image = _get_image_as_pil(sample.filepath)
+            img_np = np.array(image)
+            img_h, img_w = img_np.shape[:2]
+
+            inference_state = self.processor.set_image(image)
+
+            all_dets = []
+            for prompt_text in multi_prompts:
+                output = self.processor.set_text_prompt(
+                    state=inference_state,
+                    prompt=prompt_text,
+                )
+                dets = _concept_output_to_detections(
+                    output, img_h, img_w, label=PLACEHOLDER_LABEL
+                )
+                all_dets.extend(dets.detections)
+
+            sample[direct_field] = Detections(detections=all_dets)
+
+        _assert_parity(
+            self,
+            self.dataset,
+            fo_field,
+            direct_field,
+            eval_key="eval_sam3_multi",
+        )
+
+
+class TestSAM3VisualParity(unittest.TestCase):
+    """Compare FiftyOne SAM3 visual-mode integration outputs against
+    direct SAM3 interactive predictor inference."""
+
+    MODEL_NAME = "segment-anything-3-image-torch"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.fo_model = foz.load_zoo_model(
+            cls.MODEL_NAME,
+            operation_mode="visual",
+        )
+
+        from sam3.model_builder import build_sam3_image_model
+        from sam3.model.sam3_image_processor import Sam3Processor
+
+        sam3_model = build_sam3_image_model(
+            enable_inst_interactivity=True,
+        )
+        tracker_model = sam3_model.inst_interactive_predictor.model
+        if getattr(tracker_model, "backbone", None) is None:
+            tracker_model.backbone = sam3_model.backbone
+        cls.predictor = sam3_model.inst_interactive_predictor
+
+        cls.device = "cuda" if torch.cuda.is_available() else "cpu"
+        cls.dataset = _create_test_dataset(num_samples=4, seed=21)
+        cls.output_processor = fo.utils.sam.SAMSegmenterOutputProcessor()
+
+    def test_box_prompt_parity(self):
+        """Box prompts: FiftyOne apply_model vs. direct predictor."""
+        fo_field = "sam3_box_fo"
+        direct_field = "sam3_box_direct"
+
+        # FiftyOne model inference with box prompts
+        self.dataset.apply_model(
+            self.fo_model,
+            label_field=fo_field,
+            prompt_field="ground_truth",
+        )
+
+        # Direct SAM3 inference with box prompts
+        for sample in self.dataset.iter_samples(progress=False, autosave=True):
+            gt = sample.get_field("ground_truth")
+
+            image = _get_image_as_numpy(sample.filepath)
+            h, w = image.shape[:2]
+
+            self.predictor.set_image(image)
+
+            masks = []
+            scores = []
+            dims_hw = (h, w)
+            box_prompts = []
+            labels = []
+            for gt_det in gt.detections:
+                box_abs = _box_to_sam_abs(gt_det.bounding_box, w, h)
+                _masks, _scores, _ = self.predictor.predict(
+                    box=box_abs,
+                    multimask_output=False,
+                )
+                masks.append(_masks[None, ...])
+                scores.append(_scores[None, ...])
+                box_prompts.append(box_abs)
+                labels.append(gt_det.label)
+
+            outputs = {
+                "masks": torch.as_tensor(np.concatenate(masks, axis=0)),
+                "iou_predictions": torch.as_tensor(
+                    np.concatenate(scores, axis=0)
+                ),
+            }
+            sample[direct_field] = self.output_processor(
+                output=[outputs],
+                frame_size=[dims_hw],
+                box_prompts=[box_prompts],
+                labels=[labels],
+            )[0]
+
+        _assert_parity(
+            self,
+            self.dataset,
+            fo_field,
+            direct_field,
+            eval_key="eval_sam3_box",
+        )
+
+    def test_keypoint_prompt_parity(self):
+        """Keypoint prompts: FiftyOne apply_model vs. direct predictor."""
+        kp_field = "sam3_test_kps"
+        fo_field = "sam3_kp_fo"
+        direct_field = "sam3_kp_direct"
+
+        kp_model = foz.load_zoo_model("vitpose-base-simple-torch")
+        with torch.amp.autocast("cuda", enabled=False):
+            self.dataset.apply_model(
+                kp_model,
+                prompt_field="ground_truth",
+                label_field=kp_field,
+            )
+
+        self.dataset.apply_model(
+            self.fo_model,
+            label_field=fo_field,
+            prompt_field=kp_field,
+        )
+        self.dataset.set_field(
+            f"{fo_field}.detections.label",
+            F("label").if_else(F("label"), PLACEHOLDER_LABEL),
+        ).save()
+
+        for sample in self.dataset.iter_samples(progress=False, autosave=True):
+            kps_label = sample.get_field(kp_field)
+            if kps_label is None or not kps_label.keypoints:
+                sample[direct_field] = Detections()
+                continue
+
+            image = _get_image_as_numpy(sample.filepath)
+            h, w = image.shape[:2]
+
+            self.predictor.set_image(image)
+
+            masks = []
+            scores = []
+            dims_hw = (h, w)
+            labels = []
+            for kp in kps_label.keypoints:
+                pts = np.array(kp.points)
+                valid = (pts[:, 0] > 0) & (pts[:, 1] > 0)
+                if not valid.any():
+                    continue
+
+                pts_abs = pts[valid] * np.array([w, h])
+                labels_arr = np.ones(len(pts_abs), dtype=np.int32)
+
+                _masks, _scores, _ = self.predictor.predict(
+                    point_coords=pts_abs,
+                    point_labels=labels_arr,
+                    multimask_output=True,
+                )
+                masks.append(_masks[None, ...])
+                scores.append(_scores[None, ...])
+                labels.append(PLACEHOLDER_LABEL)
+
+            if not masks:
+                sample[direct_field] = Detections()
+                continue
+
+            outputs = {
+                "masks": torch.as_tensor(np.concatenate(masks, axis=0)),
+                "iou_predictions": torch.as_tensor(
+                    np.concatenate(scores, axis=0)
+                ),
+            }
+            sample[direct_field] = self.output_processor(
+                output=[outputs],
+                frame_size=[dims_hw],
+                labels=[labels],
+                mask_index=self.fo_model.config.points_mask_index,
+            )[0]
+
+        _assert_parity(
+            self,
+            self.dataset,
+            fo_field,
+            direct_field,
+            eval_key="eval_sam3_kp",
+        )
+
+    def test_combined_box_and_point_prompt_parity(self):
+        """Box + center-point combined prompts."""
+        fo_field = "sam3_combo_fo"
+        direct_field = "sam3_combo_direct"
+
+        # Build synthetic center-point keypoints from ground_truth boxes
+        for sample in self.dataset.iter_samples(progress=False, autosave=True):
+            gt = sample.get_field("ground_truth")
+            if gt is None:
+                continue
+            kps = []
+            for det in gt.detections:
+                bx, by, bw, bh = det.bounding_box
+                cx, cy = bx + bw / 2, by + bh / 2
+                kps.append(Keypoint(points=[(cx, cy)], label=det.label))
+            sample["combo_points"] = Keypoints(keypoints=kps)
+
+        # FiftyOne model inference with box + point prompts
+        self.dataset.apply_model(
+            self.fo_model,
+            label_field=fo_field,
+            box_prompt_field="ground_truth",
+            point_prompt_field="combo_points",
+        )
+
+        # Direct SAM3 inference with box + center point
+        for sample in self.dataset.iter_samples(progress=False, autosave=True):
+            gt = sample.get_field("ground_truth")
+            combo_kps = sample.get_field("combo_points")
+            if gt is None or not gt.detections:
+                sample[direct_field] = Detections()
+                continue
+
+            image = _get_image_as_numpy(sample.filepath)
+            h, w = image.shape[:2]
+
+            self.predictor.set_image(image)
+
+            masks = []
+            scores = []
+            dims_hw = (h, w)
+            box_prompts = []
+            labels = []
+            for i, gt_det in enumerate(gt.detections):
+                box_abs = _box_to_sam_abs(gt_det.bounding_box, w, h)
+
+                # Also provide center point if available
+                point_coords = None
+                point_labels = None
+                if combo_kps is not None and i < len(combo_kps.keypoints):
+                    pts = combo_kps.keypoints[i].points
+                    if pts:
+                        px, py = pts[0]
+                        point_coords = np.array([[px * w, py * h]])
+                        point_labels = np.array([1])
+
+                _masks, _scores, _ = self.predictor.predict(
+                    point_coords=point_coords,
+                    point_labels=point_labels,
+                    box=box_abs,
+                    multimask_output=False,
+                )
+
+                masks.append(_masks[None, ...])
+                scores.append(_scores[None, ...])
+                box_prompts.append(box_abs)
+                labels.append(gt_det.label)
+
+            outputs = {
+                "masks": torch.as_tensor(np.concatenate(masks, axis=0)),
+                "iou_predictions": torch.as_tensor(
+                    np.concatenate(scores, axis=0)
+                ),
+            }
+            sample[direct_field] = self.output_processor(
+                output=[outputs],
+                frame_size=[dims_hw],
+                box_prompts=[box_prompts],
+                labels=[labels],
+            )[0]
+
+        _assert_parity(
+            self,
+            self.dataset,
+            fo_field,
+            direct_field,
+            eval_key="eval_sam3_combo",
         )
 
 


### PR DESCRIPTION
## 🔗 Related Issues
No related issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

<!--
Provide a clear, concise description of what this PR does and why.
-->
Adds SAM3 image model to the model zoo. Supports concept prompting (text and bounding box) and visual prompting (same as sam/sam2)

```
# Concept prompting
model = foz.load_zoo_model("segment-anything-3-image-torch",
                                               classes=["dog", "cat"],
                                               operation_mode="concept")
dataset.apply_model(model, label_field="sam3_test_concept")

# Visual prompting
model = foz.load_zoo_model("segment-anything-3-image-torch",
                                               operation_mode="visual")
dataset.apply_model(
            self.fo_model,
            label_field="sam3_test_visual",
            prompt_field="ground_truth",
        )
```

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

```
$ pytest tests/intensive/sam_image_model_tests.py --timeout=500 -v
$ pytest tests/intensive/sam_parity_tests.py --timeout=500 -v
```

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SAM3 support for text-driven (concept) and prompt-driven (visual) segmentation for images and video with mode-aware handling and concept output processing.

* **Bug Fixes**
  * Fixed original-image size handling for NumPy vs PIL-like inputs.
  * Silenced noisy runtime warnings about unused class parameters; processor now ignores supplied class lists.
  * Explicitly disallow unsupported auto-segmentation in SAM3.

* **Tests**
  * Added extensive SAM3 unit and parity tests and relaxed mask-parity threshold for robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->