### PR TITLE
SAM2 Segmentation: when saving, commit masks to path if it previously existed

### DIFF
--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -516,7 +516,7 @@ class Detection(_HasAttributesDict, _HasID, _HasMedia, _HasInstance, Label):
             if update:
                 self.mask_path = None
 
-    def export_mask(self, outpath, update=False):
+    def export_mask(self, outpath, update=False, overwrite_path=False):
         """Exports this instance's mask to the given path.
 
         Args:
@@ -524,15 +524,22 @@ class Detection(_HasAttributesDict, _HasID, _HasMedia, _HasInstance, Label):
             update (False): whether to clear this instance's :attr:`mask`
                 attribute and set its :attr:`mask_path` attribute when
                 exporting in-database segmentations
+            overwrite_path (False): whether to write the in-database
+                :attr:`mask` to disk even when :attr:`mask_path` is
+                already set. Use this when an in-app edit has produced a
+                new in-database mask that should overwrite the file at the
+                original on-disk path
         """
-        if self.mask_path is not None:
+        if self.mask_path is not None and not overwrite_path:
             etau.copy_file(self.mask_path, outpath)
-        else:
+        elif self.mask is not None:
             _write_mask(self.mask, outpath)
 
             if update:
                 self.mask = None
                 self.mask_path = outpath
+        else:
+            raise ValueError("Detection has no mask or mask_path to export")
 
     def to_polyline(self, tolerance=2, filled=True):
         """Returns a :class:`Polyline` representation of this instance.
@@ -1193,7 +1200,7 @@ class Segmentation(_HasID, _HasMedia, Label):
             if update:
                 self.mask_path = None
 
-    def export_mask(self, outpath, update=False):
+    def export_mask(self, outpath, update=False, overwrite_path=False):
         """Exports this instance's mask to the given path.
 
         Args:
@@ -1201,15 +1208,22 @@ class Segmentation(_HasID, _HasMedia, Label):
             update (False): whether to clear this instance's :attr:`mask`
                 attribute and set its :attr:`mask_path` attribute when
                 exporting in-database segmentations
+            overwrite_path (False): whether to write the in-database
+                :attr:`mask` to disk even when :attr:`mask_path` is
+                already set. Use this when an in-app edit has produced a
+                new in-database mask that should overwrite the file at the
+                original on-disk path
         """
-        if self.mask_path is not None:
+        if self.mask_path is not None and not overwrite_path:
             etau.copy_file(self.mask_path, outpath)
-        else:
+        elif self.mask is not None:
             _write_mask(self.mask, outpath)
 
             if update:
                 self.mask = None
                 self.mask_path = outpath
+        else:
+            raise ValueError("Detection has no mask or mask_path to export")
 
     def transform_mask(self, targets_map, outpath=None, update=False):
         """Transforms this instance's mask according to the provided targets

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -526,9 +526,7 @@ class Detection(_HasAttributesDict, _HasID, _HasMedia, _HasInstance, Label):
                 exporting in-database segmentations
             overwrite_path (False): whether to write the in-database
                 :attr:`mask` to disk even when :attr:`mask_path` is
-                already set. Use this when an in-app edit has produced a
-                new in-database mask that should overwrite the file at the
-                original on-disk path
+                already set
         """
         if self.mask_path is not None and not overwrite_path:
             etau.copy_file(self.mask_path, outpath)
@@ -1210,9 +1208,7 @@ class Segmentation(_HasID, _HasMedia, Label):
                 exporting in-database segmentations
             overwrite_path (False): whether to write the in-database
                 :attr:`mask` to disk even when :attr:`mask_path` is
-                already set. Use this when an in-app edit has produced a
-                new in-database mask that should overwrite the file at the
-                original on-disk path
+                already set
         """
         if self.mask_path is not None and not overwrite_path:
             etau.copy_file(self.mask_path, outpath)

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -1223,7 +1223,7 @@ class Segmentation(_HasID, _HasMedia, Label):
                 self.mask = None
                 self.mask_path = outpath
         else:
-            raise ValueError("Detection has no mask or mask_path to export")
+            raise ValueError("Segmentation has no mask or mask_path to export")
 
     def transform_mask(self, targets_map, outpath=None, update=False):
         """Transforms this instance's mask according to the provided targets

--- a/fiftyone/server/routes/sample.py
+++ b/fiftyone/server/routes/sample.py
@@ -727,9 +727,11 @@ class CommitMask(HTTPEndpoint):
             detection.export_mask(
                 mask_path, update=True, overwrite_path=True
             )
-            save_sample(sample, if_last_modified_at)
+            etag = save_sample(sample, if_last_modified_at)
+        except DbVersionMismatchError:
+            raise
         except Exception as err:
-            logger.error("Failed to commit mask to %s: %s", mask_path, err)
+            logger.exception("Failed to commit mask to %s", mask_path)
             raise HTTPException(
                 status_code=500,
                 detail=f"Failed to write mask to '{mask_path}': {err}",
@@ -741,7 +743,10 @@ class CommitMask(HTTPEndpoint):
             mask_path,
         )
 
-        return JSONResponse({"committed": True, "mask_path": mask_path})
+        return JSONResponse(
+            {"committed": True, "mask_path": mask_path},
+            headers={"ETag": etag},
+        )
 
 
 SampleRoutes = [

--- a/fiftyone/server/routes/sample.py
+++ b/fiftyone/server/routes/sample.py
@@ -679,11 +679,11 @@ class CommitMask(HTTPEndpoint):
 
         try:
             label_field = sample[field]
-        except KeyError:
+        except KeyError as err:
             raise HTTPException(
                 status_code=404,
                 detail=f"Field '{field}' not found on sample",
-            )
+            ) from err
 
         if label_field is None:
             raise HTTPException(

--- a/fiftyone/server/routes/sample.py
+++ b/fiftyone/server/routes/sample.py
@@ -664,6 +664,7 @@ class CommitMask(HTTPEndpoint):
         """
         dataset_id = request.path_params["dataset_id"]
         sample_id = request.path_params["sample_id"]
+        if_last_modified_at = get_if_last_modified_at(request)
 
         field = data.get("field")
         detection_id = data.get("detection_id")
@@ -674,8 +675,7 @@ class CommitMask(HTTPEndpoint):
                 detail="Both 'field' and 'detection_id' are required",
             )
 
-        dataset = get_dataset(dataset_id)
-        sample = dataset[sample_id]
+        sample = get_sample(dataset_id, sample_id, if_last_modified_at)
 
         try:
             label_field = sample[field]
@@ -727,7 +727,7 @@ class CommitMask(HTTPEndpoint):
             detection.export_mask(
                 mask_path, update=True, overwrite_path=True
             )
-            sample.save()
+            save_sample(sample, if_last_modified_at)
         except Exception as err:
             logger.error("Failed to commit mask to %s: %s", mask_path, err)
             raise HTTPException(

--- a/fiftyone/server/routes/sample.py
+++ b/fiftyone/server/routes/sample.py
@@ -645,10 +645,113 @@ class SampleField(HTTPEndpoint):
         )
 
 
+class CommitMask(HTTPEndpoint):
+    """Commits an in-database mask back to its on-disk mask_path."""
+
+    @decorators.route
+    async def post(self, request: Request, data: dict) -> JSONResponse:
+        """Write a Detection's in-database mask to its mask_path on disk.
+
+        After a successful write the in-database mask is cleared and mask_path
+        is preserved, matching the original storage strategy.
+
+        Args:
+            request: Starlette request with dataset_id and sample_id in path
+            data: ``{"field": "ground_truth", "detection_id": "abc123"}``
+
+        Returns:
+            ``{"committed": true, "mask_path": "..."}`` on success
+        """
+        dataset_id = request.path_params["dataset_id"]
+        sample_id = request.path_params["sample_id"]
+
+        field = data.get("field")
+        detection_id = data.get("detection_id")
+
+        if not field or not detection_id:
+            raise HTTPException(
+                status_code=400,
+                detail="Both 'field' and 'detection_id' are required",
+            )
+
+        dataset = get_dataset(dataset_id)
+        sample = dataset[sample_id]
+
+        try:
+            label_field = sample[field]
+        except KeyError:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Field '{field}' not found on sample",
+            )
+
+        if label_field is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Field '{field}' is empty on sample",
+            )
+
+        detections = getattr(label_field, "detections", None)
+        if detections is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Field '{field}' is not a Detections field",
+            )
+
+        detection = next(
+            (d for d in detections if str(d.id) == detection_id),
+            None,
+        )
+
+        if detection is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Detection '{detection_id}' not found in '{field}'",
+            )
+
+        if detection.mask_path is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Detection has no mask_path — nothing to commit",
+            )
+
+        if detection.mask is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Detection has no in-database mask to commit",
+            )
+
+        mask_path = detection.mask_path
+
+        try:
+            detection.export_mask(
+                mask_path, update=True, overwrite_path=True
+            )
+            sample.save()
+        except Exception as err:
+            logger.error("Failed to commit mask to %s: %s", mask_path, err)
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to write mask to '{mask_path}': {err}",
+            ) from err
+
+        logger.info(
+            "Committed mask for detection %s to %s",
+            detection_id,
+            mask_path,
+        )
+
+        return JSONResponse({"committed": True, "mask_path": mask_path})
+
+
 SampleRoutes = [
     ("/dataset/{dataset_id}/sample/{sample_id}", Sample),
     (
         "/dataset/{dataset_id}/sample/{sample_id}/{field_path}/{field_id}",
         SampleField,
+    ),
+    (
+        "/dataset/{dataset_id}/sample/{sample_id}/commit-mask",
+        CommitMask,
     ),
 ]

--- a/tests/unittests/label_tests.py
+++ b/tests/unittests/label_tests.py
@@ -5,6 +5,8 @@ FiftyOne Label-related unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import os
+import tempfile
 import unittest
 
 from bson import Binary, ObjectId
@@ -14,6 +16,7 @@ import numpy.testing as nptest
 import fiftyone as fo
 import fiftyone.core.labels as focl
 import fiftyone.utils.labels as foul
+from fiftyone.core.labels import _read_mask, _write_mask
 from fiftyone import ViewField as F
 
 from decorators import drop_datasets
@@ -857,6 +860,154 @@ class LabelUtilsTests(unittest.TestCase):
         )
         ids3 = dataset.values("nms3.detections.id", unwind=True)
         self.assertListEqual(ids3, [id2])
+
+
+class ExportMaskTests(unittest.TestCase):
+    """Tests for Detection.export_mask and Segmentation.export_mask."""
+
+    _MASK = np.ones((5, 5), dtype=np.uint8) * 255
+    _ZEROS = np.zeros((5, 5), dtype=np.uint8)
+
+    def _make_detection(self, mask=None, mask_path=None):
+        det = fo.Detection(
+            label="test",
+            bounding_box=[0.1, 0.1, 0.2, 0.2],
+        )
+        if mask is not None:
+            det.mask = mask
+        if mask_path is not None:
+            det.mask_path = mask_path
+        return det
+
+    def test_export_inline_mask_to_disk(self):
+        """export_mask writes in-database mask to disk when no mask_path."""
+        det = self._make_detection(mask=self._MASK.copy())
+
+        with tempfile.TemporaryDirectory() as tmp:
+            outpath = os.path.join(tmp, "mask.png")
+            det.export_mask(outpath)
+            saved = _read_mask(outpath)
+            nptest.assert_array_equal(saved, self._MASK)
+
+    def test_export_inline_mask_with_update_clears_mask(self):
+        """export_mask with update=True clears in-database mask and sets
+        mask_path."""
+        det = self._make_detection(mask=self._MASK.copy())
+
+        self.assertIsNotNone(det.mask)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            outpath = os.path.join(tmp, "mask.png")
+            det.export_mask(outpath, update=True)
+            self.assertIsNone(det.mask)
+            self.assertEqual(det.mask_path, outpath)
+
+    def test_export_copies_file_when_mask_path_set(self):
+        """export_mask copies the on-disk file when mask_path is set and
+        no in-database mask exists."""
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, "src.png")
+            dst = os.path.join(tmp, "dst.png")
+            _write_mask(self._MASK, src)
+
+            det = self._make_detection(mask_path=src)
+            det.export_mask(dst)
+
+            saved = _read_mask(dst)
+            nptest.assert_array_equal(saved, self._MASK)
+
+    _OVERWRITE_CASES = [
+        {
+            "id": "overwrite_writes_inline",
+            "overwrite_path": True,
+            "update": False,
+            "expect_mask_cleared": False,
+            "expect_new_data": True,
+        },
+        {
+            "id": "overwrite_and_update_clears_inline",
+            "overwrite_path": True,
+            "update": True,
+            "expect_mask_cleared": True,
+            "expect_new_data": True,
+        },
+        {
+            "id": "no_overwrite_copies_old_file",
+            "overwrite_path": False,
+            "update": False,
+            "expect_mask_cleared": False,
+            "expect_new_data": False,
+        },
+    ]
+
+    def test_export_overwrite_matrix(self):
+        """Behaviour when both mask and mask_path are set, varying
+        overwrite_path and update."""
+        for case in self._OVERWRITE_CASES:
+            with self.subTest(case["id"]):
+                with tempfile.TemporaryDirectory() as tmp:
+                    src = os.path.join(tmp, "original.png")
+                    dst = src if case["overwrite_path"] else os.path.join(
+                        tmp, "copy.png"
+                    )
+                    _write_mask(self._ZEROS, src)
+
+                    det = self._make_detection(
+                        mask=self._MASK.copy(), mask_path=src
+                    )
+                    self.assertIsNotNone(det.mask, case["id"])
+
+                    det.export_mask(
+                        dst,
+                        overwrite_path=case["overwrite_path"],
+                        update=case["update"],
+                    )
+
+                    saved = _read_mask(dst)
+                    if case["expect_new_data"]:
+                        self.assertTrue(saved.max() > 0, case["id"])
+                    else:
+                        self.assertEqual(saved.max(), 0, case["id"])
+
+                    if case["expect_mask_cleared"]:
+                        self.assertIsNone(det.mask, case["id"])
+                        self.assertEqual(det.mask_path, dst, case["id"])
+
+    _ERROR_CASES = [
+        {
+            "id": "no_mask_and_no_path",
+            "mask": None,
+            "mask_path": None,
+            "overwrite_path": False,
+        },
+        {
+            "id": "overwrite_but_no_inline_mask",
+            "mask": None,
+            "mask_path": "will_be_set",
+            "overwrite_path": True,
+        },
+    ]
+
+    def test_export_error_matrix(self):
+        """export_mask raises ValueError for invalid states."""
+        for case in self._ERROR_CASES:
+            with self.subTest(case["id"]):
+                with tempfile.TemporaryDirectory() as tmp:
+                    outpath = os.path.join(tmp, "mask.png")
+
+                    mp = None
+                    if case["mask_path"] is not None:
+                        mp = os.path.join(tmp, "existing.png")
+                        _write_mask(self._ZEROS, mp)
+                        outpath = mp
+
+                    det = self._make_detection(
+                        mask=case["mask"], mask_path=mp
+                    )
+                    with self.assertRaises(ValueError, msg=case["id"]):
+                        det.export_mask(
+                            outpath, overwrite_path=case["overwrite_path"]
+                        )
 
 
 if __name__ == "__main__":

--- a/tests/unittests/server/routes/test_sample.py
+++ b/tests/unittests/server/routes/test_sample.py
@@ -20,6 +20,7 @@ from starlette.responses import Response
 
 import fiftyone as fo
 import fiftyone.core.labels as fol
+from fiftyone.core.labels import _read_mask, _write_mask
 import fiftyone.server.routes.sample as fors
 from fiftyone import DynamicEmbeddedDocument
 import numpy as np
@@ -936,6 +937,211 @@ class TestArrayFieldMaskPatches:
         assert isinstance(persisted_mask, np.ndarray)
         assert persisted_mask.dtype == np.uint8
         np.testing.assert_array_equal(persisted_mask, mask)
+
+
+class TestCommitMask:
+    """Tests for the commit-mask endpoint that writes in-database masks
+    back to their on-disk mask_path."""
+
+    @pytest.fixture(name="mask_file")
+    def fixture_mask_file(self, tmp_path):
+        """Creates a temporary mask PNG file with known content."""
+        mask_path = str(tmp_path / "original_mask.png")
+        _write_mask(np.zeros((10, 10), dtype=np.uint8), mask_path)
+        return mask_path
+
+    @pytest.fixture(name="sample_with_mask_path")
+    def fixture_sample_with_mask_path(self, dataset, mask_file):
+        """Creates a sample with a Detection that has a mask_path."""
+        sample = fo.Sample(filepath="/tmp/test_commit.jpg")
+        sample["ground_truth"] = fol.Detections(
+            detections=[
+                fol.Detection(
+                    label="cat",
+                    bounding_box=[0.1, 0.1, 0.2, 0.2],
+                    mask_path=mask_file,
+                )
+            ]
+        )
+        dataset.add_sample(sample)
+        sample.save()
+        sample.reload()
+        return sample
+
+    @pytest.fixture(name="commit_endpoint")
+    def fixture_commit_endpoint(self):
+        return fors.CommitMask(
+            scope={"type": "http"}, receive=AsyncMock(), send=AsyncMock()
+        )
+
+    def _make_commit_request(
+        self, dataset_id, sample_id, field, detection_id
+    ):
+        """Build a mock POST request for the commit-mask endpoint."""
+        mock_request = MagicMock()
+        mock_request.path_params = {
+            "dataset_id": dataset_id,
+            "sample_id": str(sample_id),
+        }
+        mock_request.body = AsyncMock(
+            return_value=json_payload(
+                {"field": field, "detection_id": detection_id}
+            )
+        )
+        return mock_request
+
+    def _make_sample(self, dataset, field_name="ground_truth", **det_kwargs):
+        """Helper to create a sample with a single Detection."""
+        sample = fo.Sample(filepath="/tmp/test_commit.jpg")
+        sample[field_name] = fol.Detections(
+            detections=[
+                fol.Detection(
+                    label="test",
+                    bounding_box=[0.1, 0.1, 0.2, 0.2],
+                    **det_kwargs,
+                )
+            ]
+        )
+        dataset.add_sample(sample)
+        sample.save()
+        sample.reload()
+        return sample
+
+    @pytest.mark.asyncio
+    async def test_commit_mask_writes_to_disk_and_clears_db(
+        self, commit_endpoint, dataset_id, sample_with_mask_path, mask_file
+    ):
+        """Commit writes the in-database mask to mask_path and clears the
+        in-database mask."""
+        sample = sample_with_mask_path
+        det = sample.ground_truth.detections[0]
+        det_id = str(det.id)
+
+        # Verify original file is all zeros
+        before = _read_mask(mask_file)
+        assert before.max() == 0, "precondition: file is all zeros"
+
+        # Simulate a UI edit: set an in-DB mask
+        edited_mask = np.ones((10, 10), dtype=np.uint8)
+        det.mask = edited_mask
+        sample.save()
+
+        request = self._make_commit_request(
+            dataset_id, sample.id, "ground_truth", det_id
+        )
+        response = await commit_endpoint.post(request)
+
+        assert response.status_code == 200
+
+        # Verify DB: mask cleared, mask_path preserved
+        sample.reload()
+        det = sample.ground_truth.detections[0]
+        assert det.mask is None
+        assert det.mask_path == mask_file
+
+        # Verify disk: file was overwritten with edited mask
+        after = _read_mask(mask_file)
+        assert after.max() > 0, "file should now have content"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "field, det_id_fn, status, description",
+        [
+            # missing required params
+            (None, lambda _: "x", 400, "missing field"),
+            # nonexistent field
+            ("no_such_field", lambda _: "x", 404, "nonexistent field"),
+            # nonexistent detection
+            ("ground_truth", lambda _: str(ObjectId()), 404, "bad det id"),
+        ],
+        ids=["missing_field", "nonexistent_field", "bad_detection_id"],
+    )
+    async def test_commit_mask_error_simple(
+        self,
+        commit_endpoint,
+        dataset_id,
+        sample_with_mask_path,
+        field,
+        det_id_fn,
+        status,
+        description,
+    ):
+        """Parametrized error cases that reuse sample_with_mask_path."""
+        det_id = det_id_fn(sample_with_mask_path)
+        request = self._make_commit_request(
+            dataset_id, sample_with_mask_path.id, field, det_id
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await commit_endpoint.post(request)
+        assert exc_info.value.status_code == status, description
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "setup, status, description",
+        [
+            (
+                {"field": "ground_truth", "det_kwargs": {
+                    "mask": np.ones((5, 5), dtype=np.uint8),
+                }},
+                400,
+                "mask but no mask_path",
+            ),
+            (
+                {"field": "ground_truth", "det_kwargs": {
+                    "mask_path": "/tmp/_placeholder.png",
+                }},
+                400,
+                "mask_path but no in-database mask",
+            ),
+            (
+                {"field": "animal", "classification": True},
+                400,
+                "non-Detections field",
+            ),
+            (
+                {"field": "ground_truth", "det_kwargs": {
+                    "mask": np.ones((5, 5), dtype=np.uint8),
+                    "mask_path": "/nonexistent/dir/mask.png",
+                }},
+                500,
+                "write failure (bad path)",
+            ),
+        ],
+        ids=["no_mask_path", "no_inline_mask", "non_detections", "write_fail"],
+    )
+    async def test_commit_mask_error_custom_sample(
+        self,
+        commit_endpoint,
+        dataset,
+        dataset_id,
+        setup,
+        status,
+        description,
+    ):
+        """Parametrized error cases that need custom sample setup."""
+        if setup.get("classification"):
+            sample = fo.Sample(filepath="/tmp/test_err.jpg")
+            sample[setup["field"]] = fol.Classification(label="dog")
+            dataset.add_sample(sample)
+            sample.save()
+            sample.reload()
+            det_id = str(ObjectId())
+        else:
+            sample = self._make_sample(
+                dataset,
+                field_name=setup["field"],
+                **setup.get("det_kwargs", {}),
+            )
+            det_id = str(
+                sample[setup["field"]].detections[0].id
+            )
+
+        request = self._make_commit_request(
+            dataset_id, sample.id, setup["field"], det_id
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await commit_endpoint.post(request)
+        assert exc_info.value.status_code == status, description
 
 
 class TestSampleFieldRoute:

--- a/tests/unittests/server/routes/test_sample.py
+++ b/tests/unittests/server/routes/test_sample.py
@@ -979,6 +979,7 @@ class TestCommitMask:
     ):
         """Build a mock POST request for the commit-mask endpoint."""
         mock_request = MagicMock()
+        mock_request.headers = {}
         mock_request.path_params = {
             "dataset_id": dataset_id,
             "sample_id": str(sample_id),

--- a/tests/unittests/server/routes/test_sample.py
+++ b/tests/unittests/server/routes/test_sample.py
@@ -1099,16 +1099,8 @@ class TestCommitMask:
                 400,
                 "non-Detections field",
             ),
-            (
-                {"field": "ground_truth", "det_kwargs": {
-                    "mask": np.ones((5, 5), dtype=np.uint8),
-                    "mask_path": "/nonexistent/dir/mask.png",
-                }},
-                500,
-                "write failure (bad path)",
-            ),
         ],
-        ids=["no_mask_path", "no_inline_mask", "non_detections", "write_fail"],
+        ids=["no_mask_path", "no_inline_mask", "non_detections"],
     )
     async def test_commit_mask_error_custom_sample(
         self,
@@ -1120,6 +1112,8 @@ class TestCommitMask:
         description,
     ):
         """Parametrized error cases that need custom sample setup."""
+        det_kwargs = setup.get("det_kwargs", {})
+
         if setup.get("classification"):
             sample = fo.Sample(filepath="/tmp/test_err.jpg")
             sample[setup["field"]] = fol.Classification(label="dog")
@@ -1131,7 +1125,7 @@ class TestCommitMask:
             sample = self._make_sample(
                 dataset,
                 field_name=setup["field"],
-                **setup.get("det_kwargs", {}),
+                **det_kwargs,
             )
             det_id = str(
                 sample[setup["field"]].detections[0].id
@@ -1143,6 +1137,29 @@ class TestCommitMask:
         with pytest.raises(HTTPException) as exc_info:
             await commit_endpoint.post(request)
         assert exc_info.value.status_code == status, description
+
+    @pytest.mark.asyncio
+    async def test_commit_mask_write_failure(
+        self, commit_endpoint, dataset, dataset_id
+    ):
+        """export_mask raising an error returns 500."""
+        sample = self._make_sample(
+            dataset,
+            mask=np.ones((5, 5), dtype=np.uint8),
+            mask_path="/tmp/_write_fail.png",
+        )
+        det_id = str(sample.ground_truth.detections[0].id)
+        request = self._make_commit_request(
+            dataset_id, sample.id, "ground_truth", det_id
+        )
+
+        with patch(
+            "fiftyone.core.labels.Detection.export_mask",
+            side_effect=OSError("disk full"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await commit_endpoint.post(request)
+            assert exc_info.value.status_code == 500
 
 
 class TestSampleFieldRoute:

--- a/tests/unittests/server/routes/test_sample.py
+++ b/tests/unittests/server/routes/test_sample.py
@@ -1033,6 +1033,9 @@ class TestCommitMask:
         response = await commit_endpoint.post(request)
 
         assert response.status_code == 200
+        body = json.loads(response.body)
+        assert body["committed"] is True
+        assert body["mask_path"] == mask_file
 
         # Verify DB: mask cleared, mask_path preserved
         sample.reload()
@@ -1050,12 +1053,18 @@ class TestCommitMask:
         [
             # missing required params
             (None, lambda _: "x", 400, "missing field"),
+            ("ground_truth", lambda _: None, 400, "missing detection_id"),
             # nonexistent field
             ("no_such_field", lambda _: "x", 404, "nonexistent field"),
             # nonexistent detection
             ("ground_truth", lambda _: str(ObjectId()), 404, "bad det id"),
         ],
-        ids=["missing_field", "nonexistent_field", "bad_detection_id"],
+        ids=[
+            "missing_field",
+            "missing_detection_id",
+            "nonexistent_field",
+            "bad_detection_id",
+        ],
     )
     async def test_commit_mask_error_simple(
         self,


### PR DESCRIPTION


## 🔗 Related Issues

Fixes part of FOEPD-3463


## 📋 What changes are proposed in this pull request?

Add commit-mask endpoint to write in-DB masks back to disk. When a user edits a segmentation mask in the app and saves, the edited mask (stored in the database) is now exported back to the original mask_path on disk via Detection.export_mask(overwrite_path=True). Includes unit  tests for both the endpoint and export_mask. 

```
POST /dataset/{dataset_id}/sample/{sample_id}/commit-mask

Body: { "field": "ground_truth", "detection_id": "<det_id>" }
```                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           

Writes the in-database mask for the given detection back to its mask_path on disk, then clears the in-DB copy. Returns `{ "committed": true, "mask_path": "..." }`.

Requires: the detection must have both a `mask` (in-DB) and a `mask_path` set.                              

## 🧪 How is this patch tested? If it is not, please explain why.

- Unit tests (added)
- In-app testing (partial as the dependencies are not fully complete yet)

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an overwrite option for mask export so users can choose between exporting the in-memory mask or preserving the existing on-disk mask.
  * Added a POST endpoint to commit a detection's in-memory mask back to its on-disk path.

* **Bug Fixes**
  * Export now validates mask availability and raises clear errors when neither in-memory nor on-disk mask is present.

* **Tests**
  * Added unit and endpoint tests covering export behaviors, overwrite semantics, commit flows, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->