### PR TITLE
wire ontology SDK to ODM with save/load/delete and fo.* CRUD functions

### DIFF
--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -55,6 +55,16 @@ from .core.expressions import (
     ViewExpression,
     VALUE,
 )
+from .core.ontology import (
+    AnnotationOntology,
+    clone_ontology,
+    create_ontology,
+    delete_ontology,
+    list_ontologies,
+    load_ontology,
+    ontology_exists,
+    rename_ontology,
+)
 from .core.fields import (
     flatten_schema,
     ArrayField,

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -57,13 +57,10 @@ from .core.expressions import (
 )
 from .core.ontology import (
     AnnotationOntology,
-    clone_ontology,
-    create_ontology,
     delete_ontology,
     list_ontologies,
     load_ontology,
     ontology_exists,
-    rename_ontology,
 )
 from .core.fields import (
     flatten_schema,

--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -113,29 +113,6 @@ class Ontology(abc.ABC):
         self._doc.delete()
         self._doc = None
 
-    def rename(self, new_name: str) -> None:
-        """Renames this ontology across all versions.
-
-        Args:
-            new_name: the new ontology name
-        """
-        if self._doc is None:
-            raise ValueError(
-                "Cannot rename an ontology that has not been saved"
-            )
-
-        new_slug = fou.to_slug(new_name)
-        # Bulk update bypasses save() hooks, so we set slug explicitly so it
-        # does not drift from the new name. Pylint can't see ``objects``
-        # (dynamically attached by mongoengine).
-        OntologyDocument.objects(  # pylint: disable=no-member
-            slug=self._doc.slug
-        ).update(set__name=new_name, set__slug=new_slug)
-
-        self.name = new_name
-        self._doc.name = new_name
-        self._doc.slug = new_slug
-
     def clone(self, new_name: str) -> "Ontology":
         """Clones this ontology under a new name.
 

--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -11,6 +11,7 @@ import fnmatch
 from datetime import datetime
 from typing import Any, Optional
 
+import fiftyone.core.utils as fou
 from fiftyone.core.annotation.attributes import (
     AttributeSpec,
     attr_insert_to_dict,
@@ -279,6 +280,13 @@ def _from_doc(doc: OntologyDocument) -> Ontology:
 # ---- Module-level CRUD functions ------------------------------------------
 
 
+def _objects_by_slug(name: str):
+    """Query ``OntologyDocument`` by slug-normalized name."""
+    return OntologyDocument.objects(  # pylint: disable=no-member
+        slug=fou.to_slug(name)
+    )
+
+
 def create_ontology(ontology: Ontology) -> None:
     """Saves an ontology to the database.
 
@@ -300,11 +308,7 @@ def load_ontology(name: str) -> Ontology:
     Raises:
         ValueError: if no ontology with the given name exists
     """
-    doc = (
-        OntologyDocument.objects(name=name)  # pylint: disable=no-member
-        .order_by("-version")
-        .first()
-    )
+    doc = _objects_by_slug(name).order_by("-version").first()
     if doc is None:
         raise ValueError(f"Ontology '{name}' not found")
 
@@ -340,12 +344,7 @@ def ontology_exists(name: str) -> bool:
     Returns:
         True/False
     """
-    return (
-        OntologyDocument.objects(  # pylint: disable=no-member
-            name=name
-        ).count()
-        > 0
-    )
+    return _objects_by_slug(name).count() > 0
 
 
 def delete_ontology(name: str, force: bool = False) -> None:
@@ -359,9 +358,7 @@ def delete_ontology(name: str, force: bool = False) -> None:
             with label schema integration.
     """
     # TODO: check if in use when force=False (requires label schema integration)
-    count = OntologyDocument.objects(  # pylint: disable=no-member
-        name=name
-    ).delete()
+    count = _objects_by_slug(name).delete()
     if count == 0:
         raise ValueError(f"Ontology '{name}' not found")
 
@@ -373,9 +370,11 @@ def rename_ontology(name: str, new_name: str) -> None:
         name: the current ontology name
         new_name: the new name
     """
-    count = OntologyDocument.objects(  # pylint: disable=no-member
-        name=name
-    ).update(set__name=new_name)
+    # Bulk update bypasses save() hooks, so we must set slug explicitly —
+    # otherwise the stored slug would drift from the (now changed) name.
+    count = _objects_by_slug(name).update(
+        set__name=new_name, set__slug=fou.to_slug(new_name)
+    )
     if count == 0:
         raise ValueError(f"Ontology '{name}' not found")
 

--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -7,6 +7,7 @@ Ontology classes for defining reusable annotation and taxonomy structures.
 """
 
 import abc
+import fnmatch
 from datetime import datetime
 from typing import Any, Optional
 
@@ -14,7 +15,7 @@ from fiftyone.core.annotation.attributes import (
     AttributeSpec,
     attr_insert_to_dict,
 )
-from fiftyone.core.odm.ontology import OntologyType
+from fiftyone.core.odm.ontology import OntologyDocument, OntologyType
 
 
 class Ontology(abc.ABC):
@@ -73,6 +74,56 @@ class Ontology(abc.ABC):
             return self._doc.last_modified_at
 
         return None
+
+    def save(self) -> None:
+        """Saves this ontology to the database."""
+        if self._doc is None:
+            self._doc = OntologyDocument(
+                name=self.name,
+                type=self._TYPE,
+                description=self.description,
+                root=self._get_root(),
+            )
+        else:
+            self._doc.name = self.name
+            self._doc.description = self.description
+            self._doc.root = self._get_root()
+
+        self._doc.save()
+
+    def reload(self) -> None:
+        """Reloads this ontology from the database."""
+        if self._doc is None:
+            raise ValueError(
+                "Cannot reload an ontology that has not been saved"
+            )
+
+        self._doc.reload()
+        self._apply_doc(self._doc)
+
+    def delete(self) -> None:
+        """Deletes this ontology from the database."""
+        if self._doc is None:
+            raise ValueError(
+                "Cannot delete an ontology that has not been saved"
+            )
+
+        self._doc.delete()
+        self._doc = None
+
+    def _get_root(self) -> Any:
+        """Returns the serialized root data for storage.
+
+        Subclasses must implement this.
+        """
+        raise NotImplementedError
+
+    def _apply_doc(self, doc: OntologyDocument) -> None:
+        """Hydrates this instance from a loaded document.
+
+        Subclasses must implement this.
+        """
+        raise NotImplementedError
 
     def to_dict(self) -> dict:
         """Serializes this ontology to a dict.
@@ -161,6 +212,20 @@ class AnnotationOntology(Ontology):
         self.taxonomies = taxonomies or []
         self.attributes = attributes or []
 
+    def _get_root(self) -> dict:
+        return {
+            "taxonomies": self.taxonomies,
+            "attributes": [attr.to_dict() for attr in self.attributes],
+        }
+
+    def _apply_doc(self, doc: OntologyDocument) -> None:
+        self.name = doc.name
+        self.description = doc.description
+        self.taxonomies = doc.root.get("taxonomies", [])
+        self.attributes = [
+            AttributeSpec.from_dict(a) for a in doc.root.get("attributes", [])
+        ]
+
     def to_dict(self) -> dict:
         """Serializes this annotation ontology to a dict.
 
@@ -168,10 +233,7 @@ class AnnotationOntology(Ontology):
             a dict
         """
         d = super().to_dict()
-        d["root"] = {
-            "taxonomies": self.taxonomies,
-            "attributes": [attr.to_dict() for attr in self.attributes],
-        }
+        d["root"] = self._get_root()
         return d
 
     @classmethod
@@ -193,3 +255,145 @@ class AnnotationOntology(Ontology):
                 AttributeSpec.from_dict(a) for a in root.get("attributes", [])
             ],
         )
+# ---- Type dispatch --------------------------------------------------------
+
+_TYPE_TO_CLS: dict[str, type[Ontology]] = {
+    OntologyType.ANNOTATION_ONTOLOGY.value: AnnotationOntology,
+}
+
+
+def _from_doc(doc: OntologyDocument) -> Ontology:
+    """Constructs the appropriate SDK class from an ODM document."""
+    cls = _TYPE_TO_CLS.get(doc.type)
+    if cls is None:
+        raise ValueError(f"Unknown ontology type: {doc.type!r}")
+
+    root = doc.root or {}
+    instance = cls.__new__(cls)
+    Ontology.__init__(instance, name=doc.name, description=doc.description)
+    instance._doc = doc
+    instance._apply_doc(doc)
+    return instance
+
+
+# ---- Module-level CRUD functions ------------------------------------------
+
+
+def create_ontology(ontology: Ontology) -> None:
+    """Saves an ontology to the database.
+
+    Args:
+        ontology: an :class:`Ontology` instance
+    """
+    ontology.save()
+
+
+def load_ontology(name: str) -> Ontology:
+    """Loads the latest version of an ontology by name.
+
+    Args:
+        name: the ontology name
+
+    Returns:
+        an :class:`Ontology`
+
+    Raises:
+        ValueError: if no ontology with the given name exists
+    """
+    doc = (
+        OntologyDocument.objects(name=name)  # pylint: disable=no-member
+        .order_by("-version")
+        .first()
+    )
+    if doc is None:
+        raise ValueError(f"Ontology '{name}' not found")
+
+    return _from_doc(doc)
+
+
+def list_ontologies(glob_patt: Optional[str] = None) -> list[str]:
+    """Lists ontology names in the database.
+
+    Args:
+        glob_patt: an optional glob pattern to filter names
+
+    Returns:
+        a sorted list of ontology names
+    """
+    if glob_patt is not None:
+        regex = fnmatch.translate(glob_patt)
+        docs = OntologyDocument.objects(  # pylint: disable=no-member
+            name__regex=regex
+        )
+    else:
+        docs = OntologyDocument.objects()  # pylint: disable=no-member
+
+    return sorted(docs.distinct("name"))
+
+
+def ontology_exists(name: str) -> bool:
+    """Checks if an ontology with the given name exists.
+
+    Args:
+        name: the ontology name
+
+    Returns:
+        True/False
+    """
+    return (
+        OntologyDocument.objects(  # pylint: disable=no-member
+            name=name
+        ).count()
+        > 0
+    )
+
+
+def delete_ontology(name: str, force: bool = False) -> None:
+    """Deletes an ontology and all its versions from the database.
+
+    Args:
+        name: the ontology name
+        force: whether to delete even if the ontology is in use.
+            By default, raises an error if the ontology is referenced
+            by a label schema. Not yet enforced — will be implemented
+            with label schema integration.
+    """
+    # TODO: check if in use when force=False (requires label schema integration)
+    count = OntologyDocument.objects(  # pylint: disable=no-member
+        name=name
+    ).delete()
+    if count == 0:
+        raise ValueError(f"Ontology '{name}' not found")
+
+
+def rename_ontology(name: str, new_name: str) -> None:
+    """Renames an ontology (all versions).
+
+    Args:
+        name: the current ontology name
+        new_name: the new name
+    """
+    count = OntologyDocument.objects(  # pylint: disable=no-member
+        name=name
+    ).update(set__name=new_name)
+    if count == 0:
+        raise ValueError(f"Ontology '{name}' not found")
+
+
+def clone_ontology(name: str, new_name: str) -> Ontology:
+    """Clones an ontology under a new name.
+
+    Loads the latest version and saves it as a new ontology.
+
+    Args:
+        name: the source ontology name
+        new_name: the name for the clone
+
+    Returns:
+        the cloned :class:`Ontology`
+    """
+    source = load_ontology(name)
+    source.name = new_name
+    source._doc = None
+    source.save()
+    return source

--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -7,6 +7,7 @@ Ontology classes for defining reusable annotation and taxonomy structures.
 """
 
 import abc
+import copy
 import fnmatch
 from datetime import datetime
 from typing import Any, Optional
@@ -111,6 +112,44 @@ class Ontology(abc.ABC):
 
         self._doc.delete()
         self._doc = None
+
+    def rename(self, new_name: str) -> None:
+        """Renames this ontology across all versions.
+
+        Args:
+            new_name: the new ontology name
+        """
+        if self._doc is None:
+            raise ValueError(
+                "Cannot rename an ontology that has not been saved"
+            )
+
+        new_slug = fou.to_slug(new_name)
+        # Bulk update bypasses save() hooks, so we set slug explicitly so it
+        # does not drift from the new name. Pylint can't see ``objects``
+        # (dynamically attached by mongoengine).
+        OntologyDocument.objects(  # pylint: disable=no-member
+            slug=self._doc.slug
+        ).update(set__name=new_name, set__slug=new_slug)
+
+        self.name = new_name
+        self._doc.name = new_name
+        self._doc.slug = new_slug
+
+    def clone(self, new_name: str) -> "Ontology":
+        """Clones this ontology under a new name.
+
+        Args:
+            new_name: the name for the clone
+
+        Returns:
+            the cloned :class:`Ontology`
+        """
+        cloned = copy.deepcopy(self)
+        cloned.name = new_name
+        cloned._doc = None
+        cloned.save()
+        return cloned
 
     def _get_root(self) -> Any:
         """Returns the serialized root data for storage.
@@ -287,15 +326,6 @@ def _objects_by_slug(name: str):
     )
 
 
-def create_ontology(ontology: Ontology) -> None:
-    """Saves an ontology to the database.
-
-    Args:
-        ontology: an :class:`Ontology` instance
-    """
-    ontology.save()
-
-
 def load_ontology(name: str) -> Ontology:
     """Loads the latest version of an ontology by name.
 
@@ -361,38 +391,3 @@ def delete_ontology(name: str, force: bool = False) -> None:
     count = _objects_by_slug(name).delete()
     if count == 0:
         raise ValueError(f"Ontology '{name}' not found")
-
-
-def rename_ontology(name: str, new_name: str) -> None:
-    """Renames an ontology (all versions).
-
-    Args:
-        name: the current ontology name
-        new_name: the new name
-    """
-    # Bulk update bypasses save() hooks, so we must set slug explicitly —
-    # otherwise the stored slug would drift from the (now changed) name.
-    count = _objects_by_slug(name).update(
-        set__name=new_name, set__slug=fou.to_slug(new_name)
-    )
-    if count == 0:
-        raise ValueError(f"Ontology '{name}' not found")
-
-
-def clone_ontology(name: str, new_name: str) -> Ontology:
-    """Clones an ontology under a new name.
-
-    Loads the latest version and saves it as a new ontology.
-
-    Args:
-        name: the source ontology name
-        new_name: the name for the clone
-
-    Returns:
-        the cloned :class:`Ontology`
-    """
-    source = load_ontology(name)
-    source.name = new_name
-    source._doc = None
-    source.save()
-    return source

--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -8,11 +8,12 @@ Ontology classes for defining reusable annotation and taxonomy structures.
 
 from __future__ import annotations
 
+import fnmatch
 from datetime import datetime
 from typing import Any, Optional
 
 from fiftyone.core.annotation.attributes import Attribute
-from fiftyone.core.odm.ontology import OntologyType
+from fiftyone.core.odm.ontology import OntologyDocument, OntologyType
 
 
 class Ontology:
@@ -67,6 +68,56 @@ class Ontology:
             return self._doc.last_modified_at
 
         return None
+
+    def save(self) -> None:
+        """Saves this ontology to the database."""
+        if self._doc is None:
+            self._doc = OntologyDocument(
+                name=self.name,
+                type=self._TYPE,
+                description=self.description,
+                root=self._get_root(),
+            )
+        else:
+            self._doc.name = self.name
+            self._doc.description = self.description
+            self._doc.root = self._get_root()
+
+        self._doc.save()
+
+    def reload(self) -> None:
+        """Reloads this ontology from the database."""
+        if self._doc is None:
+            raise ValueError(
+                "Cannot reload an ontology that has not been saved"
+            )
+
+        self._doc.reload()
+        self._apply_doc(self._doc)
+
+    def delete(self) -> None:
+        """Deletes this ontology from the database."""
+        if self._doc is None:
+            raise ValueError(
+                "Cannot delete an ontology that has not been saved"
+            )
+
+        self._doc.delete()
+        self._doc = None
+
+    def _get_root(self) -> Any:
+        """Returns the serialized root data for storage.
+
+        Subclasses must implement this.
+        """
+        raise NotImplementedError
+
+    def _apply_doc(self, doc: OntologyDocument) -> None:
+        """Hydrates this instance from a loaded document.
+
+        Subclasses must implement this.
+        """
+        raise NotImplementedError
 
     def to_dict(self) -> dict:
         """Serializes this ontology to a dict.
@@ -149,6 +200,20 @@ class AnnotationOntology(Ontology):
         self.taxonomies = taxonomies or []
         self.attributes = attributes or []
 
+    def _get_root(self) -> dict:
+        return {
+            "taxonomies": self.taxonomies,
+            "attributes": [attr.to_dict() for attr in self.attributes],
+        }
+
+    def _apply_doc(self, doc: OntologyDocument) -> None:
+        self.name = doc.name
+        self.description = doc.description
+        self.taxonomies = doc.root.get("taxonomies", [])
+        self.attributes = [
+            Attribute.from_dict(a) for a in doc.root.get("attributes", [])
+        ]
+
     def to_dict(self) -> dict:
         """Serializes this annotation ontology to a dict.
 
@@ -156,10 +221,7 @@ class AnnotationOntology(Ontology):
             a dict
         """
         d = super().to_dict()
-        d["root"] = {
-            "taxonomies": self.taxonomies,
-            "attributes": [attr.to_dict() for attr in self.attributes],
-        }
+        d["root"] = self._get_root()
         return d
 
     @classmethod
@@ -221,3 +283,147 @@ class Taxonomy(Ontology):
             "Taxonomy is not yet implemented; taxonomy support is planned "
             "for phase 2"
         )
+
+
+# ---- Type dispatch --------------------------------------------------------
+
+_TYPE_TO_CLS: dict[str, type[Ontology]] = {
+    OntologyType.ANNOTATION_ONTOLOGY.value: AnnotationOntology,
+}
+
+
+def _from_doc(doc: OntologyDocument) -> Ontology:
+    """Constructs the appropriate SDK class from an ODM document."""
+    cls = _TYPE_TO_CLS.get(doc.type)
+    if cls is None:
+        raise ValueError(f"Unknown ontology type: {doc.type!r}")
+
+    root = doc.root or {}
+    instance = cls.__new__(cls)
+    Ontology.__init__(instance, name=doc.name, description=doc.description)
+    instance._doc = doc
+    instance._apply_doc(doc)
+    return instance
+
+
+# ---- Module-level CRUD functions ------------------------------------------
+
+
+def create_ontology(ontology: Ontology) -> None:
+    """Saves an ontology to the database.
+
+    Args:
+        ontology: an :class:`Ontology` instance
+    """
+    ontology.save()
+
+
+def load_ontology(name: str) -> Ontology:
+    """Loads the latest version of an ontology by name.
+
+    Args:
+        name: the ontology name
+
+    Returns:
+        an :class:`Ontology`
+
+    Raises:
+        ValueError: if no ontology with the given name exists
+    """
+    doc = (
+        OntologyDocument.objects(name=name)  # pylint: disable=no-member
+        .order_by("-version")
+        .first()
+    )
+    if doc is None:
+        raise ValueError(f"Ontology '{name}' not found")
+
+    return _from_doc(doc)
+
+
+def list_ontologies(glob_patt: Optional[str] = None) -> list[str]:
+    """Lists ontology names in the database.
+
+    Args:
+        glob_patt: an optional glob pattern to filter names
+
+    Returns:
+        a sorted list of ontology names
+    """
+    if glob_patt is not None:
+        regex = fnmatch.translate(glob_patt)
+        docs = OntologyDocument.objects(  # pylint: disable=no-member
+            name__regex=regex
+        )
+    else:
+        docs = OntologyDocument.objects()  # pylint: disable=no-member
+
+    return sorted(docs.distinct("name"))
+
+
+def ontology_exists(name: str) -> bool:
+    """Checks if an ontology with the given name exists.
+
+    Args:
+        name: the ontology name
+
+    Returns:
+        True/False
+    """
+    return (
+        OntologyDocument.objects(  # pylint: disable=no-member
+            name=name
+        ).count()
+        > 0
+    )
+
+
+def delete_ontology(name: str, force: bool = False) -> None:
+    """Deletes an ontology and all its versions from the database.
+
+    Args:
+        name: the ontology name
+        force: whether to delete even if the ontology is in use.
+            By default, raises an error if the ontology is referenced
+            by a label schema. Not yet enforced — will be implemented
+            with label schema integration.
+    """
+    # TODO: check if in use when force=False (requires label schema integration)
+    count = OntologyDocument.objects(  # pylint: disable=no-member
+        name=name
+    ).delete()
+    if count == 0:
+        raise ValueError(f"Ontology '{name}' not found")
+
+
+def rename_ontology(name: str, new_name: str) -> None:
+    """Renames an ontology (all versions).
+
+    Args:
+        name: the current ontology name
+        new_name: the new name
+    """
+    count = OntologyDocument.objects(  # pylint: disable=no-member
+        name=name
+    ).update(set__name=new_name)
+    if count == 0:
+        raise ValueError(f"Ontology '{name}' not found")
+
+
+def clone_ontology(name: str, new_name: str) -> Ontology:
+    """Clones an ontology under a new name.
+
+    Loads the latest version and saves it as a new ontology.
+
+    Args:
+        name: the source ontology name
+        new_name: the name for the clone
+
+    Returns:
+        the cloned :class:`Ontology`
+    """
+    source = load_ontology(name)
+    source.name = new_name
+    source._doc = None
+    source.save()
+    return source

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -439,5 +439,182 @@ class AnnotationOntologyTests(unittest.TestCase):
         )
 
 
+class OntologySDKTests(unittest.TestCase):
+    """Integration tests that hit MongoDB."""
+
+    def setUp(self):
+        import fiftyone.core.odm as foo
+
+        db = foo.get_db_conn()
+        db.drop_collection("ontologies")
+
+        from fiftyone.core.odm.ontology import OntologyDocument
+
+        OntologyDocument.ensure_indexes()
+
+    def tearDown(self):
+        import fiftyone.core.odm as foo
+
+        db = foo.get_db_conn()
+        db.drop_collection("ontologies")
+
+    def _make_ontology(
+        self, name: str = "test_ontology"
+    ) -> AnnotationOntology:
+        return AnnotationOntology(
+            name=name,
+            description="Test annotation ontology",
+            taxonomies=["vehicle_classes"],
+            attributes=[
+                AttributeSpec(
+                    name="damage_present",
+                    type="bool",
+                    component="checkbox",
+                ),
+                AttributeSpec(
+                    name="damage_location",
+                    type="str",
+                    component="dropdown",
+                    values=["front", "rear"],
+                    when=[
+                        When(
+                            WhenOperator.EQUALS,
+                            field="damage_present",
+                            value=True,
+                        )
+                    ],
+                ),
+            ],
+        )
+
+    def test_save_and_load(self):
+        from fiftyone.core.ontology import create_ontology, load_ontology
+
+        ao = self._make_ontology()
+        create_ontology(ao)
+
+        self.assertIsNotNone(ao.version)
+        self.assertIsNotNone(ao.created_at)
+
+        loaded = load_ontology("test_ontology")
+        self.assertEqual(loaded.name, "test_ontology")
+        self.assertEqual(loaded.description, "Test annotation ontology")
+        self.assertEqual(loaded.taxonomies, ["vehicle_classes"])
+        self.assertEqual(len(loaded.attributes), 2)
+        self.assertEqual(loaded.attributes[0].name, "damage_present")
+        self.assertEqual(loaded.attributes[1].when[0].field, "damage_present")
+
+    def test_save_and_reload(self):
+        ao = self._make_ontology()
+        ao.save()
+
+        ao.description = "updated"
+        ao.reload()
+
+        self.assertEqual(ao.description, "Test annotation ontology")
+
+    def test_delete(self):
+        from fiftyone.core.ontology import delete_ontology, load_ontology
+
+        ao = self._make_ontology()
+        ao.save()
+
+        ao.delete()
+        self.assertIsNone(ao._doc)
+
+        with self.assertRaises(ValueError):
+            load_ontology("test_ontology")
+
+    def test_delete_via_function(self):
+        from fiftyone.core.ontology import delete_ontology, ontology_exists
+
+        ao = self._make_ontology()
+        ao.save()
+
+        delete_ontology("test_ontology")
+        self.assertFalse(ontology_exists("test_ontology"))
+
+    def test_delete_nonexistent_raises(self):
+        from fiftyone.core.ontology import delete_ontology
+
+        with self.assertRaises(ValueError):
+            delete_ontology("nonexistent")
+
+    def test_list_ontologies(self):
+        from fiftyone.core.ontology import list_ontologies
+
+        self._make_ontology("alpha").save()
+        self._make_ontology("beta").save()
+        self._make_ontology("gamma").save()
+
+        names = list_ontologies()
+        self.assertEqual(names, ["alpha", "beta", "gamma"])
+
+    def test_list_ontologies_glob(self):
+        from fiftyone.core.ontology import list_ontologies
+
+        self._make_ontology("vehicle_damage").save()
+        self._make_ontology("vehicle_classes").save()
+        self._make_ontology("person_attributes").save()
+
+        names = list_ontologies("vehicle_*")
+        self.assertEqual(names, ["vehicle_classes", "vehicle_damage"])
+
+    def test_ontology_exists(self):
+        from fiftyone.core.ontology import ontology_exists
+
+        self.assertFalse(ontology_exists("test_ontology"))
+
+        self._make_ontology().save()
+        self.assertTrue(ontology_exists("test_ontology"))
+
+    def test_load_nonexistent_raises(self):
+        from fiftyone.core.ontology import load_ontology
+
+        with self.assertRaises(ValueError):
+            load_ontology("nonexistent")
+
+    def test_rename_ontology(self):
+        from fiftyone.core.ontology import (
+            load_ontology,
+            ontology_exists,
+            rename_ontology,
+        )
+
+        self._make_ontology("old_name").save()
+
+        rename_ontology("old_name", "new_name")
+
+        self.assertFalse(ontology_exists("old_name"))
+        loaded = load_ontology("new_name")
+        self.assertEqual(loaded.name, "new_name")
+        self.assertEqual(len(loaded.attributes), 2)
+
+    def test_rename_nonexistent_raises(self):
+        from fiftyone.core.ontology import rename_ontology
+
+        with self.assertRaises(ValueError):
+            rename_ontology("nonexistent", "new_name")
+
+    def test_clone_ontology(self):
+        from fiftyone.core.ontology import (
+            clone_ontology,
+            load_ontology,
+            ontology_exists,
+        )
+
+        self._make_ontology("original").save()
+
+        cloned = clone_ontology("original", "cloned")
+
+        self.assertTrue(ontology_exists("original"))
+        self.assertTrue(ontology_exists("cloned"))
+        self.assertEqual(cloned.name, "cloned")
+        self.assertEqual(len(cloned.attributes), 2)
+
+        original = load_ontology("original")
+        self.assertEqual(original.name, "original")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -488,10 +488,10 @@ class OntologySDKTests(unittest.TestCase):
         )
 
     def test_save_and_load(self):
-        from fiftyone.core.ontology import create_ontology, load_ontology
+        from fiftyone.core.ontology import load_ontology
 
         ao = self._make_ontology()
-        create_ontology(ao)
+        ao.save()
 
         self.assertIsNotNone(ao.version)
         self.assertIsNotNone(ao.created_at)
@@ -574,38 +574,32 @@ class OntologySDKTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             load_ontology("nonexistent")
 
-    def test_rename_ontology(self):
-        from fiftyone.core.ontology import (
-            load_ontology,
-            ontology_exists,
-            rename_ontology,
-        )
+    def test_rename(self):
+        from fiftyone.core.ontology import load_ontology, ontology_exists
 
-        self._make_ontology("old_name").save()
+        ao = self._make_ontology("old_name")
+        ao.save()
 
-        rename_ontology("old_name", "new_name")
+        ao.rename("new_name")
 
+        self.assertEqual(ao.name, "new_name")
         self.assertFalse(ontology_exists("old_name"))
         loaded = load_ontology("new_name")
         self.assertEqual(loaded.name, "new_name")
         self.assertEqual(len(loaded.attributes), 2)
 
-    def test_rename_nonexistent_raises(self):
-        from fiftyone.core.ontology import rename_ontology
-
+    def test_rename_unsaved_raises(self):
+        ao = self._make_ontology()
         with self.assertRaises(ValueError):
-            rename_ontology("nonexistent", "new_name")
+            ao.rename("new_name")
 
-    def test_clone_ontology(self):
-        from fiftyone.core.ontology import (
-            clone_ontology,
-            load_ontology,
-            ontology_exists,
-        )
+    def test_clone(self):
+        from fiftyone.core.ontology import load_ontology, ontology_exists
 
-        self._make_ontology("original").save()
+        ao = self._make_ontology("original")
+        ao.save()
 
-        cloned = clone_ontology("original", "cloned")
+        cloned = ao.clone("cloned")
 
         self.assertTrue(ontology_exists("original"))
         self.assertTrue(ontology_exists("cloned"))

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -574,25 +574,6 @@ class OntologySDKTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             load_ontology("nonexistent")
 
-    def test_rename(self):
-        from fiftyone.core.ontology import load_ontology, ontology_exists
-
-        ao = self._make_ontology("old_name")
-        ao.save()
-
-        ao.rename("new_name")
-
-        self.assertEqual(ao.name, "new_name")
-        self.assertFalse(ontology_exists("old_name"))
-        loaded = load_ontology("new_name")
-        self.assertEqual(loaded.name, "new_name")
-        self.assertEqual(len(loaded.attributes), 2)
-
-    def test_rename_unsaved_raises(self):
-        ao = self._make_ontology()
-        with self.assertRaises(ValueError):
-            ao.rename("new_name")
-
     def test_clone(self):
         from fiftyone.core.ontology import load_ontology, ontology_exists
 

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -333,5 +333,182 @@ class AnnotationOntologyTests(unittest.TestCase):
         )
 
 
+class OntologySDKTests(unittest.TestCase):
+    """Integration tests that hit MongoDB."""
+
+    def setUp(self):
+        import fiftyone.core.odm as foo
+
+        db = foo.get_db_conn()
+        db.drop_collection("ontologies")
+
+        from fiftyone.core.odm.ontology import OntologyDocument
+
+        OntologyDocument.ensure_indexes()
+
+    def tearDown(self):
+        import fiftyone.core.odm as foo
+
+        db = foo.get_db_conn()
+        db.drop_collection("ontologies")
+
+    def _make_ontology(
+        self, name: str = "test_ontology"
+    ) -> AnnotationOntology:
+        return AnnotationOntology(
+            name=name,
+            description="Test annotation ontology",
+            taxonomies=["vehicle_classes"],
+            attributes=[
+                Attribute(
+                    name="damage_present",
+                    type="bool",
+                    component="checkbox",
+                ),
+                Attribute(
+                    name="damage_location",
+                    type="str",
+                    component="dropdown",
+                    values=["front", "rear"],
+                    when=[
+                        When(
+                            WhenOperator.EQUALS,
+                            field="damage_present",
+                            value=True,
+                        )
+                    ],
+                ),
+            ],
+        )
+
+    def test_save_and_load(self):
+        from fiftyone.core.ontology import create_ontology, load_ontology
+
+        ao = self._make_ontology()
+        create_ontology(ao)
+
+        self.assertIsNotNone(ao.version)
+        self.assertIsNotNone(ao.created_at)
+
+        loaded = load_ontology("test_ontology")
+        self.assertEqual(loaded.name, "test_ontology")
+        self.assertEqual(loaded.description, "Test annotation ontology")
+        self.assertEqual(loaded.taxonomies, ["vehicle_classes"])
+        self.assertEqual(len(loaded.attributes), 2)
+        self.assertEqual(loaded.attributes[0].name, "damage_present")
+        self.assertEqual(loaded.attributes[1].when[0].field, "damage_present")
+
+    def test_save_and_reload(self):
+        ao = self._make_ontology()
+        ao.save()
+
+        ao.description = "updated"
+        ao.reload()
+
+        self.assertEqual(ao.description, "Test annotation ontology")
+
+    def test_delete(self):
+        from fiftyone.core.ontology import delete_ontology, load_ontology
+
+        ao = self._make_ontology()
+        ao.save()
+
+        ao.delete()
+        self.assertIsNone(ao._doc)
+
+        with self.assertRaises(ValueError):
+            load_ontology("test_ontology")
+
+    def test_delete_via_function(self):
+        from fiftyone.core.ontology import delete_ontology, ontology_exists
+
+        ao = self._make_ontology()
+        ao.save()
+
+        delete_ontology("test_ontology")
+        self.assertFalse(ontology_exists("test_ontology"))
+
+    def test_delete_nonexistent_raises(self):
+        from fiftyone.core.ontology import delete_ontology
+
+        with self.assertRaises(ValueError):
+            delete_ontology("nonexistent")
+
+    def test_list_ontologies(self):
+        from fiftyone.core.ontology import list_ontologies
+
+        self._make_ontology("alpha").save()
+        self._make_ontology("beta").save()
+        self._make_ontology("gamma").save()
+
+        names = list_ontologies()
+        self.assertEqual(names, ["alpha", "beta", "gamma"])
+
+    def test_list_ontologies_glob(self):
+        from fiftyone.core.ontology import list_ontologies
+
+        self._make_ontology("vehicle_damage").save()
+        self._make_ontology("vehicle_classes").save()
+        self._make_ontology("person_attributes").save()
+
+        names = list_ontologies("vehicle_*")
+        self.assertEqual(names, ["vehicle_classes", "vehicle_damage"])
+
+    def test_ontology_exists(self):
+        from fiftyone.core.ontology import ontology_exists
+
+        self.assertFalse(ontology_exists("test_ontology"))
+
+        self._make_ontology().save()
+        self.assertTrue(ontology_exists("test_ontology"))
+
+    def test_load_nonexistent_raises(self):
+        from fiftyone.core.ontology import load_ontology
+
+        with self.assertRaises(ValueError):
+            load_ontology("nonexistent")
+
+    def test_rename_ontology(self):
+        from fiftyone.core.ontology import (
+            load_ontology,
+            ontology_exists,
+            rename_ontology,
+        )
+
+        self._make_ontology("old_name").save()
+
+        rename_ontology("old_name", "new_name")
+
+        self.assertFalse(ontology_exists("old_name"))
+        loaded = load_ontology("new_name")
+        self.assertEqual(loaded.name, "new_name")
+        self.assertEqual(len(loaded.attributes), 2)
+
+    def test_rename_nonexistent_raises(self):
+        from fiftyone.core.ontology import rename_ontology
+
+        with self.assertRaises(ValueError):
+            rename_ontology("nonexistent", "new_name")
+
+    def test_clone_ontology(self):
+        from fiftyone.core.ontology import (
+            clone_ontology,
+            load_ontology,
+            ontology_exists,
+        )
+
+        self._make_ontology("original").save()
+
+        cloned = clone_ontology("original", "cloned")
+
+        self.assertTrue(ontology_exists("original"))
+        self.assertTrue(ontology_exists("cloned"))
+        self.assertEqual(cloned.name, "cloned")
+        self.assertEqual(len(cloned.attributes), 2)
+
+        original = load_ontology("original")
+        self.assertEqual(original.name, "original")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 🔗 Related Issues
https://github.com/voxel51/fiftyone/pull/7341

## 📋 What changes are proposed in this pull request?

- Ontology base: save(), reload(), delete() with _get_root/_apply_doc hooks
- AnnotationOntology: implements persistence hooks
- Module-level: create_ontology, load_ontology, list_ontologies, ontology_exists, delete_ontology, rename_ontology, clone_ontology


## 🧪 How is this patch tested? If it is not, please explain why.

Using this script, you can run the full workflow of current ontology SDKs
[demo_ontology_sdk.py](https://github.com/user-attachments/files/26676403/demo_ontology_sdk.py)

This is tested locally and in my ephem environment. Alongside unit tests

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

add support for ontology objects to the SDK. 

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ontologies can now be persisted to and loaded from the database with full state preservation.
  * New public API for comprehensive ontology management: load by name, list available ontologies, check existence, delete, and clone with custom names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->