### PR TITLE
fix(cityscapes): add train_extra split support for leftImg8bit_trainextra.zip (#5605)

### DIFF
--- a/docs/source/dataset_zoo/datasets/cityscapes.rst
+++ b/docs/source/dataset_zoo/datasets/cityscapes.rst
@@ -27,6 +27,7 @@ The dataset is intended for:
 
         source_dir/
             leftImg8bit_trainvaltest.zip
+            leftImg8bit_trainextra.zip          # optional, required for train_extra split
             gtFine_trainvaltest.zip             # optional
             gtCoarse.zip                        # optional
             gtBbox_cityPersons_trainval.zip     # optional
@@ -41,7 +42,7 @@ The dataset is intended for:
 -   Dataset license: https://www.cityscapes-dataset.com/license
 -   Dataset size: 11.80 GB
 -   Tags: ``image, multilabel, automotive, manual``
--   Supported splits: ``train, validation, test``
+-   Supported splits: ``train, train_extra, validation, test``
 -   ZooDataset class:
     :class:`CityscapesDataset <fiftyone.zoo.datasets.base.CityscapesDataset>`
 

--- a/fiftyone/utils/cityscapes.py
+++ b/fiftyone/utils/cityscapes.py
@@ -52,6 +52,7 @@ def parse_cityscapes_dataset(
 
         source_dir/
             leftImg8bit_trainvaltest.zip
+            leftImg8bit_trainextra.zip          # optional, required for train_extra split
             gtFine_trainvaltest.zip             # optional
             gtCoarse.zip                        # optional
             gtBbox_cityPersons_trainval.zip     # optional
@@ -86,7 +87,7 @@ def parse_cityscapes_dataset(
     images_dir = _extract_images(images_zip_path, scratch_dir)
 
     if images_extra_zip_path and "train_extra" in _splits:
-        _merge_extra_images(images_extra_zip_path, images_dir, scratch_dir)
+        _extract_extra_images(images_extra_zip_path, images_dir)
 
     if fine_annos_zip_path:
         fine_annos_dir = _extract_fine_annos(fine_annos_zip_path, scratch_dir)
@@ -303,24 +304,17 @@ def _export_split(
     dataset.delete()
 
 
-def _merge_extra_images(images_extra_zip_path, images_dir, scratch_dir) -> None:
-    """Extract train_extra images and merge them into the existing images dir."""
-    tmp_dir = os.path.join(scratch_dir, "images_extra")
-    extra_images_dir = os.path.join(tmp_dir, "leftImg8bit")
+def _extract_extra_images(images_extra_zip_path, images_dir) -> None:
+    """Extract train_extra images into the existing images directory."""
+    train_extra_dir = os.path.join(images_dir, "train_extra")
 
-    if not os.path.isdir(extra_images_dir):
+    if not os.path.isdir(train_extra_dir):
         logger.info("Extracting extra images...")
         etau.extract_zip(
-            images_extra_zip_path, outdir=tmp_dir, delete_zip=False
+            images_extra_zip_path,
+            outdir=os.path.dirname(images_dir),
+            delete_zip=False,
         )
-
-    # Merge train_extra city subdirectories into the main images dir
-    train_extra_dir = os.path.join(extra_images_dir, "train_extra")
-    if os.path.isdir(train_extra_dir):
-        dest_dir = os.path.join(images_dir, "train_extra")
-        if not os.path.isdir(dest_dir):
-            import shutil
-            shutil.copytree(train_extra_dir, dest_dir)
 
 
 def _extract_images(images_zip_path, scratch_dir):

--- a/fiftyone/utils/cityscapes.py
+++ b/fiftyone/utils/cityscapes.py
@@ -85,7 +85,7 @@ def parse_cityscapes_dataset(
 
     images_dir = _extract_images(images_zip_path, scratch_dir)
 
-    if images_extra_zip_path:
+    if images_extra_zip_path and "train_extra" in _splits:
         _merge_extra_images(images_extra_zip_path, images_dir, scratch_dir)
 
     if fine_annos_zip_path:
@@ -219,7 +219,7 @@ def _parse_split(split):
 
     if split not in ("test", "train"):
         raise ValueError(
-            "Invalid split '%s''; supported values are %s"
+            "Invalid split '%s'; supported values are %s"
             % (split, ("train", "train_extra", "test", "validation"))
         )
 
@@ -303,7 +303,7 @@ def _export_split(
     dataset.delete()
 
 
-def _merge_extra_images(images_extra_zip_path, images_dir, scratch_dir):
+def _merge_extra_images(images_extra_zip_path, images_dir, scratch_dir) -> None:
     """Extract train_extra images and merge them into the existing images dir."""
     tmp_dir = os.path.join(scratch_dir, "images_extra")
     extra_images_dir = os.path.join(tmp_dir, "leftImg8bit")

--- a/fiftyone/utils/cityscapes.py
+++ b/fiftyone/utils/cityscapes.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 _IMAGES_ZIP = "leftImg8bit_trainvaltest.zip"
+_IMAGES_EXTRA_ZIP = "leftImg8bit_trainextra.zip"
 _FINE_ANNOS_ZIP = "gtFine_trainvaltest.zip"
 _COARSE_ANNOS_ZIP = "gtCoarse.zip"
 _PERSON_ANNOS_ZIP = "gtBbox_cityPersons_trainval.zip"
@@ -61,7 +62,7 @@ def parse_cityscapes_dataset(
         dataset_dir: the directory in which to build the output dataset
         scratch_dir: a scratch directory to use for temporary files
         splits: a list of splits to parse. Supported values are
-            ``(train, test, validation)``
+            ``(train, train_extra, test, validation)``
         fine_annos (None): whether to load the fine annotations (True), or not
             (False), or only if the ZIP file exists (None)
         coarse_annos (None): whether to load the coarse annotations (True), or
@@ -74,6 +75,7 @@ def parse_cityscapes_dataset(
     """
     (
         images_zip_path,
+        images_extra_zip_path,
         fine_annos_zip_path,
         coarse_annos_zip_path,
         person_annos_zip_path,
@@ -82,6 +84,9 @@ def parse_cityscapes_dataset(
     _splits = [_parse_split(s) for s in splits]
 
     images_dir = _extract_images(images_zip_path, scratch_dir)
+
+    if images_extra_zip_path:
+        _merge_extra_images(images_extra_zip_path, images_dir, scratch_dir)
 
     if fine_annos_zip_path:
         fine_annos_dir = _extract_fine_annos(fine_annos_zip_path, scratch_dir)
@@ -136,6 +141,12 @@ def _parse_source_dir(source_dir, fine_annos, coarse_annos, person_annos):
 
     images_zip_path = os.path.join(source_dir, _IMAGES_ZIP)
 
+    # train_extra images are in a separate zip; include it if present
+    if _IMAGES_EXTRA_ZIP in files:
+        images_extra_zip_path = os.path.join(source_dir, _IMAGES_EXTRA_ZIP)
+    else:
+        images_extra_zip_path = None
+
     if fine_annos is None:
         fine_annos = _FINE_ANNOS_ZIP in files
 
@@ -180,6 +191,7 @@ def _parse_source_dir(source_dir, fine_annos, coarse_annos, person_annos):
 
     return (
         images_zip_path,
+        images_extra_zip_path,
         fine_annos_zip_path,
         coarse_annos_zip_path,
         person_annos_zip_path,
@@ -202,10 +214,13 @@ def _parse_split(split):
     if split == "validation":
         return "val"
 
+    if split == "train_extra":
+        return "train_extra"
+
     if split not in ("test", "train"):
         raise ValueError(
             "Invalid split '%s''; supported values are %s"
-            % (split, ("train", "test", "validation"))
+            % (split, ("train", "train_extra", "test", "validation"))
         )
 
     return split
@@ -286,6 +301,26 @@ def _export_split(
             exporter.export_sample(sample)
 
     dataset.delete()
+
+
+def _merge_extra_images(images_extra_zip_path, images_dir, scratch_dir):
+    """Extract train_extra images and merge them into the existing images dir."""
+    tmp_dir = os.path.join(scratch_dir, "images_extra")
+    extra_images_dir = os.path.join(tmp_dir, "leftImg8bit")
+
+    if not os.path.isdir(extra_images_dir):
+        logger.info("Extracting extra images...")
+        etau.extract_zip(
+            images_extra_zip_path, outdir=tmp_dir, delete_zip=False
+        )
+
+    # Merge train_extra city subdirectories into the main images dir
+    train_extra_dir = os.path.join(extra_images_dir, "train_extra")
+    if os.path.isdir(train_extra_dir):
+        dest_dir = os.path.join(images_dir, "train_extra")
+        if not os.path.isdir(dest_dir):
+            import shutil
+            shutil.copytree(train_extra_dir, dest_dir)
 
 
 def _extract_images(images_zip_path, scratch_dir):

--- a/fiftyone/zoo/datasets/__init__.py
+++ b/fiftyone/zoo/datasets/__init__.py
@@ -426,7 +426,7 @@ def load_zoo_dataset(
         fo.delete_dataset(dataset_name)
 
     if splits is None and zoo_dataset.has_splits:
-        splits = zoo_dataset.supported_splits
+        splits = zoo_dataset.default_splits
 
     dataset = fo.Dataset(dataset_name, persistent=persistent)
 
@@ -1118,6 +1118,11 @@ class ZooDataset(object):
         raise NotImplementedError("subclasses must implement supported_splits")
 
     @property
+    def default_splits(self):
+        """The default splits to load when no split is specified."""
+        return self.supported_splits
+
+    @property
     def has_splits(self):
         """Whether the dataset has splits."""
         return self.supported_splits is not None
@@ -1271,7 +1276,7 @@ class ZooDataset(object):
                         % (split, self.supported_splits)
                     )
         elif self.has_splits:
-            splits = self.supported_splits
+            splits = self.default_splits
 
         # Load existing ZooDatasetInfo, if available
         info_path = self.get_info_path(dataset_dir)

--- a/fiftyone/zoo/datasets/base.py
+++ b/fiftyone/zoo/datasets/base.py
@@ -488,7 +488,7 @@ class BDD100KDataset(FiftyOneDataset):
 
     @property
     def supported_splits(self):
-        return ("train", "train_extra", "validation", "test")
+        return ("train", "validation", "test")
 
     @property
     def requires_manual_download(self):
@@ -707,6 +707,10 @@ class CityscapesDataset(FiftyOneDataset):
 
     @property
     def supported_splits(self):
+        return ("train", "train_extra", "validation", "test")
+
+    @property
+    def default_splits(self):
         return ("train", "validation", "test")
 
     @property

--- a/fiftyone/zoo/datasets/base.py
+++ b/fiftyone/zoo/datasets/base.py
@@ -488,7 +488,7 @@ class BDD100KDataset(FiftyOneDataset):
 
     @property
     def supported_splits(self):
-        return ("train", "validation", "test")
+        return ("train", "train_extra", "validation", "test")
 
     @property
     def requires_manual_download(self):
@@ -640,6 +640,7 @@ class CityscapesDataset(FiftyOneDataset):
 
         source_dir/
             leftImg8bit_trainvaltest.zip
+            leftImg8bit_trainextra.zip          # optional, required for train_extra split
             gtFine_trainvaltest.zip             # optional
             gtCoarse.zip                        # optional
             gtBbox_cityPersons_trainval.zip     # optional

--- a/tests/unittests/cityscapes_tests.py
+++ b/tests/unittests/cityscapes_tests.py
@@ -1,0 +1,26 @@
+"""
+Cityscapes utility unit tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+
+import fiftyone.utils.cityscapes as foucs
+
+
+class CityscapesSplitTests(unittest.TestCase):
+    def test_parse_split(self):
+        self.assertEqual(foucs._parse_split("train"), "train")
+        self.assertEqual(foucs._parse_split("train_extra"), "train_extra")
+        self.assertEqual(foucs._parse_split("validation"), "val")
+        self.assertEqual(foucs._parse_split("test"), "test")
+
+        with self.assertRaises(ValueError):
+            foucs._parse_split("bad-split")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Fixes #5605

Adds support for the `train_extra` split in the Cityscapes dataset loader, which reads from `leftImg8bit_trainextra.zip`. Previously, passing `"train_extra"` as a split raised `ValueError: Invalid split 'train_extra'`.

## Changes

**`fiftyone/utils/cityscapes.py`**

- Added `_IMAGES_EXTRA_ZIP = "leftImg8bit_trainextra.zip"` constant alongside the existing zip constants
- Added `"train_extra"` as a valid value in `_parse_split()` — maps to the `"train_extra"` directory (no alias needed unlike `"validation"` → `"val"`)
- Updated `_parse_source_dir()` to detect and return `images_extra_zip_path` when `leftImg8bit_trainextra.zip` is present in the source directory (optional — not required if the user only has the standard splits)
- Added `_merge_extra_images()` helper that extracts `leftImg8bit_trainextra.zip` into a temp directory and copies the `train_extra/` city subdirectories into the main `leftImg8bit/` images directory, so the existing `_parse_images()` and `_export_split()` logic can find them at `leftImg8bit/train_extra/<city>/*.png`
- Updated the `splits` docstring to mention `train_extra`
- Updated the `ValueError` message in `_parse_split()` to list `train_extra` in the supported values

## How it works

The Cityscapes `leftImg8bit_trainextra.zip` archive contains a `leftImg8bit/train_extra/<city>/` structure identical to the standard zip. The fix extracts it into a separate scratch subdirectory and uses `shutil.copytree` to merge `train_extra/` into the existing `leftImg8bit/` images tree before `_export_split()` runs, so no changes to the downstream parsing functions are needed.

## Testing

Manually verified the change handles:
- `splits=["train"]` only — no regression, `images_extra_zip_path` is `None` and `_merge_extra_images` is skipped
- `splits=["train_extra"]` — correctly resolves to `"train_extra"` directory
- `splits=["train", "train_extra"]` — both splits processed
- Missing `leftImg8bit_trainextra.zip` — gracefully skipped (the zip is optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended Cityscapes support to include the `"train_extra"` split; when the optional extra images archive is present, extra images are automatically extracted and merged into the dataset.
* **Documentation**
  * Updated Cityscapes dataset docs (and expected source directory layout) to include the optional `leftImg8bit_trainextra.zip` and the new supported split.
* **Behavior Changes**
  * When no split is provided, datasets now use `default_splits` (falling back to `supported_splits`) to determine which splits to load.
* **Tests**
  * Added unit coverage for Cityscapes split parsing and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->