### PR TITLE
fix(labelstudio): migrate brush import from archived label_studio_converter to label_studio_sdk

### DIFF
--- a/fiftyone/utils/labelstudio.py
+++ b/fiftyone/utils/labelstudio.py
@@ -32,8 +32,8 @@ ls = fou.lazy_import(
     callback=lambda: fou.ensure_import("label_studio_sdk>=0.0.13"),
 )
 brush = fou.lazy_import(
-    "label_studio_converter.brush",
-    callback=lambda: fou.ensure_import("label_studio_converter.brush"),
+    "label_studio_sdk.converter.brush",
+    callback=lambda: fou.ensure_import("label_studio_sdk>=1.0.0"),
 )
 etree = fou.lazy_import(
     "lxml.etree",

--- a/fiftyone/utils/labelstudio.py
+++ b/fiftyone/utils/labelstudio.py
@@ -27,21 +27,31 @@ import fiftyone.core.media as fom
 import fiftyone.core.utils as fou
 import fiftyone.utils.annotations as foua
 
+logger = logging.getLogger(__name__)
+
 ls = fou.lazy_import(
     "label_studio_sdk",
     callback=lambda: fou.ensure_import("label_studio_sdk>=0.0.13"),
 )
-brush = fou.lazy_import(
-    "label_studio_sdk.converter.brush",
-    callback=lambda: fou.ensure_import("label_studio_sdk>=1.0.0"),
-)
+
+if fou.ensure_import("label_studio_sdk>=1.0.0", error_level=2):
+    brush = fou.lazy_import("label_studio_sdk.converter.brush")
+else:
+    brush = fou.lazy_import(
+        "label_studio_converter.brush",
+        callback=lambda: fou.ensure_import("label_studio_converter.brush"),
+    )
+    _ = brush.__file__
+    logger.warning(
+        "The 'label_studio_converter' project has been archived. "
+        "Please install 'label_studio_sdk>=1.0.0' to use the maintained "
+        "brush converter implementation."
+    )
+
 etree = fou.lazy_import(
     "lxml.etree",
     callback=lambda: fou.ensure_import("lxml.etree"),
 )
-
-
-logger = logging.getLogger(__name__)
 
 
 class LabelStudioBackendConfig(foua.AnnotationBackendConfig):


### PR DESCRIPTION
## Summary

Fixes #6282

The `label_studio_converter` package has been archived. Its brush module (`mask2rle`, `decode_rle`) is now available under the actively maintained `label_studio_sdk` package at `label_studio_sdk.converter.brush`.

## Change

**`fiftyone/utils/labelstudio.py`** (lines 34–37)

```python
# Before (archived package)
brush = fou.lazy_import(
    "label_studio_converter.brush",
    callback=lambda: fou.ensure_import("label_studio_converter.brush"),
)

# After (maintained package)
brush = fou.lazy_import(
    "label_studio_sdk.converter.brush",
    callback=lambda: fou.ensure_import("label_studio_sdk>=1.0.0"),
)
```

The three call sites that use `brush.mask2rle()` and `brush.decode_rle()` (lines 827, 887, 945) are unchanged — the API is identical between the two packages.

## Verification

`label_studio_sdk.converter.brush` is confirmed to expose the same `mask2rle` / `decode_rle` API:
- https://github.com/HumanSignal/label-studio-sdk/blob/master/src/label_studio_sdk/converter/brush.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies for mask conversion to improve compatibility with the latest Label Studio SDK versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->