### PR TITLE
Release notes for OSS 1.14.1 / Ent 2.17.1

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -3,6 +3,28 @@ FiftyOne Release Notes
 
 .. default-role:: code
 
+FiftyOne Enterprise 2.17.1
+--------------------------
+*Released April 6, 2026*
+
+Includes all updates from :ref:`FiftyOne 1.14.1 <release-notes-v1.14.1>`, plus:
+
+- Added full support for the :ref:`Labeler <enterprise-labeler>` role in the
+  :ref:`Enterprise Management SDK <enterprise-management-sdk>`.
+
+.. _release-notes-v1.14.1:
+
+FiftyOne 1.14.1
+---------------
+*Released April 6, 2026*
+
+- Fixed: Now, if an :ref:`Operator <using-operators>` defines
+  `default_choice_to_delegated=True` and allows immediate execution, the UI
+  will not default to "Execute" but correctly default to "Schedule" and select
+  an :ref:`Orchestrator <enterprise-delegated-orchestrator>`.
+  `#7285 <https://github.com/voxel51/fiftyone/pull/7285>`_
+
+
 FiftyOne Enterprise 2.17.0
 --------------------------
 *Released March 31, 2026*


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Release notes for OSS 1.14.1 / Ent 2.17.1

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Published release notes for FiftyOne Enterprise 2.17.1 and FiftyOne 1.14.1 (April 6, 2026).

* **New Features**
  * Full Labeler role support added to the Enterprise Management SDK.

* **Bug Fixes**
  * UI scheduling default now correctly chooses "Schedule" and selects the delegated Orchestrator when delegation defaults are enabled and immediate execution is allowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->