### PR TITLE
Add list_values() to execution store for efficient bulk value retrieval

### DIFF
--- a/fiftyone/factory/repos/execution_store.py
+++ b/fiftyone/factory/repos/execution_store.py
@@ -208,6 +208,31 @@ class AbstractExecutionStoreRepo(ABC):
         pass
 
     @abstractmethod
+    def list_values(
+        self,
+        store_name: str,
+        key_prefix: Optional[str] = None,
+        exclude_fields: Optional[List[str]] = None,
+    ) -> List[Dict[str, Any]]:
+        """List all values in a store in a single query.
+
+        This is more efficient than calling :meth:`list_keys` followed by
+        individual :meth:`get_key` calls for each key.
+
+        Args:
+            store_name: the name of the store
+            key_prefix: optional key prefix to filter by (e.g. ``"run:"``)
+            exclude_fields: optional list of top-level fields to exclude
+                from each value dict (e.g. ``["result_ids"]``). The
+                exclusion is applied at the database level so heavy
+                fields are never transferred over the wire.
+
+        Returns:
+            a list of value dicts
+        """
+        pass
+
+    @abstractmethod
     def count_keys(self, store_name: str) -> int:
         """Count the number of keys in a store.
 
@@ -622,6 +647,39 @@ class MongoExecutionStoreRepo(ExecutionStoreRepo):
             {"key": 1},
         )
         return [d["key"] for d in result]
+
+    def list_values(
+        self,
+        store_name: str,
+        key_prefix: Optional[str] = None,
+        exclude_fields: Optional[List[str]] = None,
+    ) -> List[Dict[str, Any]]:
+        query: Dict[str, Any] = {
+            "store_name": store_name,
+            "key": {"$ne": "__store__"},
+            "dataset_id": self._dataset_id,
+        }
+        if key_prefix:
+            query["key"] = {"$regex": f"^{key_prefix}"}
+
+        # Build MongoDB projection to exclude heavy fields at the DB level.
+        # We always exclude Mongo internals; additionally exclude any
+        # requested value sub-fields via dot-notation on the ``value`` dict.
+        projection: Dict[str, int] = {
+            "_id": 0,
+            "store_name": 0,
+            "dataset_id": 0,
+            "policy": 0,
+            "created_at": 0,
+            "updated_at": 0,
+            "expires_at": 0,
+        }
+        if exclude_fields:
+            for field in exclude_fields:
+                projection[f"value.{field}"] = 0
+
+        result = self._collection.find(query, projection)
+        return [d.get("value") for d in result if d.get("value") is not None]
 
     def count_keys(self, store_name: str) -> int:
         return self._collection.count_documents(

--- a/fiftyone/factory/repos/execution_store.py
+++ b/fiftyone/factory/repos/execution_store.py
@@ -7,6 +7,7 @@ Execution store repository interface and implementations.
 """
 
 import logging
+import re
 from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
@@ -660,7 +661,7 @@ class MongoExecutionStoreRepo(ExecutionStoreRepo):
             "dataset_id": self._dataset_id,
         }
         if key_prefix:
-            query["key"] = {"$regex": f"^{key_prefix}"}
+            query["key"]["$regex"] = f"^{re.escape(key_prefix)}"
 
         # Build MongoDB projection to exclude heavy fields at the DB level.
         # We always exclude Mongo internals; additionally exclude any
@@ -900,6 +901,32 @@ class InMemoryExecutionStoreRepo(ExecutionStoreRepo):
             for (s, k, ds) in self._docs.keys()
             if s == store_name and ds == self._dataset_id and k != "__store__"
         ]
+
+    def list_values(
+        self,
+        store_name: str,
+        key_prefix: Optional[str] = None,
+        exclude_fields: Optional[List[str]] = None,
+    ) -> List[Dict[str, Any]]:
+        values = []
+        for (s, k, ds), doc in self._docs.items():
+            if s != store_name or ds != self._dataset_id or k == "__store__":
+                continue
+            if key_prefix and not k.startswith(key_prefix):
+                continue
+
+            value = doc.get("value")
+            if value is None:
+                continue
+
+            if exclude_fields and isinstance(value, dict):
+                value = {
+                    f: v for f, v in value.items() if f not in exclude_fields
+                }
+
+            values.append(value)
+
+        return values
 
     def count_keys(self, store_name: str) -> int:
         return len(self.list_keys(store_name))

--- a/fiftyone/operators/store/service.py
+++ b/fiftyone/operators/store/service.py
@@ -249,6 +249,32 @@ class ExecutionStoreService(object):
         """
         return self._repo.list_keys(store_name)
 
+    def list_values(
+        self,
+        store_name: str,
+        key_prefix: Optional[str] = None,
+        exclude_fields: Optional[list[str]] = None,
+    ) -> list[dict[str, Any]]:
+        """Lists all values in the specified store in a single query.
+
+        This is more efficient than calling :meth:`list_keys` followed by
+        individual :meth:`get_key` calls for each key.
+
+        Args:
+            store_name: the name of the store
+            key_prefix: optional key prefix to filter by
+            exclude_fields: optional list of top-level fields to exclude
+                from each value dict at the database level
+
+        Returns:
+            a list of value dicts
+        """
+        return self._repo.list_values(
+            store_name,
+            key_prefix=key_prefix,
+            exclude_fields=exclude_fields,
+        )
+
     def count_keys(self, store_name: str) -> int:
         """Counts the keys in the specified store.
 

--- a/fiftyone/operators/store/store.py
+++ b/fiftyone/operators/store/store.py
@@ -210,6 +210,33 @@ class ExecutionStore(object):
         """
         return self._store_service.list_keys(self.store_name)
 
+    def list_values(
+        self,
+        key_prefix: Optional[str] = None,
+        exclude_fields: Optional[list[str]] = None,
+    ) -> list[dict]:
+        """Lists all values in the store in a single query.
+
+        This is more efficient than calling :meth:`list_keys` followed by
+        individual :meth:`get` calls for each key.
+
+        Args:
+            key_prefix (None): optional key prefix to filter by
+                (e.g. ``"run:"`` to only return run records)
+            exclude_fields (None): optional list of top-level fields
+                to exclude from each value dict. The exclusion is applied
+                at the database level so heavy fields are never
+                transferred over the wire.
+
+        Returns:
+            a list of value dicts
+        """
+        return self._store_service.list_values(
+            self.store_name,
+            key_prefix=key_prefix,
+            exclude_fields=exclude_fields,
+        )
+
     def subscribe(self, callback: Callable[[MessageData], None]) -> str:
         """Subscribes to changes in the store.
 

--- a/plugins/panels/similarity_search/run_manager.py
+++ b/plugins/panels/similarity_search/run_manager.py
@@ -146,21 +146,10 @@ class RunManager:
         Returns:
             list of run data dicts
         """
-        keys = self._store.list_keys()
-        runs = []
-        for key in keys:
-            if key.startswith(self._RUN_PREFIX):
-                run = self._store.get(key)
-                if run:
-                    # Strip heavy fields for listing
-                    runs.append(
-                        {
-                            k: v
-                            for k, v in run.items()
-                            if k not in self._HEAVY_FIELDS
-                        }
-                    )
-
+        runs = self._store.list_values(
+            key_prefix=self._RUN_PREFIX,
+            exclude_fields=list(self._HEAVY_FIELDS),
+        )
         runs.sort(key=lambda r: r.get("creation_time", ""), reverse=True)
         return runs
 


### PR DESCRIPTION
## 🔗 Related Issues

## 📋 What changes are proposed in this pull request?

### 
Summary

- Adds list_values() method to the execution store that retrieves all values in a single MongoDB query with optional key prefix filtering and field exclusion via projection
- Replaces the N+1 query pattern (list_keys() + individual get() per key) in the verified auto labeling panel and similarity search panel's RunManager.list_runs()

```
# Before: 
keys = self._store.list_keys()        # query 1
for key in keys:
    data = self._store.get(key)        # queries 2..N+1

# After: 
runs = self._store.list_values()       # single find()
```

reference: 
https://github.com/voxel51/fiftyone-teams/blob/develop/plugins/panels/auto_labeling/run_manager.py#L39-L62

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

purely internal optimization. The API surface for panels doesn't change, no new user-facing features, no behavior differences. Runs load the same way, just faster on the backend. 

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk retrieval of stored execution values with optional key-prefix filtering and top-level field exclusion.

* **Performance Improvements**
  * Value listing operations now fetch matching records in a single batch query instead of per-key lookups, reducing overhead.

* **Behavioral**
  * Run listing now leverages the bulk retrieval to return records filtered and sorted by creation time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->