### PR TITLE
FOEPD-3788: Enforce drag boundaries and polish interactive sidebar UX

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Sidebar.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Sidebar.tsx
@@ -1,15 +1,17 @@
 import {
-  activeFields,
   ANNOTATE,
   EXPLORE,
+  activeFields,
   datasetName,
   modalMode,
+  useDisabledCheckboxPaths,
   useModalExplorEntries,
 } from "@fiftyone/state";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useEffect } from "react";
 import { useRecoilValue } from "recoil";
 import ExploreSidebar from "../../Sidebar";
+import { createExploreIsDisabled } from "../../Sidebar/InteractiveSidebar";
 import SidebarContainer from "../../Sidebar/SidebarContainer";
 import Annotate from "./Annotate";
 import { AnnotationSliceSelector } from "./Annotate/AnnotationSliceSelector";
@@ -22,10 +24,11 @@ import { useModalSidebarRenderEntry } from "./use-sidebar-render-entry";
 
 const Explore = () => {
   const renderEntry = useModalSidebarRenderEntry();
+  const disabled = useDisabledCheckboxPaths();
 
   return (
     <ExploreSidebar
-      isDisabled={() => false}
+      isDisabled={createExploreIsDisabled(disabled)}
       render={renderEntry}
       useEntries={useModalExplorEntries}
       modal={true}

--- a/app/packages/core/src/components/Modal/Sidebar/use-sidebar-render-entry.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/use-sidebar-render-entry.tsx
@@ -23,8 +23,8 @@ export const useModalSidebarRenderEntry = () => {
     ) => {
       switch (entry.kind) {
         case fos.EntryKind.PATH: {
-          const isTag = entry.path === "tags";
-          const isLabelTag = entry.path === "_label_tags";
+          const isTag = entry.path === fos.TAGS_FIELD;
+          const isLabelTag = entry.path === fos.LABEL_TAGS_FIELD;
           const isLabel = labelPaths.includes(entry.path);
           const isOther = disabled.has(entry.path);
           const isFieldPrimitive =
@@ -74,6 +74,9 @@ export const useModalSidebarRenderEntry = () => {
                 name={entry.name}
                 modal={true}
                 key={key}
+                mutable={
+                  ![fos.OTHER_GROUP, fos.TAGS_FIELD].includes(entry.name)
+                }
                 trigger={trigger}
               />
             ),

--- a/app/packages/core/src/components/SamplesContainer.tsx
+++ b/app/packages/core/src/components/SamplesContainer.tsx
@@ -8,6 +8,7 @@ import MainSpace from "./MainSpace";
 import SchemaSettings from "./Schema/SchemaSettings";
 import { Entries, default as RenderSidebar } from "./Sidebar";
 import { Filter } from "./Sidebar/Entries";
+import { createExploreIsDisabled } from "./Sidebar/InteractiveSidebar";
 import SidebarContainer from "./Sidebar/SidebarContainer";
 import ViewSelection from "./Sidebar/ViewSelection";
 
@@ -74,7 +75,9 @@ const Sidebar = () => {
                 key={key}
                 name={entry.name}
                 modal={false}
-                mutable={!["other", "tags"].includes(entry.name)}
+                mutable={
+                  ![fos.OTHER_GROUP, fos.TAGS_FIELD].includes(entry.name)
+                }
                 trigger={trigger}
               />
             ),
@@ -120,7 +123,7 @@ const Sidebar = () => {
       </TopContainer>
 
       <RenderSidebar
-        isDisabled={() => false}
+        isDisabled={createExploreIsDisabled(disabled)}
         useEntries={fos.useGridEntries}
         render={renderGridEntry}
         modal={false}

--- a/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
@@ -25,8 +25,8 @@ const Draggable: React.FC<
 
   const disableDrag =
     !entryKey ||
-    entryKey.split(",")[1]?.includes("tags") ||
-    entryKey.split(",")[1]?.includes("_label_tags") ||
+    entryKey.split(",")[1]?.includes(fos.TAGS_FIELD) ||
+    entryKey.split(",")[1]?.includes(fos.LABEL_TAGS_FIELD) ||
     disabled ||
     isFieldVisibilityApplied;
   const active = trigger && (dragging || hovering) && !disableDrag;
@@ -34,13 +34,8 @@ const Draggable: React.FC<
   const style = useSpring({
     width: active ? 20 : 5,
     left: active ? -10 : 0,
-    cursor: disableDrag
-      ? "default"
-      : entryKey && trigger
-      ? dragging
-        ? "grabbing"
-        : "grab"
-      : "pointer",
+    cursor:
+      !trigger || disableDrag ? "default" : dragging ? "grabbing" : "grab",
   });
   const dataCyKey = entryKey
     ?.split(",")?.[1]
@@ -94,7 +89,7 @@ const Draggable: React.FC<
         }}
         title={title}
       >
-        {active && <DragIndicator style={{ color: theme.background.level1 }} />}
+        {active && <DragIndicator style={{ color: theme.background.level2 }} />}
       </animated.div>
       <div style={{ width: "100%" }}>{children}</div>
     </>

--- a/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
@@ -23,10 +23,22 @@ const Draggable: React.FC<
   const disabled = canModifySidebarGroup.enabled !== true;
   const isFieldVisibilityApplied = useRecoilValue(fos.isFieldVisibilityActive);
 
+  const entryPath = useMemo(() => {
+    if (!entryKey) return undefined;
+    try {
+      const parsed = JSON.parse(entryKey);
+      return Array.isArray(parsed)
+        ? (parsed[1] as string | undefined)
+        : undefined;
+    } catch {
+      return undefined;
+    }
+  }, [entryKey]);
+
   const disableDrag =
     !entryKey ||
-    entryKey.split(",")[1]?.includes(fos.TAGS_FIELD) ||
-    entryKey.split(",")[1]?.includes(fos.LABEL_TAGS_FIELD) ||
+    entryPath === fos.TAGS_FIELD ||
+    entryPath === fos.LABEL_TAGS_FIELD ||
     disabled ||
     isFieldVisibilityApplied;
   const active = trigger && (dragging || hovering) && !disableDrag;
@@ -37,11 +49,6 @@ const Draggable: React.FC<
     cursor:
       !trigger || disableDrag ? "default" : dragging ? "grabbing" : "grab",
   });
-  const dataCyKey = entryKey
-    ?.split(",")?.[1]
-    ?.replace(/["]/g, "")
-    ?.replace("]", "");
-
   const isDraggable = useMemo(
     () => !disableDrag && trigger && !disabled,
     [disableDrag, trigger, disabled]
@@ -57,7 +64,7 @@ const Draggable: React.FC<
     <>
       <animated.div
         data-draggable={isDraggable}
-        data-cy={`sidebar-entry-draggable-${dataCyKey}`}
+        data-cy={`sidebar-entry-draggable-${entryPath}`}
         onClick={(event) => {
           event.stopPropagation();
         }}

--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/FilterablePathEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/FilterablePathEntry.tsx
@@ -1,5 +1,6 @@
 import { useTheme } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
+import { useSidebarExpandedState } from "@fiftyone/state";
 import { makePseudoField } from "@fiftyone/utilities";
 import { Checkbox } from "@mui/material";
 import Color from "color";
@@ -10,8 +11,6 @@ import RegularEntry from "../RegularEntry";
 import FilterablePathEntries from "./FilterablePathEntries";
 import Loading from "./Loading";
 import useTitleTemplate from "./useTitleTemplate";
-
-const LABEL_TAGS = "_label_tags";
 
 const useOnClick = ({ modal, path }: { modal: boolean; path: string }) => {
   return useRecoilCallback<[React.MouseEvent<HTMLButtonElement>], void>(
@@ -54,9 +53,10 @@ const FilterableEntry = ({
   const field = useField(path);
   const fieldIsFiltered = useRecoilValue(fos.fieldIsFiltered({ path, modal }));
   const expandedPath = useRecoilValue(fos.expandPath(path));
-  const expanded = useRecoilValue(
-    fos.sidebarExpanded({ modal, path: expandedPath })
-  );
+  const [expanded, setExpanded] = useSidebarExpandedState({
+    modal,
+    path: expandedPath,
+  });
   const onClick = useOnClick({ modal, path });
   const theme = useTheme();
   const color = disabled ? theme.background.paper : pathColor;
@@ -68,11 +68,13 @@ const FilterableEntry = ({
           ? Color(color).alpha(0.25).string()
           : theme.background.level1
       }
+      clickable={!disabled}
       color={color}
       entryKey={entryKey}
+      onHeaderClick={!disabled ? () => setExpanded((v) => !v) : undefined}
       heading={
         <>
-          {!disabled && !(modal && path === LABEL_TAGS) && (
+          {!disabled && !(modal && path === fos.LABEL_TAGS_FIELD) && (
             <Checkbox
               key="checkbox"
               checked={active}
@@ -84,6 +86,7 @@ const FilterableEntry = ({
               }}
               data-cy={`checkbox-${path}`}
               onClick={onClick}
+              onMouseUp={(e) => e.stopPropagation()}
             />
           )}
           {

--- a/app/packages/core/src/components/Sidebar/Entries/GroupEntries.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/GroupEntries.tsx
@@ -290,7 +290,7 @@ interface PathGroupProps {
 export const PathGroupEntry = React.memo(
   ({ entryKey, name, modal, mutable = true, trigger }: PathGroupProps) => {
     const [expanded, setExpanded] = useShown(name, modal);
-    const renameGroup = useRenameGroup(!modal, name);
+    const renameGroup = useRenameGroup(!modal && mutable, name);
     const onDelete = useDeleteGroup(!modal && mutable, name);
 
     return (
@@ -340,7 +340,7 @@ export const PathGroupEntry = React.memo(
               }))}
           />
         }
-        trigger={trigger}
+        trigger={mutable ? trigger : undefined}
       />
     );
   }

--- a/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
@@ -180,7 +180,9 @@ const ListValueEntry = ({
           : ftype
       })`}
       backgroundColor={backgroundColor}
+      clickable
       color={color}
+      onHeaderClick={() => setExpanded(!expanded)}
       heading={
         <NameAndCountContainer>
           <FieldLabelAndInfo
@@ -218,6 +220,10 @@ const ListValueEntry = ({
               setExpanded(!expanded);
             }}
             onMouseDown={(event) => {
+              event.stopPropagation();
+              event.preventDefault();
+            }}
+            onMouseUp={(event) => {
               event.stopPropagation();
               event.preventDefault();
             }}

--- a/app/packages/core/src/components/Sidebar/InteractiveSidebar/index.ts
+++ b/app/packages/core/src/components/Sidebar/InteractiveSidebar/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./InteractiveSidebar";
+export { createExploreIsDisabled } from "./utils";

--- a/app/packages/core/src/components/Sidebar/InteractiveSidebar/utils.ts
+++ b/app/packages/core/src/components/Sidebar/InteractiveSidebar/utils.ts
@@ -334,3 +334,34 @@ const measureGroups = (
 
   return { data, activeHeight };
 };
+
+/**
+ * Returns a predicate that marks sidebar entries as non-interactive for drag
+ * ordering. Entries for tags, _label_tags, the tags/other group headers, INPUT
+ * rows, and any path in the disabled set are treated as fixed boundaries that
+ * are skipped when computing valid drop targets in `getAfterKey`.
+ */
+export const createExploreIsDisabled =
+  (disabled: Set<string>) => (entry: fos.SidebarEntry) => {
+    if (entry.kind === fos.EntryKind.PATH) {
+      return (
+        entry.path === fos.TAGS_FIELD ||
+        entry.path === fos.LABEL_TAGS_FIELD ||
+        disabled.has(entry.path)
+      );
+    }
+
+    if (entry.kind === fos.EntryKind.EMPTY) {
+      return entry.group === fos.TAGS_FIELD;
+    }
+
+    if (entry.kind === fos.EntryKind.GROUP) {
+      return entry.name === fos.TAGS_FIELD || entry.name === fos.OTHER_GROUP;
+    }
+
+    if (entry.kind === fos.EntryKind.INPUT) {
+      return true;
+    }
+
+    return false;
+  };

--- a/app/packages/state/src/accessors/index.ts
+++ b/app/packages/state/src/accessors/index.ts
@@ -1,2 +1,3 @@
 export * from "./dataset";
 export * from "./modal";
+export * from "./sidebar";

--- a/app/packages/state/src/accessors/sidebar.ts
+++ b/app/packages/state/src/accessors/sidebar.ts
@@ -1,0 +1,50 @@
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
+import { disabledCheckboxPaths } from "../recoil/sidebar";
+import { sidebarExpanded } from "../recoil/sidebarExpanded";
+
+/**
+ * Returns the set of field paths that are disabled in the sidebar checkbox list.
+ * Includes unsupported field types (DictField, VectorField, etc.) and frame fields that are not labels.
+ */
+export const useDisabledCheckboxPaths = (): Set<string> =>
+  useRecoilValue(disabledCheckboxPaths);
+
+interface SidebarExpandedParams {
+  /** The dot-notation field path, e.g. `"ground_truth"` or `"ground_truth.label"`. */
+  path: string;
+  /** Whether the sidebar is in modal context (`true`) or grid context (`false`). */
+  modal: boolean;
+}
+
+/**
+ * Returns whether the given sidebar path is currently expanded.
+ *
+ * Prefer this over reading `fos.sidebarExpanded` directly so that
+ * call sites remain decoupled from the underlying recoil atom.
+ */
+export const useSidebarExpanded = (params: SidebarExpandedParams): boolean =>
+  useRecoilValue(sidebarExpanded(params));
+
+/**
+ * Returns a setter for the expanded state of the given sidebar path.
+ * Use this when the component only needs to write, not read.
+ *
+ * @example
+ * const setExpanded = useSetSidebarExpanded({ path: "ground_truth", modal: false });
+ * setExpanded(true);
+ */
+export const useSetSidebarExpanded = (params: SidebarExpandedParams) =>
+  useSetRecoilState(sidebarExpanded(params));
+
+/**
+ * Returns `[expanded, setExpanded]` for the given sidebar path —
+ * the standard read/write accessor for toggling field expansion.
+ *
+ * @example
+ * const [expanded, setExpanded] = useSidebarExpandedState({ path, modal });
+ * setExpanded((v) => !v);
+ */
+export const useSidebarExpandedState = (
+  params: SidebarExpandedParams
+): [boolean, (value: boolean | ((prev: boolean) => boolean)) => void] =>
+  useRecoilState(sidebarExpanded(params));

--- a/app/packages/state/src/recoil/sidebar.ts
+++ b/app/packages/state/src/recoil/sidebar.ts
@@ -289,6 +289,10 @@ export const validateGroupName = (current: string[], name: string): boolean => {
   return true;
 };
 
+export const TAGS_FIELD = "tags";
+export const LABEL_TAGS_FIELD = "_label_tags";
+export const OTHER_GROUP = "other";
+
 export const RESERVED_GROUPS = new Set([
   "frame tags",
   "label tags",

--- a/e2e-pw/src/oss/poms/sidebar.ts
+++ b/e2e-pw/src/oss/poms/sidebar.ts
@@ -289,13 +289,16 @@ class SidebarAsserter {
     );
   }
 
-  async assertCannotDragField(fieldName: string) {
-    const draggableSidebarFieldArea =
-      this.sb.sidebarEntryDraggableArea(fieldName);
-
-    await expect(draggableSidebarFieldArea).toHaveAttribute(
+  async assertCanDragField(fieldName: string) {
+    await expect(this.sb.sidebarEntryDraggableArea(fieldName)).toHaveAttribute(
       "data-draggable",
-      "false"
+      "true"
     );
+  }
+
+  async assertCannotDragField(fieldName: string) {
+    await expect(
+      this.sb.sidebarEntryDraggableArea(fieldName)
+    ).not.toHaveAttribute("data-draggable", "true");
   }
 }

--- a/e2e-pw/src/oss/specs/FOEPD-3788-sidebar-explore-is-disabled.spec.ts
+++ b/e2e-pw/src/oss/specs/FOEPD-3788-sidebar-explore-is-disabled.spec.ts
@@ -1,0 +1,59 @@
+import { test as base } from "src/oss/fixtures";
+import { GridPom } from "src/oss/poms/grid";
+import { SidebarPom } from "src/oss/poms/sidebar";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+
+const datasetName = getUniqueDatasetNameWithPrefix("explore-is-disabled");
+
+const test = base.extend<{ sidebar: SidebarPom; grid: GridPom }>({
+  sidebar: async ({ page }, use) => {
+    await use(new SidebarPom(page));
+  },
+  grid: async ({ page, eventUtils }, use) => {
+    await use(new GridPom(page, eventUtils));
+  },
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+test.beforeAll(async ({ datasetFactory, foWebServer }) => {
+  await foWebServer.startWebServer();
+
+  await datasetFactory.createBlankDataset({
+    datasetName,
+    schema: {
+      ground_truth: "Detection",
+      metadata_dict: "DictField",
+    },
+    withSampleData: () => ({
+      ground_truth: {
+        _cls: "Detection",
+        label: "cat",
+        bounding_box: [0.1, 0.1, 0.5, 0.5],
+      },
+    }),
+  });
+});
+
+test.describe.serial("explore-is-disabled", () => {
+  test.beforeEach(async ({ page, fiftyoneLoader }) => {
+    await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
+  });
+
+  test("supported label field is draggable", async ({ sidebar }) => {
+    await sidebar.asserter.assertCanDragField("ground_truth");
+  });
+
+  test("dict field in disabledCheckboxPaths is not draggable", async ({
+    sidebar,
+  }) => {
+    await sidebar.toggleSidebarGroup("OTHER");
+    await sidebar.asserter.assertCannotDragField("metadata_dict");
+  });
+
+  test("_label_tags is not draggable", async ({ sidebar }) => {
+    await sidebar.asserter.assertCannotDragField("_label_tags");
+  });
+});

--- a/e2e-pw/src/shared/dataset-factory/index.ts
+++ b/e2e-pw/src/shared/dataset-factory/index.ts
@@ -46,7 +46,12 @@ type Label = "Classification" | "Classifications" | "Detection" | "Detections";
  * All supported field types for dataset schema definitions.
  * Includes both primitive scalar types and FiftyOne {@link Label} types.
  */
-type FieldType = Label | "IntField" | "FloatField" | "StringField";
+type FieldType =
+  | Label
+  | "IntField"
+  | "FloatField"
+  | "StringField"
+  | "DictField";
 
 /**
  * A recursive type representing any valid JSON value.


### PR DESCRIPTION
## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

- `createExploreIsDisabled` enforces drag boundaries — tags, `_label_tags`, unsupported field types, and reserved group headers (TAGS, OTHER) are no longer valid drop targets or draggable
- Reserved group headers can no longer be renamed
- Clicking a filterable path entry or list value entry row now toggles expand/collapse (not just the arrow)
- Drag indicator dots are visible on grey group headers in dark mode
- Replaces hardcoded `"tags"`, `"_label_tags"`, `"other"` with named constants from `@fiftyone/state`
- Adds an e2e spec for `createExploreIsDisabled`


## 🧪 How is this patch tested? If it is not, please explain why.

- [x] TAGS and OTHER group headers cannot be dragged or renamed
- [x] Clicking a label field row or list entry header expands/collapses it
- [x] `yarn e2e -g "sidebar-explore-is-disabled"` passes


## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixed reserved sidebar groups (Tags, Other) being draggable and editable. Clicking a field row in the modal sidebar now expands/collapses it without needing to hit the arrow. 

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Explore sidebar now respects disabled checkbox paths and prevents interactions accordingly
  * Drag-and-drop blocks interaction for special fields and non-mutable groups

* **Improvements**
  * Clearer cursor/visual feedback during dragging
  * Sidebar headers and checkboxes handle clicks to avoid accidental toggles and edits
  * Non-mutable entries more reliably block rename/drag interactions

* **Tests**
  * Added end-to-end tests verifying sidebar drag behavior

* **Improvements**
  * Dataset factory accepts dictionary-style fields for test/sample creation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7494)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->