### PR TITLE
[HA] Clean up points after user commits to a generated mask

### DIFF
--- a/app/packages/annotation/src/agents/hooks/usePointSelection.ts
+++ b/app/packages/annotation/src/agents/hooks/usePointSelection.ts
@@ -47,6 +47,13 @@ export interface PointSelection {
    */
   deactivate(): void;
 
+  /**
+   * Clears all placed points while keeping point selection active. The
+   * overlay and interactive handler remain in place — the user can continue
+   * placing new points on an empty canvas.
+   */
+  clearPoints(): void;
+
   /** The current activation status of the point selection tool. */
   isActive: boolean;
 }
@@ -68,7 +75,7 @@ const pointSelectionActiveAtom = atom(false);
  * Hook which provides activation/deactivation functions for point selection.
  */
 export const usePointSelection = (): PointSelection => {
-  const { scene, overlayFactory } = useLighter();
+  const { getOverlay, scene, overlayFactory } = useLighter();
   const eventBus = useLighterEventBus(
     scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
   );
@@ -130,5 +137,15 @@ export const usePointSelection = (): PointSelection => {
     setIsActive(false);
   }, [isActive, keypointOverlayId, scene, setIsActive, setKeypointOverlayId]);
 
-  return { activate, deactivate, isActive };
+  const clearPoints = useCallback(() => {
+    if (!keypointOverlayId) {
+      return;
+    }
+    const overlay = getOverlay(keypointOverlayId);
+    if (overlay instanceof KeypointOverlay) {
+      overlay.clearPoints();
+    }
+  }, [getOverlay, keypointOverlayId]);
+
+  return { activate, clearPoints, deactivate, isActive };
 };

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
@@ -46,7 +46,30 @@ export const useSegmentationMode = (): SegmentationMode => {
   }, [agentSelector]);
 
   const selectedLabelRef = useRef(selectedLabel);
+  const previousSelectedLabelIdRef = useRef<string | null>(
+    selectedLabel?.overlay?.id ?? null
+  );
   selectedLabelRef.current = selectedLabel;
+
+  // When the user commits/exits a label (selected label transitions away
+  // from a populated overlay), wipe the inference prompt points so the next
+  // label starts from a clean slate. We stay in segmentation mode.
+  useEffect(() => {
+    if (!segmentationModeActive) {
+      previousSelectedLabelIdRef.current = selectedLabel?.overlay?.id ?? null;
+      return;
+    }
+
+    const previousId = previousSelectedLabelIdRef.current;
+    const currentId = selectedLabel?.overlay?.id ?? null;
+
+    if (previousId && previousId !== currentId) {
+      pointSelection.clearPoints();
+      resetToolsState();
+    }
+
+    previousSelectedLabelIdRef.current = currentId;
+  }, [pointSelection, resetToolsState, segmentationModeActive, selectedLabel]);
 
   // Points placed on the current label's mask are interpreted as negative;
   // points placed off-mask are positive


### PR DESCRIPTION
## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

When user commit to a generated mask label, clear the inference points. 

## 🧪 How is this patch tested? If it is not, please explain why.


https://github.com/user-attachments/assets/af49edb5-2153-4966-add1-2334754bb6db



## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to clear placed points while keeping point selection active.
  * Auto-clears point selections and resets tools when switching labels during segmentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->