### PR TITLE
lighter: add mask codec utilities + $binary transport handling

### DIFF
--- a/app/packages/lighter/src/utils/color.ts
+++ b/app/packages/lighter/src/utils/color.ts
@@ -7,6 +7,34 @@
  */
 
 /**
+ * Parses a CSS color string into 8-bit RGBA components.
+ *
+ * Convenience wrapper around {@link parseColorWithAlpha} that unpacks the
+ * packed hex color into separate `r`/`g`/`b` bytes and converts the
+ * normalized `[0, 1]` alpha into a `[0, 255]` integer suitable for direct
+ * write into an `ImageData` / `Uint8ClampedArray` buffer.
+ *
+ * @param cssColor - CSS color string (e.g. `"#ff0000"`, `"rgba(255, 0, 0, 0.5)"`,
+ *   `"hsl(0, 100%, 50%)"`).
+ * @returns `{ r, g, b, a }` with each channel an integer in `[0, 255]`.
+ */
+export function parseColorToRGBA(cssColor: string): {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+} {
+  const { color: hexColor, alpha } = parseColorWithAlpha(cssColor);
+
+  return {
+    r: (hexColor >> 16) & 0xff,
+    g: (hexColor >> 8) & 0xff,
+    b: hexColor & 0xff,
+    a: Math.round(alpha * 255),
+  };
+}
+
+/**
  * Parses a CSS color string and converts it to PixiJS color format with alpha.
  * Supports hex, rgb, rgba, hsl, and hsla color formats.
  *

--- a/app/packages/lighter/src/utils/createMaskCanvas.test.ts
+++ b/app/packages/lighter/src/utils/createMaskCanvas.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { createMaskCanvas } from "./createMaskCanvas";
+
+describe("createMaskCanvas", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("returns canvas and 2d context with the requested dimensions", () => {
+    const { maskCanvas, maskContext } = createMaskCanvas(64, 32);
+
+    expect(maskCanvas).toBeInstanceOf(HTMLCanvasElement);
+    expect(maskCanvas.width).toBe(64);
+    expect(maskCanvas.height).toBe(32);
+    expect(maskContext).toBeDefined();
+  });
+
+  test("requests willReadFrequently to avoid GPU readback penalty", () => {
+    const getContextSpy = vi.spyOn(HTMLCanvasElement.prototype, "getContext");
+
+    createMaskCanvas(8, 8);
+
+    expect(getContextSpy).toHaveBeenCalledWith("2d", {
+      willReadFrequently: true,
+    });
+  });
+
+  test("defaults to a 0x0 canvas when no dimensions are given", () => {
+    const { maskCanvas } = createMaskCanvas();
+    expect(maskCanvas.width).toBe(0);
+    expect(maskCanvas.height).toBe(0);
+  });
+
+  test("draws the seed bitmap at the given offset when provided", () => {
+    const drawImage = vi.fn();
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({
+      drawImage,
+    } as unknown as CanvasRenderingContext2D);
+
+    const bitmap = {} as ImageBitmap;
+    createMaskCanvas(16, 16, 4, 6, bitmap);
+
+    expect(drawImage).toHaveBeenCalledTimes(1);
+    expect(drawImage).toHaveBeenCalledWith(bitmap, 4, 6);
+  });
+
+  test("does not call drawImage when no bitmap is supplied", () => {
+    const drawImage = vi.fn();
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({
+      drawImage,
+    } as unknown as CanvasRenderingContext2D);
+
+    createMaskCanvas(16, 16);
+
+    expect(drawImage).not.toHaveBeenCalled();
+  });
+
+  test("throws when the browser cannot provide a 2d context", () => {
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
+
+    expect(() => createMaskCanvas(4, 4, 0, 0, {} as ImageBitmap)).toThrow();
+  });
+});

--- a/app/packages/lighter/src/utils/createMaskCanvas.ts
+++ b/app/packages/lighter/src/utils/createMaskCanvas.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+/**
+ * Creates a 2D canvas suited for mask painting and pixel-level read-back.
+ *
+ * The context is configured with `willReadFrequently: true` so repeated
+ * `getImageData` calls (used by hit-testing and `paintEnd`'s threshold pass)
+ * stay on the CPU rather than incurring a GPU readback per call.
+ *
+ * @param width - Canvas width in pixels.
+ * @param height - Canvas height in pixels.
+ * @param xOffset - X offset (in canvas pixels) for the seeded bitmap.
+ * @param yOffset - Y offset (in canvas pixels) for the seeded bitmap.
+ * @param maskBitmap - Optional bitmap to draw onto the canvas at
+ *   `(xOffset, yOffset)` — used to seed an editing canvas from an existing
+ *   decoded mask.
+ * @returns The created `<canvas>` element and its 2D context.
+ * @throws If the browser cannot supply a 2D context.
+ */
+export const createMaskCanvas = (
+  width = 0,
+  height = 0,
+  xOffset = 0,
+  yOffset = 0,
+  maskBitmap?: ImageBitmap
+) => {
+  const maskCanvas = document.createElement("canvas");
+  maskCanvas.width = width;
+  maskCanvas.height = height;
+
+  const maskContext = maskCanvas?.getContext("2d", {
+    willReadFrequently: true,
+  });
+
+  if (!maskContext) throw new Error("Failed to get 2d context");
+
+  if (maskBitmap) {
+    maskContext.drawImage(maskBitmap, xOffset, yOffset);
+  }
+
+  return {
+    maskCanvas,
+    maskContext,
+  };
+};

--- a/app/packages/lighter/src/utils/index.ts
+++ b/app/packages/lighter/src/utils/index.ts
@@ -1,0 +1,5 @@
+export { createMaskCanvas } from "./createMaskCanvas";
+export { decodeMask } from "./maskDecoding";
+export { encodeMask } from "./maskEncoding";
+export { maskBounds } from "./maskBounds";
+export type { MaskBounds } from "./maskBounds";

--- a/app/packages/lighter/src/utils/maskBounds.test.ts
+++ b/app/packages/lighter/src/utils/maskBounds.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { describe, expect, test } from "vitest";
+import { maskBounds } from "./maskBounds";
+
+/**
+ * Builds an `ImageData`-shaped object large enough for `maskBounds` to
+ * iterate. jsdom doesn't ship `ImageData`, but the function only reads
+ * `data`, `width`, `height` — a plain object is enough.
+ */
+const makeImageData = (
+  width: number,
+  height: number,
+  paint: (px: number, py: number) => boolean
+): ImageData => {
+  const data = new Uint8ClampedArray(width * height * 4);
+  for (let py = 0; py < height; py++) {
+    for (let px = 0; px < width; px++) {
+      if (paint(px, py)) {
+        // Only the alpha byte matters for `maskBounds`.
+        data[(py * width + px) * 4 + 3] = 255;
+      }
+    }
+  }
+  return { data, width, height } as ImageData;
+};
+
+describe("maskBounds", () => {
+  test("returns null when fully transparent", () => {
+    const image = makeImageData(8, 8, () => false);
+    expect(maskBounds(image)).toBeNull();
+  });
+
+  test("computes a single-pixel bbox for one opaque pixel", () => {
+    const image = makeImageData(8, 8, (px, py) => px === 3 && py === 5);
+    expect(maskBounds(image)).toEqual({
+      minX: 3,
+      minY: 5,
+      maxX: 3,
+      maxY: 5,
+    });
+  });
+
+  test("computes a tight bbox around a rectangular opaque region", () => {
+    // Opaque rectangle from (2,1) to (5,4), inclusive.
+    const image = makeImageData(
+      8,
+      8,
+      (px, py) => px >= 2 && px <= 5 && py >= 1 && py <= 4
+    );
+    expect(maskBounds(image)).toEqual({
+      minX: 2,
+      minY: 1,
+      maxX: 5,
+      maxY: 4,
+    });
+  });
+
+  test("captures pixels at all four edges", () => {
+    const image = makeImageData(
+      4,
+      4,
+      (px, py) =>
+        (px === 0 && py === 0) || // top-left
+        (px === 3 && py === 0) || // top-right
+        (px === 0 && py === 3) || // bottom-left
+        (px === 3 && py === 3) // bottom-right
+    );
+    expect(maskBounds(image)).toEqual({
+      minX: 0,
+      minY: 0,
+      maxX: 3,
+      maxY: 3,
+    });
+  });
+
+  test("ignores the gap between sparse opaque pixels", () => {
+    // Two opaque pixels at (1,1) and (5,3); bbox should span both.
+    const image = makeImageData(
+      8,
+      8,
+      (px, py) => (px === 1 && py === 1) || (px === 5 && py === 3)
+    );
+    expect(maskBounds(image)).toEqual({
+      minX: 1,
+      minY: 1,
+      maxX: 5,
+      maxY: 3,
+    });
+  });
+
+  test("treats any non-zero alpha as opaque", () => {
+    // Build an image with alpha = 1 (lowest non-zero) on a single pixel.
+    const data = new Uint8ClampedArray(4 * 4 * 4);
+    data[(2 * 4 + 1) * 4 + 3] = 1;
+    const image = { data, width: 4, height: 4 } as ImageData;
+
+    expect(maskBounds(image)).toEqual({
+      minX: 1,
+      minY: 2,
+      maxX: 1,
+      maxY: 2,
+    });
+  });
+});

--- a/app/packages/lighter/src/utils/maskBounds.ts
+++ b/app/packages/lighter/src/utils/maskBounds.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+export interface MaskBounds {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+/**
+ * Computes the tight axis-aligned bounding box of opaque pixels in an
+ * `ImageData`. A pixel is "opaque" if its alpha byte is non-zero.
+ *
+ * Used to crop the editing canvas to the actual painted region after a
+ * stroke ends, and to size new canvases when extending bounds during paint.
+ *
+ * @param maskData - Source `ImageData` (RGBA, alpha channel determines fill).
+ * @returns Inclusive bounding box `{ minX, minY, maxX, maxY }` (in canvas
+ *   pixels) covering all opaque pixels — the box covers the pixels from
+ *   `minX..maxX` and `minY..maxY`, **both endpoints included**. Returns
+ *   `null` when the image has no opaque pixels.
+ */
+export const maskBounds = (maskData: ImageData): MaskBounds | null => {
+  const { data, height, width } = maskData;
+  let minX = width;
+  let minY = height;
+  let maxX = -1;
+  let maxY = -1;
+
+  for (let py = 0; py < height; py++) {
+    for (let px = 0; px < width; px++) {
+      if (data[(py * width + px) * 4 + 3] > 0) {
+        if (px < minX) minX = px;
+        if (px > maxX) maxX = px;
+        if (py < minY) minY = py;
+        if (py > maxY) maxY = py;
+      }
+    }
+  }
+
+  if (maxX < 0 || maxY < 0) {
+    return null;
+  }
+
+  return {
+    minX,
+    minY,
+    maxX,
+    maxY,
+  };
+};

--- a/app/packages/lighter/src/utils/maskDecoding.test.ts
+++ b/app/packages/lighter/src/utils/maskDecoding.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { deserialize } from "@fiftyone/looker/src/numpy";
+import { decodeMask } from "./maskDecoding";
+
+/**
+ * Real mask from an existing FiftyOne detection (base64-encoded,
+ * zlib-compressed numpy uint8 array). Identical to the fixture used by
+ * `maskEncoding.test.ts`, so failures here vs. there localize the bug.
+ */
+const SAMPLE_MASK =
+  "eJyb7BfqGxDJyFDGUK2eklqcXKRupaBek2SorqOgnpZfVFKUmBefX5SSChJ3S8wpTgWKF2ckFqQC+RoWhjoKRqaaOgq1CmQCLkZGBuyAEQJwSmDKMmIAnBJQKZIkGIeLBCOdJIaNRwZOgnHkSjAOE4mBDMRBmW2pWCRTTwJnRUE9CdJrKepJ4KwkGZABTglkSQwJqBw2cbAclAYAWfUiKw==";
+
+describe("decodeMask", () => {
+  /**
+   * jsdom doesn't provide `ImageData` or `createImageBitmap`. Stub both so
+   * tests can inspect the RGBA buffer that would have been rasterized.
+   */
+  type StubImageData = {
+    data: Uint8ClampedArray;
+    width: number;
+    height: number;
+  };
+  let lastImageData: StubImageData | undefined;
+
+  beforeEach(() => {
+    lastImageData = undefined;
+
+    vi.stubGlobal(
+      "ImageData",
+      class {
+        data: Uint8ClampedArray;
+        width: number;
+        height: number;
+        constructor(data: Uint8ClampedArray, width: number, height: number) {
+          this.data = data;
+          this.width = width;
+          this.height = height;
+        }
+      }
+    );
+
+    vi.stubGlobal(
+      "createImageBitmap",
+      vi.fn(async (data: StubImageData) => {
+        lastImageData = data;
+        return data as unknown as ImageBitmap;
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("rawPixels normalizes source values for hit-testing", async () => {
+    const overlayMask = deserialize(SAMPLE_MASK);
+    const [height, width] = overlayMask.shape;
+
+    const { rawPixels } = await decodeMask(SAMPLE_MASK, "#ffffff");
+
+    expect(rawPixels.width).toBe(width);
+    expect(rawPixels.height).toBe(height);
+    expect(rawPixels.src.length).toBe(width * height);
+    expect(rawPixels.src).toEqual(
+      Uint8Array.from(new Uint8Array(overlayMask.buffer), (value) =>
+        value > 0 ? 1 : 0
+      )
+    );
+  });
+
+  test("paints non-zero mask pixels with the requested color", async () => {
+    await decodeMask(SAMPLE_MASK, "#ff0000");
+
+    expect(lastImageData).toBeDefined();
+    const { data, width, height } = lastImageData!;
+    const overlayMask = deserialize(SAMPLE_MASK);
+    const src = new Uint8Array(overlayMask.buffer);
+
+    expect(width).toBe(overlayMask.shape[1]);
+    expect(height).toBe(overlayMask.shape[0]);
+
+    let paintedCount = 0;
+    let transparentCount = 0;
+
+    for (let i = 0; i < src.length; i++) {
+      const r = data[i * 4];
+      const g = data[i * 4 + 1];
+      const b = data[i * 4 + 2];
+      const a = data[i * 4 + 3];
+
+      if (src[i] > 0) {
+        // Painted: full red, opaque.
+        expect(r).toBe(255);
+        expect(g).toBe(0);
+        expect(b).toBe(0);
+        expect(a).toBe(255);
+        paintedCount++;
+      } else {
+        // Background: untouched (zeroed RGBA buffer).
+        expect(a).toBe(0);
+        transparentCount++;
+      }
+    }
+
+    // Sanity: the fixture has a mix of mask and background pixels.
+    expect(paintedCount).toBeGreaterThan(0);
+    expect(transparentCount).toBeGreaterThan(0);
+  });
+
+  test("respects the alpha component of an rgba(...) color", async () => {
+    await decodeMask(SAMPLE_MASK, "rgba(0, 128, 0, 0.5)");
+
+    expect(lastImageData).toBeDefined();
+    const { data } = lastImageData!;
+    const overlayMask = deserialize(SAMPLE_MASK);
+    const src = new Uint8Array(overlayMask.buffer);
+
+    // Find one painted pixel and assert its RGBA matches the parsed color.
+    const paintedIndex = src.findIndex((v) => v > 0);
+    expect(paintedIndex).toBeGreaterThanOrEqual(0);
+
+    const r = data[paintedIndex * 4];
+    const g = data[paintedIndex * 4 + 1];
+    const b = data[paintedIndex * 4 + 2];
+    const a = data[paintedIndex * 4 + 3];
+
+    expect(r).toBe(0);
+    expect(g).toBe(128);
+    expect(b).toBe(0);
+    // 0.5 alpha → ~128 (Math.round(0.5 * 255) = 128).
+    expect(a).toBe(128);
+  });
+
+  test("returns a bitmap promise", async () => {
+    const { bitmap } = await decodeMask(SAMPLE_MASK, "#ffffff");
+    expect(bitmap).toBeDefined();
+  });
+});

--- a/app/packages/lighter/src/utils/maskDecoding.ts
+++ b/app/packages/lighter/src/utils/maskDecoding.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import {
+  ARRAY_TYPES,
+  deserialize,
+  type OverlayMask,
+} from "@fiftyone/looker/src/numpy";
+import { parseColorToRGBA } from "./color";
+
+export interface DecodedMask {
+  bitmap: ImageBitmap;
+  /** Single-channel pixel data for hit-testing (non-zero = mask). */
+  rawPixels: { src: Uint8Array; width: number; height: number };
+}
+
+/**
+ * Decodes a base64-encoded numpy mask string and paints it with the given
+ * color, returning an ImageBitmap ready for rendering alongside the raw
+ * single-channel pixel data for hit-testing.
+ *
+ * Pipeline: base64 → inflate → numpy parse → paint RGBA → ImageBitmap
+ *
+ * @param maskData - Base64-encoded, zlib-compressed numpy array
+ * @param color - CSS color string for non-zero mask pixels
+ */
+export async function decodeMask(
+  maskData: string,
+  color: string
+): Promise<DecodedMask> {
+  const overlayMask = deserialize(maskData);
+  const rgbaBuffer = paintMask(overlayMask, color);
+  const [height, width] = overlayMask.shape;
+  const imageData = new ImageData(
+    new Uint8ClampedArray(rgbaBuffer),
+    width,
+    height
+  );
+  const bitmap = await createImageBitmap(imageData);
+
+  const ArrayType = ARRAY_TYPES[overlayMask.arrayType];
+  if (!ArrayType) {
+    throw new Error(`Unsupported mask array type: ${overlayMask.arrayType}`);
+  }
+
+  const typed = new ArrayType(overlayMask.buffer);
+  const src = new Uint8Array(typed.length);
+  for (let i = 0; i < typed.length; i++) {
+    src[i] = typed[i] ? 1 : 0;
+  }
+
+  return { bitmap, rawPixels: { src, width, height } };
+}
+
+/**
+ * Paints a deserialized mask into an RGBA buffer using the given color.
+ * Non-zero mask values become the color; zero values stay transparent.
+ */
+function paintMask(mask: OverlayMask, cssColor: string): ArrayBuffer {
+  if (mask.channels !== 1) {
+    throw new Error(`Expected single-channel mask, got ${mask.channels}`);
+  }
+
+  const [height, width] = mask.shape;
+  const rgbaBuffer = new ArrayBuffer(width * height * 4);
+  const overlay = new Uint32Array(rgbaBuffer);
+
+  const { r, g, b, a } = parseColorToRGBA(cssColor);
+
+  // Pack as RGBA (little-endian: ABGR in Uint32)
+  const packedColor = (a << 24) | (b << 16) | (g << 8) | r;
+  const ArrayType = ARRAY_TYPES[mask.arrayType];
+
+  if (!ArrayType) {
+    throw new Error(`Unsupported mask array type: ${mask.arrayType}`);
+  }
+
+  const targets = new ArrayType(mask.buffer);
+  const expectedPixels = width * height;
+
+  if (targets.length !== expectedPixels) {
+    throw new Error(
+      `Mask payload length mismatch: expected ${expectedPixels}, got ${targets.length}`
+    );
+  }
+
+  for (let i = 0; i < expectedPixels; i++) {
+    if (targets[i]) {
+      overlay[i] = packedColor;
+    }
+  }
+
+  return rgbaBuffer;
+}

--- a/app/packages/lighter/src/utils/maskEncoding.test.ts
+++ b/app/packages/lighter/src/utils/maskEncoding.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { describe, expect, test } from "vitest";
+import { deserialize } from "@fiftyone/looker/src/numpy";
+import { encodeMaskData } from "./maskEncoding";
+
+/**
+ * Real mask from an existing FiftyOne detection (base64-encoded,
+ * zlib-compressed numpy uint8 array).
+ */
+const SAMPLE_MASK =
+  "eJyb7BfqGxDJyFDGUK2eklqcXKRupaBek2SorqOgnpZfVFKUmBefX5SSChJ3S8wpTgWKF2ckFqQC+RoWhjoKRqaaOgq1CmQCLkZGBuyAEQJwSmDKMmIAnBJQKZIkGIeLBCOdJIaNRwZOgnHkSjAOE4mBDMRBmW2pWCRTTwJnRUE9CdJrKepJ4KwkGZABTglkSQwJqBw2cbAclAYAWfUiKw==";
+
+const readMask = (buffer: ArrayBuffer): Uint8Array => new Uint8Array(buffer);
+
+const roundTrip = async (mask: Uint8Array, shape: readonly number[]) => {
+  const encoded = await encodeMaskData(mask, shape);
+  return deserialize(encoded);
+};
+
+describe("maskEncoding", () => {
+  test("encode → decode round-trip preserves shape and data", async () => {
+    // Decode the original mask
+    const original = deserialize(SAMPLE_MASK);
+
+    // Re-encode
+    const reEncoded = await encodeMaskData(
+      new Uint8Array(original.buffer),
+      original.shape
+    );
+
+    // Decode the re-encoded mask using the same real deserializer
+    const roundTripped = deserialize(reEncoded);
+
+    // Shape must match
+    expect(roundTripped.shape).toEqual(original.shape);
+
+    // Data must match byte-for-byte
+    expect(new Uint8Array(roundTripped.buffer)).toEqual(
+      new Uint8Array(original.buffer)
+    );
+  });
+
+  test("decoded mask has expected numpy properties", () => {
+    const mask = deserialize(SAMPLE_MASK);
+
+    // Shape should be [height, width] with positive dimensions
+    expect(mask.shape[0]).toBeGreaterThan(0);
+    expect(mask.shape[1]).toBeGreaterThan(0);
+
+    // Data length should equal height * width
+    const data = new Uint8Array(mask.buffer);
+    expect(data.length).toBe(mask.shape[0] * mask.shape[1]);
+
+    // Mask values should be 0 or 1
+    for (let i = 0; i < data.length; i++) {
+      expect(data[i] === 0 || data[i] === 1).toBe(true);
+    }
+  });
+
+  describe("round-trip with looker deserialize", () => {
+    test("preserves a 2D mask with mixed values", async () => {
+      const shape = [2, 3];
+      const mask = new Uint8Array([0, 1, 1, 0, 0, 1]);
+
+      const result = await roundTrip(mask, shape);
+
+      expect(result.shape).toEqual(shape);
+      expect(result.channels).toBe(1);
+      expect(result.arrayType).toBe("Uint8Array");
+      expect(Array.from(readMask(result.buffer))).toEqual([0, 1, 1, 0, 0, 1]);
+    });
+
+    test("supports 3D shapes with channels", async () => {
+      const shape = [2, 2, 3];
+      // 2x2 mask with 3 channels
+      const mask = new Uint8Array([
+        1, 0, 1, // row 0 col 0
+        0, 1, 0, // row 0 col 1
+        1, 0, 1, // row 1 col 0
+        0, 1, 0, // row 1 col 1
+      ]);
+
+      const result = await roundTrip(mask, shape);
+
+      expect(result.shape).toEqual([2, 2]);
+      expect(result.channels).toBe(3);
+      expect(Array.from(readMask(result.buffer))).toEqual([
+        1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0,
+      ]);
+    });
+
+    test("handles a single-pixel mask", async () => {
+      const result = await roundTrip(new Uint8Array([1]), [1, 1]);
+
+      expect(result.shape).toEqual([1, 1]);
+      expect(result.channels).toBe(1);
+      expect(Array.from(readMask(result.buffer))).toEqual([1]);
+    });
+
+    test("handles a larger mask (64x64)", async () => {
+      const h = 64;
+      const w = 64;
+      const mask = new Uint8Array(h * w);
+
+      for (let i = 0; i < mask.length; i++) {
+        // alternating pattern
+        mask[i] = i % 3 === 0 ? 1 : 0;
+      }
+
+      const result = await roundTrip(mask, [h, w]);
+
+      expect(result.shape).toEqual([h, w]);
+      expect(readMask(result.buffer)).toHaveLength(h * w);
+      expect(Array.from(readMask(result.buffer))).toEqual(Array.from(mask));
+    });
+
+    test("produces header padding aligned to 64 bytes (small shape)", async () => {
+      // Exercises the header-padding branch; a bad alignment would make the
+      // uint16 header length mismatch and deserialize would throw.
+      const result = await roundTrip(new Uint8Array([1, 0, 1, 0]), [2, 2]);
+      expect(result.shape).toEqual([2, 2]);
+    });
+
+    test("produces header padding aligned to 64 bytes (3D shape)", async () => {
+      const result = await roundTrip(new Uint8Array(12), [2, 2, 3]);
+      expect(result.shape).toEqual([2, 2]);
+      expect(result.channels).toBe(3);
+    });
+  });
+
+  describe("validation", () => {
+    test("throws when shape is empty", async () => {
+      await expect(encodeMaskData(new Uint8Array(0), [])).rejects.toThrow(
+        /Mask shape must be 2D or 3D/
+      );
+    });
+
+    test("throws when shape contains a negative dimension", async () => {
+      await expect(
+        encodeMaskData(new Uint8Array(4), [2, -2])
+      ).rejects.toThrow(/Mask shape must be 2D or 3D/);
+    });
+
+    test("throws when shape contains a non-integer dimension", async () => {
+      await expect(
+        encodeMaskData(new Uint8Array(4), [2, 2.5])
+      ).rejects.toThrow(/Mask shape must be 2D or 3D/);
+    });
+
+    test("throws when shape does not match array length", async () => {
+      await expect(
+        encodeMaskData(new Uint8Array(5), [2, 3])
+      ).rejects.toThrow(/does not match shape/);
+    });
+  });
+
+  describe("output format", () => {
+    test("returns a valid base64 string", async () => {
+      const encoded = await encodeMaskData(new Uint8Array([1, 0]), [1, 2]);
+      expect(typeof encoded).toBe("string");
+      expect(encoded).toMatch(/^[A-Za-z0-9+/]+=*$/);
+    });
+  });
+});

--- a/app/packages/lighter/src/utils/maskEncoding.ts
+++ b/app/packages/lighter/src/utils/maskEncoding.ts
@@ -1,0 +1,166 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Encodes a mask canvas into the base64-encoded, zlib-compressed numpy format
+ * that FiftyOne stores in the database.
+ *
+ * Pipeline: canvas → uint8 mask → numpy .npy → zlib deflate → base64
+ */
+
+/**
+ * Encodes a mask editing canvas into a base64 string matching FiftyOne's
+ * stored mask format.
+ *
+ * @param canvas - The mask editing canvas (RGBA). Any pixel with non-zero
+ *   alpha is treated as masked (value 1); fully transparent pixels are 0.
+ * @returns Base64-encoded, zlib-compressed numpy array string.
+ */
+export async function encodeMask(canvas: HTMLCanvasElement): Promise<string> {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Cannot get 2d context from mask canvas");
+
+  const { width, height } = canvas;
+  const imageData = ctx.getImageData(0, 0, width, height);
+
+  // Extract single-channel uint8: non-zero alpha → 1, zero → 0
+  const mask = new Uint8Array(width * height);
+  const rgba = imageData.data;
+  for (let i = 0; i < mask.length; i++) {
+    mask[i] = rgba[i * 4 + 3] > 0 ? 1 : 0;
+  }
+
+  return encodeMaskData(mask, [height, width]);
+}
+
+/**
+ * Encodes a raw uint8 mask array into a base64 string matching FiftyOne's
+ * stored mask format.
+ *
+ * @param mask - Flat uint8 array of mask values.
+ * @param shape - Array shape (e.g. `[height, width]` or `[height, width, channels]`).
+ * @returns Base64-encoded, zlib-compressed numpy array string.
+ */
+export async function encodeMaskData(
+  mask: Uint8Array,
+  shape: readonly number[]
+): Promise<string> {
+  if (
+    (shape.length !== 2 && shape.length !== 3) ||
+    shape.some((dim) => !Number.isInteger(dim) || dim <= 0)
+  ) {
+    throw new Error(
+      "Mask shape must be 2D or 3D with positive integer dimensions"
+    );
+  }
+
+  const expectedLength = shape.reduce((product, dim) => product * dim, 1);
+  if (mask.length !== expectedLength) {
+    throw new Error(
+      `Mask length ${mask.length} does not match shape ${shape.join("x")}`
+    );
+  }
+
+  const npy = buildNpy(mask, shape);
+  const compressed = await deflate(npy);
+
+  const bytes = new Uint8Array(compressed);
+  const CHUNK_SIZE = 0x8000;
+  const parts: string[] = [];
+
+  for (let i = 0; i < bytes.length; i += CHUNK_SIZE) {
+    parts.push(String.fromCharCode(...bytes.subarray(i, i + CHUNK_SIZE)));
+  }
+
+  return btoa(parts.join(""));
+}
+
+/**
+ * Builds a numpy v1.0 `.npy` byte array.
+ *
+ * Format spec: https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html
+ *
+ * @param data - Flat uint8 array of mask values.
+ * @param shape - Array shape.
+ * @returns Uint8Array containing the complete .npy file.
+ */
+function buildNpy(data: Uint8Array, shape: readonly number[]): Uint8Array {
+  // Header dict — must match what numpy's parse expects.
+  // 1-tuples need a trailing comma: `(N,)` not `(N)`.
+  const shapeStr =
+    shape.length === 1 ? `(${shape[0]},)` : `(${shape.join(", ")})`;
+  const headerStr = `{'descr': '|u1', 'fortran_order': False, 'shape': ${shapeStr}, }`;
+
+  // Pad header so that magic(6) + version(2) + headerLen(2) + header is
+  // aligned to a 64-byte boundary, terminated by a newline.
+  const preambleLen = 10; // magic(6) + version(2) + headerLen(2)
+  const rawLen = preambleLen + headerStr.length + 1; // +1 for trailing \n
+  const padded = Math.ceil(rawLen / 64) * 64;
+  const paddingLen = padded - rawLen;
+  const headerBytes = headerStr + " ".repeat(paddingLen) + "\n";
+  const headerLen = headerBytes.length;
+
+  const totalLen = preambleLen + headerLen + data.length;
+  const buf = new Uint8Array(totalLen);
+
+  // Magic: \x93NUMPY
+  buf[0] = 0x93;
+  buf[1] = 0x4e; // N
+  buf[2] = 0x55; // U
+  buf[3] = 0x4d; // M
+  buf[4] = 0x50; // P
+  buf[5] = 0x59; // Y
+
+  // Version 1.0
+  buf[6] = 1;
+  buf[7] = 0;
+
+  // Header length (little-endian uint16)
+  buf[8] = headerLen & 0xff;
+  buf[9] = (headerLen >> 8) & 0xff;
+
+  // Header string
+  for (let i = 0; i < headerLen; i++) {
+    buf[preambleLen + i] = headerBytes.charCodeAt(i);
+  }
+
+  // Raw data
+  buf.set(data, preambleLen + headerLen);
+
+  return buf;
+}
+
+/**
+ * Compresses data using zlib deflate via the browser's CompressionStream API.
+ */
+async function deflate(data: Uint8Array): Promise<ArrayBuffer> {
+  const cs = new CompressionStream("deflate");
+  const writer = cs.writable.getWriter();
+  const reader = cs.readable.getReader();
+
+  // Kick off the write+close in the background and surface any errors at the
+  // end so they don't go unhandled.
+  const writePromise = writer.write(data).then(() => writer.close());
+
+  const chunks: Uint8Array[] = [];
+  let totalLen = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    totalLen += value.length;
+  }
+
+  // Surface write/close errors deterministically once the readable side is
+  // drained — without this, a rejection would be unhandled.
+  await writePromise;
+
+  const result = new Uint8Array(totalLen);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return result.buffer;
+}


### PR DESCRIPTION
Utility functions to:  
\- create a new canvas and potentially write mask data to it  
\- decode masks  
\- encode masks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mask encoding and decoding utilities for serialized mask handling.
  * Added canvas-based mask creation with optional bitmap seeding.
  * Added mask boundary detection that returns bounding boxes or null for empty masks.

* **Tests**
  * Added tests covering mask encoding/decoding, canvas creation behavior, and boundary detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->