### PR TITLE
[FOEPD-3650] Fix histogram tooltip lag and position offset

### DIFF
--- a/app/packages/core/src/components/Histogram.tsx
+++ b/app/packages/core/src/components/Histogram.tsx
@@ -14,6 +14,7 @@ import {
   prettify,
 } from "../utils/generic";
 import { ContentDiv, ContentHeader } from "./utils";
+import { CategoricalChartState } from "recharts/types/chart/types";
 
 const Container = styled.div`
   overflow-y: hidden;
@@ -189,7 +190,7 @@ const HistogramRenderer: React.FC<{ path: string }> = ({ path }) => {
         barCategoryGap={"4px"}
         data={strData}
         margin={{ top: 0, left: 0, bottom: 5, right: 5 }}
-        onMouseMove={(state: any) => {
+        onMouseMove={(state: CategoricalChartState) => {
           if (state?.chartX != null && state?.chartY != null) {
             setTooltipPos({ x: state.chartX + 8, y: state.chartY - 10 });
           }

--- a/app/packages/core/src/components/Histogram.tsx
+++ b/app/packages/core/src/components/Histogram.tsx
@@ -16,6 +16,9 @@ import {
 import { ContentDiv, ContentHeader } from "./utils";
 import { CategoricalChartState } from "recharts/types/chart/types";
 
+const TOOLTIP_OFFSET_X = 8;
+const TOOLTIP_OFFSET_Y = -10;
+
 const Container = styled.div`
   overflow-y: hidden;
   overflow-x: auto;
@@ -192,7 +195,7 @@ const HistogramRenderer: React.FC<{ path: string }> = ({ path }) => {
         margin={{ top: 0, left: 0, bottom: 5, right: 5 }}
         onMouseMove={(state: CategoricalChartState) => {
           if (state?.chartX != null && state?.chartY != null) {
-            setTooltipPos({ x: state.chartX + 8, y: state.chartY - 10 });
+            setTooltipPos({ x: state.chartX + TOOLTIP_OFFSET_X, y: state.chartY + TOOLTIP_OFFSET_Y});
           }
         }}
         onMouseLeave={() => setTooltipPos(undefined)}

--- a/app/packages/core/src/components/Histogram.tsx
+++ b/app/packages/core/src/components/Histogram.tsx
@@ -134,6 +134,9 @@ const makeData = (counts: readonly number[], values: readonly number[]) => {
 const HistogramRenderer: React.FC<{ path: string }> = ({ path }) => {
   const [ref, { height }] = useMeasure();
   const theme = useTheme();
+  const [tooltipPos, setTooltipPos] = React.useState<
+    { x: number; y: number } | undefined
+  >();
 
   const { data, ticks } = useData(path);
   const hasMore = data.length >= LIMIT;
@@ -186,6 +189,12 @@ const HistogramRenderer: React.FC<{ path: string }> = ({ path }) => {
         barCategoryGap={"4px"}
         data={strData}
         margin={{ top: 0, left: 0, bottom: 5, right: 5 }}
+        onMouseMove={(state: any) => {
+          if (state?.chartX != null && state?.chartY != null) {
+            setTooltipPos({ x: state.chartX + 8, y: state.chartY - 10 });
+          }
+        }}
+        onMouseLeave={() => setTooltipPos(undefined)}
       >
         <XAxis
           dataKey="key"
@@ -203,6 +212,8 @@ const HistogramRenderer: React.FC<{ path: string }> = ({ path }) => {
         />
         <Tooltip
           cursor={false}
+          isAnimationActive={false}
+          position={tooltipPos}
           content={(point) => {
             const key = point?.payload[0]?.payload?.key;
             const count = point?.payload[0]?.payload?.count;


### PR DESCRIPTION
Fixes histogram tooltip lag and position offset by tracking cursor
coordinates directly instead of relying on Recharts' default positioning.

## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

The histogram tooltip had two issues: it lagged behind the cursor due to
Recharts' built-in animation, and it appeared offset from the pointer
because Recharts positions it at the top of the hovered bar rather than
at the cursor. This fix disables tooltip animation via `isAnimationActive={false}`
and tracks the actual cursor position via `onMouseMove` on the BarChart,
passing those coordinates directly to the `position` prop so the tooltip
follows the cursor immediately and accurately.

## 🧪 How is this patch tested? If it is not, please explain why.

Manually verified by hovering over histogram bars and confirming the
tooltip appears immediately at the cursor position without lag or vertical
offset. No unit tests — this is a UI interaction fix with no logic changes.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved histogram tooltip behavior: tooltip now follows the pointer more accurately, uses explicit positioning for stable display, disables animation for consistent placement, and reliably clears when leaving the chart area for clearer real-time data visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->