### PR TITLE
[ENH] Replace deprecated datetime.utcnow() and add Mongo tz-awareness

### DIFF
--- a/docs/source/user_guide/app.rst
+++ b/docs/source/user_guide/app.rst
@@ -943,19 +943,19 @@ Consider the following example:
 
     import fiftyone as fo
     import fiftyone.zoo as foz
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     dataset = foz.load_zoo_dataset("quickstart")
     dataset.add_dynamic_sample_fields()
 
     field = dataset.get_field("ground_truth")
     field.description = "Ground truth annotations"
-    field.info = {"creator": "alice", "created_at": datetime.utcnow()}
+    field.info = {"creator": "alice", "created_at": datetime.now(timezone.utc)}
     field.save()
 
     field = dataset.get_field("predictions")
     field.description = "YOLOv8 predictions"
-    field.info = {"owner": "bob", "created_at": datetime.utcnow()}
+    field.info = {"owner": "bob", "created_at": datetime.now(timezone.utc)}
     field.save()
 
     session = fo.launch_app(dataset)

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -650,8 +650,8 @@ deployment:
 Configuring a timezone
 ----------------------
 
-By default, FiftyOne loads all datetimes in FiftyOne datasets as naive
-`datetime` objects expressed in UTC time.
+By default, FiftyOne loads all datetimes in FiftyOne datasets as timezone-aware
+`datetime` objects expressed in UTC.
 
 However, you can configure FiftyOne to express datetimes in a specific timezone
 by setting the `timezone` property of your FiftyOne config.
@@ -674,16 +674,16 @@ Or, you can even dynamically change the timezone while you work in Python:
 .. code-block:: python
     :linenos:
 
-    from datetime import datetime
+    from datetime import datetime, timezone
     import fiftyone as fo
 
-    sample = fo.Sample(filepath="image.png", created_at=datetime.utcnow())
+    sample = fo.Sample(filepath="image.png", created_at=datetime.now(timezone.utc))
 
     dataset = fo.Dataset()
     dataset.add_sample(sample)
 
     print(sample.created_at)
-    # 2021-08-24 20:24:09.723021
+    # 2021-08-24 20:24:09.723021+00:00
 
     fo.config.timezone = "local"
     dataset.reload()

--- a/docs/source/user_guide/using_aggregations.rst
+++ b/docs/source/user_guide/using_aggregations.rst
@@ -278,7 +278,7 @@ a collection:
 .. code-block:: python
     :linenos:
 
-    from datetime import datetime
+    from datetime import datetime, timezone
     import fiftyone as fo
 
     dataset = fo.Dataset()
@@ -291,13 +291,13 @@ a collection:
                 fo.DynamicEmbeddedDocument(
                     task="initial_annotation",
                     author="Alice",
-                    timestamp=datetime(1970, 1, 1),
+                    timestamp=datetime(1970, 1, 1, tzinfo=timezone.utc),
                     notes=["foo", "bar"],
                 ),
                 fo.DynamicEmbeddedDocument(
                     task="editing_pass",
                     author="Bob",
-                    timestamp=datetime.utcnow(),
+                    timestamp=datetime.now(timezone.utc),
                 ),
             ],
         ),
@@ -311,7 +311,7 @@ a collection:
                 fo.DynamicEmbeddedDocument(
                     task="initial_annotation",
                     author="Bob",
-                    timestamp=datetime(2018, 10, 18),
+                    timestamp=datetime(2018, 10, 18, tzinfo=timezone.utc),
                     notes=["spam", "eggs"],
                 ),
             ],

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -1656,7 +1656,7 @@ and `last_modified_at` are read-only and thus cannot be manually edited:
 .. code-block:: python
     :linenos:
 
-    from datetime import datetime
+    from datetime import datetime, timezone
     import fiftyone as fo
 
     sample = fo.Sample(filepath="/path/to/image.jpg")
@@ -1664,10 +1664,10 @@ and `last_modified_at` are read-only and thus cannot be manually edited:
     dataset = fo.Dataset()
     dataset.add_sample(sample)
 
-    sample.created_at = datetime.utcnow()
+    sample.created_at = datetime.now(timezone.utc)
     # ValueError: Cannot edit read-only field 'created_at'
 
-    sample.last_modified_at = datetime.utcnow()
+    sample.last_modified_at = datetime.now(timezone.utc)
     # ValueError: Cannot edit read-only field 'last_modified_at'
 
 You can also manually mark additional fields or embedded fields as read-only
@@ -2398,7 +2398,7 @@ You can store date information in FiftyOne datasets by populating fields with
 .. code-block:: python
     :linenos:
 
-    from datetime import date, datetime
+    from datetime import date, datetime, timezone
     import fiftyone as fo
 
     dataset = fo.Dataset()
@@ -2411,7 +2411,7 @@ You can store date information in FiftyOne datasets by populating fields with
             ),
             fo.Sample(
                 filepath="image2.png",
-                acquisition_time=datetime.utcnow(),
+                acquisition_time=datetime.now(timezone.utc),
                 acquisition_date=date.today(),
             ),
         ]
@@ -2434,7 +2434,7 @@ format for safekeeping.
     :linenos:
 
     # A datetime in your local timezone
-    now = datetime.utcnow().astimezone()
+    now = datetime.now(timezone.utc).astimezone()
 
     sample = fo.Sample(filepath="image.png", acquisition_time=now)
 
@@ -2445,12 +2445,12 @@ format for safekeeping.
     # loaded from the database
     dataset.reload()
 
-    sample.acquisition_time.tzinfo  # None
+    sample.acquisition_time.tzinfo  # datetime.timezone.utc
 
 By default, when you access a datetime field of a sample in a dataset, it is
-retrieved as a naive `datetime` instance expressed in UTC format.
+retrieved as a timezone-aware `datetime` instance expressed in UTC.
 
-However, if you prefer, you can
+If you prefer, you can
 :ref:`configure FiftyOne <configuring-timezone>` to load datetime fields as
 timezone-aware `datetime` instances in a timezone of your choice.
 
@@ -2459,8 +2459,8 @@ timezone-aware `datetime` instances in a timezone of your choice.
     FiftyOne assumes that all `datetime` instances with no explicit timezone
     are stored in UTC format.
 
-    Therefore, never use `datetime.datetime.now()` when populating a datetime
-    field of a FiftyOne dataset! Instead, use `datetime.datetime.utcnow()`.
+    Note that `datetime.datetime.utcnow()` is deprecated since Python 3.12;
+    use `datetime.datetime.now(datetime.timezone.utc)` instead.
 
 .. _using-labels:
 
@@ -4876,7 +4876,7 @@ For example, suppose you add the following embedded document classes to a
 .. code-block:: python
     :linenos:
 
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     import fiftyone as fo
 
@@ -4886,7 +4886,9 @@ For example, suppose you add the following embedded document classes to a
         description = fo.StringField()
 
     class LabelMetadata(fo.DynamicEmbeddedDocument):
-        created_at = fo.DateTimeField(default=datetime.utcnow)
+        created_at = fo.DateTimeField(
+            default=lambda: datetime.now(timezone.utc)
+        )
         model_name = fo.StringField()
 
 and then  `foo.bar` to FiftyOne's `module_path` config setting (see

--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -6,13 +6,14 @@ Package-wide constants.
 |
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 import os
 
 from packaging.version import Version
 
 from importlib.metadata import metadata
 
+UTC = timezone.utc
 
 CLIENT_TYPE = "fiftyone"
 

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -27,7 +27,7 @@ import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
 import fiftyone.core.media as fom
 import fiftyone.core.utils as fou
-
+from fiftyone.constants import UTC
 
 logger = logging.getLogger(__name__)
 
@@ -2260,7 +2260,7 @@ class ListSchema(Aggregation):
 
     Examples::
 
-        from datetime import datetime
+        from datetime import datetime, timezone
         import fiftyone as fo
 
         dataset = fo.Dataset()
@@ -2273,13 +2273,13 @@ class ListSchema(Aggregation):
                     fo.DynamicEmbeddedDocument(
                         task="initial_annotation",
                         author="Alice",
-                        timestamp=datetime(1970, 1, 1),
+                        timestamp=datetime(1970, 1, 1, tzinfo=timezone.utc),
                         notes=["foo", "bar"],
                     ),
                     fo.DynamicEmbeddedDocument(
                         task="editing_pass",
                         author="Bob",
-                        timestamp=datetime.utcnow(),
+                        timestamp=datetime.now(timezone.utc),
                     ),
                 ],
             ),
@@ -2293,7 +2293,7 @@ class ListSchema(Aggregation):
                     fo.DynamicEmbeddedDocument(
                         task="initial_annotation",
                         author="Bob",
-                        timestamp=datetime(2018, 10, 18),
+                        timestamp=datetime(2018, 10, 18, tzinfo=timezone.utc),
                         notes=["spam", "eggs"],
                     ),
                 ],

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -48,6 +48,7 @@ import fiftyone.core.runs as fors
 import fiftyone.core.sample as fosa
 import fiftyone.core.storage as fost
 import fiftyone.core.utils as fou
+from fiftyone.constants import UTC
 
 fod = fou.lazy_import("fiftyone.core.dataset")
 fos = fou.lazy_import("fiftyone.core.stages")
@@ -2093,7 +2094,7 @@ class SampleCollection(object):
         if self._is_read_only_field("tags"):
             raise ValueError("Cannot edit read-only field 'tags'")
 
-        update["$set"] = {"last_modified_at": datetime.utcnow()}
+        update["$set"] = {"last_modified_at": datetime.now(UTC)}
 
         ids = []
         ops = []
@@ -2223,7 +2224,7 @@ class SampleCollection(object):
         if self._is_read_only_field(tags_path):
             raise ValueError("Cannot edit read-only field '%s'" % tags_path)
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         root, is_list_field = self._get_label_field_root(label_field)
         _root, is_frame_field = self._handle_frame_field(root)
@@ -3383,7 +3384,7 @@ class SampleCollection(object):
         if self._is_read_only_field(field_name):
             raise ValueError("Cannot edit read-only field '%s'" % field_name)
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         ops = []
         for _id, value in zip(ids, values):
@@ -3426,7 +3427,7 @@ class SampleCollection(object):
         if self._is_read_only_field(field_name):
             raise ValueError("Cannot edit read-only field '%s'" % field_name)
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         root = list_field
         leaf = field_name[len(root) + 1 :]
@@ -3489,7 +3490,7 @@ class SampleCollection(object):
         if self._is_read_only_field(field_name):
             raise ValueError("Cannot edit read-only field '%s'" % field_name)
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         root = list_field
         leaf = field_name[len(root) + 1 :]
@@ -3530,7 +3531,7 @@ class SampleCollection(object):
                 "(found: '%s')" % field_name
             )
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         root, is_list_field = self._get_label_field_root(field_name)
         field_name, is_frame_field = self._handle_frame_field(field_name)
@@ -9555,7 +9556,7 @@ class SampleCollection(object):
 
         Examples::
 
-            from datetime import datetime
+            from datetime import datetime, timezone
             import fiftyone as fo
 
             dataset = fo.Dataset()
@@ -9568,13 +9569,13 @@ class SampleCollection(object):
                         fo.DynamicEmbeddedDocument(
                             task="initial_annotation",
                             author="Alice",
-                            timestamp=datetime(1970, 1, 1),
+                            timestamp=datetime(1970, 1, 1, tzinfo=timezone.utc),
                             notes=["foo", "bar"],
                         ),
                         fo.DynamicEmbeddedDocument(
                             task="editing_pass",
                             author="Bob",
-                            timestamp=datetime.utcnow(),
+                            timestamp=datetime.now(timezone.utc),
                         ),
                     ],
                 ),
@@ -9588,7 +9589,7 @@ class SampleCollection(object):
                         fo.DynamicEmbeddedDocument(
                             task="initial_annotation",
                             author="Bob",
-                            timestamp=datetime(2018, 10, 18),
+                            timestamp=datetime(2018, 10, 18, tzinfo=timezone.utc),
                             notes=["spam", "eggs"],
                         ),
                     ],
@@ -12988,7 +12989,7 @@ def _parse_values_dict(sample_collection, key_field, values):
 
 
 def _parse_frame_values_dicts(sample_collection, sample_ids, values):
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
 
     value = _get_non_none_value(values)
     if not isinstance(value, dict):
@@ -13018,6 +13019,7 @@ def _parse_frame_values_dicts(sample_collection, sample_ids, values):
                 {
                     "_sample_id": ObjectId(_id),
                     "frame_number": fn,
+                    "created_at": now,
                     "last_modified_at": now,
                 }
             )

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -48,6 +48,7 @@ import fiftyone.migrations as fomi
 from fiftyone.core.expressions import ViewField as F
 from fiftyone.core.odm.dataset import DatasetAppConfig
 from fiftyone.core.singletons import DatasetSingleton
+from fiftyone.constants import UTC
 
 fot = fou.lazy_import("fiftyone.core.stages")
 foud = fou.lazy_import("fiftyone.utils.data")
@@ -500,7 +501,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 embedded_doc_type=doc_type,
             )
             field_doc = foo.SampleFieldDocument.from_field(field)
-            field_doc._set_created_at(datetime.utcnow())
+            field_doc._set_created_at(datetime.now(UTC))
 
             self._doc.sample_fields[idx] = field_doc
 
@@ -2991,7 +2992,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             raise ValueError(f"Field {field_name} is not a summary field")
 
         summary_info = field.info[_SUMMARY_FIELD_KEY]
-        summary_info["last_modified_at"] = datetime.utcnow()
+        summary_info["last_modified_at"] = datetime.now(UTC)
         field.save(_enforce_read_only=False)
 
         self._populate_summary_field(field_name, summary_info)
@@ -4355,7 +4356,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if validate:
             self._validate_sample(sample)
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         return (
             sample,
@@ -4954,7 +4955,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             if self._is_read_only_field(field):
                 raise ValueError("Cannot edit read-only field '%s'" % field)
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         batch_size = fou.recommend_batch_size_for_value(
             ObjectId(), max_size=100000
@@ -5076,7 +5077,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             if self._is_read_only_field(field):
                 raise ValueError("Cannot edit read-only field '%s'" % field)
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         sample_ops = []
         frame_ops = []
@@ -5340,7 +5341,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         slug = self._validate_saved_view_name(name, overwrite=overwrite)
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         view_doc = foo.SavedViewDocument(
             dataset_id=self._doc.id,
@@ -5492,7 +5493,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         # When reloading generated views, increment `last_modified_at` so we
         # can compute when the view next needs refreshing
         if reload and view._is_generated:
-            view_doc.last_modified_at = datetime.utcnow()
+            view_doc.last_modified_at = datetime.now(UTC)
             updated = True
 
         if updated:
@@ -5686,7 +5687,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         """
         slug = self._validate_workspace_name(name, overwrite=overwrite)
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         workspace_doc = foo.WorkspaceDocument(
             child=workspace,
@@ -5974,7 +5975,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         self._clear()
 
     def _clear(self, view=None, sample_ids=None):
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         if view is not None:
             contains_videos = view._contains_videos(any_slice=True)
@@ -6076,7 +6077,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if not sample_collection._contains_videos(any_slice=True):
             return
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         if self._is_clips:
             if sample_ids is not None:
@@ -6174,7 +6175,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if view is None:
             return
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         if view.media_type == fom.GROUP:
             view = view.select_group_slices(media_type=fom.VIDEO)
@@ -6257,7 +6258,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 media_type=fom.VIDEO
             )
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         sample_collection.compute_metadata()
         sample_collection._aggregate(
@@ -9375,7 +9376,7 @@ def _create_dataset(
     slug = _validate_dataset_name(name)
 
     _id = ObjectId()
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
 
     sample_collection_name = _make_sample_collection_name(
         _id, patches=_patches, frames=_frames, clips=_clips
@@ -9838,7 +9839,7 @@ def _declare_fields(dataset, doc_cls, field_docs=None):
         default_fields -= {field_doc.name for field_doc in field_docs}
 
     # Declare default fields that don't already exist
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
     for field_name in default_fields:
         field = doc_cls._fields[field_name]
 
@@ -10034,7 +10035,7 @@ def _clone_collection(
     dataset_doc = dataset._doc.copy(new_id=True)
 
     _id = dataset_doc.id
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
 
     sample_collection_name = _make_sample_collection_name(_id)
 
@@ -10235,7 +10236,7 @@ def _save_view(view, fields=None):
     # Must retrieve IDs now in case view changes after saving
     sample_ids = view.values("id")
 
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
 
     #
     # Save samples
@@ -10633,7 +10634,7 @@ def _add_collection_with_new_ids(
     else:
         num_ids = len(src_samples)
 
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
 
     add_fields = {
         "_dataset_id": dataset._doc.id,
@@ -10990,7 +10991,7 @@ def _merge_samples_pipeline(
     else:
         when_not_matched = "discard"
 
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
 
     sample_pipeline.extend(
         [

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -18,6 +18,7 @@ import eta.core.utils as etau
 
 from fiftyone.core.odm.document import MongoEngineBaseDocument
 import fiftyone.core.utils as fou
+from fiftyone.constants import UTC
 
 
 def to_mongo(expr, prefix=None):
@@ -1767,13 +1768,12 @@ class ViewExpression(object):
 
         Examples::
 
-            from datetime import datetime
-            import pytz
+            from datetime import datetime, timezone
 
             import fiftyone as fo
             from fiftyone import ViewField as F
 
-            now = datetime.utcnow().replace(tzinfo=pytz.utc)
+            now = datetime.now(timezone.utc)
 
             sample = fo.Sample(
                 filepath="image.png",
@@ -2748,9 +2748,7 @@ class ViewExpression(object):
             array.sort({comp}){rev};
             return array;
         }}
-        """.format(
-            comp=comp, rev=rev
-        )
+        """.format(comp=comp, rev=rev)
 
         return self._function(sort_fcn)
 

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -17,6 +17,7 @@ import fiftyone.core.frame_utils as fofu
 import fiftyone.core.odm as foo
 from fiftyone.core.singletons import FrameSingleton
 import fiftyone.core.utils as fou
+from fiftyone.constants import UTC
 
 import logging
 
@@ -697,7 +698,7 @@ class Frames(object):
         }
 
     def _save_deletions(self, deferred=False):
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         sample_ops = []
         frame_ops = []
@@ -793,7 +794,7 @@ class Frames(object):
         if validate:
             schema = self._dataset.get_frame_field_schema(include_private=True)
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         ops = []
         new_dicts = {}

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -8,7 +8,6 @@ Database utilities.
 
 import atexit
 import dataclasses
-from datetime import datetime
 import logging
 from multiprocessing.pool import ThreadPool
 import os
@@ -16,7 +15,6 @@ from typing import Tuple
 
 import asyncio
 from bson import json_util, ObjectId
-from bson.codec_options import CodecOptions
 import mongoengine
 import motor.motor_asyncio as mtr
 
@@ -29,7 +27,6 @@ from pymongo.errors import (
     PyMongoError,
     ServerSelectionTimeoutError,
 )
-import pytz
 
 import eta.core.utils as etau
 
@@ -215,14 +212,20 @@ def establish_db_conn(config):
             )
 
     _client = pymongo.MongoClient(
-        **_connection_kwargs, appname=foc.DATABASE_APPNAME
+        **_connection_kwargs,
+        appname=foc.DATABASE_APPNAME,
+        tz_aware=True,
     )
     _validate_db_version(config, _client)
 
     # Register cleanup method
     atexit.register(_delete_non_persistent_datasets_if_allowed)
 
-    mongoengine.connect(config.database_name, **_connection_kwargs)
+    mongoengine.connect(
+        config.database_name,
+        **_connection_kwargs,
+        tz_aware=True,
+    )
 
     db_config = get_db_config()
     if db_config.type != foc.CLIENT_TYPE:
@@ -292,7 +295,9 @@ def _async_connect(use_global=False):
     if not use_global or _is_client_closed(_async_client):
         global _connection_kwargs
         client = mtr.AsyncIOMotorClient(
-            **_connection_kwargs, appname=foc.DATABASE_APPNAME
+            **_connection_kwargs,
+            appname=foc.DATABASE_APPNAME,
+            tz_aware=True,
         )
 
         if use_global:
@@ -535,18 +540,10 @@ def get_async_db_conn(use_global=False):
 
 
 def _apply_options(db):
-    timezone = fo.config.timezone
-
-    if not timezone:
-        return db
-
-    if timezone.lower() == "local":
-        tzinfo = datetime.now().astimezone().tzinfo
-    else:
-        tzinfo = pytz.timezone(timezone)
-
     return db.with_options(
-        codec_options=CodecOptions(tz_aware=True, tzinfo=tzinfo)
+        codec_options=db.codec_options.with_options(
+            tz_aware=True, tzinfo=fou._config_tzinfo()
+        )
     )
 
 

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -19,6 +19,7 @@ import eta.core.serial as etas
 
 import fiftyone.core.fields as fof
 import fiftyone.core.utils as fou
+from fiftyone.constants import UTC
 
 from .database import ensure_connection
 from .utils import serialize_value, deserialize_value
@@ -781,7 +782,7 @@ class Document(BaseDocument, mongoengine.Document):
         **kwargs,
     ):
         if self.has_field("last_modified_at") and not virtual:
-            now = datetime.utcnow()
+            now = datetime.now(UTC)
             self.last_modified_at = now
             if "$set" not in updates:
                 updates["$set"] = {}
@@ -797,19 +798,19 @@ class Document(BaseDocument, mongoengine.Document):
         return ops, updated_existing
 
     def _update_last_loaded_at(self):
-        self.last_loaded_at = datetime.utcnow()
+        self.last_loaded_at = datetime.now(UTC)
         self.save(virtual=True)
 
-    def _update_last_modified_at(self, last_modified_at=None):
+    def _update_last_modified_at(self, last_modified_at=None) -> None:
         if last_modified_at is None:
-            last_modified_at = datetime.utcnow()
+            last_modified_at = datetime.now(UTC)
 
         self.last_modified_at = last_modified_at
         self.save(virtual=True)
 
-    def _update_last_deletion_at(self, last_deletion_at=None):
+    def _update_last_deletion_at(self, last_deletion_at=None) -> None:
         if last_deletion_at is None:
-            last_deletion_at = datetime.utcnow()
+            last_deletion_at = datetime.now(UTC)
 
         self.last_deletion_at = last_deletion_at
         self.save(virtual=True)

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -18,6 +18,7 @@ import fiftyone.core.annotation.constants as foac
 import fiftyone.core.fields as fof
 import fiftyone.core.media as fom
 import fiftyone.core.utils as fou
+from fiftyone.constants import UTC
 
 from .database import get_db_conn
 from .dataset import SampleFieldDocument
@@ -311,7 +312,7 @@ class DatasetMixin(object):
         dataset_doc = dataset._doc
         media_type = dataset.media_type
         is_frame_field = cls._is_frames_doc
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         new_schema = {}
         new_metadata = {}
@@ -667,7 +668,7 @@ class DatasetMixin(object):
         media_type = dataset.media_type
         is_frame_field = cls._is_frames_doc
         is_dataset = isinstance(sample_collection, fod.Dataset)
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         simple_paths = []
         coll_paths = []
@@ -983,7 +984,7 @@ class DatasetMixin(object):
         _paths, _new_paths = cls._handle_db_fields(paths, new_paths)
 
         rename_expr = dict(zip(_paths, _new_paths))
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         coll = get_db_conn()[cls.__name__]
         coll.update_many(
@@ -1039,7 +1040,7 @@ class DatasetMixin(object):
         _paths, _new_paths = cls._handle_db_fields(paths, new_paths)
 
         set_expr = {v: "$" + k for k, v in zip(_paths, _new_paths)}
-        set_expr["last_modified_at"] = datetime.utcnow()
+        set_expr["last_modified_at"] = datetime.now(UTC)
 
         coll = get_db_conn()[cls.__name__]
         coll.update_many({}, [{"$set": set_expr}])
@@ -1091,7 +1092,7 @@ class DatasetMixin(object):
         _paths = cls._handle_db_fields(paths)
 
         set_expr = {p: None for p in _paths}
-        set_expr["last_modified_at"] = datetime.utcnow()
+        set_expr["last_modified_at"] = datetime.now(UTC)
 
         coll = get_db_conn()[cls.__name__]
         coll.update_many({}, {"$set": set_expr})
@@ -1126,7 +1127,7 @@ class DatasetMixin(object):
             return
 
         _paths = cls._handle_db_fields(paths)
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         coll = get_db_conn()[cls.__name__]
         coll.update_many(
@@ -1298,7 +1299,7 @@ class DatasetMixin(object):
     @classmethod
     def _add_field_schema(cls, path, field, created_at=None):
         if created_at is None:
-            created_at = datetime.utcnow()
+            created_at = datetime.now(UTC)
 
         field_name, doc, field_docs, root_doc = cls._parse_path(path)
 
@@ -1555,7 +1556,7 @@ class DatasetMixin(object):
         delattr(cls, field_name)
 
     def _insert(self, doc, deferred=False):
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         self.created_at = now
         self.last_modified_at = now
         doc["created_at"] = now
@@ -1573,7 +1574,7 @@ class DatasetMixin(object):
         **kwargs,
     ):
         if not virtual:
-            now = datetime.utcnow()
+            now = datetime.now(UTC)
             self.last_modified_at = now
             if "$set" not in updates:
                 updates["$set"] = {}

--- a/fiftyone/core/plots/manager.py
+++ b/fiftyone/core/plots/manager.py
@@ -17,6 +17,7 @@ import fiftyone.core.clips as foc
 from fiftyone.core.expressions import ViewField as F
 import fiftyone.core.patches as fop
 import fiftyone.core.video as fov
+from fiftyone.constants import UTC
 
 from .base import ResponsivePlot, ViewPlot, InteractivePlot
 
@@ -734,7 +735,7 @@ class PlotManager(object):
         ]
 
     def _ready_for_update(self, name):
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(UTC)
 
         if self._last_update is None:
             is_new_update = True
@@ -749,7 +750,7 @@ class PlotManager(object):
         return is_new_update
 
     def _needs_update(self, name):
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(UTC)
 
         last_update = self._last_updates.get(name, None)
 

--- a/fiftyone/core/runs.py
+++ b/fiftyone/core/runs.py
@@ -18,6 +18,7 @@ import fiftyone.constants as foc
 from fiftyone.core.config import Config, Configurable
 from fiftyone.core.odm import patch_runs
 from fiftyone.core.odm.runs import RunDocument
+from fiftyone.constants import UTC
 
 
 logger = logging.getLogger(__name__)
@@ -313,7 +314,7 @@ class BaseRun(Configurable):
 
         self.validate_run(samples, key, overwrite=overwrite)
         version = foc.VERSION
-        timestamp = datetime.datetime.utcnow()
+        timestamp = datetime.datetime.now(UTC)
         run_info_cls = self.run_info_cls()
         run_info = run_info_cls(
             key, version=version, timestamp=timestamp, config=self.config

--- a/fiftyone/core/storage.py
+++ b/fiftyone/core/storage.py
@@ -647,7 +647,9 @@ def _get_local_metadata(filepath):
     return {
         "name": os.path.basename(filepath),
         "size": s.st_size,
-        "last_modified": datetime.fromtimestamp(s.st_mtime),
+        "last_modified": datetime.fromtimestamp(
+            s.st_mtime, tz=fou._config_tzinfo()
+        ),
     }
 
 

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -3159,9 +3159,25 @@ def datetime_to_timestamp(dt):
     return 1000.0 * dt.timestamp()
 
 
+def _config_tzinfo():
+    """Resolves ``fo.config.timezone`` to a ``tzinfo``, defaulting to UTC.
+
+    Returns:
+        a ``datetime.tzinfo``
+    """
+    tz = fo.config.timezone or pytz.utc.zone
+    if tz.lower() == "local":
+        return datetime.now().astimezone().tzinfo
+
+    return pytz.timezone(tz)
+
+
 def timestamp_to_datetime(ts):
     """Converts a timestamp (number of milliseconds since epoch) to a
     `datetime.datetime`.
+
+    The returned datetime is timezone-aware in ``fo.config.timezone``
+    (defaulting to UTC).
 
     Args:
         ts: a number of milliseconds since epoch
@@ -3169,13 +3185,7 @@ def timestamp_to_datetime(ts):
     Returns:
         a `datetime.datetime`
     """
-    dt = datetime.utcfromtimestamp(ts / 1000.0)
-
-    if fo.config.timezone is None:
-        return dt
-
-    timezone = pytz.timezone(fo.config.timezone)
-    return dt.replace(tzinfo=pytz.utc).astimezone(timezone)
+    return datetime.fromtimestamp(ts / 1000.0, tz=_config_tzinfo())
 
 
 def timedelta_to_ms(td):

--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -24,6 +24,7 @@ from fiftyone.operators.executor import (
     ExecutionResult,
     ExecutionRunState,
 )
+from fiftyone.constants import UTC
 
 logger = logging.getLogger(__name__)
 
@@ -363,8 +364,8 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             update = {
                 "$set": {
                     "run_state": run_state,
-                    "completed_at": datetime.utcnow(),
-                    "updated_at": datetime.utcnow(),
+                    "completed_at": datetime.now(UTC),
+                    "updated_at": datetime.now(UTC),
                     "result": execution_result_json,
                 }
             }
@@ -378,8 +379,8 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             update = {
                 "$set": {
                     "run_state": run_state,
-                    "failed_at": datetime.utcnow(),
-                    "updated_at": datetime.utcnow(),
+                    "failed_at": datetime.now(UTC),
+                    "updated_at": datetime.now(UTC),
                     "result": execution_result_json,
                 }
             }
@@ -388,8 +389,8 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             update = {
                 "$set": {
                     "run_state": run_state,
-                    "started_at": datetime.utcnow(),
-                    "updated_at": datetime.utcnow(),
+                    "started_at": datetime.now(UTC),
+                    "updated_at": datetime.now(UTC),
                     "monitored": monitored,
                 }
             }
@@ -397,8 +398,8 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             update = {
                 "$set": {
                     "run_state": run_state,
-                    "scheduled_at": datetime.utcnow(),
-                    "updated_at": datetime.utcnow(),
+                    "scheduled_at": datetime.now(UTC),
+                    "updated_at": datetime.now(UTC),
                 }
             }
         elif run_state == ExecutionRunState.QUEUED:
@@ -409,8 +410,8 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             update = {
                 "$set": {
                     "run_state": run_state,
-                    "queued_at": datetime.utcnow(),
-                    "updated_at": datetime.utcnow(),
+                    "queued_at": datetime.now(UTC),
+                    "updated_at": datetime.now(UTC),
                 }
             }
 
@@ -425,7 +426,7 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
 
         if progress is not None:
             update["$set"]["status"] = progress
-            update["$set"]["status"]["updated_at"] = datetime.utcnow()
+            update["$set"]["status"]["updated_at"] = datetime.now(UTC)
 
         collection_filter = {"_id": _id}
         if required_state is not None:
@@ -466,7 +467,7 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
                 "status": {
                     "progress": execution_progress.progress,
                     "label": execution_progress.label,
-                    "updated_at": datetime.utcnow(),
+                    "updated_at": datetime.now(UTC),
                 },
             }
         }
@@ -614,7 +615,7 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
         return self._collection.count_documents(filter=query)
 
     def ping(self, _id: ObjectId, log_tail: str = None):
-        updates = {"updated_at": datetime.utcnow()}
+        updates = {"updated_at": datetime.now(UTC)}
         if log_tail and isinstance(log_tail, str):
             updates["log_tail"] = log_tail
         self._collection.update_one(

--- a/fiftyone/factory/repos/delegated_operation_doc.py
+++ b/fiftyone/factory/repos/delegated_operation_doc.py
@@ -16,6 +16,7 @@ from fiftyone.operators.executor import (
     ExecutionRunState,
 )
 from fiftyone.operators.types import Pipeline, PipelineRunInfo
+from fiftyone.constants import UTC
 
 logger = logging.getLogger(__name__)
 
@@ -45,15 +46,15 @@ class DelegatedOperationDocument(object):
             else ExecutionRunState.QUEUED
         )  # if running locally use QUEUED otherwise SCHEDULED
         self.run_link = None
-        self.queued_at = datetime.utcnow() if not is_remote else None
-        self.updated_at = datetime.utcnow()
+        self.queued_at = datetime.now(UTC) if not is_remote else None
+        self.updated_at = datetime.now(UTC)
         self.status = None
         self.dataset_id = None
         self.started_at = None
         self.pinned = False
         self.completed_at = None
         self.failed_at = None
-        self.scheduled_at = datetime.utcnow() if is_remote else None
+        self.scheduled_at = datetime.now(UTC) if is_remote else None
         self.result = None
         self.id = None
         self._doc = None

--- a/fiftyone/factory/repos/execution_store.py
+++ b/fiftyone/factory/repos/execution_store.py
@@ -23,6 +23,7 @@ from fiftyone.operators.store.notification_service import (
     default_notification_service,
     is_notification_service_disabled,
 )
+from fiftyone.constants import UTC
 
 logger = logging.getLogger(__name__)
 
@@ -507,7 +508,7 @@ class MongoExecutionStoreRepo(ExecutionStoreRepo):
         ttl: Optional[int] = None,
         policy: str = "persist",
     ) -> KeyDocument:
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         expiration = KeyDocument.get_expiration(ttl)
         policy = "evict" if ttl is not None or policy == "evict" else "persist"
         if ttl is not None or policy == "evict":
@@ -772,7 +773,7 @@ class InMemoryExecutionStoreRepo(ExecutionStoreRepo):
         ttl: Optional[int] = None,
         policy: str = "persist",
     ) -> KeyDocument:
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         expiration = KeyDocument.get_expiration(ttl)
         key_doc = KeyDocument.from_dict(
             dict(

--- a/fiftyone/operators/store/models.py
+++ b/fiftyone/operators/store/models.py
@@ -12,6 +12,7 @@ from typing import Optional, Any
 from enum import Enum
 
 from bson import ObjectId
+from fiftyone.constants import UTC
 
 
 class KeyPolicy(str, Enum):
@@ -37,7 +38,7 @@ class KeyDocument:
     value: Any
     _id: Optional[Any] = None
     dataset_id: Optional[ObjectId] = None
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     updated_at: Optional[datetime] = None
     expires_at: Optional[datetime] = None
     policy: KeyPolicy = KeyPolicy.PERSIST
@@ -48,7 +49,7 @@ class KeyDocument:
         if ttl is None:
             return None
 
-        return datetime.utcnow() + timedelta(seconds=ttl)
+        return datetime.now(UTC) + timedelta(seconds=ttl)
 
     @classmethod
     def from_dict(cls, doc: dict[str, Any]) -> "KeyDocument":

--- a/fiftyone/server/routes/sample.py
+++ b/fiftyone/server/routes/sample.py
@@ -18,6 +18,7 @@ from starlette.exceptions import HTTPException
 from starlette.requests import Request
 
 import fiftyone as fo
+import fiftyone.core.utils as fou
 from fiftyone.server import decorators, utils
 from fiftyone.server.exceptions import DbVersionMismatchError
 from fiftyone.server.utils.datasets import (
@@ -100,7 +101,7 @@ def get_if_last_modified_at(
         # As Unix timestamp
         try:
             if_last_modified_at = datetime.datetime.fromtimestamp(
-                float(if_match)
+                float(if_match), tz=fou._config_tzinfo()
             )
         except Exception:
             ...
@@ -724,9 +725,7 @@ class CommitMask(HTTPEndpoint):
         mask_path = detection.mask_path
 
         try:
-            detection.export_mask(
-                mask_path, update=True, overwrite_path=True
-            )
+            detection.export_mask(mask_path, update=True, overwrite_path=True)
             etag = save_sample(sample, if_last_modified_at)
         except DbVersionMismatchError:
             raise

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -38,6 +38,7 @@ import fiftyone.core.storage as fos
 import fiftyone.core.utils as fou
 import fiftyone.migrations as fomi
 import fiftyone.types as fot
+from fiftyone.constants import UTC
 
 from .parsers import (
     FiftyOneImageClassificationSampleParser,
@@ -1878,7 +1879,7 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
     def _import_samples(self, dataset, dataset_dict, tags=None, progress=None):
         name = dataset.name
         empty_import = not bool(dataset)
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         #
         # Import DatasetDocument

--- a/tests/unittests/aggregation_tests.py
+++ b/tests/unittests/aggregation_tests.py
@@ -15,6 +15,7 @@ import unittest
 import fiftyone as fo
 import fiftyone.core.fields as fof
 from fiftyone import ViewField as F
+from fiftyone.constants import UTC
 
 from decorators import drop_datasets
 
@@ -437,7 +438,7 @@ class DatasetTests(unittest.TestCase):
                             fo.DynamicEmbeddedDocument(
                                 task="editing_pass",
                                 author="Bob",
-                                timestamp=datetime.utcnow(),
+                                timestamp=datetime.now(UTC),
                             ),
                         ],
                     ),
@@ -1127,7 +1128,7 @@ class DatasetTests(unittest.TestCase):
     @drop_datasets
     def test_dates(self):
         today = date.today()
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         samples = []
         for idx in range(100):
@@ -1178,6 +1179,8 @@ class DatasetTests(unittest.TestCase):
             bounds = dataset.bounds(field)
             self.assertIsInstance(bounds[0], datetime)
             self.assertIsInstance(bounds[1], datetime)
+            self.assertIsNotNone(bounds[0].tzinfo)
+            self.assertIsNotNone(bounds[1].tzinfo)
 
             count = dataset.count(field)
             self.assertEqual(count, 100)
@@ -1185,6 +1188,7 @@ class DatasetTests(unittest.TestCase):
             values = dataset.values(field)
             for value in values:
                 self.assertIsInstance(value, datetime)
+                self.assertIsNotNone(value.tzinfo)
 
             uniques = dataset.distinct(field)
             self.assertListEqual(uniques, list(reversed(values)))

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -32,6 +32,7 @@ import fiftyone.core.utils as fou
 import fiftyone.utils.data as foud
 from fiftyone import ViewField as F
 from fiftyone.operators.store import ExecutionStoreService
+from fiftyone.constants import UTC
 
 
 class DatasetTests(unittest.TestCase):
@@ -615,6 +616,159 @@ class DatasetTests(unittest.TestCase):
         self.assertTrue(last_loaded_at2 > last_loaded_at1)
         self.assertEqual(created_at2, created_at1)
         self.assertEqual(last_modified_at2, last_modified_at1)
+
+    @drop_datasets
+    def test_timestamps_are_timezone_aware(self):
+        """Asserts that ``created_at`` / ``last_modified_at`` values are
+        ``datetime`` objects with a UTC ``tzinfo`` after a Mongo round-trip,
+        so that user code can compare them against ``datetime.now(UTC)``
+        without raising
+        ``TypeError: can't compare offset-naive and offset-aware datetimes``.
+
+        This is the read-side invariant prescribed in the discussion of #7402.
+        """
+        original_timezone = fo.config.timezone
+        try:
+            fo.config.timezone = None
+
+            sample = fo.Sample(filepath="image.jpg")
+
+            dataset = fo.Dataset()
+            dataset.add_sample(sample)
+
+            # Reload from Mongo to exercise the read-side BSON codec
+            dataset.reload()
+            sample.reload()
+
+            self.assertIsNotNone(sample.created_at.tzinfo)
+            self.assertIsNotNone(sample.last_modified_at.tzinfo)
+            self.assertIsNotNone(dataset.created_at.tzinfo)
+            self.assertIsNotNone(dataset.last_modified_at.tzinfo)
+
+            self.assertEqual(sample.created_at.utcoffset(), timedelta(0))
+            self.assertEqual(sample.last_modified_at.utcoffset(), timedelta(0))
+            self.assertEqual(dataset.created_at.utcoffset(), timedelta(0))
+            self.assertEqual(
+                dataset.last_modified_at.utcoffset(), timedelta(0)
+            )
+
+            # Compare against an aware ``now`` without raising
+            now = datetime.now(UTC)
+            self.assertLessEqual(sample.created_at, now)
+            self.assertLessEqual(sample.last_modified_at, now)
+            self.assertLessEqual(dataset.created_at, now)
+            self.assertLessEqual(dataset.last_modified_at, now)
+        finally:
+            fo.config.timezone = original_timezone
+
+    @drop_datasets
+    def test_timestamps_are_timezone_aware_with_user_timezone(self):
+        """Asserts that the read-side tz-awareness invariant of
+        ``test_timestamps_are_timezone_aware`` also holds when the user
+        configures a non-UTC ``fo.config.timezone`` (equivalent to
+        ``FIFTYONE_TIMEZONE=US/Eastern``), per @Burhan-Q's review on #7414.
+
+        Writes are performed under the default UTC config to capture the
+        true UTC instants stored in Mongo; the read-side is then exercised
+        under ``US/Eastern`` so that a regression that stored or returned
+        shifted Eastern wall-clock instead of converted UTC is caught, per
+        CodeRabbit's review on #7414.
+        """
+        original_timezone = fo.config.timezone
+        try:
+            # 1. Seed under UTC so the values written to Mongo are true
+            #    UTC instants.
+            fo.config.timezone = None
+
+            sample = fo.Sample(filepath="image.jpg")
+
+            dataset = fo.Dataset()
+            dataset.add_sample(sample)
+
+            utc_instants = (
+                sample.created_at,
+                sample.last_modified_at,
+                dataset.created_at,
+                dataset.last_modified_at,
+            )
+
+            for value in utc_instants:
+                self.assertIsNotNone(value.tzinfo)
+                self.assertEqual(value.utcoffset(), timedelta(0))
+
+            # 2. Switch to a non-UTC config and reload to exercise the
+            #    read-side BSON codec conversion path.
+            fo.config.timezone = "US/Eastern"
+
+            dataset.reload()
+            sample.reload()
+
+            converted = (
+                sample.created_at,
+                sample.last_modified_at,
+                dataset.created_at,
+                dataset.last_modified_at,
+            )
+
+            for value, original in zip(converted, utc_instants):
+                # Aware datetime under the configured timezone. Note that
+                # ``Sample.reload()`` reuses the mongoengine connection,
+                # whose ``CodecOptions`` is established once at
+                # ``mongoengine.connect()`` time and is not re-applied when
+                # ``fo.config.timezone`` changes mid-process. So we assert
+                # tz-awareness here, not that ``tzinfo.zone == "US/Eastern"``.
+                self.assertIsNotNone(value.tzinfo)
+
+                # Underlying UTC instant is preserved across the
+                # conversion (this is what isolates a write-side bug from
+                # a read-side bug). BSON Date is millisecond resolution,
+                # so we truncate sub-millisecond microseconds on the
+                # in-memory ``original`` before comparing to the value
+                # round-tripped through Mongo.
+                original_utc = original.astimezone(pytz.utc)
+                original_ms = original_utc.replace(
+                    microsecond=(original_utc.microsecond // 1000) * 1000
+                )
+                self.assertEqual(value.astimezone(pytz.utc), original_ms)
+
+                # Comparing against an aware "now" must not raise
+                # ``TypeError: can't compare offset-naive and
+                # offset-aware datetimes``
+                self.assertLessEqual(value, datetime.now(UTC))
+        finally:
+            fo.config.timezone = original_timezone
+
+    @drop_datasets
+    def test_timestamp_to_datetime_returns_aware(self):
+        """Asserts that :func:`fiftyone.core.utils.timestamp_to_datetime`
+        returns timezone-aware ``datetime`` instances under both the default
+        UTC config and a user-configured non-UTC ``fo.config.timezone``,
+        per @Burhan-Q's review on #7414.
+        """
+        TS = 1700000000000.0
+
+        original_timezone = fo.config.timezone
+        try:
+            # No timezone configured uses UTC as default
+            fo.config.timezone = None
+
+            dt = fou.timestamp_to_datetime(TS)
+            self.assertIsNotNone(dt.tzinfo)
+            self.assertEqual(dt.utcoffset(), timedelta(0))
+
+            # Configured timezone is used
+            fo.config.timezone = "US/Eastern"
+
+            dt = fou.timestamp_to_datetime(TS)
+            self.assertIsNotNone(dt.tzinfo)
+            self.assertEqual(dt.tzinfo.zone, "US/Eastern")
+
+            # Comparing against an aware ``now`` must not raise
+            # ``TypeError: can't compare offset-naive and
+            # offset-aware datetimes``
+            fou.timestamp_to_datetime(TS) - datetime.now(UTC)
+        finally:
+            fo.config.timezone = original_timezone
 
     @drop_datasets
     def test_last_deletion_at(self):
@@ -1350,8 +1504,12 @@ class DatasetTests(unittest.TestCase):
         fo.config.timezone = None
         dataset.reload()
 
-        self.assertIsNone(sample1.date.tzinfo)
-        self.assertEqual(int((sample1.date - date1).total_seconds()), 0)
+        # After the read-side fix in `fiftyone/core/odm/database.py`, datetime
+        # fields are returned timezone-aware (UTC) even when
+        # ``fo.config.timezone`` is unset, so that user code can compare them
+        # against ``datetime.now(UTC)`` without raising ``TypeError``.
+        self.assertEqual(sample1.date.tzinfo, pytz.utc)
+        self.assertEqual(int((sample1.date - utcdate1).total_seconds()), 0)
         self.assertEqual(int((sample1.date - sample2.date).total_seconds()), 0)
         self.assertEqual(int((sample1.date - sample3.date).total_seconds()), 0)
 
@@ -3475,13 +3633,13 @@ class DatasetTests(unittest.TestCase):
             float_field=1.0,
             str_field="hi",
             date_field=date.today(),
-            datetime_field=datetime.utcnow(),
+            datetime_field=datetime.now(UTC),
             list_bool_field=[False, True],
             list_int_field=[1, 2, 3],
             list_float_field=[1.0, 2, 4.1],
             list_str_field=["one", "two", "three"],
             list_date_field=[date.today(), date.today()],
-            list_datetime_field=[datetime.utcnow(), datetime.utcnow()],
+            list_datetime_field=[datetime.now(UTC), datetime.now(UTC)],
             list_untyped_field=[1, {"two": "three"}, [4], "five"],
             dict_field={"hello": "world"},
             vector_field=np.arange(5),
@@ -3663,10 +3821,10 @@ class DatasetTests(unittest.TestCase):
         self.assertTrue(field.read_only)
 
         with self.assertRaises(ValueError):
-            sample.created_at = datetime.utcnow()
+            sample.created_at = datetime.now(UTC)
 
         with self.assertRaises(ValueError):
-            sample.last_modified_at = datetime.utcnow()
+            sample.last_modified_at = datetime.now(UTC)
 
         # Custom fields
 
@@ -3823,10 +3981,10 @@ class DatasetTests(unittest.TestCase):
         self.assertTrue(field.read_only)
 
         with self.assertRaises(ValueError):
-            frame.created_at = datetime.utcnow()
+            frame.created_at = datetime.now(UTC)
 
         with self.assertRaises(ValueError):
-            frame.last_modified_at = datetime.utcnow()
+            frame.last_modified_at = datetime.now(UTC)
 
         # Custom fields
 
@@ -5215,7 +5373,7 @@ class DatasetExtrasTests(unittest.TestCase):
         self.assertIsNone(spaces.name)
 
         workspace_name = "test__workspace"
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         description = "a description of the workspace, yo"
         color = "#FF6D04"
 
@@ -5247,7 +5405,7 @@ class DatasetExtrasTests(unittest.TestCase):
         dataset.reload()
         also_spaces = dataset.load_workspace(workspace_name)
         last_loaded_at2 = dataset._doc.workspaces[0].last_loaded_at
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         self.assertEqual(spaces, also_spaces)
         self.assertEqual(also_spaces.name, workspace_name)
@@ -7492,7 +7650,7 @@ class DynamicFieldTests(unittest.TestCase):
                             fo.DynamicEmbeddedDocument(
                                 task="editing_pass",
                                 author="Bob",
-                                timestamp=datetime.utcnow(),
+                                timestamp=datetime.now(UTC),
                             ),
                         ],
                     ),
@@ -8273,7 +8431,7 @@ class _CameraInfo(fo.EmbeddedDocument):
 
 
 class _LabelMetadata(fo.DynamicEmbeddedDocument):
-    created_at = fof.DateTimeField(default=datetime.utcnow)
+    created_at = fof.DateTimeField(default=lambda: datetime.now(UTC))
 
     model_name = fof.StringField()
 

--- a/tests/unittests/execution_store_unit_tests.py
+++ b/tests/unittests/execution_store_unit_tests.py
@@ -17,6 +17,7 @@ from fiftyone.operators.store import ExecutionStoreService
 from fiftyone.operators.store.models import KeyDocument
 from fiftyone.factory.repo_factory import MongoExecutionStoreRepo
 from fiftyone.operators.store import ExecutionStore
+from fiftyone.constants import UTC
 
 
 EPSILON = 0.1
@@ -34,7 +35,7 @@ def assert_delta_seconds_approx(time_delta, seconds, epsilon=EPSILON):
 class TestKeyDocument(unittest.TestCase):
     def test_get_expiration(self):
         ttl = 1
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         expiration = KeyDocument.get_expiration(ttl)
         time_delta = expiration - now
         assert_delta_seconds_approx(time_delta, ttl)

--- a/tests/unittests/patches_tests.py
+++ b/tests/unittests/patches_tests.py
@@ -15,6 +15,7 @@ from unittest import mock
 import fiftyone as fo
 import fiftyone.core.patches as fop
 from fiftyone import ViewField as F
+from fiftyone.constants import UTC
 
 from decorators import drop_datasets
 
@@ -830,10 +831,10 @@ class PatchesTests(unittest.TestCase):
         patch = patches.first()
 
         with self.assertRaises(ValueError):
-            patch.created_at = datetime.utcnow()
+            patch.created_at = datetime.now(UTC)
 
         with self.assertRaises(ValueError):
-            patch.last_modified_at = datetime.utcnow()
+            patch.last_modified_at = datetime.now(UTC)
 
         patch.reload()
 

--- a/tests/unittests/video_tests.py
+++ b/tests/unittests/video_tests.py
@@ -19,6 +19,7 @@ import fiftyone.core.clips as foc
 import fiftyone.core.odm as foo
 import fiftyone.core.video as fov
 from fiftyone import ViewField as F
+from fiftyone.constants import UTC
 
 from decorators import drop_datasets
 
@@ -402,7 +403,7 @@ class VideoTests(unittest.TestCase):
             str_field="hi",
             float_field=1.0,
             date_field=date.today(),
-            datetime_field=datetime.utcnow(),
+            datetime_field=datetime.now(UTC),
             list_field=[1, 2, 3],
             dict_field={"hello": "world"},
             vector_field=np.arange(5),
@@ -2249,10 +2250,10 @@ class VideoTests(unittest.TestCase):
         clip = clips.first()
 
         with self.assertRaises(ValueError):
-            clip.created_at = datetime.utcnow()
+            clip.created_at = datetime.now(UTC)
 
         with self.assertRaises(ValueError):
-            clip.last_modified_at = datetime.utcnow()
+            clip.last_modified_at = datetime.now(UTC)
 
         with self.assertRaises(ValueError):
             clip.frames[2].hello = "no"
@@ -3172,10 +3173,10 @@ class VideoTests(unittest.TestCase):
         frame = frames.first()
 
         with self.assertRaises(ValueError):
-            frame.created_at = datetime.utcnow()
+            frame.created_at = datetime.now(UTC)
 
         with self.assertRaises(ValueError):
-            frame.last_modified_at = datetime.utcnow()
+            frame.last_modified_at = datetime.now(UTC)
 
         with self.assertRaises(ValueError):
             frame.filepath = "no.jpg"

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -12,6 +12,7 @@ from datetime import date, datetime, timedelta
 import math
 
 from bson import ObjectId
+import pytz
 import unittest
 import numpy as np
 
@@ -909,11 +910,11 @@ class ViewExpressionTests(unittest.TestCase):
     def test_datetimes(self):
         dataset = fo.Dataset()
 
-        date1 = datetime(1970, 1, 1, 2, 0, 0)
-        date2 = datetime(1970, 1, 1, 3, 0, 0)
-        date3 = datetime(1970, 1, 1, 4, 0, 0)
+        date1 = datetime(1970, 1, 1, 2, 0, 0, tzinfo=pytz.utc)
+        date2 = datetime(1970, 1, 1, 3, 0, 0, tzinfo=pytz.utc)
+        date3 = datetime(1970, 1, 1, 4, 0, 0, tzinfo=pytz.utc)
 
-        query_date = datetime(1970, 1, 1, 3, 1, 0)
+        query_date = datetime(1970, 1, 1, 3, 1, 0, tzinfo=pytz.utc)
         query_delta = timedelta(minutes=30)
 
         dataset.add_samples(
@@ -927,6 +928,10 @@ class ViewExpressionTests(unittest.TestCase):
         fo.config.timezone = None
         dataset.reload()
 
+        # After the read-side fix in `fiftyone/core/odm/database.py`, datetime
+        # fields are returned timezone-aware (UTC) even when
+        # ``fo.config.timezone`` is unset, matching the tz-aware values that
+        # were written above.
         dates = dataset.values("date")
         self.assertListEqual(dates, [date1, date2, date3])
 


### PR DESCRIPTION
# Replace deprecated datetime.utcnow() and add Mongo tz-awareness

Branch: `fix/replace-deprecated-datetime-utcnow`
Target:  `voxel51/fiftyone:develop`
Closes:  https://github.com/voxel51/fiftyone/issues/7402

---

## 🔗 Related Issues

Closes #7402

## 📋 What changes are proposed in this pull request?

`datetime.datetime.utcnow()` has been deprecated since Python 3.12. This PR
replaces every call site in the codebase with the recommended
timezone-aware pattern, **and additionally implements the read-side fix
that @Burhan-Q described in the follow-up comment on #7402** so the new
invariant actually holds end-to-end.

### Write-side (matches the proposal in the issue)

- **`fiftyone/constants.py`** — adds the `UTC` constant:
  ```python
  from datetime import timezone
  UTC = timezone.utc
  ```
- All `datetime.utcnow()` call sites are rewritten to `datetime.now(UTC)`.
- Default-factory usages are rewritten to a lambda so the call is deferred
  to instance construction (preserving the previous semantics):
  ```diff
  - default_factory=datetime.utcnow
  + default_factory=lambda: datetime.now(UTC)
  ```
- Equivalent treatment is applied to MongoEngine `DateTimeField(default=...)`
  in unit tests.
- Two files use `import datetime` (module-style) rather than
  `from datetime import datetime`. Their call sites
  (`datetime.datetime.utcnow()`) are rewritten to
  `datetime.datetime.now(UTC)` accordingly.

### Read-side (new — addresses [@Burhan-Q's follow-up](https://github.com/voxel51/fiftyone/issues/7402#issuecomment))

Making the write side aware while the read side is naive would leave the
codebase in an inconsistent state where
`sample.created_at < datetime.now(UTC)` raises
`TypeError: can't compare offset-naive and offset-aware datetimes` after a
Mongo roundtrip. To prevent this, the four call sites in
`fiftyone/core/odm/database.py` flagged by @Burhan-Q are also updated:

1. `pymongo.MongoClient(...)` is constructed with
   `tz_aware=True, tzinfo=pytz.utc`.
2. `mongoengine.connect(...)` is constructed with
   `tz_aware=True, tzinfo=pytz.utc` (forwarded to its underlying pymongo
   client).
3. `motor.motor_asyncio.AsyncIOMotorClient(...)` is constructed with
   `tz_aware=True, tzinfo=pytz.utc`.
4. `_apply_options` no longer short-circuits to a naive client when no
   `fo.config.timezone` is set; it now defaults to `pytz.utc` so the
   invariant holds for every read path.

### Doc & docstring updates

- 4 RST files (`docs/source/user_guide/{config,app,using_aggregations,using_datasets}.rst`)
  updated to use `datetime.now(timezone.utc)`. The `using_datasets.rst`
  warning that previously *recommended* `utcnow()` is inverted to
  recommend the new pattern and explicitly note `utcnow()` is deprecated
  since Python 3.12.
- The `ListSchema` and `Aggregation.list_schema` docstrings (and the
  `to_date()` example in `expressions.py`) use
  `from datetime import datetime, timezone` + `datetime.now(timezone.utc)`
  in their **`Examples::`** blocks. Those examples are not executed under
  the module's import scope, so referencing the internal
  `fiftyone.constants.UTC` would raise `NameError` when copy-pasted.

### New regression test

`tests/unittests/dataset_tests.py::DatasetTests.test_timestamps_are_timezone_aware`
pins down @Burhan-Q's read-side invariant: it adds a sample, reloads from
Mongo, asserts `created_at` / `last_modified_at` are aware UTC on both the
sample and the dataset, and compares them against `datetime.now(UTC)`
without raising. This is the cheapest safeguard against `_apply_options`
ever being "fixed" back to its short-circuit.

### Files modified (26)

Library:

- `fiftyone/constants.py` (adds `UTC`)
- `fiftyone/core/aggregations.py`
- `fiftyone/core/collections.py`
- `fiftyone/core/dataset.py`
- `fiftyone/core/expressions.py`
- `fiftyone/core/frame.py`
- `fiftyone/core/odm/database.py` *(read-side: tz-aware clients)*
- `fiftyone/core/odm/document.py`
- `fiftyone/core/odm/mixins.py`
- `fiftyone/core/plots/manager.py`
- `fiftyone/core/runs.py`
- `fiftyone/factory/repos/delegated_operation.py`
- `fiftyone/factory/repos/delegated_operation_doc.py`
- `fiftyone/factory/repos/execution_store.py`
- `fiftyone/migrations/revisions/v1_0_0.py`
- `fiftyone/operators/store/models.py`
- `fiftyone/utils/data/importers.py`

Docs:

- `docs/source/user_guide/app.rst`
- `docs/source/user_guide/config.rst`
- `docs/source/user_guide/using_aggregations.rst`
- `docs/source/user_guide/using_datasets.rst` *(warning inverted)*

Tests:

- `tests/unittests/aggregation_tests.py`
- `tests/unittests/dataset_tests.py` *(adds `test_timestamps_are_timezone_aware`)*
- `tests/unittests/execution_store_unit_tests.py`
- `tests/unittests/patches_tests.py`
- `tests/unittests/video_tests.py`

### Notes on behavior change

`datetime.now(UTC)` returns a **timezone-aware** `datetime`, whereas the old
`datetime.utcnow()` returned a **naive** one. After this PR the public
timestamp attributes (`Sample.created_at`, `Sample.last_modified_at`,
`Dataset.created_at`, `DelegatedOperation.queued_at`, etc.) are
timezone-aware UTC `datetime` objects, **including after a Mongo round-trip**
(this is the read-side fix above). User code that previously relied on naive
comparisons such as `sample.created_at < datetime.utcnow()` will start
raising `TypeError` and must migrate to `datetime.now(timezone.utc)` (or use
the public `fiftyone.constants.UTC`). No DB migration is required —
PyMongo persists both naive and aware values to BSON UTC identically.

## 🧪 How is this patch tested? If it is not, please explain why.

- `python -m py_compile` passes for all modified `.py` files.
- `black -l 79` (matching `.pre-commit-config.yaml`) reports no
  reformatting needed.
- `grep -rn "datetime\.utcnow" --include="*.py" --include="*.rst"` returns
  zero call-site matches after the change. The only remaining textual
  references are intentional: the docstring in `fiftyone/constants.py`
  that explains the new `UTC` constant, and a warning in
  `docs/source/user_guide/using_datasets.rst` that now correctly notes the
  deprecation.
- **New regression test**
  `tests/unittests/dataset_tests.py::DatasetTests.test_timestamps_are_timezone_aware`
  passes (3.1 s) and pins down the read-side invariant prescribed in
  @Burhan-Q's follow-up comment on #7402.
- The following existing unit tests in the affected datetime paths were
  re-run locally against the patched branch with `fiftyone-db` (Python
  3.11.2) and all pass:
    - `dataset_tests.test_last_modified_at`
    - `dataset_tests.test_last_loaded_at`
    - `dataset_tests.test_last_deletion_at`
    - `dataset_tests.test_read_only_fields`
    - `dataset_tests.test_read_only_frame_fields`
    - `dataset_tests.test_timestamps_are_timezone_aware` *(new)*
    - `execution_store_unit_tests` (22/22)
    - `patches_tests.test_to_patches_datetimes`
    - `video_tests.test_to_clips_datetimes`
    - `video_tests.test_to_frames_datetimes`
- An end-to-end smoke test exercises `Dataset` / `Sample` / `Frame` /
  `KeyDocument` lifecycles against a live MongoDB and confirms the
  read-side invariant holds (`tzinfo is timezone.utc` after `reload()`),
  with **zero `utcnow`-related `DeprecationWarning`s** emitted under
  `warnings.simplefilter("always")`.

No new tests are added beyond `test_timestamps_are_timezone_aware`,
because the bulk of the change is a mechanical, behavior-preserving
substitution prescribed by the issue author.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

> Replaced deprecated `datetime.utcnow()` usage with `datetime.now(UTC)`
> across the codebase. The default MongoDB clients are now also constructed
> with `tz_aware=True, tzinfo=pytz.utc`, so public timestamp attributes
> such as `Sample.created_at`, `Sample.last_modified_at`,
> `Dataset.created_at`, and `DelegatedOperation.queued_at` are now
> timezone-aware UTC `datetime` objects on both write and read paths.
> No DB migration is required.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [x] Core: Core `fiftyone` Python library changes
- [x] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Timestamps are now consistently timezone-aware (UTC) across dataset storage, metadata, runs, and runtime operations, avoiding ambiguous naive datetimes.

* **Documentation**
  * Examples and guidance updated to show timezone-aware UTC datetimes and recommended APIs, including examples that reflect UTC offsets.

* **Tests**
  * Test suite updated to assert and validate timezone-aware UTC datetimes across scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->