### PR TITLE
cascade-aware delete_ontology

### DIFF
--- a/fiftyone/core/annotation/__init__.py
+++ b/fiftyone/core/annotation/__init__.py
@@ -19,6 +19,7 @@ from .generate_label_schemas import generate_label_schemas
 from .hydrate_label_schemas import (
     dehydrate_applied_ontology,
     hydrate_applied_ontology,
+    inline_applied_ontology,
 )
 from .validate_label_schemas import validate_label_schemas
 

--- a/fiftyone/core/annotation/hydrate_label_schemas.py
+++ b/fiftyone/core/annotation/hydrate_label_schemas.py
@@ -132,6 +132,37 @@ def dehydrate_applied_ontology(label_schema: dict) -> dict:
     return cleaned
 
 
+def inline_applied_ontology(label_schema: dict, ontology: Any) -> dict:
+    """Permanently inlines an annotation ontology's attributes into a
+    label schema as local copies and removes the ``applied_ontology``
+    reference.
+
+    Used when the referenced ontology is about to be deleted (or for
+    any other "freeze the current ontology state into the schema"
+    operation). Unlike :func:`hydrate_applied_ontology`, the merged
+    attributes are NOT marked with ``_source`` — they are now
+    first-class local attributes — and the ``applied_ontology`` key
+    is stripped from the result.
+
+    The caller is responsible for resolving the ontology; this
+    function does not load anything.
+
+    Args:
+        label_schema: a label schema dict
+        ontology: an :class:`AnnotationOntology` whose attributes
+            should be inlined
+
+    Returns:
+        a deep-copied schema with the ontology's attributes merged in
+        as locals and the ``applied_ontology`` reference removed
+    """
+    merged = _merge(label_schema, ontology)
+    for attr in merged.get(foac.ATTRIBUTES, []):
+        attr.pop(_SOURCE, None)
+    merged.pop(foac.APPLIED_ONTOLOGY, None)
+    return merged
+
+
 def _merge(label_schema: dict, ontology: Any) -> dict:
     hydrated = copy.deepcopy(label_schema)
     existing = hydrated.get(foac.ATTRIBUTES, [])

--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -10,7 +10,7 @@ import abc
 import copy
 import fnmatch
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, NamedTuple, Optional
 
 import fiftyone.core.annotation.constants as foac
 import fiftyone.core.utils as fou
@@ -392,21 +392,142 @@ def ontology_exists(name: str) -> bool:
     return _objects_by_slug(name).count() > 0
 
 
+class LabelSchemaOntologyRef(NamedTuple):
+    """One dataset's ``applied_ontology`` references for a given ontology.
+
+    Attributes:
+        dataset_id: the ``DatasetDocument`` id (string form)
+        field_names: the label-schema field names on that dataset that
+            reference the ontology
+    """
+
+    dataset_id: str
+    field_names: list[str]
+
+
+def _find_label_schema_refs_by_ontology(
+    ontology_name: str,
+) -> list[LabelSchemaOntologyRef]:
+    """Finds every label-schema field across every dataset that
+    references the named ontology via ``applied_ontology``.
+
+    The filter happens server-side in MongoDB rather than in Python,
+    which avoids deserializing every dataset doc and only sends back
+    the matches — meaningfully faster than a Python iteration when
+    there are many datasets.
+
+    Returns:
+        one :class:`LabelSchemaOntologyRef` per dataset that has at
+        least one matching reference. Empty if no dataset references
+        the ontology.
+    """
+    from fiftyone.core.odm.dataset import DatasetDocument
+
+    pipeline = [
+        # Field names inside ``label_schemas`` are user-defined
+        # (``ground_truth``, ``predictions``, etc.), so we can't
+        # query them by a fixed path. $objectToArray flattens the
+        # dict into ``[{k: "ground_truth", v: {...}}, ...]`` so
+        # $filter can iterate it; we keep only the pairs whose
+        # value's applied_ontology matches the target. ($$this is
+        # the current pair, ``.v`` is its value — the schema dict.)
+        {
+            "$addFields": {
+                "_matching_fields": {
+                    "$filter": {
+                        "input": {"$objectToArray": "$label_schemas"},
+                        "cond": {
+                            "$eq": [
+                                "$$this.v.applied_ontology",
+                                ontology_name,
+                            ]
+                        },
+                    }
+                }
+            }
+        },
+        # Drop datasets with zero matches. ``_matching_fields.0``
+        # exists iff the array has at least one entry.
+        {"$match": {"_matching_fields.0": {"$exists": True}}},
+        # Project just the doc id and the field names (.k of each
+        # matching {k, v} pair).
+        {
+            "$project": {
+                "_id": 1,
+                "matching_fields": "$_matching_fields.k",
+            }
+        },
+    ]
+
+    # pylint: disable-next=no-member
+    matches = DatasetDocument.objects.aggregate(pipeline)
+    return [
+        LabelSchemaOntologyRef(
+            dataset_id=str(d["_id"]),
+            field_names=d["matching_fields"],
+        )
+        for d in matches
+    ]
+
+
 @require_feature("VFF_ONTOLOGY_CA")
 def delete_ontology(name: str, force: bool = False) -> None:
     """Deletes an ontology and all its versions from the database.
 
+    If any label schema references this ontology (via
+    ``applied_ontology`` on a field), the default behavior is to raise
+    rather than silently break those schemas. Pass ``force=True`` to
+    inline the ontology's attributes into each affected schema as
+    permanent local copies and then delete the ontology.
+
+    Inlining and deletion run as two phases: every affected schema is
+    inlined and saved first, and the ontology is deleted only if every
+    save succeeds. If something fails mid-inline, the ontology still
+    exists and the call is safely re-runnable — already-inlined
+    schemas no longer match the lookup.
+
     Args:
         name: the ontology name
-        force: whether to delete even if the ontology is in use.
-            By default, raises an error if the ontology is referenced
-            by a label schema. Not yet enforced — will be implemented
-            with label schema integration.
+        force: if False (default), raise if any label schema references
+            the ontology. If True, inline the ontology's attributes
+            into each affected schema as local copies before deleting.
+
+    Raises:
+        ValueError: if the ontology does not exist, or if it is in use
+            and ``force=False``
     """
-    # TODO: check if in use when force=False (requires label schema integration)
-    count = _objects_by_slug(name).delete()
-    if count == 0:
-        raise ValueError(f"Ontology '{name}' not found")
+    # Late imports to avoid circular dependency with annotation/dataset.
+    from fiftyone.core.annotation import inline_applied_ontology
+    from fiftyone.core.odm.dataset import DatasetDocument
+
+    ontology = load_ontology(name)
+    affected = _find_label_schema_refs_by_ontology(name)
+
+    if affected and not force:
+        n_fields = sum(len(ref.field_names) for ref in affected)
+        raise ValueError(
+            f"Ontology '{name}' is referenced by {n_fields} label-schema "
+            f"field(s) across {len(affected)} dataset(s). Pass "
+            "force=True to inline the ontology's attributes into each "
+            "affected schema and delete."
+        )
+
+    # Phase 1: inline every affected schema. The ontology is deleted
+    # below only if every save here succeeds.
+    for ref in affected:
+        # pylint: disable-next=no-member
+        dataset_doc = DatasetDocument.objects.get(id=ref.dataset_id)
+        for field_name in ref.field_names:
+            schema = dataset_doc.label_schemas.get(field_name, {})
+            dataset_doc.label_schemas[field_name] = inline_applied_ontology(
+                schema, ontology
+            )
+        dataset_doc.save()
+
+    # Phase 2: delete the ontology last. On mid-inline failure the
+    # ontology survives, leaving the system recoverable — re-running
+    # the call is idempotent.
+    _objects_by_slug(name).delete()
 
 
 def apply_ontology(

--- a/tests/unittests/ontology_delete_tests.py
+++ b/tests/unittests/ontology_delete_tests.py
@@ -1,0 +1,353 @@
+"""
+FiftyOne ontology delete cascade unit tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import os
+import unittest
+
+# Ontology SDK is gated by VFF_ONTOLOGY_CA; enable for the whole module.
+os.environ.setdefault("VFF_ONTOLOGY_CA", "1")
+
+import fiftyone as fo
+import fiftyone.core.odm as foo
+from fiftyone.core.annotation.attributes import AttributeSpec
+from fiftyone.core.ontology import (
+    AnnotationOntology,
+    _find_label_schema_refs_by_ontology,
+    delete_ontology,
+)
+
+
+_ONTOLOGY_NAME = "test_ontology"
+
+
+def _make_ontology(name: str = _ONTOLOGY_NAME) -> None:
+    AnnotationOntology(
+        name=name,
+        attributes=[
+            AttributeSpec(
+                name="severity",
+                type="str",
+                component="dropdown",
+                values=["low", "medium", "high"],
+            ),
+            AttributeSpec(
+                name="confirmed",
+                type="bool",
+                component="checkbox",
+            ),
+        ],
+    ).save()
+
+
+def _stamp(dataset: fo.Dataset, fields: list[str], ontology_name: str) -> None:
+    """Sets ``applied_ontology`` on the given fields by direct doc
+    mutation. Bypasses the SDK so the test setup doesn't depend on
+    higher-level convenience APIs.
+    """
+    doc = dataset._doc
+    schemas = dict(doc.label_schemas or {})
+    for field in fields:
+        entry = dict(schemas.get(field) or {})
+        entry["applied_ontology"] = ontology_name
+        schemas[field] = entry
+    doc.label_schemas = schemas
+    doc.save()
+
+
+class DeleteOntologyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        db = foo.get_db_conn()
+        db.drop_collection("ontologies")
+        fo.delete_non_persistent_datasets()
+
+    def tearDown(self) -> None:
+        db = foo.get_db_conn()
+        db.drop_collection("ontologies")
+        fo.delete_non_persistent_datasets()
+
+    def test_delete_unreferenced_ontology_succeeds(self) -> None:
+        _make_ontology()
+
+        delete_ontology(_ONTOLOGY_NAME)
+
+        self.assertFalse(fo.ontology_exists(_ONTOLOGY_NAME))
+
+    def test_delete_missing_ontology_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            delete_ontology("nonexistent")
+
+    def test_delete_referenced_ontology_without_force_raises(self) -> None:
+        _make_ontology()
+        ds = fo.Dataset()
+        _stamp(ds, ["ground_truth"], _ONTOLOGY_NAME)
+
+        with self.assertRaises(ValueError):
+            delete_ontology(_ONTOLOGY_NAME)
+
+        # Ontology and reference should be untouched.
+        self.assertTrue(fo.ontology_exists(_ONTOLOGY_NAME))
+        ds.reload()
+        self.assertEqual(
+            ds._doc.label_schemas["ground_truth"]["applied_ontology"],
+            _ONTOLOGY_NAME,
+        )
+
+    def test_delete_referenced_ontology_with_force_inlines_and_deletes(
+        self,
+    ) -> None:
+        _make_ontology()
+        ds = fo.Dataset()
+        _stamp(ds, ["ground_truth"], _ONTOLOGY_NAME)
+
+        delete_ontology(_ONTOLOGY_NAME, force=True)
+
+        # Ontology gone.
+        self.assertFalse(fo.ontology_exists(_ONTOLOGY_NAME))
+
+        # Reference stripped, ontology's attributes inlined as locals.
+        ds.reload()
+        schema = ds._doc.label_schemas["ground_truth"]
+        self.assertNotIn("applied_ontology", schema)
+        attr_names = {a["name"] for a in schema["attributes"]}
+        self.assertEqual(attr_names, {"severity", "confirmed"})
+
+    def test_inlined_attributes_have_no_source_marker(self) -> None:
+        _make_ontology()
+        ds = fo.Dataset()
+        _stamp(ds, ["ground_truth"], _ONTOLOGY_NAME)
+
+        delete_ontology(_ONTOLOGY_NAME, force=True)
+
+        ds.reload()
+        for attr in ds._doc.label_schemas["ground_truth"]["attributes"]:
+            self.assertNotIn("_source", attr)
+
+    def test_force_inlines_across_multiple_datasets(self) -> None:
+        _make_ontology()
+        ds_a = fo.Dataset()
+        ds_b = fo.Dataset()
+        _stamp(ds_a, ["ground_truth"], _ONTOLOGY_NAME)
+        _stamp(ds_b, ["predictions"], _ONTOLOGY_NAME)
+
+        delete_ontology(_ONTOLOGY_NAME, force=True)
+
+        ds_a.reload()
+        ds_b.reload()
+        self.assertNotIn(
+            "applied_ontology", ds_a._doc.label_schemas["ground_truth"]
+        )
+        self.assertNotIn(
+            "applied_ontology", ds_b._doc.label_schemas["predictions"]
+        )
+        self.assertEqual(
+            {
+                a["name"]
+                for a in ds_a._doc.label_schemas["ground_truth"]["attributes"]
+            },
+            {"severity", "confirmed"},
+        )
+        self.assertEqual(
+            {
+                a["name"]
+                for a in ds_b._doc.label_schemas["predictions"]["attributes"]
+            },
+            {"severity", "confirmed"},
+        )
+
+    def test_force_inlines_multiple_fields_on_one_dataset(self) -> None:
+        _make_ontology()
+        ds = fo.Dataset()
+        _stamp(
+            ds,
+            ["ground_truth", "predictions", "custom_attrs"],
+            _ONTOLOGY_NAME,
+        )
+
+        delete_ontology(_ONTOLOGY_NAME, force=True)
+
+        ds.reload()
+        for field in ("ground_truth", "predictions", "custom_attrs"):
+            schema = ds._doc.label_schemas[field]
+            self.assertNotIn("applied_ontology", schema)
+            self.assertEqual(
+                {a["name"] for a in schema["attributes"]},
+                {"severity", "confirmed"},
+            )
+
+    def test_local_attrs_preserved_on_inline(self) -> None:
+        # Catches a regression where the inline drops user-authored
+        # local attributes alongside the ontology-owned ones.
+        _make_ontology()
+        ds = fo.Dataset()
+        ds._doc.label_schemas = {
+            "ground_truth": {
+                "type": "detections",
+                "applied_ontology": _ONTOLOGY_NAME,
+                "attributes": [
+                    {
+                        "name": "local_only",
+                        "type": "str",
+                        "component": "text",
+                    },
+                ],
+            }
+        }
+        ds._doc.save()
+
+        delete_ontology(_ONTOLOGY_NAME, force=True)
+
+        ds.reload()
+        names = {
+            a["name"]
+            for a in ds._doc.label_schemas["ground_truth"]["attributes"]
+        }
+        self.assertEqual(names, {"local_only", "severity", "confirmed"})
+
+    def test_collision_ontology_wins(self) -> None:
+        # On name collision, the ontology's shape replaces the local
+        # one. Local ``severity`` is bool/checkbox; ontology's is
+        # str/dropdown — the survivor tells us which won.
+        _make_ontology()
+        ds = fo.Dataset()
+        ds._doc.label_schemas = {
+            "ground_truth": {
+                "applied_ontology": _ONTOLOGY_NAME,
+                "attributes": [
+                    {
+                        "name": "severity",
+                        "type": "bool",
+                        "component": "checkbox",
+                    },
+                ],
+            }
+        }
+        ds._doc.save()
+
+        delete_ontology(_ONTOLOGY_NAME, force=True)
+
+        ds.reload()
+        severity = next(
+            a
+            for a in ds._doc.label_schemas["ground_truth"]["attributes"]
+            if a["name"] == "severity"
+        )
+        self.assertEqual(severity["type"], "str")
+        self.assertEqual(severity["component"], "dropdown")
+
+    def test_other_ontology_refs_on_same_dataset_untouched(self) -> None:
+        # If a dataset references the deleted ontology and a different
+        # ontology on different fields, only the deleted one's field
+        # should be inlined.
+        _make_ontology()
+        _make_ontology(name="other_ontology")
+        ds = fo.Dataset()
+        ds._doc.label_schemas = {
+            "ground_truth": {"applied_ontology": _ONTOLOGY_NAME},
+            "predictions": {"applied_ontology": "other_ontology"},
+        }
+        ds._doc.save()
+
+        delete_ontology(_ONTOLOGY_NAME, force=True)
+
+        ds.reload()
+        self.assertNotIn(
+            "applied_ontology", ds._doc.label_schemas["ground_truth"]
+        )
+        self.assertEqual(
+            ds._doc.label_schemas["predictions"]["applied_ontology"],
+            "other_ontology",
+        )
+
+    def test_non_referencing_datasets_untouched(self) -> None:
+        _make_ontology()
+        ds_referenced = fo.Dataset()
+        _stamp(ds_referenced, ["ground_truth"], _ONTOLOGY_NAME)
+
+        ds_other = fo.Dataset()
+        ds_other._doc.label_schemas = {"ground_truth": {"type": "detections"}}
+        ds_other._doc.save()
+        snapshot_before = dict(ds_other._doc.label_schemas)
+
+        delete_ontology(_ONTOLOGY_NAME, force=True)
+
+        ds_other.reload()
+        self.assertEqual(dict(ds_other._doc.label_schemas), snapshot_before)
+
+    def test_rerun_after_deleted_raises(self) -> None:
+        _make_ontology()
+        delete_ontology(_ONTOLOGY_NAME)
+
+        with self.assertRaises(ValueError):
+            delete_ontology(_ONTOLOGY_NAME)
+
+
+class FindLabelSchemaRefsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        db = foo.get_db_conn()
+        db.drop_collection("ontologies")
+        fo.delete_non_persistent_datasets()
+
+    def tearDown(self) -> None:
+        db = foo.get_db_conn()
+        db.drop_collection("ontologies")
+        fo.delete_non_persistent_datasets()
+
+    def test_no_datasets_returns_empty(self) -> None:
+        result = _find_label_schema_refs_by_ontology(_ONTOLOGY_NAME)
+        self.assertEqual(result, [])
+
+    def test_no_references_returns_empty(self) -> None:
+        fo.Dataset()
+        fo.Dataset()
+        result = _find_label_schema_refs_by_ontology(_ONTOLOGY_NAME)
+        self.assertEqual(result, [])
+
+    def test_single_dataset_single_field(self) -> None:
+        ds = fo.Dataset()
+        _stamp(ds, ["ground_truth"], _ONTOLOGY_NAME)
+
+        result = _find_label_schema_refs_by_ontology(_ONTOLOGY_NAME)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].dataset_id, str(ds._doc.id))
+        self.assertEqual(result[0].field_names, ["ground_truth"])
+
+    def test_single_dataset_multiple_fields(self) -> None:
+        ds = fo.Dataset()
+        _stamp(ds, ["ground_truth", "predictions"], _ONTOLOGY_NAME)
+
+        result = _find_label_schema_refs_by_ontology(_ONTOLOGY_NAME)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(
+            set(result[0].field_names), {"ground_truth", "predictions"}
+        )
+
+    def test_multiple_datasets(self) -> None:
+        ds_a = fo.Dataset()
+        ds_b = fo.Dataset()
+        _stamp(ds_a, ["ground_truth"], _ONTOLOGY_NAME)
+        _stamp(ds_b, ["predictions"], _ONTOLOGY_NAME)
+
+        result = _find_label_schema_refs_by_ontology(_ONTOLOGY_NAME)
+
+        self.assertEqual(len(result), 2)
+        ids = {ref.dataset_id for ref in result}
+        self.assertEqual(ids, {str(ds_a._doc.id), str(ds_b._doc.id)})
+
+    def test_excludes_other_ontologies(self) -> None:
+        ds = fo.Dataset()
+        _stamp(ds, ["ground_truth"], "different_ontology")
+
+        result = _find_label_schema_refs_by_ontology(_ONTOLOGY_NAME)
+
+        self.assertEqual(result, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 🔗 Related Issues

https://github.com/voxel51/fiftyone/pull/7435

## 📋 What changes are proposed in this pull request?

This adds behavior that when an ontology is deleted, it:
1. checks if any label schemas/fields reference it
2. Copies all of the attributes from the ontology onto those schema field/field
3. deletes ontology

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Permanently inline ontology attributes into label schemas when removing an ontology, preserving attribute definitions on affected fields.

* **Improvements**
  * Ontology deletion now detects dataset/field references and prevents accidental removal unless forced; with force, referenced schemas are updated before deletion.

* **Tests**
  * Added comprehensive tests covering reference detection, forced deletion inlining, collision resolution, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->