### PR TITLE
[FOEPD-3652] Fix ViewStageParameter text vertical alignment

### DIFF
--- a/app/packages/core/src/components/ViewBar/ViewStage/ViewStageParameter.tsx
+++ b/app/packages/core/src/components/ViewBar/ViewStage/ViewStageParameter.tsx
@@ -28,6 +28,7 @@ const ViewStageParameterDiv = animated(styled.div`
   box-sizing: border-box;
   border: 1px solid ${({ theme }) => theme.primary.plainColor};
   display: flex;
+  align-items: center;
   overflow: visible;
   height: 100%;
 `);
@@ -36,9 +37,8 @@ const ViewStageParameterInput = animated(styled(AutosizeInput)`
   & > input {
     background-color: transparent;
     border: none;
-    padding: 0.5rem 0 0.5rem 0.5rem;
+    padding: 0 0 0 0.5rem;
     color: ${({ theme }) => theme.text.primary};
-    height: 1rem;
     font-weight: bold;
   }
 
@@ -253,7 +253,7 @@ const ObjectEditor = ({
         ref={containerRef}
       >
         {state.matches("reading") ? (
-          <div style={{ padding: "0.5em", whiteSpace: "nowrap" }}>
+          <div style={{ padding: "0 0.5em", whiteSpace: "nowrap" }}>
             {convert(value, makePlaceholder(state.context))}
           </div>
         ) : (
@@ -282,7 +282,6 @@ const ObjectEditor = ({
                 style={{
                   cursor: "pointer",
                   color: theme.text.primary,
-                  marginTop: "0.2em",
                   position: "absolute",
                   right: "0.2rem",
                 }}
@@ -442,7 +441,6 @@ const ViewStageParameter = React.memo(({ parameterRef, barRef, stageRef }) => {
                 style={{
                   cursor: "pointer",
                   color: theme.text.primary,
-                  marginTop: "0.2em",
                 }}
                 onMouseEnter={() => send("MOUSEENTER")}
                 onMouseLeave={() => send("MOUSELEAVE")}


### PR DESCRIPTION
Removes manual margin hacks and height constraints in favour of flexbox
align-items: center on the container, so parameter text and icons sit
properly centered regardless of content.

Before:
<img width="1035" height="88" alt="screenshot-2026-04-07_08-24-33" src="https://github.com/user-attachments/assets/a59ef364-0884-4e1c-be4e-6b73d364ae7a" />

After:
<img width="1137" height="94" alt="screenshot-2026-04-07_08-15-30" src="https://github.com/user-attachments/assets/e64ed3f3-68c1-4f29-9116-417923713df5" />

## 🔗 Related Issues

[Viewbar Text Alignment](https://voxel51.atlassian.net/browse/FOEPD-3652)

## 📋 What changes are proposed in this pull request?

ViewBar stage parameter inputs had misaligned text and icons caused by a
combination of a hardcoded `height: 1rem`, vertical padding on the input,
and `marginTop` offsets on the dropdown arrow icons. This replaces all of
that with `align-items: center` on the flex container, letting the browser
handle vertical centering naturally.

## 🧪 How is this patch tested? If it is not, please explain why.

Manually verified in the app by opening the ViewBar, adding stages with
various parameter types (string, object, boolean), and confirming text and
icons are vertically centered. No unit tests — this is a pure CSS layout
fix with no logic changes.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
