### PR TITLE
Hide feature-gated APIs from generated docs

### DIFF
--- a/docs/generate_docs.bash
+++ b/docs/generate_docs.bash
@@ -88,15 +88,20 @@ cd "${THIS_DIR}/.."
 ln -sfn "$FIFTYONE_BRAIN_DIR" fiftyone/brain
 
 echo "Generating API docs"
+API_DOC_EXCLUDES=(
+    fiftyone/brain/internal/models
+    fiftyone/constants
+    fiftyone/internal
+    # Multimodal APIs are feature-gated and hidden from public API docs for now.
+    fiftyone/multimodal
+    fiftyone/server
+    fiftyone/service
+)
+
 # sphinx-apidoc [OPTIONS] -o <OUTPUT_PATH> <MODULE_PATH> [EXCLUDE_PATTERN, ...]
 sphinx-apidoc --force --no-toc --separate --follow-links \
     --templatedir=docs/templates/apidoc \
-    -o docs/source/api fiftyone \
-        fiftyone/brain/internal/models \
-        fiftyone/constants \
-        fiftyone/internal \
-        fiftyone/server \
-        fiftyone/service &
+    -o docs/source/api fiftyone "${API_DOC_EXCLUDES[@]}" &
 
 sphinx-apidoc --force --no-toc --separate --follow-links \
     --templatedir=docs/templates/apidoc \

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -289,7 +289,7 @@ html_context = {
 # -- Custom app setup --------------------------------------------------------
 
 
-def _skip_hidden_from_docs(_app, _what, _name, obj, skip):
+def _skip_hidden_from_docs(_app, _what, _name, obj, skip, _options):
     if skip:
         return True
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -289,10 +289,7 @@ html_context = {
 # -- Custom app setup --------------------------------------------------------
 
 
-def _skip_hidden_from_docs(_app, _what, _name, obj, skip, _options):
-    if skip:
-        return True
-
+def _skip_hidden_from_docs(_app, _what, _name, obj, _skip, _options):
     if is_hidden_from_docs(obj):
         return True
 
@@ -304,6 +301,7 @@ def setup(app):
     app.add_config_value("redirects_file", "redirects", "env")
     app.connect("builder-inited", generate_redirects)
     app.connect("build-finished", generate_api_redirects)
+    # See https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#event-autodoc-skip-member
     app.connect("autodoc-skip-member", _skip_hidden_from_docs)
 
     # Custom directives

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,6 +25,7 @@ from custom_directives import (
     CustomAnimatedCTADirective,
     CustomUseCaseCardDirective,
 )
+from fiftyone.internal.docs import is_hidden_from_docs
 from redirects import generate_redirects, generate_api_redirects
 
 import fiftyone.constants as foc
@@ -288,11 +289,22 @@ html_context = {
 # -- Custom app setup --------------------------------------------------------
 
 
+def _skip_hidden_from_docs(_app, _what, _name, obj, skip):
+    if skip:
+        return True
+
+    if is_hidden_from_docs(obj):
+        return True
+
+    return None
+
+
 def setup(app):
     # Generate page redirects
     app.add_config_value("redirects_file", "redirects", "env")
     app.connect("builder-inited", generate_redirects)
     app.connect("build-finished", generate_api_redirects)
+    app.connect("autodoc-skip-member", _skip_hidden_from_docs)
 
     # Custom directives
     app.add_directive("custombutton", CustomButtonDirective)

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -771,7 +771,20 @@ class LazyModule(types.ModuleType):
         self._module = None
         self._callback = callback
 
+    def __repr__(self):
+        if self._module is not None:
+            return repr(self._module)
+
+        return f"<module '{self.__name__}' (lazy)>"
+
     def __getattr__(self, item):
+        # Sphinx probes this marker while filtering autodoc members.
+        # We need special handling for Sphinx, as it will look for the
+        # __sphinx_mock__ attribute on all module-level objects, and we need
+        # that to raise an AttributeError to not err out
+        if item == "__sphinx_mock__":
+            raise AttributeError(item)
+
         if self._module is None:
             self._import_module()
 

--- a/fiftyone/internal/docs.py
+++ b/fiftyone/internal/docs.py
@@ -1,0 +1,51 @@
+"""
+Internal documentation helpers.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+_HIDE_FROM_DOCS_ATTR = "_fiftyone_hide_from_docs"
+
+
+def hide_from_docs(obj):
+    """Marks an object to be skipped by generated API documentation.
+
+    This decorator does not change runtime behavior; it only attaches metadata
+    that the Sphinx autodoc configuration can inspect.
+    """
+
+    for target in _iter_docs_targets(obj):
+        try:
+            setattr(target, _HIDE_FROM_DOCS_ATTR, True)
+        except (AttributeError, TypeError):
+            pass
+
+    return obj
+
+
+def is_hidden_from_docs(obj):
+    """Returns whether the given object should be hidden from API docs."""
+
+    return any(
+        bool(getattr(target, _HIDE_FROM_DOCS_ATTR, False))
+        for target in _iter_docs_targets(obj)
+    )
+
+
+def _iter_docs_targets(obj):
+    yield obj
+
+    if isinstance(obj, property):
+        for target in (obj.fget, obj.fset, obj.fdel):
+            if target is not None:
+                yield target
+
+    func = getattr(obj, "__func__", None)
+    if func is not None:
+        yield func
+
+    wrapped = getattr(obj, "__wrapped__", None)
+    if wrapped is not None:
+        yield wrapped

--- a/tests/unittests/internal_docs_tests.py
+++ b/tests/unittests/internal_docs_tests.py
@@ -1,0 +1,86 @@
+"""
+Unit tests for internal documentation helpers.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+
+from fiftyone.internal.docs import hide_from_docs, is_hidden_from_docs
+
+
+class InternalDocsTests(unittest.TestCase):
+    def test_hides_function(self):
+        def visible():
+            pass
+
+        self.assertFalse(is_hidden_from_docs(visible))
+
+        hidden = hide_from_docs(visible)
+
+        self.assertIs(hidden, visible)
+        self.assertTrue(is_hidden_from_docs(visible))
+
+    def test_hides_class(self):
+        class Visible:
+            pass
+
+        self.assertFalse(is_hidden_from_docs(Visible))
+
+        hidden = hide_from_docs(Visible)
+
+        self.assertIs(hidden, Visible)
+        self.assertTrue(is_hidden_from_docs(Visible))
+
+    def test_hides_instance_method(self):
+        class Container:
+            @hide_from_docs
+            def method(self):
+                pass
+
+        self.assertTrue(is_hidden_from_docs(Container.method))
+        self.assertTrue(is_hidden_from_docs(Container().method))
+
+    def test_hides_property_with_inner_decorator(self):
+        class Container:
+            @property
+            @hide_from_docs
+            def value(self):
+                return 1
+
+        self.assertTrue(is_hidden_from_docs(Container.__dict__["value"]))
+
+    def test_hides_property_with_outer_decorator(self):
+        class Container:
+            @hide_from_docs
+            @property
+            def value(self):
+                return 1
+
+        self.assertTrue(is_hidden_from_docs(Container.__dict__["value"]))
+
+    def test_hides_classmethod(self):
+        class Container:
+            @hide_from_docs
+            @classmethod
+            def method(cls):
+                pass
+
+        self.assertTrue(is_hidden_from_docs(Container.__dict__["method"]))
+        self.assertTrue(is_hidden_from_docs(Container.method))
+
+    def test_hides_staticmethod(self):
+        class Container:
+            @hide_from_docs
+            @staticmethod
+            def method():
+                pass
+
+        self.assertTrue(is_hidden_from_docs(Container.__dict__["method"]))
+        self.assertTrue(is_hidden_from_docs(Container.method))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/unittests/internal_docs_tests.py
+++ b/tests/unittests/internal_docs_tests.py
@@ -49,6 +49,8 @@ class InternalDocsTests(unittest.TestCase):
         self.assertFalse(
             is_hidden_from_docs(VisibleContainer.__dict__["value"])
         )
+        self.assertFalse(is_hidden_from_docs(VisibleContainer.value))
+        self.assertFalse(is_hidden_from_docs(VisibleContainer().value))
 
         class Container:
             @property
@@ -57,6 +59,9 @@ class InternalDocsTests(unittest.TestCase):
                 return 1
 
         self.assertTrue(is_hidden_from_docs(Container.__dict__["value"]))
+        self.assertTrue(is_hidden_from_docs(Container.value))
+        # Instance property access returns the value, not the descriptor.
+        self.assertFalse(is_hidden_from_docs(Container().value))
 
     def test_hides_property_with_outer_decorator(self):
         class VisibleContainer:
@@ -67,6 +72,8 @@ class InternalDocsTests(unittest.TestCase):
         self.assertFalse(
             is_hidden_from_docs(VisibleContainer.__dict__["value"])
         )
+        self.assertFalse(is_hidden_from_docs(VisibleContainer.value))
+        self.assertFalse(is_hidden_from_docs(VisibleContainer().value))
 
         class Container:
             @hide_from_docs
@@ -75,6 +82,9 @@ class InternalDocsTests(unittest.TestCase):
                 return 1
 
         self.assertTrue(is_hidden_from_docs(Container.__dict__["value"]))
+        self.assertTrue(is_hidden_from_docs(Container.value))
+        # Instance property access returns the value, not the descriptor.
+        self.assertFalse(is_hidden_from_docs(Container().value))
 
     def test_hides_classmethod(self):
         class VisibleContainer:
@@ -86,6 +96,7 @@ class InternalDocsTests(unittest.TestCase):
             is_hidden_from_docs(VisibleContainer.__dict__["method"])
         )
         self.assertFalse(is_hidden_from_docs(VisibleContainer.method))
+        self.assertFalse(is_hidden_from_docs(VisibleContainer().method))
 
         class Container:
             @hide_from_docs
@@ -95,6 +106,7 @@ class InternalDocsTests(unittest.TestCase):
 
         self.assertTrue(is_hidden_from_docs(Container.__dict__["method"]))
         self.assertTrue(is_hidden_from_docs(Container.method))
+        self.assertTrue(is_hidden_from_docs(Container().method))
 
     def test_hides_staticmethod(self):
         class VisibleContainer:
@@ -106,6 +118,7 @@ class InternalDocsTests(unittest.TestCase):
             is_hidden_from_docs(VisibleContainer.__dict__["method"])
         )
         self.assertFalse(is_hidden_from_docs(VisibleContainer.method))
+        self.assertFalse(is_hidden_from_docs(VisibleContainer().method))
 
         class Container:
             @hide_from_docs
@@ -115,6 +128,7 @@ class InternalDocsTests(unittest.TestCase):
 
         self.assertTrue(is_hidden_from_docs(Container.__dict__["method"]))
         self.assertTrue(is_hidden_from_docs(Container.method))
+        self.assertTrue(is_hidden_from_docs(Container().method))
 
 
 if __name__ == "__main__":

--- a/tests/unittests/internal_docs_tests.py
+++ b/tests/unittests/internal_docs_tests.py
@@ -12,27 +12,12 @@ from fiftyone.internal.docs import hide_from_docs, is_hidden_from_docs
 
 
 class InternalDocsTests(unittest.TestCase):
-    def test_hides_function(self):
-        def visible():
-            pass
-
-        self.assertFalse(is_hidden_from_docs(visible))
-
-        hidden = hide_from_docs(visible)
-
-        self.assertIs(hidden, visible)
-        self.assertTrue(is_hidden_from_docs(visible))
-
     def test_hides_class(self):
-        class Visible:
+        @hide_from_docs
+        class Hidden:
             pass
 
-        self.assertFalse(is_hidden_from_docs(Visible))
-
-        hidden = hide_from_docs(Visible)
-
-        self.assertIs(hidden, Visible)
-        self.assertTrue(is_hidden_from_docs(Visible))
+        self.assertTrue(is_hidden_from_docs(Hidden))
 
     def test_hides_instance_method(self):
         class Container:

--- a/tests/unittests/internal_docs_tests.py
+++ b/tests/unittests/internal_docs_tests.py
@@ -13,6 +13,11 @@ from fiftyone.internal.docs import hide_from_docs, is_hidden_from_docs
 
 class InternalDocsTests(unittest.TestCase):
     def test_hides_class(self):
+        class Visible:
+            pass
+
+        self.assertFalse(is_hidden_from_docs(Visible))
+
         @hide_from_docs
         class Hidden:
             pass
@@ -20,6 +25,13 @@ class InternalDocsTests(unittest.TestCase):
         self.assertTrue(is_hidden_from_docs(Hidden))
 
     def test_hides_instance_method(self):
+        class VisibleContainer:
+            def method(self):
+                pass
+
+        self.assertFalse(is_hidden_from_docs(VisibleContainer.method))
+        self.assertFalse(is_hidden_from_docs(VisibleContainer().method))
+
         class Container:
             @hide_from_docs
             def method(self):
@@ -29,6 +41,15 @@ class InternalDocsTests(unittest.TestCase):
         self.assertTrue(is_hidden_from_docs(Container().method))
 
     def test_hides_property_with_inner_decorator(self):
+        class VisibleContainer:
+            @property
+            def value(self):
+                return 1
+
+        self.assertFalse(
+            is_hidden_from_docs(VisibleContainer.__dict__["value"])
+        )
+
         class Container:
             @property
             @hide_from_docs
@@ -38,6 +59,15 @@ class InternalDocsTests(unittest.TestCase):
         self.assertTrue(is_hidden_from_docs(Container.__dict__["value"]))
 
     def test_hides_property_with_outer_decorator(self):
+        class VisibleContainer:
+            @property
+            def value(self):
+                return 1
+
+        self.assertFalse(
+            is_hidden_from_docs(VisibleContainer.__dict__["value"])
+        )
+
         class Container:
             @hide_from_docs
             @property
@@ -47,6 +77,16 @@ class InternalDocsTests(unittest.TestCase):
         self.assertTrue(is_hidden_from_docs(Container.__dict__["value"]))
 
     def test_hides_classmethod(self):
+        class VisibleContainer:
+            @classmethod
+            def method(cls):
+                pass
+
+        self.assertFalse(
+            is_hidden_from_docs(VisibleContainer.__dict__["method"])
+        )
+        self.assertFalse(is_hidden_from_docs(VisibleContainer.method))
+
         class Container:
             @hide_from_docs
             @classmethod
@@ -57,6 +97,16 @@ class InternalDocsTests(unittest.TestCase):
         self.assertTrue(is_hidden_from_docs(Container.method))
 
     def test_hides_staticmethod(self):
+        class VisibleContainer:
+            @staticmethod
+            def method():
+                pass
+
+        self.assertFalse(
+            is_hidden_from_docs(VisibleContainer.__dict__["method"])
+        )
+        self.assertFalse(is_hidden_from_docs(VisibleContainer.method))
+
         class Container:
             @hide_from_docs
             @staticmethod


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

This PR keeps feature-gated multimodal APIs out of public API docs for now + adds `@hide_from_docs` decorator.

## 🧪 How is this patch tested? If it is not, please explain why.

Added unit tests in `tests/unittests/internal_docs_tests.py` covering the new internal docs helper behavior.

Not run by me; review only.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * API docs generation now supports a configurable exclude list and a hook to suppress selected internal members for cleaner public docs.
* **Tests**
  * Added unit tests covering hide-from-docs behavior across classes, methods, properties, classmethods, and staticmethods.
* **Bug Fixes**
  * Improved lazy-module representation and attribute handling so unresolved modules show a deterministic placeholder and won’t break docs generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->