### PR TITLE
[FOEPD-3498] Per-deployment model weights source configurability 

### DIFF
--- a/app/packages/annotation/src/providers/BrowserAnnotationProvider.test.ts
+++ b/app/packages/annotation/src/providers/BrowserAnnotationProvider.test.ts
@@ -2,9 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@fiftyone/utilities", () => ({
   getFetchParameters: vi.fn(),
+  mergeHeaders: vi.fn(),
 }));
 
-import { getFetchParameters } from "@fiftyone/utilities";
+import { getFetchParameters, mergeHeaders } from "@fiftyone/utilities";
 import { BrowserAnnotationProvider } from "./BrowserAnnotationProvider";
 
 // Mock Worker
@@ -31,11 +32,14 @@ describe("BrowserAnnotationProvider", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     stubBrowserAPIs();
+    vi.mocked(getFetchParameters).mockReturnValue({ origin: "", headers: {}, pathPrefix: "" });
+    vi.mocked(mergeHeaders).mockReturnValue({});
   });
 
   it("Sends init message with fetch parameters after spawning worker", async () => {
     const params = { origin: "http://api", headers: { Auth: "x" }, pathPrefix: "/api/proxy/fiftyone-xyz" };
     vi.mocked(getFetchParameters).mockReturnValue(params);
+    vi.mocked(mergeHeaders).mockReturnValue(params.headers);
 
     let instance: any;
     class TrackedWorker extends MockWorker {
@@ -53,6 +57,32 @@ describe("BrowserAnnotationProvider", () => {
       type: "init",
       payload: params,
     });
+  });
+
+  it("Normalizes Headers instance to a plain record before posting init", async () => {
+    // Headers instances aren't structured-cloneable. mergeHeaders() flattens
+    // them so postMessage doesn't throw OR silently drop headers.
+    const headersInstance = new Headers({ Auth: "x" });
+    const params = { origin: "http://api", headers: headersInstance, pathPrefix: "" };
+    const flat = { Auth: "x" };
+    vi.mocked(getFetchParameters).mockReturnValue(params as any);
+    vi.mocked(mergeHeaders).mockReturnValue(flat);
+
+    let instance: any;
+    class TrackedWorker extends MockWorker {
+      constructor() {
+        super();
+        instance = this;
+      }
+    }
+    vi.stubGlobal("Worker", TrackedWorker);
+
+    const provider = new BrowserAnnotationProvider();
+    await provider.initialize();
+
+    expect(mergeHeaders).toHaveBeenCalledWith(headersInstance);
+    expect(instance.postMessage.mock.calls[0][0].payload.headers).toEqual(flat);
+    expect(instance.postMessage.mock.calls[0][0].payload.headers).not.toBeInstanceOf(Headers);
   });
 
   it("Calls onStatus with loading then ready on successful init", async () => {

--- a/app/packages/annotation/src/providers/BrowserAnnotationProvider.test.ts
+++ b/app/packages/annotation/src/providers/BrowserAnnotationProvider.test.ts
@@ -1,4 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@fiftyone/utilities", () => ({
+  getFetchParameters: vi.fn(),
+}));
+
+import { getFetchParameters } from "@fiftyone/utilities";
 import { BrowserAnnotationProvider } from "./BrowserAnnotationProvider";
 
 // Mock Worker
@@ -25,6 +31,28 @@ describe("BrowserAnnotationProvider", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     stubBrowserAPIs();
+  });
+
+  it("Sends init message with fetch parameters after spawning worker", async () => {
+    const params = { origin: "http://api", headers: { Auth: "x" }, pathPrefix: "/api/proxy/fiftyone-xyz" };
+    vi.mocked(getFetchParameters).mockReturnValue(params);
+
+    let instance: any;
+    class TrackedWorker extends MockWorker {
+      constructor() {
+        super();
+        instance = this;
+      }
+    }
+    vi.stubGlobal("Worker", TrackedWorker);
+
+    const provider = new BrowserAnnotationProvider();
+    await provider.initialize();
+
+    expect(instance.postMessage.mock.calls[0][0]).toEqual({
+      type: "init",
+      payload: params,
+    });
   });
 
   it("Calls onStatus with loading then ready on successful init", async () => {

--- a/app/packages/annotation/src/providers/BrowserAnnotationProvider.ts
+++ b/app/packages/annotation/src/providers/BrowserAnnotationProvider.ts
@@ -1,4 +1,4 @@
-import { getFetchParameters } from "@fiftyone/utilities";
+import { getFetchParameters, mergeHeaders } from "@fiftyone/utilities";
 import type {
   AnnotationProvider,
   DownloadProgress,
@@ -98,9 +98,10 @@ export class BrowserAnnotationProvider implements AnnotationProvider {
       throw err;
     }
 
+    const params = getFetchParameters();
     this.worker.postMessage({
       type: "init",
-      payload: getFetchParameters(),
+      payload: { ...params, headers: mergeHeaders(params.headers) },
     });
 
     this.worker.onmessage = (e: MessageEvent) => {

--- a/app/packages/annotation/src/providers/BrowserAnnotationProvider.ts
+++ b/app/packages/annotation/src/providers/BrowserAnnotationProvider.ts
@@ -1,3 +1,4 @@
+import { getFetchParameters } from "@fiftyone/utilities";
 import type {
   AnnotationProvider,
   DownloadProgress,
@@ -97,6 +98,11 @@ export class BrowserAnnotationProvider implements AnnotationProvider {
       throw err;
     }
 
+    this.worker.postMessage({
+      type: "init",
+      payload: getFetchParameters(),
+    });
+
     this.worker.onmessage = (e: MessageEvent) => {
       const { id, type, success, result, error } = e.data;
 
@@ -159,6 +165,7 @@ export class BrowserAnnotationProvider implements AnnotationProvider {
     return promise;
   }
 
+  // Client-side only: rejects the pending promise but the worker keeps computing.
   // Only aborts the most recent inference. Earlier in-flight requests are not cancelled.
   abort(): void {
     if (this.lastInferenceId === null)

--- a/app/packages/annotation/src/providers/BrowserAnnotationProvider.ts
+++ b/app/packages/annotation/src/providers/BrowserAnnotationProvider.ts
@@ -98,12 +98,6 @@ export class BrowserAnnotationProvider implements AnnotationProvider {
       throw err;
     }
 
-    const params = getFetchParameters();
-    this.worker.postMessage({
-      type: "init",
-      payload: { ...params, headers: mergeHeaders(params.headers) },
-    });
-
     this.worker.onmessage = (e: MessageEvent) => {
       const { id, type, success, result, error } = e.data;
 
@@ -150,6 +144,12 @@ export class BrowserAnnotationProvider implements AnnotationProvider {
     };
 
     try {
+      const params = getFetchParameters();
+      this.worker.postMessage({
+        type: "init",
+        payload: { ...params, headers: mergeHeaders(params.headers) },
+      });
+
       await this.send("loadModel", {}).promise;
       this.onStatus?.("ready");
     } catch (err) {

--- a/app/packages/annotation/src/providers/modelCache.test.ts
+++ b/app/packages/annotation/src/providers/modelCache.test.ts
@@ -82,6 +82,7 @@ function mockStreamingResponse(chunks: Uint8Array[]) {
 }
 
 const TEST_URL = "https://example.com/model.onnx";
+const TEST_CACHE_KEY = "test:model.onnx";
 const TEST_BUFFER = new ArrayBuffer(64);
 
 describe("loadModelWeights", () => {
@@ -99,7 +100,7 @@ describe("loadModelWeights", () => {
   });
 
   it("Downloads and returns buffer on cache miss", async () => {
-    const result = await loadModelWeights(TEST_URL);
+    const result = await loadModelWeights(TEST_URL, TEST_CACHE_KEY);
 
     expect(result.byteLength).toBe(64);
     expect(global.fetch).toHaveBeenCalledTimes(1);
@@ -107,9 +108,9 @@ describe("loadModelWeights", () => {
   });
 
   it("Returns cached buffer without fetching on cache hit", async () => {
-    store.set(TEST_URL, TEST_BUFFER);
+    store.set(TEST_CACHE_KEY, TEST_BUFFER);
 
-    const result = await loadModelWeights(TEST_URL);
+    const result = await loadModelWeights(TEST_URL, TEST_CACHE_KEY);
 
     expect(result.byteLength).toBe(64);
     expect(global.fetch).not.toHaveBeenCalled();
@@ -117,10 +118,10 @@ describe("loadModelWeights", () => {
   });
 
   it("Caches downloaded buffer for subsequent calls", async () => {
-    await loadModelWeights(TEST_URL);
+    await loadModelWeights(TEST_URL, TEST_CACHE_KEY);
     (global.fetch as ReturnType<typeof vi.fn>).mockClear();
 
-    const result = await loadModelWeights(TEST_URL);
+    const result = await loadModelWeights(TEST_URL, TEST_CACHE_KEY);
 
     expect(result.byteLength).toBe(64);
     expect(global.fetch).not.toHaveBeenCalled();
@@ -128,10 +129,10 @@ describe("loadModelWeights", () => {
   });
 
   it("Calls onProgress with full size on cache hit", async () => {
-    store.set(TEST_URL, TEST_BUFFER);
+    store.set(TEST_CACHE_KEY, TEST_BUFFER);
     const onProgress = vi.fn();
 
-    await loadModelWeights(TEST_URL, onProgress);
+    await loadModelWeights(TEST_URL, TEST_CACHE_KEY, onProgress);
 
     expect(onProgress).toHaveBeenCalledWith(64, 64);
     expect(closeSpy).toHaveBeenCalledTimes(1);
@@ -143,7 +144,7 @@ describe("loadModelWeights", () => {
     global.fetch = vi.fn().mockResolvedValue(mockStreamingResponse([chunk1, chunk2]));
     const onProgress = vi.fn();
 
-    const result = await loadModelWeights(TEST_URL, onProgress);
+    const result = await loadModelWeights(TEST_URL, TEST_CACHE_KEY, onProgress);
 
     expect(result.byteLength).toBe(5);
     expect(onProgress).toHaveBeenCalledTimes(2);
@@ -166,7 +167,7 @@ describe("loadModelWeights", () => {
     if (fetchOverride)
       global.fetch = fetchOverride();
 
-    const result = await loadModelWeights(TEST_URL, onProgress);
+    const result = await loadModelWeights(TEST_URL, TEST_CACHE_KEY, onProgress);
 
     expect(result.byteLength).toBe(64);
     if (onProgress)
@@ -177,7 +178,7 @@ describe("loadModelWeights", () => {
   it("Throws on 4xx without retrying", async () => {
     global.fetch = vi.fn().mockResolvedValue(mockFetchResponse(new ArrayBuffer(0), 404));
 
-    await expect(loadModelWeights(TEST_URL)).rejects.toThrow("404");
+    await expect(loadModelWeights(TEST_URL, TEST_CACHE_KEY)).rejects.toThrow("404");
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(closeSpy).toHaveBeenCalledTimes(1);
   });
@@ -199,7 +200,7 @@ describe("loadModelWeights", () => {
     vi.useFakeTimers();
     global.fetch = mockFetch();
 
-    const promise = loadModelWeights(TEST_URL);
+    const promise = loadModelWeights(TEST_URL, TEST_CACHE_KEY);
     await vi.runAllTimersAsync();
     const result = await promise;
 
@@ -218,7 +219,7 @@ describe("loadModelWeights", () => {
         }))
       .mockResolvedValue(mockFetchResponse(TEST_BUFFER));
 
-    const promise = loadModelWeights(TEST_URL);
+    const promise = loadModelWeights(TEST_URL, TEST_CACHE_KEY);
     await vi.advanceTimersByTimeAsync(61_000);
     await vi.runAllTimersAsync();
     const result = await promise;
@@ -237,7 +238,7 @@ describe("loadModelWeights", () => {
     vi.stubGlobal("indexedDB", idb.mockIndexedDB);
     const onWarning = vi.fn();
 
-    const result = await loadModelWeights(TEST_URL, undefined, onWarning);
+    const result = await loadModelWeights(TEST_URL, TEST_CACHE_KEY, undefined, onWarning);
 
     expect(result.byteLength).toBe(64);
     expect(global.fetch).toHaveBeenCalledTimes(1);
@@ -249,7 +250,7 @@ describe("loadModelWeights", () => {
     vi.stubGlobal("indexedDB", { open: () => { throw new Error("blocked"); } });
     const onWarning = vi.fn();
 
-    const result = await loadModelWeights(TEST_URL, undefined, onWarning);
+    const result = await loadModelWeights(TEST_URL, TEST_CACHE_KEY, undefined, onWarning);
 
     expect(result.byteLength).toBe(64);
     expect(onWarning).toHaveBeenCalledWith("IndexedDB open failed, downloading instead: Error: blocked");
@@ -268,7 +269,7 @@ describe("loadModelWeights", () => {
       .mockResolvedValueOnce(truncated)
       .mockResolvedValue(mockFetchResponse(TEST_BUFFER));
 
-    const promise = loadModelWeights(TEST_URL, vi.fn());
+    const promise = loadModelWeights(TEST_URL, TEST_CACHE_KEY, vi.fn());
     await vi.runAllTimersAsync();
     const result = await promise;
 
@@ -282,7 +283,7 @@ describe("loadModelWeights", () => {
     vi.useFakeTimers();
     global.fetch = vi.fn().mockRejectedValue(new Error("Network Error"));
 
-    const promise = loadModelWeights(TEST_URL).catch((e: Error) => e);
+    const promise = loadModelWeights(TEST_URL, TEST_CACHE_KEY).catch((e: Error) => e);
     await vi.runAllTimersAsync();
     const err = await promise;
     expect(err).toBeInstanceOf(Error);
@@ -302,7 +303,7 @@ describe("loadModelWeights", () => {
     );
     global.fetch = vi.fn().mockImplementation(() => Promise.resolve(makeTruncated()));
 
-    const promise = loadModelWeights(TEST_URL, vi.fn()).catch((e: Error) => e);
+    const promise = loadModelWeights(TEST_URL, TEST_CACHE_KEY, vi.fn()).catch((e: Error) => e);
     await vi.runAllTimersAsync();
     const err = await promise;
     expect(err).toBeInstanceOf(Error);

--- a/app/packages/annotation/src/providers/modelCache.ts
+++ b/app/packages/annotation/src/providers/modelCache.ts
@@ -106,11 +106,14 @@ async function fetchWithProgress(
  * Falls back to download-only if IndexedDB is unavailable.
  *
  * @param url URL of the model weights file
+ * @param cacheKey Stable key for IndexedDB caching (independent of URL which
+ *   may change across deployments or contain signed parameters)
  * @param onProgress Called with (loaded, total) bytes during download or immediately on cache hit
  * @param onWarning Called when a non-fatal issue occurs (e.g. IndexedDB unavailable)
  */
 export async function loadModelWeights(
   url: string,
+  cacheKey: string,
   onProgress?: (loaded: number, total: number) => void,
   onWarning?: (message: string) => void
 ): Promise<ArrayBuffer> {
@@ -125,7 +128,7 @@ export async function loadModelWeights(
 
   try {
     try {
-      const cached = await idbGet(db, url);
+      const cached = await idbGet(db, cacheKey);
       if (cached) {
         onProgress?.(cached.byteLength, cached.byteLength);
         return cached;
@@ -137,7 +140,7 @@ export async function loadModelWeights(
     const buffer = await fetchWithProgress(url, onProgress);
 
     try {
-      await idbPut(db, url, buffer);
+      await idbPut(db, cacheKey, buffer);
     } catch (err) {
       onWarning?.(`IndexedDB cache write failed: ${err}`);
     }

--- a/app/packages/annotation/src/providers/worker.ts
+++ b/app/packages/annotation/src/providers/worker.ts
@@ -1,3 +1,7 @@
+import {
+  getFetchFunction,
+  setFetchFunction,
+} from "@fiftyone/utilities";
 import * as ort from "onnxruntime-web";
 import type {
   DownloadProgress,
@@ -64,16 +68,37 @@ function postError(id: number, type: string, error: string): void {
 const IMAGE_MEAN = [0.485, 0.456, 0.406];
 const IMAGE_STD = [0.229, 0.224, 0.225];
 
-// SAM2 Tiny model weights (pre-optimized ONNX)
-const HF_BASE = "https://models-cdn.voxel51.com/sam2";
-const ENCODER_URL = `${HF_BASE}/encoder.with_runtime_opt.ort`;
-const DECODER_URL = `${HF_BASE}/decoder.onnx`;
+// SAM2 model family + Tiny variant file names
+const FAMILY = "sam2";
+const ENCODER_FILE = "encoder.with_runtime_opt.ort";
+const DECODER_FILE = "decoder.onnx";
+
+// Stable cache keys (independent of URL which may vary per deployment)
+const ENCODER_CACHE_KEY = `${FAMILY}:${ENCODER_FILE}`;
+const DECODER_CACHE_KEY = `${FAMILY}:${DECODER_FILE}`;
 
 /**
  * Prefix embedding cache keys with the encoder contract so stale entries
  * are ignored if/when the model or preprocessing changes.
  */
-const CACHE_PREFIX = `${ENCODER_URL}:${SAM2_INPUT_SIZE}:`;
+const CACHE_PREFIX = `${ENCODER_CACHE_KEY}:${SAM2_INPUT_SIZE}:`;
+
+/**
+ * Resolve the download URL for a model weights file via the backend.
+ *
+ * Uses the shared fetch function so the path prefix configured by the main
+ * thread is applied. Throws on non-2xx responses.
+ */
+async function resolveModelUrl(
+  family: string,
+  file: string,
+): Promise<string> {
+  const data = await getFetchFunction()<undefined, { url: string }>(
+    "GET",
+    `/runtime-assets/models/${family}/${file}`,
+  );
+  return data.url;
+}
 
 const isCOI = typeof crossOriginIsolated !== "undefined" && crossOriginIsolated;
 ort.env.wasm.numThreads = isCOI ? navigator.hardwareConcurrency || 4 : 1;
@@ -169,14 +194,18 @@ async function loadModel(): Promise<void> {
   const opts: ort.InferenceSession.SessionOptions = { executionProviders: ["wasm"] };
 
   async function loadSession(
-    url: string,
+    family: string,
+    file: string,
+    cacheKey: string,
     name: "encoder" | "decoder",
     failureKind: "encoder_failure" | "decoder_failure",
   ): Promise<ort.InferenceSession> {
     let buf: ArrayBuffer;
     try {
+      const url = await resolveModelUrl(family, file);
       buf = await loadModelWeights(
         url,
+        cacheKey,
         (loaded, total) => postProgressNotification({ file: name, loaded, total }),
         postWarningNotification
       );
@@ -195,10 +224,10 @@ async function loadModel(): Promise<void> {
   }
 
   if (!encoderSession)
-    encoderSession = await loadSession(ENCODER_URL, "encoder", "encoder_failure");
+    encoderSession = await loadSession(FAMILY, ENCODER_FILE, ENCODER_CACHE_KEY, "encoder", "encoder_failure");
 
   if (!decoderSession)
-    decoderSession = await loadSession(DECODER_URL, "decoder", "decoder_failure");
+    decoderSession = await loadSession(FAMILY, DECODER_FILE, DECODER_CACHE_KEY, "decoder", "decoder_failure");
 }
 
 /**
@@ -316,6 +345,13 @@ self.onmessage = async (e: MessageEvent) => {
   const { id, type, payload } = e.data;
 
   try {
+    if (type === "init") {
+      // Mirror main-thread fetch params (origin, headers, pathPrefix) so
+      // getFetchFunction() routes through the right backend path.
+      const { origin, headers, pathPrefix } = payload;
+      setFetchFunction(origin, headers, pathPrefix);
+      return;
+    }
     if (type === "loadModel") {
       await loadModel();
       postResponse(id, "loadModel", undefined as void);

--- a/app/packages/app/vite.config.ts
+++ b/app/packages/app/vite.config.ts
@@ -100,6 +100,14 @@ async function loadConfig() {
           secure: false,
           ws: false,
         },
+        "/runtime-assets": {
+          target: `http://127.0.0.1:${
+            process.env.FIFTYONE_DEFAULT_APP_PORT ?? "5151"
+          }`,
+          changeOrigin: false,
+          secure: false,
+          ws: false,
+        },
       },
     },
   });

--- a/fiftyone/server/routes/__init__.py
+++ b/fiftyone/server/routes/__init__.py
@@ -21,6 +21,7 @@ from .get_similar_labels_frames import GetSimilarLabelsFrameCollection
 from .groups import GroupsRoutes
 from .media import Media
 from .plugins import Plugins
+from .runtime_assets import RuntimeAssetRoutes
 from .sample import SampleRoutes
 from .screenshot import Screenshot
 from .sort import Sort
@@ -34,6 +35,7 @@ routes = (
     + EmbeddingsRoutes
     + GroupsRoutes
     + OperatorRoutes
+    + RuntimeAssetRoutes
     + SampleRoutes
     + [
         ("/aggregate", Aggregate),

--- a/fiftyone/server/routes/runtime_assets.py
+++ b/fiftyone/server/routes/runtime_assets.py
@@ -7,6 +7,7 @@ FiftyOne Server runtime assets endpoints.
 """
 
 import os
+from pathlib import PurePosixPath
 
 from starlette.endpoints import HTTPEndpoint
 from starlette.exceptions import HTTPException
@@ -16,6 +17,31 @@ from starlette.responses import JSONResponse
 DEFAULT_MODEL_URLS = {
     "sam2": "https://models-cdn.voxel51.com/sam2",
 }
+
+
+def _validate_model_id(model_id: str) -> str:
+    """Validate and normalize a ``model_id`` path parameter.
+
+    Rejects absolute paths and parent-directory traversal so a caller can't
+    escape the configured family prefix.
+
+    Args:
+        model_id: the raw path parameter value
+
+    Returns:
+        the normalized POSIX-style relative path
+
+    Raises:
+        HTTPException: if the value is empty, absolute, or contains ``..``
+    """
+    if not model_id or model_id.startswith("/"):
+        raise HTTPException(status_code=400, detail="Invalid model_id")
+
+    parts = PurePosixPath(model_id).parts
+    if any(part in ("", "..") for part in parts):
+        raise HTTPException(status_code=400, detail="Invalid model_id")
+
+    return "/".join(parts)
 
 
 def _get_model_base_url(family: str) -> str:
@@ -71,7 +97,7 @@ class ModelWeights(HTTPEndpoint):
             JSON response containing ``{"url": "<resolved_url>"}``
         """
         family = request.path_params["family"]
-        model_id = request.path_params["model_id"]
+        model_id = _validate_model_id(request.path_params["model_id"])
 
         base_url = _get_model_base_url(family)
         url = f"{base_url}/{model_id}"

--- a/fiftyone/server/routes/runtime_assets.py
+++ b/fiftyone/server/routes/runtime_assets.py
@@ -1,0 +1,87 @@
+"""
+FiftyOne Server runtime assets endpoints.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import os
+
+from starlette.endpoints import HTTPEndpoint
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+DEFAULT_MODEL_URLS = {
+    "sam2": "https://models-cdn.voxel51.com/sam2",
+}
+
+
+def _get_model_base_url(family: str) -> str:
+    """Resolve the base URL for a model family.
+
+    Checks for an environment variable override first
+    (e.g. ``FIFTYONE_MODEL_WEIGHTS_BASE_SAM2``), then falls back to the
+    built-in default.
+
+    Args:
+        family: the model family name (e.g. ``"sam2"``)
+
+    Returns:
+        the base URL for the model family
+
+    Raises:
+        HTTPException: if no URL is configured for the family
+    """
+    env_key = f"FIFTYONE_MODEL_WEIGHTS_BASE_{family.upper()}"
+    url = os.environ.get(env_key)
+
+    if url:
+        return url.rstrip("/")
+
+    default = DEFAULT_MODEL_URLS.get(family)
+    if default:
+        return default.rstrip("/")
+
+    raise HTTPException(
+        status_code=404,
+        detail=f"No model weights configured for family '{family}'",
+    )
+
+
+class ModelWeights(HTTPEndpoint):
+    """Resolves a download URL for a model weights file.
+
+    ``GET /runtime-assets/models/{family}/{model_id}``
+
+    Returns a JSON response with the resolved URL for the requested model
+    file. Deployments can override the default public URLs by setting
+    environment variables like ``FIFTYONE_MODEL_WEIGHTS_BASE_SAM2``.
+    """
+
+    async def get(self, request: Request) -> JSONResponse:
+        """Returns the download URL for the requested model weights file.
+
+        Args:
+            request: Starlette request with ``family`` and ``model_id`` in
+                path params
+
+        Returns:
+            JSON response containing ``{"url": "<resolved_url>"}``
+        """
+        family = request.path_params["family"]
+        model_id = request.path_params["model_id"]
+
+        base_url = _get_model_base_url(family)
+        url = f"{base_url}/{model_id}"
+
+        return JSONResponse({"url": url})
+
+
+RuntimeAssetRoutes = [
+    (
+        "/runtime-assets/models/{family}/{model_id:path}",
+        ModelWeights,
+    ),
+]

--- a/tests/unittests/server/routes/test_runtime_assets.py
+++ b/tests/unittests/server/routes/test_runtime_assets.py
@@ -16,6 +16,7 @@ from fiftyone.server.routes.runtime_assets import (
     DEFAULT_MODEL_URLS,
     ModelWeights,
     _get_model_base_url,
+    _validate_model_id,
 )
 
 
@@ -111,3 +112,55 @@ class TestModelWeightsEndpoint:
             await endpoint.get(request)
 
         assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad_model_id",
+        [
+            "../private/secret",
+            "sub/../../escape",
+            "/absolute/path",
+            "..",
+            "",
+        ],
+    )
+    async def test_path_traversal_returns_400(self, endpoint, bad_model_id):
+        """Tests that a 400 is raised for traversal / absolute / empty model_id."""
+        request = _make_request("sam2", bad_model_id)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await endpoint.get(request)
+
+        assert exc_info.value.status_code == 400
+
+
+class TestValidateModelId:
+    """Tests for _validate_model_id helper."""
+
+    @pytest.mark.parametrize(
+        "model_id,expected",
+        [
+            ("encoder.onnx", "encoder.onnx"),
+            ("subdir/model.onnx", "subdir/model.onnx"),
+            ("a/b/c/file.bin", "a/b/c/file.bin"),
+        ],
+    )
+    def test_valid_paths_normalized(self, model_id, expected):
+        """Tests that valid relative paths are returned normalized."""
+        assert _validate_model_id(model_id) == expected
+
+    @pytest.mark.parametrize(
+        "bad_model_id",
+        [
+            "../private",
+            "a/../../b",
+            "/absolute",
+            "..",
+            "",
+        ],
+    )
+    def test_invalid_paths_raise_400(self, bad_model_id):
+        """Tests that traversal, absolute, and empty inputs raise 400."""
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_model_id(bad_model_id)
+        assert exc_info.value.status_code == 400

--- a/tests/unittests/server/routes/test_runtime_assets.py
+++ b/tests/unittests/server/routes/test_runtime_assets.py
@@ -1,0 +1,113 @@
+"""
+FiftyOne Server runtime assets route unit tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from starlette.exceptions import HTTPException
+
+from fiftyone.server.routes.runtime_assets import (
+    DEFAULT_MODEL_URLS,
+    ModelWeights,
+    _get_model_base_url,
+)
+
+
+class TestGetModelBaseUrl:
+    """Tests for _get_model_base_url helper."""
+
+    def test_returns_default_url(self):
+        """Tests that the built-in default URL is returned when no env var is set."""
+        url = _get_model_base_url("sam2")
+        assert url == DEFAULT_MODEL_URLS["sam2"]
+
+    def test_env_override(self, monkeypatch):
+        """Tests that an environment variable overrides the default URL."""
+        monkeypatch.setenv("FIFTYONE_MODEL_WEIGHTS_BASE_SAM2", "https://custom.example.com/sam2")
+        url = _get_model_base_url("sam2")
+        assert url == "https://custom.example.com/sam2"
+
+    def test_env_override_strips_trailing_slash(self, monkeypatch):
+        """Tests that a trailing slash on the env var value is stripped."""
+        monkeypatch.setenv("FIFTYONE_MODEL_WEIGHTS_BASE_SAM2", "https://custom.example.com/sam2/")
+        url = _get_model_base_url("sam2")
+        assert url == "https://custom.example.com/sam2"
+
+    def test_env_key_uppercases_family(self, monkeypatch):
+        """Tests that the family name is upper-cased when building the env key."""
+        monkeypatch.setenv("FIFTYONE_MODEL_WEIGHTS_BASE_MYMODEL", "https://example.com/mymodel")
+        url = _get_model_base_url("mymodel")
+        assert url == "https://example.com/mymodel"
+
+    def test_unknown_family_raises_404(self):
+        """Tests that a 404 is raised for an unconfigured family."""
+        with pytest.raises(HTTPException) as exc_info:
+            _get_model_base_url("nonexistent")
+        assert exc_info.value.status_code == 404
+        assert "nonexistent" in exc_info.value.detail
+
+
+@pytest.fixture(name="endpoint")
+def fixture_endpoint():
+    """Returns a ModelWeights endpoint instance."""
+    return ModelWeights(
+        scope={"type": "http"}, receive=AsyncMock(), send=AsyncMock()
+    )
+
+
+def _make_request(family: str, model_id: str) -> MagicMock:
+    """Helper to create a mock request with the given path params."""
+    request = MagicMock()
+    request.path_params = {"family": family, "model_id": model_id}
+    return request
+
+
+class TestModelWeightsEndpoint:
+    """Tests for the ModelWeights HTTP endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_returns_url_for_known_family(self, endpoint):
+        """Tests that the endpoint resolves a URL for a known model family."""
+        request = _make_request("sam2", "encoder.onnx")
+        response = await endpoint.get(request)
+
+        assert response.status_code == 200
+        data = json.loads(response.body)
+        assert data["url"] == f"{DEFAULT_MODEL_URLS['sam2']}/encoder.onnx"
+
+    @pytest.mark.asyncio
+    async def test_returns_url_with_nested_model_id(self, endpoint):
+        """Tests that a model_id containing path separators is preserved."""
+        request = _make_request("sam2", "subdir/model.onnx")
+        response = await endpoint.get(request)
+
+        assert response.status_code == 200
+        data = json.loads(response.body)
+        assert data["url"] == f"{DEFAULT_MODEL_URLS['sam2']}/subdir/model.onnx"
+
+    @pytest.mark.asyncio
+    async def test_env_override_reflected_in_response(self, endpoint, monkeypatch):
+        """Tests that an env var override is used in the response URL."""
+        monkeypatch.setenv("FIFTYONE_MODEL_WEIGHTS_BASE_SAM2", "https://private.cdn.com/models")
+        request = _make_request("sam2", "decoder.onnx")
+        response = await endpoint.get(request)
+
+        assert response.status_code == 200
+        data = json.loads(response.body)
+        assert data["url"] == "https://private.cdn.com/models/decoder.onnx"
+
+    @pytest.mark.asyncio
+    async def test_unknown_family_returns_404(self, endpoint):
+        """Tests that a 404 is raised for an unknown model family."""
+        request = _make_request("unknown_family", "model.onnx")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await endpoint.get(request)
+
+        assert exc_info.value.status_code == 404


### PR DESCRIPTION
## 🔗 Related Issues
FOEPD-3498

## 📋 What changes are proposed in this pull request?

Adds a new /runtime-assets/models/{family}/{model_id} endpoint with a per-family env var override (`FIFTYONE_MODEL_WEIGHTS_BASE_SAM2`), which defaults to the public CDN (could later be extended to serve other assets if needed).

SAM2 worker resolves URLs via the backend instead of hardcoded paths. Now also uses stable IDB cache keys in case URLs are variable for the same model.

## 🧪 How is this patch tested? If it is not, please explain why.

- Unit tests (existing + new)
- Local dev server + locally built app
- Ephem

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime assets API for resolving model-weight URLs, configurable via environment variables.
  * Model caching now supports independent cache keys for finer control.
  * Added SAM2 model-family support and backend-configured model fetch routing.

* **Tests**
  * Added/expanded tests for runtime-assets endpoints, model-weight URL resolution, model caching behavior, and provider/worker initialization and header handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->