### PR TITLE
add ontologies endpoint for Schema Manager picker

### DIFF
--- a/fiftyone/server/routes/__init__.py
+++ b/fiftyone/server/routes/__init__.py
@@ -20,6 +20,7 @@ from .geo import GeoPoints
 from .get_similar_labels_frames import GetSimilarLabelsFrameCollection
 from .groups import GroupsRoutes
 from .media import Media
+from .ontology import Ontologies
 from .plugins import Plugins
 from .sample import SampleRoutes
 from .screenshot import Screenshot
@@ -44,6 +45,7 @@ routes = (
         ("/frames", Frames),
         ("/geo", GeoPoints),
         ("/media", Media),
+        ("/ontologies", Ontologies),
         ("/plugins", Plugins),
         ("/sort", Sort),
         ("/screenshot/{img:str}", Screenshot),

--- a/fiftyone/server/routes/ontology.py
+++ b/fiftyone/server/routes/ontology.py
@@ -12,8 +12,8 @@ from starlette.endpoints import HTTPEndpoint
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
 
+import fiftyone.core.odm as foo
 import fiftyone.core.utils as fou
-from fiftyone.core.odm.ontology import OntologyDocument
 from fiftyone.internal.features.registry import is_feature_enabled
 from fiftyone.server.utils.json import JSONResponse
 
@@ -30,14 +30,14 @@ class Ontologies(HTTPEndpoint):
 
         return JSONResponse(
             {
-                "ontologies": _list_ontology_summaries(
+                "ontologies": await _list_ontology_summaries(
                     type_filter=type_filter, name_filter=name_filter
                 )
             }
         )
 
 
-def _list_ontology_summaries(
+async def _list_ontology_summaries(
     type_filter: Optional[str] = None,
     name_filter: Optional[str] = None,
 ) -> list[dict[str, Any]]:
@@ -71,8 +71,8 @@ def _list_ontology_summaries(
         {"$project": {"_id": 0}},
     ]
 
-    # pylint: disable-next=no-member
-    summaries = list(OntologyDocument.objects.aggregate(pipeline))
+    collection = foo.get_async_db_conn()["ontologies"]
+    summaries = await foo.aggregate(collection, pipeline).to_list(None)
     # Replace BSON datetimes with ISO strings so the JSON response is flat
     # (avoids the default ``{"$date": ...}`` BSON-extended-JSON shape).
     for s in summaries:

--- a/fiftyone/server/routes/ontology.py
+++ b/fiftyone/server/routes/ontology.py
@@ -75,6 +75,8 @@ async def _list_ontology_summaries(
     summaries = await foo.aggregate(collection, pipeline).to_list(None)
     # Replace BSON datetimes with ISO strings so the JSON response is flat
     # (avoids the default ``{"$date": ...}`` BSON-extended-JSON shape).
+    # ``last_modified_at`` may be missing on manually-inserted docs.
     for s in summaries:
-        s["last_modified_at"] = s["last_modified_at"].isoformat()
+        dt = s.get("last_modified_at")
+        s["last_modified_at"] = dt.isoformat() if dt is not None else None
     return summaries

--- a/fiftyone/server/routes/ontology.py
+++ b/fiftyone/server/routes/ontology.py
@@ -1,0 +1,80 @@
+"""
+FiftyOne Server ontology endpoints.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from typing import Any, Optional
+
+from starlette.endpoints import HTTPEndpoint
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
+
+import fiftyone.core.utils as fou
+from fiftyone.core.odm.ontology import OntologyDocument
+from fiftyone.internal.features.registry import is_feature_enabled
+from fiftyone.server.utils.json import JSONResponse
+
+
+class Ontologies(HTTPEndpoint):
+    """Endpoint that lists ontologies for the Schema Manager picker."""
+
+    async def get(self, request: Request) -> JSONResponse:
+        if not is_feature_enabled("VFF_ONTOLOGY_CA"):
+            raise HTTPException(status_code=404)
+
+        type_filter = request.query_params.get("type") or None
+        name_filter = request.query_params.get("name") or None
+
+        return JSONResponse(
+            {
+                "ontologies": _list_ontology_summaries(
+                    type_filter=type_filter, name_filter=name_filter
+                )
+            }
+        )
+
+
+def _list_ontology_summaries(
+    type_filter: Optional[str] = None,
+    name_filter: Optional[str] = None,
+) -> list[dict[str, Any]]:
+    """Returns one summary per ontology (latest version only), sorted by
+    ``last_modified_at`` descending.
+    """
+    # Optional filters; empty dict matches everything.
+    match: dict[str, Any] = {}
+    if type_filter:
+        match["type"] = type_filter
+    if name_filter:
+        match["slug"] = fou.to_slug(name_filter)
+
+    pipeline = [
+        {"$match": match},
+        # Order each slug's docs so the highest version is first; $first
+        # in the next stage then picks that latest version.
+        {"$sort": {"slug": 1, "version": -1}},
+        {
+            "$group": {
+                "_id": "$slug",
+                "name": {"$first": "$name"},
+                "type": {"$first": "$type"},
+                "version": {"$first": "$version"},
+                "last_modified_at": {"$first": "$last_modified_at"},
+            }
+        },
+        {"$sort": {"last_modified_at": -1}},
+        # Drop the grouping key from the output — clients consume
+        # name/type/version/last_modified_at, not slug.
+        {"$project": {"_id": 0}},
+    ]
+
+    # pylint: disable-next=no-member
+    summaries = list(OntologyDocument.objects.aggregate(pipeline))
+    # Replace BSON datetimes with ISO strings so the JSON response is flat
+    # (avoids the default ``{"$date": ...}`` BSON-extended-JSON shape).
+    for s in summaries:
+        s["last_modified_at"] = s["last_modified_at"].isoformat()
+    return summaries

--- a/tests/unittests/server/routes/test_ontology.py
+++ b/tests/unittests/server/routes/test_ontology.py
@@ -1,0 +1,167 @@
+"""
+FiftyOne Server ontology route unit tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Ontology SDK is gated by VFF_ONTOLOGY_CA; enable for the whole module.
+os.environ.setdefault("VFF_ONTOLOGY_CA", "1")
+
+import fiftyone.core.odm as foo
+from fiftyone.core.odm.ontology import OntologyDocument, OntologyType
+import fiftyone.server.routes.ontology as foro
+
+
+# Async test methods can't use the sync ``drop_collection`` decorator from
+# ``tests/unittests/decorators.py`` (its wrapper would return the coroutine
+# without awaiting, firing cleanup before the test body), so we drop the
+# collection via an autouse fixture instead.
+@pytest.fixture(autouse=True)
+def _drop_ontologies():
+    db = foo.get_db_conn()
+    db.drop_collection("ontologies")
+    yield
+    db.drop_collection("ontologies")
+
+
+@pytest.fixture(name="endpoint")
+def fixture_endpoint():
+    return foro.Ontologies(
+        scope={"type": "http"}, receive=AsyncMock(), send=AsyncMock()
+    )
+
+
+@pytest.fixture(name="mock_request")
+def fixture_mock_request():
+    def _make(query_params=None):
+        request = MagicMock()
+        request.query_params = query_params or {}
+        return request
+
+    return _make
+
+
+class TestOntologiesRoute:
+    @pytest.mark.asyncio
+    async def test_empty(self, endpoint, mock_request):
+        response = await endpoint.get(mock_request())
+
+        assert response.status_code == 200
+        body = json.loads(response.body)
+        assert body == {"ontologies": []}
+
+    @pytest.mark.asyncio
+    async def test_single_ontology(self, endpoint, mock_request):
+        OntologyDocument(
+            name="vehicle_damage", type=OntologyType.ANNOTATION_ONTOLOGY
+        ).save()
+
+        response = await endpoint.get(mock_request())
+
+        body = json.loads(response.body)
+        assert len(body["ontologies"]) == 1
+        summary = body["ontologies"][0]
+        assert summary["name"] == "vehicle_damage"
+        assert summary["type"] == "annotation_ontology"
+        assert summary["version"] == 1
+        assert isinstance(summary["last_modified_at"], str)
+
+    @pytest.mark.asyncio
+    async def test_sort_by_last_modified_desc(self, endpoint, mock_request):
+        OntologyDocument(
+            name="first", type=OntologyType.ANNOTATION_ONTOLOGY
+        ).save()
+        OntologyDocument(
+            name="second", type=OntologyType.ANNOTATION_ONTOLOGY
+        ).save()
+        OntologyDocument(
+            name="third", type=OntologyType.ANNOTATION_ONTOLOGY
+        ).save()
+
+        response = await endpoint.get(mock_request())
+
+        body = json.loads(response.body)
+        names = [o["name"] for o in body["ontologies"]]
+        assert names == ["third", "second", "first"]
+
+    @pytest.mark.asyncio
+    async def test_only_latest_version_per_name(self, endpoint, mock_request):
+        for v in (1, 2, 3):
+            OntologyDocument(
+                name="foo", version=v, type=OntologyType.ANNOTATION_ONTOLOGY
+            ).save()
+
+        response = await endpoint.get(mock_request())
+
+        body = json.loads(response.body)
+        assert len(body["ontologies"]) == 1
+        assert body["ontologies"][0]["version"] == 3
+
+    @pytest.mark.asyncio
+    async def test_type_filter(self, endpoint, mock_request):
+        OntologyDocument(
+            name="an_ann", type=OntologyType.ANNOTATION_ONTOLOGY
+        ).save()
+        OntologyDocument(name="a_tax", type=OntologyType.TAXONOMY).save()
+
+        response = await endpoint.get(
+            mock_request(query_params={"type": "annotation_ontology"})
+        )
+
+        body = json.loads(response.body)
+        names = [o["name"] for o in body["ontologies"]]
+        assert names == ["an_ann"]
+
+    @pytest.mark.asyncio
+    async def test_name_filter_exact(self, endpoint, mock_request):
+        OntologyDocument(
+            name="vehicle_damage", type=OntologyType.ANNOTATION_ONTOLOGY
+        ).save()
+        OntologyDocument(
+            name="other_one", type=OntologyType.ANNOTATION_ONTOLOGY
+        ).save()
+
+        response = await endpoint.get(
+            mock_request(query_params={"name": "vehicle_damage"})
+        )
+
+        body = json.loads(response.body)
+        names = [o["name"] for o in body["ontologies"]]
+        assert names == ["vehicle_damage"]
+
+    @pytest.mark.asyncio
+    async def test_name_filter_slug_normalized(self, endpoint, mock_request):
+        # Saved as "Vehicle Damage" → slug is "vehicle-damage". Looking up
+        # by any string that slugifies to the same value should match.
+        OntologyDocument(
+            name="Vehicle Damage", type=OntologyType.ANNOTATION_ONTOLOGY
+        ).save()
+
+        response = await endpoint.get(
+            mock_request(query_params={"name": "vehicle.DAMAGE"})
+        )
+
+        body = json.loads(response.body)
+        assert len(body["ontologies"]) == 1
+        assert body["ontologies"][0]["name"] == "Vehicle Damage"
+
+    @pytest.mark.asyncio
+    async def test_name_filter_no_match(self, endpoint, mock_request):
+        OntologyDocument(
+            name="vehicle_damage", type=OntologyType.ANNOTATION_ONTOLOGY
+        ).save()
+
+        response = await endpoint.get(
+            mock_request(query_params={"name": "not_there"})
+        )
+
+        body = json.loads(response.body)
+        assert body == {"ontologies": []}


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

This adds a `GET /ontologies` API endpoint to retrieve ontologies from the database for the front end to use to populate a drop down. 


## 🧪 How is this patch tested? If it is not, please explain why.

Unit tests and Tested locally with a contrived set of 10,000 ontologies. See benchmarking statistics:

| Query | Median | Stddev | Min | Max | n |
| --- | --- | --- | --- | --- | --- |
| `/ontologies` (no filter) | **146 ms** | 25 ms | 96 ms | 213 ms | 30 |
| `?type=annotation_ontology` | **119 ms** | 28 ms | 76 ms | 221 ms | 30 |
| `?type=taxonomy` | **43 ms** | 16 ms | 20 ms | 76 ms | 30 |
| `?name=<slug>` | **7.4 ms** | 1.4 ms | 5.6 ms | 11.2 ms | 30 |



## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new /ontologies API endpoint to list available ontologies.
  * Supports optional filtering by type and name (slug-normalized).
  * Returns ontology metadata: name, type, version, and last_modified_at.
  * Only the latest version per ontology is returned, sorted by most recent modification.
  * Endpoint returns 404 when the ontology feature flag is disabled.

* **Tests**
  * Added unit tests covering listing, filtering, ordering, version selection, and empty results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->