### PR TITLE
add risk_level config to operator configs

### DIFF
--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -7,7 +7,11 @@ import { getFetchFunction, isNullish, ServerError } from "@fiftyone/utilities";
 import { CallbackInterface } from "recoil";
 import { QueueItemStatus } from "./constants";
 import * as types from "./types";
-import { ExecutionCallback, OperatorExecutorOptions } from "./types-internal";
+import {
+  ExecutionCallback,
+  OperatorExecutorOptions,
+  RiskLevel,
+} from "./types-internal";
 import { stringifyError } from "./utils";
 import { ValidationContext, ValidationError } from "./validation";
 
@@ -253,6 +257,7 @@ export type OperatorConfigOptions = {
   resolveExecutionOptionsOnChange?: boolean;
   skipInput?: boolean;
   skipOutput?: boolean;
+  riskLevel?: RiskLevel;
 };
 export class OperatorConfig {
   public name: string;
@@ -271,6 +276,7 @@ export class OperatorConfig {
   public resolveExecutionOptionsOnChange = false;
   public skipInput: boolean;
   public skipOutput: boolean;
+  public riskLevel: RiskLevel = RiskLevel.LOW;
 
   constructor(options: OperatorConfigOptions) {
     this.name = options.name;
@@ -291,6 +297,7 @@ export class OperatorConfig {
       options.resolveExecutionOptionsOnChange || false;
     this.skipInput = options.skipInput || false;
     this.skipOutput = options.skipOutput || false;
+    this.riskLevel = options.riskLevel || RiskLevel.LOW;
   }
   static fromJSON(json) {
     return new OperatorConfig({
@@ -310,6 +317,7 @@ export class OperatorConfig {
       resolveExecutionOptionsOnChange: json.resolve_execution_options_on_change,
       skipInput: json.skip_input,
       skipOutput: json.skip_output,
+      riskLevel: json.risk_level,
     });
   }
 }
@@ -337,6 +345,9 @@ export class Operator {
   }
   get unlisted() {
     return this.config.unlisted;
+  }
+  get riskLevel() {
+    return this.config.riskLevel || RiskLevel.LOW;
   }
   async needsUserInput(ctx: ExecutionContext) {
     const inputs = await this.resolveInput(ctx);

--- a/app/packages/operators/src/types-internal.ts
+++ b/app/packages/operators/src/types-internal.ts
@@ -32,3 +32,10 @@ export type ResolvablePropertyOptions = {
   leading?: boolean;
   trailing?: boolean;
 };
+
+export enum RiskLevel {
+  LOW = "low",
+  MEDIUM = "medium",
+  HIGH = "high",
+  DANGEROUS = "dangerous",
+}

--- a/e2e-pw/src/shared/assets/plugins/e2e/__init__.py
+++ b/e2e-pw/src/shared/assets/plugins/e2e/__init__.py
@@ -15,6 +15,7 @@ class E2ESetView(foo.Operator):
         return foo.OperatorConfig(
             name="e2e_set_view",
             label="E2E: Set view",
+            risk_level=types.RiskLevel.LOW,
         )
 
     def execute(self, ctx):
@@ -29,6 +30,7 @@ class E2ESayHelloInModal(foo.Operator):
         return foo.OperatorConfig(
             name="e2e_say_hello_in_modal",
             label="E2E: Say hello in modal",
+            risk_level=types.RiskLevel.LOW,
         )
 
     def resolve_input(self, ctx):
@@ -52,6 +54,7 @@ class E2ESayHelloInDrawer(foo.Operator):
         return foo.OperatorConfig(
             name="e2e_say_hello_in_drawer",
             label="E2E: Say hello in drawer",
+            risk_level=types.RiskLevel.LOW,
         )
 
     def resolve_input(self, ctx):
@@ -76,6 +79,7 @@ class E2EProgress(foo.Operator):
             name="e2e_progress",
             label="E2E: Progress",
             execute_as_generator=True,
+            risk_level=types.RiskLevel.LOW,
         )
 
     async def execute(self, ctx):

--- a/fiftyone/operators/_types/config.py
+++ b/fiftyone/operators/_types/config.py
@@ -1,0 +1,18 @@
+"""
+FiftyOne operator config types.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from enum import Enum
+
+
+class RiskLevel(Enum):
+    """Risk levels that operators can declare."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    DANGEROUS = "dangerous"

--- a/fiftyone/operators/operator.py
+++ b/fiftyone/operators/operator.py
@@ -6,9 +6,34 @@ FiftyOne operators.
 |
 """
 
-from .types import PromptView
+from typing import Union
+from .types import PromptView, RiskLevel
 
 BUILTIN_OPERATOR_PREFIX = "@voxel51/operators"
+
+
+def _normalize_risk_level(
+    risk_level: Union[str, RiskLevel, None],
+) -> RiskLevel:
+    if risk_level is None:
+        return RiskLevel.DANGEROUS
+
+    if isinstance(risk_level, str):
+        try:
+            return RiskLevel[risk_level.upper()]
+        except KeyError as err:
+            raise ValueError(
+                "Invalid risk level '%s'. Valid values are: %s"
+                % (risk_level, [r.value for r in RiskLevel])
+            ) from err
+
+    if not isinstance(risk_level, RiskLevel):
+        raise ValueError(
+            "Invalid risk level '%s'. Must be a string or RiskLevel enum."
+            % risk_level
+        )
+
+    return risk_level
 
 
 class OperatorConfig(object):
@@ -46,6 +71,10 @@ class OperatorConfig(object):
         allow_distributed_execution (False): whether the operator supports
             distributing delegated execution across parallel workers.
         rerunnable (True): whether the operator can be re-run
+        risk_level (RiskLevel.DANGEROUS): the declared :class:`RiskLevel` for
+            this operator is mainly used by guardrail systems of an agent to
+            classify tool calls. If ``None``, the operator defaults to
+            :attr:`RiskLevel.DANGEROUS`
     """
 
     def __init__(
@@ -69,6 +98,7 @@ class OperatorConfig(object):
         resolve_execution_options_on_change=None,
         allow_distributed_execution=False,  # Enterprise only
         rerunnable=True,
+        risk_level=RiskLevel.DANGEROUS,
         **kwargs
     ):
         self.name = name
@@ -89,6 +119,7 @@ class OperatorConfig(object):
         self.default_choice_to_delegated = default_choice_to_delegated
         self.allow_distributed_execution = False  # Enterprise only
         self.rerunnable = rerunnable
+        self._risk_level = _normalize_risk_level(risk_level)
         if resolve_execution_options_on_change is None:
             self.resolve_execution_options_on_change = dynamic
         else:
@@ -96,6 +127,11 @@ class OperatorConfig(object):
                 resolve_execution_options_on_change
             )
         self.kwargs = kwargs  # unused, placeholder for future extensibility
+
+    @property
+    def risk_level(self):
+        """The declared :class:`RiskLevel` for this operator."""
+        return self._risk_level
 
     def to_json(self):
         return {
@@ -118,6 +154,7 @@ class OperatorConfig(object):
             "default_choice_to_delegated": self.default_choice_to_delegated,
             "resolve_execution_options_on_change": self.resolve_execution_options_on_change,
             "allow_distributed_execution": self.allow_distributed_execution,
+            "risk_level": self.risk_level.value,
         }
 
 
@@ -158,6 +195,12 @@ class Operator(object):
     def config(self):
         """The :class:`OperatorConfig` for the operator."""
         raise NotImplementedError("subclass must implement config")
+
+    @property
+    def risk_level(self):
+        """The effective risk level of the operator, which is used by guardrail
+        systems of an agent to classify tool calls."""
+        return self.config.risk_level
 
     def resolve_delegation(self, ctx):
         """Returns the resolved *forced* delegation flag.

--- a/fiftyone/operators/sse.py
+++ b/fiftyone/operators/sse.py
@@ -9,6 +9,7 @@ FiftyOne SSE operators.
 import logging
 
 import fiftyone.operators as foo
+import fiftyone.operators.types as types
 from fiftyone.operators.executor import ExecutionContext
 from fiftyone.operators.remote_notifier import default_sse_notifier
 
@@ -34,6 +35,7 @@ class SseOperatorConfig(foo.OperatorConfig):
             light_icon=light_icon,
             dark_icon=dark_icon,
             unlisted=True,
+            risk_level=types.RiskLevel.LOW,
         )
         self.store_name = store_name
 

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -9,6 +9,7 @@ import types
 
 from ._types.pipeline import Pipeline, PipelineRunInfo, PipelineStage
 from ._types.types import *
+from ._types.config import RiskLevel
 
 # This enables Sphinx refs to directly use paths imported here
 __all__ = [

--- a/plugins/operators/__init__.py
+++ b/plugins/operators/__init__.py
@@ -47,6 +47,7 @@ class EditFieldInfo(foo.Operator):
             name="edit_field_info",
             label="Edit field info",
             dynamic=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def resolve_input(self, ctx):
@@ -160,6 +161,7 @@ class EditFieldValues(foo.Operator):
             allow_immediate_execution=True,
             default_choice_to_delegated=True,
             dynamic=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def resolve_input(self, ctx):
@@ -362,6 +364,7 @@ class CloneSelectedSamples(foo.Operator):
             name="clone_selected_samples",
             label="Clone selected samples",
             dynamic=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def resolve_input(self, ctx):
@@ -407,6 +410,7 @@ class CloneSampleField(foo.Operator):
             allow_immediate_execution=True,
             default_choice_to_delegated=True,
             dynamic=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def resolve_input(self, ctx):
@@ -519,6 +523,7 @@ class CloneFrameField(foo.Operator):
             allow_immediate_execution=True,
             default_choice_to_delegated=True,
             dynamic=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def resolve_input(self, ctx):
@@ -640,6 +645,7 @@ class RenameSampleField(foo.Operator):
             allow_immediate_execution=True,
             default_choice_to_delegated=True,
             dynamic=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def resolve_input(self, ctx):
@@ -726,6 +732,7 @@ class RenameFrameField(foo.Operator):
             allow_immediate_execution=True,
             default_choice_to_delegated=True,
             dynamic=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def resolve_input(self, ctx):
@@ -821,6 +828,7 @@ class ClearSampleField(foo.Operator):
             allow_immediate_execution=True,
             default_choice_to_delegated=True,
             dynamic=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def resolve_input(self, ctx):
@@ -923,6 +931,7 @@ class ClearFrameField(foo.Operator):
             allow_immediate_execution=True,
             default_choice_to_delegated=True,
             dynamic=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def resolve_input(self, ctx):
@@ -1035,6 +1044,7 @@ class DeleteSelectedSamples(foo.Operator):
             name="delete_selected_samples",
             label="Delete selected samples",
             dynamic=True,
+            risk_level=types.RiskLevel.HIGH,
         )
 
     def resolve_input(self, ctx):
@@ -1076,6 +1086,7 @@ class DeleteSelectedLabels(foo.Operator):
             name="delete_selected_labels",
             label="Delete selected labels",
             dynamic=True,
+            risk_level=types.RiskLevel.HIGH,
         )
 
     def resolve_input(self, ctx):
@@ -1216,6 +1227,7 @@ class DeleteSampleField(foo.Operator):
             allow_immediate_execution=True,
             default_choice_to_delegated=True,
             dynamic=True,
+            risk_level=types.RiskLevel.HIGH,
         )
 
     def resolve_input(self, ctx):
@@ -1285,6 +1297,7 @@ class DeleteFrameField(foo.Operator):
             allow_immediate_execution=True,
             default_choice_to_delegated=True,
             dynamic=True,
+            risk_level=types.RiskLevel.HIGH,
         )
 
     def resolve_input(self, ctx):
@@ -1364,6 +1377,7 @@ class AddDynamicSampleFields(foo.Operator):
             name="add_dynamic_sample_fields",
             label="Add dynamic sample fields",
             dynamic=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def resolve_input(self, ctx):
@@ -1514,6 +1528,7 @@ class AddDynamicFrameFields(foo.Operator):
             name="add_dynamic_frame_fields",
             label="Add dynamic frame fields",
             dynamic=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def resolve_input(self, ctx):
@@ -1662,6 +1677,7 @@ class RemoveDynamicSampleFields(foo.Operator):
             name="remove_dynamic_sample_fields",
             label="Remove dynamic sample fields",
             dynamic=True,
+            risk_level=types.RiskLevel.HIGH,
         )
 
     def resolve_input(self, ctx):
@@ -1735,6 +1751,7 @@ class RemoveDynamicFrameFields(foo.Operator):
             name="remove_dynamic_frame_fields",
             label="Remove dynamic frame fields",
             dynamic=True,
+            risk_level=types.RiskLevel.HIGH,
         )
 
     def resolve_input(self, ctx):
@@ -1820,6 +1837,7 @@ class CreateIndex(foo.Operator):
             name="create_index",
             label="Create index",
             dynamic=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def resolve_input(self, ctx):
@@ -1968,6 +1986,7 @@ class DropIndex(foo.Operator):
             name="drop_index",
             label="Drop index",
             dynamic=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def resolve_input(self, ctx):
@@ -2029,6 +2048,7 @@ class CreateSummaryField(foo.Operator):
             allow_immediate_execution=True,
             default_choice_to_delegated=True,
             dynamic=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def resolve_input(self, ctx):
@@ -2229,6 +2249,7 @@ class UpdateSummaryField(foo.Operator):
             allow_immediate_execution=True,
             default_choice_to_delegated=True,
             dynamic=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def resolve_input(self, ctx):
@@ -2296,6 +2317,7 @@ class DeleteSummaryField(foo.Operator):
             allow_immediate_execution=True,
             default_choice_to_delegated=True,
             dynamic=True,
+            risk_level=types.RiskLevel.HIGH,
         )
 
     def resolve_input(self, ctx):
@@ -2347,6 +2369,7 @@ class AddGroupSlice(foo.Operator):
             name="add_group_slice",
             label="Add group slice",
             dynamic=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def resolve_input(self, ctx):
@@ -2410,6 +2433,7 @@ class RenameGroupSlice(foo.Operator):
             allow_immediate_execution=True,
             default_choice_to_delegated=True,
             dynamic=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def resolve_input(self, ctx):
@@ -2478,6 +2502,7 @@ class DeleteGroupSlice(foo.Operator):
             allow_immediate_execution=True,
             default_choice_to_delegated=True,
             dynamic=True,
+            risk_level=types.RiskLevel.HIGH,
         )
 
     def resolve_input(self, ctx):
@@ -2534,6 +2559,7 @@ class ListSavedViews(foo.Operator):
             name="list_saved_views",
             label="List saved views",
             unlisted=True,
+            risk_level=types.RiskLevel.LOW,
         )
 
     def execute(self, ctx):
@@ -2547,6 +2573,7 @@ class LoadSavedView(foo.Operator):
             name="load_saved_view",
             label="Load saved view",
             dynamic=True,
+            risk_level=types.RiskLevel.LOW,
         )
 
     def resolve_input(self, ctx):
@@ -2591,6 +2618,7 @@ class ReloadSavedView(foo.Operator):
             name="reload_saved_view",
             label="Reload saved view",
             dynamic=True,
+            risk_level=types.RiskLevel.LOW,
         )
 
     def resolve_placement(self, ctx):
@@ -2720,6 +2748,7 @@ class SaveView(foo.Operator):
             name="save_view",
             label="Save view",
             dynamic=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def resolve_input(self, ctx):
@@ -2792,6 +2821,7 @@ class EditSavedViewInfo(foo.Operator):
             name="edit_saved_view_info",
             label="Edit saved view info",
             dynamic=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def resolve_input(self, ctx):
@@ -2886,6 +2916,7 @@ class DeleteSavedView(foo.Operator):
             name="delete_saved_view",
             label="Delete saved view",
             dynamic=True,
+            risk_level=types.RiskLevel.HIGH,
         )
 
     def resolve_input(self, ctx):
@@ -2937,6 +2968,7 @@ class ListWorkspaces(foo.Operator):
             name="list_workspaces",
             label="List workspaces",
             unlisted=True,
+            risk_level=types.RiskLevel.LOW,
         )
 
     def execute(self, ctx):
@@ -2950,6 +2982,7 @@ class LoadWorkspace(foo.Operator):
             name="load_workspace",
             label="Load workspace",
             dynamic=True,
+            risk_level=types.RiskLevel.LOW,
         )
 
     def resolve_input(self, ctx):
@@ -2994,6 +3027,7 @@ class SaveWorkspace(foo.Operator):
             name="save_workspace",
             label="Save workspace",
             dynamic=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def resolve_input(self, ctx):
@@ -3080,6 +3114,7 @@ class EditWorkspaceInfo(foo.Operator):
             name="edit_workspace_info",
             label="Edit workspace info",
             dynamic=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def resolve_input(self, ctx):
@@ -3179,6 +3214,7 @@ class DeleteWorkspace(foo.Operator):
             name="delete_workspace",
             label="Delete workspace",
             dynamic=True,
+            risk_level=types.RiskLevel.HIGH,
         )
 
     def resolve_input(self, ctx):
@@ -3238,6 +3274,7 @@ class SyncLastModifiedAt(foo.Operator):
             allow_immediate_execution=True,
             default_choice_to_delegated=True,
             dynamic=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def resolve_input(self, ctx):
@@ -3284,6 +3321,7 @@ class ListFiles(foo.Operator):
             name="list_files",
             label="List Files",
             unlisted=True,
+            risk_level=types.RiskLevel.LOW,
         )
 
     def execute(self, ctx):
@@ -3400,6 +3438,7 @@ class DownloadFileOperator(foo.Operator):
             name="download_file",
             label="Download file",
             unlisted=True,
+            risk_level=types.RiskLevel.LOW,
         )
 
     def resolve_input(self, ctx):

--- a/plugins/operators/annotation.py
+++ b/plugins/operators/annotation.py
@@ -14,6 +14,7 @@ from fiftyone.core.annotation.validate_label_schemas import (
 )
 import fiftyone.core.fields as fof
 import fiftyone.operators as foo
+import fiftyone.operators.types as types
 
 
 class ActivateLabelSchemas(foo.Operator):
@@ -23,6 +24,7 @@ class ActivateLabelSchemas(foo.Operator):
             name="activate_label_schemas",
             label="Activate label schemas",
             unlisted=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def execute(self, ctx):
@@ -37,6 +39,7 @@ class DeleteLabelSchemas(foo.Operator):
             name="delete_label_schemas",
             label="Delete label schemas",
             unlisted=True,
+            risk_level=types.RiskLevel.HIGH,
         )
 
     def execute(self, ctx):
@@ -51,6 +54,7 @@ class DeactivateLabelSchemas(foo.Operator):
             name="deactivate_label_schemas",
             label="Deactivate label schemas",
             unlisted=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def execute(self, ctx):
@@ -65,6 +69,7 @@ class SetActiveLabelSchemas(foo.Operator):
             name="set_active_label_schemas",
             label="Set active label schemas",
             unlisted=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def execute(self, ctx):
@@ -80,6 +85,7 @@ class GenerateLabelSchemas(foo.Operator):
             name="generate_label_schemas",
             label="Generate label schemas",
             unlisted=True,
+            risk_level=types.RiskLevel.LOW,
         )
 
     def execute(self, ctx):
@@ -103,6 +109,7 @@ class GetLabelSchemas(foo.Operator):
             name="get_label_schemas",
             label="Get label schemas",
             unlisted=True,
+            risk_level=types.RiskLevel.LOW,
         )
 
     def execute(self, ctx):
@@ -151,6 +158,7 @@ class UpdateLabelSchema(foo.Operator):
             name="update_label_schema",
             label="Update label schema",
             unlisted=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def execute(self, ctx):
@@ -178,6 +186,7 @@ class ValidateLabelSchemas(foo.Operator):
             name="validate_label_schemas",
             label="Validate label schemas",
             unlisted=True,
+            risk_level=types.RiskLevel.LOW,
         )
 
     def execute(self, ctx):
@@ -210,6 +219,7 @@ class CreateAndActivateField(foo.Operator):
             name="create_and_activate_field",
             label="Create and activate field",
             unlisted=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def execute(self, ctx):
@@ -323,6 +333,7 @@ class ListValidAnnotationFields(foo.Operator):
             name="list_valid_annotation_fields",
             label="List valid annotation fields",
             unlisted=True,
+            risk_level=types.RiskLevel.LOW,
         )
 
     def execute(self, ctx: foo.ExecutionContext):

--- a/plugins/operators/group_by.py
+++ b/plugins/operators/group_by.py
@@ -20,6 +20,7 @@ class GroupBy(foo.Operator):
             label="Group by",
             dynamic=True,
             icon="merge",
+            risk_level=types.RiskLevel.LOW,
         )
 
     def resolve_placement(self, ctx):

--- a/plugins/operators/model_evaluation/__init__.py
+++ b/plugins/operators/model_evaluation/__init__.py
@@ -46,6 +46,7 @@ class ConfigureScenario(foo.Operator):
             label="Configure scenario",
             dynamic=True,
             unlisted=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     @execution_cache(
@@ -1062,6 +1063,7 @@ class ConfigureScenarioPlotResolver(foo.Operator):
             label="Configure scenario plot resolver",
             dynamic=True,
             unlisted=True,
+            risk_level=types.RiskLevel.LOW,
         )
 
     def execute(self, ctx):

--- a/plugins/panels/similarity_search/operators.py
+++ b/plugins/panels/similarity_search/operators.py
@@ -13,6 +13,7 @@ from datetime import datetime, timezone
 import numpy as np
 
 import fiftyone.operators as foo
+import fiftyone.operators.types as types
 
 from .constants import STORE_NAME, RunStatus
 from .run_manager import RunManager
@@ -55,6 +56,7 @@ class SimilaritySearchOperator(foo.Operator):
             unlisted=True,
             allow_immediate_execution=True,
             allow_delegated_execution=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def execute(self, ctx):
@@ -363,6 +365,7 @@ class InitSimilarityRunOperator(foo.Operator):
             name="init_similarity_run",
             label="Initialize Similarity Run",
             unlisted=True,
+            risk_level=types.RiskLevel.MEDIUM,
         )
 
     def execute(self, ctx):
@@ -395,6 +398,7 @@ class ListSimilarityRunsOperator(foo.Operator):
             name="list_similarity_runs",
             label="List Similarity Runs",
             unlisted=True,
+            risk_level=types.RiskLevel.LOW,
         )
 
     def execute(self, ctx):

--- a/tests/unittests/operators/operator_tests.py
+++ b/tests/unittests/operators/operator_tests.py
@@ -1,0 +1,235 @@
+"""
+FiftyOne operator config tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+
+from fiftyone.operators.operator import OperatorConfig
+from fiftyone.operators.types import RiskLevel
+
+
+class TestOperatorConfigDefaults(unittest.TestCase):
+    def test_name_only_defaults(self):
+        config = OperatorConfig("my_op")
+
+        self.assertEqual(config.name, "my_op")
+        self.assertEqual(config.label, "my_op")
+        self.assertIsNone(config.description)
+        self.assertFalse(config.dynamic)
+        self.assertFalse(config.execute_as_generator)
+        self.assertFalse(config.unlisted)
+        self.assertFalse(config.on_startup)
+        self.assertFalse(config.on_dataset_open)
+        self.assertFalse(config.disable_schema_validation)
+        self.assertIsNone(config.delegation_target)
+        self.assertIsNone(config.icon)
+        self.assertIsNone(config.light_icon)
+        self.assertIsNone(config.dark_icon)
+        self.assertTrue(config.allow_immediate_execution)
+        self.assertFalse(config.allow_delegated_execution)
+        self.assertFalse(config.default_choice_to_delegated)
+        self.assertFalse(config.allow_distributed_execution)
+        self.assertTrue(config.rerunnable)
+        self.assertEqual(config.risk_level, RiskLevel.DANGEROUS)
+        self.assertFalse(config.resolve_execution_options_on_change)
+        self.assertEqual(config.kwargs, {})
+
+    def test_label_defaults_to_name(self):
+        config = OperatorConfig("my_op")
+        self.assertEqual(config.label, "my_op")
+
+    def test_label_override(self):
+        config = OperatorConfig("my_op", label="My Op")
+        self.assertEqual(config.label, "My Op")
+
+    def test_all_overrides(self):
+        config = OperatorConfig(
+            "my_op",
+            label="My Op",
+            description="desc",
+            dynamic=True,
+            execute_as_generator=True,
+            unlisted=True,
+            on_startup=True,
+            on_dataset_open=True,
+            disable_schema_validation=True,
+            delegation_target="target",
+            icon="icon.svg",
+            light_icon="light.svg",
+            dark_icon="dark.svg",
+            allow_immediate_execution=False,
+            allow_delegated_execution=True,
+            default_choice_to_delegated=True,
+            resolve_execution_options_on_change=True,
+            rerunnable=False,
+            risk_level=RiskLevel.LOW,
+        )
+
+        self.assertEqual(config.name, "my_op")
+        self.assertEqual(config.label, "My Op")
+        self.assertEqual(config.description, "desc")
+        self.assertTrue(config.dynamic)
+        self.assertTrue(config.execute_as_generator)
+        self.assertTrue(config.unlisted)
+        self.assertTrue(config.on_startup)
+        self.assertTrue(config.on_dataset_open)
+        self.assertTrue(config.disable_schema_validation)
+        self.assertEqual(config.delegation_target, "target")
+        self.assertEqual(config.icon, "icon.svg")
+        self.assertEqual(config.light_icon, "light.svg")
+        self.assertEqual(config.dark_icon, "dark.svg")
+        self.assertFalse(config.allow_immediate_execution)
+        self.assertTrue(config.allow_delegated_execution)
+        self.assertTrue(config.default_choice_to_delegated)
+        self.assertTrue(config.resolve_execution_options_on_change)
+        self.assertFalse(config.rerunnable)
+        self.assertEqual(config.risk_level, RiskLevel.LOW)
+
+
+class TestOperatorConfigDistributedExecution(unittest.TestCase):
+    def test_distributed_execution_forced_false_when_passed_true(self):
+        config = OperatorConfig("my_op", allow_distributed_execution=True)
+        self.assertFalse(config.allow_distributed_execution)
+
+    def test_distributed_execution_default_false(self):
+        config = OperatorConfig("my_op")
+        self.assertFalse(config.allow_distributed_execution)
+
+
+class TestOperatorConfigResolveExecutionOptionsOnChange(unittest.TestCase):
+    def test_defaults_to_dynamic_false(self):
+        config = OperatorConfig("my_op", dynamic=False)
+        self.assertFalse(config.resolve_execution_options_on_change)
+
+    def test_defaults_to_dynamic_true(self):
+        config = OperatorConfig("my_op", dynamic=True)
+        self.assertTrue(config.resolve_execution_options_on_change)
+
+    def test_explicit_overrides_dynamic(self):
+        config = OperatorConfig(
+            "my_op",
+            dynamic=True,
+            resolve_execution_options_on_change=False,
+        )
+        self.assertFalse(config.resolve_execution_options_on_change)
+
+        config = OperatorConfig(
+            "my_op",
+            dynamic=False,
+            resolve_execution_options_on_change=True,
+        )
+        self.assertTrue(config.resolve_execution_options_on_change)
+
+
+class TestOperatorConfigRiskLevel(unittest.TestCase):
+    def test_default_risk_level_is_dangerous(self):
+        config = OperatorConfig("my_op")
+        self.assertEqual(config.risk_level, RiskLevel.DANGEROUS)
+
+    def test_none_risk_level_normalized_to_dangerous(self):
+        config = OperatorConfig("my_op", risk_level=None)
+        self.assertEqual(config.risk_level, RiskLevel.DANGEROUS)
+
+    def test_risk_level_enum(self):
+        for level in RiskLevel:
+            config = OperatorConfig("my_op", risk_level=level)
+            self.assertEqual(config.risk_level, level)
+
+    def test_risk_level_from_string_lowercase(self):
+        config = OperatorConfig("my_op", risk_level="low")
+        self.assertEqual(config.risk_level, RiskLevel.LOW)
+
+    def test_risk_level_from_string_uppercase(self):
+        config = OperatorConfig("my_op", risk_level="HIGH")
+        self.assertEqual(config.risk_level, RiskLevel.HIGH)
+
+    def test_risk_level_from_string_mixed_case(self):
+        config = OperatorConfig("my_op", risk_level="Medium")
+        self.assertEqual(config.risk_level, RiskLevel.MEDIUM)
+
+    def test_invalid_risk_level_string_raises(self):
+        with self.assertRaises(ValueError):
+            OperatorConfig("my_op", risk_level="bogus")
+
+    def test_invalid_risk_level_type_raises(self):
+        with self.assertRaises(ValueError):
+            OperatorConfig("my_op", risk_level=123)
+
+    def test_risk_level_property_is_read_only(self):
+        config = OperatorConfig("my_op", risk_level=RiskLevel.LOW)
+        with self.assertRaises(AttributeError):
+            config.risk_level = RiskLevel.HIGH
+
+
+class TestOperatorConfigKwargs(unittest.TestCase):
+    def test_extra_kwargs_stored(self):
+        config = OperatorConfig("my_op", foo="bar", baz=42)
+        self.assertEqual(config.kwargs, {"foo": "bar", "baz": 42})
+
+    def test_no_kwargs_is_empty_dict(self):
+        config = OperatorConfig("my_op")
+        self.assertEqual(config.kwargs, {})
+
+
+class TestOperatorConfigToJson(unittest.TestCase):
+    def test_to_json_defaults(self):
+        config = OperatorConfig("my_op")
+        expected = {
+            "name": "my_op",
+            "label": "my_op",
+            "description": None,
+            "execute_as_generator": False,
+            "unlisted": False,
+            "dynamic": False,
+            "on_startup": False,
+            "on_dataset_open": False,
+            "disable_schema_validation": False,
+            "delegation_target": None,
+            "icon": None,
+            "light_icon": None,
+            "dark_icon": None,
+            "allow_immediate_execution": True,
+            "allow_delegated_execution": False,
+            "rerunnable": True,
+            "default_choice_to_delegated": False,
+            "resolve_execution_options_on_change": False,
+            "allow_distributed_execution": False,
+            "risk_level": "dangerous",
+        }
+        self.assertEqual(config.to_json(), expected)
+
+    def test_to_json_with_overrides(self):
+        config = OperatorConfig(
+            "my_op",
+            label="My Op",
+            description="desc",
+            dynamic=True,
+            risk_level=RiskLevel.LOW,
+            allow_delegated_execution=True,
+        )
+        result = config.to_json()
+
+        self.assertEqual(result["name"], "my_op")
+        self.assertEqual(result["label"], "My Op")
+        self.assertEqual(result["description"], "desc")
+        self.assertTrue(result["dynamic"])
+        self.assertTrue(result["resolve_execution_options_on_change"])
+        self.assertEqual(result["risk_level"], "low")
+        self.assertTrue(result["allow_delegated_execution"])
+
+    def test_to_json_risk_level_is_string_value(self):
+        for level in RiskLevel:
+            config = OperatorConfig("my_op", risk_level=level)
+            self.assertEqual(config.to_json()["risk_level"], level.value)
+
+    def test_to_json_distributed_execution_always_false(self):
+        config = OperatorConfig("my_op", allow_distributed_execution=True)
+        self.assertFalse(config.to_json()["allow_distributed_execution"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 🔗 Related Issues

No related issue to link

## 📋 What changes are proposed in this pull request?

Add a new `risk_level` config for OperatorConfig mainly used by agents to determine the riskiness of an operator. By default, python operators will be assigned `RiskLevel.DANGEROUS` if not provided and JavaScript operators  will be assigned `RiskLevel.LOW`.

## 🧪 How is this patch tested? If it is not, please explain why.

Using list_operators and unit tests

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

See above

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced operator risk-level classification (LOW, MEDIUM, HIGH, DANGEROUS) with defaults; operators now expose risk metadata across the app and UI surfaces.
  * Many built-in operators, panels, and plugins were annotated with explicit risk tiers to surface safety/impact information to users.

* **Tests**
  * Added unit tests covering operator config defaults, normalization, JSON serialization, and risk-level handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7478)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->