### PR TITLE
[SSP] Misc bugfixes and type tightening

### DIFF
--- a/app/packages/core/src/subscription/useExecutionStoreSubscribe.ts
+++ b/app/packages/core/src/subscription/useExecutionStoreSubscribe.ts
@@ -65,7 +65,10 @@ export const useExecutionStoreSubscribe = <T>({
     }
 
     if (!event.data) {
-      console.error("No data in execution store subscribe event");
+      // Empty-data frames are emitted by sse-starlette keep-alive
+      // comments / unnamed events. Not an error — just skip silently
+      // (debug-level so it's still discoverable if you need it).
+      console.debug("No data in execution store subscribe event");
       return;
     }
 

--- a/app/packages/operators/src/ExecutionOptionItem.tsx
+++ b/app/packages/operators/src/ExecutionOptionItem.tsx
@@ -13,10 +13,14 @@ export default function ExecutionOptionItem({ label, tag, disabled }) {
       {tag}
     </span>
   ) : null;
+  // Use an inline-level wrapper so this component can be rendered
+  // inside phrasing content (e.g. MUI <Typography>, which defaults to
+  // <p>). A <div> here produced "<div> cannot appear as a descendant
+  // of <p>" warnings in callers like OperatorExecutionMenu.
   return (
-    <div style={{ display: "flex", alignItems: "center" }}>
+    <span style={{ display: "inline-flex", alignItems: "center" }}>
       {label}
       {tagEl}
-    </div>
+    </span>
   );
 }

--- a/app/packages/similarity-search/src/components/Home/RunActions.tsx
+++ b/app/packages/similarity-search/src/components/Home/RunActions.tsx
@@ -42,7 +42,7 @@ export default function RunActions({
 }: RunActionsProps) {
   const isImage = run.query_type === QueryType.Image && !run.patches_field;
   // Upload runs can't be cloned — the original image isn't persisted.
-  const canClone = run.query_type !== QueryType.Upload;
+  const isUpload = run.query_type === QueryType.Upload;
 
   return (
     <Stack
@@ -61,17 +61,26 @@ export default function RunActions({
             disabled={run.status !== RunStatus.Completed}
           />
         </Tooltip>
-        {canClone && (
-          <Tooltip content={tip("Clone search")}>
+        <Tooltip
+          content={tip(
+            isUpload
+              ? "Clone is not supported for file upload searches"
+              : "Clone search"
+          )}
+        >
+          {/* span wrapper lets the tooltip still fire on hover when the
+              underlying button is disabled */}
+          <span>
             <Button
               aria-label="Clone search"
               size={Size.Md}
               variant={Variant.Borderless}
               leadingIcon={IconName.ContentCopy}
               onClick={stop(() => onClone(run.run_id))}
+              disabled={isUpload}
             />
-          </Tooltip>
-        )}
+          </span>
+        </Tooltip>
         <Tooltip content={tip("Delete")}>
           <Button
             aria-label="Delete"

--- a/app/packages/similarity-search/src/components/Home/RunActions.tsx
+++ b/app/packages/similarity-search/src/components/Home/RunActions.tsx
@@ -41,6 +41,8 @@ export default function RunActions({
   onToggleExpand,
 }: RunActionsProps) {
   const isImage = run.query_type === QueryType.Image && !run.patches_field;
+  // Upload runs can't be cloned — the original image isn't persisted.
+  const canClone = run.query_type !== QueryType.Upload;
 
   return (
     <Stack
@@ -59,15 +61,17 @@ export default function RunActions({
             disabled={run.status !== RunStatus.Completed}
           />
         </Tooltip>
-        <Tooltip content={tip("Clone search")}>
-          <Button
-            aria-label="Clone search"
-            size={Size.Md}
-            variant={Variant.Borderless}
-            leadingIcon={IconName.ContentCopy}
-            onClick={stop(() => onClone(run.run_id))}
-          />
-        </Tooltip>
+        {canClone && (
+          <Tooltip content={tip("Clone search")}>
+            <Button
+              aria-label="Clone search"
+              size={Size.Md}
+              variant={Variant.Borderless}
+              leadingIcon={IconName.ContentCopy}
+              onClick={stop(() => onClone(run.run_id))}
+            />
+          </Tooltip>
+        )}
         <Tooltip content={tip("Delete")}>
           <Button
             aria-label="Delete"

--- a/app/packages/similarity-search/src/components/Home/RunList.tsx
+++ b/app/packages/similarity-search/src/components/Home/RunList.tsx
@@ -29,7 +29,12 @@ import {
   RunFilterState,
 } from "../../types";
 import { useSampleMedia } from "../../hooks/useSampleMedia";
-import { HIGHLIGHT_STYLE, MIDDLE_DOT, POINTER_STYLE } from "../../constants";
+import {
+  HIGHLIGHT_STYLE,
+  MAX_RUN_NAME_LENGTH,
+  MIDDLE_DOT,
+  POINTER_STYLE,
+} from "../../constants";
 import { formatQuery, formatTime } from "../../utils";
 import StatusBadge from "./StatusBadge";
 import RunActions from "./RunActions";
@@ -52,8 +57,6 @@ function QueryTypeIcon({ queryType }: { queryType: string }) {
     />
   );
 }
-
-const MAX_RUN_NAME_LENGTH = 40;
 
 function RunName({
   name,

--- a/app/packages/similarity-search/src/components/NewSearch/NewSearch.tsx
+++ b/app/packages/similarity-search/src/components/NewSearch/NewSearch.tsx
@@ -22,7 +22,7 @@ import {
   Variant,
 } from "@voxel51/voodo";
 import { FileUploadOutlined } from "../../mui";
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { OperatorExecutionButton } from "@fiftyone/operators";
 import {
   BrainKeyConfig,
@@ -34,6 +34,7 @@ import {
   SEARCH_OPERATOR_URI,
   CHECK_MARK,
   CROSS_MARK,
+  K_MAX,
   MIDDLE_DOT,
   UPLOAD_ACCEPTED_TYPES,
   UPLOAD_MAX_SIZE,
@@ -67,6 +68,15 @@ export default function NewSearch({
 }: NewSearchProps) {
   const form = useNewSearchForm(brainKeys, cloneConfig, onSubmitted);
   const [uploadError, setUploadError] = useState<string | null>(null);
+
+  // Guard against setting state after unmount — `fileToBase64` resolves
+  // asynchronously and the user can navigate away mid-read.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   return (
     <NewSearchContainer>
@@ -274,6 +284,7 @@ export default function NewSearch({
                     return;
                   }
                   const { result, error } = await fileToBase64(file);
+                  if (!mountedRef.current) return;
                   if (error || !result) {
                     setUploadError(
                       "Failed to read the image file. Please try again."
@@ -323,7 +334,9 @@ export default function NewSearch({
         <FormField
           label="Number of matches"
           error={
-            form.kError ? "Number of results cannot exceed 10,000" : undefined
+            form.kError
+              ? `Number of results cannot exceed ${K_MAX.toLocaleString()}`
+              : undefined
           }
           control={
             <Input

--- a/app/packages/similarity-search/src/constants.ts
+++ b/app/packages/similarity-search/src/constants.ts
@@ -44,6 +44,21 @@ export const THUMB_SIZE = 36;
 export const THUMB_GAP = 4;
 export const THUMB_SINGLE_ROW_MAX = 10;
 
+// Maximum characters to display in a run name before truncation +
+// tooltip fallback. Used in the run list and the rename tooltip.
+export const MAX_RUN_NAME_LENGTH = 40;
+
+// Maximum entries held by the sample-media LRU cache.
+export const SAMPLE_MEDIA_CACHE_MAX_ENTRIES = 500;
+
+// Consecutive fetch failures after which we stop auto-retrying
+// list_similarity_runs. The user can still manually refresh.
+export const RUNS_REFRESH_MAX_RETRY = 5;
+
+// Bounds on the `k` (number of matches) input on the new-search form.
+export const K_MIN = 1;
+export const K_MAX = 10_000;
+
 // Filter defaults
 export const DEFAULT_DATE_PRESET: DateFilterPreset = "last_30_days";
 export const OWNER_ALL: OwnerFilter = "all";

--- a/app/packages/similarity-search/src/hooks/useFilteredRuns.ts
+++ b/app/packages/similarity-search/src/hooks/useFilteredRuns.ts
@@ -1,10 +1,10 @@
-import { useEffect, useMemo, useRef } from "react";
-import { atom, useAtom } from "jotai";
-import { useRecoilValue } from "recoil";
-import { datasetName as datasetNameAtom } from "@fiftyone/state";
+import { useMemo } from "react";
+import { usePanelStatePartial } from "@fiftyone/spaces";
 import { SimilarityRun, RunFilterState } from "../types";
 import { DEFAULT_DATE_PRESET, OWNER_MINE } from "../constants";
 import { getDateRange, matchesText, matchesDate } from "../utils";
+
+export const FILTER_STATE_KEY = "filterState";
 
 export const DEFAULT_FILTER_STATE: RunFilterState = {
   searchText: "",
@@ -12,9 +12,27 @@ export const DEFAULT_FILTER_STATE: RunFilterState = {
   ownerFilter: OWNER_MINE,
 };
 
-// Exported so non-React callers (e.g. `useRuns.refreshRuns`) can read
-// the current filter state at call time via `getDefaultStore().get(...)`.
-export const filterStateAtom = atom<RunFilterState>(DEFAULT_FILTER_STATE);
+/**
+ * Shared access to the panel's filter state.
+ *
+ * State lives in the panels' local (non-persisted) Recoil map keyed by
+ * ``panelId``. When the dataset changes, the workspace loads a fresh
+ * panel instance with a new ``panelId``, so the framework handles the
+ * "reset on dataset change" behavior for us — no manual effect needed.
+ *
+ * Multiple hooks in the same panel can call this and will share state.
+ */
+export const usePanelFilterState = (): [
+  RunFilterState,
+  (state: RunFilterState) => void
+] => {
+  const [state, setState] = usePanelStatePartial<RunFilterState>(
+    FILTER_STATE_KEY,
+    DEFAULT_FILTER_STATE,
+    true // local-only; filters are UI state, not server-persisted
+  );
+  return [state as RunFilterState, setState as (s: RunFilterState) => void];
+};
 
 export const useFilteredRuns = (
   runs: SimilarityRun[]
@@ -23,26 +41,7 @@ export const useFilteredRuns = (
   filterState: RunFilterState;
   setFilterState: (state: RunFilterState) => void;
 } => {
-  const [filterState, setFilterState] = useAtom(filterStateAtom);
-
-  // Reset filter state when the dataset changes so filters don't
-  // bleed across datasets. The atom is module-scoped so without this
-  // a previous dataset's searchText / datePreset / ownerFilter would
-  // persist. Skip the very first run so we don't reset on mount.
-  const datasetName = useRecoilValue(datasetNameAtom);
-  const firstRunRef = useRef(true);
-  const lastDatasetRef = useRef<string | null | undefined>(null);
-  useEffect(() => {
-    if (firstRunRef.current) {
-      firstRunRef.current = false;
-      lastDatasetRef.current = datasetName;
-      return;
-    }
-    if (lastDatasetRef.current !== datasetName) {
-      lastDatasetRef.current = datasetName;
-      setFilterState(DEFAULT_FILTER_STATE);
-    }
-  }, [datasetName, setFilterState]);
+  const [filterState, setFilterState] = usePanelFilterState();
 
   // Owner filter is applied server-side by
   // plugins/panels/similarity_search. Only date + search are applied here.

--- a/app/packages/similarity-search/src/hooks/useFilteredRuns.ts
+++ b/app/packages/similarity-search/src/hooks/useFilteredRuns.ts
@@ -1,16 +1,20 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { atom, useAtom } from "jotai";
+import { useRecoilValue } from "recoil";
+import { datasetName as datasetNameAtom } from "@fiftyone/state";
 import { SimilarityRun, RunFilterState } from "../types";
 import { DEFAULT_DATE_PRESET, OWNER_MINE } from "../constants";
 import { getDateRange, matchesText, matchesDate } from "../utils";
 
-// Exported so non-React callers (e.g. `useRuns.refreshRuns`) can read
-// the current filter state at call time via `getDefaultStore().get(...)`.
-export const filterStateAtom = atom<RunFilterState>({
+export const DEFAULT_FILTER_STATE: RunFilterState = {
   searchText: "",
   datePreset: DEFAULT_DATE_PRESET,
   ownerFilter: OWNER_MINE,
-});
+};
+
+// Exported so non-React callers (e.g. `useRuns.refreshRuns`) can read
+// the current filter state at call time via `getDefaultStore().get(...)`.
+export const filterStateAtom = atom<RunFilterState>(DEFAULT_FILTER_STATE);
 
 export const useFilteredRuns = (
   runs: SimilarityRun[]
@@ -20,6 +24,25 @@ export const useFilteredRuns = (
   setFilterState: (state: RunFilterState) => void;
 } => {
   const [filterState, setFilterState] = useAtom(filterStateAtom);
+
+  // Reset filter state when the dataset changes so filters don't
+  // bleed across datasets. The atom is module-scoped so without this
+  // a previous dataset's searchText / datePreset / ownerFilter would
+  // persist. Skip the very first run so we don't reset on mount.
+  const datasetName = useRecoilValue(datasetNameAtom);
+  const firstRunRef = useRef(true);
+  const lastDatasetRef = useRef<string | null | undefined>(null);
+  useEffect(() => {
+    if (firstRunRef.current) {
+      firstRunRef.current = false;
+      lastDatasetRef.current = datasetName;
+      return;
+    }
+    if (lastDatasetRef.current !== datasetName) {
+      lastDatasetRef.current = datasetName;
+      setFilterState(DEFAULT_FILTER_STATE);
+    }
+  }, [datasetName, setFilterState]);
 
   // Owner filter is applied server-side by
   // plugins/panels/similarity_search. Only date + search are applied here.

--- a/app/packages/similarity-search/src/hooks/useRuns.ts
+++ b/app/packages/similarity-search/src/hooks/useRuns.ts
@@ -8,7 +8,11 @@ import {
   datasetId as datasetIdAtom,
   datasetName as datasetNameAtom,
 } from "@fiftyone/state";
-import { LIST_RUNS_OPERATOR_URI, SSE_OPERATOR_URI } from "../constants";
+import {
+  LIST_RUNS_OPERATOR_URI,
+  RUNS_REFRESH_MAX_RETRY,
+  SSE_OPERATOR_URI,
+} from "../constants";
 import { SimilarityRun } from "../types";
 import { filterStateAtom } from "./useFilteredRuns";
 
@@ -57,7 +61,6 @@ export const useRuns = (): UseRunsResult => {
   const pendingRef = useRef(false);
   const inFlightRef = useRef<Promise<void> | null>(null);
   const errorCountRef = useRef(0);
-  const MAX_RETRY = 5;
 
   const refreshRuns = useCallback(() => {
     // If a fetch is already in flight, queue a follow-up refresh
@@ -82,6 +85,9 @@ export const useRuns = (): UseRunsResult => {
 
             if (result?.error) {
               console.error("Error fetching similarity runs:", result.error);
+              // Still mark the panel as loaded so the UI can render an
+              // empty/error state instead of spinning forever.
+              setLoaded(true);
               reject(new Error(String(result.error)));
               return;
             }
@@ -104,6 +110,7 @@ export const useRuns = (): UseRunsResult => {
       ).catch((error: unknown) => {
         fetchingRef.current = false;
         console.error("Operator execution failed for fetchRuns:", error);
+        setLoaded(true);
         reject(error instanceof Error ? error : new Error(String(error)));
       });
     });
@@ -124,7 +131,10 @@ export const useRuns = (): UseRunsResult => {
       })
       .finally(() => {
         inFlightRef.current = null;
-        if (pendingRef.current && errorCountRef.current < MAX_RETRY) {
+        if (
+          pendingRef.current &&
+          errorCountRef.current < RUNS_REFRESH_MAX_RETRY
+        ) {
           pendingRef.current = false;
           refreshRuns();
         } else {

--- a/app/packages/similarity-search/src/hooks/useRuns.ts
+++ b/app/packages/similarity-search/src/hooks/useRuns.ts
@@ -1,4 +1,4 @@
-import { atom, getDefaultStore, useAtom } from "jotai";
+import { atom, useAtom } from "jotai";
 import { useCallback, useEffect, useRef } from "react";
 import { useRecoilValue } from "recoil";
 import { useOperatorExecutor } from "@fiftyone/operators";
@@ -14,7 +14,7 @@ import {
   SSE_OPERATOR_URI,
 } from "../constants";
 import { SimilarityRun } from "../types";
-import { filterStateAtom } from "./useFilteredRuns";
+import { usePanelFilterState } from "./useFilteredRuns";
 
 const runsAtom = atom<SimilarityRun[]>([]);
 const loadedAtom = atom(false);
@@ -62,6 +62,15 @@ export const useRuns = (): UseRunsResult => {
   const inFlightRef = useRef<Promise<void> | null>(null);
   const errorCountRef = useRef(0);
 
+  // Subscribe to the panel's filter state via the shared hook, and
+  // mirror the owner value into a ref so refreshRuns() can read it
+  // synchronously from SSE callbacks and other non-React contexts.
+  // useFilteredRuns subscribes via the same hook; both consumers share
+  // the underlying panel-local Recoil state.
+  const [filterState] = usePanelFilterState();
+  const ownerFilterRef = useRef(filterState.ownerFilter);
+  ownerFilterRef.current = filterState.ownerFilter;
+
   const refreshRuns = useCallback(() => {
     // If a fetch is already in flight, queue a follow-up refresh
     // and return the in-flight promise so callers can still await.
@@ -71,10 +80,7 @@ export const useRuns = (): UseRunsResult => {
     }
     fetchingRef.current = true;
 
-    // Owner filter is applied server-side. Read the latest value at
-    // call time so SSE-driven refreshes always pick up the current
-    // selection without needing to live in React state.
-    const { ownerFilter } = getDefaultStore().get(filterStateAtom);
+    const ownerFilter = ownerFilterRef.current;
 
     const promise = new Promise<void>((resolve, reject) => {
       fetchRuns(

--- a/app/packages/similarity-search/src/hooks/useRuns.ts
+++ b/app/packages/similarity-search/src/hooks/useRuns.ts
@@ -91,9 +91,6 @@ export const useRuns = (): UseRunsResult => {
 
             if (result?.error) {
               console.error("Error fetching similarity runs:", result.error);
-              // Still mark the panel as loaded so the UI can render an
-              // empty/error state instead of spinning forever.
-              setLoaded(true);
               reject(new Error(String(result.error)));
               return;
             }
@@ -105,7 +102,6 @@ export const useRuns = (): UseRunsResult => {
               if (response?.runs) {
                 setRuns([...response.runs].sort(sortFn));
               }
-              setLoaded(true);
               resolve();
             } catch (e) {
               console.error("Error processing runs callback:", e);
@@ -116,7 +112,6 @@ export const useRuns = (): UseRunsResult => {
       ).catch((error: unknown) => {
         fetchingRef.current = false;
         console.error("Operator execution failed for fetchRuns:", error);
-        setLoaded(true);
         reject(error instanceof Error ? error : new Error(String(error)));
       });
     });
@@ -136,6 +131,9 @@ export const useRuns = (): UseRunsResult => {
         errorCountRef.current += 1;
       })
       .finally(() => {
+        // Mark loaded once the attempt settles regardless of outcome —
+        // lets the UI drop its spinner even on error / parse failure.
+        setLoaded(true);
         inFlightRef.current = null;
         if (
           pendingRef.current &&
@@ -170,10 +168,16 @@ export const useRuns = (): UseRunsResult => {
     }
   }, [refreshRuns, panelId, datasetName]);
 
-  // Subscribe to execution store changes via SSE for auto-refresh
+  // Subscribe to execution store changes via SSE for auto-refresh.
+  // Use a ref for refreshRuns so this callback is stable across
+  // fetchRuns identity churn (useOperatorExecutor re-memoizes `execute`
+  // whenever any recoil state read by useExecutionContext changes —
+  // view, filters, selectedSamples, etc).
+  const refreshRunsRef = useRef(refreshRuns);
+  refreshRunsRef.current = refreshRuns;
   const onStoreChange = useCallback(() => {
-    refreshRuns();
-  }, [refreshRuns]);
+    refreshRunsRef.current();
+  }, []);
 
   useExecutionStoreSubscribe({
     operatorUri: SSE_OPERATOR_URI,

--- a/app/packages/similarity-search/src/hooks/useSampleMedia.ts
+++ b/app/packages/similarity-search/src/hooks/useSampleMedia.ts
@@ -1,7 +1,6 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { SimilarityRun } from "../types";
-
-const DEFAULT_MAX_ENTRIES = 500;
+import { SAMPLE_MEDIA_CACHE_MAX_ENTRIES } from "../constants";
 
 /**
  * Simple LRU cache backed by a Map (which preserves insertion order).
@@ -64,7 +63,7 @@ type UseSampleMediaOptions = {
   filteredRuns: SimilarityRun[];
   /** Trigger to fetch media for given sample IDs. */
   onGetSampleMedia: (payload: { sample_ids: string[] }) => void;
-  /** Maximum cache entries. Default: 500. */
+  /** Maximum cache entries. Default: SAMPLE_MEDIA_CACHE_MAX_ENTRIES. */
   maxEntries?: number;
 };
 
@@ -86,7 +85,7 @@ export const useSampleMedia = ({
   expandedRunIds,
   filteredRuns,
   onGetSampleMedia,
-  maxEntries = DEFAULT_MAX_ENTRIES,
+  maxEntries = SAMPLE_MEDIA_CACHE_MAX_ENTRIES,
 }: UseSampleMediaOptions): UseSampleMediaResult => {
   const cacheRef = useRef(new LRUCache<string, string>(maxEntries));
   const pendingFetchRef = useRef<string | null>(null);
@@ -130,10 +129,17 @@ export const useSampleMedia = ({
     }
   }, [expandedRunIds, filteredRuns, onGetSampleMedia]);
 
-  const mergedMedia = {
-    ...cacheRef.current.toRecord(),
-    ...sampleMedia,
-  };
+  // Memoize the merged map so consumers (RichList items) don't see a
+  // new reference on every render. Recomputes when the incoming batch
+  // changes — at that point the cache has just been updated by the
+  // effect above, so reading it here is consistent.
+  const mergedMedia = useMemo(
+    () => ({
+      ...cacheRef.current.toRecord(),
+      ...sampleMedia,
+    }),
+    [sampleMedia]
+  );
 
   return { mergedMedia, handleToggleExpand };
 };

--- a/app/packages/similarity-search/src/hooks/useSearchSubmission.ts
+++ b/app/packages/similarity-search/src/hooks/useSearchSubmission.ts
@@ -3,7 +3,7 @@ import { useOperatorExecutor } from "@fiftyone/operators";
 import * as fos from "@fiftyone/state";
 import { useBrowserStorage } from "@fiftyone/state";
 import { BrainKeyConfig, QueryType, SearchScope } from "../types";
-import { INIT_RUN_OPERATOR_URI } from "../constants";
+import { INIT_RUN_OPERATOR_URI, K_MAX, K_MIN } from "../constants";
 import { canSubmitSearch, buildExecutionParams, UploadedImage } from "../utils";
 
 type UseSearchSubmissionInput = {
@@ -111,8 +111,8 @@ export const useSearchSubmission = (input: UseSearchSubmissionInput) => {
     input.k !== "" &&
     (!Number.isFinite(input.k) ||
       !Number.isInteger(input.k) ||
-      input.k < 1 ||
-      input.k > 10000);
+      input.k < K_MIN ||
+      input.k > K_MAX);
 
   const canSubmit =
     !kError &&

--- a/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
+++ b/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
@@ -344,9 +344,12 @@ export const useSimilarityPanel = (props: SimilaritySearchViewProps) => {
     refreshRunsRef.current();
   }, [ownerFilter]);
 
-  // Auto-apply immediate execution runs when they complete.
-  // Delegated runs (operator_run_id is set) are excluded — there's no
-  // completion event for those, so the user applies them manually.
+  // Auto-apply any run that just transitioned to Completed, regardless
+  // of whether it was executed immediately or delegated — in both cases
+  // the status flip from RUNNING/PENDING → Completed arrives via the
+  // same refreshRuns path (immediate: operator return; delegated: SSE
+  // from the worker's set_run write), and we want the result view to
+  // show automatically once the run finishes.
   const prevRunStatusesRef = useRef<Map<string, string>>(new Map());
 
   useEffect(() => {

--- a/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
+++ b/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
@@ -1,13 +1,19 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRecoilValue } from "recoil";
 import * as fos from "@fiftyone/state";
-import { RunStatus, SimilaritySearchViewProps, SimilarityRun } from "../types";
+import {
+  CloneConfig,
+  QueryType,
+  RunStatus,
+  SimilaritySearchViewProps,
+  SimilarityRun,
+} from "../types";
 import { useNavigate } from "./useNavigate";
 import { useRuns } from "./useRuns";
 import { useFilteredRuns } from "./useFilteredRuns";
 import { useMultiSelect } from "./useMultiSelect";
 import { useCloneConfig } from "./useCloneConfig";
-import useTriggers from "./useTriggers";
+import useTriggers, { TriggerOptions } from "./useTriggers";
 
 // ─── Derived State ──────────────────────────────────────────────────
 
@@ -117,18 +123,18 @@ type PanelActionsDeps = {
   navigateHome: () => void;
   navigateNewSearch: () => void;
   triggers: {
-    applyRun: (payload: { run_id: string }) => void;
-    deleteRun: (payload: { run_id: string }) => void;
-    bulkDeleteRuns: (payload: { run_ids: string[] }) => void;
+    applyRun: (payload: { run_id: string }, options?: TriggerOptions) => void;
+    deleteRun: (payload: { run_id: string }, options?: TriggerOptions) => void;
+    bulkDeleteRuns: (
+      payload: { run_ids: string[] },
+      options?: TriggerOptions
+    ) => void;
+    renameRun: (
+      payload: { run_id: string; new_name: string },
+      options?: TriggerOptions
+    ) => void;
   };
-  setCloneConfig: (config: {
-    brain_key: string;
-    query_type: "text" | "image";
-    query?: string;
-    k?: number;
-    reverse: boolean;
-    dist_field?: string;
-  }) => void;
+  setCloneConfig: (config: CloneConfig) => void;
   clearCloneConfig: () => void;
   clearAndExit: () => void;
 };
@@ -160,35 +166,67 @@ const useSimilarityPanelActions = (deps: PanelActionsDeps) => {
 
   const handleDelete = useCallback(
     (runId: string) => {
-      triggers.deleteRun({ run_id: runId });
+      // Optimistic remove; on backend failure we re-sync from truth.
       removeRun(runId);
+      triggers.deleteRun(
+        { run_id: runId },
+        {
+          onSettled: (result) => {
+            if (result?.error) {
+              console.error(
+                "Delete run failed; reconciling from server:",
+                result.error
+              );
+              refreshRuns();
+            }
+          },
+        }
+      );
     },
-    [triggers, removeRun]
+    [triggers, removeRun, refreshRuns]
   );
 
   const handleBulkDelete = useCallback(
     (runIds: string[]) => {
-      triggers.bulkDeleteRuns({ run_ids: runIds });
+      // Optimistic remove; on backend failure we re-sync from truth.
       removeRuns(runIds);
       clearAndExit();
+      triggers.bulkDeleteRuns(
+        { run_ids: runIds },
+        {
+          onSettled: (result) => {
+            if (result?.error) {
+              console.error(
+                "Bulk delete failed; reconciling from server:",
+                result.error
+              );
+              refreshRuns();
+            }
+          },
+        }
+      );
     },
-    [triggers, removeRuns, clearAndExit]
+    [triggers, removeRuns, clearAndExit, refreshRuns]
   );
 
   const handleClone = useCallback(
     (runId: string) => {
       const run = runs.find((r) => r.run_id === runId);
-      if (run) {
-        setCloneConfig({
-          brain_key: run.brain_key,
-          query_type: run.query_type as "text" | "image",
-          query: typeof run.query === "string" ? run.query : undefined,
-          k: run.k,
-          reverse: run.reverse,
-          dist_field: run.dist_field,
-        });
-        navigateNewSearch();
-      }
+      if (!run) return;
+      // Upload queries can't be re-run without the original image; fall
+      // back to Image search so the form prompts the user to select
+      // samples rather than silently coercing to the wrong query_type.
+      const queryType =
+        run.query_type === QueryType.Upload ? QueryType.Image : run.query_type;
+      setCloneConfig({
+        brain_key: run.brain_key,
+        query_type: queryType,
+        query: typeof run.query === "string" ? run.query : undefined,
+        k: run.k,
+        reverse: run.reverse,
+        dist_field: run.dist_field,
+      });
+      navigateNewSearch();
     },
     [runs, setCloneConfig, navigateNewSearch]
   );
@@ -253,23 +291,29 @@ export const useSimilarityPanel = (props: SimilaritySearchViewProps) => {
     deselectAll,
   } = useMultiSelect();
 
+  // Only the triggers that the frontend actually invokes are declared
+  // here. clone/list/getBrainKeys schema entries are handled without
+  // round-tripping through the panel event bus.
   const triggers = useTriggers<{
-    applyRun: (payload: { run_id: string }) => void;
-    deleteRun: (payload: { run_id: string }) => void;
-    bulkDeleteRuns: (payload: { run_ids: string[] }) => void;
-    cloneRun: (payload: { run_id: string }) => void;
-    renameRun: (payload: { run_id: string; new_name: string }) => void;
-    listRuns: (payload?: { owner?: string }) => void;
-    getBrainKeys: () => void;
-    getSampleMedia: (payload: { sample_ids: string[] }) => void;
+    applyRun: (payload: { run_id: string }, options?: TriggerOptions) => void;
+    deleteRun: (payload: { run_id: string }, options?: TriggerOptions) => void;
+    bulkDeleteRuns: (
+      payload: { run_ids: string[] },
+      options?: TriggerOptions
+    ) => void;
+    renameRun: (
+      payload: { run_id: string; new_name: string },
+      options?: TriggerOptions
+    ) => void;
+    getSampleMedia: (
+      payload: { sample_ids: string[] },
+      options?: TriggerOptions
+    ) => void;
   }>({
     applyRun: view.apply_run,
     deleteRun: view.delete_run,
     bulkDeleteRuns: view.bulk_delete_runs,
-    cloneRun: view.clone_run,
     renameRun: view.rename_run,
-    listRuns: view.list_runs,
-    getBrainKeys: view.get_brain_keys,
     getSampleMedia: view.get_sample_media,
   });
 

--- a/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
+++ b/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
@@ -3,7 +3,6 @@ import { useRecoilValue } from "recoil";
 import * as fos from "@fiftyone/state";
 import {
   CloneConfig,
-  QueryType,
   RunStatus,
   SimilaritySearchViewProps,
   SimilarityRun,
@@ -213,14 +212,9 @@ const useSimilarityPanelActions = (deps: PanelActionsDeps) => {
     (runId: string) => {
       const run = runs.find((r) => r.run_id === runId);
       if (!run) return;
-      // Upload queries can't be re-run without the original image; fall
-      // back to Image search so the form prompts the user to select
-      // samples rather than silently coercing to the wrong query_type.
-      const queryType =
-        run.query_type === QueryType.Upload ? QueryType.Image : run.query_type;
       setCloneConfig({
         brain_key: run.brain_key,
-        query_type: queryType,
+        query_type: run.query_type,
         query: typeof run.query === "string" ? run.query : undefined,
         k: run.k,
         reverse: run.reverse,

--- a/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
+++ b/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
@@ -330,15 +330,19 @@ export const useSimilarityPanel = (props: SimilaritySearchViewProps) => {
   // Re-fetch runs whenever the owner filter changes — it's applied
   // server-side. Skip the initial render so we don't double-fetch
   // alongside the panel's initial load.
+
   const ownerFilter = state.filterState.ownerFilter;
   const ownerInitRef = useRef(true);
+  const refreshRunsRef = useRef(state.refreshRuns);
+  refreshRunsRef.current = state.refreshRuns;
+
   useEffect(() => {
     if (ownerInitRef.current) {
       ownerInitRef.current = false;
       return;
     }
-    state.refreshRuns();
-  }, [ownerFilter, state.refreshRuns]);
+    refreshRunsRef.current();
+  }, [ownerFilter]);
 
   // Auto-apply immediate execution runs when they complete.
   // Delegated runs (operator_run_id is set) are excluded — there's no

--- a/app/packages/similarity-search/src/hooks/useTriggers.ts
+++ b/app/packages/similarity-search/src/hooks/useTriggers.ts
@@ -2,8 +2,19 @@ import { useTriggerPanelEvent } from "@fiftyone/operators";
 import { useMemo, useRef } from "react";
 
 /**
+ * Options for a single trigger invocation.
+ *
+ * `onSettled` fires with the raw panel-event result (or error) after
+ * the backend has responded. Callers can use this to reconcile
+ * optimistic UI updates if the backend fails.
+ */
+export type TriggerOptions = {
+  onSettled?: (result?: { result?: unknown; error?: unknown }) => void;
+};
+
+/**
  * Given a record of keys to event names, returns a record of trigger functions.
- * Follows the panel event pattern for frontend-to-panel communication.
+ * Each trigger accepts an optional `TriggerOptions` arg for callbacks.
  */
 export default function useTriggers<
   T extends Record<string, (...args: any[]) => void>
@@ -17,8 +28,13 @@ export default function useTriggers<
 
     for (const key in eventMapRef.current) {
       const k = key;
-      result[k] = ((payload?: any) =>
-        safeTrigger(trigger, eventMapRef.current[k], payload)) as T[typeof k];
+      result[k] = ((payload?: any, options?: TriggerOptions) =>
+        safeTrigger(
+          trigger,
+          eventMapRef.current[k],
+          payload,
+          options
+        )) as T[typeof k];
     }
 
     return result;
@@ -28,14 +44,20 @@ export default function useTriggers<
 }
 
 function safeTrigger(
-  trigger: (eventName: string, payload?: any) => void,
+  trigger: (
+    eventName: string,
+    payload?: any,
+    prompt?: boolean,
+    callback?: (result?: { result?: unknown; error?: unknown }) => void
+  ) => void,
   eventName: string,
-  payload?: any
+  payload?: any,
+  options?: TriggerOptions
 ) {
   if (payload?._reactName) {
     // Support <button onClick={triggers.myTrigger} />
     // by ignoring react synthetic events
     payload = undefined;
   }
-  return trigger(eventName, payload);
+  return trigger(eventName, payload, undefined, options?.onSettled);
 }

--- a/app/packages/similarity-search/src/types/index.ts
+++ b/app/packages/similarity-search/src/types/index.ts
@@ -57,7 +57,6 @@ export type SimilarityRun = {
   creation_time?: string;
   start_time?: string;
   end_time?: string;
-  source_view?: Record<string, unknown>[];
   operator_run_id?: string;
   status_details?: string;
   created_by?: string;

--- a/plugins/panels/similarity_search/constants.py
+++ b/plugins/panels/similarity_search/constants.py
@@ -6,11 +6,13 @@ Similarity search panel constants.
 |
 """
 
+from enum import Enum
+
 STORE_NAME = "similarity_search_panel"
 
 
-class RunStatus:
-    """Constants for similarity search run statuses."""
+class RunStatus(str, Enum):
+    """Statuses a similarity search run can be in."""
 
     PENDING = "pending"
     RUNNING = "running"
@@ -18,8 +20,9 @@ class RunStatus:
     FAILED = "failed"
 
 
-class QueryType:
-    """Constants for similarity query types."""
+class QueryType(str, Enum):
+    """Types of similarity queries."""
 
     TEXT = "text"
     IMAGE = "image"
+    UPLOAD = "upload"

--- a/plugins/panels/similarity_search/run_manager.py
+++ b/plugins/panels/similarity_search/run_manager.py
@@ -40,7 +40,7 @@ class RunManager:
     _OPID_PREFIX = "opid:"
 
     # Fields too large for listing — only needed by get_run / apply_run
-    _HEAVY_FIELDS = {"result_ids", "result_view", "source_view"}
+    _HEAVY_FIELDS = {"result_ids", "result_view"}
 
     def __init__(self, ctx):
         dataset_id = get_head_dataset_id(ctx.dataset)
@@ -75,7 +75,6 @@ class RunManager:
             "creation_time": now,
             "start_time": None,
             "end_time": None,
-            "source_view": run_params.get("source_view"),
             "negative_query_ids": run_params.get("negative_query_ids"),
             "operator_run_id": None,
             "status_details": None,


### PR DESCRIPTION
## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

Some bugfixes:

- Reset filter state when the dataset changes. The filter atom was module-scoped, so switching datasets carried over searchText / datePreset / ownerFilter from the previous dataset. useFilteredRuns now watches datasetName and resets on change (skipping the initial mount). (commit 4b0d671757)
- refreshRuns no longer leaves the panel spinning on error. Both error paths now call setLoaded(true) so the UI drops to its empty/error state instead of hanging on the spinner.
- Optimistic delete / bulk-delete now reconcile on backend error. useTriggers grew an onSettled option; on failure we refreshRuns() to pull truth back from the server instead of leaving the local state diverged.

Some Type tightening:

- PanelActionsDeps.triggers now includes renameRun (it was being called against a type that didn't declare it — was a latent TS error masked by any).
- setCloneConfig dep widens to the shared CloneConfig type; the previous narrow {"text"|"image"} signature was forcing an unsafe as cast.
- Dropped dead frontend triggers cloneRun / listRuns / getBrainKeys — none were ever invoked (cloning reads from local state, list/brainkeys go through operators directly). Python-side entries kept for now so we don't fan out the change.

Additional: 
Demote the empty-data SSE frame log from `console.error` to `console.debug` because `sse-starlette`'s keep-alive comment pings surface as empty-data events and were polluting the console with a benign "error" every ~15 s.

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rename action; clone button now disables for file-upload searches with explanatory tooltip

* **Bug Fixes**
  * UI no longer stays loading after refresh failures; delete/bulk-delete use optimistic removal with server reconciliation
  * Prevented state updates after component unmount to avoid errors

* **Improvements**
  * Configurable bounds for "number of matches"; centralized run-name truncation and media-cache limits; reduced automatic retry attempts for run refreshes
* **API/Behavior**
  * Clone/delete triggers accept optional completion callbacks; minor run data exposure adjusted for consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->