### PR TITLE
rename _source marker to source_ontology

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/AttributeFormContent.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/AttributeFormContent.tsx
@@ -132,7 +132,7 @@ const AttributeFormContent = ({
             <Text variant={TextVariant.Md} color={TextColor.Secondary}>
               Ontology:
             </Text>
-            <Text variant={TextVariant.Md}>{formState._source}</Text>
+            <Text variant={TextVariant.Md}>{formState.source_ontology}</Text>
           </Stack>
         )}
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/AttributesSection.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/AttributesSection.tsx
@@ -131,7 +131,7 @@ const AttributesSection = ({
           onDelete: handleDeleteAttribute,
           canDrag: true,
           isEditing: true,
-          readOnly: !!config._source,
+          readOnly: !!config.source_ontology,
         });
       }
 
@@ -161,7 +161,9 @@ const AttributesSection = ({
                 {secondaryParts.join(" · ")}
               </Text>
               {config.read_only && <Pill size={Size.Md}>Read-only</Pill>}
-              {config._source && <Pill size={Size.Md}>{config._source}</Pill>}
+              {config.source_ontology && (
+                <Pill size={Size.Md}>{config.source_ontology}</Pill>
+              )}
             </Stack>
           ),
           actions: <EditAction onEdit={() => handleStartEdit(name)} />,

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/useAttributeForm.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/useAttributeForm.ts
@@ -65,7 +65,7 @@ export default function useAttributeForm({
   const isIntegerType =
     formState.type === "int" || formState.type === "list<int>";
   const isListType = LIST_TYPES.includes(formState.type);
-  const isFromOntology = !!formState._source;
+  const isFromOntology = !!formState.source_ontology;
   const whenPreview = useMemo(() => {
     const conditions = formState.when;
     if (!conditions || conditions.length === 0) return null;

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/utils.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/utils.ts
@@ -63,7 +63,7 @@ export interface AttributeConfig {
   default?: string | number | (string | number)[]; // Array for list types
   read_only?: boolean;
   when?: AttributeCondition[];
-  _source?: string;
+  source_ontology?: string;
 }
 
 // Class configuration
@@ -96,7 +96,7 @@ export interface AttributeFormData {
   listDefault: (string | number)[]; // For list types
   read_only: boolean;
   when?: AttributeCondition[];
-  _source?: string;
+  source_ontology?: string;
 }
 
 // =============================================================================
@@ -312,7 +312,7 @@ export const toFormData = (config: AttributeConfig): AttributeFormData => {
     listDefault,
     read_only: config.read_only || false,
     when: config.when,
-    _source: config._source,
+    source_ontology: config.source_ontology,
   };
 };
 

--- a/fiftyone/core/annotation/hydrate_label_schemas.py
+++ b/fiftyone/core/annotation/hydrate_label_schemas.py
@@ -3,7 +3,7 @@ Annotation label schema hydration
 
 Resolves ``applied_ontology`` references in label schemas by merging the
 referenced annotation ontology's attributes into the schema's ``attributes``
-list, tagging merged attributes with a ``_source`` marker.
+list, tagging merged attributes with a ``source_ontology`` marker.
 
 | Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
@@ -19,7 +19,7 @@ import fiftyone.core.annotation.constants as foac
 
 logger = logging.getLogger(__name__)
 
-_SOURCE = "_source"
+SOURCE_ONTOLOGY = "source_ontology"
 
 
 def hydrate_applied_ontology(label_schema: dict) -> dict:
@@ -29,8 +29,8 @@ def hydrate_applied_ontology(label_schema: dict) -> dict:
     If ``label_schema`` has an ``applied_ontology`` key that resolves to an
     annotation ontology, returns a new dict with the ontology's attributes
     merged into the ``attributes`` list. Each merged attribute carries a
-    ``_source: <ontology_name>`` marker. Attributes are matched by ``name``
-    and ontology values win on collision.
+    ``source_ontology: <ontology_name>`` marker. Attributes are matched by
+    ``name`` and ontology values win on collision.
 
     If the schema has no ``applied_ontology`` reference, the schema is
     returned unchanged. If the reference is dangling (deleted ontology)
@@ -87,7 +87,7 @@ def dehydrate_applied_ontology(label_schema: dict) -> dict:
     Companion to :func:`hydrate_applied_ontology`. When the schema has an
     ``applied_ontology`` that resolves to an annotation ontology, drops
     any attribute whose ``name`` matches an ontology-owned attribute and
-    strips the ``_source`` marker from the remaining attributes.
+    strips the ``source_ontology`` marker from the remaining attributes.
 
     Otherwise (no reference, dangling reference, or non-annotation
     reference) the schema is returned unchanged — the validator will
@@ -121,11 +121,11 @@ def dehydrate_applied_ontology(label_schema: dict) -> dict:
     cleaned = copy.deepcopy(label_schema)
     kept = []
     for attr in cleaned.get(foac.ATTRIBUTES, []):
-        # ontology-owned attrs get dropped entirely, so their _source goes
-        # with them; only the kept (local) attrs need _source popped
+        # ontology-owned attrs get dropped entirely, so their source_ontology
+        # goes with them; only the kept (local) attrs need it popped
         if attr.get(foac.NAME) in ontology_owned_names:
             continue
-        attr.pop(_SOURCE, None)
+        attr.pop(SOURCE_ONTOLOGY, None)
         kept.append(attr)
 
     cleaned[foac.ATTRIBUTES] = kept
@@ -140,7 +140,7 @@ def inline_applied_ontology(label_schema: dict, ontology: Any) -> dict:
     Used when the referenced ontology is about to be deleted (or for
     any other "freeze the current ontology state into the schema"
     operation). Unlike :func:`hydrate_applied_ontology`, the merged
-    attributes are NOT marked with ``_source`` — they are now
+    attributes are NOT marked with ``source_ontology`` — they are now
     first-class local attributes — and the ``applied_ontology`` key
     is stripped from the result.
 
@@ -158,7 +158,7 @@ def inline_applied_ontology(label_schema: dict, ontology: Any) -> dict:
     """
     merged = _merge(label_schema, ontology)
     for attr in merged.get(foac.ATTRIBUTES, []):
-        attr.pop(_SOURCE, None)
+        attr.pop(SOURCE_ONTOLOGY, None)
     merged.pop(foac.APPLIED_ONTOLOGY, None)
     return merged
 
@@ -173,7 +173,7 @@ def _merge(label_schema: dict, ontology: Any) -> dict:
 
     for attr_spec in ontology.attributes:
         attr_dict = attr_spec.to_dict()
-        attr_dict[_SOURCE] = ontology.name
+        attr_dict[SOURCE_ONTOLOGY] = ontology.name
         name = attr_dict.get(foac.NAME)
         if name not in by_name:
             ordered_names.append(name)

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1817,9 +1817,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             ExceptionGroup: if the label schema is invalid
         """
         # Defensive: the frontend is expected to submit a schema with no
-        # ontology-sourced attributes or _source markers, but strip them here
-        # regardless so a hand-edited / malformed payload cannot persist
-        # ontology content as local copies.
+        # ontology-sourced attributes or source_ontology markers, but strip
+        # them here regardless so a hand-edited / malformed payload cannot
+        # persist ontology content as local copies.
         label_schema = foa.dehydrate_applied_ontology(label_schema)
         foa.validate_label_schemas(
             self,

--- a/tests/unittests/annotation/dataset_label_schemas_tests.py
+++ b/tests/unittests/annotation/dataset_label_schemas_tests.py
@@ -463,8 +463,8 @@ class DatasetAnnotationTests(unittest.TestCase):
         dataset.set_label_schemas({"detections": {"type": "detections"}})
 
         # simulate the frontend echoing back a hydrated schema: an
-        # ontology-owned attribute with a _source marker, plus a local
-        # attribute that somehow acquired a forged _source
+        # ontology-owned attribute with a source_ontology marker, plus a local
+        # attribute that somehow acquired a forged source_ontology
         hydrated_payload = {
             "type": "detections",
             "applied_ontology": "my_ontology",
@@ -473,13 +473,13 @@ class DatasetAnnotationTests(unittest.TestCase):
                     "name": "owned",
                     "type": "bool",
                     "component": "checkbox",
-                    "_source": "my_ontology",
+                    "source_ontology": "my_ontology",
                 },
                 {
                     "name": "local",
                     "type": "str",
                     "component": "text",
-                    "_source": "forged",
+                    "source_ontology": "forged",
                 },
             ],
         }
@@ -490,7 +490,7 @@ class DatasetAnnotationTests(unittest.TestCase):
         saved = dataset.label_schemas["detections"]
         names = [a["name"] for a in saved["attributes"]]
         self.assertEqual(names, ["local"])
-        self.assertNotIn("_source", saved["attributes"][0])
+        self.assertNotIn("source_ontology", saved["attributes"][0])
 
 
 def _make_applied_ontology_test_dataset(ontology_name: str = "my_ontology"):

--- a/tests/unittests/annotation/hydrate_label_schemas_tests.py
+++ b/tests/unittests/annotation/hydrate_label_schemas_tests.py
@@ -55,7 +55,9 @@ class HydrateLabelSchemasTests(unittest.TestCase):
         result = hydrate_applied_ontology(schema)
         self.assertEqual(len(result["attributes"]), 1)
         self.assertEqual(result["attributes"][0]["name"], "damage_location")
-        self.assertEqual(result["attributes"][0]["_source"], "my_ontology")
+        self.assertEqual(
+            result["attributes"][0]["source_ontology"], "my_ontology"
+        )
 
     @drop_datasets
     @drop_ontologies
@@ -84,7 +86,7 @@ class HydrateLabelSchemasTests(unittest.TestCase):
         color = result["attributes"][0]
         self.assertEqual(color["component"], "dropdown")
         self.assertEqual(color["values"], ["red", "blue"])
-        self.assertEqual(color["_source"], "my_ontology")
+        self.assertEqual(color["source_ontology"], "my_ontology")
 
     @drop_datasets
     @drop_ontologies
@@ -115,8 +117,8 @@ class HydrateLabelSchemasTests(unittest.TestCase):
         ontology_attr = next(
             a for a in result["attributes"] if a["name"] == "damage"
         )
-        self.assertNotIn("_source", local)
-        self.assertEqual(ontology_attr["_source"], "my_ontology")
+        self.assertNotIn("source_ontology", local)
+        self.assertEqual(ontology_attr["source_ontology"], "my_ontology")
 
     @drop_datasets
     @drop_ontologies
@@ -167,7 +169,7 @@ class DehydrateLabelSchemasTests(unittest.TestCase):
                     "name": "color",
                     "type": "str",
                     "component": "text",
-                    "_source": "stray",
+                    "source_ontology": "stray",
                 }
             ],
         }
@@ -192,7 +194,7 @@ class DehydrateLabelSchemasTests(unittest.TestCase):
                     "name": "owned",
                     "type": "bool",
                     "component": "checkbox",
-                    "_source": "my_ontology",
+                    "source_ontology": "my_ontology",
                 },
                 {"name": "local", "type": "str", "component": "text"},
             ],
@@ -203,7 +205,7 @@ class DehydrateLabelSchemasTests(unittest.TestCase):
 
     @drop_datasets
     @drop_ontologies
-    def test_source_stripped_from_local_attributes(self):
+    def test_source_ontology_stripped_from_local_attributes(self):
         AnnotationOntology(
             name="my_ontology",
             attributes=[
@@ -219,12 +221,12 @@ class DehydrateLabelSchemasTests(unittest.TestCase):
                     "name": "local",
                     "type": "str",
                     "component": "text",
-                    "_source": "forged",
+                    "source_ontology": "forged",
                 },
             ],
         }
         result = dehydrate_applied_ontology(schema)
-        self.assertNotIn("_source", result["attributes"][0])
+        self.assertNotIn("source_ontology", result["attributes"][0])
 
     @drop_datasets
     @drop_ontologies
@@ -237,7 +239,7 @@ class DehydrateLabelSchemasTests(unittest.TestCase):
                     "name": "local",
                     "type": "str",
                     "component": "text",
-                    "_source": "stray",
+                    "source_ontology": "stray",
                 }
             ],
         }

--- a/tests/unittests/ontology_delete_tests.py
+++ b/tests/unittests/ontology_delete_tests.py
@@ -125,7 +125,7 @@ class DeleteOntologyTests(unittest.TestCase):
 
         ds.reload()
         for attr in ds._doc.label_schemas["ground_truth"]["attributes"]:
-            self.assertNotIn("_source", attr)
+            self.assertNotIn("source_ontology", attr)
 
     def test_force_inlines_across_multiple_datasets(self) -> None:
         _make_ontology()


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

This refactors the dynamically populated `_source` variable to `source_ontology` so it is more clear to the client what this field actually refers to. 

## 🧪 How is this patch tested? If it is not, please explain why.

Tested locally in browser and SDK, Unit tests still passing 

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
