### PR TITLE
[HA] (polylines 3/n) Add undoable commands for polyline edit actions

### DIFF
--- a/app/packages/lighter/src/commands/AddPolylinePointCommand.ts
+++ b/app/packages/lighter/src/commands/AddPolylinePointCommand.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import type { Undoable } from "@fiftyone/commands";
+import type { PolylineOverlay } from "../overlay/PolylineOverlay";
+
+/**
+ * Undoable command for adding a single point to a PolylineOverlay.
+ *
+ * When `createsNewSegment` is `true`, redo splices a new segment slot at
+ * `segmentIdx` before placing the point — this matches the gesture where a
+ * user begins a new line with the first click. Undo removes the point; the
+ * empty segment slot drops automatically.
+ */
+export class AddPolylinePointCommand implements Undoable {
+  readonly id: string;
+  readonly description: string;
+
+  constructor(
+    private overlay: PolylineOverlay,
+    private segmentIdx: number,
+    private indexInSegment: number,
+    private pointId: string,
+    private relativePosition: [number, number],
+    private variant?: string,
+    private createsNewSegment: boolean = false
+  ) {
+    this.id = `add-polyline-point-${pointId}-${Date.now()}`;
+    this.description = `Add polyline point ${pointId}`;
+  }
+
+  execute(): void {
+    if (this.createsNewSegment) {
+      this.overlay.insertPointInNewSegment(
+        this.segmentIdx,
+        this.relativePosition,
+        this.variant,
+        this.pointId
+      );
+    } else {
+      this.overlay.insertPointInSegment(
+        this.segmentIdx,
+        this.indexInSegment,
+        this.relativePosition,
+        this.variant,
+        this.pointId
+      );
+    }
+  }
+
+  undo(): void {
+    this.overlay.removePointFromSegment(this.segmentIdx, this.indexInSegment);
+  }
+}

--- a/app/packages/lighter/src/commands/RemovePolylinePointCommand.ts
+++ b/app/packages/lighter/src/commands/RemovePolylinePointCommand.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import type { Undoable } from "@fiftyone/commands";
+import type { PolylineOverlay } from "../overlay/PolylineOverlay";
+
+/**
+ * Undoable command for removing a single point from a PolylineOverlay.
+ *
+ * The constructor captures the point's id, relative position, variant, and
+ * whether it was the segment's sole inhabitant — so undo restores both the
+ * point and (when needed) the segment slot.
+ */
+export class RemovePolylinePointCommand implements Undoable {
+  readonly id: string;
+  readonly description: string;
+
+  private readonly pointId: string;
+  private readonly relativePosition: [number, number];
+  private readonly variant?: string;
+  private readonly wasSoleInSegment: boolean;
+
+  constructor(
+    private overlay: PolylineOverlay,
+    private segmentIdx: number,
+    private indexInSegment: number
+  ) {
+    const id = overlay.getPointIdInSegment(segmentIdx, indexInSegment);
+    if (id === null) {
+      throw new Error(
+        `RemovePolylinePointCommand: no point at segment ${segmentIdx} index ${indexInSegment}`
+      );
+    }
+
+    const entry = overlay.getPointById(id);
+    if (!entry) {
+      throw new Error(
+        `RemovePolylinePointCommand: missing entry for point ${id}`
+      );
+    }
+
+    this.pointId = id;
+    this.relativePosition = entry.position;
+    this.variant = entry.variant;
+    this.wasSoleInSegment = overlay.getSegmentLength(segmentIdx) === 1;
+
+    this.id = `remove-polyline-point-${id}-${Date.now()}`;
+    this.description = `Remove polyline point ${id}`;
+  }
+
+  execute(): void {
+    this.overlay.removePointFromSegment(this.segmentIdx, this.indexInSegment);
+  }
+
+  undo(): void {
+    if (this.wasSoleInSegment) {
+      this.overlay.insertPointInNewSegment(
+        this.segmentIdx,
+        this.relativePosition,
+        this.variant,
+        this.pointId
+      );
+    } else {
+      this.overlay.insertPointInSegment(
+        this.segmentIdx,
+        this.indexInSegment,
+        this.relativePosition,
+        this.variant,
+        this.pointId
+      );
+    }
+  }
+}

--- a/app/packages/lighter/src/overlay/KeypointOverlay.ts
+++ b/app/packages/lighter/src/overlay/KeypointOverlay.ts
@@ -720,6 +720,20 @@ export class KeypointOverlay
   }
 
   /**
+   * Returns the id of the point at the given flat-array index, or `null` if
+   * the index is out of range.
+   *
+   * @param index Flat-array index across all points.
+   */
+  protected getPointIdAt(index: number): string | null {
+    if (index < 0 || index >= this.#points.length) {
+      return null;
+    }
+
+    return this.#points[index].id;
+  }
+
+  /**
    * Inserts a point at the given flat-array index using relative coordinates.
    *
    * Connections referencing indices >= `index` are shifted up by one.

--- a/app/packages/lighter/src/overlay/PolylineOverlay.ts
+++ b/app/packages/lighter/src/overlay/PolylineOverlay.ts
@@ -367,6 +367,61 @@ export class PolylineOverlay extends KeypointOverlay {
   }
 
   /**
+   * Splices a new segment at `segmentIdx` containing a single point. Existing
+   * segments at or after that index shift up by one. Use this for the
+   * "start new line + place first point" gesture, and to undo a removal that
+   * dropped a segment slot.
+   *
+   * @param segmentIdx Zero-based index for the new segment, in the inclusive
+   *  range `[0, segmentCount]`. A value equal to `segmentCount` appends a
+   *  trailing segment.
+   * @param relPoint Relative-coordinate position `[x, y]` of the new point.
+   * @param variant Optional variant key used to determine render style.
+   * @param id Optional point id; one is generated when omitted.
+   * @returns The id of the new point.
+   * @throws RangeError if `segmentIdx` is out of range.
+   */
+  insertPointInNewSegment(
+    segmentIdx: number,
+    relPoint: [number, number],
+    variant?: string,
+    id?: string
+  ): string {
+    if (segmentIdx < 0 || segmentIdx > this.segmentBoundaries.length) {
+      throw new RangeError(
+        `PolylineOverlay: segmentIdx ${segmentIdx} out of bounds [0, ${this.segmentBoundaries.length}]`
+      );
+    }
+
+    const segStart = this.segmentStart(segmentIdx);
+    this.segmentBoundaries.splice(segmentIdx, 0, segStart);
+    return this.insertPointInSegment(segmentIdx, 0, relPoint, variant, id);
+  }
+
+  /**
+   * Returns the id of the point at `(segmentIdx, indexInSegment)`, or `null`
+   * if either coordinate is out of range.
+   *
+   * @param segmentIdx Zero-based segment index.
+   * @param indexInSegment Zero-based position within the segment.
+   */
+  getPointIdInSegment(
+    segmentIdx: number,
+    indexInSegment: number
+  ): string | null {
+    if (segmentIdx < 0 || segmentIdx >= this.segmentBoundaries.length) {
+      return null;
+    }
+
+    const segLen = this.getSegmentLength(segmentIdx);
+    if (indexInSegment < 0 || indexInSegment >= segLen) {
+      return null;
+    }
+
+    return this.getPointIdAt(this.segmentStart(segmentIdx) + indexInSegment);
+  }
+
+  /**
    * Locates the closest edge to `worldPoint` within `thresholdOverride` (or
    * the default `EDGE_THRESHOLD` adjusted for the current scale).
    *


### PR DESCRIPTION
## 🔗 Related Issues

PR 3/n in the 2d polyline stack

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

Adds undoable commands for point creation + deletion.

## 🧪 How is this patch tested? If it is not, please explain why.

local

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced undo/redo functionality for polyline point operations, enabling users to add and remove individual points with complete reversibility
  * Enhanced polyline editing with dynamic segment creation capabilities for improved drawing and annotation workflows
  * Added support for reverting point removal operations to restore annotations to previous states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->