### PR TITLE
feat: ensure images are processed by configurable sample ids

### DIFF
--- a/fiftyone/utils/labels.py
+++ b/fiftyone/utils/labels.py
@@ -924,14 +924,17 @@ def index_to_instance(
             :class:`fiftyone.core.labels.Polylines`,
             :class:`fiftyone.core.labels.Keypoint`, and
             :class:`fiftyone.core.labels.Keypoints`
-        id_field ("id"): the attribute identifying samples/frames of the
-            same video/sequence. Samples with the same id_field are processed
-            together. For dynamic grouped views from
+        id_field ("id"): the attribute identifying samples of the same
+            sequence, e.g. image frames of a dynamically grouped video. Samples
+            with the same ``id_field`` are processed together. For dynamically
+            grouped views created via
             :meth:`fiftyone.core.collections.SampleCollection.group_by` with
-            ``flat=False``, this must be the group key (e.g. ``"sample_id"`` when
-            grouping frames by parent video). For pinned group datasets,
-            ``id_field`` names an attribute under the dataset's ``group_field``
-            (the default ``"id"`` refers to ``<group_field>.id``)
+            ``flat=False``, this must be the group key (e.g. ``"sample_id"``
+            when grouping frames for a video). For group datasets, ``id_field``
+            names an attribute under the dataset's ``group_field`` (the default
+            ``"id"`` refers to ``<group_field>.id``). If the resolved field path
+            is not present on any sample in the collection, it falls back to ``"id"``
+            (or ``<group_field>.id`` for group datasets)
         index_attr ("index"): the attribute whose unique values define the
             object instances. When ``index_attr="index"`` specifically, the
             ``(label, index)`` of each object is used as the unique identifier.
@@ -958,19 +961,29 @@ def index_to_instance(
         ),
     )
 
-    if sample_collection.media_type == fom.GROUP:
-        if sample_collection._is_dynamic_groups:
-            id_path = id_field
-            ids = list(dict.fromkeys(sample_collection.values(id_path)))
-        else:
-            id_path = sample_collection.group_field + "." + id_field
-            ids = list(dict.fromkeys(sample_collection.values(id_path)))
-            sample_collection = sample_collection.select_group_slices(
-                _allow_mixed=True
+    if sample_collection.media_type == fom.GROUP and (
+        not sample_collection._is_dynamic_groups
+    ):
+        id_path = sample_collection.group_field + "." + id_field
+        ids = list(dict.fromkeys(sample_collection.values(id_path)))
+        if None in ids:
+            logger.warning(
+                "Some samples have no %s; defaulting to 'id'", id_path
             )
+            id_path = sample_collection.group_field + "." + "id"
+            ids = list(dict.fromkeys(sample_collection.values(id_path)))
+        sample_collection = sample_collection.select_group_slices(
+            _allow_mixed=True
+        )
     else:
         id_path = id_field
         ids = list(dict.fromkeys(sample_collection.values(id_path)))
+        if None in ids:
+            logger.warning(
+                "Some samples have no %s; defaulting to 'id'", id_path
+            )
+            id_path = "id"
+            ids = list(dict.fromkeys(sample_collection.values(id_path)))
 
     is_frame_field = sample_collection._is_frame_field(label_field)
     root, _ = sample_collection._get_label_field_root(label_field)

--- a/fiftyone/utils/labels.py
+++ b/fiftyone/utils/labels.py
@@ -9,6 +9,7 @@ import eta.core.utils as etau
 from typing import Any, Callable, Dict, List, Optional
 import logging
 
+import fiftyone.core.expressions as foe
 import fiftyone.core.labels as fol
 import fiftyone.core.media as fom
 import fiftyone.core.utils as fou
@@ -905,14 +906,17 @@ def classifications_to_detections(
 def index_to_instance(
     sample_collection,
     label_field,
-    id_field="id",
     index_attr="index",
     clear_index=False,
     progress=None,
 ):
     """Populates :class:`fiftyone.core.labels.Instance` values in the
-    ``instance``attribute of the specified label field based on the values in
-    the specified index attribute.
+    ``instance`` attribute of the specified label field based on the values in
+    the specified index attribute. Instance IDs are shared across frames of
+    the same video (identified by the same `id`, or `sample_id` for a
+    FramesView), slices in a group (for a group dataset), or samples in a
+    dynamic group. To identify per a custom field, pass a `sample_collection`
+    created via :meth:`group_by`.
 
     Args:
         sample_collection: a
@@ -924,13 +928,6 @@ def index_to_instance(
             :class:`fiftyone.core.labels.Polylines`,
             :class:`fiftyone.core.labels.Keypoint`, and
             :class:`fiftyone.core.labels.Keypoints`
-        id_field ("id"): the attribute identifying samples of the same
-            sequence, e.g. image frames of a dynamically grouped video. Samples
-            with the same ``id_field`` are processed together. For group datasets,
-            ``id_field`` names an attribute under the dataset's ``group_field``
-            (the default ``"id"`` refers to ``<group_field>.id``). If the resolved
-            field path is not present on any sample in the collection, it
-            falls back to ``"id"`` (or ``<group_field>.id`` for group datasets)
         index_attr ("index"): the attribute whose unique values define the
             object instances. When ``index_attr="index"`` specifically, the
             ``(label, index)`` of each object is used as the unique identifier.
@@ -957,42 +954,45 @@ def index_to_instance(
         ),
     )
 
-    is_native_group = (
-        sample_collection.media_type == fom.GROUP
-        and not sample_collection._is_dynamic_groups
-    )
+    if (
+        sample_collection._is_frames
+        and sample_collection.media_type == fom.IMAGE
+    ):
+        id_path = "sample_id"
+    else:
+        id_path = "id"
 
-    if is_native_group:
-        group_field = sample_collection.group_field
-        id_path = group_field + "." + id_field
-        id_field_resolution_view = sample_collection.select_group_slices(
-            _allow_mixed=True
-        )
-    elif sample_collection._is_dynamic_groups:
-        _, _, dynamic_root, _ = sample_collection._parse_dynamic_groups()
-        id_path = id_field
+    use_dynamic_group_iteration = False
+    if sample_collection._is_dynamic_groups:
+        (
+            group_expr,
+            _,
+            dynamic_root,
+            _,
+        ) = sample_collection._parse_dynamic_groups()
+        group_values = sample_collection.values(foe.ViewExpression(group_expr))
+        if None not in group_values:
+            use_dynamic_group_iteration = True
+        else:
+            logger.warning(
+                "Some samples have no '%s'; defaulting to '%s'",
+                group_expr,
+                id_path,
+            )
         if dynamic_root.media_type == fom.GROUP:
             id_field_resolution_view = dynamic_root.select_group_slices(
                 _allow_mixed=True
             )
         else:
             id_field_resolution_view = dynamic_root
-    else:
-        id_path = id_field
-        id_field_resolution_view = sample_collection
-
-    fallback_to_id = True
-    if id_field_resolution_view.has_field(id_path):
-        ids = list(dict.fromkeys(id_field_resolution_view.values(id_path)))
-        fallback_to_id = None in ids
-
-    if fallback_to_id:
-        logger.warning(
-            "Some samples have no '%s'; defaulting to 'id'",
-            id_path,
+    elif sample_collection.media_type == fom.GROUP:
+        group_field = sample_collection.group_field
+        id_path = group_field + "." + id_path
+        id_field_resolution_view = sample_collection.select_group_slices(
+            _allow_mixed=True
         )
-        id_path = ".".join(id_path.split(".")[:-1] + ["id"])
-        ids = list(dict.fromkeys(id_field_resolution_view.values(id_path)))
+    else:
+        id_field_resolution_view = sample_collection
 
     is_frame_field = sample_collection._is_frame_field(label_field)
     root, _ = sample_collection._get_label_field_root(label_field)
@@ -1004,58 +1004,50 @@ def index_to_instance(
     else:
         index_paths = [index_path]
 
-    def _id_path_matches_dynamic_group_by_key(sample_collection, id_path):
-        """True if ``id_path`` is the sample field used by the view's ``group_by`` stage."""
-        group_expr, _, _, _ = sample_collection._parse_dynamic_groups()
-        if etau.is_str(group_expr):
-            return id_path == group_expr.lstrip("$")
-        if isinstance(group_expr, (list, tuple)):
-            return id_path in (expr.lstrip("$") for expr in group_expr)
-        return False
+    def _process_view(view):
+        if is_frame_field:
+            sample_ids, frame_numbers, *indexes = view.values(
+                ["id", "frames.frame_number"] + index_paths
+            )
+            indexes = _zip_values(*indexes)
 
-    with fou.ProgressBar(progress=progress) as pb:
-        for uid in pb(ids):
-            if (
-                sample_collection._is_dynamic_groups
-                and not fallback_to_id
-                and _id_path_matches_dynamic_group_by_key(
-                    sample_collection, id_path
-                )
-            ):
-                view = sample_collection.get_dynamic_group(uid)
+            instances = _frame_index_to_instance(
+                sample_ids, frame_numbers, indexes
+            )
+        else:
+            sample_ids, *indexes = view.values(["id"] + index_paths)
+            indexes = _zip_values(*indexes)
+
+            instances = _index_to_instance(sample_ids, indexes)
+
+        if not instances:
+            return
+
+        view.set_values(instance_path, instances, key_field="id")
+
+        if clear_index:
+            view.set_values(
+                index_path, _to_none_values(instances), key_field="id"
+            )
+
+    if use_dynamic_group_iteration:
+        with fou.ProgressBar(total=sample_collection, progress=progress) as pb:
+            for view in pb(sample_collection._iter_dynamic_groups()):
                 if (
                     view.media_type == fom.GROUP
                     and view.group_field is not None
                     and not view._is_dynamic_groups
                 ):
                     view = view.select_group_slices(_allow_mixed=True)
-            else:
+
+                _process_view(view)
+    else:
+        ids = list(dict.fromkeys(id_field_resolution_view.values(id_path)))
+
+        with fou.ProgressBar(progress=progress) as pb:
+            for uid in pb(ids):
                 view = id_field_resolution_view.select_by(id_path, uid)
-
-            if is_frame_field:
-                sample_ids, frame_numbers, *indexes = view.values(
-                    ["id", "frames.frame_number"] + index_paths
-                )
-                indexes = _zip_values(*indexes)
-
-                instances = _frame_index_to_instance(
-                    sample_ids, frame_numbers, indexes
-                )
-            else:
-                sample_ids, *indexes = view.values(["id"] + index_paths)
-                indexes = _zip_values(*indexes)
-
-                instances = _index_to_instance(sample_ids, indexes)
-
-            if not instances:
-                continue
-
-            view.set_values(instance_path, instances, key_field="id")
-
-            if clear_index:
-                view.set_values(
-                    index_path, _to_none_values(instances), key_field="id"
-                )
+                _process_view(view)
 
 
 def _index_to_instance(sample_ids, indexes):

--- a/fiftyone/utils/labels.py
+++ b/fiftyone/utils/labels.py
@@ -926,15 +926,11 @@ def index_to_instance(
             :class:`fiftyone.core.labels.Keypoints`
         id_field ("id"): the attribute identifying samples of the same
             sequence, e.g. image frames of a dynamically grouped video. Samples
-            with the same ``id_field`` are processed together. For dynamically
-            grouped views created via
-            :meth:`fiftyone.core.collections.SampleCollection.group_by` with
-            ``flat=False``, this must be the group key (e.g. ``"sample_id"``
-            when grouping frames for a video). For group datasets, ``id_field``
-            names an attribute under the dataset's ``group_field`` (the default
-            ``"id"`` refers to ``<group_field>.id``). If the resolved field path
-            is not present on any sample in the collection, it falls back to ``"id"``
-            (or ``<group_field>.id`` for group datasets)
+            with the same ``id_field`` are processed together. For group datasets,
+            ``id_field`` names an attribute under the dataset's ``group_field``
+            (the default ``"id"`` refers to ``<group_field>.id``). If the resolved
+            field path is not present on any sample in the collection, it
+            falls back to ``"id"`` (or ``<group_field>.id`` for group datasets)
         index_attr ("index"): the attribute whose unique values define the
             object instances. When ``index_attr="index"`` specifically, the
             ``(label, index)`` of each object is used as the unique identifier.
@@ -961,29 +957,42 @@ def index_to_instance(
         ),
     )
 
-    if sample_collection.media_type == fom.GROUP and (
-        not sample_collection._is_dynamic_groups
-    ):
-        id_path = sample_collection.group_field + "." + id_field
-        ids = list(dict.fromkeys(sample_collection.values(id_path)))
-        if None in ids:
-            logger.warning(
-                "Some samples have no %s; defaulting to 'id'", id_path
-            )
-            id_path = sample_collection.group_field + "." + "id"
-            ids = list(dict.fromkeys(sample_collection.values(id_path)))
-        sample_collection = sample_collection.select_group_slices(
+    is_native_group = (
+        sample_collection.media_type == fom.GROUP
+        and not sample_collection._is_dynamic_groups
+    )
+
+    if is_native_group:
+        group_field = sample_collection.group_field
+        id_path = group_field + "." + id_field
+        id_field_resolution_view = sample_collection.select_group_slices(
             _allow_mixed=True
         )
+    elif sample_collection._is_dynamic_groups:
+        _, _, dynamic_root, _ = sample_collection._parse_dynamic_groups()
+        id_path = id_field
+        if dynamic_root.media_type == fom.GROUP:
+            id_field_resolution_view = dynamic_root.select_group_slices(
+                _allow_mixed=True
+            )
+        else:
+            id_field_resolution_view = dynamic_root
     else:
         id_path = id_field
-        ids = list(dict.fromkeys(sample_collection.values(id_path)))
-        if None in ids:
-            logger.warning(
-                "Some samples have no %s; defaulting to 'id'", id_path
-            )
-            id_path = "id"
-            ids = list(dict.fromkeys(sample_collection.values(id_path)))
+        id_field_resolution_view = sample_collection
+
+    fallback_to_id = True
+    if id_field_resolution_view.has_field(id_path):
+        ids = list(dict.fromkeys(id_field_resolution_view.values(id_path)))
+        fallback_to_id = None in ids
+
+    if fallback_to_id:
+        logger.warning(
+            "Some samples have no '%s'; defaulting to 'id'",
+            id_path,
+        )
+        id_path = ".".join(id_path.split(".")[:-1] + ["id"])
+        ids = list(dict.fromkeys(id_field_resolution_view.values(id_path)))
 
     is_frame_field = sample_collection._is_frame_field(label_field)
     root, _ = sample_collection._get_label_field_root(label_field)
@@ -995,12 +1004,33 @@ def index_to_instance(
     else:
         index_paths = [index_path]
 
+    def _id_path_matches_dynamic_group_by_key(sample_collection, id_path):
+        """True if ``id_path`` is the sample field used by the view's ``group_by`` stage."""
+        group_expr, _, _, _ = sample_collection._parse_dynamic_groups()
+        if etau.is_str(group_expr):
+            return id_path == group_expr.lstrip("$")
+        if isinstance(group_expr, (list, tuple)):
+            return id_path in (expr.lstrip("$") for expr in group_expr)
+        return False
+
     with fou.ProgressBar(progress=progress) as pb:
-        for id in pb(ids):
-            if sample_collection._is_dynamic_groups:
-                view = sample_collection.get_dynamic_group(id)
+        for uid in pb(ids):
+            if (
+                sample_collection._is_dynamic_groups
+                and not fallback_to_id
+                and _id_path_matches_dynamic_group_by_key(
+                    sample_collection, id_path
+                )
+            ):
+                view = sample_collection.get_dynamic_group(uid)
+                if (
+                    view.media_type == fom.GROUP
+                    and view.group_field is not None
+                    and not view._is_dynamic_groups
+                ):
+                    view = view.select_group_slices(_allow_mixed=True)
             else:
-                view = sample_collection.select_by(id_path, id)
+                view = id_field_resolution_view.select_by(id_path, uid)
 
             if is_frame_field:
                 sample_ids, frame_numbers, *indexes = view.values(

--- a/fiftyone/utils/labels.py
+++ b/fiftyone/utils/labels.py
@@ -905,6 +905,7 @@ def classifications_to_detections(
 def index_to_instance(
     sample_collection,
     label_field,
+    id_field="id",
     index_attr="index",
     clear_index=False,
     progress=None,
@@ -923,6 +924,14 @@ def index_to_instance(
             :class:`fiftyone.core.labels.Polylines`,
             :class:`fiftyone.core.labels.Keypoint`, and
             :class:`fiftyone.core.labels.Keypoints`
+        id_field ("id"): the attribute identifying samples/frames of the
+            same video/sequence. Samples with the same id_field are processed
+            together. For dynamic grouped views from
+            :meth:`fiftyone.core.collections.SampleCollection.group_by` with
+            ``flat=False``, this must be the group key (e.g. ``"sample_id"`` when
+            grouping frames by parent video). For pinned group datasets,
+            ``id_field`` names an attribute under the dataset's ``group_field``
+            (the default ``"id"`` refers to ``<group_field>.id``)
         index_attr ("index"): the attribute whose unique values define the
             object instances. When ``index_attr="index"`` specifically, the
             ``(label, index)`` of each object is used as the unique identifier.
@@ -950,15 +959,18 @@ def index_to_instance(
     )
 
     if sample_collection.media_type == fom.GROUP:
-        id_path = sample_collection.group_field + ".id"
-        ids = sample_collection.values(id_path)
-
-        sample_collection = sample_collection.select_group_slices(
-            _allow_mixed=True
-        )
+        if sample_collection._is_dynamic_groups:
+            id_path = id_field
+            ids = list(dict.fromkeys(sample_collection.values(id_path)))
+        else:
+            id_path = sample_collection.group_field + "." + id_field
+            ids = list(dict.fromkeys(sample_collection.values(id_path)))
+            sample_collection = sample_collection.select_group_slices(
+                _allow_mixed=True
+            )
     else:
-        id_path = "id"
-        ids = sample_collection.values(id_path)
+        id_path = id_field
+        ids = list(dict.fromkeys(sample_collection.values(id_path)))
 
     is_frame_field = sample_collection._is_frame_field(label_field)
     root, _ = sample_collection._get_label_field_root(label_field)
@@ -972,7 +984,10 @@ def index_to_instance(
 
     with fou.ProgressBar(progress=progress) as pb:
         for id in pb(ids):
-            view = sample_collection.select_by(id_path, id)
+            if sample_collection._is_dynamic_groups:
+                view = sample_collection.get_dynamic_group(id)
+            else:
+                view = sample_collection.select_by(id_path, id)
 
             if is_frame_field:
                 sample_ids, frame_numbers, *indexes = view.values(
@@ -992,12 +1007,10 @@ def index_to_instance(
             if not instances:
                 continue
 
-            sample_collection.set_values(
-                instance_path, instances, key_field="id"
-            )
+            view.set_values(instance_path, instances, key_field="id")
 
             if clear_index:
-                sample_collection.set_values(
+                view.set_values(
                     index_path, _to_none_values(instances), key_field="id"
                 )
 

--- a/tests/unittests/label_tests.py
+++ b/tests/unittests/label_tests.py
@@ -730,8 +730,7 @@ class LabelUtilsTests(unittest.TestCase):
         foul.index_to_instance(
             dataset_frames,
             "ground_truth",
-            id_field="sample_id",
-            clear_index=False,
+            clear_index=True,
         )
 
         instances_sample_id_wise = dataset_frames.count_values(
@@ -752,34 +751,21 @@ class LabelUtilsTests(unittest.TestCase):
             {cat1: 3, cat2: 2, cat3: 1, dog1: 2, dog2: 2, None: 3},
         )
 
-        foul.index_to_instance(
-            dataset_frames,
-            "ground_truth",
-            id_field="sample_id_nonexistent",  # this will cause fallback to "id"
-            clear_index=True,
-        )
-        instances_id_wise = dataset_frames.count_values(
-            "ground_truth.detections.instance._id"
-        )
-        indexes = dataset_frames.count_values("ground_truth.detections.index")
-
-        for inst_id, count in instances_id_wise.items():
-            if inst_id is not None:
-                self.assertEqual(count, 1)
-
         self.assertDictEqual(indexes, {None: 13})
 
     @drop_datasets
     def test_label_to_instance_dynamic_grouped_frames(self):
         dataset_frames = _make_video_dataset().to_frames(sample_frames=True)
+        dataset_frames.set_values(
+            "cloned_sample_id", dataset_frames.values("sample_id")
+        )
         dataset_grouped = dataset_frames.group_by(
-            "sample_id", order_by="frame_number"
+            "cloned_sample_id", order_by="frame_number"
         )
 
         foul.index_to_instance(
             dataset_grouped,
             "ground_truth",
-            id_field="sample_id",
             clear_index=True,
         )
 
@@ -903,7 +889,6 @@ class LabelUtilsTests(unittest.TestCase):
         foul.index_to_instance(
             dataset_grouped,
             "ground_truth",
-            id_field="sequence_index",
             clear_index=False,
         )
 
@@ -946,7 +931,6 @@ class LabelUtilsTests(unittest.TestCase):
         foul.index_to_instance(
             dataset_grouped,
             "ground_truth",
-            id_field="sequence_index",  # this will cause fallback to "id"
             clear_index=True,
         )
 

--- a/tests/unittests/label_tests.py
+++ b/tests/unittests/label_tests.py
@@ -731,10 +731,10 @@ class LabelUtilsTests(unittest.TestCase):
             dataset_frames,
             "ground_truth",
             id_field="sample_id",
-            clear_index=True,
+            clear_index=False,
         )
 
-        instances = dataset_frames.count_values(
+        instances_sample_id_wise = dataset_frames.count_values(
             "ground_truth.detections.instance._id"
         )
         indexes = dataset_frames.count_values("ground_truth.detections.index")
@@ -748,12 +748,29 @@ class LabelUtilsTests(unittest.TestCase):
         dog2 = sample5.ground_truth.detections[3].instance._id
 
         self.assertDictEqual(
-            instances, {cat1: 3, cat2: 2, cat3: 1, dog1: 2, dog2: 2, None: 3}
+            instances_sample_id_wise,
+            {cat1: 3, cat2: 2, cat3: 1, dog1: 2, dog2: 2, None: 3},
         )
+
+        foul.index_to_instance(
+            dataset_frames,
+            "ground_truth",
+            id_field="sample_id_nonexistent",  # this will cause fallback to "id"
+            clear_index=True,
+        )
+        instances_id_wise = dataset_frames.count_values(
+            "ground_truth.detections.instance._id"
+        )
+        indexes = dataset_frames.count_values("ground_truth.detections.index")
+
+        for inst_id, count in instances_id_wise.items():
+            if inst_id is not None:
+                self.assertEqual(count, 1)
+
         self.assertDictEqual(indexes, {None: 13})
 
     @drop_datasets
-    def test_label_to_instance_frames_view_grouped(self):
+    def test_label_to_instance_dynamic_grouped_frames(self):
         dataset_frames = _make_video_dataset().to_frames(sample_frames=True)
         dataset_grouped = dataset_frames.group_by(
             "sample_id", order_by="frame_number"
@@ -784,6 +801,167 @@ class LabelUtilsTests(unittest.TestCase):
             instances, {cat1: 3, cat2: 2, cat3: 1, dog1: 2, dog2: 2, None: 3}
         )
         self.assertDictEqual(indexes, {None: 13})
+
+    @drop_datasets
+    def test_label_to_instance_dynamic_grouped_group(self):
+        group1 = fo.Group()
+        left_sample1 = fo.Sample(
+            filepath="left-image1.jpg",
+            group=group1.element("left"),
+            sequence_index="a",
+            ground_truth=fo.Detections(
+                detections=[
+                    fo.Detection(label="cat", index=1),
+                    fo.Detection(label="cat", index=2),
+                    fo.Detection(label="dog", index=1),
+                    fo.Detection(label="none"),
+                ]
+            ),
+        )
+        right_sample1 = fo.Sample(
+            filepath="right-image1.jpg",
+            group=group1.element("right"),
+            sequence_index="a",
+            ground_truth=fo.Detections(
+                detections=[
+                    fo.Detection(label="cat", index=1),
+                    fo.Detection(label="dog", index=1),
+                    fo.Detection(label="none"),
+                    fo.Detection(label="dog", index=2),
+                ]
+            ),
+        )
+
+        group2 = fo.Group()
+        left_sample2 = fo.Sample(
+            filepath="left-image2.jpg",
+            group=group2.element("left"),
+            sequence_index="a",
+        )
+        right_sample2 = fo.Sample(
+            filepath="right-image2.jpg",
+            group=group2.element("right"),
+            sequence_index="a",
+            ground_truth=fo.Detections(
+                detections=[
+                    fo.Detection(label="cat", index=1),
+                    fo.Detection(label="dog", index=1),
+                    fo.Detection(label="none"),
+                ]
+            ),
+        )
+
+        group3 = fo.Group()
+        left_sample3 = fo.Sample(
+            filepath="left-image3.jpg",
+            group=group3.element("left"),
+            sequence_index="b",
+            ground_truth=fo.Detections(),
+        )
+        right_sample3 = fo.Sample(
+            filepath="right-image3.jpg",
+            group=group3.element("right"),
+            sequence_index="b",
+        )
+
+        group4 = fo.Group()
+        left_sample4 = fo.Sample(
+            filepath="left-image4.jpg",
+            group=group4.element("left"),
+            sequence_index="b",
+        )
+        right_sample4 = fo.Sample(
+            filepath="right-image4.jpg",
+            group=group4.element("right"),
+            sequence_index="b",
+            ground_truth=fo.Detections(
+                detections=[
+                    fo.Detection(label="cat", index=1),
+                    fo.Detection(label="dog", index=1),
+                    fo.Detection(label="none"),
+                ]
+            ),
+        )
+
+        dataset = fo.Dataset()
+        dataset.add_samples(
+            [
+                left_sample1,
+                right_sample1,
+                left_sample2,
+                right_sample2,
+                left_sample3,
+                right_sample3,
+                left_sample4,
+                right_sample4,
+            ]
+        )
+        dataset_grouped = dataset.group_by("sequence_index")
+        self.assertTrue(dataset_grouped._is_dynamic_groups)
+        self.assertEqual(len(dataset_grouped), 2)
+
+        foul.index_to_instance(
+            dataset_grouped,
+            "ground_truth",
+            id_field="sequence_index",
+            clear_index=False,
+        )
+
+        view = dataset.select_group_slices()
+        instances = view.count_values("ground_truth.detections.instance._id")
+
+        cat_a1 = left_sample1.ground_truth.detections[0].instance._id
+        cat_a2 = left_sample1.ground_truth.detections[1].instance._id
+        cat_b = right_sample4.ground_truth.detections[0].instance._id
+        dog_a1 = left_sample1.ground_truth.detections[2].instance._id
+        dog_a2 = right_sample1.ground_truth.detections[3].instance._id
+        dog_b = right_sample4.ground_truth.detections[1].instance._id
+
+        self.assertNotEqual(cat_a1, cat_b)
+        self.assertNotEqual(dog_a1, dog_b)
+        self.assertEqual(
+            right_sample1.ground_truth.detections[0].instance._id, cat_a1
+        )
+        self.assertEqual(
+            right_sample2.ground_truth.detections[0].instance._id, cat_a1
+        )
+        self.assertDictEqual(
+            instances,
+            {
+                cat_a1: 3,
+                cat_a2: 1,
+                cat_b: 1,
+                dog_a1: 3,
+                dog_a2: 1,
+                dog_b: 1,
+                None: 4,
+            },
+        )
+
+        # set one of the sequence_index values to None
+        sample = dataset_grouped.first()
+        sample["sequence_index"] = None
+        sample.save()
+
+        foul.index_to_instance(
+            dataset_grouped,
+            "ground_truth",
+            id_field="sequence_index",  # this will cause fallback to "id"
+            clear_index=True,
+        )
+
+        view = dataset.select_group_slices()
+        instances = view.count_values("ground_truth.detections.instance._id")
+        indexes = view.count_values("ground_truth.detections.index")
+
+        cat_a1l1 = left_sample1.ground_truth.detections[0].instance._id
+        cat_a1r1 = right_sample1.ground_truth.detections[0].instance._id
+        cat_a1r2 = right_sample2.ground_truth.detections[0].instance._id
+
+        self.assertNotEqual(cat_a1l1, cat_a1r1)
+        self.assertNotEqual(cat_a1l1, cat_a1r2)
+        self.assertNotEqual(cat_a1r1, cat_a1r2)
+        self.assertDictEqual(indexes, {None: 14})
 
     @drop_datasets
     def test_label_to_instance_group(self):

--- a/tests/unittests/label_tests.py
+++ b/tests/unittests/label_tests.py
@@ -649,52 +649,59 @@ class LabelTests(unittest.TestCase):
         self.assertEqual(dataset.count("frames.ground_truth.detections"), 10)
 
 
+def _make_video_dataset():
+    """One video sample with the same frame layout used by label-to-instance tests."""
+    sample = fo.Sample(filepath="video.mp4")
+    sample.frames[1] = fo.Frame(
+        ground_truth=fo.Detections(
+            detections=[
+                fo.Detection(label="cat", index=1),
+                fo.Detection(label="cat", index=2),
+                fo.Detection(label="dog", index=1),
+                fo.Detection(label="none"),
+            ]
+        )
+    )
+    sample.frames[2] = fo.Frame()
+    sample.frames[3] = fo.Frame(
+        ground_truth=fo.Detections(
+            detections=[
+                fo.Detection(label="cat", index=1),
+                fo.Detection(label="cat", index=2),
+                fo.Detection(label="none"),
+                fo.Detection(label="dog", index=1),
+            ]
+        )
+    )
+    sample.frames[4] = fo.Frame(ground_truth=fo.Detections())
+    sample.frames[5] = fo.Frame(
+        ground_truth=fo.Detections(
+            detections=[
+                fo.Detection(label="cat", index=1),
+                fo.Detection(label="cat", index=3),
+                fo.Detection(label="none"),
+                fo.Detection(label="dog", index=2),
+            ]
+        )
+    )
+    sample.frames[6] = fo.Frame(
+        ground_truth=fo.Detections(
+            detections=[
+                fo.Detection(label="dog", index=2),
+            ]
+        )
+    )
+
+    dataset = fo.Dataset()
+    dataset.add_sample(sample)
+    return dataset
+
+
 class LabelUtilsTests(unittest.TestCase):
     @drop_datasets
     def test_label_to_instance_video(self):
-        sample = fo.Sample(filepath="video.mp4")
-        sample.frames[1] = fo.Frame(
-            ground_truth=fo.Detections(
-                detections=[
-                    fo.Detection(label="cat", index=1),
-                    fo.Detection(label="cat", index=2),
-                    fo.Detection(label="dog", index=1),
-                    fo.Detection(label="none"),
-                ]
-            )
-        )
-        sample.frames[2] = fo.Frame()
-        sample.frames[3] = fo.Frame(
-            ground_truth=fo.Detections(
-                detections=[
-                    fo.Detection(label="cat", index=1),
-                    fo.Detection(label="cat", index=2),
-                    fo.Detection(label="none"),
-                    fo.Detection(label="dog", index=1),
-                ]
-            )
-        )
-        sample.frames[4] = fo.Frame(ground_truth=fo.Detections())
-        sample.frames[5] = fo.Frame(
-            ground_truth=fo.Detections(
-                detections=[
-                    fo.Detection(label="cat", index=1),
-                    fo.Detection(label="cat", index=3),
-                    fo.Detection(label="none"),
-                    fo.Detection(label="dog", index=2),
-                ]
-            )
-        )
-        sample.frames[6] = fo.Frame(
-            ground_truth=fo.Detections(
-                detections=[
-                    fo.Detection(label="dog", index=2),
-                ]
-            )
-        )
-
-        dataset = fo.Dataset()
-        dataset.add_sample(sample)
+        dataset = _make_video_dataset()
+        sample = dataset.first()
 
         foul.index_to_instance(
             dataset, "frames.ground_truth", clear_index=True
@@ -710,6 +717,68 @@ class LabelUtilsTests(unittest.TestCase):
         cat3 = sample.frames[5].ground_truth.detections[1].instance._id
         dog1 = sample.frames[1].ground_truth.detections[2].instance._id
         dog2 = sample.frames[5].ground_truth.detections[3].instance._id
+
+        self.assertDictEqual(
+            instances, {cat1: 3, cat2: 2, cat3: 1, dog1: 2, dog2: 2, None: 3}
+        )
+        self.assertDictEqual(indexes, {None: 13})
+
+    @drop_datasets
+    def test_label_to_instance_frames_view(self):
+        dataset_frames = _make_video_dataset().to_frames(sample_frames=True)
+
+        foul.index_to_instance(
+            dataset_frames,
+            "ground_truth",
+            id_field="sample_id",
+            clear_index=True,
+        )
+
+        instances = dataset_frames.count_values(
+            "ground_truth.detections.instance._id"
+        )
+        indexes = dataset_frames.count_values("ground_truth.detections.index")
+
+        sample1 = dataset_frames.first()
+        sample5 = dataset_frames[-2:-1].first()
+        cat1 = sample1.ground_truth.detections[0].instance._id
+        cat2 = sample1.ground_truth.detections[1].instance._id
+        cat3 = sample5.ground_truth.detections[1].instance._id
+        dog1 = sample1.ground_truth.detections[2].instance._id
+        dog2 = sample5.ground_truth.detections[3].instance._id
+
+        self.assertDictEqual(
+            instances, {cat1: 3, cat2: 2, cat3: 1, dog1: 2, dog2: 2, None: 3}
+        )
+        self.assertDictEqual(indexes, {None: 13})
+
+    @drop_datasets
+    def test_label_to_instance_frames_view_grouped(self):
+        dataset_frames = _make_video_dataset().to_frames(sample_frames=True)
+        dataset_grouped = dataset_frames.group_by(
+            "sample_id", order_by="frame_number"
+        )
+
+        foul.index_to_instance(
+            dataset_grouped,
+            "ground_truth",
+            id_field="sample_id",
+            clear_index=True,
+        )
+
+        instances = dataset_frames.count_values(
+            "ground_truth.detections.instance._id"
+        )
+        indexes = dataset_frames.count_values("ground_truth.detections.index")
+
+        sample1 = dataset_frames.first()
+        sample5 = dataset_frames[-2:-1].first()
+
+        cat1 = sample1.ground_truth.detections[0].instance._id
+        cat2 = sample1.ground_truth.detections[1].instance._id
+        cat3 = sample5.ground_truth.detections[1].instance._id
+        dog1 = sample1.ground_truth.detections[2].instance._id
+        dog2 = sample5.ground_truth.detections[3].instance._id
 
         self.assertDictEqual(
             instances, {cat1: 3, cat2: 2, cat3: 1, dog1: 2, dog2: 2, None: 3}
@@ -947,8 +1016,10 @@ class ExportMaskTests(unittest.TestCase):
             with self.subTest(case["id"]):
                 with tempfile.TemporaryDirectory() as tmp:
                     src = os.path.join(tmp, "original.png")
-                    dst = src if case["overwrite_path"] else os.path.join(
-                        tmp, "copy.png"
+                    dst = (
+                        src
+                        if case["overwrite_path"]
+                        else os.path.join(tmp, "copy.png")
                     )
                     _write_mask(self._ZEROS, src)
 
@@ -1001,9 +1072,7 @@ class ExportMaskTests(unittest.TestCase):
                         _write_mask(self._ZEROS, mp)
                         outpath = mp
 
-                    det = self._make_detection(
-                        mask=case["mask"], mask_path=mp
-                    )
+                    det = self._make_detection(mask=case["mask"], mask_path=mp)
                     with self.assertRaises(ValueError, msg=case["id"]):
                         det.export_mask(
                             outpath, overwrite_path=case["overwrite_path"]


### PR DESCRIPTION
## 🔗 Related Issues

Internal context for issue: https://voxel51.slack.com/archives/C08KF01388P/p1777724100560819?thread_ts=1776433614.028989&cid=C08KF01388P

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

Previously, the `index_to_instance` method operated on samples with the same `id` at a time, since instance IDs only intend to be shared within the same video frame. This did not work for frames views of the video or dynamically grouped datasets, since frames of the video are most commonly identified by the same `sample_id`.

This PR makes the ID field (among which to track the same instances) configurable.

## 🧪 How is this patch tested? If it is not, please explain why.

Added two new unit tests that reproduced the issue, that pass with these changes
- `test_label_to_instance_frames_view`
- `test_label_to_instance_frames_view_grouped`

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

The `fiftyone.utils.labels.index_to_instance` method now also works on `to_frames` views of a video, as well as on dynamically grouped datasets.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable label-to-instance mapping for dynamic groups and grouped/frame collections; added support for specifying a custom ID field, safer fallback when ID paths are missing, and per-group/frame updates that only modify the selected view (optionally clearing original index values).

* **Tests**
  * Added a shared helper and new tests covering frames views and grouped frames ordering to validate instance/index distributions; minor test formatting tweaks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->