### PR TITLE
[HA] Add logic to invert point variant when holding shift

### DIFF
--- a/app/packages/annotation/src/agents/hooks/usePointSelection.ts
+++ b/app/packages/annotation/src/agents/hooks/usePointSelection.ts
@@ -1,5 +1,9 @@
 import { useCallback } from "react";
-import type { DrawStyle, Point } from "@fiftyone/lighter";
+import type {
+  DrawStyle,
+  KeypointVariantResolverContext,
+  Point,
+} from "@fiftyone/lighter";
 import {
   InteractiveKeypointHandler,
   KeypointOptions,
@@ -38,7 +42,10 @@ export interface PointSelection {
    * placed point and should return the variant key to associate with it.
    */
   activate(
-    resolveVariant?: (relativePoint: Point) => PointSelectionVariant
+    resolveVariant?: (
+      relativePoint: Point,
+      ctx: KeypointVariantResolverContext
+    ) => PointSelectionVariant
   ): void;
 
   /**
@@ -79,7 +86,12 @@ export const usePointSelection = (): PointSelection => {
   const [isActive, setIsActive] = useAtom(pointSelectionActiveAtom);
 
   const activate = useCallback(
-    (resolveVariant?: (relativePoint: Point) => PointSelectionVariant) => {
+    (
+      resolveVariant?: (
+        relativePoint: Point,
+        ctx: KeypointVariantResolverContext
+      ) => PointSelectionVariant
+    ) => {
       if (isActive) {
         return;
       }

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
@@ -8,7 +8,11 @@ import {
   usePointSelection,
   useToolsState,
 } from "@fiftyone/annotation/src/agents";
-import { BoundingBoxOverlay } from "@fiftyone/lighter";
+import {
+  BoundingBoxOverlay,
+  KeypointVariantResolverContext,
+  Point,
+} from "@fiftyone/lighter";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { atom, useAtom } from "jotai";
 import { useAnnotationContext } from "./state";
@@ -49,15 +53,26 @@ export const useSegmentationMode = (): SegmentationMode => {
   selectedLabelRef.current = selectedLabel;
 
   // Points placed on the current label's mask are interpreted as negative;
-  // points placed off-mask are positive
+  // points placed off-mask are positive.
+  // Holding shift inverts the result.
   const resolvePointVariant = useCallback(
-    (relativePoint: { x: number; y: number }): PointSelectionVariant => {
+    (
+      relativePoint: Point,
+      { shiftKey }: KeypointVariantResolverContext
+    ): PointSelectionVariant => {
       const label = selectedLabelRef.current;
-      if (!label || !(label.overlay instanceof BoundingBoxOverlay)) {
-        return POSITIVE_POINT_VARIANT;
-      }
+      const onMask =
+        label && label.overlay instanceof BoundingBoxOverlay
+          ? label.overlay.containsMaskPixel(relativePoint)
+          : false;
 
-      return label.overlay.containsMaskPixel(relativePoint)
+      const variant = onMask ? NEGATIVE_POINT_VARIANT : POSITIVE_POINT_VARIANT;
+
+      return !shiftKey
+        ? // normal variant if shift key is not pressed
+          variant
+        : // otherwise invert the variant
+        variant === POSITIVE_POINT_VARIANT
         ? NEGATIVE_POINT_VARIANT
         : POSITIVE_POINT_VARIANT;
     },

--- a/app/packages/lighter/src/index.ts
+++ b/app/packages/lighter/src/index.ts
@@ -47,6 +47,7 @@ export { InteractionManager } from "./interaction/InteractionManager";
 export type { InteractionHandler } from "./interaction/InteractionManager";
 export { InteractiveDetectionHandler } from "./interaction/InteractiveDetectionHandler";
 export { InteractiveKeypointHandler } from "./interaction/InteractiveKeypointHandler";
+export type { KeypointVariantResolverContext } from "./interaction/InteractiveKeypointHandler";
 
 // Selection exports
 export type { Selectable } from "./selection/Selectable";

--- a/app/packages/lighter/src/interaction/InteractiveKeypointHandler.ts
+++ b/app/packages/lighter/src/interaction/InteractiveKeypointHandler.ts
@@ -11,6 +11,18 @@ import type { InteractionHandler } from "./InteractionManager";
 const INTERACTIVE_KEYPOINT_HANDLER_ID = "interactive-keypoint-handler";
 
 /**
+ * Modifier flags forwarded to the variant resolver from the triggering
+ * pointer event. Resolver consumers can branch on these to implement
+ * hold-to-modify behaviors (e.g. shift to invert semantics).
+ */
+export interface KeypointVariantResolverContext {
+  shiftKey: boolean;
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+}
+
+/**
  * Interactive keypoint handler for creating keypoint annotations.
  *
  * Each click places a new point. Double-click or external signal to finish.
@@ -24,7 +36,8 @@ export class InteractiveKeypointHandler implements InteractionHandler {
     public readonly overlay: KeypointOverlay,
     private readonly eventBus: EventDispatcher<LighterEventGroup>,
     private readonly resolveVariant?: (
-      relativePoint: Point
+      relativePoint: Point,
+      ctx: KeypointVariantResolverContext
     ) => string | undefined
   ) {}
 
@@ -56,10 +69,18 @@ export class InteractiveKeypointHandler implements InteractionHandler {
   onPointerDown(
     _point: Point,
     worldPoint: Point,
-    _event: PointerEvent
+    event: PointerEvent
   ): boolean {
     const rp = this.overlay.absolutePointToRelative(worldPoint);
-    const variant = this.resolveVariant?.({ x: rp[0], y: rp[1] });
+    const variant = this.resolveVariant?.(
+      { x: rp[0], y: rp[1] },
+      {
+        shiftKey: event.shiftKey,
+        altKey: event.altKey,
+        ctrlKey: event.ctrlKey,
+        metaKey: event.metaKey,
+      }
+    );
     this.overlay.addPoint(worldPoint, variant);
     return true;
   }


### PR DESCRIPTION
## 🔗 Related Issues

None

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

Builds on the changes in #7367 to add variant inversion when holding the `shift` key. 

Normal point placement semantics dictate that a point placed on an existing portion of the mask should be considered a **negative** point prompt, while all other points should be considered a **positive** point prompt. This PR adds logic to check for a shift key modifier and inverts the variant if shift is pressed.

The end result is that `shift + click` when placing a point on a mask will result in a **positive** point, while `shift + click` off-mask will result in a **negative** point.

## 🧪 How is this patch tested? If it is not, please explain why.

local

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced keypoint selection interaction with modifier-key support (Shift, Alt, Ctrl, Meta).
  * Shift-key now toggles point variant classification during keypoint annotation.
  * Improved point selection API with expanded contextual information for variant resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->