### PR TITLE
Segmentation Toolbar Migration

### DIFF
--- a/app/packages/components/package.json
+++ b/app/packages/components/package.json
@@ -42,6 +42,7 @@
         "@emotion/styled": "^11.10.4",
         "@fiftyone/commands": "workspace:^",
         "@fiftyone/state": "*",
+        "@voxel51/voodo": "*",
         "@mui/icons-material": "^5.16.7",
         "@mui/material": "^5.9.0",
         "@react-spring/web": "^9.7.3",

--- a/app/packages/components/src/components/ActionToolbar/ActionToolbar.tsx
+++ b/app/packages/components/src/components/ActionToolbar/ActionToolbar.tsx
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Domain-agnostic renderer for a data-driven Voodo toolbar.
+ *
+ * Accepts a list of AnnotationActionGroup objects and renders them using the
+ * Voodo Toolbar/ToolbarGroup/ToolbarAction primitives. Owns NO portal logic,
+ * NO domain state, and NO visibility gating — callers are responsible for
+ * those concerns.
+ *
+ * Used by:
+ *  - AnnotationToolbar  (@fiftyone/looker-3d) — 3D annotation tools
+ *  - SegmentationToolbar (@fiftyone/core)     — 2D segmentation brush tools
+ */
+
+import { Box, Typography, styled } from "@mui/material";
+import {
+  Anchor,
+  Orientation,
+  Toolbar,
+  ToolbarAction,
+  ToolbarGroup,
+  Tooltip,
+  ZIndex,
+} from "@voxel51/voodo";
+import type { AnnotationAction, AnnotationActionGroup } from "./types";
+
+const GroupLabel = styled(Typography)(({ theme }) => ({
+  fontSize: "9px",
+  fontWeight: 600,
+  color: theme.palette.text.secondary,
+  textAlign: "center",
+  marginBottom: "2px",
+  textTransform: "uppercase",
+  letterSpacing: "0.3px",
+}));
+
+export interface ActionToolbarProps {
+  groups: AnnotationActionGroup[];
+  orientation?: Orientation;
+  lockX?: boolean;
+  lockY?: boolean;
+  xOffset?: number;
+  yOffset?: number;
+  zIndex?: ZIndex;
+  visible?: boolean;
+  className?: string;
+}
+
+const ActionButton = ({ action }: { action: AnnotationAction }) => (
+  <Tooltip
+    portal
+    content={
+      <Box>
+        {typeof action.tooltip === "string" ? (
+          <Typography variant="body2">{action.tooltip}</Typography>
+        ) : (
+          action.tooltip
+        )}
+        {action.shortcut && (
+          <Typography variant="caption" sx={{ opacity: 0.7 }}>
+            {action.shortcut}
+          </Typography>
+        )}
+      </Box>
+    }
+    anchor={Anchor.Right}
+  >
+    <ToolbarAction
+      active={action.isActive}
+      disabled={action.isDisabled}
+      onClick={action.onClick}
+    >
+      {action.icon}
+    </ToolbarAction>
+  </Tooltip>
+);
+
+export const ActionToolbar = ({
+  groups,
+  orientation = Orientation.Column,
+  lockX,
+  lockY,
+  xOffset,
+  yOffset,
+  zIndex = ZIndex.AboveModal,
+  visible,
+  className,
+}: ActionToolbarProps) => (
+  <Toolbar
+    className={className}
+    orientation={orientation}
+    lockX={lockX}
+    lockY={lockY}
+    xOffset={xOffset}
+    yOffset={yOffset}
+    zIndex={zIndex}
+    visible={visible}
+  >
+    {groups
+      .filter((group) => !group.isHidden)
+      .filter((group) =>
+        group.actions.some((action) => action.isVisible !== false)
+      )
+      .map((group) => (
+        <ToolbarGroup key={group.id}>
+          {group.label && <GroupLabel>{group.label}</GroupLabel>}
+          {group.actions
+            .filter((action) => action.isVisible !== false)
+            .map((action) =>
+              action.customComponent ? (
+                <div key={action.id}>{action.customComponent}</div>
+              ) : (
+                <ActionButton key={action.id} action={action} />
+              )
+            )}
+        </ToolbarGroup>
+      ))}
+  </Toolbar>
+);

--- a/app/packages/components/src/components/ActionToolbar/ActionToolbar.tsx
+++ b/app/packages/components/src/components/ActionToolbar/ActionToolbar.tsx
@@ -94,9 +94,10 @@ export const ActionToolbar = ({
     visible={visible}
   >
     {groups
-      .filter((group) => !group.isHidden)
-      .filter((group) =>
-        group.actions.some((action) => action.isVisible !== false)
+      .filter(
+        (group) =>
+          !group.isHidden &&
+          group.actions.some((action) => action.isVisible !== false)
       )
       .map((group) => (
         <ToolbarGroup key={group.id}>

--- a/app/packages/components/src/components/ActionToolbar/ActionToolbar.tsx
+++ b/app/packages/components/src/components/ActionToolbar/ActionToolbar.tsx
@@ -43,34 +43,43 @@ export interface ActionToolbarProps {
   className?: string;
 }
 
-const ActionButton = ({ action }: { action: ToolbarActionItem }) => (
-  <Tooltip
-    portal
-    content={
-      <Box>
-        {typeof action.tooltip === "string" ? (
-          <Typography variant="body2">{action.tooltip}</Typography>
-        ) : (
-          action.tooltip
-        )}
-        {action.shortcut && (
-          <Typography variant="caption" sx={{ opacity: 0.7 }}>
-            {action.shortcut}
-          </Typography>
-        )}
-      </Box>
-    }
-    anchor={Anchor.Right}
-  >
+const ActionButton = ({ action }: { action: ToolbarActionItem }) => {
+  const button = (
     <ToolbarAction
       active={action.isActive}
       disabled={action.isDisabled}
       onClick={action.onClick}
+      aria-label={action.label}
     >
       {action.icon}
     </ToolbarAction>
-  </Tooltip>
-);
+  );
+
+  if (!action.tooltip && !action.shortcut) return button;
+
+  return (
+    <Tooltip
+      portal
+      content={
+        <Box>
+          {typeof action.tooltip === "string" ? (
+            <Typography variant="body2">{action.tooltip}</Typography>
+          ) : (
+            action.tooltip
+          )}
+          {action.shortcut && (
+            <Typography variant="caption" sx={{ opacity: 0.7 }}>
+              {action.shortcut}
+            </Typography>
+          )}
+        </Box>
+      }
+      anchor={Anchor.Right}
+    >
+      {button}
+    </Tooltip>
+  );
+};
 
 export const ActionToolbar = ({
   groups,

--- a/app/packages/components/src/components/ActionToolbar/ActionToolbar.tsx
+++ b/app/packages/components/src/components/ActionToolbar/ActionToolbar.tsx
@@ -3,14 +3,10 @@
  *
  * Domain-agnostic renderer for a data-driven Voodo toolbar.
  *
- * Accepts a list of AnnotationActionGroup objects and renders them using the
+ * Accepts a list of ToolbarActionGroup objects and renders them using the
  * Voodo Toolbar/ToolbarGroup/ToolbarAction primitives. Owns NO portal logic,
  * NO domain state, and NO visibility gating — callers are responsible for
  * those concerns.
- *
- * Used by:
- *  - AnnotationToolbar  (@fiftyone/looker-3d) — 3D annotation tools
- *  - SegmentationToolbar (@fiftyone/core)     — 2D segmentation brush tools
  */
 
 import { Box, Typography, styled } from "@mui/material";
@@ -23,7 +19,7 @@ import {
   Tooltip,
   ZIndex,
 } from "@voxel51/voodo";
-import type { AnnotationAction, AnnotationActionGroup } from "./types";
+import type { ToolbarActionItem, ToolbarActionGroup } from "./types";
 
 const GroupLabel = styled(Typography)(({ theme }) => ({
   fontSize: "9px",
@@ -36,7 +32,7 @@ const GroupLabel = styled(Typography)(({ theme }) => ({
 }));
 
 export interface ActionToolbarProps {
-  groups: AnnotationActionGroup[];
+  groups: ToolbarActionGroup[];
   orientation?: Orientation;
   lockX?: boolean;
   lockY?: boolean;
@@ -47,7 +43,7 @@ export interface ActionToolbarProps {
   className?: string;
 }
 
-const ActionButton = ({ action }: { action: AnnotationAction }) => (
+const ActionButton = ({ action }: { action: ToolbarActionItem }) => (
   <Tooltip
     portal
     content={

--- a/app/packages/components/src/components/ActionToolbar/index.ts
+++ b/app/packages/components/src/components/ActionToolbar/index.ts
@@ -1,0 +1,3 @@
+export { ActionToolbar } from "./ActionToolbar";
+export type { ActionToolbarProps } from "./ActionToolbar";
+export type { AnnotationAction, AnnotationActionGroup } from "./types";

--- a/app/packages/components/src/components/ActionToolbar/index.ts
+++ b/app/packages/components/src/components/ActionToolbar/index.ts
@@ -1,3 +1,3 @@
 export { ActionToolbar } from "./ActionToolbar";
 export type { ActionToolbarProps } from "./ActionToolbar";
-export type { AnnotationAction, AnnotationActionGroup } from "./types";
+export type { ToolbarActionItem, ToolbarActionGroup } from "./types";

--- a/app/packages/components/src/components/ActionToolbar/types.ts
+++ b/app/packages/components/src/components/ActionToolbar/types.ts
@@ -9,7 +9,7 @@
 
 import type { ReactNode } from "react";
 
-export interface AnnotationAction {
+export interface ToolbarActionItem {
   id: string;
   label: string;
   icon: ReactNode;
@@ -23,9 +23,9 @@ export interface AnnotationAction {
   customComponent?: ReactNode;
 }
 
-export interface AnnotationActionGroup {
+export interface ToolbarActionGroup {
   id: string;
   label?: string;
   isHidden?: boolean;
-  actions: AnnotationAction[];
+  actions: ToolbarActionItem[];
 }

--- a/app/packages/components/src/components/ActionToolbar/types.ts
+++ b/app/packages/components/src/components/ActionToolbar/types.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Shared data types for the data-driven ActionToolbar renderer.
+ * These live in @fiftyone/components so both @fiftyone/core (2D segmentation)
+ * and @fiftyone/looker-3d (3D annotation) can depend on them without creating
+ * a cross-package dependency between those two packages.
+ */
+
+import type { ReactNode } from "react";
+
+export interface AnnotationAction {
+  id: string;
+  label: string;
+  icon: ReactNode;
+  shortcut?: string;
+  tooltip?: string | ReactNode;
+  isActive?: boolean;
+  isDisabled?: boolean;
+  isVisible?: boolean;
+  onClick: () => void;
+  /** Escape hatch: renders this node instead of the standard icon button. */
+  customComponent?: ReactNode;
+}
+
+export interface AnnotationActionGroup {
+  id: string;
+  label?: string;
+  isHidden?: boolean;
+  actions: AnnotationAction[];
+}

--- a/app/packages/components/src/components/Icons/Icons.tsx
+++ b/app/packages/components/src/components/Icons/Icons.tsx
@@ -109,6 +109,14 @@ export function LookerArrowRightIcon(props: SvgIconProps) {
   );
 }
 
+export function EraserIcon(props: SvgIconProps = {}) {
+  return (
+    <SvgIcon {...props}>
+      <path d="M16.24 3.56l4.95 4.94c.78.79.78 2.05 0 2.84L12 20.53a4.008 4.008 0 01-5.66 0L2.81 17c-.78-.79-.78-2.05 0-2.84l10.6-10.6c.79-.78 2.05-.78 2.83 0zM4.22 15.58l3.54 3.53c.78.79 2.04.79 2.83 0l3.53-3.53-4.95-4.95-4.95 4.95z" />
+    </SvgIcon>
+  );
+}
+
 export { KeyboardArrowDown, KeyboardArrowUp } from "@mui/icons-material";
 export { IconButton } from "@mui/material";
 export { InfoIcon };

--- a/app/packages/components/src/components/Icons/index.ts
+++ b/app/packages/components/src/components/Icons/index.ts
@@ -1,7 +1,9 @@
 export {
   Close,
   Copy,
+  DiscordLink,
   DocsLink,
+  EraserIcon,
   GitHubLink,
   HelpIcon,
   IconButton,
@@ -12,5 +14,4 @@ export {
   KeyboardArrowUp,
   LookerArrowLeftIcon,
   LookerArrowRightIcon,
-  DiscordLink,
 } from "./Icons";

--- a/app/packages/components/src/components/index.ts
+++ b/app/packages/components/src/components/index.ts
@@ -13,6 +13,12 @@ export { default as EditableLabel } from "./EditableLabel";
 export { default as ErrorBoundary, ErrorDisplayMarkup } from "./ErrorBoundary";
 export { default as ExternalLink, useExternalLink } from "./ExternalLink";
 export { default as FilterAndSelectionIndicator } from "./FilterAndSelectionIndicator";
+export { ActionToolbar } from "./ActionToolbar";
+export type {
+  ActionToolbarProps,
+  AnnotationAction,
+  AnnotationActionGroup,
+} from "./ActionToolbar";
 export { FloatingToolbar } from "./FloatingToolbar";
 export type {
   FloatingToolbarActionProps,

--- a/app/packages/components/src/components/index.ts
+++ b/app/packages/components/src/components/index.ts
@@ -16,8 +16,8 @@ export { default as FilterAndSelectionIndicator } from "./FilterAndSelectionIndi
 export { ActionToolbar } from "./ActionToolbar";
 export type {
   ActionToolbarProps,
-  AnnotationAction,
-  AnnotationActionGroup,
+  ToolbarActionItem,
+  ToolbarActionGroup,
 } from "./ActionToolbar";
 export { FloatingToolbar } from "./FloatingToolbar";
 export type {

--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -352,7 +352,6 @@ const Modal = () => {
         data-cy="modal"
       >
         <Actions />
-        <SegmentationToolbar />
         {isAnnotationEnabled && <AnnotationHandlerRegistration />}
         <TooltipInfo />
         <ModalContainer style={{ ...screenParams }}>
@@ -367,6 +366,7 @@ const Modal = () => {
           >
             <OperatorPromptArea area={OPERATOR_PROMPT_AREAS.DRAWER_LEFT} />
             <ModalNavigation closePanels={closePanels} />
+            <SegmentationToolbar />
             <SpacesContainer>
               <ModalSpace />
             </SpacesContainer>

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/SegmentationToolbar.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/SegmentationToolbar.tsx
@@ -1,176 +1,42 @@
 /**
  * Copyright 2017-2026, Voxel51, Inc.
  *
- * Segmentation-specific toolbar built on the generic FloatingToolbar.
- *
- * This is a thin composition layer — all layout, dragging, and portal logic
- * lives in `@fiftyone/components/FloatingToolbar`.
+ * Thin wrapper that wires segmentation tool state into the shared
+ * ActionToolbar renderer. All state logic lives in useSegmentationActions;
+ * all rendering logic lives in ActionToolbar (@fiftyone/components).
  */
 
-import { FloatingToolbar, Tooltip } from "@fiftyone/components";
-import {
-  Brush,
-  CircleOutlined,
-  CropSquare,
-  FormatColorReset,
-  Redo,
-  Undo,
-} from "@mui/icons-material";
-import React from "react";
-import styled from "styled-components";
-import {
-  MAX_TOOL_SIZE,
-  MIN_TOOL_SIZE,
-  useSegmentationMode,
-} from "./useSegmentationMode";
-
-// ---------------------------------------------------------------------------
-// Local styled helpers (domain-specific, not in FloatingToolbar)
-// ---------------------------------------------------------------------------
-
-const SizeInput = styled.input`
-  width: 32px;
-  border: 1px solid ${({ theme }) => theme.primary.plainBorder};
-  border-radius: 3px;
-  background: ${({ theme }) => theme.background.level1};
-  color: ${({ theme }) => theme.text.primary};
-  font-size: 11px;
-  text-align: center;
-  outline: none;
-
-  &:focus {
-    border-color: ${({ theme }) => theme.primary.main};
-  }
-
-  &::-webkit-inner-spin-button {
-    opacity: 1;
-  }
-`;
-
-// ---------------------------------------------------------------------------
-// Icons
-// ---------------------------------------------------------------------------
-
-const EraserIcon = () => (
-  <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
-    <path d="M16.24 3.56l4.95 4.94c.78.79.78 2.05 0 2.84L12 20.53a4.008 4.008 0 01-5.66 0L2.81 17c-.78-.79-.78-2.05 0-2.84l10.6-10.6c.79-.78 2.05-.78 2.83 0zM4.22 15.58l3.54 3.53c.78.79 2.04.79 2.83 0l3.53-3.53-4.95-4.95-4.95 4.95z" />
-  </svg>
-);
-
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
+import { ActionToolbar } from "@fiftyone/components";
+import { Orientation } from "@voxel51/voodo";
+import { useSegmentationActions } from "./useSegmentationActions";
 
 export interface SegmentationToolbarProps {
   onUndo?: () => void;
   onRedo?: () => void;
   canUndo?: boolean;
   canRedo?: boolean;
-  /**
-   * When true (default), the toolbar manages its own SegmentationBrushHandler
-   * lifecycle. Set to false when the parent (e.g. InstanceMaskEditor) manages
-   * the handler externally.
-   */
-  standalone?: boolean;
 }
 
-export const SegmentationToolbar: React.FC<SegmentationToolbarProps> = ({
+export const SegmentationToolbar = ({
   onUndo,
   onRedo,
   canUndo = false,
   canRedo = false,
-}) => {
-  const {
-    segmentationModeActive,
-    tool,
-    toolSize,
-    toolShape,
-    switchTool,
-    switchToolShape,
-    setToolSize,
-  } = useSegmentationMode();
+}: SegmentationToolbarProps) => {
+  const { groups, visible } = useSegmentationActions({
+    onUndo,
+    onRedo,
+    canUndo,
+    canRedo,
+  });
 
   return (
-    <FloatingToolbar
-      orientation="vertical"
-      defaultPosition={{ x: 5, y: 50 }}
-      visible={segmentationModeActive}
-    >
-      {/* ---- Tool selection ---- */}
-      <FloatingToolbar.Group label="Tool">
-        <Tooltip placement="left-center" text="Brush (B)">
-          <FloatingToolbar.Action
-            active={tool === "brush"}
-            onClick={() => switchTool("brush")}
-          >
-            <Brush />
-          </FloatingToolbar.Action>
-        </Tooltip>
-        <Tooltip placement="left-center" text="Eraser (E)">
-          <FloatingToolbar.Action
-            active={tool === "eraser"}
-            onClick={() => switchTool("eraser")}
-          >
-            <EraserIcon />
-          </FloatingToolbar.Action>
-        </Tooltip>
-      </FloatingToolbar.Group>
-
-      {/* ---- Brush size ---- */}
-      <FloatingToolbar.Group label="Size">
-        <SizeInput
-          type="number"
-          min={MIN_TOOL_SIZE}
-          max={MAX_TOOL_SIZE}
-          value={toolSize}
-          onChange={(e) => setToolSize(Number(e.target.value))}
-        />
-      </FloatingToolbar.Group>
-
-      {/* ---- Brush shape ---- */}
-      <FloatingToolbar.Group label="Shape">
-        <Tooltip placement="left-center" text="Circle">
-          <FloatingToolbar.Action
-            active={toolShape === "circle"}
-            onClick={() => switchToolShape("circle")}
-          >
-            <CircleOutlined />
-          </FloatingToolbar.Action>
-        </Tooltip>
-        <Tooltip placement="left-center" text="Square">
-          <FloatingToolbar.Action
-            active={toolShape === "square"}
-            onClick={() => switchToolShape("square")}
-          >
-            <CropSquare />
-          </FloatingToolbar.Action>
-        </Tooltip>
-      </FloatingToolbar.Group>
-
-      {/* ---- Actions ---- */}
-      <FloatingToolbar.Group label="Actions">
-        <Tooltip placement="left-center" text="Undo (Ctrl+Z)">
-          <FloatingToolbar.Action
-            disabled={!canUndo}
-            onClick={canUndo ? onUndo : undefined}
-          >
-            <Undo />
-          </FloatingToolbar.Action>
-        </Tooltip>
-        <Tooltip placement="left-center" text="Redo (Ctrl+Shift+Z)">
-          <FloatingToolbar.Action
-            disabled={!canRedo}
-            onClick={canRedo ? onRedo : undefined}
-          >
-            <Redo />
-          </FloatingToolbar.Action>
-        </Tooltip>
-        <Tooltip placement="left-center" text="Clear mask">
-          <FloatingToolbar.Action>
-            <FormatColorReset />
-          </FloatingToolbar.Action>
-        </Tooltip>
-      </FloatingToolbar.Group>
-    </FloatingToolbar>
+    <ActionToolbar
+      groups={groups}
+      orientation={Orientation.Column}
+      xOffset={5}
+      yOffset={50}
+      visible={visible}
+    />
   );
 };

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/SegmentationToolbar.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/SegmentationToolbar.tsx
@@ -34,8 +34,8 @@ export const SegmentationToolbar = ({
     <ActionToolbar
       groups={groups}
       orientation={Orientation.Column}
-      xOffset={5}
-      yOffset={50}
+      xOffset={60}
+      yOffset={200}
       visible={visible}
     />
   );

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationActions.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationActions.tsx
@@ -1,0 +1,183 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { EraserIcon, type AnnotationActionGroup } from "@fiftyone/components";
+import {
+  Brush,
+  CircleOutlined,
+  CropSquare,
+  FormatColorReset,
+  Redo,
+  Undo,
+} from "@mui/icons-material";
+import { useMemo } from "react";
+import styled from "styled-components";
+import {
+  MAX_TOOL_SIZE,
+  MIN_TOOL_SIZE,
+  useSegmentationMode,
+} from "./useSegmentationMode";
+
+const SizeInput = styled.input`
+  width: 32px;
+  border: 1px solid ${({ theme }) => theme.primary.plainBorder};
+  border-radius: 3px;
+  background: ${({ theme }) => theme.background.level1};
+  color: ${({ theme }) => theme.text.primary};
+  font-size: 11px;
+  text-align: center;
+  outline: none;
+
+  &:focus {
+    border-color: ${({ theme }) => theme.primary.main};
+  }
+
+  &::-webkit-inner-spin-button {
+    opacity: 1;
+  }
+`;
+
+interface UseSegmentationActionsArgs {
+  onUndo?: () => void;
+  onRedo?: () => void;
+  canUndo?: boolean;
+  canRedo?: boolean;
+}
+
+export const useSegmentationActions = ({
+  onUndo,
+  onRedo,
+  canUndo = false,
+  canRedo = false,
+}: UseSegmentationActionsArgs): {
+  groups: AnnotationActionGroup[];
+  visible: boolean;
+} => {
+  const {
+    segmentationModeActive,
+    tool,
+    toolSize,
+    toolShape,
+    switchTool,
+    switchToolShape,
+    setToolSize,
+  } = useSegmentationMode();
+
+  const groups: AnnotationActionGroup[] = useMemo(
+    () => [
+      {
+        id: "tool",
+        label: "Tool",
+        actions: [
+          {
+            id: "brush",
+            label: "Brush",
+            icon: <Brush />,
+            shortcut: "B",
+            tooltip: "Brush",
+            isActive: tool === "brush",
+            onClick: () => switchTool("brush"),
+          },
+          {
+            id: "eraser",
+            label: "Eraser",
+            icon: <EraserIcon />,
+            shortcut: "E",
+            tooltip: "Eraser",
+            isActive: tool === "eraser",
+            onClick: () => switchTool("eraser"),
+          },
+        ],
+      },
+      {
+        id: "size",
+        label: "Size",
+        actions: [
+          {
+            id: "size-input",
+            label: "Size",
+            icon: <></>,
+            onClick: () => {},
+            customComponent: (
+              <SizeInput
+                type="number"
+                min={MIN_TOOL_SIZE}
+                max={MAX_TOOL_SIZE}
+                value={toolSize}
+                onChange={(e) => setToolSize(Number(e.target.value))}
+              />
+            ),
+          },
+        ],
+      },
+      {
+        id: "shape",
+        label: "Shape",
+        actions: [
+          {
+            id: "circle",
+            label: "Circle",
+            icon: <CircleOutlined />,
+            tooltip: "Circle",
+            isActive: toolShape === "circle",
+            onClick: () => switchToolShape("circle"),
+          },
+          {
+            id: "square",
+            label: "Square",
+            icon: <CropSquare />,
+            tooltip: "Square",
+            isActive: toolShape === "square",
+            onClick: () => switchToolShape("square"),
+          },
+        ],
+      },
+      {
+        id: "actions",
+        label: "Actions",
+        actions: [
+          {
+            id: "undo",
+            label: "Undo",
+            icon: <Undo />,
+            shortcut: "Ctrl+Z",
+            tooltip: "Undo",
+            isDisabled: !canUndo,
+            onClick: () => canUndo && onUndo?.(),
+          },
+          {
+            id: "redo",
+            label: "Redo",
+            icon: <Redo />,
+            shortcut: "Ctrl+Shift+Z",
+            tooltip: "Redo",
+            isDisabled: !canRedo,
+            onClick: () => canRedo && onRedo?.(),
+          },
+          {
+            id: "clear",
+            label: "Clear mask",
+            icon: <FormatColorReset />,
+            tooltip: "Clear mask",
+            onClick: () => {},
+          },
+        ],
+      },
+    ],
+    [
+      tool,
+      toolSize,
+      toolShape,
+      switchTool,
+      switchToolShape,
+      setToolSize,
+      canUndo,
+      canRedo,
+      onUndo,
+      onRedo,
+    ]
+  );
+
+  return { groups, visible: segmentationModeActive };
+};

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationActions.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationActions.tsx
@@ -2,7 +2,7 @@
  * Copyright 2017-2026, Voxel51, Inc.
  */
 
-import { EraserIcon, type AnnotationActionGroup } from "@fiftyone/components";
+import { EraserIcon, type ToolbarActionGroup } from "@fiftyone/components";
 import {
   Brush,
   CircleOutlined,
@@ -51,7 +51,7 @@ export const useSegmentationActions = ({
   canUndo = false,
   canRedo = false,
 }: UseSegmentationActionsArgs): {
-  groups: AnnotationActionGroup[];
+  groups: ToolbarActionGroup[];
   visible: boolean;
 } => {
   const {
@@ -64,7 +64,7 @@ export const useSegmentationActions = ({
     setToolSize,
   } = useSegmentationMode();
 
-  const groups: AnnotationActionGroup[] = useMemo(
+  const groups: ToolbarActionGroup[] = useMemo(
     () => [
       {
         id: "tool",

--- a/app/packages/looker-3d/src/annotation/annotation-toolbar/AnnotationToolbar.tsx
+++ b/app/packages/looker-3d/src/annotation/annotation-toolbar/AnnotationToolbar.tsx
@@ -1,59 +1,12 @@
 import useCanAnnotate from "@fiftyone/core/src/components/Modal/Sidebar/Annotate/useCanAnnotate";
+import { ActionToolbar } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
-import { Box, Typography, styled } from "@mui/material";
 import { useEffect, useState } from "react";
-import ReactDOM from "react-dom";
+import { createPortal } from "react-dom";
 import { useRecoilValue } from "recoil";
-import type { AnnotationAction, AnnotationToolbarProps } from "../types";
+import type { AnnotationToolbarProps } from "../types";
 import { useAnnotationActions } from "./useAnnotationActions";
-import {
-  Anchor,
-  Orientation,
-  Toolbar,
-  ToolbarAction,
-  ToolbarGroup,
-  Tooltip,
-  ZIndex,
-} from "@voxel51/voodo";
-
-const GroupLabel = styled(Typography)(({ theme }) => ({
-  fontSize: "9px",
-  fontWeight: 600,
-  color: theme.palette.text.secondary,
-  textAlign: "center",
-  marginBottom: "2px",
-  textTransform: "uppercase",
-  letterSpacing: "0.3px",
-}));
-
-const ActionButton = ({ action }: { action: AnnotationAction }) => (
-  <Tooltip
-    portal
-    content={
-      <Box>
-        {typeof action.tooltip === "string" ? (
-          <Typography variant="body2">{action.tooltip}</Typography>
-        ) : (
-          action.tooltip
-        )}
-        {action.shortcut && (
-          <Typography variant="caption" sx={{ opacity: 0.7 }}>
-            {action.shortcut}
-          </Typography>
-        )}
-      </Box>
-    }
-    anchor={Anchor.Right}
-  >
-    <ToolbarAction
-      active={action.isActive}
-      disabled={action.isDisabled}
-      onClick={action.onClick}
-    >
-      {action.icon}
-    </ToolbarAction>
-  </Tooltip>
-);
+import { Orientation, ZIndex } from "@voxel51/voodo";
 
 export const AnnotationToolbar = ({ className }: AnnotationToolbarProps) => {
   const { actions } = useAnnotationActions();
@@ -82,37 +35,16 @@ export const AnnotationToolbar = ({ className }: AnnotationToolbarProps) => {
     return null;
   }
 
-  const toolbarContent = (
-    <Toolbar
+  return createPortal(
+    <ActionToolbar
       className={className}
+      groups={actions}
       orientation={Orientation.Column}
       lockX
       xOffset={isFullscreen ? 8 : 50}
       yOffset={isFullscreen ? 55 : 100}
       zIndex={ZIndex.AboveModal}
-    >
-      {actions
-        .filter((group) => !group.isHidden)
-        .filter((group) =>
-          group.actions.some((action) => action.isVisible !== false)
-        )
-        .map((group) => (
-          <ToolbarGroup key={group.id}>
-            {group.label && <GroupLabel>{group.label}</GroupLabel>}
-            {group.actions
-              .filter((action) => action.isVisible !== false)
-              .map((action) =>
-                action.customComponent ? (
-                  <div key={action.id}>{action.customComponent}</div>
-                ) : (
-                  <ActionButton key={action.id} action={action} />
-                )
-              )}
-          </ToolbarGroup>
-        ))}
-    </Toolbar>
+    />,
+    portalContainer
   );
-
-  // Render the toolbar in a portal to ensure it's in the same stacking context as navigation arrows
-  return ReactDOM.createPortal(toolbarContent, portalContainer);
 };

--- a/app/packages/looker-3d/src/annotation/annotation-toolbar/index.ts
+++ b/app/packages/looker-3d/src/annotation/annotation-toolbar/index.ts
@@ -1,7 +1,7 @@
 export { AnnotationToolbar } from "./AnnotationToolbar";
 export type {
-  AnnotationAction,
-  AnnotationActionGroup,
+  ToolbarActionItem,
+  ToolbarActionGroup,
   AnnotationToolbarProps,
 } from "../types";
 export { useAnnotationActions } from "./useAnnotationActions";

--- a/app/packages/looker-3d/src/annotation/annotation-toolbar/useAnnotationActions.tsx
+++ b/app/packages/looker-3d/src/annotation/annotation-toolbar/useAnnotationActions.tsx
@@ -34,7 +34,7 @@ import {
   usePolylineOperations,
   useWorkingDoc,
 } from "../store";
-import type { AnnotationActionGroup, TransformMode } from "../types";
+import type { ToolbarActionGroup, TransformMode } from "../types";
 import { AnnotationPlaneTooltip } from "./AnnotationPlaneTooltip";
 import {
   PlaneCoordinateInputs,
@@ -265,8 +265,8 @@ export const useAnnotationActions = () => {
 
   const onExit = useExit();
 
-  const actions: AnnotationActionGroup[] = useMemo(() => {
-    const baseActions: AnnotationActionGroup[] = [
+  const actions: ToolbarActionGroup[] = useMemo(() => {
+    const baseActions: ToolbarActionGroup[] = [
       {
         id: "edit-actions",
         label: "",

--- a/app/packages/looker-3d/src/annotation/annotation-toolbar/useAnnotationActions.tsx
+++ b/app/packages/looker-3d/src/annotation/annotation-toolbar/useAnnotationActions.tsx
@@ -390,7 +390,7 @@ export const useAnnotationActions = () => {
             icon: <OpenWith />,
             tooltip: "Translate or move object",
             isActive:
-              currentArchetypeSelectedForTransform &&
+              !!currentArchetypeSelectedForTransform &&
               transformMode === "translate",
             isDisabled: !currentArchetypeSelectedForTransform,
             onClick: () => handleTransformModeChange("translate"),

--- a/app/packages/looker-3d/src/annotation/types.ts
+++ b/app/packages/looker-3d/src/annotation/types.ts
@@ -1,25 +1,9 @@
-import { ReactNode } from "react";
 import type { OverlayLabel } from "../labels/loader";
 
-export interface AnnotationAction {
-  id: string;
-  label: string;
-  icon: ReactNode;
-  shortcut?: string;
-  tooltip?: string | ReactNode;
-  isActive?: boolean;
-  isDisabled?: boolean;
-  isVisible?: boolean;
-  onClick: () => void;
-  customComponent?: ReactNode;
-}
-
-export interface AnnotationActionGroup {
-  id: string;
-  label?: string;
-  isHidden?: boolean;
-  actions: AnnotationAction[];
-}
+export type {
+  AnnotationAction,
+  AnnotationActionGroup,
+} from "@fiftyone/components";
 
 export interface AnnotationToolbarProps {
   className?: string;

--- a/app/packages/looker-3d/src/annotation/types.ts
+++ b/app/packages/looker-3d/src/annotation/types.ts
@@ -1,8 +1,8 @@
 import type { OverlayLabel } from "../labels/loader";
 
 export type {
-  AnnotationAction,
-  AnnotationActionGroup,
+  ToolbarActionItem,
+  ToolbarActionGroup,
 } from "@fiftyone/components";
 
 export interface AnnotationToolbarProps {


### PR DESCRIPTION
## 🔗 Related Issues
https://voxel51.atlassian.net/browse/FOEPD-3733

This PR migrates `SegmentationToolbar` to utilize the new Voodo design system Toolbar components.

## 📋 What changes are proposed in this pull request?
- Created a generic `ActionToolbar` component in `@fiftyone/components` that leverages Voodo design system component
- Moved Eraser icon into `components/icons` for reuse
- Renamed and moved the export of `ToolbarAction` and `ToolbarActionGroup` types from 3d to `@fiftyone/components` to facilitate reuse and proper generic naming
- Created a new hook `useSegmentationActions` to consume state from the existing `useSegmentationMode` hook and define groups of actions to be passed to the thin component `SegmentationToolbar`


## 🧪 How is this patch tested? If it is not, please explain why.
Manual testing



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable ActionToolbar for data-driven, grouped toolbar actions.
  * Added a new Eraser icon.

* **Refactor**
  * Segmentation and annotation toolbars now use the shared ActionToolbar for consistent behavior and appearance.

* **Bug Fixes**
  * Segmentation toolbar rendering moved into modal content to improve stability and visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->