### PR TITLE
Bump version to 1.15.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import os
 from setuptools import setup, find_packages
 
 
-VERSION = "1.15.0"
+VERSION = "1.15.1"
 
 
 def get_version():


### PR DESCRIPTION
Patch release version bump for `1.15.1`.

Part of the `OSS 1.15.1 / Enterprise 2.18.1` patch release coordinated in [#release-coordination](https://voxel51.slack.com/archives/C05L68A72FM).

Targets release branch `release/v1.15.1` (cut from `main`).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.15.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->