### PR TITLE
ontology SDK feature flag gate

### DIFF
--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -18,6 +18,7 @@ from fiftyone.core.annotation.attributes import (
     attr_insert_to_dict,
 )
 from fiftyone.core.odm.ontology import OntologyDocument, OntologyType
+from fiftyone.internal.features.registry import require_feature
 
 
 class Ontology(abc.ABC):
@@ -77,6 +78,7 @@ class Ontology(abc.ABC):
 
         return None
 
+    @require_feature("VFF_ONTOLOGY_CA")
     def save(self) -> None:
         """Saves this ontology to the database."""
         if self._doc is None:
@@ -93,6 +95,7 @@ class Ontology(abc.ABC):
 
         self._doc.save()
 
+    @require_feature("VFF_ONTOLOGY_CA")
     def reload(self) -> None:
         """Reloads this ontology from the database."""
         if self._doc is None:
@@ -103,6 +106,7 @@ class Ontology(abc.ABC):
         self._doc.reload()
         self._apply_doc(self._doc)
 
+    @require_feature("VFF_ONTOLOGY_CA")
     def delete(self) -> None:
         """Deletes this ontology from the database."""
         if self._doc is None:
@@ -113,6 +117,7 @@ class Ontology(abc.ABC):
         self._doc.delete()
         self._doc = None
 
+    @require_feature("VFF_ONTOLOGY_CA")
     def clone(self, new_name: str) -> "Ontology":
         """Clones this ontology under a new name.
 
@@ -303,6 +308,7 @@ def _objects_by_slug(name: str):
     )
 
 
+@require_feature("VFF_ONTOLOGY_CA")
 def load_ontology(name: str) -> Ontology:
     """Loads the latest version of an ontology by name.
 
@@ -322,6 +328,7 @@ def load_ontology(name: str) -> Ontology:
     return _from_doc(doc)
 
 
+@require_feature("VFF_ONTOLOGY_CA")
 def list_ontologies(glob_patt: Optional[str] = None) -> list[str]:
     """Lists ontology names in the database.
 
@@ -342,6 +349,7 @@ def list_ontologies(glob_patt: Optional[str] = None) -> list[str]:
     return sorted(docs.distinct("name"))
 
 
+@require_feature("VFF_ONTOLOGY_CA")
 def ontology_exists(name: str) -> bool:
     """Checks if an ontology with the given name exists.
 
@@ -354,6 +362,7 @@ def ontology_exists(name: str) -> bool:
     return _objects_by_slug(name).count() > 0
 
 
+@require_feature("VFF_ONTOLOGY_CA")
 def delete_ontology(name: str, force: bool = False) -> None:
     """Deletes an ontology and all its versions from the database.
 

--- a/fiftyone/internal/features/flags.py
+++ b/fiftyone/internal/features/flags.py
@@ -8,6 +8,9 @@ FiftyOne feature flags.
 
 from typing import Literal
 
-
-FeatureFlag = Literal["VFF_AI_SEGMENTATION", "VFF_MULTIMODAL"]
+FeatureFlag = Literal[
+    "VFF_AI_SEGMENTATION",
+    "VFF_MULTIMODAL",
+    "VFF_ONTOLOGY_CA",
+]
 """Enumeration of active feature flags."""

--- a/fiftyone/internal/features/registry.py
+++ b/fiftyone/internal/features/registry.py
@@ -6,6 +6,7 @@ FiftyOne feature flag registry.
 |
 """
 
+import functools
 from typing import get_args, List
 
 from .environment_manager import EnvironmentFeatureManager
@@ -64,3 +65,34 @@ def is_feature_enabled(feature: FeatureFlag) -> bool:
         True if the feature is enabled, else False
     """
     return get_feature_manager().is_feature_enabled(feature)
+
+
+def require_feature(feature: FeatureFlag):
+    """Decorator that gates a callable behind a feature flag.
+
+    Raises ``RuntimeError`` when the flag is disabled, naming the flag so
+    users know which env var to set.
+
+    Args:
+        feature: the feature name
+
+    Example::
+
+        @require_feature("VFF_ONTOLOGY_CA")
+        def create_ontology(ontology):
+            ontology.save()
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            if not is_feature_enabled(feature):
+                raise RuntimeError(
+                    f"This feature is gated behind the {feature} feature "
+                    f"flag; set the {feature} env var to enable"
+                )
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -6,7 +6,12 @@ FiftyOne ontology data class unit tests.
 |
 """
 
+import os
 import unittest
+
+# Ontology SDK is gated by VFF_ONTOLOGY_CA; enable for the whole module.
+# Tests that need the flag off manage the env var themselves.
+os.environ.setdefault("VFF_ONTOLOGY_CA", "1")
 
 from fiftyone.core.annotation.attributes import (
     AttributeSpec,


### PR DESCRIPTION
## 🔗 Related Issues
https://github.com/voxel51/fiftyone/pull/7341

## 📋 What changes are proposed in this pull request?

- Feature feature on the back end to use decorator on functions. 
- Adds feature flag for ontology and conditional attributes. 
- Applies decorator with the feature flag to ontology SDK methods. 

## 🧪 How is this patch tested? If it is not, please explain why.

Tested locally, unit tests. 


## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

add support for ontology objects to the SDK. 

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Features**
  * Ontology operations (save, reload, delete, clone) and related utility functions are now protected by a feature flag requirement. Users must enable the feature flag to access ontology functionality. Attempting operations without the flag enabled will display an error message with activation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->