### PR TITLE
[HA] per-point undo for pen tool

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/usePenTool.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/usePenTool.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+// Pen-tool lifecycle: installs an InteractivePenHandler on the selected
+// detection while the pen tool is active, and tears it down on tool/mode/
+// selection change. Modeled on `usePolylineMode`'s install/exit shape.
+
+import { useEffect, useRef } from "react";
+
+import type { Scene2D } from "@fiftyone/lighter";
+import { DetectionOverlay, InteractivePenHandler } from "@fiftyone/lighter";
+import type { AnnotationLabel } from "@fiftyone/state";
+
+import { SegmentationTool } from "./useManualSegmentationTools";
+
+export interface UsePenToolArgs {
+  /** The active Scene2D, or undefined while uninitialized. */
+  scene: Scene2D | undefined;
+  /** Whether segmentation mode is currently active. */
+  segmentationModeActive: boolean;
+  /** The active segmentation tool from `useManualSegmentationTools`. */
+  tool: SegmentationTool;
+  /** The overlay of the currently-selected annotation label, if any. */
+  selectedOverlay: AnnotationLabel["overlay"] | undefined;
+}
+
+/**
+ * Installs an {@link InteractivePenHandler} on `selectedOverlay` whenever the
+ * pen tool is the active gesture (`tool === Pen` + segmentation mode active
+ * + a `DetectionOverlay` is selected). Exits the handler on any condition
+ * change, and on unmount.
+ *
+ * No-op when the pen tool isn't active or there's no detection selected —
+ * the legacy first-click create path handles overlay creation, after which
+ * selection lands on the new overlay and this effect re-runs to install the
+ * handler for subsequent clicks.
+ */
+export const usePenTool = ({
+  scene,
+  segmentationModeActive,
+  tool,
+  selectedOverlay,
+}: UsePenToolArgs): void => {
+  const installedHandlerRef = useRef<InteractivePenHandler | null>(null);
+
+  // Keep a stable reference to `scene` for the unmount-cleanup effect so it
+  // doesn't capture a stale value across re-renders.
+  const sceneRef = useRef(scene);
+  sceneRef.current = scene;
+
+  useEffect(() => {
+    const exit = () => {
+      const installed = installedHandlerRef.current;
+      if (!installed) return;
+      installed.cleanup();
+      sceneRef.current?.exitInteractiveMode();
+      installedHandlerRef.current = null;
+    };
+
+    if (!scene || !segmentationModeActive) {
+      exit();
+      return;
+    }
+
+    if (tool !== SegmentationTool.Pen) {
+      exit();
+      return;
+    }
+
+    if (!(selectedOverlay instanceof DetectionOverlay)) {
+      exit();
+      return;
+    }
+
+    const installed = installedHandlerRef.current;
+    if (installed && installed.overlay === selectedOverlay) {
+      return;
+    }
+
+    exit();
+
+    // The legacy first-click create path leaves the scene in interactive mode
+    // wrapping an InteractiveDetectionHandler that's already been removed
+    // from the handler list. `enterInteractiveMode` is a no-op in that state,
+    // so flip it off before re-entering with the pen handler.
+    scene.exitInteractiveMode();
+
+    const handler = new InteractivePenHandler(selectedOverlay);
+    scene.enterInteractiveMode(handler);
+    installedHandlerRef.current = handler;
+  }, [scene, segmentationModeActive, tool, selectedOverlay]);
+
+  // Tear down on unmount.
+  useEffect(() => {
+    return () => {
+      const installed = installedHandlerRef.current;
+      if (!installed) return;
+      installed.cleanup();
+      sceneRef.current?.exitInteractiveMode();
+      installedHandlerRef.current = null;
+    };
+  }, []);
+};

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
@@ -6,7 +6,14 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { atom, useAtom, useAtomValue, useSetAtom } from "jotai";
 import { useRecoilValue } from "recoil";
 
-import { BaseOverlay, DetectionOverlay, useLighter } from "@fiftyone/lighter";
+import { CommandContextManager } from "@fiftyone/commands";
+import {
+  AddOverlayCommand,
+  BaseOverlay,
+  DetectionOverlay,
+  InteractivePenHandler,
+  useLighter,
+} from "@fiftyone/lighter";
 import { isPatchesView } from "@fiftyone/state";
 import { DETECTION } from "@fiftyone/utilities";
 
@@ -226,6 +233,69 @@ export const useSegmentationMode = () => {
     [aiMode, closeOpenLabel, manualMode, mergeTool, onExit]
   );
 
+  // Pen tool: install an InteractivePenHandler on the selected detection so
+  // each click pushes a per-point undo entry (mirrors the polyline pattern).
+  // The handler is torn down whenever the tool, mode, or selection changes
+  // such that pen editing is no longer the active gesture.
+  const installedPenHandlerRef = useRef<InteractivePenHandler | null>(null);
+  useEffect(() => {
+    const exit = () => {
+      const installed = installedPenHandlerRef.current;
+      if (!installed) return;
+      installed.cleanup();
+      sceneRef.current?.exitInteractiveMode();
+      installedPenHandlerRef.current = null;
+    };
+
+    if (!scene || !segmentationModeActive) {
+      exit();
+      return;
+    }
+
+    if (manualMode.tool !== SegmentationTool.Pen) {
+      exit();
+      return;
+    }
+
+    const overlay = selectedLabel?.overlay;
+    if (!(overlay instanceof DetectionOverlay)) {
+      // No detection selected yet — the first click goes through the legacy
+      // create path (segmentationModePaint) which builds the overlay and adds
+      // the first point. Once selection lands on the new overlay, this effect
+      // re-runs and installs the handler for subsequent clicks.
+      exit();
+      return;
+    }
+
+    const installed = installedPenHandlerRef.current;
+    if (installed && installed.overlay === overlay) {
+      return;
+    }
+
+    exit();
+
+    // The legacy first-click create path leaves the scene in interactive mode
+    // wrapping an InteractiveDetectionHandler that's already been removed
+    // from the handler list. `enterInteractiveMode` is a no-op in that state,
+    // so flip it off before re-entering with the pen handler.
+    scene.exitInteractiveMode();
+
+    const handler = new InteractivePenHandler(overlay);
+    scene.enterInteractiveMode(handler);
+    installedPenHandlerRef.current = handler;
+  }, [manualMode.tool, scene, segmentationModeActive, selectedLabel?.overlay]);
+
+  // Tear down on unmount.
+  useEffect(() => {
+    return () => {
+      const installed = installedPenHandlerRef.current;
+      if (!installed) return;
+      installed.cleanup();
+      sceneRef.current?.exitInteractiveMode();
+      installedPenHandlerRef.current = null;
+    };
+  }, []);
+
   // Auto-enable segmentation mode when a pre-existing mask detection is selected,
   // auto-disable when a pre-existing label of a different type is selected.
   //
@@ -268,8 +338,22 @@ export const useSegmentationMode = () => {
 
     if (newLabel?.overlay instanceof DetectionOverlay) {
       newLabel.overlay.initMask();
+
+      // Pen tool: the `overlay-establish` event that normally pushes
+      // `AddOverlayCommand` doesn't fire because `onPenPointerDown` doesn't
+      // seed the moveStart state. Push it explicitly so the new detection
+      // can be undone after the user finishes (or abandons) the polygon.
+      // Brush tool reaches establish through the bbox-style drag and pushes
+      // the command itself, so we skip it there.
+      if (manualMode.tool === SegmentationTool.Pen) {
+        CommandContextManager.instance()
+          .getActiveContext()
+          .pushUndoable(
+            new AddOverlayCommand(sceneRef.current!, newLabel.overlay)
+          );
+      }
     }
-  }, [closeOpenLabel, createDetection]);
+  }, [closeOpenLabel, createDetection, manualMode.tool]);
 
   /**
    * Accept the current AI mask, tear down point selection, and switch to the

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
@@ -11,7 +11,6 @@ import {
   AddOverlayCommand,
   BaseOverlay,
   DetectionOverlay,
-  InteractivePenHandler,
   useLighter,
 } from "@fiftyone/lighter";
 import { isPatchesView } from "@fiftyone/state";
@@ -31,6 +30,7 @@ import {
   useManualSegmentationTools,
 } from "./useManualSegmentationTools";
 import { useMergeTool } from "./useMergeTool";
+import { usePenTool } from "./usePenTool";
 
 // Re-export tool types/constants and unsafe atoms so existing import paths
 // (e.g. `import { SegmentationTool } from "./useSegmentationMode"`) keep
@@ -233,68 +233,15 @@ export const useSegmentationMode = () => {
     [aiMode, closeOpenLabel, manualMode, mergeTool, onExit]
   );
 
-  // Pen tool: install an InteractivePenHandler on the selected detection so
-  // each click pushes a per-point undo entry (mirrors the polyline pattern).
-  // The handler is torn down whenever the tool, mode, or selection changes
-  // such that pen editing is no longer the active gesture.
-  const installedPenHandlerRef = useRef<InteractivePenHandler | null>(null);
-  useEffect(() => {
-    const exit = () => {
-      const installed = installedPenHandlerRef.current;
-      if (!installed) return;
-      installed.cleanup();
-      sceneRef.current?.exitInteractiveMode();
-      installedPenHandlerRef.current = null;
-    };
-
-    if (!scene || !segmentationModeActive) {
-      exit();
-      return;
-    }
-
-    if (manualMode.tool !== SegmentationTool.Pen) {
-      exit();
-      return;
-    }
-
-    const overlay = selectedLabel?.overlay;
-    if (!(overlay instanceof DetectionOverlay)) {
-      // No detection selected yet — the first click goes through the legacy
-      // create path (segmentationModePaint) which builds the overlay and adds
-      // the first point. Once selection lands on the new overlay, this effect
-      // re-runs and installs the handler for subsequent clicks.
-      exit();
-      return;
-    }
-
-    const installed = installedPenHandlerRef.current;
-    if (installed && installed.overlay === overlay) {
-      return;
-    }
-
-    exit();
-
-    // The legacy first-click create path leaves the scene in interactive mode
-    // wrapping an InteractiveDetectionHandler that's already been removed
-    // from the handler list. `enterInteractiveMode` is a no-op in that state,
-    // so flip it off before re-entering with the pen handler.
-    scene.exitInteractiveMode();
-
-    const handler = new InteractivePenHandler(overlay);
-    scene.enterInteractiveMode(handler);
-    installedPenHandlerRef.current = handler;
-  }, [manualMode.tool, scene, segmentationModeActive, selectedLabel?.overlay]);
-
-  // Tear down on unmount.
-  useEffect(() => {
-    return () => {
-      const installed = installedPenHandlerRef.current;
-      if (!installed) return;
-      installed.cleanup();
-      sceneRef.current?.exitInteractiveMode();
-      installedPenHandlerRef.current = null;
-    };
-  }, []);
+  // Pen-tool lifecycle: install/exit the InteractivePenHandler reactively.
+  // See `usePenTool` for the full state machine and the rationale behind
+  // bypassing the no-detection-selected case (legacy first-click path).
+  usePenTool({
+    scene,
+    segmentationModeActive,
+    tool: manualMode.tool,
+    selectedOverlay: selectedLabel?.overlay,
+  });
 
   // Auto-enable segmentation mode when a pre-existing mask detection is selected,
   // auto-disable when a pre-existing label of a different type is selected.

--- a/app/packages/lighter/src/commands/AddMaskKeypointCommand.ts
+++ b/app/packages/lighter/src/commands/AddMaskKeypointCommand.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import type { Undoable } from "@fiftyone/commands";
+import type { DetectionOverlay } from "../overlay/DetectionOverlay";
+import type { Point } from "../types";
+
+/**
+ * Undoable command for adding a single keypoint to a pen-tool polygon-in-progress
+ * on a {@link DetectionOverlay}.
+ *
+ * Mirrors {@link AddPolylinePointCommand}: undo removes the point, redo
+ * re-adds it at the same world position with the same id so connection
+ * topology stays stable across undo/redo cycles.
+ */
+export class AddMaskKeypointCommand implements Undoable {
+  readonly id: string;
+  readonly description: string;
+
+  constructor(
+    private overlay: DetectionOverlay,
+    private pointId: string,
+    private worldPoint: Point,
+    private variant?: string
+  ) {
+    this.id = `add-mask-keypoint-${pointId}-${Date.now()}`;
+    this.description = `Add mask keypoint ${pointId}`;
+  }
+
+  execute(): void {
+    this.overlay.addMaskKeypoint(this.worldPoint, {
+      id: this.pointId,
+      variant: this.variant,
+    });
+  }
+
+  undo(): void {
+    this.overlay.removeMaskKeypointById(this.pointId);
+  }
+}

--- a/app/packages/lighter/src/index.ts
+++ b/app/packages/lighter/src/index.ts
@@ -69,6 +69,7 @@ export {
   KeypointPointHitAction,
 } from "./interaction/InteractiveKeypointHandler";
 export type { KeypointPointHitContext } from "./interaction/InteractiveKeypointHandler";
+export { InteractivePenHandler } from "./interaction/InteractivePenHandler";
 export {
   InteractivePolylineHandler,
   PolylineEdgeHitAction,
@@ -88,6 +89,8 @@ export type { SelectionOptions } from "./selection/SelectionManager";
 export { AddKeypointPointCommand } from "./commands/AddKeypointPointCommand";
 export { MergeDetectionsCommand } from "./commands/MergeDetectionsCommand";
 export type { MergeDetectionsCommandDeps } from "./commands/MergeDetectionsCommand";
+export { AddMaskKeypointCommand } from "./commands/AddMaskKeypointCommand";
+export { AddOverlayCommand } from "./commands/AddOverlayCommand";
 export { MoveKeypointPointCommand } from "./commands/MoveKeypointPointCommand";
 export { MoveOverlayCommand } from "./commands/MoveOverlayCommand";
 export { RemoveKeypointPointCommand } from "./commands/RemoveKeypointPointCommand";

--- a/app/packages/lighter/src/interaction/InteractionManager.ts
+++ b/app/packages/lighter/src/interaction/InteractionManager.ts
@@ -22,6 +22,7 @@ import { buildBrushCursor } from "./buildBrushCursor";
 import { InteractiveCreationHandler } from "./InteractiveCreationHandler";
 import { InteractiveDetectionHandler } from "./InteractiveDetectionHandler";
 import { InteractiveKeypointHandler } from "./InteractiveKeypointHandler";
+import { InteractivePenHandler } from "./InteractivePenHandler";
 import { InteractivePolylineHandler } from "./InteractivePolylineHandler";
 import { v4 as generateUUID } from "uuid";
 
@@ -66,6 +67,7 @@ function isSelfManagedInteractiveHandler(handler: InteractionHandler): boolean {
   return (
     handler instanceof InteractiveKeypointHandler ||
     handler instanceof InteractivePolylineHandler ||
+    handler instanceof InteractivePenHandler ||
     handler instanceof InteractiveCreationHandler
   );
 }
@@ -1076,7 +1078,15 @@ export class InteractionManager {
           segmentationToolState,
         });
 
-        if (interactiveHandler) {
+        if (interactiveHandler instanceof InteractivePenHandler) {
+          // Replace the per-point undo entries with the single
+          // PaintStrokeCommand emitted by commitPenPolygon. The handler stays
+          // installed so the user can keep drawing more polygons.
+          interactiveHandler.pruneCommands();
+        } else if (interactiveHandler) {
+          // First-click case: an InteractiveDetectionHandler still wraps the
+          // freshly-created overlay. Tear it down and emit overlay-establish
+          // so the AddOverlayCommand makes it into the undo stack.
           this.removeHandler(interactiveHandler);
           this.eventBus.dispatch("lighter:overlay-establish", {
             id: handler.id,

--- a/app/packages/lighter/src/interaction/InteractivePenHandler.ts
+++ b/app/packages/lighter/src/interaction/InteractivePenHandler.ts
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { CommandContextManager } from "@fiftyone/commands";
+import { AddMaskKeypointCommand } from "../commands/AddMaskKeypointCommand";
+import type { DetectionOverlay } from "../overlay/DetectionOverlay";
+import type { Point } from "../types";
+import type { InteractionHandler, OverlayEvent } from "./InteractionManager";
+
+const INTERACTIVE_PEN_HANDLER_ID = "interactive-pen-handler";
+
+// PointerEvent.buttons & 1 == left button held down.
+const LEFT_MOUSE_BUTTON = 1;
+
+/**
+ * Editing handler for the pen tool on a {@link DetectionOverlay}'s mask.
+ *
+ * Mirrors {@link InteractivePolylineHandler}: while installed via
+ * `scene.enterInteractiveMode`, captures every click and routes it as a
+ * single pen keypoint placement. Each placement pushes an
+ * {@link AddMaskKeypointCommand} so users can undo points individually.
+ *
+ * Commit to the mask (right-click) is handled separately in
+ * {@link InteractionManager.handleRightClick} via `overlay.commitPenPolygon`;
+ * on commit the per-point commands are pruned and replaced by the single
+ * `PaintStrokeCommand` that represents the filled polygon.
+ */
+export class InteractivePenHandler implements InteractionHandler {
+  readonly id = INTERACTIVE_PEN_HANDLER_ID;
+  readonly cursor = "crosshair";
+
+  private readonly pushedCommandIds = new Set<string>();
+
+  constructor(public readonly overlay: DetectionOverlay) {}
+
+  containsPoint(): boolean {
+    // Capture all clicks while active.
+    return true;
+  }
+
+  getOverlay(): DetectionOverlay {
+    return this.overlay;
+  }
+
+  markDirty(): void {
+    this.overlay.markDirty();
+  }
+
+  onPointerDown({ worldPoint }: OverlayEvent): boolean {
+    this.placePoint(worldPoint, false);
+    return true;
+  }
+
+  onMove({ worldPoint, event }: OverlayEvent): boolean {
+    if ((event.buttons & LEFT_MOUSE_BUTTON) === LEFT_MOUSE_BUTTON) {
+      this.placePoint(worldPoint, true);
+    } else {
+      this.overlay.updatePenMousePosition(worldPoint);
+    }
+    return true;
+  }
+
+  onPointerUp(): boolean {
+    return true;
+  }
+
+  onCanvasLeave(): void {
+    this.overlay.updatePenMousePosition(null);
+  }
+
+  cleanup(): void {
+    this.overlay.updatePenMousePosition(null);
+  }
+
+  /**
+   * Removes every per-point undo entry pushed by this handler. Called after
+   * `commitPenPolygon` so the resulting `PaintStrokeCommand` becomes the
+   * single undoable artifact for the whole polygon.
+   */
+  pruneCommands(): void {
+    if (this.pushedCommandIds.size === 0) return;
+
+    CommandContextManager.instance()
+      .getActiveContext()
+      .pruneUndoables((u) => this.pushedCommandIds.has(u.id));
+
+    this.pushedCommandIds.clear();
+  }
+
+  private placePoint(worldPoint: Point, dragging: boolean): void {
+    const pointId = this.overlay.addMaskKeypoint(worldPoint, { dragging });
+    if (pointId === null) return;
+
+    const cmd = new AddMaskKeypointCommand(this.overlay, pointId, {
+      x: worldPoint.x,
+      y: worldPoint.y,
+    });
+    CommandContextManager.instance().getActiveContext().pushUndoable(cmd);
+    this.pushedCommandIds.add(cmd.id);
+  }
+}

--- a/app/packages/lighter/src/overlay/DetectionOverlay.ts
+++ b/app/packages/lighter/src/overlay/DetectionOverlay.ts
@@ -1124,6 +1124,53 @@ export class DetectionOverlay
   }
 
   /**
+   * Adds a point to the in-progress pen polygon. Lazily constructs the
+   * `MaskKeypoints` overlay on the first call. Returns the new point id, or
+   * `null` if the dragging-throttle rejected the placement.
+   */
+  addMaskKeypoint(
+    worldPoint: Point,
+    options?: { id?: string; variant?: string; dragging?: boolean }
+  ): string | null {
+    this.maskKeypoints ??= new MaskKeypoints({
+      coordinateSystem: this.coordinateSystem,
+      renderer: this.renderer,
+    });
+
+    const pointId = this.maskKeypoints.addPoint({ ...worldPoint }, options);
+    if (pointId !== null) {
+      this.interactionState = "PAINTING";
+      this.markDirty();
+    }
+    return pointId;
+  }
+
+  /**
+   * Removes a pen-polygon point by id. Disposes the in-progress polygon when
+   * the last point is removed so a subsequent click starts a fresh ring.
+   */
+  removeMaskKeypointById(pointId: string): void {
+    if (!this.maskKeypoints) return;
+
+    this.maskKeypoints.removePointById(pointId);
+
+    if (this.maskKeypoints.getAbsolutePoints().length === 0) {
+      this.maskKeypoints.destroy();
+      this.maskKeypoints = undefined;
+      this.interactionState = "NONE";
+    }
+
+    this.markDirty();
+  }
+
+  /**
+   * Number of points currently in the in-progress pen polygon.
+   */
+  getMaskKeypointCount(): number {
+    return this.maskKeypoints?.getAbsolutePoints().length ?? 0;
+  }
+
+  /**
    * Fills the pen polygon onto the mask canvas and clears the pen state.
    * Uses the current paint mode from the last known segmentation state.
    */

--- a/app/packages/lighter/src/overlay/MaskKeypoints.ts
+++ b/app/packages/lighter/src/overlay/MaskKeypoints.ts
@@ -101,25 +101,40 @@ export class MaskKeypoints extends KeypointOverlay {
 
     if (shouldAddPoint) {
       const pointID = super.addPoint(worldPoint, options);
-      const points = this.getAbsolutePoints();
-
-      const connections = points.reduce(
-        (memo, _point, index) =>
-          index === 0
-            ? memo
-            : index === points.length - 1
-            ? [...memo, [index - 1, index], [index, 0]]
-            : [...memo, [index - 1, index]],
-        []
-      );
-
-      this.setConnections(connections);
-
+      this.rebuildRingConnections();
       this.lastKeypoint = { ...worldPoint };
       return pointID;
     }
 
     return null;
+  }
+
+  /**
+   * Removes a point by id and rebuilds the closing-ring connections so the
+   * remaining points stay correctly chained.
+   */
+  override removePointById(pointId: string): void {
+    super.removePointById(pointId);
+    this.rebuildRingConnections();
+
+    const points = this.getAbsolutePoints();
+    this.lastKeypoint = points.length
+      ? { x: points[points.length - 1].x, y: points[points.length - 1].y }
+      : undefined;
+  }
+
+  private rebuildRingConnections(): void {
+    const points = this.getAbsolutePoints();
+    const connections = points.reduce(
+      (memo, _point, index) =>
+        index === 0
+          ? memo
+          : index === points.length - 1
+          ? [...memo, [index - 1, index], [index, 0]]
+          : [...memo, [index - 1, index]],
+      []
+    );
+    this.setConnections(connections);
   }
 
   protected override renderImpl(renderer: Renderer2D): void {


### PR DESCRIPTION
## 🔗 Related Issues

## Summary

Adopt the polyline editing pattern for the pen tool so each dropped keypoint
becomes an individual undo entry, and the new detection itself remains
undoable. Previously, pen clicks were either no-ops on the undo stack or
collapsed onto the previously-committed shape, which made it impossible to
walk a pen polygon back point by point.

**Issue**: The new detection created by the pen tool can't be undone. The
   `overlay-establish` event that normally pushes `AddOverlayCommand` never
   fires for the pen flow because `onPenPointerDown` doesn't seed
   `moveStart` state, so the empty detection had no undo entry.
  
   ## Approach

Mirror `InteractivePolylineHandler`: a self-managed interactive handler
captures every pen click and pushes one `AddMaskKeypointCommand` per
placement. On commit (right-click), the handler prunes its per-point
entries so the resulting `PaintStrokeCommand` becomes the single artifact
that represents the filled polygon.

The new detection's `AddOverlayCommand` is pushed explicitly from
`useSegmentationMode.create()` for the Pen tool, since the legacy
establish-event path doesn't fire here.

For a fresh pen polygon with N points:
pre-commit: [..., AddOverlayCommand, AddMaskKeypointCmd_2, ..., AddMaskKeypointCmd_N]
post-commit: [..., AddOverlayCommand, PaintStrokeCommand]

## 📋 What changes are proposed in this pull request?


https://github.com/user-attachments/assets/72af2580-e27f-41b2-aa8d-fcdc9993666b



## 🧪 How is this patch tested? If it is not, please explain why.

## Test plan
- [ ] Pen tool: click N points, press undo N-1 times → each click removed
      one at a time, detection remains.
- [ ] Pen tool: click N points, undo until detection itself is removed →
      no orphan state, scene is clean.
- [ ] Pen tool: click N points, right-click commit → mask filled, single
      `PaintStrokeCommand` on stack. Undo reverts mask; another undo
      removes the detection.
- [ ] Pen tool: click 1 point, right-click → polygon cancelled, detection
      stays, can be undone via the `AddOverlayCommand`.
- [ ] Pen tool: switch to brush mid-polygon → handler exits, brush works
      against the same overlay. Switch back to pen → handler reinstalls.
- [ ] Brush tool regression: brush stroke is still undoable, no duplicate
      `AddOverlayCommand` pushed.
- [ ] AI tool regression: switching into AI from pen tears down the pen
      handler cleanly.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pen drawing now adds/removes individual mask keypoints with undo/redo.
  * Overlay objects expose pen-point count and support incremental pen-point editing.
  * Interactive pen mode improved to keep drawing active and streamline command history into single-stroke commits.

* **Bug Fixes**
  * Finalizing an overlay in pen mode preserves pen handler state so drawing can continue without interruption.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7507)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->