### PR TITLE
Ontology when classes

### DIFF
--- a/fiftyone/core/annotation/attributes.py
+++ b/fiftyone/core/annotation/attributes.py
@@ -127,6 +127,62 @@ class When:
         return parts + ")"
 
 
+class WhenEquals(When):
+    """Convenience subclass of :class:`When` for ``equals`` conditions.
+
+    Equivalent to ``When(WhenOperator.EQUALS, field=..., value=...)``
+    without spelling the operator. Inherits ``to_dict``,
+    ``__post_init__`` validation, and operator-based dispatch from
+    :class:`When`.
+
+    Example::
+
+        WhenEquals(field="damage_present", value=True)
+    """
+
+    def __init__(self, field: str, value: Any, then: Optional[dict] = None):
+        super().__init__(
+            operator=WhenOperator.EQUALS,
+            field=field,
+            value=value,
+            then=then,
+        )
+
+    def __repr__(self) -> str:
+        parts = f"WhenEquals(field={self.field!r}, value={self.value!r}"
+        if self.then is not None:
+            parts += f", then={self.then!r}"
+        return parts + ")"
+
+
+class WhenIn(When):
+    """Convenience subclass of :class:`When` for ``in`` conditions.
+
+    Equivalent to ``When(WhenOperator.IN, field=..., value=[...])``
+    without spelling the operator. Inherits ``to_dict``,
+    ``__post_init__`` validation, and operator-based dispatch from
+    :class:`When`.
+
+    Example::
+
+        WhenIn(field="car_model", value=["camry", "corolla"])
+    """
+
+    def __init__(self, field: str, value: list, then: Optional[dict] = None):
+        super().__init__(
+            operator=WhenOperator.IN,
+            field=field,
+            value=value,
+            then=then,
+        )
+
+    def __repr__(self) -> str:
+        parts = f"WhenIn(field={self.field!r}, value={self.value!r}"
+        if self.then is not None:
+            parts += f", then={self.then!r}"
+        return parts + ")"
+
+
 @dataclass(repr=False)
 class AttributeSpec:
     """A typed annotation attribute with optional conditional visibility.

--- a/fiftyone/core/annotation/attributes.py
+++ b/fiftyone/core/annotation/attributes.py
@@ -206,7 +206,7 @@ class AttributeSpec:
             type="str",
             component="dropdown",
             values=["front", "rear", "driver_side", "passenger_side"],
-            when=[When(WhenOperator.EQUALS, field="damage_present", value=True)],
+            when=[WhenEquals(field="damage_present", value=True)],
         )
     """
 

--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -215,7 +215,7 @@ class AnnotationOntology(Ontology):
                     type="str",
                     component="dropdown",
                     values=["front", "rear", "driver_side", "passenger_side"],
-                    when=[When(WhenOperator.EQUALS, field="damage_present", value=True)],
+                    when=[WhenEquals(field="damage_present", value=True)],
                 ),
             ],
         )
@@ -277,6 +277,8 @@ class AnnotationOntology(Ontology):
                 AttributeSpec.from_dict(a) for a in root.get("attributes", [])
             ],
         )
+
+
 # ---- Type dispatch --------------------------------------------------------
 
 _TYPE_TO_CLS: dict[str, type[Ontology]] = {

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -16,6 +16,8 @@ os.environ.setdefault("VFF_ONTOLOGY_CA", "1")
 from fiftyone.core.annotation.attributes import (
     AttributeSpec,
     When,
+    WhenEquals,
+    WhenIn,
     WhenOperator,
 )
 from fiftyone.core.ontology import AnnotationOntology
@@ -122,6 +124,58 @@ class WhenTests(unittest.TestCase):
         self.assertEqual(restored.field, original.field)
         self.assertEqual(restored.value, original.value)
         self.assertEqual(restored.then, original.then)
+
+
+class WhenEqualsTests(unittest.TestCase):
+    def test_pre_fills_operator(self):
+        w = WhenEquals(field="damage_present", value=True)
+        self.assertEqual(w.operator, WhenOperator.EQUALS)
+        self.assertEqual(w.field, "damage_present")
+        self.assertEqual(w.value, True)
+        self.assertIsNone(w.then)
+
+    def test_isinstance_of_when(self):
+        # Existing CA-2 validators / dispatchers branch on
+        # ``isinstance(x, When)``; subclasses must satisfy that.
+        self.assertIsInstance(WhenEquals(field="f", value=1), When)
+
+    def test_to_dict_matches_when(self):
+        # Wire format and MongoDB storage are unchanged — the
+        # subclass should produce the same dict as a hand-rolled When.
+        sub = WhenEquals(field="f", value=1)
+        base = When(WhenOperator.EQUALS, field="f", value=1)
+        self.assertEqual(sub.to_dict(), base.to_dict())
+
+    def test_with_then(self):
+        w = WhenEquals(
+            field="vehicle_type",
+            value="car",
+            then={"values": ["sedan", "suv"]},
+        )
+        self.assertEqual(w.then, {"values": ["sedan", "suv"]})
+
+    def test_repr_uses_subclass_name(self):
+        self.assertIn("WhenEquals(", repr(WhenEquals(field="f", value=1)))
+
+
+class WhenInTests(unittest.TestCase):
+    def test_pre_fills_operator(self):
+        w = WhenIn(field="car_model", value=["camry", "corolla"])
+        self.assertEqual(w.operator, WhenOperator.IN)
+        self.assertEqual(w.field, "car_model")
+        self.assertEqual(w.value, ["camry", "corolla"])
+        self.assertIsNone(w.then)
+
+    def test_isinstance_of_when(self):
+        self.assertIsInstance(WhenIn(field="f", value=[1]), When)
+
+    def test_to_dict_matches_when(self):
+        sub = WhenIn(field="f", value=[1, 2])
+        base = When(WhenOperator.IN, field="f", value=[1, 2])
+        self.assertEqual(sub.to_dict(), base.to_dict())
+
+    def test_repr_uses_subclass_name(self):
+        self.assertIn("WhenIn(", repr(WhenIn(field="f", value=[1])))
 
 
 class AttributeSpecTests(unittest.TestCase):

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -185,9 +185,7 @@ class AttributeSpecTests(unittest.TestCase):
             type="str",
             component="dropdown",
             values=["front", "rear"],
-            when=[
-                When(WhenOperator.EQUALS, field="damage_present", value=True)
-            ],
+            when=[WhenEquals(field="damage_present", value=True)],
         )
         self.assertEqual(attr.name, "damage_location")
         self.assertEqual(attr.type, "str")
@@ -270,9 +268,7 @@ class AttributeSpecTests(unittest.TestCase):
             type="str",
             component="radio",
             values=["minor", "moderate", "severe"],
-            when=[
-                When(WhenOperator.EQUALS, field="damage_present", value=True)
-            ],
+            when=[WhenEquals(field="damage_present", value=True)],
         )
         d = attr.to_dict()
         self.assertEqual(d["name"], "severity")
@@ -310,9 +306,7 @@ class AttributeSpecTests(unittest.TestCase):
             type="str",
             component="dropdown",
             values=["front", "rear"],
-            when=[
-                When(WhenOperator.EQUALS, field="damage_present", value=True)
-            ],
+            when=[WhenEquals(field="damage_present", value=True)],
         )
         restored = AttributeSpec.from_dict(original.to_dict())
         self.assertEqual(restored.name, original.name)
@@ -342,13 +336,7 @@ class AnnotationOntologyTests(unittest.TestCase):
                     type="str",
                     component="dropdown",
                     values=["front", "rear", "driver_side", "passenger_side"],
-                    when=[
-                        When(
-                            WhenOperator.EQUALS,
-                            field="damage_present",
-                            value=True,
-                        )
-                    ],
+                    when=[WhenEquals(field="damage_present", value=True)],
                 ),
             ],
         )
@@ -466,25 +454,13 @@ class AnnotationOntologyTests(unittest.TestCase):
                     type="str",
                     component="dropdown",
                     values=["front", "rear"],
-                    when=[
-                        When(
-                            WhenOperator.EQUALS,
-                            field="damage_present",
-                            value=True,
-                        )
-                    ],
+                    when=[WhenEquals(field="damage_present", value=True)],
                 ),
                 AttributeSpec(
                     name="airbags_deployed",
                     type="bool",
                     component="checkbox",
-                    when=[
-                        When(
-                            WhenOperator.EQUALS,
-                            field="damage_location",
-                            value="front",
-                        )
-                    ],
+                    when=[WhenEquals(field="damage_location", value="front")],
                 ),
             ],
         )
@@ -535,13 +511,7 @@ class OntologySDKTests(unittest.TestCase):
                     type="str",
                     component="dropdown",
                     values=["front", "rear"],
-                    when=[
-                        When(
-                            WhenOperator.EQUALS,
-                            field="damage_present",
-                            value=True,
-                        )
-                    ],
+                    when=[WhenEquals(field="damage_present", value=True)],
                 ),
             ],
         )


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?


This adds `WhenEquals` and `WhenIn` provide convenience and of just using plain `When`. 

## Before

```python
from fiftyone.core.annotation.attributes import (
    AttributeSpec,
    When,
    WhenOperator,
)

AttributeSpec(
    name="damage_location",
    type="str",
    component="dropdown",
    values=["front", "rear"],
    when=[
        When(WhenOperator.EQUALS, field="damage_present", value=True),
    ],
)

AttributeSpec(
    name="car_model",
    type="str",
    component="dropdown",
    when=[
        When(WhenOperator.IN, field="brand", value=["toyota", "honda"]),
    ],
)
```

## After

```python
from fiftyone.core.annotation.attributes import (
    AttributeSpec,
    WhenEquals,
    WhenIn,
)

AttributeSpec(
    name="damage_location",
    type="str",
    component="dropdown",
    values=["front", "rear"],
    when=[
        WhenEquals(field="damage_present", value=True),
    ],
)

AttributeSpec(
    name="car_model",
    type="str",
    component="dropdown",
    when=[
        WhenIn(field="brand", value=["toyota", "honda"]),
    ],
)
```

`When(WhenOperator.X, ...)` still works for backward compatibility — `WhenEquals` and `WhenIn` are subclasses of `When` that pre-fill the operator. Wire format, MongoDB storage, and existing validators are unchanged.


## 🧪 How is this patch tested? If it is not, please explain why.

Tested locally with some scripts in my dev environment, unit tests

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `WhenEquals` and `WhenIn` convenience classes for simplified conditional annotation display logic.

* **Documentation**
  * Updated examples in annotation ontology documentation to demonstrate the new convenience classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->