### PR TITLE
lighter: pointer handlers take a single OverlayEvent param

### DIFF
--- a/app/packages/lighter/src/interaction/InteractionManager.ts
+++ b/app/packages/lighter/src/interaction/InteractionManager.ts
@@ -16,6 +16,23 @@ import { InteractiveKeypointHandler } from "./InteractiveKeypointHandler";
 import { v4 as generateUUID } from "uuid";
 
 /**
+ * Unified event object passed to overlay interaction handlers.
+ * Contains all pointer-event context needed for down / move / up handling.
+ */
+export interface OverlayEvent {
+  /** Canvas-space (screen-space) pointer position. */
+  point: Point;
+  /** World-space pointer position (after inverse camera transform). */
+  worldPoint: Point;
+  /** The original DOM pointer event. */
+  event: PointerEvent;
+  /** Current camera zoom scale factor. */
+  scale: number;
+  /** Whether shift-key aspect-ratio lock is active. */
+  maintainAspectRatio?: boolean;
+}
+
+/**
  * Interface for handlers that support sub-selecting and removing individual
  * points (e.g. keypoint overlays).
  */
@@ -87,45 +104,25 @@ export interface InteractionHandler {
   getMoveStartBounds?(): Rect | undefined;
 
   /**
-   * Handle pointer down event.
-   * @param point - The point where the event occurred.
-   * @param worldPoint - Screen point translated to viewport point.
-   * @param event - The original pointer event.
-   * @param scale - The current scaling factor of the renderer.
+   * Handle pointer-down event.
+   * @param params - The overlay event containing pointer and viewport state.
    * @returns True if the event was handled and should not propagate.
    */
-  onPointerDown?(
-    point: Point,
-    worldPoint: Point,
-    event: PointerEvent,
-    scale: number
-  ): boolean;
+  onPointerDown?(params: OverlayEvent): boolean;
 
   /**
-   * Handle pointer move event.
-   * @param point - The point where the event occurred.
-   * @param worldPoint - Screen point translated to viewport point.
-   * @param event - The original pointer event.
-   * @param scale - The current scaling factor of the renderer.
-   * @param maintainAspectRatio - Maintain aspect ratio during resize (shift key held).
+   * Handle pointer-move event while a gesture is active.
+   * @param params - The overlay event containing pointer and viewport state.
    * @returns True if the event was handled.
    */
-  onMove?(
-    point: Point,
-    worldPoint: Point,
-    event: PointerEvent,
-    scale: number,
-    maintainAspectRatio?: boolean
-  ): boolean;
+  onMove?(params: OverlayEvent): boolean;
 
   /**
-   * Handle pointer up event.
-   * @param point - The point where the event occurred.
-   * @param event - The original pointer event.
-   * @param scale - The current scaling factor of the renderer.
+   * Handle pointer-up event.
+   * @param params - The overlay event containing pointer and viewport state.
    * @returns True if the event was handled.
    */
-  onPointerUp?(point: Point, event: PointerEvent, scale: number): boolean;
+  onPointerUp?(params: OverlayEvent): boolean;
 
   /**
    * Handle click event.
@@ -328,7 +325,7 @@ export class InteractionManager {
       }
     }
 
-    if (handler?.onPointerDown?.(point, worldPoint, event, scale)) {
+    if (handler?.onPointerDown?.({ point, worldPoint, event, scale })) {
       const cursor = handler.getCursor?.(worldPoint, scale);
       if (cursor) {
         this.canvas.style.cursor = cursor;
@@ -408,21 +405,21 @@ export class InteractionManager {
         this.selectionManager.select(handler.id);
 
         // Initialize the handler with the original pointerdown point
-        handler.onPointerDown?.(
-          pending.point,
-          pending.worldPoint,
+        handler.onPointerDown?.({
+          point: pending.point,
+          worldPoint: pending.worldPoint,
           event,
-          pending.scale
-        );
+          scale: pending.scale,
+        });
 
         // Update with the current pointer position
-        handler.onMove?.(
+        handler.onMove?.({
           point,
           worldPoint,
           event,
           scale,
-          this.maintainAspectRatio
-        );
+          maintainAspectRatio: this.maintainAspectRatio,
+        });
 
         if (TypeGuards.isSpatial(handler)) {
           this.eventBus.dispatch("lighter:overlay-drag-start", {
@@ -474,15 +471,17 @@ export class InteractionManager {
 
     // Apply drag gate to prevent accidental overlay dragging on click
     if (handler) {
+      const moveParams: OverlayEvent = {
+        point,
+        worldPoint,
+        event,
+        scale,
+        maintainAspectRatio: this.maintainAspectRatio,
+      };
+
       // Handle drag move
       if (!interactiveHandler) {
-        handler.onMove?.(
-          point,
-          worldPoint,
-          event,
-          scale,
-          this.maintainAspectRatio
-        );
+        handler.onMove?.(moveParams);
       } else {
         handler =
           interactiveHandler instanceof InteractiveKeypointHandler
@@ -491,13 +490,7 @@ export class InteractionManager {
             : // otherwise defer to the handler's overlay
               interactiveHandler.getOverlay();
 
-        handler.onMove?.(
-          point,
-          worldPoint,
-          event,
-          scale,
-          this.maintainAspectRatio
-        );
+        handler.onMove?.(moveParams);
       }
 
       if (handler.isMoving?.()) {
@@ -571,7 +564,7 @@ export class InteractionManager {
       const startPosition = handler.getMoveStartPosition?.();
 
       // Handle drag end
-      handler.onPointerUp?.(point, event, scale);
+      handler.onPointerUp?.({ point, worldPoint, event, scale });
 
       if (interactiveHandler) {
         // When interactive detection is complete, remove the interactive handler
@@ -616,7 +609,7 @@ export class InteractionManager {
       this.handleClick(point, event, now);
 
       // Clean up drag handler
-      handler.onPointerUp?.(point, event, scale);
+      handler.onPointerUp?.({ point, worldPoint, event, scale });
       this.canvas.releasePointerCapture(event.pointerId);
     } else {
       // Handle click

--- a/app/packages/lighter/src/interaction/InteractiveDetectionHandler.ts
+++ b/app/packages/lighter/src/interaction/InteractiveDetectionHandler.ts
@@ -4,7 +4,10 @@
 
 import { DetectionOverlay } from "../overlay/DetectionOverlay";
 import type { Point } from "../types";
-import type { InteractionHandler } from "./InteractionManager";
+import type {
+  InteractionHandler,
+  OverlayEvent,
+} from "./InteractionManager";
 
 const INTERACTIVE_DETECTION_HANDLER_ID = "interactive-detection-handler";
 
@@ -38,11 +41,7 @@ export class InteractiveDetectionHandler implements InteractionHandler {
     this.overlay.markDirty();
   }
 
-  onPointerDown(
-    point: Point,
-    _worldPoint: Point,
-    _event: PointerEvent
-  ): boolean {
+  onPointerDown({ point }: OverlayEvent): boolean {
     this.startPoint = point;
     this._isDragging = true;
     this.overlay.toggleSelected();
@@ -76,13 +75,7 @@ export class InteractiveDetectionHandler implements InteractionHandler {
     return true;
   }
 
-  onMove(
-    point: Point,
-    _worldPoint: Point,
-    _event: PointerEvent,
-    _scale: number,
-    _maintainAspectRatio?: boolean
-  ): boolean {
+  onMove({ point }: OverlayEvent): boolean {
     return this.updateBounds(point);
   }
 
@@ -90,7 +83,7 @@ export class InteractiveDetectionHandler implements InteractionHandler {
     return this.updateBounds(point);
   }
 
-  onPointerUp(_point: Point, _event: PointerEvent): boolean {
+  onPointerUp(_params: OverlayEvent): boolean {
     if (!this._isDragging || !this.startPoint) {
       this._isDragging = false;
       return false;

--- a/app/packages/lighter/src/interaction/InteractiveKeypointHandler.ts
+++ b/app/packages/lighter/src/interaction/InteractiveKeypointHandler.ts
@@ -9,7 +9,10 @@ import { RemoveKeypointPointCommand } from "../commands/RemoveKeypointPointComma
 import type { LighterEventGroup } from "../events";
 import { KeypointOverlay } from "../overlay/KeypointOverlay";
 import type { Point } from "../types";
-import type { InteractionHandler } from "./InteractionManager";
+import type {
+  InteractionHandler,
+  OverlayEvent,
+} from "./InteractionManager";
 import { ClickEventModifiers, getClickModifiers } from "@fiftyone/utilities";
 
 const INTERACTIVE_KEYPOINT_HANDLER_ID = "interactive-keypoint-handler";
@@ -82,11 +85,7 @@ export class InteractiveKeypointHandler implements InteractionHandler {
     return false;
   }
 
-  onPointerDown(
-    _point: Point,
-    worldPoint: Point,
-    event: PointerEvent
-  ): boolean {
+  onPointerDown({ worldPoint, event }: OverlayEvent): boolean {
     const rp = this.overlay.absolutePointToRelative(worldPoint);
     const modifiers = getClickModifiers(event);
 
@@ -131,12 +130,12 @@ export class InteractiveKeypointHandler implements InteractionHandler {
     return true;
   }
 
-  onMove(_point: Point, worldPoint: Point, _event: PointerEvent): boolean {
+  onMove({ worldPoint }: OverlayEvent): boolean {
     this.overlay.setPreviewPoint(worldPoint);
     return true;
   }
 
-  onPointerUp(_point: Point, _event: PointerEvent): boolean {
+  onPointerUp(_params: OverlayEvent): boolean {
     // No-op — points are placed on pointer down, not release
     return true;
   }

--- a/app/packages/lighter/src/overlay/BaseOverlay.ts
+++ b/app/packages/lighter/src/overlay/BaseOverlay.ts
@@ -5,7 +5,10 @@
 import { type EventDispatcher, getEventBus } from "@fiftyone/events";
 import { CONTAINS } from "../core/Scene2D";
 import type { LighterEventGroup } from "../events";
-import type { InteractionHandler } from "../interaction/InteractionManager";
+import type {
+  InteractionHandler,
+  OverlayEvent,
+} from "../interaction/InteractionManager";
 import type { Renderer2D } from "../renderer/Renderer2D";
 import type { ResourceLoader } from "../resource/ResourceLoader";
 import type {
@@ -327,45 +330,28 @@ export abstract class BaseOverlay<Label extends RawLookerLabel = RawLookerLabel>
   }
 
   /**
-   * Handle pointer down event.
+   * Handle pointer-down event.
    * Override in subclasses to implement custom behavior.
-   * @param point - The point where the event occurred.
-   * @param worldPoint - Screen point translated to viewport point.
-   * @param event - The original pointer event.
-   * @param scale - The current scaling factor of the viewport.
+   * @param params - The overlay event containing pointer and viewport state.
    * @returns True if the event was handled.
    */
-  onPointerDown?(
-    point: Point,
-    worldPoint: Point,
-    event: PointerEvent,
-    scale: number
-  ): boolean;
+  onPointerDown?(params: OverlayEvent): boolean;
 
   /**
-   * Handle drag event.
+   * Handle pointer-move event while a gesture is active.
    * Override in subclasses to implement custom behavior.
-   * @param point - The point where the event occurred.
-   * @param worldPoint - Screen point translated to viewport point.
-   * @param event - The original pointer event.
-   * @param scale - The current scaling factor of the viewport.
+   * @param params - The overlay event containing pointer and viewport state.
    * @returns True if the event was handled.
    */
-  onMove?(
-    point: Point,
-    worldPoint: Point,
-    event: PointerEvent,
-    scale: number
-  ): boolean;
+  onMove?(params: OverlayEvent): boolean;
 
   /**
-   * Handle pointer up event.
+   * Handle pointer-up event.
    * Override in subclasses to implement custom behavior.
-   * @param point - The point where the event occurred.
-   * @param event - The original pointer event.
+   * @param params - The overlay event containing pointer and viewport state.
    * @returns True if the event was handled.
    */
-  onPointerUp?(point: Point, event: PointerEvent): boolean;
+  onPointerUp?(params: OverlayEvent): boolean;
 
   /**
    * Handle click event.

--- a/app/packages/lighter/src/overlay/DetectionOverlay.ts
+++ b/app/packages/lighter/src/overlay/DetectionOverlay.ts
@@ -12,6 +12,7 @@ import {
   STROKE_WIDTH,
 } from "../constants";
 import { CONTAINS } from "../core/Scene2D";
+import type { OverlayEvent } from "../interaction/InteractionManager";
 import type { Renderer2D } from "../renderer/Renderer2D";
 import type { Selectable } from "../selection/Selectable";
 import type {
@@ -401,12 +402,7 @@ export class DetectionOverlay
   }
 
   // Interaction handlers
-  onPointerDown(
-    point: Point,
-    worldPoint: Point,
-    _event: PointerEvent,
-    scale: number
-  ): boolean {
+  onPointerDown({ point, worldPoint, scale }: OverlayEvent): boolean {
     const resizeRegion = this.getResizeRegion(worldPoint, scale);
     const cursorState = !this.hasValidBounds()
       ? "SETTING"
@@ -440,13 +436,12 @@ export class DetectionOverlay
     return true;
   }
 
-  onMove(
-    point: Point,
-    worldPoint: Point,
-    event: PointerEvent,
-    scale: number,
-    maintainAspectRatio?: boolean
-  ): boolean {
+  onMove({
+    point,
+    event,
+    scale,
+    maintainAspectRatio,
+  }: OverlayEvent): boolean {
     if (this.moveState === "DRAGGING") {
       return this.onDrag(point, event, scale);
     }
@@ -586,7 +581,7 @@ export class DetectionOverlay
     return true;
   }
 
-  onPointerUp(_point: Point, _event: PointerEvent): boolean {
+  onPointerUp(_params: OverlayEvent): boolean {
     if (!this.moveStartPoint || !this.moveStartBounds) return false;
 
     this.moveState = "NONE";

--- a/app/packages/lighter/src/overlay/KeypointOverlay.ts
+++ b/app/packages/lighter/src/overlay/KeypointOverlay.ts
@@ -16,6 +16,7 @@ import {
   STROKE_WIDTH,
 } from "../constants";
 import { CONTAINS } from "../core/Scene2D";
+import type { OverlayEvent } from "../interaction/InteractionManager";
 import type { Renderer2D } from "../renderer/Renderer2D";
 import type { Selectable } from "../selection/Selectable";
 import type {
@@ -558,12 +559,7 @@ export class KeypointOverlay
     return "default";
   }
 
-  onPointerDown(
-    point: Point,
-    worldPoint: Point,
-    _event: PointerEvent,
-    scale: number
-  ): boolean {
+  onPointerDown({ point, worldPoint, scale }: OverlayEvent): boolean {
     const nearestIdx = this.findNearestPointIndex(worldPoint, scale);
 
     if (nearestIdx >= 0) {
@@ -586,12 +582,7 @@ export class KeypointOverlay
     return false;
   }
 
-  onMove(
-    _point: Point,
-    worldPoint: Point,
-    _event: PointerEvent,
-    _scale: number
-  ): boolean {
+  onMove({ worldPoint }: OverlayEvent): boolean {
     if (
       this.dragPointIndex === null ||
       !this.moveStartScreenPoint ||
@@ -610,7 +601,7 @@ export class KeypointOverlay
     return true;
   }
 
-  onPointerUp(_point: Point, _event: PointerEvent): boolean {
+  onPointerUp(_params: OverlayEvent): boolean {
     if (this.dragPointIndex === null) return false;
 
     const movedIdx = this.dragPointIndex;


### PR DESCRIPTION
## OverlayEvent

With our growing list of parameters I moved our implementations from a standard parameter chain to an Object such that our handlers can now pull the data pertinent to their tasks and ignore the rest.