### PR TITLE
docs: add v2.18.1 release notes

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -3,6 +3,24 @@ FiftyOne Release Notes
 
 .. default-role:: code
 
+FiftyOne Enterprise 2.18.1
+--------------------------
+*Released May 7, 2026*
+
+App
+
+- Fixed a bug that caused global cloud credentials to incorrectly appear under
+  the "Groups" tab on the Cloud credentials settings page when no groups
+  existed in the system
+
+Security
+
+- Updated a number of dependencies in the FiftyOne Enterprise App in order to
+  resolve security vulnerabilities: `picomatch`, `protobufjs`,
+  `@xmldom/xmldom`, and `langchain-core`
+- Updated a number of dependencies in the FiftyOne Enterprise API in order to
+  resolve security vulnerabilities: `ujson` and `pyjwt`
+
 FiftyOne Enterprise 2.18.0
 --------------------------
 *Released May 1, 2026*


### PR DESCRIPTION
Adds release notes for FiftyOne Enterprise 2.18.1, covering the cloud creds Groups fix and dependency CVE bumps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed global cloud credentials appearing under Groups when no groups exist.

* **Security**
  * Updated enterprise app and API dependencies to address known vulnerabilities.

* **Documentation**
  * Added release notes for Enterprise 2.18.1 (no OSS updates). No public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->