### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,34 +1,8 @@
 *   @voxel51/developers
 
-# Frontend
-.prettierignore              @voxel51/frontend-devs
-.prettierrc.js               @voxel51/frontend-devs
-/app/                        @voxel51/frontend-devs
-/e2e-pw/                     @voxel51/frontend-devs
-/fiftyone/server/            @voxel51/frontend-devs
-
-# Plugins
-/plugins/panels/             @voxel51/plugin-pros
-/fiftyone/operators/         @voxel51/plugin-pros @voxel51/backend-squad
-
-# Backend
-/fiftyone/api/               @voxel51/backend-squad
-/fiftyone/core/              @voxel51/backend-squad
-/fiftyone/core/models.py
-/fiftyone/factory/           @voxel51/backend-squad
-/fiftyone/internal/          @voxel51/backend-squad
-/fiftyone/management/        @voxel51/backend-squad
-/fiftyone/migrations/        @voxel51/backend-squad
-
 # Aloha Shirts care about versioning
 .github/                     @voxel51/aloha-shirts
 Dockerfile                   @voxel51/aloha-shirts
 setup.py                     @voxel51/aloha-shirts
 requirements.txt             @voxel51/aloha-shirts
 requirements/                @voxel51/aloha-shirts
-
-# e2e test workflow has shared ownership
-.github/workflows/e2e.yml    @voxel51/aloha-shirts sashank@voxel51.com  # implementer of e2e workflow
-
-# Exclusions ('!' syntax not supported by github)
-/fiftyone/internal/features/  @voxel51/developers


### PR DESCRIPTION
Only keep Aloha - remove other codeowners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code ownership configuration to reflect current project structure and team responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->