### PR TITLE
Wire multimodal app client to server query routes

### DIFF
--- a/app/packages/multimodal/package.json
+++ b/app/packages/multimodal/package.json
@@ -6,11 +6,19 @@
     "types": "./src/index.ts",
     "exports": {
         ".": "./src/index.ts",
+        "./client": "./src/client/index.ts",
+        "./client/hooks": "./src/client/hooks/index.ts",
         "./inject": "./src/inject/index.ts",
         "./schemas/v1": "./src/schemas/v1/index.ts"
     },
     "typesVersions": {
         "*": {
+            "client/hooks": [
+                "src/client/hooks/index.ts"
+            ],
+            "client": [
+                "src/client/index.ts"
+            ],
             "inject": [
                 "src/inject/index.ts"
             ],
@@ -28,6 +36,7 @@
     },
     "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",
-        "@fiftyone/plugins": "*"
+        "@fiftyone/plugins": "*",
+        "@fiftyone/utilities": "*"
     }
 }

--- a/app/packages/multimodal/src/client/fetch-protobuf.ts
+++ b/app/packages/multimodal/src/client/fetch-protobuf.ts
@@ -1,0 +1,19 @@
+import type { DescMessage, MessageShape } from "@bufbuild/protobuf";
+import { fromBinary } from "@bufbuild/protobuf";
+import { getFetchFunction } from "@fiftyone/utilities";
+
+/**
+ * Fetches a protobuf response through FiftyOne's configured app transport and
+ * decodes it with the provided schema.
+ */
+export async function fetchProtobuf<Schema extends DescMessage>(
+  path: string,
+  schema: Schema
+): Promise<MessageShape<Schema>> {
+  const buffer = await getFetchFunction({ cache: true })<
+    undefined,
+    ArrayBuffer
+  >("GET", path, undefined, "arrayBuffer");
+
+  return fromBinary(schema, new Uint8Array(buffer));
+}

--- a/app/packages/multimodal/src/client/hooks/index.ts
+++ b/app/packages/multimodal/src/client/hooks/index.ts
@@ -1,0 +1,3 @@
+export type { MultimodalQueryState } from "./types";
+export { usePlaybackPlan } from "./use-playback-plan";
+export { useSceneInventory } from "./use-scene-inventory";

--- a/app/packages/multimodal/src/client/hooks/types.ts
+++ b/app/packages/multimodal/src/client/hooks/types.ts
@@ -1,0 +1,19 @@
+/**
+ * Async load state returned by multimodal query hooks.
+ */
+export type MultimodalQueryState<Data> =
+  | {
+      readonly data: null;
+      readonly error: null;
+      readonly status: "idle" | "loading";
+    }
+  | {
+      readonly data: Data;
+      readonly error: null;
+      readonly status: "loaded";
+    }
+  | {
+      readonly data: null;
+      readonly error: Error;
+      readonly status: "error";
+    };

--- a/app/packages/multimodal/src/client/hooks/use-multimodal-query.ts
+++ b/app/packages/multimodal/src/client/hooks/use-multimodal-query.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import type { MultimodalQueryState } from "./types";
+
+const IDLE_STATE = { data: null, error: null, status: "idle" } as const;
+const LOADING_STATE = { data: null, error: null, status: "loading" } as const;
+
+function normalizeError(error: unknown): Error {
+  return error instanceof Error
+    ? error
+    : new Error(typeof error === "string" ? error : "Unknown error");
+}
+
+/**
+ * Runs one nullable async multimodal query and guards against stale updates.
+ */
+export function useMultimodalQuery<Data>(
+  load: (() => Promise<Data>) | null
+): MultimodalQueryState<Data> {
+  const [state, setState] = useState<MultimodalQueryState<Data>>(IDLE_STATE);
+
+  useEffect(() => {
+    if (!load) {
+      setState(IDLE_STATE);
+      return;
+    }
+
+    let active = true;
+    setState(LOADING_STATE);
+
+    load()
+      .then((data) => {
+        if (active) {
+          setState({ data, error: null, status: "loaded" });
+        }
+      })
+      .catch((error: unknown) => {
+        if (active) {
+          setState({
+            data: null,
+            error: normalizeError(error),
+            status: "error",
+          });
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [load]);
+
+  return state;
+}

--- a/app/packages/multimodal/src/client/hooks/use-playback-plan.ts
+++ b/app/packages/multimodal/src/client/hooks/use-playback-plan.ts
@@ -1,0 +1,29 @@
+import { useMemo } from "react";
+import type { PlaybackPlan } from "../../schemas/v1";
+import {
+  defaultMultimodalClient,
+  type MultimodalQueryClient,
+  type PlaybackPlanRequest,
+} from "../index";
+import type { MultimodalQueryState } from "./types";
+import { useMultimodalQuery } from "./use-multimodal-query";
+
+/**
+ * Loads the playback plan for a resolved inventory artifact.
+ */
+export function usePlaybackPlan(
+  request: PlaybackPlanRequest | null | undefined,
+  client: MultimodalQueryClient = defaultMultimodalClient
+): MultimodalQueryState<PlaybackPlan> {
+  const inventoryId = request?.inventoryId;
+
+  const load = useMemo(() => {
+    if (!inventoryId) {
+      return null;
+    }
+
+    return () => client.getPlaybackPlan({ inventoryId });
+  }, [client, inventoryId]);
+
+  return useMultimodalQuery(load);
+}

--- a/app/packages/multimodal/src/client/hooks/use-scene-inventory.ts
+++ b/app/packages/multimodal/src/client/hooks/use-scene-inventory.ts
@@ -1,0 +1,30 @@
+import { useMemo } from "react";
+import type { SceneInventory } from "../../schemas/v1";
+import {
+  defaultMultimodalClient,
+  type MultimodalQueryClient,
+  type SceneInventoryRequest,
+} from "../index";
+import type { MultimodalQueryState } from "./types";
+import { useMultimodalQuery } from "./use-multimodal-query";
+
+/**
+ * Loads the scene inventory for a dataset sample.
+ */
+export function useSceneInventory(
+  request: SceneInventoryRequest | null | undefined,
+  client: MultimodalQueryClient = defaultMultimodalClient
+): MultimodalQueryState<SceneInventory> {
+  const datasetId = request?.datasetId;
+  const sampleId = request?.sampleId;
+
+  const load = useMemo(() => {
+    if (!datasetId || !sampleId) {
+      return null;
+    }
+
+    return () => client.getSceneInventory({ datasetId, sampleId });
+  }, [client, datasetId, sampleId]);
+
+  return useMultimodalQuery(load);
+}

--- a/app/packages/multimodal/src/client/index.ts
+++ b/app/packages/multimodal/src/client/index.ts
@@ -1,0 +1,64 @@
+import {
+  PlaybackPlanSchema,
+  SceneInventorySchema,
+  type PlaybackPlan,
+  type SceneInventory,
+} from "../schemas/v1";
+import { fetchProtobuf } from "./fetch-protobuf";
+
+/**
+ * Identifies the sample whose source inventory should be resolved.
+ */
+export interface SceneInventoryRequest {
+  readonly datasetId: string;
+  readonly sampleId: string;
+}
+
+/**
+ * Identifies the inventory artifact to convert into a playback plan.
+ */
+export interface PlaybackPlanRequest {
+  readonly inventoryId: string;
+}
+
+/**
+ * Minimal query surface for source-agnostic multimodal server artifacts.
+ */
+export interface MultimodalQueryClient {
+  getSceneInventory(request: SceneInventoryRequest): Promise<SceneInventory>;
+  getPlaybackPlan(request: PlaybackPlanRequest): Promise<PlaybackPlan>;
+}
+
+/**
+ * Default query client backed by FiftyOne's multimodal server routes.
+ */
+export const defaultMultimodalClient: MultimodalQueryClient = {
+  getPlaybackPlan,
+  getSceneInventory,
+};
+
+/**
+ * Fetches the inventory artifact for a dataset sample.
+ */
+export function getSceneInventory(
+  request: SceneInventoryRequest
+): Promise<SceneInventory> {
+  const sceneInventoryPath = `/dataset/${encodeURIComponent(
+    request.datasetId
+  )}/sample/${encodeURIComponent(request.sampleId)}/multimodal/scene-inventory`;
+  return fetchProtobuf(sceneInventoryPath, SceneInventorySchema);
+}
+
+/**
+ * Fetches the playback plan for an inventory artifact.
+ */
+export function getPlaybackPlan(
+  request: PlaybackPlanRequest
+): Promise<PlaybackPlan> {
+  const playbackPlanPath = `/multimodal/playback-plan/${encodeURIComponent(
+    request.inventoryId
+  )}`;
+  return fetchProtobuf(playbackPlanPath, PlaybackPlanSchema);
+}
+
+export { fetchProtobuf } from "./fetch-protobuf";

--- a/app/packages/multimodal/src/index.ts
+++ b/app/packages/multimodal/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./archetypes";
+export * from "./client";
 export { DecoderRegistry } from "./decoders";
 export type {
   DecodeContext,

--- a/app/packages/multimodal/src/mcap/GridRenderer.tsx
+++ b/app/packages/multimodal/src/mcap/GridRenderer.tsx
@@ -1,5 +1,33 @@
 import type { SampleRendererProps } from "@fiftyone/plugins";
+import { useSceneInventory } from "../client/hooks";
+import { getSampleIdentifiers } from "./sample";
 
-export const GridRenderer = (_props: SampleRendererProps) => {
-  return <div>hi from grid</div>;
-};
+/**
+ * Grid proof renderer for MCAP-backed multimodal samples.
+ */
+export function GridRenderer({ ctx }: SampleRendererProps) {
+  const { datasetId, sampleId } = getSampleIdentifiers(ctx);
+  const inventoryState = useSceneInventory(
+    datasetId && sampleId ? { datasetId, sampleId } : null
+  );
+
+  if (inventoryState.status === "loaded") {
+    return <div>{inventoryState.data.streams.length} streams</div>;
+  }
+
+  const message =
+    !datasetId || !sampleId
+      ? "Inventory identifiers missing"
+      : inventoryState.status === "error"
+      ? "Inventory unavailable"
+      : "Loading inventory";
+
+  return (
+    <div>
+      <div>{message}</div>
+      {inventoryState.status === "error" && (
+        <div>{inventoryState.error.message}</div>
+      )}
+    </div>
+  );
+}

--- a/app/packages/multimodal/src/mcap/ModalRenderer.tsx
+++ b/app/packages/multimodal/src/mcap/ModalRenderer.tsx
@@ -1,7 +1,25 @@
 import type { SampleRendererProps } from "@fiftyone/plugins";
+import { usePlaybackPlan, useSceneInventory } from "../client/hooks";
+import { getSampleIdentifiers } from "./sample";
 
-// TODO: implement MCAP renderers.
+/**
+ * Modal proof renderer for MCAP-backed multimodal samples.
+ */
+export function ModalRenderer({ ctx }: SampleRendererProps) {
+  const { datasetId, sampleId } = getSampleIdentifiers(ctx);
+  const inventoryState = useSceneInventory(
+    datasetId && sampleId ? { datasetId, sampleId } : null
+  );
+  const playbackPlanState = usePlaybackPlan(
+    inventoryState.status === "loaded" && inventoryState.data.inventoryId
+      ? { inventoryId: inventoryState.data.inventoryId }
+      : null
+  );
 
-export const ModalRenderer = (_props: SampleRendererProps) => {
-  return <div>hi from modal</div>;
-};
+  return (
+    <div>
+      <div>Scene inventory ID: {inventoryState.data?.inventoryId}</div>
+      <div>Playback ID: {playbackPlanState.data?.planId}</div>
+    </div>
+  );
+}

--- a/app/packages/multimodal/src/mcap/sample.ts
+++ b/app/packages/multimodal/src/mcap/sample.ts
@@ -1,0 +1,35 @@
+import type { SampleRendererProps } from "@fiftyone/plugins";
+
+type SampleContext = SampleRendererProps["ctx"];
+
+function normalizeIdentifier(value: unknown): string | null {
+  if (typeof value === "string" && value) {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    return value.toString();
+  }
+
+  return null;
+}
+
+/**
+ * Extracts the dataset and sample identifiers.
+ */
+export function getSampleIdentifiers(ctx: SampleContext): {
+  readonly datasetId: string | null;
+  readonly sampleId: string | null;
+} {
+  const sampleRecord = ctx.sample.sample as {
+    readonly _id?: unknown;
+    readonly id?: unknown;
+  };
+
+  return {
+    datasetId: normalizeIdentifier(ctx.dataset.datasetId),
+    sampleId:
+      normalizeIdentifier(sampleRecord._id) ??
+      normalizeIdentifier(sampleRecord.id),
+  };
+}

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3086,6 +3086,7 @@ __metadata:
   dependencies:
     "@bufbuild/protobuf": "npm:^2.11.0"
     "@fiftyone/plugins": "npm:*"
+    "@fiftyone/utilities": "npm:*"
   languageName: unknown
   linkType: soft
 

--- a/fiftyone/multimodal/server/routes.py
+++ b/fiftyone/multimodal/server/routes.py
@@ -42,10 +42,10 @@ class PlaybackPlanEndpoint(HTTPEndpoint):
     """Playback plan query endpoint."""
 
     @decorators.route
-    async def post(self, request: Request, data: dict) -> Response:
+    async def get(self, request: Request) -> Response:
         """Returns a serialized PlaybackPlan protobuf."""
 
-        inventory_id = _get_required_body_field(data, "inventory_id")
+        inventory_id = _get_required_path_param(request, "inventory_id")
 
         plan = resolve_playback_plan(inventory_id)
 
@@ -57,18 +57,6 @@ class PlaybackPlanEndpoint(HTTPEndpoint):
 
 def _get_required_path_param(request: Request, field: str) -> str:
     value = request.path_params.get(field)
-
-    return _require_string(value, field)
-
-
-def _get_required_body_field(data: dict, field: str) -> str:
-    if not isinstance(data, dict):
-        raise HTTPException(
-            status_code=400,
-            detail="JSON body must be an object",
-        )
-
-    value = data.get(field)
 
     return _require_string(value, field)
 
@@ -85,7 +73,7 @@ def _require_string(value, field: str) -> str:
 
 MultimodalRoutes = [
     (
-        "/multimodal/playback-plan",
+        "/multimodal/playback-plan/{inventory_id}",
         PlaybackPlanEndpoint,
     ),
     (


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Adds the app-side query path for the multimodal server routes introduced in #7461 

This PR:
- Switches the playback-plan endpoint to `GET /multimodal/playback-plan/{inventory_id}`
- Adds a lightweight `@fiftyone/multimodal/client` surface for fetching protobuf query artifacts
- Adds React hooks for loading scene inventory and playback plans
- Wires the MCAP grid/modal proof renderers to fetch server-backed multimodal artifacts

## 🧪 How is this patch tested? If it is not, please explain why.

- Unit tests
- All strict lint commands green

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multimodal client for fetching scene inventory and playback plan data
  * Implemented data loading hooks for managing asynchronous state
  * Grid and modal views now display real scene data instead of placeholders

<!-- end of auto-generated comment: release notes by coderabbit.ai -->