### PR TITLE
[DON'T MERGE] Shift-click functionality update

### DIFF
--- a/app/packages/core/src/components/Grid/GridCustomRendererItem.tsx
+++ b/app/packages/core/src/components/Grid/GridCustomRendererItem.tsx
@@ -113,9 +113,16 @@ const GridCustomRendererWrapper = ({
   const [hovering, setHovering] = React.useState(false);
   const showSelectionControl = hovering || selected;
 
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.shiftKey) {
+      onSelect(event as unknown as React.MouseEvent<HTMLButtonElement>);
+    }
+  };
+
   return (
     <div
       style={CONTAINER_STYLES}
+      onClick={handleClick}
       onMouseEnter={() => setHovering(true)}
       onMouseMove={() => setHovering(true)}
       onMouseLeave={() => setHovering(false)}

--- a/app/packages/looker/src/elements/common/looker.ts
+++ b/app/packages/looker/src/elements/common/looker.ts
@@ -3,6 +3,7 @@
  */
 
 import { SELECTION_TEXT } from "../../constants";
+import { getThumbnailSelectionModifiers } from "../../selection";
 import type { BaseState, Control } from "../../state";
 import { ControlEventKeyType } from "../../state";
 import type { Events } from "../base";
@@ -19,10 +20,22 @@ export class LookerElement<State extends BaseState> extends BaseElement<
 
   getEvents(): Events<State> {
     return {
-      click: ({ update }) => {
-        update(({ config: { thumbnail } }) =>
-          thumbnail ? { hovering: false } : {}
-        );
+      click: ({ event, update, dispatchEvent }) => {
+        update(({ config: { thumbnail }, options: { selected } }) => {
+          if (!thumbnail) {
+            return {};
+          }
+          if (event.shiftKey) {
+            event.stopPropagation();
+            event.preventDefault();
+            dispatchEvent(
+              "selectthumbnail",
+              getThumbnailSelectionModifiers(event)
+            );
+            return { hovering: false, options: { selected: !selected } };
+          }
+          return { hovering: false };
+        });
       },
       keydown: ({ event, update, dispatchEvent }) => {
         if (event.altKey || event.ctrlKey || event.metaKey) {


### PR DESCRIPTION
## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

Shift-click on a sample is not treated as a selection today (select count does not increase), but in the grid it is displayed as a selection with the checkbox on the sample being ticked. This PR fixes that behavior.

## 🧪 How is this patch tested? If it is not, please explain why.

Tested manually

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixed a bug in shift-click behavior, earlier shift-click was not treated as a regular selection in the grid, this PR updates that. 

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
