### PR TITLE
[HA] (polylines 5/n) Implement hook to manage polyline editing state

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/usePolylineMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/usePolylineMode.ts
@@ -18,8 +18,13 @@ import { fieldsOfType, useAnnotationContext } from "./state";
  * Active flag for 2D polyline annotation mode. While `true`, selecting a
  * polyline overlay installs an {@link InteractivePolylineHandler} on it; the
  * handler is torn down on selection change or mode deactivation.
+ *
+ * This atom is exported (as `_unsafe…`) for inspection from non-React code
+ * such as InteractionManager bridges; React code should use
+ * {@link usePolylineMode} instead.
  */
 const polylineModeActiveAtom = atom<boolean>(false);
+export { polylineModeActiveAtom as _unsafePolylineModeActiveAtom };
 
 /**
  * Modifier policy: Alt-click on a point deletes it.
@@ -37,18 +42,18 @@ const resolveEmptyHit = (ctx: PolylineEmptyHitContext) =>
 /**
  * Centralized hook for 2D polyline annotation mode.
  *
- * Lifecycle:
- * - Toggling on activates the mode; toggling off exits.
- * - While active, whenever the currently-edited annotation is a 2D polyline,
- *   an {@link InteractivePolylineHandler} is installed via
- *   `scene.enterInteractiveMode`. Selecting a different label or deselecting
- *   tears the handler down; the next polyline selection installs a fresh
- *   one.
- * - 3D polyline labels (`PolylineAnnotationLabel` whose overlay isn't a
- *   real `PolylineOverlay`) are ignored — they have their own annotation
- *   pipeline.
+ * Two paths activate the mode:
  *
- * Creation of new polylines is wired up separately (see `useCreate`).
+ * 1. **Toolbar toggle** — primes the UX for creating a new polyline. No
+ *    overlay is selected yet.
+ * 2. **Selection of a 2D polyline** — auto-activates the mode (if not
+ *    already) and installs an {@link InteractivePolylineHandler} on the
+ *    selected overlay via `scene.enterInteractiveMode`.
+ *
+ * The mode exits when:
+ *
+ * - The deactivation function is called explicitly, or
+ * - Selection moves from a 2D polyline to a different label, or to nothing.
  */
 export const usePolylineMode = () => {
   const [polylineModeActive, setPolylineModeActive] = useAtom(
@@ -83,24 +88,43 @@ export const usePolylineMode = () => {
     installedHandlerRef.current = null;
   }, [scene]);
 
-  // Install / re-install / tear down based on selection while mode is active.
+  // Selection drives the mode. Selecting a 2D polyline activates polyline
+  // mode; selecting a non-polyline (or deselecting) exits it.
+  // Toolbar activations with no selection are preserved (the previous selection
+  // ref lets us distinguish "no change" from "user deselected").
+  const prevSelectedLabelRef = useRef(selectedLabel);
+  useEffect(() => {
+    const prev = prevSelectedLabelRef.current;
+    prevSelectedLabelRef.current = selectedLabel;
+
+    const isPolyline2d =
+      selectedLabel?.type === "Polyline" &&
+      selectedLabel.overlay instanceof PolylineOverlay;
+
+    const wasPolyline2d =
+      prev?.type === "Polyline" && prev.overlay instanceof PolylineOverlay;
+
+    if (isPolyline2d) {
+      setPolylineModeActive(true);
+    } else if (wasPolyline2d) {
+      // Selection moved away from a polyline (different label or deselect).
+      setPolylineModeActive(false);
+    }
+    // Otherwise the selection isn't (and wasn't) a polyline — leave the mode
+    // alone so toolbar-driven activations stick around for creation.
+  }, [selectedLabel, setPolylineModeActive]);
+
+  // Mode + selection drive the installed handler.
   useEffect(() => {
     if (!scene) {
       return;
     }
 
-    if (!polylineModeActive) {
-      exitInstalledHandler();
-      return;
-    }
-
-    // Only target real 2D PolylineOverlay instances. 3D polyline labels use
-    // a generic overlay shape and have a separate pipeline.
     const isPolyline2d =
       selectedLabel?.type === "Polyline" &&
       selectedLabel.overlay instanceof PolylineOverlay;
 
-    if (!isPolyline2d) {
+    if (!polylineModeActive || !isPolyline2d) {
       exitInstalledHandler();
       return;
     }

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/usePolylineMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/usePolylineMode.ts
@@ -1,0 +1,168 @@
+import {
+  InteractivePolylineHandler,
+  KeypointPointHitAction,
+  KeypointPointHitContext,
+  PolylineEmptyHitAction,
+  PolylineEmptyHitContext,
+  PolylineOverlay,
+  useLighter,
+} from "@fiftyone/lighter";
+import { isPatchesView } from "@fiftyone/state";
+import { POLYLINE } from "@fiftyone/utilities";
+import { atom, useAtom, useAtomValue } from "jotai";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useRecoilValue } from "recoil";
+import { fieldsOfType, useAnnotationContext } from "./state";
+
+/**
+ * Active flag for 2D polyline annotation mode. While `true`, selecting a
+ * polyline overlay installs an {@link InteractivePolylineHandler} on it; the
+ * handler is torn down on selection change or mode deactivation.
+ */
+const polylineModeActiveAtom = atom<boolean>(false);
+
+/**
+ * Modifier policy: Alt-click on a point deletes it.
+ */
+const resolvePointHit = (ctx: KeypointPointHitContext) =>
+  ctx.modifiers.altKey ? KeypointPointHitAction.DELETE : undefined;
+
+/**
+ * Modifier policy: Shift-click on empty space starts a new segment instead
+ * of extending the nearest endpoint.
+ */
+const resolveEmptyHit = (ctx: PolylineEmptyHitContext) =>
+  ctx.modifiers.shiftKey ? PolylineEmptyHitAction.NEW_SEGMENT : undefined;
+
+/**
+ * Centralized hook for 2D polyline annotation mode.
+ *
+ * Lifecycle:
+ * - Toggling on activates the mode; toggling off exits.
+ * - While active, whenever the currently-edited annotation is a 2D polyline,
+ *   an {@link InteractivePolylineHandler} is installed via
+ *   `scene.enterInteractiveMode`. Selecting a different label or deselecting
+ *   tears the handler down; the next polyline selection installs a fresh
+ *   one.
+ * - 3D polyline labels (`PolylineAnnotationLabel` whose overlay isn't a
+ *   real `PolylineOverlay`) are ignored — they have their own annotation
+ *   pipeline.
+ *
+ * Creation of new polylines is wired up separately (see `useCreate`).
+ */
+export const usePolylineMode = () => {
+  const [polylineModeActive, setPolylineModeActive] = useAtom(
+    polylineModeActiveAtom
+  );
+  const { scene } = useLighter();
+  const { selectedLabel } = useAnnotationContext();
+  const isPatchView = useRecoilValue(isPatchesView);
+  const fields = useAtomValue(fieldsOfType(POLYLINE));
+
+  // The handler currently installed via scene.enterInteractiveMode, or null
+  // when no polyline is selected (or the mode is off).
+  const installedHandlerRef = useRef<InteractivePolylineHandler | null>(null);
+
+  const noActiveFields = fields.length === 0;
+  const disabled = isPatchView || noActiveFields;
+
+  const tooltip = isPatchView
+    ? "Editing polylines is not supported in this view"
+    : noActiveFields
+    ? "No active fields"
+    : polylineModeActive
+    ? "Exit polyline mode"
+    : "Edit polylines";
+
+  const exitInstalledHandler = useCallback(() => {
+    if (!installedHandlerRef.current) {
+      return;
+    }
+
+    scene?.exitInteractiveMode();
+    installedHandlerRef.current = null;
+  }, [scene]);
+
+  // Install / re-install / tear down based on selection while mode is active.
+  useEffect(() => {
+    if (!scene) {
+      return;
+    }
+
+    if (!polylineModeActive) {
+      exitInstalledHandler();
+      return;
+    }
+
+    // Only target real 2D PolylineOverlay instances. 3D polyline labels use
+    // a generic overlay shape and have a separate pipeline.
+    const isPolyline2d =
+      selectedLabel?.type === "Polyline" &&
+      selectedLabel.overlay instanceof PolylineOverlay;
+
+    if (!isPolyline2d) {
+      exitInstalledHandler();
+      return;
+    }
+
+    const targetOverlay = selectedLabel.overlay as PolylineOverlay;
+
+    // Already installed for this overlay — nothing to do.
+    if (installedHandlerRef.current?.overlay === targetOverlay) {
+      return;
+    }
+
+    // Different overlay (or first install) — swap handlers.
+    exitInstalledHandler();
+
+    const handler = new InteractivePolylineHandler(
+      targetOverlay,
+      resolvePointHit,
+      undefined,
+      resolveEmptyHit
+    );
+
+    scene.enterInteractiveMode(handler);
+    installedHandlerRef.current = handler;
+  }, [exitInstalledHandler, polylineModeActive, scene, selectedLabel]);
+
+  // Tear down on unmount (e.g., scene swap, modal close).
+  useEffect(() => {
+    return () => {
+      exitInstalledHandler();
+    };
+  }, [exitInstalledHandler]);
+
+  const activatePolylineMode = useCallback(
+    () => setPolylineModeActive(true),
+    [setPolylineModeActive]
+  );
+
+  const deactivatePolylineMode = useCallback(
+    () => setPolylineModeActive(false),
+    [setPolylineModeActive]
+  );
+
+  const togglePolylineMode = useCallback(() => {
+    setPolylineModeActive((prev) => !prev);
+  }, [setPolylineModeActive]);
+
+  return useMemo(
+    () => ({
+      polylineModeActive,
+      disabled,
+      tooltip,
+      activatePolylineMode,
+      deactivatePolylineMode,
+      togglePolylineMode,
+    }),
+    [
+      polylineModeActive,
+      disabled,
+      tooltip,
+      activatePolylineMode,
+      deactivatePolylineMode,
+      togglePolylineMode,
+    ]
+  );
+};

--- a/app/packages/lighter/src/index.ts
+++ b/app/packages/lighter/src/index.ts
@@ -53,6 +53,15 @@ export {
   KeypointPointHitAction,
 } from "./interaction/InteractiveKeypointHandler";
 export type { KeypointPointHitContext } from "./interaction/InteractiveKeypointHandler";
+export {
+  InteractivePolylineHandler,
+  PolylineEdgeHitAction,
+  PolylineEmptyHitAction,
+} from "./interaction/InteractivePolylineHandler";
+export type {
+  PolylineEdgeHitContext,
+  PolylineEmptyHitContext,
+} from "./interaction/InteractivePolylineHandler";
 
 // Selection exports
 export type { Selectable } from "./selection/Selectable";


### PR DESCRIPTION
## 🔗 Related Issues

PR 5/n in the 2d polyline stack

## 📋 What changes are proposed in this pull request?

Implements the base `usePolylineMode` hook to manage the polyline editing state

## 🧪 How is this patch tested? If it is not, please explain why.

local

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive polyline annotation editing mode with the ability to modify 2D polylines
  * Implemented point editing controls using keyboard modifiers: Alt+click to delete points, Shift+click to create new segments
  * New toolbar option to toggle polyline editing mode on and off

<!-- end of auto-generated comment: release notes by coderabbit.ai -->