### PR TITLE
Replace deprecated datetime.utcnow usage

### DIFF
--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -6,7 +6,7 @@ Package-wide constants.
 |
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 import os
 
 from packaging.version import Version
@@ -15,6 +15,7 @@ from importlib.metadata import metadata
 
 
 CLIENT_TYPE = "fiftyone"
+UTC = timezone.utc
 
 FIFTYONE_DIR = os.path.dirname(os.path.abspath(__file__))
 FIFTYONE_CONFIG_DIR = os.path.join(os.path.expanduser("~"), ".fiftyone")

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -19,6 +19,7 @@ from mongoengine.base import get_document
 
 import eta.core.utils as etau
 
+from fiftyone.constants import UTC
 import fiftyone.core.expressions as foe
 from fiftyone.core.expressions import VALUE
 from fiftyone.core.expressions import ViewExpression as E
@@ -2279,7 +2280,7 @@ class ListSchema(Aggregation):
                     fo.DynamicEmbeddedDocument(
                         task="editing_pass",
                         author="Bob",
-                        timestamp=datetime.utcnow(),
+                        timestamp=datetime.now(UTC),
                     ),
                 ],
             ),

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -29,6 +29,7 @@ from pymongo import InsertOne, UpdateMany, UpdateOne, WriteConcern
 import eta.core.serial as etas
 import eta.core.utils as etau
 
+from fiftyone.constants import UTC
 import fiftyone.core.aggregations as foa
 import fiftyone.core.annotation as foan
 import fiftyone.core.brain as fob
@@ -2093,7 +2094,7 @@ class SampleCollection(object):
         if self._is_read_only_field("tags"):
             raise ValueError("Cannot edit read-only field 'tags'")
 
-        update["$set"] = {"last_modified_at": datetime.utcnow()}
+        update["$set"] = {"last_modified_at": datetime.now(UTC)}
 
         ids = []
         ops = []
@@ -2223,7 +2224,7 @@ class SampleCollection(object):
         if self._is_read_only_field(tags_path):
             raise ValueError("Cannot edit read-only field '%s'" % tags_path)
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         root, is_list_field = self._get_label_field_root(label_field)
         _root, is_frame_field = self._handle_frame_field(root)
@@ -3383,7 +3384,7 @@ class SampleCollection(object):
         if self._is_read_only_field(field_name):
             raise ValueError("Cannot edit read-only field '%s'" % field_name)
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         ops = []
         for _id, value in zip(ids, values):
@@ -3426,7 +3427,7 @@ class SampleCollection(object):
         if self._is_read_only_field(field_name):
             raise ValueError("Cannot edit read-only field '%s'" % field_name)
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         root = list_field
         leaf = field_name[len(root) + 1 :]
@@ -3489,7 +3490,7 @@ class SampleCollection(object):
         if self._is_read_only_field(field_name):
             raise ValueError("Cannot edit read-only field '%s'" % field_name)
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         root = list_field
         leaf = field_name[len(root) + 1 :]
@@ -3530,7 +3531,7 @@ class SampleCollection(object):
                 "(found: '%s')" % field_name
             )
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         root, is_list_field = self._get_label_field_root(field_name)
         field_name, is_frame_field = self._handle_frame_field(field_name)
@@ -9574,7 +9575,7 @@ class SampleCollection(object):
                         fo.DynamicEmbeddedDocument(
                             task="editing_pass",
                             author="Bob",
-                            timestamp=datetime.utcnow(),
+                            timestamp=datetime.now(UTC),
                         ),
                     ],
                 ),
@@ -12988,7 +12989,7 @@ def _parse_values_dict(sample_collection, key_field, values):
 
 
 def _parse_frame_values_dicts(sample_collection, sample_ids, values):
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
 
     value = _get_non_none_value(values)
     if not isinstance(value, dict):

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -29,6 +29,7 @@ from pymongo.errors import BulkWriteError, CursorNotFound
 
 import fiftyone as fo
 import fiftyone.constants as focn
+from fiftyone.constants import UTC
 import fiftyone.core.camera as focam
 import fiftyone.core.annotation as foa
 import fiftyone.core.collections as foc
@@ -500,7 +501,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 embedded_doc_type=doc_type,
             )
             field_doc = foo.SampleFieldDocument.from_field(field)
-            field_doc._set_created_at(datetime.utcnow())
+            field_doc._set_created_at(datetime.now(UTC))
 
             self._doc.sample_fields[idx] = field_doc
 
@@ -2991,7 +2992,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             raise ValueError(f"Field {field_name} is not a summary field")
 
         summary_info = field.info[_SUMMARY_FIELD_KEY]
-        summary_info["last_modified_at"] = datetime.utcnow()
+        summary_info["last_modified_at"] = datetime.now(UTC)
         field.save(_enforce_read_only=False)
 
         self._populate_summary_field(field_name, summary_info)
@@ -4355,7 +4356,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if validate:
             self._validate_sample(sample)
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         return (
             sample,
@@ -4954,7 +4955,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             if self._is_read_only_field(field):
                 raise ValueError("Cannot edit read-only field '%s'" % field)
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         batch_size = fou.recommend_batch_size_for_value(
             ObjectId(), max_size=100000
@@ -5076,7 +5077,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             if self._is_read_only_field(field):
                 raise ValueError("Cannot edit read-only field '%s'" % field)
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         sample_ops = []
         frame_ops = []
@@ -5340,7 +5341,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         slug = self._validate_saved_view_name(name, overwrite=overwrite)
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         view_doc = foo.SavedViewDocument(
             dataset_id=self._doc.id,
@@ -5492,7 +5493,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         # When reloading generated views, increment `last_modified_at` so we
         # can compute when the view next needs refreshing
         if reload and view._is_generated:
-            view_doc.last_modified_at = datetime.utcnow()
+            view_doc.last_modified_at = datetime.now(UTC)
             updated = True
 
         if updated:
@@ -5686,7 +5687,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         """
         slug = self._validate_workspace_name(name, overwrite=overwrite)
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         workspace_doc = foo.WorkspaceDocument(
             child=workspace,
@@ -5974,7 +5975,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         self._clear()
 
     def _clear(self, view=None, sample_ids=None):
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         if view is not None:
             contains_videos = view._contains_videos(any_slice=True)
@@ -6076,7 +6077,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if not sample_collection._contains_videos(any_slice=True):
             return
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         if self._is_clips:
             if sample_ids is not None:
@@ -6174,7 +6175,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if view is None:
             return
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         if view.media_type == fom.GROUP:
             view = view.select_group_slices(media_type=fom.VIDEO)
@@ -6257,7 +6258,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 media_type=fom.VIDEO
             )
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         sample_collection.compute_metadata()
         sample_collection._aggregate(
@@ -9375,7 +9376,7 @@ def _create_dataset(
     slug = _validate_dataset_name(name)
 
     _id = ObjectId()
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
 
     sample_collection_name = _make_sample_collection_name(
         _id, patches=_patches, frames=_frames, clips=_clips
@@ -9838,7 +9839,7 @@ def _declare_fields(dataset, doc_cls, field_docs=None):
         default_fields -= {field_doc.name for field_doc in field_docs}
 
     # Declare default fields that don't already exist
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
     for field_name in default_fields:
         field = doc_cls._fields[field_name]
 
@@ -10034,7 +10035,7 @@ def _clone_collection(
     dataset_doc = dataset._doc.copy(new_id=True)
 
     _id = dataset_doc.id
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
 
     sample_collection_name = _make_sample_collection_name(_id)
 
@@ -10235,7 +10236,7 @@ def _save_view(view, fields=None):
     # Must retrieve IDs now in case view changes after saving
     sample_ids = view.values("id")
 
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
 
     #
     # Save samples
@@ -10633,7 +10634,7 @@ def _add_collection_with_new_ids(
     else:
         num_ids = len(src_samples)
 
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
 
     add_fields = {
         "_dataset_id": dataset._doc.id,
@@ -10990,7 +10991,7 @@ def _merge_samples_pipeline(
     else:
         when_not_matched = "discard"
 
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
 
     sample_pipeline.extend(
         [

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -1767,13 +1767,12 @@ class ViewExpression(object):
 
         Examples::
 
-            from datetime import datetime
-            import pytz
+            from datetime import datetime, timezone
 
             import fiftyone as fo
             from fiftyone import ViewField as F
 
-            now = datetime.utcnow().replace(tzinfo=pytz.utc)
+            now = datetime.now(timezone.utc)
 
             sample = fo.Sample(
                 filepath="image.png",

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -12,6 +12,7 @@ import itertools
 from bson import ObjectId
 from pymongo import ReplaceOne, UpdateOne, DeleteOne, DeleteMany
 
+from fiftyone.constants import UTC
 from fiftyone.core.document import Document, DocumentView
 import fiftyone.core.frame_utils as fofu
 import fiftyone.core.odm as foo
@@ -697,7 +698,7 @@ class Frames(object):
         }
 
     def _save_deletions(self, deferred=False):
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         sample_ops = []
         frame_ops = []
@@ -793,7 +794,7 @@ class Frames(object):
         if validate:
             schema = self._dataset.get_frame_field_schema(include_private=True)
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         ops = []
         new_dicts = {}

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -17,6 +17,7 @@ from pymongo import InsertOne, UpdateOne
 
 import eta.core.serial as etas
 
+from fiftyone.constants import UTC
 import fiftyone.core.fields as fof
 import fiftyone.core.utils as fou
 
@@ -781,7 +782,7 @@ class Document(BaseDocument, mongoengine.Document):
         **kwargs,
     ):
         if self.has_field("last_modified_at") and not virtual:
-            now = datetime.utcnow()
+            now = datetime.now(UTC)
             self.last_modified_at = now
             if "$set" not in updates:
                 updates["$set"] = {}
@@ -797,19 +798,19 @@ class Document(BaseDocument, mongoengine.Document):
         return ops, updated_existing
 
     def _update_last_loaded_at(self):
-        self.last_loaded_at = datetime.utcnow()
+        self.last_loaded_at = datetime.now(UTC)
         self.save(virtual=True)
 
     def _update_last_modified_at(self, last_modified_at=None):
         if last_modified_at is None:
-            last_modified_at = datetime.utcnow()
+            last_modified_at = datetime.now(UTC)
 
         self.last_modified_at = last_modified_at
         self.save(virtual=True)
 
     def _update_last_deletion_at(self, last_deletion_at=None):
         if last_deletion_at is None:
-            last_deletion_at = datetime.utcnow()
+            last_deletion_at = datetime.now(UTC)
 
         self.last_deletion_at = last_deletion_at
         self.save(virtual=True)

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -14,6 +14,7 @@ from bson import ObjectId
 import mongoengine
 from pymongo import UpdateOne
 
+from fiftyone.constants import UTC
 import fiftyone.core.annotation.constants as foac
 import fiftyone.core.fields as fof
 import fiftyone.core.media as fom
@@ -311,7 +312,7 @@ class DatasetMixin(object):
         dataset_doc = dataset._doc
         media_type = dataset.media_type
         is_frame_field = cls._is_frames_doc
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         new_schema = {}
         new_metadata = {}
@@ -667,7 +668,7 @@ class DatasetMixin(object):
         media_type = dataset.media_type
         is_frame_field = cls._is_frames_doc
         is_dataset = isinstance(sample_collection, fod.Dataset)
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         simple_paths = []
         coll_paths = []
@@ -983,7 +984,7 @@ class DatasetMixin(object):
         _paths, _new_paths = cls._handle_db_fields(paths, new_paths)
 
         rename_expr = dict(zip(_paths, _new_paths))
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         coll = get_db_conn()[cls.__name__]
         coll.update_many(
@@ -1039,7 +1040,7 @@ class DatasetMixin(object):
         _paths, _new_paths = cls._handle_db_fields(paths, new_paths)
 
         set_expr = {v: "$" + k for k, v in zip(_paths, _new_paths)}
-        set_expr["last_modified_at"] = datetime.utcnow()
+        set_expr["last_modified_at"] = datetime.now(UTC)
 
         coll = get_db_conn()[cls.__name__]
         coll.update_many({}, [{"$set": set_expr}])
@@ -1091,7 +1092,7 @@ class DatasetMixin(object):
         _paths = cls._handle_db_fields(paths)
 
         set_expr = {p: None for p in _paths}
-        set_expr["last_modified_at"] = datetime.utcnow()
+        set_expr["last_modified_at"] = datetime.now(UTC)
 
         coll = get_db_conn()[cls.__name__]
         coll.update_many({}, {"$set": set_expr})
@@ -1126,7 +1127,7 @@ class DatasetMixin(object):
             return
 
         _paths = cls._handle_db_fields(paths)
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         coll = get_db_conn()[cls.__name__]
         coll.update_many(
@@ -1298,7 +1299,7 @@ class DatasetMixin(object):
     @classmethod
     def _add_field_schema(cls, path, field, created_at=None):
         if created_at is None:
-            created_at = datetime.utcnow()
+            created_at = datetime.now(UTC)
 
         field_name, doc, field_docs, root_doc = cls._parse_path(path)
 
@@ -1555,7 +1556,7 @@ class DatasetMixin(object):
         delattr(cls, field_name)
 
     def _insert(self, doc, deferred=False):
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         self.created_at = now
         self.last_modified_at = now
         doc["created_at"] = now
@@ -1573,7 +1574,7 @@ class DatasetMixin(object):
         **kwargs,
     ):
         if not virtual:
-            now = datetime.utcnow()
+            now = datetime.now(UTC)
             self.last_modified_at = now
             if "$set" not in updates:
                 updates["$set"] = {}

--- a/fiftyone/core/plots/manager.py
+++ b/fiftyone/core/plots/manager.py
@@ -13,6 +13,7 @@ from bson import ObjectId
 
 import eta.core.utils as etau
 
+from fiftyone.constants import UTC
 import fiftyone.core.clips as foc
 from fiftyone.core.expressions import ViewField as F
 import fiftyone.core.patches as fop
@@ -734,7 +735,7 @@ class PlotManager(object):
         ]
 
     def _ready_for_update(self, name):
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(UTC)
 
         if self._last_update is None:
             is_new_update = True
@@ -749,7 +750,7 @@ class PlotManager(object):
         return is_new_update
 
     def _needs_update(self, name):
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(UTC)
 
         last_update = self._last_updates.get(name, None)
 

--- a/fiftyone/core/runs.py
+++ b/fiftyone/core/runs.py
@@ -15,6 +15,7 @@ import eta.core.serial as etas
 import eta.core.utils as etau
 
 import fiftyone.constants as foc
+from fiftyone.constants import UTC
 from fiftyone.core.config import Config, Configurable
 from fiftyone.core.odm import patch_runs
 from fiftyone.core.odm.runs import RunDocument
@@ -313,7 +314,7 @@ class BaseRun(Configurable):
 
         self.validate_run(samples, key, overwrite=overwrite)
         version = foc.VERSION
-        timestamp = datetime.datetime.utcnow()
+        timestamp = datetime.datetime.now(UTC)
         run_info_cls = self.run_info_cls()
         run_info = run_info_cls(
             key, version=version, timestamp=timestamp, config=self.config

--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -15,6 +15,7 @@ import pymongo
 from pymongo import IndexModel
 from pymongo.collection import Collection
 
+from fiftyone.constants import UTC
 from fiftyone.factory import DelegatedOperationPagingParams
 from fiftyone.factory.repos import DelegatedOperationDocument
 from fiftyone.internal.util import is_remote_service
@@ -363,8 +364,8 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             update = {
                 "$set": {
                     "run_state": run_state,
-                    "completed_at": datetime.utcnow(),
-                    "updated_at": datetime.utcnow(),
+                    "completed_at": datetime.now(UTC),
+                    "updated_at": datetime.now(UTC),
                     "result": execution_result_json,
                 }
             }
@@ -378,8 +379,8 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             update = {
                 "$set": {
                     "run_state": run_state,
-                    "failed_at": datetime.utcnow(),
-                    "updated_at": datetime.utcnow(),
+                    "failed_at": datetime.now(UTC),
+                    "updated_at": datetime.now(UTC),
                     "result": execution_result_json,
                 }
             }
@@ -388,8 +389,8 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             update = {
                 "$set": {
                     "run_state": run_state,
-                    "started_at": datetime.utcnow(),
-                    "updated_at": datetime.utcnow(),
+                    "started_at": datetime.now(UTC),
+                    "updated_at": datetime.now(UTC),
                     "monitored": monitored,
                 }
             }
@@ -397,8 +398,8 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             update = {
                 "$set": {
                     "run_state": run_state,
-                    "scheduled_at": datetime.utcnow(),
-                    "updated_at": datetime.utcnow(),
+                    "scheduled_at": datetime.now(UTC),
+                    "updated_at": datetime.now(UTC),
                 }
             }
         elif run_state == ExecutionRunState.QUEUED:
@@ -409,8 +410,8 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             update = {
                 "$set": {
                     "run_state": run_state,
-                    "queued_at": datetime.utcnow(),
-                    "updated_at": datetime.utcnow(),
+                    "queued_at": datetime.now(UTC),
+                    "updated_at": datetime.now(UTC),
                 }
             }
 
@@ -425,7 +426,7 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
 
         if progress is not None:
             update["$set"]["status"] = progress
-            update["$set"]["status"]["updated_at"] = datetime.utcnow()
+            update["$set"]["status"]["updated_at"] = datetime.now(UTC)
 
         collection_filter = {"_id": _id}
         if required_state is not None:
@@ -466,7 +467,7 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
                 "status": {
                     "progress": execution_progress.progress,
                     "label": execution_progress.label,
-                    "updated_at": datetime.utcnow(),
+                    "updated_at": datetime.now(UTC),
                 },
             }
         }
@@ -614,7 +615,7 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
         return self._collection.count_documents(filter=query)
 
     def ping(self, _id: ObjectId, log_tail: str = None):
-        updates = {"updated_at": datetime.utcnow()}
+        updates = {"updated_at": datetime.now(UTC)}
         if log_tail and isinstance(log_tail, str):
             updates["log_tail"] = log_tail
         self._collection.update_one(

--- a/fiftyone/factory/repos/delegated_operation_doc.py
+++ b/fiftyone/factory/repos/delegated_operation_doc.py
@@ -9,6 +9,7 @@ import copy
 from datetime import datetime
 import logging
 
+from fiftyone.constants import UTC
 from fiftyone.operators.executor import (
     ExecutionContext,
     ExecutionProgress,
@@ -45,15 +46,15 @@ class DelegatedOperationDocument(object):
             else ExecutionRunState.QUEUED
         )  # if running locally use QUEUED otherwise SCHEDULED
         self.run_link = None
-        self.queued_at = datetime.utcnow() if not is_remote else None
-        self.updated_at = datetime.utcnow()
+        self.queued_at = datetime.now(UTC) if not is_remote else None
+        self.updated_at = datetime.now(UTC)
         self.status = None
         self.dataset_id = None
         self.started_at = None
         self.pinned = False
         self.completed_at = None
         self.failed_at = None
-        self.scheduled_at = datetime.utcnow() if is_remote else None
+        self.scheduled_at = datetime.now(UTC) if is_remote else None
         self.result = None
         self.id = None
         self._doc = None

--- a/fiftyone/factory/repos/execution_store.py
+++ b/fiftyone/factory/repos/execution_store.py
@@ -13,6 +13,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from bson import ObjectId
 
+from fiftyone.constants import UTC
 from fiftyone.operators.store.models import (
     KeyDocument,
     StoreDocument,
@@ -507,7 +508,7 @@ class MongoExecutionStoreRepo(ExecutionStoreRepo):
         ttl: Optional[int] = None,
         policy: str = "persist",
     ) -> KeyDocument:
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         expiration = KeyDocument.get_expiration(ttl)
         policy = "evict" if ttl is not None or policy == "evict" else "persist"
         if ttl is not None or policy == "evict":
@@ -772,7 +773,7 @@ class InMemoryExecutionStoreRepo(ExecutionStoreRepo):
         ttl: Optional[int] = None,
         policy: str = "persist",
     ) -> KeyDocument:
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         expiration = KeyDocument.get_expiration(ttl)
         key_doc = KeyDocument.from_dict(
             dict(

--- a/fiftyone/migrations/revisions/v1_0_0.py
+++ b/fiftyone/migrations/revisions/v1_0_0.py
@@ -7,12 +7,14 @@ FiftyOne v1.0.0 revision.
 """
 from datetime import datetime
 
+from fiftyone.constants import UTC
+
 
 def up(db, dataset_name):
     match_d = {"name": dataset_name}
     dataset_dict = db.datasets.find_one(match_d)
 
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
 
     # Populate `Dataset.last_modified_at`
     if dataset_dict.get("last_modified_at", None) is None:

--- a/fiftyone/operators/store/models.py
+++ b/fiftyone/operators/store/models.py
@@ -13,6 +13,8 @@ from enum import Enum
 
 from bson import ObjectId
 
+from fiftyone.constants import UTC
+
 
 class KeyPolicy(str, Enum):
     """
@@ -37,7 +39,7 @@ class KeyDocument:
     value: Any
     _id: Optional[Any] = None
     dataset_id: Optional[ObjectId] = None
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     updated_at: Optional[datetime] = None
     expires_at: Optional[datetime] = None
     policy: KeyPolicy = KeyPolicy.PERSIST
@@ -48,7 +50,7 @@ class KeyDocument:
         if ttl is None:
             return None
 
-        return datetime.utcnow() + timedelta(seconds=ttl)
+        return datetime.now(UTC) + timedelta(seconds=ttl)
 
     @classmethod
     def from_dict(cls, doc: dict[str, Any]) -> "KeyDocument":

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -22,6 +22,7 @@ import eta.core.serial as etas
 import eta.core.utils as etau
 import eta.core.video as etav
 
+from fiftyone.constants import UTC
 import fiftyone.core.annotation as foa
 import fiftyone.core.brain as fob
 import fiftyone.core.dataset as fod
@@ -1878,7 +1879,7 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
     def _import_samples(self, dataset, dataset_dict, tags=None, progress=None):
         name = dataset.name
         empty_import = not bool(dataset)
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         #
         # Import DatasetDocument

--- a/tests/unittests/aggregation_tests.py
+++ b/tests/unittests/aggregation_tests.py
@@ -13,6 +13,7 @@ import numpy as np
 import unittest
 
 import fiftyone as fo
+from fiftyone.constants import UTC
 import fiftyone.core.fields as fof
 from fiftyone import ViewField as F
 
@@ -437,7 +438,7 @@ class DatasetTests(unittest.TestCase):
                             fo.DynamicEmbeddedDocument(
                                 task="editing_pass",
                                 author="Bob",
-                                timestamp=datetime.utcnow(),
+                                timestamp=datetime.now(UTC),
                             ),
                         ],
                     ),
@@ -1127,7 +1128,7 @@ class DatasetTests(unittest.TestCase):
     @drop_datasets
     def test_dates(self):
         today = date.today()
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         samples = []
         for idx in range(100):

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -26,6 +26,7 @@ from freezegun import freeze_time
 from mongoengine import ValidationError
 
 import fiftyone as fo
+from fiftyone.constants import UTC
 import fiftyone.core.fields as fof
 import fiftyone.core.odm as foo
 import fiftyone.core.utils as fou
@@ -3475,13 +3476,13 @@ class DatasetTests(unittest.TestCase):
             float_field=1.0,
             str_field="hi",
             date_field=date.today(),
-            datetime_field=datetime.utcnow(),
+            datetime_field=datetime.now(UTC),
             list_bool_field=[False, True],
             list_int_field=[1, 2, 3],
             list_float_field=[1.0, 2, 4.1],
             list_str_field=["one", "two", "three"],
             list_date_field=[date.today(), date.today()],
-            list_datetime_field=[datetime.utcnow(), datetime.utcnow()],
+            list_datetime_field=[datetime.now(UTC), datetime.now(UTC)],
             list_untyped_field=[1, {"two": "three"}, [4], "five"],
             dict_field={"hello": "world"},
             vector_field=np.arange(5),
@@ -3663,10 +3664,10 @@ class DatasetTests(unittest.TestCase):
         self.assertTrue(field.read_only)
 
         with self.assertRaises(ValueError):
-            sample.created_at = datetime.utcnow()
+            sample.created_at = datetime.now(UTC)
 
         with self.assertRaises(ValueError):
-            sample.last_modified_at = datetime.utcnow()
+            sample.last_modified_at = datetime.now(UTC)
 
         # Custom fields
 
@@ -3823,10 +3824,10 @@ class DatasetTests(unittest.TestCase):
         self.assertTrue(field.read_only)
 
         with self.assertRaises(ValueError):
-            frame.created_at = datetime.utcnow()
+            frame.created_at = datetime.now(UTC)
 
         with self.assertRaises(ValueError):
-            frame.last_modified_at = datetime.utcnow()
+            frame.last_modified_at = datetime.now(UTC)
 
         # Custom fields
 
@@ -5215,7 +5216,7 @@ class DatasetExtrasTests(unittest.TestCase):
         self.assertIsNone(spaces.name)
 
         workspace_name = "test__workspace"
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         description = "a description of the workspace, yo"
         color = "#FF6D04"
 
@@ -5247,7 +5248,7 @@ class DatasetExtrasTests(unittest.TestCase):
         dataset.reload()
         also_spaces = dataset.load_workspace(workspace_name)
         last_loaded_at2 = dataset._doc.workspaces[0].last_loaded_at
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         self.assertEqual(spaces, also_spaces)
         self.assertEqual(also_spaces.name, workspace_name)
@@ -7492,7 +7493,7 @@ class DynamicFieldTests(unittest.TestCase):
                             fo.DynamicEmbeddedDocument(
                                 task="editing_pass",
                                 author="Bob",
-                                timestamp=datetime.utcnow(),
+                                timestamp=datetime.now(UTC),
                             ),
                         ],
                     ),
@@ -8273,7 +8274,7 @@ class _CameraInfo(fo.EmbeddedDocument):
 
 
 class _LabelMetadata(fo.DynamicEmbeddedDocument):
-    created_at = fof.DateTimeField(default=datetime.utcnow)
+    created_at = fof.DateTimeField(default=lambda: datetime.now(UTC))
 
     model_name = fof.StringField()
 

--- a/tests/unittests/execution_store_unit_tests.py
+++ b/tests/unittests/execution_store_unit_tests.py
@@ -13,6 +13,7 @@ from unittest.mock import patch, MagicMock, ANY, Mock
 
 from bson import ObjectId
 
+from fiftyone.constants import UTC
 from fiftyone.operators.store import ExecutionStoreService
 from fiftyone.operators.store.models import KeyDocument
 from fiftyone.factory.repo_factory import MongoExecutionStoreRepo
@@ -34,7 +35,7 @@ def assert_delta_seconds_approx(time_delta, seconds, epsilon=EPSILON):
 class TestKeyDocument(unittest.TestCase):
     def test_get_expiration(self):
         ttl = 1
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         expiration = KeyDocument.get_expiration(ttl)
         time_delta = expiration - now
         assert_delta_seconds_approx(time_delta, ttl)

--- a/tests/unittests/patches_tests.py
+++ b/tests/unittests/patches_tests.py
@@ -13,6 +13,7 @@ import unittest
 from unittest import mock
 
 import fiftyone as fo
+from fiftyone.constants import UTC
 import fiftyone.core.patches as fop
 from fiftyone import ViewField as F
 
@@ -830,10 +831,10 @@ class PatchesTests(unittest.TestCase):
         patch = patches.first()
 
         with self.assertRaises(ValueError):
-            patch.created_at = datetime.utcnow()
+            patch.created_at = datetime.now(UTC)
 
         with self.assertRaises(ValueError):
-            patch.last_modified_at = datetime.utcnow()
+            patch.last_modified_at = datetime.now(UTC)
 
         patch.reload()
 

--- a/tests/unittests/video_tests.py
+++ b/tests/unittests/video_tests.py
@@ -15,6 +15,7 @@ import unittest
 from unittest import mock
 
 import fiftyone as fo
+from fiftyone.constants import UTC
 import fiftyone.core.clips as foc
 import fiftyone.core.odm as foo
 import fiftyone.core.video as fov
@@ -402,7 +403,7 @@ class VideoTests(unittest.TestCase):
             str_field="hi",
             float_field=1.0,
             date_field=date.today(),
-            datetime_field=datetime.utcnow(),
+            datetime_field=datetime.now(UTC),
             list_field=[1, 2, 3],
             dict_field={"hello": "world"},
             vector_field=np.arange(5),
@@ -2249,10 +2250,10 @@ class VideoTests(unittest.TestCase):
         clip = clips.first()
 
         with self.assertRaises(ValueError):
-            clip.created_at = datetime.utcnow()
+            clip.created_at = datetime.now(UTC)
 
         with self.assertRaises(ValueError):
-            clip.last_modified_at = datetime.utcnow()
+            clip.last_modified_at = datetime.now(UTC)
 
         with self.assertRaises(ValueError):
             clip.frames[2].hello = "no"
@@ -3172,10 +3173,10 @@ class VideoTests(unittest.TestCase):
         frame = frames.first()
 
         with self.assertRaises(ValueError):
-            frame.created_at = datetime.utcnow()
+            frame.created_at = datetime.now(UTC)
 
         with self.assertRaises(ValueError):
-            frame.last_modified_at = datetime.utcnow()
+            frame.last_modified_at = datetime.now(UTC)
 
         with self.assertRaises(ValueError):
             frame.filepath = "no.jpg"


### PR DESCRIPTION
## Summary
- add a package-level UTC timezone constant
- replace deprecated datetime.utcnow() calls with datetime.now(UTC)
- update affected unit test fixtures and the to_date doc example

Fixes #7402

## Testing
- python3 -m compileall -q $(git diff --name-only -- '*.py')

Note: pytest was not run locally because this fresh environment does not have the project test dependencies installed (pytest/packaging are missing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal timestamp handling across the codebase to use timezone-aware UTC timestamps consistently throughout dataset operations, aggregations, frame management, runs, operations, and utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->