### PR TITLE
Ontology slug uniqueness

### DIFF
--- a/fiftyone/core/odm/ontology.py
+++ b/fiftyone/core/odm/ontology.py
@@ -102,10 +102,16 @@ class OntologyDocument(Document):
             self.reload()
             return self
 
-        # version is internal bookkeeping; compute from the DB on first save
-        # too, so a caller-supplied value can't bypass append-only invariants.
-        # Symmetric with the slug recomputation above.
-        self.version = self._next_version()
+        # First-save defense: refuse to silently append to an existing
+        # lineage. Updates must go through the in_db path (load the
+        # existing doc, mutate, save), which exercises append-only
+        # versioning explicitly.
+        self._reject_if_slug_exists()
+
+        # version is internal bookkeeping; a caller-supplied value is
+        # discarded. We've just verified the slug has no lineage, so the
+        # first version is always 1.
+        self.version = 1
 
         if self.created_at is None:
             self.created_at = now
@@ -131,6 +137,28 @@ class OntologyDocument(Document):
             raise ValueError(
                 "Cannot change ontology slug via save(); use "
                 "rename_ontology() to rename across all versions"
+            )
+
+    # pylint disable: mongoengine's ``objects`` queryset manager is attached
+    # dynamically and not introspectable by pylint.
+    def _reject_if_slug_exists(  # pylint: disable=no-member
+        self,
+    ) -> None:
+        """Raises if any document with this slug is already persisted.
+
+        First-save defense: an unpersisted document whose slug already
+        exists indicates the caller is trying to recreate an ontology
+        that exists. Updates must go through the loaded-doc path, which
+        appends a new version explicitly.
+        """
+        if (
+            OntologyDocument.objects(slug=self.slug).only("id").first()
+            is not None
+        ):
+            raise ValueError(
+                f"Ontology '{self.name}' already exists. To update it, "
+                f"load the existing ontology and save the loaded "
+                f"instance to create a new version."
             )
 
     # pylint disable: mongoengine's ``objects`` queryset manager is attached

--- a/fiftyone/core/odm/ontology.py
+++ b/fiftyone/core/odm/ontology.py
@@ -102,6 +102,11 @@ class OntologyDocument(Document):
             self.reload()
             return self
 
+        # version is internal bookkeeping; compute from the DB on first save
+        # too, so a caller-supplied value can't bypass append-only invariants.
+        # Symmetric with the slug recomputation above.
+        self.version = self._next_version()
+
         if self.created_at is None:
             self.created_at = now
 
@@ -130,21 +135,25 @@ class OntologyDocument(Document):
 
     # pylint disable: mongoengine's ``objects`` queryset manager is attached
     # dynamically and not introspectable by pylint.
-    def _save_as_new_version(  # pylint: disable=no-member
-        self, now: datetime, *args: Any, **kwargs: Any
-    ) -> OntologyDocument:
-        # Append-only versioning: create a new document instead of updating
-        # the existing one.
+    def _next_version(  # pylint: disable=no-member
+        self,
+    ) -> int:
+        """Returns the next version number for this slug's lineage."""
         latest = (
             OntologyDocument.objects(slug=self.slug)
             .order_by("-version")
             .only("version")
             .first()
         )
-        next_version = (latest.version + 1) if latest else 1
+        return (latest.version + 1) if latest else 1
 
+    def _save_as_new_version(
+        self, now: datetime, *args: Any, **kwargs: Any
+    ) -> OntologyDocument:
+        # Append-only versioning: create a new document instead of updating
+        # the existing one.
         new_doc = self.copy_with_new_id()
-        new_doc.version = next_version
+        new_doc.version = self._next_version()
         new_doc.schema_version = CURRENT_SCHEMA_VERSION
         new_doc.created_at = now
         new_doc.last_modified_at = now

--- a/tests/unittests/ontology_tests.py
+++ b/tests/unittests/ontology_tests.py
@@ -12,7 +12,6 @@ import unittest
 from datetime import datetime, timezone
 
 from mongoengine.errors import ValidationError
-from pymongo.errors import DuplicateKeyError
 
 import fiftyone.core.odm as foo
 from fiftyone.core.odm import ontology as foo_ontology
@@ -120,21 +119,40 @@ class OntologyDocumentTests(unittest.TestCase):
         self.assertIn("when", loaded.root["attributes"][1])
         self.assertEqual(loaded.root["taxonomies"], ["vehicle_classes"])
 
-    def test_name_version_uniqueness(self):
-        OntologyDocument(
-            name="test_ontology",
-            version=1,
+    def test_caller_supplied_version_overwritten_on_first_save(self):
+        # version is internal bookkeeping; a caller-supplied value on a
+        # brand-new slug is silently replaced with 1.
+        doc = OntologyDocument(
+            name="brand_new_slug",
+            version=99,
             type=OntologyType.TAXONOMY,
             root={"name": "root"},
-        ).save()
+        )
+        doc.save()
+        self.assertEqual(doc.version, 1)
 
-        with self.assertRaises(DuplicateKeyError):
+    def test_caller_supplied_version_overwritten_for_existing_slug(self):
+        # When the slug already has a lineage, a fresh document with a
+        # caller-supplied version is bumped to next-from-DB instead of
+        # honoring the supplied value.
+        for v in range(1, 4):
             OntologyDocument(
-                name="test_ontology",
-                version=1,
+                name="lineage",
                 type=OntologyType.TAXONOMY,
-                root={"name": "root"},
+                root={"name": "root", "v": v},
             ).save()
+
+        # Now the slug has versions 1, 2, 3. A new construction with
+        # version=99 should land at 4, not 99.
+        new_doc = OntologyDocument(
+            name="lineage",
+            version=99,
+            type=OntologyType.TAXONOMY,
+            root={"name": "root", "v": "fresh"},
+        )
+        new_doc.save()
+        self.assertEqual(new_doc.version, 4)
+        self.assertEqual(OntologyDocument.objects(slug="lineage").count(), 4)
 
     def test_multiple_versions(self):
         for v in range(1, 4):
@@ -271,21 +289,25 @@ class OntologyDocumentTests(unittest.TestCase):
 
         self.assertEqual(doc.slug, "my-ontology-v1")
 
-    def test_case_insensitive_uniqueness(self):
+    def test_case_variant_names_land_in_same_lineage(self):
+        # "Cars" and "CARS" normalize to the same slug, so two new-doc
+        # saves append to the same lineage (versions 1 and 2) rather than
+        # colliding on the unique (slug, version) index — the version is
+        # computed from the DB on each save.
         OntologyDocument(
             name="Cars",
-            version=1,
             type=OntologyType.TAXONOMY,
             root={"name": "root"},
         ).save()
 
-        with self.assertRaises(DuplicateKeyError):
-            OntologyDocument(
-                name="CARS",
-                version=1,
-                type=OntologyType.TAXONOMY,
-                root={"name": "root"},
-            ).save()
+        OntologyDocument(
+            name="CARS",
+            type=OntologyType.TAXONOMY,
+            root={"name": "root"},
+        ).save()
+
+        docs = OntologyDocument.objects(slug="cars").order_by("version")
+        self.assertEqual([d.version for d in docs], [1, 2])
 
     def test_slug_differs_across_versions(self):
         for v in range(1, 4):

--- a/tests/unittests/ontology_tests.py
+++ b/tests/unittests/ontology_tests.py
@@ -131,38 +131,54 @@ class OntologyDocumentTests(unittest.TestCase):
         doc.save()
         self.assertEqual(doc.version, 1)
 
-    def test_caller_supplied_version_overwritten_for_existing_slug(self):
-        # When the slug already has a lineage, a fresh document with a
-        # caller-supplied version is bumped to next-from-DB instead of
-        # honoring the supplied value.
-        for v in range(1, 4):
+    def test_first_save_raises_when_slug_already_exists(self):
+        # Recreating an existing ontology via fresh construction is
+        # rejected. To create a new version, callers must load the
+        # existing instance and save the loaded copy.
+        OntologyDocument(
+            name="cars",
+            type=OntologyType.TAXONOMY,
+            root={"name": "root"},
+        ).save()
+
+        with self.assertRaises(ValueError):
             OntologyDocument(
-                name="lineage",
+                name="cars",
                 type=OntologyType.TAXONOMY,
-                root={"name": "root", "v": v},
+                root={"name": "root"},
             ).save()
 
-        # Now the slug has versions 1, 2, 3. A new construction with
-        # version=99 should land at 4, not 99.
-        new_doc = OntologyDocument(
-            name="lineage",
-            version=99,
+    def test_first_save_raises_for_case_variant_of_existing_slug(self):
+        # Case-only variants normalize to the same slug, so they hit the
+        # existing-slug defense too.
+        OntologyDocument(
+            name="Cars",
             type=OntologyType.TAXONOMY,
-            root={"name": "root", "v": "fresh"},
-        )
-        new_doc.save()
-        self.assertEqual(new_doc.version, 4)
-        self.assertEqual(OntologyDocument.objects(slug="lineage").count(), 4)
+            root={"name": "root"},
+        ).save()
+
+        with self.assertRaises(ValueError):
+            OntologyDocument(
+                name="CARS",
+                type=OntologyType.TAXONOMY,
+                root={"name": "root"},
+            ).save()
 
     def test_multiple_versions(self):
-        for v in range(1, 4):
-            OntologyDocument(
-                name="versioned",
-                version=v,
-                type=OntologyType.TAXONOMY,
-                description=f"Version {v}",
-                root={"name": "root", "version_data": v},
-            ).save()
+        # Successive versions of the same slug are produced via the
+        # load+save (in_db) path; first-save with an existing slug raises.
+        doc = OntologyDocument(
+            name="versioned",
+            type=OntologyType.TAXONOMY,
+            description="Version 1",
+            root={"name": "root", "version_data": 1},
+        )
+        doc.save()
+
+        for v in range(2, 4):
+            doc.description = f"Version {v}"
+            doc.root = {"name": "root", "version_data": v}
+            doc.save()
 
         all_versions = OntologyDocument.objects(name="versioned")
         self.assertEqual(all_versions.count(), 3)
@@ -217,23 +233,22 @@ class OntologyDocumentTests(unittest.TestCase):
         self.assertEqual(restored.version, doc.version)
         self.assertEqual(restored.root, doc.root)
 
-    def test_same_name_different_types(self):
+    def test_same_name_different_types_rejected(self):
+        # The (slug, version) lineage doesn't distinguish by type, so a
+        # second ontology with the same name — even of a different type —
+        # collides with the existing-slug defense and is rejected.
         OntologyDocument(
             name="shared_name",
-            version=1,
             type=OntologyType.TAXONOMY,
             root={"name": "root"},
         ).save()
 
-        OntologyDocument(
-            name="shared_name",
-            version=2,
-            type=OntologyType.ANNOTATION_ONTOLOGY,
-            root={"classes": [], "attributes": [], "taxonomies": []},
-        ).save()
-
-        docs = OntologyDocument.objects(name="shared_name")
-        self.assertEqual(docs.count(), 2)
+        with self.assertRaises(ValueError):
+            OntologyDocument(
+                name="shared_name",
+                type=OntologyType.ANNOTATION_ONTOLOGY,
+                root={"classes": [], "attributes": [], "taxonomies": []},
+            ).save()
 
     def test_query_by_type(self):
         OntologyDocument(
@@ -289,34 +304,17 @@ class OntologyDocumentTests(unittest.TestCase):
 
         self.assertEqual(doc.slug, "my-ontology-v1")
 
-    def test_case_variant_names_land_in_same_lineage(self):
-        # "Cars" and "CARS" normalize to the same slug, so two new-doc
-        # saves append to the same lineage (versions 1 and 2) rather than
-        # colliding on the unique (slug, version) index — the version is
-        # computed from the DB on each save.
-        OntologyDocument(
-            name="Cars",
+    def test_slug_consistent_across_versions(self):
+        # Successive versions of the same ontology share the same slug;
+        # versions are produced via the load+save (in_db) path.
+        doc = OntologyDocument(
+            name="My Ontology",
             type=OntologyType.TAXONOMY,
             root={"name": "root"},
-        ).save()
-
-        OntologyDocument(
-            name="CARS",
-            type=OntologyType.TAXONOMY,
-            root={"name": "root"},
-        ).save()
-
-        docs = OntologyDocument.objects(slug="cars").order_by("version")
-        self.assertEqual([d.version for d in docs], [1, 2])
-
-    def test_slug_differs_across_versions(self):
-        for v in range(1, 4):
-            OntologyDocument(
-                name="My Ontology",
-                version=v,
-                type=OntologyType.TAXONOMY,
-                root={"name": "root"},
-            ).save()
+        )
+        doc.save()
+        for _ in range(2):
+            doc.save()
 
         docs = OntologyDocument.objects(slug="my-ontology")
         self.assertEqual(docs.count(), 3)

--- a/tests/unittests/server/routes/test_ontology.py
+++ b/tests/unittests/server/routes/test_ontology.py
@@ -99,10 +99,12 @@ class TestOntologiesRoute:
 
     @pytest.mark.asyncio
     async def test_only_latest_version_per_name(self, endpoint, mock_request):
-        for v in (1, 2, 3):
-            OntologyDocument(
-                name="foo", version=v, type=OntologyType.ANNOTATION_ONTOLOGY
-            ).save()
+        doc = OntologyDocument(
+            name="foo", type=OntologyType.ANNOTATION_ONTOLOGY
+        )
+        doc.save()
+        for _ in range(2):
+            doc.save()
 
         response = await endpoint.get(mock_request())
 


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Because we have uniqueness constraints on (`slug`, `version`) It's very important that the user cannot override the version and that it's maintained internally. This adds validation checks and overrides to make sure that this is enforced strictly. 

To some degree, it is Python still and probably could be bypassed. But I think this very strongly enforces it on the SDK side and should prevent any accidental conflicts. 

## 🧪 How is this patch tested? If it is not, please explain why.

Tested locally and unit tests. 

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents accidental creation of duplicate ontologies with the same identifier (slug), including case-only variants.
  * Forces initial version to 1 on first save, overriding any caller-supplied value to ensure consistent versioning.
  * Rejects creating a new ontology with the same name but different type to preserve lineage integrity.
* **Tests**
  * Expanded tests covering first-save behavior, versioning rules, slug uniqueness, multi-version saves, and adjusted route test to exercise in-db versioning via repeated saves.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7479)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->