### PR TITLE
fix: replace deprecated datetime.utcnow() with datetime.now(UTC) in delegated_operation.py

### DIFF
--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -7,9 +7,6 @@ FiftyOne delegated operation repository.
 """
 
 from datetime import datetime, timezone
-
-# UTC timezone constant — avoids the deprecated datetime.now(_UTC)
-_UTC = timezone.utc
 import logging
 from typing import Any, List, Optional, Union
 
@@ -29,6 +26,9 @@ from fiftyone.operators.executor import (
 )
 
 logger = logging.getLogger(__name__)
+
+# UTC singleton — use datetime.now(_UTC) instead of the deprecated datetime.utcnow()
+_UTC = timezone.utc
 
 
 class DelegatedOperationRepo(object):

--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -6,7 +6,10 @@ FiftyOne delegated operation repository.
 |
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
+
+# UTC timezone constant — avoids the deprecated datetime.now(_UTC)
+_UTC = timezone.utc
 import logging
 from typing import Any, List, Optional, Union
 
@@ -363,8 +366,8 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             update = {
                 "$set": {
                     "run_state": run_state,
-                    "completed_at": datetime.utcnow(),
-                    "updated_at": datetime.utcnow(),
+                    "completed_at": datetime.now(_UTC),
+                    "updated_at": datetime.now(_UTC),
                     "result": execution_result_json,
                 }
             }
@@ -378,8 +381,8 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             update = {
                 "$set": {
                     "run_state": run_state,
-                    "failed_at": datetime.utcnow(),
-                    "updated_at": datetime.utcnow(),
+                    "failed_at": datetime.now(_UTC),
+                    "updated_at": datetime.now(_UTC),
                     "result": execution_result_json,
                 }
             }
@@ -388,8 +391,8 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             update = {
                 "$set": {
                     "run_state": run_state,
-                    "started_at": datetime.utcnow(),
-                    "updated_at": datetime.utcnow(),
+                    "started_at": datetime.now(_UTC),
+                    "updated_at": datetime.now(_UTC),
                     "monitored": monitored,
                 }
             }
@@ -397,8 +400,8 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             update = {
                 "$set": {
                     "run_state": run_state,
-                    "scheduled_at": datetime.utcnow(),
-                    "updated_at": datetime.utcnow(),
+                    "scheduled_at": datetime.now(_UTC),
+                    "updated_at": datetime.now(_UTC),
                 }
             }
         elif run_state == ExecutionRunState.QUEUED:
@@ -409,8 +412,8 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             update = {
                 "$set": {
                     "run_state": run_state,
-                    "queued_at": datetime.utcnow(),
-                    "updated_at": datetime.utcnow(),
+                    "queued_at": datetime.now(_UTC),
+                    "updated_at": datetime.now(_UTC),
                 }
             }
 
@@ -425,7 +428,7 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
 
         if progress is not None:
             update["$set"]["status"] = progress
-            update["$set"]["status"]["updated_at"] = datetime.utcnow()
+            update["$set"]["status"]["updated_at"] = datetime.now(_UTC)
 
         collection_filter = {"_id": _id}
         if required_state is not None:
@@ -466,7 +469,7 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
                 "status": {
                     "progress": execution_progress.progress,
                     "label": execution_progress.label,
-                    "updated_at": datetime.utcnow(),
+                    "updated_at": datetime.now(_UTC),
                 },
             }
         }
@@ -614,7 +617,7 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
         return self._collection.count_documents(filter=query)
 
     def ping(self, _id: ObjectId, log_tail: str = None):
-        updates = {"updated_at": datetime.utcnow()}
+        updates = {"updated_at": datetime.now(_UTC)}
         if log_tail and isinstance(log_tail, str):
             updates["log_tail"] = log_tail
         self._collection.update_one(


### PR DESCRIPTION
Closes #7402

## What

Replaces all 13 occurrences of the deprecated `datetime.utcnow()` in `fiftyone/factory/repos/delegated_operation.py` with `datetime.now(_UTC)` where `_UTC = timezone.utc`.

## Changes

- Added `timezone` to the existing `from datetime import datetime` import
- Added module-level constant `_UTC = timezone.utc` with a comment
- Replaced every `datetime.utcnow()` call → `datetime.now(_UTC)`

## Why

`datetime.utcnow()` was deprecated in Python 3.12 and returns a naive datetime with no timezone info, which can cause subtle bugs. `datetime.now(timezone.utc)` returns an aware datetime and is the recommended replacement per the [Python docs](https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcnow) and [ruff rule DTZ003](https://docs.astral.sh/ruff/rules/call-datetime-utcnow/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured operation-related timestamps are stored as timezone-aware UTC values. This fixes inconsistent timestamp records for start, completion, failure, queue, scheduled and update times, improving cross-system consistency and reliability of operation timelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->