### PR TITLE
lighter: brush/paint primitives for segmentation

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/bridgeSegmentationMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/bridgeSegmentationMode.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Bridge for accessing segmentation mask state from non-React code
+ * (e.g., SegmentationBrushHandler, InteractionManager).
+ *
+ * Selection and editing state are managed by Lighter's SelectionManager
+ * and the annotation editing atom — not duplicated here.
+ * This bridge only exposes segmentation-specific tool state.
+ */
+
+import { getDefaultStore } from "jotai";
+import {
+  _unsafeToolModeAtom,
+  _unsafeToolAtom,
+  _unsafeToolSizeAtom,
+  _unsafeSegmentationModeActiveAtom,
+  _unsafeToolShapeAtom,
+  MIN_CURSOR_SIZE,
+  MAX_CURSOR_SIZE,
+} from "./useSegmentationMode";
+import type {
+  SegmentationToolMode,
+  SegmentationTool,
+  SegmentationToolShape,
+  SegmentationToolState,
+} from "./useSegmentationMode";
+
+/**
+ * Segmentation masks bridge for non-React code.
+ * Provides read-only access to segmentation tool state.
+ */
+export const segmentationModeBridge = {
+  /**
+   * Whether segmentation mask mode is active.
+   */
+  isActive(): boolean {
+    return getDefaultStore().get(_unsafeSegmentationModeActiveAtom);
+  },
+
+  /**
+   * Current segmentation tool.
+   */
+  getActiveTool(): SegmentationTool {
+    return getDefaultStore().get(_unsafeToolAtom);
+  },
+
+  /**
+   * Current brush/eraser size in pixels.
+   */
+  getToolSize(): number {
+    return getDefaultStore().get(_unsafeToolSizeAtom);
+  },
+
+  /**
+   * Current brush shape.
+   */
+  getToolShape(): SegmentationToolShape {
+    return getDefaultStore().get(_unsafeToolShapeAtom);
+  },
+
+  /**
+   * Current paint mode (add to mask vs. remove from mask).
+   */
+  getToolMode(): SegmentationToolMode {
+    return getDefaultStore().get(_unsafeToolModeAtom);
+  },
+
+  /**
+   * Returns the full segmentation tool state.
+   * @param scale - Viewport scale factor. `cursorSize` is the clamped
+   *   screen-pixel size for the CSS cursor. `size` is the corresponding
+   *   world-space value (`cursorSize / scale`) so the painted dab is
+   *   always 1:1 with the visual cursor.
+   */
+  getToolState(scale = 1): SegmentationToolState {
+    const cursorSize = Math.min(
+      MAX_CURSOR_SIZE,
+      Math.max(MIN_CURSOR_SIZE, Math.round(this.getToolSize() * scale))
+    );
+
+    return {
+      active: this.isActive(),
+      cursorSize,
+      shape: this.getToolShape(),
+      size: cursorSize / scale,
+      tool: this.getActiveTool(),
+      mode: this.getToolMode(),
+    };
+  },
+};

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { atom } from "jotai";
+
+export const DEFAULT_TOOL_SIZE = 16;
+export const MIN_TOOL_SIZE = 1;
+export const MAX_TOOL_SIZE = 32;
+export const MIN_CURSOR_SIZE = 1;
+export const MAX_CURSOR_SIZE = 100;
+
+export const SegmentationTool = {
+  Select: "select",
+  Brush: "brush",
+  Pen: "pen",
+  AI: "ai",
+} as const;
+export type SegmentationTool =
+  (typeof SegmentationTool)[keyof typeof SegmentationTool];
+
+export const SegmentationToolShape = {
+  Circle: "circle",
+  Square: "square",
+} as const;
+export type SegmentationToolShape =
+  (typeof SegmentationToolShape)[keyof typeof SegmentationToolShape];
+
+export const SegmentationToolMode = {
+  Add: "add",
+  Remove: "remove",
+} as const;
+export type SegmentationToolMode =
+  (typeof SegmentationToolMode)[keyof typeof SegmentationToolMode];
+
+export const DEFAULT_TOOL_MODE: SegmentationToolMode = SegmentationToolMode.Add;
+
+export interface SegmentationToolState {
+  active: boolean;
+  size: number; // World-space dab size (for painting on the mask canvas)
+  cursorSize: number; // Screen-pixel cursor size, clamped to [MIN_CURSOR_SIZE, MAX_CURSOR_SIZE]
+  tool: SegmentationTool;
+  shape: SegmentationToolShape;
+  mode: SegmentationToolMode;
+}
+
+// ---------------------------------------------------------------------------
+// Atoms (internal)
+// ---------------------------------------------------------------------------
+
+const segmentationModeActiveAtom = atom<boolean>(false);
+const toolAtom = atom<SegmentationTool>(SegmentationTool.Select);
+const toolSizeAtom = atom<number>(DEFAULT_TOOL_SIZE);
+const toolShapeAtom = atom<SegmentationToolShape>(SegmentationToolShape.Circle);
+const toolModeAtom = atom<SegmentationToolMode>(DEFAULT_TOOL_MODE);
+
+// ---------------------------------------------------------------------------
+// Unsafe exports for non-React bridge access only.
+// ---------------------------------------------------------------------------
+
+/** @internal */ export { segmentationModeActiveAtom as _unsafeSegmentationModeActiveAtom };
+/** @internal */ export { toolAtom as _unsafeToolAtom };
+/** @internal */ export { toolSizeAtom as _unsafeToolSizeAtom };
+/** @internal */ export { toolShapeAtom as _unsafeToolShapeAtom };
+/** @internal */ export { toolModeAtom as _unsafeToolModeAtom };

--- a/app/packages/lighter/src/commands/PaintStrokeCommand.ts
+++ b/app/packages/lighter/src/commands/PaintStrokeCommand.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import type { Undoable } from "@fiftyone/commands";
+import type { MaskSnapshot } from "../overlay/MaskCanvas";
+import type { DetectionOverlay } from "../overlay/DetectionOverlay";
+import type { Rect } from "../types";
+
+/**
+ * Undoable command for a single paint stroke (pointer-down to pointer-up).
+ * Stores before/after canvas snapshots and overlay bounds so that undo
+ * restores pixel data and redo re-applies it, both synchronously.
+ */
+export class PaintStrokeCommand implements Undoable {
+  readonly id: string;
+
+  constructor(
+    private overlay: DetectionOverlay,
+    overlayId: string,
+    private beforeSnapshot: MaskSnapshot | undefined,
+    private beforeBounds: Rect | undefined,
+    private afterSnapshot: MaskSnapshot | undefined,
+    private afterBounds: Rect | undefined
+  ) {
+    this.id = `paint-${overlayId}-${Date.now()}`;
+  }
+
+  execute(): void {
+    this.overlay.restoreMaskSnapshot(this.afterSnapshot, this.afterBounds);
+  }
+
+  undo(): void {
+    this.overlay.restoreMaskSnapshot(this.beforeSnapshot, this.beforeBounds);
+  }
+}

--- a/app/packages/lighter/src/events/index.ts
+++ b/app/packages/lighter/src/events/index.ts
@@ -2,9 +2,10 @@
  * Copyright 2017-2026, Voxel51, Inc.
  */
 
-import type { Command } from "../commands/Command";
+import type { Undoable } from "@fiftyone/commands";
 import type { InteractionHandler } from "../interaction/InteractionManager";
 import type { BaseOverlay } from "../overlay/BaseOverlay";
+import type { PaintStrokeData } from "../overlay/MaskCanvas";
 import type { Point, Rect } from "../types";
 
 /**
@@ -35,7 +36,7 @@ export type LighterEventGroup = {
   "lighter:command-executed": {
     commandId: string;
     isUndoable: boolean;
-    command: Command;
+    command: Undoable;
   };
   /** Emitted when a command is undone (reversed) */
   "lighter:undo": { commandId: string };
@@ -115,6 +116,11 @@ export type LighterEventGroup = {
   "lighter:overlay-all-unhover": { point: Point };
   /** Emitted when the mouse moves while hovering over an overlay */
   "lighter:overlay-hover-move": { id: string; point: Point };
+  /** Emitted when a paint stroke (brush/eraser) ends */
+  "lighter:overlay-paint-end": {
+    id: string;
+    paintStrokeData: PaintStrokeData | undefined;
+  };
   /** Emitted when user clicks without dragging in detection mode to exit */
   "lighter:detection-mode-quit": { eventId: string };
 

--- a/app/packages/lighter/src/index.ts
+++ b/app/packages/lighter/src/index.ts
@@ -43,8 +43,12 @@ export type { ResourceLoader } from "./resource/ResourceLoader";
 export type { LighterEventGroup } from "./events";
 
 // Interaction exports
+export { buildBrushCursor } from "./interaction/buildBrushCursor";
 export { InteractionManager } from "./interaction/InteractionManager";
-export type { InteractionHandler } from "./interaction/InteractionManager";
+export type {
+  InteractionHandler,
+  OverlayEvent,
+} from "./interaction/InteractionManager";
 export { InteractiveDetectionHandler } from "./interaction/InteractiveDetectionHandler";
 export {
   InteractiveKeypointHandler,

--- a/app/packages/lighter/src/interaction/InteractionManager.ts
+++ b/app/packages/lighter/src/interaction/InteractionManager.ts
@@ -3,14 +3,17 @@
  */
 
 import { detectionModeBridge } from "@fiftyone/core/src/components/Modal/Sidebar/Annotate/Edit/bridgeDetectionMode";
+import { segmentationModeBridge } from "@fiftyone/core/src/components/Modal/Sidebar/Annotate/Edit/bridgeSegmentationMode";
+import type { SegmentationToolState } from "@fiftyone/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode";
 import { EventDispatcher, getEventBus } from "@fiftyone/events";
 import { TypeGuards } from "../core/Scene2D";
 import type { LighterEventGroup } from "../events";
 import type { BaseOverlay } from "../overlay/BaseOverlay";
-import { type MoveState } from "../overlay/DetectionOverlay";
+import { type InteractionState } from "../overlay/DetectionOverlay";
 import type { Renderer2D } from "../renderer/Renderer2D";
 import type { SelectionManager } from "../selection/SelectionManager";
 import type { Point, Rect } from "../types";
+import { buildBrushCursor } from "./buildBrushCursor";
 import { InteractiveDetectionHandler } from "./InteractiveDetectionHandler";
 import { InteractiveKeypointHandler } from "./InteractiveKeypointHandler";
 import { v4 as generateUUID } from "uuid";
@@ -30,6 +33,8 @@ export interface OverlayEvent {
   scale: number;
   /** Whether shift-key aspect-ratio lock is active. */
   maintainAspectRatio?: boolean;
+  /** Segmentation painting tool state, if segmentation mode is active. */
+  segmentationToolState?: SegmentationToolState;
 }
 
 /**
@@ -64,7 +69,7 @@ export interface InteractionHandler {
   /**
    * Returns true if the handler is being dragged or resized.
    */
-  isMoving?(): boolean;
+  isInteracting?(): boolean;
 
   /**
    * Returns true if the handler is being dragged.
@@ -91,7 +96,7 @@ export interface InteractionHandler {
   /**
    * Returns the current move state of the handler
    */
-  getMoveState?(): MoveState;
+  getInteractionState?(): InteractionState;
 
   /**
    * Returns the position from the start of handler movement
@@ -325,7 +330,15 @@ export class InteractionManager {
       }
     }
 
-    if (handler?.onPointerDown?.({ point, worldPoint, event, scale })) {
+    if (
+      handler?.onPointerDown?.({
+        point,
+        worldPoint,
+        event,
+        scale,
+        segmentationToolState: segmentationModeBridge.getToolState(scale),
+      })
+    ) {
       const cursor = handler.getCursor?.(worldPoint, scale);
       if (cursor) {
         this.canvas.style.cursor = cursor;
@@ -369,6 +382,10 @@ export class InteractionManager {
       !handler.isSelected()
     ) {
       this.canvas.style.cursor = "pointer";
+    } else if (segmentationModeBridge.isActive()) {
+      this.canvas.style.cursor = buildBrushCursor(
+        segmentationModeBridge.getToolState(scale)
+      );
     } else if (TypeGuards.isInteractionHandler(handler) && handler.getCursor) {
       this.canvas.style.cursor = handler.getCursor(worldPoint, scale);
     }
@@ -477,6 +494,7 @@ export class InteractionManager {
         event,
         scale,
         maintainAspectRatio: this.maintainAspectRatio,
+        segmentationToolState: segmentationModeBridge.getToolState(scale),
       };
 
       // Handle drag move
@@ -493,7 +511,7 @@ export class InteractionManager {
         handler.onMove?.(moveParams);
       }
 
-      if (handler.isMoving?.()) {
+      if (handler.isInteracting?.()) {
         // Emit move event with bounds information
         if (TypeGuards.isSpatial(handler)) {
           const type = handler.isDragging?.()
@@ -558,13 +576,19 @@ export class InteractionManager {
       handler = this.findMovingHandler() || this.findHandlerAtPoint(point);
     }
 
-    if (handler?.isMoving?.()) {
-      const moveState = handler.getMoveState?.();
+    if (handler?.isInteracting?.()) {
+      const interactionState = handler.getInteractionState?.();
       const startBounds = handler.getMoveStartBounds?.();
       const startPosition = handler.getMoveStartPosition?.();
 
       // Handle drag end
-      handler.onPointerUp?.({ point, worldPoint, event, scale });
+      handler.onPointerUp?.({
+        point,
+        worldPoint,
+        event,
+        scale,
+        segmentationToolState: segmentationModeBridge.getToolState(scale),
+      });
 
       if (interactiveHandler) {
         // When interactive detection is complete, remove the interactive handler
@@ -582,10 +606,10 @@ export class InteractionManager {
           bounds: handler.bounds,
         };
 
-        if (moveState === "SETTING") {
+        if (interactionState === "SETTING") {
           if (!interactiveHandler) {
             throw new Error(
-              "Invariant violation: moveState is SETTING but interactiveHandler is undefined"
+              "Invariant violation: interactionState is SETTING but interactiveHandler is undefined"
             );
           }
 
@@ -595,7 +619,7 @@ export class InteractionManager {
           });
         } else {
           const type =
-            moveState === "DRAGGING"
+            interactionState === "DRAGGING"
               ? "lighter:overlay-drag-end"
               : "lighter:overlay-resize-end";
           this.eventBus.dispatch(type, detail);
@@ -604,12 +628,18 @@ export class InteractionManager {
 
       this.canvas.releasePointerCapture(event.pointerId);
       event.preventDefault();
-    } else if (handler && !handler.isMoving?.()) {
+    } else if (handler && !handler.isInteracting?.()) {
       // This was a click, not a drag - handle as click for selection
       this.handleClick(point, event, now);
 
       // Clean up drag handler
-      handler.onPointerUp?.({ point, worldPoint, event, scale });
+      handler.onPointerUp?.({
+        point,
+        worldPoint,
+        event,
+        scale,
+        segmentationToolState: segmentationModeBridge.getToolState(scale),
+      });
       this.canvas.releasePointerCapture(event.pointerId);
     } else {
       // Handle click
@@ -1043,7 +1073,7 @@ export class InteractionManager {
    */
   findMovingHandler(): InteractionHandler | undefined {
     return this.handlers.find(
-      (handler) => handler.isMoving && handler.isMoving()
+      (handler) => handler.isInteracting && handler.isInteracting()
     );
   }
 

--- a/app/packages/lighter/src/interaction/InteractiveDetectionHandler.ts
+++ b/app/packages/lighter/src/interaction/InteractiveDetectionHandler.ts
@@ -55,7 +55,7 @@ export class InteractiveDetectionHandler implements InteractionHandler {
     return true;
   }
 
-  isMoving(): boolean {
+  isInteracting(): boolean {
     return this._isDragging;
   }
 

--- a/app/packages/lighter/src/interaction/InteractiveKeypointHandler.ts
+++ b/app/packages/lighter/src/interaction/InteractiveKeypointHandler.ts
@@ -77,7 +77,7 @@ export class InteractiveKeypointHandler implements InteractionHandler {
     this.overlay.markDirty();
   }
 
-  isMoving(): boolean {
+  isInteracting(): boolean {
     return false;
   }
 

--- a/app/packages/lighter/src/interaction/buildBrushCursor.ts
+++ b/app/packages/lighter/src/interaction/buildBrushCursor.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Generates a CSS cursor data-URL for the segmentation brush tool.
+ */
+
+import {
+  SegmentationTool,
+  SegmentationToolMode,
+  SegmentationToolShape,
+  type SegmentationToolState,
+} from "@fiftyone/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode";
+
+/**
+ * Returns a CSS `cursor` value (data-URL SVG + hotspot) for the given brush
+ * configuration.  Falls back to `"crosshair"` when the computed size is too
+ * small to render meaningfully.
+ */
+export function buildBrushCursor({
+  tool,
+  cursorSize,
+  shape,
+  mode,
+}: SegmentationToolState): string {
+  if (tool === SegmentationTool.Select) return "default";
+  if (tool === SegmentationTool.Pen) return "crosshair";
+  if (tool === SegmentationTool.AI) return "crosshair";
+
+  const isRemove = mode === SegmentationToolMode.Remove;
+  const dashColor = isRemove ? "red" : "black";
+
+  const half = cursorSize / 2;
+  const pad = 2;
+  const svgSize = cursorSize + pad * 2;
+  const center = half + pad;
+
+  let shapeMarkup: string;
+
+  if (shape === "square") {
+    shapeMarkup =
+      `<rect x="${pad}" y="${pad}" width="${cursorSize}" height="${cursorSize}" fill="none" stroke="white" stroke-width="1.5"/>` +
+      `<rect x="${pad}" y="${pad}" width="${cursorSize}" height="${cursorSize}" fill="none" stroke="${dashColor}" stroke-width="1.5" stroke-dasharray="3,3"/>`;
+  } else {
+    shapeMarkup =
+      `<circle cx="${center}" cy="${center}" r="${half}" fill="none" stroke="white" stroke-width="1.5"/>` +
+      `<circle cx="${center}" cy="${center}" r="${half}" fill="none" stroke="${dashColor}" stroke-width="1.5" stroke-dasharray="3,3"/>`;
+  }
+
+  let removeMarkup = "";
+
+  if (isRemove) {
+    // Slash from bottom-left to top-right, edge to edge
+    let x1: number, y1: number, x2: number, y2: number;
+    if (shape === SegmentationToolShape.Square) {
+      x1 = pad;
+      y1 = pad + cursorSize;
+      x2 = pad + cursorSize;
+      y2 = pad;
+    } else {
+      const diag = half * Math.SQRT1_2;
+      x1 = center - diag;
+      y1 = center + diag;
+      x2 = center + diag;
+      y2 = center - diag;
+    }
+
+    removeMarkup =
+      `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="white" stroke-width="1.5" stroke-dasharray="3,3" stroke-dashoffset="3"/>` +
+      `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="red" stroke-width="1.5" stroke-dasharray="3,3"/>`;
+  }
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${svgSize}" height="${svgSize}">${shapeMarkup}${removeMarkup}</svg>`;
+
+  return `url("data:image/svg+xml,${encodeURIComponent(
+    svg
+  )}") ${center} ${center}, crosshair`;
+}

--- a/app/packages/lighter/src/overlay/DetectionOverlay.ts
+++ b/app/packages/lighter/src/overlay/DetectionOverlay.ts
@@ -11,6 +11,10 @@ import {
   SELECTED_DASH_LENGTH,
   STROKE_WIDTH,
 } from "../constants";
+import {
+  SegmentationTool,
+  type SegmentationToolState,
+} from "@fiftyone/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode";
 import { CONTAINS } from "../core/Scene2D";
 import type { OverlayEvent } from "../interaction/InteractionManager";
 import type { Renderer2D } from "../renderer/Renderer2D";
@@ -31,6 +35,7 @@ import {
 import { distanceFromLineSegment } from "../utils/geometry";
 import { BaseOverlay } from "./BaseOverlay";
 import { MaskCanvas } from "./MaskCanvas";
+import type { MaskSnapshot, PaintStrokeData } from "./MaskCanvas";
 import type { SerializedMask } from "@fiftyone/utilities";
 import { BASE_ALPHA } from "@fiftyone/looker/src/constants";
 
@@ -65,7 +70,12 @@ export type ResizeRegion =
   | "RESIZE_W"
   | "RESIZE_NW";
 
-export type MoveState = ResizeRegion | "NONE" | "DRAGGING" | "SETTING";
+export type InteractionState =
+  | ResizeRegion
+  | "NONE"
+  | "DRAGGING"
+  | "SETTING"
+  | "PAINTING";
 
 export const NO_BOUNDS = { x: NaN, y: NaN, width: NaN, height: NaN };
 
@@ -78,7 +88,8 @@ export class DetectionOverlay
 {
   private isDraggable: boolean;
   private isResizeable: boolean;
-  private moveState: MoveState = "NONE";
+  private interactionState: InteractionState = "NONE";
+  private segmentationTool?: SegmentationToolState;
   private moveStartPoint?: Point;
   private moveStartPosition?: Point;
   private moveStartBounds?: Rect;
@@ -179,7 +190,7 @@ export class DetectionOverlay
     return this.id;
   }
 
-  protected renderImpl(renderer: Renderer2D, _renderMeta: RenderMeta): void {
+  protected renderImpl(renderer: Renderer2D, renderMeta: RenderMeta): void {
     // Dispose of old elements before creating new ones
     renderer.dispose(this.containerId);
 
@@ -189,14 +200,38 @@ export class DetectionOverlay
 
     // Draw the segmentation mask beneath the box outline when available.
     const maskColor = style.strokeStyle || style.fillStyle || "#ffffff";
+    const isEditingMask = this.isSelected() && this.hasMask();
+
     this.mask?.render(
       renderer,
       this.bounds,
       this.containerId,
       maskColor,
-      style.opacity ?? BASE_ALPHA,
+      isEditingMask ? 0.7 : style.opacity ?? BASE_ALPHA,
       () => this.markDirty()
     );
+
+    // Lightweight border + scrim when editing detection mask
+    if (isEditingMask) {
+      renderer.drawScrim(
+        this.bounds,
+        renderMeta.canonicalMediaBounds,
+        this.containerId
+      );
+
+      renderer.drawRect(
+        this.bounds,
+        {
+          strokeStyle: style.strokeStyle || "#ffffff",
+          lineWidth: 1,
+          dashPattern: [4, 4],
+        },
+        this.containerId
+      );
+
+      this.emitLoaded();
+      return;
+    }
 
     // Check if this label has an instance to determine stroke styling
     const hasInstance = this.label?.instance?._id !== undefined;
@@ -259,7 +294,7 @@ export class DetectionOverlay
       const color = colorObj.color;
       renderer.drawScrim(
         this.bounds,
-        _renderMeta.canonicalMediaBounds,
+        renderMeta.canonicalMediaBounds,
         this.containerId
       );
       renderer.drawHandles(
@@ -317,24 +352,28 @@ export class DetectionOverlay
     return this.moveStartBounds;
   }
 
-  getMoveState() {
-    return this.moveState;
+  getInteractionState() {
+    return this.interactionState;
   }
 
-  isMoving() {
-    return this.moveState !== "NONE";
+  isInteracting() {
+    return this.interactionState !== "NONE";
   }
 
   isDragging() {
-    return this.moveState === "DRAGGING";
+    return this.interactionState === "DRAGGING";
   }
 
   isResizing() {
-    return this.moveState.startsWith("RESIZE_");
+    return this.interactionState.startsWith("RESIZE_");
   }
 
   isSetting() {
-    return this.moveState === "SETTING";
+    return this.interactionState === "SETTING";
+  }
+
+  isPainting() {
+    return this.interactionState === "PAINTING";
   }
 
   private getResizeRegion(
@@ -369,7 +408,9 @@ export class DetectionOverlay
 
   getCursor(worldPoint: Point, scale: number): string {
     if (!this.hasValidBounds()) return "crosshair";
+    if (this.isPaintingActive()) return "crosshair";
     if (!this.isSelected()) return "pointer";
+    if (this.hasMask()) return "default";
 
     if (!this.isDraggable && !this.isResizeable) {
       return "default";
@@ -408,7 +449,26 @@ export class DetectionOverlay
   }
 
   // Interaction handlers
-  onPointerDown({ point, worldPoint, scale }: OverlayEvent): boolean {
+  onPointerDown({
+    point,
+    worldPoint,
+    scale,
+    segmentationToolState,
+  }: OverlayEvent): boolean {
+    this.segmentationTool = segmentationToolState;
+
+    // Segmentation painting takes priority over drag/resize
+    if (this.isPaintingActive()) {
+      return this.onSegmentationPointerDown(
+        point,
+        worldPoint,
+        segmentationToolState!
+      );
+    }
+
+    // Mask detections are painted, not dragged/resized
+    if (this.hasMask()) return false;
+
     const resizeRegion = this.getResizeRegion(worldPoint, scale);
     const cursorState = !this.hasValidBounds()
       ? "SETTING"
@@ -421,7 +481,7 @@ export class DetectionOverlay
       this.renderer?.disableZoomPan();
     }
 
-    this.moveState = cursorState;
+    this.interactionState = cursorState;
 
     if (cursorState === "SETTING") {
       this.bounds = {
@@ -442,21 +502,104 @@ export class DetectionOverlay
     return true;
   }
 
+  private onSegmentationPointerDown(
+    point: Point,
+    worldPoint: Point,
+    toolState: SegmentationToolState
+  ): boolean {
+    if (!this.hasValidBounds()) {
+      // Bootstrap bounds from the brush dab so the canvas has a size
+      const size = toolState?.size ?? 0;
+      const half = size / 2;
+
+      this.bounds = {
+        x: worldPoint.x - half,
+        y: worldPoint.y - half,
+        width: size,
+        height: size,
+      };
+    }
+
+    this.mask ??= new MaskCanvas(this.label.mask);
+
+    const updatedBounds = this.mask.paintAt(
+      worldPoint,
+      this.bounds,
+      toolState,
+      this.currentStyle
+    );
+
+    if (updatedBounds) {
+      this.bounds = updatedBounds;
+      this.interactionState = "PAINTING";
+      this.moveStartPoint = point;
+      this.moveStartPosition = {
+        x: this.bounds.x,
+        y: this.bounds.y,
+      };
+      this.moveStartBounds = { ...this.bounds };
+      this.markDirty();
+      this.renderer?.disableZoomPan();
+    } else {
+      this.bounds = undefined;
+    }
+
+    return true;
+  }
+
   onMove({
     point,
+    worldPoint,
     event,
     scale,
     maintainAspectRatio,
+    segmentationToolState,
   }: OverlayEvent): boolean {
-    if (this.moveState === "DRAGGING") {
+    this.segmentationTool = segmentationToolState;
+
+    if (this.interactionState === "PAINTING") {
+      return this.onSegmentationMove(point, worldPoint, segmentationToolState);
+    }
+
+    if (this.interactionState === "DRAGGING") {
       return this.onDrag(point, event, scale);
     }
 
-    if (this.moveState === "SETTING" || this.moveState.startsWith("RESIZE_")) {
+    if (this.interactionState === "SETTING" || this.interactionState.startsWith("RESIZE_")) {
       return this.onResize(point, event, scale, maintainAspectRatio);
     }
 
     return false;
+  }
+
+  private onSegmentationMove(
+    point: Point,
+    worldPoint: Point,
+    toolState: SegmentationToolState | undefined
+  ): boolean {
+    const updatedBounds = this.mask?.paintAt(
+      worldPoint,
+      this.bounds,
+      toolState!,
+      this.currentStyle
+    );
+
+    if (updatedBounds) {
+      this.bounds = updatedBounds;
+      this.interactionState = "PAINTING";
+      this.moveStartPoint = point;
+      this.moveStartPosition = {
+        x: this.bounds.x,
+        y: this.bounds.y,
+      };
+      this.moveStartBounds = { ...this.bounds };
+      this.markDirty();
+      this.renderer?.disableZoomPan();
+    } else {
+      this.bounds = undefined;
+    }
+
+    return true;
   }
 
   private onDrag(point: Point, _event: PointerEvent, scale: number): boolean {
@@ -512,55 +655,55 @@ export class DetectionOverlay
 
     let { x, y, width, height } = this.moveStartBounds;
 
-    if (["RESIZE_NW", "RESIZE_N", "RESIZE_NE"].includes(this.moveState)) {
-      maintainY = this.moveState === "RESIZE_NE" ? maintainY * -1 : maintainY;
-      maintainY = this.moveState === "RESIZE_E" ? 0 : maintainY;
+    if (["RESIZE_NW", "RESIZE_N", "RESIZE_NE"].includes(this.interactionState)) {
+      maintainY = this.interactionState === "RESIZE_NE" ? maintainY * -1 : maintainY;
+      maintainY = this.interactionState === "RESIZE_E" ? 0 : maintainY;
 
       y += maintainY || delta.y;
       height -= maintainY || delta.y;
 
-      if (this.moveState === "RESIZE_N") {
+      if (this.interactionState === "RESIZE_N") {
         x += maintainX / 2;
         width -= maintainX;
       }
     }
 
     if (
-      ["SETTING", "RESIZE_NW", "RESIZE_W", "RESIZE_SW"].includes(this.moveState)
+      ["SETTING", "RESIZE_NW", "RESIZE_W", "RESIZE_SW"].includes(this.interactionState)
     ) {
-      maintainX = this.moveState === "RESIZE_SW" ? maintainX * -1 : maintainX;
-      maintainX = this.moveState === "RESIZE_W" ? 0 : maintainX;
+      maintainX = this.interactionState === "RESIZE_SW" ? maintainX * -1 : maintainX;
+      maintainX = this.interactionState === "RESIZE_W" ? 0 : maintainX;
 
       x += maintainX || delta.x;
       width -= maintainX || delta.x;
 
-      if (this.moveState === "RESIZE_W") {
+      if (this.interactionState === "RESIZE_W") {
         y += maintainY / 2;
         height -= maintainY;
       }
     }
 
     if (
-      ["SETTING", "RESIZE_SW", "RESIZE_S", "RESIZE_SE"].includes(this.moveState)
+      ["SETTING", "RESIZE_SW", "RESIZE_S", "RESIZE_SE"].includes(this.interactionState)
     ) {
-      maintainY = this.moveState === "RESIZE_SW" ? maintainY * -1 : maintainY;
-      maintainY = this.moveState === "RESIZE_S" ? 0 : maintainY;
+      maintainY = this.interactionState === "RESIZE_SW" ? maintainY * -1 : maintainY;
+      maintainY = this.interactionState === "RESIZE_S" ? 0 : maintainY;
 
       height += maintainY || delta.y;
 
-      if (this.moveState === "RESIZE_S") {
+      if (this.interactionState === "RESIZE_S") {
         x -= maintainX / 2;
         width += maintainX;
       }
     }
 
-    if (["RESIZE_NE", "RESIZE_E", "RESIZE_SE"].includes(this.moveState)) {
-      maintainX = this.moveState === "RESIZE_NE" ? maintainX * -1 : maintainX;
-      maintainX = this.moveState === "RESIZE_E" ? 0 : maintainX;
+    if (["RESIZE_NE", "RESIZE_E", "RESIZE_SE"].includes(this.interactionState)) {
+      maintainX = this.interactionState === "RESIZE_NE" ? maintainX * -1 : maintainX;
+      maintainX = this.interactionState === "RESIZE_E" ? 0 : maintainX;
 
       width += maintainX || delta.x;
 
-      if (this.moveState === "RESIZE_E") {
+      if (this.interactionState === "RESIZE_E") {
         y -= maintainY / 2;
         height += maintainY;
       }
@@ -587,14 +730,30 @@ export class DetectionOverlay
     return true;
   }
 
-  onPointerUp(_params: OverlayEvent): boolean {
+  onPointerUp({ segmentationToolState }: OverlayEvent): boolean {
+    this.segmentationTool = segmentationToolState;
+
     if (!this.moveStartPoint || !this.moveStartBounds) return false;
 
-    this.moveState = "NONE";
+    const wasPainting = this.interactionState === "PAINTING";
+
+    this.interactionState = "NONE";
+    if (wasPainting) {
+      this.mask?.paintEnd(this.bounds, () => {
+        this.markDirty();
+      });
+    }
     this.moveStartPoint = undefined;
     this.moveStartPosition = undefined;
     this.moveStartBounds = undefined;
     this.renderer?.enableZoomPan();
+
+    if (wasPainting) {
+      this.eventBus.dispatch("lighter:overlay-paint-end", {
+        id: this.id,
+        paintStrokeData: this.mask?.getPaintStrokeData(),
+      });
+    }
 
     return true;
   }
@@ -657,7 +816,7 @@ export class DetectionOverlay
     if (this.isPointInRect(point, drawnBounds)) {
       // For mask detections, narrow CONTENT to actual mask pixels so the
       // hit area matches the painted shape rather than the bbox rectangle.
-      if (!!this.mask) {
+      if (this.hasMask()) {
         return this.mask!.containsMaskPixel(point, this.bounds)
           ? CONTAINS.CONTENT
           : CONTAINS.NONE;
@@ -780,11 +939,80 @@ export class DetectionOverlay
    * the rectangular bounding box.
    */
   override containsPoint(point: Point): boolean {
-    if (!!this.mask && this.renderer) {
+    if (this.hasMask() && this.renderer) {
       const worldPoint = this.renderer.screenToWorld(point);
       return this.mask!.containsMaskPixel(worldPoint, this.bounds);
     }
     return super.containsPoint(point);
+  }
+
+  /**
+   * Returns true if this detection has a mask (inline or editing canvas).
+   */
+  hasMask(): boolean {
+    return !!this.mask;
+  }
+
+  /**
+   * Initializes an empty MaskCanvas so the overlay is treated as a mask
+   * detection (no resize handles, etc.) before any paint occurs.
+   */
+  initMask(): void {
+    if (!this.mask) {
+      this.mask = new MaskCanvas();
+      this.markDirty();
+    }
+  }
+
+  /**
+   * Removes the mask from this detection, destroying the MaskCanvas.
+   */
+  removeMask(): void {
+    this.mask?.destroy();
+    this.mask = undefined;
+    this.markDirty();
+  }
+
+  /**
+   * Whether segmentation brush should intercept pointer events.
+   */
+  private isPaintingActive(): boolean {
+    if (!this.segmentationTool?.active) return false;
+    return this.segmentationTool.tool === SegmentationTool.Brush;
+  }
+
+  /**
+   * Consumes and returns the pending encoded mask, if any. After calling,
+   * the pending mask is cleared.
+   */
+  getPendingMask(): string | undefined {
+    return this.mask?.getPendingMask();
+  }
+
+  /**
+   * Returns the mask as a drawable source for sidebar preview rendering.
+   */
+  getMaskPreviewSource(): HTMLCanvasElement | ImageBitmap | undefined {
+    return this.mask?.getPreviewSource();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Segmentation undo/redo support
+  // ---------------------------------------------------------------------------
+
+  getPaintStrokeData(): PaintStrokeData | undefined {
+    return this.mask?.getPaintStrokeData();
+  }
+
+  restoreMaskSnapshot(
+    snapshot: MaskSnapshot | undefined,
+    bounds: Rect | undefined
+  ): void {
+    this.mask ??= new MaskCanvas();
+
+    this.mask.restoreSnapshot(snapshot);
+    this.bounds = bounds;
+    this.markDirty();
   }
 
   override destroy(): void {

--- a/app/packages/lighter/src/overlay/MaskCanvas.ts
+++ b/app/packages/lighter/src/overlay/MaskCanvas.ts
@@ -2,18 +2,54 @@
  * Copyright 2017-2026, Voxel51, Inc.
  */
 
+import {
+  SegmentationToolMode,
+  SegmentationToolShape,
+  type SegmentationToolState,
+} from "@fiftyone/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode";
 import type { SerializedMask } from "@fiftyone/utilities";
 import type { Renderer2D } from "../renderer/Renderer2D";
-import type { Point, Rect } from "../types";
-import { decodeMask } from "../utils";
+import type { DrawStyle, Point, Rect } from "../types";
+import { parseColorToRGBA } from "../utils/color";
+import {
+  createMaskCanvas,
+  decodeMask,
+  encodeMask,
+  maskBounds,
+  type MaskBounds,
+} from "../utils";
+
+export interface MaskSnapshot {
+  imageData: ImageData;
+  width: number;
+  height: number;
+}
+
+export interface PaintStrokeData {
+  afterBounds: Rect | undefined;
+  afterSnapshot: MaskSnapshot | undefined;
+  beforeBounds: Rect | undefined;
+  beforeSnapshot: MaskSnapshot | undefined;
+}
 
 /**
- * Manages mask decoding and rendering for a detection overlay. Owns the
- * decoded bitmap and the single-channel pixel buffer used for hit-testing.
+ * Manages mask decoding, rendering, and interactive painting for a
+ * detection overlay. Owns the decoded bitmap, the mutable editing canvas,
+ * and all painting helpers.
+ *
+ * ## Lifecycle
+ *
+ * The mask has two phases: display and editing. Transitioning to editing
+ * (via `ensureCanvas`) is a one-way door — the display-only fields are
+ * released and the canvas becomes the source of truth.
  *
  * ```
- * rawMaskData ──(decodeMask)──> maskBitmap   (color-painted, for rendering)
- *                               rawPixels    (single-channel, for hit-testing)
+ * Display phase
+ *   rawMaskData ──(decodeMask)──> maskBitmap   (color-painted, for rendering)
+ *                                 rawPixels    (single-channel, for hit-testing)
+ *
+ * Editing phase  (ensureCanvas — copies bitmap into canvas, then releases it)
+ *   canvas ──(encodeMask)──> pendingMask  (base64, for backend persistence)
  * ```
  */
 export class MaskCanvas {
@@ -28,6 +64,22 @@ export class MaskCanvas {
 
   /** Raw single-channel pixel data for hit-testing via containsMaskPixel(). */
   private rawPixels?: { src: Uint8Array; width: number; height: number };
+
+  // canvas contents encoded for persistence to backend
+  private pendingMask?: string;
+
+  // ---- Editing canvas state ----
+  private canvas?: HTMLCanvasElement;
+  private context?: CanvasRenderingContext2D;
+  private lastPoint?: Point;
+  private currentColor?: string;
+  private lastColor?: string;
+
+  // ---- snapshots for undo/redo ----
+  private preStrokeSnapshot?: MaskSnapshot;
+  private preStrokeBounds?: Rect;
+  private postStrokeSnapshot?: MaskSnapshot;
+  private postStrokeBounds?: Rect;
 
   constructor(maskData?: SerializedMask) {
     this.rawMaskData = MaskCanvas.extractB64(maskData);
@@ -45,8 +97,9 @@ export class MaskCanvas {
 
   /**
    * Replaces the raw mask source data. Returns true if the source actually
-   * changed (caller should markDirty). Drops all derived state so subsequent
-   * renders / hit-tests reflect the new source.
+   * changed (caller should markDirty). Drops all derived state — decoded
+   * bitmap, raw pixels, editing canvas, undo snapshots — so that subsequent
+   * renders / hit-tests reflect the new source rather than a stale canvas.
    */
   updateSource(mask?: SerializedMask): boolean {
     const b64 = MaskCanvas.extractB64(mask);
@@ -58,15 +111,36 @@ export class MaskCanvas {
   }
 
   /**
-   * Tears down all derived state (bitmap, raw pixels, decoded-color cache)
-   * and the source data. Leaves the instance usable but empty.
+   * Tears down all derived state (bitmap, raw pixels, editing canvas, undo
+   * snapshots, pending encode) and the source data. Leaves the instance
+   * usable but empty; the next render decodes from a fresh `rawMaskData` if
+   * one is set afterward.
    */
   private reset(): void {
     this.maskBitmap?.close();
     this.maskBitmap = undefined;
     this.rawMaskData = undefined;
     this.rawPixels = undefined;
+
+    this.canvas = undefined;
+    this.context = undefined;
+    this.pendingMask = undefined;
+
     this.decodedColor = undefined;
+    this.lastColor = undefined;
+    this.lastPoint = undefined;
+
+    this.preStrokeSnapshot = undefined;
+    this.preStrokeBounds = undefined;
+    this.postStrokeSnapshot = undefined;
+    this.postStrokeBounds = undefined;
+  }
+
+  /**
+   * Returns true if a mask is available for rendering (editing canvas or decoded bitmap).
+   */
+  private hasRenderable(): boolean {
+    return this.canvas != null || this.maskBitmap != null;
   }
 
   /**
@@ -77,7 +151,7 @@ export class MaskCanvas {
   private decodeMaskIfNeeded(color: string, onDecoded?: () => void): void {
     if (!this.rawMaskData || this.decoding) return;
 
-    // Already decoded with this color
+    // Already decoded with this color and raw pixels are available
     if (this.maskBitmap && this.decodedColor === color) return;
 
     // Snapshot the source so a concurrent updateSource() can invalidate this
@@ -113,8 +187,9 @@ export class MaskCanvas {
   }
 
   /**
-   * Draws the mask within the given bounds. Triggers lazy decode on first
-   * call when color is known.
+   * Draws the mask within the given bounds.
+   * Prefers the mutable editing canvas over the decoded bitmap.
+   * Triggers lazy decode on first call when color is known.
    */
   render(
     renderer: Renderer2D,
@@ -124,16 +199,93 @@ export class MaskCanvas {
     opacity: number,
     onDecoded?: () => void
   ): void {
+    this.currentColor = color;
     this.decodeMaskIfNeeded(color, onDecoded);
 
-    if (!this.maskBitmap) return;
+    if (!this.hasRenderable()) return;
 
-    renderer.drawImage(
-      { type: "bitmap", bitmap: this.maskBitmap },
-      bounds,
-      { opacity },
-      containerId
-    );
+    if (this.canvas) {
+      // When the overlay color first becomes available or changes, rebuild the
+      // canvas so every pixel is recolored and alpha-thresholded in one pass.
+      if (this.currentColor !== this.lastColor) {
+        this.updateCanvas(this.canvas.width, this.canvas.height);
+      }
+
+      renderer.drawImage(
+        { type: "canvas", canvas: this.canvas },
+        bounds,
+        { opacity },
+        containerId
+      );
+
+      return;
+    }
+
+    if (this.maskBitmap) {
+      renderer.drawImage(
+        { type: "bitmap", bitmap: this.maskBitmap },
+        bounds,
+        { opacity },
+        containerId
+      );
+
+      return;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Editing canvas lifecycle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Lazily creates (or reuses) the mask editing canvas.
+   * Always sizes the canvas to match the detection bounds so that
+   * canvas pixels map 1:1 with sample. When seeding from a
+   * decoded bitmap, the bitmap is drawn scaled to fill the canvas.
+   */
+  private ensureCanvas(bounds: Rect): void {
+    if (this.canvas) return;
+
+    const width = Math.max(1, Math.round(bounds.width));
+    const height = Math.max(1, Math.round(bounds.height));
+
+    const { maskCanvas, maskContext } = createMaskCanvas(width, height);
+
+    this.canvas = maskCanvas;
+    this.context = maskContext;
+
+    if (this.maskBitmap) {
+      this.context.drawImage(this.maskBitmap, 0, 0, width, height);
+      this.maskBitmap.close();
+      this.maskBitmap = undefined;
+    }
+
+    this.rawMaskData = undefined;
+    this.decodedColor = undefined;
+  }
+
+  /**
+   * Clears the mask editing canvas contents.
+   */
+  clearCanvas(): void {
+    if (this.context && this.canvas) {
+      this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    }
+  }
+
+  getPendingMask(): string | undefined {
+    const mask = this.pendingMask;
+    this.pendingMask = undefined;
+
+    return mask;
+  }
+
+  /**
+   * Returns the current mask as a drawable source for sidebar preview.
+   * Prefers the editing canvas (most up-to-date), falls back to decoded bitmap.
+   */
+  getPreviewSource(): HTMLCanvasElement | ImageBitmap | undefined {
+    return this.canvas ?? this.maskBitmap;
   }
 
   /**
@@ -161,6 +313,435 @@ export class MaskCanvas {
 
     return src[py * width + px] > 0;
   }
+
+  // ---------------------------------------------------------------------------
+  // Painting
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Captures the canvas state and bounds before a stroke begins.
+   */
+  private paintStart(bounds: Rect): void {
+    this.preStrokeSnapshot = this.takeSnapshot();
+    this.preStrokeBounds = { ...bounds };
+  }
+
+  /**
+   * Converts a world-space point to mask-pixel coordinates.
+   */
+  private worldToMask(worldPoint: Point, bounds: Rect): Point | undefined {
+    if (
+      !bounds ||
+      bounds.width <= 0 ||
+      bounds.height <= 0 ||
+      !Number.isFinite(bounds.width) ||
+      !Number.isFinite(bounds.height) ||
+      !this.canvas
+    ) {
+      return undefined;
+    }
+
+    return {
+      x: ((worldPoint.x - bounds.x) / bounds.width) * this.canvas.width,
+      y: ((worldPoint.y - bounds.y) / bounds.height) * this.canvas.height,
+    };
+  }
+
+  private paint(
+    point: Point,
+    toolState: SegmentationToolState,
+    style: DrawStyle | undefined
+  ) {
+    if (!this.context) return;
+
+    const size = toolState.size ?? 0;
+    const shape = toolState.shape ?? SegmentationToolShape.Circle;
+    const radius = size / 2;
+
+    if (toolState.mode === SegmentationToolMode.Remove) {
+      this.context.globalCompositeOperation = "destination-out";
+      this.context.fillStyle = "rgba(0,0,0,1)";
+    } else {
+      this.context.globalCompositeOperation = "source-over";
+      this.context.fillStyle =
+        style?.strokeStyle ||
+        style?.fillStyle ||
+        this.currentColor ||
+        "#ffffff";
+    }
+
+    this.context.beginPath();
+    if (shape === SegmentationToolShape.Circle) {
+      this.context.arc(point.x, point.y, radius, 0, Math.PI * 2);
+    } else {
+      this.context.rect(point.x - radius, point.y - radius, size, size);
+    }
+    this.context.fill();
+  }
+
+  /**
+   * Paints a single dab at the given mask-pixel coordinate.
+   */
+  paintAt(
+    worldPoint: Point,
+    bounds: Rect,
+    toolState: SegmentationToolState,
+    style: DrawStyle | undefined
+  ): Rect | undefined {
+    this.ensureCanvas(bounds);
+
+    if (!this.preStrokeSnapshot) {
+      this.paintStart(bounds);
+    }
+
+    // Compute dab extent: add mode expands bounds, remove mode does not
+    let minX = bounds.x;
+    let minY = bounds.y;
+    let maxX = bounds.x + bounds.width;
+    let maxY = bounds.y + bounds.height;
+
+    if (toolState.mode === SegmentationToolMode.Add) {
+      const half = (toolState.size ?? 0) / 2;
+      minX = Math.min(minX, worldPoint.x - half);
+      minY = Math.min(minY, worldPoint.y - half);
+      maxX = Math.max(maxX, worldPoint.x + half);
+      maxY = Math.max(maxY, worldPoint.y + half);
+    }
+
+    const updatedBounds = this.updateBounds(bounds, { minX, minY, maxX, maxY });
+    const maskPoint = this.worldToMask(worldPoint, updatedBounds ?? bounds);
+
+    if (maskPoint) {
+      const lastPoint = this.lastPoint;
+      this.lastPoint = maskPoint;
+
+      if (lastPoint) {
+        this.paintLine(lastPoint, maskPoint, toolState, style);
+      } else {
+        this.paint(maskPoint, toolState, style);
+      }
+    }
+
+    return updatedBounds;
+  }
+
+  /**
+   * Fills a closed polygon region on the mask canvas.
+   * Uses the current paint mode (add paints, remove subtracts).
+   */
+  fillPolygon(
+    worldPoints: Point[],
+    bounds: Rect,
+    toolState: SegmentationToolState,
+    style: DrawStyle | undefined
+  ): Rect | undefined {
+    if (worldPoints.length < 3) return undefined;
+
+    this.ensureCanvas(bounds);
+    if (!this.context) return undefined;
+
+    if (!this.preStrokeSnapshot) {
+      this.paintStart(bounds);
+    }
+
+    // Compute polygon extent: add mode expands to contain all points
+    let minX = bounds.x;
+    let minY = bounds.y;
+    let maxX = bounds.x + bounds.width;
+    let maxY = bounds.y + bounds.height;
+
+    if (toolState.mode === SegmentationToolMode.Add) {
+      for (const wp of worldPoints) {
+        minX = Math.min(minX, wp.x);
+        minY = Math.min(minY, wp.y);
+        maxX = Math.max(maxX, wp.x);
+        maxY = Math.max(maxY, wp.y);
+      }
+    }
+
+    const updatedBounds = this.updateBounds(bounds, { minX, minY, maxX, maxY });
+    const activeBounds = updatedBounds ?? bounds;
+
+    // Convert world points to mask-pixel coords
+    const maskPoints = worldPoints
+      .map((wp) => this.worldToMask(wp, activeBounds))
+      .filter((p): p is Point => p !== undefined);
+
+    if (maskPoints.length < 3) return undefined;
+
+    if (toolState.mode === SegmentationToolMode.Remove) {
+      this.context.globalCompositeOperation = "destination-out";
+      this.context.fillStyle = "rgba(0,0,0,1)";
+    } else {
+      this.context.globalCompositeOperation = "source-over";
+      this.context.fillStyle =
+        style?.strokeStyle ||
+        style?.fillStyle ||
+        this.currentColor ||
+        "#ffffff";
+    }
+
+    this.context.beginPath();
+    this.context.moveTo(maskPoints[0].x, maskPoints[0].y);
+    for (let i = 1; i < maskPoints.length; i++) {
+      this.context.lineTo(maskPoints[i].x, maskPoints[i].y);
+    }
+    this.context.closePath();
+    this.context.fill();
+
+    return updatedBounds;
+  }
+
+  paintEnd(bounds: Rect, onEncoded?: () => void) {
+    if (!this.canvas) return;
+
+    this.lastPoint = undefined;
+
+    // Rebuild the canvas to recolor + threshold anti-aliased edge pixels
+    // before the snapshot and encode.
+    this.updateCanvas(this.canvas.width, this.canvas.height);
+
+    this.postStrokeBounds = { ...bounds };
+    this.postStrokeSnapshot = this.takeSnapshot();
+
+    // Refresh single-channel mask data so hit-testing reflects the edit.
+    this.updateRawPixelsFromCanvas();
+
+    const capturedCanvas = this.canvas;
+    encodeMask(capturedCanvas)
+      .then((encoded) => {
+        if (this.canvas !== capturedCanvas) return;
+        this.pendingMask = encoded;
+        onEncoded?.();
+      })
+      .catch((err) => {
+        console.error("[MaskCanvas] paintEnd encode failed:", err);
+      });
+  }
+
+  getPaintStrokeData(): PaintStrokeData {
+    const paintStrokeData = {
+      afterBounds: this.postStrokeBounds,
+      afterSnapshot: this.postStrokeSnapshot,
+      beforeBounds: this.preStrokeBounds,
+      beforeSnapshot: this.preStrokeSnapshot,
+    };
+
+    this.postStrokeBounds = undefined;
+    this.postStrokeSnapshot = undefined;
+    this.preStrokeBounds = undefined;
+    this.preStrokeSnapshot = undefined;
+
+    return paintStrokeData;
+  }
+
+  /**
+   * Interpolates between two mask-pixel points, painting a dab at each step
+   * to avoid gaps during fast mouse movement.
+   */
+  paintLine(
+    from: Point,
+    to: Point,
+    tool: SegmentationToolState,
+    style: DrawStyle | undefined
+  ): void {
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+    const distance = Math.hypot(dx, dy);
+    const steps = Math.max(1, Math.ceil(distance));
+
+    for (let i = 0; i <= steps; i++) {
+      const t = i / steps;
+      this.paint({ x: from.x + dx * t, y: from.y + dy * t }, tool, style);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Bounds recomputation
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Returns the tight inclusive bounding box of opaque pixels on the editing
+   * canvas, in canvas-pixel coordinates. Returns `null` when no canvas exists
+   * yet, or when the canvas is fully transparent.
+   *
+   * @see {@link maskBounds} for the shape of the returned box.
+   */
+  private getBounds(): MaskBounds | null {
+    if (!this.canvas || !this.context) return null;
+
+    const { width, height } = this.canvas;
+    return maskBounds(this.context.getImageData(0, 0, width, height));
+  }
+
+  /**
+   * Allocates a new canvas, copies existing pixels into it, and recolors
+   * every non-transparent pixel to {@link currentColor} while snapping alpha
+   * to 0 or 255.  This serves double duty:
+   *
+   * 1. Resizing the canvas when the mask bounds expand during painting.
+   * 2. Correcting wrong-colored pixels and eliminating anti-aliased edges
+   *    produced by Canvas 2D path drawing (arc/fill always anti-alias).
+   */
+  private updateCanvas(
+    width: number,
+    height: number,
+    offsetX = 0,
+    offsetY = 0
+  ) {
+    const { maskCanvas, maskContext } = createMaskCanvas(width, height);
+
+    if (this.canvas && this.context) {
+      const { width, height } = this.canvas;
+      const imageData = this.context.getImageData(0, 0, width, height);
+
+      // Recolor + threshold: snap every non-transparent pixel to the
+      // overlay color with full alpha, eliminating anti-aliased fringes
+      // and correcting any pixels painted before the color was known.
+      if (this.currentColor) {
+        const { r, g, b } = parseColorToRGBA(this.currentColor);
+        const data = imageData.data;
+
+        for (let i = 0; i < data.length; i += 4) {
+          if (data[i + 3] > 0) {
+            data[i] = r;
+            data[i + 1] = g;
+            data[i + 2] = b;
+            data[i + 3] = 255;
+          }
+        }
+
+        this.lastColor = this.currentColor;
+      }
+
+      maskContext.putImageData(imageData, offsetX, offsetY);
+    }
+
+    this.canvas = maskCanvas;
+    this.context = maskContext;
+  }
+
+  /**
+   * Clamps the caller-supplied extent against preStrokeBounds, resizes the
+   * canvas to fit, and returns the new world-space bounds.
+   *
+   * Each caller is responsible for computing its own extent (e.g. dab extent
+   * for paintAt, polygon extent for fillPolygon) before calling this method.
+   */
+  private updateBounds(
+    oldBounds: Rect,
+    extent: { minX: number; minY: number; maxX: number; maxY: number }
+  ): Rect | undefined {
+    if (!this.canvas || !this.context) return undefined;
+
+    const origMaxX = this.preStrokeBounds!.x + this.preStrokeBounds!.width;
+    const origMaxY = this.preStrokeBounds!.y + this.preStrokeBounds!.height;
+
+    const minX = Math.floor(Math.min(this.preStrokeBounds!.x, extent.minX));
+    const minY = Math.floor(Math.min(this.preStrokeBounds!.y, extent.minY));
+    const maxX = Math.max(origMaxX, extent.maxX);
+    const maxY = Math.max(origMaxY, extent.maxY);
+
+    const newWidth = Math.max(1, Math.ceil(maxX - minX));
+    const newHeight = Math.max(1, Math.ceil(maxY - minY));
+
+    // offset to place old mask in new canvas
+    const offsetX = Math.round(oldBounds.x - minX);
+    const offsetY = Math.round(oldBounds.y - minY);
+
+    this.updateCanvas(newWidth, newHeight, offsetX, offsetY);
+
+    return {
+      x: minX,
+      y: minY,
+      width: newWidth,
+      height: newHeight,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Snapshots (for undo/redo)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Rebuilds the single-channel `rawPixels` cache from the current canvas
+   * contents so that {@link containsMaskPixel} reflects post-edit state.
+   * Treats any pixel with non-zero alpha as set.
+   */
+  private updateRawPixelsFromCanvas(): void {
+    if (!this.canvas || !this.context) {
+      this.rawPixels = undefined;
+      return;
+    }
+
+    const { width, height } = this.canvas;
+    const rgba = this.context.getImageData(0, 0, width, height).data;
+    const src = new Uint8Array(width * height);
+
+    for (let i = 0; i < src.length; i++) {
+      src[i] = rgba[i * 4 + 3] > 0 ? 1 : 0;
+    }
+
+    this.rawPixels = { src, width, height };
+  }
+
+  /**
+   * Returns a copy of the current canvas pixel data, or `undefined` if the
+   * canvas has not been created yet.
+   */
+  private takeSnapshot(): MaskSnapshot | undefined {
+    if (!this.canvas || !this.context) return undefined;
+
+    const { width, height } = this.canvas;
+    return {
+      imageData: this.context.getImageData(0, 0, width, height),
+      width,
+      height,
+    };
+  }
+
+  /**
+   * Replaces the current canvas contents with a previously captured snapshot.
+   * If `snapshot` is `undefined`, clears the canvas entirely (restoring the
+   * "no mask" state). Kicks off `encodeMask` so `pendingMask` stays in sync.
+   */
+  restoreSnapshot(snapshot: MaskSnapshot | undefined): void {
+    if (!snapshot) {
+      this.canvas = undefined;
+      this.context = undefined;
+      this.lastPoint = undefined;
+      this.pendingMask = undefined;
+      this.rawPixels = undefined;
+      return;
+    }
+
+    const { maskCanvas, maskContext } = createMaskCanvas(
+      snapshot.width,
+      snapshot.height
+    );
+    maskContext.putImageData(snapshot.imageData, 0, 0);
+
+    this.canvas = maskCanvas;
+    this.context = maskContext;
+    this.lastPoint = undefined;
+
+    // Refresh single-channel mask data so hit-testing reflects the snapshot.
+    this.updateRawPixelsFromCanvas();
+
+    const capturedCanvas = this.canvas;
+    encodeMask(capturedCanvas)
+      .then((encoded) => {
+        if (this.canvas !== capturedCanvas) return;
+        this.pendingMask = encoded;
+      })
+      .catch((err) => {
+        console.error("[MaskCanvas] restoreSnapshot encode failed:", err);
+      });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Cleanup
+  // ---------------------------------------------------------------------------
 
   destroy(): void {
     this.reset();


### PR DESCRIPTION
## Mask Editing & useSegmentationMode Stub

- useSementationMode stub to establish atoms used by bridgeSegmentationMode
- bridgeSegmentation mode provides state from the React side to Lighter
- paintStrokeCommands for undo/redo
- InteractionManager udated to provide data to overlay handlers when in segmentation mode
- buildBrushCursor to create our custom cursors for editing
- MaskCanvas updates to actually provide a canvas and editing capabilities