### PR TITLE
10x improve performance of label tag aggregation (poc)

### DIFF
--- a/app/packages/core/src/components/Actions/Tag/Tag.tsx
+++ b/app/packages/core/src/components/Actions/Tag/Tag.tsx
@@ -14,6 +14,7 @@ import type { MutableRefObject } from "react";
 import React, { Suspense, useLayoutEffect, useState } from "react";
 import type { RecoilState, RecoilValue } from "recoil";
 import {
+  atom,
   useRecoilCallback,
   useRecoilRefresher_UNSTABLE,
   useRecoilState,
@@ -423,17 +424,13 @@ const useLabelPlaceHolder = (
   return (): [number, string] => {
     const selectedSamples = useRecoilValue(fos.selectedSamples).size;
     const selectedLabels = useRecoilValue(fos.selectedLabelIds).size;
-    const selectedLabelCount = useRecoilValue(
+    const labelCount = useRecoilValue(
       numItemsInSelection({ labels: true, modal })
     );
-    const totalLabelCount = useRecoilValue(
-      fos.labelCount({ modal, extended: true })
-    );
     if (modal && selectedLabels) {
-      const labelCount = selectedLabels > 0 ? selectedLabels : totalLabelCount;
-      return [labelCount, labelsModalPlaceholder(selectedLabels, labelCount)];
+      const count = selectedLabels > 0 ? selectedLabels : labelCount;
+      return [count, labelsModalPlaceholder(selectedLabels, count)];
     }
-    const labelCount = selectedSamples ? selectedLabelCount : totalLabelCount;
     return [
       labelCount,
       labelsPlaceholder(selectedSamples, labelCount, null, elementNames),
@@ -474,6 +471,11 @@ const SuspenseLoading = () => {
   );
 };
 
+const lastTagTabAtom = atom<boolean | null>({
+  key: "lastTagTab",
+  default: null,
+});
+
 type TaggerProps = {
   modal: boolean;
   close: () => void;
@@ -482,7 +484,8 @@ type TaggerProps = {
 };
 
 const Tagger = ({ modal, close, lookerRef, anchorRef }: TaggerProps) => {
-  const [labels, setLabels] = useState(modal);
+  const [lastTab, setLastTab] = useRecoilState(lastTagTabAtom);
+  const [labels, setLabels] = useState(lastTab ?? modal);
   const elementNames = useRecoilValue(fos.elementNames);
   const theme = useTheme();
   const sampleProps = useSpring({
@@ -513,14 +516,24 @@ const Tagger = ({ modal, close, lookerRef, anchorRef }: TaggerProps) => {
         <SwitchDiv
           data-cy="tagger-switch-sample"
           style={sampleProps}
-          onClick={() => labels && setLabels(false)}
+          onClick={() => {
+            if (labels) {
+              setLabels(false);
+              setLastTab(false);
+            }
+          }}
         >
           {modal ? elementNames.singular : elementNames.plural}
         </SwitchDiv>
         <SwitchDiv
           data-cy="tagger-switch-label"
           style={labelProps}
-          onClick={() => !labels && setLabels(true)}
+          onClick={() => {
+            if (!labels) {
+              setLabels(true);
+              setLastTab(true);
+            }
+          }}
         >
           Labels
         </SwitchDiv>

--- a/app/packages/core/src/components/Actions/Tag/state.test.ts
+++ b/app/packages/core/src/components/Actions/Tag/state.test.ts
@@ -9,12 +9,11 @@ vi.mock("recoil-relay");
 describe("Resolves tag counts", () => {
   it("resolves all", () => {
     setMockAtoms({
-      labelTagCounts: (params) => ({ one: 1, two: 1, three: 1 }),
-      sampleTagCounts: (params) => ({ one: 1, two: 1, three: 1 }),
       tagStatistics: (modal) => ({
         count: 2,
         items: 1,
         tags: { one: 1, two: 1 },
+        all_tags: ["one", "two", "three"],
       }),
     });
 

--- a/app/packages/core/src/components/Actions/Tag/state.ts
+++ b/app/packages/core/src/components/Actions/Tag/state.ts
@@ -20,6 +20,7 @@ export const tagStatistics = selectorFamily<
     count: number;
     items: number;
     tags: { [key: string]: number };
+    all_tags: string[];
   },
   { modal: boolean; labels: boolean }
 >({
@@ -86,19 +87,12 @@ export const tagStats = selectorFamily<
   get:
     ({ modal, labels }) =>
     ({ get }) => {
-      const data = modal
-        ? []
-        : Object.keys(
-            get(
-              labels
-                ? fos.labelTagCounts({ modal: false, extended: false })
-                : fos.sampleTagCounts({ modal: false, extended: false })
-            )
-          ).map((t) => [t, 0]);
+      const stats = get(tagStatistics({ modal, labels }));
+      const baseline = modal ? [] : stats.all_tags.map((t) => [t, 0]);
 
       return {
-        ...Object.fromEntries(data),
-        ...get(tagStatistics({ modal, labels })).tags,
+        ...Object.fromEntries(baseline),
+        ...stats.tags,
       };
     },
 });

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -11549,7 +11549,6 @@ class SampleCollection(object):
             for idx, pipeline in facet_pipelines.items():
                 idx_map[idx] = len(pipelines)
                 pipelines.append(pipeline)
-
             # Run all aggregations
             coll_name = self._dataset._sample_collection_name
             collection = foo.get_async_db_conn()[coll_name]

--- a/fiftyone/server/routes/tagging.py
+++ b/fiftyone/server/routes/tagging.py
@@ -6,17 +6,26 @@ FiftyOne Server /tagging route
 |
 """
 
-from collections import defaultdict
+import asyncio
+import logging
+import time
 
 from starlette.endpoints import HTTPEndpoint
 from starlette.requests import Request
 
 import fiftyone.core.aggregations as foa
 import fiftyone.core.collections as foc
+import fiftyone.core.dataset as fod
 import fiftyone.core.labels as fol
+import fiftyone.core.odm as foo
 from fiftyone.server.decorators import route
 from fiftyone.server.filters import GroupElementFilter, SampleFilter
 import fiftyone.server.tags as fost
+
+logger = logging.getLogger(__name__)
+
+SAMPLES_PER_SLICE = 10_000
+MAX_SLICES = 8
 
 
 class Tagging(HTTPEndpoint):
@@ -53,37 +62,258 @@ class Tagging(HTTPEndpoint):
             target_labels=target_labels,
         )
 
+        is_filtered = bool(
+            stages
+            or filters
+            or extended
+            or sample_ids
+            or labels
+            or hidden_labels
+        )
+
+        t0 = time.perf_counter()
+
         if target_labels:
-            count_aggs, tag_aggs = build_label_tag_aggregations(view)
-            results = await view._async_aggregate(count_aggs + tag_aggs)
+            count, tags = await _aggregate_label_tags(view)
             items = None
-            count = sum(results[: len(count_aggs)])
-            tags = defaultdict(int)
-
-            for result in results[len(count_aggs) :]:
-                for tag, num in result.items():
-                    if tag is None:
-                        continue
-
-                    tags[tag] += num
         else:
             tags, items = await view._async_aggregate(
                 [foa.CountValues("tags"), foa.Count()]
             )
             count = sum([v for k, v in tags.items() if k is not None])
 
-        return {"count": count, "tags": tags, "items": items}
+        t1 = time.perf_counter()
+        logger.warning(
+            "[tagging] view agg took %.3fs (target_labels=%s, is_filtered=%s, dataset=%s)",
+            t1 - t0,
+            target_labels,
+            is_filtered,
+            dataset,
+        )
+
+        if is_filtered:
+            all_tags = await _get_all_dataset_tags(dataset, target_labels)
+            t2 = time.perf_counter()
+            logger.warning(
+                "[tagging] all_tags (dataset scan) took %.3fs",
+                t2 - t1,
+            )
+        else:
+            all_tags = sorted(t for t in tags.keys() if t is not None)
+
+        return {
+            "count": count,
+            "tags": tags,
+            "items": items,
+            "all_tags": all_tags,
+        }
 
 
-def build_label_tag_aggregations(sample_collection: foc.SampleCollection):
-    counts = []
-    tags = []
+def _build_label_tag_facet(sample_collection):
+    """Builds a single $facet stage with per-field count and tag branches."""
+    facet_stages = {}
+
     for path, field in foc._iter_label_fields(sample_collection):
         label_type = field.document_type
+        safe_name = path.replace("-", "_").replace(".", "__")
+
         if issubclass(label_type, fol._HasLabelList):
-            path += "." + label_type._LABEL_LIST_FIELD
+            list_path = path + "." + label_type._LABEL_LIST_FIELD
+            facet_stages[f"{safe_name}__count"] = [
+                {"$unwind": f"${list_path}"},
+                {"$count": "count"},
+            ]
+            facet_stages[f"{safe_name}__tags"] = [
+                {"$unwind": f"${list_path}"},
+                {"$unwind": f"${list_path}.tags"},
+                {
+                    "$group": {
+                        "_id": f"${list_path}.tags",
+                        "count": {"$sum": 1},
+                    }
+                },
+            ]
+        else:
+            facet_stages[f"{safe_name}__count"] = [
+                {"$match": {path: {"$ne": None}}},
+                {"$count": "count"},
+            ]
+            facet_stages[f"{safe_name}__tags"] = [
+                {"$match": {path: {"$ne": None}}},
+                {"$unwind": f"${path}.tags"},
+                {
+                    "$group": {
+                        "_id": f"${path}.tags",
+                        "count": {"$sum": 1},
+                    }
+                },
+            ]
 
-        counts.append(foa.Count(path))
-        tags.append(foa.CountValues(path + ".tags"))
+    return facet_stages
 
-    return counts, tags
+
+async def _get_id_boundaries(collection, n_splits):
+    """Gets _id boundaries for splitting a collection into parallel slices.
+
+    Uses $bucketAuto on the _id index for evenly distributed splits.
+    """
+    pipeline = [
+        {"$project": {"_id": 1}},
+        {"$bucketAuto": {"groupBy": "$_id", "buckets": n_splits}},
+    ]
+    cursor = collection.aggregate(pipeline, hint={"_id": 1})
+    buckets = [doc async for doc in cursor]
+    return [b["_id"]["min"] for b in buckets[1:]]
+
+
+def _merge_facet_results(all_results):
+    """Merges results from parallel $facet pipeline runs."""
+    count = 0
+    tags = {}
+    for doc in all_results:
+        for key, value in doc.items():
+            if key.endswith("__count"):
+                count += value[0]["count"] if value else 0
+            elif key.endswith("__tags"):
+                for entry in value:
+                    tag = entry["_id"]
+                    if tag is not None:
+                        tags[tag] = tags.get(tag, 0) + entry["count"]
+    return count, tags
+
+
+async def _aggregate_label_tags(view):
+    """Computes label count and tag value counts using parallel pipelines.
+
+    Splits the collection into slices by _id range and runs a $facet pipeline
+    on each slice concurrently, then merges the results. This parallelizes
+    across MongoDB's single-threaded aggregation limitation.
+    """
+    facet_stages = _build_label_tag_facet(view)
+
+    if not facet_stages:
+        return 0, {}
+
+    view_pipeline = view._pipeline()
+    coll_name = view._dataset._sample_collection_name
+    collection = foo.get_async_db_conn()[coll_name]
+    estimated = await collection.estimated_document_count()
+    n_slices = min(max(1, estimated // SAMPLES_PER_SLICE), MAX_SLICES)
+
+    if n_slices <= 1:
+        cursor = collection.aggregate(
+            view_pipeline + [{"$facet": facet_stages}],
+            allowDiskUse=True,
+        )
+        result = await cursor.to_list(length=1)
+        return _merge_facet_results([result[0]] if result else [])
+
+    boundaries = await _get_id_boundaries(collection, n_slices)
+
+    # Build _id range match stages
+    all_bounds = [None] + boundaries + [None]
+    range_matches = []
+    for i in range(len(all_bounds) - 1):
+        id_filter = {}
+        if all_bounds[i] is not None:
+            id_filter["$gte"] = all_bounds[i]
+        if all_bounds[i + 1] is not None:
+            id_filter["$lt"] = all_bounds[i + 1]
+        range_matches.append(
+            {"$match": {"_id": id_filter}} if id_filter else {"$match": {}}
+        )
+
+    async def run_slice(match_stage):
+        pipeline = view_pipeline + [match_stage, {"$facet": facet_stages}]
+        cursor = collection.aggregate(
+            pipeline, allowDiskUse=True, hint={"_id": 1}
+        )
+        result = await cursor.to_list(length=1)
+        return result[0] if result else {}
+
+    results = await asyncio.gather(*[run_slice(m) for m in range_matches])
+
+    return _merge_facet_results(results)
+
+
+async def _get_all_dataset_tags(dataset_name, target_labels):
+    """Returns all distinct tag names from the unfiltered dataset.
+
+    This allows the frontend to display 0-count tags (tags that exist in the
+    dataset but not in the current view) without triggering expensive GraphQL
+    aggregation queries.
+
+    Uses parallel _id-range slices for large collections.
+    """
+    ds = fod.load_dataset(dataset_name, reload=False)
+    coll_name = ds._sample_collection_name
+    collection = foo.get_async_db_conn()[coll_name]
+
+    if target_labels:
+        facet_stages = _build_label_tag_facet(ds)
+        tag_facets = {
+            k: v for k, v in facet_stages.items() if k.endswith("__tags")
+        }
+
+        if not tag_facets:
+            return []
+
+        estimated = await collection.estimated_document_count()
+        n_slices = min(max(1, estimated // SAMPLES_PER_SLICE), MAX_SLICES)
+
+        if n_slices <= 1:
+            cursor = collection.aggregate(
+                [{"$facet": tag_facets}], allowDiskUse=True
+            )
+            result = await cursor.to_list(length=1)
+            results = [result[0]] if result else []
+        else:
+            boundaries = await _get_id_boundaries(collection, n_slices)
+            all_bounds = [None] + boundaries + [None]
+
+            async def run_slice(lo, hi):
+                id_filter = {}
+                if lo is not None:
+                    id_filter["$gte"] = lo
+                if hi is not None:
+                    id_filter["$lt"] = hi
+                match = (
+                    {"$match": {"_id": id_filter}}
+                    if id_filter
+                    else {"$match": {}}
+                )
+                pipeline = [match, {"$facet": tag_facets}]
+                cursor = collection.aggregate(
+                    pipeline, allowDiskUse=True, hint={"_id": 1}
+                )
+                result = await cursor.to_list(length=1)
+                return result[0] if result else {}
+
+            results = await asyncio.gather(
+                *[
+                    run_slice(all_bounds[i], all_bounds[i + 1])
+                    for i in range(len(all_bounds) - 1)
+                ]
+            )
+
+        all_tags = set()
+        for doc in results:
+            for key, value in doc.items():
+                for entry in value:
+                    if entry["_id"] is not None:
+                        all_tags.add(entry["_id"])
+
+        return sorted(all_tags)
+    else:
+        pipeline = [
+            {"$unwind": "$tags"},
+            {"$group": {"_id": None, "tags": {"$addToSet": "$tags"}}},
+        ]
+        cursor = collection.aggregate(pipeline)
+        result = await cursor.to_list(length=1)
+
+        if not result:
+            return []
+
+        all_tags = result[0].get("tags", [])
+        return sorted(t for t in all_tags if t is not None)

--- a/fiftyone/server/routes/tagging.py
+++ b/fiftyone/server/routes/tagging.py
@@ -7,8 +7,6 @@ FiftyOne Server /tagging route
 """
 
 import asyncio
-import logging
-import time
 
 from starlette.endpoints import HTTPEndpoint
 from starlette.requests import Request
@@ -21,8 +19,6 @@ import fiftyone.core.odm as foo
 from fiftyone.server.decorators import route
 from fiftyone.server.filters import GroupElementFilter, SampleFilter
 import fiftyone.server.tags as fost
-
-logger = logging.getLogger(__name__)
 
 SAMPLES_PER_SLICE = 10_000
 MAX_SLICES = 8
@@ -71,8 +67,6 @@ class Tagging(HTTPEndpoint):
             or hidden_labels
         )
 
-        t0 = time.perf_counter()
-
         if target_labels:
             count, tags = await _aggregate_label_tags(view)
             items = None
@@ -82,22 +76,8 @@ class Tagging(HTTPEndpoint):
             )
             count = sum([v for k, v in tags.items() if k is not None])
 
-        t1 = time.perf_counter()
-        logger.warning(
-            "[tagging] view agg took %.3fs (target_labels=%s, is_filtered=%s, dataset=%s)",
-            t1 - t0,
-            target_labels,
-            is_filtered,
-            dataset,
-        )
-
         if is_filtered:
             all_tags = await _get_all_dataset_tags(dataset, target_labels)
-            t2 = time.perf_counter()
-            logger.warning(
-                "[tagging] all_tags (dataset scan) took %.3fs",
-                t2 - t1,
-            )
         else:
             all_tags = sorted(t for t in tags.keys() if t is not None)
 


### PR DESCRIPTION
## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?
 
- improve performance of builtin label tagging button by parallelizing aggregation across the collection and saving the selection so that closing and reopening restores the tab state, skipping the samples count


### Before (per request)
- N separate MongoDB pipelines (one per label field), each with `$project` + `$facet` containing Count + CountValues
- Each pipeline does a full collection scan independently
- Frontend also triggered additional GraphQL `aggregationsQuery` for all label subfields (`.confidence`, `.id`, `.label`, `.tags`, etc.) via `labelTagCounts` selector

### After (per request)
- Single `/tagging` endpoint call (no GraphQL aggregation queries)
- One `$facet` with per-field branches, split into parallel `_id`-range slices
- `$bucketAuto` for even boundary distribution
- Scales slices by dataset size: `min(max(1, estimated // 10_000), 8)`
- Skips `all_tags` dataset scan when view is unfiltered (derives from `tags.keys()`)


## 🧪 How is this patch tested? If it is not, please explain why.

<img width="1997" height="873" alt="image" src="https://github.com/user-attachments/assets/1e98dd89-fa4b-4bec-932c-54a84f133b57" />


## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The tag selector now remembers your last selected tab (samples or labels) between sessions.

* **Improvements**
  * Enhanced tag counting and availability tracking when dataset filters are applied.
  * Optimized tag aggregation performance for large datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->