### PR TITLE
chore: Release 1.14.1 (merge-to-main)

### DIFF
--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -323,11 +323,15 @@ const useOperatorPromptSubmitOptions = (
     hasAvailableOrchestrators &&
     executionOptions.orchestratorRegistrationEnabled
   ) {
-    for (let orc of execDetails.executionOptions.availableOrchestrators) {
+    for (let [
+      index,
+      orc,
+    ] of execDetails.executionOptions.availableOrchestrators.entries()) {
       options.push({
         label: "Schedule",
         choiceLabel: `Schedule on ${orc.instanceID}`,
         id: orc.id,
+        default: defaultToSchedule && index === 0,
         description: `Run this operation on ${orc.instanceID}`,
         onSelect() {
           setSelectedID(orc.id);

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -3,6 +3,28 @@ FiftyOne Release Notes
 
 .. default-role:: code
 
+FiftyOne Enterprise 2.17.1
+--------------------------
+*Released April 6, 2026*
+
+Includes all updates from :ref:`FiftyOne 1.14.1 <release-notes-v1.14.1>`, plus:
+
+- Added full support for the :ref:`Labeler <enterprise-labeler>` role in the
+  :ref:`Enterprise Management SDK <enterprise-management-sdk>`.
+
+.. _release-notes-v1.14.1:
+
+FiftyOne 1.14.1
+---------------
+*Released April 6, 2026*
+
+- Fixed: Now, if an :ref:`Operator <using-operators>` defines
+  `default_choice_to_delegated=True` and allows immediate execution, the UI
+  will not default to "Execute" but correctly default to "Schedule" and select
+  an :ref:`Orchestrator <enterprise-delegated-orchestrator>`.
+  `#7285 <https://github.com/voxel51/fiftyone/pull/7285>`_
+
+
 FiftyOne Enterprise 2.17.0
 --------------------------
 *Released March 31, 2026*

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import os
 from setuptools import setup, find_packages
 
 
-VERSION = "1.14.0"
+VERSION = "1.14.1"
 
 
 def get_version():


### PR DESCRIPTION
( automated release PR )

Release 1.14.1 (merge-to-main)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed default orchestrator selection for scheduled/delegated actions so the first available orchestrator is correctly chosen by default.
* **Documentation**
  * Added release notes for FiftyOne 1.14.1 and Enterprise 2.17.1; documented full support for the Labeler role and the UI default-action fix.
* **Chores**
  * Version bumped to 1.14.1
<!-- end of auto-generated comment: release notes by coderabbit.ai -->