### PR TITLE
ontology SDK versioning

### DIFF
--- a/fiftyone/core/odm/ontology.py
+++ b/fiftyone/core/odm/ontology.py
@@ -79,7 +79,7 @@ class OntologyDocument(Document):
             self.slug = fou.to_slug(self.name)
 
         # If this document already exists in MongoDB, don't update it in-place;
-        # create and save a new (name, version) document instead.
+        # create and save a new (slug, version) document instead.
         if self.in_db:
             return self._save_as_new_version(now, *args, **kwargs)
 
@@ -96,7 +96,7 @@ class OntologyDocument(Document):
         # Append-only versioning: create a new document instead of updating the
         # existing one.
         latest = (
-            OntologyDocument.objects(name=self.name)
+            OntologyDocument.objects(slug=self.slug)
             .order_by("-version")
             .only("version")
             .first()

--- a/fiftyone/core/odm/ontology.py
+++ b/fiftyone/core/odm/ontology.py
@@ -81,7 +81,14 @@ class OntologyDocument(Document):
         # If this document already exists in MongoDB, don't update it in-place;
         # create and save a new (slug, version) document instead.
         if self.in_db:
-            return self._save_as_new_version(now, *args, **kwargs)
+            self._reject_slug_change()
+            new_doc = self._save_as_new_version(now, *args, **kwargs)
+            # Re-point self at the newly written version so callers retain a
+            # live reference to the latest row, matching the standard
+            # ``doc.save()`` contract.
+            self.id = new_doc.id
+            self.reload()
+            return self
 
         if self.created_at is None:
             self.created_at = now
@@ -90,11 +97,31 @@ class OntologyDocument(Document):
 
         return super().save(*args, **kwargs)
 
+    # pylint disable: mongoengine's ``objects`` queryset manager is attached
+    # dynamically and not introspectable by pylint.
+    def _reject_slug_change(  # pylint: disable=no-member
+        self,
+    ) -> None:
+        """Raises if the in-memory slug differs from the persisted slug.
+
+        Slug is the lineage key for append-only versioning; renames must go
+        through :func:`fiftyone.core.ontology.rename_ontology`, which updates
+        all versions in bulk.
+        """
+        persisted = OntologyDocument.objects(id=self.id).only("slug").first()
+        if persisted is not None and self.slug != persisted.slug:
+            raise ValueError(
+                "Cannot change ontology slug via save(); use "
+                "rename_ontology() to rename across all versions"
+            )
+
+    # pylint disable: mongoengine's ``objects`` queryset manager is attached
+    # dynamically and not introspectable by pylint.
     def _save_as_new_version(  # pylint: disable=no-member
         self, now: datetime, *args: Any, **kwargs: Any
     ) -> OntologyDocument:
-        # Append-only versioning: create a new document instead of updating the
-        # existing one.
+        # Append-only versioning: create a new document instead of updating
+        # the existing one.
         latest = (
             OntologyDocument.objects(slug=self.slug)
             .order_by("-version")

--- a/fiftyone/core/odm/ontology.py
+++ b/fiftyone/core/odm/ontology.py
@@ -6,8 +6,11 @@ Ontology documents.
 |
 """
 
+from __future__ import annotations
+
 from enum import Enum
 from datetime import datetime, timezone
+from typing import Any
 
 import fiftyone.core.utils as fou
 from fiftyone.core.fields import (
@@ -69,15 +72,39 @@ class OntologyDocument(Document):
     created_at = DateTimeField()
     last_modified_at = DateTimeField()
 
-    def save(self, *args, **kwargs):
+    def save(self, *args: Any, **kwargs: Any) -> OntologyDocument:
         now = datetime.now(timezone.utc)
 
         if self.name is not None:
             self.slug = fou.to_slug(self.name)
 
-        if not self.in_db and self.created_at is None:
+        # If this document already exists in MongoDB, don't update it in-place;
+        # create and save a new (name, version) document instead.
+        if self.in_db:
+            return self._save_as_new_version(now, *args, **kwargs)
+
+        if self.created_at is None:
             self.created_at = now
 
         self.last_modified_at = now
 
         return super().save(*args, **kwargs)
+
+    def _save_as_new_version(  # pylint: disable=no-member
+        self, now: datetime, *args: Any, **kwargs: Any
+    ) -> OntologyDocument:
+        # Append-only versioning: create a new document instead of updating the
+        # existing one.
+        latest = (
+            OntologyDocument.objects(name=self.name)
+            .order_by("-version")
+            .only("version")
+            .first()
+        )
+        next_version = (latest.version + 1) if latest else 1
+
+        new_doc = self.copy_with_new_id()
+        new_doc.version = next_version
+        new_doc.created_at = now
+        new_doc.last_modified_at = now
+        return super(OntologyDocument, new_doc).save(*args, **kwargs)

--- a/fiftyone/core/odm/ontology.py
+++ b/fiftyone/core/odm/ontology.py
@@ -41,6 +41,13 @@ class OntologyType(str, Enum):  # TODO - update to StrEnum
 _ONTOLOGY_TYPE_VALUES = tuple(t.value for t in OntologyType)
 
 
+# Internal layout version of an ``OntologyDocument`` row. Bump this paired
+# with a forward migration whenever the persisted structure (in particular
+# ``root``) changes shape. ``version`` (user-facing content history) is
+# orthogonal to this.
+CURRENT_SCHEMA_VERSION = 1
+
+
 class OntologyDocument(Document):
     """Backing document for ontologies.
 
@@ -48,6 +55,10 @@ class OntologyDocument(Document):
     Multiple datasets can reference the same ontology by name. Each
     save creates a new versioned document; ``(slug, version)`` is unique,
     so names differing only in case or punctuation collide on save.
+
+    ``schema_version`` records the internal layout version of the row at
+    write time. Bump :data:`CURRENT_SCHEMA_VERSION` and add a migration when
+    changing the persisted structure (especially ``root``).
     """
 
     meta = {
@@ -66,6 +77,7 @@ class OntologyDocument(Document):
     name = StringField(required=True)
     slug = StringField(required=True)
     version = IntField(required=True, default=1)
+    schema_version = IntField(required=True, default=1)
     type = StringField(required=True, choices=_ONTOLOGY_TYPE_VALUES)
     description = StringField(default=None)
     root = DictField()
@@ -94,6 +106,7 @@ class OntologyDocument(Document):
             self.created_at = now
 
         self.last_modified_at = now
+        self.schema_version = CURRENT_SCHEMA_VERSION
 
         return super().save(*args, **kwargs)
 
@@ -132,6 +145,7 @@ class OntologyDocument(Document):
 
         new_doc = self.copy_with_new_id()
         new_doc.version = next_version
+        new_doc.schema_version = CURRENT_SCHEMA_VERSION
         new_doc.created_at = now
         new_doc.last_modified_at = now
         return super(OntologyDocument, new_doc).save(*args, **kwargs)

--- a/tests/unittests/ontology_tests.py
+++ b/tests/unittests/ontology_tests.py
@@ -198,25 +198,6 @@ class OntologyDocumentTests(unittest.TestCase):
         self.assertEqual(restored.version, doc.version)
         self.assertEqual(restored.root, doc.root)
 
-    def test_last_modified_at_auto_updates(self):
-        doc = OntologyDocument(
-            name="timestamp_test",
-            version=1,
-            type="taxonomy",
-            root={"name": "root"},
-        )
-        doc.save()
-        self.assertIsNotNone(doc.created_at)
-
-        original_modified = doc.last_modified_at
-
-        doc.description = "updated"
-        doc.save()
-        doc.reload()
-
-        self.assertIsNotNone(doc.last_modified_at)
-        self.assertNotEqual(doc.last_modified_at, original_modified)
-
     def test_same_name_different_types(self):
         OntologyDocument(
             name="shared_name",
@@ -340,6 +321,41 @@ class OntologyDocumentTests(unittest.TestCase):
         doc.delete()
 
         self.assertEqual(OntologyDocument.objects(name="to_delete").count(), 0)
+
+    def test_save_creates_new_version(self):
+        doc = OntologyDocument(
+            name="versioning_test",
+            version=1,
+            type="taxonomy",
+            root={"name": "root"},
+        )
+        doc.save()
+        self.assertIsNotNone(doc.created_at)
+        self.assertEqual(doc.version, 1)
+
+        # Saving an existing doc creates a new version
+        doc.description = "updated"
+        new_doc = doc.save()
+
+        self.assertEqual(new_doc.version, 2)
+        self.assertNotEqual(new_doc.id, doc.id)
+        self.assertIsNotNone(new_doc.created_at)
+
+        # Both versions exist in the database
+        all_versions = OntologyDocument.objects(name="versioning_test")
+        self.assertEqual(all_versions.count(), 2)
+
+        # Original is unchanged
+        original = OntologyDocument.objects.get(
+            name="versioning_test", version=1
+        )
+        self.assertIsNone(original.description)
+
+        # New version has the update
+        latest = OntologyDocument.objects.get(
+            name="versioning_test", version=2
+        )
+        self.assertEqual(latest.description, "updated")
 
 
 if __name__ == "__main__":

--- a/tests/unittests/ontology_tests.py
+++ b/tests/unittests/ontology_tests.py
@@ -332,30 +332,31 @@ class OntologyDocumentTests(unittest.TestCase):
         doc.save()
         self.assertIsNotNone(doc.created_at)
         self.assertEqual(doc.version, 1)
+        original_id = doc.id
 
-        # Saving an existing doc creates a new version
+        # Saving an existing doc creates a new version and re-points self
+        # at the new row.
         doc.description = "updated"
-        new_doc = doc.save()
+        result = doc.save()
 
-        self.assertEqual(new_doc.version, 2)
-        self.assertNotEqual(new_doc.id, doc.id)
-        self.assertIsNotNone(new_doc.created_at)
+        self.assertIs(result, doc)
+        self.assertEqual(doc.version, 2)
+        self.assertNotEqual(doc.id, original_id)
+        self.assertIsNotNone(doc.created_at)
 
         # Both versions exist in the database
         all_versions = OntologyDocument.objects(name="versioning_test")
         self.assertEqual(all_versions.count(), 2)
 
-        # Original is unchanged
-        original = OntologyDocument.objects.get(
-            name="versioning_test", version=1
-        )
+        # Original row is unchanged
+        original = OntologyDocument.objects.get(id=original_id)
         self.assertIsNone(original.description)
+        self.assertEqual(original.version, 1)
 
-        # New version has the update
-        latest = OntologyDocument.objects.get(
-            name="versioning_test", version=2
-        )
+        # New row has the update
+        latest = OntologyDocument.objects.get(id=doc.id)
         self.assertEqual(latest.description, "updated")
+        self.assertEqual(latest.version, 2)
 
     def test_save_bumps_version_across_case_only_rename(self):
         doc = OntologyDocument(
@@ -370,13 +371,47 @@ class OntologyDocumentTests(unittest.TestCase):
         # Renaming to a case variant of the original name keeps the same slug;
         # the next version should chain off the existing slug, not restart at 1.
         doc.name = "my ontology"
-        new_doc = doc.save()
+        doc.save()
 
-        self.assertEqual(new_doc.slug, original_slug)
-        self.assertEqual(new_doc.version, 2)
+        self.assertEqual(doc.slug, original_slug)
+        self.assertEqual(doc.version, 2)
         self.assertEqual(
             OntologyDocument.objects(slug=original_slug).count(), 2
         )
+
+    def test_save_rejects_slug_change(self):
+        doc = OntologyDocument(
+            name="cars",
+            version=1,
+            type="taxonomy",
+            root={"name": "root"},
+        )
+        doc.save()
+
+        # Changing to a name that produces a different slug breaks lineage —
+        # rename_ontology() is the supported way to rename.
+        doc.name = "vehicles"
+        with self.assertRaises(ValueError):
+            doc.save()
+
+        # Failed save leaves only the original row.
+        self.assertEqual(OntologyDocument.objects().count(), 1)
+
+    def test_save_returns_self(self):
+        doc = OntologyDocument(
+            name="returns_self",
+            version=1,
+            type="taxonomy",
+            root={"name": "root"},
+        )
+        # New save also returns the same instance.
+        self.assertIs(doc.save(), doc)
+
+        # Versioned save updates and returns the same instance.
+        doc.description = "v2"
+        self.assertIs(doc.save(), doc)
+        self.assertEqual(doc.version, 2)
+        self.assertEqual(doc.description, "v2")
 
 
 if __name__ == "__main__":

--- a/tests/unittests/ontology_tests.py
+++ b/tests/unittests/ontology_tests.py
@@ -357,6 +357,27 @@ class OntologyDocumentTests(unittest.TestCase):
         )
         self.assertEqual(latest.description, "updated")
 
+    def test_save_bumps_version_across_case_only_rename(self):
+        doc = OntologyDocument(
+            name="My Ontology",
+            version=1,
+            type="taxonomy",
+            root={"name": "root"},
+        )
+        doc.save()
+        original_slug = doc.slug
+
+        # Renaming to a case variant of the original name keeps the same slug;
+        # the next version should chain off the existing slug, not restart at 1.
+        doc.name = "my ontology"
+        new_doc = doc.save()
+
+        self.assertEqual(new_doc.slug, original_slug)
+        self.assertEqual(new_doc.version, 2)
+        self.assertEqual(
+            OntologyDocument.objects(slug=original_slug).count(), 2
+        )
+
 
 if __name__ == "__main__":
     fo_unittest = unittest.TestLoader().loadTestsFromTestCase(

--- a/tests/unittests/ontology_tests.py
+++ b/tests/unittests/ontology_tests.py
@@ -15,6 +15,7 @@ from mongoengine.errors import ValidationError
 from pymongo.errors import DuplicateKeyError
 
 import fiftyone.core.odm as foo
+from fiftyone.core.odm import ontology as foo_ontology
 from fiftyone.core.odm.ontology import OntologyDocument, OntologyType
 
 
@@ -412,6 +413,37 @@ class OntologyDocumentTests(unittest.TestCase):
         self.assertIs(doc.save(), doc)
         self.assertEqual(doc.version, 2)
         self.assertEqual(doc.description, "v2")
+
+    def test_schema_version_stamped_on_new_save(self):
+        doc = OntologyDocument(
+            name="schema_version_test",
+            version=1,
+            type="taxonomy",
+            root={"name": "root"},
+        )
+        doc.save()
+        self.assertEqual(
+            doc.schema_version, foo_ontology.CURRENT_SCHEMA_VERSION
+        )
+
+    def test_schema_version_overwritten_on_versioned_save(self):
+        doc = OntologyDocument(
+            name="schema_version_test",
+            version=1,
+            type="taxonomy",
+            root={"name": "root"},
+        )
+        doc.save()
+
+        # A stale in-memory schema_version must not survive a save: the
+        # next-version write should always stamp CURRENT_SCHEMA_VERSION.
+        doc.schema_version = 999
+        doc.description = "updated"
+        doc.save()
+
+        self.assertEqual(
+            doc.schema_version, foo_ontology.CURRENT_SCHEMA_VERSION
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🔗 Related Issues
https://github.com/voxel51/fiftyone/pull/7345

## 📋 What changes are proposed in this pull request?

Updates ontology SDKs to have append only versioning.  Saves create a new version of the same document and leave the existing document in place. 


## 🧪 How is this patch tested? If it is not, please explain why.

Tested locally, unit tests. 


## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

add support for ontology objects to the SDK. 

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ontology documents now use append-only versioning: saving an existing document creates a new version while preserving prior versions.
  * Documents are stamped with the current schema version on save.
* **Bug Fixes**
  * Prevents unintended changes to document identifiers (slug); case-only renames are handled as version bumps, other slug changes are rejected.
* **Tests**
  * Unit tests updated to validate versioning, schema stamping, slug rules, and save return semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->