### PR TITLE
fix: transform patch for sam2

### DIFF
--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -26,6 +26,29 @@ sam = fou.lazy_import("segment_anything")
 logger = logging.getLogger(__name__)
 
 
+def _expand_sam_prompt_field(field_mapping):
+    """Expand ``prompt_field`` into box/point field names (in-place)."""
+    if "prompt_field" not in field_mapping:
+        return
+    has_box = "box_prompt_field" in field_mapping
+    has_point = "point_prompt_field" in field_mapping
+
+    if has_box and has_point:
+        raise ValueError(
+            "The generic prompt_field cannot be used when both box_prompt_field and point_prompt_field are present."
+        )
+
+    value = field_mapping["prompt_field"]
+    # Copy to box and/or point fields since prompt type is unknown.
+    if not has_box:
+        logger.debug("Moving prompt_field to box_prompt_field")
+        field_mapping["box_prompt_field"] = value
+
+    if not has_point:
+        logger.debug("Moving prompt_field to point_prompt_field")
+        field_mapping["point_prompt_field"] = value
+
+
 class SegmentAnythingModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
     """Configuration for running a :class:`SegmentAnythingModel`.
 
@@ -98,12 +121,14 @@ class _SAMPredictor:
         image_torch = image_torch.permute(2, 0, 1).contiguous()[None, :, :, :]
         return image_torch, img.shape[:2]
 
-    def box_transform(self, boxes_xyxy, img_hw):
+    def box_transform(self, boxes_xyxy, img_hw, resolution=None):
         """Transforms boxes for SAM model prompts.
 
         Args:
             boxes_xyxy: list of boxes in XYXY pixels
             img_hw: original image height and width
+            resolution (None): optional SAM2-style prompt resolution scaling
+                parameter; ignored by SAM transforms
 
         Returns:
             resized boxes for SAM as a Bx4 tensor
@@ -114,13 +139,17 @@ class _SAMPredictor:
             (img_hw[0], img_hw[1]),
         )
 
-    def point_transform(self, points, img_hw, point_labels=None):
+    def point_transform(
+        self, points, img_hw, point_labels=None, resolution=None
+    ):
         """Transforms points for SAM model prompts.
 
         Args:
             points: relative points in xyxy format
             img_hw: original image height and width
             point_labels (None): list containing positive (1) and negative (0) point labels. Defaults to None.
+            resolution (None): optional SAM2-style prompt resolution scaling
+                parameter; ignored by SAM transforms
 
         Returns:
             a torch tensor containing points in XYXY pixels for SAM model
@@ -231,6 +260,10 @@ class SegmentAnythingImageGetItem(fout.GetItem):
             and Torch tensors when loading data
         box_transform (None): SAM specific box transform function to apply
         point_transform (None): SAM specific point transform function to apply
+        resolution (None): when set, ``box_transform`` / ``point_transform``
+            are called with ``resolution=self.resolution`` (SAM2 helpers in
+            ``fiftyone.utils.sam2``). Leave unset for SAM (two-arg transforms
+            only).
     """
 
     def __init__(
@@ -240,6 +273,7 @@ class SegmentAnythingImageGetItem(fout.GetItem):
         use_numpy=False,
         box_transform=None,
         point_transform=None,
+        resolution=None,
         **kwargs,
     ):
         field_mapping = {} if field_mapping is None else dict(field_mapping)
@@ -258,6 +292,8 @@ class SegmentAnythingImageGetItem(fout.GetItem):
             )
 
         self.mode = self._set_mode(field_mapping)
+
+        self.resolution = float(resolution) if resolution is not None else None
 
         super().__init__(field_mapping=field_mapping, **kwargs)
         self.transform = transform
@@ -1004,23 +1040,7 @@ class SegmentAnythingModel(fout.TorchImageModelWithPrompts):
         get_item_args = dict(self.config.get_item_args or {})
         field_mapping = {} if field_mapping is None else dict(field_mapping)
 
-        if "prompt_field" in field_mapping:
-            # Maintain backward compability of prompt_field.
-            if (
-                "box_prompt_field" in field_mapping
-                and "point_prompt_field" in field_mapping
-            ):
-                raise ValueError(
-                    "The generic prompt_field cannot be used when both box_prompt_field and point_prompt_field are present."
-                )
-            value = field_mapping["prompt_field"]
-            # Copy to box and/or point fields since prompt type is unknown.
-            if "box_prompt_field" not in field_mapping:
-                logger.debug("Moving prompt_field to box_prompt_field")
-                field_mapping["box_prompt_field"] = value
-            if "point_prompt_field" not in field_mapping:
-                logger.debug("Moving prompt_field to point_prompt_field")
-                field_mapping["point_prompt_field"] = value
+        _expand_sam_prompt_field(field_mapping)
 
         return get_item(
             field_mapping=field_mapping,
@@ -1034,6 +1054,7 @@ class SegmentAnythingModel(fout.TorchImageModelWithPrompts):
             point_transform=get_item_args.pop(
                 "point_transform", self._sam_predictor.point_transform
             ),
+            resolution=get_item_args.pop("resolution", None),
             **get_item_args,
         )
 

--- a/fiftyone/utils/sam2.py
+++ b/fiftyone/utils/sam2.py
@@ -32,6 +32,36 @@ smutil = fou.lazy_import("sam2.utils.misc")
 logger = logging.getLogger(__name__)
 
 
+def _sam2_image_transform(img):
+    """Pass-through image and `(H, W)`; SAM2 resizes in `set_image`."""
+    return img, img.shape[:2]
+
+
+def _sam2_boxes_transform(boxes_xyxy, orig_hw, *, resolution):
+    """Normalize XYXY boxes to `[0,1]` then scale by `resolution` (SAM2-aligned)."""
+    boxes = torch.as_tensor(boxes_xyxy, dtype=torch.float32)
+    h, w = orig_hw
+    coords = boxes.reshape(-1, 2, 2).clone()
+    coords[..., 0] = coords[..., 0] / w
+    coords[..., 1] = coords[..., 1] / h
+    return coords * resolution
+
+
+def _sam2_point_transform(points, img_hw, point_labels=None, *, resolution):
+    """Normalize keypoints then scale by `resolution` (SAM2-aligned)."""
+    _ = img_hw
+    norm_points, labels = fosam._to_sam_points(
+        points,
+        height=1,
+        width=1,
+        point_labels=point_labels,
+    )
+    unnorm_points = (
+        torch.as_tensor(norm_points, dtype=torch.float32) * resolution
+    )
+    return unnorm_points, torch.tensor(labels, dtype=torch.int)
+
+
 class SegmentAnything2ImageModelConfig(fosam.SegmentAnythingModelConfig):
     """Configuration for running a :class:`SegmentAnything2ImageModel`.
 
@@ -44,6 +74,10 @@ class SegmentAnything2ImageModelConfig(fosam.SegmentAnythingModelConfig):
 
 class _SAM2Predictor(fosam._SAMPredictor):
     """Wrapper for ``sam2.sam2_image_predictor.SAM2ImagePredictor``.
+
+    Prompt geometry for ``GetItem``/workers is implemented in module-level
+    :func:`_sam2_image_transform`, :func:`_sam2_boxes_transform`, and
+    :func:`_sam2_point_transform` to avoid pickling ``SAM2Transforms`` (TorchScript).
 
     Args:
         model: a :class:`sam2.modeling.sam2_base.SAM2Base` model
@@ -58,6 +92,11 @@ class _SAM2Predictor(fosam._SAMPredictor):
         )
         self.image_id = None
 
+    @property
+    def _resolution(self):
+        """Input resolution scale from ``SAM2Transforms`` (shared by picklable helpers)."""
+        return float(self.sam_transforms.resolution)
+
     def image_transform(self, img):
         """Transforms image for SAM2 model input.
 
@@ -68,9 +107,7 @@ class _SAM2Predictor(fosam._SAMPredictor):
             a uint8 numpy array containing image in HWC format
             a tuple containing original image dimensions
         """
-        # SAM2 does image pre-processing when it calls SAM2ImagePredictor.set_image.
-        # No straight-forward way to decouple them other than extracting the functionality.
-        return img, img.shape[:2]
+        return _sam2_image_transform(img)
 
     def box_transform(self, boxes_xyxy, img_hw):
         """Transforms boxes for SAM2 model prompts.
@@ -82,10 +119,8 @@ class _SAM2Predictor(fosam._SAMPredictor):
         Returns:
             resized boxes for SAM2 as a Bx4 tensor
         """
-        return self.sam_transforms.transform_boxes(
-            torch.tensor(boxes_xyxy, dtype=torch.float),
-            normalize=True,
-            orig_hw=img_hw,
+        return _sam2_boxes_transform(
+            boxes_xyxy, img_hw, resolution=self._resolution
         )
 
     def point_transform(self, points, img_hw, point_labels=None):
@@ -100,15 +135,11 @@ class _SAM2Predictor(fosam._SAMPredictor):
             a torch tensor containing points in XYXY pixels for SAM2 model
             a torch tensor containing positive and negative labels
         """
-        norm_points, labels = fosam._to_sam_points(
+        return _sam2_point_transform(
             points,
-            height=1,
-            width=1,
-            point_labels=point_labels,
-        )
-        unnorm_points = self.sam_transforms.transform_coords(norm_points)
-        return torch.tensor(unnorm_points, dtype=torch.float64), torch.tensor(
-            labels, dtype=torch.int
+            img_hw,
+            point_labels,
+            resolution=self._resolution,
         )
 
     def valid_image(self, curr_id):
@@ -230,6 +261,41 @@ class SegmentAnything2ImageModel(fosam.SegmentAnythingModel):
 
     def _load_predictor(self):
         return _SAM2Predictor(self._model)
+
+    def build_get_item(self, field_mapping=None):
+        """Same as :meth:`fosam.SegmentAnythingModel.build_get_item` but uses picklable
+        module transforms and :attr:`fosam.SegmentAnythingImageGetItem.resolution`
+        so ``FiftyOneTorchDataset`` works with ``spawn`` (no TorchScript).
+
+        Does not mutate ``self.config``.
+        """
+        get_item_cls = self.config.get_item_cls
+        if get_item_cls is None:
+            raise ValueError("GetItem class is set to None")
+
+        if not etau.is_str(self.config.get_item_cls):
+            raise TypeError(
+                f"Expected class string. GetItem class can't be initialized from {get_item_cls}"
+            )
+        get_item = etau.get_class(get_item_cls)
+        get_item_args = dict(self.config.get_item_args or {})
+        resolution = self._sam_predictor._resolution
+        field_mapping = {} if field_mapping is None else dict(field_mapping)
+        fosam._expand_sam_prompt_field(field_mapping)
+
+        return get_item(
+            field_mapping=field_mapping,
+            transform=get_item_args.pop("transform", _sam2_image_transform),
+            use_numpy=get_item_args.pop("use_numpy", True),
+            box_transform=get_item_args.pop(
+                "box_transform", _sam2_boxes_transform
+            ),
+            point_transform=get_item_args.pop(
+                "point_transform", _sam2_point_transform
+            ),
+            resolution=get_item_args.pop("resolution", resolution),
+            **get_item_args,
+        )
 
     def _load_auto_generator(self):
         kwargs = self.config.auto_kwargs or {}


### PR DESCRIPTION
## 🔗 Related Issues

Seeing failures on running the following suite of tests locally
`pytest tests/intensive/model_zoo_tests.py -s -k test_sam2`
Specifically, `test_sam2_auto` `test_sam2_boxes` `test_sam2_points` fail with a pickling error
```
RuntimeError: Tried to serialize object __torch__.torch.nn.modules.container.Sequential which does not have a __getstate__ method defined!
```
Possibly, this is due to MacOS spawning workers differently (thereby requiring everything in `FiftyOneTorchDataset` to be picklable). This [appears to not be an issue for linux machines](https://github.com/voxel51/fiftyone/pull/7180#issuecomment-4194649975).

## 📋 What changes are proposed in this pull request?

Prompt preprocessing is implemented as `@staticmethod` helpers (`_sam2_*`) so that :meth:`SegmentAnything2ImageModel.build_get_item` can pass the same callables to workers without pickling TorchScript `SAM2Transforms`

## 🧪 How is this patch tested? If it is not, please explain why.

`pytest tests/intensive/model_zoo_tests.py -s` on a Mac system.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other: Sam2 integration changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved prompt preprocessing for both legacy and new segmentation backends so image, box, and point transforms are picklable, stabilizing multiprocessing and worker-process data loading.
  * Introduced consistent resolution handling across transforms so prompts and spatial inputs scale reliably.
  * Enhanced prompt-field mapping to preserve legacy compatibility and prevent conflicting or incomplete prompt configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->