### PR TITLE
[SSP] Integrate alt selected samples with similarity search panel

### DIFF
--- a/app/packages/core/package.json
+++ b/app/packages/core/package.json
@@ -23,7 +23,7 @@
         "@mui/material": "^5.9.0",
         "@react-spring/web": "^9.4.3",
         "@use-gesture/react": "^10.3.0",
-        "@voxel51/voodo": "^0.0.21",
+        "@voxel51/voodo": "^0.0.22",
         "@xstate/react": "1.3.3",
         "classnames": "^2.2.6",
         "color": "^4.2.3",

--- a/app/packages/similarity-search/src/components/Home/RunActions.tsx
+++ b/app/packages/similarity-search/src/components/Home/RunActions.tsx
@@ -11,6 +11,7 @@ import {
   ContentCopyIcon as ContentCopy,
   GridViewIcon as GridView,
 } from "../../mui";
+import { QUERY_IMAGE } from "../../constants";
 import { SimilarityRun } from "../../types";
 import { tooltipTextStyle } from "../styled";
 
@@ -36,7 +37,7 @@ export default function RunActions({
   onDelete,
   onToggleExpand,
 }: RunActionsProps) {
-  const isImage = run.query_type === "image" && !run.patches_field;
+  const isImage = run.query_type === QUERY_IMAGE && !run.patches_field;
 
   return (
     <Stack>

--- a/app/packages/similarity-search/src/components/Home/RunActions.tsx
+++ b/app/packages/similarity-search/src/components/Home/RunActions.tsx
@@ -7,16 +7,9 @@ import {
   Variant,
 } from "@voxel51/voodo";
 import React from "react";
-import {
-  ContentCopyIcon as ContentCopy,
-  GridViewIcon as GridView,
-} from "../../mui";
 import { QUERY_IMAGE } from "../../constants";
 import { SimilarityRun } from "../../types";
 import { tooltipTextStyle } from "../styled";
-
-const ApplyIcon = () => <GridView fontSize="small" />;
-const CloneIcon = () => <ContentCopy fontSize="small" />;
 
 const tip = (text: string) => <span style={tooltipTextStyle}>{text}</span>;
 
@@ -46,7 +39,7 @@ export default function RunActions({
           aria-label="Show results"
           size={Size.Md}
           variant={Variant.Borderless}
-          leadingIcon={ApplyIcon}
+          leadingIcon={IconName.GridView}
           onClick={() => onApply(run.run_id)}
           disabled={run.status !== "completed"}
         />
@@ -56,7 +49,7 @@ export default function RunActions({
           aria-label="Clone search"
           size={Size.Md}
           variant={Variant.Borderless}
-          leadingIcon={CloneIcon}
+          leadingIcon={IconName.ContentCopy}
           onClick={() => onClone(run.run_id)}
         />
       </Tooltip>
@@ -70,9 +63,9 @@ export default function RunActions({
         />
       </Tooltip>
       {isImage && (
-        <Tooltip content={isExpanded ? tip("Collapse") : tip("Show samples")}>
+        <Tooltip content={isExpanded ? tip("Collapse") : tip("Show prompts")}>
           <Button
-            aria-label={isExpanded ? "Collapse" : "Show samples"}
+            aria-label={isExpanded ? "Collapse" : "Show prompts"}
             size={Size.Md}
             variant={Variant.Borderless}
             leadingIcon={

--- a/app/packages/similarity-search/src/components/Home/RunActions.tsx
+++ b/app/packages/similarity-search/src/components/Home/RunActions.tsx
@@ -36,7 +36,7 @@ export default function RunActions({
   onDelete,
   onToggleExpand,
 }: RunActionsProps) {
-  const isImage = run.query_type === "image";
+  const isImage = run.query_type === "image" && !run.patches_field;
 
   return (
     <Stack>

--- a/app/packages/similarity-search/src/components/NewSearch/NewSearch.tsx
+++ b/app/packages/similarity-search/src/components/NewSearch/NewSearch.tsx
@@ -24,7 +24,13 @@ import {
 import React from "react";
 import { OperatorExecutionButton } from "@fiftyone/operators";
 import { BrainKeyConfig, CloneConfig, SearchScope } from "../../types";
-import { SEARCH_OPERATOR_URI, CHECK_MARK, CROSS_MARK } from "../../constants";
+import {
+  SEARCH_OPERATOR_URI,
+  CHECK_MARK,
+  CROSS_MARK,
+  QUERY_IMAGE,
+  QUERY_TEXT,
+} from "../../constants";
 import { useNewSearchForm } from "../../hooks/useNewSearchForm";
 import {
   NewSearchContainer,
@@ -143,20 +149,24 @@ export default function NewSearch({
           <Stack orientation={Orientation.Row} spacing={Spacing.Xs}>
             <Button
               variant={
-                form.queryType === "image" ? Variant.Primary : Variant.Secondary
+                form.queryType === QUERY_IMAGE
+                  ? Variant.Primary
+                  : Variant.Secondary
               }
               size={Size.Sm}
-              onClick={() => form.setQueryType("image")}
+              onClick={() => form.setQueryType(QUERY_IMAGE)}
               style={{ flex: 1 }}
             >
               Image Search
             </Button>
             <Button
               variant={
-                form.queryType === "text" ? Variant.Primary : Variant.Secondary
+                form.queryType === QUERY_TEXT
+                  ? Variant.Primary
+                  : Variant.Secondary
               }
               size={Size.Sm}
-              onClick={() => form.setQueryType("text")}
+              onClick={() => form.setQueryType(QUERY_TEXT)}
               style={{ flex: 1 }}
             >
               Text Search
@@ -165,7 +175,7 @@ export default function NewSearch({
         )}
 
         {/* Query input */}
-        {form.queryType === "text" ? (
+        {form.queryType === QUERY_TEXT ? (
           <FormField
             label="Text query"
             control={
@@ -204,7 +214,9 @@ export default function NewSearch({
         {/* Number of matches */}
         <FormField
           label="Number of matches"
-          error={form.kError ? "Exceeds maximum of 10,000" : undefined}
+          error={
+            form.kError ? "Number of results cannot exceed 10,000" : undefined
+          }
           control={
             <Input
               type={InputType.Number}

--- a/app/packages/similarity-search/src/components/NewSearch/NewSearch.tsx
+++ b/app/packages/similarity-search/src/components/NewSearch/NewSearch.tsx
@@ -186,13 +186,17 @@ export default function NewSearch({
                 form.selectedLabels.length > 0
                   ? "labels"
                   : "samples"
-              } selected (positive)`}
+              } selected (positive)${
+                form.negativeQueryIds.length > 0
+                  ? ` \u00B7 ${form.negativeQueryIds.length} negative`
+                  : ""
+              }`}
             </Text>
           </QuerySelectorBoxActive>
         ) : (
           <QuerySelectorBoxInactive>
             <Text variant={TextVariant.Sm} color={TextColor.Secondary}>
-              Select samples in the grid
+              Select samples in the grid (Alt+click for negative)
             </Text>
           </QuerySelectorBoxInactive>
         )}

--- a/app/packages/similarity-search/src/components/NewSearch/NewSearch.tsx
+++ b/app/packages/similarity-search/src/components/NewSearch/NewSearch.tsx
@@ -143,16 +143,6 @@ export default function NewSearch({
           <Stack orientation={Orientation.Row} spacing={Spacing.Xs}>
             <Button
               variant={
-                form.queryType === "text" ? Variant.Primary : Variant.Secondary
-              }
-              size={Size.Sm}
-              onClick={() => form.setQueryType("text")}
-              style={{ flex: 1 }}
-            >
-              Text Search
-            </Button>
-            <Button
-              variant={
                 form.queryType === "image" ? Variant.Primary : Variant.Secondary
               }
               size={Size.Sm}
@@ -160,6 +150,16 @@ export default function NewSearch({
               style={{ flex: 1 }}
             >
               Image Search
+            </Button>
+            <Button
+              variant={
+                form.queryType === "text" ? Variant.Primary : Variant.Secondary
+              }
+              size={Size.Sm}
+              onClick={() => form.setQueryType("text")}
+              style={{ flex: 1 }}
+            >
+              Text Search
             </Button>
           </Stack>
         )}

--- a/app/packages/similarity-search/src/components/SimilarityIndex/SimilarityIndex.tsx
+++ b/app/packages/similarity-search/src/components/SimilarityIndex/SimilarityIndex.tsx
@@ -59,6 +59,11 @@ export default function SimilarityIndex({
                 Supports text queries?{" "}
                 {bk.supports_prompts ? "\u2705" : "\u274C"}
               </Text>
+              {bk.embeddings_field && (
+                <Text variant={TextVariant.Md} color={TextColor.Secondary}>
+                  Embeddings field: {bk.embeddings_field}
+                </Text>
+              )}
               {bk.patches_field && (
                 <Text variant={TextVariant.Md} color={TextColor.Muted}>
                   Patches field: {bk.patches_field}

--- a/app/packages/similarity-search/src/components/SimilarityIndex/SimilarityIndex.tsx
+++ b/app/packages/similarity-search/src/components/SimilarityIndex/SimilarityIndex.tsx
@@ -2,6 +2,8 @@ import { constants } from "@fiftyone/utilities";
 import {
   Align,
   Button,
+  Icon,
+  IconColor,
   IconName,
   Justify,
   RichList,
@@ -55,10 +57,22 @@ export default function SimilarityIndex({
                   Backend: {bk.backend}
                 </Text>
               )}
-              <Text variant={TextVariant.Md} color={TextColor.Secondary}>
-                Supports text queries?{" "}
-                {bk.supports_prompts ? "\u2705" : "\u274C"}
-              </Text>
+              <Stack
+                orientation={Orientation.Row}
+                spacing={Spacing.Xs}
+                align={Align.Center}
+              >
+                <Text variant={TextVariant.Md} color={TextColor.Secondary}>
+                  Supports text queries?
+                </Text>
+                <Icon
+                  name={bk.supports_prompts ? IconName.Check : IconName.Close}
+                  size={Size.Sm}
+                  color={
+                    bk.supports_prompts ? IconColor.Success : IconColor.Error
+                  }
+                />
+              </Stack>
               {bk.embeddings_field && (
                 <Text variant={TextVariant.Md} color={TextColor.Secondary}>
                   Embeddings field: {bk.embeddings_field}

--- a/app/packages/similarity-search/src/components/SimilaritySearchCTA.tsx
+++ b/app/packages/similarity-search/src/components/SimilaritySearchCTA.tsx
@@ -1,16 +1,16 @@
 import { PanelCTA, PanelCTAProps } from "@fiftyone/components";
-import { usePromptOperatorInput } from "@fiftyone/operators";
 import { Button, Size, Variant } from "@voxel51/voodo";
 import React from "react";
-import { BRAIN_COMPUTE_SIMILARITY_URI } from "../constants";
+import useComputeSimilarity from "../hooks/useComputeSimilarity";
 
 function Actions() {
-  const promptForInput = usePromptOperatorInput();
+  const computeSim = useComputeSimilarity();
+  if (!computeSim.isAvailable) return null;
   return (
     <Button
       variant={Variant.Primary}
       size={Size.Sm}
-      onClick={() => promptForInput(BRAIN_COMPUTE_SIMILARITY_URI)}
+      onClick={() => computeSim.prompt()}
     >
       Compute Similarity Index
     </Button>

--- a/app/packages/similarity-search/src/constants.ts
+++ b/app/packages/similarity-search/src/constants.ts
@@ -1,5 +1,5 @@
 import { TextColor } from "@voxel51/voodo";
-import { OwnerFilter, RunStatus, SearchScope } from "./types";
+import { OwnerFilter, QueryType, RunStatus, SearchScope } from "./types";
 
 export const SEARCH_OPERATOR_URI = "@voxel51/panels/similarity_search";
 export const INIT_RUN_OPERATOR_URI = "@voxel51/panels/init_similarity_run";
@@ -36,6 +36,10 @@ export const THUMB_SINGLE_ROW_MAX = 10;
 // Owner filter values
 export const OWNER_ALL: OwnerFilter = "all";
 export const OWNER_MINE: OwnerFilter = "mine";
+
+// Query type values
+export const QUERY_IMAGE: QueryType = "image";
+export const QUERY_TEXT: QueryType = "text";
 
 // Search scope values
 export const SCOPE_VIEW: SearchScope = "view";

--- a/app/packages/similarity-search/src/constants.ts
+++ b/app/packages/similarity-search/src/constants.ts
@@ -3,7 +3,7 @@ import { OwnerFilter, QueryType, RunStatus, SearchScope } from "./types";
 
 export const SEARCH_OPERATOR_URI = "@voxel51/panels/similarity_search";
 export const INIT_RUN_OPERATOR_URI = "@voxel51/panels/init_similarity_run";
-export const BRAIN_COMPUTE_SIMILARITY_URI = "@voxel51/brain/compute_similarity";
+export const COMPUTE_SIMILARITY_URI = "@voxel51/operators/compute_similarity";
 
 export const DAY_MS = 86_400_000;
 

--- a/app/packages/similarity-search/src/hooks/useComputeSimilarity.ts
+++ b/app/packages/similarity-search/src/hooks/useComputeSimilarity.ts
@@ -1,0 +1,26 @@
+import { useFirstExistingUri, usePanelEvent } from "@fiftyone/operators";
+import { usePanelId } from "@fiftyone/spaces";
+import { constants } from "@fiftyone/utilities";
+import { useCallback } from "react";
+import { COMPUTE_SIMILARITY_URI } from "../constants";
+
+export default function useComputeSimilarity() {
+  const { firstExistingUri: computeSimUri, exists: hasComputeSimilarity } =
+    useFirstExistingUri([COMPUTE_SIMILARITY_URI]);
+
+  const panelId = usePanelId();
+  const triggerEvent = usePanelEvent();
+
+  const prompt = useCallback(() => {
+    triggerEvent(panelId, {
+      params: { delegate: true },
+      operator: computeSimUri,
+      prompt: true,
+    });
+  }, [panelId, triggerEvent, computeSimUri]);
+
+  return {
+    isAvailable: constants.IS_APP_MODE_FIFTYONE ? false : hasComputeSimilarity,
+    prompt,
+  };
+}

--- a/app/packages/similarity-search/src/hooks/useNewSearchForm.ts
+++ b/app/packages/similarity-search/src/hooks/useNewSearchForm.ts
@@ -24,24 +24,17 @@ export const useNewSearchForm = (
     hasView,
   } = useSearchSelection();
 
-  const firstTextKey = useMemo(
-    () => brainKeys.find((bk) => bk.supports_prompts),
-    [brainKeys]
-  );
-
   const defaultBrainKey = useMemo(() => {
     if (cloneConfig?.brain_key) return cloneConfig.brain_key;
     if (hasSamplesSelected) return brainKeys[0]?.key ?? "";
-    if (firstTextKey) return firstTextKey.key;
     return brainKeys[0]?.key ?? "";
-  }, [cloneConfig, hasSamplesSelected, firstTextKey, brainKeys]);
+  }, [cloneConfig, hasSamplesSelected, brainKeys]);
 
   const defaultQueryType = useMemo((): QueryType => {
     if (cloneConfig?.query_type) return cloneConfig.query_type;
     if (hasSamplesSelected) return "image";
-    if (firstTextKey) return "text";
     return "image";
-  }, [cloneConfig, hasSamplesSelected, firstTextKey]);
+  }, [cloneConfig, hasSamplesSelected]);
 
   // ─── Form fields ────────────────────────────────────────────────
 

--- a/app/packages/similarity-search/src/hooks/useNewSearchForm.ts
+++ b/app/packages/similarity-search/src/hooks/useNewSearchForm.ts
@@ -15,8 +15,14 @@ export const useNewSearchForm = (
   cloneConfig: CloneConfig | null | undefined,
   onSubmitted: () => void
 ) => {
-  const { selectedLabels, view, hasSamplesSelected, queryIds, hasView } =
-    useSearchSelection();
+  const {
+    selectedLabels,
+    view,
+    hasSamplesSelected,
+    queryIds,
+    negativeQueryIds,
+    hasView,
+  } = useSearchSelection();
 
   const firstTextKey = useMemo(
     () => brainKeys.find((bk) => bk.supports_prompts),
@@ -92,6 +98,7 @@ export const useNewSearchForm = (
     queryType,
     textQuery,
     queryIds,
+    negativeQueryIds,
     reverse,
     selectedConfig,
     searchScope,
@@ -140,6 +147,7 @@ export const useNewSearchForm = (
     supportsPrompts,
     supportsLeast,
     queryIds,
+    negativeQueryIds,
     selectedLabels,
     kError,
     canSubmit,

--- a/app/packages/similarity-search/src/hooks/useNewSearchForm.ts
+++ b/app/packages/similarity-search/src/hooks/useNewSearchForm.ts
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { BrainKeyConfig, CloneConfig, QueryType, SearchScope } from "../types";
-import { SCOPE_VIEW, SCOPE_DATASET } from "../constants";
+import {
+  QUERY_IMAGE,
+  QUERY_TEXT,
+  SCOPE_VIEW,
+  SCOPE_DATASET,
+} from "../constants";
 import { useSearchSelection } from "./useSearchSelection";
 import { useSearchSubmission } from "./useSearchSubmission";
 
@@ -24,17 +29,24 @@ export const useNewSearchForm = (
     hasView,
   } = useSearchSelection();
 
+  const firstTextKey = useMemo(
+    () => brainKeys.find((bk) => bk.supports_prompts),
+    [brainKeys]
+  );
+
   const defaultBrainKey = useMemo(() => {
     if (cloneConfig?.brain_key) return cloneConfig.brain_key;
     if (hasSamplesSelected) return brainKeys[0]?.key ?? "";
+    if (firstTextKey) return firstTextKey.key;
     return brainKeys[0]?.key ?? "";
-  }, [cloneConfig, hasSamplesSelected, brainKeys]);
+  }, [cloneConfig, hasSamplesSelected, firstTextKey, brainKeys]);
 
   const defaultQueryType = useMemo((): QueryType => {
     if (cloneConfig?.query_type) return cloneConfig.query_type;
-    if (hasSamplesSelected) return "image";
-    return "image";
-  }, [cloneConfig, hasSamplesSelected]);
+    if (hasSamplesSelected) return QUERY_IMAGE;
+    if (firstTextKey) return QUERY_TEXT;
+    return QUERY_IMAGE;
+  }, [cloneConfig, hasSamplesSelected, firstTextKey]);
 
   // ─── Form fields ────────────────────────────────────────────────
 
@@ -65,8 +77,8 @@ export const useNewSearchForm = (
   }, [brainKey, brainKeys]);
 
   useEffect(() => {
-    if (!supportsPrompts && queryType === "text") {
-      setQueryType("image");
+    if (!supportsPrompts && queryType === QUERY_TEXT) {
+      setQueryType(QUERY_IMAGE);
     }
   }, [supportsPrompts, queryType]);
 

--- a/app/packages/similarity-search/src/hooks/useSearchSelection.ts
+++ b/app/packages/similarity-search/src/hooks/useSearchSelection.ts
@@ -23,10 +23,22 @@ export const useSearchSelection = () => {
       return selectedLabels.map((l: { label_id: string }) => l.label_id);
     }
     if (selectedSamples && selectedSamples.size > 0) {
-      return Array.from(selectedSamples);
+      // Only include "default" (positive) selections as query IDs
+      return Array.from(selectedSamples.entries())
+        .filter(([, type]) => type === "default")
+        .map(([id]) => id);
     }
     return [];
   }, [selectedSamples, selectedLabels]);
+
+  const negativeQueryIds = useMemo(() => {
+    if (selectedSamples && selectedSamples.size > 0) {
+      return Array.from(selectedSamples.entries())
+        .filter(([, type]) => type === "alt")
+        .map(([id]) => id);
+    }
+    return [];
+  }, [selectedSamples]);
 
   const hasView = Array.isArray(view) && view.length > 0;
 
@@ -36,6 +48,7 @@ export const useSearchSelection = () => {
     view,
     hasSamplesSelected,
     queryIds,
+    negativeQueryIds,
     hasView,
   };
 };

--- a/app/packages/similarity-search/src/hooks/useSearchSubmission.ts
+++ b/app/packages/similarity-search/src/hooks/useSearchSubmission.ts
@@ -4,13 +4,12 @@ import { BrainKeyConfig, QueryType, SearchScope } from "../types";
 import { INIT_RUN_OPERATOR_URI } from "../constants";
 import { canSubmitSearch, buildExecutionParams } from "../utils";
 
-const EMPTY_NEGATIVE_IDS: string[] = [];
-
 type UseSearchSubmissionInput = {
   brainKey: string;
   queryType: QueryType;
   textQuery: string;
   queryIds: string[];
+  negativeQueryIds: string[];
   reverse: boolean;
   selectedConfig?: BrainKeyConfig;
   searchScope: SearchScope;
@@ -49,7 +48,7 @@ export const useSearchSubmission = (input: UseSearchSubmissionInput) => {
         k: input.k,
         distField: input.distField,
         runName: input.runName,
-        negativeQueryIds: EMPTY_NEGATIVE_IDS,
+        negativeQueryIds: input.negativeQueryIds,
         dynamicResults: input.dynamicResults,
       }),
     [
@@ -66,6 +65,7 @@ export const useSearchSubmission = (input: UseSearchSubmissionInput) => {
       input.searchScope,
       input.hasView,
       input.queryIds,
+      input.negativeQueryIds,
     ]
   );
 

--- a/app/packages/similarity-search/src/mui.ts
+++ b/app/packages/similarity-search/src/mui.ts
@@ -1,14 +1,10 @@
 /**
- * Centralized MUI imports for icons without voodo equivalents.
+ * Centralized MUI imports for components without voodo equivalents.
  *
- * Most icons have been migrated to voodo's IconName enum.
- * Only icons listed here have no voodo counterpart yet.
+ * All icons have been migrated to voodo's IconName strings (v0.0.22+).
+ * Only layout components remain here pending voodo equivalents.
  */
 
-// Icons without voodo equivalents (pending PRs in design-system now)
-export { default as ContentCopyIcon } from "@mui/icons-material/ContentCopy";
-export { default as GridViewIcon } from "@mui/icons-material/GridView";
-
-// Components (no voodo equivalent)
+// Components (pending voodo ImageList)
 export { default as ImageList } from "@mui/material/ImageList";
 export { default as ImageListItem } from "@mui/material/ImageListItem";

--- a/app/packages/similarity-search/src/utils.ts
+++ b/app/packages/similarity-search/src/utils.ts
@@ -5,15 +5,15 @@ import {
   QueryType,
   SearchScope,
 } from "./types";
-import { DAY_MS } from "./constants";
+import { DAY_MS, QUERY_TEXT, QUERY_IMAGE } from "./constants";
 
 export const formatQuery = (run: SimilarityRun): string => {
-  if (run.query_type === "text" && typeof run.query === "string") {
+  if (run.query_type === QUERY_TEXT && typeof run.query === "string") {
     return run.query.length > 50
       ? run.query.substring(0, 50) + "..."
       : run.query;
   }
-  if (run.query_type === "image") {
+  if (run.query_type === QUERY_IMAGE) {
     const count = Array.isArray(run.query) ? run.query.length : 0;
     const negCount = run.negative_query_ids?.length ?? 0;
     if (negCount > 0) {
@@ -100,8 +100,8 @@ export const canSubmitSearch = (
   queryIdCount: number
 ): boolean => {
   if (!brainKey) return false;
-  if (queryType === "text" && !textQuery.trim()) return false;
-  if (queryType === "image" && queryIdCount === 0) return false;
+  if (queryType === QUERY_TEXT && !textQuery.trim()) return false;
+  if (queryType === QUERY_IMAGE && queryIdCount === 0) return false;
   return true;
 };
 
@@ -147,7 +147,7 @@ export const buildExecutionParams = (
     negativeQueryIds,
   } = input;
 
-  const query = queryType === "text" ? textQuery.trim() : queryIds;
+  const query = queryType === QUERY_TEXT ? textQuery.trim() : queryIds;
 
   const params: Record<string, unknown> = {
     brain_key: brainKey,

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2596,7 +2596,7 @@ __metadata:
     "@types/styled-components": "npm:^5.1.23"
     "@use-gesture/react": "npm:^10.3.0"
     "@vitejs/plugin-react-refresh": "npm:^1.3.3"
-    "@voxel51/voodo": "npm:^0.0.21"
+    "@voxel51/voodo": "npm:^0.0.22"
     "@xstate/react": "npm:1.3.3"
     classnames: "npm:^2.2.6"
     color: "npm:^4.2.3"
@@ -7313,9 +7313,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@voxel51/voodo@npm:^0.0.21":
-  version: 0.0.21
-  resolution: "@voxel51/voodo@npm:0.0.21"
+"@voxel51/voodo@npm:^0.0.22":
+  version: 0.0.22
+  resolution: "@voxel51/voodo@npm:0.0.22"
   dependencies:
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/sortable": "npm:^10.0.0"
@@ -7332,7 +7332,7 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
     react-is: ^18.0.0
-  checksum: 10/129cd91c80f47ebb9372c15dc018bdb8d3391ae959043ebab3c6338851f79aba40f0146d478e248f46f6603ae9d9fbc5cd30079cf9a42b38f385884041a16b94
+  checksum: 10/009bf8a98874fca595a09906bd0673f6e6ca21dc5d79956a43ea15e468fad29b972c1aa4ad69f3b4238d38503b8fd1cb7a3b32f5f0fde07e574a86a93f1357d2
   languageName: node
   linkType: hard
 

--- a/plugins/panels/similarity_search/__init__.py
+++ b/plugins/panels/similarity_search/__init__.py
@@ -52,8 +52,14 @@ class SimilaritySearchPanel(Panel):
         view_state = ctx.panel.get_state("view") or {"page": "home"}
         ctx.panel.set_state("view", view_state)
 
+        # Enable alt-selection visual feedback for negative queries
+        ctx.ops.set_sample_selection_style(
+            default="green-checkmark", alt="red-checkmark"
+        )
+
     def on_unload(self, ctx):
         ctx.panel.set_state("applied_run_id", None)
+        ctx.ops.clear_sample_selection_style()
 
     # -- Panel methods exposed to frontend --
 

--- a/plugins/panels/similarity_search/operators.py
+++ b/plugins/panels/similarity_search/operators.py
@@ -107,6 +107,13 @@ class SimilaritySearchOperator(foo.Operator):
 
             # Handle negative query IDs (alt-selected samples)
             negative_query_ids = ctx.params.get("negative_query_ids")
+            if not negative_query_ids:
+                # Derive from alt-selected samples in execution context
+                negative_query_ids = [
+                    s["id"]
+                    for s in ctx.selected_samples
+                    if isinstance(s, dict) and s.get("type") == "alt"
+                ]
             if negative_query_ids and isinstance(query, list):
                 # Vector arithmetic: mean(positive) - mean(negative)
                 query = self._compute_combined_query(

--- a/plugins/panels/similarity_search/operators.py
+++ b/plugins/panels/similarity_search/operators.py
@@ -217,9 +217,17 @@ class SimilaritySearchOperator(foo.Operator):
 
         if neg_embeddings:
             neg_mean = np.mean(neg_embeddings, axis=0)
-            return pos_mean - neg_mean
+            combined = pos_mean - neg_mean
         else:
-            return pos_mean
+            combined = pos_mean
+
+        # Normalize for backend-agnostic correctness (cosine doesn't
+        # need it, but dot-product and L2 backends do)
+        norm = np.linalg.norm(combined)
+        if norm > 0:
+            combined = combined / norm
+
+        return combined
 
 
 class InitSimilarityRunOperator(foo.Operator):

--- a/plugins/panels/similarity_search/operators.py
+++ b/plugins/panels/similarity_search/operators.py
@@ -107,13 +107,6 @@ class SimilaritySearchOperator(foo.Operator):
 
             # Handle negative query IDs (alt-selected samples)
             negative_query_ids = ctx.params.get("negative_query_ids")
-            if not negative_query_ids:
-                # Derive from alt-selected samples in execution context
-                negative_query_ids = [
-                    s["id"]
-                    for s in ctx.selected_samples
-                    if isinstance(s, dict) and s.get("type") == "alt"
-                ]
             if negative_query_ids and isinstance(query, list):
                 # Vector arithmetic: mean(positive) - mean(negative)
                 query = self._compute_combined_query(

--- a/plugins/panels/similarity_search/operators.py
+++ b/plugins/panels/similarity_search/operators.py
@@ -215,9 +215,11 @@ class SimilaritySearchOperator(foo.Operator):
 
         pos_mean = np.mean(pos_embeddings, axis=0)
 
+        # Qdrant-style: query = avg(pos) + (avg(pos) - avg(neg))
+        #                    = 2 * avg(pos) - avg(neg)
         if neg_embeddings:
             neg_mean = np.mean(neg_embeddings, axis=0)
-            combined = pos_mean - neg_mean
+            combined = 2 * pos_mean - neg_mean
         else:
             combined = pos_mean
 

--- a/plugins/panels/similarity_search/operators.py
+++ b/plugins/panels/similarity_search/operators.py
@@ -108,7 +108,7 @@ class SimilaritySearchOperator(foo.Operator):
             # Handle negative query IDs (alt-selected samples)
             negative_query_ids = ctx.params.get("negative_query_ids")
             if negative_query_ids and isinstance(query, list):
-                # Vector arithmetic: mean(positive) - mean(negative)
+                # Weighted vector arithmetic: 2 * mean(positive) - mean(negative)
                 query = self._compute_combined_query(
                     dataset,
                     brain_key,
@@ -181,7 +181,12 @@ class SimilaritySearchOperator(foo.Operator):
     ):
         """Compute a combined query vector from positive and negative samples.
 
-        Uses vector arithmetic: mean(positive_embeddings) - mean(negative_embeddings)
+        Uses weighted vector arithmetic:
+        2 * mean(positive_embeddings) - mean(negative_embeddings)
+
+        The 2x weight on positives ensures the query stays anchored in
+        the positive direction while gently steering away from negatives
+        (Qdrant-style recommendation formula).
 
         Args:
             dataset: the dataset


### PR DESCRIPTION
## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

Integreates teh newly merged alt-selected-samples feature (PR #7109 ) with the similarity search panel
- **Panel lifecycle**: Sets green-checkmark/red-checkmark selection styles on panel load, clears on unload — gives users visual feedback for positive vs negative selections
- **Frontend selection splitting**: `useSearchSelection` splits the `selectedSamples` Map by type (`"default"` → positive `queryIds`, `"alt"` → negative `negativeQueryIds`) and wires through `useNewSearchForm` → `useSearchSubmission` → `buildExecutionParams`
- **Operator normalization**: `_compute_combined_query` now L2-normalizes the combined vector (`mean(positive) - mean(negative)`) for backend-agnostic correctness
- **UX improvements**: Image search is now the default mode; query selector shows negative count ("3 samples selected (positive) · 1 negative") and hint text ("Alt+click for negative"); patch-based runs hide the expand chevron since crop previews are not yet supported


## 🧪 How is this patch tested? If it is not, please explain why.

Manual testing:
- Opened panel → grid samples show green-checkmark / red-checkmark icons
- Regular click → positive selection shown in New Search form
- Alt+click → negative count displayed in query selector
- Submitted search with positive + negative samples → operator computes combined vector query correctly
- Closed panel → selection icons reverted to default checkmarks
- Patches view → search works, expand chevron hidden for patch runs because we don't support preview selected patches
- Existing unit tests in `__tests__/utils.test.ts` cover `buildExecutionParams` with `negativeQueryIds`


## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Negative-query support added with distinct visual styles and negative counts shown in active search summary.
  * New compute-similarity action integrated that appears only when the operator is available.

* **Bug Fixes**
  * Search combination logic updated to weight and normalize positive/negative embeddings.
  * Fixed Text/Image toggle and selection behavior to match labels and selection semantics.

* **UI**
  * Samples expand/collapse tooltip renamed to “Show prompts”; control shown only for image searches without patched samples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->