### PR TITLE
Ontology add missing  attribute properties

### DIFF
--- a/fiftyone/core/annotation/attributes.py
+++ b/fiftyone/core/annotation/attributes.py
@@ -142,6 +142,10 @@ class AttributeSpec:
         values: optional list of allowed values
         when: optional list of :class:`When` conditions controlling when
             this attribute is visible or field overrides
+        read_only: optional flag marking the attribute as non-editable
+        default: optional default value (type matches ``type``)
+        range: optional ``[min, max]`` for numeric-with-slider components
+        precision: optional decimal places for float-with-text components
 
     Example::
 
@@ -159,6 +163,10 @@ class AttributeSpec:
     component: str
     values: Optional[list] = None
     when: Optional[list[When]] = None
+    read_only: Optional[bool] = None
+    default: Any = None
+    range: Optional[list] = None
+    precision: Optional[int] = None
 
     def __post_init__(self) -> None:
         invalid_fields = [
@@ -184,6 +192,10 @@ class AttributeSpec:
             "component": self.component,
         }
         attr_insert_to_dict(d, "values", self)
+        attr_insert_to_dict(d, "read_only", self)
+        attr_insert_to_dict(d, "default", self)
+        attr_insert_to_dict(d, "range", self)
+        attr_insert_to_dict(d, "precision", self)
         if self.when is not None:
             d["when"] = [w.to_dict() for w in self.when]
         return d
@@ -218,6 +230,10 @@ class AttributeSpec:
             component=d["component"],
             values=values,
             when=when,
+            read_only=d.get("read_only"),
+            default=d.get("default"),
+            range=d.get("range"),
+            precision=d.get("precision"),
         )
 
     def __repr__(self) -> str:

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -270,6 +270,99 @@ class AttributeSpecTests(unittest.TestCase):
             restored.when[0].to_dict(), original.when[0].to_dict()
         )
 
+    def test_create_with_extended_fields(self):
+        attr = AttributeSpec(
+            name="severity",
+            type="float",
+            component="slider",
+            read_only=True,
+            default=0.5,
+            range=[0.0, 1.0],
+            precision=2,
+        )
+        self.assertEqual(attr.read_only, True)
+        self.assertEqual(attr.default, 0.5)
+        self.assertEqual(attr.range, [0.0, 1.0])
+        self.assertEqual(attr.precision, 2)
+
+    def test_to_dict_omits_unset_extended_fields(self):
+        attr = AttributeSpec(name="flag", type="bool", component="checkbox")
+        d = attr.to_dict()
+        self.assertNotIn("read_only", d)
+        self.assertNotIn("default", d)
+        self.assertNotIn("range", d)
+        self.assertNotIn("precision", d)
+
+    def test_to_dict_emits_falsy_extended_fields(self):
+        attr = AttributeSpec(
+            name="flag",
+            type="bool",
+            component="checkbox",
+            read_only=False,
+            default=False,
+        )
+        d = attr.to_dict()
+        self.assertEqual(d["read_only"], False)
+        self.assertEqual(d["default"], False)
+
+    def test_to_dict_emits_extended_fields(self):
+        attr = AttributeSpec(
+            name="severity",
+            type="float",
+            component="slider",
+            read_only=True,
+            default=0.5,
+            range=[0.0, 1.0],
+            precision=2,
+        )
+        d = attr.to_dict()
+        self.assertEqual(d["read_only"], True)
+        self.assertEqual(d["default"], 0.5)
+        self.assertEqual(d["range"], [0.0, 1.0])
+        self.assertEqual(d["precision"], 2)
+
+    def test_from_dict_reads_extended_fields(self):
+        attr = AttributeSpec.from_dict(
+            {
+                "name": "severity",
+                "type": "float",
+                "component": "slider",
+                "read_only": True,
+                "default": 0.5,
+                "range": [0.0, 1.0],
+                "precision": 2,
+            }
+        )
+        self.assertEqual(attr.read_only, True)
+        self.assertEqual(attr.default, 0.5)
+        self.assertEqual(attr.range, [0.0, 1.0])
+        self.assertEqual(attr.precision, 2)
+
+    def test_from_dict_handles_missing_extended_fields(self):
+        attr = AttributeSpec.from_dict(
+            {"name": "flag", "type": "bool", "component": "checkbox"}
+        )
+        self.assertIsNone(attr.read_only)
+        self.assertIsNone(attr.default)
+        self.assertIsNone(attr.range)
+        self.assertIsNone(attr.precision)
+
+    def test_roundtrip_with_extended_fields(self):
+        original = AttributeSpec(
+            name="severity",
+            type="float",
+            component="slider",
+            read_only=True,
+            default=0.5,
+            range=[0.0, 1.0],
+            precision=2,
+        )
+        restored = AttributeSpec.from_dict(original.to_dict())
+        self.assertEqual(restored.read_only, original.read_only)
+        self.assertEqual(restored.default, original.default)
+        self.assertEqual(restored.range, original.range)
+        self.assertEqual(restored.precision, original.precision)
+
 
 class AnnotationOntologyTests(unittest.TestCase):
     def test_create(self):


### PR DESCRIPTION
## 🔗 Related Issues

https://github.com/voxel51/fiftyone/pull/7435

## 📋 What changes are proposed in this pull request?

This adds some missing attributes that should be included in annotation attributes to the `AttributeSpec`

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
