### PR TITLE
Remove VectorField from paginate_samples projection

### DIFF
--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -98,7 +98,8 @@ def get_view(
             :class:`fiftyone.core.stages.ViewStage` instances
         filters (None): an optional ``dict`` of App defined filters
         pagination_data (False): whether process samples as pagination data
-            - excludes all :class:`fiftyone.core.fields.DictField` values
+            - excludes all :class:`fiftyone.core.fields.DictField` and
+              :class:`fiftyone.core.fields.DictField` values
             - filters label fields
         dynamic_group (None): an optional dynamic group value to select. Only
             applicable when a :class:`fiftyone.core.stages.GroupBy` stage is
@@ -237,7 +238,7 @@ def get_extended_view(
             )
 
     if pagination_data:
-        # omit all dict field values for performance, not needed by grid
+        # omit all dict and vector field values for performance, not needed by grid
         view = _project_pagination_paths(view, media_types)
         view = _add_labels_tags_counts(view)
 

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -385,7 +385,7 @@ def _project_pagination_paths(
     excluded = [
         path
         for path, field in schema.items()
-        if isinstance(field, fof.DictField)
+        if isinstance(field, (fof.DictField, fof.VectorField))
     ]
 
     selected_fields = ["_group"]  # store dynamic group values


### PR DESCRIPTION
## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

Remove embeddings from samples grid projection since they aren't consumed in the app anyways


## 🧪 How is this patch tested? If it is not, please explain why.

run app locally

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pagination and grid views now omit certain complex field types (dicts and vectors) from projection to improve pagination performance, reduce rendering inconsistencies, and ensure more accurate page results in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->