### PR TITLE
bugfix: view change should not reset sample/label selection style to default

### DIFF
--- a/app/packages/app/src/useSetters/onSetView.ts
+++ b/app/packages/app/src/useSetters/onSetView.ts
@@ -1,7 +1,6 @@
 import { rollbackViewBar } from "@fiftyone/core";
 import { setView, type setViewMutation } from "@fiftyone/relay";
 import {
-  DEFAULT_SELECTION_STYLE,
   type State,
   datasetName,
   stateSubscription,
@@ -44,7 +43,6 @@ const onSetView: RegisteredSetter =
 
         sessionRef.current.selectedLabels = [];
         sessionRef.current.selectedSamples = new Map();
-        sessionRef.current.sampleSelectionStyle = DEFAULT_SELECTION_STYLE;
         sessionRef.current.fieldVisibilityStage = undefined;
         router.history.push(
           resolveURL({

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -274,8 +274,6 @@ class Mutation(SetColorScheme):
         state.sample_id = None
         state.selected_labels = []
         state.selected_samples = []
-        state.sample_selection_style = dict(DEFAULT_SELECTION_STYLE)
-        state.label_selection_style = dict(DEFAULT_LABEL_SELECTION_STYLE)
 
         if not dataset_name:
             state.dataset = None

--- a/fiftyone/server/routes/sort.py
+++ b/fiftyone/server/routes/sort.py
@@ -46,7 +46,6 @@ class Sort(HTTPEndpoint):
         state = fose.get_state()
         state.selected_labels = []
         state.selected_samples = []
-        state.sample_selection_style = dict(DEFAULT_SELECTION_STYLE)
 
         await fose.dispatch_event(subscription, StateUpdate(state))
 


### PR DESCRIPTION


## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

<!--
Provide a clear, concise description of what this PR does and why.
-->

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sample and label selection styling preferences are preserved when changing views and when performing sorts (including sort-by-similarity), so custom selection styles no longer reset to defaults.

* **New Features**
  * Added memoized caching for label tag count computations to improve responsiveness when viewing repeated samples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->