### PR TITLE
Document custom sample renderers for custom media types

### DIFF
--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -4829,6 +4829,8 @@ Using the custom component as the view for a Python operator field:
         def execute(self, ctx):
             return {}
 
+.. _custom-sample-renderers:
+
 Custom sample renderers
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -6100,6 +6100,11 @@ keyword argument. Adding the sample to a |Dataset| will result in a dataset
 with `media_type` inherited from the sample. Custom media types can be used
 to extend functionality for sample types that are not natively supported.
 
+For App support in the grid or the modal, pair custom media types with
+:ref:`custom sample renderers <custom-sample-renderers>`. This plugin feature
+lets you provide domain-specific rendering for custom media types whose samples
+may not be handled by FiftyOne's built-in media renderers.
+
 .. code:: python
     :linenos:
 


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

This PR updates the custom datasets documentation to mention that custom media types can use custom sample renderers for domain-specific App rendering in the grid and modal.

It also adds an explicit anchor for the “Custom sample renderers” plugin documentation so the custom datasets section can link directly to it.

## 🧪 How is this patch tested? If it is not, please explain why.

N/A

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated documentation with a new reference target for cross-linking to the "Custom sample renderers" section.
* Added clarification on enabling App rendering for datasets with custom sample media types by associating them with custom sample renderer plugins for domain-specific visualization support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->