### PR TITLE
[HA] Add disambiguation between positive/negative point selection

### DIFF
--- a/app/packages/annotation/src/agents/hooks/usePointSelection.ts
+++ b/app/packages/annotation/src/agents/hooks/usePointSelection.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import type { Point } from "@fiftyone/lighter";
+import type { DrawStyle, Point } from "@fiftyone/lighter";
 import {
   InteractiveKeypointHandler,
   KeypointOptions,
@@ -11,9 +11,41 @@ import {
 import { atom, useAtom } from "jotai";
 import { v4 as uuidv4 } from "uuid";
 
+/** Variant keys used by point selection. */
+export const POSITIVE_POINT_VARIANT = "positive" as const;
+export const NEGATIVE_POINT_VARIANT = "negative" as const;
+
+type PointSelectionVariant =
+  | typeof POSITIVE_POINT_VARIANT
+  | typeof NEGATIVE_POINT_VARIANT;
+
+/** Mapping of supported variant styles to draw styles. */
+const POINT_SELECTION_VARIANT_STYLES: Record<PointSelectionVariant, DrawStyle> =
+  {
+    [POSITIVE_POINT_VARIANT]: {
+      fillStyle: "#1e7d45", // todo reference from voodo
+      strokeStyle: "#ffffff",
+    },
+    [NEGATIVE_POINT_VARIANT]: {
+      fillStyle: "#c33636", // todo reference from voodo
+      strokeStyle: "#ffffff",
+    },
+  };
+
 export interface PointSelection {
-  activate(hitTest?: (relativePoint: Point) => boolean): void;
+  /**
+   * Activates point selection. The optional resolver is invoked for each
+   * placed point and should return the variant key to associate with it.
+   */
+  activate(resolveVariant?: (relativePoint: Point) => string | undefined): void;
+
+  /**
+   * Deactivates point selection. Disables interactivity with the point
+   * selection business logic.
+   */
   deactivate(): void;
+
+  /** The current activation status of the point selection tool. */
   isActive: boolean;
 }
 
@@ -45,7 +77,7 @@ export const usePointSelection = (): PointSelection => {
   const [isActive, setIsActive] = useAtom(pointSelectionActiveAtom);
 
   const activate = useCallback(
-    (hitTest?: (relativePoint: Point) => boolean) => {
+    (resolveVariant?: (relativePoint: Point) => string | undefined) => {
       if (isActive) {
         return;
       }
@@ -57,6 +89,7 @@ export const usePointSelection = (): PointSelection => {
             id: uuidv4(),
             label: { label: "", points: [] },
             field: "",
+            variantStyles: POINT_SELECTION_VARIANT_STYLES,
           }
         );
 
@@ -64,7 +97,7 @@ export const usePointSelection = (): PointSelection => {
         scene.addOverlay(overlay);
 
         scene.enterInteractiveMode(
-          new InteractiveKeypointHandler(overlay, eventBus, hitTest)
+          new InteractiveKeypointHandler(overlay, eventBus, resolveVariant)
         );
 
         setIsActive(true);

--- a/app/packages/annotation/src/agents/hooks/usePointSelection.ts
+++ b/app/packages/annotation/src/agents/hooks/usePointSelection.ts
@@ -15,7 +15,7 @@ import { v4 as uuidv4 } from "uuid";
 export const POSITIVE_POINT_VARIANT = "positive" as const;
 export const NEGATIVE_POINT_VARIANT = "negative" as const;
 
-type PointSelectionVariant =
+export type PointSelectionVariant =
   | typeof POSITIVE_POINT_VARIANT
   | typeof NEGATIVE_POINT_VARIANT;
 
@@ -37,7 +37,9 @@ export interface PointSelection {
    * Activates point selection. The optional resolver is invoked for each
    * placed point and should return the variant key to associate with it.
    */
-  activate(resolveVariant?: (relativePoint: Point) => string | undefined): void;
+  activate(
+    resolveVariant?: (relativePoint: Point) => PointSelectionVariant
+  ): void;
 
   /**
    * Deactivates point selection. Disables interactivity with the point
@@ -77,7 +79,7 @@ export const usePointSelection = (): PointSelection => {
   const [isActive, setIsActive] = useAtom(pointSelectionActiveAtom);
 
   const activate = useCallback(
-    (resolveVariant?: (relativePoint: Point) => string | undefined) => {
+    (resolveVariant?: (relativePoint: Point) => PointSelectionVariant) => {
       if (isActive) {
         return;
       }

--- a/app/packages/annotation/src/agents/hooks/useRegisterAIAnnotationEventHandlers.ts
+++ b/app/packages/annotation/src/agents/hooks/useRegisterAIAnnotationEventHandlers.ts
@@ -1,5 +1,11 @@
 import { useRegisterAnnotationToolEventHandlers } from "./useRegisterAnnotationToolEventHandlers";
 
-export const useRegisterAISegmentationEventHandlers = () => {
+/**
+ * Hook which registers event handlers for AI-assisted annotation functionality.
+ *
+ * **Note: this hook must only be invoked in a single top-level component;
+ * reuse will cause duplicate event handler registration.**
+ */
+export const useRegisterAIAnnotationEventHandlers = () => {
   useRegisterAnnotationToolEventHandlers();
 };

--- a/app/packages/annotation/src/agents/hooks/useRegisterAnnotationToolEventHandlers.ts
+++ b/app/packages/annotation/src/agents/hooks/useRegisterAnnotationToolEventHandlers.ts
@@ -22,6 +22,13 @@ const isToolsContextValid = (context: ToolsContext): boolean => {
   );
 };
 
+/**
+ * Hook which registers event handlers related to AI-assisted annotation tools,
+ * e.g. point selection.
+ *
+ * **Note: this hook must only be invoked in a single top-level component;
+ * reuse will cause duplicate event handler registration.**
+ */
 export const useRegisterAnnotationToolEventHandlers = () => {
   const toolsContext = useToolsContext();
   const { reset: resetToolsState } = useToolsState();

--- a/app/packages/annotation/src/agents/hooks/useRegisterPointSelectionEventHandlers.ts
+++ b/app/packages/annotation/src/agents/hooks/useRegisterPointSelectionEventHandlers.ts
@@ -4,7 +4,7 @@ import {
   useLighterEventHandler,
 } from "@fiftyone/lighter";
 import { useToolsState } from "./useToolsContext";
-import { usePointSelection } from "./usePointSelection";
+import { NEGATIVE_POINT_VARIANT, usePointSelection } from "./usePointSelection";
 import { useCallback } from "react";
 
 /**
@@ -39,7 +39,7 @@ export const useRegisterPointSelectionEventHandlers = () => {
             point: [payload.point.x, payload.point.y] as [number, number],
           };
 
-          if (payload.onMask) {
+          if (payload.variant === NEGATIVE_POINT_VARIANT) {
             addNegativePoint(descriptor);
           } else {
             addPositivePoint(descriptor);
@@ -55,7 +55,7 @@ export const useRegisterPointSelectionEventHandlers = () => {
     useCallback(
       (payload) => {
         if (isPointSelectionActive) {
-          if (payload.onMask) {
+          if (payload.variant === NEGATIVE_POINT_VARIANT) {
             removeNegativePoint(payload.pointId);
           } else {
             removePositivePoint(payload.pointId);

--- a/app/packages/annotation/src/agents/hooks/useRegisterPointSelectionEventHandlers.ts
+++ b/app/packages/annotation/src/agents/hooks/useRegisterPointSelectionEventHandlers.ts
@@ -7,6 +7,13 @@ import { useToolsState } from "./useToolsContext";
 import { usePointSelection } from "./usePointSelection";
 import { useCallback } from "react";
 
+/**
+ * Hook which registers event handlers for the positive/negative point
+ * selection tool.
+ *
+ * **Note: this hook must only be invoked in a single top-level component;
+ * reuse will cause duplicate event handler registration.**
+ */
 export const useRegisterPointSelectionEventHandlers = () => {
   const { scene } = useLighter();
   const {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Annotate.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Annotate.tsx
@@ -16,7 +16,7 @@ import { useAnnotationContextManager } from "./useAnnotationContextManager";
 import useDelete from "./Edit/useDelete";
 import { KnownContexts, useUndoRedo } from "@fiftyone/commands";
 import LabelList from "./LabelList";
-import { useRegisterAISegmentationEventHandlers } from "@fiftyone/annotation/src/agents/hooks/useRegisterAIAnnotationEventHandlers";
+import { useRegisterAIAnnotationEventHandlers } from "@fiftyone/annotation/src/agents/hooks/useRegisterAIAnnotationEventHandlers";
 
 const DISABLED_MESSAGES: Record<
   Exclude<AnnotationDisabledReason, null>,
@@ -65,7 +65,7 @@ interface AnnotateProps {
 }
 
 const Annotate = ({ disabledReason }: AnnotateProps) => {
-  useRegisterAISegmentationEventHandlers();
+  useRegisterAIAnnotationEventHandlers();
 
   const { schemaManagerDisplayed } = useSchemaManagerModal();
   const loading = useAtomValue(labelSchemasData) === null;

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
@@ -1,6 +1,7 @@
 import {
   AgentTaskType,
   NEGATIVE_POINT_VARIANT,
+  PointSelectionVariant,
   POSITIVE_POINT_VARIANT,
   useActiveTask,
   useAgentSelector,
@@ -50,7 +51,7 @@ export const useSegmentationMode = (): SegmentationMode => {
   // Points placed on the current label's mask are interpreted as negative;
   // points placed off-mask are positive
   const resolvePointVariant = useCallback(
-    (relativePoint: { x: number; y: number }): string | undefined => {
+    (relativePoint: { x: number; y: number }): PointSelectionVariant => {
       const label = selectedLabelRef.current;
       if (!label || !(label.overlay instanceof BoundingBoxOverlay)) {
         return POSITIVE_POINT_VARIANT;

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
@@ -1,5 +1,7 @@
 import {
   AgentTaskType,
+  NEGATIVE_POINT_VARIANT,
+  POSITIVE_POINT_VARIANT,
   useActiveTask,
   useAgentSelector,
   usePointSelection,
@@ -45,21 +47,32 @@ export const useSegmentationMode = (): SegmentationMode => {
   const selectedLabelRef = useRef(selectedLabel);
   selectedLabelRef.current = selectedLabel;
 
-  // check whether the point hits the mask of the current label
-  const maskHitTest = useCallback((relativePoint: { x: number; y: number }) => {
-    const label = selectedLabelRef.current;
-    if (!label || !(label.overlay instanceof BoundingBoxOverlay)) {
-      return false;
-    }
+  // Points placed on the current label's mask are interpreted as negative;
+  // points placed off-mask are positive
+  const resolvePointVariant = useCallback(
+    (relativePoint: { x: number; y: number }): string | undefined => {
+      const label = selectedLabelRef.current;
+      if (!label || !(label.overlay instanceof BoundingBoxOverlay)) {
+        return POSITIVE_POINT_VARIANT;
+      }
 
-    return label.overlay.containsMaskPixel(relativePoint);
-  }, []);
+      return label.overlay.containsMaskPixel(relativePoint)
+        ? NEGATIVE_POINT_VARIANT
+        : POSITIVE_POINT_VARIANT;
+    },
+    []
+  );
 
   const activate = useCallback(() => {
     setSegmentationModeActive(true);
     setActiveTask(AgentTaskType.SEGMENT);
-    pointSelection.activate(maskHitTest);
-  }, [maskHitTest, pointSelection, setActiveTask, setSegmentationModeActive]);
+    pointSelection.activate(resolvePointVariant);
+  }, [
+    pointSelection,
+    resolvePointVariant,
+    setActiveTask,
+    setSegmentationModeActive,
+  ]);
 
   const deactivate = useCallback(() => {
     pointSelection.deactivate();

--- a/app/packages/lighter/src/events/index.ts
+++ b/app/packages/lighter/src/events/index.ts
@@ -127,8 +127,8 @@ export type LighterEventGroup = {
     pointId: string;
     /** Relative coordinates of the added point */
     point: Point;
-    /** True when the point was placed on an existing mask pixel */
-    onMask: boolean;
+    /** Optional keypoint variant. */
+    variant?: string;
   };
   /** Emitted when a keypoint is moved via drag */
   "lighter:keypoint-point-moved": {
@@ -143,8 +143,8 @@ export type LighterEventGroup = {
   "lighter:keypoint-point-deleted": {
     id: string;
     pointId: string;
-    /** True when the deleted point was on an existing mask pixel */
-    onMask: boolean;
+    /** Optional keypoint variant. */
+    variant?: string;
   };
 
   // ============================================================================

--- a/app/packages/lighter/src/interaction/InteractiveKeypointHandler.ts
+++ b/app/packages/lighter/src/interaction/InteractiveKeypointHandler.ts
@@ -23,7 +23,9 @@ export class InteractiveKeypointHandler implements InteractionHandler {
   constructor(
     public readonly overlay: KeypointOverlay,
     private readonly eventBus: EventDispatcher<LighterEventGroup>,
-    private readonly hitTest?: (relativePoint: Point) => boolean
+    private readonly resolveVariant?: (
+      relativePoint: Point
+    ) => string | undefined
   ) {}
 
   containsPoint(): boolean {
@@ -57,8 +59,8 @@ export class InteractiveKeypointHandler implements InteractionHandler {
     _event: PointerEvent
   ): boolean {
     const rp = this.overlay.absolutePointToRelative(worldPoint);
-    const onMask = this.hitTest?.({ x: rp[0], y: rp[1] }) ?? false;
-    this.overlay.addPoint(worldPoint, onMask);
+    const variant = this.resolveVariant?.({ x: rp[0], y: rp[1] });
+    this.overlay.addPoint(worldPoint, variant);
     return true;
   }
 

--- a/app/packages/lighter/src/overlay/KeypointOverlay.ts
+++ b/app/packages/lighter/src/overlay/KeypointOverlay.ts
@@ -345,14 +345,10 @@ export class KeypointOverlay
 
     const resolvePointStyle = (variant: string | undefined): DrawStyle => {
       const override = variant ? this.variantStyles[variant] : undefined;
-      if (!override) {
-        return defaultPointStyle;
-      }
 
       return {
-        fillStyle: override.fillStyle ?? defaultPointStyle.fillStyle,
-        strokeStyle: override.strokeStyle ?? defaultPointStyle.strokeStyle,
-        lineWidth: override.lineWidth ?? defaultPointStyle.lineWidth,
+        ...defaultPointStyle,
+        ...override,
       };
     };
 

--- a/app/packages/lighter/src/overlay/KeypointOverlay.ts
+++ b/app/packages/lighter/src/overlay/KeypointOverlay.ts
@@ -59,6 +59,11 @@ export interface KeypointOptions {
   draggable?: boolean;
   deletable?: boolean;
   selectable?: boolean;
+  /**
+   * Per-variant style overrides. Points whose variant key is absent from
+   * this map (or who have no variant) render with the overlay's currentStyle.
+   */
+  variantStyles?: Record<string, DrawStyle>;
 }
 
 /**
@@ -67,7 +72,7 @@ export interface KeypointOptions {
 type KeypointEntry = {
   id: string;
   position: [number, number];
-  onMask: boolean;
+  variant?: string;
 };
 
 /**
@@ -89,6 +94,7 @@ export class KeypointOverlay
   private isSelectable: boolean;
   private connections: number[][];
   private closed: boolean;
+  private readonly variantStyles: Record<string, DrawStyle>;
   private isSelectedState = false;
 
   #points: KeypointEntry[];
@@ -117,10 +123,10 @@ export class KeypointOverlay
     this.#points = (options.label?.points ?? []).map((p) => ({
       id: uuidv4(),
       position: [...p] as [number, number],
-      onMask: false,
     }));
     this.connections = options.connections ?? [];
     this.closed = options.closed ?? false;
+    this.variantStyles = options.variantStyles ?? {};
     this.isDraggable = options.draggable !== false;
     this.isDeletable = options.deletable !== false;
     this.isSelectable = options.selectable !== false;
@@ -329,31 +335,49 @@ export class KeypointOverlay
       );
     }
 
-    // 3. Batch all regular points into a single draw call
-    const pointStyle: DrawStyle = {
+    // 3. Batch points by variant. Points without a matching variant style fall
+    //   back to the overlay's defaults.
+    const defaultPointStyle: DrawStyle = {
       fillStyle: strokeColor,
       strokeStyle: "#ffffff",
       lineWidth,
     };
 
-    const regularPoints: Point[] = [];
+    const resolvePointStyle = (variant: string | undefined): DrawStyle => {
+      const override = variant ? this.variantStyles[variant] : undefined;
+      if (!override) {
+        return defaultPointStyle;
+      }
+
+      return {
+        fillStyle: override.fillStyle ?? defaultPointStyle.fillStyle,
+        strokeStyle: override.strokeStyle ?? defaultPointStyle.strokeStyle,
+        lineWidth: override.lineWidth ?? defaultPointStyle.lineWidth,
+      };
+    };
+
+    const buckets = new Map<string | undefined, Point[]>();
     let selectedPoint: Point | undefined;
+    let selectedVariant: string | undefined;
 
     for (let i = 0; i < absPoints.length; i++) {
       if (this.selectedPointIndex === i) {
         selectedPoint = absPoints[i];
+        selectedVariant = this.#points[i].variant;
+        continue;
+      }
+      const v = this.#points[i].variant;
+      const bucket = buckets.get(v);
+      if (bucket) {
+        bucket.push(absPoints[i]);
       } else {
-        regularPoints.push(absPoints[i]);
+        buckets.set(v, [absPoints[i]]);
       }
     }
 
-    if (regularPoints.length > 0) {
-      renderer.drawPoints(
-        regularPoints,
-        KEYPOINT_RADIUS,
-        pointStyle,
-        this.containerId
-      );
+    for (const [variant, pts] of buckets) {
+      const pointStyle = resolvePointStyle(variant);
+      renderer.drawPoints(pts, KEYPOINT_RADIUS, pointStyle, this.containerId);
     }
 
     // Draw selected point at larger radius + inner highlight (separate calls)
@@ -361,7 +385,7 @@ export class KeypointOverlay
       renderer.drawPoint(
         selectedPoint,
         KEYPOINT_SELECTED_RADIUS,
-        pointStyle,
+        resolvePointStyle(selectedVariant),
         this.containerId
       );
       renderer.drawPoint(
@@ -576,19 +600,20 @@ export class KeypointOverlay
 
   /**
    * Adds a point at the given absolute (world) position.
-   * @param onMask - Whether the point was placed on an existing mask pixel.
-   * @returns The index of the new point.
+   *
+   * @param variant - Optional variant key used to determine render style.
+   * @returns The id of the new point.
    */
-  addPoint(worldPoint: Point, onMask = false): string {
+  addPoint(worldPoint: Point, variant?: string): string {
     const position = this.absolutePointToRelative(worldPoint);
-    const entry: KeypointEntry = { id: uuidv4(), position, onMask };
+    const entry: KeypointEntry = { id: uuidv4(), position, variant };
     this.#points.push(entry);
 
     this.eventBus.dispatch("lighter:keypoint-point-added", {
       id: this.id,
       pointId: entry.id,
       point: { x: position[0], y: position[1] },
-      onMask,
+      variant,
     });
 
     this.markDirty();
@@ -602,7 +627,7 @@ export class KeypointOverlay
     if (!this.isDeletable) return;
     if (index < 0 || index >= this.#points.length) return;
 
-    const { id: pointId, onMask } = this.#points[index];
+    const { id: pointId, variant } = this.#points[index];
     this.#points.splice(index, 1);
 
     // Update connections: remove references to deleted index, shift higher indices
@@ -625,7 +650,7 @@ export class KeypointOverlay
     this.eventBus.dispatch("lighter:keypoint-point-deleted", {
       id: this.id,
       pointId,
-      onMask,
+      variant,
     });
 
     this.markDirty();


### PR DESCRIPTION
## 🔗 Related Issues

None

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

Builds on the work done in #7361 to add visual disambiguation between positive and negative point selection for inference tasks.

Key changes:
* Removes semantic coupling between segmentation mask hit testing and keypoints
* `KeypointOverlay` now associates points with a dynamic `variant`
* Point `variant` controls rendering style and is determined by consumer-provided resolution logic
* `KeypointOverlay` consumers can provide a custom mapping of `variant` -> `DrawStyle`

## 🧪 How is this patch tested? If it is not, please explain why.

local

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added variant-based point selection (positive/negative) and per-variant styling for keypoint overlays.
  * Point events now carry a variant value instead of a mask flag.

* **Refactor**
  * Renamed and reorganized AI annotation event hooks and updated point-selection APIs to resolve variants rather than boolean mask checks.

* **Documentation**
  * Added usage guidance and constraints to annotation event handler hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->