### PR TITLE
Bumping to `fiftyone-brain>=0.21.6`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
         "scikit-image<1",
         "scipy<2",
         # internal packages
-        "fiftyone-brain>=0.21.5,<0.22",
+        "fiftyone-brain>=0.21.6,<0.22",
         "fiftyone-db>=0.4,<2.0",
         "voxel51-eta>=0.15.3,<0.16",
     ],


### PR DESCRIPTION
Bumping to `fiftyone-brain>=0.21.6` per https://github.com/voxel51/fiftyone-brain/pull/288.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated fiftyone-brain dependency version requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->