### PR TITLE
Release notes/enterprise v2.18.1

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -3,6 +3,24 @@ FiftyOne Release Notes
 
 .. default-role:: code
 
+FiftyOne Enterprise 2.18.1
+--------------------------
+*Released May 7, 2026*
+
+App
+
+- Fixed a bug that caused global cloud credentials to incorrectly appear under
+  the "Groups" tab on the Cloud credentials settings page when no groups
+  existed in the system
+
+Security
+
+- Updated a number of dependencies in the FiftyOne Enterprise App in order to
+  resolve security vulnerabilities: `picomatch`, `protobufjs`,
+  `@xmldom/xmldom`, and `langchain-core`
+- Updated a number of dependencies in the FiftyOne Enterprise API in order to
+  resolve security vulnerabilities: `ujson` and `pyjwt`
+
 FiftyOne Enterprise 2.18.0
 --------------------------
 *Released May 1, 2026*

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import os
 from setuptools import setup, find_packages
 
 
-VERSION = "1.15.1"
+VERSION = "1.15.0"
 
 
 def get_version():

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import os
 from setuptools import setup, find_packages
 
 
-VERSION = "1.15.0"
+VERSION = "1.15.1"
 
 
 def get_version():


### PR DESCRIPTION
## 🔗 Related Issues

n/a

## 📋 What changes are proposed in this pull request?

The fiftyone-enterprise v2.18.1 is now an enterprise only release.  Thus I cherry-picked the release notes from the `release/v1.15.1` branch and reverted the `setup.py`'s `VERSION`change. 

## 🧪 How is this patch tested? If it is not, please explain why.

n/a

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes for FiftyOne Enterprise 2.18.1 with bug fix details addressing cloud credentials visibility in the Groups tab when no groups exist.
  * Documented security-related updates for Enterprise App and Enterprise API components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->