### PR TITLE
Update docs to reflect that fo3d usage isn't compulsory

### DIFF
--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -1990,6 +1990,8 @@ as per the table below:
     the new filepath must have the same media type. In other words,
     `media_type` is immutable.
 
+.. note::
+
     When creating new 3D datasets from direct 3D asset files such as `.glb`,
     `.pcd`, or `.ply`, pass `media_type="3d"` explicitly.
 

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -5325,7 +5325,7 @@ ___________
 
 3D datasets have media type `3d` and can be created from supported 3D asset
 files directly, or from `.fo3d` scene files. Direct assets are the simplest
-choice when a sample is a single mesh or point cloud. Wrap assets in `.fo3d`
+choice when a sample is a single :ref:`mesh <3d-meshes>` or :ref:`point cloud <3d-point-clouds>`. Wrap assets in `.fo3d`
 when you need advanced scene customization such as lights, camera
 configuration, transformations, materials, shapes, or multiple assets in one
 scene.

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -1990,6 +1990,9 @@ as per the table below:
     the new filepath must have the same media type. In other words,
     `media_type` is immutable.
 
+    When creating new 3D datasets from direct 3D asset files such as `.glb`,
+    `.pcd`, or `.ply`, pass `media_type="3d"` explicitly.
+
 .. _using-tags:
 
 Tags
@@ -5320,9 +5323,35 @@ objects across the frames of a |Sample|:
 3D datasets
 ___________
 
-Any |Sample| whose `filepath` is a file with extension `.fo3d` is
-recognized as a 3D sample, and datasets composed of 3D
-samples have media type `3d`.
+3D datasets have media type `3d` and can be created from supported 3D asset
+files directly, or from `.fo3d` scene files. Direct assets are the simplest
+choice when a sample is a single mesh or point cloud. Wrap assets in `.fo3d`
+when you need advanced scene customization such as lights, camera
+configuration, transformations, materials, shapes, or multiple assets in one
+scene.
+
+When using direct 3D assets, pass `media_type="3d"` explicitly:
+
+.. code-block:: python
+    :linenos:
+
+    import fiftyone as fo
+
+    samples = [
+        fo.Sample(filepath="/path/to/model.glb", media_type="3d"),
+        fo.Sample(filepath="/path/to/point-cloud.pcd", media_type="3d"),
+        fo.Sample(filepath="/path/to/mesh.ply", media_type="3d"),
+    ]
+
+    dataset = fo.Dataset()
+    dataset.add_samples(samples)
+
+    print(dataset.media_type)  # 3d
+
+Features such as :ref:`camera intrinsics and extrinsics
+<camera-intrinsics-extrinsics>`, camera frustum rendering, and
+:ref:`3D annotation <creating-3d-polylines>` are available whether your sample
+points directly to a supported 3D asset or to an `.fo3d` scene.
 
 An FO3D file encapsulates a 3D scene constructed using the
 :class:`Scene <fiftyone.core.threed.Scene>` class, which provides methods
@@ -5724,6 +5753,9 @@ ____________________
 
     While we'll keep supporting the `point-cloud` media type for backward
     compatibility, we recommend using the `3d` media type for new datasets.
+
+    To use a PCD file as a 3D sample in a new dataset, create it with
+    `media_type="3d"` explicitly.
 
 Any |Sample| whose `filepath` is a
 `PCD file <https://pointclouds.org/documentation/tutorials/pcd_file_format.html>`_

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -5351,7 +5351,7 @@ When using direct 3D assets, pass `media_type="3d"` explicitly:
 Features such as :ref:`camera intrinsics and extrinsics
 <camera-intrinsics-extrinsics>`, camera frustum rendering, and
 :ref:`3D annotation <creating-3d-polylines>` are available whether your sample
-points directly to a supported 3D asset or to an `.fo3d` scene.
+points directly to a :ref:`supported 3D asset <3d-meshes>` or to an `.fo3d` scene.
 
 An FO3D file encapsulates a 3D scene constructed using the
 :class:`Scene <fiftyone.core.threed.Scene>` class, which provides methods


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Updates the 3D dataset documentation to clarify that supported 3D assets can be used directly with `media_type="3d"` or wrapped in `.fo3d` for advanced scene customization.

The docs now include compact `.glb`, `.pcd`, and `.ply` sample examples, explain when FO3D is useful for lights, cameras, transforms, materials, shapes, or multi-asset scenes, and note that intrinsics/extrinsics, frustum rendering, and 3D annotation are available in both direct-asset and FO3D modes.

## 🧪 How is this patch tested? If it is not, please explain why.

- Ran a focused content check for the new direct 3D examples and references

Didn't run docs build - relying on CI.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified 3D dataset creation to accept direct 3D asset files (e.g., .glb, .ply, .pcd) as well as scene files
  * Rewrote the 3D datasets guidance to describe both input types and their feature availability
  * Added a concrete Python example showing how to mark samples as 3D when creating datasets
  * Updated guidance to explicitly recommend setting media_type="3d" for PCD files in new datasets
<!-- end of auto-generated comment: release notes by coderabbit.ai -->