### PR TITLE
Ontology hydrate label schema

### DIFF
--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -57,6 +57,7 @@ from .core.expressions import (
 )
 from .core.ontology import (
     AnnotationOntology,
+    apply_ontology,
     delete_ontology,
     list_ontologies,
     load_ontology,

--- a/fiftyone/core/annotation/__init__.py
+++ b/fiftyone/core/annotation/__init__.py
@@ -16,7 +16,10 @@ from fiftyone.core.odm import patch_annotation_runs
 
 # core methods are accessible to fiftyone.core.annotation
 from .generate_label_schemas import generate_label_schemas
-from .hydrate_label_schemas import hydrate_applied_ontology
+from .hydrate_label_schemas import (
+    dehydrate_applied_ontology,
+    hydrate_applied_ontology,
+)
 from .validate_label_schemas import validate_label_schemas
 
 

--- a/fiftyone/core/annotation/__init__.py
+++ b/fiftyone/core/annotation/__init__.py
@@ -16,6 +16,7 @@ from fiftyone.core.odm import patch_annotation_runs
 
 # core methods are accessible to fiftyone.core.annotation
 from .generate_label_schemas import generate_label_schemas
+from .hydrate_label_schemas import hydrate_applied_ontology
 from .validate_label_schemas import validate_label_schemas
 
 

--- a/fiftyone/core/annotation/attributes.py
+++ b/fiftyone/core/annotation/attributes.py
@@ -142,6 +142,10 @@ class AttributeSpec:
         values: optional list of allowed values
         when: optional list of :class:`When` conditions controlling when
             this attribute is visible or field overrides
+        read_only: optional flag marking the attribute as non-editable
+        default: optional default value (type matches ``type``)
+        range: optional ``[min, max]`` for numeric-with-slider components
+        precision: optional decimal places for float-with-text components
 
     Example::
 
@@ -159,6 +163,10 @@ class AttributeSpec:
     component: str
     values: Optional[list] = None
     when: Optional[list[When]] = None
+    read_only: Optional[bool] = None
+    default: Any = None
+    range: Optional[list] = None
+    precision: Optional[int] = None
 
     def __post_init__(self) -> None:
         invalid_fields = [
@@ -184,6 +192,10 @@ class AttributeSpec:
             "component": self.component,
         }
         attr_insert_to_dict(d, "values", self)
+        attr_insert_to_dict(d, "read_only", self)
+        attr_insert_to_dict(d, "default", self)
+        attr_insert_to_dict(d, "range", self)
+        attr_insert_to_dict(d, "precision", self)
         if self.when is not None:
             d["when"] = [w.to_dict() for w in self.when]
         return d
@@ -218,6 +230,10 @@ class AttributeSpec:
             component=d["component"],
             values=values,
             when=when,
+            read_only=d.get("read_only"),
+            default=d.get("default"),
+            range=d.get("range"),
+            precision=d.get("precision"),
         )
 
     def __repr__(self) -> str:

--- a/fiftyone/core/annotation/hydrate_label_schemas.py
+++ b/fiftyone/core/annotation/hydrate_label_schemas.py
@@ -69,9 +69,61 @@ def hydrate_applied_ontology(label_schema: dict) -> dict:
             ontology_name,
         )
         # do not cause app failure on mis-configuration
+
         return label_schema
 
     return _merge(label_schema, ontology)
+
+
+def dehydrate_applied_ontology(label_schema: dict) -> dict:
+    """Strips hydration artifacts from a label schema before it is saved.
+
+    Companion to :func:`hydrate_applied_ontology`. When the schema has an
+    ``applied_ontology`` that resolves to an annotation ontology, drops
+    any attribute whose ``name`` matches an ontology-owned attribute and
+    strips the ``_source`` marker from the remaining attributes.
+
+    Otherwise (no reference, dangling reference, or non-annotation
+    reference) the schema is returned unchanged — the validator will
+    surface the reference-level problem.
+
+    Args:
+        label_schema: a label schema dict, possibly carrying hydration
+            artifacts from :func:`hydrate_applied_ontology`
+
+    Returns:
+        a deep-copied schema with hydration artifacts removed, or
+        ``label_schema`` unchanged when there is nothing to dehydrate
+    """
+    ontology_name = label_schema.get(foac.APPLIED_ONTOLOGY)
+    if ontology_name is None:
+        return label_schema
+
+    # Late import to avoid a circular import with the ontology SDK.
+    from fiftyone.core.ontology import load_ontology
+
+    try:
+        ontology = load_ontology(ontology_name)
+    except ValueError:
+        return label_schema
+
+    if not ontology.is_annotation_ontology:
+        return label_schema
+
+    ontology_owned_names = {a.name for a in ontology.attributes}
+
+    cleaned = copy.deepcopy(label_schema)
+    kept = []
+    for attr in cleaned.get(foac.ATTRIBUTES, []):
+        # ontology-owned attrs get dropped entirely, so their _source goes
+        # with them; only the kept (local) attrs need _source popped
+        if attr.get(foac.NAME) in ontology_owned_names:
+            continue
+        attr.pop(_SOURCE, None)
+        kept.append(attr)
+
+    cleaned[foac.ATTRIBUTES] = kept
+    return cleaned
 
 
 def _merge(label_schema: dict, ontology: Any) -> dict:

--- a/fiftyone/core/annotation/hydrate_label_schemas.py
+++ b/fiftyone/core/annotation/hydrate_label_schemas.py
@@ -32,17 +32,20 @@ def hydrate_applied_ontology(label_schema: dict) -> dict:
     ``_source: <ontology_name>`` marker. Attributes are matched by ``name``
     and ontology values win on collision.
 
-    If the schema has no ``applied_ontology`` reference, or if the
-    reference is dangling or points at a non-annotation ontology, the
-    schema is returned unchanged. A dangling reference is logged at
-    WARNING so operators can detect deleted-ontology scenarios.
+    If the schema has no ``applied_ontology`` reference, the schema is
+    returned unchanged. If the reference is dangling (deleted ontology)
+    or points at a non-annotation ontology, the ``applied_ontology`` key
+    is stripped from the returned schema and a WARNING is logged. This
+    lets a subsequent save silently persist a clean schema rather than
+    failing validation on the dangling reference.
 
     Args:
         label_schema: a label schema dict
 
     Returns:
-        a hydrated copy of ``label_schema``, or ``label_schema`` unchanged
-        when there is nothing to hydrate
+        a hydrated copy of ``label_schema``, a copy with
+        ``applied_ontology`` stripped if the reference is dangling, or
+        the schema unchanged when there is nothing to do
     """
     ontology_name = label_schema.get(foac.APPLIED_ONTOLOGY)
     if ontology_name is None:
@@ -56,23 +59,26 @@ def hydrate_applied_ontology(label_schema: dict) -> dict:
     except ValueError:
         logger.warning(
             "applied_ontology '%s' does not resolve to a known ontology; "
-            "returning label schema without hydration",
+            "stripping the dangling reference from the returned schema",
             ontology_name,
         )
-        # do not cause app failure on mis-configuration
-        return label_schema
+        return _strip_applied_ontology(label_schema)
 
     if not ontology.is_annotation_ontology:
         logger.warning(
-            "applied_ontology '%s' does not resolve to an Annotation Ontology"
-            " ontology; returning label schema without hydration",
+            "applied_ontology '%s' does not resolve to an Annotation "
+            "Ontology; stripping the reference from the returned schema",
             ontology_name,
         )
-        # do not cause app failure on mis-configuration
-
-        return label_schema
+        return _strip_applied_ontology(label_schema)
 
     return _merge(label_schema, ontology)
+
+
+def _strip_applied_ontology(label_schema: dict) -> dict:
+    cleaned = dict(label_schema)
+    cleaned.pop(foac.APPLIED_ONTOLOGY, None)
+    return cleaned
 
 
 def dehydrate_applied_ontology(label_schema: dict) -> dict:

--- a/fiftyone/core/annotation/hydrate_label_schemas.py
+++ b/fiftyone/core/annotation/hydrate_label_schemas.py
@@ -1,0 +1,95 @@
+"""
+Annotation label schema hydration
+
+Resolves ``applied_ontology`` references in label schemas by merging the
+referenced annotation ontology's attributes into the schema's ``attributes``
+list, tagging merged attributes with a ``_source`` marker.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import copy
+import logging
+from typing import Any
+
+import fiftyone.core.annotation.constants as foac
+
+
+logger = logging.getLogger(__name__)
+
+_SOURCE = "_source"
+
+
+def hydrate_applied_ontology(label_schema: dict) -> dict:
+    """Merges a referenced annotation ontology's attributes into a label
+    schema.
+
+    If ``label_schema`` has an ``applied_ontology`` key that resolves to an
+    annotation ontology, returns a new dict with the ontology's attributes
+    merged into the ``attributes`` list. Each merged attribute carries a
+    ``_source: <ontology_name>`` marker. Attributes are matched by ``name``
+    and ontology values win on collision.
+
+    If the schema has no ``applied_ontology`` reference, or if the
+    reference is dangling or points at a non-annotation ontology, the
+    schema is returned unchanged. A dangling reference is logged at
+    WARNING so operators can detect deleted-ontology scenarios.
+
+    Args:
+        label_schema: a label schema dict
+
+    Returns:
+        a hydrated copy of ``label_schema``, or ``label_schema`` unchanged
+        when there is nothing to hydrate
+    """
+    ontology_name = label_schema.get(foac.APPLIED_ONTOLOGY)
+    if ontology_name is None:
+        return label_schema
+
+    # Late import to avoid a circular import with the ontology SDK.
+    from fiftyone.core.ontology import load_ontology
+
+    try:
+        ontology = load_ontology(ontology_name)
+    except ValueError:
+        logger.warning(
+            "applied_ontology '%s' does not resolve to a known ontology; "
+            "returning label schema without hydration",
+            ontology_name,
+        )
+        # do not cause app failure on mis-configuration
+        return label_schema
+
+    if not ontology.is_annotation_ontology:
+        logger.warning(
+            "applied_ontology '%s' does not resolve to an Annotation Ontology"
+            " ontology; returning label schema without hydration",
+            ontology_name,
+        )
+        # do not cause app failure on mis-configuration
+        return label_schema
+
+    return _merge(label_schema, ontology)
+
+
+def _merge(label_schema: dict, ontology: Any) -> dict:
+    hydrated = copy.deepcopy(label_schema)
+    existing = hydrated.get(foac.ATTRIBUTES, [])
+
+    # Preserve existing schema order; ontology-only attrs appended.
+    by_name: dict = {a.get(foac.NAME): a for a in existing}
+    ordered_names = [a.get(foac.NAME) for a in existing]
+
+    for attr_spec in ontology.attributes:
+        attr_dict = attr_spec.to_dict()
+        attr_dict[_SOURCE] = ontology.name
+        name = attr_dict.get(foac.NAME)
+        if name not in by_name:
+            ordered_names.append(name)
+        # ontology wins on collision
+        by_name[name] = attr_dict
+
+    hydrated[foac.ATTRIBUTES] = [by_name[n] for n in ordered_names]
+    return hydrated

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -9032,6 +9032,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
     def _expand_schema(self, sample, dynamic):
         expanded = False
+        schema = None
 
         schema = None
         if not dynamic:

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1816,6 +1816,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Raises:
             ExceptionGroup: if the label schema is invalid
         """
+        # Defensive: the frontend is expected to submit a schema with no
+        # ontology-sourced attributes or _source markers, but strip them here
+        # regardless so a hand-edited / malformed payload cannot persist
+        # ontology content as local copies.
+        label_schema = foa.dehydrate_applied_ontology(label_schema)
         foa.validate_label_schemas(
             self,
             label_schema,

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -18,6 +18,7 @@ import os
 import random
 import string
 from datetime import datetime
+from typing import Optional
 
 import cachetools
 import eta.core.serial as etas

--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -12,6 +12,7 @@ import fnmatch
 from datetime import datetime
 from typing import Any, Optional
 
+import fiftyone.core.annotation.constants as foac
 import fiftyone.core.utils as fou
 from fiftyone.core.annotation.attributes import (
     AttributeSpec,
@@ -287,6 +288,8 @@ class AnnotationOntology(Ontology):
                 AttributeSpec.from_dict(a) for a in root.get("attributes", [])
             ],
         )
+
+
 # ---- Type dispatch --------------------------------------------------------
 
 _TYPE_TO_CLS: dict[str, type[Ontology]] = {
@@ -387,3 +390,32 @@ def delete_ontology(name: str, force: bool = False) -> None:
     count = _objects_by_slug(name).delete()
     if count == 0:
         raise ValueError(f"Ontology '{name}' not found")
+
+
+def apply_ontology(
+    label_schemas: dict, field_name: str, ontology_name: Optional[str]
+) -> dict:
+    """Returns a new ``label_schemas`` dict with an annotation ontology
+    attached to (or removed from) the given field.
+
+    Pure function — does not mutate the input. Apply the result via
+    :meth:`fiftyone.core.dataset.Dataset.set_label_schemas` to persist.
+
+    Args:
+        label_schemas: a label schemas dict
+        field_name: the field to attach the ontology to
+        ontology_name: name of an annotation ontology to attach, or ``None``
+            to unset an existing reference
+
+    Returns:
+        a new label schemas dict
+    """
+    label_schemas = dict(label_schemas)
+    field_schema = dict(label_schemas.get(field_name, {}))
+    if ontology_name is None:
+        # idempotent: no-op if there is no existing reference to unset
+        field_schema.pop(foac.APPLIED_ONTOLOGY, None)
+    else:
+        field_schema[foac.APPLIED_ONTOLOGY] = ontology_name
+    label_schemas[field_name] = field_schema
+    return label_schemas

--- a/plugins/operators/annotation.py
+++ b/plugins/operators/annotation.py
@@ -9,6 +9,7 @@ Annotation label schemas operators
 import fiftyone.core.annotation.constants as foac
 import fiftyone.core.annotation.utils as foau
 from fiftyone.core.annotation.hydrate_label_schemas import (
+    dehydrate_applied_ontology,
     hydrate_applied_ontology,
 )
 from fiftyone.core.annotation.validate_label_schemas import (
@@ -187,10 +188,16 @@ class ValidateLabelSchemas(foo.Operator):
 
     def execute(self, ctx):
         errors = []
+        # Mirror update_label_schema: dehydrate before validating so the
+        # pre-save check sees the same shape that will actually be saved.
+        label_schemas = {
+            field: dehydrate_applied_ontology(schema)
+            for field, schema in ctx.params.get("label_schemas", {}).items()
+        }
         try:
             validate_label_schemas(
                 ctx.dataset,
-                ctx.params.get("label_schemas", {}),
+                label_schemas,
                 allow_new_attrs=True,
                 allow_new_fields=True,
             )

--- a/plugins/operators/annotation.py
+++ b/plugins/operators/annotation.py
@@ -8,6 +8,9 @@ Annotation label schemas operators
 
 import fiftyone.core.annotation.constants as foac
 import fiftyone.core.annotation.utils as foau
+from fiftyone.core.annotation.hydrate_label_schemas import (
+    hydrate_applied_ontology,
+)
 from fiftyone.core.annotation.validate_label_schemas import (
     ValidationErrors,
     validate_label_schemas,
@@ -136,7 +139,9 @@ class GetLabelSchemas(foo.Operator):
             }
 
             if field in label_schemas:
-                result[field]["label_schema"] = label_schemas[field]
+                result[field]["label_schema"] = hydrate_applied_ontology(
+                    label_schemas[field]
+                )
 
         return {
             "active_label_schemas": ctx.dataset.active_label_schemas,

--- a/plugins/operators/annotation.py
+++ b/plugins/operators/annotation.py
@@ -174,7 +174,15 @@ class UpdateLabelSchema(foo.Operator):
             ctx.ops.notify(str(e), variant="error")
             return {"error": str(e)}
 
-        return {"label_schema": label_schema}
+        if label_schema is None:
+            return {"label_schema": None}
+
+        # Hydrate the outgoing label schema if an ontology is attached.
+        # Re-read the saved (dehydrated) shape defensively so a caller
+        # that sent a partially-hydrated schema doesn't get double-
+        # processed.
+        saved = ctx.dataset.label_schemas.get(field, label_schema)
+        return {"label_schema": hydrate_applied_ontology(saved)}
 
 
 class ValidateLabelSchemas(foo.Operator):

--- a/tests/unittests/annotation/dataset_label_schemas_tests.py
+++ b/tests/unittests/annotation/dataset_label_schemas_tests.py
@@ -12,6 +12,7 @@ from exceptiongroup import ExceptionGroup
 
 import fiftyone as fo
 import fiftyone.core.labels as fol
+from fiftyone.core.annotation.attributes import AttributeSpec
 from fiftyone.core.ontology import AnnotationOntology, apply_ontology
 
 from decorators import drop_datasets, drop_ontologies
@@ -439,6 +440,57 @@ class DatasetAnnotationTests(unittest.TestCase):
         self.assertEqual(
             result["detections"]["applied_ontology"], "my_ontology"
         )
+
+    @drop_datasets
+    @drop_ontologies
+    def test_update_label_schema_dehydrates_before_saving(self):
+        AnnotationOntology(
+            name="my_ontology",
+            attributes=[
+                AttributeSpec(name="owned", type="bool", component="checkbox"),
+            ],
+        ).save()
+
+        dataset = fo.Dataset()
+        dataset.add_sample(
+            fo.Sample(
+                filepath="image.png",
+                detections=fo.Detections(
+                    detections=[fo.Detection(label="one")]
+                ),
+            )
+        )
+        dataset.set_label_schemas({"detections": {"type": "detections"}})
+
+        # simulate the frontend echoing back a hydrated schema: an
+        # ontology-owned attribute with a _source marker, plus a local
+        # attribute that somehow acquired a forged _source
+        hydrated_payload = {
+            "type": "detections",
+            "applied_ontology": "my_ontology",
+            "attributes": [
+                {
+                    "name": "owned",
+                    "type": "bool",
+                    "component": "checkbox",
+                    "_source": "my_ontology",
+                },
+                {
+                    "name": "local",
+                    "type": "str",
+                    "component": "text",
+                    "_source": "forged",
+                },
+            ],
+        }
+        dataset.update_label_schema(
+            "detections", hydrated_payload, allow_new_attrs=True
+        )
+
+        saved = dataset.label_schemas["detections"]
+        names = [a["name"] for a in saved["attributes"]]
+        self.assertEqual(names, ["local"])
+        self.assertNotIn("_source", saved["attributes"][0])
 
 
 def _make_applied_ontology_test_dataset(ontology_name: str = "my_ontology"):

--- a/tests/unittests/annotation/dataset_label_schemas_tests.py
+++ b/tests/unittests/annotation/dataset_label_schemas_tests.py
@@ -12,8 +12,9 @@ from exceptiongroup import ExceptionGroup
 
 import fiftyone as fo
 import fiftyone.core.labels as fol
+from fiftyone.core.ontology import AnnotationOntology, apply_ontology
 
-from decorators import drop_datasets
+from decorators import drop_datasets, drop_ontologies
 
 
 class DatasetAnnotationTests(unittest.TestCase):
@@ -374,3 +375,88 @@ class DatasetAnnotationTests(unittest.TestCase):
                 }
             )
         dataset.delete_sample_field("labels")
+
+    @drop_datasets
+    @drop_ontologies
+    def test_apply_ontology_apply(self):
+        dataset = _make_applied_ontology_test_dataset()
+        dataset.set_label_schemas({"detections": {"type": "detections"}})
+
+        schemas = apply_ontology(
+            dataset.label_schemas, "detections", "my_ontology"
+        )
+        dataset.set_label_schemas(schemas)
+
+        self.assertEqual(
+            dataset.label_schemas["detections"].get("applied_ontology"),
+            "my_ontology",
+        )
+        # other keys are preserved
+        self.assertEqual(
+            dataset.label_schemas["detections"]["type"], "detections"
+        )
+
+    @drop_datasets
+    @drop_ontologies
+    def test_apply_ontology_unset(self):
+        dataset = _make_applied_ontology_test_dataset()
+        dataset.set_label_schemas({"detections": {"type": "detections"}})
+
+        dataset.set_label_schemas(
+            apply_ontology(dataset.label_schemas, "detections", "my_ontology")
+        )
+        dataset.set_label_schemas(
+            apply_ontology(dataset.label_schemas, "detections", None)
+        )
+        self.assertNotIn(
+            "applied_ontology", dataset.label_schemas["detections"]
+        )
+
+        # idempotent: unsetting again is a no-op
+        dataset.set_label_schemas(
+            apply_ontology(dataset.label_schemas, "detections", None)
+        )
+
+    @drop_datasets
+    @drop_ontologies
+    def test_apply_ontology_invalid_reference_raises(self):
+        dataset = _make_applied_ontology_test_dataset()
+        dataset.set_label_schemas({"detections": {"type": "detections"}})
+
+        schemas = apply_ontology(
+            dataset.label_schemas, "detections", "nonexistent_ontology_xyz"
+        )
+        with self.assertRaises(ExceptionGroup):
+            dataset.set_label_schemas(schemas)
+
+    @drop_datasets
+    @drop_ontologies
+    def test_apply_ontology_does_not_mutate_input(self):
+        original = {"detections": {"type": "detections"}}
+        result = apply_ontology(original, "detections", "my_ontology")
+
+        self.assertNotIn("applied_ontology", original["detections"])
+        self.assertEqual(
+            result["detections"]["applied_ontology"], "my_ontology"
+        )
+
+
+def _make_applied_ontology_test_dataset(ontology_name: str = "my_ontology"):
+    """Dataset with a `detections` label field and a `str_field`, with a real
+    `AnnotationOntology` named ``ontology_name`` persisted to the `ontologies`
+    collection so the validator can resolve the reference.
+
+    Duplicated from `validate_label_schemas_tests.py`; consolidate later.
+    """
+    AnnotationOntology(name=ontology_name).save()
+
+    dataset = fo.Dataset()
+    dataset.add_sample(
+        fo.Sample(
+            filepath="image.png",
+            detections=fo.Detections(detections=[fo.Detection(label="one")]),
+        )
+    )
+    dataset.add_sample_field("str_field", fo.StringField)
+
+    return dataset

--- a/tests/unittests/annotation/hydrate_label_schemas_tests.py
+++ b/tests/unittests/annotation/hydrate_label_schemas_tests.py
@@ -1,0 +1,155 @@
+"""
+FiftyOne annotation unit tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from fiftyone.core.annotation.attributes import AttributeSpec
+from fiftyone.core.annotation.hydrate_label_schemas import (
+    hydrate_applied_ontology,
+)
+from fiftyone.core.ontology import AnnotationOntology, create_ontology
+
+from decorators import drop_datasets, drop_ontologies
+
+
+class HydrateLabelSchemasTests(unittest.TestCase):
+    @drop_datasets
+    @drop_ontologies
+    def test_no_applied_ontology_returns_schema_unchanged(self):
+        schema = {
+            "type": "detections",
+            "attributes": [
+                {"name": "color", "type": "str", "component": "text"}
+            ],
+        }
+        result = hydrate_applied_ontology(schema)
+        self.assertEqual(result, schema)
+
+    @drop_datasets
+    @drop_ontologies
+    def test_ontology_attributes_merged_into_empty_attributes(self):
+        create_ontology(
+            AnnotationOntology(
+                name="my_ontology",
+                attributes=[
+                    AttributeSpec(
+                        name="damage_location",
+                        type="str",
+                        component="dropdown",
+                        values=["front", "rear"],
+                    ),
+                ],
+            )
+        )
+
+        schema = {
+            "type": "detections",
+            "applied_ontology": "my_ontology",
+            "attributes": [],
+        }
+        result = hydrate_applied_ontology(schema)
+        self.assertEqual(len(result["attributes"]), 1)
+        self.assertEqual(result["attributes"][0]["name"], "damage_location")
+        self.assertEqual(result["attributes"][0]["_source"], "my_ontology")
+
+    @drop_datasets
+    @drop_ontologies
+    def test_ontology_wins_on_name_collision(self):
+        create_ontology(
+            AnnotationOntology(
+                name="my_ontology",
+                attributes=[
+                    AttributeSpec(
+                        name="color",
+                        type="str",
+                        component="dropdown",
+                        values=["red", "blue"],
+                    ),
+                ],
+            )
+        )
+
+        schema = {
+            "type": "detections",
+            "applied_ontology": "my_ontology",
+            "attributes": [
+                {"name": "color", "type": "str", "component": "text"},
+            ],
+        }
+        result = hydrate_applied_ontology(schema)
+        self.assertEqual(len(result["attributes"]), 1)
+        color = result["attributes"][0]
+        self.assertEqual(color["component"], "dropdown")
+        self.assertEqual(color["values"], ["red", "blue"])
+        self.assertEqual(color["_source"], "my_ontology")
+
+    @drop_datasets
+    @drop_ontologies
+    def test_ontology_and_local_attrs_both_preserved(self):
+        create_ontology(
+            AnnotationOntology(
+                name="my_ontology",
+                attributes=[
+                    AttributeSpec(
+                        name="damage", type="bool", component="checkbox"
+                    ),
+                ],
+            )
+        )
+
+        schema = {
+            "type": "detections",
+            "applied_ontology": "my_ontology",
+            "attributes": [
+                {"name": "local_note", "type": "str", "component": "text"},
+            ],
+        }
+        result = hydrate_applied_ontology(schema)
+        names = [a["name"] for a in result["attributes"]]
+        self.assertEqual(names, ["local_note", "damage"])
+
+        local = next(
+            a for a in result["attributes"] if a["name"] == "local_note"
+        )
+        ontology_attr = next(
+            a for a in result["attributes"] if a["name"] == "damage"
+        )
+        self.assertNotIn("_source", local)
+        self.assertEqual(ontology_attr["_source"], "my_ontology")
+
+    @drop_datasets
+    @drop_ontologies
+    def test_dangling_reference_returns_schema_unchanged(self):
+        schema = {
+            "type": "detections",
+            "applied_ontology": "nonexistent_ontology_xyz",
+            "attributes": [
+                {"name": "color", "type": "str", "component": "text"},
+            ],
+        }
+        result = hydrate_applied_ontology(schema)
+        self.assertEqual(result, schema)
+
+    @drop_datasets
+    @drop_ontologies
+    def test_non_annotation_ontology_returns_schema_unchanged(self):
+        schema = {
+            "type": "detections",
+            "applied_ontology": "some_taxonomy",
+            "attributes": [],
+        }
+        non_annotation = MagicMock(
+            is_annotation_ontology=False, name="some_taxonomy"
+        )
+        with patch(
+            "fiftyone.core.ontology.load_ontology",
+            return_value=non_annotation,
+        ):
+            result = hydrate_applied_ontology(schema)
+        self.assertEqual(result, schema)

--- a/tests/unittests/annotation/hydrate_label_schemas_tests.py
+++ b/tests/unittests/annotation/hydrate_label_schemas_tests.py
@@ -120,7 +120,7 @@ class HydrateLabelSchemasTests(unittest.TestCase):
 
     @drop_datasets
     @drop_ontologies
-    def test_dangling_reference_returns_schema_unchanged(self):
+    def test_dangling_reference_strips_applied_ontology(self):
         schema = {
             "type": "detections",
             "applied_ontology": "nonexistent_ontology_xyz",
@@ -129,11 +129,16 @@ class HydrateLabelSchemasTests(unittest.TestCase):
             ],
         }
         result = hydrate_applied_ontology(schema)
-        self.assertEqual(result, schema)
+        self.assertNotIn("applied_ontology", result)
+        self.assertEqual(result["attributes"], schema["attributes"])
+        # Input not mutated
+        self.assertEqual(
+            schema["applied_ontology"], "nonexistent_ontology_xyz"
+        )
 
     @drop_datasets
     @drop_ontologies
-    def test_non_annotation_ontology_returns_schema_unchanged(self):
+    def test_non_annotation_ontology_strips_applied_ontology(self):
         schema = {
             "type": "detections",
             "applied_ontology": "some_taxonomy",
@@ -147,7 +152,8 @@ class HydrateLabelSchemasTests(unittest.TestCase):
             return_value=non_annotation,
         ):
             result = hydrate_applied_ontology(schema)
-        self.assertEqual(result, schema)
+        self.assertNotIn("applied_ontology", result)
+        self.assertEqual(schema["applied_ontology"], "some_taxonomy")
 
 
 class DehydrateLabelSchemasTests(unittest.TestCase):

--- a/tests/unittests/annotation/hydrate_label_schemas_tests.py
+++ b/tests/unittests/annotation/hydrate_label_schemas_tests.py
@@ -11,9 +11,10 @@ from unittest.mock import MagicMock, patch
 
 from fiftyone.core.annotation.attributes import AttributeSpec
 from fiftyone.core.annotation.hydrate_label_schemas import (
+    dehydrate_applied_ontology,
     hydrate_applied_ontology,
 )
-from fiftyone.core.ontology import AnnotationOntology, create_ontology
+from fiftyone.core.ontology import AnnotationOntology
 
 from decorators import drop_datasets, drop_ontologies
 
@@ -34,19 +35,17 @@ class HydrateLabelSchemasTests(unittest.TestCase):
     @drop_datasets
     @drop_ontologies
     def test_ontology_attributes_merged_into_empty_attributes(self):
-        create_ontology(
-            AnnotationOntology(
-                name="my_ontology",
-                attributes=[
-                    AttributeSpec(
-                        name="damage_location",
-                        type="str",
-                        component="dropdown",
-                        values=["front", "rear"],
-                    ),
-                ],
-            )
-        )
+        AnnotationOntology(
+            name="my_ontology",
+            attributes=[
+                AttributeSpec(
+                    name="damage_location",
+                    type="str",
+                    component="dropdown",
+                    values=["front", "rear"],
+                ),
+            ],
+        ).save()
 
         schema = {
             "type": "detections",
@@ -61,19 +60,17 @@ class HydrateLabelSchemasTests(unittest.TestCase):
     @drop_datasets
     @drop_ontologies
     def test_ontology_wins_on_name_collision(self):
-        create_ontology(
-            AnnotationOntology(
-                name="my_ontology",
-                attributes=[
-                    AttributeSpec(
-                        name="color",
-                        type="str",
-                        component="dropdown",
-                        values=["red", "blue"],
-                    ),
-                ],
-            )
-        )
+        AnnotationOntology(
+            name="my_ontology",
+            attributes=[
+                AttributeSpec(
+                    name="color",
+                    type="str",
+                    component="dropdown",
+                    values=["red", "blue"],
+                ),
+            ],
+        ).save()
 
         schema = {
             "type": "detections",
@@ -92,16 +89,14 @@ class HydrateLabelSchemasTests(unittest.TestCase):
     @drop_datasets
     @drop_ontologies
     def test_ontology_and_local_attrs_both_preserved(self):
-        create_ontology(
-            AnnotationOntology(
-                name="my_ontology",
-                attributes=[
-                    AttributeSpec(
-                        name="damage", type="bool", component="checkbox"
-                    ),
-                ],
-            )
-        )
+        AnnotationOntology(
+            name="my_ontology",
+            attributes=[
+                AttributeSpec(
+                    name="damage", type="bool", component="checkbox"
+                ),
+            ],
+        ).save()
 
         schema = {
             "type": "detections",
@@ -153,3 +148,113 @@ class HydrateLabelSchemasTests(unittest.TestCase):
         ):
             result = hydrate_applied_ontology(schema)
         self.assertEqual(result, schema)
+
+
+class DehydrateLabelSchemasTests(unittest.TestCase):
+    @drop_datasets
+    @drop_ontologies
+    def test_no_applied_ontology_returns_schema_unchanged(self):
+        schema = {
+            "type": "detections",
+            "attributes": [
+                {
+                    "name": "color",
+                    "type": "str",
+                    "component": "text",
+                    "_source": "stray",
+                }
+            ],
+        }
+        result = dehydrate_applied_ontology(schema)
+        self.assertEqual(result, schema)
+
+    @drop_datasets
+    @drop_ontologies
+    def test_ontology_owned_attributes_dropped(self):
+        AnnotationOntology(
+            name="my_ontology",
+            attributes=[
+                AttributeSpec(name="owned", type="bool", component="checkbox"),
+            ],
+        ).save()
+
+        schema = {
+            "type": "detections",
+            "applied_ontology": "my_ontology",
+            "attributes": [
+                {
+                    "name": "owned",
+                    "type": "bool",
+                    "component": "checkbox",
+                    "_source": "my_ontology",
+                },
+                {"name": "local", "type": "str", "component": "text"},
+            ],
+        }
+        result = dehydrate_applied_ontology(schema)
+        names = [a["name"] for a in result["attributes"]]
+        self.assertEqual(names, ["local"])
+
+    @drop_datasets
+    @drop_ontologies
+    def test_source_stripped_from_local_attributes(self):
+        AnnotationOntology(
+            name="my_ontology",
+            attributes=[
+                AttributeSpec(name="owned", type="bool", component="checkbox"),
+            ],
+        ).save()
+
+        schema = {
+            "type": "detections",
+            "applied_ontology": "my_ontology",
+            "attributes": [
+                {
+                    "name": "local",
+                    "type": "str",
+                    "component": "text",
+                    "_source": "forged",
+                },
+            ],
+        }
+        result = dehydrate_applied_ontology(schema)
+        self.assertNotIn("_source", result["attributes"][0])
+
+    @drop_datasets
+    @drop_ontologies
+    def test_dangling_reference_returns_schema_unchanged(self):
+        schema = {
+            "type": "detections",
+            "applied_ontology": "nonexistent_ontology_xyz",
+            "attributes": [
+                {
+                    "name": "local",
+                    "type": "str",
+                    "component": "text",
+                    "_source": "stray",
+                }
+            ],
+        }
+        result = dehydrate_applied_ontology(schema)
+        self.assertEqual(result, schema)
+
+    @drop_datasets
+    @drop_ontologies
+    def test_roundtrip_hydrate_then_dehydrate_matches_original(self):
+        AnnotationOntology(
+            name="my_ontology",
+            attributes=[
+                AttributeSpec(name="owned", type="bool", component="checkbox"),
+            ],
+        ).save()
+
+        original = {
+            "type": "detections",
+            "applied_ontology": "my_ontology",
+            "attributes": [
+                {"name": "local", "type": "str", "component": "text"},
+            ],
+        }
+        hydrated = hydrate_applied_ontology(original)
+        dehydrated = dehydrate_applied_ontology(hydrated)
+        self.assertEqual(dehydrated["attributes"], original["attributes"])

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -270,6 +270,99 @@ class AttributeSpecTests(unittest.TestCase):
             restored.when[0].to_dict(), original.when[0].to_dict()
         )
 
+    def test_create_with_extended_fields(self):
+        attr = AttributeSpec(
+            name="severity",
+            type="float",
+            component="slider",
+            read_only=True,
+            default=0.5,
+            range=[0.0, 1.0],
+            precision=2,
+        )
+        self.assertEqual(attr.read_only, True)
+        self.assertEqual(attr.default, 0.5)
+        self.assertEqual(attr.range, [0.0, 1.0])
+        self.assertEqual(attr.precision, 2)
+
+    def test_to_dict_omits_unset_extended_fields(self):
+        attr = AttributeSpec(name="flag", type="bool", component="checkbox")
+        d = attr.to_dict()
+        self.assertNotIn("read_only", d)
+        self.assertNotIn("default", d)
+        self.assertNotIn("range", d)
+        self.assertNotIn("precision", d)
+
+    def test_to_dict_emits_falsy_extended_fields(self):
+        attr = AttributeSpec(
+            name="flag",
+            type="bool",
+            component="checkbox",
+            read_only=False,
+            default=False,
+        )
+        d = attr.to_dict()
+        self.assertEqual(d["read_only"], False)
+        self.assertEqual(d["default"], False)
+
+    def test_to_dict_emits_extended_fields(self):
+        attr = AttributeSpec(
+            name="severity",
+            type="float",
+            component="slider",
+            read_only=True,
+            default=0.5,
+            range=[0.0, 1.0],
+            precision=2,
+        )
+        d = attr.to_dict()
+        self.assertEqual(d["read_only"], True)
+        self.assertEqual(d["default"], 0.5)
+        self.assertEqual(d["range"], [0.0, 1.0])
+        self.assertEqual(d["precision"], 2)
+
+    def test_from_dict_reads_extended_fields(self):
+        attr = AttributeSpec.from_dict(
+            {
+                "name": "severity",
+                "type": "float",
+                "component": "slider",
+                "read_only": True,
+                "default": 0.5,
+                "range": [0.0, 1.0],
+                "precision": 2,
+            }
+        )
+        self.assertEqual(attr.read_only, True)
+        self.assertEqual(attr.default, 0.5)
+        self.assertEqual(attr.range, [0.0, 1.0])
+        self.assertEqual(attr.precision, 2)
+
+    def test_from_dict_handles_missing_extended_fields(self):
+        attr = AttributeSpec.from_dict(
+            {"name": "flag", "type": "bool", "component": "checkbox"}
+        )
+        self.assertIsNone(attr.read_only)
+        self.assertIsNone(attr.default)
+        self.assertIsNone(attr.range)
+        self.assertIsNone(attr.precision)
+
+    def test_roundtrip_with_extended_fields(self):
+        original = AttributeSpec(
+            name="severity",
+            type="float",
+            component="slider",
+            read_only=True,
+            default=0.5,
+            range=[0.0, 1.0],
+            precision=2,
+        )
+        restored = AttributeSpec.from_dict(original.to_dict())
+        self.assertEqual(restored.read_only, original.read_only)
+        self.assertEqual(restored.default, original.default)
+        self.assertEqual(restored.range, original.range)
+        self.assertEqual(restored.precision, original.precision)
+
 
 class AnnotationOntologyTests(unittest.TestCase):
     def test_create(self):


### PR DESCRIPTION
## 🔗 Related Issues

https://github.com/voxel51/fiftyone/pull/7434

## 📋 What changes are proposed in this pull request?

This handles the merging of an ontology object and its attributes into a label schema. 

- "hydrates" - Merges attributes into the label schema attributes on a per field basis
- "dehyrates" - removes ontology attributes from the label schema so edits to the label schema itself are not affected by the ontology contents. 

Tested locally and with unit tests. See these Python scripts to demo adding ontologies to the quick start data set:

[demo_apply_ontology.py](https://github.com/user-attachments/files/27206227/demo_apply_ontology.py)
[demo_reset_ontology.py](https://github.com/user-attachments/files/27206228/demo_reset_ontology.py)


## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `apply_ontology` utility to manage ontology references in label schemas
  * Extended `AttributeSpec` with optional fields: `read_only`, `default`, `range`, and `precision`
  * Implemented automatic hydration/dehydration of ontology-attached label schemas

* **Bug Fixes**
  * Improved validation by sanitizing ontology-sourced attributes before persisting label schemas

* **Tests**
  * Added comprehensive test coverage for ontology application and hydration behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->