### PR TITLE
ai-segmentation: keypoint effects, ripple, mask persistence

### DIFF
--- a/app/packages/annotation/src/agents/SAM2BrowserAnnotationAgent.test.ts
+++ b/app/packages/annotation/src/agents/SAM2BrowserAnnotationAgent.test.ts
@@ -7,7 +7,7 @@ import {
   InferenceCapability,
   SampleDescriptor,
 } from "./types";
-import { float32ToCompressedNumpy } from "../util/conversion";
+import { encodeMaskData } from "@fiftyone/lighter/src/utils/maskEncoding";
 
 const _DATASET_ID = "dataset-id";
 const _SAMPLE_ID = "sample-id";
@@ -157,16 +157,21 @@ describe("SAM2BrowserAnnotationAgent", () => {
 
       const result = await agent.infer(makeContext());
 
+      const binary = new Uint8Array(providerResult.mask.length);
+      for (let i = 0; i < providerResult.mask.length; i++) {
+        binary[i] = providerResult.mask[i] > 0.5 ? 1 : 0;
+      }
+      const expectedMask = await encodeMaskData(binary, [
+        providerResult.maskHeight,
+        providerResult.maskWidth,
+      ]);
       expect(result).toEqual({
         type: "sync",
         taskType: AgentTaskType.SEGMENT,
         response: {
           detections: [
             {
-              mask: float32ToCompressedNumpy(providerResult.mask, [
-                providerResult.maskHeight,
-                providerResult.maskWidth,
-              ]),
+              mask: expectedMask,
               mask_width: 2,
               mask_height: 2,
               bounding_box: [0.1, 0.2, 0.3, 0.4],
@@ -203,6 +208,85 @@ describe("SAM2BrowserAnnotationAgent", () => {
       provider.infer.mockRejectedValue(new Error("Worker error"));
 
       await expect(agent.infer(makeContext())).rejects.toThrow("Worker error");
+    });
+  });
+
+  describe("mask normalization", () => {
+    const inferAndDecode = async (mask: Float32Array) => {
+      const providerResult = makeProviderResult({
+        mask,
+        maskWidth: mask.length,
+        maskHeight: 1,
+      });
+      provider.infer.mockResolvedValue(providerResult);
+      return agent.infer(makeContext());
+    };
+
+    const expectMaskMatches = async (
+      result: Awaited<ReturnType<typeof agent.infer>>,
+      expected: number[]
+    ) => {
+      const encoded = await encodeMaskData(new Uint8Array(expected), [
+        1,
+        expected.length,
+      ]);
+      if (result.type !== "sync") throw new Error("expected sync result");
+      expect(result.response.detections[0].mask).toBe(encoded);
+    };
+
+    it("thresholds values strictly greater than 0.5 to 1", async () => {
+      // 0.5 itself is NOT > 0.5, so it becomes 0
+      const result = await inferAndDecode(
+        new Float32Array([0.5, 0.50001, 0.499, 0.5])
+      );
+      await expectMaskMatches(result, [0, 1, 0, 0]);
+    });
+
+    it("maps negative values to 0", async () => {
+      const result = await inferAndDecode(
+        new Float32Array([-1, -0.0001, -100, -1e-8])
+      );
+      await expectMaskMatches(result, [0, 0, 0, 0]);
+    });
+
+    it("maps values in (0.5, 1] to 1 and [0, 0.5] to 0", async () => {
+      const result = await inferAndDecode(
+        new Float32Array([0, 0.25, 0.5, 0.75, 1.0])
+      );
+      await expectMaskMatches(result, [0, 0, 0, 1, 1]);
+    });
+
+    it("throws when mask contains NaN", async () => {
+      const providerResult = makeProviderResult({
+        mask: new Float32Array([0.1, NaN, 0.9, 0.2]),
+      });
+      provider.infer.mockResolvedValue(providerResult);
+
+      await expect(agent.infer(makeContext())).rejects.toThrow(
+        /Invalid float at index 1/
+      );
+    });
+
+    it("throws when mask contains Infinity", async () => {
+      const providerResult = makeProviderResult({
+        mask: new Float32Array([0.1, 0.2, Infinity, 0.4]),
+      });
+      provider.infer.mockResolvedValue(providerResult);
+
+      await expect(agent.infer(makeContext())).rejects.toThrow(
+        /Invalid float at index 2/
+      );
+    });
+
+    it("throws when mask contains -Infinity", async () => {
+      const providerResult = makeProviderResult({
+        mask: new Float32Array([0.1, -Infinity, 0.9]),
+      });
+      provider.infer.mockResolvedValue(providerResult);
+
+      await expect(agent.infer(makeContext())).rejects.toThrow(
+        /Invalid float at index 1/
+      );
     });
   });
 

--- a/app/packages/annotation/src/agents/SAM2BrowserAnnotationAgent.ts
+++ b/app/packages/annotation/src/agents/SAM2BrowserAnnotationAgent.ts
@@ -13,7 +13,7 @@ import {
   PointLabel,
   type PromptPoint,
 } from "../providers";
-import { float32ToCompressedNumpy } from "../util/conversion";
+import { encodeMaskData } from "@fiftyone/lighter/src/utils/maskEncoding";
 import { getSampleSrc } from "@fiftyone/state/src/recoil/utils";
 
 /**
@@ -60,7 +60,7 @@ export class SAM2BrowserAnnotationAgent
       response: {
         detections: [
           {
-            mask: this.normalizeMask(
+            mask: await this.normalizeMask(
               result.mask,
               result.maskWidth,
               result.maskHeight
@@ -178,11 +178,23 @@ export class SAM2BrowserAnnotationAgent
     return { x: vec[0], y: vec[1], label };
   }
 
+  // 0.5 is NOT > 0.5, so it becomes 0
   private normalizeMask(
     mask: Float32Array,
     width: number,
     height: number
-  ): string {
-    return float32ToCompressedNumpy(mask, [height, width]);
+  ): Promise<string> {
+    const binary = new Uint8Array(mask.length);
+    for (let i = 0; i < mask.length; i++) {
+      const v = mask[i];
+      // Reject NaN/±Infinity loudly — silently coercing them would yield a
+      // valid-looking but degraded mask. SAM2 shouldn't emit these in normal
+      // operation, so treat them as a signal something is wrong.
+      if (!Number.isFinite(v)) {
+        throw new Error(`Invalid float at index ${i}`);
+      }
+      binary[i] = v > 0.5 ? 1 : 0;
+    }
+    return encodeMaskData(binary, [height, width]);
   }
 }

--- a/app/packages/annotation/src/agents/hooks/useKeypointRippleEffect.ts
+++ b/app/packages/annotation/src/agents/hooks/useKeypointRippleEffect.ts
@@ -1,0 +1,146 @@
+import {
+  drawRippleRings,
+  type KeypointEffect,
+  KeypointOverlay,
+} from "@fiftyone/lighter";
+import { useCallback, useEffect, useRef } from "react";
+
+const RIPPLE_EFFECT_ID = "keypoint-ripple";
+
+type OverlayRippleState = {
+  overlay: KeypointOverlay;
+  startTime: number;
+  // pointId -> performance.now() expiry. Number.POSITIVE_INFINITY means
+  // ripple indefinitely until explicitly removed.
+  deadlines: Map<string, number>;
+};
+
+export interface UseKeypointRippleEffectAPI {
+  /**
+   * Starts a ripple on `pointId` of the keypoint overlay identified by
+   * `overlayId`. If `durationMs` is provided, the ripple auto-clears once
+   * that many milliseconds have elapsed; calling again refreshes the
+   * deadline. Omit `durationMs` to ripple until explicitly removed.
+   *
+   * No-op if the overlay isn't a `KeypointOverlay`.
+   */
+  add: (overlayId: string, pointId: string, durationMs?: number) => void;
+  /** Stops the ripple on `pointId` of the given overlay, if active. */
+  remove: (overlayId: string, pointId: string) => void;
+}
+
+/**
+ * React-side owner of keypoint ripple animations. Drives a single rAF loop
+ * across every overlay with active ripples, registers a draw effect on each
+ * overlay only while it has work to do, and cleans up on unmount.
+ *
+ * Keeps the overlay class itself ignorant of ripple state — it just exposes
+ * a generic effect registry, and this hook plugs the ripple effect into it.
+ */
+export const useKeypointRippleEffect = (
+  getOverlay: (id: string) => unknown
+): UseKeypointRippleEffectAPI => {
+  const statesRef = useRef<Map<string, OverlayRippleState>>(new Map());
+  const rafRef = useRef<number | null>(null);
+
+  // The tick captured below references `statesRef.current` directly, so
+  // it always sees the latest map without re-binding.
+  const tick = useCallback(() => {
+    rafRef.current = null;
+    const states = statesRef.current;
+    const now = performance.now();
+
+    for (const [overlayId, state] of states) {
+      // Expire deadlines elapsed since the last frame.
+      for (const [pointId, deadline] of state.deadlines) {
+        if (now >= deadline) state.deadlines.delete(pointId);
+      }
+      // Always mark dirty so the frame where the last ripple expires gets
+      // a final repaint that erases its trailing ring.
+      state.overlay.markDirty();
+      if (state.deadlines.size === 0) {
+        state.overlay.unregisterEffect(RIPPLE_EFFECT_ID);
+        states.delete(overlayId);
+      }
+    }
+
+    if (states.size > 0) {
+      rafRef.current = requestAnimationFrame(tick);
+    }
+  }, []);
+
+  const ensureLoop = useCallback(() => {
+    if (rafRef.current === null && statesRef.current.size > 0) {
+      rafRef.current = requestAnimationFrame(tick);
+    }
+  }, [tick]);
+
+  const add = useCallback(
+    (overlayId: string, pointId: string, durationMs?: number) => {
+      const overlay = getOverlay(overlayId);
+      if (!(overlay instanceof KeypointOverlay)) return;
+
+      let state = statesRef.current.get(overlayId);
+      if (!state) {
+        const newState: OverlayRippleState = {
+          overlay,
+          startTime: performance.now(),
+          deadlines: new Map(),
+        };
+        const draw: KeypointEffect = ({
+          renderer,
+          points,
+          resolveStyle,
+          containerId,
+        }) => {
+          const elapsedMs = performance.now() - newState.startTime;
+          for (const p of points) {
+            if (!newState.deadlines.has(p.id)) continue;
+            const style = resolveStyle(p.variant);
+            drawRippleRings({
+              renderer,
+              center: p.position,
+              color: style.fillStyle || style.strokeStyle || "#ffffff",
+              elapsedMs,
+              containerId,
+            });
+          }
+        };
+        overlay.registerEffect(RIPPLE_EFFECT_ID, draw);
+        statesRef.current.set(overlayId, newState);
+        state = newState;
+      }
+
+      state.deadlines.set(
+        pointId,
+        durationMs == null
+          ? Number.POSITIVE_INFINITY
+          : performance.now() + durationMs
+      );
+      overlay.markDirty();
+      ensureLoop();
+    },
+    [getOverlay, ensureLoop]
+  );
+
+  const remove = useCallback((overlayId: string, pointId: string) => {
+    const state = statesRef.current.get(overlayId);
+    if (!state) return;
+    if (state.deadlines.delete(pointId)) state.overlay.markDirty();
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      for (const state of statesRef.current.values()) {
+        state.overlay.unregisterEffect(RIPPLE_EFFECT_ID);
+      }
+      statesRef.current.clear();
+    };
+  }, []);
+
+  return { add, remove };
+};

--- a/app/packages/annotation/src/agents/hooks/useRegisterPointSelectionEventHandlers.ts
+++ b/app/packages/annotation/src/agents/hooks/useRegisterPointSelectionEventHandlers.ts
@@ -1,4 +1,5 @@
 import {
+  RIPPLE_VISIBLE_MS,
   UNDEFINED_LIGHTER_SCENE_ID,
   useLighter,
   useLighterEventHandler,
@@ -6,6 +7,7 @@ import {
 import { useToolsState } from "./useToolsContext";
 import { NEGATIVE_POINT_VARIANT, usePointSelection } from "./usePointSelection";
 import { useCallback } from "react";
+import { useKeypointRippleEffect } from "./useKeypointRippleEffect";
 
 /**
  * Hook which registers event handlers for the positive/negative point
@@ -15,7 +17,7 @@ import { useCallback } from "react";
  * reuse will cause duplicate event handler registration.**
  */
 export const useRegisterPointSelectionEventHandlers = () => {
-  const { scene } = useLighter();
+  const { scene, getOverlay } = useLighter();
   const {
     addNegativePoint,
     addPositivePoint,
@@ -28,6 +30,8 @@ export const useRegisterPointSelectionEventHandlers = () => {
     scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
   );
   const { isActive: isPointSelectionActive } = usePointSelection();
+  const { add: addRipple, remove: removeRipple } =
+    useKeypointRippleEffect(getOverlay);
 
   useEventHandler(
     "lighter:keypoint-point-added",
@@ -44,9 +48,14 @@ export const useRegisterPointSelectionEventHandlers = () => {
           } else {
             addPositivePoint(descriptor);
           }
+
+          // Surface a ripple on the new point for a guaranteed-visible
+          // duration. Decoupled from inference timing so fast inference
+          // doesn't make the indicator flash invisibly.
+          addRipple(payload.id, payload.pointId, RIPPLE_VISIBLE_MS);
         }
       },
-      [addNegativePoint, addPositivePoint, isPointSelectionActive]
+      [addNegativePoint, addPositivePoint, addRipple, isPointSelectionActive]
     )
   );
 
@@ -54,6 +63,12 @@ export const useRegisterPointSelectionEventHandlers = () => {
     "lighter:keypoint-point-deleted",
     useCallback(
       (payload) => {
+        // Defensive cleanup of any active ripple. Time-based pruning in
+        // the rAF loop covers finite deadlines, but indefinite ripples
+        // would otherwise keep the loop alive forever once the source
+        // point is gone.
+        removeRipple(payload.id, payload.pointId);
+
         if (isPointSelectionActive) {
           if (payload.variant === NEGATIVE_POINT_VARIANT) {
             removeNegativePoint(payload.pointId);
@@ -62,7 +77,12 @@ export const useRegisterPointSelectionEventHandlers = () => {
           }
         }
       },
-      [isPointSelectionActive, removeNegativePoint, removePositivePoint]
+      [
+        isPointSelectionActive,
+        removeNegativePoint,
+        removePositivePoint,
+        removeRipple,
+      ]
     )
   );
 

--- a/app/packages/annotation/src/persistence/useLighterDeltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/useLighterDeltaSupplier.ts
@@ -34,9 +34,30 @@ const buildAnnotationLabel = (overlay: BaseOverlay): LabelProxy | undefined => {
     ];
 
     if (hasValidBounds(boundingBox)) {
+      // Pull mask/mask_path off so we can decide what (if anything) to persist
+      // for the mask channel.
+      const { mask: _mask, mask_path: _maskPath, ...data } = overlay.label;
+      const pendingMask = overlay.getPendingMask();
+
+      // Include mask data only when the overlay still has a mask.
+      // Explicitly null out mask/mask_path when removed so the merge
+      // in buildDetectionsMutationDelta overrides the existing value.
+      const hadMask = _mask || _maskPath;
+      const maskData = overlay.hasMask()
+        ? {
+            ...(_mask && { mask: _mask }),
+            ...(pendingMask && { mask: pendingMask }),
+          }
+        : hadMask
+        ? { mask: null, mask_path: null }
+        : {};
+
       return {
         type: "Detection",
-        data: overlay.label as DetectionLabel,
+        data: {
+          ...data,
+          ...maskData,
+        } as DetectionLabel,
         boundingBox,
         path: overlay.field,
       };

--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -46,6 +46,7 @@ import { Sidebar } from "./Sidebar";
 import SchemaManagementProvider from "./Sidebar/Annotate/SchemaManagementProvider";
 import useCanManageSchema from "./Sidebar/Annotate/useCanManageSchema";
 import { useAnnotationTracking } from "./Sidebar/Annotate/useAnnotationTracking";
+import { SegmentationToolbar } from "./Sidebar/Annotate/Edit/SegmentationToolbar";
 import { TooltipInfo } from "./TooltipInfo";
 import { useLookerHelpers, useTooltipEventHandler } from "./hooks";
 import { modalContext } from "./modal-context";
@@ -365,6 +366,7 @@ const Modal = () => {
           >
             <OperatorPromptArea area={OPERATOR_PROMPT_AREAS.DRAWER_LEFT} />
             <ModalNavigation closePanels={closePanels} />
+            <SegmentationToolbar />
             <SpacesContainer>
               <ModalSpace />
             </SpacesContainer>

--- a/app/packages/lighter/src/constants.ts
+++ b/app/packages/lighter/src/constants.ts
@@ -64,6 +64,19 @@ export const KEYPOINT_HIT_RADIUS = 10;
 export const PREVIEW_LINE_OPACITY = 0.6;
 
 /**
+ * Settings related to the keypoint ripple animation.
+ *
+ * `RIPPLE_VISIBLE_MS` and `RIPPLE_CYCLE_MS` are intentionally equal so the
+ * ring fades to opacity 0 right as it's removed (no abrupt mid-cycle cut).
+ */
+export const RIPPLE_VISIBLE_MS = 1200;
+export const RIPPLE_CYCLE_MS = 1200;
+export const RIPPLE_MAX_RADIUS = 22;
+export const RIPPLE_RING_COUNT = 2;
+export const RIPPLE_PEAK_OPACITY = 0.75;
+export const RIPPLE_LINE_WIDTH = 3;
+
+/**
  * Opacity of selected bounding boxes
  */
 export const SELECTED_ALPHA = 0.1;

--- a/app/packages/lighter/src/index.ts
+++ b/app/packages/lighter/src/index.ts
@@ -26,7 +26,16 @@ export type { ClassificationOptions } from "./overlay/ClassificationOverlay";
 export { ImageOverlay } from "./overlay/ImageOverlay";
 export type { ImageOptions } from "./overlay/ImageOverlay";
 export { KeypointOverlay } from "./overlay/KeypointOverlay";
-export type { KeypointLabel, KeypointOptions } from "./overlay/KeypointOverlay";
+export type {
+  KeypointEffect,
+  KeypointEffectContext,
+  KeypointEffectPoint,
+  KeypointLabel,
+  KeypointOptions,
+} from "./overlay/KeypointOverlay";
+export { drawRippleRings } from "./overlay/rippleRing";
+export type { DrawRippleRingsArgs } from "./overlay/rippleRing";
+export { RIPPLE_VISIBLE_MS } from "./constants";
 export { OverlayFactory } from "./overlay/OverlayFactory";
 export type { OverlayConstructor } from "./overlay/OverlayFactory";
 

--- a/app/packages/lighter/src/overlay/KeypointOverlay.ts
+++ b/app/packages/lighter/src/overlay/KeypointOverlay.ts
@@ -6,13 +6,11 @@ import { CommandContextManager } from "@fiftyone/commands";
 import { MoveKeypointPointCommand } from "../commands/MoveKeypointPointCommand";
 import {
   EDGE_THRESHOLD,
-  HOVERED_DASH_LENGTH,
   KEYPOINT_HIT_RADIUS,
   KEYPOINT_RADIUS,
   KEYPOINT_SELECTED_RADIUS,
   LABEL_ARCHETYPE_PRIORITY,
   PREVIEW_LINE_OPACITY,
-  SELECTED_DASH_LENGTH,
   STROKE_WIDTH,
 } from "../constants";
 import { CONTAINS } from "../core/Scene2D";
@@ -33,7 +31,6 @@ import {
   distanceFromLineSegment,
   pointInPolygon,
 } from "../utils/geometry";
-import { getSimpleStrokeStyles } from "../utils/colorMapping";
 import { BaseOverlay } from "./BaseOverlay";
 import { NO_BOUNDS } from "./DetectionOverlay";
 import { v4 as uuidv4 } from "uuid";
@@ -82,6 +79,38 @@ type KeypointEntry = {
 };
 
 /**
+ * Per-point snapshot passed to render effects for a single frame.
+ */
+export interface KeypointEffectPoint {
+  id: string;
+  position: Point;
+  variant?: string;
+}
+
+/**
+ * Context passed to a {@link KeypointEffect} once per frame. The overlay
+ * owns frame timing and point geometry; effects own only their own draw
+ * contribution.
+ */
+export interface KeypointEffectContext {
+  overlay: KeypointOverlay;
+  renderer: Renderer2D;
+  /** Per-point snapshot for this frame, in entry order. */
+  points: ReadonlyArray<KeypointEffectPoint>;
+  /** Resolves a variant key to the same draw style points use. */
+  resolveStyle: (variant: string | undefined) => DrawStyle;
+  containerId: string;
+}
+
+/**
+ * A custom render contribution for a {@link KeypointOverlay}. Invoked once
+ * per frame, behind the points themselves. The caller owns lifecycle —
+ * driving frame invalidation via `markDirty()` while animating, and
+ * unregistering when done.
+ */
+export type KeypointEffect = (ctx: KeypointEffectContext) => void;
+
+/**
  * Keypoint overlay implementation with per-point interaction, optional connections,
  * and optional polygon closure.
  *
@@ -115,6 +144,11 @@ export class KeypointOverlay
 
   // Preview point for interactive creation (cursor tracking)
   protected previewPoint?: Point | null = null;
+
+  // Registered render effects. Invoked once per frame, between point
+  // bucket-collection and bucket-draw, so contributions appear behind the
+  // solid points. Owners drive frame invalidation and unregister when done.
+  private renderEffects: Map<string, KeypointEffect> = new Map();
 
   // Caches — invalidated in markDirty()
   private _absPointsCache: Point[] | null = null;
@@ -308,8 +342,6 @@ export class KeypointOverlay
     const absPoints = this.getAbsolutePoints();
     const strokeColor = style.strokeStyle || "#ffffff";
     const lineWidth = style.lineWidth || STROKE_WIDTH;
-    const isHovered = this.isHoveredState;
-    const isSelected = this.isSelectedState;
 
     // 1. Batch all connection edges into a single draw call
     const edgeSegments = this.collectEdgeSegments(absPoints);
@@ -320,28 +352,6 @@ export class KeypointOverlay
         { strokeStyle: strokeColor, lineWidth },
         this.containerId
       );
-
-      // Dashed overlay when hovered or selected, mirroring DetectionOverlay.
-      if (isHovered || isSelected) {
-        const { overlayStrokeColor, overlayDash } = getSimpleStrokeStyles({
-          isSelected,
-          strokeColor,
-          isHovered,
-          dashLength: isSelected ? SELECTED_DASH_LENGTH : HOVERED_DASH_LENGTH,
-        });
-
-        if (overlayStrokeColor && overlayDash) {
-          renderer.drawLines(
-            edgeSegments,
-            {
-              strokeStyle: overlayStrokeColor,
-              lineWidth,
-              dashPattern: [overlayDash, overlayDash],
-            },
-            this.containerId
-          );
-        }
-      }
     }
 
     // 2. Draw preview line (during interactive creation — dashed, separate call)
@@ -387,9 +397,7 @@ export class KeypointOverlay
     let selectedVariant: string | undefined;
 
     for (let i = 0; i < absPoints.length; i++) {
-      // When hovered, every point renders in its sub-selected state, so
-      // there's no need to peel out the explicitly-selected point.
-      if (!isHovered && this.selectedPointIndex === i) {
+      if (this.selectedPointIndex === i) {
         selectedPoint = absPoints[i];
         selectedVariant = this.#points[i].variant;
         continue;
@@ -403,23 +411,30 @@ export class KeypointOverlay
       }
     }
 
-    const pointRadius = isHovered ? KEYPOINT_SELECTED_RADIUS : KEYPOINT_RADIUS;
-    for (const [variant, pts] of buckets) {
-      const pointStyle = resolvePointStyle(variant);
-      renderer.drawPoints(pts, pointRadius, pointStyle, this.containerId);
+    // Custom render effects — drawn behind the points so they appear
+    // beneath the solid point markers. Owners drive their own animation
+    // timing and frame invalidation.
+    if (this.renderEffects.size > 0) {
+      const effectPoints: KeypointEffectPoint[] = absPoints.map(
+        (position, i) => ({
+          id: this.#points[i].id,
+          position,
+          variant: this.#points[i].variant,
+        })
+      );
+      const ctx: KeypointEffectContext = {
+        overlay: this,
+        renderer,
+        points: effectPoints,
+        resolveStyle: resolvePointStyle,
+        containerId: this.containerId,
+      };
+      for (const effect of this.renderEffects.values()) effect(ctx);
     }
 
-    // When hovered, overlay an inner white highlight on every point so each
-    // vertex matches the sub-selected appearance.
-    if (isHovered) {
-      for (const [, pts] of buckets) {
-        renderer.drawPoints(
-          pts,
-          KEYPOINT_RADIUS,
-          { fillStyle: "#ffffff" },
-          this.containerId
-        );
-      }
+    for (const [variant, pts] of buckets) {
+      const pointStyle = resolvePointStyle(variant);
+      renderer.drawPoints(pts, KEYPOINT_RADIUS, pointStyle, this.containerId);
     }
 
     // Draw selected point at larger radius + inner highlight (separate calls)
@@ -779,6 +794,26 @@ export class KeypointOverlay
   setPreviewPoint(worldPoint: Point | null): void {
     this.previewPoint = worldPoint;
     this.markDirty();
+  }
+
+  /**
+   * Registers a custom render effect. The effect is invoked once per frame
+   * during {@link renderImpl}, behind the points themselves. Returns a
+   * teardown function; {@link unregisterEffect} is also available for callers
+   * that prefer id-based removal.
+   *
+   * The caller owns animation timing — the overlay only re-renders when
+   * dirty, so animated effects must call {@link markDirty} each tick.
+   */
+  registerEffect(id: string, effect: KeypointEffect): () => void {
+    this.renderEffects.set(id, effect);
+    this.markDirty();
+    return () => this.unregisterEffect(id);
+  }
+
+  /** Removes a previously registered render effect by id. */
+  unregisterEffect(id: string): void {
+    if (this.renderEffects.delete(id)) this.markDirty();
   }
 
   /**

--- a/app/packages/lighter/src/overlay/rippleRing.ts
+++ b/app/packages/lighter/src/overlay/rippleRing.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Pure render helper for the keypoint ripple animation.
+ *
+ * Draws a series of staggered rings expanding outward from `center`. Knows
+ * nothing about which points should ripple, when to start, or when to stop —
+ * the caller owns that lifecycle and is responsible for invalidating the
+ * frame each tick (e.g. via `requestAnimationFrame` + `markDirty`).
+ */
+
+import {
+  KEYPOINT_RADIUS,
+  RIPPLE_CYCLE_MS,
+  RIPPLE_LINE_WIDTH,
+  RIPPLE_MAX_RADIUS,
+  RIPPLE_PEAK_OPACITY,
+  RIPPLE_RING_COUNT,
+} from "../constants";
+import type { Renderer2D } from "../renderer/Renderer2D";
+import type { Point } from "../types";
+
+export interface DrawRippleRingsArgs {
+  renderer: Renderer2D;
+  center: Point;
+  color: string;
+  /** Milliseconds since the ripple started; controls the cycle position. */
+  elapsedMs: number;
+  containerId: string;
+}
+
+/**
+ * Draws the ripple rings for a single point. Pass screen-pixel radii — the
+ * renderer divides by viewport scale internally so the rings stay a constant
+ * size on screen across zoom levels.
+ */
+export const drawRippleRings = ({
+  renderer,
+  center,
+  color,
+  elapsedMs,
+  containerId,
+}: DrawRippleRingsArgs): void => {
+  const cycleProgress = (elapsedMs % RIPPLE_CYCLE_MS) / RIPPLE_CYCLE_MS;
+
+  for (let ring = 0; ring < RIPPLE_RING_COUNT; ring++) {
+    const ringProgress = (cycleProgress - ring / RIPPLE_RING_COUNT + 1) % 1;
+    // Ease-out cubic — fast start, slow finish.
+    const eased = 1 - Math.pow(1 - ringProgress, 3);
+    const radius = KEYPOINT_RADIUS + eased * RIPPLE_MAX_RADIUS;
+    const opacity = (1 - eased) * RIPPLE_PEAK_OPACITY;
+
+    if (opacity <= 0.01) continue;
+
+    renderer.drawPoint(
+      center,
+      radius,
+      { strokeStyle: color, lineWidth: RIPPLE_LINE_WIDTH, opacity },
+      containerId
+    );
+  }
+};


### PR DESCRIPTION
##  

- useLighterDeltaSupplier - updated to remove a potential `isEditingMask` flag and apply any mask updates back to the label for persistence
- "agents" - I didn't touch these files, I used Claude to break down my feature branch and I think it may have split the file here. Ultimately, I don't think any changes were made.