### PR TITLE
Ontology set applied ontology

### DIFF
--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -57,6 +57,7 @@ from .core.expressions import (
 )
 from .core.ontology import (
     AnnotationOntology,
+    apply_ontology,
     delete_ontology,
     list_ontologies,
     load_ontology,

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -9032,6 +9032,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
     def _expand_schema(self, sample, dynamic):
         expanded = False
+        schema = None
 
         schema = None
         if not dynamic:

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -18,6 +18,7 @@ import os
 import random
 import string
 from datetime import datetime
+from typing import Optional
 
 import cachetools
 import eta.core.serial as etas

--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -12,6 +12,7 @@ import fnmatch
 from datetime import datetime
 from typing import Any, Optional
 
+import fiftyone.core.annotation.constants as foac
 import fiftyone.core.utils as fou
 from fiftyone.core.annotation.attributes import (
     AttributeSpec,
@@ -287,6 +288,8 @@ class AnnotationOntology(Ontology):
                 AttributeSpec.from_dict(a) for a in root.get("attributes", [])
             ],
         )
+
+
 # ---- Type dispatch --------------------------------------------------------
 
 _TYPE_TO_CLS: dict[str, type[Ontology]] = {
@@ -387,3 +390,32 @@ def delete_ontology(name: str, force: bool = False) -> None:
     count = _objects_by_slug(name).delete()
     if count == 0:
         raise ValueError(f"Ontology '{name}' not found")
+
+
+def apply_ontology(
+    label_schemas: dict, field_name: str, ontology_name: Optional[str]
+) -> dict:
+    """Returns a new ``label_schemas`` dict with an annotation ontology
+    attached to (or removed from) the given field.
+
+    Pure function — does not mutate the input. Apply the result via
+    :meth:`fiftyone.core.dataset.Dataset.set_label_schemas` to persist.
+
+    Args:
+        label_schemas: a label schemas dict
+        field_name: the field to attach the ontology to
+        ontology_name: name of an annotation ontology to attach, or ``None``
+            to unset an existing reference
+
+    Returns:
+        a new label schemas dict
+    """
+    label_schemas = dict(label_schemas)
+    field_schema = dict(label_schemas.get(field_name, {}))
+    if ontology_name is None:
+        # idempotent: no-op if there is no existing reference to unset
+        field_schema.pop(foac.APPLIED_ONTOLOGY, None)
+    else:
+        field_schema[foac.APPLIED_ONTOLOGY] = ontology_name
+    label_schemas[field_name] = field_schema
+    return label_schemas

--- a/tests/unittests/annotation/dataset_label_schemas_tests.py
+++ b/tests/unittests/annotation/dataset_label_schemas_tests.py
@@ -12,8 +12,9 @@ from exceptiongroup import ExceptionGroup
 
 import fiftyone as fo
 import fiftyone.core.labels as fol
+from fiftyone.core.ontology import AnnotationOntology, apply_ontology
 
-from decorators import drop_datasets
+from decorators import drop_datasets, drop_ontologies
 
 
 class DatasetAnnotationTests(unittest.TestCase):
@@ -374,3 +375,88 @@ class DatasetAnnotationTests(unittest.TestCase):
                 }
             )
         dataset.delete_sample_field("labels")
+
+    @drop_datasets
+    @drop_ontologies
+    def test_apply_ontology_apply(self):
+        dataset = _make_applied_ontology_test_dataset()
+        dataset.set_label_schemas({"detections": {"type": "detections"}})
+
+        schemas = apply_ontology(
+            dataset.label_schemas, "detections", "my_ontology"
+        )
+        dataset.set_label_schemas(schemas)
+
+        self.assertEqual(
+            dataset.label_schemas["detections"].get("applied_ontology"),
+            "my_ontology",
+        )
+        # other keys are preserved
+        self.assertEqual(
+            dataset.label_schemas["detections"]["type"], "detections"
+        )
+
+    @drop_datasets
+    @drop_ontologies
+    def test_apply_ontology_unset(self):
+        dataset = _make_applied_ontology_test_dataset()
+        dataset.set_label_schemas({"detections": {"type": "detections"}})
+
+        dataset.set_label_schemas(
+            apply_ontology(dataset.label_schemas, "detections", "my_ontology")
+        )
+        dataset.set_label_schemas(
+            apply_ontology(dataset.label_schemas, "detections", None)
+        )
+        self.assertNotIn(
+            "applied_ontology", dataset.label_schemas["detections"]
+        )
+
+        # idempotent: unsetting again is a no-op
+        dataset.set_label_schemas(
+            apply_ontology(dataset.label_schemas, "detections", None)
+        )
+
+    @drop_datasets
+    @drop_ontologies
+    def test_apply_ontology_invalid_reference_raises(self):
+        dataset = _make_applied_ontology_test_dataset()
+        dataset.set_label_schemas({"detections": {"type": "detections"}})
+
+        schemas = apply_ontology(
+            dataset.label_schemas, "detections", "nonexistent_ontology_xyz"
+        )
+        with self.assertRaises(ExceptionGroup):
+            dataset.set_label_schemas(schemas)
+
+    @drop_datasets
+    @drop_ontologies
+    def test_apply_ontology_does_not_mutate_input(self):
+        original = {"detections": {"type": "detections"}}
+        result = apply_ontology(original, "detections", "my_ontology")
+
+        self.assertNotIn("applied_ontology", original["detections"])
+        self.assertEqual(
+            result["detections"]["applied_ontology"], "my_ontology"
+        )
+
+
+def _make_applied_ontology_test_dataset(ontology_name: str = "my_ontology"):
+    """Dataset with a `detections` label field and a `str_field`, with a real
+    `AnnotationOntology` named ``ontology_name`` persisted to the `ontologies`
+    collection so the validator can resolve the reference.
+
+    Duplicated from `validate_label_schemas_tests.py`; consolidate later.
+    """
+    AnnotationOntology(name=ontology_name).save()
+
+    dataset = fo.Dataset()
+    dataset.add_sample(
+        fo.Sample(
+            filepath="image.png",
+            detections=fo.Detections(detections=[fo.Detection(label="one")]),
+        )
+    )
+    dataset.add_sample_field("str_field", fo.StringField)
+
+    return dataset


### PR DESCRIPTION
## 🔗 Related Issues

https://github.com/voxel51/fiftyone/pull/7430

## 📋 What changes are proposed in this pull request?

This adds the public API to set our ontology on a label schema. This was discussed between Brian and Mike and the assumption is that the user will use the `set_label_schema` to apply that label schema to the dataset alongside this

## 🧪 How is this patch tested? If it is not, please explain why.

locally, unit tests

See these Python scripts for applying and unapplying ontologies. to the quick start dataset. 

[demo_apply_ontology.py](https://github.com/user-attachments/files/27205619/demo_apply_ontology.py)

[demo_reset_ontology.py](https://github.com/user-attachments/files/27205620/demo_reset_ontology.py)

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
