### PR TITLE
Optimize local media range serving

### DIFF
--- a/fiftyone/server/routes/media.py
+++ b/fiftyone/server/routes/media.py
@@ -6,6 +6,7 @@ FiftyOne Server /media route
 |
 """
 
+import errno
 import os
 import stat
 
@@ -13,7 +14,6 @@ import anyio
 from starlette.endpoints import HTTPEndpoint
 from starlette.requests import Request
 from starlette.responses import FileResponse, Response
-
 
 _MEDIA_HEADERS = {
     "Accept-Ranges": "bytes",

--- a/fiftyone/server/routes/media.py
+++ b/fiftyone/server/routes/media.py
@@ -7,149 +7,70 @@ FiftyOne Server /media route
 """
 
 import os
-import typing as t
+import stat
 
 import anyio
-import aiofiles
-from aiofiles.threadpool.binary import AsyncBufferedReader
-from aiofiles.os import stat as aio_stat
 from starlette.endpoints import HTTPEndpoint
 from starlette.requests import Request
-from starlette.responses import (
-    FileResponse,
-    Response,
-    StreamingResponse,
-    guess_type,
-)
+from starlette.responses import FileResponse, Response
 
 
-async def ranged(
-    file: AsyncBufferedReader,
-    start: int = 0,
-    end: int = None,
-    block_size: int = 8192,
-) -> t.AsyncGenerator:
-    consumed = 0
+_MEDIA_HEADERS = {
+    "Accept-Ranges": "bytes",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+    "Access-Control-Allow-Headers": "Range, Content-Type, Authorization",
+    "Access-Control-Expose-Headers": (
+        "Accept-Ranges, Content-Range, Content-Length"
+    ),
+}
+MEDIA_FILE_RESPONSE_CHUNK_SIZE = 256 * 1024
 
-    await file.seek(start)
 
-    while True:
-        data_length = (
-            min(block_size, end - start - consumed) if end else block_size
-        )
+def _media_headers(extra=None):
+    headers = dict(_MEDIA_HEADERS)
 
-        if data_length <= 0:
-            break
+    if extra:
+        headers.update(extra)
 
-        data = await file.read(data_length)
+    return headers
 
-        if not data:
-            break
 
-        consumed += data_length
+def _not_found_response():
+    return Response(
+        content="Not found",
+        status_code=404,
+        headers=_media_headers(),
+    )
 
-        yield data
 
-    if hasattr(file, "close"):
-        await file.close()
+class MediaFileResponse(FileResponse):
+    # Optimize local media serving for large range reads.
+    chunk_size = MEDIA_FILE_RESPONSE_CHUNK_SIZE
 
 
 class Media(HTTPEndpoint):
-    async def get(
-        self, request: Request
-    ) -> t.Union[FileResponse, StreamingResponse]:
+    async def get(self, request: Request) -> Response:
+        # Note for HEAD: Starlette routes HEAD through GET when no HEAD handler exists.
         path = request.query_params["filepath"]
+        return await self._file_response(path)
 
-        response: t.Union[FileResponse, StreamingResponse]
-
+    async def _file_response(self, path: str) -> Response:
         try:
-            await anyio.to_thread.run_sync(os.stat, path)
+            stat_result = await anyio.to_thread.run_sync(os.stat, path)
         except FileNotFoundError:
-            return Response(content="Not found", status_code=404)
+            return _not_found_response()
 
-        if request.headers.get("range"):
-            response = await self.ranged_file_response(path, request)
-        else:
-            response = FileResponse(
-                path,
-            )
-        response.headers["Accept-Ranges"] = "bytes"
+        if not stat.S_ISREG(stat_result.st_mode):
+            return _not_found_response()
 
-        response.headers["Access-Control-Allow-Origin"] = "*"
-        response.headers["Access-Control-Allow-Methods"] = "GET, HEAD, OPTIONS"
-        response.headers[
-            "Access-Control-Allow-Headers"
-        ] = "Range, Content-Type, Authorization"
-        response.headers[
-            "Access-Control-Expose-Headers"
-        ] = "Accept-Ranges, Content-Range, Content-Length"
-        return response
-
-    async def ranged_file_response(
-        self, path: str, request: Request
-    ) -> StreamingResponse:
-        file = await aiofiles.open(path, "rb")
-        file_size = (await aio_stat(path)).st_size
-        content_range = request.headers.get("range")
-        content_length = file_size
-        status_code = 200
-        headers = {}
-
-        if content_range is not None:
-            content_range = content_range.strip().lower()
-
-            content_ranges = content_range.split("=")[-1]
-
-            range_start, range_end, *_ = map(
-                str.strip, (content_ranges + "-").split("-")
-            )
-
-            start, end = (
-                int(range_start) if range_start else 0,
-                int(range_end) if range_end else file_size - 1,
-            )
-            range_start = max(0, start)
-            range_end = min(file_size - 1, int(end))
-
-            content_length = (end - start) + 1
-
-            file_response = ranged(file, start=start, end=end + 1)
-
-            status_code = 206
-
-            headers["Content-Range"] = f"bytes {start}-{end}/{file_size}"
-
-        response = StreamingResponse(
-            file_response,
-            media_type=guess_type(path)[0],
-            status_code=status_code,
+        return MediaFileResponse(
+            path,
+            stat_result=stat_result,
+            headers=_media_headers(),
         )
-
-        response.headers.update(
-            {
-                "Accept-Ranges": "bytes",
-                "Content-Length": str(content_length),
-                **headers,
-            }
-        )
-
-        return response
-
-    async def head(self, request: Request) -> Response:
-        path = request.query_params["filepath"]
-        response = Response()
-        size = (await aio_stat(path)).st_size
-        response.headers.update(
-            {
-                "Accept-Ranges": "bytes",
-                "Content-Type": guess_type(path)[0],
-                "Content-Length": size,
-            }
-        )
-        return response
 
     async def options(self, request: Request) -> Response:
-        response = Response()
-        response.headers["Accept-Ranges"] = "bytes"
-        response.headers["Allow"] = "OPTIONS, GET, HEAD"
-        return response
+        return Response(
+            headers=_media_headers({"Allow": "OPTIONS, GET, HEAD"})
+        )

--- a/fiftyone/server/routes/media.py
+++ b/fiftyone/server/routes/media.py
@@ -52,7 +52,15 @@ class MediaFileResponse(FileResponse):
 class Media(HTTPEndpoint):
     async def get(self, request: Request) -> Response:
         # Note for HEAD: Starlette routes HEAD through GET when no HEAD handler exists.
-        path = request.query_params["filepath"]
+        path = request.query_params.get("filepath")
+
+        if not path:
+            return Response(
+                content="Missing required query parameter: filepath",
+                status_code=400,
+                headers=_media_headers(),
+            )
+
         return await self._file_response(path)
 
     async def _file_response(self, path: str) -> Response:

--- a/fiftyone/server/routes/media.py
+++ b/fiftyone/server/routes/media.py
@@ -66,7 +66,7 @@ class Media(HTTPEndpoint):
     async def _file_response(self, path: str) -> Response:
         try:
             stat_result = await anyio.to_thread.run_sync(os.stat, path)
-        except FileNotFoundError:
+        except (FileNotFoundError, NotADirectoryError, PermissionError):
             return _not_found_response()
 
         if not stat.S_ISREG(stat_result.st_mode):

--- a/fiftyone/server/routes/media.py
+++ b/fiftyone/server/routes/media.py
@@ -68,6 +68,10 @@ class Media(HTTPEndpoint):
             stat_result = await anyio.to_thread.run_sync(os.stat, path)
         except (FileNotFoundError, NotADirectoryError, PermissionError):
             return _not_found_response()
+        except OSError as e:
+            if e.errno in {errno.ENAMETOOLONG, errno.ELOOP}:
+                return _not_found_response()
+            raise
 
         if not stat.S_ISREG(stat_result.st_mode):
             return _not_found_response()

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         "retrying>=1,<2",
         "sseclient-py>=1.7.2,<2",
         "sse-starlette>=0.10.3,<4",
-        "starlette>=0.24.0,<0.53",
+        "starlette>=0.49.1,<0.53",
         "strawberry-graphql>=0.262.4,<0.292.0",
         "tabulate>=0.7,<0.10",
         "tqdm>=2,<5",

--- a/tests/unittests/server/routes/test_media.py
+++ b/tests/unittests/server/routes/test_media.py
@@ -123,6 +123,16 @@ def test_missing_file_returns_404(client, tmp_path):
     _assert_range_headers(response)
 
 
+@pytest.mark.parametrize("error", [NotADirectoryError, PermissionError])
+def test_stat_error_returns_404(client, media_file, error):
+    with patch("fiftyone.server.routes.media.os.stat", side_effect=error):
+        response = client.get(_media_url(media_file))
+
+    assert response.status_code == 404
+    assert response.text == "Not found"
+    _assert_range_headers(response)
+
+
 def test_directory_returns_404(client, tmp_path):
     response = client.get(_media_url(tmp_path))
 

--- a/tests/unittests/server/routes/test_media.py
+++ b/tests/unittests/server/routes/test_media.py
@@ -1,0 +1,130 @@
+"""
+FiftyOne Server media route unit tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+import fiftyone.server.routes.media as form
+
+
+@pytest.fixture(name="media_file")
+def fixture_media_file(tmp_path):
+    path = tmp_path / "example.pcd"
+    path.write_bytes(b"0123456789abcdef")
+    return path
+
+
+@pytest.fixture(name="client")
+def fixture_client():
+    app = Starlette(routes=[Route("/media", form.Media)])
+    return TestClient(app)
+
+
+def _media_url(path):
+    return f"/media?filepath={path}"
+
+
+def _assert_range_headers(response):
+    assert response.headers["accept-ranges"] == "bytes"
+    assert (
+        response.headers["access-control-expose-headers"]
+        == "Accept-Ranges, Content-Range, Content-Length"
+    )
+
+
+def test_get_returns_file(client, media_file):
+    response = client.get(_media_url(media_file))
+
+    assert response.status_code == 200
+    assert response.content == b"0123456789abcdef"
+    assert response.headers["content-length"] == "16"
+    _assert_range_headers(response)
+
+
+def test_get_stats_once(client, media_file):
+    with patch("fiftyone.server.routes.media.os.stat", wraps=os.stat) as stat:
+        response = client.get(_media_url(media_file))
+
+    assert response.status_code == 200
+    assert stat.call_count == 1
+
+
+def test_head_returns_headers_without_body(client, media_file):
+    response = client.head(_media_url(media_file))
+
+    assert response.status_code == 200
+    assert response.content == b""
+    assert response.headers["content-length"] == "16"
+    _assert_range_headers(response)
+
+
+@pytest.mark.parametrize(
+    "range_header,expected_content,expected_content_range",
+    [
+        ("bytes=2-5", b"2345", "bytes 2-5/16"),
+        ("bytes=4-", b"456789abcdef", "bytes 4-15/16"),
+        ("bytes=-4", b"cdef", "bytes 12-15/16"),
+    ],
+)
+def test_range_requests(
+    client, media_file, range_header, expected_content, expected_content_range
+):
+    response = client.get(
+        _media_url(media_file),
+        headers={"Range": range_header},
+    )
+
+    assert response.status_code == 206
+    assert response.content == expected_content
+    assert response.headers["content-range"] == expected_content_range
+    _assert_range_headers(response)
+
+
+@pytest.mark.parametrize(
+    "range_header,status_code",
+    [
+        ("bytes=99-120", 416),
+        ("items=2-5", 400),
+    ],
+)
+def test_invalid_range_requests(client, media_file, range_header, status_code):
+    response = client.get(
+        _media_url(media_file),
+        headers={"Range": range_header},
+    )
+
+    assert response.status_code == status_code
+
+
+def test_missing_file_returns_404(client, tmp_path):
+    response = client.get(_media_url(tmp_path / "missing.pcd"))
+
+    assert response.status_code == 404
+    assert response.text == "Not found"
+    _assert_range_headers(response)
+
+
+def test_directory_returns_404(client, tmp_path):
+    response = client.get(_media_url(tmp_path))
+
+    assert response.status_code == 404
+    assert response.text == "Not found"
+    _assert_range_headers(response)
+
+
+def test_options_returns_allow_and_range_headers(client):
+    response = client.options("/media")
+
+    assert response.status_code == 200
+    assert response.headers["allow"] == "OPTIONS, GET, HEAD"
+    _assert_range_headers(response)

--- a/tests/unittests/server/routes/test_media.py
+++ b/tests/unittests/server/routes/test_media.py
@@ -59,6 +59,15 @@ def test_get_stats_once(client, media_file):
     assert stat.call_count == 1
 
 
+@pytest.mark.parametrize("url", ["/media", "/media?filepath="])
+def test_get_requires_filepath(client, url):
+    response = client.get(url)
+
+    assert response.status_code == 400
+    assert response.text == "Missing required query parameter: filepath"
+    _assert_range_headers(response)
+
+
 def test_head_returns_headers_without_body(client, media_file):
     response = client.head(_media_url(media_file))
 


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Refactors the `/media` route to delegate range request handling to Starlette `FileResponse` instead of the custom 8 KiB streamer.

This removes local range parsing, avoids duplicate stat work, uses a larger local media chunk size for range-heavy reads, and bumps the Starlette floor to a version with safe native `FileResponse` range support.

## 🧪 How is this patch tested? If it is not, please explain why.

- Added unit coverage for `/media` GET, HEAD, valid/invalid range requests, missing/non-file paths, and OPTIONS headers.
- Ran `pytest tests/unittests/server/routes/test_media.py`

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Improved local `/media` range request handling by using Starlette’s native file response support, which can improve throughput for large local media reads.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved media file serving with unified handling of range requests and centralized headers.

* **Bug Fixes**
  * Consistent 400 for missing parameters and 404 for missing/unreadable/invalid files; CORS and range headers are now applied to success, OPTIONS, and error responses.

* **Tests**
  * Added comprehensive tests for byte-range behavior, header consistency, error cases, HEAD, and OPTIONS.

* **Chores**
  * Raised minimum supported version of the server framework.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->