### PR TITLE
lighter: pen tool for mask polygons

### DIFF
--- a/app/packages/lighter/src/commands/AddKeypointPointCommand.ts
+++ b/app/packages/lighter/src/commands/AddKeypointPointCommand.ts
@@ -26,7 +26,10 @@ export class AddKeypointPointCommand implements Undoable {
     const worldPoint = this.overlay.relativePointToAbsolute(
       this.relativePosition
     );
-    this.overlay.addPoint(worldPoint, this.variant, this.pointId);
+    this.overlay.addPoint(worldPoint, {
+      variant: this.variant,
+      id: this.pointId,
+    });
   }
 
   undo(): void {

--- a/app/packages/lighter/src/commands/RemoveKeypointPointCommand.ts
+++ b/app/packages/lighter/src/commands/RemoveKeypointPointCommand.ts
@@ -40,6 +40,9 @@ export class RemoveKeypointPointCommand implements Undoable {
     const worldPoint = this.overlay.relativePointToAbsolute(
       this.relativePosition
     );
-    this.overlay.addPoint(worldPoint, this.variant, this.pointId);
+    this.overlay.addPoint(worldPoint, {
+      variant: this.variant,
+      id: this.pointId,
+    });
   }
 }

--- a/app/packages/lighter/src/interaction/InteractiveKeypointHandler.ts
+++ b/app/packages/lighter/src/interaction/InteractiveKeypointHandler.ts
@@ -115,7 +115,7 @@ export class InteractiveKeypointHandler implements InteractionHandler {
     }
 
     const variant = this.resolveVariant?.({ x: rp[0], y: rp[1] }, modifiers);
-    const pointId = this.overlay.addPoint(worldPoint, variant);
+    const pointId = this.overlay.addPoint(worldPoint, { variant });
 
     const command = new AddKeypointPointCommand(
       this.overlay,

--- a/app/packages/lighter/src/overlay/DetectionOverlay.ts
+++ b/app/packages/lighter/src/overlay/DetectionOverlay.ts
@@ -36,6 +36,7 @@ import { distanceFromLineSegment } from "../utils/geometry";
 import { BaseOverlay } from "./BaseOverlay";
 import { MaskCanvas } from "./MaskCanvas";
 import type { MaskSnapshot, PaintStrokeData } from "./MaskCanvas";
+import { MaskKeypoints } from "./MaskKeypoints";
 import type { SerializedMask } from "@fiftyone/utilities";
 import { BASE_ALPHA } from "@fiftyone/looker/src/constants";
 
@@ -79,6 +80,9 @@ export type InteractionState =
 
 export const NO_BOUNDS = { x: NaN, y: NaN, width: NaN, height: NaN };
 
+// PointerEvent: `event.buttons === 1` -> left mouse button depressed
+const LEFT_MOUSE_BUTTON = 1;
+
 /**
  * Bounding box overlay implementation with drag support, selection, and spatial coordinates.
  */
@@ -100,6 +104,9 @@ export class DetectionOverlay
   private textBounds?: Rect;
 
   private mask?: MaskCanvas;
+
+  // Pen tool state
+  private maskKeypoints?: MaskKeypoints;
 
   public cursor = "pointer";
 
@@ -190,6 +197,11 @@ export class DetectionOverlay
     return this.id;
   }
 
+  override setRenderer(renderer: Renderer2D): void {
+    super.setRenderer(renderer);
+    this.maskKeypoints?.setRenderer(renderer);
+  }
+
   protected renderImpl(renderer: Renderer2D, renderMeta: RenderMeta): void {
     // Dispose of old elements before creating new ones
     renderer.dispose(this.containerId);
@@ -200,7 +212,8 @@ export class DetectionOverlay
 
     // Draw the segmentation mask beneath the box outline when available.
     const maskColor = style.strokeStyle || style.fillStyle || "#ffffff";
-    const isEditingMask = this.isSelected() && this.hasMask();
+    const isEditingMask =
+      this.isSelected() && (this.hasMask() || !!this.maskKeypoints);
 
     this.mask?.render(
       renderer,
@@ -228,6 +241,8 @@ export class DetectionOverlay
         },
         this.containerId
       );
+
+      this.maskKeypoints?.render(renderer, style, renderMeta);
 
       this.emitLoaded();
       return;
@@ -507,6 +522,10 @@ export class DetectionOverlay
     worldPoint: Point,
     toolState: SegmentationToolState
   ): boolean {
+    if (toolState.tool === SegmentationTool.Pen) {
+      return this.onPenPointerDown(point, worldPoint, toolState);
+    }
+
     if (!this.hasValidBounds()) {
       // Bootstrap bounds from the brush dab so the canvas has a size
       const size = toolState?.size ?? 0;
@@ -558,7 +577,12 @@ export class DetectionOverlay
     this.segmentationTool = segmentationToolState;
 
     if (this.interactionState === "PAINTING") {
-      return this.onSegmentationMove(point, worldPoint, segmentationToolState);
+      return this.onSegmentationMove(
+        point,
+        worldPoint,
+        event,
+        segmentationToolState
+      );
     }
 
     if (this.interactionState === "DRAGGING") {
@@ -575,8 +599,13 @@ export class DetectionOverlay
   private onSegmentationMove(
     point: Point,
     worldPoint: Point,
+    event: PointerEvent,
     toolState: SegmentationToolState | undefined
   ): boolean {
+    if (toolState?.tool === SegmentationTool.Pen) {
+      return this.onPenMove(worldPoint, event);
+    }
+
     const updatedBounds = this.mask?.paintAt(
       worldPoint,
       this.bounds,
@@ -600,6 +629,109 @@ export class DetectionOverlay
     }
 
     return true;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pen tool
+  // ---------------------------------------------------------------------------
+
+  private onPenPointerDown(
+    _point: Point,
+    worldPoint: Point,
+    _toolState: SegmentationToolState
+  ): boolean {
+    this.maskKeypoints ??= new MaskKeypoints({
+      coordinateSystem: this.coordinateSystem,
+      renderer: this.renderer!,
+    });
+
+    this.maskKeypoints.addPoint({ ...worldPoint }, { dragging: false });
+    this.interactionState = "PAINTING";
+    this.markDirty();
+
+    return true;
+  }
+
+  private onPenMove(worldPoint: Point, event: PointerEvent): boolean {
+    this.updatePenMousePosition(worldPoint);
+
+    // Dragging: drop points at intervals
+    if (
+      event.buttons === LEFT_MOUSE_BUTTON &&
+      this.maskKeypoints?.hasValidBounds()
+    ) {
+      this.maskKeypoints.addPoint({ ...worldPoint }, { dragging: true });
+    }
+
+    this.markDirty();
+    return true;
+  }
+
+  /**
+   * Returns true if a pen polygon is currently being built.
+   */
+  hasPenPolygon(): boolean {
+    return !!this.maskKeypoints?.hasValidBounds();
+  }
+
+  /**
+   * Fills the pen polygon onto the mask canvas and clears the pen state.
+   */
+  commitPenPolygon({ segmentationToolState }: OverlayEvent): boolean {
+    if (!this.maskKeypoints) return false;
+
+    const absolutePoints = this.maskKeypoints.getAbsolutePoints();
+
+    if (absolutePoints.length < 3) {
+      this.cancelPenPolygon();
+      return false;
+    }
+
+    if (!this.hasValidBounds()) {
+      this.bounds = this.maskKeypoints.bounds;
+    }
+
+    this.mask ??= new MaskCanvas(this.label.mask);
+
+    const updatedBounds = this.mask.fillPolygon(
+      absolutePoints,
+      this.bounds,
+      segmentationToolState!,
+      this.currentStyle
+    );
+
+    if (updatedBounds) {
+      this.bounds = updatedBounds;
+    }
+
+    this.mask.paintEnd(this.bounds, () => {
+      this.markDirty();
+    });
+
+    this.eventBus.dispatch("lighter:overlay-paint-end", {
+      id: this.id,
+      paintStrokeData: this.mask?.getPaintStrokeData(),
+    });
+
+    this.cancelPenPolygon();
+    return true;
+  }
+
+  /**
+   * Discards the current pen polygon without filling.
+   */
+  cancelPenPolygon(): void {
+    this.maskKeypoints?.destroy();
+    this.maskKeypoints = undefined;
+    this.interactionState = "NONE";
+    this.markDirty();
+  }
+
+  /**
+   * Updates the pen cursor position for live preview rendering.
+   */
+  updatePenMousePosition(worldPoint: Point | null): void {
+    this.maskKeypoints?.setPreviewPoint(worldPoint);
   }
 
   private onDrag(point: Point, _event: PointerEvent, scale: number): boolean {
@@ -974,11 +1106,14 @@ export class DetectionOverlay
   }
 
   /**
-   * Whether segmentation brush should intercept pointer events.
+   * Whether segmentation brush/pen should intercept pointer events.
    */
   private isPaintingActive(): boolean {
     if (!this.segmentationTool?.active) return false;
-    return this.segmentationTool.tool === SegmentationTool.Brush;
+    return (
+      this.segmentationTool.tool === SegmentationTool.Brush ||
+      this.segmentationTool.tool === SegmentationTool.Pen
+    );
   }
 
   /**
@@ -1018,6 +1153,8 @@ export class DetectionOverlay
   override destroy(): void {
     this.mask?.destroy();
     this.mask = undefined;
+    this.maskKeypoints?.destroy();
+    this.maskKeypoints = undefined;
     super.destroy();
   }
 

--- a/app/packages/lighter/src/overlay/KeypointOverlay.ts
+++ b/app/packages/lighter/src/overlay/KeypointOverlay.ts
@@ -98,7 +98,7 @@ export class KeypointOverlay
   private isDraggable: boolean;
   private isDeletable: boolean;
   private isSelectable: boolean;
-  private connections: number[][];
+  protected connections: number[][];
   private closed: boolean;
   private readonly variantStyles: Record<string, DrawStyle>;
   private isSelectedState = false;
@@ -106,7 +106,7 @@ export class KeypointOverlay
   #points: KeypointEntry[];
 
   // Per-point sub-selection
-  private selectedPointIndex: number | null = null;
+  protected selectedPointIndex: number | null = null;
 
   // Drag state for individual points
   private dragPointIndex: number | null = null;
@@ -114,7 +114,7 @@ export class KeypointOverlay
   private moveStartRelativePoint?: [number, number];
 
   // Preview point for interactive creation (cursor tracking)
-  private previewPoint?: Point | null = null;
+  protected previewPoint?: Point | null = null;
 
   // Caches — invalidated in markDirty()
   private _absPointsCache: Point[] | null = null;
@@ -159,7 +159,7 @@ export class KeypointOverlay
     return [(ap.x - t.offsetX) / t.scaleX, (ap.y - t.offsetY) / t.scaleY];
   }
 
-  private getAbsolutePoints(): Point[] {
+  protected getAbsolutePoints(): Point[] {
     if (this._absPointsCache) return this._absPointsCache;
     this._absPointsCache = this.#points.map((e) =>
       this.relativePointToAbsolute(e.position)
@@ -275,7 +275,7 @@ export class KeypointOverlay
   /**
    * Collects edge segments from connections with bounds-checked indices.
    */
-  private collectEdgeSegments(absPoints: Point[]): Array<[Point, Point]> {
+  protected collectEdgeSegments(absPoints: Point[]): Array<[Point, Point]> {
     const segments: Array<[Point, Point]> = [];
     const len = absPoints.length;
     for (const path of this.connections) {
@@ -637,12 +637,20 @@ export class KeypointOverlay
   /**
    * Adds a point at the given absolute (world) position.
    *
-   * @param variant - Optional variant key used to determine render style.
-   * @param id - Optional ID. When provided, reuses this id instead of
+   * @param options.variant - Optional variant key used to determine render style.
+   * @param options.id - Optional ID. When provided, reuses this id instead of
    *             generating one. Useful when referential integrity is desired.
+   * @param options.dragging - Whether this point is being placed as part of a
+   *             continuous drag. Subclasses (e.g. `MaskKeypoints`) may gate
+   *             dragged placements by a minimum-distance threshold while
+   *             always honoring discrete clicks.
    * @returns The id of the new point.
    */
-  addPoint(worldPoint: Point, variant?: string, id?: string): string {
+  addPoint(
+    worldPoint: Point,
+    options?: { variant?: string; id?: string; dragging?: boolean }
+  ): string {
+    const { variant, id } = options ?? {};
     const position = this.absolutePointToRelative(worldPoint);
     const entry: KeypointEntry = { id: id ?? uuidv4(), position, variant };
     this.#points.push(entry);

--- a/app/packages/lighter/src/overlay/MaskKeypoints.ts
+++ b/app/packages/lighter/src/overlay/MaskKeypoints.ts
@@ -1,0 +1,228 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import {
+  KEYPOINT_RADIUS,
+  KEYPOINT_SELECTED_RADIUS,
+  PREVIEW_LINE_OPACITY,
+  STROKE_WIDTH,
+} from "../constants";
+import type { Renderer2D } from "../renderer/Renderer2D";
+import type { CoordinateSystem, DrawStyle, Point, Rect } from "../types";
+import { NO_BOUNDS } from "./DetectionOverlay";
+import { KeypointOverlay } from "./KeypointOverlay";
+import { v4 as generateUUID } from "uuid";
+
+export interface MaskKeypointsOptions {
+  id?: string;
+  coordinateSystem: CoordinateSystem;
+  renderer: Renderer2D;
+  keypointThreshold?: number;
+}
+
+const KEYPOINT_THRESHOLD = 25;
+
+/**
+ * Extended keypoint overlay for mask pen-tool polygon drawing.
+ *
+ * Adds:
+ * - exposes absolute points
+ * - provides bounds without padding
+ * - provides a minimum threshold for point distance
+ * - `addPoint`: auto-connects all points
+ */
+export class MaskKeypoints extends KeypointOverlay {
+  private lastKeypoint?: Point;
+  private keypointThreshold: number;
+
+  constructor(options: MaskKeypointsOptions) {
+    super({
+      id: options.id ?? generateUUID(),
+      label: { label: "", points: [] },
+      field: "",
+    });
+
+    this.coordinateSystem = options.coordinateSystem;
+    this.renderer = options.renderer;
+    this.keypointThreshold = options.keypointThreshold ?? KEYPOINT_THRESHOLD;
+  }
+
+  /**
+   * Returns a copy of points in world space.
+   */
+  override getAbsolutePoints(): Point[] {
+    return super.getAbsolutePoints();
+  }
+
+  /**
+   * Tight bounds around the points with no padding.
+   */
+  override get bounds(): Rect {
+    const points = this.getAbsolutePoints();
+    if (points.length === 0) return NO_BOUNDS;
+
+    let minX = Infinity,
+      minY = Infinity,
+      maxX = -Infinity,
+      maxY = -Infinity;
+
+    for (const point of points) {
+      if (point.x < minX) minX = point.x;
+      if (point.x > maxX) maxX = point.x;
+      if (point.y < minY) minY = point.y;
+      if (point.y > maxY) maxY = point.y;
+    }
+
+    return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+  }
+
+  /**
+   * Adds a point and connects it to any prior point.
+   *
+   * When `options.dragging` is true, throttles placements by `keypointThreshold`
+   * to avoid clustering during a drag. Discrete clicks (`dragging` falsy) always
+   * place a point so users can manually add points closer than the threshold.
+   */
+  override addPoint(
+    worldPoint: Point,
+    options?: { variant?: string; id?: string; dragging?: boolean }
+  ): string | null {
+    let shouldAddPoint = true;
+
+    if (options?.dragging && this.lastKeypoint) {
+      const dist = Math.hypot(
+        worldPoint.x - this.lastKeypoint.x,
+        worldPoint.y - this.lastKeypoint.y
+      );
+
+      shouldAddPoint = dist >= this.keypointThreshold;
+    }
+
+    if (shouldAddPoint) {
+      const pointID = super.addPoint(worldPoint, options);
+      const points = this.getAbsolutePoints();
+
+      const connections = points.reduce(
+        (memo, _point, index) =>
+          index === 0
+            ? memo
+            : index === points.length - 1
+            ? [...memo, [index - 1, index], [index, 0]]
+            : [...memo, [index - 1, index]],
+        []
+      );
+
+      this.setConnections(connections);
+
+      this.lastKeypoint = { ...worldPoint };
+      return pointID;
+    }
+
+    return null;
+  }
+
+  protected override renderImpl(renderer: Renderer2D): void {
+    renderer.dispose(this.containerId);
+
+    const style = this.currentStyle;
+    if (!style) return;
+
+    const absPoints = this.getAbsolutePoints();
+    const strokeColor = style.strokeStyle || "#ffffff";
+    const lineWidth = style.lineWidth || STROKE_WIDTH;
+
+    // 1. Batch all connection edges into a single draw call
+    const edgeSegments = this.collectEdgeSegments(absPoints);
+
+    if (edgeSegments.length > 0) {
+      renderer.drawLines(
+        edgeSegments,
+        { strokeStyle: strokeColor, lineWidth },
+        this.containerId
+      );
+    }
+
+    // 2. Draw preview lines (during interactive creation — dashed)
+    if (this.previewPoint && absPoints.length > 0) {
+      const lastPoint = absPoints[absPoints.length - 1];
+      renderer.drawLine(
+        lastPoint,
+        this.previewPoint,
+        {
+          strokeStyle: strokeColor,
+          lineWidth,
+          dashPattern: [6, 4],
+          opacity: PREVIEW_LINE_OPACITY,
+        },
+        this.containerId
+      );
+
+      // a second preview line to the first point
+      if (absPoints.length >= 2) {
+        const firstPoint = absPoints[0];
+        renderer.drawLine(
+          firstPoint,
+          this.previewPoint,
+          {
+            strokeStyle: strokeColor,
+            lineWidth,
+            dashPattern: [6, 4],
+            opacity: PREVIEW_LINE_OPACITY,
+          },
+          this.containerId
+        );
+      }
+    }
+
+    // 3. Batch all regular points into a single draw call
+    const pointStyle: DrawStyle = {
+      fillStyle: strokeColor,
+      strokeStyle: "#ffffff",
+      lineWidth,
+    };
+
+    const regularPoints: Point[] = [];
+    let selectedPoint: Point | undefined;
+
+    for (let i = 0; i < absPoints.length; i++) {
+      if (this.selectedPointIndex === i) {
+        selectedPoint = absPoints[i];
+      } else {
+        regularPoints.push(absPoints[i]);
+      }
+    }
+
+    if (regularPoints.length > 0) {
+      renderer.drawPoints(
+        regularPoints,
+        KEYPOINT_RADIUS,
+        pointStyle,
+        this.containerId
+      );
+    }
+
+    // Draw selected point at larger radius + inner highlight (separate calls)
+    if (selectedPoint) {
+      renderer.drawPoint(
+        selectedPoint,
+        KEYPOINT_SELECTED_RADIUS,
+        pointStyle,
+        this.containerId
+      );
+      renderer.drawPoint(
+        selectedPoint,
+        KEYPOINT_RADIUS,
+        { fillStyle: "#ffffff" },
+        this.containerId
+      );
+    }
+
+    this.emitLoaded();
+  }
+
+  override destroy(): void {
+    super.destroy();
+    this.renderer?.dispose(this.id);
+  }
+}


### PR DESCRIPTION
Pen Tool

- MaskKeypoints extends KeypointOverlay to facilitate point-and-click or drag-to-draw keypoints to form a polygon to add/remove from a mask
- DetectionOverlay updated to direct user interactions to MaskKeypoints when appropriate and apply those edits to MaskCanvas