### PR TITLE
[SSP] bugfix and UI improvements

### DIFF
--- a/app/packages/core/src/components/Actions/Similarity/constants.ts
+++ b/app/packages/core/src/components/Actions/Similarity/constants.ts
@@ -1,4 +1,12 @@
-// Duplicated from @fiftyone/similarity-search/constants to avoid
+// Duplicated from @fiftyone/similarity-search to avoid
 // a cross-package dependency (core does not depend on similarity-search)
 export const SEARCH_OPERATOR_URI = "@voxel51/panels/similarity_search";
 export const PANEL_NAME = "similarity_search_panel";
+
+// Query type values (mirrors QueryType enum in similarity-search)
+export const QUERY_TYPE_IMAGE = "image" as const;
+export const QUERY_TYPE_TEXT = "text" as const;
+
+// Search scope values (mirrors SearchScope type in similarity-search)
+export const SCOPE_VIEW = "view" as const;
+export const SCOPE_DATASET = "dataset" as const;

--- a/app/packages/core/src/components/Actions/Similarity/useSimilarityPopover.ts
+++ b/app/packages/core/src/components/Actions/Similarity/useSimilarityPopover.ts
@@ -3,7 +3,13 @@ import * as fos from "@fiftyone/state";
 import { useBrowserStorage } from "@fiftyone/state";
 import { useCallback, useMemo, useState } from "react";
 import { useRecoilCallback, useRecoilValue } from "recoil";
-import { PANEL_NAME, SEARCH_OPERATOR_URI } from "./constants";
+import {
+  PANEL_NAME,
+  QUERY_TYPE_IMAGE,
+  QUERY_TYPE_TEXT,
+  SCOPE_VIEW,
+  SEARCH_OPERATOR_URI,
+} from "./constants";
 import {
   availableSimilarityKeys,
   buildRunName,
@@ -110,11 +116,12 @@ export default function useSimilarityPopover({
 
         const params: Record<string, unknown> = {
           brain_key: resolvedBrainKey,
-          query_type: isImageSearch ? "image" : "text",
+          query_type: isImageSearch ? QUERY_TYPE_IMAGE : QUERY_TYPE_TEXT,
           query: isImageSearch ? queryIds : textQuery.trim(),
           reverse: false,
           k: DEFAULT_K,
           run_name: runName,
+          search_scope: SCOPE_VIEW,
         };
         if (patchesField) {
           params.patches_field = patchesField;

--- a/app/packages/core/src/components/Actions/Similarity/utils.ts
+++ b/app/packages/core/src/components/Actions/Similarity/utils.ts
@@ -174,16 +174,21 @@ export function buildRunName({
   patchesField?: string;
 }): string {
   if (!isImageSearch) {
-    return `Text: "${textQuery}"`;
+    return textQuery.trim();
   }
 
-  const positiveCount = Array.isArray(queryIds) ? queryIds.length : 1;
-  const negativeCount = negativeQueryIds?.length ?? 0;
-  const unit = patchesField ? "patches" : "samples";
+  const count = Array.isArray(queryIds) ? queryIds.length : 1;
+  const negCount = negativeQueryIds?.length ?? 0;
+  const unit = patchesField ? "patch" : "sample";
+  const pluralize = (n: number, u: string) =>
+    `${n} ${n === 1 ? u : u + (u === "patch" ? "es" : "s")}`;
 
-  if (negativeCount > 0) {
-    return `Image: ${positiveCount} prompt(s), ${negativeCount} negative`;
+  if (negCount > 0) {
+    return `${pluralize(count, unit)} positive, ${pluralize(
+      negCount,
+      unit
+    )} negative`;
   }
 
-  return `Image: ${positiveCount} ${unit}`;
+  return pluralize(count, unit);
 }

--- a/app/packages/core/src/components/Actions/Similarity/utils.ts
+++ b/app/packages/core/src/components/Actions/Similarity/utils.ts
@@ -160,45 +160,5 @@ export const sortType = selectorFamily<string, boolean>({
     },
 });
 
-const pluralizeUnit = (n: number, u: string) =>
-  `${n} ${n === 1 ? u : u + (u === "patch" ? "es" : "s")}`;
-
-export function buildRunName({
-  isImageSearch,
-  isUpload,
-  textQuery,
-  queryIds,
-  negativeQueryIds,
-  patchesField,
-  hasUploadedImage,
-}: {
-  isImageSearch: boolean;
-  isUpload?: boolean;
-  textQuery?: string;
-  queryIds?: string[] | string;
-  negativeQueryIds?: string[];
-  patchesField?: string;
-  hasUploadedImage?: boolean;
-}): string {
-  if (isUpload) {
-    const count = hasUploadedImage ? 1 : 0;
-    return `${count} ${count === 1 ? "image" : "images"}`;
-  }
-
-  if (!isImageSearch) {
-    return textQuery?.trim() || "text query";
-  }
-
-  const count = Array.isArray(queryIds) ? queryIds.length : queryIds ? 1 : 0;
-  const negCount = negativeQueryIds?.length ?? 0;
-  const unit = patchesField ? "patch" : "sample";
-
-  if (negCount > 0) {
-    return `${pluralizeUnit(count, unit)} positive, ${pluralizeUnit(
-      negCount,
-      unit
-    )} negative`;
-  }
-
-  return pluralizeUnit(count, unit);
-}
+// Re-export from utilities so existing callers within core still work.
+export { buildSimilarityRunName as buildRunName } from "@fiftyone/utilities";

--- a/app/packages/core/src/components/Actions/Similarity/utils.ts
+++ b/app/packages/core/src/components/Actions/Similarity/utils.ts
@@ -160,35 +160,45 @@ export const sortType = selectorFamily<string, boolean>({
     },
 });
 
+const pluralizeUnit = (n: number, u: string) =>
+  `${n} ${n === 1 ? u : u + (u === "patch" ? "es" : "s")}`;
+
 export function buildRunName({
   isImageSearch,
+  isUpload,
   textQuery,
   queryIds,
   negativeQueryIds,
   patchesField,
+  hasUploadedImage,
 }: {
   isImageSearch: boolean;
-  textQuery: string;
-  queryIds: string[] | string | undefined;
+  isUpload?: boolean;
+  textQuery?: string;
+  queryIds?: string[] | string;
   negativeQueryIds?: string[];
   patchesField?: string;
+  hasUploadedImage?: boolean;
 }): string {
-  if (!isImageSearch) {
-    return textQuery.trim();
+  if (isUpload) {
+    const count = hasUploadedImage ? 1 : 0;
+    return `${count} ${count === 1 ? "image" : "images"}`;
   }
 
-  const count = Array.isArray(queryIds) ? queryIds.length : 1;
+  if (!isImageSearch) {
+    return textQuery?.trim() || "text query";
+  }
+
+  const count = Array.isArray(queryIds) ? queryIds.length : queryIds ? 1 : 0;
   const negCount = negativeQueryIds?.length ?? 0;
   const unit = patchesField ? "patch" : "sample";
-  const pluralize = (n: number, u: string) =>
-    `${n} ${n === 1 ? u : u + (u === "patch" ? "es" : "s")}`;
 
   if (negCount > 0) {
-    return `${pluralize(count, unit)} positive, ${pluralize(
+    return `${pluralizeUnit(count, unit)} positive, ${pluralizeUnit(
       negCount,
       unit
     )} negative`;
   }
 
-  return pluralize(count, unit);
+  return pluralizeUnit(count, unit);
 }

--- a/app/packages/similarity-search/src/__tests__/utils.test.ts
+++ b/app/packages/similarity-search/src/__tests__/utils.test.ts
@@ -299,25 +299,31 @@ describe("buildExecutionParams", () => {
     expect(params.run_name).toBe("My search");
   });
 
-  it("includes source_view when searching within view", () => {
-    const viewStages = [{ _cls: "FilterField" }];
+  it("sets search_scope to 'view' when searching within view", () => {
     const params = buildExecutionParams({
       ...baseInput,
       searchScope: "view",
       hasView: true,
-      view: viewStages,
+      view: [{ _cls: "FilterField" }],
     });
-    expect(params.source_view).toEqual(viewStages);
+    expect(params.search_scope).toBe("view");
+    expect(params.source_view).toBeUndefined();
   });
 
-  it("excludes source_view when searching full dataset", () => {
+  it("sets search_scope to 'dataset' when searching full dataset", () => {
     const params = buildExecutionParams({
       ...baseInput,
       searchScope: "dataset",
       hasView: true,
       view: [{ _cls: "FilterField" }],
     });
+    expect(params.search_scope).toBe("dataset");
     expect(params.source_view).toBeUndefined();
+  });
+
+  it("defaults search_scope to 'dataset'", () => {
+    const params = buildExecutionParams(baseInput);
+    expect(params.search_scope).toBe("dataset");
   });
 
   it("includes negative_query_ids when present", () => {

--- a/app/packages/similarity-search/src/__tests__/utils.test.ts
+++ b/app/packages/similarity-search/src/__tests__/utils.test.ts
@@ -8,14 +8,14 @@ import {
   matchesDate,
   canSubmitSearch,
 } from "../utils";
-import { SimilarityRun, QueryType } from "../types";
+import { SimilarityRun, QueryType, RunStatus } from "../types";
 import { DAY_MS } from "../constants";
 
 function makeRun(overrides: Partial<SimilarityRun> = {}): SimilarityRun {
   return {
     run_id: "r1",
     run_name: "Test Run",
-    status: "completed",
+    status: RunStatus.Completed,
     brain_key: "clip",
     query_type: QueryType.Text,
     query: "a dog",

--- a/app/packages/similarity-search/src/__tests__/utils.test.ts
+++ b/app/packages/similarity-search/src/__tests__/utils.test.ts
@@ -7,9 +7,8 @@ import {
   matchesText,
   matchesDate,
   canSubmitSearch,
-  buildExecutionParams,
 } from "../utils";
-import { SimilarityRun } from "../types";
+import { SimilarityRun, QueryType } from "../types";
 import { DAY_MS } from "../constants";
 
 function makeRun(overrides: Partial<SimilarityRun> = {}): SimilarityRun {
@@ -18,7 +17,7 @@ function makeRun(overrides: Partial<SimilarityRun> = {}): SimilarityRun {
     run_name: "Test Run",
     status: "completed",
     brain_key: "clip",
-    query_type: "text",
+    query_type: QueryType.Text,
     query: "a dog",
     reverse: false,
     result_count: 10,
@@ -28,19 +27,19 @@ function makeRun(overrides: Partial<SimilarityRun> = {}): SimilarityRun {
 
 describe("formatQuery", () => {
   it("returns short text queries as-is", () => {
-    const run = makeRun({ query_type: "text", query: "a dog" });
+    const run = makeRun({ query_type: QueryType.Text, query: "a dog" });
     expect(formatQuery(run)).toBe("a dog");
   });
 
   it("truncates text queries longer than 50 chars", () => {
     const longQuery = "a".repeat(60);
-    const run = makeRun({ query_type: "text", query: longQuery });
+    const run = makeRun({ query_type: QueryType.Text, query: longQuery });
     expect(formatQuery(run)).toBe("a".repeat(50) + "...");
   });
 
   it("formats image query with prompt count", () => {
     const run = makeRun({
-      query_type: "image",
+      query_type: QueryType.Image,
       query: ["id1", "id2", "id3"],
     });
     expect(formatQuery(run)).toBe("Image similarity (3 prompts)");
@@ -48,7 +47,7 @@ describe("formatQuery", () => {
 
   it("uses singular 'prompt' for one image", () => {
     const run = makeRun({
-      query_type: "image",
+      query_type: QueryType.Image,
       query: ["id1"],
     });
     expect(formatQuery(run)).toBe("Image similarity (1 prompt)");
@@ -56,7 +55,7 @@ describe("formatQuery", () => {
 
   it("shows positive and negative counts for image queries", () => {
     const run = makeRun({
-      query_type: "image",
+      query_type: QueryType.Image,
       query: ["id1", "id2"],
       negative_query_ids: ["neg1"],
     });
@@ -65,14 +64,14 @@ describe("formatQuery", () => {
 
   it("handles image query with no query array", () => {
     const run = makeRun({
-      query_type: "image",
+      query_type: QueryType.Image,
       query: undefined,
     });
     expect(formatQuery(run)).toBe("Image similarity (0 prompts)");
   });
 
   it("falls back to query_type for unknown types", () => {
-    const run = makeRun({ query_type: "text", query: undefined });
+    const run = makeRun({ query_type: QueryType.Text, query: undefined });
     expect(formatQuery(run)).toBe("text");
   });
 });
@@ -209,128 +208,23 @@ describe("matchesDate", () => {
 
 describe("canSubmitSearch", () => {
   it("returns false without brain key", () => {
-    expect(canSubmitSearch("", "text", "query", 0)).toBe(false);
+    expect(canSubmitSearch("", QueryType.Text, "query", 0)).toBe(false);
   });
 
   it("returns false for empty text query", () => {
-    expect(canSubmitSearch("clip", "text", "", 0)).toBe(false);
-    expect(canSubmitSearch("clip", "text", "  ", 0)).toBe(false);
+    expect(canSubmitSearch("clip", QueryType.Text, "", 0)).toBe(false);
+    expect(canSubmitSearch("clip", QueryType.Text, "  ", 0)).toBe(false);
   });
 
   it("returns true for valid text query", () => {
-    expect(canSubmitSearch("clip", "text", "dogs", 0)).toBe(true);
+    expect(canSubmitSearch("clip", QueryType.Text, "dogs", 0)).toBe(true);
   });
 
   it("returns false for image query with no samples", () => {
-    expect(canSubmitSearch("clip", "image", "", 0)).toBe(false);
+    expect(canSubmitSearch("clip", QueryType.Image, "", 0)).toBe(false);
   });
 
   it("returns true for image query with samples", () => {
-    expect(canSubmitSearch("clip", "image", "", 3)).toBe(true);
-  });
-});
-
-describe("buildExecutionParams", () => {
-  const baseInput = {
-    brainKey: "clip",
-    queryType: "text" as const,
-    textQuery: "dogs",
-    queryIds: [],
-    reverse: false,
-    patchesField: undefined,
-    searchScope: "dataset" as const,
-    hasView: false,
-    view: [],
-    k: "" as const,
-    distField: "",
-    runName: "",
-    negativeQueryIds: [],
-    dynamicResults: false,
-  };
-
-  it("builds basic text query params", () => {
-    const params = buildExecutionParams(baseInput);
-    expect(params.brain_key).toBe("clip");
-    expect(params.query_type).toBe("text");
-    expect(params.query).toBe("dogs");
-    expect(params.reverse).toBe(false);
-  });
-
-  it("trims text query", () => {
-    const params = buildExecutionParams({
-      ...baseInput,
-      textQuery: "  dogs  ",
-    });
-    expect(params.query).toBe("dogs");
-  });
-
-  it("uses queryIds for image queries", () => {
-    const params = buildExecutionParams({
-      ...baseInput,
-      queryType: "image",
-      queryIds: ["id1", "id2"],
-    });
-    expect(params.query).toEqual(["id1", "id2"]);
-  });
-
-  it("includes k when set", () => {
-    const params = buildExecutionParams({ ...baseInput, k: 25 });
-    expect(params.k).toBe(25);
-  });
-
-  it("excludes k when empty", () => {
-    const params = buildExecutionParams({ ...baseInput, k: "" });
-    expect(params.k).toBeUndefined();
-  });
-
-  it("includes dist_field when set", () => {
-    const params = buildExecutionParams({
-      ...baseInput,
-      distField: "sim_dist",
-    });
-    expect(params.dist_field).toBe("sim_dist");
-  });
-
-  it("includes run_name when set", () => {
-    const params = buildExecutionParams({
-      ...baseInput,
-      runName: "My search",
-    });
-    expect(params.run_name).toBe("My search");
-  });
-
-  it("sets search_scope to 'view' when searching within view", () => {
-    const params = buildExecutionParams({
-      ...baseInput,
-      searchScope: "view",
-      hasView: true,
-      view: [{ _cls: "FilterField" }],
-    });
-    expect(params.search_scope).toBe("view");
-    expect(params.source_view).toBeUndefined();
-  });
-
-  it("sets search_scope to 'dataset' when searching full dataset", () => {
-    const params = buildExecutionParams({
-      ...baseInput,
-      searchScope: "dataset",
-      hasView: true,
-      view: [{ _cls: "FilterField" }],
-    });
-    expect(params.search_scope).toBe("dataset");
-    expect(params.source_view).toBeUndefined();
-  });
-
-  it("defaults search_scope to 'dataset'", () => {
-    const params = buildExecutionParams(baseInput);
-    expect(params.search_scope).toBe("dataset");
-  });
-
-  it("includes negative_query_ids when present", () => {
-    const params = buildExecutionParams({
-      ...baseInput,
-      negativeQueryIds: ["neg1", "neg2"],
-    });
-    expect(params.negative_query_ids).toEqual(["neg1", "neg2"]);
+    expect(canSubmitSearch("clip", QueryType.Image, "", 3)).toBe(true);
   });
 });

--- a/app/packages/similarity-search/src/components/Home/FilterBar.tsx
+++ b/app/packages/similarity-search/src/components/Home/FilterBar.tsx
@@ -13,10 +13,55 @@ import {
   Spacing,
   Variant,
 } from "@voxel51/voodo";
-import React from "react";
+import React, { useState } from "react";
 import { RunFilterState, DateFilterPreset } from "../../types";
 import { DATE_PRESET_OPTIONS, OWNER_ALL, OWNER_MINE } from "../../constants";
 import { FilterBarSearchCol, FilterBarDateCol } from "../styled";
+
+/**
+ * Local-state search input. Commits to the parent only on blur or Enter,
+ * so typing doesn't re-filter on every keystroke. Parent should pass a
+ * `key={committed}` to remount the input when the committed value is
+ * reset externally.
+ */
+function SearchInput({
+  initial,
+  onCommit,
+}: {
+  initial: string;
+  onCommit: (value: string) => void;
+}) {
+  const [value, setValue] = useState(initial);
+
+  const commit = () => {
+    if (value !== initial) {
+      onCommit(value);
+    }
+  };
+
+  return (
+    <Input
+      type={InputType.Search}
+      placeholder="Filter by name, query, or brain key..."
+      value={value}
+      onChange={(e) => {
+        const next = e.target.value;
+        setValue(next);
+        // commit immediately when clicking reset
+        if (next === "" && initial !== "") {
+          onCommit("");
+        }
+      }}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          commit();
+        }
+      }}
+      size={Size.Sm}
+    />
+  );
+}
 
 type FilterBarProps = {
   filterState: RunFilterState;
@@ -50,14 +95,10 @@ export default function FilterBar({
         align={Align.Center}
       >
         <FilterBarSearchCol>
-          <Input
-            type={InputType.Search}
-            placeholder="Filter by name, query, or brain key..."
-            value={filterState.searchText}
-            onChange={(e) =>
-              onChange({ ...filterState, searchText: e.target.value })
-            }
-            size={Size.Sm}
+          <SearchInput
+            key={filterState.searchText}
+            initial={filterState.searchText}
+            onCommit={(v) => onChange({ ...filterState, searchText: v })}
           />
         </FilterBarSearchCol>
         <FilterBarDateCol>

--- a/app/packages/similarity-search/src/components/Home/RunActions.tsx
+++ b/app/packages/similarity-search/src/components/Home/RunActions.tsx
@@ -1,6 +1,8 @@
 import {
+  Align,
   Button,
   IconName,
+  Orientation,
   Size,
   Stack,
   Tooltip,
@@ -32,47 +34,55 @@ export default function RunActions({
   const isImage = run.query_type === QueryType.Image && !run.patches_field;
 
   return (
-    <Stack>
-      <Tooltip content={tip("Show results")}>
-        <Button
-          aria-label="Show results"
-          size={Size.Md}
-          variant={Variant.Borderless}
-          leadingIcon={IconName.GridView}
-          onClick={() => onApply(run.run_id)}
-          disabled={run.status !== "completed"}
-        />
-      </Tooltip>
-      <Tooltip content={tip("Clone search")}>
-        <Button
-          aria-label="Clone search"
-          size={Size.Md}
-          variant={Variant.Borderless}
-          leadingIcon={IconName.ContentCopy}
-          onClick={() => onClone(run.run_id)}
-        />
-      </Tooltip>
-      <Tooltip content={tip("Delete")}>
-        <Button
-          aria-label="Delete"
-          size={Size.Md}
-          variant={Variant.Borderless}
-          leadingIcon={IconName.Delete}
-          onClick={() => onDelete(run.run_id)}
-        />
-      </Tooltip>
-      {isImage && (
-        <Tooltip content={isExpanded ? tip("Collapse") : tip("Show prompts")}>
+    <Stack
+      orientation={Orientation.Column}
+      align={Align.End}
+      style={{ gap: "2rem" }}
+    >
+      <Stack>
+        <Tooltip content={tip("Show results")}>
           <Button
-            aria-label={isExpanded ? "Collapse" : "Show prompts"}
+            aria-label="Show results"
             size={Size.Md}
             variant={Variant.Borderless}
-            leadingIcon={
-              isExpanded ? IconName.ChevronTop : IconName.ChevronBottom
-            }
-            onClick={() => onToggleExpand(run)}
+            leadingIcon={IconName.GridView}
+            onClick={() => onApply(run.run_id)}
+            disabled={run.status !== "completed"}
           />
         </Tooltip>
+        <Tooltip content={tip("Clone search")}>
+          <Button
+            aria-label="Clone search"
+            size={Size.Md}
+            variant={Variant.Borderless}
+            leadingIcon={IconName.ContentCopy}
+            onClick={() => onClone(run.run_id)}
+          />
+        </Tooltip>
+        <Tooltip content={tip("Delete")}>
+          <Button
+            aria-label="Delete"
+            size={Size.Md}
+            variant={Variant.Borderless}
+            leadingIcon={IconName.Delete}
+            onClick={() => onDelete(run.run_id)}
+          />
+        </Tooltip>
+      </Stack>
+      {isImage && (
+        <Stack>
+          <Tooltip content={isExpanded ? tip("Collapse") : tip("Show prompts")}>
+            <Button
+              aria-label={isExpanded ? "Collapse" : "Show prompts"}
+              size={Size.Md}
+              variant={Variant.Borderless}
+              leadingIcon={
+                isExpanded ? IconName.ChevronTop : IconName.ChevronBottom
+              }
+              onClick={() => onToggleExpand(run)}
+            />
+          </Tooltip>
+        </Stack>
       )}
     </Stack>
   );

--- a/app/packages/similarity-search/src/components/Home/RunActions.tsx
+++ b/app/packages/similarity-search/src/components/Home/RunActions.tsx
@@ -10,7 +10,7 @@ import {
   Variant,
 } from "@voxel51/voodo";
 import React from "react";
-import { QueryType, SimilarityRun } from "../../types";
+import { QueryType, RunStatus, SimilarityRun } from "../../types";
 import { tooltipTextStyle } from "../styled";
 
 const tip = (text: string) => <span style={tooltipTextStyle}>{text}</span>;
@@ -56,7 +56,7 @@ export default function RunActions({
             variant={Variant.Borderless}
             leadingIcon={IconName.GridView}
             onClick={stop(() => onApply(run.run_id))}
-            disabled={run.status !== "completed"}
+            disabled={run.status !== RunStatus.Completed}
           />
         </Tooltip>
         <Tooltip content={tip("Clone search")}>

--- a/app/packages/similarity-search/src/components/Home/RunActions.tsx
+++ b/app/packages/similarity-search/src/components/Home/RunActions.tsx
@@ -14,6 +14,14 @@ import { tooltipTextStyle } from "../styled";
 
 const tip = (text: string) => <span style={tooltipTextStyle}>{text}</span>;
 
+/** Wrap a handler to stop propagation so card-level onClick doesn't fire. */
+const stop =
+  (fn: () => void): React.MouseEventHandler =>
+  (e) => {
+    e.stopPropagation();
+    fn();
+  };
+
 type RunActionsProps = {
   run: SimilarityRun;
   isExpanded: boolean;
@@ -56,7 +64,7 @@ export default function RunActions({
             size={Size.Md}
             variant={Variant.Borderless}
             leadingIcon={IconName.ContentCopy}
-            onClick={() => onClone(run.run_id)}
+            onClick={stop(() => onClone(run.run_id))}
           />
         </Tooltip>
         <Tooltip content={tip("Delete")}>
@@ -65,7 +73,7 @@ export default function RunActions({
             size={Size.Md}
             variant={Variant.Borderless}
             leadingIcon={IconName.Delete}
-            onClick={() => onDelete(run.run_id)}
+            onClick={stop(() => onDelete(run.run_id))}
           />
         </Tooltip>
       </Stack>
@@ -79,7 +87,7 @@ export default function RunActions({
               leadingIcon={
                 isExpanded ? IconName.ChevronTop : IconName.ChevronBottom
               }
-              onClick={() => onToggleExpand(run)}
+              onClick={stop(() => onToggleExpand(run))}
             />
           </Tooltip>
         </Stack>

--- a/app/packages/similarity-search/src/components/Home/RunActions.tsx
+++ b/app/packages/similarity-search/src/components/Home/RunActions.tsx
@@ -54,7 +54,7 @@ export default function RunActions({
             size={Size.Md}
             variant={Variant.Borderless}
             leadingIcon={IconName.GridView}
-            onClick={() => onApply(run.run_id)}
+            onClick={stop(() => onApply(run.run_id))}
             disabled={run.status !== "completed"}
           />
         </Tooltip>

--- a/app/packages/similarity-search/src/components/Home/RunActions.tsx
+++ b/app/packages/similarity-search/src/components/Home/RunActions.tsx
@@ -4,6 +4,7 @@ import {
   IconName,
   Orientation,
   Size,
+  Spacing,
   Stack,
   Tooltip,
   Variant,
@@ -45,7 +46,7 @@ export default function RunActions({
     <Stack
       orientation={Orientation.Column}
       align={Align.End}
-      style={{ gap: "2rem" }}
+      spacing={Spacing.Xl}
     >
       <Stack>
         <Tooltip content={tip("Show results")}>

--- a/app/packages/similarity-search/src/components/Home/RunList.tsx
+++ b/app/packages/similarity-search/src/components/Home/RunList.tsx
@@ -27,7 +27,7 @@ import {
   RunFilterState,
 } from "../../types";
 import { useSampleMedia } from "../../hooks/useSampleMedia";
-import { MIDDLE_DOT } from "../../constants";
+import { HIGHLIGHT_STYLE, MIDDLE_DOT, POINTER_STYLE } from "../../constants";
 import { formatQuery, formatTime } from "../../utils";
 import StatusBadge from "./StatusBadge";
 import RunActions from "./RunActions";
@@ -204,13 +204,8 @@ export default function RunList({
               }
             : undefined,
           style: {
-            ...(!selectMode ? { cursor: "pointer" } : {}),
-            ...(highlightedRunId === run.run_id
-              ? {
-                  boxShadow: "0 0 8px 2px rgba(255, 109, 4, 0.4)",
-                  borderRadius: 6,
-                }
-              : {}),
+            ...(!selectMode ? POINTER_STYLE : {}),
+            ...(highlightedRunId === run.run_id ? HIGHLIGHT_STYLE : {}),
           },
           primaryContent: (
             <Stack orientation={Orientation.Column} spacing={Spacing.Xs}>

--- a/app/packages/similarity-search/src/components/Home/RunList.tsx
+++ b/app/packages/similarity-search/src/components/Home/RunList.tsx
@@ -18,6 +18,7 @@ import {
   Spacing,
   Variant,
 } from "@voxel51/voodo";
+import { EditableLabel } from "@fiftyone/components";
 import { FileUploadOutlined } from "../../mui";
 import { useCallback, useMemo, useState } from "react";
 import {
@@ -53,26 +54,49 @@ function QueryTypeIcon({ queryType }: { queryType: string }) {
 
 const MAX_RUN_NAME_LENGTH = 40;
 
-function RunName({ name }: { name: string }) {
-  const isTruncated = name.length > MAX_RUN_NAME_LENGTH;
-  const displayName = isTruncated
-    ? name.slice(0, MAX_RUN_NAME_LENGTH) + "..."
-    : name;
+function RunName({
+  name,
+  onRename,
+}: {
+  name: string;
+  onRename: (newName: string) => void;
+}) {
+  const [hovering, setHovering] = useState(false);
+  const isLong = name.length > MAX_RUN_NAME_LENGTH;
 
-  const content = (
-    <Text
-      variant={TextVariant.Md}
-      style={{ fontWeight: "bold", whiteSpace: "nowrap" }}
+  const handleSave = (newName: string) => {
+    const trimmed = newName?.trim();
+    if (trimmed && trimmed !== name) {
+      onRename(trimmed);
+    }
+  };
+
+  const label = (
+    <div
+      onMouseEnter={() => setHovering(true)}
+      onMouseLeave={() => setHovering(false)}
+      style={{ minWidth: 0 }}
     >
-      {displayName}
-    </Text>
+      <EditableLabel
+        label={name}
+        onSave={handleSave}
+        showEditIcon={hovering}
+        labelProps={{
+          sx: {
+            fontWeight: "bold",
+            fontSize: "0.9rem",
+            maxWidth: `${MAX_RUN_NAME_LENGTH}ch`,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          },
+        }}
+        title="Rename"
+      />
+    </div>
   );
 
-  if (isTruncated) {
-    return <Tooltip content={name}>{content}</Tooltip>;
-  }
-
-  return content;
+  return isLong ? <Tooltip content={name}>{label}</Tooltip> : label;
 }
 
 type SelectionState = {
@@ -95,6 +119,7 @@ type RunListProps = {
   onClone: (runId: string) => void;
   onDelete: (runId: string) => void;
   onBulkDelete: (runIds: string[]) => void;
+  onRename: (runId: string, newName: string) => void;
   onRefresh: () => void;
   onNewSearch: () => void;
   onSettings: () => void;
@@ -117,6 +142,7 @@ export default function RunList({
   onClone,
   onDelete,
   onBulkDelete,
+  onRename,
   onRefresh,
   onNewSearch,
   onSettings,
@@ -209,7 +235,10 @@ export default function RunList({
                 align={Align.Center}
               >
                 <QueryTypeIcon queryType={run.query_type} />
-                <RunName name={run.run_name} />
+                <RunName
+                  name={run.run_name}
+                  onRename={(newName) => onRename(run.run_id, newName)}
+                />
                 <StatusBadge status={run.status} />
                 {run.status === "completed" && (
                   <Text variant={TextVariant.Md} color={TextColor.Muted}>
@@ -260,6 +289,7 @@ export default function RunList({
       onApply,
       onClone,
       onDelete,
+      onRename,
       handleToggleExpand,
     ]
   );

--- a/app/packages/similarity-search/src/components/Home/RunList.tsx
+++ b/app/packages/similarity-search/src/components/Home/RunList.tsx
@@ -5,7 +5,6 @@ import {
   Heading,
   HeadingLevel,
   Icon,
-  IconColor,
   IconName,
   Justify,
   RichList,
@@ -19,7 +18,7 @@ import {
   Spacing,
   Variant,
 } from "@voxel51/voodo";
-import FileUploadOutlined from "@mui/icons-material/FileUploadOutlined";
+import { FileUploadOutlined } from "../../mui";
 import { useCallback, useMemo, useState } from "react";
 import {
   BrainKeyConfig,
@@ -39,17 +38,41 @@ import { SelectAllRow, tooltipTextStyle } from "../styled";
 
 function QueryTypeIcon({ queryType }: { queryType: string }) {
   if (queryType === QueryType.Upload) {
-    return <FileUploadOutlined sx={{ fontSize: 18, opacity: 0.7 }} />;
+    return <FileUploadOutlined sx={{ fontSize: 18 }} />;
   }
   return (
     <Icon
       name={
         queryType === QueryType.Text ? IconName.Search : IconName.ImageSearch
       }
-      size={Size.Sm}
-      color={IconColor.Subtle}
+      size={Size.Xl}
+      color={TextColor.Primary}
     />
   );
+}
+
+const MAX_RUN_NAME_LENGTH = 40;
+
+function RunName({ name }: { name: string }) {
+  const isTruncated = name.length > MAX_RUN_NAME_LENGTH;
+  const displayName = isTruncated
+    ? name.slice(0, MAX_RUN_NAME_LENGTH) + "..."
+    : name;
+
+  const content = (
+    <Text
+      variant={TextVariant.Md}
+      style={{ fontWeight: "bold", whiteSpace: "nowrap" }}
+    >
+      {displayName}
+    </Text>
+  );
+
+  if (isTruncated) {
+    return <Tooltip content={name}>{content}</Tooltip>;
+  }
+
+  return content;
 }
 
 type SelectionState = {
@@ -186,9 +209,7 @@ export default function RunList({
                 align={Align.Center}
               >
                 <QueryTypeIcon queryType={run.query_type} />
-                <Text variant={TextVariant.Md} style={{ fontWeight: "bold" }}>
-                  {run.run_name}
-                </Text>
+                <RunName name={run.run_name} />
                 <StatusBadge status={run.status} />
                 {run.status === "completed" && (
                   <Text variant={TextVariant.Md} color={TextColor.Muted}>

--- a/app/packages/similarity-search/src/components/Home/RunList.tsx
+++ b/app/packages/similarity-search/src/components/Home/RunList.tsx
@@ -90,6 +90,8 @@ type RunListProps = {
   filteredRuns: SimilarityRun[];
   brainKeys: BrainKeyConfig[];
   appliedRunId?: string;
+  highlightedRunId?: string;
+  onHighlight: (runId: string | undefined) => void;
   sampleMedia: Record<string, string>;
   onApply: (runId: string) => void;
   onClone: (runId: string) => void;
@@ -112,6 +114,8 @@ export default function RunList({
   filteredRuns,
   brainKeys,
   appliedRunId,
+  highlightedRunId,
+  onHighlight,
   sampleMedia,
   onApply,
   onClone,
@@ -193,14 +197,21 @@ export default function RunList({
         id: run.run_id,
         data: {
           canSelect: selectMode,
-          onClick:
-            !selectMode && run.status === "completed"
-              ? () => onApply(run.run_id)
-              : undefined,
-          style:
-            !selectMode && run.status === "completed"
-              ? { cursor: "pointer" }
-              : undefined,
+          onClick: !selectMode
+            ? () => {
+                onHighlight(run.run_id);
+                if (run.status === "completed") onApply(run.run_id);
+              }
+            : undefined,
+          style: {
+            ...(!selectMode ? { cursor: "pointer" } : {}),
+            ...(highlightedRunId === run.run_id
+              ? {
+                  boxShadow: "0 0 8px 2px rgba(255, 109, 4, 0.4)",
+                  borderRadius: 6,
+                }
+              : {}),
+          },
           primaryContent: (
             <Stack orientation={Orientation.Column} spacing={Spacing.Xs}>
               <Stack
@@ -256,6 +267,8 @@ export default function RunList({
       selectMode,
       expandedRunIds,
       mergedMedia,
+      highlightedRunId,
+      onHighlight,
       onApply,
       onClone,
       onDelete,

--- a/app/packages/similarity-search/src/components/Home/RunList.tsx
+++ b/app/packages/similarity-search/src/components/Home/RunList.tsx
@@ -90,8 +90,6 @@ type RunListProps = {
   filteredRuns: SimilarityRun[];
   brainKeys: BrainKeyConfig[];
   appliedRunId?: string;
-  highlightedRunId?: string;
-  onHighlight: (runId: string | undefined) => void;
   sampleMedia: Record<string, string>;
   onApply: (runId: string) => void;
   onClone: (runId: string) => void;
@@ -114,8 +112,6 @@ export default function RunList({
   filteredRuns,
   brainKeys,
   appliedRunId,
-  highlightedRunId,
-  onHighlight,
   sampleMedia,
   onApply,
   onClone,
@@ -197,15 +193,13 @@ export default function RunList({
         id: run.run_id,
         data: {
           canSelect: selectMode,
-          onClick: !selectMode
-            ? () => {
-                onHighlight(run.run_id);
-                if (run.status === "completed") onApply(run.run_id);
-              }
-            : undefined,
+          onClick:
+            !selectMode && run.status === "completed"
+              ? () => onApply(run.run_id)
+              : undefined,
           style: {
-            ...(!selectMode ? POINTER_STYLE : {}),
-            ...(highlightedRunId === run.run_id ? HIGHLIGHT_STYLE : {}),
+            ...(!selectMode && run.status === "completed" ? POINTER_STYLE : {}),
+            ...(appliedRunId === run.run_id ? HIGHLIGHT_STYLE : {}),
           },
           primaryContent: (
             <Stack orientation={Orientation.Column} spacing={Spacing.Xs}>
@@ -262,8 +256,7 @@ export default function RunList({
       selectMode,
       expandedRunIds,
       mergedMedia,
-      highlightedRunId,
-      onHighlight,
+      appliedRunId,
       onApply,
       onClone,
       onDelete,

--- a/app/packages/similarity-search/src/components/Home/RunList.tsx
+++ b/app/packages/similarity-search/src/components/Home/RunList.tsx
@@ -198,10 +198,7 @@ export default function RunList({
         data: {
           canSelect: selectMode,
           onClick: !selectMode
-            ? (e: MouseEvent) => {
-                // Ignore clicks on interactive descendants (action buttons)
-                const target = e.target as HTMLElement;
-                if (target.closest("button, a, [role='button']")) return;
+            ? () => {
                 onHighlight(run.run_id);
                 if (run.status === "completed") onApply(run.run_id);
               }

--- a/app/packages/similarity-search/src/components/Home/RunList.tsx
+++ b/app/packages/similarity-search/src/components/Home/RunList.tsx
@@ -198,7 +198,10 @@ export default function RunList({
         data: {
           canSelect: selectMode,
           onClick: !selectMode
-            ? () => {
+            ? (e: MouseEvent) => {
+                // Ignore clicks on interactive descendants (action buttons)
+                const target = e.target as HTMLElement;
+                if (target.closest("button, a, [role='button']")) return;
                 onHighlight(run.run_id);
                 if (run.status === "completed") onApply(run.run_id);
               }

--- a/app/packages/similarity-search/src/components/Home/RunList.tsx
+++ b/app/packages/similarity-search/src/components/Home/RunList.tsx
@@ -24,6 +24,7 @@ import { useCallback, useMemo, useState } from "react";
 import {
   BrainKeyConfig,
   QueryType,
+  RunStatus,
   SimilarityRun,
   RunFilterState,
 } from "../../types";
@@ -220,11 +221,13 @@ export default function RunList({
         data: {
           canSelect: selectMode,
           onClick:
-            !selectMode && run.status === "completed"
+            !selectMode && run.status === RunStatus.Completed
               ? () => onApply(run.run_id)
               : undefined,
           style: {
-            ...(!selectMode && run.status === "completed" ? POINTER_STYLE : {}),
+            ...(!selectMode && run.status === RunStatus.Completed
+              ? POINTER_STYLE
+              : {}),
             ...(appliedRunId === run.run_id ? HIGHLIGHT_STYLE : {}),
           },
           primaryContent: (
@@ -240,7 +243,7 @@ export default function RunList({
                   onRename={(newName) => onRename(run.run_id, newName)}
                 />
                 <StatusBadge status={run.status} />
-                {run.status === "completed" && (
+                {run.status === RunStatus.Completed && (
                   <Text variant={TextVariant.Md} color={TextColor.Muted}>
                     {run.result_count} results
                   </Text>
@@ -255,7 +258,7 @@ export default function RunList({
                 {formatTime(run.creation_time)}
                 {run.created_by ? ` by ${run.created_by}` : ""}
               </Text>
-              {run.status === "failed" && run.status_details && (
+              {run.status === RunStatus.Failed && run.status_details && (
                 <Text variant={TextVariant.Md} color={TextColor.Destructive}>
                   {run.status_details}
                 </Text>

--- a/app/packages/similarity-search/src/components/Home/RunList.tsx
+++ b/app/packages/similarity-search/src/components/Home/RunList.tsx
@@ -4,6 +4,8 @@ import {
   Checkbox,
   Heading,
   HeadingLevel,
+  Icon,
+  IconColor,
   IconName,
   Justify,
   RichList,
@@ -17,8 +19,14 @@ import {
   Spacing,
   Variant,
 } from "@voxel51/voodo";
+import FileUploadOutlined from "@mui/icons-material/FileUploadOutlined";
 import { useCallback, useMemo, useState } from "react";
-import { BrainKeyConfig, SimilarityRun, RunFilterState } from "../../types";
+import {
+  BrainKeyConfig,
+  QueryType,
+  SimilarityRun,
+  RunFilterState,
+} from "../../types";
 import { useSampleMedia } from "../../hooks/useSampleMedia";
 import { MIDDLE_DOT } from "../../constants";
 import { formatQuery, formatTime } from "../../utils";
@@ -28,6 +36,21 @@ import ExpandedThumbnails from "./ExpandedThumbnails";
 import FilterBar from "./FilterBar";
 import BulkActionBar from "./BulkActionBar";
 import { SelectAllRow, tooltipTextStyle } from "../styled";
+
+function QueryTypeIcon({ queryType }: { queryType: string }) {
+  if (queryType === QueryType.Upload) {
+    return <FileUploadOutlined sx={{ fontSize: 18, opacity: 0.7 }} />;
+  }
+  return (
+    <Icon
+      name={
+        queryType === QueryType.Text ? IconName.Search : IconName.ImageSearch
+      }
+      size={Size.Sm}
+      color={IconColor.Subtle}
+    />
+  );
+}
 
 type SelectionState = {
   selectMode: boolean;
@@ -147,6 +170,14 @@ export default function RunList({
         id: run.run_id,
         data: {
           canSelect: selectMode,
+          onClick:
+            !selectMode && run.status === "completed"
+              ? () => onApply(run.run_id)
+              : undefined,
+          style:
+            !selectMode && run.status === "completed"
+              ? { cursor: "pointer" }
+              : undefined,
           primaryContent: (
             <Stack orientation={Orientation.Column} spacing={Spacing.Xs}>
               <Stack
@@ -154,6 +185,7 @@ export default function RunList({
                 spacing={Spacing.Sm}
                 align={Align.Center}
               >
+                <QueryTypeIcon queryType={run.query_type} />
                 <Text variant={TextVariant.Md} style={{ fontWeight: "bold" }}>
                   {run.run_name}
                 </Text>

--- a/app/packages/similarity-search/src/components/NewSearch/NewSearch.tsx
+++ b/app/packages/similarity-search/src/components/NewSearch/NewSearch.tsx
@@ -113,6 +113,20 @@ export default function NewSearch({
                   Backend: {form.selectedConfig.backend}
                 </Text>
               )}
+              {form.selectedConfig.metric && (
+                <Text variant={TextVariant.Md} color={TextColor.Secondary}>
+                  Metric: {form.selectedConfig.metric}
+                </Text>
+              )}
+              {form.selectedConfig.identifiers?.map((id) => (
+                <Text
+                  key={id.label}
+                  variant={TextVariant.Md}
+                  color={TextColor.Secondary}
+                >
+                  {id.label}: {id.value}
+                </Text>
+              ))}
               <Text variant={TextVariant.Md} color={TextColor.Secondary}>
                 Supports text queries?{" "}
                 {form.selectedConfig.supports_prompts ? CHECK_MARK : CROSS_MARK}

--- a/app/packages/similarity-search/src/components/NewSearch/NewSearch.tsx
+++ b/app/packages/similarity-search/src/components/NewSearch/NewSearch.tsx
@@ -21,7 +21,7 @@ import {
   Spacing,
   Variant,
 } from "@voxel51/voodo";
-import FileUploadOutlined from "@mui/icons-material/FileUploadOutlined";
+import { FileUploadOutlined } from "../../mui";
 import React, { useState } from "react";
 import { OperatorExecutionButton } from "@fiftyone/operators";
 import {

--- a/app/packages/similarity-search/src/components/NewSearch/NewSearch.tsx
+++ b/app/packages/similarity-search/src/components/NewSearch/NewSearch.tsx
@@ -21,6 +21,7 @@ import {
   Spacing,
   Variant,
 } from "@voxel51/voodo";
+import FileUploadOutlined from "@mui/icons-material/FileUploadOutlined";
 import React, { useState } from "react";
 import { OperatorExecutionButton } from "@fiftyone/operators";
 import {
@@ -163,6 +164,7 @@ export default function NewSearch({
                   : Variant.Secondary
               }
               size={Size.Sm}
+              leadingIcon={IconName.ImageSearch}
               onClick={() => form.setQueryType(QueryType.Image)}
               style={{ flex: 1 }}
             >
@@ -176,6 +178,7 @@ export default function NewSearch({
                     : Variant.Secondary
                 }
                 size={Size.Sm}
+                leadingIcon={() => <FileUploadOutlined sx={{ fontSize: 16 }} />}
                 onClick={() => form.setQueryType(QueryType.Upload)}
                 style={{ flex: 1 }}
               >
@@ -190,6 +193,7 @@ export default function NewSearch({
                     : Variant.Secondary
                 }
                 size={Size.Sm}
+                leadingIcon={IconName.Search}
                 onClick={() => form.setQueryType(QueryType.Text)}
                 style={{ flex: 1 }}
               >
@@ -330,7 +334,7 @@ export default function NewSearch({
           />
         )}
 
-        {/* Dynamic results */}
+        {/* Dynamic results — commented out; all searches use cached (static) results for now
         <Toggle
           checked={form.dynamicResults}
           onChange={(checked) => form.setDynamicResults(checked)}
@@ -341,6 +345,7 @@ export default function NewSearch({
           }
           size={Size.Sm}
         />
+        */}
 
         {/* Distance field */}
         <FormField

--- a/app/packages/similarity-search/src/components/SimilarityIndex/SimilarityIndex.tsx
+++ b/app/packages/similarity-search/src/components/SimilarityIndex/SimilarityIndex.tsx
@@ -57,6 +57,20 @@ export default function SimilarityIndex({
                   Backend: {bk.backend}
                 </Text>
               )}
+              {bk.metric && (
+                <Text variant={TextVariant.Md} color={TextColor.Secondary}>
+                  Metric: {bk.metric}
+                </Text>
+              )}
+              {bk.identifiers?.map((id) => (
+                <Text
+                  key={id.label}
+                  variant={TextVariant.Md}
+                  color={TextColor.Secondary}
+                >
+                  {id.label}: {id.value}
+                </Text>
+              ))}
               <Stack
                 orientation={Orientation.Row}
                 spacing={Spacing.Xs}

--- a/app/packages/similarity-search/src/components/SimilaritySearchView.tsx
+++ b/app/packages/similarity-search/src/components/SimilaritySearchView.tsx
@@ -32,8 +32,6 @@ function SimilaritySearchReady(props: SimilaritySearchViewProps) {
           filteredRuns={panel.filteredRuns}
           brainKeys={panel.brainKeys}
           appliedRunId={panel.appliedRunId}
-          highlightedRunId={panel.highlightedRunId}
-          onHighlight={panel.setHighlightedRunId}
           sampleMedia={panel.sampleMedia}
           onApply={panel.handleApply}
           onClone={panel.handleClone}

--- a/app/packages/similarity-search/src/components/SimilaritySearchView.tsx
+++ b/app/packages/similarity-search/src/components/SimilaritySearchView.tsx
@@ -37,6 +37,7 @@ function SimilaritySearchReady(props: SimilaritySearchViewProps) {
           onClone={panel.handleClone}
           onDelete={panel.handleDelete}
           onBulkDelete={panel.handleBulkDelete}
+          onRename={panel.handleRename}
           onRefresh={panel.refreshRuns}
           onNewSearch={panel.handleNewSearch}
           onSettings={panel.navigateSimilarityIndex}

--- a/app/packages/similarity-search/src/components/SimilaritySearchView.tsx
+++ b/app/packages/similarity-search/src/components/SimilaritySearchView.tsx
@@ -32,6 +32,8 @@ function SimilaritySearchReady(props: SimilaritySearchViewProps) {
           filteredRuns={panel.filteredRuns}
           brainKeys={panel.brainKeys}
           appliedRunId={panel.appliedRunId}
+          highlightedRunId={panel.highlightedRunId}
+          onHighlight={panel.setHighlightedRunId}
           sampleMedia={panel.sampleMedia}
           onApply={panel.handleApply}
           onClone={panel.handleClone}

--- a/app/packages/similarity-search/src/constants.ts
+++ b/app/packages/similarity-search/src/constants.ts
@@ -20,17 +20,17 @@ export const DATE_PRESET_OPTIONS = [
 ];
 
 export const STATUS_COLORS: Record<RunStatus, TextColor> = {
-  pending: TextColor.Muted,
-  running: TextColor.Info,
-  completed: TextColor.Success,
-  failed: TextColor.Destructive,
+  [RunStatus.Pending]: TextColor.Muted,
+  [RunStatus.Running]: TextColor.Info,
+  [RunStatus.Completed]: TextColor.Success,
+  [RunStatus.Failed]: TextColor.Destructive,
 };
 
 export const STATUS_LABELS: Record<RunStatus, string> = {
-  pending: "Pending",
-  running: "Running",
-  completed: "Completed",
-  failed: "Failed",
+  [RunStatus.Pending]: "Pending",
+  [RunStatus.Running]: "Running",
+  [RunStatus.Completed]: "Completed",
+  [RunStatus.Failed]: "Failed",
 };
 
 // Run list styles

--- a/app/packages/similarity-search/src/constants.ts
+++ b/app/packages/similarity-search/src/constants.ts
@@ -1,5 +1,5 @@
 import { TextColor } from "@voxel51/voodo";
-import { OwnerFilter, RunStatus, SearchScope } from "./types";
+import { DateFilterPreset, OwnerFilter, RunStatus, SearchScope } from "./types";
 
 export const SEARCH_OPERATOR_URI = "@voxel51/panels/similarity_search";
 export const INIT_RUN_OPERATOR_URI = "@voxel51/panels/init_similarity_run";
@@ -36,7 +36,8 @@ export const THUMB_SIZE = 36;
 export const THUMB_GAP = 4;
 export const THUMB_SINGLE_ROW_MAX = 10;
 
-// Owner filter values
+// Filter defaults
+export const DEFAULT_DATE_PRESET: DateFilterPreset = "last_30_days";
 export const OWNER_ALL: OwnerFilter = "all";
 export const OWNER_MINE: OwnerFilter = "mine";
 

--- a/app/packages/similarity-search/src/constants.ts
+++ b/app/packages/similarity-search/src/constants.ts
@@ -33,6 +33,13 @@ export const STATUS_LABELS: Record<RunStatus, string> = {
   failed: "Failed",
 };
 
+// Run list styles
+export const POINTER_STYLE = { cursor: "pointer" } as const;
+export const HIGHLIGHT_STYLE = {
+  boxShadow: "0 0 8px 2px rgba(255, 109, 4, 0.4)",
+  borderRadius: 6,
+} as const;
+
 export const THUMB_SIZE = 36;
 export const THUMB_GAP = 4;
 export const THUMB_SINGLE_ROW_MAX = 10;

--- a/app/packages/similarity-search/src/constants.ts
+++ b/app/packages/similarity-search/src/constants.ts
@@ -5,6 +5,7 @@ export const SEARCH_OPERATOR_URI = "@voxel51/panels/similarity_search";
 export const INIT_RUN_OPERATOR_URI = "@voxel51/panels/init_similarity_run";
 export const COMPUTE_SIMILARITY_URI = "@voxel51/operators/compute_similarity";
 export const PANEL_NAME = "similarity_search_panel";
+export const LIST_RUNS_OPERATOR_URI = "@voxel51/panels/list_similarity_runs";
 export const SSE_OPERATOR_URI =
   "@voxel51/panels/get_similarity_search_subscription_notifier";
 

--- a/app/packages/similarity-search/src/hooks/useFilteredRuns.ts
+++ b/app/packages/similarity-search/src/hooks/useFilteredRuns.ts
@@ -1,11 +1,12 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { atom, useAtom } from "jotai";
 import { SimilarityRun, RunFilterState } from "../types";
+import { DEFAULT_DATE_PRESET, OWNER_ALL, OWNER_MINE } from "../constants";
 
 const filterStateAtom = atom<RunFilterState>({
   searchText: "",
-  datePreset: "all",
-  ownerFilter: "all",
+  datePreset: DEFAULT_DATE_PRESET,
+  ownerFilter: OWNER_ALL,
 });
 import { getDateRange, matchesText, matchesDate } from "../utils";
 
@@ -18,6 +19,18 @@ export const useFilteredRuns = (
   setFilterState: (state: RunFilterState) => void;
 } => {
   const [filterState, setFilterState] = useAtom(filterStateAtom);
+  const defaultsApplied = useRef(false);
+
+  // In FOE (currentUser is set), default ownerFilter to "mine"
+  useEffect(() => {
+    if (!defaultsApplied.current && currentUser) {
+      defaultsApplied.current = true;
+      setFilterState((prev) => ({
+        ...prev,
+        ownerFilter: OWNER_MINE,
+      }));
+    }
+  }, [currentUser, setFilterState]);
 
   const filteredRuns = useMemo(() => {
     const { searchText, datePreset, ownerFilter } = filterState;

--- a/app/packages/similarity-search/src/hooks/useFilteredRuns.ts
+++ b/app/packages/similarity-search/src/hooks/useFilteredRuns.ts
@@ -25,8 +25,9 @@ export const useFilteredRuns = (
 } => {
   const [filterState, setFilterState] = useAtom(filterStateAtom);
   const prevDatasetRef = useRef<string | null | undefined>(undefined);
+  const defaultsApplied = useRef(false);
 
-  // Reset filter state when dataset changes or on first mount
+  // Reset filter state when dataset changes
   useEffect(() => {
     if (
       prevDatasetRef.current !== undefined &&
@@ -36,6 +37,19 @@ export const useFilteredRuns = (
     }
     prevDatasetRef.current = datasetName;
   }, [datasetName, currentUser, setFilterState]);
+
+  // On first mount, fix up ownerFilter for logged-in users
+  // (module-level atom initializes without currentUser)
+  useEffect(() => {
+    if (!defaultsApplied.current && currentUser) {
+      defaultsApplied.current = true;
+      setFilterState((prev) =>
+        prev.ownerFilter === OWNER_ALL
+          ? { ...prev, ownerFilter: OWNER_MINE }
+          : prev
+      );
+    }
+  }, [currentUser, setFilterState]);
 
   const filteredRuns = useMemo(() => {
     const { searchText, datePreset, ownerFilter } = filterState;

--- a/app/packages/similarity-search/src/hooks/useFilteredRuns.ts
+++ b/app/packages/similarity-search/src/hooks/useFilteredRuns.ts
@@ -28,7 +28,7 @@ export const useFilteredRuns = (
       if (searchText && !matchesText(run, searchText)) return false;
       if (!matchesDate(run, start, end)) return false;
       if (
-        ownerFilter === "mine" &&
+        ownerFilter === OWNER_MINE &&
         currentUser &&
         run.created_by !== currentUser
       )

--- a/app/packages/similarity-search/src/hooks/useFilteredRuns.ts
+++ b/app/packages/similarity-search/src/hooks/useFilteredRuns.ts
@@ -1,55 +1,24 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useMemo } from "react";
 import { atom, useAtom } from "jotai";
 import { SimilarityRun, RunFilterState } from "../types";
-import { DEFAULT_DATE_PRESET, OWNER_ALL, OWNER_MINE } from "../constants";
+import { DEFAULT_DATE_PRESET, OWNER_MINE } from "../constants";
 import { getDateRange, matchesText, matchesDate } from "../utils";
 
-const makeDefaultFilterState = (
-  currentUser?: string | null
-): RunFilterState => ({
+const filterStateAtom = atom<RunFilterState>({
   searchText: "",
   datePreset: DEFAULT_DATE_PRESET,
-  ownerFilter: currentUser ? OWNER_MINE : OWNER_ALL,
+  ownerFilter: OWNER_MINE,
 });
-
-const filterStateAtom = atom<RunFilterState>(makeDefaultFilterState());
 
 export const useFilteredRuns = (
   runs: SimilarityRun[],
-  currentUser?: string | null,
-  datasetName?: string | null
+  currentUser?: string | null
 ): {
   filteredRuns: SimilarityRun[];
   filterState: RunFilterState;
   setFilterState: (state: RunFilterState) => void;
 } => {
   const [filterState, setFilterState] = useAtom(filterStateAtom);
-  const prevDatasetRef = useRef<string | null | undefined>(undefined);
-  const defaultsApplied = useRef(false);
-
-  // Reset filter state when dataset changes
-  useEffect(() => {
-    if (
-      prevDatasetRef.current !== undefined &&
-      prevDatasetRef.current !== datasetName
-    ) {
-      setFilterState(makeDefaultFilterState(currentUser));
-    }
-    prevDatasetRef.current = datasetName;
-  }, [datasetName, currentUser, setFilterState]);
-
-  // On first mount, fix up ownerFilter for logged-in users
-  // (module-level atom initializes without currentUser)
-  useEffect(() => {
-    if (!defaultsApplied.current && currentUser) {
-      defaultsApplied.current = true;
-      setFilterState((prev) =>
-        prev.ownerFilter === OWNER_ALL
-          ? { ...prev, ownerFilter: OWNER_MINE }
-          : prev
-      );
-    }
-  }, [currentUser, setFilterState]);
 
   const filteredRuns = useMemo(() => {
     const { searchText, datePreset, ownerFilter } = filterState;

--- a/app/packages/similarity-search/src/hooks/useFilteredRuns.ts
+++ b/app/packages/similarity-search/src/hooks/useFilteredRuns.ts
@@ -2,35 +2,40 @@ import { useEffect, useMemo, useRef } from "react";
 import { atom, useAtom } from "jotai";
 import { SimilarityRun, RunFilterState } from "../types";
 import { DEFAULT_DATE_PRESET, OWNER_ALL, OWNER_MINE } from "../constants";
+import { getDateRange, matchesText, matchesDate } from "../utils";
 
-const filterStateAtom = atom<RunFilterState>({
+const makeDefaultFilterState = (
+  currentUser?: string | null
+): RunFilterState => ({
   searchText: "",
   datePreset: DEFAULT_DATE_PRESET,
-  ownerFilter: OWNER_ALL,
+  ownerFilter: currentUser ? OWNER_MINE : OWNER_ALL,
 });
-import { getDateRange, matchesText, matchesDate } from "../utils";
+
+const filterStateAtom = atom<RunFilterState>(makeDefaultFilterState());
 
 export const useFilteredRuns = (
   runs: SimilarityRun[],
-  currentUser?: string | null
+  currentUser?: string | null,
+  datasetName?: string | null
 ): {
   filteredRuns: SimilarityRun[];
   filterState: RunFilterState;
   setFilterState: (state: RunFilterState) => void;
 } => {
   const [filterState, setFilterState] = useAtom(filterStateAtom);
-  const defaultsApplied = useRef(false);
+  const prevDatasetRef = useRef<string | null | undefined>(undefined);
 
-  // In FOE (currentUser is set), default ownerFilter to "mine"
+  // Reset filter state when dataset changes or on first mount
   useEffect(() => {
-    if (!defaultsApplied.current && currentUser) {
-      defaultsApplied.current = true;
-      setFilterState((prev) => ({
-        ...prev,
-        ownerFilter: OWNER_MINE,
-      }));
+    if (
+      prevDatasetRef.current !== undefined &&
+      prevDatasetRef.current !== datasetName
+    ) {
+      setFilterState(makeDefaultFilterState(currentUser));
     }
-  }, [currentUser, setFilterState]);
+    prevDatasetRef.current = datasetName;
+  }, [datasetName, currentUser, setFilterState]);
 
   const filteredRuns = useMemo(() => {
     const { searchText, datePreset, ownerFilter } = filterState;

--- a/app/packages/similarity-search/src/hooks/useNewSearchForm.ts
+++ b/app/packages/similarity-search/src/hooks/useNewSearchForm.ts
@@ -57,9 +57,7 @@ export const useNewSearchForm = (
   const [uploadedImage, setUploadedImage] = useState<UploadedImage | null>(
     null
   );
-  const [searchScope, setSearchScope] = useState<SearchScope>(
-    hasView ? SCOPE_VIEW : SCOPE_DATASET
-  );
+  const [searchScope, setSearchScope] = useState<SearchScope>(SCOPE_DATASET);
 
   // ─── Derived config ─────────────────────────────────────────────
 

--- a/app/packages/similarity-search/src/hooks/useRuns.ts
+++ b/app/packages/similarity-search/src/hooks/useRuns.ts
@@ -8,7 +8,7 @@ import {
   datasetId as datasetIdAtom,
   datasetName as datasetNameAtom,
 } from "@fiftyone/state";
-import { SSE_OPERATOR_URI } from "../constants";
+import { LIST_RUNS_OPERATOR_URI, SSE_OPERATOR_URI } from "../constants";
 import { SimilarityRun } from "../types";
 
 const runsAtom = atom<SimilarityRun[]>([]);
@@ -41,41 +41,31 @@ export const useRuns = (): UseRunsResult => {
   const panelId = usePanelId();
   const datasetName = useRecoilValue(datasetNameAtom);
   const datasetId = useRecoilValue(datasetIdAtom);
-  const { execute: fetchRuns } = useOperatorExecutor(
-    "@voxel51/panels/list_similarity_runs"
-  );
+  const { execute: fetchRuns } = useOperatorExecutor(LIST_RUNS_OPERATOR_URI);
+
+  // ── Coalescing refresh mechanism ───────────────────────────────
+  // SSE events and user actions can trigger refreshRuns() at any
+  // time, including while a fetch is already in flight.  Instead of
+  // dropping those requests or firing concurrent fetches, we
+  // coalesce them: when a refresh is requested during an in-flight
+  // fetch, we set a "pending" flag.  Once the current fetch settles,
+  // we automatically fire one more refresh to pick up whatever
+  // changed.  A consecutive-error counter (max 5) prevents runaway
+  // retries when the backend is persistently failing.
   const fetchingRef = useRef(false);
-  const pendingRefreshRef = useRef(false);
+  const pendingRef = useRef(false);
   const inFlightRef = useRef<Promise<void> | null>(null);
-  const consecutiveErrorsRef = useRef(0);
+  const errorCountRef = useRef(0);
   const MAX_RETRY = 5;
 
   const refreshRuns = useCallback(() => {
     // If a fetch is already in flight, queue a follow-up refresh
     // and return the in-flight promise so callers can still await.
     if (fetchingRef.current) {
-      pendingRefreshRef.current = true;
+      pendingRef.current = true;
       return inFlightRef.current ?? Promise.resolve();
     }
     fetchingRef.current = true;
-
-    const drainPending = (isError: boolean) => {
-      if (isError) {
-        consecutiveErrorsRef.current += 1;
-      } else {
-        consecutiveErrorsRef.current = 0;
-      }
-
-      if (
-        pendingRefreshRef.current &&
-        consecutiveErrorsRef.current < MAX_RETRY
-      ) {
-        pendingRefreshRef.current = false;
-        refreshRuns();
-      } else {
-        pendingRefreshRef.current = false;
-      }
-    };
 
     const promise = new Promise<void>((resolve, reject) => {
       fetchRuns(
@@ -83,13 +73,14 @@ export const useRuns = (): UseRunsResult => {
         {
           callback: (result?: Record<string, unknown>) => {
             fetchingRef.current = false;
-            try {
-              if (result?.error) {
-                console.error("Error fetching similarity runs:", result.error);
-                reject(new Error(String(result.error)));
-                return;
-              }
 
+            if (result?.error) {
+              console.error("Error fetching similarity runs:", result.error);
+              reject(new Error(String(result.error)));
+              return;
+            }
+
+            try {
               const response = result?.result as
                 | { runs?: SimilarityRun[] }
                 | undefined;
@@ -101,22 +92,36 @@ export const useRuns = (): UseRunsResult => {
             } catch (e) {
               console.error("Error processing runs callback:", e);
               reject(e instanceof Error ? e : new Error(String(e)));
-            } finally {
-              drainPending(false);
             }
           },
         }
       ).catch((error: unknown) => {
         fetchingRef.current = false;
         console.error("Operator execution failed for fetchRuns:", error);
-        drainPending(true);
         reject(error instanceof Error ? error : new Error(String(error)));
       });
     });
 
-    inFlightRef.current = promise.finally(() => {
-      inFlightRef.current = null;
-    });
+    // After each attempt settles, check whether a refresh was
+    // requested while we were busy.  On success the error counter
+    // resets; on failure it increments, and we stop retrying after
+    // MAX_RETRY consecutive failures.
+    inFlightRef.current = promise
+      .then(() => {
+        errorCountRef.current = 0;
+      })
+      .catch(() => {
+        errorCountRef.current += 1;
+      })
+      .finally(() => {
+        inFlightRef.current = null;
+        if (pendingRef.current && errorCountRef.current < MAX_RETRY) {
+          pendingRef.current = false;
+          refreshRuns();
+        } else {
+          pendingRef.current = false;
+        }
+      });
 
     return inFlightRef.current;
   }, [fetchRuns, setRuns]);

--- a/app/packages/similarity-search/src/hooks/useRuns.ts
+++ b/app/packages/similarity-search/src/hooks/useRuns.ts
@@ -46,17 +46,38 @@ export const useRuns = (): UseRunsResult => {
   );
   const fetchingRef = useRef(false);
   const pendingRefreshRef = useRef(false);
+  const inFlightRef = useRef<Promise<void> | null>(null);
+  const consecutiveErrorsRef = useRef(0);
+  const MAX_RETRY = 5;
 
   const refreshRuns = useCallback(() => {
     // If a fetch is already in flight, queue a follow-up refresh
-    // instead of silently dropping this request.
+    // and return the in-flight promise so callers can still await.
     if (fetchingRef.current) {
       pendingRefreshRef.current = true;
-      return Promise.resolve();
+      return inFlightRef.current ?? Promise.resolve();
     }
     fetchingRef.current = true;
 
-    return new Promise<void>((resolve, reject) => {
+    const drainPending = (isError: boolean) => {
+      if (isError) {
+        consecutiveErrorsRef.current += 1;
+      } else {
+        consecutiveErrorsRef.current = 0;
+      }
+
+      if (
+        pendingRefreshRef.current &&
+        consecutiveErrorsRef.current < MAX_RETRY
+      ) {
+        pendingRefreshRef.current = false;
+        refreshRuns();
+      } else {
+        pendingRefreshRef.current = false;
+      }
+    };
+
+    const promise = new Promise<void>((resolve, reject) => {
       fetchRuns(
         {},
         {
@@ -81,26 +102,23 @@ export const useRuns = (): UseRunsResult => {
               console.error("Error processing runs callback:", e);
               reject(e instanceof Error ? e : new Error(String(e)));
             } finally {
-              // If another refresh was requested while we were fetching,
-              // fire it now so we don't miss SSE updates.
-              if (pendingRefreshRef.current) {
-                pendingRefreshRef.current = false;
-                refreshRuns();
-              }
+              drainPending(false);
             }
           },
         }
       ).catch((error: unknown) => {
         fetchingRef.current = false;
         console.error("Operator execution failed for fetchRuns:", error);
-        // Also drain pending refresh on error
-        if (pendingRefreshRef.current) {
-          pendingRefreshRef.current = false;
-          refreshRuns();
-        }
+        drainPending(true);
         reject(error instanceof Error ? error : new Error(String(error)));
       });
     });
+
+    inFlightRef.current = promise.finally(() => {
+      inFlightRef.current = null;
+    });
+
+    return inFlightRef.current;
   }, [fetchRuns, setRuns]);
 
   useEffect(() => {

--- a/app/packages/similarity-search/src/hooks/useRuns.ts
+++ b/app/packages/similarity-search/src/hooks/useRuns.ts
@@ -45,9 +45,13 @@ export const useRuns = (): UseRunsResult => {
     "@voxel51/panels/list_similarity_runs"
   );
   const fetchingRef = useRef(false);
+  const pendingRefreshRef = useRef(false);
 
   const refreshRuns = useCallback(() => {
+    // If a fetch is already in flight, queue a follow-up refresh
+    // instead of silently dropping this request.
     if (fetchingRef.current) {
+      pendingRefreshRef.current = true;
       return Promise.resolve();
     }
     fetchingRef.current = true;
@@ -76,12 +80,24 @@ export const useRuns = (): UseRunsResult => {
             } catch (e) {
               console.error("Error processing runs callback:", e);
               reject(e instanceof Error ? e : new Error(String(e)));
+            } finally {
+              // If another refresh was requested while we were fetching,
+              // fire it now so we don't miss SSE updates.
+              if (pendingRefreshRef.current) {
+                pendingRefreshRef.current = false;
+                refreshRuns();
+              }
             }
           },
         }
       ).catch((error: unknown) => {
         fetchingRef.current = false;
         console.error("Operator execution failed for fetchRuns:", error);
+        // Also drain pending refresh on error
+        if (pendingRefreshRef.current) {
+          pendingRefreshRef.current = false;
+          refreshRuns();
+        }
         reject(error instanceof Error ? error : new Error(String(error)));
       });
     });

--- a/app/packages/similarity-search/src/hooks/useRuns.ts
+++ b/app/packages/similarity-search/src/hooks/useRuns.ts
@@ -106,7 +106,10 @@ export const useRuns = (): UseRunsResult => {
     // requested while we were busy.  On success the error counter
     // resets; on failure it increments, and we stop retrying after
     // MAX_RETRY consecutive failures.
-    inFlightRef.current = promise
+    //
+    // We use a separate chain for coalescing so the original promise's
+    // rejection propagates to callers (e.g. handleSubmitted's await).
+    promise
       .then(() => {
         errorCountRef.current = 0;
       })
@@ -123,7 +126,8 @@ export const useRuns = (): UseRunsResult => {
         }
       });
 
-    return inFlightRef.current;
+    inFlightRef.current = promise;
+    return promise;
   }, [fetchRuns, setRuns]);
 
   useEffect(() => {

--- a/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
+++ b/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
@@ -28,7 +28,10 @@ const useDerivedPanelState = (props: SimilaritySearchViewProps) => {
   } = useRuns();
   const [submitting, setSubmitting] = useState(false);
 
-  const allBrainKeys = panelData.brain_keys ?? [];
+  const allBrainKeys = useMemo(
+    () => panelData.brain_keys ?? [],
+    [panelData.brain_keys]
+  );
   const appliedRunId = (panelData as Record<string, unknown>).applied_run_id as
     | string
     | undefined;
@@ -174,7 +177,7 @@ const useSimilarityPanelActions = (deps: PanelActionsDeps) => {
       if (run) {
         setCloneConfig({
           brain_key: run.brain_key,
-          query_type: run.query_type,
+          query_type: run.query_type as "text" | "image",
           query: typeof run.query === "string" ? run.query : undefined,
           k: run.k,
           reverse: run.reverse,

--- a/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
+++ b/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useRecoilValue } from "recoil";
 import * as fos from "@fiftyone/state";
 import { SimilaritySearchViewProps, SimilarityRun } from "../types";
@@ -274,35 +274,6 @@ export const useSimilarityPanel = (props: SimilaritySearchViewProps) => {
     clearAndExit,
   });
 
-  // Auto-highlight the most recently completed run
-  const [highlightedRunId, setHighlightedRunId] = useState<
-    string | undefined
-  >();
-  const prevRunStatusesRef = useRef<Map<string, string>>(new Map());
-
-  useEffect(() => {
-    const prev = prevRunStatusesRef.current;
-    const next = new Map(state.runs.map((r) => [r.run_id, r.status]));
-
-    // Find runs that just transitioned to "completed"
-    for (const [id, status] of next) {
-      if (status === "completed" && prev.get(id) !== "completed") {
-        setHighlightedRunId(id);
-        break;
-      }
-    }
-
-    prevRunStatusesRef.current = next;
-  }, [state.runs]);
-
-  const handleApplyWithHighlight = useCallback(
-    (runId: string) => {
-      setHighlightedRunId(runId);
-      actions.handleApply(runId);
-    },
-    [actions, setHighlightedRunId]
-  );
-
   const selection = useMemo(
     () => ({
       selectMode,
@@ -333,8 +304,6 @@ export const useSimilarityPanel = (props: SimilaritySearchViewProps) => {
     brainKeys: state.brainKeys,
     isPatchesView: state.isPatchesView,
     appliedRunId: state.appliedRunId,
-    highlightedRunId,
-    setHighlightedRunId,
     sampleMedia: state.sampleMedia,
     cloneConfig,
     filterState: state.filterState,
@@ -343,7 +312,7 @@ export const useSimilarityPanel = (props: SimilaritySearchViewProps) => {
 
     // actions
     ...actions,
-    handleApply: handleApplyWithHighlight,
+    handleApply: actions.handleApply,
     refreshRuns: state.refreshRuns,
     setFilterState: state.setFilterState,
     navigateHome,

--- a/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
+++ b/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
@@ -38,6 +38,8 @@ const useDerivedPanelState = (props: SimilaritySearchViewProps) => {
       string
     >) ?? {};
 
+  const datasetName = useRecoilValue(fos.datasetName);
+
   // Detect patches view and filter brain keys accordingly
   const isPatchesView = useRecoilValue(fos.isPatchesView);
   const viewStages = useRecoilValue(fos.view);
@@ -76,7 +78,8 @@ const useDerivedPanelState = (props: SimilaritySearchViewProps) => {
   const canFilterByOwner = !!currentUser;
   const { filteredRuns, filterState, setFilterState } = useFilteredRuns(
     runs,
-    currentUser
+    currentUser,
+    datasetName
   );
 
   return {
@@ -295,6 +298,14 @@ export const useSimilarityPanel = (props: SimilaritySearchViewProps) => {
     prevRunStatusesRef.current = next;
   }, [state.runs]);
 
+  const handleApplyWithHighlight = useCallback(
+    (runId: string) => {
+      setHighlightedRunId(runId);
+      actions.handleApply(runId);
+    },
+    [actions, setHighlightedRunId]
+  );
+
   const selection = useMemo(
     () => ({
       selectMode,
@@ -335,13 +346,7 @@ export const useSimilarityPanel = (props: SimilaritySearchViewProps) => {
 
     // actions
     ...actions,
-    handleApply: useCallback(
-      (runId: string) => {
-        setHighlightedRunId(runId);
-        actions.handleApply(runId);
-      },
-      [actions.handleApply, setHighlightedRunId]
-    ),
+    handleApply: handleApplyWithHighlight,
     refreshRuns: state.refreshRuns,
     setFilterState: state.setFilterState,
     navigateHome,

--- a/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
+++ b/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRecoilValue } from "recoil";
 import * as fos from "@fiftyone/state";
 import { SimilaritySearchViewProps, SimilarityRun } from "../types";
@@ -274,6 +274,27 @@ export const useSimilarityPanel = (props: SimilaritySearchViewProps) => {
     clearAndExit,
   });
 
+  // Auto-highlight the most recently completed run
+  const [highlightedRunId, setHighlightedRunId] = useState<
+    string | undefined
+  >();
+  const prevRunStatusesRef = useRef<Map<string, string>>(new Map());
+
+  useEffect(() => {
+    const prev = prevRunStatusesRef.current;
+    const next = new Map(state.runs.map((r) => [r.run_id, r.status]));
+
+    // Find runs that just transitioned to "completed"
+    for (const [id, status] of next) {
+      if (status === "completed" && prev.get(id) !== "completed") {
+        setHighlightedRunId(id);
+        break;
+      }
+    }
+
+    prevRunStatusesRef.current = next;
+  }, [state.runs]);
+
   const selection = useMemo(
     () => ({
       selectMode,
@@ -304,6 +325,8 @@ export const useSimilarityPanel = (props: SimilaritySearchViewProps) => {
     brainKeys: state.brainKeys,
     isPatchesView: state.isPatchesView,
     appliedRunId: state.appliedRunId,
+    highlightedRunId,
+    setHighlightedRunId,
     sampleMedia: state.sampleMedia,
     cloneConfig,
     filterState: state.filterState,
@@ -312,6 +335,13 @@ export const useSimilarityPanel = (props: SimilaritySearchViewProps) => {
 
     // actions
     ...actions,
+    handleApply: useCallback(
+      (runId: string) => {
+        setHighlightedRunId(runId);
+        actions.handleApply(runId);
+      },
+      [actions.handleApply, setHighlightedRunId]
+    ),
     refreshRuns: state.refreshRuns,
     setFilterState: state.setFilterState,
     navigateHome,

--- a/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
+++ b/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
@@ -284,11 +284,7 @@ export const useSimilarityPanel = (props: SimilaritySearchViewProps) => {
     const next = new Map(state.runs.map((r) => [r.run_id, r.status]));
 
     for (const run of state.runs) {
-      if (
-        run.status === "completed" &&
-        prev.get(run.run_id) !== "completed" &&
-        !run.operator_run_id
-      ) {
+      if (run.status === "completed" && prev.get(run.run_id) !== "completed") {
         actions.handleApply(run.run_id);
         break;
       }

--- a/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
+++ b/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
@@ -38,8 +38,6 @@ const useDerivedPanelState = (props: SimilaritySearchViewProps) => {
       string
     >) ?? {};
 
-  const datasetName = useRecoilValue(fos.datasetName);
-
   // Detect patches view and filter brain keys accordingly
   const isPatchesView = useRecoilValue(fos.isPatchesView);
   const viewStages = useRecoilValue(fos.view);
@@ -78,8 +76,7 @@ const useDerivedPanelState = (props: SimilaritySearchViewProps) => {
   const canFilterByOwner = !!currentUser;
   const { filteredRuns, filterState, setFilterState } = useFilteredRuns(
     runs,
-    currentUser,
-    datasetName
+    currentUser
   );
 
   return {

--- a/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
+++ b/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
@@ -186,6 +186,13 @@ const useSimilarityPanelActions = (deps: PanelActionsDeps) => {
     [runs, setCloneConfig, navigateNewSearch]
   );
 
+  const handleRename = useCallback(
+    (runId: string, newName: string) => {
+      triggers.renameRun({ run_id: runId, new_name: newName });
+    },
+    [triggers]
+  );
+
   const handleNewSearch = useCallback(() => {
     clearCloneConfig();
     navigateNewSearch();
@@ -207,6 +214,7 @@ const useSimilarityPanelActions = (deps: PanelActionsDeps) => {
     handleDelete,
     handleBulkDelete,
     handleNewSearch,
+    handleRename,
     handleSubmitted,
   };
 };

--- a/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
+++ b/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRecoilValue } from "recoil";
 import * as fos from "@fiftyone/state";
-import { SimilaritySearchViewProps, SimilarityRun } from "../types";
+import { RunStatus, SimilaritySearchViewProps, SimilarityRun } from "../types";
 import { useNavigate } from "./useNavigate";
 import { useRuns } from "./useRuns";
 import { useFilteredRuns } from "./useFilteredRuns";
@@ -292,7 +292,10 @@ export const useSimilarityPanel = (props: SimilaritySearchViewProps) => {
     const next = new Map(state.runs.map((r) => [r.run_id, r.status]));
 
     for (const run of state.runs) {
-      if (run.status === "completed" && prev.get(run.run_id) !== "completed") {
+      if (
+        run.status === RunStatus.Completed &&
+        prev.get(run.run_id) !== RunStatus.Completed
+      ) {
         actions.handleApply(run.run_id);
         break;
       }

--- a/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
+++ b/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRecoilValue } from "recoil";
 import * as fos from "@fiftyone/state";
 import { SimilaritySearchViewProps, SimilarityRun } from "../types";
@@ -273,6 +273,29 @@ export const useSimilarityPanel = (props: SimilaritySearchViewProps) => {
     clearCloneConfig,
     clearAndExit,
   });
+
+  // Auto-apply immediate execution runs when they complete.
+  // Delegated runs (operator_run_id is set) are excluded — there's no
+  // completion event for those, so the user applies them manually.
+  const prevRunStatusesRef = useRef<Map<string, string>>(new Map());
+
+  useEffect(() => {
+    const prev = prevRunStatusesRef.current;
+    const next = new Map(state.runs.map((r) => [r.run_id, r.status]));
+
+    for (const run of state.runs) {
+      if (
+        run.status === "completed" &&
+        prev.get(run.run_id) !== "completed" &&
+        !run.operator_run_id
+      ) {
+        actions.handleApply(run.run_id);
+        break;
+      }
+    }
+
+    prevRunStatusesRef.current = next;
+  }, [state.runs, actions]);
 
   const selection = useMemo(
     () => ({

--- a/app/packages/similarity-search/src/mui.ts
+++ b/app/packages/similarity-search/src/mui.ts
@@ -1,8 +1,9 @@
 /**
- * Centralized MUI imports for components without voodo equivalents.
+ * Centralized MUI imports for components and icons without voodo equivalents.
  *
- * All icons have been migrated to voodo's IconName strings (v0.0.22+).
- * Only layout components remain here pending voodo equivalents.
+ * Most icons have been migrated to voodo's IconName strings (v0.0.22+).
+ * Remaining here: layout components pending voodo equivalents, plus
+ * individual icons that voodo doesn't yet provide.
  */
 
 // Components (pending voodo ImageList)

--- a/app/packages/similarity-search/src/mui.ts
+++ b/app/packages/similarity-search/src/mui.ts
@@ -8,3 +8,6 @@
 // Components (pending voodo ImageList)
 export { default as ImageList } from "@mui/material/ImageList";
 export { default as ImageListItem } from "@mui/material/ImageListItem";
+
+// Icons (no voodo equivalent yet)
+export { default as FileUploadOutlined } from "@mui/icons-material/FileUploadOutlined";

--- a/app/packages/similarity-search/src/types/index.ts
+++ b/app/packages/similarity-search/src/types/index.ts
@@ -57,6 +57,25 @@ export type SimilarityRun = {
 };
 
 /**
+ * Parameters sent to the similarity_search operator.
+ * Shared between the panel's buildExecutionParams and the popover.
+ */
+export type SimilaritySearchParams = {
+  brain_key: string;
+  query_type: QueryType;
+  query: string | string[];
+  reverse: boolean;
+  search_scope: SearchScope;
+  patches_field?: string;
+  k?: number;
+  dist_field?: string;
+  run_name?: string;
+  negative_query_ids?: string[];
+  dynamic_results?: boolean;
+  query_image?: { content: string; name: string };
+};
+
+/**
  * Clone config returned when cloning a run.
  */
 export type CloneConfig = {

--- a/app/packages/similarity-search/src/types/index.ts
+++ b/app/packages/similarity-search/src/types/index.ts
@@ -28,6 +28,8 @@ export type BrainKeyConfig = {
   model?: string;
   backend?: string;
   embeddings_field?: string;
+  metric?: string;
+  identifiers?: { label: string; value: string }[];
 };
 
 /**

--- a/app/packages/similarity-search/src/types/index.ts
+++ b/app/packages/similarity-search/src/types/index.ts
@@ -1,7 +1,12 @@
 /**
  * Status of a similarity search run.
  */
-export type RunStatus = "pending" | "running" | "completed" | "failed";
+export enum RunStatus {
+  Pending = "pending",
+  Running = "running",
+  Completed = "completed",
+  Failed = "failed",
+}
 
 /**
  * Type of similarity query.

--- a/app/packages/similarity-search/src/utils.ts
+++ b/app/packages/similarity-search/src/utils.ts
@@ -160,6 +160,54 @@ export function fileToBase64(
   });
 }
 
+/**
+ * Generate a default run name when the user doesn't provide one.
+ *
+ * - Text: the raw query string (rendering handles truncation/tooltip)
+ * - Image: "X samples" or "X patches" (singular/plural)
+ * - Upload: "X images" (singular/plural)
+ */
+export function buildDefaultRunName({
+  queryType,
+  textQuery,
+  queryIds,
+  negativeQueryIds,
+  patchesField,
+  uploadedImage,
+}: {
+  queryType: QueryType;
+  textQuery?: string;
+  queryIds?: string[];
+  negativeQueryIds?: string[];
+  patchesField?: string;
+  uploadedImage?: UploadedImage | null;
+}): string {
+  if (queryType === QueryType.Text) {
+    return textQuery?.trim() || "text query";
+  }
+
+  if (queryType === QueryType.Upload) {
+    const count = uploadedImage ? 1 : 0;
+    return `${count} ${count === 1 ? "image" : "images"}`;
+  }
+
+  // Image query
+  const count = queryIds?.length ?? 0;
+  const negCount = negativeQueryIds?.length ?? 0;
+  const unit = patchesField ? "patch" : "sample";
+  const pluralize = (n: number, u: string) =>
+    `${n} ${n === 1 ? u : u + (u === "patch" ? "es" : "s")}`;
+
+  if (negCount > 0) {
+    return `${pluralize(count, unit)} positive, ${pluralize(
+      negCount,
+      unit
+    )} negative`;
+  }
+
+  return pluralize(count, unit);
+}
+
 export const buildExecutionParams = (
   input: BuildExecutionParamsInput
 ): SimilaritySearchParams => {
@@ -201,7 +249,16 @@ export const buildExecutionParams = (
 
   if (k !== "") params.k = k;
   if (distField.trim()) params.dist_field = distField.trim();
-  if (runName.trim()) params.run_name = runName.trim();
+  params.run_name =
+    runName.trim() ||
+    buildDefaultRunName({
+      queryType,
+      textQuery,
+      queryIds,
+      negativeQueryIds,
+      patchesField,
+      uploadedImage: input.uploadedImage,
+    });
 
   if (negativeQueryIds.length > 0) {
     params.negative_query_ids = negativeQueryIds;

--- a/app/packages/similarity-search/src/utils.ts
+++ b/app/packages/similarity-search/src/utils.ts
@@ -1,5 +1,5 @@
 import { getFetchParameters } from "@fiftyone/utilities";
-import { buildRunName } from "@fiftyone/core/src/components/Actions/Similarity/utils";
+import { buildSimilarityRunName } from "@fiftyone/utilities";
 import {
   SimilarityRun,
   SimilaritySearchParams,
@@ -204,7 +204,7 @@ export const buildExecutionParams = (
   if (distField.trim()) params.dist_field = distField.trim();
   params.run_name =
     runName.trim() ||
-    buildRunName({
+    buildSimilarityRunName({
       isImageSearch: queryType === QueryType.Image,
       isUpload: queryType === QueryType.Upload,
       textQuery,

--- a/app/packages/similarity-search/src/utils.ts
+++ b/app/packages/similarity-search/src/utils.ts
@@ -1,4 +1,5 @@
 import { getFetchParameters } from "@fiftyone/utilities";
+import { buildRunName } from "@fiftyone/core/src/components/Actions/Similarity/utils";
 import {
   SimilarityRun,
   SimilaritySearchParams,
@@ -160,54 +161,6 @@ export function fileToBase64(
   });
 }
 
-/**
- * Generate a default run name when the user doesn't provide one.
- *
- * - Text: the raw query string (rendering handles truncation/tooltip)
- * - Image: "X samples" or "X patches" (singular/plural)
- * - Upload: "X images" (singular/plural)
- */
-export function buildDefaultRunName({
-  queryType,
-  textQuery,
-  queryIds,
-  negativeQueryIds,
-  patchesField,
-  uploadedImage,
-}: {
-  queryType: QueryType;
-  textQuery?: string;
-  queryIds?: string[];
-  negativeQueryIds?: string[];
-  patchesField?: string;
-  uploadedImage?: UploadedImage | null;
-}): string {
-  if (queryType === QueryType.Text) {
-    return textQuery?.trim() || "text query";
-  }
-
-  if (queryType === QueryType.Upload) {
-    const count = uploadedImage ? 1 : 0;
-    return `${count} ${count === 1 ? "image" : "images"}`;
-  }
-
-  // Image query
-  const count = queryIds?.length ?? 0;
-  const negCount = negativeQueryIds?.length ?? 0;
-  const unit = patchesField ? "patch" : "sample";
-  const pluralize = (n: number, u: string) =>
-    `${n} ${n === 1 ? u : u + (u === "patch" ? "es" : "s")}`;
-
-  if (negCount > 0) {
-    return `${pluralize(count, unit)} positive, ${pluralize(
-      negCount,
-      unit
-    )} negative`;
-  }
-
-  return pluralize(count, unit);
-}
-
 export const buildExecutionParams = (
   input: BuildExecutionParamsInput
 ): SimilaritySearchParams => {
@@ -251,13 +204,14 @@ export const buildExecutionParams = (
   if (distField.trim()) params.dist_field = distField.trim();
   params.run_name =
     runName.trim() ||
-    buildDefaultRunName({
-      queryType,
+    buildRunName({
+      isImageSearch: queryType === QueryType.Image,
+      isUpload: queryType === QueryType.Upload,
       textQuery,
       queryIds,
       negativeQueryIds,
       patchesField,
-      uploadedImage: input.uploadedImage,
+      hasUploadedImage: !!input.uploadedImage,
     });
 
   if (negativeQueryIds.length > 0) {

--- a/app/packages/similarity-search/src/utils.ts
+++ b/app/packages/similarity-search/src/utils.ts
@@ -1,6 +1,7 @@
 import { getFetchParameters } from "@fiftyone/utilities";
 import {
   SimilarityRun,
+  SimilaritySearchParams,
   DateFilterPreset,
   QueryType,
   SearchScope,
@@ -161,7 +162,7 @@ export function fileToBase64(
 
 export const buildExecutionParams = (
   input: BuildExecutionParamsInput
-): Record<string, unknown> => {
+): SimilaritySearchParams => {
   const {
     brainKey,
     queryType,
@@ -170,8 +171,6 @@ export const buildExecutionParams = (
     reverse,
     patchesField,
     searchScope,
-    hasView,
-    view,
     k,
     distField,
     runName,
@@ -187,22 +186,17 @@ export const buildExecutionParams = (
     query = queryIds;
   }
 
-  const isUpload = queryType === QueryType.Upload;
-
-  const params: Record<string, unknown> = {
+  const params: SimilaritySearchParams = {
     brain_key: brainKey,
     query_type: queryType,
     query,
     reverse,
+    search_scope: searchScope,
     patches_field: patchesField,
   };
 
-  if (isUpload && input.uploadedImage) {
+  if (queryType === QueryType.Upload && input.uploadedImage) {
     params.query_image = input.uploadedImage;
-  }
-
-  if (searchScope === "view" && hasView) {
-    params.source_view = view;
   }
 
   if (k !== "") params.k = k;

--- a/app/packages/utilities/src/format.ts
+++ b/app/packages/utilities/src/format.ts
@@ -1,3 +1,56 @@
+/**
+ * Pluralize a unit string: adds "s" for most words, "es" for "patch".
+ */
+export const pluralizeUnit = (count: number, unit: string): string =>
+  `${count} ${count === 1 ? unit : unit + (unit === "patch" ? "es" : "s")}`;
+
+/**
+ * Build a default display name for a similarity search run.
+ *
+ * - Text queries: return the raw query string
+ * - Upload queries: "1 image" / "0 images"
+ * - Image queries: "N samples" / "N patches" with optional negative counts
+ */
+export function buildSimilarityRunName({
+  isImageSearch,
+  isUpload,
+  textQuery,
+  queryIds,
+  negativeQueryIds,
+  patchesField,
+  hasUploadedImage,
+}: {
+  isImageSearch: boolean;
+  isUpload?: boolean;
+  textQuery?: string;
+  queryIds?: string[] | string;
+  negativeQueryIds?: string[];
+  patchesField?: string;
+  hasUploadedImage?: boolean;
+}): string {
+  if (isUpload) {
+    const count = hasUploadedImage ? 1 : 0;
+    return `${count} ${count === 1 ? "image" : "images"}`;
+  }
+
+  if (!isImageSearch) {
+    return textQuery?.trim() || "text query";
+  }
+
+  const count = Array.isArray(queryIds) ? queryIds.length : queryIds ? 1 : 0;
+  const negCount = negativeQueryIds?.length ?? 0;
+  const unit = patchesField ? "patch" : "sample";
+
+  if (negCount > 0) {
+    return `${pluralizeUnit(count, unit)} positive, ${pluralizeUnit(
+      negCount,
+      unit
+    )} negative`;
+  }
+
+  return pluralizeUnit(count, unit);
+}
+
 export function formatValueAsNumber(
   value: string | number,
   fractionDigits = 3

--- a/plugins/panels/similarity_search/__init__.py
+++ b/plugins/panels/similarity_search/__init__.py
@@ -45,8 +45,13 @@ class SimilaritySearchPanel(Panel):
         ctx.panel.set_data("runs", runs)
         ctx.panel.set_data("brain_keys", brain_keys)
 
-        # None in OSS, populated by FiftyOne Teams
-        current_user = str(ctx.user_id) if ctx.user_id else None
+        # None in OSS, populated by FiftyOne Teams.
+        # Must match the created_by format used by operators.py.
+        current_user = (
+            (getattr(ctx.user, "name", None) or str(ctx.user_id))
+            if ctx.user_id
+            else None
+        )
         ctx.panel.set_data("current_user", current_user)
 
         # Enable alt-selection visual feedback for negative queries

--- a/plugins/panels/similarity_search/__init__.py
+++ b/plugins/panels/similarity_search/__init__.py
@@ -22,6 +22,54 @@ from .run_manager import RunManager
 
 logger = logging.getLogger(__name__)
 
+# Persisted identifier fields per similarity backend. These are names of
+# remote collections/indexes/tables the user has configured — safe to
+# surface to users so they can recognize which remote resource this run
+# is backed by. Not all backends have identifiers (e.g. sklearn).
+_IDENTIFIER_FIELDS_BY_BACKEND = {
+    "qdrant": [("collection_name", "Collection")],
+    "milvus": [("collection_name", "Collection")],
+    "pinecone": [
+        ("index_name", "Index"),
+        ("namespace", "Namespace"),
+    ],
+    "mosaic": [("index_name", "Index")],
+    "mongodb": [("index_name", "Index")],
+    "elasticsearch": [("index_name", "Index")],
+    "redis": [("index_name", "Index")],
+    "pgvector": [
+        ("index_name", "Index"),
+        ("table_name", "Table"),
+    ],
+    "lancedb": [("table_name", "Table")],
+}
+
+
+def _extract_identifiers(config, backend):
+    """Return a list of ``{"label", "value"}`` dicts for the backend's
+    persisted identifier fields. Returns an empty list if the backend is
+    unknown, or if the config doesn't expose any of the expected fields.
+    """
+    if not backend or config is None:
+        return []
+    spec = _IDENTIFIER_FIELDS_BY_BACKEND.get(backend.lower())
+    if not spec:
+        return []
+
+    identifiers = []
+    for field, label in spec:
+        try:
+            value = getattr(config, field, None)
+        except Exception:
+            value = None
+        if value is None:
+            continue
+        value_str = str(value).strip()
+        if not value_str:
+            continue
+        identifiers.append({"label": label, "value": value_str})
+    return identifiers
+
 
 class SimilaritySearchPanel(Panel):
     """Panel for running and managing similarity search queries."""
@@ -262,6 +310,16 @@ class SimilaritySearchPanel(Panel):
                 model = getattr(config, "model", None)
                 backend = getattr(config, "method", None)
                 embeddings_field = getattr(config, "embeddings_field", None)
+                metric = getattr(config, "metric", None)
+                try:
+                    identifiers = _extract_identifiers(config, backend)
+                except Exception as e:
+                    logger.warning(
+                        "Failed to extract identifiers for key %s: %s",
+                        key,
+                        e,
+                    )
+                    identifiers = []
 
                 supports_least = False
                 try:
@@ -288,6 +346,8 @@ class SimilaritySearchPanel(Panel):
                         "model": model,
                         "backend": backend,
                         "embeddings_field": embeddings_field,
+                        "metric": metric,
+                        "identifiers": identifiers,
                     }
                 )
             except Exception as e:

--- a/plugins/panels/similarity_search/operators.py
+++ b/plugins/panels/similarity_search/operators.py
@@ -98,11 +98,15 @@ class SimilaritySearchOperator(foo.Operator):
 
             dataset = ctx.dataset
 
-            # Always sort against the base dataset view.
-            # source_view is stored in the run record for context
-            # but not used for the sort itself, because the brain
-            # index may have been computed on the base dataset.
-            view = dataset.view()
+            # Determine the base view for the search.
+            # "view" uses ctx.view (includes view stages, sidebar
+            # filters, and extended stages from the app).
+            # "dataset" (default) uses the bare dataset view.
+            search_scope = ctx.params.get("search_scope", "dataset")
+            if search_scope == "view":
+                view = ctx.view
+            else:
+                view = dataset.view()
 
             ctx.set_progress(0.2, label="Preparing query...")
 
@@ -145,7 +149,7 @@ class SimilaritySearchOperator(foo.Operator):
 
             ctx.set_progress(0.7, label="Collecting results...")
 
-            dynamic_results = ctx.params.get("dynamic_results", True)
+            dynamic_results = ctx.params.get("dynamic_results", False)
 
             result_ids = []
             result_view_stages = None

--- a/plugins/panels/similarity_search/operators.py
+++ b/plugins/panels/similarity_search/operators.py
@@ -149,6 +149,15 @@ class SimilaritySearchOperator(foo.Operator):
 
             ctx.set_progress(0.7, label="Collecting results...")
 
+            # dynamic_results controls how results are persisted:
+            #   True  → save the serialized SortBySimilarity view stages;
+            #           results are recomputed on apply, always reflecting
+            #           the latest dataset state (slower to load).
+            #   False → save a static list of result IDs; results are
+            #           fixed at search time (faster to load).
+            # The UI toggle for this is currently commented out in
+            # NewSearch.tsx — awaiting user feedback before deciding
+            # whether to remove it entirely.
             dynamic_results = ctx.params.get("dynamic_results", False)
 
             result_ids = []


### PR DESCRIPTION
## 🔗 Related Issues

fixes the following issues:
- current view is not respected in the run
- sim search table: added icons next to the run and added them to new search cards; 
- whole card is a click target for load search view, onClick it load results. 
- Mine | All filter wasn't working: "Mine" has a mismatch condition with user_id and user_name. 
- Update default run filter to "Mine" and "last 30 days"
- Commented out dynamic toggle: all searches will be "cached" results instead of the serialized view for now
- moved the shared util function to fiftyone/utilities package

---
New improvement:

- Added a softglow for newly completely run or selected run in the sim search table


## 📋 What changes are proposed in this pull request?

**New Features**

- Added visual icons to distinguish search types (image, text, upload)
- Completed searches now clickable for quick application
- Added search scope selection between view and dataset searches

**Improvements**


- Enhanced run name display with truncation and full-text tooltips
- Optimized refresh handling for concurrent requests
- Improved default filter settings and automatic user detection
- Restructured search action buttons layout
- Updated search results persistence behavior

selected state:
https://github.com/user-attachments/assets/07f1f1ad-b1c7-48b5-bef1-d292b315f6c5


## 🧪 How is this patch tested? If it is not, please explain why.


https://github.com/user-attachments/assets/ea7c8434-7a94-434f-8723-febbe3ea8e31

A user can trigger a similarity sort run from the pop over or from within the panel, 
under both immediate execution and delegated operation, 
in the run list page, if a run completes, automatically load the results for that run. Meanwhile, the run card will be highlighted. 

Clicking on the run card will load the results for that run (if completed). 

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image/text/upload query types and view/dataset search scope selectable.
  * Run highlighting and icons showing query type; truncated run names show full text in tooltips.

* **Improvements**
  * Improved run naming (upload counts, pluralization, cleaner text labels).
  * Default date filter preset applied; dynamic-results now off by default.
  * More robust run refresh/concurrency handling and tweaked run-actions layout/interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->