### PR TITLE
chore: remove python_requires upper bound, print warning in windows i…

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -54,13 +54,12 @@ IF NOT ERRORLEVEL 1 (
 )
 
 for /f %%v in ('%PYTHON_CMD% -c "import sys; print(""{}.{}"".format(sys.version_info[0], sys.version_info[1]))"') do set PY_VER=%%v
-%PYTHON_CMD% -c "import sys; raise SystemExit(0 if sys.version_info[0] == 3 and %MINOR_MIN% <= sys.version_info[1] <= %MINOR_MAX% else 1)"
-IF ERRORLEVEL 1 (
-  echo Python %PY_VER% is NOT supported. Please use Python 3.%MINOR_MIN% - 3.%MINOR_MAX%.
-  exit /b 1
+for /f %%s in ('%PYTHON_CMD% -c "import sys; print('SUPPORTED' if (sys.version_info[0] == 3 and %MINOR_MIN% <= sys.version_info[1] <= %MINOR_MAX%) else 'UNSUPPORTED')"') do set PY_STATUS=%%s
+IF /I "%PY_STATUS%"=="UNSUPPORTED" (
+  echo Warning: Python %PY_VER% is not officially supported. It is recommended to use Python 3.%MINOR_MIN% - 3.%MINOR_MAX%.
+) else (
+  echo Python %PY_VER% is supported.
 )
-
-echo Python %PY_VER% is supported.
 
 :: Resolve pip backend
 where uv >nul 2>&1

--- a/setup.py
+++ b/setup.py
@@ -122,5 +122,5 @@ setup(
         "Programming Language :: Python :: 3.12",
     ],
     entry_points={"console_scripts": ["fiftyone=fiftyone.core.cli:main"]},
-    python_requires=">=3.9,<3.13",
+    python_requires=">=3.9",
 )


### PR DESCRIPTION
…nstaller

## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

No related issues to link
-->

## 📋 What changes are proposed in this pull request?

<!--
Provide a clear, concise description of what this PR does and why.
-->

* Removes the upper bound of `<3.13` in `python_requires`. Upper bounds here are considered harmful (unless there's a specific known incompatibility).
* Makes the Windows installer log a warning about not-officially-supported-versions instead failing the installation process

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

Tested via GitHub Actions using a `windows-latest` runner.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [X] No. (This is essentially a revert, and the upper bound was never released.)
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [X] Other -- Installer and package metadata


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended Python version compatibility to support Python 3.13 and newer versions
  * Modified installation Python compatibility checks to display warnings for unsupported versions instead of blocking installation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->