### PR TITLE
Foepd 3705 e2 e test large groups is failing

### DIFF
--- a/e2e-pw/src/oss/poms/modal/index.ts
+++ b/e2e-pw/src/oss/poms/modal/index.ts
@@ -171,6 +171,30 @@ export class ModalPom {
     }, left);
   }
 
+  async scrollCarouselTo(slice: string) {
+    await this.groupCarousel
+      .getByTestId("flashlight")
+      .evaluate(async (el, targetText) => {
+        const hasTarget = () => {
+          for (const t of el.querySelectorAll('[data-cy="thumbnail-title"]')) {
+            if (t.textContent === targetText) return true;
+          }
+          return false;
+        };
+
+        if (hasTarget()) return;
+
+        // 384ms is the debounce time for Flashlight's zooming plus two frames of margin
+        const ZOOMING_DEBOUNCE_MS = 384;
+        const step = Math.max(el.clientWidth, 200);
+        for (let pos = 0; pos <= el.scrollWidth; pos += step) {
+          el.scrollTo({ left: pos });
+          await new Promise((r) => setTimeout(r, ZOOMING_DEBOUNCE_MS));
+          if (hasTarget()) return;
+        }
+      }, slice);
+  }
+
   async navigateCarousel(index: number, allowErrorInfo = false) {
     const looker = this.groupCarousel.getByTestId("looker").nth(index);
 

--- a/e2e-pw/src/oss/specs/groups/large-groups.spec.ts
+++ b/e2e-pw/src/oss/specs/groups/large-groups.spec.ts
@@ -76,27 +76,27 @@ test.describe.serial("group carousel", () => {
       await modal.sidebar.toggleSidebarGroup("GROUP");
       await modal.sidebar.assert.verifySidebarEntryText("group.name", "0");
       await modal.waitForCarouselToLoad();
-      await modal.scrollCarousel();
+      await modal.scrollCarouselTo("19");
       await modal.navigateSlice("group.name", "19", true);
       await modal.sidebar.assert.verifySidebarEntryText("group.name", "19");
 
-      await modal.scrollCarousel();
+      await modal.scrollCarouselTo("39");
       await modal.navigateSlice("group.name", "39", true);
       await modal.sidebar.assert.verifySidebarEntryText("group.name", "39");
 
-      await modal.scrollCarousel();
+      await modal.scrollCarouselTo("59");
       await modal.navigateSlice("group.name", "59", true);
       await modal.sidebar.assert.verifySidebarEntryText("group.name", "59");
 
-      await modal.scrollCarousel();
+      await modal.scrollCarouselTo("79");
       await modal.navigateSlice("group.name", "79", true);
       await modal.sidebar.assert.verifySidebarEntryText("group.name", "79");
 
-      await modal.scrollCarousel();
+      await modal.scrollCarouselTo("99");
       await modal.navigateSlice("group.name", "99", true);
       await modal.sidebar.assert.verifySidebarEntryText("group.name", "99");
 
-      await modal.scrollCarousel(0);
+      await modal.scrollCarouselTo("0");
       await modal.navigateSlice("group.name", "0", true);
       await modal.sidebar.assert.verifySidebarEntryText("group.name", "0");
       await modal.close();

--- a/e2e-pw/src/oss/specs/regression-tests/grid-page.spec.ts
+++ b/e2e-pw/src/oss/specs/regression-tests/grid-page.spec.ts
@@ -64,7 +64,7 @@ test.describe.serial("grid page", () => {
     await grid.openFirstSample();
     await modal.sidebar.toggleSidebarGroup("GROUP");
     await modal.waitForCarouselToLoad();
-    await modal.scrollCarousel();
+    await modal.scrollCarouselTo("20");
     await modal.navigateSlice("group.name", "20", true);
     await modal.sidebar.assert.verifySidebarEntryText("group.name", "20");
   });
@@ -81,7 +81,7 @@ test.describe.serial("grid page", () => {
     await grid.openFirstSample();
     await modal.group.setDynamicGroupsNavigationMode("carousel");
     await modal.waitForCarouselToLoad();
-    await modal.scrollCarousel();
+    await modal.scrollCarouselTo("20");
     await modal.navigateSlice("i", "20", true);
     await modal.sidebar.assert.verifySidebarEntryText("i", "20");
   });


### PR DESCRIPTION
## 🔗 Related Issues
https://voxel51.atlassian.net/browse/FOEPD-3705

## 📋 What changes are proposed in this pull request?

The `large-groups` carousel e2e test was failing because `scrollCarousel` scrolls to `scrollWidth` which overshoots the target slice when pages load faster than expected. I believe a recent commit sped up server side response times causing extra pages to load during Flashlight's zooming debounce window. Additionally, large scroll jumps trigger Flashlight's zooming mode, which renders sections with `soft=true` and skips creating looker elements, leaving the DOM with empty section containers that Playwright's `hasText` filter has a hard time matching. The fix introduces `scrollCarouselTo(slice)`, which incrementally scrolls the carousel one viewport width at a time, waiting out the 384ms zooming debounce at each step, and stops as soon as the target thumbnail title appears in the DOM. This stops the test from overshooting targets when scrolling with `scrollCarousel`.


## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn e2e large-groups`


## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced carousel navigation in test scenarios with targeted scrolling functionality
  * Updated test flows to navigate to specific carousel items with improved precision and reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->