### PR TITLE
[HA] Add support for deleting keypoints in point selection mode

### DIFF
--- a/app/packages/annotation/src/agents/hooks/usePointSelection.ts
+++ b/app/packages/annotation/src/agents/hooks/usePointSelection.ts
@@ -1,7 +1,8 @@
 import { useCallback } from "react";
 import type {
   DrawStyle,
-  KeypointVariantResolverContext,
+  KeypointPointHitAction,
+  KeypointPointHitContext,
   Point,
 } from "@fiftyone/lighter";
 import {
@@ -14,11 +15,14 @@ import {
 } from "@fiftyone/lighter";
 import { atom, useAtom } from "jotai";
 import { v4 as uuidv4 } from "uuid";
+import { ClickEventModifiers } from "@fiftyone/utilities";
 
-/** Variant keys used by point selection. */
+/** Positive points are explicitly *included* in inference results. */
 export const POSITIVE_POINT_VARIANT = "positive" as const;
+/** Negative points are explicitly *excluded* from inference results. */
 export const NEGATIVE_POINT_VARIANT = "negative" as const;
 
+/** Union of supported point selection variants. */
 export type PointSelectionVariant =
   | typeof POSITIVE_POINT_VARIANT
   | typeof NEGATIVE_POINT_VARIANT;
@@ -38,14 +42,22 @@ const POINT_SELECTION_VARIANT_STYLES: Record<PointSelectionVariant, DrawStyle> =
 
 export interface PointSelection {
   /**
-   * Activates point selection. The optional resolver is invoked for each
-   * placed point and should return the variant key to associate with it.
+   * Activates point selection.
+   *
+   * @param resolveVariant Invoked for each new point placement; returns
+   *   the variant key to associate with the point.
+   * @param resolvePointHit Invoked when a click lands on an existing
+   *   point; returning an action (e.g. "delete") overrides the default
+   *   behavior.
    */
   activate(
     resolveVariant?: (
       relativePoint: Point,
-      ctx: KeypointVariantResolverContext
-    ) => PointSelectionVariant
+      ctx: ClickEventModifiers
+    ) => PointSelectionVariant,
+    resolvePointHit?: (
+      ctx: KeypointPointHitContext
+    ) => KeypointPointHitAction | undefined
   ): void;
 
   /**
@@ -96,8 +108,11 @@ export const usePointSelection = (): PointSelection => {
     (
       resolveVariant?: (
         relativePoint: Point,
-        ctx: KeypointVariantResolverContext
-      ) => PointSelectionVariant
+        ctx: ClickEventModifiers
+      ) => PointSelectionVariant,
+      resolvePointHit?: (
+        ctx: KeypointPointHitContext
+      ) => KeypointPointHitAction | undefined
     ) => {
       if (isActive) {
         return;
@@ -118,7 +133,12 @@ export const usePointSelection = (): PointSelection => {
         scene.addOverlay(overlay);
 
         scene.enterInteractiveMode(
-          new InteractiveKeypointHandler(overlay, eventBus, resolveVariant)
+          new InteractiveKeypointHandler(
+            overlay,
+            eventBus,
+            resolveVariant,
+            resolvePointHit
+          )
         );
 
         setIsActive(true);

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
@@ -10,12 +10,13 @@ import {
 } from "@fiftyone/annotation/src/agents";
 import {
   BoundingBoxOverlay,
-  KeypointVariantResolverContext,
+  KeypointPointHitAction,
   Point,
 } from "@fiftyone/lighter";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { atom, useAtom } from "jotai";
 import { useAnnotationContext } from "./state";
+import { ClickEventModifiers } from "@fiftyone/utilities";
 
 export interface SegmentationMode {
   activate(): void;
@@ -73,7 +74,7 @@ export const useSegmentationMode = (): SegmentationMode => {
     }
 
     previousSelectedLabelIdRef.current = currentId;
-  }, [pointSelection, resetToolsState, segmentationModeActive, selectedLabel]);
+  }, [selectedLabel]);
 
   // Points placed on the current label's mask are interpreted as negative;
   // points placed off-mask are positive.
@@ -81,7 +82,7 @@ export const useSegmentationMode = (): SegmentationMode => {
   const resolvePointVariant = useCallback(
     (
       relativePoint: Point,
-      { shiftKey }: KeypointVariantResolverContext
+      { shiftKey }: ClickEventModifiers
     ): PointSelectionVariant => {
       const label = selectedLabelRef.current;
       const onMask =
@@ -102,12 +103,16 @@ export const useSegmentationMode = (): SegmentationMode => {
     []
   );
 
+  // Clicking an existing point deletes it
+  const resolvePointHit = useCallback(() => KeypointPointHitAction.DELETE, []);
+
   const activate = useCallback(() => {
     setSegmentationModeActive(true);
     setActiveTask(AgentTaskType.SEGMENT);
-    pointSelection.activate(resolvePointVariant);
+    pointSelection.activate(resolvePointVariant, resolvePointHit);
   }, [
     pointSelection,
+    resolvePointHit,
     resolvePointVariant,
     setActiveTask,
     setSegmentationModeActive,

--- a/app/packages/lighter/src/commands/RemoveKeypointPointCommand.ts
+++ b/app/packages/lighter/src/commands/RemoveKeypointPointCommand.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import type { Undoable } from "@fiftyone/commands";
+import type { KeypointOverlay } from "../overlay/KeypointOverlay";
+
+/**
+ * Undoable command for removing a single point from a KeypointOverlay.
+ *
+ * Constructor captures the point's relative position and variant so undo
+ * can re-add it with the same ID.
+ */
+export class RemoveKeypointPointCommand implements Undoable {
+  readonly id: string;
+  readonly description: string;
+
+  private readonly relativePosition: [number, number];
+  private readonly variant?: string;
+
+  constructor(private overlay: KeypointOverlay, private pointId: string) {
+    const entry = overlay.getPointById(pointId);
+    if (!entry) {
+      throw new Error(
+        `RemoveKeypointPointCommand: no point with id ${pointId}`
+      );
+    }
+
+    this.relativePosition = entry.position;
+    this.variant = entry.variant;
+    this.id = `remove-keypoint-point-${pointId}-${Date.now()}`;
+    this.description = `Remove keypoint point ${pointId}`;
+  }
+
+  execute(): void {
+    this.overlay.removePointById(this.pointId);
+  }
+
+  undo(): void {
+    const worldPoint = this.overlay.relativePointToAbsolute(
+      this.relativePosition
+    );
+    this.overlay.addPoint(worldPoint, this.variant, this.pointId);
+  }
+}

--- a/app/packages/lighter/src/index.ts
+++ b/app/packages/lighter/src/index.ts
@@ -46,8 +46,11 @@ export type { LighterEventGroup } from "./events";
 export { InteractionManager } from "./interaction/InteractionManager";
 export type { InteractionHandler } from "./interaction/InteractionManager";
 export { InteractiveDetectionHandler } from "./interaction/InteractiveDetectionHandler";
-export { InteractiveKeypointHandler } from "./interaction/InteractiveKeypointHandler";
-export type { KeypointVariantResolverContext } from "./interaction/InteractiveKeypointHandler";
+export {
+  InteractiveKeypointHandler,
+  KeypointPointHitAction,
+} from "./interaction/InteractiveKeypointHandler";
+export type { KeypointPointHitContext } from "./interaction/InteractiveKeypointHandler";
 
 // Selection exports
 export type { Selectable } from "./selection/Selectable";
@@ -58,6 +61,7 @@ export type { SelectionOptions } from "./selection/SelectionManager";
 export { AddKeypointPointCommand } from "./commands/AddKeypointPointCommand";
 export { MoveKeypointPointCommand } from "./commands/MoveKeypointPointCommand";
 export { MoveOverlayCommand } from "./commands/MoveOverlayCommand";
+export { RemoveKeypointPointCommand } from "./commands/RemoveKeypointPointCommand";
 export { TransformOverlayCommand } from "./commands/TransformOverlayCommand";
 export { UpdateLabelCommand } from "./commands/UpdateLabelCommand";
 

--- a/app/packages/lighter/src/interaction/InteractiveKeypointHandler.ts
+++ b/app/packages/lighter/src/interaction/InteractiveKeypointHandler.ts
@@ -5,24 +5,33 @@
 import { CommandContextManager } from "@fiftyone/commands";
 import type { EventDispatcher } from "@fiftyone/events";
 import { AddKeypointPointCommand } from "../commands/AddKeypointPointCommand";
+import { RemoveKeypointPointCommand } from "../commands/RemoveKeypointPointCommand";
 import type { LighterEventGroup } from "../events";
 import { KeypointOverlay } from "../overlay/KeypointOverlay";
 import type { Point } from "../types";
 import type { InteractionHandler } from "./InteractionManager";
+import { ClickEventModifiers, getClickModifiers } from "@fiftyone/utilities";
 
 const INTERACTIVE_KEYPOINT_HANDLER_ID = "interactive-keypoint-handler";
 
 /**
- * Modifier flags forwarded to the variant resolver from the triggering
- * pointer event. Resolver consumers can branch on these to implement
- * hold-to-modify behaviors (e.g. shift to invert semantics).
+ * Action returned by a point-hit resolver.
+ *
+ * Callers returning `undefined` fall through to the default click behavior.
  */
-export interface KeypointVariantResolverContext {
-  shiftKey: boolean;
-  altKey: boolean;
-  ctrlKey: boolean;
-  metaKey: boolean;
+export enum KeypointPointHitAction {
+  DELETE = "delete",
 }
+
+/**
+ * Context passed to a point-hit resolver when a click lands on an existing
+ * point.
+ */
+export type KeypointPointHitContext = {
+  pointId: string;
+  relativePoint: Point;
+  modifiers: ClickEventModifiers;
+};
 
 /**
  * Interactive keypoint handler for creating keypoint annotations.
@@ -39,8 +48,11 @@ export class InteractiveKeypointHandler implements InteractionHandler {
     private readonly eventBus: EventDispatcher<LighterEventGroup>,
     private readonly resolveVariant?: (
       relativePoint: Point,
-      ctx: KeypointVariantResolverContext
-    ) => string | undefined
+      ctx: ClickEventModifiers
+    ) => string | undefined,
+    private readonly resolvePointHit?: (
+      ctx: KeypointPointHitContext
+    ) => KeypointPointHitAction | undefined
   ) {}
 
   containsPoint(): boolean {
@@ -74,15 +86,30 @@ export class InteractiveKeypointHandler implements InteractionHandler {
     event: PointerEvent
   ): boolean {
     const rp = this.overlay.absolutePointToRelative(worldPoint);
-    const variant = this.resolveVariant?.(
-      { x: rp[0], y: rp[1] },
-      {
-        shiftKey: event.shiftKey,
-        altKey: event.altKey,
-        ctrlKey: event.ctrlKey,
-        metaKey: event.metaKey,
+    const modifiers = getClickModifiers(event);
+
+    // Click landed on an existing point;
+    // check whether the resolver should override the default behavior.
+    const hitId = this.overlay.findPointIdAt(worldPoint);
+    if (hitId && this.resolvePointHit) {
+      const action = this.resolvePointHit({
+        pointId: hitId,
+        relativePoint: { x: rp[0], y: rp[1] },
+        modifiers,
+      });
+
+      if (action === KeypointPointHitAction.DELETE) {
+        const command = new RemoveKeypointPointCommand(this.overlay, hitId);
+        command.execute();
+        CommandContextManager.instance()
+          .getActiveContext()
+          .pushUndoable(command);
+        return true;
       }
-    );
+      // else fall through to default behavior
+    }
+
+    const variant = this.resolveVariant?.({ x: rp[0], y: rp[1] }, modifiers);
     const pointId = this.overlay.addPoint(worldPoint, variant);
 
     CommandContextManager.instance()

--- a/app/packages/lighter/src/overlay/KeypointOverlay.ts
+++ b/app/packages/lighter/src/overlay/KeypointOverlay.ts
@@ -664,6 +664,38 @@ export class KeypointOverlay
   }
 
   /**
+   * Returns the ID of the point at the given absolute (world) position, or
+   * null if no point is within hit range.
+   *
+   * @param worldPoint Point in absolute coordinates
+   */
+  findPointIdAt(worldPoint: Point): string | null {
+    const scale = this.renderer?.getScale() ?? 1;
+    const index = this.findNearestPointIndex(worldPoint, scale);
+    return index >= 0 ? this.#points[index].id : null;
+  }
+
+  /**
+   * Returns a snapshot of the point with the given ID, or `null` if none.
+   * Returns copies so callers can safely retain the data.
+   *
+   * @param pointId Point ID
+   */
+  getPointById(
+    pointId: string
+  ): { position: [number, number]; variant?: string } | null {
+    const entry = this.#points.find((p) => p.id === pointId);
+    if (!entry) {
+      return null;
+    }
+
+    return {
+      position: [entry.position[0], entry.position[1]],
+      variant: entry.variant,
+    };
+  }
+
+  /**
    * Removes the point at the given index.
    */
   removePoint(index: number): void {

--- a/app/packages/utilities/src/events.ts
+++ b/app/packages/utilities/src/events.ts
@@ -1,0 +1,23 @@
+/**
+ * Modifier flags associated with a {@link PointerEvent}.
+ */
+export type ClickEventModifiers = {
+  shiftKey: boolean;
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+};
+
+/**
+ * Extract the {@link ClickEventModifiers} from a {@link PointerEvent}.
+ *
+ * @param event Event from which to extract click modifiers
+ */
+export const getClickModifiers = (
+  event: PointerEvent
+): ClickEventModifiers => ({
+  shiftKey: event.shiftKey,
+  altKey: event.altKey,
+  ctrlKey: event.ctrlKey,
+  metaKey: event.metaKey,
+});

--- a/app/packages/utilities/src/index.ts
+++ b/app/packages/utilities/src/index.ts
@@ -8,6 +8,7 @@ export * from "./color";
 export * as constants from "./constants";
 export * from "./datetime";
 export * from "./errors";
+export * from "./events";
 export * from "./fetch";
 export * from "./format";
 export * from "./ids";


### PR DESCRIPTION
## 🔗 Related Issues

None

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

Adds configurable on-click behavior for individual points in an active `KeypointOverlay`. 

For AI-assisted annotation, caller specifies that clicking on a point should delete the point. Supports undo/redo and integrates into existing annotation tooling stack.

## 🧪 How is this patch tested? If it is not, please explain why.

local

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to delete keypoints through click interaction with point-hit callbacks
  * Extended point selection activation API to support custom behavior when clicking existing points

* **Refactor**
  * Updated click modifier context handling across keypoint interaction modules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->