### PR TITLE
Cherry-pick docs exclude PR

### DIFF
--- a/docs/generate_docs.bash
+++ b/docs/generate_docs.bash
@@ -88,15 +88,20 @@ cd "${THIS_DIR}/.."
 ln -sfn "$FIFTYONE_BRAIN_DIR" fiftyone/brain
 
 echo "Generating API docs"
+API_DOC_EXCLUDES=(
+    fiftyone/brain/internal/models
+    fiftyone/constants
+    fiftyone/internal
+    # Multimodal APIs are feature-gated and hidden from public API docs for now.
+    fiftyone/multimodal
+    fiftyone/server
+    fiftyone/service
+)
+
 # sphinx-apidoc [OPTIONS] -o <OUTPUT_PATH> <MODULE_PATH> [EXCLUDE_PATTERN, ...]
 sphinx-apidoc --force --no-toc --separate --follow-links \
     --templatedir=docs/templates/apidoc \
-    -o docs/source/api fiftyone \
-        fiftyone/brain/internal/models \
-        fiftyone/constants \
-        fiftyone/internal \
-        fiftyone/server \
-        fiftyone/service &
+    -o docs/source/api fiftyone "${API_DOC_EXCLUDES[@]}" &
 
 sphinx-apidoc --force --no-toc --separate --follow-links \
     --templatedir=docs/templates/apidoc \

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,6 +25,7 @@ from custom_directives import (
     CustomAnimatedCTADirective,
     CustomUseCaseCardDirective,
 )
+from fiftyone.internal.docs import is_hidden_from_docs
 from redirects import generate_redirects, generate_api_redirects
 
 import fiftyone.constants as foc
@@ -288,11 +289,20 @@ html_context = {
 # -- Custom app setup --------------------------------------------------------
 
 
+def _skip_hidden_from_docs(_app, _what, _name, obj, _skip, _options):
+    if is_hidden_from_docs(obj):
+        return True
+
+    return None
+
+
 def setup(app):
     # Generate page redirects
     app.add_config_value("redirects_file", "redirects", "env")
     app.connect("builder-inited", generate_redirects)
     app.connect("build-finished", generate_api_redirects)
+    # See https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#event-autodoc-skip-member
+    app.connect("autodoc-skip-member", _skip_hidden_from_docs)
 
     # Custom directives
     app.add_directive("custombutton", CustomButtonDirective)

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -771,7 +771,20 @@ class LazyModule(types.ModuleType):
         self._module = None
         self._callback = callback
 
+    def __repr__(self):
+        if self._module is not None:
+            return repr(self._module)
+
+        return f"<module '{self.__name__}' (lazy)>"
+
     def __getattr__(self, item):
+        # Sphinx probes this marker while filtering autodoc members.
+        # We need special handling for Sphinx, as it will look for the
+        # __sphinx_mock__ attribute on all module-level objects, and we need
+        # that to raise an AttributeError to not err out
+        if item == "__sphinx_mock__":
+            raise AttributeError(item)
+
         if self._module is None:
             self._import_module()
 

--- a/fiftyone/internal/docs.py
+++ b/fiftyone/internal/docs.py
@@ -1,0 +1,51 @@
+"""
+Internal documentation helpers.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+_HIDE_FROM_DOCS_ATTR = "_fiftyone_hide_from_docs"
+
+
+def hide_from_docs(obj):
+    """Marks an object to be skipped by generated API documentation.
+
+    This decorator does not change runtime behavior; it only attaches metadata
+    that the Sphinx autodoc configuration can inspect.
+    """
+
+    for target in _iter_docs_targets(obj):
+        try:
+            setattr(target, _HIDE_FROM_DOCS_ATTR, True)
+        except (AttributeError, TypeError):
+            pass
+
+    return obj
+
+
+def is_hidden_from_docs(obj):
+    """Returns whether the given object should be hidden from API docs."""
+
+    return any(
+        bool(getattr(target, _HIDE_FROM_DOCS_ATTR, False))
+        for target in _iter_docs_targets(obj)
+    )
+
+
+def _iter_docs_targets(obj):
+    yield obj
+
+    if isinstance(obj, property):
+        for target in (obj.fget, obj.fset, obj.fdel):
+            if target is not None:
+                yield target
+
+    func = getattr(obj, "__func__", None)
+    if func is not None:
+        yield func
+
+    wrapped = getattr(obj, "__wrapped__", None)
+    if wrapped is not None:
+        yield wrapped

--- a/tests/unittests/internal_docs_tests.py
+++ b/tests/unittests/internal_docs_tests.py
@@ -1,0 +1,135 @@
+"""
+Unit tests for internal documentation helpers.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+
+from fiftyone.internal.docs import hide_from_docs, is_hidden_from_docs
+
+
+class InternalDocsTests(unittest.TestCase):
+    def test_hides_class(self):
+        class Visible:
+            pass
+
+        self.assertFalse(is_hidden_from_docs(Visible))
+
+        @hide_from_docs
+        class Hidden:
+            pass
+
+        self.assertTrue(is_hidden_from_docs(Hidden))
+
+    def test_hides_instance_method(self):
+        class VisibleContainer:
+            def method(self):
+                pass
+
+        self.assertFalse(is_hidden_from_docs(VisibleContainer.method))
+        self.assertFalse(is_hidden_from_docs(VisibleContainer().method))
+
+        class Container:
+            @hide_from_docs
+            def method(self):
+                pass
+
+        self.assertTrue(is_hidden_from_docs(Container.method))
+        self.assertTrue(is_hidden_from_docs(Container().method))
+
+    def test_hides_property_with_inner_decorator(self):
+        class VisibleContainer:
+            @property
+            def value(self):
+                return 1
+
+        self.assertFalse(
+            is_hidden_from_docs(VisibleContainer.__dict__["value"])
+        )
+        self.assertFalse(is_hidden_from_docs(VisibleContainer.value))
+        self.assertFalse(is_hidden_from_docs(VisibleContainer().value))
+
+        class Container:
+            @property
+            @hide_from_docs
+            def value(self):
+                return 1
+
+        self.assertTrue(is_hidden_from_docs(Container.__dict__["value"]))
+        self.assertTrue(is_hidden_from_docs(Container.value))
+        # Instance property access returns the value, not the descriptor.
+        self.assertFalse(is_hidden_from_docs(Container().value))
+
+    def test_hides_property_with_outer_decorator(self):
+        class VisibleContainer:
+            @property
+            def value(self):
+                return 1
+
+        self.assertFalse(
+            is_hidden_from_docs(VisibleContainer.__dict__["value"])
+        )
+        self.assertFalse(is_hidden_from_docs(VisibleContainer.value))
+        self.assertFalse(is_hidden_from_docs(VisibleContainer().value))
+
+        class Container:
+            @hide_from_docs
+            @property
+            def value(self):
+                return 1
+
+        self.assertTrue(is_hidden_from_docs(Container.__dict__["value"]))
+        self.assertTrue(is_hidden_from_docs(Container.value))
+        # Instance property access returns the value, not the descriptor.
+        self.assertFalse(is_hidden_from_docs(Container().value))
+
+    def test_hides_classmethod(self):
+        class VisibleContainer:
+            @classmethod
+            def method(cls):
+                pass
+
+        self.assertFalse(
+            is_hidden_from_docs(VisibleContainer.__dict__["method"])
+        )
+        self.assertFalse(is_hidden_from_docs(VisibleContainer.method))
+        self.assertFalse(is_hidden_from_docs(VisibleContainer().method))
+
+        class Container:
+            @hide_from_docs
+            @classmethod
+            def method(cls):
+                pass
+
+        self.assertTrue(is_hidden_from_docs(Container.__dict__["method"]))
+        self.assertTrue(is_hidden_from_docs(Container.method))
+        self.assertTrue(is_hidden_from_docs(Container().method))
+
+    def test_hides_staticmethod(self):
+        class VisibleContainer:
+            @staticmethod
+            def method():
+                pass
+
+        self.assertFalse(
+            is_hidden_from_docs(VisibleContainer.__dict__["method"])
+        )
+        self.assertFalse(is_hidden_from_docs(VisibleContainer.method))
+        self.assertFalse(is_hidden_from_docs(VisibleContainer().method))
+
+        class Container:
+            @hide_from_docs
+            @staticmethod
+            def method():
+                pass
+
+        self.assertTrue(is_hidden_from_docs(Container.__dict__["method"]))
+        self.assertTrue(is_hidden_from_docs(Container.method))
+        self.assertTrue(is_hidden_from_docs(Container().method))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Cherry-pick https://github.com/voxel51/fiftyone/pull/7410 from develop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Refactored API documentation generation to support configurable module exclusions.
  * Enhanced documentation tooling to selectively control visibility of components in public API docs.

* **Tests**
  * Added comprehensive test coverage for documentation visibility controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->