### PR TITLE
Support URL filepaths

### DIFF
--- a/fiftyone/core/odm/sample.py
+++ b/fiftyone/core/odm/sample.py
@@ -49,6 +49,8 @@ type :class:`NoDatasetSampleDocument` to type ``dataset._sample_doc_cls``::
 from collections import OrderedDict
 import random
 
+import eta.core.web as etaw
+
 import fiftyone.core.fields as fof
 import fiftyone.core.metadata as fom
 import fiftyone.core.media as fomm
@@ -113,7 +115,9 @@ class NoDatasetSampleDocument(NoDatasetMixin, SerializableDocument):
     )
 
     def __init__(self, **kwargs):
-        filepath = fos.normalize_path(kwargs["filepath"])
+        filepath = kwargs["filepath"]
+        if not etaw.is_url(filepath):
+            filepath = fos.normalize_path(filepath)
 
         kwargs["id"] = kwargs.get("id", None)
         kwargs["filepath"] = filepath

--- a/tests/unittests/sample_tests.py
+++ b/tests/unittests/sample_tests.py
@@ -37,6 +37,13 @@ class SampleTests(unittest.TestCase):
         self.assertEqual(sample.filepath, abs_filepath)
 
     @drop_datasets
+    def test_url_filepath(self):
+        filepath = "https://example.com/file.png"
+
+        sample = fo.Sample(filepath=filepath)
+        self.assertEqual(sample.filepath, filepath)
+
+    @drop_datasets
     def test_get_field(self):
         field_value = "custom_value"
         sample = fo.Sample(filepath="/path/to/image.jpg", field1=field_value)
@@ -239,6 +246,17 @@ class SampleInDatasetTests(unittest.TestCase):
             dataset.add_sample(sample)
 
         self.assertEqual(len(dataset), 0)
+
+    @drop_datasets
+    def test_add_sample_with_url_filepath(self):
+        dataset = fo.Dataset()
+        filepath = "https://example.com/file.png"
+
+        sample = fo.Sample(filepath=filepath)
+        dataset.add_sample(sample)
+
+        self.assertEqual(sample.filepath, filepath)
+        self.assertEqual(dataset.first().filepath, filepath)
 
     @drop_datasets
     def test_dataset_clear(self):


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Preserve URL filepaths when constructing samples.

Previously, `fo.Sample(filepath="https://...")` treated the URL as a local relative path and normalized it into an absolute disk path. This keeps URL filepaths unchanged using the existing URL detection helper, while preserving local filepath normalization behavior.

## 🧪 How is this patch tested? If it is not, please explain why.

Added unit coverage for:

- `fo.Sample(filepath=url)` preserving the URL

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

FiftyOne now preserves URL filepaths passed to `fo.Sample(filepath=...)` instead of converting them to local absolute paths.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of URL-based file paths in samples. URLs are now properly preserved in their original form when creating individual samples and when adding samples to datasets, instead of being incorrectly converted to local file paths. This ensures consistent behavior when working with remote file resources across sample operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->