### PR TITLE
fix height and width not working for ImageView

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/ImageView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ImageView.tsx
@@ -1,10 +1,9 @@
-import { Box } from "@mui/material";
-import React from "react";
-import HeaderView from "./HeaderView";
-import { getComponentProps } from "../utils";
-import { usePanelId } from "@fiftyone/spaces";
 import { usePanelEvent } from "@fiftyone/operators";
 import { OperatorResult } from "@fiftyone/operators/src/operators";
+import { usePanelId } from "@fiftyone/spaces";
+import { Box, Link } from "@mui/material";
+import { getComponentProps, parseSize } from "../utils";
+import HeaderView from "./HeaderView";
 
 export default function ImageView(props) {
   const { schema, data } = props;
@@ -16,50 +15,62 @@ export default function ImageView(props) {
     operator,
     prompt = false,
     params,
-    cursor = false,
   } = schema?.view || {};
   const imageURI = data ?? schema?.default;
 
   const panelId = usePanelId();
   const handleClick = usePanelEvent();
+  const operatorIsString = typeof operator === "string";
+  const hrefIsString = typeof href === "string";
+  const isClickable = operatorIsString || hrefIsString;
 
-  const openLink = () => href && window.open(href, "_blank");
+  const onClick = operatorIsString
+    ? () => {
+        handleClick(panelId, {
+          params,
+          operator,
+          prompt,
+          callback: (result: OperatorResult) => {
+            // execution after operator
+            if (result?.error) {
+              console.error(result?.error);
+              console.error(result?.errorMessage);
+            }
+          },
+        });
+      }
+    : undefined;
 
-  const onClick = () => {
-    if (operator) {
-      handleClick(panelId, {
-        params: params,
-        operator,
-        prompt,
-        callback: (result: OperatorResult) => {
-          // execution after operator
-
-          if (result?.error) {
-            console.log(result?.error);
-            console.log(result?.errorMessage);
-          } else {
-            openLink();
-          }
-        },
-      });
-    } else {
-      // execute if operator not defined
-      openLink();
-    }
+  const imageStyles = {
+    cursor: isClickable ? "pointer" : "default",
+    height: parseSize(height, undefined, "px"),
+    width: parseSize(width, undefined, "px"),
   };
+
+  const img = (
+    <img
+      {...getComponentProps(props, "image", { style: imageStyles })}
+      src={imageURI}
+      alt={alt}
+      onClick={onClick}
+    />
+  );
 
   return (
     <Box {...getComponentProps(props, "container")}>
       <HeaderView {...props} nested />
-      <img
-        src={imageURI}
-        height={height}
-        width={width}
-        alt={alt}
-        onClick={onClick}
-        style={{ cursor: cursor ? "pointer" : "default" }} // Change cursor based on href
-        {...getComponentProps(props, "image")}
-      />
+      {hrefIsString ? (
+        <Link
+          target="_blank"
+          rel="noopener noreferrer"
+          {...getComponentProps(props, "link")}
+          href={href}
+        >
+          {img}
+        </Link>
+      ) : (
+        img
+      )}
     </Box>
   );
 }

--- a/app/packages/core/src/plugins/SchemaIO/utils/layout.ts
+++ b/app/packages/core/src/plugins/SchemaIO/utils/layout.ts
@@ -4,15 +4,28 @@ import { SchemaViewType, ViewPropsType } from "./types";
 const CSS_UNIT_PATTERN =
   /(\d+)(cm|mm|in|px|pt|pc|em|ex|ch|rem|vw|vh|vmin|vmax|%)$/;
 
-export function parseSize(value: number | string, max?: number) {
+export function parseSize(
+  value: number | string,
+  max?: number,
+  defaultUnit?: string
+) {
   const valueIsNumber = typeof value === "number";
   const valueIsRelativeString =
     typeof value === "string" && !CSS_UNIT_PATTERN.test(value);
+
   const maxIsNumber = typeof max === "number";
-  if ((valueIsNumber || valueIsRelativeString) && maxIsNumber) {
+  if (maxIsNumber && (valueIsNumber || valueIsRelativeString)) {
     const floatValue = parseFloat(value.toString());
     return Math.min(1, Math.max(floatValue / 100, 0)) * max;
   }
+
+  if (defaultUnit !== undefined && valueIsRelativeString) {
+    const numericValue = parseFloat(value);
+    if (!Number.isNaN(numericValue)) {
+      return `${numericValue}${defaultUnit}`;
+    }
+  }
+
   return value;
 }
 


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Fix an issue where height and width provided for ImageView is overriden by base styles

## 🧪 How is this patch tested? If it is not, please explain why.

Using an example panel with ImageView

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixed an issue where height and width provided for ImageView is overriden by base styles

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Images now render at correct pixel dimensions to prevent scaling or clipping issues.
  * Link-wrapped images open safely in a new tab with noopener/noreferrer behavior.

* **New Features**
  * Images show clickability only when truly actionable and invoke configured actions; failures report errors gracefully instead of automatically navigating.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7406)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->