### PR TITLE
[SSP] Trigger new sort run from similarity popover in the grid/sample modal + bugfix + remove feature flag

### DIFF
--- a/app/packages/core/src/components/Actions/Similarity/Helper.tsx
+++ b/app/packages/core/src/components/Actions/Similarity/Helper.tsx
@@ -1,8 +1,25 @@
-import { PopoutSectionTitle, useTheme } from "@fiftyone/components";
-import { useSimilarityType } from "@fiftyone/state";
-import React from "react";
-import { SORT_BY_SIMILARITY } from "../../../utils/links";
-import { ActionOption } from "../Common";
+import { PopoutSectionTitle } from "@fiftyone/components";
+import { executeOperator } from "@fiftyone/operators";
+import SettingsIcon from "@mui/icons-material/Settings";
+import React, { useCallback } from "react";
+import styled from "styled-components";
+import { PANEL_NAME } from "./constants";
+
+const ActionRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  cursor: pointer;
+  border-radius: 4px;
+  color: ${({ theme }) => theme.text.secondary};
+  font-size: 13px;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.background.level1};
+    color: ${({ theme }) => theme.text.primary};
+  }
+`;
 
 interface Props {
   hasSimilarityKeys: boolean;
@@ -10,34 +27,31 @@ interface Props {
 }
 
 const Helper = (props: Props) => {
-  const theme = useTheme();
   const { isImageSearch } = props;
-  const { text } = useSimilarityType({ isImageSearch });
+
+  const openPanel = useCallback(() => {
+    executeOperator("open_panel", {
+      name: PANEL_NAME,
+      isActive: true,
+      layout: "horizontal",
+      data: { view: { page: "similarity_index" } },
+    });
+  }, []);
 
   return (
     <>
-      {!props.hasSimilarityKeys && (
-        <PopoutSectionTitle style={{ fontSize: 12 }}>
-          {isImageSearch
-            ? "No available brain keys"
-            : "No brain keys support text prompts"}
-        </PopoutSectionTitle>
-      )}
-      <PopoutSectionTitle>
-        <ActionOption
-          id="sort-by-similarity"
-          href={SORT_BY_SIMILARITY}
-          text={text}
-          title={"About sorting by similarity"}
-          style={{
-            background: "unset",
-            color: theme.text.primary,
-            paddingTop: 0,
-            paddingBottom: 0,
-          }}
-          svgStyles={{ height: "1rem", marginTop: 7.5 }}
-        />
+      <PopoutSectionTitle style={{ fontSize: 12 }}>
+        {isImageSearch
+          ? "No available brain keys"
+          : "No brain keys support text prompts"}
       </PopoutSectionTitle>
+      <ActionRow
+        onClick={openPanel}
+        title="Open similarity panel to manage indexes"
+      >
+        <SettingsIcon style={{ fontSize: 16 }} />
+        Manage similarity indexes
+      </ActionRow>
     </>
   );
 };

--- a/app/packages/core/src/components/Actions/Similarity/Similar.tsx
+++ b/app/packages/core/src/components/Actions/Similarity/Similar.tsx
@@ -1,3 +1,4 @@
+import { PopoutSectionTitle } from "@fiftyone/components";
 import { executeOperator } from "@fiftyone/operators";
 import * as fos from "@fiftyone/state";
 import { useBrowserStorage } from "@fiftyone/state";
@@ -11,11 +12,7 @@ import { useRecoilCallback, useRecoilValue } from "recoil";
 import Input from "../../Common/Input";
 import { Button } from "../../utils";
 import Popout from "../Popout";
-import {
-  INIT_RUN_OPERATOR_URI,
-  PANEL_NAME,
-  SEARCH_OPERATOR_URI,
-} from "./constants";
+import { PANEL_NAME, SEARCH_OPERATOR_URI } from "./constants";
 import GroupButton, { type ButtonDetail } from "./GroupButton";
 import Helper from "./Helper";
 import { availableSimilarityKeys, getQueryIds, sortType } from "./utils";
@@ -48,6 +45,19 @@ const SimilarityPopover = ({
     availableSimilarityKeys({ modal, isImageSearch })
   );
   const hasSimilarityKeys = keys.length > 0;
+  const hasSelectedLabels = useRecoilValue(fos.hasSelectedLabels);
+  const selectedLabelsList = useRecoilValue(fos.selectedLabels);
+
+  // Detect if selected labels span multiple fields
+  const selectedLabelFields = useMemo(() => {
+    if (!modal || !hasSelectedLabels) return new Set<string>();
+    return new Set(selectedLabelsList.map((l) => l.field));
+  }, [modal, hasSelectedLabels, selectedLabelsList]);
+
+  const hasMixedFields = selectedLabelFields.size > 1;
+  const showMixedFieldWarning = modal && isImageSearch && hasMixedFields;
+  const showNoIndexWarning =
+    modal && isImageSearch && !hasMixedFields && !hasSimilarityKeys;
 
   const type = useRecoilValue(sortType(modal));
   const datasetId = fos.useAssertedRecoilValue(fos.datasetId);
@@ -88,7 +98,7 @@ const SimilarityPopover = ({
   }, []);
 
   const handleSearch = useRecoilCallback(
-    ({ snapshot }) =>
+    ({ snapshot, set }) =>
       async () => {
         if (!resolvedBrainKey) return;
 
@@ -99,7 +109,7 @@ const SimilarityPopover = ({
         if (isImageSearch && (!queryIds || queryIds.length === 0)) return;
         if (!isImageSearch && !textQuery.trim()) return;
 
-        const pf = await resolvePatchesField(resolvedBrainKey);
+        const patchesField = await resolvePatchesField(resolvedBrainKey);
 
         const params: Record<string, unknown> = {
           brain_key: resolvedBrainKey,
@@ -108,8 +118,8 @@ const SimilarityPopover = ({
           reverse: false,
           k: DEFAULT_K,
         };
-        if (pf) {
-          params.patches_field = pf;
+        if (patchesField) {
+          params.patches_field = patchesField;
         }
 
         const current = lastUsedBrainKeys ? JSON.parse(lastUsedBrainKeys) : {};
@@ -120,15 +130,27 @@ const SimilarityPopover = ({
         close();
 
         executeOperator(SEARCH_OPERATOR_URI, params, {
-          callback: (result) => {
-            if (result?.delegated) {
-              const resultObj = result?.result as
-                | { id?: { $oid?: string } }
-                | undefined;
-              const operatorRunId = resultObj?.id?.$oid;
+          callback: () => {
+            if (modal) {
+              set(fos.modalSelector, null);
+            }
+            executeOperator("clear_selected_samples");
+            executeOperator("clear_selected_labels");
+            set(fos.extendedSelection, { selection: [] });
+
+            if (patchesField) {
+              // Patches search completed: switch to patches view,
+              // then open panel
               executeOperator(
-                INIT_RUN_OPERATOR_URI,
-                { ...params, operator_run_id: operatorRunId },
+                "set_view",
+                {
+                  view: [
+                    {
+                      _cls: "fiftyone.core.stages.ToPatches",
+                      kwargs: [["field", patchesField]],
+                    },
+                  ],
+                },
                 { callback: () => openPanel() }
               );
             } else {
@@ -144,16 +166,24 @@ const SimilarityPopover = ({
       resolvePatchesField,
       close,
       openPanel,
+      modal,
       lastUsedBrainKeys,
       setLastUsedBrainKeys,
       datasetId,
     ]
   );
 
-  const handleOpenPanel = useCallback(() => {
-    close();
-    openPanel();
-  }, [close, openPanel]);
+  const handleOpenPanel = useRecoilCallback(
+    ({ set }) =>
+      () => {
+        close();
+        if (modal) {
+          set(fos.modalSelector, null);
+        }
+        openPanel();
+      },
+    [close, modal, openPanel]
+  );
 
   const groupButtons: ButtonDetail[] = [
     {
@@ -175,7 +205,17 @@ const SimilarityPopover = ({
 
   return (
     <Popout modal={modal} style={{ minWidth: 280 }} fixed anchorRef={anchorRef}>
-      {hasSimilarityKeys && (
+      {showMixedFieldWarning && (
+        <PopoutSectionTitle style={{ fontSize: 12 }}>
+          Selected labels must be from the same field to search by similarity
+        </PopoutSectionTitle>
+      )}
+      {showNoIndexWarning && (
+        <PopoutSectionTitle style={{ fontSize: 12 }}>
+          No similarity index found for the selected label field
+        </PopoutSectionTitle>
+      )}
+      {!showMixedFieldWarning && !showNoIndexWarning && hasSimilarityKeys && (
         <div
           style={{
             display: "flex",
@@ -193,7 +233,7 @@ const SimilarityPopover = ({
           )}
           {isImageSearch && (
             <Button
-              text={"Show similar samples"}
+              text={modal ? "Show similar patches" : "Show similar samples"}
               title={`Search by similarity to the selected ${type}`}
               onClick={handleSearch}
               style={LONG_BUTTON_STYLE}
@@ -202,7 +242,7 @@ const SimilarityPopover = ({
           <GroupButton buttons={groupButtons} />
         </div>
       )}
-      {!hasSimilarityKeys && (
+      {!showMixedFieldWarning && !showNoIndexWarning && !hasSimilarityKeys && (
         <Helper hasSimilarityKeys={false} isImageSearch={isImageSearch} />
       )}
     </Popout>

--- a/app/packages/core/src/components/Actions/Similarity/Similar.tsx
+++ b/app/packages/core/src/components/Actions/Similarity/Similar.tsx
@@ -1,32 +1,24 @@
-import { useExternalLink } from "@fiftyone/components";
+import { executeOperator } from "@fiftyone/operators";
 import * as fos from "@fiftyone/state";
 import { useBrowserStorage } from "@fiftyone/state";
 import React, {
-  MutableRefObject,
+  type MutableRefObject,
   useCallback,
-  useEffect,
-  useLayoutEffect,
   useMemo,
   useState,
 } from "react";
 import { useRecoilCallback, useRecoilValue } from "recoil";
-import { SORT_BY_SIMILARITY } from "../../../utils/links";
 import Input from "../../Common/Input";
-import RadioGroup from "../../Common/RadioGroup";
 import { Button } from "../../utils";
 import Popout from "../Popout";
-import GroupButton, { ButtonDetail } from "./GroupButton";
-import Helper from "./Helper";
-import MaxKWarning from "./MaxKWarning";
 import {
-  availableSimilarityKeys,
-  currentBrainConfig,
-  currentSimilarityKeys,
-  sortType,
-  useSortBySimilarity,
-} from "./utils";
-
-const DEFAULT_K = 25;
+  INIT_RUN_OPERATOR_URI,
+  PANEL_NAME,
+  SEARCH_OPERATOR_URI,
+} from "./constants";
+import GroupButton, { type ButtonDetail } from "./GroupButton";
+import Helper from "./Helper";
+import { availableSimilarityKeys, getQueryIds, sortType } from "./utils";
 
 const LONG_BUTTON_STYLE: React.CSSProperties = {
   margin: "0.5rem 0",
@@ -35,55 +27,58 @@ const LONG_BUTTON_STYLE: React.CSSProperties = {
   textAlign: "center",
 };
 
-interface SortBySimilarityProps {
-  isImageSearch: boolean;
+interface SimilarityPopoverProps {
   modal: boolean;
+  isImageSearch: boolean;
   close: () => void;
   anchorRef?: MutableRefObject<HTMLElement>;
 }
 
-const SortBySimilarity = ({
+const SimilarityPopover = ({
   modal,
-  close,
   isImageSearch,
+  close,
   anchorRef,
-}: SortBySimilarityProps) => {
+}: SimilarityPopoverProps) => {
+  const [textQuery, setTextQuery] = useState("");
+
   const current = useRecoilValue(fos.similarityParameters);
-  const datasetId = fos.useAssertedRecoilValue(fos.datasetId);
-  const [lastUsedBrainKeys] = useBrowserStorage("lastUsedBrainKeys");
+  const hasSorting = Boolean(current);
 
-  const lastUsedBrainkey = useMemo(() => {
-    return lastUsedBrainKeys ? JSON.parse(lastUsedBrainKeys)[datasetId] : null;
-  }, [lastUsedBrainKeys, datasetId]);
-
-  const [open, setOpen] = useState(false);
-  const [showMaxKWarning, setShowMaxKWarning] = useState(false);
-
-  const [state, setState] = useState<fos.State.SortBySimilarityParameters>(
-    () =>
-      current || {
-        brainKey: lastUsedBrainkey,
-        distField: undefined,
-        reverse: false,
-        k: DEFAULT_K,
-      }
+  const keys = useRecoilValue(
+    availableSimilarityKeys({ modal, isImageSearch })
   );
-  const updateState = useCallback(
-    (partial: Partial<fos.State.SortBySimilarityParameters>) =>
-      setState((state) => ({ ...state, ...partial })),
+  const hasSimilarityKeys = keys.length > 0;
+
+  const type = useRecoilValue(sortType(modal));
+  const datasetId = fos.useAssertedRecoilValue(fos.datasetId);
+  const [lastUsedBrainKeys, setLastUsedBrainKeys] =
+    useBrowserStorage("lastUsedBrainKeys");
+
+  const resolvedBrainKey = useMemo(() => {
+    if (keys.length === 0) return undefined;
+    try {
+      const stored = lastUsedBrainKeys
+        ? JSON.parse(lastUsedBrainKeys)[datasetId]
+        : null;
+      if (stored && keys.includes(stored)) return stored;
+    } catch {
+      // parse may fail
+    }
+    return keys[0];
+  }, [keys, lastUsedBrainKeys, datasetId]);
+
+  const resolvePatchesField = useRecoilCallback(
+    ({ snapshot }) =>
+      async (brainKey: string) => {
+        const methods = await snapshot.getPromise(fos.similarityMethods);
+        const match = methods.patches.find(
+          ([method]) => method.key === brainKey
+        );
+        return match ? match[1] : undefined;
+      },
     []
   );
-
-  const hasSorting = Boolean(current);
-  const hasSimilarityKeys =
-    useRecoilValue(availableSimilarityKeys({ modal, isImageSearch })).length >
-    0;
-  const choices = useRecoilValue(
-    currentSimilarityKeys({ modal, isImageSearch })
-  );
-  const sortBySimilarity = useSortBySimilarity(close);
-  const type = useRecoilValue(sortType(modal));
-  const brainConfig = useRecoilValue(currentBrainConfig(state.brainKey));
 
   const reset = useRecoilCallback(
     ({ reset }) =>
@@ -92,100 +87,94 @@ const SortBySimilarity = ({
       },
     []
   );
-  const isLoading = useRecoilValue(fos.similaritySorting);
-  const canCreateNewField = useRecoilValue(fos.canCreateNewField);
-  const disabled = !canCreateNewField.enabled;
-  const disableMsg = canCreateNewField.message;
 
-  useLayoutEffect(() => {
-    if (!choices.choices.includes(state.brainKey)) {
-      const newKey =
-        choices.choices.length > 0 ? choices.choices[0] : undefined;
-      updateState({ brainKey: newKey });
-    }
-  }, [choices, state.brainKey, updateState]);
+  const openPanel = useCallback(() => {
+    executeOperator("open_panel", {
+      name: PANEL_NAME,
+      isActive: true,
+      layout: "horizontal",
+    });
+  }, []);
 
-  useLayoutEffect(() => {
-    current && setState(current);
-  }, [current]);
+  const handleSearch = useRecoilCallback(
+    ({ snapshot }) =>
+      async () => {
+        if (!resolvedBrainKey) return;
 
-  const meetsKRequirement = useMemo(() => {
-    if (state?.k === undefined) {
-      return false;
-    }
+        const queryIds = isImageSearch
+          ? await getQueryIds(snapshot, resolvedBrainKey)
+          : undefined;
 
-    if (brainConfig?.maxK && state.k > brainConfig.maxK) {
-      return false;
-    }
+        if (isImageSearch && (!queryIds || queryIds.length === 0)) return;
+        if (!isImageSearch && !textQuery.trim()) return;
 
-    return true;
-  }, [brainConfig?.maxK, state?.k]);
+        const pf = await resolvePatchesField(resolvedBrainKey);
 
-  // show warning if k is undefined or k > maxK
-  useEffect(() => {
-    setShowMaxKWarning(!meetsKRequirement);
-  }, [meetsKRequirement]);
+        const params: Record<string, unknown> = {
+          brain_key: resolvedBrainKey,
+          query_type: isImageSearch ? "image" : "text",
+          query: isImageSearch ? queryIds : textQuery.trim(),
+          reverse: false,
+        };
+        if (pf) {
+          params.patches_field = pf;
+        }
 
-  const loadingButton: ButtonDetail[] = isLoading
-    ? [
-        {
-          icon: "ProgressIcon",
-          ariaLabel: "In progress...",
-          tooltipText: "",
-          onClick: () => {},
-        },
-      ]
-    : [];
+        const current = lastUsedBrainKeys ? JSON.parse(lastUsedBrainKeys) : {};
+        setLastUsedBrainKeys(
+          JSON.stringify({ ...current, [datasetId]: resolvedBrainKey })
+        );
 
-  let groupButtons: ButtonDetail[] = [
-    ...loadingButton,
-    {
-      icon: "InfoIcon",
-      ariaLabel: "information",
-      tooltipText: "Learn more about sorting by similarity",
-      onClick: () => {
-        useExternalLink(SORT_BY_SIMILARITY);
-        window.open(SORT_BY_SIMILARITY, "_blank");
+        close();
+
+        executeOperator(SEARCH_OPERATOR_URI, params, {
+          callback: (result) => {
+            if (result?.delegated) {
+              const operatorRunId = result?.result?.id?.$oid;
+              executeOperator(INIT_RUN_OPERATOR_URI, {
+                ...params,
+                operator_run_id: operatorRunId,
+              });
+            }
+            openPanel();
+          },
+        });
       },
-    },
+    [
+      resolvedBrainKey,
+      isImageSearch,
+      textQuery,
+      resolvePatchesField,
+      close,
+      openPanel,
+      lastUsedBrainKeys,
+      setLastUsedBrainKeys,
+      datasetId,
+    ]
+  );
+
+  const handleOpenPanel = useCallback(() => {
+    close();
+    openPanel();
+  }, [close, openPanel]);
+
+  const groupButtons: ButtonDetail[] = [
     {
       icon: "SettingsIcon",
-      ariaLabel: "Advanced settings",
-      tooltipText: "Advanced settings",
-      onClick: () => setOpen((o) => !o),
+      ariaLabel: "Open similarity panel",
+      tooltipText: "Open similarity panel",
+      onClick: handleOpenPanel,
     },
   ];
 
-  if (!isImageSearch && !hasSorting && !isLoading) {
-    groupButtons = [
-      {
-        icon: "SearchIcon",
-        ariaLabel: "Submit",
-        tooltipText: "Search by similarity to the provided text",
-        onClick: () =>
-          meetsKRequirement &&
-          state.query &&
-          state.query.length > 0 &&
-          sortBySimilarity(state),
-      },
-      ...loadingButton,
-      ...groupButtons,
-    ];
+  if (!isImageSearch && !hasSorting) {
+    groupButtons.unshift({
+      icon: "SearchIcon",
+      ariaLabel: "Search",
+      tooltipText: "Search by text similarity",
+      onClick: handleSearch,
+    });
   }
-
-  const onChangeBrainKey = useRecoilCallback(
-    ({ snapshot }) =>
-      async (brainKey: string) => {
-        const config = await snapshot.getPromise(currentBrainConfig(brainKey));
-        if (config?.maxK && state.k && state.k > config.maxK) {
-          setShowMaxKWarning(true);
-        } else {
-          setShowMaxKWarning(false);
-        }
-        updateState({ reverse: false, brainKey });
-      },
-    [updateState, state]
-  );
 
   return (
     <Popout modal={modal} style={{ minWidth: 280 }} fixed anchorRef={anchorRef}>
@@ -200,21 +189,16 @@ const SortBySimilarity = ({
           {!isImageSearch && !hasSorting && (
             <Input
               placeholder={"Type anything!"}
-              value={(state.query as string) ?? ""}
-              setter={(value) => updateState({ query: value })}
-              onEnter={() =>
-                meetsKRequirement &&
-                state.query &&
-                state.query.length > 0 &&
-                sortBySimilarity(state)
-              }
+              value={textQuery}
+              setter={setTextQuery}
+              onEnter={handleSearch}
             />
           )}
           {isImageSearch && !hasSorting && (
             <Button
               text={"Show similar samples"}
               title={`Search by similarity to the selected ${type}`}
-              onClick={() => sortBySimilarity(state)}
+              onClick={handleSearch}
               style={LONG_BUTTON_STYLE}
             />
           )}
@@ -232,70 +216,11 @@ const SortBySimilarity = ({
           <GroupButton buttons={groupButtons} />
         </div>
       )}
-      {!hasSimilarityKeys && <Helper hasSimilarityKeys isImageSearch />}
-      {open && hasSimilarityKeys && (
-        <div>
-          <div>
-            Find the
-            <Input
-              placeholder={"k"}
-              validator={(value) => /^[0-9\b]+$/.test(value) || value === ""}
-              value={state?.k ? String(state.k) : ""}
-              setter={(value) => {
-                updateState({ k: value === "" ? undefined : Number(value) });
-              }}
-              style={{
-                width: 40,
-                display: "inline-block",
-                margin: 3,
-              }}
-            />
-            {brainConfig?.supportsLeastSimilarity === false ? (
-              "most "
-            ) : (
-              <Button
-                text={state.reverse ? "least" : "most"}
-                title={"select most or least"}
-                onClick={() => updateState({ reverse: !state.reverse })}
-                style={{
-                  textAlign: "center",
-                  width: 50,
-                  display: "inline-block",
-                  margin: 3,
-                }}
-              />
-            )}
-            {"similar samples "}
-            {showMaxKWarning && (
-              <MaxKWarning
-                maxK={brainConfig?.maxK}
-                currentK={state.k}
-                onClose={() => setShowMaxKWarning(false)}
-              />
-            )}
-            using this brain key
-            <RadioGroup
-              choices={choices.choices}
-              value={state?.brainKey}
-              setValue={(brainKey) => onChangeBrainKey(brainKey)}
-            />
-          </div>
-          Optional: store the distance between each sample and the query in this
-          field
-          <Input
-            disabled={disabled}
-            placeholder={"dist_field (default = None)"}
-            validator={(value) => !value.startsWith("_")}
-            value={state.distField ?? ""}
-            setter={(value) =>
-              updateState({ distField: !value.length ? undefined : value })
-            }
-            title={disableMsg}
-          />
-        </div>
+      {!hasSimilarityKeys && (
+        <Helper hasSimilarityKeys={false} isImageSearch={isImageSearch} />
       )}
     </Popout>
   );
 };
 
-export default SortBySimilarity;
+export default SimilarityPopover;

--- a/app/packages/core/src/components/Actions/Similarity/Similar.tsx
+++ b/app/packages/core/src/components/Actions/Similarity/Similar.tsx
@@ -1,23 +1,11 @@
 import { PopoutSectionTitle } from "@fiftyone/components";
-import { executeOperator } from "@fiftyone/operators";
-import * as fos from "@fiftyone/state";
-import { useBrowserStorage } from "@fiftyone/state";
-import React, {
-  type MutableRefObject,
-  useCallback,
-  useMemo,
-  useState,
-} from "react";
-import { useRecoilCallback, useRecoilValue } from "recoil";
+import React, { type MutableRefObject } from "react";
 import Input from "../../Common/Input";
 import { Button } from "../../utils";
 import Popout from "../Popout";
-import { PANEL_NAME, SEARCH_OPERATOR_URI } from "./constants";
 import GroupButton, { type ButtonDetail } from "./GroupButton";
 import Helper from "./Helper";
-import { availableSimilarityKeys, getQueryIds, sortType } from "./utils";
-
-const DEFAULT_K = 25;
+import useSimilarityPopover from "./useSimilarityPopover";
 
 const LONG_BUTTON_STYLE: React.CSSProperties = {
   margin: "0.5rem 0",
@@ -39,151 +27,16 @@ const SimilarityPopover = ({
   close,
   anchorRef,
 }: SimilarityPopoverProps) => {
-  const [textQuery, setTextQuery] = useState("");
-
-  const keys = useRecoilValue(
-    availableSimilarityKeys({ modal, isImageSearch })
-  );
-  const hasSimilarityKeys = keys.length > 0;
-  const hasSelectedLabels = useRecoilValue(fos.hasSelectedLabels);
-  const selectedLabelsList = useRecoilValue(fos.selectedLabels);
-
-  // Detect if selected labels span multiple fields
-  const selectedLabelFields = useMemo(() => {
-    if (!modal || !hasSelectedLabels) return new Set<string>();
-    return new Set(selectedLabelsList.map((l) => l.field));
-  }, [modal, hasSelectedLabels, selectedLabelsList]);
-
-  const hasMixedFields = selectedLabelFields.size > 1;
-  const showMixedFieldWarning = modal && isImageSearch && hasMixedFields;
-  const showNoIndexWarning =
-    modal && isImageSearch && !hasMixedFields && !hasSimilarityKeys;
-
-  const type = useRecoilValue(sortType(modal));
-  const datasetId = fos.useAssertedRecoilValue(fos.datasetId);
-  const [lastUsedBrainKeys, setLastUsedBrainKeys] =
-    useBrowserStorage("lastUsedBrainKeys");
-
-  const resolvedBrainKey = useMemo(() => {
-    if (keys.length === 0) return undefined;
-    try {
-      const stored = lastUsedBrainKeys
-        ? JSON.parse(lastUsedBrainKeys)[datasetId]
-        : null;
-      if (stored && keys.includes(stored)) return stored;
-    } catch {
-      // parse may fail
-    }
-    return keys[0];
-  }, [keys, lastUsedBrainKeys, datasetId]);
-
-  const resolvePatchesField = useRecoilCallback(
-    ({ snapshot }) =>
-      async (brainKey: string) => {
-        const methods = await snapshot.getPromise(fos.similarityMethods);
-        const match = methods.patches.find(
-          ([method]) => method.key === brainKey
-        );
-        return match ? match[1] : undefined;
-      },
-    []
-  );
-
-  const openPanel = useCallback(() => {
-    executeOperator("open_panel", {
-      name: PANEL_NAME,
-      isActive: true,
-      layout: "horizontal",
-    });
-  }, []);
-
-  const handleSearch = useRecoilCallback(
-    ({ snapshot, set }) =>
-      async () => {
-        if (!resolvedBrainKey) return;
-
-        const queryIds = isImageSearch
-          ? await getQueryIds(snapshot, resolvedBrainKey)
-          : undefined;
-
-        if (isImageSearch && (!queryIds || queryIds.length === 0)) return;
-        if (!isImageSearch && !textQuery.trim()) return;
-
-        const patchesField = await resolvePatchesField(resolvedBrainKey);
-
-        const params: Record<string, unknown> = {
-          brain_key: resolvedBrainKey,
-          query_type: isImageSearch ? "image" : "text",
-          query: isImageSearch ? queryIds : textQuery.trim(),
-          reverse: false,
-          k: DEFAULT_K,
-        };
-        if (patchesField) {
-          params.patches_field = patchesField;
-        }
-
-        const current = lastUsedBrainKeys ? JSON.parse(lastUsedBrainKeys) : {};
-        setLastUsedBrainKeys(
-          JSON.stringify({ ...current, [datasetId]: resolvedBrainKey })
-        );
-
-        close();
-
-        executeOperator(SEARCH_OPERATOR_URI, params, {
-          callback: () => {
-            if (modal) {
-              set(fos.modalSelector, null);
-            }
-            executeOperator("clear_selected_samples");
-            executeOperator("clear_selected_labels");
-            set(fos.extendedSelection, { selection: [] });
-
-            if (patchesField) {
-              // Patches search completed: switch to patches view,
-              // then open panel
-              executeOperator(
-                "set_view",
-                {
-                  view: [
-                    {
-                      _cls: "fiftyone.core.stages.ToPatches",
-                      kwargs: [["field", patchesField]],
-                    },
-                  ],
-                },
-                { callback: () => openPanel() }
-              );
-            } else {
-              openPanel();
-            }
-          },
-        });
-      },
-    [
-      resolvedBrainKey,
-      isImageSearch,
-      textQuery,
-      resolvePatchesField,
-      close,
-      openPanel,
-      modal,
-      lastUsedBrainKeys,
-      setLastUsedBrainKeys,
-      datasetId,
-    ]
-  );
-
-  const handleOpenPanel = useRecoilCallback(
-    ({ set }) =>
-      () => {
-        close();
-        if (modal) {
-          set(fos.modalSelector, null);
-        }
-        openPanel();
-      },
-    [close, modal, openPanel]
-  );
+  const {
+    textQuery,
+    setTextQuery,
+    type,
+    hasSimilarityKeys,
+    showMixedFieldWarning,
+    showNoIndexWarning,
+    handleSearch,
+    handleOpenPanel,
+  } = useSimilarityPopover({ modal, isImageSearch, close });
 
   const groupButtons: ButtonDetail[] = [
     {

--- a/app/packages/core/src/components/Actions/Similarity/Similar.tsx
+++ b/app/packages/core/src/components/Actions/Similarity/Similar.tsx
@@ -34,6 +34,7 @@ const SimilarityPopover = ({
     hasSimilarityKeys,
     showMixedFieldWarning,
     showNoIndexWarning,
+    noIndexWarningText,
     searchButtonText,
     handleSearch,
     handleOpenPanel,
@@ -66,7 +67,7 @@ const SimilarityPopover = ({
       )}
       {showNoIndexWarning && (
         <PopoutSectionTitle style={{ fontSize: 12 }}>
-          No similarity index found for the selected label field
+          {noIndexWarningText}
         </PopoutSectionTitle>
       )}
       {!showMixedFieldWarning && !showNoIndexWarning && hasSimilarityKeys && (

--- a/app/packages/core/src/components/Actions/Similarity/Similar.tsx
+++ b/app/packages/core/src/components/Actions/Similarity/Similar.tsx
@@ -42,9 +42,6 @@ const SimilarityPopover = ({
 }: SimilarityPopoverProps) => {
   const [textQuery, setTextQuery] = useState("");
 
-  const current = useRecoilValue(fos.similarityParameters);
-  const hasSorting = Boolean(current);
-
   const keys = useRecoilValue(
     availableSimilarityKeys({ modal, isImageSearch })
   );
@@ -76,14 +73,6 @@ const SimilarityPopover = ({
           ([method]) => method.key === brainKey
         );
         return match ? match[1] : undefined;
-      },
-    []
-  );
-
-  const reset = useRecoilCallback(
-    ({ reset }) =>
-      () => {
-        reset(fos.similarityParameters);
       },
     []
   );
@@ -130,13 +119,18 @@ const SimilarityPopover = ({
         executeOperator(SEARCH_OPERATOR_URI, params, {
           callback: (result) => {
             if (result?.delegated) {
-              const operatorRunId = result?.result?.id?.$oid;
-              executeOperator(INIT_RUN_OPERATOR_URI, {
-                ...params,
-                operator_run_id: operatorRunId,
-              });
+              const resultObj = result?.result as
+                | { id?: { $oid?: string } }
+                | undefined;
+              const operatorRunId = resultObj?.id?.$oid;
+              executeOperator(
+                INIT_RUN_OPERATOR_URI,
+                { ...params, operator_run_id: operatorRunId },
+                { callback: () => openPanel() }
+              );
+            } else {
+              openPanel();
             }
-            openPanel();
           },
         });
       },
@@ -167,7 +161,7 @@ const SimilarityPopover = ({
     },
   ];
 
-  if (!isImageSearch && !hasSorting) {
+  if (!isImageSearch) {
     groupButtons.unshift({
       icon: "SearchIcon",
       ariaLabel: "Search",
@@ -186,7 +180,7 @@ const SimilarityPopover = ({
             flexDirection: "row",
           }}
         >
-          {!isImageSearch && !hasSorting && (
+          {!isImageSearch && (
             <Input
               placeholder={"Type anything!"}
               value={textQuery}
@@ -194,22 +188,11 @@ const SimilarityPopover = ({
               onEnter={handleSearch}
             />
           )}
-          {isImageSearch && !hasSorting && (
+          {isImageSearch && (
             <Button
               text={"Show similar samples"}
               title={`Search by similarity to the selected ${type}`}
               onClick={handleSearch}
-              style={LONG_BUTTON_STYLE}
-            />
-          )}
-          {hasSorting && (
-            <Button
-              text={"Reset"}
-              title={"Clear sorting"}
-              onClick={() => {
-                close();
-                reset();
-              }}
               style={LONG_BUTTON_STYLE}
             />
           )}

--- a/app/packages/core/src/components/Actions/Similarity/Similar.tsx
+++ b/app/packages/core/src/components/Actions/Similarity/Similar.tsx
@@ -20,6 +20,8 @@ import GroupButton, { type ButtonDetail } from "./GroupButton";
 import Helper from "./Helper";
 import { availableSimilarityKeys, getQueryIds, sortType } from "./utils";
 
+const DEFAULT_K = 25;
+
 const LONG_BUTTON_STYLE: React.CSSProperties = {
   margin: "0.5rem 0",
   height: "2rem",
@@ -104,6 +106,7 @@ const SimilarityPopover = ({
           query_type: isImageSearch ? "image" : "text",
           query: isImageSearch ? queryIds : textQuery.trim(),
           reverse: false,
+          k: DEFAULT_K,
         };
         if (pf) {
           params.patches_field = pf;

--- a/app/packages/core/src/components/Actions/Similarity/Similar.tsx
+++ b/app/packages/core/src/components/Actions/Similarity/Similar.tsx
@@ -19,6 +19,8 @@ interface SimilarityPopoverProps {
   isImageSearch: boolean;
   close: () => void;
   anchorRef?: MutableRefObject<HTMLElement>;
+  onSearchStart?: () => void;
+  onSearchEnd?: () => void;
 }
 
 const SimilarityPopover = ({
@@ -26,6 +28,8 @@ const SimilarityPopover = ({
   isImageSearch,
   close,
   anchorRef,
+  onSearchStart,
+  onSearchEnd,
 }: SimilarityPopoverProps) => {
   const {
     textQuery,
@@ -38,7 +42,13 @@ const SimilarityPopover = ({
     searchButtonText,
     handleSearch,
     handleOpenPanel,
-  } = useSimilarityPopover({ modal, isImageSearch, close });
+  } = useSimilarityPopover({
+    modal,
+    isImageSearch,
+    close,
+    onSearchStart,
+    onSearchEnd,
+  });
 
   const groupButtons: ButtonDetail[] = [
     {

--- a/app/packages/core/src/components/Actions/Similarity/Similar.tsx
+++ b/app/packages/core/src/components/Actions/Similarity/Similar.tsx
@@ -34,6 +34,7 @@ const SimilarityPopover = ({
     hasSimilarityKeys,
     showMixedFieldWarning,
     showNoIndexWarning,
+    searchButtonText,
     handleSearch,
     handleOpenPanel,
   } = useSimilarityPopover({ modal, isImageSearch, close });
@@ -86,7 +87,7 @@ const SimilarityPopover = ({
           )}
           {isImageSearch && (
             <Button
-              text={modal ? "Show similar patches" : "Show similar samples"}
+              text={searchButtonText}
               title={`Search by similarity to the selected ${type}`}
               onClick={handleSearch}
               style={LONG_BUTTON_STYLE}

--- a/app/packages/core/src/components/Actions/Similarity/constants.ts
+++ b/app/packages/core/src/components/Actions/Similarity/constants.ts
@@ -1,0 +1,3 @@
+export const SEARCH_OPERATOR_URI = "@voxel51/panels/similarity_search";
+export const INIT_RUN_OPERATOR_URI = "@voxel51/panels/init_similarity_run";
+export const PANEL_NAME = "similarity_search_panel";

--- a/app/packages/core/src/components/Actions/Similarity/constants.ts
+++ b/app/packages/core/src/components/Actions/Similarity/constants.ts
@@ -1,3 +1,4 @@
+// Duplicated from @fiftyone/similarity-search/constants to avoid
+// a cross-package dependency (core does not depend on similarity-search)
 export const SEARCH_OPERATOR_URI = "@voxel51/panels/similarity_search";
-export const INIT_RUN_OPERATOR_URI = "@voxel51/panels/init_similarity_run";
 export const PANEL_NAME = "similarity_search_panel";

--- a/app/packages/core/src/components/Actions/Similarity/index.tsx
+++ b/app/packages/core/src/components/Actions/Similarity/index.tsx
@@ -4,7 +4,7 @@ import { Search, Wallpaper } from "@mui/icons-material";
 import React, { useCallback, useRef, useState } from "react";
 import type { ActionProps } from "../types";
 import { ActionDiv, getStringAndNumberProps } from "../utils";
-import SortBySimilarity from "./Similar";
+import SimilarityPopover from "./Similar";
 
 const Similarity = ({
   modal,
@@ -21,8 +21,8 @@ const Similarity = ({
     isImageSearch,
   });
 
-  const toggleSimilarity = useCallback(() => {
-    setOpen((open) => !open);
+  const togglePopover = useCallback(() => {
+    setOpen((o) => !o);
     setIsImageSearch(showImageSimilarityIcon);
   }, [showImageSimilarityIcon]);
 
@@ -36,7 +36,7 @@ const Similarity = ({
         icon={showImageSimilarityIcon ? <Wallpaper /> : <Search />}
         open={open}
         tooltipPlacement={modal ? "bottom" : "top"}
-        onClick={toggleSimilarity}
+        onClick={togglePopover}
         highlight={open}
         title={`Sort by ${
           showImageSimilarityIcon ? "image" : "text"
@@ -45,11 +45,10 @@ const Similarity = ({
         data-cy="action-sort-by-similarity"
       />
       {open && (
-        <SortBySimilarity
-          key={`similary-${showImageSimilarityIcon ? "image" : "text"}`}
+        <SimilarityPopover
           modal={modal}
-          close={() => setOpen(false)}
           isImageSearch={isImageSearch}
+          close={() => setOpen(false)}
           anchorRef={ref}
         />
       )}

--- a/app/packages/core/src/components/Actions/Similarity/index.tsx
+++ b/app/packages/core/src/components/Actions/Similarity/index.tsx
@@ -1,11 +1,15 @@
 import { PillButton } from "@fiftyone/components";
+import { executeOperator } from "@fiftyone/operators";
 import { useOutsideClick, useSimilarityType } from "@fiftyone/state";
 import { Search, Wallpaper } from "@mui/icons-material";
 import React, { useCallback, useRef, useState } from "react";
+import { useRecoilValue } from "recoil";
 import Loading from "../Loading";
 import type { ActionProps } from "../types";
 import { ActionDiv, getStringAndNumberProps } from "../utils";
+import { PANEL_NAME } from "./constants";
 import SimilarityPopover from "./Similar";
+import { availableSimilarityKeys } from "./utils";
 
 const Similarity = ({
   modal,
@@ -23,11 +27,25 @@ const Similarity = ({
     isImageSearch,
   });
 
+  const keys = useRecoilValue(
+    availableSimilarityKeys({ modal, isImageSearch: showImageSimilarityIcon })
+  );
+
   const togglePopover = useCallback(() => {
     if (searching) return;
+    if (keys.length === 0) {
+      // No applicable keys — open panel directly
+      executeOperator("open_panel", {
+        name: PANEL_NAME,
+        isActive: true,
+        layout: "horizontal",
+        data: { view: { page: "similarity_index" } },
+      });
+      return;
+    }
     setOpen((o) => !o);
     setIsImageSearch(showImageSimilarityIcon);
-  }, [showImageSimilarityIcon, searching]);
+  }, [showImageSimilarityIcon, searching, keys]);
 
   const icon = searching ? (
     <Loading />

--- a/app/packages/core/src/components/Actions/Similarity/index.tsx
+++ b/app/packages/core/src/components/Actions/Similarity/index.tsx
@@ -46,6 +46,7 @@ const Similarity = ({
       />
       {open && (
         <SimilarityPopover
+          key={`similarity-${isImageSearch ? "image" : "text"}`}
           modal={modal}
           isImageSearch={isImageSearch}
           close={() => setOpen(false)}

--- a/app/packages/core/src/components/Actions/Similarity/index.tsx
+++ b/app/packages/core/src/components/Actions/Similarity/index.tsx
@@ -2,6 +2,7 @@ import { PillButton } from "@fiftyone/components";
 import { useOutsideClick, useSimilarityType } from "@fiftyone/state";
 import { Search, Wallpaper } from "@mui/icons-material";
 import React, { useCallback, useRef, useState } from "react";
+import Loading from "../Loading";
 import type { ActionProps } from "../types";
 import { ActionDiv, getStringAndNumberProps } from "../utils";
 import SimilarityPopover from "./Similar";
@@ -13,6 +14,7 @@ const Similarity = ({
   modal: boolean;
 }) => {
   const [open, setOpen] = useState(false);
+  const [searching, setSearching] = useState(false);
   const [isImageSearch, setIsImageSearch] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   useOutsideClick(ref, () => open && setOpen(false));
@@ -22,9 +24,18 @@ const Similarity = ({
   });
 
   const togglePopover = useCallback(() => {
+    if (searching) return;
     setOpen((o) => !o);
     setIsImageSearch(showImageSimilarityIcon);
-  }, [showImageSimilarityIcon]);
+  }, [showImageSimilarityIcon, searching]);
+
+  const icon = searching ? (
+    <Loading />
+  ) : showImageSimilarityIcon ? (
+    <Wallpaper />
+  ) : (
+    <Search />
+  );
 
   return (
     <ActionDiv
@@ -33,7 +44,7 @@ const Similarity = ({
     >
       <PillButton
         key={"button"}
-        icon={showImageSimilarityIcon ? <Wallpaper /> : <Search />}
+        icon={icon}
         open={open}
         tooltipPlacement={modal ? "bottom" : "top"}
         onClick={togglePopover}
@@ -41,7 +52,7 @@ const Similarity = ({
         title={`Sort by ${
           showImageSimilarityIcon ? "image" : "text"
         } similarity`}
-        style={{ cursor: "pointer" }}
+        style={{ cursor: searching ? "default" : "pointer" }}
         data-cy="action-sort-by-similarity"
       />
       {open && (
@@ -51,6 +62,8 @@ const Similarity = ({
           isImageSearch={isImageSearch}
           close={() => setOpen(false)}
           anchorRef={ref}
+          onSearchStart={() => setSearching(true)}
+          onSearchEnd={() => setSearching(false)}
         />
       )}
     </ActionDiv>

--- a/app/packages/core/src/components/Actions/Similarity/useSimilarityPopover.ts
+++ b/app/packages/core/src/components/Actions/Similarity/useSimilarityPopover.ts
@@ -132,7 +132,10 @@ export default function useSimilarityPopover({
                   view: [
                     {
                       _cls: "fiftyone.core.stages.ToPatches",
-                      kwargs: [["field", patchesField]],
+                      kwargs: [
+                        ["field", patchesField],
+                        ["_state", null],
+                      ],
                     },
                   ],
                 },

--- a/app/packages/core/src/components/Actions/Similarity/useSimilarityPopover.ts
+++ b/app/packages/core/src/components/Actions/Similarity/useSimilarityPopover.ts
@@ -37,6 +37,9 @@ export default function useSimilarityPopover({
   const showMixedFieldWarning = modal && isImageSearch && hasMixedFields;
   const showNoIndexWarning =
     modal && isImageSearch && !hasMixedFields && !hasSimilarityKeys;
+  const noIndexWarningText = hasSelectedLabels
+    ? "No similarity index found for the selected label field"
+    : "No similarity index available";
 
   const type = useRecoilValue(sortType(modal));
   const datasetId = fos.useAssertedRecoilValue(fos.datasetId);
@@ -185,6 +188,7 @@ export default function useSimilarityPopover({
     hasSimilarityKeys,
     showMixedFieldWarning,
     showNoIndexWarning,
+    noIndexWarningText,
     searchButtonText,
     handleSearch,
     handleOpenPanel,

--- a/app/packages/core/src/components/Actions/Similarity/useSimilarityPopover.ts
+++ b/app/packages/core/src/components/Actions/Similarity/useSimilarityPopover.ts
@@ -93,12 +93,19 @@ export default function useSimilarityPopover({
         const patchesField = await resolvePatchesField(resolvedBrainKey);
         const currentView = await snapshot.getPromise(fos.view);
 
+        const runName = isImageSearch
+          ? `Image: ${Array.isArray(queryIds) ? queryIds.length : 1} ${
+              patchesField ? "patches" : "samples"
+            }`
+          : `Text: "${textQuery.trim()}"`;
+
         const params: Record<string, unknown> = {
           brain_key: resolvedBrainKey,
           query_type: isImageSearch ? "image" : "text",
           query: isImageSearch ? queryIds : textQuery.trim(),
           reverse: false,
           k: DEFAULT_K,
+          run_name: runName,
         };
         if (patchesField) {
           params.patches_field = patchesField;

--- a/app/packages/core/src/components/Actions/Similarity/useSimilarityPopover.ts
+++ b/app/packages/core/src/components/Actions/Similarity/useSimilarityPopover.ts
@@ -4,7 +4,12 @@ import { useBrowserStorage } from "@fiftyone/state";
 import { useCallback, useMemo, useState } from "react";
 import { useRecoilCallback, useRecoilValue } from "recoil";
 import { PANEL_NAME, SEARCH_OPERATOR_URI } from "./constants";
-import { availableSimilarityKeys, getQueryIds, sortType } from "./utils";
+import {
+  availableSimilarityKeys,
+  buildRunName,
+  getQueryIds,
+  sortType,
+} from "./utils";
 
 const DEFAULT_K = 25;
 
@@ -83,21 +88,25 @@ export default function useSimilarityPopover({
       async () => {
         if (!resolvedBrainKey) return;
 
-        const queryIds = isImageSearch
+        const queryResult = isImageSearch
           ? await getQueryIds(snapshot, resolvedBrainKey)
           : undefined;
+
+        const queryIds = queryResult?.queryIds;
+        const negativeQueryIds = queryResult?.negativeQueryIds;
 
         if (isImageSearch && (!queryIds || queryIds.length === 0)) return;
         if (!isImageSearch && !textQuery.trim()) return;
 
         const patchesField = await resolvePatchesField(resolvedBrainKey);
-        const currentView = await snapshot.getPromise(fos.view);
 
-        const runName = isImageSearch
-          ? `Image: ${Array.isArray(queryIds) ? queryIds.length : 1} ${
-              patchesField ? "patches" : "samples"
-            }`
-          : `Text: "${textQuery.trim()}"`;
+        const runName = buildRunName({
+          isImageSearch,
+          textQuery: textQuery.trim(),
+          queryIds,
+          negativeQueryIds,
+          patchesField,
+        });
 
         const params: Record<string, unknown> = {
           brain_key: resolvedBrainKey,
@@ -110,12 +119,8 @@ export default function useSimilarityPopover({
         if (patchesField) {
           params.patches_field = patchesField;
         }
-        if (
-          currentView &&
-          Array.isArray(currentView) &&
-          currentView.length > 0
-        ) {
-          params.source_view = currentView;
+        if (negativeQueryIds && negativeQueryIds.length > 0) {
+          params.negative_query_ids = negativeQueryIds;
         }
 
         setLastUsedBrainKeys({

--- a/app/packages/core/src/components/Actions/Similarity/useSimilarityPopover.ts
+++ b/app/packages/core/src/components/Actions/Similarity/useSimilarityPopover.ts
@@ -1,0 +1,175 @@
+import { executeOperator } from "@fiftyone/operators";
+import * as fos from "@fiftyone/state";
+import { useBrowserStorage } from "@fiftyone/state";
+import { useCallback, useMemo, useState } from "react";
+import { useRecoilCallback, useRecoilValue } from "recoil";
+import { PANEL_NAME, SEARCH_OPERATOR_URI } from "./constants";
+import { availableSimilarityKeys, getQueryIds, sortType } from "./utils";
+
+const DEFAULT_K = 25;
+
+type UseSimilarityPopoverProps = {
+  modal: boolean;
+  isImageSearch: boolean;
+  close: () => void;
+};
+
+export default function useSimilarityPopover({
+  modal,
+  isImageSearch,
+  close,
+}: UseSimilarityPopoverProps) {
+  const [textQuery, setTextQuery] = useState("");
+
+  const keys = useRecoilValue(
+    availableSimilarityKeys({ modal, isImageSearch })
+  );
+  const hasSimilarityKeys = keys.length > 0;
+  const hasSelectedLabels = useRecoilValue(fos.hasSelectedLabels);
+  const selectedLabelsList = useRecoilValue(fos.selectedLabels);
+
+  const selectedLabelFields = useMemo(() => {
+    if (!modal || !hasSelectedLabels) return new Set<string>();
+    return new Set(selectedLabelsList.map((l) => l.field));
+  }, [modal, hasSelectedLabels, selectedLabelsList]);
+
+  const hasMixedFields = selectedLabelFields.size > 1;
+  const showMixedFieldWarning = modal && isImageSearch && hasMixedFields;
+  const showNoIndexWarning =
+    modal && isImageSearch && !hasMixedFields && !hasSimilarityKeys;
+
+  const type = useRecoilValue(sortType(modal));
+  const datasetId = fos.useAssertedRecoilValue(fos.datasetId);
+  const [lastUsedBrainKeys, setLastUsedBrainKeys] = useBrowserStorage<
+    Record<string, string>
+  >("lastUsedBrainKeys", {});
+
+  const resolvedBrainKey = useMemo(() => {
+    if (keys.length === 0) return undefined;
+    const stored = lastUsedBrainKeys?.[datasetId];
+    if (stored && keys.includes(stored)) return stored;
+    return keys[0];
+  }, [keys, lastUsedBrainKeys, datasetId]);
+
+  const resolvePatchesField = useRecoilCallback(
+    ({ snapshot }) =>
+      async (brainKey: string) => {
+        const methods = await snapshot.getPromise(fos.similarityMethods);
+        const match = methods.patches.find(
+          ([method]) => method.key === brainKey
+        );
+        return match ? match[1] : undefined;
+      },
+    []
+  );
+
+  const openPanel = useCallback(() => {
+    executeOperator("open_panel", {
+      name: PANEL_NAME,
+      isActive: true,
+      layout: "horizontal",
+    });
+  }, []);
+
+  const handleSearch = useRecoilCallback(
+    ({ snapshot, set }) =>
+      async () => {
+        if (!resolvedBrainKey) return;
+
+        const queryIds = isImageSearch
+          ? await getQueryIds(snapshot, resolvedBrainKey)
+          : undefined;
+
+        if (isImageSearch && (!queryIds || queryIds.length === 0)) return;
+        if (!isImageSearch && !textQuery.trim()) return;
+
+        const patchesField = await resolvePatchesField(resolvedBrainKey);
+
+        const params: Record<string, unknown> = {
+          brain_key: resolvedBrainKey,
+          query_type: isImageSearch ? "image" : "text",
+          query: isImageSearch ? queryIds : textQuery.trim(),
+          reverse: false,
+          k: DEFAULT_K,
+        };
+        if (patchesField) {
+          params.patches_field = patchesField;
+        }
+
+        setLastUsedBrainKeys({
+          ...(lastUsedBrainKeys || {}),
+          [datasetId]: resolvedBrainKey,
+        });
+
+        close();
+
+        executeOperator(SEARCH_OPERATOR_URI, params, {
+          callback: (result) => {
+            if (result?.error) {
+              console.error("Similarity search failed:", result.error);
+              return;
+            }
+
+            if (modal) {
+              set(fos.modalSelector, null);
+            }
+            executeOperator("clear_selected_samples");
+            executeOperator("clear_selected_labels");
+            set(fos.extendedSelection, { selection: [] });
+
+            if (patchesField) {
+              executeOperator(
+                "set_view",
+                {
+                  view: [
+                    {
+                      _cls: "fiftyone.core.stages.ToPatches",
+                      kwargs: [["field", patchesField]],
+                    },
+                  ],
+                },
+                { callback: () => openPanel() }
+              );
+            } else {
+              openPanel();
+            }
+          },
+        });
+      },
+    [
+      resolvedBrainKey,
+      isImageSearch,
+      textQuery,
+      resolvePatchesField,
+      close,
+      openPanel,
+      modal,
+      lastUsedBrainKeys,
+      setLastUsedBrainKeys,
+      datasetId,
+    ]
+  );
+
+  const handleOpenPanel = useRecoilCallback(
+    ({ set }) =>
+      () => {
+        close();
+        if (modal) {
+          set(fos.modalSelector, null);
+        }
+        openPanel();
+      },
+    [close, modal, openPanel]
+  );
+
+  return {
+    textQuery,
+    setTextQuery,
+    type,
+    hasSimilarityKeys,
+    showMixedFieldWarning,
+    showNoIndexWarning,
+    handleSearch,
+    handleOpenPanel,
+  };
+}

--- a/app/packages/core/src/components/Actions/Similarity/useSimilarityPopover.ts
+++ b/app/packages/core/src/components/Actions/Similarity/useSimilarityPopover.ts
@@ -12,12 +12,16 @@ type UseSimilarityPopoverProps = {
   modal: boolean;
   isImageSearch: boolean;
   close: () => void;
+  onSearchStart?: () => void;
+  onSearchEnd?: () => void;
 };
 
 export default function useSimilarityPopover({
   modal,
   isImageSearch,
   close,
+  onSearchStart,
+  onSearchEnd,
 }: UseSimilarityPopoverProps) {
   const [textQuery, setTextQuery] = useState("");
 
@@ -113,9 +117,11 @@ export default function useSimilarityPopover({
         });
 
         close();
+        onSearchStart?.();
 
         executeOperator(SEARCH_OPERATOR_URI, params, {
           callback: (result) => {
+            onSearchEnd?.();
             if (result?.error) {
               console.error("Similarity search failed:", result.error);
               return;
@@ -161,6 +167,8 @@ export default function useSimilarityPopover({
       lastUsedBrainKeys,
       setLastUsedBrainKeys,
       datasetId,
+      onSearchStart,
+      onSearchEnd,
     ]
   );
 
@@ -171,9 +179,14 @@ export default function useSimilarityPopover({
         if (modal) {
           set(fos.modalSelector, null);
         }
-        openPanel();
+        executeOperator("open_panel", {
+          name: PANEL_NAME,
+          isActive: true,
+          layout: "horizontal",
+          data: { view: { page: "new_search" } },
+        });
       },
-    [close, modal, openPanel]
+    [close, modal]
   );
 
   const searchButtonText =

--- a/app/packages/core/src/components/Actions/Similarity/useSimilarityPopover.ts
+++ b/app/packages/core/src/components/Actions/Similarity/useSimilarityPopover.ts
@@ -84,6 +84,7 @@ export default function useSimilarityPopover({
         if (!isImageSearch && !textQuery.trim()) return;
 
         const patchesField = await resolvePatchesField(resolvedBrainKey);
+        const currentView = await snapshot.getPromise(fos.view);
 
         const params: Record<string, unknown> = {
           brain_key: resolvedBrainKey,
@@ -94,6 +95,13 @@ export default function useSimilarityPopover({
         };
         if (patchesField) {
           params.patches_field = patchesField;
+        }
+        if (
+          currentView &&
+          Array.isArray(currentView) &&
+          currentView.length > 0
+        ) {
+          params.source_view = currentView;
         }
 
         setLastUsedBrainKeys({
@@ -162,6 +170,11 @@ export default function useSimilarityPopover({
     [close, modal, openPanel]
   );
 
+  const searchButtonText =
+    modal && hasSelectedLabels
+      ? "Show similar patches"
+      : "Show similar samples";
+
   return {
     textQuery,
     setTextQuery,
@@ -169,6 +182,7 @@ export default function useSimilarityPopover({
     hasSimilarityKeys,
     showMixedFieldWarning,
     showNoIndexWarning,
+    searchButtonText,
     handleSearch,
     handleOpenPanel,
   };

--- a/app/packages/core/src/components/Actions/Similarity/utils.ts
+++ b/app/packages/core/src/components/Actions/Similarity/utils.ts
@@ -1,10 +1,8 @@
 import type { Method } from "@fiftyone/state";
 import * as fos from "@fiftyone/state";
-import { selectedLabels, useBrowserStorage } from "@fiftyone/state";
-import { getFetchFunction, toSnakeCase } from "@fiftyone/utilities";
-import { useMemo } from "react";
+import { selectedLabels } from "@fiftyone/state";
 import type { Snapshot } from "recoil";
-import { selectorFamily, useRecoilCallback } from "recoil";
+import { selectorFamily } from "recoil";
 
 export const getQueryIds = async (
   snapshot: Snapshot,
@@ -32,62 +30,6 @@ export const getQueryIds = async (
   }
 
   return await snapshot.getPromise(fos.modalSampleId);
-};
-
-export const useSortBySimilarity = (close) => {
-  const [lastUsedBrainkeys, setLastUsedBrainKeys] =
-    useBrowserStorage("lastUsedBrainKeys");
-  const current = useMemo(() => {
-    return lastUsedBrainkeys ? JSON.parse(lastUsedBrainkeys) : {};
-  }, [lastUsedBrainkeys]);
-
-  return useRecoilCallback(
-    ({ snapshot, set }) =>
-      async (parameters: fos.State.SortBySimilarityParameters) => {
-        set(fos.similaritySorting, true);
-        const dataset = await snapshot.getPromise(fos.dataset);
-        if (!dataset) {
-          throw new Error("dataset is not defined");
-        }
-
-        const queryIds = parameters.query
-          ? undefined
-          : await getQueryIds(snapshot, parameters.brainKey);
-
-        const view = await snapshot.getPromise(fos.view);
-        const subscription = await snapshot.getPromise(fos.stateSubscription);
-        const slice = await snapshot.getPromise(fos.sessionGroupSlice);
-
-        const { query, ...commonParams } = parameters;
-
-        const combinedParameters: fos.State.SortBySimilarityParameters = {
-          ...commonParams,
-        };
-
-        combinedParameters.query = query ?? queryIds;
-        const filters = await snapshot.getPromise(fos.filters);
-
-        // save the brainkey into local storage
-        setLastUsedBrainKeys(
-          JSON.stringify({
-            ...current,
-            [dataset.datasetId]: combinedParameters.brainKey,
-          })
-        );
-
-        const stage = await getFetchFunction()("POST", "/sort", {
-          dataset: dataset.name,
-          view,
-          subscription,
-          filters,
-          extended: toSnakeCase(combinedParameters),
-          slice,
-        });
-        set(fos.similarityParameters, Object.fromEntries(stage.kwargs));
-        close();
-      },
-    []
-  );
 };
 
 export const availableSimilarityKeys = selectorFamily<
@@ -161,22 +103,6 @@ const availablePatchesSimilarityKeys = selectorFamily<
     },
 });
 
-export const currentSimilarityKeys = selectorFamily<
-  { total: number; choices: string[] },
-  { modal: boolean; isImageSearch: boolean }
->({
-  key: "currentSimilarityKeys",
-  get:
-    ({ modal, isImageSearch }) =>
-    ({ get }) => {
-      const keys = get(availableSimilarityKeys({ modal, isImageSearch }));
-      return {
-        total: keys.length,
-        choices: keys,
-      };
-    },
-});
-
 export const sortType = selectorFamily<string, boolean>({
   key: "sortBySimilarityType",
   get:
@@ -193,23 +119,5 @@ export const sortType = selectorFamily<string, boolean>({
       }
 
       return "patches";
-    },
-});
-
-export const currentBrainConfig = selectorFamily<Method | undefined, string>({
-  key: "currenBrainConfig",
-  get:
-    (key) =>
-    ({ get }) => {
-      if (get(fos.isPatchesView)) {
-        const { patches } = get(fos.similarityMethods);
-        const patch = patches.find(([method, _]) => method.key === key);
-        if (patch) {
-          return patch[0];
-        }
-      }
-
-      const { samples: methods } = get(fos.similarityMethods);
-      return methods.find((method) => method.key === key);
     },
 });

--- a/app/packages/core/src/components/Actions/Similarity/utils.ts
+++ b/app/packages/core/src/components/Actions/Similarity/utils.ts
@@ -8,28 +8,36 @@ export const getQueryIds = async (
   snapshot: Snapshot,
   brainKey?: string
 ): Promise<string[] | string | undefined> => {
-  const selectedLabelIds = await snapshot.getPromise(fos.selectedLabelIds);
-  const selectedLabels = await snapshot.getPromise(fos.selectedLabels);
+  const isModal = await snapshot.getPromise(fos.isModalActive);
 
-  if (selectedLabelIds.size) {
-    const methods = await snapshot.getPromise(fos.similarityMethods);
-    const labels_field = methods.patches
-      .filter(([method]) => method.key === brainKey)
-      .map(([_, value]) => value)[0];
-    return [...selectedLabelIds].filter(
-      (id) => selectedLabels[id].field === labels_field
-    );
+  // In modal: check selected labels for patch-based similarity
+  if (isModal) {
+    const selectedLabelIds = await snapshot.getPromise(fos.selectedLabelIds);
+    const selectedLabelMap = await snapshot.getPromise(fos.selectedLabelMap);
+
+    if (selectedLabelIds.size) {
+      const methods = await snapshot.getPromise(fos.similarityMethods);
+      const labels_field = methods.patches
+        .filter(([method]) => method.key === brainKey)
+        .map(([_, value]) => value)[0];
+      return [...selectedLabelIds].filter(
+        (id) => selectedLabelMap[id]?.field === labels_field
+      );
+    }
+
+    return await snapshot.getPromise(fos.modalSampleId);
   }
 
+  // Grid: use selected samples
   const selectedSamples = Array.from(
     (await snapshot.getPromise(fos.selectedSamples)).keys()
   );
 
   if (selectedSamples.length) {
-    return [...selectedSamples];
+    return selectedSamples;
   }
 
-  return await snapshot.getPromise(fos.modalSampleId);
+  return undefined;
 };
 
 export const availableSimilarityKeys = selectorFamily<

--- a/app/packages/core/src/components/Actions/Similarity/utils.ts
+++ b/app/packages/core/src/components/Actions/Similarity/utils.ts
@@ -4,10 +4,15 @@ import { selectedLabels } from "@fiftyone/state";
 import type { Snapshot } from "recoil";
 import { selectorFamily } from "recoil";
 
+export type QueryIds = {
+  queryIds: string[] | string | undefined;
+  negativeQueryIds?: string[];
+};
+
 export const getQueryIds = async (
   snapshot: Snapshot,
   brainKey?: string
-): Promise<string[] | string | undefined> => {
+): Promise<QueryIds> => {
   const isModal = await snapshot.getPromise(fos.isModalActive);
 
   // In modal: check selected labels for patch-based similarity
@@ -20,24 +25,49 @@ export const getQueryIds = async (
       const labels_field = methods.patches
         .filter(([method]) => method.key === brainKey)
         .map(([_, value]) => value)[0];
-      return [...selectedLabelIds].filter(
+
+      const matching = [...selectedLabelIds].filter(
         (id) => selectedLabelMap[id]?.field === labels_field
       );
+
+      // Separate positive (default) and negative (alt) labels
+      const positive = matching.filter(
+        (id) => selectedLabelMap[id]?.type !== "alt"
+      );
+      const negative = matching.filter(
+        (id) => selectedLabelMap[id]?.type === "alt"
+      );
+
+      return {
+        queryIds: positive.length > 0 ? positive : undefined,
+        negativeQueryIds: negative.length > 0 ? negative : undefined,
+      };
     }
 
-    return await snapshot.getPromise(fos.modalSampleId);
+    return { queryIds: await snapshot.getPromise(fos.modalSampleId) };
   }
 
   // Grid: use selected samples
-  const selectedSamples = Array.from(
-    (await snapshot.getPromise(fos.selectedSamples)).keys()
-  );
+  const selectedSamplesMap = await snapshot.getPromise(fos.selectedSamples);
+  const positive: string[] = [];
+  const negative: string[] = [];
 
-  if (selectedSamples.length) {
-    return selectedSamples;
+  for (const [id, type] of selectedSamplesMap.entries()) {
+    if (type === "alt") {
+      negative.push(id);
+    } else {
+      positive.push(id);
+    }
   }
 
-  return undefined;
+  if (positive.length > 0 || negative.length > 0) {
+    return {
+      queryIds: positive.length > 0 ? positive : undefined,
+      negativeQueryIds: negative.length > 0 ? negative : undefined,
+    };
+  }
+
+  return { queryIds: undefined };
 };
 
 export const availableSimilarityKeys = selectorFamily<
@@ -129,3 +159,31 @@ export const sortType = selectorFamily<string, boolean>({
       return "patches";
     },
 });
+
+export function buildRunName({
+  isImageSearch,
+  textQuery,
+  queryIds,
+  negativeQueryIds,
+  patchesField,
+}: {
+  isImageSearch: boolean;
+  textQuery: string;
+  queryIds: string[] | string | undefined;
+  negativeQueryIds?: string[];
+  patchesField?: string;
+}): string {
+  if (!isImageSearch) {
+    return `Text: "${textQuery}"`;
+  }
+
+  const positiveCount = Array.isArray(queryIds) ? queryIds.length : 1;
+  const negativeCount = negativeQueryIds?.length ?? 0;
+  const unit = patchesField ? "patches" : "samples";
+
+  if (negativeCount > 0) {
+    return `Image: ${positiveCount} prompt(s), ${negativeCount} negative`;
+  }
+
+  return `Image: ${positiveCount} ${unit}`;
+}

--- a/app/packages/core/src/components/Modal/Actions/index.tsx
+++ b/app/packages/core/src/components/Modal/Actions/index.tsx
@@ -18,7 +18,7 @@ import HiddenLabels from "./HiddenLabels";
 import ToggleFullscreen from "./ToggleFullscreen";
 import { useAtomValue } from "jotai";
 import { EXPLORE, modalMode } from "@fiftyone/state";
- 
+
 const MODAL_ACTION_BAR_HANDLE_CLASS = "fo-modal-action-bar-handle";
 
 const Container = styled.div<{ $isFullScreen: boolean }>`
@@ -102,9 +102,10 @@ export default () => {
       <Container $isFullScreen={isFullScreen}>
         <DragActionsRow />
         <HiddenLabels modal />
-        { mode === EXPLORE && <Selected modal lookerRef={activeLookerRef} /> }
+        {mode === EXPLORE && <Selected modal lookerRef={activeLookerRef} />}
+        {mode === EXPLORE && <Similarity modal />}
         <ColorScheme modal />
-        { mode === EXPLORE && <Tag modal lookerRef={activeLookerRef} />}
+        {mode === EXPLORE && <Tag modal lookerRef={activeLookerRef} />}
         <Options modal />
         {isGroup && <GroupVisibility />}
         <BrowseOperations modal />

--- a/app/packages/similarity-search/src/components/NewSearch/NewSearch.tsx
+++ b/app/packages/similarity-search/src/components/NewSearch/NewSearch.tsx
@@ -147,7 +147,7 @@ export default function NewSearch({
               }
               value={form.searchScope}
               onChange={(value) => form.setSearchScope(value as SearchScope)}
-              size={Size.Sm}
+              size={Size.Md}
               style={{ display: "flex", flexDirection: "row", gap: "1rem" }}
             />
           }

--- a/app/packages/similarity-search/src/constants.ts
+++ b/app/packages/similarity-search/src/constants.ts
@@ -5,6 +5,8 @@ export const SEARCH_OPERATOR_URI = "@voxel51/panels/similarity_search";
 export const INIT_RUN_OPERATOR_URI = "@voxel51/panels/init_similarity_run";
 export const COMPUTE_SIMILARITY_URI = "@voxel51/operators/compute_similarity";
 export const PANEL_NAME = "similarity_search_panel";
+export const SSE_OPERATOR_URI =
+  "@voxel51/panels/get_similarity_search_subscription_notifier";
 
 export const DAY_MS = 86_400_000;
 

--- a/app/packages/similarity-search/src/constants.ts
+++ b/app/packages/similarity-search/src/constants.ts
@@ -4,6 +4,7 @@ import { OwnerFilter, RunStatus, SearchScope } from "./types";
 export const SEARCH_OPERATOR_URI = "@voxel51/panels/similarity_search";
 export const INIT_RUN_OPERATOR_URI = "@voxel51/panels/init_similarity_run";
 export const COMPUTE_SIMILARITY_URI = "@voxel51/operators/compute_similarity";
+export const PANEL_NAME = "similarity_search_panel";
 
 export const DAY_MS = 86_400_000;
 

--- a/app/packages/similarity-search/src/hooks/useNavigate.ts
+++ b/app/packages/similarity-search/src/hooks/useNavigate.ts
@@ -16,9 +16,11 @@ type NavigateResult = {
  * Hook for panel page navigation.
  */
 export const useNavigate = (): NavigateResult => {
-  const [viewState, setViewState] = usePanelStatePartial<ViewState>("view", {
-    page: "home",
-  });
+  const [viewState, setViewState] = usePanelStatePartial<ViewState>(
+    "view",
+    { page: "home" },
+    true // local-only — no server round-trip on navigation, since we don't want grid to update
+  );
 
   const navigateHome = useCallback(() => {
     setViewState({ page: "home" });

--- a/app/packages/similarity-search/src/hooks/useRuns.ts
+++ b/app/packages/similarity-search/src/hooks/useRuns.ts
@@ -2,8 +2,13 @@ import { atom, useAtom } from "jotai";
 import { useCallback, useEffect, useRef } from "react";
 import { useRecoilValue } from "recoil";
 import { useOperatorExecutor } from "@fiftyone/operators";
+import { useExecutionStoreSubscribe } from "@fiftyone/core/src/subscription/useExecutionStoreSubscribe";
 import { usePanelId } from "@fiftyone/spaces";
-import { datasetName as datasetNameAtom } from "@fiftyone/state";
+import {
+  datasetId as datasetIdAtom,
+  datasetName as datasetNameAtom,
+} from "@fiftyone/state";
+import { SSE_OPERATOR_URI } from "../constants";
 import { SimilarityRun } from "../types";
 
 const runsAtom = atom<SimilarityRun[]>([]);
@@ -35,6 +40,7 @@ export const useRuns = (): UseRunsResult => {
   const lastDatasetName = useRef<string | null | undefined>();
   const panelId = usePanelId();
   const datasetName = useRecoilValue(datasetNameAtom);
+  const datasetId = useRecoilValue(datasetIdAtom);
   const { execute: fetchRuns } = useOperatorExecutor(
     "@voxel51/panels/list_similarity_runs"
   );
@@ -98,6 +104,17 @@ export const useRuns = (): UseRunsResult => {
       refreshRuns();
     }
   }, [refreshRuns, panelId, datasetName]);
+
+  // Subscribe to execution store changes via SSE for auto-refresh
+  const onStoreChange = useCallback(() => {
+    refreshRuns();
+  }, [refreshRuns]);
+
+  useExecutionStoreSubscribe({
+    operatorUri: SSE_OPERATOR_URI,
+    callback: onStoreChange,
+    datasetId: datasetId ?? undefined,
+  });
 
   const updateRun = useCallback(
     (run: SimilarityRun) => {

--- a/app/packages/similarity-search/src/hooks/useSearchSubmission.ts
+++ b/app/packages/similarity-search/src/hooks/useSearchSubmission.ts
@@ -1,5 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
 import { useOperatorExecutor } from "@fiftyone/operators";
+import * as fos from "@fiftyone/state";
+import { useBrowserStorage } from "@fiftyone/state";
 import { BrainKeyConfig, QueryType, SearchScope } from "../types";
 import { INIT_RUN_OPERATOR_URI } from "../constants";
 import { canSubmitSearch, buildExecutionParams, UploadedImage } from "../utils";
@@ -29,10 +31,18 @@ type UseSearchSubmissionInput = {
 export const useSearchSubmission = (input: UseSearchSubmissionInput) => {
   const { execute: initRun } = useOperatorExecutor(INIT_RUN_OPERATOR_URI);
   const [submitting, setSubmitting] = useState(false);
+  const datasetId = fos.useAssertedRecoilValue(fos.datasetId);
+  const [lastUsedBrainKeys, setLastUsedBrainKeys] =
+    useBrowserStorage("lastUsedBrainKeys");
 
   const handleOptionSelected = useCallback(() => {
     setSubmitting(true);
-  }, []);
+
+    const current = lastUsedBrainKeys ? JSON.parse(lastUsedBrainKeys) : {};
+    setLastUsedBrainKeys(
+      JSON.stringify({ ...current, [datasetId]: input.brainKey })
+    );
+  }, [lastUsedBrainKeys, setLastUsedBrainKeys, datasetId, input.brainKey]);
 
   const executionParams = useMemo(
     () =>

--- a/app/packages/similarity-search/src/hooks/useSearchSubmission.ts
+++ b/app/packages/similarity-search/src/hooks/useSearchSubmission.ts
@@ -32,16 +32,17 @@ export const useSearchSubmission = (input: UseSearchSubmissionInput) => {
   const { execute: initRun } = useOperatorExecutor(INIT_RUN_OPERATOR_URI);
   const [submitting, setSubmitting] = useState(false);
   const datasetId = fos.useAssertedRecoilValue(fos.datasetId);
-  const [lastUsedBrainKeys, setLastUsedBrainKeys] =
-    useBrowserStorage("lastUsedBrainKeys");
+  const [lastUsedBrainKeys, setLastUsedBrainKeys] = useBrowserStorage<
+    Record<string, string>
+  >("lastUsedBrainKeys", {});
 
   const handleOptionSelected = useCallback(() => {
     setSubmitting(true);
 
-    const current = lastUsedBrainKeys ? JSON.parse(lastUsedBrainKeys) : {};
-    setLastUsedBrainKeys(
-      JSON.stringify({ ...current, [datasetId]: input.brainKey })
-    );
+    setLastUsedBrainKeys({
+      ...(lastUsedBrainKeys || {}),
+      [datasetId]: input.brainKey,
+    });
   }, [lastUsedBrainKeys, setLastUsedBrainKeys, datasetId, input.brainKey]);
 
   const executionParams = useMemo(

--- a/fiftyone/internal/features/flags.py
+++ b/fiftyone/internal/features/flags.py
@@ -8,5 +8,5 @@ FiftyOne feature flags.
 
 from typing import Literal
 
-FeatureFlag = Literal["VFF_SIMILARITY_SEARCH"]
+FeatureFlag = Literal[""]
 """Enumeration of active feature flags."""

--- a/plugins/panels/__init__.py
+++ b/plugins/panels/__init__.py
@@ -6,25 +6,20 @@ Builtin panels.
 |
 """
 
-from fiftyone.internal.features.registry import is_feature_enabled
-
 from .model_evaluation import EvaluationPanel
+from .similarity_search import SimilaritySearchPanel
+from .similarity_search.operators import (
+    InitSimilarityRunOperator,
+    ListSimilarityRunsOperator,
+    SimilaritySearchOperator,
+    SimilaritySearchSubscriptionOperator,
+)
 
 
 def register(p):
     p.register(EvaluationPanel)
-
-    if is_feature_enabled("VFF_SIMILARITY_SEARCH"):
-        from .similarity_search import SimilaritySearchPanel
-        from .similarity_search.operators import (
-            InitSimilarityRunOperator,
-            ListSimilarityRunsOperator,
-            SimilaritySearchOperator,
-            SimilaritySearchSubscriptionOperator,
-        )
-
-        p.register(SimilaritySearchPanel)
-        p.register(SimilaritySearchOperator)
-        p.register(ListSimilarityRunsOperator)
-        p.register(InitSimilarityRunOperator)
-        p.register(SimilaritySearchSubscriptionOperator)
+    p.register(SimilaritySearchPanel)
+    p.register(SimilaritySearchOperator)
+    p.register(ListSimilarityRunsOperator)
+    p.register(InitSimilarityRunOperator)
+    p.register(SimilaritySearchSubscriptionOperator)

--- a/plugins/panels/similarity_search/__init__.py
+++ b/plugins/panels/similarity_search/__init__.py
@@ -49,9 +49,6 @@ class SimilaritySearchPanel(Panel):
         current_user = str(ctx.user_id) if ctx.user_id else None
         ctx.panel.set_data("current_user", current_user)
 
-        view_state = ctx.panel.get_state("view") or {"page": "home"}
-        ctx.panel.set_state("view", view_state)
-
         # Enable alt-selection visual feedback for negative queries
         ctx.ops.set_sample_selection_style(
             default="green-checkmark", alt="red-checkmark"

--- a/plugins/panels/similarity_search/__init__.py
+++ b/plugins/panels/similarity_search/__init__.py
@@ -108,6 +108,8 @@ class SimilaritySearchPanel(Panel):
             else:
                 view = ctx.dataset.select(result_ids, ordered=True)
 
+            ctx.ops.clear_selected_samples()
+            ctx.ops.clear_selected_labels()
             ctx.ops.set_view(view)
             ctx.panel.set_state("applied_run_id", run_id)
 

--- a/plugins/panels/similarity_search/operators.py
+++ b/plugins/panels/similarity_search/operators.py
@@ -98,14 +98,11 @@ class SimilaritySearchOperator(foo.Operator):
 
             dataset = ctx.dataset
 
-            # Reconstruct the source view if provided
-            source_view = ctx.params.get("source_view")
-            if source_view:
-                from fiftyone.core.view import DatasetView
-
-                view = DatasetView._build(dataset, source_view)
-            else:
-                view = dataset.view()
+            # Always sort against the base dataset view.
+            # source_view is stored in the run record for context
+            # but not used for the sort itself, because the brain
+            # index may have been computed on the base dataset.
+            view = dataset.view()
 
             ctx.set_progress(0.2, label="Preparing query...")
 

--- a/plugins/panels/similarity_search/operators.py
+++ b/plugins/panels/similarity_search/operators.py
@@ -150,6 +150,9 @@ class SimilaritySearchOperator(foo.Operator):
 
             dynamic_results = ctx.params.get("dynamic_results", False)
 
+            result_ids = []
+            result_view_stages = None
+
             if dynamic_results:
                 result_view_stages = result_view._serialize(
                     include_uuids=False
@@ -157,7 +160,6 @@ class SimilaritySearchOperator(foo.Operator):
                 result_count = len(result_view)
             else:
                 result_ids = [str(rid) for rid in result_view.values("id")]
-                result_view_stages = None
                 result_count = len(result_ids)
 
             ctx.set_progress(0.9, label="Saving results...")

--- a/plugins/panels/similarity_search/operators.py
+++ b/plugins/panels/similarity_search/operators.py
@@ -145,7 +145,7 @@ class SimilaritySearchOperator(foo.Operator):
 
             ctx.set_progress(0.7, label="Collecting results...")
 
-            dynamic_results = ctx.params.get("dynamic_results", False)
+            dynamic_results = ctx.params.get("dynamic_results", True)
 
             result_ids = []
             result_view_stages = None

--- a/plugins/panels/similarity_search/operators.py
+++ b/plugins/panels/similarity_search/operators.py
@@ -130,6 +130,11 @@ class SimilaritySearchOperator(foo.Operator):
 
             ctx.set_progress(0.3, label="Running similarity query...")
 
+            # For patches-based searches, ensure we're on a patches
+            # view before sorting (skip if already on patches)
+            if patches_field and not view._is_patches:
+                view = view.to_patches(patches_field)
+
             # Build kwargs, omitting None values
             kwargs = {"brain_key": brain_key}
             if k is not None:


### PR DESCRIPTION
## 🔗 Related Issues

closes #FOEPD-3370

## 📋 What changes are proposed in this pull request?

**Summary**
Replaces the old direct POST /sort similarity flow with an operator-based flow that triggers @voxel51/panels/similarity_search and opens the similarity search panel.

**Popover changes:**

- Simplified the grid/modal action popover — always shows search UI (text input or "Show similar samples/patches"), no more Reset button or inline advanced settings
- Text search: type query + Enter/click Search → runs operator → opens panel
- Image search (selected samples): click "Show similar samples" → runs operator → opens panel
- Patches search (selected label in modal): click "Show similar patches" → runs operator → closes modal → switches to patches view → opens panel
- Settings icon: closes modal (if open) → opens panel
- Warns when labels from multiple fields are selected, or when no similarity index exists for the selected label's field
- Persists lastUsedBrainKeys per-dataset from both popover and panel

**Panel changes:**

- Added SSE subscription in useRuns for auto-refresh when execution store changes
- useSearchSubmission now persists lastUsedBrainKeys per-dataset
- apply_run clears selected samples and labels before setting the view

**Operator changes:**

- Patches-based searches now convert to patches view before sort_by_similarity when not already on a patches view
- Fixed result ID collection to use patch IDs (not sample IDs) for patches searches

**Modal:**

- Restored Similarity action button to the modal action bar (conditional on EXPLORE mode)

## 🧪 How is this patch tested? If it is not, please explain why.

Compute similarity index on dataset and on `predictions` patch view:

```
import fiftyone.brain as fob

fob.compute_similarity(
    dataset,
    model="clip-vit-base32-torch",
    brain_key="clip_similarity",
    backend="sklearn",
    metric="cosine",
)

fob.compute_similarity(
    dataset,
    patches_field="predictions",
    model="clip-vit-base32-torch",
    brain_key="predictions_similarity",
    backend="sklearn",
    metric="cosine",
)
```

- [ ] click the similarity popover, the setting icon should open the similarity panel
- [ ] select an image from the sample grid, click the similarity popover, and click "show similar images". This should open the similarity panel and kick off a new similarity run using the last used similarity index. 
- [ ] click the similarity popover (no selection on the grid), type in "dog" and hit enter. This should open the similarity panel and kick off a new similarity run using the last used similarity index. 
- [ ] open a sample modal, select a "predictions" label, and click similarity popover, click "show similar patches". This should go to the toPatches view first, then open the similarity panel and kick off a new similarity sort run. Click show results, it should load the correct patch search results. 
- [ ] open a sample modal, select labels from different fields, similarity popover would display warning texts. 

select label -> one click patch search:

https://github.com/user-attachments/assets/71844868-efe4-48b4-9a3c-d8fae0c4c0fc

select sample -> one click sample search:

https://github.com/user-attachments/assets/e3e7c5d9-9d12-4a02-84d9-6b63ce056955

text -> one click text search: 

https://github.com/user-attachments/assets/ef6e21aa-8b36-4165-ba7f-8352c558bdd2



## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streamlined similarity popover with simple text input and single-action buttons.
  * Per-dataset “last used” similarity key is persisted and restored automatically.
  * Search runs can auto-refresh in real time via background updates.

* **Improvements**
  * Advanced similarity controls removed for a cleaner UX; settings preserved via a single settings button.
  * Submissions block when query/input is empty or no image IDs are available.
  * Applying a run now clears prior selections for a consistent view.

* **Bug Fixes**
  * Patch-mode searches now return patch-level results when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->