### PR TITLE
Add multimodal scene inventory + playback plans server route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ coverage.xml
 pyvenv.cfg
 
 .env
+
+.playwright-mcp

--- a/fiftyone/multimodal/query/__init__.py
+++ b/fiftyone/multimodal/query/__init__.py
@@ -5,3 +5,7 @@ Query scaffolding for multimodal workflows.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
+from .scene_inventory import resolve_scene_inventory
+
+__all__ = ["resolve_scene_inventory"]

--- a/fiftyone/multimodal/query/__init__.py
+++ b/fiftyone/multimodal/query/__init__.py
@@ -6,6 +6,7 @@ Query scaffolding for multimodal workflows.
 |
 """
 
+from .playback_plan import resolve_playback_plan
 from .scene_inventory import resolve_scene_inventory
 
-__all__ = ["resolve_scene_inventory"]
+__all__ = ["resolve_playback_plan", "resolve_scene_inventory"]

--- a/fiftyone/multimodal/query/playback_plan.py
+++ b/fiftyone/multimodal/query/playback_plan.py
@@ -1,0 +1,163 @@
+"""
+Playback plan query helpers for multimodal workflows.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from fiftyone.multimodal.schemas import v1 as foms
+
+
+def resolve_playback_plan(inventory_id: str) -> foms.PlaybackPlan:
+    """Resolves the playback plan for a scene inventory.
+
+    TODO:
+    THIS IS A SMOKE-TEST MOCK IMPLEMENTATION.
+    """
+
+    time_track_ids = ["sample.index", "capture.time"]
+
+    return foms.PlaybackPlan(
+        plan_id=f"mock-playback-plan:{inventory_id}",
+        scene_id=_resolve_mock_scene_id(inventory_id),
+        source_inventory_id=inventory_id,
+        plan_version="v1",
+        clock=foms.PlaybackClock(
+            time_track_ids=time_track_ids,
+            default_time_track_id="sample.index",
+            value_range=foms.TimeValueRange(start=0, end=24),
+            start_value=0,
+            playback_rate=1.0,
+            sync_mode=foms.PlaybackSyncMode.PLAYBACK_SYNC_MODE_NEAREST,
+            loop=True,
+        ),
+        time_tracks=[
+            foms.TimeTrack(
+                time_track_id="sample.index",
+                type=foms.TimeTrackType.TIME_TRACK_TYPE_SEQUENCE,
+                role=foms.TimeTrackRole.TIME_TRACK_ROLE_SAMPLE_INDEX,
+                display_name="Sample index",
+                source_path="sample.index",
+                value_range=foms.TimeValueRange(start=0, end=24),
+                sort_order=foms.TimeSortOrder.TIME_SORT_ORDER_MONOTONIC,
+                sort_scope=foms.TimeSortScope.TIME_SORT_SCOPE_SCENE,
+            ),
+            foms.TimeTrack(
+                time_track_id="capture.time",
+                type=foms.TimeTrackType.TIME_TRACK_TYPE_TIMESTAMP_NS,
+                role=foms.TimeTrackRole.TIME_TRACK_ROLE_CAPTURE_TIME,
+                display_name="Capture time",
+                source_path="capture_time",
+                value_range=foms.TimeValueRange(
+                    start=1710000000000000000,
+                    end=1710000002400000000,
+                ),
+                sort_order=foms.TimeSortOrder.TIME_SORT_ORDER_MONOTONIC,
+                sort_scope=foms.TimeSortScope.TIME_SORT_SCOPE_SCENE,
+            ),
+        ],
+        streams=[
+            foms.StreamPlaybackSpec(
+                stream_id="camera.front",
+                decoder_id="mock.image",
+                time_track_ids=time_track_ids,
+                default_time_track_id="sample.index",
+                metadata={"kind": "image", "field": "camera.front"},
+            ),
+            foms.StreamPlaybackSpec(
+                stream_id="camera.rear",
+                decoder_id="mock.image",
+                time_track_ids=time_track_ids,
+                default_time_track_id="sample.index",
+                metadata={"kind": "image", "field": "camera.rear"},
+            ),
+            foms.StreamPlaybackSpec(
+                stream_id="lidar.top",
+                decoder_id="mock.point-cloud",
+                time_track_ids=time_track_ids,
+                default_time_track_id="sample.index",
+                metadata={"kind": "point-cloud", "field": "lidar.top"},
+            ),
+        ],
+        panels=[
+            foms.PanelSpec(
+                panel_id="front-camera",
+                kind=foms.PanelKind.PANEL_KIND_IMAGE,
+                title="Front camera",
+                streams=[
+                    foms.PanelStreamBinding(
+                        stream_id="camera.front",
+                        role=foms.PanelStreamRole.PANEL_STREAM_ROLE_PRIMARY,
+                        coordinate_frame_id="camera_front",
+                    )
+                ],
+                settings=foms.PanelSettings(
+                    image=foms.ImagePanelSettings(fit_mode="contain")
+                ),
+            ),
+            foms.PanelSpec(
+                panel_id="rear-camera",
+                kind=foms.PanelKind.PANEL_KIND_IMAGE,
+                title="Rear camera",
+                streams=[
+                    foms.PanelStreamBinding(
+                        stream_id="camera.rear",
+                        role=foms.PanelStreamRole.PANEL_STREAM_ROLE_PRIMARY,
+                        coordinate_frame_id="camera_rear",
+                    )
+                ],
+                settings=foms.PanelSettings(
+                    image=foms.ImagePanelSettings(fit_mode="contain")
+                ),
+            ),
+            foms.PanelSpec(
+                panel_id="top-lidar",
+                kind=foms.PanelKind.PANEL_KIND_THREE_D,
+                title="Top lidar",
+                streams=[
+                    foms.PanelStreamBinding(
+                        stream_id="lidar.top",
+                        role=foms.PanelStreamRole.PANEL_STREAM_ROLE_PRIMARY,
+                        coordinate_frame_id="lidar_top",
+                    )
+                ],
+                settings=foms.PanelSettings(
+                    three_d=foms.ThreeDPanelSettings(
+                        camera_preset="ego", color_by_field="intensity"
+                    )
+                ),
+            ),
+        ],
+        root_layout=foms.LayoutNode(
+            node_id="root",
+            visible=True,
+            container=foms.ContainerLayout(
+                kind=foms.LayoutContainerKind.LAYOUT_CONTAINER_KIND_GRID,
+                children=[
+                    _panel_node("front-camera"),
+                    _panel_node("rear-camera"),
+                    _panel_node("top-lidar"),
+                ],
+                child_weights=[1.0, 1.0, 1.0],
+            ),
+        ),
+        produced_at="2026-01-01T00:00:00Z",
+        produced_by="fiftyone.multimodal.mock",
+    )
+
+
+def _resolve_mock_scene_id(inventory_id: str) -> str:
+    parts = inventory_id.split(":")
+
+    if len(parts) == 3 and parts[0] == "mock-inventory":
+        return f"mock-scene:{parts[2]}"
+
+    return f"mock-scene:{inventory_id}"
+
+
+def _panel_node(panel_id: str) -> foms.LayoutNode:
+    return foms.LayoutNode(
+        node_id=f"{panel_id}-node",
+        panel=foms.PanelLayout(panel_id=panel_id),
+    )

--- a/fiftyone/multimodal/query/scene_inventory.py
+++ b/fiftyone/multimodal/query/scene_inventory.py
@@ -1,0 +1,102 @@
+"""
+Scene inventory query helpers for multimodal workflows.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from fiftyone.multimodal.schemas import v1 as foms
+
+
+def resolve_scene_inventory(
+    dataset_id: str, sample_id: str
+) -> foms.SceneInventory:
+    """Resolves the scene inventory for a dataset sample.
+
+    TODO:
+    THIS IS A SMOKE-TEST MOCK IMPLEMENTATION.
+    """
+
+    return foms.SceneInventory(
+        inventory_id=f"mock-inventory:{dataset_id}:{sample_id}",
+        scene_id=f"mock-scene:{sample_id}",
+        source_format="mock",
+        source_fingerprint=foms.SourceFingerprint(size_bytes=0),
+        inventory_version="v1",
+        time_tracks=[
+            foms.TimeTrack(
+                time_track_id="sample.index",
+                type=foms.TimeTrackType.TIME_TRACK_TYPE_SEQUENCE,
+                role=foms.TimeTrackRole.TIME_TRACK_ROLE_SAMPLE_INDEX,
+                display_name="Sample index",
+                source_path="sample.index",
+                value_range=foms.TimeValueRange(start=0, end=24),
+                sort_order=foms.TimeSortOrder.TIME_SORT_ORDER_MONOTONIC,
+                sort_scope=foms.TimeSortScope.TIME_SORT_SCOPE_SCENE,
+            ),
+            foms.TimeTrack(
+                time_track_id="capture.time",
+                type=foms.TimeTrackType.TIME_TRACK_TYPE_TIMESTAMP_NS,
+                role=foms.TimeTrackRole.TIME_TRACK_ROLE_CAPTURE_TIME,
+                display_name="Capture time",
+                source_path="capture_time",
+                value_range=foms.TimeValueRange(
+                    start=1710000000000000000,
+                    end=1710000002400000000,
+                ),
+                sort_order=foms.TimeSortOrder.TIME_SORT_ORDER_MONOTONIC,
+                sort_scope=foms.TimeSortScope.TIME_SORT_SCOPE_SCENE,
+            ),
+        ],
+        streams=[
+            foms.StreamInventory(
+                stream_id="camera.front",
+                payload=foms.PayloadDescriptor(encoding="image/jpeg"),
+                record_count=24,
+                display_name="Front camera",
+                coordinate_frame_id="camera_front",
+                metadata={"kind": "image", "field": "camera.front"},
+            ),
+            foms.StreamInventory(
+                stream_id="camera.rear",
+                payload=foms.PayloadDescriptor(encoding="image/jpeg"),
+                record_count=24,
+                display_name="Rear camera",
+                coordinate_frame_id="camera_rear",
+                metadata={"kind": "image", "field": "camera.rear"},
+            ),
+            foms.StreamInventory(
+                stream_id="lidar.top",
+                payload=foms.PayloadDescriptor(encoding="point-cloud/xyz"),
+                record_count=12,
+                display_name="Top lidar",
+                coordinate_frame_id="lidar_top",
+                metadata={"kind": "point-cloud", "field": "lidar.top"},
+            ),
+        ],
+        static_coordinate_frame_edges=[
+            foms.StaticCoordinateFrameEdge(
+                parent_frame_id="ego",
+                child_frame_id="camera_front",
+                source_stream_id="camera.front",
+            ),
+            foms.StaticCoordinateFrameEdge(
+                parent_frame_id="ego",
+                child_frame_id="camera_rear",
+                source_stream_id="camera.rear",
+            ),
+            foms.StaticCoordinateFrameEdge(
+                parent_frame_id="ego",
+                child_frame_id="lidar_top",
+                source_stream_id="lidar.top",
+            ),
+        ],
+        metadata={
+            "dataset_id": dataset_id,
+            "sample_id": sample_id,
+            "resolver": "mock",
+        },
+        produced_at="2026-01-01T00:00:00Z",
+        produced_by="fiftyone.multimodal.mock",
+    )

--- a/fiftyone/multimodal/server/__init__.py
+++ b/fiftyone/multimodal/server/__init__.py
@@ -8,12 +8,14 @@ Server scaffolding for multimodal workflows.
 
 from .routes import (
     MultimodalRoutes,
+    PlaybackPlanEndpoint,
     PROTOBUF_MEDIA_TYPE,
     SceneInventoryEndpoint,
 )
 
 __all__ = [
     "MultimodalRoutes",
+    "PlaybackPlanEndpoint",
     "PROTOBUF_MEDIA_TYPE",
     "SceneInventoryEndpoint",
 ]

--- a/fiftyone/multimodal/server/__init__.py
+++ b/fiftyone/multimodal/server/__init__.py
@@ -5,3 +5,15 @@ Server scaffolding for multimodal workflows.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
+from .routes import (
+    MultimodalRoutes,
+    PROTOBUF_MEDIA_TYPE,
+    SceneInventoryEndpoint,
+)
+
+__all__ = [
+    "MultimodalRoutes",
+    "PROTOBUF_MEDIA_TYPE",
+    "SceneInventoryEndpoint",
+]

--- a/fiftyone/multimodal/server/routes.py
+++ b/fiftyone/multimodal/server/routes.py
@@ -74,7 +74,7 @@ def _get_required_body_field(data: dict, field: str) -> str:
 
 
 def _require_string(value, field: str) -> str:
-    if not isinstance(value, str) or not value:
+    if not isinstance(value, str) or not value.strip():
         raise HTTPException(
             status_code=400,
             detail=f"'{field}' is required",

--- a/fiftyone/multimodal/server/routes.py
+++ b/fiftyone/multimodal/server/routes.py
@@ -11,7 +11,10 @@ from starlette.exceptions import HTTPException
 from starlette.requests import Request
 from starlette.responses import Response
 
-from fiftyone.multimodal.query import resolve_scene_inventory
+from fiftyone.multimodal.query import (
+    resolve_playback_plan,
+    resolve_scene_inventory,
+)
 from fiftyone.server import decorators
 
 PROTOBUF_MEDIA_TYPE = "application/x-protobuf"
@@ -35,9 +38,36 @@ class SceneInventoryEndpoint(HTTPEndpoint):
         )
 
 
+class PlaybackPlanEndpoint(HTTPEndpoint):
+    """Playback plan query endpoint."""
+
+    @decorators.route
+    async def post(self, request: Request, data: dict) -> Response:
+        """Returns a serialized PlaybackPlan protobuf."""
+
+        inventory_id = _get_required_body_field(data, "inventory_id")
+
+        plan = resolve_playback_plan(inventory_id)
+
+        return Response(
+            plan.SerializeToString(),
+            media_type=PROTOBUF_MEDIA_TYPE,
+        )
+
+
 def _get_required_path_param(request: Request, field: str) -> str:
     value = request.path_params.get(field)
 
+    return _require_string(value, field)
+
+
+def _get_required_body_field(data: dict, field: str) -> str:
+    value = data.get(field)
+
+    return _require_string(value, field)
+
+
+def _require_string(value, field: str) -> str:
     if not isinstance(value, str) or not value:
         raise HTTPException(
             status_code=400,
@@ -48,6 +78,10 @@ def _get_required_path_param(request: Request, field: str) -> str:
 
 
 MultimodalRoutes = [
+    (
+        "/multimodal/playback-plan",
+        PlaybackPlanEndpoint,
+    ),
     (
         "/dataset/{dataset_id}/sample/{sample_id}/multimodal/scene-inventory",
         SceneInventoryEndpoint,

--- a/fiftyone/multimodal/server/routes.py
+++ b/fiftyone/multimodal/server/routes.py
@@ -62,6 +62,12 @@ def _get_required_path_param(request: Request, field: str) -> str:
 
 
 def _get_required_body_field(data: dict, field: str) -> str:
+    if not isinstance(data, dict):
+        raise HTTPException(
+            status_code=400,
+            detail="JSON body must be an object",
+        )
+
     value = data.get(field)
 
     return _require_string(value, field)

--- a/fiftyone/multimodal/server/routes.py
+++ b/fiftyone/multimodal/server/routes.py
@@ -1,0 +1,55 @@
+"""
+Multimodal server routes.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from starlette.endpoints import HTTPEndpoint
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
+from starlette.responses import Response
+
+from fiftyone.multimodal.query import resolve_scene_inventory
+from fiftyone.server import decorators
+
+PROTOBUF_MEDIA_TYPE = "application/x-protobuf"
+
+
+class SceneInventoryEndpoint(HTTPEndpoint):
+    """Scene inventory query endpoint."""
+
+    @decorators.route(parse_body=False)
+    async def get(self, request: Request) -> Response:
+        """Returns a serialized SceneInventory protobuf."""
+
+        dataset_id = _get_required_path_param(request, "dataset_id")
+        sample_id = _get_required_path_param(request, "sample_id")
+
+        inventory = resolve_scene_inventory(dataset_id, sample_id)
+
+        return Response(
+            inventory.SerializeToString(),
+            media_type=PROTOBUF_MEDIA_TYPE,
+        )
+
+
+def _get_required_path_param(request: Request, field: str) -> str:
+    value = request.path_params.get(field)
+
+    if not isinstance(value, str) or not value:
+        raise HTTPException(
+            status_code=400,
+            detail=f"'{field}' is required",
+        )
+
+    return value
+
+
+MultimodalRoutes = [
+    (
+        "/dataset/{dataset_id}/sample/{sample_id}/multimodal/scene-inventory",
+        SceneInventoryEndpoint,
+    ),
+]

--- a/fiftyone/server/decorators.py
+++ b/fiftyone/server/decorators.py
@@ -9,6 +9,7 @@ FiftyOne Server decorators
 import traceback
 import typing as t
 import logging
+from functools import wraps
 
 from starlette.endpoints import HTTPEndpoint
 from starlette.exceptions import HTTPException
@@ -20,43 +21,58 @@ from fiftyone.server import utils
 from fiftyone.server.exceptions import DbVersionMismatchError
 
 
-def route(func):
-    """A decorator for HTTPEndpoint methods that parses JSON request bodies
-    and handles exceptions."""
+def route(func=None, *, parse_body: bool = True):
+    """A decorator for HTTPEndpoint methods that handles exceptions.
 
-    async def wrapper(
-        endpoint: HTTPEndpoint, request: Request, *args
-    ) -> t.Union[dict, Response]:
-        try:
-            body = await request.body()
-            payload = body.decode("utf-8")
-            data = utils.json.loads(payload)
-            response = await func(endpoint, request, data, *args)
-            if isinstance(response, Response):
-                return response
+    By default, it assumes JSON body parsing behavior (for legacy support) and
+    passes parsed data as the third handler argument. Routes without a request
+    body can opt out with ``@route(parse_body=False)``.
+    """
 
-            return await create_response(response)
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(
+            endpoint: HTTPEndpoint, request: Request, *args
+        ) -> t.Union[dict, Response]:
+            try:
+                if parse_body:
+                    body = await request.body()
+                    payload = body.decode("utf-8")
+                    data = utils.json.loads(payload)
+                    response = await func(endpoint, request, data, *args)
+                else:
+                    response = await func(endpoint, request, *args)
 
-        except Exception as e:
-            # Immediately re-raise starlette HTTP exceptions
-            if isinstance(e, HTTPException):
-                raise e
+                if isinstance(response, Response):
+                    return response
 
-            if isinstance(e, DbVersionMismatchError):
-                return utils.json.JSONResponse(
-                    utils.json.serialize(e.sample),
-                    status_code=412,
-                    headers={"ETag": e.etag},
+                return await create_response(response)
+
+            except Exception as e:
+                # Immediately re-raise starlette HTTP exceptions
+                if isinstance(e, HTTPException):
+                    raise e
+
+                if isinstance(e, DbVersionMismatchError):
+                    return utils.json.JSONResponse(
+                        utils.json.serialize(e.sample),
+                        status_code=412,
+                        headers={"ETag": e.etag},
+                    )
+
+                # Cast non-starlette HTTP exceptions as JSON with 500 status code
+                logging.exception(e)
+                return JSONResponse(
+                    {
+                        "kind": "Server Error",
+                        "stack": traceback.format_exc(),
+                    },
+                    status_code=500,
                 )
 
-            # Cast non-starlette HTTP exceptions as JSON with 500 status code
-            logging.exception(e)
-            return JSONResponse(
-                {
-                    "kind": "Server Error",
-                    "stack": traceback.format_exc(),
-                },
-                status_code=500,
-            )
+        return wrapper
 
-    return wrapper
+    if func is None:
+        return decorator
+
+    return decorator(func)

--- a/fiftyone/server/decorators.py
+++ b/fiftyone/server/decorators.py
@@ -21,21 +21,30 @@ from fiftyone.server import utils
 from fiftyone.server.exceptions import DbVersionMismatchError
 
 
-def route(func=None, *, parse_body: bool = True):
+_BODY_METHOD_NAMES = {"post", "put", "patch"}
+
+
+def route(func=None, *, parse_body: t.Optional[bool] = None):
     """A decorator for HTTPEndpoint methods that handles exceptions.
 
-    By default, it assumes JSON body parsing behavior (for legacy support) and
-    passes parsed data as the third handler argument. Routes without a request
-    body can opt out with ``@route(parse_body=False)``.
+    By default, POST, PUT, and PATCH handlers parse the JSON body and receive
+    the parsed data as the third handler argument. Other handlers skip body
+    parsing. This behavior can be explicitly overridden with ``parse_body``.
     """
 
     def decorator(func):
+        should_parse_body = (
+            func.__name__.lower() in _BODY_METHOD_NAMES
+            if parse_body is None
+            else parse_body
+        )
+
         @wraps(func)
         async def wrapper(
             endpoint: HTTPEndpoint, request: Request, *args
         ) -> t.Union[dict, Response]:
             try:
-                if parse_body:
+                if should_parse_body:
                     body = await request.body()
                     payload = body.decode("utf-8")
                     data = utils.json.loads(payload)

--- a/fiftyone/server/decorators.py
+++ b/fiftyone/server/decorators.py
@@ -46,8 +46,15 @@ def route(func=None, *, parse_body: t.Optional[bool] = None):
             try:
                 if should_parse_body:
                     body = await request.body()
-                    payload = body.decode("utf-8")
-                    data = utils.json.loads(payload)
+                    try:
+                        payload = body.decode("utf-8")
+                        data = utils.json.loads(payload)
+                    except (UnicodeDecodeError, ValueError) as e:
+                        raise HTTPException(
+                            status_code=400,
+                            detail="Malformed JSON body",
+                        ) from e
+
                     response = await func(endpoint, request, data, *args)
                 else:
                     response = await func(endpoint, request, *args)

--- a/fiftyone/server/routes/__init__.py
+++ b/fiftyone/server/routes/__init__.py
@@ -6,6 +6,7 @@ FiftyOne Server routes
 |
 """
 
+from fiftyone.multimodal.server import MultimodalRoutes
 from fiftyone.operators.server import OperatorRoutes
 
 from .aggregate import Aggregate
@@ -33,6 +34,7 @@ routes = (
     CameraRoutes
     + EmbeddingsRoutes
     + GroupsRoutes
+    + MultimodalRoutes
     + OperatorRoutes
     + SampleRoutes
     + [

--- a/fiftyone/server/routes/features.py
+++ b/fiftyone/server/routes/features.py
@@ -9,6 +9,7 @@ FiftyOne Server feature endpoints.
 from dataclasses import dataclass, asdict
 
 from starlette.endpoints import HTTPEndpoint
+from starlette.requests import Request
 
 from fiftyone.internal.features.registry import list_enabled_features
 from fiftyone.server import decorators
@@ -25,8 +26,8 @@ class ListFeaturesResponse:
 class Features(HTTPEndpoint):
     """Endpoints supporting feature flags for safer internal development."""
 
-    @decorators.route
-    async def get(self, *args) -> dict:
+    @decorators.route(parse_body=False)
+    async def get(self, _request: Request) -> dict:
         """Get a list of enabled features."""
         return asdict(
             ListFeaturesResponse(

--- a/fiftyone/server/routes/fiftyone.py
+++ b/fiftyone/server/routes/fiftyone.py
@@ -15,8 +15,8 @@ from fiftyone.server.decorators import route
 
 
 class FiftyOne(HTTPEndpoint):
-    @route
-    async def get(self, request: Request, data: dict) -> dict:
+    @route(parse_body=False)
+    async def get(self, _request: Request) -> dict:
         return {
             "version": foc.VERSION,
             "dev": foc.DEV_INSTALL or foc.RC_INSTALL,

--- a/fiftyone/server/routes/plugins.py
+++ b/fiftyone/server/routes/plugins.py
@@ -13,6 +13,6 @@ from fiftyone.plugins import list_plugins
 
 
 class Plugins(HTTPEndpoint):
-    @route
-    async def get(self, request: Request, data: dict):
+    @route(parse_body=False)
+    async def get(self, _request: Request):
         return {"plugins": [pd.to_dict() for pd in list_plugins()]}

--- a/fiftyone/server/routes/screenshot.py
+++ b/fiftyone/server/routes/screenshot.py
@@ -20,10 +20,8 @@ from fiftyone.server.events import dispatch_event
 
 
 class Screenshot(HTTPEndpoint):
-    @route
-    async def get(
-        self, request: Request, data: t.Dict
-    ) -> t.Union[t.Dict, Response]:
+    @route(parse_body=False)
+    async def get(self, request: Request) -> t.Union[t.Dict, Response]:
         img = request.path_params["img"]
         if "." not in img:
             dispatch_event(img, DeactivateNotebookCell())

--- a/tests/unittests/server_decorators_tests.py
+++ b/tests/unittests/server_decorators_tests.py
@@ -6,10 +6,13 @@ FiftyOne Server decorators.
 |
 """
 
+import json
 import unittest
+from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np
 
+from fiftyone.server import decorators
 from fiftyone.server.decorators import create_response
 
 
@@ -30,3 +33,37 @@ class TestNumPyResponse(unittest.IsolatedAsyncioTestCase):
                 "uint64": np.array([8], dtype=np.uint64),
             }
         )
+
+
+class TestRouteDecorator(unittest.IsolatedAsyncioTestCase):
+    async def test_route_parses_json_body_by_default(self):
+        class Endpoint:
+            @decorators.route
+            async def post(self, request, data):
+                return {"value": data["value"]}
+
+        request = MagicMock()
+        request.body = AsyncMock(return_value=b'{"value": "ok"}')
+
+        # pylint: disable-next=no-value-for-parameter
+        response = await Endpoint().post(request)
+
+        request.body.assert_awaited_once()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.body), {"value": "ok"})
+
+    async def test_route_can_skip_body_parsing(self):
+        class Endpoint:
+            @decorators.route(parse_body=False)
+            async def get(self, request):
+                return {"value": request.path_params["value"]}
+
+        request = MagicMock()
+        request.body = AsyncMock(side_effect=AssertionError("unexpected body"))
+        request.path_params = {"value": "ok"}
+
+        response = await Endpoint().get(request)
+
+        request.body.assert_not_called()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.body), {"value": "ok"})

--- a/tests/unittests/server_decorators_tests.py
+++ b/tests/unittests/server_decorators_tests.py
@@ -36,7 +36,7 @@ class TestNumPyResponse(unittest.IsolatedAsyncioTestCase):
 
 
 class TestRouteDecorator(unittest.IsolatedAsyncioTestCase):
-    async def test_route_parses_json_body_by_default(self):
+    async def test_route_parses_json_body_by_default_post(self):
         class Endpoint:
             @decorators.route
             async def post(self, request, data):
@@ -52,9 +52,9 @@ class TestRouteDecorator(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(json.loads(response.body), {"value": "ok"})
 
-    async def test_route_can_skip_body_parsing(self):
+    async def test_route_skips_body_parsing_for_get_by_default(self):
         class Endpoint:
-            @decorators.route(parse_body=False)
+            @decorators.route
             async def get(self, request):
                 return {"value": request.path_params["value"]}
 
@@ -63,6 +63,22 @@ class TestRouteDecorator(unittest.IsolatedAsyncioTestCase):
         request.path_params = {"value": "ok"}
 
         response = await Endpoint().get(request)
+
+        request.body.assert_not_called()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.body), {"value": "ok"})
+
+    async def test_route_skips_body_parsing_for_delete_by_default(self):
+        class Endpoint:
+            @decorators.route
+            async def delete(self, request):
+                return {"value": request.path_params["value"]}
+
+        request = MagicMock()
+        request.body = AsyncMock(side_effect=AssertionError("unexpected body"))
+        request.path_params = {"value": "ok"}
+
+        response = await Endpoint().delete(request)
 
         request.body.assert_not_called()
         self.assertEqual(response.status_code, 200)
@@ -83,6 +99,22 @@ class TestRouteDecorator(unittest.IsolatedAsyncioTestCase):
         request.body.assert_awaited_once()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(json.loads(response.body), {"value": "manual"})
+
+    async def test_route_can_force_body_parsing_for_get(self):
+        class Endpoint:
+            @decorators.route(parse_body=True)
+            async def get(self, request, data):
+                return {"value": data["value"]}
+
+        request = MagicMock()
+        request.body = AsyncMock(return_value=b'{"value": "forced"}')
+
+        # pylint: disable-next=no-value-for-parameter
+        response = await Endpoint().get(request)
+
+        request.body.assert_awaited_once()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.body), {"value": "forced"})
 
     async def test_route_returns_server_error_for_malformed_json_body(self):
         handler_was_called = False

--- a/tests/unittests/server_decorators_tests.py
+++ b/tests/unittests/server_decorators_tests.py
@@ -67,3 +67,43 @@ class TestRouteDecorator(unittest.IsolatedAsyncioTestCase):
         request.body.assert_not_called()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(json.loads(response.body), {"value": "ok"})
+
+    async def test_route_can_skip_body_parsing_with_body_present(self):
+        class Endpoint:
+            @decorators.route(parse_body=False)
+            async def post(self, request):
+                data = json.loads((await request.body()).decode("utf-8"))
+                return {"value": data["value"]}
+
+        request = MagicMock()
+        request.body = AsyncMock(return_value=b'{"value": "manual"}')
+
+        response = await Endpoint().post(request)
+
+        request.body.assert_awaited_once()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.body), {"value": "manual"})
+
+    async def test_route_returns_server_error_for_malformed_json_body(self):
+        handler_was_called = False
+
+        class Endpoint:
+            @decorators.route
+            async def post(self, request, data):
+                nonlocal handler_was_called
+                handler_was_called = True
+                return {"value": data["value"]}
+
+        request = MagicMock()
+        request.body = AsyncMock(return_value=b'{"value":')
+
+        # pylint: disable-next=no-value-for-parameter
+        response = await Endpoint().post(request)
+
+        request.body.assert_awaited_once()
+        self.assertFalse(handler_was_called)
+        self.assertEqual(response.status_code, 500)
+
+        body = json.loads(response.body)
+        self.assertEqual(body["kind"], "Server Error")
+        self.assertIn("JSONDecodeError", body["stack"])

--- a/tests/unittests/server_decorators_tests.py
+++ b/tests/unittests/server_decorators_tests.py
@@ -11,6 +11,7 @@ import unittest
 from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np
+from starlette.exceptions import HTTPException
 
 from fiftyone.server import decorators
 from fiftyone.server.decorators import create_response
@@ -116,7 +117,7 @@ class TestRouteDecorator(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(json.loads(response.body), {"value": "forced"})
 
-    async def test_route_returns_server_error_for_malformed_json_body(self):
+    async def test_route_returns_bad_request_for_malformed_json_body(self):
         handler_was_called = False
 
         class Endpoint:
@@ -129,13 +130,10 @@ class TestRouteDecorator(unittest.IsolatedAsyncioTestCase):
         request = MagicMock()
         request.body = AsyncMock(return_value=b'{"value":')
 
-        # pylint: disable-next=no-value-for-parameter
-        response = await Endpoint().post(request)
+        with self.assertRaises(HTTPException) as exc:
+            # pylint: disable-next=no-value-for-parameter
+            await Endpoint().post(request)
 
         request.body.assert_awaited_once()
         self.assertFalse(handler_was_called)
-        self.assertEqual(response.status_code, 500)
-
-        body = json.loads(response.body)
-        self.assertEqual(body["kind"], "Server Error")
-        self.assertIn("JSONDecodeError", body["stack"])
+        self.assertEqual(exc.exception.status_code, 400)


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Add `SceneInventoryEndpoint` and `PlaybackPlanEndpoint` that return mock data (for now)

This PR also extends `decorators.route` with `parse_body=False` support for bodyless GET routes while preserving default JSON body parsing.

## 🧪 How is this patch tested? If it is not, please explain why.

Unit tests

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multimodal query helpers and server endpoints to provide scene inventories and playback plans via protobuf responses; multimodal routes are now included in server routing.

* **Improvements**
  * Route decorator now supports optional request-body parsing; several endpoints updated to skip body parsing by default.

* **Tests**
  * Added unit tests covering route decorator body-parsing behavior.

* **Chores**
  * Updated ignore rules to explicitly ignore environment and Playwright-related files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->