### PR TITLE
[FOEPD-3719] Upgrade strawberry-graphql to >=0.312.3 but <0.313.0 to resolve CVE-2026-35523

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         "sseclient-py>=1.7.2,<2",
         "sse-starlette>=0.10.3,<4",
         "starlette>=0.49.1,<0.53",
-        "strawberry-graphql>=0.262.4,<0.292.0",
+        "strawberry-graphql>=0.312.3,<0.313.0",
         "tabulate>=0.7,<0.10",
         "tqdm>=2,<5",
         "xmltodict>=1,<2",


### PR DESCRIPTION
## 🔗 Related Issues

[FOEPD-3719](https://voxel51.atlassian.net/browse/FOEPD-3719)

## 📋 What changes are proposed in this pull request?

Upgrade strawberry-graphql to >=0.312.3 but <0.313.0 to resolve CVE-2026-35523

## 🧪 How is this patch tested? If it is not, please explain why.

1. Built `dist` and Docker image locally, ran `docker scout cves`, confirmed CVE found
2. Updated `setup.py` with new version constraints for strawberry-graphql
3. Rebuilt FiftyOne
4. Built `dist` and Docker image locally, ran `docker scout cves`, confirmed CVE not found

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [x] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

[FOEPD-3719]: https://voxel51.atlassian.net/browse/FOEPD-3719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependency constraint to a newer stable version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->