### PR TITLE
[HA] Prune undo/redo stack when exiting AI annotation tools

### DIFF
--- a/app/packages/annotation/src/agents/hooks/usePointSelection.ts
+++ b/app/packages/annotation/src/agents/hooks/usePointSelection.ts
@@ -112,6 +112,12 @@ const keypointOverlayIdAtom = atom<string | null>(null);
  * currently active.
  */
 const pointSelectionActiveAtom = atom(false);
+/**
+ * Shared reference to the interactive handler for the active point selection
+ * session. Held in an atom so activation and deactivation can happen from
+ * different component instances of the hook.
+ */
+const interactiveHandlerAtom = atom<InteractiveKeypointHandler | null>(null);
 
 /**
  * Hook which provides activation/deactivation functions for point selection.
@@ -121,6 +127,9 @@ export const usePointSelection = (): PointSelection => {
     keypointOverlayIdAtom
   );
   const [isActive, setIsActive] = useAtom(pointSelectionActiveAtom);
+  const [interactiveHandler, setInteractiveHandler] = useAtom(
+    interactiveHandlerAtom
+  );
 
   const { getOverlay, scene, overlayFactory } = useLighter();
   const eventBus = useLighterEventBus(
@@ -161,14 +170,14 @@ export const usePointSelection = (): PointSelection => {
 
       // Enter interactive mode with a keypoint handler;
       // this will allow for creating/removing points.
-      scene.enterInteractiveMode(
-        new InteractiveKeypointHandler(
-          overlay,
-          eventBus,
-          resolveVariant,
-          resolvePointHit
-        )
+      const handler = new InteractiveKeypointHandler(
+        overlay,
+        eventBus,
+        resolveVariant,
+        resolvePointHit
       );
+      setInteractiveHandler(handler);
+      scene.enterInteractiveMode(handler);
 
       setIsActive(true);
     }
@@ -178,6 +187,7 @@ export const usePointSelection = (): PointSelection => {
     overlayFactory,
     resolveVariant,
     scene,
+    setInteractiveHandler,
     setIsActive,
     setKeypointOverlayId,
   ]);
@@ -186,6 +196,11 @@ export const usePointSelection = (): PointSelection => {
     if (!isActive) {
       return;
     }
+
+    // Points are ephemeral:
+    // drop any undo/redo entries pushed before tearing down interactive mode
+    interactiveHandler?.pruneCommands();
+    setInteractiveHandler(null);
 
     // Clear the interactive keypoint handler; deactivates point interaction
     scene?.exitInteractiveMode();
@@ -197,7 +212,15 @@ export const usePointSelection = (): PointSelection => {
     }
 
     setIsActive(false);
-  }, [isActive, keypointOverlayId, scene, setIsActive, setKeypointOverlayId]);
+  }, [
+    interactiveHandler,
+    isActive,
+    keypointOverlayId,
+    scene,
+    setInteractiveHandler,
+    setIsActive,
+    setKeypointOverlayId,
+  ]);
 
   // Clear points from the overlay without removing the overlay from the scene
   const clearPoints = useCallback(() => {

--- a/app/packages/commands/src/actions/ActionManager.test.ts
+++ b/app/packages/commands/src/actions/ActionManager.test.ts
@@ -58,4 +58,75 @@ describe("ActionManager", () => {
     //not called after unsub
     expect(listener).toBeCalledTimes(3);
   });
+
+  describe("prune", () => {
+    const make = (id: string) =>
+      new DelegatingUndoable(
+        id,
+        () => {
+          return;
+        },
+        () => {
+          return;
+        }
+      );
+
+    it("removes matching entries from the undo stack", async () => {
+      await manager.execute(make("keep.a"));
+      await manager.execute(make("drop.a"));
+      await manager.execute(make("keep.b"));
+      await manager.execute(make("drop.b"));
+      expect(manager.getUndoStackSize()).toBe(4);
+
+      manager.prune((u) => u.id.startsWith("drop."));
+
+      expect(manager.getUndoStackSize()).toBe(2);
+      expect(manager.canUndo()).toBe(true);
+    });
+
+    it("removes matching entries from the redo stack", async () => {
+      await manager.execute(make("drop.a"));
+      await manager.execute(make("keep.a"));
+      await manager.undo();
+      await manager.undo();
+      expect(manager.getRedoStackSize()).toBe(2);
+
+      manager.prune((u) => u.id === "drop.a");
+
+      expect(manager.getRedoStackSize()).toBe(1);
+      expect(manager.getUndoStackSize()).toBe(0);
+    });
+
+    it("fires undo listeners when entries are removed", async () => {
+      await manager.execute(make("drop.a"));
+      const listener = vi.fn();
+      manager.subscribeUndo(listener);
+
+      manager.prune((u) => u.id === "drop.a");
+
+      expect(listener).toBeCalledTimes(1);
+      expect(listener.mock.calls[0]).toEqual([false, false]);
+    });
+
+    it("does not fire undo listeners when nothing matches", async () => {
+      await manager.execute(make("keep.a"));
+      const listener = vi.fn();
+      manager.subscribeUndo(listener);
+
+      manager.prune((u) => u.id === "nothing.matches");
+
+      expect(listener).not.toBeCalled();
+    });
+
+    it("is a no-op on empty stacks", () => {
+      const listener = vi.fn();
+      manager.subscribeUndo(listener);
+
+      manager.prune(() => true);
+
+      expect(listener).not.toBeCalled();
+      expect(manager.getUndoStackSize()).toBe(0);
+      expect(manager.getRedoStackSize()).toBe(0);
+    });
+  });
 });

--- a/app/packages/commands/src/actions/ActionManager.ts
+++ b/app/packages/commands/src/actions/ActionManager.ts
@@ -140,6 +140,25 @@ export class ActionManager {
   }
 
   /**
+   * Removes all entries matching the predicate from both the undo
+   * and redo stacks.
+   *
+   * @param predicate Returns true for entries that should be removed.
+   */
+  prune(predicate: (undoable: Undoable) => boolean): void {
+    const beforeUndo = this.undoStack.length;
+    const beforeRedo = this.redoStack.length;
+    this.undoStack = this.undoStack.filter((u) => !predicate(u));
+    this.redoStack = this.redoStack.filter((u) => !predicate(u));
+    if (
+      this.undoStack.length !== beforeUndo ||
+      this.redoStack.length !== beforeRedo
+    ) {
+      this.fireUndoListeners();
+    }
+  }
+
+  /**
    * Gets the current undo stack size.
    * @returns Number of undoable actions in undo stack.
    */

--- a/app/packages/commands/src/context/CommandContext.ts
+++ b/app/packages/commands/src/context/CommandContext.ts
@@ -362,4 +362,15 @@ export class CommandContext {
     this.actions.clear();
     this.parent?.clearUndoRedoStack();
   }
+
+  /**
+   * Removes all undo/redo entries matching the predicate from this
+   * context and any parent contexts.
+   *
+   * @param predicate Returns true for entries that should be removed.
+   */
+  public pruneUndoables(predicate: (undoable: Undoable) => boolean) {
+    this.actions.prune(predicate);
+    this.parent?.pruneUndoables(predicate);
+  }
 }

--- a/app/packages/commands/src/context/context.test.ts
+++ b/app/packages/commands/src/context/context.test.ts
@@ -106,6 +106,71 @@ describe("CommandContext", () => {
     expect(listener).toBeCalledTimes(2);
   });
 
+  it("prunes matching undoables from the local stack", async () => {
+    const drop = new DelegatingUndoable(
+      "fo.test.drop",
+      async () => undefined,
+      async () => undefined
+    );
+    const keep = new DelegatingUndoable(
+      "fo.test.keep",
+      async () => undefined,
+      async () => undefined
+    );
+    await context.executeAction(drop);
+    await context.executeAction(keep);
+
+    context.pruneUndoables((u) => u.id === drop.id);
+
+    expect(context.canUndo()).toBe(true);
+    await context.undo();
+    expect(testUndo).toBeCalledTimes(0); // drop's undo should never run
+    expect(context.canUndo()).toBe(false);
+  });
+
+  it("prunes matching undoables from parent contexts", async () => {
+    const parent = new CommandContext("parent");
+    parent.activate();
+    const child = new CommandContext("child", parent);
+    child.activate();
+
+    const parentUndoable = new DelegatingUndoable(
+      "fo.test.parent",
+      async () => undefined,
+      async () => undefined
+    );
+    const childUndoable = new DelegatingUndoable(
+      "fo.test.child",
+      async () => undefined,
+      async () => undefined
+    );
+    await parent.executeAction(parentUndoable);
+    await child.executeAction(childUndoable);
+    expect(child.canUndo()).toBe(true);
+
+    child.pruneUndoables((u) => u.id === parentUndoable.id);
+
+    // child entry remains, parent entry is gone
+    expect(child.canUndo()).toBe(true);
+    await child.undo();
+    expect(child.canUndo()).toBe(false);
+    expect(parent.canUndo()).toBe(false);
+
+    child.deactivate();
+    parent.deactivate();
+  });
+
+  it("fires undo state listeners when prune removes the last entry", async () => {
+    await context.executeAction(testUndoable);
+    const listener = vi.fn();
+    context.subscribeUndoState(listener);
+
+    context.pruneUndoables((u) => u.id === testUndoable.id);
+
+    expect(listener).toBeCalledTimes(1);
+    expect(listener.mock.calls[0]).toEqual([false, false]);
+  });
+
   it("fires action events on execute/undo/redo", async () => {
     const listener = vi.fn((_id, _isUndo) => {
       return;

--- a/app/packages/lighter/src/interaction/InteractiveKeypointHandler.ts
+++ b/app/packages/lighter/src/interaction/InteractiveKeypointHandler.ts
@@ -43,6 +43,8 @@ export class InteractiveKeypointHandler implements InteractionHandler {
   readonly id = INTERACTIVE_KEYPOINT_HANDLER_ID;
   readonly cursor = "crosshair";
 
+  private readonly pushedCommandIds = new Set<string>();
+
   constructor(
     public readonly overlay: KeypointOverlay,
     private readonly eventBus: EventDispatcher<LighterEventGroup>,
@@ -100,10 +102,14 @@ export class InteractiveKeypointHandler implements InteractionHandler {
 
       if (action === KeypointPointHitAction.DELETE) {
         const command = new RemoveKeypointPointCommand(this.overlay, hitId);
+
         command.execute();
+
         CommandContextManager.instance()
           .getActiveContext()
           .pushUndoable(command);
+        this.pushedCommandIds.add(command.id);
+
         return true;
       }
       // else fall through to default behavior
@@ -112,11 +118,15 @@ export class InteractiveKeypointHandler implements InteractionHandler {
     const variant = this.resolveVariant?.({ x: rp[0], y: rp[1] }, modifiers);
     const pointId = this.overlay.addPoint(worldPoint, variant);
 
-    CommandContextManager.instance()
-      .getActiveContext()
-      .pushUndoable(
-        new AddKeypointPointCommand(this.overlay, pointId, rp, variant)
-      );
+    const command = new AddKeypointPointCommand(
+      this.overlay,
+      pointId,
+      rp,
+      variant
+    );
+
+    CommandContextManager.instance().getActiveContext().pushUndoable(command);
+    this.pushedCommandIds.add(command.id);
 
     return true;
   }
@@ -148,5 +158,21 @@ export class InteractiveKeypointHandler implements InteractionHandler {
 
   cleanup(): void {
     this.overlay.setPreviewPoint(null);
+  }
+
+  /**
+   * Removes all undo/redo entries that this handler pushed during its
+   * lifetime from the active command context.
+   */
+  pruneCommands(): void {
+    if (this.pushedCommandIds.size === 0) {
+      return;
+    }
+
+    CommandContextManager.instance()
+      .getActiveContext()
+      .pruneUndoables((u) => this.pushedCommandIds.has(u.id));
+
+    this.pushedCommandIds.clear();
   }
 }


### PR DESCRIPTION
## 🔗 Related Issues

None

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

When using the point selection mode in AI-assisted annotation, point-related actions (add/remove) are added to the undo/redo stack and operate as expected. When leaving this mode, we want to prune the stack and remove all entries related to these points.
* Added `prune(predicate)` method to `ActionManager` and `CommandContext`
* Added command ID tracking in `InteractiveKeypointHandler` and public `pruneCommands` method
* Updated `usePointSelection` to prune commands when exiting interactive mode

## 🧪 How is this patch tested? If it is not, please explain why.

local + updated unit tests

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add selective undo/redo pruning to remove specific history entries while preserving stack integrity.
  * Pruning now propagates across hierarchical command contexts so child/parent histories stay consistent.
  * Point-selection interaction now tracks and clears related command history when exiting interactive mode.

* **Tests**
  * Added unit tests validating pruning behavior, stack size updates, listener notifications, and hierarchical pruning scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->