### PR TITLE
core: wire segmentation toolbar + edit UI

### DIFF
--- a/app/packages/core/src/components/Modal/Lighter/useBridge.ts
+++ b/app/packages/core/src/components/Modal/Lighter/useBridge.ts
@@ -31,6 +31,8 @@ import {
   currentData,
   savedLabel,
 } from "../Sidebar/Annotate/Edit/state";
+import { useDetectionMode } from "../Sidebar/Annotate/Edit/useDetectionMode";
+import { useSegmentationMode } from "../Sidebar/Annotate/Edit/useSegmentationMode";
 import { coerceStringBooleans, useLabelsContext } from "../Sidebar/Annotate";
 import useColorMappingContext from "./useColorMappingContext";
 import { useLighterTooltipEventHandler } from "./useLighterTooltipEventHandler";
@@ -67,6 +69,9 @@ export const useBridge = (scene: Scene2D | null) => {
   const fieldSchema = useRecoilValue(
     fos.fieldSchema({ space: fos.State.SPACE.SAMPLE })
   );
+
+  const segmentationMode = useSegmentationMode();
+  const detectionMode = useDetectionMode();
 
   useAnnotationEventHandler(
     "annotation:sidebarValueUpdated",
@@ -251,6 +256,65 @@ export const useBridge = (scene: Scene2D | null) => {
   );
 
   useEventHandler("lighter:command-executed", handleCommandEvent);
+
+  // Sync sidebar/edit state when an overlay's label is mutated outside the
+  // command stack (e.g. AI inference applying a new mask via updateLabel).
+  useEventHandler(
+    "lighter:overlay-label-updated",
+    useCallback(
+      (payload) => {
+        if (!payload.label) return;
+
+        const newLabel = coerceStringBooleans(
+          payload.label as Record<string, unknown>
+        );
+
+        if (newLabel) {
+          save(newLabel);
+        }
+
+        segmentationMode.setEditingMask(payload.id, payload.hasMask);
+        detectionMode.setEditingMask(payload.id, payload.hasMask);
+      },
+      [detectionMode, save, segmentationMode]
+    )
+  );
+
+  useEventHandler(
+    "lighter:overlay-create",
+    useCallback(() => {
+      if (segmentationMode.segmentationModeActive) {
+        segmentationMode.create();
+      } else if (detectionMode.detectionModeActive) {
+        detectionMode.create();
+      }
+    }, [detectionMode, segmentationMode])
+  );
+
+  useEventHandler(
+    "lighter:segmentation-mode-quit",
+    useCallback(() => {
+      if (segmentationMode.segmentationModeActive) {
+        segmentationMode.deactivateSegmentationMode();
+      }
+    }, [segmentationMode])
+  );
+
+  useEventHandler(
+    "lighter:detection-mode-quit",
+    useCallback(() => {
+      detectionMode.deactivateDetectionMode();
+    }, [detectionMode])
+  );
+
+  useEventHandler(
+    "lighter:point-selection-finalize",
+    useCallback(() => {
+      if (segmentationMode.segmentationModeActive) {
+        segmentationMode.finalizePointSelection();
+      }
+    }, [segmentationMode])
+  );
 
   const context = useColorMappingContext();
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Actions.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Actions.tsx
@@ -1,4 +1,12 @@
 import { useUndoRedo } from "@fiftyone/commands";
+import {
+  ClassificationIcon,
+  DetectionIcon,
+  RedoIcon,
+  SegmentationIcon,
+  SelectIcon,
+  UndoIcon,
+} from "@fiftyone/components";
 import { use3dAnnotationFields } from "@fiftyone/looker-3d/src/annotation/use3dAnnotationFields";
 import {
   ANNOTATION_CUBOID,
@@ -23,11 +31,11 @@ import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 import { ItemLeft, ItemRight } from "./Components";
 import { editing } from "./Edit";
-import { useClassificationMode } from "./Edit/useClassificationMode";
 import { fieldsOfType } from "./Edit/state";
+import { useClassificationMode } from "./Edit/useClassificationMode";
 import { useDetectionMode } from "./Edit/useDetectionMode";
-import { Anchor, Icon, IconName, Text, Tooltip } from "@voxel51/voodo";
-import { useAIAnnotationMode } from "./Edit/useAIAnnotationMode";
+import { useSegmentationMode } from "./Edit/useSegmentationMode";
+import { Anchor, Text, Tooltip } from "@voxel51/voodo";
 import { FeatureFlag, FeatureFlagged } from "@fiftyone/feature-flags";
 
 const ActionsDiv = styled.div`
@@ -156,21 +164,7 @@ const Select = ({ active }: { active: boolean }) => {
         data-cy-active={active}
         onClick={active ? undefined : deactivateAll}
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="19"
-          height="18"
-          viewBox="0 0 19 18"
-          fill="none"
-        >
-          <title>Select</title>
-          <path
-            className="stroke-icon"
-            d="M4 3L4 17L8 13L14 13L4 3Z"
-            strokeWidth="1.5"
-            strokeLinejoin="round"
-          />
-        </svg>
+        <SelectIcon />
       </Square>
     </Tooltip>
   );
@@ -198,27 +192,19 @@ const Classification = () => {
         }}
         className={disabled ? "disabled" : ""}
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="19"
-          height="18"
-          viewBox="0 0 19 18"
-          fill="none"
-        >
-          <title>Classification</title>
-          <path
-            d="M3.5 14.9995C3.0875 14.9995 2.73438 14.8526 2.44063 14.5589C2.14687 14.2651 2 13.912 2 13.4995V4.49951C2 4.08701 2.14687 3.73389 2.44063 3.44014C2.73438 3.14639 3.0875 2.99951 3.5 2.99951H11.75C11.9875 2.99951 12.2125 3.05264 12.425 3.15889C12.6375 3.26514 12.8125 3.41201 12.95 3.59951L16.325 8.09951C16.525 8.36201 16.625 8.66201 16.625 8.99951C16.625 9.33701 16.525 9.63701 16.325 9.89951L12.95 14.3995C12.8125 14.587 12.6375 14.7339 12.425 14.8401C12.2125 14.9464 11.9875 14.9995 11.75 14.9995H3.5ZM3.5 13.4995H11.75L15.125 8.99951L11.75 4.49951H3.5V13.4995Z"
-            fill="currentColor"
-          />
-        </svg>
+        <ClassificationIcon />
       </Square>
     </Tooltip>
   );
 };
 
 const Detection = () => {
-  const { activateDetectionMode, detectionModeActive, disabled, tooltip } =
-    useDetectionMode();
+  const {
+    activateDetectionMode,
+    detectionModeActive,
+    disabled,
+    tooltip,
+  } = useDetectionMode();
   const deactivateAll = useDeactivateAll();
 
   return (
@@ -234,44 +220,38 @@ const Detection = () => {
           if (!detectionModeActive) activateDetectionMode();
         }}
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="19"
-          height="18"
-          viewBox="0 0 19 18"
-          fill="none"
-        >
-          <title>Detection</title>
-          <path
-            d="M4.25 15.75C3.8375 15.75 3.48438 15.6031 3.19063 15.3094C2.89687 15.0156 2.75 14.6625 2.75 14.25V3.75C2.75 3.3375 2.89687 2.98438 3.19063 2.69063C3.48438 2.39687 3.8375 2.25 4.25 2.25H14.75C15.1625 2.25 15.5156 2.39687 15.8094 2.69063C16.1031 2.98438 16.25 3.3375 16.25 3.75V14.25C16.25 14.6625 16.1031 15.0156 15.8094 15.3094C15.5156 15.6031 15.1625 15.75 14.75 15.75H4.25ZM4.25 14.25H14.75V3.75H4.25V14.25Z"
-            fill="currentColor"
-          />
-        </svg>
+        <DetectionIcon />
       </Square>
     </Tooltip>
   );
 };
 
 const Segmentation = () => {
-  const { isActive, activate, deactivate } = useAIAnnotationMode();
+  const {
+    segmentationModeActive,
+    disabled,
+    tooltip,
+    activateSegmentationMode,
+  } = useSegmentationMode();
   const deactivateAll = useDeactivateAll();
 
   return (
-    <Tooltip anchor={Anchor.Top} content={<Text>Segment</Text>} portal>
+    <Tooltip anchor={Anchor.Top} content={<Text>{tooltip}</Text>} portal>
       <Square
-        $active={isActive}
+        $active={segmentationModeActive}
+        className={disabled ? "disabled" : ""}
         data-cy="segmentation-mode"
-        data-cy-active={isActive}
+        data-cy-active={segmentationModeActive}
         onClick={() => {
+          if (disabled) return;
           deactivateAll();
-          if (!isActive) {
-            activate();
-          } else {
-            deactivate();
+
+          if (!segmentationModeActive) {
+            activateSegmentationMode();
           }
         }}
       >
-        <Icon name={IconName.Workspaces} />
+        <SegmentationIcon />
       </Square>
     </Tooltip>
   );
@@ -287,19 +267,7 @@ export const Undo = () => {
         className={undoEnabled ? "" : "disabled"}
         data-cy="undo-button"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="13"
-          height="12"
-          viewBox="0 0 13 12"
-          fill="none"
-        >
-          <title>Undo</title>
-          <path
-            d="M2.98395 12C2.74746 12 2.54922 11.9211 2.38925 11.7633C2.22927 11.6055 2.14928 11.4099 2.14928 11.1767C2.14928 10.9434 2.22927 10.7479 2.38925 10.5901C2.54922 10.4322 2.74746 10.3533 2.98395 10.3533H8.07544C8.95185 10.3533 9.71348 10.0789 10.3604 9.53002C11.0072 8.98113 11.3307 8.29503 11.3307 7.4717C11.3307 6.64837 11.0072 5.96226 10.3604 5.41338C9.71348 4.86449 8.95185 4.59005 8.07544 4.59005H2.81701L4.40289 6.15437C4.55591 6.30532 4.63242 6.49743 4.63242 6.7307C4.63242 6.96398 4.55591 7.15609 4.40289 7.30703C4.24987 7.45798 4.05511 7.53345 3.81862 7.53345C3.58213 7.53345 3.38737 7.45798 3.23435 7.30703L0.229535 4.34305C0.146067 4.26072 0.0869449 4.17153 0.0521669 4.07547C0.017389 3.97942 0 3.8765 0 3.76672C0 3.65695 0.017389 3.55403 0.0521669 3.45798C0.0869449 3.36192 0.146067 3.27273 0.229535 3.19039L3.23435 0.226415C3.38737 0.0754717 3.58213 0 3.81862 0C4.05511 0 4.24987 0.0754717 4.40289 0.226415C4.55591 0.377358 4.63242 0.569468 4.63242 0.802744C4.63242 1.03602 4.55591 1.22813 4.40289 1.37907L2.81701 2.9434H8.07544C9.42483 2.9434 10.5829 3.37564 11.5498 4.24014C12.5166 5.10463 13 6.18182 13 7.4717C13 8.76158 12.5166 9.83877 11.5498 10.7033C10.5829 11.5678 9.42483 12 8.07544 12H2.98395Z"
-            fill="currentColor"
-          />
-        </svg>
+        <UndoIcon />
       </Round>
     </Tooltip>
   );
@@ -315,19 +283,7 @@ export const Redo = () => {
         className={redoEnabled ? "" : "disabled"}
         data-cy="redo-button"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="13"
-          height="12"
-          viewBox="0 0 13 12"
-          fill="none"
-        >
-          <title>Redo</title>
-          <path
-            d="M10.0161 12C10.2525 12 10.4508 11.9211 10.6108 11.7633C10.7707 11.6055 10.8507 11.4099 10.8507 11.1767C10.8507 10.9434 10.7707 10.7479 10.6108 10.5901C10.4508 10.4322 10.2525 10.3533 10.0161 10.3533H4.92456C4.04815 10.3533 3.28652 10.0789 2.63965 9.53002C1.99278 8.98113 1.66934 8.29503 1.66934 7.4717C1.66934 6.64837 1.99278 5.96226 2.63965 5.41338C3.28652 4.86449 4.04815 4.59005 4.92456 4.59005H10.183L8.59711 6.15437C8.44409 6.30532 8.36758 6.49743 8.36758 6.7307C8.36758 6.96398 8.44409 7.15609 8.59711 7.30703C8.75013 7.45798 8.94489 7.53345 9.18138 7.53345C9.41787 7.53345 9.61263 7.45798 9.76565 7.30703L12.7705 4.34305C12.8539 4.26072 12.9131 4.17153 12.9478 4.07547C12.9826 3.97942 13 3.8765 13 3.76672C13 3.65695 12.9826 3.55403 12.9478 3.45798C12.9131 3.36192 12.8539 3.27273 12.7705 3.19039L9.76565 0.226415C9.61263 0.0754717 9.41787 0 9.18138 0C8.94489 0 8.75013 0.0754717 8.59711 0.226415C8.44409 0.377358 8.36758 0.569468 8.36758 0.802744C8.36758 1.03602 8.44409 1.22813 8.59711 1.37907L10.183 2.9434H4.92456C3.57517 2.9434 2.41707 3.37564 1.45024 4.24014C0.483414 5.10463 0 6.18182 0 7.4717C0 8.76158 0.483414 9.83877 1.45024 10.7033C2.41707 11.5678 3.57517 12 4.92456 12H10.0161Z"
-            fill="currentColor"
-          />
-        </svg>
+        <RedoIcon />
       </Round>
     </Tooltip>
   );
@@ -450,13 +406,15 @@ const Actions = () => {
   // This checks if a 3d sample is pinned - is true when media type is `group` with a 3d slice pinned
   const { isPinned: is3dSamplePinned } = useRenderConfig3dState();
 
-  const { classificationModeActive, deactivateClassificationMode } =
-    useClassificationMode();
+  const {
+    classificationModeActive,
+    deactivateClassificationMode,
+  } = useClassificationMode();
   const { detectionModeActive, deactivateDetectionMode } = useDetectionMode();
   const {
-    isActive: segmentationModeActive,
-    deactivate: deactivateSegmentationMode,
-  } = useAIAnnotationMode();
+    segmentationModeActive,
+    deactivateSegmentationMode,
+  } = useSegmentationMode();
   const current3dAnnotationMode = useCurrent3dAnnotationMode();
   const setCurrent3dAnnotationMode = useSetCurrent3dAnnotationMode();
 
@@ -469,9 +427,9 @@ const Actions = () => {
 
   const deactivateAll = useCallback(() => {
     deactivateClassificationMode();
-    setCurrent3dAnnotationMode(null);
     deactivateDetectionMode();
     deactivateSegmentationMode();
+    setCurrent3dAnnotationMode(null);
   }, [
     deactivateClassificationMode,
     deactivateDetectionMode,

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Edit.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Edit.tsx
@@ -1,6 +1,6 @@
 import { DetectionLabel } from "@fiftyone/looker";
 import { useClearModal } from "@fiftyone/state";
-import { DETECTION, KEYPOINT, POLYLINE } from "@fiftyone/utilities";
+import { DETECTION, POLYLINE } from "@fiftyone/utilities";
 import { useAtomValue } from "jotai";
 import { useEffect } from "react";
 import styled from "styled-components";
@@ -9,11 +9,12 @@ import AnnotationSchema from "./AnnotationSchema";
 import Field from "./Field";
 import Header from "./Header";
 import Id from "./Id";
-import { KeypointDetails } from "./KeypointDetails";
+import MaskPreview from "./MaskPreview";
 import { PolylineDetails } from "./PolylineDetails";
 import Position from "./Position";
 import Position3d from "./Position3d";
 import {
+  currentData,
   currentField,
   currentFieldIsReadOnlyAtom,
   currentOverlay,
@@ -22,10 +23,12 @@ import {
 import PrimitiveWrapper from "./PrimitiveWrapper";
 import useActivePrimitive from "./useActivePrimitive";
 import useExit from "./useExit";
+import { useSegmentationMode } from "./useSegmentationMode";
 
 const ContentContainer = styled.div`
   margin: 0.25rem 1rem;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -36,6 +39,7 @@ const Content = styled.div`
   border-radius: var(--radius-xs);
   width: 100%;
   flex: 1;
+  min-height: 0;
   padding: 1rem;
   overflow: auto;
   display: flex;
@@ -47,7 +51,10 @@ export default function Edit() {
   const field = useAtomValue(currentField);
   const overlay = useAtomValue(currentOverlay);
   const type = useAtomValue(currentType);
+  const data = useAtomValue(currentData);
   const isReadOnly = useAtomValue(currentFieldIsReadOnlyAtom);
+  const { isEditingMask } = useSegmentationMode();
+  const isMaskDetection = !!(data?.mask || isEditingMask);
   const [activePrimitivePath] = useActivePrimitive();
 
   const clear = useClearModal();
@@ -92,14 +99,14 @@ export default function Edit() {
         {!primitiveEditingActive && <Field />}
         {primitiveEditingActive && <PrimitiveWrapper />}
         {type === DETECTION && overlay && !is3dDetection && (
-          <Position readOnly={isReadOnly} />
+          <Position readOnly={isReadOnly || isMaskDetection} />
         )}
         {type === DETECTION && overlay && is3dDetection && (
           <Position3d readOnly={isReadOnly} />
         )}
         {type === POLYLINE && <PolylineDetails />}
-        {type === KEYPOINT && <KeypointDetails />}
         {field && <AnnotationSchema readOnly={isReadOnly} />}
+        {isMaskDetection && <MaskPreview />}
       </Content>
     </ContentContainer>
   );

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Header.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Header.tsx
@@ -1,11 +1,12 @@
-import { useAtomValue } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useRef, useState } from "react";
 import { Round } from "../Actions";
 
-import { useLighter } from "@fiftyone/lighter";
+import { DetectionOverlay, useLighter } from "@fiftyone/lighter";
 import { West as Back } from "@mui/icons-material";
 import { Box, Menu, MenuItem, Stack } from "@mui/material";
 import { Clickable, Icon, IconName, Size, Text } from "@voxel51/voodo";
+import { DETECTION } from "@fiftyone/utilities";
 import { ItemLeft, ItemRight } from "../Components";
 import { ICONS } from "../Icons";
 import { Row } from "./Components";
@@ -16,6 +17,7 @@ import { isGeneratedView } from "@fiftyone/state";
 import { useRecoilValue } from "recoil";
 import { useSchemaManagerModal } from "../SchemaManager/hooks";
 import {
+  currentData,
   currentFieldIsReadOnlyAtom,
   currentOverlay,
   currentType,
@@ -26,6 +28,7 @@ import { KnownCommands, KnownContexts, useCommand } from "@fiftyone/commands";
 import useColor from "./useColor";
 import useExit from "./useExit";
 import { useDetectionMode } from "./useDetectionMode";
+import { useSegmentationMode } from "./useSegmentationMode";
 import { useAnnotationController } from "@fiftyone/annotation";
 
 const LabelHamburgerMenu = () => {
@@ -43,6 +46,31 @@ const LabelHamburgerMenu = () => {
   const { openSchemaManager } = useSchemaManagerModal();
   const isGenerated = useRecoilValue(isGeneratedView);
 
+  // Mask state
+  const type = useAtomValue(currentType);
+  const data = useAtomValue(currentData);
+  const overlay = useAtomValue(currentOverlay);
+  const setData = useSetAtom(currentData);
+  const { isEditingMask } = useSegmentationMode();
+
+  const isMaskDetection = !!(data?.mask || isEditingMask);
+  const isDetection = type === DETECTION;
+
+  const handleAddMask = useCallback(() => {
+    if (overlay instanceof DetectionOverlay) {
+      overlay.initMask();
+      setOpen(false);
+    }
+  }, [overlay]);
+
+  const handleRemoveMask = useCallback(() => {
+    if (overlay instanceof DetectionOverlay) {
+      overlay.removeMask();
+      setData({ mask: undefined });
+      setOpen(false);
+    }
+  }, [overlay, setData]);
+
   const handleOpenSchemaManager = () => {
     openSchemaManager();
     setOpen(false);
@@ -50,7 +78,12 @@ const LabelHamburgerMenu = () => {
 
   const showEditSchema = canEditLabels.enabled && currentFieldIsReadOnly;
   const showDelete = !isGenerated;
-  const hasMenuItems = showDelete || showEditSchema;
+  const showAddMask =
+    isDetection && !isMaskDetection && !currentFieldIsReadOnly;
+  const showRemoveMask =
+    isDetection && isMaskDetection && !currentFieldIsReadOnly;
+  const hasMenuItems =
+    showDelete || showEditSchema || showAddMask || showRemoveMask;
 
   if (!hasMenuItems) {
     return null;
@@ -70,6 +103,10 @@ const LabelHamburgerMenu = () => {
         onClose={() => setOpen(false)}
         sx={{ zIndex: 9999 }}
       >
+        {showAddMask && <MenuItem onClick={handleAddMask}>Add mask</MenuItem>}
+        {showRemoveMask && (
+          <MenuItem onClick={handleRemoveMask}>Remove mask</MenuItem>
+        )}
         {showDelete && (
           <MenuItem onClick={deleteCommand.callback}>
             <Stack direction="row" gap={1} alignItems="center">

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/MaskPreview.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/MaskPreview.tsx
@@ -1,0 +1,160 @@
+import { useTheme } from "@fiftyone/components";
+import {
+  DetectionOverlay,
+  UNDEFINED_LIGHTER_SCENE_ID,
+  useLighter,
+  useLighterEventHandler,
+} from "@fiftyone/lighter";
+import { useAtomValue } from "jotai";
+import { useCallback, useEffect, useRef } from "react";
+import styled from "styled-components";
+import { currentOverlay } from "./state";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  row-gap: 0.25rem;
+`;
+
+const Label = styled.div`
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.text.secondary};
+`;
+
+const CanvasContainer = styled.div<{ $bg: string }>`
+  background: ${({ $bg }) => $bg};
+  border-radius: var(--radius-xs, 4px);
+  padding: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const StyledCanvas = styled.canvas`
+  display: block;
+  width: 100%;
+  height: auto;
+`;
+
+const MAX_PREVIEW_WIDTH = 256;
+
+/**
+ * Draws a {@link CanvasImageSource} to the preview canvas as a monochrome mask.
+ */
+function drawPreview(
+  canvas: HTMLCanvasElement,
+  source: CanvasImageSource,
+  srcWidth: number,
+  srcHeight: number,
+  isDark: boolean
+) {
+  if (srcWidth === 0 || srcHeight === 0) return;
+
+  const scale = Math.min(1, MAX_PREVIEW_WIDTH / srcWidth);
+  const w = Math.round(srcWidth * scale);
+  const h = Math.round(srcHeight * scale);
+
+  canvas.width = w;
+  canvas.height = h;
+
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+
+  ctx.clearRect(0, 0, w, h);
+  ctx.drawImage(source, 0, 0, w, h);
+
+  const imageData = ctx.getImageData(0, 0, w, h);
+  const pixels = imageData.data;
+  const c = isDark ? 0 : 255;
+
+  for (let i = 0; i < pixels.length; i += 4) {
+    if (pixels[i + 3] > 0) {
+      pixels[i] = c;
+      pixels[i + 1] = c;
+      pixels[i + 2] = c;
+      pixels[i + 3] = 255;
+    }
+  }
+
+  ctx.putImageData(imageData, 0, 0);
+}
+
+/**
+ * Renders a monochrome mask preview in the sidebar.
+ * Dark mode: black mask on white background.
+ * Light mode: white mask on black background.
+ *
+ * Draws once on mount from the overlay's existing canvas/bitmap, then
+ * re-draws when:
+ * - A paint stroke ends (brush/eraser/pen commit)
+ * - The overlay finishes rendering (async mask decode completes)
+ */
+export default function MaskPreview() {
+  const overlay = useAtomValue(currentOverlay);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const theme = useTheme();
+  const isDark = theme.themeMode === "dark";
+
+  const { scene } = useLighter();
+  const useEventHandler = useLighterEventHandler(
+    scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
+  );
+
+  // Draws the preview from the overlay's current canvas or decoded bitmap.
+  const drawFromOverlay = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !(overlay instanceof DetectionOverlay)) return;
+
+    const source = overlay.getMaskPreviewSource();
+    if (!source) return;
+
+    drawPreview(canvas, source, source.width, source.height, isDark);
+  }, [overlay, isDark]);
+
+  // Initial draw (may be empty if the async decode hasn't completed yet).
+  useEffect(drawFromOverlay, [drawFromOverlay]);
+
+  // On paint-end, prefer the afterSnapshot from the event payload (already in
+  // memory), fall back to the overlay's preview source.
+  const handlePaintEnd = useCallback(
+    (payload: {
+      paintStrokeData?: { afterSnapshot?: { imageData: ImageData } };
+    }) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+
+      const snapshot = payload.paintStrokeData?.afterSnapshot;
+      if (snapshot) {
+        const { imageData } = snapshot;
+        const tmp = new OffscreenCanvas(imageData.width, imageData.height);
+        tmp.getContext("2d")!.putImageData(imageData, 0, 0);
+        drawPreview(canvas, tmp, imageData.width, imageData.height, isDark);
+        return;
+      }
+
+      drawFromOverlay();
+    },
+    [isDark, drawFromOverlay]
+  );
+
+  useEventHandler("lighter:overlay-paint-end", handlePaintEnd);
+
+  // Re-draw when the overlay finishes rendering (e.g. after async mask decode
+  // completes for AI detections, or after the first pen polygon commit).
+  useEventHandler("lighter:overlay-loaded", drawFromOverlay);
+
+  if (!(overlay instanceof DetectionOverlay) || !overlay.hasMask()) {
+    return null;
+  }
+
+  const bg = isDark ? "#ffffff" : "#000000";
+
+  return (
+    <Container>
+      <Label>Mask</Label>
+      <CanvasContainer $bg={bg}>
+        <StyledCanvas ref={canvasRef} />
+      </CanvasContainer>
+    </Container>
+  );
+}

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/SegmentationToolbar.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/SegmentationToolbar.tsx
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Thin wrapper that wires segmentation tool state into the shared
+ * ActionToolbar renderer. All state logic lives in useSegmentationActions;
+ * all rendering logic lives in ActionToolbar (@fiftyone/components).
+ */
+
+import { ActionToolbar } from "@fiftyone/components";
+import { Orientation } from "@voxel51/voodo";
+import { useSegmentationActions } from "./useSegmentationActions";
+
+export interface SegmentationToolbarProps {
+  onUndo?: () => void;
+  onRedo?: () => void;
+  canUndo?: boolean;
+  canRedo?: boolean;
+}
+
+export const SegmentationToolbar = ({
+  onUndo,
+  onRedo,
+  canUndo = false,
+  canRedo = false,
+}: SegmentationToolbarProps) => {
+  const { groups, visible } = useSegmentationActions({
+    onUndo,
+    onRedo,
+    canUndo,
+    canRedo,
+  });
+
+  return (
+    <ActionToolbar
+      groups={groups}
+      orientation={Orientation.Column}
+      xOffset="5%"
+      yOffset="25%"
+      visible={visible}
+    />
+  );
+};

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/bridgeDetectionMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/bridgeDetectionMode.ts
@@ -14,7 +14,7 @@ export const detectionModeBridge = {
    * Check if detection mode is currently active.
    * @returns true if detection mode is active, false otherwise
    */
-  isDetectionModeActive(): boolean {
+  isActive(): boolean {
     const store = getDefaultStore();
     return store.get(_unsafeDetectionModeActiveAtom);
   },

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/state.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/state.ts
@@ -121,7 +121,9 @@ export const currentField = atom(
     }
 
     const currentData = currentLabel.data;
-    const data = buildNewLabelData(path, currentData._cls, currentData?._id);
+    const data = buildNewLabelData(path, currentData._cls, {
+      id: currentData?._id,
+    });
     data.bounding_box = currentData?.bounding_box;
 
     currentLabel.overlay?.updateField(path);

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useAIAnnotationMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useAIAnnotationMode.ts
@@ -43,12 +43,9 @@ const useDefaultAgent = () => {
  */
 const useLabelReset = (isActive: boolean, reset: () => void) => {
   const { selectedLabel } = useAnnotationContext();
-  const selectedLabelRef = useRef(selectedLabel);
   const previousSelectedLabelIdRef = useRef<string | null>(
     selectedLabel?.overlay?.id ?? null
   );
-
-  selectedLabelRef.current = selectedLabel;
 
   // When the selected label changes,
   // reset state to ensure a clean starting point for the next label
@@ -82,8 +79,9 @@ export const useAIAnnotationMode = (): AIAnnotationMode => {
   // bootstrap AI annotation capabilities
   useDefaultAgent();
 
+  // Clears prompt state without tearing down point selection. Used on
+  // label change — we stay in AI mode for the next label.
   const resetTools = useCallback(() => {
-    pointSelection.deactivate();
     pointSelection.clearPoints();
     resetToolsState();
   }, [pointSelection, resetToolsState]);
@@ -95,20 +93,22 @@ export const useAIAnnotationMode = (): AIAnnotationMode => {
       return;
     }
 
-    setIsActive(true);
     setActiveTask(AgentTaskType.SEGMENT);
-  }, [isActive, setActiveTask, setIsActive]);
+    setIsActive(true);
+    pointSelection.activate();
+  }, [isActive, pointSelection, setActiveTask, setIsActive]);
 
   const deactivate = useCallback(() => {
     if (!isActive) {
       return;
     }
 
+    pointSelection.deactivate();
     resetTools();
 
     setActiveTask(null);
     setIsActive(false);
-  }, [isActive, resetTools, setActiveTask, setIsActive]);
+  }, [resetTools, isActive, pointSelection, setActiveTask, setIsActive]);
 
   return useMemo(
     () => ({

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useCreate.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useCreate.ts
@@ -20,6 +20,7 @@ import type { LabelType } from "./state";
 import { defaultField, editing, savedLabel } from "./state";
 
 export interface CreateOptions {
+  id?: string;
   field?: string;
   labelValue?: string;
 }
@@ -43,8 +44,11 @@ const useCreateAnnotationLabel = () => {
       // Extract default values from the label schema for new annotations
       const fieldSchema = store.get(labelSchemaData(field));
 
-      // Build label data with defaults and detection mode values (if applicable)
-      const data = buildNewLabelData(field, type, id, labelValue);
+      // Build label data with defaults and detection/segmentation mode values (if applicable)
+      const data = buildNewLabelData(field, type, {
+        id,
+        labelValue,
+      });
 
       if (type === CLASSIFICATION) {
         const overlay = overlayFactory.create<
@@ -124,17 +128,16 @@ export default function useCreate(type: LabelType) {
 export function buildNewLabelData(
   field: string,
   type: LabelType,
-  id?: string,
-  label?: string
+  options?: CreateOptions
 ) {
-  const labelId = id || objectId();
+  const labelId = options?.id ?? objectId();
   const store = getDefaultStore();
 
   // Extract default values from the label schema for new annotations
   const fieldSchema = store.get(labelSchemaData(field));
   const labelSchema = fieldSchema?.label_schema;
   const defaults: Record<string, unknown> = {};
-  const labelValue = label || labelSchema?.classes?.[0];
+  const labelValue = options?.labelValue || labelSchema?.classes?.[0];
 
   // Top-level default applies to the "label" value (e.g., default class)
   if (labelSchema?.default !== undefined) {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useDetectionMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useDetectionMode.ts
@@ -5,11 +5,7 @@ import { atom, useAtom, useAtomValue, useSetAtom } from "jotai";
 import type { PrimitiveAtom } from "jotai";
 import { useRecoilValue } from "recoil";
 
-import {
-  UNDEFINED_LIGHTER_SCENE_ID,
-  useLighter,
-  useLighterEventHandler,
-} from "@fiftyone/lighter";
+import { useLighter } from "@fiftyone/lighter";
 import { DETECTION } from "@fiftyone/utilities";
 
 import { labelsByPath } from "../useLabels";
@@ -19,6 +15,7 @@ import useExit from "./useExit";
 import { isPatchesView } from "@fiftyone/state";
 import { fieldType, isFieldReadOnly, labelSchemaData } from "../state";
 import {
+  current,
   currentType,
   defaultField,
   fieldsOfType,
@@ -52,14 +49,20 @@ const lastUsedLabelAtom = atomFamily(
   (_field: string) => atom<string | null>(null) as PrimitiveAtom<string | null>
 );
 
-const detectionTypes = new Set(["Detection", "Detections"]);
+// Set of label ids currently being authored as masks. Updated by
+// `useBridge` via the public `setEditingMask` action.
+const editingMaskLabelIdsAtom = atom<ReadonlySet<string>>(new Set<string>());
 
-/**
- * Tracks the last processed event ID for each event type so that only one
- * `useDetectionMode` instance handles each event, even though the hook is
- * called in multiple components.
- */
-const claimedEventsAtom = atom<Map<string, string>>(new Map());
+// Derived: does the currently-edited label have a mask?
+const isEditingMaskAtom = atom((get) => {
+  const ids = get(editingMaskLabelIdsAtom);
+  if (ids.size === 0) return false;
+
+  const data = get(current)?.data as { _id?: string } | undefined;
+  return data?._id !== undefined && ids.has(data._id);
+});
+
+const detectionTypes = new Set(["Detection", "Detections"]);
 
 /**
  * Centralized hook for managing detection mode state and operations.
@@ -69,7 +72,6 @@ export const useDetectionMode = () => {
     detectionModeActiveAtom
   );
   const editingLabelType = useAtomValue(currentType);
-  const isEditingDetection = editingLabelType === DETECTION;
   const isPatchView = useRecoilValue(isPatchesView);
   const setLastUsedField = useSetAtom(lastUsedFieldAtom);
   const labelsMap = useAtomValue(labelsByPath);
@@ -80,16 +82,38 @@ export const useDetectionMode = () => {
   const onExit = useExit();
   const fields = useAtomValue(fieldsOfType(DETECTION));
 
-  const useEventHandler = useLighterEventHandler(
-    scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
-  );
-
   // Using refs to prevent shared closure contexts from retaining old Scene2D instances.
   const sceneRef = useRef(scene);
   sceneRef.current = scene;
 
   const selectedLabelRef = useRef(selectedLabel);
   selectedLabelRef.current = selectedLabel;
+
+  const isEditingMask = useAtomValue(isEditingMaskAtom);
+  const setEditingMaskIds = useSetAtom(editingMaskLabelIdsAtom);
+
+  // Mark `id` as mid-mask authoring (when `hasMask`) or clear that
+  const setEditingMask = useCallback(
+    (id: string, hasMask: boolean) => {
+      setEditingMaskIds((prev) => {
+        const has = prev.has(id);
+        if (hasMask === has) return prev;
+
+        const next = new Set(prev);
+        if (hasMask) next.add(id);
+        else next.delete(id);
+
+        return next;
+      });
+    },
+    [setEditingMaskIds]
+  );
+
+  const isEditingDetection =
+    editingLabelType === DETECTION &&
+    !selectedLabel?.isNew &&
+    !selectedLabel?.data?.mask &&
+    !isEditingMask;
 
   const noActiveFields = fields.length === 0;
   const disabled = isPatchView || noActiveFields;
@@ -170,23 +194,27 @@ export const useDetectionMode = () => {
     setDetectionModeActive(false);
   }, [finalizeCurrentDetection, setDetectionModeActive]);
 
-  // Auto-enable detection mode when a detection is being edited,
-  // auto-disable when a different label type is selected.
+  // Auto-activate detection mode when a pre-existing bbox detection is selected,
+  // auto-deactivate when a pre-existing label of a different type is selected.
+  // New labels are ignored — the mode was set intentionally via the toolbar button.
   useEffect(() => {
+    if (selectedLabel?.isNew) return;
+
     if (isEditingDetection && !detectionModeActive) {
       setDetectionModeActive(true);
     } else if (editingLabelType && !isEditingDetection && detectionModeActive) {
       setDetectionModeActive(false);
     }
   }, [
+    detectionModeActive,
     editingLabelType,
     isEditingDetection,
-    detectionModeActive,
+    selectedLabel?.isNew,
     setDetectionModeActive,
   ]);
 
   /**
-   * Get the auto-assigned detection field path.
+   * Determine field path to use.
    *
    * Auto-assignment priority:
    * 1. Last-used detection field (if in detection mode and previously set)
@@ -199,7 +227,7 @@ export const useDetectionMode = () => {
    * a field set by `trackLastUsedDetection` in the same synchronous call-stack
    * is visible immediately (avoids stale closure).
    */
-  const getDetectionModeField = useAtomCallback(
+  const getLastField = useAtomCallback(
     useCallback(
       (get): string | null => {
         const lastField = get(lastUsedFieldAtom);
@@ -250,7 +278,7 @@ export const useDetectionMode = () => {
    *
    * Returns null if no label value can be determined.
    */
-  const getDetectionModeLabel = useCallback(
+  const getLastLabel = useCallback(
     (fieldPath: string): string | null => {
       const lastUsedLabel = getLastUsedLabel(fieldPath);
 
@@ -289,24 +317,8 @@ export const useDetectionMode = () => {
     [getLabelSchema, getLastUsedLabel, labelsMap]
   );
 
-  const claimEvent = useAtomCallback(
-    useCallback((get, set, eventType: string, eventId: string) => {
-      const claimedEvents = get(claimedEventsAtom);
-      if (claimedEvents.get(eventType) === eventId) {
-        return false;
-      }
-
-      const updatedEvents = new Map(claimedEvents);
-      updatedEvents.set(eventType, eventId);
-      set(claimedEventsAtom, updatedEvents);
-
-      return true;
-    }, [])
-  );
-
   /**
-   * Toggle detection mode. When exiting, deactivateDetectionMode handles
-   * finalization (caches field/label, exits interactive mode, closes edit form).
+   * Toggle detection mode.
    */
   const toggleDetectionMode = useCallback(() => {
     if (detectionModeActive) {
@@ -317,53 +329,17 @@ export const useDetectionMode = () => {
   }, [detectionModeActive, deactivateDetectionMode, activateDetectionMode]);
 
   /**
-   * Cache field/label for auto-assignment
-   * Close out previous label
-   * Create the next detection.
+   * Finalize the previous detection and create the next one with auto-
+   * assigned field/label.
    */
-  useEventHandler(
-    "lighter:overlay-create",
-    useCallback(
-      (payload) => {
-        if (!claimEvent("overlay-create", payload.eventId)) {
-          return;
-        }
+  const create = useCallback(() => {
+    finalizeCurrentDetection();
 
-        finalizeCurrentDetection();
+    const field = getLastField() ?? undefined;
+    const labelValue = field ? getLastLabel(field) ?? undefined : undefined;
 
-        const field = getDetectionModeField() ?? undefined;
-        const labelValue = field
-          ? getDetectionModeLabel(field) ?? undefined
-          : undefined;
-
-        createDetection({ field, labelValue });
-      },
-      [
-        claimEvent,
-        createDetection,
-        finalizeCurrentDetection,
-        getDetectionModeField,
-        getDetectionModeLabel,
-      ]
-    )
-  );
-
-  /**
-   * Exit detection mode (triggered when user clicks without dragging).
-   */
-  useEventHandler(
-    "lighter:detection-mode-quit",
-    useCallback(
-      (payload) => {
-        if (!claimEvent("detection-mode-quit", payload.eventId)) {
-          return;
-        }
-
-        deactivateDetectionMode();
-      },
-      [claimEvent, deactivateDetectionMode]
-    )
-  );
+    createDetection({ field, labelValue });
+  }, [createDetection, finalizeCurrentDetection, getLastField, getLastLabel]);
 
   return useMemo(
     () => ({
@@ -376,6 +352,10 @@ export const useDetectionMode = () => {
       activateDetectionMode,
       deactivateDetectionMode,
       toggleDetectionMode,
+
+      // Bridge actions (wired to Lighter events by `useBridge`)
+      create,
+      setEditingMask,
     }),
     [
       activateDetectionMode,
@@ -384,6 +364,8 @@ export const useDetectionMode = () => {
       disabled,
       toggleDetectionMode,
       tooltip,
+      create,
+      setEditingMask,
     ]
   );
 };

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useManualSegmentationTools.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useManualSegmentationTools.ts
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { useCallback, useMemo } from "react";
+import { atom, useAtom } from "jotai";
+
+export const DEFAULT_TOOL_SIZE = 16;
+export const MIN_TOOL_SIZE = 1;
+export const MAX_TOOL_SIZE = 32;
+export const MIN_CURSOR_SIZE = 1;
+export const MAX_CURSOR_SIZE = 100;
+
+export const SegmentationTool = {
+  Select: "select",
+  Brush: "brush",
+  Pen: "pen",
+  AI: "ai",
+} as const;
+export type SegmentationTool =
+  (typeof SegmentationTool)[keyof typeof SegmentationTool];
+
+export const SegmentationToolShape = {
+  Circle: "circle",
+  Square: "square",
+} as const;
+export type SegmentationToolShape =
+  (typeof SegmentationToolShape)[keyof typeof SegmentationToolShape];
+
+export const SegmentationToolMode = {
+  Add: "add",
+  Remove: "remove",
+} as const;
+export type SegmentationToolMode =
+  (typeof SegmentationToolMode)[keyof typeof SegmentationToolMode];
+
+export const DEFAULT_TOOL_MODE: SegmentationToolMode = SegmentationToolMode.Add;
+
+export interface SegmentationToolState {
+  active: boolean;
+  size: number; // World-space dab size (for painting on the mask canvas)
+  cursorSize: number; // Screen-pixel cursor size, clamped to [MIN_CURSOR_SIZE, MAX_CURSOR_SIZE]
+  tool: SegmentationTool;
+  shape: SegmentationToolShape;
+  mode: SegmentationToolMode;
+}
+
+const toolAtom = atom<SegmentationTool>(SegmentationTool.Select);
+const toolSizeAtom = atom<number>(DEFAULT_TOOL_SIZE);
+const toolShapeAtom = atom<SegmentationToolShape>(SegmentationToolShape.Circle);
+const toolModeAtom = atom<SegmentationToolMode>(DEFAULT_TOOL_MODE);
+
+/** @internal */ export { toolAtom as _unsafeToolAtom };
+/** @internal */ export { toolSizeAtom as _unsafeToolSizeAtom };
+/** @internal */ export { toolShapeAtom as _unsafeToolShapeAtom };
+/** @internal */ export { toolModeAtom as _unsafeToolModeAtom };
+
+/**
+ * Hook providing the manual (brush/pen/select) segmentation tool state and
+ * the actions to mutate it. AI tool behavior lives in `useAIAnnotationMode`.
+ */
+export const useManualSegmentationTools = () => {
+  const [tool, setTool] = useAtom(toolAtom);
+  const [toolSize, setToolSizeRaw] = useAtom(toolSizeAtom);
+  const [toolShape, setToolShape] = useAtom(toolShapeAtom);
+  const [toolMode, setToolMode] = useAtom(toolModeAtom);
+
+  const switchTool = useCallback(
+    (newTool: SegmentationTool) => {
+      setTool(newTool);
+    },
+    [setTool]
+  );
+
+  const increaseToolSize = useCallback(() => {
+    setToolSizeRaw((prev) => Math.min(prev + 1, MAX_TOOL_SIZE));
+  }, [setToolSizeRaw]);
+
+  const decreaseToolSize = useCallback(() => {
+    setToolSizeRaw((prev) => Math.max(prev - 1, MIN_TOOL_SIZE));
+  }, [setToolSizeRaw]);
+
+  const setToolSize = useCallback(
+    (size: number) => {
+      const n = Number(size);
+      if (Number.isNaN(n)) return;
+      setToolSizeRaw(Math.max(MIN_TOOL_SIZE, Math.min(n, MAX_TOOL_SIZE)));
+    },
+    [setToolSizeRaw]
+  );
+
+  const switchToolShape = useCallback(
+    (shape: SegmentationToolShape) => {
+      setToolShape(shape);
+    },
+    [setToolShape]
+  );
+
+  const switchToolMode = useCallback(
+    (mode: SegmentationToolMode) => {
+      setToolMode(mode);
+    },
+    [setToolMode]
+  );
+
+  return useMemo(
+    () => ({
+      tool,
+      toolSize,
+      toolShape,
+      toolMode,
+      switchTool,
+      switchToolShape,
+      switchToolMode,
+      increaseToolSize,
+      decreaseToolSize,
+      setToolSize,
+    }),
+    [
+      tool,
+      toolSize,
+      toolShape,
+      toolMode,
+      switchTool,
+      switchToolShape,
+      switchToolMode,
+      increaseToolSize,
+      decreaseToolSize,
+      setToolSize,
+    ]
+  );
+};

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationActions.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationActions.tsx
@@ -1,0 +1,349 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { SelectIcon, type ToolbarActionGroup } from "@fiftyone/components";
+import { buildBrushCursor } from "@fiftyone/lighter";
+import {
+  Add,
+  ArrowDropDown,
+  ArrowDropUp,
+  AutoAwesome,
+  Brush,
+  CircleOutlined,
+  CropSquare,
+  FormatColorReset,
+  Redo,
+  Remove,
+  Timeline,
+  Undo,
+} from "@mui/icons-material";
+import { useEffect, useMemo, useRef } from "react";
+import styled from "styled-components";
+import {
+  MAX_CURSOR_SIZE,
+  MAX_TOOL_SIZE,
+  MIN_CURSOR_SIZE,
+  MIN_TOOL_SIZE,
+  SegmentationTool,
+  SegmentationToolMode,
+  SegmentationToolShape,
+  useSegmentationMode,
+} from "./useSegmentationMode";
+
+const SizeControl = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: 32px;
+  border: 1px solid ${({ theme }) => theme.primary.plainBorder};
+  border-radius: 3px;
+  background: ${({ theme }) => theme.background.level1};
+  overflow: hidden;
+  user-select: none;
+`;
+
+const SizeArrow = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 14px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: ${({ theme }) => theme.text.primary};
+  cursor: pointer;
+  outline: none;
+
+  &:hover:not(:disabled) {
+    background: ${({ theme }) => theme.background.level2};
+  }
+
+  &:disabled {
+    color: ${({ theme }) => theme.text.tertiary};
+    cursor: not-allowed;
+  }
+
+  svg {
+    font-size: 18px;
+  }
+`;
+
+const SizeValue = styled.div<{ $cursor: string }>`
+  text-align: center;
+  color: ${({ theme }) => theme.text.primary};
+  font-size: 11px;
+  padding: 1px 0;
+  font-variant-numeric: tabular-nums;
+  cursor: ${({ $cursor }) => $cursor};
+`;
+
+interface BrushSizeProps {
+  value: number;
+  min: number;
+  max: number;
+  cursor: string;
+  onIncrease: () => void;
+  onDecrease: () => void;
+}
+
+const BrushSize = ({
+  value,
+  min,
+  max,
+  cursor,
+  onIncrease,
+  onDecrease,
+}: BrushSizeProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return undefined;
+
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+
+      if (e.deltaY < 0) onDecrease();
+      else if (e.deltaY > 0) onIncrease();
+    };
+
+    node.addEventListener("wheel", onWheel, { passive: false });
+    return () => node.removeEventListener("wheel", onWheel);
+  }, [onIncrease, onDecrease]);
+
+  return (
+    <SizeControl ref={ref}>
+      <SizeArrow
+        type="button"
+        aria-label="Increase brush size"
+        onClick={onIncrease}
+        disabled={value >= max}
+      >
+        <ArrowDropUp />
+      </SizeArrow>
+      <SizeValue $cursor={cursor}>{value}</SizeValue>
+      <SizeArrow
+        type="button"
+        aria-label="Decrease brush size"
+        onClick={onDecrease}
+        disabled={value <= min}
+      >
+        <ArrowDropDown />
+      </SizeArrow>
+    </SizeControl>
+  );
+};
+
+interface UseSegmentationActionsArgs {
+  onUndo?: () => void;
+  onRedo?: () => void;
+  canUndo?: boolean;
+  canRedo?: boolean;
+}
+
+export const useSegmentationActions = ({
+  onUndo,
+  onRedo,
+  canUndo = false,
+  canRedo = false,
+}: UseSegmentationActionsArgs): {
+  groups: ToolbarActionGroup[];
+  visible: boolean;
+} => {
+  const {
+    segmentationModeActive,
+    tool,
+    toolSize,
+    toolShape,
+    toolMode,
+    switchTool,
+    switchToolShape,
+    switchToolMode,
+    increaseToolSize,
+    decreaseToolSize,
+  } = useSegmentationMode();
+
+  const brushCursor = useMemo(() => {
+    const cursorSize = Math.min(
+      MAX_CURSOR_SIZE,
+      Math.max(MIN_CURSOR_SIZE, toolSize)
+    );
+
+    return buildBrushCursor({
+      active: true,
+      tool: SegmentationTool.Brush,
+      shape: toolShape,
+      size: toolSize,
+      cursorSize,
+      mode: toolMode,
+    });
+  }, [toolShape, toolSize, toolMode]);
+
+  const groups: ToolbarActionGroup[] = useMemo(
+    () => [
+      {
+        id: "tool",
+        label: "Tool",
+        actions: [
+          {
+            id: SegmentationTool.Select,
+            label: "Select",
+            icon: <SelectIcon />,
+            shortcut: "S",
+            tooltip: "Select",
+            isActive: tool === SegmentationTool.Select,
+            onClick: () => switchTool(SegmentationTool.Select),
+          },
+          {
+            id: SegmentationTool.Brush,
+            label: "Brush",
+            icon: <Brush />,
+            shortcut: "B",
+            tooltip: "Brush",
+            isActive: tool === SegmentationTool.Brush,
+            onClick: () => switchTool(SegmentationTool.Brush),
+          },
+          {
+            id: SegmentationTool.Pen,
+            label: "Pen",
+            icon: <Timeline />,
+            shortcut: "P",
+            tooltip: "Pen",
+            isActive: tool === SegmentationTool.Pen,
+            onClick: () => switchTool(SegmentationTool.Pen),
+          },
+          {
+            id: SegmentationTool.AI,
+            label: "AI",
+            icon: <AutoAwesome />,
+            shortcut: "A",
+            tooltip: "AI",
+            isActive: tool === SegmentationTool.AI,
+            onClick: () => switchTool(SegmentationTool.AI),
+          },
+        ],
+      },
+      {
+        id: "mode",
+        label: "Mode",
+        isHidden: !(
+          tool === SegmentationTool.Brush || tool === SegmentationTool.Pen
+        ),
+        actions: [
+          {
+            id: SegmentationToolMode.Add,
+            label: "Add",
+            icon: <Add />,
+            tooltip: "Add to mask",
+            isActive: toolMode === SegmentationToolMode.Add,
+            onClick: () => switchToolMode(SegmentationToolMode.Add),
+          },
+          {
+            id: SegmentationToolMode.Remove,
+            label: "Remove",
+            icon: <Remove />,
+            tooltip: "Remove from mask",
+            isActive: toolMode === SegmentationToolMode.Remove,
+            onClick: () => switchToolMode(SegmentationToolMode.Remove),
+          },
+        ],
+      },
+      {
+        id: "size",
+        label: "Size",
+        isHidden: tool !== SegmentationTool.Brush,
+        actions: [
+          {
+            id: "size-input",
+            label: "Size",
+            icon: <></>,
+            onClick: () => {},
+            customComponent: (
+              <BrushSize
+                value={toolSize}
+                min={MIN_TOOL_SIZE}
+                max={MAX_TOOL_SIZE}
+                cursor={brushCursor}
+                onIncrease={increaseToolSize}
+                onDecrease={decreaseToolSize}
+              />
+            ),
+          },
+        ],
+      },
+      {
+        id: "shape",
+        label: "Shape",
+        isHidden: tool !== SegmentationTool.Brush,
+        actions: [
+          {
+            id: SegmentationToolShape.Circle,
+            label: "Circle",
+            icon: <CircleOutlined />,
+            tooltip: "Circle",
+            isActive: toolShape === SegmentationToolShape.Circle,
+            onClick: () => switchToolShape(SegmentationToolShape.Circle),
+          },
+          {
+            id: SegmentationToolShape.Square,
+            label: "Square",
+            icon: <CropSquare />,
+            tooltip: "Square",
+            isActive: toolShape === SegmentationToolShape.Square,
+            onClick: () => switchToolShape(SegmentationToolShape.Square),
+          },
+        ],
+      },
+      {
+        id: "actions",
+        label: "Actions",
+        actions: [
+          {
+            id: "undo",
+            label: "Undo",
+            icon: <Undo />,
+            shortcut: "Ctrl+Z",
+            tooltip: "Undo",
+            isDisabled: !canUndo,
+            onClick: () => canUndo && onUndo?.(),
+          },
+          {
+            id: "redo",
+            label: "Redo",
+            icon: <Redo />,
+            shortcut: "Ctrl+Shift+Z",
+            tooltip: "Redo",
+            isDisabled: !canRedo,
+            onClick: () => canRedo && onRedo?.(),
+          },
+          {
+            id: "clear",
+            label: "Clear mask",
+            icon: <FormatColorReset />,
+            tooltip: "Clear mask",
+            onClick: () => {},
+          },
+        ],
+      },
+    ],
+    [
+      tool,
+      toolSize,
+      toolShape,
+      toolMode,
+      switchTool,
+      switchToolShape,
+      switchToolMode,
+      increaseToolSize,
+      decreaseToolSize,
+      brushCursor,
+      canUndo,
+      canRedo,
+      onUndo,
+      onRedo,
+    ]
+  );
+
+  return { groups, visible: segmentationModeActive };
+};

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
@@ -2,64 +2,297 @@
  * Copyright 2017-2026, Voxel51, Inc.
  */
 
-import { atom } from "jotai";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { atom, useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useRecoilValue } from "recoil";
 
-export const DEFAULT_TOOL_SIZE = 16;
-export const MIN_TOOL_SIZE = 1;
-export const MAX_TOOL_SIZE = 32;
-export const MIN_CURSOR_SIZE = 1;
-export const MAX_CURSOR_SIZE = 100;
+import { BaseOverlay, DetectionOverlay, useLighter } from "@fiftyone/lighter";
+import { isPatchesView } from "@fiftyone/state";
+import { DETECTION } from "@fiftyone/utilities";
 
-export const SegmentationTool = {
-  Select: "select",
-  Brush: "brush",
-  Pen: "pen",
-  AI: "ai",
-} as const;
-export type SegmentationTool =
-  (typeof SegmentationTool)[keyof typeof SegmentationTool];
+import {
+  current,
+  currentType,
+  fieldsOfType,
+  useAnnotationContext,
+} from "./state";
+import { useAIAnnotationMode } from "./useAIAnnotationMode";
+import useCreate from "./useCreate";
+import useExit from "./useExit";
+import {
+  SegmentationTool,
+  useManualSegmentationTools,
+} from "./useManualSegmentationTools";
 
-export const SegmentationToolShape = {
-  Circle: "circle",
-  Square: "square",
-} as const;
-export type SegmentationToolShape =
-  (typeof SegmentationToolShape)[keyof typeof SegmentationToolShape];
-
-export const SegmentationToolMode = {
-  Add: "add",
-  Remove: "remove",
-} as const;
-export type SegmentationToolMode =
-  (typeof SegmentationToolMode)[keyof typeof SegmentationToolMode];
-
-export const DEFAULT_TOOL_MODE: SegmentationToolMode = SegmentationToolMode.Add;
-
-export interface SegmentationToolState {
-  active: boolean;
-  size: number; // World-space dab size (for painting on the mask canvas)
-  cursorSize: number; // Screen-pixel cursor size, clamped to [MIN_CURSOR_SIZE, MAX_CURSOR_SIZE]
-  tool: SegmentationTool;
-  shape: SegmentationToolShape;
-  mode: SegmentationToolMode;
-}
-
-// ---------------------------------------------------------------------------
-// Atoms (internal)
-// ---------------------------------------------------------------------------
+// Re-export tool types/constants and unsafe atoms so existing import paths
+// (e.g. `import { SegmentationTool } from "./useSegmentationMode"`) keep
+// working after the split into focused hooks.
+export {
+  DEFAULT_TOOL_MODE,
+  DEFAULT_TOOL_SIZE,
+  MAX_CURSOR_SIZE,
+  MAX_TOOL_SIZE,
+  MIN_CURSOR_SIZE,
+  MIN_TOOL_SIZE,
+  SegmentationTool,
+  SegmentationToolMode,
+  SegmentationToolShape,
+  _unsafeToolAtom,
+  _unsafeToolModeAtom,
+  _unsafeToolShapeAtom,
+  _unsafeToolSizeAtom,
+} from "./useManualSegmentationTools";
+export type { SegmentationToolState } from "./useManualSegmentationTools";
 
 const segmentationModeActiveAtom = atom<boolean>(false);
-const toolAtom = atom<SegmentationTool>(SegmentationTool.Select);
-const toolSizeAtom = atom<number>(DEFAULT_TOOL_SIZE);
-const toolShapeAtom = atom<SegmentationToolShape>(SegmentationToolShape.Circle);
-const toolModeAtom = atom<SegmentationToolMode>(DEFAULT_TOOL_MODE);
-
-// ---------------------------------------------------------------------------
-// Unsafe exports for non-React bridge access only.
-// ---------------------------------------------------------------------------
 
 /** @internal */ export { segmentationModeActiveAtom as _unsafeSegmentationModeActiveAtom };
-/** @internal */ export { toolAtom as _unsafeToolAtom };
-/** @internal */ export { toolSizeAtom as _unsafeToolSizeAtom };
-/** @internal */ export { toolShapeAtom as _unsafeToolShapeAtom };
-/** @internal */ export { toolModeAtom as _unsafeToolModeAtom };
+
+// Set of label ids currently being authored as masks. Updated by
+// `useBridge` via the public `setEditingMask` action.
+const editingMaskLabelIdsAtom = atom<ReadonlySet<string>>(new Set<string>());
+
+// Derived: does the currently-edited label have a mask?
+const isEditingMaskAtom = atom((get) => {
+  const ids = get(editingMaskLabelIdsAtom);
+  if (ids.size === 0) return false;
+
+  const data = get(current)?.data as { _id?: string } | undefined;
+  return data?._id !== undefined && ids.has(data._id);
+});
+
+/**
+ * Segmentation mask tool state hook.
+ *
+ * Composes:
+ * - `useManualSegmentationTools` — brush/pen/select tool state and actions
+ * - `useAIAnnotationMode` — AI tool point selection
+ *
+ * Plus the cross-concern glue (mode activation/deactivation, auto-activate
+ * on mask selection, AI tool effect, `create`/`finalizePointSelection` for
+ * the bridge).
+ */
+export const useSegmentationMode = () => {
+  const { scene, addOverlay } = useLighter();
+  const { selectedLabel } = useAnnotationContext();
+  const onExit = useExit();
+  const isPatchView = useRecoilValue(isPatchesView);
+  const fields = useAtomValue(fieldsOfType(DETECTION));
+  const isEditingMask = useAtomValue(isEditingMaskAtom);
+  const setEditingMaskIds = useSetAtom(editingMaskLabelIdsAtom);
+  const [segmentationModeActive, setSegmentationModeActive] = useAtom(
+    segmentationModeActiveAtom
+  );
+
+  // Mark `id` as mid-mask authoring (when `hasMask`) or clear that
+  const setEditingMask = useCallback(
+    (id: string, hasMask: boolean) => {
+      setEditingMaskIds((prev) => {
+        const has = prev.has(id);
+        if (hasMask === has) return prev;
+
+        const next = new Set(prev);
+
+        if (hasMask) next.add(id);
+        else next.delete(id);
+
+        return next;
+      });
+    },
+    [setEditingMaskIds]
+  );
+
+  const manualMode = useManualSegmentationTools();
+  const aiMode = useAIAnnotationMode();
+
+  const createDetection = useCreate(DETECTION);
+  const editingLabelType = useAtomValue(currentType);
+
+  const sceneRef = useRef(scene);
+  sceneRef.current = scene;
+
+  const selectedLabelRef = useRef(selectedLabel);
+  selectedLabelRef.current = selectedLabel;
+
+  const isEditingSegmentation =
+    editingLabelType === DETECTION &&
+    (!!selectedLabel?.data?.mask || isEditingMask);
+
+  const noActiveFields = fields.length === 0;
+  const disabled = isPatchView || noActiveFields;
+
+  const tooltip = isPatchView
+    ? "Creating masks is not supported in this view"
+    : noActiveFields
+    ? "No active fields"
+    : segmentationModeActive
+    ? "Exit mask creation"
+    : "Create new mask";
+
+  // ---------------  Segmentation mode activation / deactivation  --------- //
+
+  const activateSegmentationMode = useCallback(() => {
+    setSegmentationModeActive(true);
+  }, [setSegmentationModeActive]);
+
+  /**
+   * Disable segmentation mode and gracefully close out any label being edited.
+   */
+  const deactivateSegmentationMode = useCallback(() => {
+    sceneRef.current?.exitInteractiveMode();
+    onExit();
+    aiMode.deactivate();
+    setSegmentationModeActive(false);
+  }, [aiMode, onExit, setSegmentationModeActive]);
+
+  const toggleSegmentationMode = useCallback(() => {
+    if (segmentationModeActive) {
+      deactivateSegmentationMode();
+    } else {
+      activateSegmentationMode();
+    }
+  }, [
+    segmentationModeActive,
+    deactivateSegmentationMode,
+    activateSegmentationMode,
+  ]);
+
+  /**
+   * Persist any in-progress mask edit and exit interactive paint mode.
+   * Idempotent — safe to call when there's no open label.
+   */
+  const closeOpenLabel = useCallback(() => {
+    const currentScene = sceneRef.current;
+    const currentLabel = selectedLabelRef.current;
+
+    if (
+      currentScene &&
+      !currentScene.isDestroyed &&
+      currentScene.renderLoopActive
+    ) {
+      currentScene.exitInteractiveMode();
+
+      if (currentLabel?.overlay) {
+        addOverlay(currentLabel.overlay as BaseOverlay);
+      }
+    }
+  }, [addOverlay]);
+
+  // Activate/deactivate AI point selection when switching to/from the AI tool.
+  // Switching INTO AI finalizes any open manual edit so the user starts the
+  // AI flow on a clean slate.
+  useEffect(() => {
+    if (!segmentationModeActive) return;
+
+    if (manualMode.tool === SegmentationTool.AI) {
+      if (!aiMode.isActive) {
+        closeOpenLabel();
+      }
+      aiMode.activate();
+    } else if (aiMode.isActive) {
+      aiMode.deactivate();
+    }
+  }, [manualMode.tool, segmentationModeActive, aiMode, closeOpenLabel]);
+
+  // Auto-enable segmentation mode when a pre-existing mask detection is selected,
+  // auto-disable when a pre-existing label of a different type is selected.
+  //
+  // New labels are ignored — the mode was set intentionally via the toolbar button.
+  useEffect(() => {
+    if (selectedLabel?.isNew) {
+      return;
+    }
+
+    if (isEditingSegmentation && !segmentationModeActive) {
+      setSegmentationModeActive(true);
+    } else if (
+      editingLabelType &&
+      !isEditingSegmentation &&
+      segmentationModeActive
+    ) {
+      setSegmentationModeActive(false);
+    }
+  }, [
+    selectedLabel?.isNew,
+    selectedLabel?.overlay,
+    editingLabelType,
+    isEditingSegmentation,
+    segmentationModeActive,
+    setSegmentationModeActive,
+    manualMode.tool,
+    scene,
+  ]);
+
+  // -----------------------  Bridge Event Handlers  ----------------------- //
+
+  /**
+   * Finalize the previous mask detection (if any) and start a new one.
+   */
+  const create = useCallback(() => {
+    closeOpenLabel();
+    // TODO: assume previous `field` and `labelValue`
+    // e.g. createDetection({ field, labelValue });
+    const newLabel = createDetection();
+
+    if (newLabel?.overlay instanceof DetectionOverlay) {
+      newLabel.overlay.initMask();
+    }
+  }, [closeOpenLabel, createDetection]);
+
+  /**
+   * Accept the current AI mask, tear down point selection, and switch to the
+   * brush so the user can refine the mask manually. The overlay stays
+   * selected and in editing mode.
+   */
+  const finalizePointSelection = useCallback(() => {
+    aiMode.deactivate();
+    manualMode.switchTool(SegmentationTool.Brush);
+  }, [aiMode, manualMode]);
+
+  // ----------------------------  Public interface  ----------------------- //
+
+  return useMemo(
+    () => ({
+      // State (read-only)
+      segmentationModeActive,
+      isEditingMask,
+      disabled,
+      tooltip,
+
+      // Mode control
+      activateSegmentationMode,
+      deactivateSegmentationMode,
+      toggleSegmentationMode,
+
+      // Bridge actions (wired to Lighter events by `useBridge`)
+      create,
+      finalizePointSelection,
+      setEditingMask,
+
+      // Tool state and actions
+      tool: manualMode.tool,
+      toolSize: manualMode.toolSize,
+      toolShape: manualMode.toolShape,
+      toolMode: manualMode.toolMode,
+      switchTool: manualMode.switchTool,
+      switchToolShape: manualMode.switchToolShape,
+      switchToolMode: manualMode.switchToolMode,
+      increaseToolSize: manualMode.increaseToolSize,
+      decreaseToolSize: manualMode.decreaseToolSize,
+      setToolSize: manualMode.setToolSize,
+    }),
+    [
+      segmentationModeActive,
+      isEditingMask,
+      disabled,
+      tooltip,
+      activateSegmentationMode,
+      deactivateSegmentationMode,
+      toggleSegmentationMode,
+      create,
+      finalizePointSelection,
+      setEditingMask,
+      manualMode,
+    ]
+  );
+};

--- a/app/packages/lighter/src/events/index.ts
+++ b/app/packages/lighter/src/events/index.ts
@@ -6,7 +6,7 @@ import type { Undoable } from "@fiftyone/commands";
 import type { InteractionHandler } from "../interaction/InteractionManager";
 import type { BaseOverlay } from "../overlay/BaseOverlay";
 import type { PaintStrokeData } from "../overlay/MaskCanvas";
-import type { Point, Rect } from "../types";
+import type { Point, RawLookerLabel, Rect } from "../types";
 
 /**
  * Event type definitions for lighter events.
@@ -27,6 +27,17 @@ export type LighterEventGroup = {
   "lighter:overlay-bounds-changed": {
     id: string;
     bounds: Rect;
+  };
+  /**
+   * Emitted when an overlay's label is updated, or when an overlay's
+   * editing state changes in a way subscribers need to observe (e.g.
+   * `DetectionOverlay.initMask`/`removeMask` flipping mask-canvas state
+   * without changing label data).
+   */
+  "lighter:overlay-label-updated": {
+    id: string;
+    label: RawLookerLabel;
+    hasMask: boolean;
   };
 
   // ============================================================================
@@ -123,6 +134,10 @@ export type LighterEventGroup = {
   };
   /** Emitted when user clicks without dragging in detection mode to exit */
   "lighter:detection-mode-quit": { eventId: string };
+  /** Emitted when user clicks without dragging in segmentation mode to close out the current detection */
+  "lighter:segmentation-mode-quit": { eventId: string };
+  /** Emitted when the AI mask should be established and point selection ended (e.g. right-click) */
+  "lighter:point-selection-finalize": { eventId: string };
 
   // ============================================================================
   // KEYPOINT EVENTS

--- a/app/packages/lighter/src/interaction/InteractionManager.ts
+++ b/app/packages/lighter/src/interaction/InteractionManager.ts
@@ -310,7 +310,7 @@ export class InteractionManager {
       // Detection mode: defer overlay creation until we confirm this is a drag.
       // If the user releases without dragging (a click), exit detection mode.
       // Clicking on an existing overlay selects it normally instead.
-      if (detectionModeBridge.isDetectionModeActive()) {
+      if (detectionModeBridge.isActive()) {
         const isNonOverlay = !handler || handler.id === this.canonicalMediaId;
 
         if (isNonOverlay) {
@@ -376,7 +376,7 @@ export class InteractionManager {
     scale: number
   ): void {
     if (
-      detectionModeBridge.isDetectionModeActive() &&
+      detectionModeBridge.isActive() &&
       handler &&
       TypeGuards.isSelectable(handler) &&
       !handler.isSelected()
@@ -528,7 +528,7 @@ export class InteractionManager {
       }
       this.configureCursorStyle(handler, worldPoint, scale);
     } else if (
-      detectionModeBridge.isDetectionModeActive() &&
+      detectionModeBridge.isActive() &&
       !interactiveHandler
     ) {
       this.canvas.style.cursor = "crosshair";

--- a/app/packages/lighter/src/overlay/DetectionOverlay.ts
+++ b/app/packages/lighter/src/overlay/DetectionOverlay.ts
@@ -45,6 +45,7 @@ export type DetectionLabel = RawLookerLabel & {
   bounding_box: number[];
   confidence?: number;
   mask?: SerializedMask;
+  mask_path?: string;
 };
 
 /**
@@ -145,15 +146,19 @@ export class DetectionOverlay
       } else {
         this.mask = new MaskCanvas(label.mask);
       }
-
       this.markDirty();
     } else {
       const hadMask = !!this.mask;
       this.mask?.destroy();
       this.mask = undefined;
-
       if (hadMask) this.markDirty();
     }
+
+    this.eventBus.dispatch("lighter:overlay-label-updated", {
+      id: this.id,
+      label,
+      hasMask: !!this.mask,
+    });
   }
 
   getPosition() {
@@ -1093,6 +1098,11 @@ export class DetectionOverlay
     if (!this.mask) {
       this.mask = new MaskCanvas();
       this.markDirty();
+      this.eventBus.dispatch("lighter:overlay-label-updated", {
+        id: this.id,
+        label: this.label,
+        hasMask: true,
+      });
     }
   }
 
@@ -1100,9 +1110,17 @@ export class DetectionOverlay
    * Removes the mask from this detection, destroying the MaskCanvas.
    */
   removeMask(): void {
+    const hadMask = !!this.mask;
     this.mask?.destroy();
     this.mask = undefined;
     this.markDirty();
+    if (hadMask) {
+      this.eventBus.dispatch("lighter:overlay-label-updated", {
+        id: this.id,
+        label: this.label,
+        hasMask: false,
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
## Editing UI

- Actions.tsx - add segmentation mode to the Actions bar
- Edit.tsx - x, y, w, h now read-only for masks, add mask preview
- Header.tsx - add/remove mask menu option for detections
- useSegmentationActions - tools for the floating toolbar
- useSegmentationMode - the actual hook to manage which segmentation tool is currently employed