### PR TITLE
Ontology/convert or condition to and

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/evaluateWhen.test.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/evaluateWhen.test.ts
@@ -86,13 +86,25 @@ describe("evaluateWhen", () => {
   // typed as Record<AttributeCondition["operator"], ...>, so TypeScript will
   // error if a new operator is added to the union without a handler entry.
 
-  describe("OR semantics — multiple conditions", () => {
-    it("returns true if ANY condition is satisfied", () => {
+  describe("AND semantics — multiple conditions", () => {
+    it("returns true when ALL conditions are satisfied", () => {
       const conditions = [
         { operator: "equals" as const, field: "category", value: "mammal" },
-        { operator: "equals" as const, field: "category", value: "bird" },
+        { operator: "equals" as const, field: "size", value: "large" },
       ];
-      expect(evaluateWhen(conditions, { category: "bird" })).toBe(true);
+      expect(
+        evaluateWhen(conditions, { category: "mammal", size: "large" })
+      ).toBe(true);
+    });
+
+    it("returns false when only some conditions are satisfied", () => {
+      const conditions = [
+        { operator: "equals" as const, field: "category", value: "mammal" },
+        { operator: "equals" as const, field: "size", value: "large" },
+      ];
+      expect(
+        evaluateWhen(conditions, { category: "mammal", size: "small" })
+      ).toBe(false);
     });
 
     it("returns false when no conditions are satisfied", () => {
@@ -180,13 +192,21 @@ describe("isWhenFulfillable", () => {
     });
   });
 
-  describe("OR semantics — multiple conditions", () => {
-    it("returns true if ANY condition is fulfillable", () => {
+  describe("AND semantics — multiple conditions", () => {
+    it("returns true when ALL conditions are fulfillable", () => {
+      const conditions = [
+        { operator: "equals" as const, field: "category", value: "mammal" },
+        { operator: "equals" as const, field: "size", value: "large" },
+      ];
+      expect(isWhenFulfillable(conditions, animalAttributes)).toBe(true);
+    });
+
+    it("returns false when any condition is unfulfillable", () => {
       const conditions = [
         { operator: "equals" as const, field: "category", value: "insect" },
         { operator: "equals" as const, field: "category", value: "mammal" },
       ];
-      expect(isWhenFulfillable(conditions, animalAttributes)).toBe(true);
+      expect(isWhenFulfillable(conditions, animalAttributes)).toBe(false);
     });
 
     it("returns false when all conditions are unfulfillable", () => {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/evaluateWhen.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/evaluateWhen.ts
@@ -34,8 +34,8 @@ const OPERATOR_HANDLERS: Record<
 /**
  * Evaluates a set of `when` conditions against the current label field values.
  *
- * Visibility semantics: an attribute is visible if ANY of its conditions are
- * satisfied (OR logic), matching the preview logic in the Schema Manager.
+ * Visibility semantics: an attribute is visible only if ALL of its conditions
+ * are satisfied (AND logic).
  *
  * @param conditions - The `when` array from an attribute definition, or
  *   undefined/empty for unconditionally-visible attributes.
@@ -50,7 +50,7 @@ export function evaluateWhen(
 ): boolean {
   if (!conditions || conditions.length === 0) return true;
 
-  return conditions.some((cond) => {
+  return conditions.every((cond) => {
     const handler = OPERATOR_HANDLERS[cond.operator];
     if (!handler) {
       throw new Error(`Unhandled operator: ${cond.operator}`);
@@ -60,8 +60,8 @@ export function evaluateWhen(
 }
 
 /**
- * Determines whether a set of `when` conditions can ever be satisfied given
- * the possible values of the referenced fields in the schema.
+ * Determines whether a set of `when` conditions can ever be simultaneously
+ * satisfied given the possible values of the referenced fields in the schema.
  *
  * Used to detect attributes whose conditions are structurally unfulfillable
  * (e.g. `when: [{ field: "category", operator: "equals", value: "insect" }]`
@@ -69,11 +69,14 @@ export function evaluateWhen(
  * when also marked `required` — must be rendered unconditionally so the
  * annotator can still fill them in.
  *
+ * With AND semantics, every condition must be independently fulfillable for
+ * the set as a whole to be considered fulfillable.
+ *
  * @param conditions - The `when` conditions to check.
  * @param schemaAttributes - All attribute configs for the current label schema,
  *   used to look up each referenced field's allowed values.
- * @returns `true` if at least one condition could be satisfied, `false` if
- *   every condition references a value that isn't in the field's value list.
+ * @returns `true` if every condition could be satisfied, `false` if any
+ *   condition references a value that isn't in the field's value list.
  */
 export function isWhenFulfillable(
   conditions: AttributeCondition[] | undefined,
@@ -95,7 +98,7 @@ export function isWhenFulfillable(
     }
   }
 
-  return conditions.some((cond) => {
+  return conditions.every((cond) => {
     const allowed = valuesByField.get(cond.field);
     if (!allowed) {
       // Field has no constrained value list — condition could be satisfied.


### PR DESCRIPTION
## 🔗 Related Issues

Converted `evaluateWhen` logic to evaluate arrays of `when` conditions with logical `AND` rather than logical `OR`

## 🧪 How is this patch tested? If it is not, please explain why.

Manual

Notice from the screenshot that the `damage_locations` field won't be visible unless `has_damage` is `true` **AND** `vehicle_type` is within `[car, truck]`
<img width="540" height="249" alt="Screenshot 2026-05-11 at 2 05 12 PM" src="https://github.com/user-attachments/assets/073f3103-5b74-4aed-ad94-0ca4aa0efafa" />

Here is a video proving this logic is working:

https://github.com/user-attachments/assets/33b56715-8514-4d88-b632-75c6824eb16f




