### PR TITLE
[HA] Add support for keypoint per-point attribute editing

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
@@ -14,12 +14,15 @@ import {
   currentOverlay,
   currentSchema,
 } from "./state";
+import { useLabelSchemaExclusions } from "./useLabelSchemaExclusions";
 
 const useSchema = (readOnly: boolean) => {
   const config = useAtomValue(currentSchema);
   const isLabelReadOnly = config?.read_only;
   // respect either the field OR the parent schema's readOnly flag
   const effectiveReadOnly = readOnly || isLabelReadOnly;
+  // fields excluded from the top-level schema
+  const exclusions = useLabelSchemaExclusions();
 
   return useMemo(() => {
     const attributes = Array.isArray(config?.attributes)
@@ -27,6 +30,7 @@ const useSchema = (readOnly: boolean) => {
       : [];
     const properties = attributes
       .filter(({ name }) => name && !["id", "attributes"].includes(name))
+      .filter(({ name }) => !exclusions.has(name))
       .reduce(
         (schema: SchemaType, value: SchemaType) => ({
           ...schema,
@@ -52,7 +56,7 @@ const useSchema = (readOnly: boolean) => {
       },
       properties,
     };
-  }, [config, effectiveReadOnly]);
+  }, [config, effectiveReadOnly, exclusions]);
 };
 
 const useHandleChanges = () => {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Edit.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Edit.tsx
@@ -25,9 +25,10 @@ import useExit from "./useExit";
 
 const ContentContainer = styled.div`
   margin: 0.25rem 1rem;
-  height: 100%;
   display: flex;
   flex-direction: column;
+  flex: 1;
+  min-height: 0;
   justify-content: space-between;
 `;
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Edit.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Edit.tsx
@@ -98,8 +98,8 @@ export default function Edit() {
           <Position3d readOnly={isReadOnly} />
         )}
         {type === POLYLINE && <PolylineDetails />}
-        {type === KEYPOINT && <KeypointDetails />}
         {field && <AnnotationSchema readOnly={isReadOnly} />}
+        {type === KEYPOINT && <KeypointDetails />}
       </Content>
     </ContentContainer>
   );

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/KeypointDetails.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/KeypointDetails.tsx
@@ -26,6 +26,7 @@ import { isEqual } from "lodash";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { SchemaIOComponent } from "../../../../../plugins/SchemaIO";
 import { SchemaType } from "../../../../../plugins/SchemaIO/utils/types";
+import { createXYGroupSchema } from "./positionSchema";
 import { generatePrimitiveSchema } from "./schemaHelpers";
 import { useAnnotationContext } from "./state";
 import {
@@ -83,17 +84,21 @@ const PerPointEditor = ({
   pointCount,
   attributes,
   pointName,
+  point,
 }: {
   pointIndex: number;
   pointCount: number;
   attributes: KeypointAttribute[];
   pointName?: string;
+  point: [number, number] | null | undefined;
 }) => {
   const { selectedLabel } = useAnnotationContext();
   const eventBus = useAnnotationEventBus();
 
   const schema = useMemo<SchemaType>(() => {
-    const properties: Record<string, SchemaType> = {};
+    const properties: Record<string, SchemaType> = {
+      position: createXYGroupSchema(true),
+    };
     for (const attribute of attributes) {
       const property = buildAttributeProperty(attribute);
       if (property) {
@@ -109,8 +114,14 @@ const PerPointEditor = ({
   }, [attributes]);
 
   const data = useMemo(() => {
-    return Object.fromEntries(attributes.map((a) => [a.name, a.value]));
-  }, [attributes]);
+    const base: Record<string, unknown> = {
+      position: Array.isArray(point) ? { x: point[0], y: point[1] } : {},
+    };
+    for (const attribute of attributes) {
+      base[attribute.name] = attribute.value;
+    }
+    return base;
+  }, [attributes, point]);
 
   const overlay = selectedLabel?.overlay;
 
@@ -157,7 +168,7 @@ const PerPointEditor = ({
     [attributes, eventBus, overlay.id, overlay.label, pointIndex, selectedLabel]
   );
 
-  if (!selectedLabel || attributes.length === 0) {
+  if (!selectedLabel) {
     return null;
   }
 
@@ -238,10 +249,11 @@ const PointRenderer = ({
 
       <AccordionDetails>
         <PerPointEditor
-          attributes={keypointMeta?.attributes}
+          attributes={keypointMeta?.attributes ?? []}
           pointCount={totalPoints}
           pointIndex={pointIndex}
           pointName={pointName}
+          point={label?.points?.[pointIndex]}
         />
       </AccordionDetails>
     </Accordion>

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/KeypointDetails.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/KeypointDetails.tsx
@@ -3,43 +3,39 @@ import {
   KeypointAnnotationLabel,
   useGetKeypointSkeleton,
 } from "@fiftyone/state";
-import { Box } from "@mui/material";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Divider,
+} from "@mui/material";
 import {
   Align,
+  Icon,
+  IconName,
+  Justify,
   Orientation,
+  Size,
   Spacing,
   Stack,
   Text,
   TextColor,
-  Tooltip,
-  TooltipProps,
 } from "@voxel51/voodo";
 import { isEqual } from "lodash";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { SchemaIOComponent } from "../../../../../plugins/SchemaIO";
 import { SchemaType } from "../../../../../plugins/SchemaIO/utils/types";
 import { generatePrimitiveSchema } from "./schemaHelpers";
 import { useAnnotationContext } from "./state";
-import { KeypointAttribute, useSelectedKeypoint } from "./useSelectedKeypoint";
-
-const ConditionalTooltip = ({
-  anchor,
-  children,
-  content,
-  enabled,
-}: Pick<TooltipProps, "anchor" | "children" | "content"> & {
-  enabled: boolean;
-}) => {
-  if (!enabled) {
-    return <>{children}</>;
-  }
-
-  return (
-    <Tooltip portal content={content} anchor={anchor}>
-      {children}
-    </Tooltip>
-  );
-};
+import {
+  getKeypointAttributes,
+  KeypointAttribute,
+  useSelectedKeypointIndex,
+  useSelectedKeypointOverlay,
+} from "./useSelectedKeypoint";
+import { useAnnotationSchemaContext } from "../state";
+import { LabelSchemaMeta } from "../useSchemaManager";
 
 /**
  * Schema attribute types are described as they appear on the parent label
@@ -184,11 +180,82 @@ const PerPointEditor = ({
   );
 };
 
+const PointRenderer = ({
+  label,
+  pointIndex,
+  pointName,
+  schema,
+  forceExpand,
+  onExpand,
+  onCollapse,
+}: {
+  label: KeypointAnnotationLabel["data"];
+  pointIndex: number;
+  pointName: string | null;
+  schema: LabelSchemaMeta;
+  forceExpand?: boolean;
+  onExpand?: () => void;
+  onCollapse?: () => void;
+}) => {
+  const [expanded, setExpanded] = useState<boolean>(false);
+
+  const keypointMeta = getKeypointAttributes(label, pointIndex, schema);
+  const totalPoints = label?.points?.length ?? 0;
+
+  // allow for controlled behavior to force expansion
+  useEffect(() => {
+    if (forceExpand) {
+      setExpanded(true);
+    }
+  }, [forceExpand]);
+
+  return (
+    <Accordion expanded={expanded} disableGutters>
+      <AccordionSummary
+        expandIcon={
+          <Icon
+            name={expanded ? IconName.ChevronTop : IconName.ChevronRight}
+            size={Size.Md}
+          />
+        }
+        onClick={() => {
+          if (!expanded) {
+            onExpand?.();
+          } else {
+            onCollapse?.();
+          }
+
+          setExpanded((prev) => !prev);
+        }}
+        sx={{ flexDirection: "row-reverse", gap: 1, alignItems: "center" }}
+      >
+        {pointName ? (
+          <Text>{pointName}</Text>
+        ) : (
+          <Text>Point {pointIndex + 1}</Text>
+        )}
+      </AccordionSummary>
+
+      <AccordionDetails>
+        <PerPointEditor
+          attributes={keypointMeta?.attributes}
+          pointCount={totalPoints}
+          pointIndex={pointIndex}
+          pointName={pointName}
+        />
+      </AccordionDetails>
+    </Accordion>
+  );
+};
+
 export const KeypointDetails = () => {
   const { selectedLabel } = useAnnotationContext();
   const currentData = selectedLabel?.data as KeypointAnnotationLabel["data"];
   const getKeypointSkeleton = useGetKeypointSkeleton();
-  const selectedKeypoint = useSelectedKeypoint();
+  const { labelSchema } = useAnnotationSchemaContext();
+  const fieldSchema = labelSchema?.[selectedLabel?.path];
+  const keypointOverlay = useSelectedKeypointOverlay();
+  const selectedPointIndex = useSelectedKeypointIndex();
 
   const keypointSkeleton = useMemo(() => {
     if (selectedLabel?.path) {
@@ -201,36 +268,50 @@ export const KeypointDetails = () => {
   const pointCount = currentData?.points?.length ?? 0;
 
   return (
-    <Box sx={{ py: 1 }}>
-      <Stack orientation={Orientation.Column} spacing={Spacing.Md}>
-        <Stack
-          orientation={Orientation.Row}
-          align={Align.Center}
-          spacing={Spacing.Sm}
-        >
-          <Text color={TextColor.Secondary}>
-            {keypointSkeleton?.edges?.length ?? 0} edges
-          </Text>
+    <>
+      <Divider />
+      <Box>
+        <Stack orientation={Orientation.Column} spacing={Spacing.Md}>
+          <Stack orientation={Orientation.Row} justify={Justify.Between}>
+            <Stack
+              orientation={Orientation.Row}
+              align={Align.Center}
+              spacing={Spacing.Sm}
+            >
+              <Text color={TextColor.Secondary}>POINTS</Text>
+            </Stack>
 
-          <Text color={TextColor.Secondary}>&bull;</Text>
+            <Text color={TextColor.Secondary}>{pointCount}</Text>
+          </Stack>
 
-          <ConditionalTooltip
-            enabled={keypointSkeleton?.labels?.length > 0}
-            content={<Text>{keypointSkeleton?.labels?.join(", ")}</Text>}
-          >
-            <Text color={TextColor.Secondary}>{pointCount} points</Text>
-          </ConditionalTooltip>
+          {pointCount > 0 && (
+            <Stack orientation={Orientation.Column} spacing={Spacing.None}>
+              {currentData.points.map((_, idx) => {
+                if (selectedLabel?.type !== "Keypoint") {
+                  return null;
+                }
+
+                return (
+                  <PointRenderer
+                    key={idx}
+                    label={currentData}
+                    pointIndex={idx}
+                    pointName={keypointSkeleton?.labels?.[idx]}
+                    schema={fieldSchema}
+                    forceExpand={idx === selectedPointIndex}
+                    onExpand={() => keypointOverlay?.setSelectedPointIndex(idx)}
+                    onCollapse={() => {
+                      if (idx === selectedPointIndex) {
+                        keypointOverlay?.setSelectedPointIndex(null);
+                      }
+                    }}
+                  />
+                );
+              })}
+            </Stack>
+          )}
         </Stack>
-
-        {selectedKeypoint && (
-          <PerPointEditor
-            pointIndex={selectedKeypoint.pointIndex}
-            pointCount={selectedKeypoint.pointCount}
-            attributes={selectedKeypoint.attributes}
-            pointName={keypointSkeleton?.labels?.[selectedKeypoint.pointIndex]}
-          />
-        )}
-      </Stack>
-    </Box>
+      </Box>
+    </>
   );
 };

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/KeypointDetails.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/KeypointDetails.tsx
@@ -1,5 +1,9 @@
+import { useAnnotationEventBus } from "@fiftyone/annotation";
+import {
+  KeypointAnnotationLabel,
+  useGetKeypointSkeleton,
+} from "@fiftyone/state";
 import { Box } from "@mui/material";
-import { useAnnotationContext } from "./state";
 import {
   Align,
   Orientation,
@@ -10,11 +14,13 @@ import {
   Tooltip,
   TooltipProps,
 } from "@voxel51/voodo";
-import {
-  KeypointAnnotationLabel,
-  useGetKeypointSkeleton,
-} from "@fiftyone/state";
-import { useMemo } from "react";
+import { isEqual } from "lodash";
+import { useCallback, useMemo } from "react";
+import { SchemaIOComponent } from "../../../../../plugins/SchemaIO";
+import { SchemaType } from "../../../../../plugins/SchemaIO/utils/types";
+import { generatePrimitiveSchema } from "./schemaHelpers";
+import { useAnnotationContext } from "./state";
+import { KeypointAttribute, useSelectedKeypoint } from "./useSelectedKeypoint";
 
 const ConditionalTooltip = ({
   anchor,
@@ -35,10 +41,154 @@ const ConditionalTooltip = ({
   );
 };
 
+/**
+ * Schema attribute types are described as they appear on the parent label
+ * (e.g. `list<float>` for `confidence`), but the per-point editor renders a
+ * single element. Unwraps `list<T>` to `T` so we get the element-level
+ * editor (number/bool/str) instead of a list widget.
+ */
+const unwrapListType = (type: string): string => {
+  const match = /^list<(.+)>$/.exec(type);
+  return match ? match[1] : type;
+};
+
+/**
+ * Builds a SchemaIO property descriptor for a single per-point attribute,
+ * preferring a matching schema entry and falling back to type inference from
+ * the current value when the attribute is dynamic.
+ */
+const buildAttributeProperty = (
+  attribute: KeypointAttribute
+): SchemaType | undefined => {
+  if (attribute.schema) {
+    return generatePrimitiveSchema(attribute.name, {
+      ...attribute.schema,
+      type: unwrapListType(attribute.schema.type),
+      readOnly: attribute.schema.read_only,
+    });
+  }
+
+  const valueType = typeof attribute.value;
+  if (valueType === "string") {
+    return generatePrimitiveSchema(attribute.name, { type: "str" });
+  }
+  if (valueType === "number") {
+    return generatePrimitiveSchema(attribute.name, { type: "float" });
+  }
+  if (valueType === "boolean") {
+    return generatePrimitiveSchema(attribute.name, { type: "bool" });
+  }
+
+  return undefined;
+};
+
+const PerPointEditor = ({
+  pointIndex,
+  pointCount,
+  attributes,
+  pointName,
+}: {
+  pointIndex: number;
+  pointCount: number;
+  attributes: KeypointAttribute[];
+  pointName?: string;
+}) => {
+  const { selectedLabel } = useAnnotationContext();
+  const eventBus = useAnnotationEventBus();
+
+  const schema = useMemo<SchemaType>(() => {
+    const properties: Record<string, SchemaType> = {};
+    for (const attribute of attributes) {
+      const property = buildAttributeProperty(attribute);
+      if (property) {
+        properties[attribute.name] = property;
+      }
+    }
+
+    return {
+      type: "object",
+      view: { component: "ObjectView" },
+      properties,
+    };
+  }, [attributes]);
+
+  const data = useMemo(() => {
+    return Object.fromEntries(attributes.map((a) => [a.name, a.value]));
+  }, [attributes]);
+
+  const overlay = selectedLabel?.overlay;
+
+  const onChange = useCallback(
+    (changes: Record<string, unknown>) => {
+      if (!selectedLabel?.data) {
+        return;
+      }
+
+      const currentLabel =
+        selectedLabel.data as KeypointAnnotationLabel["data"];
+      let mutated = false;
+      const newLabel: Record<string, unknown> = { ...currentLabel };
+
+      for (const attribute of attributes) {
+        const changedValue = changes[attribute.name];
+        if (changedValue === attribute.value) {
+          continue;
+        }
+
+        const original = (currentLabel as Record<string, unknown>)[
+          attribute.name
+        ];
+        if (!Array.isArray(original)) {
+          continue;
+        }
+
+        const newAttributeValue = [...original];
+        newAttributeValue[pointIndex] = changedValue;
+        newLabel[attribute.name] = newAttributeValue;
+        mutated = true;
+      }
+
+      if (!mutated || isEqual(newLabel, overlay.label)) {
+        return;
+      }
+
+      eventBus.dispatch("annotation:sidebarValueUpdated", {
+        overlayId: overlay.id,
+        currentLabel: overlay.label as KeypointAnnotationLabel["data"],
+        value: newLabel as KeypointAnnotationLabel["data"],
+      });
+    },
+    [attributes, eventBus, overlay.id, overlay.label, pointIndex, selectedLabel]
+  );
+
+  if (!selectedLabel || attributes.length === 0) {
+    return null;
+  }
+
+  return (
+    <Stack orientation={Orientation.Column} spacing={Spacing.Md}>
+      <Text color={TextColor.Secondary}>
+        {pointName ? `${pointName} ` : ""}
+        (point {pointIndex + 1} of {pointCount})
+      </Text>
+
+      <SchemaIOComponent
+        key={`${overlay.id}-${pointIndex}`}
+        smartForm={true}
+        smartFormProps={{ liveValidate: "onChange" }}
+        schema={schema}
+        data={data}
+        onChange={onChange}
+      />
+    </Stack>
+  );
+};
+
 export const KeypointDetails = () => {
   const { selectedLabel } = useAnnotationContext();
   const currentData = selectedLabel?.data as KeypointAnnotationLabel["data"];
   const getKeypointSkeleton = useGetKeypointSkeleton();
+  const selectedKeypoint = useSelectedKeypoint();
 
   const keypointSkeleton = useMemo(() => {
     if (selectedLabel?.path) {
@@ -52,23 +202,34 @@ export const KeypointDetails = () => {
 
   return (
     <Box sx={{ py: 1 }}>
-      <Stack
-        orientation={Orientation.Row}
-        align={Align.Center}
-        spacing={Spacing.Sm}
-      >
-        <Text color={TextColor.Secondary}>
-          {keypointSkeleton?.edges?.length ?? 0} edges
-        </Text>
-
-        <Text color={TextColor.Secondary}>&bull;</Text>
-
-        <ConditionalTooltip
-          enabled={keypointSkeleton?.labels?.length > 0}
-          content={<Text>{keypointSkeleton?.labels?.join(", ")}</Text>}
+      <Stack orientation={Orientation.Column} spacing={Spacing.Md}>
+        <Stack
+          orientation={Orientation.Row}
+          align={Align.Center}
+          spacing={Spacing.Sm}
         >
-          <Text color={TextColor.Secondary}>{pointCount} points</Text>
-        </ConditionalTooltip>
+          <Text color={TextColor.Secondary}>
+            {keypointSkeleton?.edges?.length ?? 0} edges
+          </Text>
+
+          <Text color={TextColor.Secondary}>&bull;</Text>
+
+          <ConditionalTooltip
+            enabled={keypointSkeleton?.labels?.length > 0}
+            content={<Text>{keypointSkeleton?.labels?.join(", ")}</Text>}
+          >
+            <Text color={TextColor.Secondary}>{pointCount} points</Text>
+          </ConditionalTooltip>
+        </Stack>
+
+        {selectedKeypoint && (
+          <PerPointEditor
+            pointIndex={selectedKeypoint.pointIndex}
+            pointCount={selectedKeypoint.pointCount}
+            attributes={selectedKeypoint.attributes}
+            pointName={keypointSkeleton?.labels?.[selectedKeypoint.pointIndex]}
+          />
+        )}
       </Stack>
     </Box>
   );

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/KeypointDetails.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/KeypointDetails.tsx
@@ -127,7 +127,7 @@ const PerPointEditor = ({
 
   const onChange = useCallback(
     (changes: Record<string, unknown>) => {
-      if (!selectedLabel?.data) {
+      if (!selectedLabel?.data || !overlay) {
         return;
       }
 
@@ -165,7 +165,7 @@ const PerPointEditor = ({
         value: newLabel as KeypointAnnotationLabel["data"],
       });
     },
-    [attributes, eventBus, overlay.id, overlay.label, pointIndex, selectedLabel]
+    [attributes, eventBus, overlay, pointIndex, selectedLabel]
   );
 
   if (!selectedLabel) {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Position.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Position.tsx
@@ -13,33 +13,8 @@ import {
   imagePixelsToCanvasPixels,
   relativeToImagePixels,
 } from "./coordinateConversion";
+import { createWHGroupSchema, createXYGroupSchema } from "./positionSchema";
 import { currentData, currentOverlay } from "./state";
-
-const createInput = (name: string, readOnly?: boolean) => {
-  return {
-    [name]: {
-      type: "number",
-      view: {
-        name: "View",
-        label: name,
-        component: "FieldView",
-        readOnly,
-      },
-      multipleOf: 0.01,
-    },
-  };
-};
-
-const createStack = () => {
-  return {
-    name: "HStackView",
-    component: "GridView",
-    orientation: "horizontal",
-    gap: 1,
-    align_x: "left",
-    align_y: "top",
-  };
-};
 
 interface Coordinates {
   position: { x?: number; y?: number };
@@ -66,9 +41,10 @@ export default function Position({ readOnly = false }: PositionProps) {
 
   const toImagePixels = useCallback(
     (relative: Parameters<typeof relativeToImagePixels>[0]) => {
-      const dims = scene
-        ?.getCanonicalMedia()
-        ?.getOriginalDimensions() ?? { width: 1, height: 1 };
+      const dims = scene?.getCanonicalMedia()?.getOriginalDimensions() ?? {
+        width: 1,
+        height: 1,
+      };
       return relativeToImagePixels(relative, dims);
     },
     [scene]
@@ -77,8 +53,16 @@ export default function Position({ readOnly = false }: PositionProps) {
   const toCanvasPixels = useCallback(
     (imageRect: Parameters<typeof imagePixelsToCanvasPixels>[0]) => {
       const canonicalMedia = scene?.getCanonicalMedia();
-      const dims = canonicalMedia?.getOriginalDimensions() ?? { width: 1, height: 1 };
-      const rendered = canonicalMedia?.getRenderedBounds() ?? { x: 0, y: 0, width: 1, height: 1 };
+      const dims = canonicalMedia?.getOriginalDimensions() ?? {
+        width: 1,
+        height: 1,
+      };
+      const rendered = canonicalMedia?.getRenderedBounds() ?? {
+        x: 0,
+        y: 0,
+        width: 1,
+        height: 1,
+      };
       return imagePixelsToCanvasPixels(imageRect, dims, rendered);
     },
     [scene]
@@ -133,22 +117,8 @@ export default function Position({ readOnly = false }: PositionProps) {
         component: "ObjectView",
       },
       properties: {
-        position: {
-          type: "object",
-          view: createStack(),
-          properties: {
-            ...createInput("x", readOnly),
-            ...createInput("y", readOnly),
-          },
-        },
-        dimensions: {
-          type: "object",
-          view: createStack(),
-          properties: {
-            ...createInput("width", readOnly),
-            ...createInput("height", readOnly),
-          },
-        },
+        position: createXYGroupSchema(readOnly),
+        dimensions: createWHGroupSchema(readOnly),
       },
     }),
     [readOnly]
@@ -179,7 +149,12 @@ export default function Position({ readOnly = false }: PositionProps) {
           };
           const newCanvasBounds = toCanvasPixels(newImagePixels);
           scene?.executeCommand(
-            new TransformOverlayCommand(overlay, overlay.id, oldBounds, newCanvasBounds)
+            new TransformOverlayCommand(
+              overlay,
+              overlay.id,
+              oldBounds,
+              newCanvasBounds
+            )
           );
         }}
       />

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/positionSchema.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/positionSchema.ts
@@ -1,0 +1,69 @@
+import type { SchemaType } from "../../../../../plugins/SchemaIO/utils/types";
+
+/**
+ * Builds a single numeric SchemaIO `FieldView` input keyed by `name`, returned
+ * as a one-entry object so it can be spread into a parent `properties` map.
+ *
+ * @param name The property key and label rendered for the input.
+ * @param readOnly When true, the field renders as read-only.
+ */
+const createCoordinateInputSchema = (name: string, readOnly?: boolean) => ({
+  [name]: {
+    type: "number",
+    view: {
+      name: "View",
+      label: name,
+      component: "FieldView",
+      readOnly,
+    },
+  },
+});
+
+/**
+ * View descriptor that lays out child fields in a single horizontal row,
+ * intended to be used as the `view` for a SchemaIO object schema.
+ */
+const createCoordinateStackSchema = () => ({
+  name: "HStackView",
+  component: "GridView",
+  orientation: "horizontal",
+  gap: 1,
+  align_x: "left",
+  align_y: "top",
+});
+
+/**
+ * Builds a coordinate group schema for a pair of coordinate values.
+ *
+ * @param xName Name of the "x" coordinate; appears first in the row
+ * @param yName Name of the "y" coordinate; appears second in the row
+ * @param readOnly When true, coordinate fields render as read-only.
+ */
+const createCoordinateGroupSchema = (
+  xName: string,
+  yName: string,
+  readOnly?: boolean
+): SchemaType => ({
+  type: "object",
+  view: createCoordinateStackSchema(),
+  properties: {
+    ...createCoordinateInputSchema(xName, readOnly),
+    ...createCoordinateInputSchema(yName, readOnly),
+  },
+});
+
+/**
+ * Object schema with horizontally-stacked `x` and `y` numeric inputs.
+ *
+ * @param readOnly When true, both fields render as read-only.
+ */
+export const createXYGroupSchema = (readOnly?: boolean): SchemaType =>
+  createCoordinateGroupSchema("x", "y", readOnly);
+
+/**
+ * Object schema with horizontally-stacked `width` and `height` numeric inputs,
+ *
+ * @param readOnly When true, both fields render as read-only.
+ */
+export const createWHGroupSchema = (readOnly?: boolean): SchemaType =>
+  createCoordinateGroupSchema("width", "height", readOnly);

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useLabelSchemaExclusions.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useLabelSchemaExclusions.ts
@@ -1,0 +1,11 @@
+import { usePerPointAttributeNames } from "./useSelectedKeypoint";
+
+/**
+ * Hook which returns a set of attribute names which should be excluded
+ * from the top-level editing schema.
+ *
+ * These fields are handled through mechanisms specific to their label type.
+ */
+export const useLabelSchemaExclusions = (): Set<string> => {
+  return usePerPointAttributeNames();
+};

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSelectedKeypoint.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSelectedKeypoint.ts
@@ -10,6 +10,7 @@ import { useCallback, useMemo, useReducer } from "react";
 import { useAnnotationSchemaContext } from "../state";
 import type { AttributeConfig } from "../SchemaManager/utils";
 import { useAnnotationContext } from "./state";
+import { LabelSchemaMeta } from "../useSchemaManager";
 
 /**
  * Reserved label fields that should never be treated as per-point attributes
@@ -82,7 +83,7 @@ export interface KeypointAttribute {
   schema?: AttributeConfig;
 }
 
-export interface SelectedKeypoint {
+export interface KeypointMeta {
   /** Index of the sub-selected point on the keypoint overlay */
   pointIndex: number;
   /** Total number of points on the keypoint label */
@@ -90,6 +91,51 @@ export interface SelectedKeypoint {
   /** Per-point attributes inferred from the label data */
   attributes: KeypointAttribute[];
 }
+
+/**
+ * Get the per-point attributes for the provided point index.
+ *
+ * @param label Keypoint label containing source data
+ * @param pointIndex Point index
+ * @param schema Field schema
+ */
+export const getKeypointAttributes = (
+  label: KeypointAnnotationLabel["data"] | null,
+  pointIndex: number | null,
+  schema: LabelSchemaMeta | null
+): KeypointMeta | null => {
+  if (pointIndex === null) {
+    return null;
+  }
+
+  const points = label?.points;
+  if (!Array.isArray(points) || pointIndex >= points.length) {
+    return null;
+  }
+
+  const schemaAttributes =
+    (schema?.label_schema?.attributes as unknown as
+      | AttributeConfig[]
+      | undefined) ?? [];
+  const schemaByName = new Map(schemaAttributes.map((a) => [a.name, a]));
+
+  const perPointNames = getPerPointAttributeNames(label);
+  const attributes: KeypointAttribute[] = [];
+  for (const name of perPointNames) {
+    const list = (label as Record<string, unknown>)[name] as unknown[];
+    attributes.push({
+      name,
+      value: list[pointIndex],
+      schema: schemaByName.get(name),
+    });
+  }
+
+  return {
+    pointIndex,
+    pointCount: points.length,
+    attributes,
+  };
+};
 
 /**
  * Returns the currently active keypoint overlay (when a keypoint label is
@@ -150,48 +196,18 @@ export const useSelectedKeypointIndex = (): number | null => {
  * itself) is treated as a per-point list, per the FiftyOne keypoint
  * documentation.
  */
-export const useSelectedKeypoint = (): SelectedKeypoint | null => {
+export const useSelectedKeypoint = (): KeypointMeta | null => {
   const { selectedLabel } = useAnnotationContext();
-  const overlay = useSelectedKeypointOverlay();
   const pointIndex = useSelectedKeypointIndex();
   const { labelSchema } = useAnnotationSchemaContext();
 
   const fieldSchema = labelSchema?.[selectedLabel?.path];
 
   return useMemo(() => {
-    if (!overlay || pointIndex === null) {
+    if (selectedLabel?.type !== "Keypoint") {
       return null;
     }
 
-    const data = selectedLabel?.data as
-      | KeypointAnnotationLabel["data"]
-      | undefined;
-    const points = data?.points;
-    if (!Array.isArray(points) || pointIndex >= points.length) {
-      return null;
-    }
-
-    const schemaAttributes =
-      (fieldSchema?.label_schema?.attributes as unknown as
-        | AttributeConfig[]
-        | undefined) ?? [];
-    const schemaByName = new Map(schemaAttributes.map((a) => [a.name, a]));
-
-    const perPointNames = getPerPointAttributeNames(data);
-    const attributes: KeypointAttribute[] = [];
-    for (const name of perPointNames) {
-      const list = (data as Record<string, unknown>)[name] as unknown[];
-      attributes.push({
-        name,
-        value: list[pointIndex],
-        schema: schemaByName.get(name),
-      });
-    }
-
-    return {
-      pointIndex,
-      pointCount: points.length,
-      attributes,
-    };
-  }, [overlay, pointIndex, selectedLabel, fieldSchema]);
+    return getKeypointAttributes(selectedLabel?.data, pointIndex, fieldSchema);
+  }, [pointIndex, selectedLabel, fieldSchema]);
 };

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSelectedKeypoint.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSelectedKeypoint.ts
@@ -1,0 +1,154 @@
+import {
+  KeypointOverlay,
+  UNDEFINED_LIGHTER_SCENE_ID,
+  useLighter,
+  useLighterEventHandler,
+} from "@fiftyone/lighter";
+import type { KeypointAnnotationLabel } from "@fiftyone/state";
+import { KEYPOINT } from "@fiftyone/utilities";
+import { useCallback, useMemo, useReducer } from "react";
+import { useAnnotationSchemaContext } from "../state";
+import type { AttributeConfig } from "../SchemaManager/utils";
+import { useAnnotationContext } from "./state";
+
+/**
+ * Reserved label fields that should never be treated as per-point attributes
+ * even if their length happens to match the point count.
+ */
+const RESERVED_KEYS = new Set(["points"]);
+
+/**
+ * Per-point attribute surfaced for the currently sub-selected vertex.
+ */
+export interface KeypointAttribute {
+  /** Field name on the parent label (e.g. "occluded", "confidence") */
+  name: string;
+  /** Value for the currently-selected point */
+  value: unknown;
+  /** Matching schema entry, when one is defined for this attribute */
+  schema?: AttributeConfig;
+}
+
+export interface SelectedKeypoint {
+  /** Index of the sub-selected point on the keypoint overlay */
+  pointIndex: number;
+  /** Total number of points on the keypoint label */
+  pointCount: number;
+  /** Per-point attributes inferred from the label data */
+  attributes: KeypointAttribute[];
+}
+
+/**
+ * Returns the currently active keypoint overlay (when a keypoint label is
+ * being edited), or `null` otherwise.
+ */
+export const useSelectedKeypointOverlay = (): KeypointOverlay | null => {
+  const { selectedLabel } = useAnnotationContext();
+
+  if (
+    selectedLabel?.type !== KEYPOINT ||
+    !(selectedLabel.overlay instanceof KeypointOverlay)
+  ) {
+    return null;
+  }
+
+  return selectedLabel.overlay;
+};
+
+/**
+ * Tracks the sub-selected point index for the currently active keypoint
+ * overlay, reacting to {@link KeypointOverlay} sub-selection events. Returns
+ * `null` when no keypoint label is being edited or no point is sub-selected.
+ */
+export const useSelectedKeypointIndex = (): number | null => {
+  const overlay = useSelectedKeypointOverlay();
+  const { scene } = useLighter();
+  const useEventHandler = useLighterEventHandler(
+    scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
+  );
+
+  // stateless re-render trigger
+  const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
+
+  useEventHandler(
+    "lighter:keypoint-sub-selection-changed",
+    useCallback(
+      (payload) => {
+        if (!overlay || payload.id !== overlay.id) {
+          return;
+        }
+
+        forceUpdate();
+      },
+      [overlay]
+    )
+  );
+
+  return overlay?.getSelectedPointIndex() ?? null;
+};
+
+/**
+ * Returns information about the currently sub-selected point of the active
+ * keypoint overlay, or `null` when no keypoint label is being edited or no
+ * point has been selected within it.
+ *
+ * Per-point attributes are inferred from the label's data: any field whose
+ * value is an array with `length === points.length` (excluding `points`
+ * itself) is treated as a per-point list, per the FiftyOne keypoint
+ * documentation.
+ */
+export const useSelectedKeypoint = (): SelectedKeypoint | null => {
+  const { selectedLabel } = useAnnotationContext();
+  const overlay = useSelectedKeypointOverlay();
+  const pointIndex = useSelectedKeypointIndex();
+  const { labelSchema } = useAnnotationSchemaContext();
+
+  const fieldSchema = labelSchema?.[selectedLabel?.path];
+
+  return useMemo(() => {
+    if (!overlay || pointIndex === null) {
+      return null;
+    }
+
+    const data = selectedLabel?.data as
+      | KeypointAnnotationLabel["data"]
+      | undefined;
+    const points = data?.points;
+    if (!Array.isArray(points) || pointIndex >= points.length) {
+      return null;
+    }
+
+    const schemaAttributes =
+      (fieldSchema?.label_schema?.attributes as unknown as
+        | AttributeConfig[]
+        | undefined) ?? [];
+    const schemaByName = new Map(schemaAttributes.map((a) => [a.name, a]));
+
+    const attributes: KeypointAttribute[] = [];
+    for (const [name, value] of Object.entries(data ?? {})) {
+      if (RESERVED_KEYS.has(name)) {
+        continue;
+      }
+
+      if (!Array.isArray(value)) {
+        continue;
+      }
+
+      if (value.length !== points.length) {
+        continue;
+      }
+
+      attributes.push({
+        name,
+        value: value[pointIndex],
+        schema: schemaByName.get(name),
+      });
+    }
+
+    return {
+      pointIndex,
+      pointCount: points.length,
+      attributes,
+    };
+  }, [overlay, pointIndex, selectedLabel, fieldSchema]);
+};

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSelectedKeypoint.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSelectedKeypoint.ts
@@ -109,7 +109,7 @@ export const getKeypointAttributes = (
   }
 
   const points = label?.points;
-  if (!Array.isArray(points) || pointIndex >= points.length) {
+  if (!Array.isArray(points) || pointIndex >= points.length || pointIndex < 0) {
     return null;
   }
 
@@ -204,7 +204,7 @@ export const useSelectedKeypoint = (): KeypointMeta | null => {
   const fieldSchema = labelSchema?.[selectedLabel?.path];
 
   return useMemo(() => {
-    if (selectedLabel?.type !== "Keypoint") {
+    if (selectedLabel?.type !== KEYPOINT) {
       return null;
     }
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSelectedKeypoint.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSelectedKeypoint.ts
@@ -122,12 +122,14 @@ export const getKeypointAttributes = (
   const perPointNames = getPerPointAttributeNames(label);
   const attributes: KeypointAttribute[] = [];
   for (const name of perPointNames) {
-    const list = (label as Record<string, unknown>)[name] as unknown[];
-    attributes.push({
-      name,
-      value: list[pointIndex],
-      schema: schemaByName.get(name),
-    });
+    if (schemaByName.has(name)) {
+      const list = (label as Record<string, unknown>)[name] as unknown[];
+      attributes.push({
+        name,
+        value: list[pointIndex],
+        schema: schemaByName.get(name),
+      });
+    }
   }
 
   return {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSelectedKeypoint.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSelectedKeypoint.ts
@@ -18,6 +18,59 @@ import { useAnnotationContext } from "./state";
 const RESERVED_KEYS = new Set(["points"]);
 
 /**
+ * Returns the set of label fields that should be treated as per-point
+ * attributes for a keypoint label — any field whose value is an array with
+ * `length === points.length` (excluding {@link RESERVED_KEYS}). Returns an
+ * empty set when the input doesn't have a usable points array.
+ */
+export const getPerPointAttributeNames = (
+  data: KeypointAnnotationLabel["data"] | undefined
+): Set<string> => {
+  const names = new Set<string>();
+  const points = data?.points;
+  if (!Array.isArray(points)) {
+    return names;
+  }
+
+  for (const [name, value] of Object.entries(data ?? {})) {
+    if (RESERVED_KEYS.has(name)) {
+      continue;
+    }
+
+    if (!Array.isArray(value)) {
+      continue;
+    }
+
+    if (value.length !== points.length) {
+      continue;
+    }
+
+    names.add(name);
+  }
+
+  return names;
+};
+
+/**
+ * Hook variant of {@link getPerPointAttributeNames} that resolves the current
+ * label automatically. Returns an empty set when the active label is not a
+ * keypoint, so consumers can apply it unconditionally.
+ */
+export const usePerPointAttributeNames = (): Set<string> => {
+  const { selectedLabel } = useAnnotationContext();
+
+  return useMemo(() => {
+    if (selectedLabel?.type !== KEYPOINT) {
+      return new Set<string>();
+    }
+
+    return getPerPointAttributeNames(
+      selectedLabel.data as KeypointAnnotationLabel["data"]
+    );
+  }, [selectedLabel]);
+};
+
+/**
  * Per-point attribute surfaced for the currently sub-selected vertex.
  */
 export interface KeypointAttribute {
@@ -124,23 +177,13 @@ export const useSelectedKeypoint = (): SelectedKeypoint | null => {
         | undefined) ?? [];
     const schemaByName = new Map(schemaAttributes.map((a) => [a.name, a]));
 
+    const perPointNames = getPerPointAttributeNames(data);
     const attributes: KeypointAttribute[] = [];
-    for (const [name, value] of Object.entries(data ?? {})) {
-      if (RESERVED_KEYS.has(name)) {
-        continue;
-      }
-
-      if (!Array.isArray(value)) {
-        continue;
-      }
-
-      if (value.length !== points.length) {
-        continue;
-      }
-
+    for (const name of perPointNames) {
+      const list = (data as Record<string, unknown>)[name] as unknown[];
       attributes.push({
         name,
-        value: value[pointIndex],
+        value: list[pointIndex],
         schema: schemaByName.get(name),
       });
     }

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Icons.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Icons.tsx
@@ -67,7 +67,7 @@ export const Polyline = ({ fill }: { fill: string }) => {
 export const Keypoint = ({ fill }: { fill: string }) => {
   return (
     <Container style={{ color: fill }}>
-      <Icon name={IconName.Embeddings} size={Size.Md} />
+      <Icon name={IconName.Radio} size={Size.Md} />
     </Container>
   );
 };

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/LabelEntry.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/LabelEntry.tsx
@@ -91,6 +91,10 @@ const LabelEntry = ({ atom }: { atom: PrimitiveAtom<AnnotationLabel> }) => {
   return (
     <Container
       onClick={() => {
+        // Clicking on a label will unmount this component,
+        // causing onMouseLeave to never be fired
+        handleMouseLeave();
+
         const store = getDefaultStore();
         scene?.selectOverlay(store.get(atom).overlay.id);
 

--- a/app/packages/core/src/components/Sidebar/SidebarContainer.tsx
+++ b/app/packages/core/src/components/Sidebar/SidebarContainer.tsx
@@ -30,6 +30,8 @@ const SidebarContainer = ({
       style={{
         borderTopRightRadius: 8,
         zIndex: modal ? muiTheme.zIndex.tooltip + 1 : undefined,
+        display: "flex",
+        flexDirection: "column",
       }}
     >
       {children}

--- a/app/packages/lighter/src/events/index.ts
+++ b/app/packages/lighter/src/events/index.ts
@@ -146,6 +146,12 @@ export type LighterEventGroup = {
     /** Optional keypoint variant. */
     variant?: string;
   };
+  /** Emitted when a keypoint overlay's per-point sub-selection changes */
+  "lighter:keypoint-sub-selection-changed": {
+    id: string;
+    /** Index of the selected point, or null when no point is selected */
+    pointIndex: number | null;
+  };
 
   // ============================================================================
   // SELECTION EVENTS

--- a/app/packages/lighter/src/overlay/KeypointOverlay.ts
+++ b/app/packages/lighter/src/overlay/KeypointOverlay.ts
@@ -619,7 +619,7 @@ export class KeypointOverlay
     const nearestIdx = this.findNearestPointIndex(worldPoint, scale);
 
     if (nearestIdx >= 0) {
-      this.selectedPointIndex = nearestIdx;
+      this.setSelectedPointIndex(nearestIdx);
 
       if (this.isDraggable) {
         this.dragPointIndex = nearestIdx;
@@ -633,7 +633,7 @@ export class KeypointOverlay
     }
 
     // Clicked away from any point — clear sub-selection
-    this.selectedPointIndex = null;
+    this.setSelectedPointIndex(null);
     this.markDirty();
     return false;
   }
@@ -809,12 +809,12 @@ export class KeypointOverlay
 
     // Clear sub-selection if it was the deleted point
     if (this.selectedPointIndex === index) {
-      this.selectedPointIndex = null;
+      this.setSelectedPointIndex(null);
     } else if (
       this.selectedPointIndex !== null &&
       this.selectedPointIndex > index
     ) {
-      this.selectedPointIndex--;
+      this.setSelectedPointIndex(this.selectedPointIndex - 1);
     }
 
     this.eventBus.dispatch("lighter:keypoint-point-deleted", {
@@ -839,7 +839,7 @@ export class KeypointOverlay
    */
   clearPoints(): void {
     this.#points = [];
-    this.selectedPointIndex = null;
+    this.setSelectedPointIndex(null);
     this.dragPointIndex = null;
     this.previewPoint = null;
     this.markDirty();
@@ -862,7 +862,7 @@ export class KeypointOverlay
       id: uuidv4(),
       position: [p[0], p[1]],
     }));
-    this.selectedPointIndex = null;
+    this.setSelectedPointIndex(null);
     this.dragPointIndex = null;
     this.previewPoint = null;
     this.markDirty();
@@ -873,6 +873,22 @@ export class KeypointOverlay
    */
   getSelectedPointIndex(): number | null {
     return this.selectedPointIndex;
+  }
+
+  /**
+   * Updates the sub-selected point index and dispatches a change event when
+   * the value changes.
+   */
+  private setSelectedPointIndex(index: number | null): void {
+    if (this.selectedPointIndex === index) {
+      return;
+    }
+
+    this.selectedPointIndex = index;
+    this.eventBus.dispatch("lighter:keypoint-sub-selection-changed", {
+      id: this.id,
+      pointIndex: index,
+    });
   }
 
   /**
@@ -903,7 +919,7 @@ export class KeypointOverlay
     if (this.isSelectedState !== selected) {
       this.isSelectedState = selected;
       if (!selected) {
-        this.selectedPointIndex = null;
+        this.setSelectedPointIndex(null);
       }
       this.markDirty();
     }

--- a/app/packages/lighter/src/overlay/KeypointOverlay.ts
+++ b/app/packages/lighter/src/overlay/KeypointOverlay.ts
@@ -879,7 +879,7 @@ export class KeypointOverlay
    * Updates the sub-selected point index and dispatches a change event when
    * the value changes.
    */
-  private setSelectedPointIndex(index: number | null): void {
+  setSelectedPointIndex(index: number | null): void {
     if (this.selectedPointIndex === index) {
       return;
     }
@@ -889,6 +889,7 @@ export class KeypointOverlay
       id: this.id,
       pointIndex: index,
     });
+    this.markDirty();
   }
 
   /**


### PR DESCRIPTION
## 🔗 Related Issues

None

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

Builds on #7411 to add per-point attribute editing. `fo.Keypoint` labels support implicit point attributes through same-sized list attributes (e.g. per-point `confidence` values). The current annotation experience surfaces these attributes as lists, making it cumbersome to update per-point values. 

This PR leverages keypoint sub-selection and surfaces per-point attributes for more intuitive editing. When a specific point is selected, the relevant per-point attributes will be shown and are available for editing. Updates are rolled into the base attribute list, though that process is opaque to the user.

## 🧪 How is this patch tested? If it is not, please explain why.

local app

<video src="https://github.com/user-attachments/assets/5594d77e-e58a-442f-932f-17409769e646" />

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-point attribute editor for keypoint annotations with accordion-based editors for each point.
  * Automatic exclusion of per-point attributes from top-level annotation editing.
  * Grouped X/Y and W/H controls for position editing.

* **Improvements**
  * More reliable keypoint sub-selection updates and event handling.
  * Reordered sidebar content and improved scrolling/layout behavior.
  * Immediate unhover on label click and updated keypoint icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->