### PR TITLE
ontology annotation validation

### DIFF
--- a/fiftyone/core/annotation/constants.py
+++ b/fiftyone/core/annotation/constants.py
@@ -6,6 +6,8 @@ Annotation constants
 |
 """
 
+from datetime import date, datetime
+
 import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
 import fiftyone.core.media as fom
@@ -89,6 +91,24 @@ LABEL_SETTINGS = ALL_TYPES_SETTINGS.union(
 STR_SETTINGS = ALL_TYPES_SETTINGS.union({DEFAULT})
 STR_LIST_SETTINGS = ALL_TYPES_SETTINGS.union({DEFAULT})
 VALUES_COMPONENTS = {CHECKBOXES, DROPDOWN, RADIO}
+
+
+### Valid components per type
+
+
+TYPE_TO_COMPONENTS = {
+    BOOL: BOOL_COMPONENTS,
+    DATE: DATE_DATETIME_COMPONENTS,
+    DATETIME: DATE_DATETIME_COMPONENTS,
+    DICT: DICT_COMPONENTS,
+    FLOAT: FLOAT_INT_COMPONENTS,
+    FLOAT_LIST: FLOAT_INT_LIST_COMPONENTS,
+    ID: ID_COMPONENTS,
+    INT: FLOAT_INT_COMPONENTS,
+    INT_LIST: FLOAT_INT_LIST_COMPONENTS,
+    STR: STR_COMPONENTS,
+    STR_LIST: STR_LIST_COMPONENTS,
+}
 
 
 ### Default components

--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -92,6 +92,7 @@ class Ontology(abc.ABC):
     @require_feature("VFF_ONTOLOGY_CA")
     def save(self) -> None:
         """Saves this ontology to the database."""
+        self._validate()
         if self._doc is None:
             self._doc = OntologyDocument(
                 name=self.name,
@@ -143,6 +144,12 @@ class Ontology(abc.ABC):
         cloned._doc = None
         cloned.save()
         return cloned
+
+    def _validate(self) -> None:
+        """Hook called by :meth:`save` to validate the ontology before
+        persisting. Default is a no-op; subclasses override to call
+        their type-specific validator.
+        """
 
     def _get_root(self) -> Any:
         """Returns the serialized root data for storage.
@@ -244,6 +251,16 @@ class AnnotationOntology(Ontology):
         super().__init__(name=name, description=description)
         self.taxonomies = taxonomies or []
         self.attributes = attributes or []
+
+    def _validate(self) -> None:
+        # Lazy import — ``ontology_validation`` imports
+        # ``AnnotationOntology`` for type hints, so a top-level import
+        # here would be circular.
+        from fiftyone.core.ontology_validation import (
+            validate_annotation_ontology,
+        )
+
+        validate_annotation_ontology(self)
 
     def _get_root(self) -> dict:
         return {

--- a/fiftyone/core/ontology_validation.py
+++ b/fiftyone/core/ontology_validation.py
@@ -34,7 +34,6 @@ def validate_annotation_ontology(ontology: AnnotationOntology) -> None:
     # `Taxonomy` documents; validate that each `ontology.taxonomies` name
     # resolves to a `Taxonomy` in the DB once the type exists.
     errors: list[str] = [
-        *_validate_unique_attribute_names(ontology),
         *_validate_when_operators(ontology),
         *_validate_types(ontology),
         *_validate_components(ontology),
@@ -47,21 +46,6 @@ def validate_annotation_ontology(ontology: AnnotationOntology) -> None:
         raise ValueError(
             f"Invalid AnnotationOntology {ontology.name!r}:\n{bullet_list}"
         )
-
-
-def _validate_unique_attribute_names(
-    ontology: AnnotationOntology,
-) -> list[str]:
-    seen: set[str] = set()
-    duplicates: set[str] = set()
-    for attr in ontology.attributes:
-        if attr.name in seen:
-            duplicates.add(attr.name)
-        seen.add(attr.name)
-
-    if duplicates:
-        return [f"duplicate attribute name(s): {sorted(duplicates)}"]
-    return []
 
 
 def _validate_when_operators(ontology: AnnotationOntology) -> list[str]:

--- a/fiftyone/core/ontology_validation.py
+++ b/fiftyone/core/ontology_validation.py
@@ -1,0 +1,160 @@
+"""
+Validation for :class:`fiftyone.core.ontology.AnnotationOntology`.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from fiftyone.core.annotation import constants as _fac
+from fiftyone.core.annotation.attributes import WhenOperator
+from fiftyone.core.ontology import AnnotationOntology
+
+
+_ALLOWED_THEN_KEYS = {"values", "component"}
+
+
+def validate_annotation_ontology(ontology: AnnotationOntology) -> None:
+    """Validates an :class:`AnnotationOntology`.
+
+    Runs every rule and aggregates all failures into a single error.
+
+    Args:
+        ontology: the ontology to validate
+
+    Raises:
+        ValueError: if any rule fails
+    """
+    # TODO: `When.field` resolution is deferred — `field` may reference
+    # an attribute in another label-schema layer, so it needs the full
+    # label-schema context. Enforce at resolution time or in the frontend.
+    #
+    # TODO: taxonomy-reference resolution is deferred until Phase 2 ships
+    # `Taxonomy` documents; validate that each `ontology.taxonomies` name
+    # resolves to a `Taxonomy` in the DB once the type exists.
+    errors: list[str] = [
+        *_validate_unique_attribute_names(ontology),
+        *_validate_when_operators(ontology),
+        *_validate_types(ontology),
+        *_validate_components(ontology),
+        *_validate_no_cycles(ontology),
+        *_validate_then_keys(ontology),
+    ]
+
+    if errors:
+        bullet_list = "\n".join(f"  - {e}" for e in errors)
+        raise ValueError(
+            f"Invalid AnnotationOntology {ontology.name!r}:\n{bullet_list}"
+        )
+
+
+def _validate_unique_attribute_names(
+    ontology: AnnotationOntology,
+) -> list[str]:
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for attr in ontology.attributes:
+        if attr.name in seen:
+            duplicates.add(attr.name)
+        seen.add(attr.name)
+
+    if duplicates:
+        return [f"duplicate attribute name(s): {sorted(duplicates)}"]
+    return []
+
+
+def _validate_when_operators(ontology: AnnotationOntology) -> list[str]:
+    """Safety net for ``When.operator`` — ``When.__post_init__`` rejects
+    invalid operators at construction, so this only catches values
+    mutated onto a constructed instance.
+    """
+    errors: list[str] = []
+    for attr in ontology.attributes:
+        if attr.when is None:
+            continue
+        for w in attr.when:
+            try:
+                WhenOperator(w.operator)
+            except ValueError:
+                errors.append(
+                    f"attribute {attr.name!r}: invalid When.operator "
+                    f"{w.operator!r}"
+                )
+    return errors
+
+
+def _validate_types(ontology: AnnotationOntology) -> list[str]:
+    """Check each ``AttributeSpec.type`` against the label-schema type
+    registry (``constants.TYPE_TO_FIELD``).
+    """
+    errors: list[str] = []
+    for attr in ontology.attributes:
+        if attr.type not in _fac.TYPE_TO_FIELD:
+            errors.append(
+                f"attribute {attr.name!r}: unsupported type {attr.type!r}"
+            )
+    return errors
+
+
+def _validate_components(ontology: AnnotationOntology) -> list[str]:
+    """Check each ``AttributeSpec.component`` is valid for its declared
+    type (per ``constants.TYPE_TO_COMPONENTS``).
+
+    Attributes with an unsupported type are skipped — ``_validate_types``
+    reports those separately so we avoid double-flagging.
+    """
+    errors: list[str] = []
+    for attr in ontology.attributes:
+        valid = _fac.TYPE_TO_COMPONENTS.get(attr.type)
+        if valid is None:
+            continue
+        if attr.component not in valid:
+            errors.append(
+                f"attribute {attr.name!r}: component {attr.component!r} "
+                f"not valid for type {attr.type!r}"
+            )
+    return errors
+
+
+def _validate_then_keys(ontology: AnnotationOntology) -> list[str]:
+    """Reject ``When.then`` overrides containing keys outside the
+    allowed set (currently ``values`` and ``component``).
+    """
+    errors: list[str] = []
+    for attr in ontology.attributes:
+        if attr.when is None:
+            continue
+        for w in attr.when:
+            if w.then is None:
+                continue
+            # set difference: keys present in w.then but not in the
+            # allow-list are disallowed.
+            disallowed_keys = set(w.then) - _ALLOWED_THEN_KEYS
+            if disallowed_keys:
+                errors.append(
+                    f"attribute {attr.name!r}: When.then has disallowed "
+                    f"key(s) {sorted(disallowed_keys)}"
+                )
+    return errors
+
+
+def _validate_no_cycles(ontology: AnnotationOntology) -> list[str]:
+    """Reject cycles in the When graph (internal refs only)."""
+    graph: dict[str, list[str]] = {
+        attr.name: [w.field for w in (attr.when or [])]
+        for attr in ontology.attributes
+    }
+    errors: list[str] = []
+    for start in graph:
+        to_visit = list(graph[start])
+        seen: set[str] = set()
+        while to_visit:
+            node = to_visit.pop()
+            if node == start:
+                errors.append(f"cycle involving attribute {start!r}")
+                break
+            if node in seen or node not in graph:
+                continue
+            seen.add(node)
+            to_visit.extend(graph[node])
+    return errors

--- a/fiftyone/core/ontology_validation.py
+++ b/fiftyone/core/ontology_validation.py
@@ -17,7 +17,8 @@ _ALLOWED_THEN_KEYS = {"values", "component"}
 def validate_annotation_ontology(ontology: AnnotationOntology) -> None:
     """Validates an :class:`AnnotationOntology`.
 
-    Runs every rule and aggregates all failures into a single error.
+    Aggregates all ontology-level failures into a single error.
+    :class:`When` operators are validated on construction.
 
     Args:
         ontology: the ontology to validate

--- a/fiftyone/core/ontology_validation.py
+++ b/fiftyone/core/ontology_validation.py
@@ -60,7 +60,10 @@ def _validate_when_operators(ontology: AnnotationOntology) -> list[str]:
         for w in attr.when:
             try:
                 WhenOperator(w.operator)
-            except ValueError:
+            except (ValueError, TypeError):
+                # ``WhenOperator(unhashable)`` (e.g. a list) raises
+                # ``TypeError`` from the enum's value lookup; treat it
+                # the same as any other invalid operator value.
                 errors.append(
                     f"attribute {attr.name!r}: invalid When.operator "
                     f"{w.operator!r}"
@@ -124,11 +127,17 @@ def _validate_then_keys(ontology: AnnotationOntology) -> list[str]:
 
 
 def _validate_no_cycles(ontology: AnnotationOntology) -> list[str]:
-    """Reject cycles in the When graph (internal refs only)."""
-    graph: dict[str, list[str]] = {
-        attr.name: [w.field for w in (attr.when or [])]
-        for attr in ontology.attributes
-    }
+    """Reject cycles in the When graph (internal refs only).
+
+    Same-name attributes (multi-variant pattern) accumulate their
+    ``When.field`` edges under a single key — using a dict comprehension
+    here would let later variants overwrite earlier ones and silently
+    drop their edges from the cycle graph.
+    """
+    graph: dict[str, list[str]] = {}
+    for attr in ontology.attributes:
+        edges = [w.field for w in (attr.when or [])]
+        graph.setdefault(attr.name, []).extend(edges)
     errors: list[str] = []
     for start in graph:
         to_visit = list(graph[start])

--- a/tests/unittests/ontology_validation_tests.py
+++ b/tests/unittests/ontology_validation_tests.py
@@ -21,26 +21,6 @@ from fiftyone.core.ontology import AnnotationOntology
 from fiftyone.core.ontology_validation import validate_annotation_ontology
 
 
-class UniqueAttributeNamesTests(unittest.TestCase):
-    def test_rejects_duplicate_names(self):
-        ao = AnnotationOntology(
-            name="test",
-            attributes=[
-                AttributeSpec(name="damage", type="str", component="dropdown"),
-                AttributeSpec(
-                    name="damage", type="bool", component="checkbox"
-                ),
-            ],
-        )
-        with self.assertRaises(ValueError) as cm:
-            validate_annotation_ontology(ao)
-        self.assertIn("damage", str(cm.exception))
-
-    def test_accepts_empty_attributes(self):
-        ao = AnnotationOntology(name="empty")
-        validate_annotation_ontology(ao)
-
-
 class OperatorValidTests(unittest.TestCase):
     def test_rejects_invalid_operator_on_mutated_when(self):
         # Safety net for direct mutation past __post_init__.

--- a/tests/unittests/ontology_validation_tests.py
+++ b/tests/unittests/ontology_validation_tests.py
@@ -91,6 +91,36 @@ class NoCyclesTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             validate_annotation_ontology(ao)
 
+    def test_rejects_cycle_through_overwritten_variant(self):
+        # A multi-variant attribute (same `name`, different `when`)
+        # used to lose its edges when a later same-name variant
+        # overwrote it in the cycle graph. The edges from every variant
+        # must contribute, otherwise a cycle through the dropped variant
+        # goes silently unreported.
+        ao = AnnotationOntology(
+            name="test",
+            attributes=[
+                AttributeSpec(
+                    name="a",
+                    type="str",
+                    component="dropdown",
+                    when=[When(WhenOperator.EQUALS, field="b", value="x")],
+                ),
+                # Same-name variant with no `when` — would have erased
+                # the cyclic edge from the first variant under the old
+                # graph-build code.
+                AttributeSpec(name="a", type="str", component="dropdown"),
+                AttributeSpec(
+                    name="b",
+                    type="str",
+                    component="dropdown",
+                    when=[When(WhenOperator.EQUALS, field="a", value="y")],
+                ),
+            ],
+        )
+        with self.assertRaises(ValueError):
+            validate_annotation_ontology(ao)
+
 
 class ThenKeysValidTests(unittest.TestCase):
     def test_rejects_then_with_disallowed_key(self):

--- a/tests/unittests/ontology_validation_tests.py
+++ b/tests/unittests/ontology_validation_tests.py
@@ -6,7 +6,11 @@ FiftyOne annotation ontology validation unit tests.
 |
 """
 
+import os
 import unittest
+
+# Ontology SDK is gated by VFF_ONTOLOGY_CA; enable for the whole module.
+os.environ.setdefault("VFF_ONTOLOGY_CA", "1")
 
 from fiftyone.core.annotation.attributes import (
     AttributeSpec,
@@ -130,6 +134,31 @@ class ThenKeysValidTests(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             validate_annotation_ontology(ao)
+
+
+class SaveInvokesValidationTests(unittest.TestCase):
+    def test_save_invokes_validation(self):
+        # Auto-validate hook in Ontology.save() — invalid ontologies
+        # raise before any DB interaction.
+        ao = AnnotationOntology(
+            name="bad",
+            attributes=[
+                AttributeSpec(
+                    name="a",
+                    type="str",
+                    component="dropdown",
+                    when=[When(WhenOperator.EQUALS, field="b", value="x")],
+                ),
+                AttributeSpec(
+                    name="b",
+                    type="str",
+                    component="dropdown",
+                    when=[When(WhenOperator.EQUALS, field="a", value="y")],
+                ),
+            ],
+        )
+        with self.assertRaises(ValueError):
+            ao.save()
 
 
 if __name__ == "__main__":

--- a/tests/unittests/ontology_validation_tests.py
+++ b/tests/unittests/ontology_validation_tests.py
@@ -1,0 +1,136 @@
+"""
+FiftyOne annotation ontology validation unit tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+
+from fiftyone.core.annotation.attributes import (
+    AttributeSpec,
+    When,
+    WhenOperator,
+)
+from fiftyone.core.ontology import AnnotationOntology
+from fiftyone.core.ontology_validation import validate_annotation_ontology
+
+
+class UniqueAttributeNamesTests(unittest.TestCase):
+    def test_rejects_duplicate_names(self):
+        ao = AnnotationOntology(
+            name="test",
+            attributes=[
+                AttributeSpec(name="damage", type="str", component="dropdown"),
+                AttributeSpec(
+                    name="damage", type="bool", component="checkbox"
+                ),
+            ],
+        )
+        with self.assertRaises(ValueError) as cm:
+            validate_annotation_ontology(ao)
+        self.assertIn("damage", str(cm.exception))
+
+    def test_accepts_empty_attributes(self):
+        ao = AnnotationOntology(name="empty")
+        validate_annotation_ontology(ao)
+
+
+class OperatorValidTests(unittest.TestCase):
+    def test_rejects_invalid_operator_on_mutated_when(self):
+        # Safety net for direct mutation past __post_init__.
+        w = When(WhenOperator.EQUALS, field="flag", value=True)
+        w.operator = "mock_operator"
+        ao = AnnotationOntology(
+            name="test",
+            attributes=[
+                AttributeSpec(name="flag", type="bool", component="checkbox"),
+                AttributeSpec(
+                    name="location",
+                    type="str",
+                    component="dropdown",
+                    when=[w],
+                ),
+            ],
+        )
+        with self.assertRaises(ValueError):
+            validate_annotation_ontology(ao)
+
+
+class TypeValidTests(unittest.TestCase):
+    def test_rejects_unsupported_type(self):
+        ao = AnnotationOntology(
+            name="test",
+            attributes=[
+                AttributeSpec(
+                    name="mock_attr", type="mock_type", component="text"
+                ),
+            ],
+        )
+        with self.assertRaises(ValueError):
+            validate_annotation_ontology(ao)
+
+
+class ComponentCompatibleTests(unittest.TestCase):
+    def test_rejects_component_invalid_for_type(self):
+        # bool accepts checkbox/toggle only; dropdown is invalid
+        ao = AnnotationOntology(
+            name="test",
+            attributes=[
+                AttributeSpec(name="flag", type="bool", component="dropdown"),
+            ],
+        )
+        with self.assertRaises(ValueError):
+            validate_annotation_ontology(ao)
+
+
+class NoCyclesTests(unittest.TestCase):
+    def test_rejects_cycle_between_attributes(self):
+        ao = AnnotationOntology(
+            name="test",
+            attributes=[
+                AttributeSpec(
+                    name="a",
+                    type="str",
+                    component="dropdown",
+                    when=[When(WhenOperator.EQUALS, field="b", value="x")],
+                ),
+                AttributeSpec(
+                    name="b",
+                    type="str",
+                    component="dropdown",
+                    when=[When(WhenOperator.EQUALS, field="a", value="y")],
+                ),
+            ],
+        )
+        with self.assertRaises(ValueError):
+            validate_annotation_ontology(ao)
+
+
+class ThenKeysValidTests(unittest.TestCase):
+    def test_rejects_then_with_disallowed_key(self):
+        w = When(
+            WhenOperator.EQUALS,
+            field="other",
+            value=True,
+            then={"name": "renamed"},
+        )
+        ao = AnnotationOntology(
+            name="test",
+            attributes=[
+                AttributeSpec(name="other", type="bool", component="checkbox"),
+                AttributeSpec(
+                    name="attr",
+                    type="str",
+                    component="dropdown",
+                    when=[w],
+                ),
+            ],
+        )
+        with self.assertRaises(ValueError):
+            validate_annotation_ontology(ao)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 🔗 Related Issues
https://github.com/voxel51/fiftyone/pull/7341

## 📋 What changes are proposed in this pull request?

Adds validation logic for verifying integrity of conditional attributes within a annotation ontology

This is not wired in anywhere yet, and this may be expanded (or contracted) later.

## 🧪 How is this patch tested? If it is not, please explain why.

Tested locally, unit tests. 


## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

add support for ontology objects to the SDK. 

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for annotation ontologies: checks for duplicate attribute names, allowed condition operators, type/component compatibility, permitted override keys, cyclic dependency detection, and automatic validation when saving an ontology.
  * Expanded type-to-component mappings to improve compatibility checks and error reporting.

* **Tests**
  * Added tests covering validation failures and edge cases, including mutated conditions, unsupported types, component mismatches, invalid overrides, and cyclic dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->