### PR TITLE
add schema_version field to OntologyDocument

### DIFF
--- a/fiftyone/core/odm/ontology.py
+++ b/fiftyone/core/odm/ontology.py
@@ -41,6 +41,13 @@ class OntologyType(str, Enum):  # TODO - update to StrEnum
 _ONTOLOGY_TYPE_VALUES = tuple(t.value for t in OntologyType)
 
 
+# Internal layout version of an ``OntologyDocument`` row. Bump this paired
+# with a forward migration whenever the persisted structure (in particular
+# ``root``) changes shape. ``version`` (user-facing content history) is
+# orthogonal to this.
+CURRENT_SCHEMA_VERSION = 1
+
+
 class OntologyDocument(Document):
     """Backing document for ontologies.
 
@@ -48,6 +55,10 @@ class OntologyDocument(Document):
     Multiple datasets can reference the same ontology by name. Each
     save creates a new versioned document; ``(slug, version)`` is unique,
     so names differing only in case or punctuation collide on save.
+
+    ``schema_version`` records the internal layout version of the row at
+    write time. Bump :data:`CURRENT_SCHEMA_VERSION` and add a migration when
+    changing the persisted structure (especially ``root``).
     """
 
     meta = {
@@ -66,6 +77,7 @@ class OntologyDocument(Document):
     name = StringField(required=True)
     slug = StringField(required=True)
     version = IntField(required=True, default=1)
+    schema_version = IntField(required=True, default=1)
     type = StringField(required=True, choices=_ONTOLOGY_TYPE_VALUES)
     description = StringField(default=None)
     root = DictField()
@@ -94,6 +106,7 @@ class OntologyDocument(Document):
             self.created_at = now
 
         self.last_modified_at = now
+        self.schema_version = CURRENT_SCHEMA_VERSION
 
         return super().save(*args, **kwargs)
 
@@ -132,6 +145,7 @@ class OntologyDocument(Document):
 
         new_doc = self.copy_with_new_id()
         new_doc.version = next_version
+        new_doc.schema_version = CURRENT_SCHEMA_VERSION
         new_doc.created_at = now
         new_doc.last_modified_at = now
         return super(OntologyDocument, new_doc).save(*args, **kwargs)

--- a/tests/unittests/ontology_tests.py
+++ b/tests/unittests/ontology_tests.py
@@ -15,6 +15,7 @@ from mongoengine.errors import ValidationError
 from pymongo.errors import DuplicateKeyError
 
 import fiftyone.core.odm as foo
+from fiftyone.core.odm import ontology as foo_ontology
 from fiftyone.core.odm.ontology import OntologyDocument, OntologyType
 
 
@@ -412,6 +413,37 @@ class OntologyDocumentTests(unittest.TestCase):
         self.assertIs(doc.save(), doc)
         self.assertEqual(doc.version, 2)
         self.assertEqual(doc.description, "v2")
+
+    def test_schema_version_stamped_on_new_save(self):
+        doc = OntologyDocument(
+            name="schema_version_test",
+            version=1,
+            type="taxonomy",
+            root={"name": "root"},
+        )
+        doc.save()
+        self.assertEqual(
+            doc.schema_version, foo_ontology.CURRENT_SCHEMA_VERSION
+        )
+
+    def test_schema_version_overwritten_on_versioned_save(self):
+        doc = OntologyDocument(
+            name="schema_version_test",
+            version=1,
+            type="taxonomy",
+            root={"name": "root"},
+        )
+        doc.save()
+
+        # A stale in-memory schema_version must not survive a save: the
+        # next-version write should always stamp CURRENT_SCHEMA_VERSION.
+        doc.schema_version = 999
+        doc.description = "updated"
+        doc.save()
+
+        self.assertEqual(
+            doc.schema_version, foo_ontology.CURRENT_SCHEMA_VERSION
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🔗 Related Issues

https://github.com/voxel51/fiftyone/pull/7372


## 📋 What changes are proposed in this pull request?

This adds the concept of schema versioning to ontology documents. 

## 🧪 How is this patch tested? If it is not, please explain why.

Locally and unit tests 

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
