### PR TITLE
[HA] Add support for keypoint attribute editing

### DIFF
--- a/app/packages/annotation/src/deltas.test.ts
+++ b/app/packages/annotation/src/deltas.test.ts
@@ -1,13 +1,23 @@
 import { describe, expect, it } from "vitest";
 import {
   buildAnnotationPath,
+  buildDeletionDeltas,
   buildJsonPath,
+  buildKeypointMutationDeltas,
+  buildKeypointsMutationDeltas,
   buildSingleMutationDelta,
   type LabelProxy,
 } from "./deltas";
+import type { KeypointLabel } from "@fiftyone/lighter";
 import type { AnnotationLabel } from "@fiftyone/state";
+import type { Field } from "@fiftyone/utilities";
 
 type LabelData = AnnotationLabel["data"];
+
+const makeField = (embeddedDocType: string): Field =>
+  ({
+    embeddedDocType,
+  } as Field);
 
 describe("delta calculation utilities", () => {
   describe("buildAnnotationPath", () => {
@@ -172,6 +182,201 @@ describe("delta calculation utilities", () => {
         path: "/tags/1",
         value: "updated",
       });
+    });
+  });
+
+  describe("buildKeypointMutationDeltas", () => {
+    it("merges with existing single Keypoint and produces replace deltas", () => {
+      const path = "kp";
+      const existing: KeypointLabel = {
+        _cls: "Keypoint",
+        _id: "kp-1",
+        label: "head",
+        tags: [],
+        points: [[0.1, 0.2]],
+      } as unknown as KeypointLabel;
+      const sample = { [path]: existing };
+
+      const deltas = buildKeypointMutationDeltas(sample, {
+        type: "Keypoint",
+        path,
+        data: {
+          _cls: "Keypoint",
+          _id: "kp-1",
+          label: "shoulder",
+          tags: [],
+          points: [[0.1, 0.2]],
+        } as unknown as KeypointLabel,
+      });
+
+      expect(deltas).toEqual([
+        { op: "replace", path: "/label", value: "shoulder" },
+      ]);
+    });
+  });
+
+  describe("buildKeypointsMutationDeltas", () => {
+    const path = "keypoints";
+    const existingKeypoint: KeypointLabel = {
+      _cls: "Keypoint",
+      _id: "kp-1",
+      label: "head",
+      tags: ["foo"],
+      points: [[0.1, 0.2]],
+    } as unknown as KeypointLabel;
+
+    it("upserts an existing keypoint by _id and merges server fields", () => {
+      const sample = {
+        [path]: { _cls: "Keypoints", keypoints: [existingKeypoint] },
+      };
+
+      const deltas = buildKeypointsMutationDeltas(sample, {
+        type: "Keypoint",
+        path,
+        data: {
+          _id: "kp-1",
+          label: "shoulder",
+        } as unknown as KeypointLabel,
+      });
+
+      expect(deltas).toEqual([
+        { op: "replace", path: "/keypoints/0/label", value: "shoulder" },
+      ]);
+    });
+
+    it("inserts a new keypoint when the _id is not present", () => {
+      const sample = {
+        [path]: { _cls: "Keypoints", keypoints: [existingKeypoint] },
+      };
+
+      const newKeypoint = {
+        _cls: "Keypoint",
+        _id: "kp-2",
+        label: "foot",
+        tags: [],
+        points: [[0.5, 0.6]],
+      } as unknown as KeypointLabel;
+
+      const deltas = buildKeypointsMutationDeltas(sample, {
+        type: "Keypoint",
+        path,
+        data: newKeypoint,
+      });
+
+      expect(deltas).toContainEqual({
+        op: "add",
+        path: "/keypoints/1",
+        value: newKeypoint,
+      });
+    });
+
+    it("seeds a keypoints list when none exists at the path", () => {
+      const newKeypoint = {
+        _cls: "Keypoint",
+        _id: "kp-1",
+        label: "head",
+        tags: [],
+        points: [[0.1, 0.2]],
+      } as unknown as KeypointLabel;
+
+      const deltas = buildKeypointsMutationDeltas(
+        {},
+        { type: "Keypoint", path, data: newKeypoint }
+      );
+
+      expect(deltas.some((d) => d.op === "add")).toBe(true);
+    });
+  });
+
+  describe("buildDeletionDeltas (Keypoint)", () => {
+    const path = "keypoints";
+
+    it("filters out a keypoint by _id from a Keypoints list", () => {
+      const sample = {
+        [path]: {
+          _cls: "Keypoints",
+          keypoints: [
+            {
+              _cls: "Keypoint",
+              _id: "kp-1",
+              label: "head",
+              points: [[0.1, 0.2]],
+            },
+            {
+              _cls: "Keypoint",
+              _id: "kp-2",
+              label: "foot",
+              points: [[0.5, 0.6]],
+            },
+          ],
+        },
+      };
+
+      const deltas = buildDeletionDeltas(
+        sample,
+        {
+          type: "Keypoint",
+          path,
+          data: { _id: "kp-1" } as unknown as KeypointLabel,
+        },
+        makeField("fiftyone.core.labels.Keypoints")
+      );
+
+      // fast-json-patch emits a "shift down + pop" sequence: the trailing
+      // index is removed, and prior indices are rewritten to the surviving
+      // elements.
+      expect(deltas).toContainEqual({
+        op: "remove",
+        path: "/keypoints/1",
+      });
+      expect(deltas).toContainEqual({
+        op: "replace",
+        path: "/keypoints/0/_id",
+        value: "kp-2",
+      });
+    });
+
+    it("returns a root remove for a single Keypoint field", () => {
+      const deltas = buildDeletionDeltas(
+        { kp: { _cls: "Keypoint", _id: "kp-1" } },
+        {
+          type: "Keypoint",
+          path: "kp",
+          data: { _id: "kp-1" } as unknown as KeypointLabel,
+        },
+        makeField("fiftyone.core.labels.Keypoint")
+      );
+
+      expect(deltas).toEqual([{ op: "remove", path: "/" }]);
+    });
+
+    it("short-circuits to a root remove for generated views", () => {
+      const deltas = buildDeletionDeltas(
+        {},
+        {
+          type: "Keypoint",
+          path: "keypoints",
+          data: { _id: "kp-1" } as unknown as KeypointLabel,
+        },
+        makeField("fiftyone.core.labels.Keypoints"),
+        true
+      );
+
+      expect(deltas).toEqual([{ op: "remove", path: "/" }]);
+    });
+
+    it("warns and returns [] when the keypoints list is missing", () => {
+      const deltas = buildDeletionDeltas(
+        {},
+        {
+          type: "Keypoint",
+          path: "keypoints",
+          data: { _id: "kp-1" } as unknown as KeypointLabel,
+        },
+        makeField("fiftyone.core.labels.Keypoints")
+      );
+
+      expect(deltas).toEqual([]);
     });
   });
 });

--- a/app/packages/annotation/src/deltas.ts
+++ b/app/packages/annotation/src/deltas.ts
@@ -314,7 +314,7 @@ export const buildDeletionDeltas = (
           (ply) => ply._id !== label.data._id
         ),
       });
-    } else {
+    } else if (isFieldType(schema, "Polyline")) {
       return [{ op: "remove", path: "/" }];
     }
   } else if (label.type === "Keypoint") {
@@ -335,7 +335,7 @@ export const buildDeletionDeltas = (
           (kpt) => kpt._id !== label.data._id
         ),
       });
-    } else {
+    } else if (isFieldType(schema, "Keypoint")) {
       return [{ op: "remove", path: "/" }];
     }
   }

--- a/app/packages/annotation/src/deltas.ts
+++ b/app/packages/annotation/src/deltas.ts
@@ -4,6 +4,7 @@ import {
   extractNestedField,
   generateJsonPatch,
 } from "@fiftyone/core/src/utils/json";
+import type { KeypointLabel } from "@fiftyone/lighter";
 import type { ClassificationLabel } from "@fiftyone/looker/src/overlays/classifications";
 import type { DetectionLabel } from "@fiftyone/looker/src/overlays/detection";
 import type { PolylineLabel } from "@fiftyone/looker/src/overlays/polyline";
@@ -23,6 +24,13 @@ import { arePrimitivesEqual, isPrimitiveFieldType } from "./util";
  */
 export type PolylinesParent = {
   polylines: PolylineLabel[];
+};
+
+/**
+ * Helper type representing a `fo.Keypoints`-like element.
+ */
+export type KeypointsParent = {
+  keypoints: KeypointLabel[];
 };
 
 /**
@@ -48,7 +56,9 @@ type FieldType =
   | "Classification"
   | "Classifications"
   | "Polyline"
-  | "Polylines";
+  | "Polylines"
+  | "Keypoint"
+  | "Keypoints";
 
 const isFieldType = (field: Field, fieldType: FieldType): boolean => {
   return field?.embeddedDocType === `fiftyone.core.labels.${fieldType}`;
@@ -78,7 +88,10 @@ export const buildAnnotationPath = (
  * Helper type encapsulating label metadata relevant to delta calculations.
  */
 type LabelMetadata<T> = {
-  type: Extract<FieldType, "Detection" | "Classification" | "Polyline">;
+  type: Extract<
+    FieldType,
+    "Detection" | "Classification" | "Polyline" | "Keypoint"
+  >;
   path: string;
   data: T;
 };
@@ -97,7 +110,9 @@ type Detection2DMetadata = LabelMetadata<DetectionLabel> & {
  * This type represents a union of valid {@link LabelMetadata} variants.
  */
 export type LabelProxy =
-  | LabelMetadata<ClassificationLabel | DetectionLabel | PolylineLabel>
+  | LabelMetadata<
+      ClassificationLabel | DetectionLabel | PolylineLabel | KeypointLabel
+    >
   | Detection2DMetadata
   | PrimitiveValue;
 
@@ -185,6 +200,18 @@ export const buildMutationDeltas = (
       return buildPolylineMutationDeltas(
         sample,
         label as LabelMetadata<PolylineLabel>
+      );
+    }
+  } else if (label.type === "Keypoint") {
+    if (isFieldType(schema, "Keypoints")) {
+      return buildKeypointsMutationDeltas(
+        sample,
+        label as LabelMetadata<KeypointLabel>
+      );
+    } else if (isFieldType(schema, "Keypoint")) {
+      return buildKeypointMutationDeltas(
+        sample,
+        label as LabelMetadata<KeypointLabel>
       );
     }
   } else if (isPrimitiveFieldType(schema)) {
@@ -285,6 +312,27 @@ export const buildDeletionDeltas = (
         ...existingLabel,
         polylines: existingLabel.polylines.filter(
           (ply) => ply._id !== label.data._id
+        ),
+      });
+    } else {
+      return [{ op: "remove", path: "/" }];
+    }
+  } else if (label.type === "Keypoint") {
+    if (isFieldType(schema, "Keypoints")) {
+      const existingLabel = <KeypointsParent>(
+        extractNestedField(sample, label.path)
+      );
+
+      if (!existingLabel || !Array.isArray(existingLabel.keypoints)) {
+        // label doesn't exist
+        console.warn(`can't delete label; no keypoints found at ${label.path}`);
+        return [];
+      }
+
+      return generateJsonPatch(existingLabel, {
+        ...existingLabel,
+        keypoints: existingLabel.keypoints.filter(
+          (kpt) => kpt._id !== label.data._id
         ),
       });
     } else {
@@ -529,6 +577,64 @@ export const buildPolylinesMutationDeltas = (
   const newLabel = {
     ...existingLabel,
     polylines: newArray,
+  };
+
+  return generateJsonPatch(existingLabel, newLabel);
+};
+
+/**
+ * Build a list of JSON deltas for the given sample and keypoint label.
+ *
+ * This method assumes that the keypoint exists as a top-level field (i.e. not
+ * part of an `fo.Keypoints` field).
+ *
+ * @param sample Sample containing unmodified label data
+ * @param label Current label state
+ */
+export const buildKeypointMutationDeltas = (
+  sample: Sample,
+  label: LabelMetadata<KeypointLabel>
+): JSONDeltas => {
+  return buildSingleMutationDelta(sample, label.path, label.data);
+};
+
+/**
+ * Build a list of JSON deltas for the given sample and keypoint label.
+ *
+ * This method assumes that the keypoint exists as part of a parent
+ * `fo.Keypoints` field.
+ *
+ * @param sample Sample containing unmodified label data
+ * @param label Current label state
+ */
+export const buildKeypointsMutationDeltas = (
+  sample: Sample,
+  label: LabelMetadata<KeypointLabel>
+): JSONDeltas => {
+  const existingLabel = <{ keypoints: KeypointLabel[] }>(
+    extractNestedField(sample, label.path)
+  ) ?? {
+    keypoints: [],
+  };
+
+  const existingKeypoint = existingLabel.keypoints.find(
+    (kpt) => kpt._id === label.data._id
+  );
+
+  const mergedKeypoint = existingKeypoint
+    ? { ...existingKeypoint, ...label.data }
+    : { ...label.data };
+
+  const newArray = [...existingLabel.keypoints];
+  upsertArrayElement(
+    newArray,
+    mergedKeypoint,
+    (kpt) => kpt._id === label.data._id
+  );
+
+  const newLabel = {
+    ...existingLabel,
+    keypoints: newArray,
   };
 
   return generateJsonPatch(existingLabel, newLabel);

--- a/app/packages/annotation/src/persistence/useGetLabelDelta.ts
+++ b/app/packages/annotation/src/persistence/useGetLabelDelta.ts
@@ -31,6 +31,7 @@ const LABEL_TYPE_TO_EMBEDDED_DOC: Record<string, string> = {
   Detection: "fiftyone.core.labels.Detections",
   Classification: "fiftyone.core.labels.Classifications",
   Polyline: "fiftyone.core.labels.Polylines",
+  Keypoint: "fiftyone.core.labels.Keypoints",
 };
 
 /**

--- a/app/packages/annotation/src/persistence/useLighterDeltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/useLighterDeltaSupplier.ts
@@ -2,6 +2,8 @@ import {
   type BaseOverlay,
   BoundingBoxOverlay,
   ClassificationOverlay,
+  KeypointOverlay,
+  type KeypointLabel,
   useLighter,
 } from "@fiftyone/lighter";
 import type { DetectionLabel } from "@fiftyone/looker";
@@ -41,9 +43,20 @@ const buildAnnotationLabel = (overlay: BaseOverlay): LabelProxy | undefined => {
     }
   } else if (overlay instanceof ClassificationOverlay) {
     const label = overlay.label as ClassificationLabel;
+
     if (label.label) {
       return {
         type: "Classification",
+        data: label,
+        path: overlay.field,
+      };
+    }
+  } else if (overlay instanceof KeypointOverlay) {
+    const label = overlay.label as KeypointLabel;
+
+    if (label.label) {
+      return {
+        type: "Keypoint",
         data: label,
         path: overlay.field,
       };

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Edit.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Edit.tsx
@@ -1,6 +1,6 @@
 import { DetectionLabel } from "@fiftyone/looker";
 import { useClearModal } from "@fiftyone/state";
-import { DETECTION, POLYLINE } from "@fiftyone/utilities";
+import { DETECTION, KEYPOINT, POLYLINE } from "@fiftyone/utilities";
 import { useAtomValue } from "jotai";
 import { useEffect } from "react";
 import styled from "styled-components";
@@ -9,6 +9,7 @@ import AnnotationSchema from "./AnnotationSchema";
 import Field from "./Field";
 import Header from "./Header";
 import Id from "./Id";
+import { KeypointDetails } from "./KeypointDetails";
 import { PolylineDetails } from "./PolylineDetails";
 import Position from "./Position";
 import Position3d from "./Position3d";
@@ -97,6 +98,7 @@ export default function Edit() {
           <Position3d readOnly={isReadOnly} />
         )}
         {type === POLYLINE && <PolylineDetails />}
+        {type === KEYPOINT && <KeypointDetails />}
         {field && <AnnotationSchema readOnly={isReadOnly} />}
       </Content>
     </ContentContainer>

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/KeypointDetails.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/KeypointDetails.tsx
@@ -10,7 +10,10 @@ import {
   Tooltip,
   TooltipProps,
 } from "@voxel51/voodo";
-import { KeypointAnnotationLabel, useKeypointSkeleton } from "@fiftyone/state";
+import {
+  KeypointAnnotationLabel,
+  useGetKeypointSkeleton,
+} from "@fiftyone/state";
 import { useMemo } from "react";
 
 const ConditionalTooltip = ({
@@ -35,7 +38,7 @@ const ConditionalTooltip = ({
 export const KeypointDetails = () => {
   const { selectedLabel } = useAnnotationContext();
   const currentData = selectedLabel?.data as KeypointAnnotationLabel["data"];
-  const getKeypointSkeleton = useKeypointSkeleton();
+  const getKeypointSkeleton = useGetKeypointSkeleton();
 
   const keypointSkeleton = useMemo(() => {
     if (selectedLabel?.path) {
@@ -43,7 +46,7 @@ export const KeypointDetails = () => {
     }
 
     return undefined;
-  }, [getKeypointSkeleton, selectedLabel.path]);
+  }, [getKeypointSkeleton, selectedLabel?.path]);
 
   const pointCount = currentData?.points?.length ?? 0;
 
@@ -55,14 +58,14 @@ export const KeypointDetails = () => {
         spacing={Spacing.Sm}
       >
         <Text color={TextColor.Secondary}>
-          {keypointSkeleton.edges.length} edges
+          {keypointSkeleton?.edges?.length ?? 0} edges
         </Text>
 
         <Text color={TextColor.Secondary}>&bull;</Text>
 
         <ConditionalTooltip
           enabled={keypointSkeleton?.labels?.length > 0}
-          content={<Text>{keypointSkeleton.labels.join(", ")}</Text>}
+          content={<Text>{keypointSkeleton?.labels?.join(", ")}</Text>}
         >
           <Text color={TextColor.Secondary}>{pointCount} points</Text>
         </ConditionalTooltip>

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/KeypointDetails.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/KeypointDetails.tsx
@@ -1,17 +1,72 @@
 import { Box } from "@mui/material";
 import { useAnnotationContext } from "./state";
-import { Text, TextColor } from "@voxel51/voodo";
-import { KeypointAnnotationLabel } from "@fiftyone/state";
+import {
+  Align,
+  Orientation,
+  Spacing,
+  Stack,
+  Text,
+  TextColor,
+  Tooltip,
+  TooltipProps,
+} from "@voxel51/voodo";
+import { KeypointAnnotationLabel, useKeypointSkeleton } from "@fiftyone/state";
+import { useMemo } from "react";
+
+const ConditionalTooltip = ({
+  anchor,
+  children,
+  content,
+  enabled,
+}: Pick<TooltipProps, "anchor" | "children" | "content"> & {
+  enabled: boolean;
+}) => {
+  if (!enabled) {
+    return <>{children}</>;
+  }
+
+  return (
+    <Tooltip portal content={content} anchor={anchor}>
+      {children}
+    </Tooltip>
+  );
+};
 
 export const KeypointDetails = () => {
   const { selectedLabel } = useAnnotationContext();
   const currentData = selectedLabel?.data as KeypointAnnotationLabel["data"];
+  const getKeypointSkeleton = useKeypointSkeleton();
+
+  const keypointSkeleton = useMemo(() => {
+    if (selectedLabel?.path) {
+      return getKeypointSkeleton(selectedLabel.path);
+    }
+
+    return undefined;
+  }, [getKeypointSkeleton, selectedLabel.path]);
 
   const pointCount = currentData?.points?.length ?? 0;
 
   return (
-    <Box sx={{ px: 1.5, py: 1 }}>
-      <Text color={TextColor.Secondary}>{pointCount} points</Text>
+    <Box sx={{ py: 1 }}>
+      <Stack
+        orientation={Orientation.Row}
+        align={Align.Center}
+        spacing={Spacing.Sm}
+      >
+        <Text color={TextColor.Secondary}>
+          {keypointSkeleton.edges.length} edges
+        </Text>
+
+        <Text color={TextColor.Secondary}>&bull;</Text>
+
+        <ConditionalTooltip
+          enabled={keypointSkeleton?.labels?.length > 0}
+          content={<Text>{keypointSkeleton.labels.join(", ")}</Text>}
+        >
+          <Text color={TextColor.Secondary}>{pointCount} points</Text>
+        </ConditionalTooltip>
+      </Stack>
     </Box>
   );
 };

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/KeypointDetails.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/KeypointDetails.tsx
@@ -1,0 +1,17 @@
+import { Box } from "@mui/material";
+import { useAnnotationContext } from "./state";
+import { Text, TextColor } from "@voxel51/voodo";
+import { KeypointAnnotationLabel } from "@fiftyone/state";
+
+export const KeypointDetails = () => {
+  const { selectedLabel } = useAnnotationContext();
+  const currentData = selectedLabel?.data as KeypointAnnotationLabel["data"];
+
+  const pointCount = currentData?.points?.length ?? 0;
+
+  return (
+    <Box sx={{ px: 1.5, py: 1 }}>
+      <Text color={TextColor.Secondary}>{pointCount} points</Text>
+    </Box>
+  );
+};

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/state.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/state.ts
@@ -4,6 +4,8 @@ import {
   CLASSIFICATIONS,
   DETECTION,
   DETECTIONS,
+  KEYPOINT,
+  KEYPOINTS,
   POLYLINE,
   POLYLINES,
 } from "@fiftyone/utilities";
@@ -55,17 +57,20 @@ export const hasChanges = atom((get) => {
 const IS_CLASSIFICIATION = new Set([CLASSIFICATION, CLASSIFICATIONS]);
 const IS_DETECTION = new Set([DETECTION, DETECTIONS]);
 const IS_POLYLINE = new Set([POLYLINE, POLYLINES]);
-const IS_LIST = new Set([CLASSIFICATIONS, DETECTIONS, POLYLINES]);
+const IS_KEYPOINT = new Set([KEYPOINT, KEYPOINTS]);
+const IS_LIST = new Set([CLASSIFICATIONS, DETECTIONS, POLYLINES, KEYPOINTS]);
 const IS = {
   [CLASSIFICATION]: IS_CLASSIFICIATION,
   [DETECTION]: IS_DETECTION,
   [POLYLINE]: IS_POLYLINE,
+  [KEYPOINT]: IS_KEYPOINT,
 };
 
 export type LabelType =
   | typeof CLASSIFICATION
   | typeof DETECTION
-  | typeof POLYLINE;
+  | typeof POLYLINE
+  | typeof KEYPOINT;
 
 export const current = atom(
   (get) => {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Icons.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Icons.tsx
@@ -7,6 +7,7 @@ import {
   VisibilityOutlined,
 } from "@mui/icons-material";
 import styled from "styled-components";
+import { Icon, IconName, Size } from "@voxel51/voodo";
 
 export const Container = styled.div`
   display: flex;
@@ -63,6 +64,14 @@ export const Polyline = ({ fill }: { fill: string }) => {
   );
 };
 
+export const Keypoint = ({ fill }: { fill: string }) => {
+  return (
+    <Container style={{ color: fill }}>
+      <Icon name={IconName.Embeddings} size={Size.Md} />
+    </Container>
+  );
+};
+
 export const Locking = ({ on }: { on: boolean }) => {
   const theme = useTheme();
   const color = on ? theme.text.secondary : theme.text.disabled;
@@ -92,4 +101,6 @@ export const ICONS = {
   detections: Detection,
   polyline: Polyline,
   polylines: Polyline,
+  keypoint: Keypoint,
+  keypoints: Keypoint,
 };

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useAddAnnotationLabelToRenderer.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useAddAnnotationLabelToRenderer.ts
@@ -1,6 +1,10 @@
-import { BoundingBoxOverlay, useLighter } from "@fiftyone/lighter";
+import {
+  BoundingBoxOverlay,
+  KeypointOverlay,
+  useLighter,
+} from "@fiftyone/lighter";
 import type { AnnotationLabel } from "@fiftyone/state";
-import { CLASSIFICATION, DETECTION } from "@fiftyone/utilities";
+import { CLASSIFICATION, DETECTION, KEYPOINT } from "@fiftyone/utilities";
 import { useCallback } from "react";
 
 /**
@@ -15,6 +19,8 @@ export const useAddAnnotationLabelToRenderer = () => {
         addOverlay(label.overlay);
       } else if (label.type === DETECTION) {
         addOverlay(label.overlay as BoundingBoxOverlay);
+      } else if (label.type === KEYPOINT) {
+        addOverlay(label.overlay as KeypointOverlay);
       }
     },
     [addOverlay]

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useCreateAnnotationLabel.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useCreateAnnotationLabel.ts
@@ -1,15 +1,22 @@
 import { useCallback } from "react";
 import type { LabelType } from "./Edit/state";
-import { CLASSIFICATION, DETECTION, POLYLINE } from "@fiftyone/utilities";
+import {
+  CLASSIFICATION,
+  DETECTION,
+  KEYPOINT,
+  POLYLINE,
+} from "@fiftyone/utilities";
 import {
   BoundingBoxOptions,
   BoundingBoxOverlay,
   ClassificationOptions,
   ClassificationOverlay,
+  KeypointOptions,
+  KeypointOverlay,
   useLighter,
 } from "@fiftyone/lighter";
 import { PolylineLabel } from "@fiftyone/looker/src/overlays/polyline";
-import { AnnotationLabel } from "@fiftyone/state";
+import { AnnotationLabel, useKeypointSkeleton } from "@fiftyone/state";
 import { getDefaultStore } from "jotai";
 import { isFieldReadOnly, labelSchemaData } from "./state";
 
@@ -18,6 +25,9 @@ import { isFieldReadOnly, labelSchemaData } from "./state";
  */
 export const useCreateAnnotationLabel = () => {
   const { overlayFactory } = useLighter();
+
+  // Getter for resolving keypoint skeletons by field
+  const getSkeletonForField = useKeypointSkeleton();
 
   return useCallback(
     (
@@ -81,8 +91,28 @@ export const useCreateAnnotationLabel = () => {
         };
       }
 
+      if (type === KEYPOINT) {
+        const fieldSkeleton = getSkeletonForField(field);
+
+        const overlay = overlayFactory.create<KeypointOptions, KeypointOverlay>(
+          "keypoint",
+          {
+            id: data._id,
+            field,
+            label: data as KeypointOptions["label"],
+            connections: fieldSkeleton?.edges ?? [],
+            closed: false,
+            draggable: false,
+            deletable: false,
+            selectable: true,
+          }
+        );
+
+        return { data, overlay, path: field, type };
+      }
+
       throw new Error(`unable to create label of type '${type}'`);
     },
-    [overlayFactory]
+    [getSkeletonForField, overlayFactory]
   );
 };

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useCreateAnnotationLabel.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useCreateAnnotationLabel.ts
@@ -16,7 +16,7 @@ import {
   useLighter,
 } from "@fiftyone/lighter";
 import { PolylineLabel } from "@fiftyone/looker/src/overlays/polyline";
-import { AnnotationLabel, useKeypointSkeleton } from "@fiftyone/state";
+import { AnnotationLabel, useGetKeypointSkeleton } from "@fiftyone/state";
 import { getDefaultStore } from "jotai";
 import { isFieldReadOnly, labelSchemaData } from "./state";
 
@@ -27,7 +27,7 @@ export const useCreateAnnotationLabel = () => {
   const { overlayFactory } = useLighter();
 
   // Getter for resolving keypoint skeletons by field
-  const getSkeletonForField = useKeypointSkeleton();
+  const getSkeletonForField = useGetKeypointSkeleton();
 
   return useCallback(
     (

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
@@ -36,6 +36,7 @@ const LABEL_LIST_INFO: Record<string, { listKey: string; type: LabelType }> = {
   Detections: { listKey: "detections", type: "Detection" },
   Classifications: { listKey: "classifications", type: "Classification" },
   Polylines: { listKey: "polylines", type: "Polyline" },
+  Keypoints: { listKey: "keypoints", type: "Keypoint" },
 };
 
 const handleSample = async ({
@@ -83,6 +84,7 @@ const handleSample = async ({
     "Classification",
     "Detection",
     "Polyline",
+    "Keypoint",
   ]);
 
   for (const schemaPath of schemas) {

--- a/app/packages/state/src/accessors/dataset.ts
+++ b/app/packages/state/src/accessors/dataset.ts
@@ -53,7 +53,7 @@ export const useSelectedMediaFieldGrid = () => {
  * Hook which provides a function to get the default keypoint skeleton for a
  * given field.
  */
-export const useKeypointSkeleton = () => {
+export const useGetKeypointSkeleton = () => {
   return useRecoilCallback(
     ({ snapshot }) =>
       (field: string) =>

--- a/app/packages/state/src/accessors/dataset.ts
+++ b/app/packages/state/src/accessors/dataset.ts
@@ -1,10 +1,11 @@
-import { useRecoilValue } from "recoil";
+import { useRecoilCallback, useRecoilValue } from "recoil";
 import {
   dataset,
   datasetId,
   datasetName,
   fieldSchema,
   selectedMediaField,
+  skeleton,
   State,
 } from "../recoil";
 
@@ -46,4 +47,17 @@ export const useSampleSchema = () =>
  */
 export const useSelectedMediaFieldGrid = () => {
   return useRecoilValue(selectedMediaField(false));
+};
+
+/**
+ * Hook which provides a function to get the default keypoint skeleton for a
+ * given field.
+ */
+export const useKeypointSkeleton = () => {
+  return useRecoilCallback(
+    ({ snapshot }) =>
+      (field: string) =>
+        snapshot.getLoadable(skeleton(field)).getValue(),
+    []
+  );
 };

--- a/app/packages/state/src/recoil/sidebar.ts
+++ b/app/packages/state/src/recoil/sidebar.ts
@@ -1,6 +1,8 @@
 import type {
   BoundingBoxOverlay,
   ClassificationOverlay,
+  KeypointLabel,
+  KeypointOverlay,
 } from "@fiftyone/lighter";
 import { ClassificationLabel } from "@fiftyone/looker/src/overlays/classifications";
 import { DetectionLabel } from "@fiftyone/looker/src/overlays/detection";
@@ -162,11 +164,18 @@ export interface PolylineAnnotationLabel extends Label {
   type: "Polyline";
 }
 
+export interface KeypointAnnotationLabel extends Label {
+  data: KeypointLabel;
+  overlay: KeypointOverlay;
+  type: "Keypoint";
+}
+
 export type AnnotationLabel =
   | ClassificationAnnotationLabel
   | DetectionAnnotationLabel
   | Detection3DAnnotationLabel
-  | PolylineAnnotationLabel;
+  | PolylineAnnotationLabel
+  | KeypointAnnotationLabel;
 
 export type AnnotationLabelData = AnnotationLabel["data"];
 

--- a/fiftyone/core/annotation/constants.py
+++ b/fiftyone/core/annotation/constants.py
@@ -178,6 +178,8 @@ SUPPORTED_LABEL_TYPES_BY_MEDIA_TYPE = {
     fom.IMAGE: {
         fol.Detection,
         fol.Detections,
+        fol.Keypoint,
+        fol.Keypoints,
     },
     fom.THREE_D: {fol.Detection, fol.Detections, fol.Polyline, fol.Polylines},
 }

--- a/fiftyone/core/annotation/generate_label_schemas.py
+++ b/fiftyone/core/annotation/generate_label_schemas.py
@@ -364,9 +364,13 @@ def _generate_field_label_schema(collection, field_name, scan_samples):
             # [0, 1] floats, omit for special handling by the App
             continue
 
-        if f.name == foac.POINTS and field.document_type == fol.Polyline:
+        if f.name == foac.POINTS and field.document_type in (
+            fol.Polyline,
+            fol.Keypoint,
+        ):
             # points is a list of (x, y) or (x, y, z) coordinate lists that
-            # define the polyline shape, omit for special handling by the App
+            # define the polyline/keypoint shape, omit for special handling by
+            # the App
             continue
 
         try:


### PR DESCRIPTION
## 🔗 Related Issues

None

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

Adds basic support for in-app annotation of `fo.Keypoint` labels. This PR:
* Enables `fo.Keypoint` and `fo.Keypoints` labels in annotation schemas
* Parses `fo.Keypoint` labels on the sample when active in the annotation schema
* Adds keypoint rendering for active labels
* Adds attribute editing for active labels

Out of scope:
* Editing of spatial keypoint attributes
* Adding new keypoints
* Deleting keypoints
* Creating new keypoint fields from the in-app schema manager

## 🧪 How is this patch tested? If it is not, please explain why.

local app + unit tests

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Added support for editing attributes of `fo.Keypoint` labels using in-app annotation

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keypoint annotation support for images (creation, editing, renderer overlays).
  * Keypoint details panel showing edge and point counts with optional label tooltips.
  * Keypoint icon in the annotation toolbar.
  * Support for keypoint skeleton lookup for overlays and label creation.
  * Server/state delta support for upserting and deleting keypoint labels.

* **Tests**
  * Added unit tests covering keypoint mutation and deletion delta behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->