### PR TITLE
add support for opening panel with initial state/data

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -150,6 +150,14 @@ class OpenPanel extends Operator {
       label: "Force (skips panel exists check)",
       default: false,
     });
+    inputs.obj("sessionState", {
+      label: "Initial session state",
+      view: new types.HiddenView({}),
+    });
+    inputs.obj("localState", {
+      label: "Initial local state",
+      view: new types.HiddenView({}),
+    });
     return new types.Property(inputs);
   }
   useHooks() {
@@ -157,7 +165,15 @@ class OpenPanel extends Operator {
     const availablePanels = usePanels();
     const { spaces } = useSpaces(FIFTYONE_GRID_SPACES_ID);
     const openedPanels = useSpaceNodes(FIFTYONE_GRID_SPACES_ID);
-    return { availablePanels, openedPanels, spaces };
+    const setPanelStateById = useSetPanelStateById();
+    const setPanelStateLocalById = useSetPanelStateById(true);
+    return {
+      availablePanels,
+      openedPanels,
+      spaces,
+      setPanelStateById,
+      setPanelStateLocalById,
+    };
   }
   findFirstPanelContainer(node: SpaceNode): SpaceNode | null {
     if (node.isPanelContainer()) {
@@ -171,8 +187,15 @@ class OpenPanel extends Operator {
     return null;
   }
   async execute({ hooks, params }: ExecutionContext) {
-    const { spaces, openedPanels, availablePanels } = hooks;
-    const { name, isActive, layout, force, forceDuplicate } = params;
+    const {
+      spaces,
+      openedPanels,
+      availablePanels,
+      setPanelStateById,
+      setPanelStateLocalById,
+    } = hooks;
+    const { name, isActive, layout, force, forceDuplicate, state, data } =
+      params;
     const targetSpace = this.findFirstPanelContainer(spaces.root);
     if (!targetSpace) {
       return console.error("No panel container found");
@@ -189,6 +212,12 @@ class OpenPanel extends Operator {
       return;
     }
     const newNode = new SpaceNode();
+    if (state) {
+      setPanelStateById(newNode.id, () => state);
+    }
+    if (data) {
+      setPanelStateLocalById(newNode.id, () => data);
+    }
     newNode.type = name;
     // add panel to the default space as an inactive panels
     spaces.addNodeAfter(targetSpace, newNode, isActive);
@@ -1714,7 +1743,6 @@ export function registerBuiltInOperators() {
     _registerBuiltInOperator(BrowserDownload);
     _registerBuiltInOperator(ClearActiveFields);
   } catch (e) {
-    console.error("Error registering built-in operators");
     console.error(e);
   }
 }

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -275,6 +275,8 @@ class Operations(object):
         layout=None,
         force=False,
         force_duplicate=False,
+        state=None,
+        data=None,
     ):
         """Open a panel with the given name and layout options in the App.
 
@@ -288,12 +290,16 @@ class Operations(object):
                 declares ``allow_multiple=False``
             force_duplicate (False): whether to force open the panel even if it
                 is already open. Only applicable if force is ``True``
+            state (None): optional initial state to set for the panel
+            data (None): optional initial data to set for the panel
         """
         params = {
             "name": name,
             "isActive": is_active,
             "force": force,
             "forceDuplicate": force_duplicate,
+            "state": state,
+            "data": data,
         }
         if layout is not None:
             params["layout"] = layout


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Add support for opening a panel with initial state/data

## 🧪 How is this patch tested? If it is not, please explain why.

Using an operator and a panel

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

See the Usage section below

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

### Usage

```py
class OpenImgVizEmbeddings(foo.Operator):
    @property
    def config(self):
        return foo.OperatorConfig(
            name="open_img_viz_embeddings",
            label="IM: Open img_viz Embeddings",
        )

    def execute(self, ctx):
        ctx.ops.open_panel(
            "Embeddings",
            state={ # state is available in fiftyone session
                "brainResult": "img_viz",
                "colorByField": "brightness",
                "pointsField": None,
            },
            data={  # data is not available in fiftyone session
                "my_local_data": "123"
            }   
        )
        return {}
```

See https://docs.voxel51.com/plugins/developing_plugins.html#panel-state-and-data for more details on when to use state vs data

#### Note: for python panels, the state and data must be set in nested state and data property as shown in example

```py
    def execute(self, ctx):
        ctx.ops.open_panel(
            "Embeddings",
            state={ # state is available in fiftyone session
                "state": {
                    "brainResult": "img_viz",
                    "colorByField": "brightness",
                    "pointsField": None,
                }
            },
            data={  # data is not available in fiftyone session
                "data": {
                    "my_local_data": "123"
                }
            }   
        )
        return {}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Panel operations now accept optional state and data parameters, enabling custom state to be passed when opening panels
  * Extended state management capabilities with support for both session and local state configurations

* **Bug Fixes**
  * Improved error handling by removing redundant logging and reporting only actual exceptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->