### PR TITLE
add unit tests for various areas of operator prompt and useNotification

### DIFF
--- a/app/packages/operators/src/components/OperatorPromptFooter.test.tsx
+++ b/app/packages/operators/src/components/OperatorPromptFooter.test.tsx
@@ -1,0 +1,209 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import OperatorPromptFooter from "./OperatorPromptFooter";
+
+vi.mock("./RequiresOrchestrator", () => ({
+  default: () => <div data-testid="requires-orchestrator" />,
+}));
+
+describe("OperatorPromptFooter", () => {
+  const submitButtonOptions = [{ id: "execute-default", label: "Execute" }];
+
+  afterEach(cleanup);
+
+  it("renders RequiresOrchestrator card when requiresOrchestratorSetup is true", () => {
+    render(
+      <OperatorPromptFooter
+        requiresOrchestratorSetup
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByTestId("requires-orchestrator")).not.toBeNull();
+  });
+
+  it("does not render RequiresOrchestrator card when requiresOrchestratorSetup is false", () => {
+    render(
+      <OperatorPromptFooter
+        requiresOrchestratorSetup={false}
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByTestId("requires-orchestrator")).toBeNull();
+  });
+
+  it("renders only the Close button when requiresOrchestratorSetup is true", () => {
+    render(
+      <OperatorPromptFooter
+        requiresOrchestratorSetup
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: "Close" })).not.toBeNull();
+    expect(screen.queryAllByRole("button").length).toBe(1);
+    expect(screen.queryByRole("button", { name: /execute/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /cancel/i })).toBeNull();
+  });
+
+  it("renders SplitButton and Cancel button when hasSubmitButtonOptions is true", () => {
+    render(
+      <OperatorPromptFooter
+        requiresOrchestratorSetup={false}
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+        hasSubmitButtonOptions={true}
+        submitButtonOptions={submitButtonOptions}
+      />
+    );
+
+    expect(screen.getByLabelText("split button")).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeNull();
+  });
+
+  it("renders execute and cancel buttons when hasSubmitButtonOptions is false", () => {
+    render(
+      <OperatorPromptFooter
+        requiresOrchestratorSetup={false}
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+        hasSubmitButtonOptions={false}
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: /execute/i })).not.toBeNull();
+    expect(screen.queryByRole("button", { name: /cancel/i })).not.toBeNull();
+    expect(screen.queryByLabelText("split button")).toBeNull();
+  });
+
+  it("calls onCancel when Close button is clicked", () => {
+    const onCancel = vi.fn();
+    render(
+      <OperatorPromptFooter
+        requiresOrchestratorSetup
+        onCancel={onCancel}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    screen.getByRole("button", { name: "Close" }).click();
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("calls onCancel when Cancel button is clicked", () => {
+    const onCancel = vi.fn();
+    render(
+      <OperatorPromptFooter
+        requiresOrchestratorSetup={false}
+        onCancel={onCancel}
+        onSubmit={vi.fn()}
+        hasSubmitButtonOptions={false}
+      />
+    );
+
+    screen.getByRole("button", { name: /cancel/i }).click();
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("calls onSubmit when Execute button is clicked", () => {
+    const onSubmit = vi.fn();
+    render(
+      <OperatorPromptFooter
+        requiresOrchestratorSetup={false}
+        onCancel={vi.fn()}
+        onSubmit={onSubmit}
+        hasSubmitButtonOptions={false}
+      />
+    );
+
+    screen.getByRole("button", { name: /execute/i }).click();
+    expect(onSubmit).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onSubmit when disableSubmit is true", () => {
+    const onSubmit = vi.fn();
+    render(
+      <OperatorPromptFooter
+        requiresOrchestratorSetup={false}
+        onCancel={vi.fn()}
+        onSubmit={onSubmit}
+        hasSubmitButtonOptions={false}
+        disableSubmit
+        disabledReason="Submission disabled"
+      />
+    );
+
+    const executeButton = screen.getByRole("button", { name: /execute/i });
+    expect((executeButton as HTMLButtonElement).disabled).toBe(true);
+
+    executeButton.click();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("hides execute submit control when submitOptionsLoading is true", () => {
+    render(
+      <OperatorPromptFooter
+        requiresOrchestratorSetup={false}
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+        hasSubmitButtonOptions={false}
+        submitOptionsLoading
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: /execute/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /cancel/i })).not.toBeNull();
+  });
+
+  it("hides split submit control when submitOptionsLoading is true", () => {
+    render(
+      <OperatorPromptFooter
+        requiresOrchestratorSetup={false}
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+        hasSubmitButtonOptions={true}
+        submitButtonOptions={submitButtonOptions}
+        submitOptionsLoading
+      />
+    );
+
+    expect(screen.queryByLabelText("split button")).toBeNull();
+    expect(screen.queryByRole("button", { name: /cancel/i })).not.toBeNull();
+  });
+
+  it("renders loading indicator when loading is true", () => {
+    render(
+      <OperatorPromptFooter
+        requiresOrchestratorSetup={false}
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+        hasSubmitButtonOptions={false}
+        loading
+      />
+    );
+
+    expect(screen.queryByRole("progressbar")).not.toBeNull();
+    expect(screen.queryByRole("button", { name: /execute/i })).not.toBeNull();
+  });
+
+  it("calls onSubmit when SplitButton is clicked", () => {
+    const onSubmit = vi.fn();
+    render(
+      <OperatorPromptFooter
+        requiresOrchestratorSetup={false}
+        onCancel={vi.fn()}
+        onSubmit={onSubmit}
+        hasSubmitButtonOptions={true}
+        submitButtonOptions={submitButtonOptions}
+      />
+    );
+
+    expect(screen.getByLabelText("split button")).not.toBeNull();
+    screen.getByRole("button", { name: /execute/i }).click();
+    expect(onSubmit).toHaveBeenCalledOnce();
+  });
+});

--- a/app/packages/operators/src/state.test.ts
+++ b/app/packages/operators/src/state.test.ts
@@ -1,0 +1,437 @@
+import { act, renderHook } from "@testing-library/react";
+import React, { useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  OperatorExecutionOption,
+  useOperatorPromptSubmitOptions,
+} from "./state";
+
+vi.mock("recoil", () => ({
+  atom: vi.fn(() => ({ key: "mocked-atom" })),
+  selector: vi.fn(() => ({ key: "mocked-selector" })),
+  selectorFamily: vi.fn(() => () => ({ key: "mocked-selector-family" })),
+  useRecoilCallback: vi.fn(),
+  useRecoilState: vi.fn(() => [null, vi.fn()]),
+  useRecoilTransaction_UNSTABLE: vi.fn(),
+  useRecoilValue: vi.fn(),
+  useRecoilValueLoadable: vi.fn(),
+  useSetRecoilState: vi.fn(),
+}));
+
+vi.mock("@fiftyone/analytics", () => ({
+  useAnalyticsInfo: vi.fn(),
+}));
+
+vi.mock("@fiftyone/components", async () => {
+  return {
+    Markdown: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("span", null, children),
+  };
+});
+
+vi.mock("@fiftyone/state", async () => {
+  return {
+    useBrowserStorage: (_key: string, defaultValue: unknown) =>
+      useState(defaultValue),
+    useNotification: vi.fn(() => vi.fn()),
+    getBrowserStorageEffectForKey: vi.fn(() => () => {}),
+    modal: null,
+    datasetName: null,
+    view: null,
+    extendedStages: null,
+    filters: null,
+    selectedSamples: null,
+    selectedLabels: null,
+    viewName: null,
+    extendedSelection: null,
+    groupSlice: null,
+    queryPerformance: null,
+    sessionSpaces: null,
+    activeFields: vi.fn(() => null),
+    currentSampleId: null,
+    editingFieldAtom: null,
+  };
+});
+
+vi.mock("./operators", () => ({
+  ExecutionContext: vi.fn().mockImplementation(() => ({})),
+  InvocationRequestQueue: vi.fn(),
+  OperatorResult: vi.fn(),
+  executeOperatorWithContext: vi.fn(),
+  getInvocationRequestQueue: vi.fn(),
+  getLocalOrRemoteOperator: vi.fn(() => ({ operator: {}, isRemote: false })),
+  listLocalAndRemoteOperators: vi.fn(),
+  resolveExecutionOptions: vi.fn(),
+  resolveOperatorURI: vi.fn(),
+}));
+
+vi.mock("./utils", () => ({
+  generateOperatorSessionId: vi.fn(() => "test-session-id"),
+  optimizeCtx: vi.fn((ctx: unknown) => ctx),
+  stringifyError: vi.fn(),
+  onEnter: vi.fn((fn: unknown) => fn),
+}));
+
+vi.mock("./validation", () => ({
+  ValidationContext: vi.fn(),
+}));
+
+describe("useOperatorPromptSubmitOptions", () => {
+  let mockExecute: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockExecute = vi.fn();
+    vi.clearAllMocks();
+  });
+
+  it("returns no options when there are no applicable execution modes", () => {
+    const { result } = renderHook(() =>
+      useOperatorPromptSubmitOptions(
+        OPERATOR_URI,
+        createMockExecDetails({
+          allowDelegatedExecution: true,
+          orchestratorRegistrationEnabled: true,
+          availableOrchestrators: [],
+          allowImmediateExecution: false,
+        }),
+        mockExecute
+      )
+    );
+    expect(result.current.hasOptions).toBe(false);
+    expect(result.current.options).toHaveLength(0);
+  });
+
+  it("includes the execute option when allowImmediateExecution is true", () => {
+    const { result } = renderHook(() =>
+      useOperatorPromptSubmitOptions(
+        OPERATOR_URI,
+        createMockExecDetails({ allowImmediateExecution: true }),
+        mockExecute
+      )
+    );
+    expect(result.current.hasOptions).toBe(true);
+    expect(result.current.options).toHaveLength(1);
+    const [opt] = result.current.options;
+    expect(opt.id).toBe("execute");
+    expect(opt.label).toBe("Execute");
+    expect(opt.isDelegated).toBe(false);
+  });
+
+  it("uses provided label as the execute option label", () => {
+    const { result } = renderHook(() =>
+      useOperatorPromptSubmitOptions(
+        OPERATOR_URI,
+        createMockExecDetails({ allowImmediateExecution: true }),
+        mockExecute,
+        { submitButtonLabel: "Run Now" }
+      )
+    );
+    expect(result.current.options[0].label).toBe("Run Now");
+  });
+
+  it("uses operator provided label as the execute option label", () => {
+    const { result } = renderHook(() =>
+      useOperatorPromptSubmitOptions(
+        OPERATOR_URI,
+        createMockExecDetails({ allowImmediateExecution: true }),
+        mockExecute,
+        { submit_button_label: "Run!" }
+      )
+    );
+    expect(result.current.options[0].label).toBe("Run!");
+  });
+
+  it("includes a schedule option when allowDelegatedExecution is true and orchestratorRegistrationEnabled is false", () => {
+    const { result } = renderHook(() =>
+      useOperatorPromptSubmitOptions(
+        OPERATOR_URI,
+        createMockExecDetails({ allowDelegatedExecution: true }),
+        mockExecute
+      )
+    );
+    expect(result.current.options).toHaveLength(1);
+    const [opt] = result.current.options;
+    expect(opt.id).toBe("schedule");
+    expect(opt.isDelegated).toBe(true);
+  });
+
+  it("includes both execute and schedule when both modes are allowed (no orchestrator registration)", () => {
+    const { result } = renderHook(() =>
+      useOperatorPromptSubmitOptions(
+        OPERATOR_URI,
+        createMockExecDetails({
+          allowImmediateExecution: true,
+          allowDelegatedExecution: true,
+        }),
+        mockExecute
+      )
+    );
+    expect(result.current.options).toHaveLength(2);
+    const ids = result.current.options.map((o) => o.id);
+    expect(ids).toContain("execute");
+    expect(ids).toContain("schedule");
+  });
+
+  it("puts the execute option first when defaultChoiceToDelegated is false", () => {
+    const { result } = renderHook(() =>
+      useOperatorPromptSubmitOptions(
+        OPERATOR_URI,
+        createMockExecDetails({
+          allowImmediateExecution: true,
+          allowDelegatedExecution: true,
+          defaultChoiceToDelegated: false,
+        }),
+        mockExecute
+      )
+    );
+    expect(result.current.options[0].id).toBe("execute");
+  });
+
+  it("puts the schedule option first when defaultChoiceToDelegated is true", () => {
+    const { result } = renderHook(() =>
+      useOperatorPromptSubmitOptions(
+        OPERATOR_URI,
+        createMockExecDetails({
+          allowImmediateExecution: true,
+          allowDelegatedExecution: true,
+          defaultChoiceToDelegated: true,
+        }),
+        mockExecute
+      )
+    );
+    expect(result.current.options[0].id).toBe("schedule");
+  });
+
+  it("creates per-orchestrator schedule options when orchestrators are available", () => {
+    const orchestrators = [
+      { id: "orc-1", instanceID: "worker-1" },
+      { id: "orc-2", instanceID: "worker-2" },
+    ];
+    const { result } = renderHook(() =>
+      useOperatorPromptSubmitOptions(
+        OPERATOR_URI,
+        createMockExecDetails({
+          allowImmediateExecution: true,
+          allowDelegatedExecution: true,
+          orchestratorRegistrationEnabled: true,
+          availableOrchestrators: orchestrators,
+        }),
+        mockExecute
+      )
+    );
+    expect(result.current.options).toHaveLength(3);
+    const orcOpts = result.current.options.filter((o) => o.isDelegated);
+    expect(orcOpts).toHaveLength(2);
+    expect(orcOpts[0].id).toBe("orc-1");
+    expect(orcOpts[0].choiceLabel).toBe("Schedule on worker-1");
+    expect(orcOpts[1].id).toBe("orc-2");
+    expect(orcOpts[1].choiceLabel).toBe("Schedule on worker-2");
+  });
+
+  it("adds a disabled-schedule option when orchestrator registration is enabled but no orchestrators exist", () => {
+    const { result } = renderHook(() =>
+      useOperatorPromptSubmitOptions(
+        OPERATOR_URI,
+        createMockExecDetails({
+          allowImmediateExecution: true,
+          allowDelegatedExecution: true,
+          orchestratorRegistrationEnabled: true,
+          availableOrchestrators: [],
+        }),
+        mockExecute
+      )
+    );
+    const disabledOption = result.current.options.find(
+      (o) => o.id === "disabled-schedule"
+    ) as OperatorExecutionOption;
+    expect(disabledOption).toBeDefined();
+    expect(disabledOption.isDisabledSchedule).toBe(true);
+    expect(disabledOption.tag).toBe("NOT AVAILABLE");
+  });
+
+  it("sets requiresOrchestratorSetup to true when orchestrator is required but not available", () => {
+    const { result } = renderHook(() =>
+      useOperatorPromptSubmitOptions(
+        OPERATOR_URI,
+        createMockExecDetails({
+          allowDelegatedExecution: true,
+          orchestratorRegistrationEnabled: true,
+          availableOrchestrators: [],
+          allowImmediateExecution: false,
+        }),
+        mockExecute
+      )
+    );
+    expect(result.current.requiresOrchestratorSetup).toBe(true);
+  });
+
+  it("sets requiresOrchestratorSetup to false when allowImmediateExecution is true", () => {
+    const { result } = renderHook(() =>
+      useOperatorPromptSubmitOptions(
+        OPERATOR_URI,
+        createMockExecDetails({
+          allowImmediateExecution: true,
+          allowDelegatedExecution: true,
+          orchestratorRegistrationEnabled: true,
+          availableOrchestrators: [],
+        }),
+        mockExecute
+      )
+    );
+    expect(result.current.requiresOrchestratorSetup).toBe(false);
+  });
+
+  it("sets requiresOrchestratorSetup to false when orchestrators are available", () => {
+    const { result } = renderHook(() =>
+      useOperatorPromptSubmitOptions(
+        OPERATOR_URI,
+        createMockExecDetails({
+          allowDelegatedExecution: true,
+          orchestratorRegistrationEnabled: true,
+          availableOrchestrators: [{ id: "orc-1", instanceID: "worker-1" }],
+        }),
+        mockExecute
+      )
+    );
+    expect(result.current.requiresOrchestratorSetup).toBe(false);
+  });
+
+  it("sets isLoading to true when execDetails is loading", () => {
+    const { result } = renderHook(() =>
+      useOperatorPromptSubmitOptions(
+        OPERATOR_URI,
+        createMockExecDetails({
+          allowImmediateExecution: true,
+          isLoading: true,
+        }),
+        mockExecute
+      )
+    );
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("sets isLoading to false when execDetails is not loading", () => {
+    const { result } = renderHook(() =>
+      useOperatorPromptSubmitOptions(
+        OPERATOR_URI,
+        createMockExecDetails({
+          allowImmediateExecution: true,
+          isLoading: false,
+        }),
+        mockExecute
+      )
+    );
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("calls execute without args when the execute option is selected", () => {
+    const { result } = renderHook(() =>
+      useOperatorPromptSubmitOptions(
+        OPERATOR_URI,
+        createMockExecDetails({ allowImmediateExecution: true }),
+        mockExecute
+      )
+    );
+    act(() => {
+      result.current.handleSubmit();
+    });
+    expect(mockExecute).toHaveBeenCalledWith();
+  });
+
+  it("calls execute with requestDelegation when the schedule option is selected", () => {
+    const { result } = renderHook(() =>
+      useOperatorPromptSubmitOptions(
+        OPERATOR_URI,
+        createMockExecDetails({
+          allowDelegatedExecution: true,
+          defaultChoiceToDelegated: true,
+        }),
+        mockExecute
+      )
+    );
+    act(() => {
+      result.current.handleSubmit();
+    });
+    expect(mockExecute).toHaveBeenCalledWith({ requestDelegation: true });
+  });
+
+  it("calls execute with delegationTarget when an orchestrator option is selected", () => {
+    const { result } = renderHook(() =>
+      useOperatorPromptSubmitOptions(
+        OPERATOR_URI,
+        createMockExecDetails({
+          allowDelegatedExecution: true,
+          orchestratorRegistrationEnabled: true,
+          availableOrchestrators: [{ id: "orc-1", instanceID: "worker-1" }],
+        }),
+        mockExecute
+      )
+    );
+    act(() => {
+      result.current.handleSubmit();
+    });
+    expect(mockExecute).toHaveBeenCalledWith({
+      delegationTarget: "worker-1",
+      requestDelegation: true,
+    });
+  });
+
+  it("marks the currently selected option with selected:true", () => {
+    const { result } = renderHook(() =>
+      useOperatorPromptSubmitOptions(
+        OPERATOR_URI,
+        createMockExecDetails({ allowImmediateExecution: true }),
+        mockExecute
+      )
+    );
+    const selected = result.current.options.filter((o) => o.selected);
+    expect(selected).toHaveLength(1);
+    expect(selected[0].id).toBe("execute");
+  });
+
+  it("updates the selected option when onSelect is called", () => {
+    const { result } = renderHook(() =>
+      useOperatorPromptSubmitOptions(
+        OPERATOR_URI,
+        createMockExecDetails({
+          allowImmediateExecution: true,
+          allowDelegatedExecution: true,
+          defaultChoiceToDelegated: false,
+        }),
+        mockExecute
+      )
+    );
+
+    // Initially execute is selected (first / default)
+    expect(result.current.options[0].selected).toBe(true);
+    expect(result.current.options[0].id).toBe("execute");
+
+    // Switch selection to schedule
+    act(() => {
+      result.current.options.find((o) => o.id === "schedule")?.onSelect?.();
+    });
+
+    expect(
+      result.current.options.find((o) => o.id === "schedule")?.selected
+    ).toBe(true);
+    expect(
+      result.current.options.find((o) => o.id === "execute")?.selected
+    ).toBeUndefined();
+  });
+});
+
+const OPERATOR_URI = "test/operator";
+
+function createMockExecDetails(opts: ExecutionOptions = {}) {
+  const { isLoading = false, ...executionOptions } = opts;
+  return { isLoading, executionOptions };
+}
+
+type ExecutionOptions = {
+  allowImmediateExecution?: boolean;
+  allowDelegatedExecution?: boolean;
+  defaultChoiceToDelegated?: boolean;
+  orchestratorRegistrationEnabled?: boolean;
+  availableOrchestrators?: Array<{ id: string; instanceID: string }>;
+  isLoading?: boolean;
+};

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -266,7 +266,7 @@ export type OperatorExecutionOption = {
   isDisabledSchedule?: boolean;
 };
 
-const useOperatorPromptSubmitOptions = (
+export const useOperatorPromptSubmitOptions = (
   operatorURI,
   execDetails,
   execute: (options?: OperatorExecutorOptions) => void,

--- a/app/packages/operators/src/utils.test.ts
+++ b/app/packages/operators/src/utils.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it, vi } from "vitest";
+import { OperatorPromptType } from "./types";
+import { getOperatorPromptConfigs } from "./utils";
+
+describe("getOperatorPromptConfigs", () => {
+  it("show is false when nothing is active", () => {
+    const { show, showResultOrError } = getOperatorPromptConfigs(
+      createOperatorPromptOptions()
+    );
+    expect(show).toBe(false);
+    expect(showResultOrError).toBeFalsy();
+  });
+
+  it("show is true when hasResultOrError is true", () => {
+    const { show, showResultOrError } = getOperatorPromptConfigs(
+      createOperatorPromptOptions({ hasResultOrError: true })
+    );
+    expect(showResultOrError).toBe(true);
+    expect(show).toBe(true);
+  });
+
+  it("show is truthy when executorError is set", () => {
+    const { show, showResultOrError } = getOperatorPromptConfigs(
+      createOperatorPromptOptions({
+        executorError: new Error("Executor error"),
+      })
+    );
+    expect(showResultOrError).toBeTruthy();
+    expect(show).toBeTruthy();
+  });
+
+  it("show is truthy when resolveError is set", () => {
+    const { show } = getOperatorPromptConfigs(
+      createOperatorPromptOptions({
+        resolveError: new Error("Resolve error"),
+      })
+    );
+    expect(show).toBeTruthy();
+  });
+
+  it("show is true when showPrompt is true", () => {
+    const { show } = getOperatorPromptConfigs(
+      createOperatorPromptOptions({
+        showPrompt: true,
+        inputFields: { view: {} },
+      })
+    );
+    expect(show).toBe(true);
+  });
+
+  it("show is true when isExecuting is true", () => {
+    const { show } = getOperatorPromptConfigs(
+      createOperatorPromptOptions({ isExecuting: true })
+    );
+    expect(show).toBe(true);
+  });
+
+  it("submitButtonText defaults to Execute", () => {
+    const { submitButtonText } = getOperatorPromptConfigs(
+      createOperatorPromptOptions()
+    );
+    expect(submitButtonText).toBe("Execute");
+  });
+
+  it("cancelButtonText defaults to Cancel", () => {
+    const { cancelButtonText } = getOperatorPromptConfigs(
+      createOperatorPromptOptions()
+    );
+    expect(cancelButtonText).toBe("Cancel");
+  });
+
+  it("uses submitButtonLabel from PromptView when present", () => {
+    const { submitButtonText } = getOperatorPromptConfigs(
+      createOperatorPromptOptions({
+        promptView: {
+          name: "PromptView",
+          submit_button_label: "Run!",
+          label: "My prompt",
+        },
+      })
+    );
+    expect(submitButtonText).toBe("Run!");
+  });
+
+  it("keeps default submitButtonText when PromptView has no label", () => {
+    const { submitButtonText } = getOperatorPromptConfigs(
+      createOperatorPromptOptions({
+        promptView: { name: "PromptView", label: "My prompt" },
+      })
+    );
+    expect(submitButtonText).toBe("Execute");
+  });
+
+  it("sets onSubmit and onCancel from prompt when showPrompt is true", () => {
+    const onSubmit = vi.fn();
+    const cancel = vi.fn();
+    const configs = getOperatorPromptConfigs(
+      createOperatorPromptOptions({
+        showPrompt: true,
+        onSubmit,
+        cancel,
+        inputFields: { view: {} },
+      })
+    );
+    expect(configs.onSubmit).toBe(onSubmit);
+    expect(configs.onCancel).toBe(cancel);
+    expect(configs.cancelButtonText).toBe("Cancel");
+  });
+
+  it("sets onCancel to close and cancelButtonText to Close when showing result or error", () => {
+    const close = vi.fn();
+    const configs = getOperatorPromptConfigs(
+      createOperatorPromptOptions({ hasResultOrError: true, close })
+    );
+    expect(configs.onCancel).toBe(close);
+    expect(configs.cancelButtonText).toBe("Close");
+  });
+
+  it("returns onSubmit as undefined when neither showPrompt nor showResultOrError", () => {
+    const { onSubmit } = getOperatorPromptConfigs(
+      createOperatorPromptOptions()
+    );
+    expect(onSubmit).toBeUndefined();
+  });
+
+  it("falls back to close when onCancel is not set", () => {
+    const close = vi.fn();
+    const { onClose } = getOperatorPromptConfigs(
+      createOperatorPromptOptions({ close })
+    );
+    expect(onClose).toBe(close);
+  });
+
+  it("uses onCancel as onClose when set", () => {
+    const close = vi.fn();
+    const cancel = vi.fn();
+    const { onClose } = getOperatorPromptConfigs(
+      createOperatorPromptOptions({
+        showPrompt: true,
+        cancel,
+        close,
+        inputFields: { view: {} },
+      })
+    );
+    expect(onClose).toBe(cancel);
+  });
+
+  it("hasValidationErrors is false when array is empty", () => {
+    const { hasValidationErrors, disableSubmit } = getOperatorPromptConfigs(
+      createOperatorPromptOptions({ validationErrors: [] })
+    );
+    expect(hasValidationErrors).toBe(false);
+    expect(disableSubmit).toBe(false);
+  });
+
+  it("hasValidationErrors is true and disableSubmit is true when errors exist", () => {
+    const {
+      hasValidationErrors,
+      disableSubmit,
+      validationErrorsStr,
+      disabledReason,
+    } = getOperatorPromptConfigs(
+      createOperatorPromptOptions({
+        validationErrors: [
+          { path: "foo", reason: "required" },
+          { path: "bar", reason: "invalid" },
+        ],
+      })
+    );
+    expect(hasValidationErrors).toBe(true);
+    expect(disableSubmit).toBe(true);
+    expect(validationErrorsStr).toBe(
+      "params.foo: required\nparams.bar: invalid"
+    );
+    expect(disabledReason).toContain(
+      "Cannot execute operator with validation errors"
+    );
+  });
+
+  it("disabledReason mentions validation errors when there are validation errors", () => {
+    const { disabledReason } = getOperatorPromptConfigs(
+      createOperatorPromptOptions({
+        validationErrors: [{ path: "x", reason: "bad" }],
+      })
+    );
+    expect(disabledReason).toContain("validation errors");
+    expect(disabledReason).toContain("params.x: bad");
+  });
+
+  it("disabledReason mentions validating when resolving and there are no validation errors", () => {
+    const { disabledReason } = getOperatorPromptConfigs(
+      createOperatorPromptOptions({ resolving: true })
+    );
+    expect(disabledReason).toContain("validating");
+  });
+
+  it("loading is true when resolving", () => {
+    const { loading } = getOperatorPromptConfigs(
+      createOperatorPromptOptions({ resolving: true })
+    );
+    expect(loading).toBe(true);
+  });
+
+  it("disableSubmit is true when resolving", () => {
+    const { disableSubmit } = getOperatorPromptConfigs(
+      createOperatorPromptOptions({ resolving: true })
+    );
+    expect(disableSubmit).toBe(true);
+  });
+
+  it("passes through submitOptions fields", () => {
+    const options = [{ label: "opt1" }];
+    const configs = getOperatorPromptConfigs(
+      createOperatorPromptOptions({
+        submitOptions: {
+          options,
+          isLoading: true,
+          hasOptions: true,
+          requiresOrchestratorSetup: true,
+        },
+      })
+    );
+    expect(configs.submitButtonOptions).toBe(options);
+    expect(configs.submitButtonLoading).toBe(true);
+    expect(configs.hasSubmitButtonOptions).toBe(true);
+    expect(configs.requiresOrchestratorSetup).toBe(true);
+  });
+
+  it("returns title from inputFields view label when showPrompt is true", () => {
+    const { title } = getOperatorPromptConfigs(
+      createOperatorPromptOptions({
+        showPrompt: true,
+        inputFields: { view: { label: "My Input" } },
+      })
+    );
+    expect(title).toBe("My Input");
+  });
+
+  it("returns title from outputFields view label when not showing prompt", () => {
+    const { title } = getOperatorPromptConfigs(
+      createOperatorPromptOptions({
+        showPrompt: false,
+        outputFields: { view: { label: "My Output" } },
+      })
+    );
+    expect(title).toBe("My Output");
+  });
+
+  it("returns undefined title when no fields", () => {
+    const { title } = getOperatorPromptConfigs(createOperatorPromptOptions());
+    expect(title).toBeUndefined();
+  });
+
+  it("exposes customPrompt and customPromptName from promptView", () => {
+    const promptView = { name: "PromptView", label: "test" };
+    const { customPrompt, customPromptName } = getOperatorPromptConfigs(
+      createOperatorPromptOptions({ promptView })
+    );
+    expect(customPrompt).toBe(promptView);
+    expect(customPromptName).toBe("PromptView");
+  });
+
+  it("customPrompt and customPromptName are null/undefined when promptView is null", () => {
+    const { customPrompt, customPromptName } = getOperatorPromptConfigs(
+      createOperatorPromptOptions({ promptView: null })
+    );
+    expect(customPrompt).toBeNull();
+    expect(customPromptName).toBeUndefined();
+  });
+});
+
+function createOperatorPromptOptions(
+  overrides: Partial<OperatorPromptForConfig> = {}
+): OperatorPromptForConfig {
+  return {
+    hasResultOrError: false,
+    executorError: null,
+    resolveError: null,
+    showPrompt: false,
+    isExecuting: false,
+    promptView: null,
+    submitOptions: {
+      options: [],
+      isLoading: false,
+      hasOptions: false,
+      requiresOrchestratorSetup: false,
+    },
+    onSubmit: vi.fn(),
+    cancel: vi.fn(),
+    close: vi.fn(),
+    validationErrors: [],
+    resolving: false,
+    inputFields: null,
+    outputFields: null,
+    ...overrides,
+  };
+}
+
+type OperatorPromptForConfig = Pick<
+  NonNullable<OperatorPromptType>,
+  | "hasResultOrError"
+  | "executorError"
+  | "resolveError"
+  | "showPrompt"
+  | "isExecuting"
+  | "promptView"
+  | "submitOptions"
+  | "onSubmit"
+  | "cancel"
+  | "close"
+  | "validationErrors"
+  | "resolving"
+  | "inputFields"
+  | "outputFields"
+>;

--- a/app/packages/state/src/hooks/useNotification.test.tsx
+++ b/app/packages/state/src/hooks/useNotification.test.tsx
@@ -1,0 +1,213 @@
+import type { ButtonProps, IconButtonProps, StackProps } from "@mui/material";
+import { render, renderHook } from "@testing-library/react";
+import {
+  closeSnackbar,
+  enqueueSnackbar,
+  OptionsObject,
+  SnackbarMessage,
+} from "notistack";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import useNotification from "./useNotification";
+
+const NOTIFICATION_MESSAGE = "Test notification";
+const NOTIFICATION_KEY = "test-notification-key";
+
+vi.mock("notistack", () => ({
+  enqueueSnackbar: vi.fn(),
+  closeSnackbar: vi.fn(),
+}));
+
+// MUI components used in the action JSX
+vi.mock("@mui/material", () => ({
+  Button: ({ children, onClick, href, ...props }: ButtonProps) =>
+    React.createElement("button", { onClick, href, ...props }, children),
+  IconButton: ({ children, onClick }: IconButtonProps) =>
+    React.createElement("button", { onClick }, children),
+  Stack: ({ children }: StackProps) =>
+    React.createElement("div", null, children),
+}));
+
+vi.mock("@mui/icons-material/Close", () => ({
+  default: () => React.createElement("span", null, "Close"),
+}));
+
+type EnqueueOptions = OptionsObject & { message?: SnackbarMessage };
+
+const mockEnqueueSnackbar = vi.mocked(enqueueSnackbar);
+const mockCloseSnackbar = vi.mocked(closeSnackbar);
+
+const getCallParams = (callIndex = 0): EnqueueOptions =>
+  mockEnqueueSnackbar.mock.calls[callIndex][0] as EnqueueOptions;
+
+describe("useNotification", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns a callable function", () => {
+    const { result } = renderHook(() => useNotification());
+    expect(typeof result.current).toBe("function");
+  });
+
+  it("calls enqueueSnackbar with the correct base options", () => {
+    const { result } = renderHook(() => useNotification());
+
+    result.current({ msg: NOTIFICATION_MESSAGE });
+
+    expect(mockEnqueueSnackbar).toHaveBeenCalledOnce();
+    const params = getCallParams();
+    expect(params.key).toBe(NOTIFICATION_MESSAGE);
+    expect(params.message).toBe(NOTIFICATION_MESSAGE);
+    expect(params.anchorOrigin).toEqual({
+      horizontal: "center",
+      vertical: "bottom",
+    });
+    expect(params.autoHideDuration).toBe(3000);
+    expect(params.preventDuplicate).toBe(true);
+  });
+
+  it("passes extra options through to enqueueSnackbar", () => {
+    const { result } = renderHook(() => useNotification());
+
+    result.current({
+      msg: NOTIFICATION_MESSAGE,
+      variant: "success",
+      autoHideDuration: 5000,
+      preventDuplicate: false,
+      key: NOTIFICATION_KEY,
+      anchorOrigin: { horizontal: "left", vertical: "top" },
+    });
+
+    const { variant, autoHideDuration, preventDuplicate, key } =
+      getCallParams();
+
+    expect(variant).toBe("success");
+    expect(autoHideDuration).toBe(5000);
+    expect(preventDuplicate).toBe(false);
+    expect(key).toBe(NOTIFICATION_KEY);
+    expect(getCallParams().anchorOrigin).toEqual({
+      horizontal: "left",
+      vertical: "top",
+    });
+  });
+
+  it("uses a provided numeric key of 0 for enqueue and close", () => {
+    const { result } = renderHook(() => useNotification());
+    result.current({ msg: NOTIFICATION_MESSAGE, key: 0 });
+    expect(getCallParams().key).toBe(0);
+    const action = getCallParams().action as React.ReactElement;
+    const { container } = render(action);
+    const buttons = container.querySelectorAll("button");
+    buttons[buttons.length - 1].click();
+    expect(mockCloseSnackbar).toHaveBeenCalledWith(0);
+  });
+
+  it("uses a provided empty string key for enqueue and close", () => {
+    const { result } = renderHook(() => useNotification());
+    result.current({ msg: NOTIFICATION_MESSAGE, key: "" });
+    expect(getCallParams().key).toBe("");
+    const action = getCallParams().action as React.ReactElement;
+    const { container } = render(action);
+    const buttons = container.querySelectorAll("button");
+    buttons[buttons.length - 1].click();
+    expect(mockCloseSnackbar).toHaveBeenCalledWith("");
+  });
+
+  it("renders action as a valid React element", () => {
+    const { result } = renderHook(() => useNotification());
+
+    result.current({ msg: NOTIFICATION_MESSAGE });
+
+    const action = getCallParams().action as React.ReactElement;
+    expect(React.isValidElement(action)).toBe(true);
+  });
+
+  it("includes action buttons for each provided action", () => {
+    const onClick = vi.fn();
+    const { result } = renderHook(() => useNotification());
+
+    result.current({
+      msg: NOTIFICATION_MESSAGE,
+      actions: [
+        { label: "View details", onClick },
+        { label: "Docs", href: "https://fiftyone.ai" },
+      ],
+    });
+
+    const action = getCallParams().action as React.ReactElement;
+    const { container } = render(action);
+    const buttons = container.querySelectorAll("button");
+    const viewDetailsButton = buttons[0];
+    const docsButton = buttons[1];
+    // Two action buttons + one close button
+    expect(buttons.length).toBe(3);
+    expect(viewDetailsButton.textContent).toBe("View details");
+    expect(docsButton.getAttribute("href")).toBe("https://fiftyone.ai");
+  });
+
+  it("action button onClick handler is wired correctly", () => {
+    const onClick = vi.fn();
+    const { result } = renderHook(() => useNotification());
+
+    result.current({
+      msg: NOTIFICATION_MESSAGE,
+      actions: [{ label: "View details", onClick }],
+    });
+
+    const action = getCallParams().action as React.ReactElement;
+    const { container } = render(action);
+    const buttons = container.querySelectorAll("button");
+    const viewDetailsButton = buttons[0];
+    viewDetailsButton.click();
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("close button calls closeSnackbar with the message as key", () => {
+    const { result } = renderHook(() => useNotification());
+
+    result.current({ msg: NOTIFICATION_MESSAGE });
+
+    const action = getCallParams().action as React.ReactElement;
+    const { container } = render(action);
+    const buttons = container.querySelectorAll("button");
+    // Last button is the close (IconButton)
+    buttons[buttons.length - 1].click();
+    expect(mockCloseSnackbar).toHaveBeenCalledWith(NOTIFICATION_MESSAGE);
+  });
+
+  it("close button calls closeSnackbar with the key if provided", () => {
+    const { result } = renderHook(() => useNotification());
+
+    result.current({ msg: NOTIFICATION_MESSAGE, key: NOTIFICATION_KEY });
+
+    const action = getCallParams().action as React.ReactElement;
+    const { container } = render(action);
+    const buttons = container.querySelectorAll("button");
+    // Last button is the close (IconButton)
+    buttons[buttons.length - 1].click();
+    expect(mockCloseSnackbar).toHaveBeenCalledWith(NOTIFICATION_KEY);
+  });
+
+  it("defaults to an empty actions array when actions are not provided", () => {
+    const { result } = renderHook(() => useNotification());
+
+    result.current({ msg: NOTIFICATION_MESSAGE });
+
+    const action = getCallParams().action as React.ReactElement;
+    const { container } = render(action);
+    // Only the close button should be present
+    expect(container.querySelectorAll("button").length).toBe(1);
+  });
+
+  it("preventDuplicate defaults to true", () => {
+    const { result } = renderHook(() => useNotification());
+
+    result.current({ msg: NOTIFICATION_MESSAGE });
+    result.current({ msg: NOTIFICATION_MESSAGE });
+
+    expect(mockEnqueueSnackbar).toHaveBeenCalledTimes(2);
+    expect(getCallParams(0).preventDuplicate).toBe(true);
+    expect(getCallParams(1).preventDuplicate).toBe(true);
+  });
+});

--- a/app/packages/state/src/hooks/useNotification.tsx
+++ b/app/packages/state/src/hooks/useNotification.tsx
@@ -9,9 +9,10 @@ export default function useNotification(): (
   options: NotificationOption
 ) => void {
   return (options: NotificationOption) => {
-    const { msg, actions = [], ...otherOptions } = options;
+    const { msg, key, actions = [], ...otherOptions } = options;
+    const computedKey = key ?? msg;
     enqueueSnackbar({
-      key: msg,
+      key: computedKey,
       message: msg,
       anchorOrigin: { horizontal: "center", vertical: "bottom" },
       autoHideDuration: SNACKBAR_AUTO_HIDE_DURATION,
@@ -40,11 +41,12 @@ export default function useNotification(): (
             );
           })}
           <IconButton
+            aria-label="Close notification"
             onClick={() => {
-              closeSnackbar(msg);
+              closeSnackbar(computedKey);
             }}
           >
-            <Close fontSize="small" sx={{ color: "white" }} />
+            <Close fontSize="small" sx={{ color: "#FFFFFF" }} />
           </IconButton>
         </Stack>
       ),


### PR DESCRIPTION
## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->
- https://github.com/voxel51/fiftyone/pull/7228
- https://github.com/voxel51/fiftyone/pull/7230
- https://github.com/voxel51/fiftyone/pull/7266

## 📋 What changes are proposed in this pull request?

add unit tests for various areas of operator prompt and useNotification

## 🧪 How is this patch tested? If it is not, please explain why.

Ran the new tests locally

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for prompt footer UI, submit-option state, prompt configuration handling, and notification behavior.

* **New Features**
  * Notifications accept custom keys for targeted message management.

* **Bug Fixes**
  * Notification dismissal now reliably closes the intended message when custom keys are used.

* **Style**
  * Updated notification close icon color and added accessible label.

* **Chores**
  * Made submit-option logic exported for broader reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->