### PR TITLE
fix flaky test_sort_by_last_modified_desc

### DIFF
--- a/tests/unittests/server/routes/test_ontology.py
+++ b/tests/unittests/server/routes/test_ontology.py
@@ -8,6 +8,7 @@ FiftyOne Server ontology route unit tests.
 
 import json
 import os
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -76,15 +77,19 @@ class TestOntologiesRoute:
 
     @pytest.mark.asyncio
     async def test_sort_by_last_modified_desc(self, endpoint, mock_request):
-        OntologyDocument(
+        base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        first = OntologyDocument(
             name="first", type=OntologyType.ANNOTATION_ONTOLOGY
         ).save()
-        OntologyDocument(
+        first.modify(set__last_modified_at=base)
+        second = OntologyDocument(
             name="second", type=OntologyType.ANNOTATION_ONTOLOGY
         ).save()
-        OntologyDocument(
+        second.modify(set__last_modified_at=base + timedelta(seconds=1))
+        third = OntologyDocument(
             name="third", type=OntologyType.ANNOTATION_ONTOLOGY
         ).save()
+        third.modify(set__last_modified_at=base + timedelta(seconds=2))
 
         response = await endpoint.get(mock_request())
 


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

sub ms DB writes cause these three ontologies to be written at the same time stamp. Which returns an unexpected order when sorting by last modified at.

change these to be explicitly updated to expected last modified add order 

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined ontology sorting test data setup to use fixed, time zone-aware timestamps, ensuring consistent and reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->