### PR TITLE
Check and log exit_code for do processes that are not alive

### DIFF
--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -893,6 +893,16 @@ class DelegatedOperationService(object):
             child_process.join(timeout=check_interval_seconds)
 
             if not child_process.is_alive():
+                code = child_process.exitcode
+                logger.error(
+                    "Child process for operation %s exited with code %s",
+                    operation_id,
+                    code,
+                )
+                if code != 0:
+                    return ExecutionResult(
+                        error=f"Child process exited unexpectedly with code {code}"
+                    )
                 return None
 
             try:

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -889,21 +889,33 @@ class DelegatedOperationService(object):
         """
         Monitors the child_process and operation state for failures.
         """
-        while child_process.is_alive():
+        while True:
             child_process.join(timeout=check_interval_seconds)
 
             if not child_process.is_alive():
                 code = child_process.exitcode
+                if code == 0:
+                    logger.debug(
+                        "Child process for operation %s exited cleanly",
+                        operation_id,
+                    )
+                    return None
+
                 logger.error(
-                    "Child process for operation %s exited with code %s",
+                    "Child process for operation %s exited unexpectedly "
+                    "with code %s",
                     operation_id,
                     code,
                 )
-                if code != 0:
-                    return ExecutionResult(
-                        error=f"Child process exited unexpectedly with code {code}"
-                    )
-                return None
+                result = ExecutionResult(
+                    error=f"Child process exited unexpectedly with code {code}"
+                )
+                self.set_failed(
+                    doc_id=operation_id,
+                    result=result,
+                    required_state=ExecutionRunState.RUNNING,
+                )
+                return result
 
             try:
                 op_doc = self.get(operation_id)

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -872,10 +872,35 @@ class DelegatedOperationService(object):
                     result = ExecutionResult()
         finally:
             listener.stop()
-            if child_process and child_process.is_alive():
-                self._terminate_child_process(
-                    child_process, operation.id, "Executor shutting down"
-                )
+            if child_process is not None:
+                if child_process.is_alive():
+                    self._terminate_child_process(
+                        child_process, operation.id, "Executor shutting down"
+                    )
+                # Reap the child so multiprocessing.Process.exitcode is
+                # populated from the OS exit status.
+                child_process.join(timeout=5)
+
+                code = child_process.exitcode
+                if code == 0:
+                    logger.debug(
+                        "Child process for operation %s exited cleanly",
+                        operation.id,
+                    )
+                elif code is not None:
+                    logger.error(
+                        "Child process for operation %s exited unexpectedly "
+                        "with code %s",
+                        operation.id,
+                        code,
+                    )
+                    if result is not None and result.error is None:
+                        result.error = f"Child process exited unexpectedly with code {code}"
+                        self.set_failed(
+                            doc_id=operation.id,
+                            result=result,
+                            required_state=ExecutionRunState.RUNNING,
+                        )
 
         return result
 
@@ -889,33 +914,13 @@ class DelegatedOperationService(object):
         """
         Monitors the child_process and operation state for failures.
         """
-        while True:
+        while child_process.is_alive():
             child_process.join(timeout=check_interval_seconds)
 
             if not child_process.is_alive():
-                code = child_process.exitcode
-                if code == 0:
-                    logger.debug(
-                        "Child process for operation %s exited cleanly",
-                        operation_id,
-                    )
-                    return None
-
-                logger.error(
-                    "Child process for operation %s exited unexpectedly "
-                    "with code %s",
-                    operation_id,
-                    code,
-                )
-                result = ExecutionResult(
-                    error=f"Child process exited unexpectedly with code {code}"
-                )
-                self.set_failed(
-                    doc_id=operation_id,
-                    result=result,
-                    required_state=ExecutionRunState.RUNNING,
-                )
-                return result
+                # Child exited; the caller's finally block reads the exit
+                # code and surfaces non-zero exits as a failure.
+                return None
 
             try:
                 op_doc = self.get(operation_id)

--- a/tests/unittests/operators/delegated_tests.py
+++ b/tests/unittests/operators/delegated_tests.py
@@ -936,6 +936,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         mock_process = mock.MagicMock()
 
         mock_process.is_alive.side_effect = [True, True, True, False, False]
+        mock_process.exitcode = 0
 
         mock_context = mock.MagicMock()
         mock_context.Process.return_value = mock_process
@@ -1139,8 +1140,9 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         _mock_get_operator,
     ):
         mock_process = mock.MagicMock()
-        # Dead immediately, both inside _monitor_operation and in the
-        # execute_operation finally block
+        # Child appears dead at every is_alive() check: the monitor's while
+        # loop exits immediately, the caller's finally block sees a dead
+        # child with a non-zero exitcode, and surfaces the failure.
         mock_process.is_alive.return_value = False
         mock_process.exitcode = 1
         mock_process.pid = 12345

--- a/tests/unittests/operators/delegated_tests.py
+++ b/tests/unittests/operators/delegated_tests.py
@@ -1135,16 +1135,9 @@ class DelegatedOperationServiceTests(unittest.TestCase):
     def test_execute_operation_monitor_unclean_exit(
         self,
         mock_get_context,
-        mock_listener,
-        mock_get_operator,
+        _mock_listener,
+        _mock_get_operator,
     ):
-        """A non-zero child exit (e.g. SIGKILL/OOM/segfault) must surface as
-        an error result and transition the doc to FAILED.
-
-        Previously the monitor returned None for any exit; the caller then
-        fetched the still-RUNNING doc and silently produced an empty
-        ExecutionResult(), leaving the operation orphaned in RUNNING state.
-        """
         mock_process = mock.MagicMock()
         # Dead immediately, both inside _monitor_operation and in the
         # execute_operation finally block
@@ -1171,10 +1164,10 @@ class DelegatedOperationServiceTests(unittest.TestCase):
             result = self.svc.execute_operation(
                 operation=doc, log=False, monitor=True
             )
-
         self.assertIsNotNone(result)
         self.assertIsNotNone(result.error)
         self.assertIn("exited unexpectedly", result.error)
+        # Exit code should be included in the error message
         self.assertIn("code 1", result.error)
 
         # Doc must be transitioned out of RUNNING so it doesn't sit orphaned

--- a/tests/unittests/operators/delegated_tests.py
+++ b/tests/unittests/operators/delegated_tests.py
@@ -1132,6 +1132,63 @@ class DelegatedOperationServiceTests(unittest.TestCase):
 
     @patch("logging.handlers.QueueListener")
     @patch("multiprocessing.get_context")
+    def test_execute_operation_monitor_unclean_exit(
+        self,
+        mock_get_context,
+        mock_listener,
+        mock_get_operator,
+    ):
+        """A non-zero child exit (e.g. SIGKILL/OOM/segfault) must surface as
+        an error result and transition the doc to FAILED.
+
+        Previously the monitor returned None for any exit; the caller then
+        fetched the still-RUNNING doc and silently produced an empty
+        ExecutionResult(), leaving the operation orphaned in RUNNING state.
+        """
+        mock_process = mock.MagicMock()
+        # Dead immediately, both inside _monitor_operation and in the
+        # execute_operation finally block
+        mock_process.is_alive.return_value = False
+        mock_process.exitcode = 1
+        mock_process.pid = 12345
+
+        mock_context = mock.MagicMock()
+        mock_context.Process.return_value = mock_process
+        mock_context.Queue.return_value = mock.MagicMock()
+        mock_get_context.return_value = mock_context
+
+        doc = self.svc.queue_operation(
+            operator=f"{TEST_DO_PREFIX}/operator/monitor_unclean_exit",
+            context=ExecutionContext(
+                request_params={"dataset_id": str(ObjectId())}
+            ),
+        )
+        self.docs_to_delete.append(doc)
+
+        with patch(
+            "fiftyone.operators.delegated._execute_operator_in_child_process"
+        ), patch.object(self.svc, "set_failed") as mock_set_failed:
+            result = self.svc.execute_operation(
+                operation=doc, log=False, monitor=True
+            )
+
+        self.assertIsNotNone(result)
+        self.assertIsNotNone(result.error)
+        self.assertIn("exited unexpectedly", result.error)
+        self.assertIn("code 1", result.error)
+
+        # Doc must be transitioned out of RUNNING so it doesn't sit orphaned
+        mock_set_failed.assert_called_once()
+        call_kwargs = mock_set_failed.call_args.kwargs
+        self.assertEqual(call_kwargs["doc_id"], doc.id)
+        self.assertEqual(
+            call_kwargs["required_state"], ExecutionRunState.RUNNING
+        )
+        self.assertIsInstance(call_kwargs["result"], ExecutionResult)
+        self.assertIn("code 1", call_kwargs["result"].error)
+
+    @patch("logging.handlers.QueueListener")
+    @patch("multiprocessing.get_context")
     def test_execute_operation_monitor_ping_exception(
         self,
         mock_get_context,


### PR DESCRIPTION
## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

- add logging for exit_codes and return an execution error for dead processes that did not exit cleanly

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of delegated operations that exit unexpectedly: non-zero child-process exits are now surfaced, logged with exit-code details, and cause the operation to be marked as failed so it is not left running.
* **Tests**
  * Added a unit test simulating an unexpected child-process exit to verify error reporting and that operations transition to a failed state consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->