### PR TITLE
move setup now button to its own component

### DIFF
--- a/app/packages/operators/src/components/RequiresOrchestrator.tsx
+++ b/app/packages/operators/src/components/RequiresOrchestrator.tsx
@@ -8,15 +8,18 @@ export default function RequiresOrchestrator() {
       description="Production workflows require dedicated compute resources."
       icon={IconName.Orchestrator}
       compact
-      action={
-        <Link
-          href="https://docs.voxel51.com/plugins/using_plugins.html#delegated-operations"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Button variant={Variant.Secondary}>Set up now</Button>
-        </Link>
-      }
+      action={<SetupNow />}
     />
+  );
+}
+function SetupNow() {
+  return (
+    <Link
+      href="https://docs.voxel51.com/plugins/using_plugins.html#delegated-operations"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <Button variant={Variant.Secondary}>Set up now</Button>
+    </Link>
   );
 }


### PR DESCRIPTION
## 🔗 Related Issues

https://github.com/voxel51/fiftyone/pull/7266

## 📋 What changes are proposed in this pull request?

move setup now button to its own component

## 🧪 How is this patch tested? If it is not, please explain why.

In the app using a test operator

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->