### PR TITLE
Fix DatasetView has no field '_label_tags' error  triggered from the FE

### DIFF
--- a/app/packages/state/src/recoil/pathData/counts.test.ts
+++ b/app/packages/state/src/recoil/pathData/counts.test.ts
@@ -8,16 +8,42 @@ import {
 } from "../../../../../__mocks__/recoil";
 import * as counts from "./counts";
 
-// Tracks `aggregation(params)` calls so tests below can assert that
+// Tracks every `aggregation(params)` lookup so tests can assert that
 // `_label_tags` never reaches the server-side aggregations resolver (there is
 // no `_label_tags` field on the view; it is derived client-side).
 const aggregationCalls: { path: string }[] = [];
-const cumulativeCountsCalls: { path: string; ftype: string }[] = [];
+
+const LABEL_TAG_AGGS: Record<
+  string,
+  {
+    __typename: "StringAggregation";
+    values: { value: string; count: number }[];
+  }
+> = {
+  "ground_truth.detections.tags": {
+    __typename: "StringAggregation",
+    values: [
+      { value: "labelTest", count: 10 },
+      { value: "correct", count: 5 },
+    ],
+  },
+  "predictions.detections.tags": {
+    __typename: "StringAggregation",
+    values: [{ value: "labelTest", count: 7 }],
+  },
+};
 
 setMockAtoms({
   aggregation: (params: { path: string }) => {
     aggregationCalls.push(params);
-    return undefined;
+    if (params.path === "_label_tags") {
+      // The regression we're guarding against: the server raises
+      // `DatasetView has no field '_label_tags'` if this path is ever sent.
+      throw new Error(
+        "aggregation should never be called with path '_label_tags'"
+      );
+    }
+    return LABEL_TAG_AGGS[params.path];
   },
   count: ({ path }: { path: string }) => {
     if (path !== "my_keypoints.keypoints") {
@@ -25,11 +51,19 @@ setMockAtoms({
     }
     return 1;
   },
-  cumulativeCounts: (params: { path: string; ftype: string }) => {
-    cumulativeCountsCalls.push(params);
-    return { labelTest: 17, correct: 5 };
-  },
-  field: () => undefined,
+  // Re-enter the real `counts` / `cumulativeCounts` resolvers when they appear
+  // in a `get(...)` inside another selector. This keeps the full
+  // counts → cumulativeCounts → counts(sub-path) → aggregation chain live
+  // rather than stubbing it to a tautology.
+  counts: (params) => (counts.counts(params) as unknown as () => unknown)(),
+  cumulativeCounts: (params) =>
+    (counts.cumulativeCounts(params) as unknown as () => unknown)(),
+  gatheredPaths: () => ["ground_truth.detections", "predictions.detections"],
+  // Any non-empty object is fine — we only need `Boolean(field)` to be truthy
+  // so that `counts` does not short-circuit into the skeleton / pseudo-path
+  // branches when resolving the per-label-field sub-paths.
+  field: (path: string) =>
+    path === "_label_tags" ? undefined : { name: path, ftype: "StringField" },
   isListField: () => false,
 });
 
@@ -56,23 +90,22 @@ describe("counts for _label_tags pseudo-path", () => {
     }))
   );
 
-  it("routes through cumulativeCounts(MATCH_LABEL_TAGS) without hitting aggregation", () => {
+  it("sums real per-label-field .tags aggregations; never aggregates on _label_tags", () => {
     aggregationCalls.length = 0;
-    cumulativeCountsCalls.length = 0;
 
-    // sums come from per-label-field `.tags` aggregations via cumulativeCounts
+    // End-to-end summation: {labelTest: 10+7, correct: 5}. The numbers come
+    // from running the real cumulativeCounts → counts → aggregation chain
+    // over the two mocked label paths.
     expect(testCounts()).toEqual({ labelTest: 17, correct: 5 });
 
-    // server has no `_label_tags` field — we must never aggregate on it
-    expect(aggregationCalls.some((c) => c?.path === "_label_tags")).toBe(false);
+    const paths = aggregationCalls.map((c) => c.path);
 
-    // one cumulativeCounts call, shaped like MATCH_LABEL_TAGS (path: "tags",
-    // ftype: EMBEDDED_DOCUMENT_FIELD)
-    expect(cumulativeCountsCalls).toHaveLength(1);
-    expect(cumulativeCountsCalls[0]).toMatchObject({
-      extended: false,
-      modal: false,
-      path: "tags",
-    });
+    // Real label-field `.tags` aggregations DID fire (this is the query that
+    // still needs to hit the server for full-view counts).
+    expect(paths).toContain("ground_truth.detections.tags");
+    expect(paths).toContain("predictions.detections.tags");
+
+    // The pseudo-path itself must never be aggregated.
+    expect(paths).not.toContain("_label_tags");
   });
 });

--- a/app/packages/state/src/recoil/pathData/counts.test.ts
+++ b/app/packages/state/src/recoil/pathData/counts.test.ts
@@ -8,6 +8,31 @@ import {
 } from "../../../../../__mocks__/recoil";
 import * as counts from "./counts";
 
+// Tracks `aggregation(params)` calls so tests below can assert that
+// `_label_tags` never reaches the server-side aggregations resolver (there is
+// no `_label_tags` field on the view; it is derived client-side).
+const aggregationCalls: { path: string }[] = [];
+const cumulativeCountsCalls: { path: string; ftype: string }[] = [];
+
+setMockAtoms({
+  aggregation: (params: { path: string }) => {
+    aggregationCalls.push(params);
+    return undefined;
+  },
+  count: ({ path }: { path: string }) => {
+    if (path !== "my_keypoints.keypoints") {
+      throw new Error(`wrong path ${path}`);
+    }
+    return 1;
+  },
+  cumulativeCounts: (params: { path: string; ftype: string }) => {
+    cumulativeCountsCalls.push(params);
+    return { labelTest: 17, correct: 5 };
+  },
+  field: () => undefined,
+  isListField: () => false,
+});
+
 describe("resolves none counts", () => {
   const testNoneCount = <TestSelectorFamily<typeof counts.noneCount>>(
     (<unknown>counts.noneCount({
@@ -17,18 +42,37 @@ describe("resolves none counts", () => {
     }))
   );
 
-  setMockAtoms({
-    aggregation: () => undefined,
-    count: ({ path }) => {
-      if (path !== "my_keypoints.keypoints") {
-        throw new Error(`wrong path ${path}`);
-      }
-      return 1;
-    },
-    isListField: () => false,
-  });
-
   it("resolves with undefined count", () => {
     expect(testNoneCount()).toBe(1);
+  });
+});
+
+describe("counts for _label_tags pseudo-path", () => {
+  const testCounts = <TestSelectorFamily<typeof counts.counts>>(
+    (<unknown>counts.counts({
+      extended: false,
+      modal: false,
+      path: "_label_tags",
+    }))
+  );
+
+  it("routes through cumulativeCounts(MATCH_LABEL_TAGS) without hitting aggregation", () => {
+    aggregationCalls.length = 0;
+    cumulativeCountsCalls.length = 0;
+
+    // sums come from per-label-field `.tags` aggregations via cumulativeCounts
+    expect(testCounts()).toEqual({ labelTest: 17, correct: 5 });
+
+    // server has no `_label_tags` field — we must never aggregate on it
+    expect(aggregationCalls.some((c) => c?.path === "_label_tags")).toBe(false);
+
+    // one cumulativeCounts call, shaped like MATCH_LABEL_TAGS (path: "tags",
+    // ftype: EMBEDDED_DOCUMENT_FIELD)
+    expect(cumulativeCountsCalls).toHaveLength(1);
+    expect(cumulativeCountsCalls[0]).toMatchObject({
+      extended: false,
+      modal: false,
+      path: "tags",
+    });
   });
 });

--- a/app/packages/state/src/recoil/pathData/counts.ts
+++ b/app/packages/state/src/recoil/pathData/counts.ts
@@ -105,6 +105,12 @@ export const counts = selectorFamily({
   get:
     (params: { extended: boolean; path: string; modal: boolean }) =>
     ({ get }): { [key: string]: number } => {
+      // _label_tags is a pseudo-path derived client-side so queries
+      // for it should not reach the server
+      if (params.path === "_label_tags") {
+        return get(cumulativeCounts({ ...params, ...MATCH_LABEL_TAGS }));
+      }
+
       const exists = Boolean(get(schemaAtoms.field(params.path)));
 
       if (!exists) {

--- a/e2e-pw/src/oss/fixtures/aggregation-watcher.ts
+++ b/e2e-pw/src/oss/fixtures/aggregation-watcher.ts
@@ -1,0 +1,59 @@
+import type { Page } from "@playwright/test";
+
+type GraphQLOp = {
+  operationName?: string;
+  variables?: { form?: { paths?: unknown } };
+};
+
+/**
+ * Passively records every path requested via `aggregationsQuery`. Use it to
+ * assert on what aggregations an interaction did (or did not) send to the
+ * server — e.g. that client-only pseudo paths are never requested, that no
+ * path is requested more times than expected, or that an interaction only
+ * aggregates an allowlisted subset of the schema.
+ *
+ * Implemented with `page.on("request")`, which is a passive observer: no
+ * routing, no request modification, no added latency, no races.
+ */
+export class AggregationWatcher {
+  private paths: string[] = [];
+
+  constructor(page: Page) {
+    page.on("request", (req) => {
+      if (!req.url().endsWith("/graphql")) return;
+
+      let body: unknown;
+      try {
+        body = req.postDataJSON();
+      } catch {
+        return;
+      }
+      if (!body) return;
+
+      const ops: GraphQLOp[] = Array.isArray(body)
+        ? (body as GraphQLOp[])
+        : [body as GraphQLOp];
+
+      for (const op of ops) {
+        if (op?.operationName !== "aggregationsQuery") continue;
+        const p = op.variables?.form?.paths;
+        if (Array.isArray(p)) {
+          for (const entry of p) {
+            if (typeof entry === "string") this.paths.push(entry);
+          }
+        }
+      }
+    });
+  }
+
+  /** Returns a snapshot of every `paths` entry seen so far across all
+   * `aggregationsQuery` requests. Duplicates are preserved intentionally so
+   * callers can reason about how many times a path was requested. */
+  allPaths() {
+    return [...this.paths];
+  }
+
+  reset() {
+    this.paths = [];
+  }
+}

--- a/e2e-pw/src/oss/fixtures/index.ts
+++ b/e2e-pw/src/oss/fixtures/index.ts
@@ -3,6 +3,7 @@ import { DatasetFactory } from "src/shared/dataset-factory";
 import { EventUtils } from "src/shared/event-utils";
 import { MediaFactory } from "src/shared/media-factory";
 import { AbstractFiftyoneLoader } from "../../shared/abstract-loader";
+import { AggregationWatcher } from "./aggregation-watcher";
 import { AnnotateSDK } from "./annotate-sdk";
 import { FoWebServer } from "./fo-server";
 import { OssLoader } from "./loader";
@@ -22,6 +23,7 @@ export type CustomFixturesWithoutPage = {
 // these fixtures have access to the {page} fixture
 export type CustomFixturesWithPage = {
   eventUtils: EventUtils;
+  aggregationWatcher: AggregationWatcher;
 };
 
 const customFixtures = base.extend<object, CustomFixturesWithoutPage>({
@@ -76,6 +78,9 @@ const customFixtures = base.extend<object, CustomFixturesWithoutPage>({
 export const test = customFixtures.extend<CustomFixturesWithPage>({
   eventUtils: async ({ page }, use) => {
     await use(new EventUtils(page));
+  },
+  aggregationWatcher: async ({ page }, use) => {
+    await use(new AggregationWatcher(page));
   },
   baseURL: async ({ fiftyoneServerPort }, use) => {
     if (process.env.USE_DEV_BUILD?.toLocaleLowerCase() === "true") {

--- a/e2e-pw/src/oss/specs/smoke-tests/tagger.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/tagger.spec.ts
@@ -82,6 +82,7 @@ test.describe.serial("tag", () => {
   });
 
   test("In grid, I can add a new label tag to all samples", async ({
+    aggregationWatcher,
     grid,
     page,
     sidebar,
@@ -103,6 +104,15 @@ test.describe.serial("tag", () => {
     const bubble2 = page.getByTestId("tag-_label_tags-labeltest:-22");
     await expect(bubble1).toBeVisible();
     await expect(bubble2).toBeVisible();
+
+    // `_label_tags` is a client-derived pseudo path; the server has no such
+    // field on the view and throws `DatasetView has no field '_label_tags'`
+    // if it ever appears in an aggregations form. Full-view label-tag counts
+    // come from per-label-field `.tags` aggregations (via cumulativeCounts).
+    expect(
+      aggregationWatcher.allPaths(),
+      "aggregationsQuery must never request '_label_tags'"
+    ).not.toContain("_label_tags");
   });
 
   test("In modal, I can add a label tag to a filtered sample", async ({


### PR DESCRIPTION
## 🔗 Related Issues

Occasionally app e2e tests will fail on shard 4 with this in the logs:
```
 stderr: DatasetView has no field '_label_tags'                                                                                            
                                                                                                                                            
                                                                                                                                            
  GraphQL request:4:3                                                                                                                       
  3 | ) {                                                                                                                                   
  4 |   aggregations(form: $form) {                                                                                                         
    |   ^                                                                                                                                   
  5 |     __typename                                                                                                                        
  Traceback (most recent call last):                                                                                                        
    File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/graphql/execution/execute.py", line 530, in await_result     
      return_type, field_nodes, info, path, await result                                                                                    
    File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/strawberry/schema/schema_converter.py", line 789, in         
  _async_resolver                                                                                                                           
      return await await_maybe(                                                                                                             
    File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/strawberry/utils/await_maybe.py", line 13, in await_maybe    
      return await value                                                                                                                    
    File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/fiftyone/server/aggregations.py", line 167, in               
  aggregate_resolver                                                                                                                        
      result = await view._async_aggregate(flattened, maxTimeMS=maxTimeMS)                                                                  
    File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/fiftyone/core/collections.py", line 12292, in                
  _async_aggregate                                                                                                                          
      compiled_facet_aggs, facet_pipelines, hints = self._build_facets(                                                                     
    File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/fiftyone/core/collections.py", line 12431, in _build_facets  
      pipeline=aggregation.to_mongo(self),                                                                                                  
    File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/fiftyone/core/aggregations.py", line 580, in to_mongo        
      path, pipeline, _, _, _ = _parse_field_and_expr(                                                                                      
    File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/fiftyone/core/aggregations.py", line 3089, in                
  _parse_field_and_expr                                                                                                                     
      ) = sample_collection._parse_field_name(                                                                                              
    File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/fiftyone/core/collections.py", line 12702, in                
  _parse_field_name                                                                                                                         
      return _parse_field_name(                                                                                                             
    File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/fiftyone/core/collections.py", line 13844, in                
  _parse_field_name                                                                                                                         
      raise ValueError(                                                                                                                     
  ValueError: DatasetView has no field '_label_tags'. Do not switch branches as I am working on something in this branch.     
```

## 📋 What changes are proposed in this pull request?

Cleans up an unintended side effect where the sidebar's label-tag entry sent the pseudo-path _label_tags to aggregationsQuery, leading to `DatasetView has no field '_label_tags'`.

## 🧪 How is this patch tested? If it is not, please explain why.

- tested running app locally and siebar label and sample tags still render/filter fine
- added/updated tests

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized label tag functionality with improved client-side data handling, reducing unnecessary server requests.

* **Tests**
  * Added comprehensive test coverage for label tag operations.
  * Introduced test instrumentation to monitor and validate server request behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->