### PR TITLE
[HA] bugfix: only destroy the mask when label.mask does not exist

### DIFF
--- a/app/packages/lighter/src/overlay/DetectionOverlay.ts
+++ b/app/packages/lighter/src/overlay/DetectionOverlay.ts
@@ -148,10 +148,8 @@ export class DetectionOverlay
       }
       this.markDirty();
     } else if (label.mask === null) {
-      // Explicit removal — destroy any existing mask.
-      // `undefined` means the caller didn't supply mask data (e.g. the sidebar
-      // schema update only carries primitive fields), so preserve the
-      // in-progress MaskCanvas instead of throwing away the user's edit.
+      // null — explicit removal
+      // `undefined` can be cases when mask has not been saved yet - leave it alone
       const hadMask = !!this.mask;
       this.mask?.destroy();
       this.mask = undefined;

--- a/app/packages/lighter/src/overlay/DetectionOverlay.ts
+++ b/app/packages/lighter/src/overlay/DetectionOverlay.ts
@@ -147,7 +147,11 @@ export class DetectionOverlay
         this.mask = new MaskCanvas(label.mask);
       }
       this.markDirty();
-    } else {
+    } else if (label.mask === null) {
+      // Explicit removal — destroy any existing mask.
+      // `undefined` means the caller didn't supply mask data (e.g. the sidebar
+      // schema update only carries primitive fields), so preserve the
+      // in-progress MaskCanvas instead of throwing away the user's edit.
       const hadMask = !!this.mask;
       this.mask?.destroy();
       this.mask = undefined;


### PR DESCRIPTION
## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

bug: 

https://github.com/user-attachments/assets/27a368b5-223f-4967-9aca-97594b9ae36f

This PR fixes the bug. 

How to test it?
- go to polygon tool in segmentation, draw a shape (try not to trigger save)
- immediately change the label value
The mask should still be there

If there is any other downstream cases that may get impacted, those should be verified. 

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mask handling in detection overlays to properly distinguish between explicitly removed masks and unsaved masks, ensuring correct update behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7506)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->