### PR TITLE
[HA] (polylines 4/n) Implement interactive polyline handler

### DIFF
--- a/app/packages/lighter/src/interaction/InteractionManager.ts
+++ b/app/packages/lighter/src/interaction/InteractionManager.ts
@@ -13,7 +13,21 @@ import type { SelectionManager } from "../selection/SelectionManager";
 import type { Point, Rect } from "../types";
 import { InteractiveDetectionHandler } from "./InteractiveDetectionHandler";
 import { InteractiveKeypointHandler } from "./InteractiveKeypointHandler";
+import { InteractivePolylineHandler } from "./InteractivePolylineHandler";
 import { v4 as generateUUID } from "uuid";
+
+/**
+ * Predicate for interactive handlers that own their own pointer-event
+ * dispatch (drag, hit-testing, etc.) and shouldn't have events forwarded to
+ * their `getOverlay()`. The default routing — defer to the wrapped overlay —
+ * applies to creation handlers like {@link InteractiveDetectionHandler}.
+ */
+function isSelfManagedInteractiveHandler(handler: InteractionHandler): boolean {
+  return (
+    handler instanceof InteractiveKeypointHandler ||
+    handler instanceof InteractivePolylineHandler
+  );
+}
 
 /**
  * Interface for handlers that support sub-selecting and removing individual
@@ -281,12 +295,11 @@ export class InteractionManager {
     const interactiveHandler = this.getInteractiveHandler();
 
     if (interactiveHandler) {
-      handler =
-        interactiveHandler instanceof InteractiveKeypointHandler
-          ? // keypoint handlers manage their own placement
-            interactiveHandler
-          : // otherwise defer to the handler's overlay
-            interactiveHandler.getOverlay();
+      handler = isSelfManagedInteractiveHandler(interactiveHandler)
+        ? // self-managed handlers route their own pointer events
+          interactiveHandler
+        : // otherwise defer to the handler's overlay
+          interactiveHandler.getOverlay();
       this.selectionManager.select(interactiveHandler.getOverlay().id);
     } else {
       handler = this.findHandlerAtPoint(point);
@@ -484,12 +497,11 @@ export class InteractionManager {
           this.maintainAspectRatio
         );
       } else {
-        handler =
-          interactiveHandler instanceof InteractiveKeypointHandler
-            ? // keypoint handlers manage their own points
-              interactiveHandler
-            : // otherwise defer to the handler's overlay
-              interactiveHandler.getOverlay();
+        handler = isSelfManagedInteractiveHandler(interactiveHandler)
+          ? // self-managed handlers route their own move events
+            interactiveHandler
+          : // otherwise defer to the handler's overlay
+            interactiveHandler.getOverlay();
 
         handler.onMove?.(
           point,
@@ -555,12 +567,11 @@ export class InteractionManager {
     const interactiveHandler = this.getInteractiveHandler();
 
     if (interactiveHandler) {
-      handler =
-        interactiveHandler instanceof InteractiveKeypointHandler
-          ? // keypoint handlers manage their own points
-            interactiveHandler
-          : // otherwise defer to the handler's overlay
-            interactiveHandler.getOverlay();
+      handler = isSelfManagedInteractiveHandler(interactiveHandler)
+        ? // self-managed handlers route their own pointer-up events
+          interactiveHandler
+        : // otherwise defer to the handler's overlay
+          interactiveHandler.getOverlay();
     } else {
       handler = this.findMovingHandler() || this.findHandlerAtPoint(point);
     }
@@ -853,11 +864,16 @@ export class InteractionManager {
 
   private getInteractiveHandler():
     | InteractiveKeypointHandler
+    | InteractivePolylineHandler
     | InteractiveDetectionHandler
     | undefined {
-    // keypoint handlers take precedence to allow placing points on top of detections
+    // self-managed handlers take precedence to allow editing on top of detections
+    const selfManaged = this.handlers.find((h) =>
+      isSelfManagedInteractiveHandler(h)
+    ) as InteractiveKeypointHandler | InteractivePolylineHandler | undefined;
+
     return (
-      this.handlers.find((h) => h instanceof InteractiveKeypointHandler) ??
+      selfManaged ??
       this.handlers.find((h) => h instanceof InteractiveDetectionHandler)
     );
   }

--- a/app/packages/lighter/src/interaction/InteractivePolylineHandler.ts
+++ b/app/packages/lighter/src/interaction/InteractivePolylineHandler.ts
@@ -1,0 +1,366 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { CommandContextManager } from "@fiftyone/commands";
+import { ClickEventModifiers, getClickModifiers } from "@fiftyone/utilities";
+import { AddPolylinePointCommand } from "../commands/AddPolylinePointCommand";
+import { MoveKeypointPointCommand } from "../commands/MoveKeypointPointCommand";
+import { RemovePolylinePointCommand } from "../commands/RemovePolylinePointCommand";
+import type { PolylineOverlay } from "../overlay/PolylineOverlay";
+import type { Point } from "../types";
+import type { InteractionHandler } from "./InteractionManager";
+import {
+  KeypointPointHitAction,
+  type KeypointPointHitContext,
+} from "./InteractiveKeypointHandler";
+import { KeypointOverlay } from "../overlay/KeypointOverlay";
+
+const INTERACTIVE_POLYLINE_HANDLER_ID = "interactive-polyline-handler";
+
+/**
+ * Action returned by the edge-hit resolver. `undefined` falls through to the
+ * default ({@link PolylineEdgeHitAction.INSERT}).
+ */
+export enum PolylineEdgeHitAction {
+  INSERT = "insert",
+  IGNORE = "ignore",
+}
+
+/**
+ * Action returned by the empty-space-hit resolver. `undefined` falls through
+ * to the default ({@link PolylineEmptyHitAction.EXTEND}).
+ */
+export enum PolylineEmptyHitAction {
+  EXTEND = "extend",
+  NEW_SEGMENT = "new-segment",
+  IGNORE = "ignore",
+}
+
+/**
+ * Context passed to the edge-hit resolver when a click lands on an existing
+ * polyline edge.
+ */
+export type PolylineEdgeHitContext = {
+  segmentIdx: number;
+  edgeIdx: number;
+  /** Click projected onto the matched edge, in relative coordinates. */
+  projectedRel: Point;
+  modifiers: ClickEventModifiers;
+};
+
+/**
+ * Context passed to the empty-space-hit resolver when a click lands away
+ * from any point or edge.
+ */
+export type PolylineEmptyHitContext = {
+  worldPoint: Point;
+  relativePoint: Point;
+  modifiers: ClickEventModifiers;
+};
+
+/**
+ * Editing handler for an existing {@link PolylineOverlay}.
+ *
+ * Captures all clicks while active and dispatches them by hit kind:
+ *
+ * - **Hit on an existing point** — drag (default), or whatever the
+ *   `resolvePointHit` resolver returns (e.g. `DELETE` on Alt-click).
+ * - **Hit on an edge** — insert a new point at the projected position
+ *   (default), or whatever `resolveEdgeHit` returns. After insert, the new
+ *   point enters drag immediately so the user can fine-tune its position.
+ * - **Empty-space click** — extend the nearest segment endpoint (default),
+ *   `NEW_SEGMENT` to start a fresh segment, or whatever `resolveEmptyHit`
+ *   returns.
+ *
+ * Resolvers are optional; sensible defaults cover the common case. Returning
+ * `undefined` from a resolver also falls through to the default. Each
+ * mutation pushes an undoable command onto the active context;
+ * {@link pruneCommands} removes everything pushed by this handler instance,
+ * for use when an editing session is cancelled.
+ */
+export class InteractivePolylineHandler implements InteractionHandler {
+  readonly id = INTERACTIVE_POLYLINE_HANDLER_ID;
+  readonly cursor = "crosshair";
+
+  private readonly pushedCommandIds = new Set<string>();
+
+  private dragPointId: string | null = null;
+  private dragStartRelative: [number, number] | null = null;
+
+  constructor(
+    public readonly overlay: PolylineOverlay,
+    private readonly resolvePointHit?: (
+      ctx: KeypointPointHitContext
+    ) => KeypointPointHitAction | undefined,
+    private readonly resolveEdgeHit?: (
+      ctx: PolylineEdgeHitContext
+    ) => PolylineEdgeHitAction | undefined,
+    private readonly resolveEmptyHit?: (
+      ctx: PolylineEmptyHitContext
+    ) => PolylineEmptyHitAction | undefined
+  ) {}
+
+  containsPoint(): boolean {
+    // Capture all clicks while active
+    return true;
+  }
+
+  getOverlay(): PolylineOverlay {
+    return this.overlay;
+  }
+
+  isMoving(): boolean {
+    return this.dragPointId !== null;
+  }
+
+  isDragging(): boolean {
+    return this.dragPointId !== null;
+  }
+
+  markDirty(): void {
+    this.overlay.markDirty();
+  }
+
+  onPointerDown(
+    _point: Point,
+    worldPoint: Point,
+    event: PointerEvent
+  ): boolean {
+    const modifiers = getClickModifiers(event);
+    const rp = this.overlay.absolutePointToRelative(worldPoint);
+    const relativePoint: Point = { x: rp[0], y: rp[1] };
+
+    // 1) Existing point?
+    const hitId = this.overlay.findPointIdAt(worldPoint);
+    if (hitId) {
+      const action = this.resolvePointHit?.({
+        pointId: hitId,
+        relativePoint,
+        modifiers,
+      });
+
+      if (action === KeypointPointHitAction.DELETE) {
+        this.deletePointById(hitId);
+      } else {
+        this.startDrag(hitId);
+      }
+
+      return true;
+    }
+
+    // 2) Edge?
+    const edgeHit = this.overlay.findEdgeAt(worldPoint);
+    if (edgeHit) {
+      const action =
+        this.resolveEdgeHit?.({
+          segmentIdx: edgeHit.segmentIdx,
+          edgeIdx: edgeHit.edgeIdx,
+          projectedRel: {
+            x: edgeHit.projectedRel[0],
+            y: edgeHit.projectedRel[1],
+          },
+          modifiers,
+        }) ?? PolylineEdgeHitAction.INSERT;
+
+      if (action === PolylineEdgeHitAction.IGNORE) {
+        return true;
+      }
+
+      const newId = this.insertOnEdge(edgeHit);
+      this.startDrag(newId);
+      return true;
+    }
+
+    // 3) Empty space.
+    const action =
+      this.resolveEmptyHit?.({
+        worldPoint,
+        relativePoint,
+        modifiers,
+      }) ?? PolylineEmptyHitAction.EXTEND;
+
+    if (action === PolylineEmptyHitAction.IGNORE) {
+      return true;
+    }
+
+    if (action === PolylineEmptyHitAction.NEW_SEGMENT) {
+      this.startNewSegmentWithPoint(rp);
+      return true;
+    }
+
+    this.extendNearestEndpoint(worldPoint, rp);
+    return true;
+  }
+
+  onMove(_point: Point, worldPoint: Point, _event: PointerEvent): boolean {
+    if (this.dragPointId !== null) {
+      this.overlay.movePointById(
+        this.dragPointId,
+        this.overlay.absolutePointToRelative(worldPoint)
+      );
+
+      return true;
+    }
+
+    // Hover preview — telegraphs where the next click will place a point.
+    this.overlay.setPreviewPoint(worldPoint);
+
+    return true;
+  }
+
+  onPointerUp(_point: Point, _event: PointerEvent): boolean {
+    if (this.dragPointId === null) {
+      return true;
+    }
+
+    const id = this.dragPointId;
+    const from = this.dragStartRelative;
+    const entry = this.overlay.getPointById(id);
+
+    this.dragPointId = null;
+    this.dragStartRelative = null;
+
+    if (!entry || !from) {
+      return true;
+    }
+
+    const to = entry.position;
+    if (from[0] === to[0] && from[1] === to[1]) {
+      return true;
+    }
+
+    const cmd = new MoveKeypointPointCommand(
+      this.overlay as unknown as KeypointOverlay,
+      id,
+      from,
+      to
+    );
+    CommandContextManager.instance().getActiveContext().pushUndoable(cmd);
+    this.pushedCommandIds.add(cmd.id);
+
+    return true;
+  }
+
+  cleanup(): void {
+    this.overlay.setPreviewPoint(null);
+  }
+
+  /**
+   * Removes all undo/redo entries that this handler pushed during its
+   * lifetime from the active command context.
+   */
+  pruneCommands(): void {
+    if (this.pushedCommandIds.size === 0) return;
+
+    CommandContextManager.instance()
+      .getActiveContext()
+      .pruneUndoables((u) => this.pushedCommandIds.has(u.id));
+
+    this.pushedCommandIds.clear();
+  }
+
+  private startDrag(pointId: string): void {
+    const entry = this.overlay.getPointById(pointId);
+    if (!entry) {
+      return;
+    }
+
+    this.dragPointId = pointId;
+    this.dragStartRelative = [entry.position[0], entry.position[1]];
+  }
+
+  private deletePointById(pointId: string): void {
+    const loc = this.overlay.findPointLocationById(pointId);
+    if (!loc) {
+      return;
+    }
+
+    const cmd = new RemovePolylinePointCommand(
+      this.overlay,
+      loc.segmentIdx,
+      loc.indexInSegment
+    );
+    cmd.execute();
+    CommandContextManager.instance().getActiveContext().pushUndoable(cmd);
+    this.pushedCommandIds.add(cmd.id);
+  }
+
+  private insertOnEdge(edgeHit: {
+    segmentIdx: number;
+    edgeIdx: number;
+    projectedRel: [number, number];
+  }): string {
+    // Inserting after edgeIdx means new point sits at indexInSegment = edgeIdx + 1.
+    // For closing edges (edgeIdx === segLen - 1) that resolves to segLen, which
+    // appends — closure auto-reforms.
+    const indexInSegment = edgeHit.edgeIdx + 1;
+    const newId = this.overlay.insertPointInSegment(
+      edgeHit.segmentIdx,
+      indexInSegment,
+      edgeHit.projectedRel
+    );
+
+    const cmd = new AddPolylinePointCommand(
+      this.overlay,
+      edgeHit.segmentIdx,
+      indexInSegment,
+      newId,
+      edgeHit.projectedRel
+    );
+    CommandContextManager.instance().getActiveContext().pushUndoable(cmd);
+    this.pushedCommandIds.add(cmd.id);
+
+    return newId;
+  }
+
+  private startNewSegmentWithPoint(rp: [number, number]): string {
+    const newSegIdx = this.overlay.startNewSegment();
+    const newId = this.overlay.appendPointToSegment(newSegIdx, rp);
+
+    const cmd = new AddPolylinePointCommand(
+      this.overlay,
+      newSegIdx,
+      0,
+      newId,
+      rp,
+      undefined,
+      true
+    );
+    CommandContextManager.instance().getActiveContext().pushUndoable(cmd);
+    this.pushedCommandIds.add(cmd.id);
+
+    return newId;
+  }
+
+  private extendNearestEndpoint(
+    worldPoint: Point,
+    rp: [number, number]
+  ): string {
+    const target = this.overlay.findNearestEndpoint(worldPoint);
+    // No segments yet — extend gesture seeds the first segment.
+    if (!target) {
+      return this.startNewSegmentWithPoint(rp);
+    }
+
+    const segLen = this.overlay.getSegmentLength(target.segmentIdx);
+    const indexInSegment = target.end === "head" ? 0 : segLen;
+
+    const newId = this.overlay.insertPointInSegment(
+      target.segmentIdx,
+      indexInSegment,
+      rp
+    );
+    const cmd = new AddPolylinePointCommand(
+      this.overlay,
+      target.segmentIdx,
+      indexInSegment,
+      newId,
+      rp
+    );
+    CommandContextManager.instance().getActiveContext().pushUndoable(cmd);
+    this.pushedCommandIds.add(cmd.id);
+
+    return newId;
+  }
+}

--- a/app/packages/lighter/src/overlay/PolylineOverlay.ts
+++ b/app/packages/lighter/src/overlay/PolylineOverlay.ts
@@ -422,6 +422,31 @@ export class PolylineOverlay extends KeypointOverlay {
   }
 
   /**
+   * Returns the `(segmentIdx, indexInSegment)` coordinates of the point with
+   * the given id, or `null` if no such point exists. Inverse of
+   * {@link getPointIdInSegment}.
+   *
+   * @param pointId Id of the point to locate.
+   */
+  findPointLocationById(
+    pointId: string
+  ): { segmentIdx: number; indexInSegment: number } | null {
+    const total = this.getRelativePoints().length;
+
+    for (let i = 0; i < total; i++) {
+      if (this.getPointIdAt(i) === pointId) {
+        const segmentIdx = this.locateSegmentForIndex(i);
+        return {
+          segmentIdx,
+          indexInSegment: i - this.segmentStart(segmentIdx),
+        };
+      }
+    }
+
+    return null;
+  }
+
+  /**
    * Locates the closest edge to `worldPoint` within `thresholdOverride` (or
    * the default `EDGE_THRESHOLD` adjusted for the current scale).
    *


### PR DESCRIPTION
## 🔗 Related Issues

PR 4/n in the 2d polyline stack

## 📋 What changes are proposed in this pull request?

Implements foundation of `PolylineInteractiveHandler` for mapping user interactions to overlay

## 🧪 How is this patch tested? If it is not, please explain why.

local

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Polyline editing now supports interactive pointer-based manipulation, enabling users to hover for previews, drag individual points, add points by clicking on edges or segments, and remove points through click actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->