### PR TITLE
Ontology: Fully Composable Conditions

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/evaluateWhen.test.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/evaluateWhen.test.ts
@@ -11,109 +11,268 @@ import type { AttributeConfig } from "../SchemaManager/utils";
 // ---------------------------------------------------------------------------
 
 describe("evaluateWhen", () => {
-  it("returns true when conditions are undefined", () => {
+  it("returns true when condition is undefined", () => {
     expect(evaluateWhen(undefined, {})).toBe(true);
   });
 
-  it("returns true when conditions array is empty", () => {
-    expect(evaluateWhen([], { category: "mammal" })).toBe(true);
-  });
-
-  describe("operator: equals", () => {
+  describe("operator: equals (leaf)", () => {
     it("returns true when the field value equals the condition value", () => {
-      const conditions = [
-        { operator: "equals" as const, field: "category", value: "mammal" },
-      ];
-      expect(evaluateWhen(conditions, { category: "mammal" })).toBe(true);
-    });
-
-    it("returns false when the field value does not match", () => {
-      const conditions = [
-        { operator: "equals" as const, field: "category", value: "mammal" },
-      ];
-      expect(evaluateWhen(conditions, { category: "bird" })).toBe(false);
-    });
-
-    it("returns false when the field is absent from currentValues", () => {
-      const conditions = [
-        { operator: "equals" as const, field: "category", value: "mammal" },
-      ];
-      expect(evaluateWhen(conditions, {})).toBe(false);
-    });
-
-    it("uses strict equality (no type coercion)", () => {
-      const conditions = [
-        { operator: "equals" as const, field: "score", value: 1 },
-      ];
-      expect(evaluateWhen(conditions, { score: "1" })).toBe(false);
-      expect(evaluateWhen(conditions, { score: 1 })).toBe(true);
-    });
-  });
-
-  describe("operator: in", () => {
-    it("returns true when field value is in the condition value array", () => {
-      const conditions = [
-        {
-          operator: "in" as const,
-          field: "category",
-          value: ["mammal", "bird"],
-        },
-      ];
-      expect(evaluateWhen(conditions, { category: "mammal" })).toBe(true);
-      expect(evaluateWhen(conditions, { category: "bird" })).toBe(true);
-    });
-
-    it("returns false when field value is not in the array", () => {
-      const conditions = [
-        {
-          operator: "in" as const,
-          field: "category",
-          value: ["mammal", "bird"],
-        },
-      ];
-      expect(evaluateWhen(conditions, { category: "reptile" })).toBe(false);
-    });
-
-    it("returns false when condition value is not an array", () => {
-      const conditions = [
-        { operator: "in" as const, field: "category", value: "mammal" },
-      ];
-      expect(evaluateWhen(conditions, { category: "mammal" })).toBe(false);
-    });
-  });
-
-  // Unknown operators are prevented at compile time: OPERATOR_HANDLERS is
-  // typed as Record<AttributeCondition["operator"], ...>, so TypeScript will
-  // error if a new operator is added to the union without a handler entry.
-
-  describe("AND semantics — multiple conditions", () => {
-    it("returns true when ALL conditions are satisfied", () => {
-      const conditions = [
-        { operator: "equals" as const, field: "category", value: "mammal" },
-        { operator: "equals" as const, field: "size", value: "large" },
-      ];
       expect(
-        evaluateWhen(conditions, { category: "mammal", size: "large" })
+        evaluateWhen(
+          { operator: "equals", field: "category", value: "mammal" },
+          { category: "mammal" }
+        )
       ).toBe(true);
     });
 
-    it("returns false when only some conditions are satisfied", () => {
-      const conditions = [
-        { operator: "equals" as const, field: "category", value: "mammal" },
-        { operator: "equals" as const, field: "size", value: "large" },
-      ];
+    it("returns false when the field value does not match", () => {
       expect(
-        evaluateWhen(conditions, { category: "mammal", size: "small" })
+        evaluateWhen(
+          { operator: "equals", field: "category", value: "mammal" },
+          { category: "bird" }
+        )
       ).toBe(false);
     });
 
-    it("returns false when no conditions are satisfied", () => {
-      const conditions = [
-        { operator: "equals" as const, field: "category", value: "mammal" },
-        { operator: "equals" as const, field: "category", value: "bird" },
-      ];
-      expect(evaluateWhen(conditions, { category: "reptile" })).toBe(false);
+    it("returns false when the field is absent from currentValues", () => {
+      expect(
+        evaluateWhen(
+          { operator: "equals", field: "category", value: "mammal" },
+          {}
+        )
+      ).toBe(false);
     });
+
+    it("uses strict equality (no type coercion)", () => {
+      const cond = { operator: "equals" as const, field: "score", value: 1 };
+      expect(evaluateWhen(cond, { score: "1" })).toBe(false);
+      expect(evaluateWhen(cond, { score: 1 })).toBe(true);
+    });
+  });
+
+  describe("operator: in (leaf)", () => {
+    it("returns true when field value is in the condition value array", () => {
+      const cond = {
+        operator: "in" as const,
+        field: "category",
+        value: ["mammal", "bird"],
+      };
+      expect(evaluateWhen(cond, { category: "mammal" })).toBe(true);
+      expect(evaluateWhen(cond, { category: "bird" })).toBe(true);
+    });
+
+    it("returns false when field value is not in the array", () => {
+      expect(
+        evaluateWhen(
+          { operator: "in", field: "category", value: ["mammal", "bird"] },
+          { category: "reptile" }
+        )
+      ).toBe(false);
+    });
+
+    it("returns false when condition value is not an array", () => {
+      expect(
+        evaluateWhen(
+          { operator: "in", field: "category", value: "mammal" },
+          { category: "mammal" }
+        )
+      ).toBe(false);
+    });
+  });
+
+  // Unknown leaf operators are prevented at compile time by LEAF_OPERATOR_HANDLERS
+  // being typed as Record<AttributeConditionLeaf["operator"], ...>.
+
+  describe("operator: and (group)", () => {
+    it("returns true when ALL child conditions are satisfied", () => {
+      expect(
+        evaluateWhen(
+          {
+            operator: "and",
+            conditions: [
+              { operator: "equals", field: "category", value: "mammal" },
+              { operator: "equals", field: "size", value: "large" },
+            ],
+          },
+          { category: "mammal", size: "large" }
+        )
+      ).toBe(true);
+    });
+
+    it("returns false when only some child conditions are satisfied", () => {
+      expect(
+        evaluateWhen(
+          {
+            operator: "and",
+            conditions: [
+              { operator: "equals", field: "category", value: "mammal" },
+              { operator: "equals", field: "size", value: "large" },
+            ],
+          },
+          { category: "mammal", size: "small" }
+        )
+      ).toBe(false);
+    });
+
+    it("returns false when no child conditions are satisfied", () => {
+      expect(
+        evaluateWhen(
+          {
+            operator: "and",
+            conditions: [
+              { operator: "equals", field: "category", value: "mammal" },
+              { operator: "equals", field: "category", value: "bird" },
+            ],
+          },
+          { category: "reptile" }
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe("operator: or (group)", () => {
+    it("returns true when any child condition is satisfied", () => {
+      const cond = {
+        operator: "or" as const,
+        conditions: [
+          { operator: "equals" as const, field: "category", value: "mammal" },
+          { operator: "equals" as const, field: "category", value: "bird" },
+        ],
+      };
+      expect(evaluateWhen(cond, { category: "mammal" })).toBe(true);
+      expect(evaluateWhen(cond, { category: "bird" })).toBe(true);
+    });
+
+    it("returns false when no child condition is satisfied", () => {
+      expect(
+        evaluateWhen(
+          {
+            operator: "or",
+            conditions: [
+              { operator: "equals", field: "category", value: "mammal" },
+              { operator: "equals", field: "category", value: "bird" },
+            ],
+          },
+          { category: "reptile" }
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe("nested conditions", () => {
+    it("AND containing an OR: passes when outer leaf and any inner OR branch match", () => {
+      const cond = {
+        operator: "and" as const,
+        conditions: [
+          { operator: "equals" as const, field: "has_damage", value: true },
+          {
+            operator: "or" as const,
+            conditions: [
+              {
+                operator: "equals" as const,
+                field: "region",
+                value: "front",
+              },
+              { operator: "equals" as const, field: "region", value: "rear" },
+            ],
+          },
+        ],
+      };
+      expect(evaluateWhen(cond, { has_damage: true, region: "front" })).toBe(
+        true
+      );
+      expect(evaluateWhen(cond, { has_damage: true, region: "rear" })).toBe(
+        true
+      );
+    });
+
+    it("AND containing an OR: fails when outer leaf doesn't match", () => {
+      const cond = {
+        operator: "and" as const,
+        conditions: [
+          { operator: "equals" as const, field: "has_damage", value: true },
+          {
+            operator: "or" as const,
+            conditions: [
+              {
+                operator: "equals" as const,
+                field: "region",
+                value: "front",
+              },
+              { operator: "equals" as const, field: "region", value: "rear" },
+            ],
+          },
+        ],
+      };
+      expect(evaluateWhen(cond, { has_damage: false, region: "front" })).toBe(
+        false
+      );
+    });
+
+    it("OR containing an AND: passes when the AND branch is fully satisfied", () => {
+      const cond = {
+        operator: "or" as const,
+        conditions: [
+          { operator: "equals" as const, field: "priority", value: "urgent" },
+          {
+            operator: "and" as const,
+            conditions: [
+              {
+                operator: "equals" as const,
+                field: "category",
+                value: "mammal",
+              },
+              { operator: "equals" as const, field: "size", value: "large" },
+            ],
+          },
+        ],
+      };
+      expect(
+        evaluateWhen(cond, {
+          category: "mammal",
+          size: "large",
+          priority: "low",
+        })
+      ).toBe(true);
+      expect(evaluateWhen(cond, { priority: "urgent" })).toBe(true);
+    });
+
+    it("deep nesting: AND(OR(leaf, AND(leaf, leaf)), leaf)", () => {
+      const cond = {
+        operator: "and" as const,
+        conditions: [
+          {
+            operator: "or" as const,
+            conditions: [
+              { operator: "equals" as const, field: "a", value: 1 },
+              {
+                operator: "and" as const,
+                conditions: [
+                  { operator: "equals" as const, field: "b", value: 2 },
+                  { operator: "equals" as const, field: "c", value: 3 },
+                ],
+              },
+            ],
+          },
+          { operator: "equals" as const, field: "d", value: 4 },
+        ],
+      };
+      // a=1 satisfies OR branch 1; d=4 satisfies outer AND leaf
+      expect(evaluateWhen(cond, { a: 1, d: 4 })).toBe(true);
+      // b=2, c=3 satisfies OR branch 2 (inner AND); d=4 satisfies outer AND leaf
+      expect(evaluateWhen(cond, { b: 2, c: 3, d: 4 })).toBe(true);
+      // neither OR branch satisfied
+      expect(evaluateWhen(cond, { a: 0, b: 2, c: 0, d: 4 })).toBe(false);
+      // outer leaf not satisfied
+      expect(evaluateWhen(cond, { a: 1, d: 99 })).toBe(false);
+    });
+  });
+
+  it("throws on an unknown operator (exhaustiveness guard)", () => {
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      evaluateWhen({ operator: "contains" as any, field: "x", value: "y" }, {})
+    ).toThrow("Unhandled operator: contains");
   });
 });
 
@@ -137,99 +296,198 @@ const animalAttributes: AttributeConfig[] = [
 ];
 
 describe("isWhenFulfillable", () => {
-  it("returns true when conditions are undefined", () => {
+  it("returns true when condition is undefined", () => {
     expect(isWhenFulfillable(undefined, animalAttributes)).toBe(true);
   });
 
-  it("returns true when conditions are empty", () => {
-    expect(isWhenFulfillable([], animalAttributes)).toBe(true);
-  });
-
-  describe("operator: equals", () => {
+  describe("operator: equals (leaf)", () => {
     it("returns true when the value exists in the referenced field's values", () => {
-      const conditions = [
-        { operator: "equals" as const, field: "category", value: "mammal" },
-      ];
-      expect(isWhenFulfillable(conditions, animalAttributes)).toBe(true);
+      expect(
+        isWhenFulfillable(
+          { operator: "equals", field: "category", value: "mammal" },
+          animalAttributes
+        )
+      ).toBe(true);
     });
 
     it("returns false when the value is not in the referenced field's values", () => {
-      const conditions = [
-        { operator: "equals" as const, field: "category", value: "insect" },
-      ];
-      expect(isWhenFulfillable(conditions, animalAttributes)).toBe(false);
+      expect(
+        isWhenFulfillable(
+          { operator: "equals", field: "category", value: "insect" },
+          animalAttributes
+        )
+      ).toBe(false);
     });
 
     it("returns true when the referenced field has no values list (open-ended)", () => {
-      const conditions = [
-        { operator: "equals" as const, field: "notes", value: "foo" },
-      ];
-      expect(isWhenFulfillable(conditions, animalAttributes)).toBe(true);
+      expect(
+        isWhenFulfillable(
+          { operator: "equals", field: "notes", value: "foo" },
+          animalAttributes
+        )
+      ).toBe(true);
     });
   });
 
-  describe("operator: in", () => {
+  describe("operator: in (leaf)", () => {
     it("returns true when at least one value in the list is allowed", () => {
-      const conditions = [
-        {
-          operator: "in" as const,
-          field: "category",
-          value: ["insect", "mammal"],
-        },
-      ];
-      expect(isWhenFulfillable(conditions, animalAttributes)).toBe(true);
+      expect(
+        isWhenFulfillable(
+          { operator: "in", field: "category", value: ["insect", "mammal"] },
+          animalAttributes
+        )
+      ).toBe(true);
     });
 
     it("returns false when none of the values in the list are allowed", () => {
-      const conditions = [
-        {
-          operator: "in" as const,
-          field: "category",
-          value: ["insect", "fungus"],
-        },
-      ];
-      expect(isWhenFulfillable(conditions, animalAttributes)).toBe(false);
+      expect(
+        isWhenFulfillable(
+          { operator: "in", field: "category", value: ["insect", "fungus"] },
+          animalAttributes
+        )
+      ).toBe(false);
     });
   });
 
-  describe("AND semantics — multiple conditions", () => {
+  describe("operator: and (group)", () => {
     it("returns true when ALL conditions are fulfillable", () => {
-      const conditions = [
-        { operator: "equals" as const, field: "category", value: "mammal" },
-        { operator: "equals" as const, field: "size", value: "large" },
-      ];
-      expect(isWhenFulfillable(conditions, animalAttributes)).toBe(true);
+      expect(
+        isWhenFulfillable(
+          {
+            operator: "and",
+            conditions: [
+              { operator: "equals", field: "category", value: "mammal" },
+              { operator: "equals", field: "size", value: "large" },
+            ],
+          },
+          animalAttributes
+        )
+      ).toBe(true);
     });
 
     it("returns false when any condition is unfulfillable", () => {
-      const conditions = [
-        { operator: "equals" as const, field: "category", value: "insect" },
-        { operator: "equals" as const, field: "category", value: "mammal" },
-      ];
-      expect(isWhenFulfillable(conditions, animalAttributes)).toBe(false);
+      expect(
+        isWhenFulfillable(
+          {
+            operator: "and",
+            conditions: [
+              { operator: "equals", field: "category", value: "insect" },
+              { operator: "equals", field: "category", value: "mammal" },
+            ],
+          },
+          animalAttributes
+        )
+      ).toBe(false);
     });
 
     it("returns false when all conditions are unfulfillable", () => {
-      const conditions = [
-        { operator: "equals" as const, field: "category", value: "insect" },
-        { operator: "equals" as const, field: "category", value: "fungus" },
-      ];
-      expect(isWhenFulfillable(conditions, animalAttributes)).toBe(false);
+      expect(
+        isWhenFulfillable(
+          {
+            operator: "and",
+            conditions: [
+              { operator: "equals", field: "category", value: "insect" },
+              { operator: "equals", field: "category", value: "fungus" },
+            ],
+          },
+          animalAttributes
+        )
+      ).toBe(false);
     });
   });
 
-  it("returns true for the ontology_test is_domesticated attribute", () => {
-    const conditions = [
-      { operator: "equals" as const, field: "category", value: "mammal" },
-    ];
-    expect(isWhenFulfillable(conditions, animalAttributes)).toBe(true);
+  describe("operator: or (group)", () => {
+    it("returns true when at least one child is fulfillable", () => {
+      expect(
+        isWhenFulfillable(
+          {
+            operator: "or",
+            conditions: [
+              { operator: "equals", field: "category", value: "insect" },
+              { operator: "equals", field: "category", value: "mammal" },
+            ],
+          },
+          animalAttributes
+        )
+      ).toBe(true);
+    });
+
+    it("returns false when all children are unfulfillable", () => {
+      expect(
+        isWhenFulfillable(
+          {
+            operator: "or",
+            conditions: [
+              { operator: "equals", field: "category", value: "insect" },
+              { operator: "equals", field: "category", value: "fungus" },
+            ],
+          },
+          animalAttributes
+        )
+      ).toBe(false);
+    });
   });
 
-  it("returns false for a fictitious value not in ontology_test category list", () => {
-    const conditions = [
-      { operator: "equals" as const, field: "category", value: "dragon" },
-    ];
-    expect(isWhenFulfillable(conditions, animalAttributes)).toBe(false);
+  describe("nested groups", () => {
+    it("AND(OR(fulfillable, unfulfillable), fulfillable) is fulfillable", () => {
+      expect(
+        isWhenFulfillable(
+          {
+            operator: "and",
+            conditions: [
+              {
+                operator: "or",
+                conditions: [
+                  { operator: "equals", field: "category", value: "mammal" },
+                  { operator: "equals", field: "category", value: "insect" },
+                ],
+              },
+              { operator: "equals", field: "size", value: "large" },
+            ],
+          },
+          animalAttributes
+        )
+      ).toBe(true);
+    });
+
+    it("AND(OR(unfulfillable, unfulfillable), fulfillable) is not fulfillable", () => {
+      expect(
+        isWhenFulfillable(
+          {
+            operator: "and",
+            conditions: [
+              {
+                operator: "or",
+                conditions: [
+                  { operator: "equals", field: "category", value: "insect" },
+                  { operator: "equals", field: "category", value: "fungus" },
+                ],
+              },
+              { operator: "equals", field: "size", value: "large" },
+            ],
+          },
+          animalAttributes
+        )
+      ).toBe(false);
+    });
+  });
+
+  it("returns true for a fulfillable named attribute", () => {
+    expect(
+      isWhenFulfillable(
+        { operator: "equals", field: "category", value: "mammal" },
+        animalAttributes
+      )
+    ).toBe(true);
+  });
+
+  it("returns false for a fictitious value not in the category list", () => {
+    expect(
+      isWhenFulfillable(
+        { operator: "equals", field: "category", value: "dragon" },
+        animalAttributes
+      )
+    ).toBe(false);
   });
 
   describe("duplicate attribute names — values are merged, not overwritten", () => {
@@ -247,54 +505,50 @@ describe("isWhenFulfillable", () => {
         type: "str",
         component: "dropdown",
         values: ["dog", "cat"],
-        when: [
-          { operator: "equals" as const, field: "category", value: "mammal" },
-        ],
+        when: {
+          operator: "equals" as const,
+          field: "category",
+          value: "mammal",
+        },
       },
       {
         name: "animal_name",
         type: "str",
         component: "dropdown",
         values: ["snake", "lizard"],
-        when: [
-          { operator: "equals" as const, field: "category", value: "reptile" },
-        ],
+        when: {
+          operator: "equals" as const,
+          field: "category",
+          value: "reptile",
+        },
       },
     ];
 
     it("finds a value from the first duplicate entry even when the second entry is last", () => {
-      const conditions = [
-        {
-          operator: "equals" as const,
-          field: "animal_name",
-          value: "dog",
-        },
-      ];
-      expect(isWhenFulfillable(conditions, duplicateNameAttributes)).toBe(true);
+      expect(
+        isWhenFulfillable(
+          { operator: "equals", field: "animal_name", value: "dog" },
+          duplicateNameAttributes
+        )
+      ).toBe(true);
     });
 
     it("finds a value from the second duplicate entry", () => {
-      const conditions = [
-        {
-          operator: "equals" as const,
-          field: "animal_name",
-          value: "snake",
-        },
-      ];
-      expect(isWhenFulfillable(conditions, duplicateNameAttributes)).toBe(true);
+      expect(
+        isWhenFulfillable(
+          { operator: "equals", field: "animal_name", value: "snake" },
+          duplicateNameAttributes
+        )
+      ).toBe(true);
     });
 
     it("returns false when the value is in neither duplicate entry", () => {
-      const conditions = [
-        {
-          operator: "equals" as const,
-          field: "animal_name",
-          value: "dragon",
-        },
-      ];
-      expect(isWhenFulfillable(conditions, duplicateNameAttributes)).toBe(
-        false
-      );
+      expect(
+        isWhenFulfillable(
+          { operator: "equals", field: "animal_name", value: "dragon" },
+          duplicateNameAttributes
+        )
+      ).toBe(false);
     });
 
     it("produces the same result regardless of duplicate entry order", () => {
@@ -303,25 +557,42 @@ describe("isWhenFulfillable", () => {
         duplicateNameAttributes[2], // reptile first
         duplicateNameAttributes[1], // mammal second
       ];
-      const conditions = [
-        { operator: "equals" as const, field: "animal_name", value: "dog" },
-      ];
-      expect(isWhenFulfillable(conditions, duplicateNameAttributes)).toBe(
-        isWhenFulfillable(conditions, reversed)
+      const cond = {
+        operator: "equals" as const,
+        field: "animal_name",
+        value: "dog",
+      };
+      expect(isWhenFulfillable(cond, duplicateNameAttributes)).toBe(
+        isWhenFulfillable(cond, reversed)
       );
     });
   });
 
   it("throws on an unknown operator (exhaustiveness guard)", () => {
-    const conditions = [
-      // Cast through `any` to simulate a future operator arriving at runtime
-      // before the frontend is updated (e.g. from a newer backend).
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      { operator: "contains" as any, field: "category", value: "mammal" },
-    ];
-    expect(() => isWhenFulfillable(conditions, animalAttributes)).toThrow(
-      "Unhandled operator: contains"
-    );
+    expect(() =>
+      isWhenFulfillable(
+        // Cast through `any` to simulate a future operator arriving at runtime
+        // before the frontend is updated (e.g. from a newer backend).
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { operator: "contains" as any, field: "category", value: "mammal" },
+        animalAttributes
+      )
+    ).toThrow("Unhandled operator: contains");
+  });
+
+  it("throws on an unknown operator inside a group node (exhaustiveness guard)", () => {
+    expect(() =>
+      isWhenFulfillable(
+        {
+          operator: "and",
+          conditions: [
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            { operator: "contains" as any, field: "category", value: "mammal" },
+          ],
+        },
+        animalAttributes
+      )
+    ).toThrow("Unhandled operator: contains");
   });
 });
 
@@ -341,22 +612,20 @@ const schemaWithVariants: AttributeConfig[] = [
     type: "str",
     component: "dropdown",
     values: ["dog", "cat"],
-    when: [{ operator: "equals" as const, field: "category", value: "mammal" }],
+    when: { operator: "equals" as const, field: "category", value: "mammal" },
   },
   {
     name: "animal_name",
     type: "str",
     component: "dropdown",
     values: ["snake", "lizard"],
-    when: [
-      { operator: "equals" as const, field: "category", value: "reptile" },
-    ],
+    when: { operator: "equals" as const, field: "category", value: "reptile" },
   },
   {
     name: "impossible_field",
     type: "str",
     component: "text",
-    when: [{ operator: "equals" as const, field: "category", value: "dragon" }],
+    when: { operator: "equals" as const, field: "category", value: "dragon" },
   },
   {
     name: "size",
@@ -443,6 +712,57 @@ describe("resolveVisibleAttribute", () => {
     });
     expect(before).toBe(after);
   });
+
+  describe("WhenAnd entry — variant gated on two conditions", () => {
+    const schemaWithAndVariant: AttributeConfig[] = [
+      {
+        name: "has_damage",
+        type: "bool",
+        component: "checkbox",
+      },
+      {
+        name: "vehicle_type",
+        type: "str",
+        component: "dropdown",
+        values: ["car", "truck", "motorcycle"],
+      },
+      {
+        name: "damage_location",
+        type: "str",
+        component: "dropdown",
+        values: ["front", "rear"],
+        when: {
+          operator: "and" as const,
+          conditions: [
+            { operator: "equals" as const, field: "has_damage", value: true },
+            {
+              operator: "in" as const,
+              field: "vehicle_type",
+              value: ["car", "truck"],
+            },
+          ],
+        },
+      },
+    ];
+
+    it("resolves the entry when both AND conditions are met", () => {
+      const result = resolveVisibleAttribute(
+        "damage_location",
+        schemaWithAndVariant,
+        { has_damage: true, vehicle_type: "car" }
+      );
+      expect(result).toBe(schemaWithAndVariant[2]);
+    });
+
+    it("returns undefined when only one AND condition is met", () => {
+      const result = resolveVisibleAttribute(
+        "damage_location",
+        schemaWithAndVariant,
+        { has_damage: true, vehicle_type: "motorcycle" }
+      );
+      expect(result).toBeUndefined();
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -476,9 +796,7 @@ describe("mixed conditional/unconditional variants for the same name", () => {
       name: "notes",
       type: "str",
       component: "text",
-      when: [
-        { operator: "equals" as const, field: "category", value: "mammal" },
-      ],
+      when: { operator: "equals" as const, field: "category", value: "mammal" },
     },
   ];
 
@@ -492,7 +810,7 @@ describe("mixed conditional/unconditional variants for the same name", () => {
     expect(result).toBeUndefined();
   });
 
-  it("resolveVisibleAttribute returns undefined even when the conditional sibling is visible", () => {
+  it("resolveVisibleAttribute returns the conditional entry when it is visible", () => {
     // Both variants coexist for category = "mammal"; resolveVisibleAttribute
     // still returns the conditional entry (not the unconditional one).
     const result = resolveVisibleAttribute("notes", mixedAttributes, {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/evaluateWhen.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/evaluateWhen.ts
@@ -1,10 +1,11 @@
 import type {
   AttributeCondition,
+  AttributeConditionLeaf,
   AttributeConfig,
 } from "../SchemaManager/utils";
 
 /**
- * Handler signature for a single operator.
+ * Handler signature for a single leaf operator.
  *
  * @param fieldValue - The current value of the referenced field.
  * @param condValue  - The value (or array of values) declared in the condition.
@@ -12,19 +13,19 @@ import type {
  * Note: comparison assumes primitive values. If condValue or fieldValue could
  * be objects, we'll need to implement a deep-equality check.
  */
-type OperatorHandler = (fieldValue: unknown, condValue: unknown) => boolean;
+type LeafOperatorHandler = (fieldValue: unknown, condValue: unknown) => boolean;
 
 /**
- * Typed map of every supported `when` operator to its evaluation logic.
+ * Typed map of every supported leaf `when` operator to its evaluation logic.
  *
- * Using `Record<AttributeCondition["operator"], ...>` means TypeScript will
- * produce a compile error here if a new operator is added to the union without
- * a corresponding handler — ensuring no operator is silently unhandled at
- * runtime.
+ * Using `Record<AttributeConditionLeaf["operator"], ...>` means TypeScript will
+ * produce a compile error here if a new leaf operator is added to the union
+ * without a corresponding handler — ensuring no operator is silently unhandled
+ * at runtime.
  */
-const OPERATOR_HANDLERS: Record<
-  AttributeCondition["operator"],
-  OperatorHandler
+const LEAF_OPERATOR_HANDLERS: Record<
+  AttributeConditionLeaf["operator"],
+  LeafOperatorHandler
 > = {
   equals: (fieldValue, condValue) => fieldValue === condValue,
   in: (fieldValue, condValue) =>
@@ -32,57 +33,128 @@ const OPERATOR_HANDLERS: Record<
 };
 
 /**
- * Evaluates a set of `when` conditions against the current label field values.
+ * Recursively evaluates a single condition node against the current label
+ * field values.
  *
- * Visibility semantics: an attribute is visible only if ALL of its conditions
- * are satisfied (AND logic).
+ * - `"and"` nodes pass when every child passes.
+ * - `"or"` nodes pass when any child passes.
+ * - `"equals"` / `"in"` leaves delegate to {@link LEAF_OPERATOR_HANDLERS}.
+ */
+function evaluateCondition(
+  cond: AttributeCondition,
+  currentValues: Record<string, unknown>
+): boolean {
+  switch (cond.operator) {
+    case "and":
+      return cond.conditions.every((c) => evaluateCondition(c, currentValues));
+    case "or":
+      return cond.conditions.some((c) => evaluateCondition(c, currentValues));
+    case "equals":
+    case "in": {
+      const handler = LEAF_OPERATOR_HANDLERS[cond.operator];
+      return handler(currentValues[cond.field], cond.value);
+    }
+    default: {
+      const _exhaustive: never = cond;
+      throw new Error(
+        `Unhandled operator: ${(_exhaustive as AttributeCondition).operator}`
+      );
+    }
+  }
+}
+
+/**
+ * Evaluates a `when` condition tree against the current label field values.
  *
- * @param conditions - The `when` array from an attribute definition, or
- *   undefined/empty for unconditionally-visible attributes.
+ * Visibility semantics: an attribute is visible only if its condition tree
+ * evaluates to true. Compose AND / OR logic via
+ * {@link AttributeConditionAnd} / {@link AttributeConditionOr} nodes; a bare
+ * leaf condition is a single field check.
+ *
+ * @param condition - The `when` root node from an attribute definition, or
+ *   `undefined` for unconditionally-visible attributes.
  * @param currentValues - Flat map of the label's current field values
  *   (e.g. `{ label: "dog", category: "mammal" }`).
  * @returns `true` if the attribute should be shown, `false` if it should be
  *   hidden.
  */
 export function evaluateWhen(
-  conditions: AttributeCondition[] | undefined,
+  condition: AttributeCondition | undefined,
   currentValues: Record<string, unknown>
 ): boolean {
-  if (!conditions || conditions.length === 0) return true;
-
-  return conditions.every((cond) => {
-    const handler = OPERATOR_HANDLERS[cond.operator];
-    if (!handler) {
-      throw new Error(`Unhandled operator: ${cond.operator}`);
-    }
-    return handler(currentValues[cond.field], cond.value);
-  });
+  if (!condition) return true;
+  return evaluateCondition(condition, currentValues);
 }
 
 /**
- * Determines whether a set of `when` conditions can ever be simultaneously
- * satisfied given the possible values of the referenced fields in the schema.
+ * Recursively determines whether a condition node can ever be satisfied given
+ * the possible values of the referenced fields in the schema.
+ *
+ * - `"and"` is fulfillable when every child is fulfillable.
+ * - `"or"` is fulfillable when any child is fulfillable.
+ * - Leaf nodes check whether the referenced field's allowed value set contains
+ *   a matching value.
+ */
+function isConditionFulfillable(
+  cond: AttributeCondition,
+  valuesByField: Map<string, Set<unknown>>
+): boolean {
+  switch (cond.operator) {
+    case "and":
+      return cond.conditions.every((c) =>
+        isConditionFulfillable(c, valuesByField)
+      );
+    case "or":
+      return cond.conditions.some((c) =>
+        isConditionFulfillable(c, valuesByField)
+      );
+    case "equals": {
+      const allowed = valuesByField.get(cond.field);
+      // Field has no constrained value list — condition could be satisfied.
+      if (!allowed) return true;
+      return allowed.has(cond.value);
+    }
+    case "in": {
+      const allowed = valuesByField.get(cond.field);
+      if (!allowed) return true;
+      return (
+        Array.isArray(cond.value) &&
+        (cond.value as unknown[]).some((v) => allowed.has(v))
+      );
+    }
+    default: {
+      const _exhaustive: never = cond;
+      throw new Error(
+        `Unhandled operator: ${(_exhaustive as AttributeCondition).operator}`
+      );
+    }
+  }
+}
+
+/**
+ * Determines whether a `when` condition tree can ever be satisfied given the
+ * possible values of the referenced fields in the schema.
  *
  * Used to detect attributes whose conditions are structurally unfulfillable
- * (e.g. `when: [{ field: "category", operator: "equals", value: "insect" }]`
+ * (e.g. `when: { operator: "equals", field: "category", value: "insect" }`
  * but `category` has no "insect" in its `values` list). Such attributes —
  * when also marked `required` — must be rendered unconditionally so the
  * annotator can still fill them in.
  *
- * With AND semantics, every condition must be independently fulfillable for
- * the set as a whole to be considered fulfillable.
+ * For `"and"` trees, every branch must be independently fulfillable.
+ * For `"or"` trees, at least one branch must be fulfillable.
  *
- * @param conditions - The `when` conditions to check.
+ * @param condition - The `when` root node to check.
  * @param schemaAttributes - All attribute configs for the current label schema,
  *   used to look up each referenced field's allowed values.
- * @returns `true` if every condition could be satisfied, `false` if any
- *   condition references a value that isn't in the field's value list.
+ * @returns `true` if the condition could be satisfied, `false` if it is
+ *   structurally impossible given the schema's value constraints.
  */
 export function isWhenFulfillable(
-  conditions: AttributeCondition[] | undefined,
+  condition: AttributeCondition | undefined,
   schemaAttributes: AttributeConfig[]
 ): boolean {
-  if (!conditions || conditions.length === 0) return true;
+  if (!condition) return true;
 
   // Merge values from all attributes with the same name so that duplicate
   // entries (e.g. "animal_name" for "mammal" and "reptile" variants) each
@@ -98,28 +170,7 @@ export function isWhenFulfillable(
     }
   }
 
-  return conditions.every((cond) => {
-    const allowed = valuesByField.get(cond.field);
-    if (!allowed) {
-      // Field has no constrained value list — condition could be satisfied.
-      return true;
-    }
-
-    // Reuse the same operator handlers, but against the set of allowed values
-    switch (cond.operator) {
-      case "equals":
-        return allowed.has(cond.value);
-      case "in":
-        return (
-          Array.isArray(cond.value) &&
-          (cond.value as unknown[]).some((v) => allowed.has(v))
-        );
-      default: {
-        const _exhaustive: never = cond.operator;
-        throw new Error(`Unhandled operator: ${_exhaustive}`);
-      }
-    }
-  });
+  return isConditionFulfillable(condition, valuesByField);
 }
 
 /**

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/useAttributeForm.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/useAttributeForm.ts
@@ -80,6 +80,7 @@ export default function useAttributeForm({
       cond: AttributeCondition
     ): AttributeConditionLeaf[] => {
       if (cond.operator === "and" || cond.operator === "or") {
+        if (!Array.isArray(cond.conditions)) return [];
         return cond.conditions.flatMap(collectLeaves);
       }
       return [cond];

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/useAttributeForm.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/useAttributeForm.ts
@@ -17,6 +17,8 @@ import {
 import {
   getAttributeFormErrors,
   hasAttributeFormError,
+  type AttributeCondition,
+  type AttributeConditionLeaf,
   type AttributeFormData,
 } from "../../utils";
 
@@ -67,30 +69,37 @@ export default function useAttributeForm({
   const isListType = LIST_TYPES.includes(formState.type);
   const isFromOntology = !!formState._source;
   const whenPreview = useMemo(() => {
-    const conditions = formState.when;
-    if (!conditions || conditions.length === 0) return null;
+    const when = formState.when;
+    if (!when) return null;
 
-    const formatValue = (v: unknown): string => {
-      if (typeof v === "string") return v;
-      return JSON.stringify(v);
-    };
+    const formatValue = (v: unknown): string =>
+      typeof v === "string" ? v : JSON.stringify(v);
 
-    const formatCondition = (condition: typeof conditions[number]): string => {
-      if (condition.operator === "in" && Array.isArray(condition.value)) {
-        const list = (condition.value as unknown[])
-          .map((v) => formatValue(v))
-          .join(", ");
-        return `${condition.field} in [${list}]`;
+    // Recursively collect all leaf conditions from the condition tree.
+    const collectLeaves = (
+      cond: AttributeCondition
+    ): AttributeConditionLeaf[] => {
+      if (cond.operator === "and" || cond.operator === "or") {
+        return cond.conditions.flatMap(collectLeaves);
       }
-      return `${condition.field} = ${formatValue(condition.value)}`;
+      return [cond];
     };
 
-    const condition = formatCondition(conditions[0]);
+    const leaves = collectLeaves(when);
+    if (leaves.length === 0) return null;
 
-    if (conditions.length === 1) return { condition, suffix: null };
+    const first = leaves[0];
+    const condition =
+      first.operator === "in" && Array.isArray(first.value)
+        ? `${first.field} in [${(first.value as unknown[])
+            .map(formatValue)
+            .join(", ")}]`
+        : `${first.field} = ${formatValue(first.value)}`;
 
-    const remaining = conditions.length - 1;
-    const suffix = `, or ${remaining} other condition${
+    if (leaves.length === 1) return { condition, suffix: null };
+
+    const remaining = leaves.length - 1;
+    const suffix = `, +${remaining} more condition${
       remaining !== 1 ? "s" : ""
     }`;
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/utils.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/utils.ts
@@ -44,13 +44,30 @@ export interface RichListItemOptions {
   className?: string;
 }
 
-// Conditional visibility rule for an attribute from an applied ontology.
-// Describes a condition under which the attribute should be shown.
-export interface AttributeCondition {
+// Leaf condition: a single field comparison (equals / in).
+export interface AttributeConditionLeaf {
   operator: "equals" | "in";
   field: string;
   value: unknown;
 }
+
+// Group condition: satisfied when ALL child conditions are met.
+export interface AttributeConditionAnd {
+  operator: "and";
+  conditions: AttributeCondition[];
+}
+
+// Group condition: satisfied when ANY child condition is met.
+export interface AttributeConditionOr {
+  operator: "or";
+  conditions: AttributeCondition[];
+}
+
+// Discriminated union over all condition node shapes.
+export type AttributeCondition =
+  | AttributeConditionLeaf
+  | AttributeConditionAnd
+  | AttributeConditionOr;
 
 // Attribute configuration (matches API)
 // Note: When stored in schema, attributes include 'name' field
@@ -62,7 +79,7 @@ export interface AttributeConfig {
   range?: [number, number];
   default?: string | number | (string | number)[]; // Array for list types
   read_only?: boolean;
-  when?: AttributeCondition[];
+  when?: AttributeCondition;
   _source?: string;
 }
 
@@ -95,7 +112,7 @@ export interface AttributeFormData {
   default: string;
   listDefault: (string | number)[]; // For list types
   read_only: boolean;
-  when?: AttributeCondition[];
+  when?: AttributeCondition;
   _source?: string;
 }
 

--- a/fiftyone/core/annotation/attributes.py
+++ b/fiftyone/core/annotation/attributes.py
@@ -9,7 +9,8 @@ Annotation attribute primitives for label schemas and ontologies.
 import abc
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Generator, Literal, Optional, Union
+from collections.abc import Generator
+from typing import Any, Literal, Optional, Union
 
 
 #: Maximum nesting depth allowed for a ``when`` condition tree. Mirrors the

--- a/fiftyone/core/annotation/attributes.py
+++ b/fiftyone/core/annotation/attributes.py
@@ -12,6 +12,11 @@ from enum import Enum
 from typing import Any, Generator, Literal, Optional, Union
 
 
+#: Maximum nesting depth allowed for a ``when`` condition tree. Mirrors the
+#: 20-level taxonomy depth limit cited in the PRD.
+MAX_CONDITION_DEPTH = 20
+
+
 def attr_insert_to_dict(d: dict, name: str, obj: object) -> dict:
     """Inserts ``obj.<name>`` into ``d`` under key ``name`` if it is set
     (i.e. not ``None``).
@@ -40,10 +45,12 @@ def _require_keys(d: dict, keys: tuple, cls: type) -> None:
 
 
 class WhenOperator(str, Enum):
-    """Supported logical operators for :class:`When` leaf conditions."""
+    """Supported logical operators for all :class:`WhenCondition` nodes."""
 
     EQUALS = "equals"
     IN = "in"
+    AND = "and"
+    OR = "or"
 
 
 class WhenCondition(abc.ABC):
@@ -69,7 +76,7 @@ class WhenCondition(abc.ABC):
         """
 
     @classmethod
-    def from_dict(cls, d: dict) -> "WhenCondition":
+    def from_dict(cls, d: dict, _depth: int = 0) -> "WhenCondition":
         """Deserializes a condition from a plain dict.
 
         Dispatches to :class:`WhenAnd`, :class:`WhenOr`, or :class:`When`
@@ -81,21 +88,27 @@ class WhenCondition(abc.ABC):
         Returns:
             a :class:`WhenCondition`
         """
+        if _depth > MAX_CONDITION_DEPTH:
+            raise ValueError(
+                f"condition tree exceeds the maximum nesting depth of "
+                f"{MAX_CONDITION_DEPTH}"
+            )
         if not isinstance(d, dict):
             raise ValueError(
                 f"WhenCondition.from_dict expects a dict, got "
                 f"{type(d).__name__}"
             )
         op = d.get("operator")
-        if op == "and":
-            return WhenAnd.from_dict(d)
-        if op == "or":
-            return WhenOr.from_dict(d)
+        if op == WhenOperator.AND:
+            return WhenAnd.from_dict(d, _depth=_depth + 1)
+        if op == WhenOperator.OR:
+            return WhenOr.from_dict(d, _depth=_depth + 1)
         return When.from_dict(d)
 
 
 def collect_leaf_conditions(
     root: WhenCondition,
+    _depth: int = 0,
 ) -> Generator["When", None, None]:
     """Recursively yields all leaf :class:`When` nodes in a condition tree.
 
@@ -112,13 +125,21 @@ def collect_leaf_conditions(
     Yields:
         each leaf :class:`When` node in the tree
     """
-    if root is None:
-        return
+    if _depth > MAX_CONDITION_DEPTH:
+        raise ValueError(
+            f"condition tree exceeds the maximum nesting depth of "
+            f"{MAX_CONDITION_DEPTH}"
+        )
     if isinstance(root, (WhenAnd, WhenOr)):
         for child in root.conditions:
-            yield from collect_leaf_conditions(child)
+            yield from collect_leaf_conditions(child, _depth=_depth + 1)
+    elif isinstance(root, When):
+        yield root
     else:
-        yield root  # type: ignore[misc]
+        raise TypeError(
+            f"collect_leaf_conditions encountered an unexpected node type: "
+            f"{type(root).__name__!r}"
+        )
 
 
 @dataclass(repr=False)
@@ -294,6 +315,12 @@ class WhenAnd(WhenCondition):
     def __post_init__(self) -> None:
         if not isinstance(self.conditions, list) or not self.conditions:
             raise ValueError("WhenAnd.conditions must be a non-empty list")
+        for i, c in enumerate(self.conditions):
+            if not isinstance(c, WhenCondition):
+                raise ValueError(
+                    f"WhenAnd.conditions[{i}] must be a WhenCondition, "
+                    f"got {type(c).__name__!r}"
+                )
 
     def to_dict(self) -> dict:
         """Serializes this group condition to a dict.
@@ -302,12 +329,12 @@ class WhenAnd(WhenCondition):
             a dict
         """
         return {
-            "operator": "and",
+            "operator": WhenOperator.AND.value,
             "conditions": [c.to_dict() for c in self.conditions],
         }
 
     @classmethod
-    def from_dict(cls, d: dict) -> "WhenAnd":
+    def from_dict(cls, d: dict, _depth: int = 0) -> "WhenAnd":
         """Creates a :class:`WhenAnd` from a dict.
 
         Args:
@@ -320,7 +347,10 @@ class WhenAnd(WhenCondition):
         if not isinstance(d["conditions"], list):
             raise ValueError("WhenAnd.conditions must be a list")
         return cls(
-            conditions=[WhenCondition.from_dict(c) for c in d["conditions"]]
+            [
+                WhenCondition.from_dict(c, _depth=_depth)
+                for c in d["conditions"]
+            ]
         )
 
     def __repr__(self) -> str:
@@ -362,6 +392,12 @@ class WhenOr(WhenCondition):
     def __post_init__(self) -> None:
         if not isinstance(self.conditions, list) or not self.conditions:
             raise ValueError("WhenOr.conditions must be a non-empty list")
+        for i, c in enumerate(self.conditions):
+            if not isinstance(c, WhenCondition):
+                raise ValueError(
+                    f"WhenOr.conditions[{i}] must be a WhenCondition, "
+                    f"got {type(c).__name__!r}"
+                )
 
     def to_dict(self) -> dict:
         """Serializes this group condition to a dict.
@@ -370,12 +406,12 @@ class WhenOr(WhenCondition):
             a dict
         """
         return {
-            "operator": "or",
+            "operator": WhenOperator.OR.value,
             "conditions": [c.to_dict() for c in self.conditions],
         }
 
     @classmethod
-    def from_dict(cls, d: dict) -> "WhenOr":
+    def from_dict(cls, d: dict, _depth: int = 0) -> "WhenOr":
         """Creates a :class:`WhenOr` from a dict.
 
         Args:
@@ -388,7 +424,10 @@ class WhenOr(WhenCondition):
         if not isinstance(d["conditions"], list):
             raise ValueError("WhenOr.conditions must be a list")
         return cls(
-            conditions=[WhenCondition.from_dict(c) for c in d["conditions"]]
+            [
+                WhenCondition.from_dict(c, _depth=_depth)
+                for c in d["conditions"]
+            ]
         )
 
     def __repr__(self) -> str:

--- a/fiftyone/core/annotation/attributes.py
+++ b/fiftyone/core/annotation/attributes.py
@@ -112,6 +112,8 @@ def collect_leaf_conditions(
     Yields:
         each leaf :class:`When` node in the tree
     """
+    if root is None:
+        return
     if isinstance(root, (WhenAnd, WhenOr)):
         for child in root.conditions:
             yield from collect_leaf_conditions(child)

--- a/fiftyone/core/annotation/attributes.py
+++ b/fiftyone/core/annotation/attributes.py
@@ -6,9 +6,10 @@ Annotation attribute primitives for label schemas and ontologies.
 |
 """
 
+import abc
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Literal, Optional, Union
+from typing import Any, Generator, Literal, Optional, Union
 
 
 def attr_insert_to_dict(d: dict, name: str, obj: object) -> dict:
@@ -39,19 +40,92 @@ def _require_keys(d: dict, keys: tuple, cls: type) -> None:
 
 
 class WhenOperator(str, Enum):
-    """Supported logical operators for :class:`When` conditions."""
+    """Supported logical operators for :class:`When` leaf conditions."""
 
     EQUALS = "equals"
     IN = "in"
 
 
+class WhenCondition(abc.ABC):
+    """Abstract base class for all condition nodes in a ``when`` expression
+    tree.
+
+    A ``when`` expression is a tree of :class:`WhenCondition` nodes.
+    Leaves are :class:`When` instances (or the convenience subclasses
+    :class:`WhenEquals` / :class:`WhenIn`). Interior nodes are
+    :class:`WhenAnd` and :class:`WhenOr`, which hold child conditions and
+    evaluate them with AND / OR semantics respectively.
+
+    Subclasses must implement :meth:`to_dict`. Deserialization always goes
+    through :meth:`from_dict`, which dispatches on the ``"operator"`` key.
+    """
+
+    @abc.abstractmethod
+    def to_dict(self) -> dict:
+        """Serializes this condition to a plain dict.
+
+        Returns:
+            a dict
+        """
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "WhenCondition":
+        """Deserializes a condition from a plain dict.
+
+        Dispatches to :class:`WhenAnd`, :class:`WhenOr`, or :class:`When`
+        based on the ``"operator"`` key.
+
+        Args:
+            d: a condition dict
+
+        Returns:
+            a :class:`WhenCondition`
+        """
+        if not isinstance(d, dict):
+            raise ValueError(
+                f"WhenCondition.from_dict expects a dict, got "
+                f"{type(d).__name__}"
+            )
+        op = d.get("operator")
+        if op == "and":
+            return WhenAnd.from_dict(d)
+        if op == "or":
+            return WhenOr.from_dict(d)
+        return When.from_dict(d)
+
+
+def collect_leaf_conditions(
+    root: WhenCondition,
+) -> Generator["When", None, None]:
+    """Recursively yields all leaf :class:`When` nodes in a condition tree.
+
+    Group nodes (:class:`WhenAnd`, :class:`WhenOr`) are traversed but not
+    yielded. Only :class:`When` leaves (including :class:`WhenEquals` and
+    :class:`WhenIn`) are yielded.
+
+    This is the correct way for validation code to inspect operators, field
+    references, and ``then`` overrides without needing to know about nesting.
+
+    Args:
+        root: the root condition node to traverse
+
+    Yields:
+        each leaf :class:`When` node in the tree
+    """
+    if isinstance(root, (WhenAnd, WhenOr)):
+        for child in root.conditions:
+            yield from collect_leaf_conditions(child)
+    else:
+        yield root  # type: ignore[misc]
+
+
 @dataclass(repr=False)
-class When:
-    """A visibility/override condition for an :class:`AttributeSpec`.
+class When(WhenCondition):
+    """A leaf visibility/override condition for an :class:`AttributeSpec`.
 
     Controls when an attribute is shown based on the value of another
-    attribute. Multiple ``When`` conditions on a single attribute are
-    combined with implicit AND.
+    attribute. Compose multiple conditions using :class:`WhenAnd` and
+    :class:`WhenOr`.
 
     Args:
         operator: the logical operator (:class:`WhenOperator` or its string
@@ -184,6 +258,142 @@ class WhenIn(When):
 
 
 @dataclass(repr=False)
+class WhenAnd(WhenCondition):
+    """An AND group condition: satisfied when ALL child conditions are met.
+
+    Child conditions may themselves be leaves (:class:`When`,
+    :class:`WhenEquals`, :class:`WhenIn`) or nested groups
+    (:class:`WhenAnd`, :class:`WhenOr`), enabling arbitrary boolean
+    composition.
+
+    Args:
+        conditions: list of child :class:`WhenCondition` nodes, all of which
+            must be satisfied
+
+    Example::
+
+        WhenAnd([
+            WhenEquals(field="has_damage", value=True),
+            WhenIn(field="vehicle_type", value=["car", "truck"]),
+        ])
+
+        # Nested composition
+        WhenAnd([
+            WhenEquals(field="has_damage", value=True),
+            WhenOr([
+                WhenEquals(field="vehicle_type", value="car"),
+                WhenEquals(field="vehicle_type", value="truck"),
+            ]),
+        ])
+    """
+
+    conditions: list
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.conditions, list) or not self.conditions:
+            raise ValueError("WhenAnd.conditions must be a non-empty list")
+
+    def to_dict(self) -> dict:
+        """Serializes this group condition to a dict.
+
+        Returns:
+            a dict
+        """
+        return {
+            "operator": "and",
+            "conditions": [c.to_dict() for c in self.conditions],
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "WhenAnd":
+        """Creates a :class:`WhenAnd` from a dict.
+
+        Args:
+            d: a condition dict with ``"operator": "and"``
+
+        Returns:
+            a :class:`WhenAnd`
+        """
+        _require_keys(d, ("conditions",), cls)
+        if not isinstance(d["conditions"], list):
+            raise ValueError("WhenAnd.conditions must be a list")
+        return cls(
+            conditions=[WhenCondition.from_dict(c) for c in d["conditions"]]
+        )
+
+    def __repr__(self) -> str:
+        return f"WhenAnd({self.conditions!r})"
+
+
+@dataclass(repr=False)
+class WhenOr(WhenCondition):
+    """An OR group condition: satisfied when ANY child condition is met.
+
+    Child conditions may themselves be leaves (:class:`When`,
+    :class:`WhenEquals`, :class:`WhenIn`) or nested groups
+    (:class:`WhenAnd`, :class:`WhenOr`), enabling arbitrary boolean
+    composition.
+
+    Args:
+        conditions: list of child :class:`WhenCondition` nodes, at least one
+            of which must be satisfied
+
+    Example::
+
+        WhenOr([
+            WhenEquals(field="vehicle_type", value="car"),
+            WhenEquals(field="vehicle_type", value="truck"),
+        ])
+
+        # Nested: show when damage is present AND region is front OR rear
+        WhenAnd([
+            WhenEquals(field="damage_present", value=True),
+            WhenOr([
+                WhenEquals(field="region", value="front"),
+                WhenEquals(field="region", value="rear"),
+            ]),
+        ])
+    """
+
+    conditions: list
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.conditions, list) or not self.conditions:
+            raise ValueError("WhenOr.conditions must be a non-empty list")
+
+    def to_dict(self) -> dict:
+        """Serializes this group condition to a dict.
+
+        Returns:
+            a dict
+        """
+        return {
+            "operator": "or",
+            "conditions": [c.to_dict() for c in self.conditions],
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "WhenOr":
+        """Creates a :class:`WhenOr` from a dict.
+
+        Args:
+            d: a condition dict with ``"operator": "or"``
+
+        Returns:
+            a :class:`WhenOr`
+        """
+        _require_keys(d, ("conditions",), cls)
+        if not isinstance(d["conditions"], list):
+            raise ValueError("WhenOr.conditions must be a list")
+        return cls(
+            conditions=[WhenCondition.from_dict(c) for c in d["conditions"]]
+        )
+
+    def __repr__(self) -> str:
+        return f"WhenOr({self.conditions!r})"
+
+
+@dataclass(repr=False)
 class AttributeSpec:
     """A typed annotation attribute with optional conditional visibility.
 
@@ -196,8 +406,9 @@ class AttributeSpec:
         component: the UI component (e.g. ``"checkbox"``, ``"dropdown"``,
             ``"radio"``)
         values: optional list of allowed values
-        when: optional list of :class:`When` conditions controlling when
-            this attribute is visible or field overrides
+        when: optional :class:`WhenCondition` controlling when this attribute
+            is visible. Use a bare leaf for a single condition, or compose
+            with :class:`WhenAnd` / :class:`WhenOr` for boolean logic.
         read_only: optional flag marking the attribute as non-editable
         default: optional default value (type matches ``type``)
         range: optional ``[min, max]`` for numeric-with-slider components
@@ -205,12 +416,39 @@ class AttributeSpec:
 
     Example::
 
+        # Single condition
         AttributeSpec(
             name="damage_location",
             type="str",
             component="dropdown",
             values=["front", "rear", "driver_side", "passenger_side"],
-            when=[WhenEquals(field="damage_present", value=True)],
+            when=WhenEquals(field="damage_present", value=True),
+        )
+
+        # AND of two conditions
+        AttributeSpec(
+            name="repair_priority",
+            type="str",
+            component="radio",
+            values=["urgent", "scheduled", "deferred"],
+            when=WhenAnd([
+                WhenEquals(field="damage_present", value=True),
+                WhenIn(field="vehicle_type", value=["car", "truck"]),
+            ]),
+        )
+
+        # Nested AND / OR
+        AttributeSpec(
+            name="repair_detail",
+            type="str",
+            component="text",
+            when=WhenAnd([
+                WhenEquals(field="damage_present", value=True),
+                WhenOr([
+                    WhenEquals(field="region", value="front"),
+                    WhenEquals(field="region", value="rear"),
+                ]),
+            ]),
         )
     """
 
@@ -218,7 +456,7 @@ class AttributeSpec:
     type: str
     component: str
     values: Optional[list] = None
-    when: Optional[list[When]] = None
+    when: Optional[WhenCondition] = None
     read_only: Optional[bool] = None
     default: Any = None
     range: Optional[list] = None
@@ -253,7 +491,7 @@ class AttributeSpec:
         attr_insert_to_dict(d, "range", self)
         attr_insert_to_dict(d, "precision", self)
         if self.when is not None:
-            d["when"] = [w.to_dict() for w in self.when]
+            d["when"] = self.when.to_dict()
         return d
 
     @classmethod
@@ -274,11 +512,7 @@ class AttributeSpec:
 
         when = None
         if "when" in d:
-            if not isinstance(d["when"], list):
-                raise ValueError(
-                    "AttributeSpec.when must be a list if provided"
-                )
-            when = [When.from_dict(w) for w in d["when"]]
+            when = WhenCondition.from_dict(d["when"])
 
         return cls(
             name=d["name"],

--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -233,7 +233,7 @@ class AnnotationOntology(Ontology):
                     type="str",
                     component="dropdown",
                     values=["front", "rear", "driver_side", "passenger_side"],
-                    when=[WhenEquals(field="damage_present", value=True)],
+                    when=WhenEquals(field="damage_present", value=True),
                 ),
             ],
         )

--- a/fiftyone/core/ontology_validation.py
+++ b/fiftyone/core/ontology_validation.py
@@ -7,7 +7,10 @@ Validation for :class:`fiftyone.core.ontology.AnnotationOntology`.
 """
 
 from fiftyone.core.annotation import constants as _fac
-from fiftyone.core.annotation.attributes import WhenOperator
+from fiftyone.core.annotation.attributes import (
+    WhenOperator,
+    collect_leaf_conditions,
+)
 from fiftyone.core.ontology import AnnotationOntology
 
 
@@ -57,7 +60,7 @@ def _validate_when_operators(ontology: AnnotationOntology) -> list[str]:
     for attr in ontology.attributes:
         if attr.when is None:
             continue
-        for w in attr.when:
+        for w in collect_leaf_conditions(attr.when):
             try:
                 WhenOperator(w.operator)
             except (ValueError, TypeError):
@@ -112,7 +115,7 @@ def _validate_then_keys(ontology: AnnotationOntology) -> list[str]:
     for attr in ontology.attributes:
         if attr.when is None:
             continue
-        for w in attr.when:
+        for w in collect_leaf_conditions(attr.when):
             if w.then is None:
                 continue
             # set difference: keys present in w.then but not in the
@@ -136,7 +139,11 @@ def _validate_no_cycles(ontology: AnnotationOntology) -> list[str]:
     """
     graph: dict[str, list[str]] = {}
     for attr in ontology.attributes:
-        edges = [w.field for w in (attr.when or [])]
+        edges = (
+            [w.field for w in collect_leaf_conditions(attr.when)]
+            if attr.when is not None
+            else []
+        )
         graph.setdefault(attr.name, []).extend(edges)
     errors: list[str] = []
     for start in graph:

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -14,6 +14,7 @@ import unittest
 os.environ.setdefault("VFF_ONTOLOGY_CA", "1")
 
 from fiftyone.core.annotation.attributes import (
+    MAX_CONDITION_DEPTH,
     AttributeSpec,
     When,
     WhenAnd,
@@ -400,6 +401,20 @@ class WhenConditionDispatchTests(unittest.TestCase):
         self.assertIsInstance(restored.conditions[0].conditions[1], WhenAnd)
         self.assertEqual(restored.to_dict(), original.to_dict())
 
+    def test_dispatch_exceeds_max_depth_raises(self):
+        # Build a dict chain MAX_CONDITION_DEPTH + 1 levels deep.  Each wrap
+        # adds one "and" node; the innermost child is the leaf.  When
+        # WhenCondition.from_dict recurses into the leaf it reaches
+        # _depth = MAX_CONDITION_DEPTH + 1, satisfying _depth > MAX_CONDITION_DEPTH.
+        d = {"operator": "equals", "field": "f", "value": 1}
+        for _ in range(MAX_CONDITION_DEPTH + 1):
+            d = {"operator": "and", "conditions": [d]}
+
+        with self.assertRaises(ValueError) as ctx:
+            WhenCondition.from_dict(d)
+
+        self.assertIn("maximum nesting depth", str(ctx.exception))
+
 
 class CollectLeafConditionsTests(unittest.TestCase):
     """collect_leaf_conditions must yield exactly the When leaves of any tree."""
@@ -443,6 +458,19 @@ class CollectLeafConditionsTests(unittest.TestCase):
         )
         for leaf in collect_leaf_conditions(tree):
             self.assertIsInstance(leaf, When)
+
+    def test_exceeds_max_depth_raises(self):
+        # Build a tree that is MAX_CONDITION_DEPTH + 1 levels deep by wrapping
+        # a leaf in WhenAnd MAX_CONDITION_DEPTH + 1 times.  The leaf ends up at
+        # depth MAX_CONDITION_DEPTH + 1, which exceeds the guard threshold.
+        tree: WhenCondition = WhenEquals(field="x", value=1)
+        for _ in range(MAX_CONDITION_DEPTH + 1):
+            tree = WhenAnd([tree])
+
+        with self.assertRaises(ValueError) as ctx:
+            list(collect_leaf_conditions(tree))
+
+        self.assertIn("maximum nesting depth", str(ctx.exception))
 
 
 class AttributeSpecTests(unittest.TestCase):

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -158,9 +158,6 @@ class WhenEqualsTests(unittest.TestCase):
         )
         self.assertEqual(w.then, {"values": ["sedan", "suv"]})
 
-    def test_repr_uses_subclass_name(self):
-        self.assertIn("WhenEquals(", repr(WhenEquals(field="f", value=1)))
-
 
 class WhenInTests(unittest.TestCase):
     def test_pre_fills_operator(self):
@@ -178,14 +175,11 @@ class WhenInTests(unittest.TestCase):
         base = When(WhenOperator.IN, field="f", value=[1, 2])
         self.assertEqual(sub.to_dict(), base.to_dict())
 
-    def test_repr_uses_subclass_name(self):
-        self.assertIn("WhenIn(", repr(WhenIn(field="f", value=[1])))
-
 
 class WhenAndTests(unittest.TestCase):
     def test_create(self):
         wa = WhenAnd(
-            conditions=[
+            [
                 WhenEquals(field="damage_present", value=True),
                 WhenIn(field="vehicle_type", value=["car", "truck"]),
             ]
@@ -194,21 +188,19 @@ class WhenAndTests(unittest.TestCase):
 
     def test_empty_conditions_raises(self):
         with self.assertRaises(ValueError):
-            WhenAnd(conditions=[])
+            WhenAnd([])
 
     def test_non_list_conditions_raises(self):
         with self.assertRaises(ValueError):
-            WhenAnd(conditions="not a list")
+            WhenAnd("not a list")
 
-    def test_accepts_mixed_condition_types(self):
-        # WhenAnd accepts any list of WhenCondition nodes without type-checking
-        # each element; type safety is enforced at the call site by type hints.
-        wa = WhenAnd(conditions=[WhenEquals(field="f", value=1)])
-        self.assertEqual(len(wa.conditions), 1)
+    def test_non_when_condition_element_raises(self):
+        with self.assertRaises(ValueError):
+            WhenAnd([WhenEquals(field="f", value=1), "not a condition"])
 
     def test_to_dict(self):
         wa = WhenAnd(
-            conditions=[
+            [
                 WhenEquals(field="a", value=1),
                 WhenIn(field="b", value=[2, 3]),
             ]
@@ -241,7 +233,7 @@ class WhenAndTests(unittest.TestCase):
 
     def test_roundtrip(self):
         original = WhenAnd(
-            conditions=[
+            [
                 WhenEquals(field="flag", value=True),
                 WhenIn(field="type", value=["a", "b"]),
             ]
@@ -254,17 +246,11 @@ class WhenAndTests(unittest.TestCase):
             original.conditions[0].to_dict(),
         )
 
-    def test_repr(self):
-        self.assertIn(
-            "WhenAnd(",
-            repr(WhenAnd(conditions=[WhenEquals(field="f", value=1)])),
-        )
-
 
 class WhenOrTests(unittest.TestCase):
     def test_create(self):
         wo = WhenOr(
-            conditions=[
+            [
                 WhenEquals(field="category", value="mammal"),
                 WhenEquals(field="category", value="bird"),
             ]
@@ -273,15 +259,19 @@ class WhenOrTests(unittest.TestCase):
 
     def test_empty_conditions_raises(self):
         with self.assertRaises(ValueError):
-            WhenOr(conditions=[])
+            WhenOr([])
 
     def test_non_list_conditions_raises(self):
         with self.assertRaises(ValueError):
-            WhenOr(conditions="not a list")
+            WhenOr("not a list")
+
+    def test_non_when_condition_element_raises(self):
+        with self.assertRaises(ValueError):
+            WhenOr([WhenEquals(field="f", value=1), 42])
 
     def test_to_dict(self):
         wo = WhenOr(
-            conditions=[
+            [
                 WhenEquals(field="a", value=1),
                 WhenEquals(field="a", value=2),
             ]
@@ -305,7 +295,7 @@ class WhenOrTests(unittest.TestCase):
 
     def test_roundtrip(self):
         original = WhenOr(
-            conditions=[
+            [
                 WhenEquals(field="x", value="yes"),
                 WhenIn(field="y", value=["p", "q"]),
             ]
@@ -320,10 +310,10 @@ class WhenOrTests(unittest.TestCase):
     def test_nested_and_inside_or(self):
         """WhenOr may contain WhenAnd children."""
         wo = WhenOr(
-            conditions=[
+            [
                 WhenEquals(field="priority", value="urgent"),
                 WhenAnd(
-                    conditions=[
+                    [
                         WhenEquals(field="category", value="mammal"),
                         WhenEquals(field="size", value="large"),
                     ]
@@ -389,12 +379,12 @@ class WhenConditionDispatchTests(unittest.TestCase):
     def test_deeply_nested_roundtrip(self):
         """AND(OR(leaf, AND(leaf, leaf)), leaf) survives a full to/from dict cycle."""
         original = WhenAnd(
-            conditions=[
+            [
                 WhenOr(
-                    conditions=[
+                    [
                         WhenEquals(field="a", value=1),
                         WhenAnd(
-                            conditions=[
+                            [
                                 WhenEquals(field="b", value=2),
                                 WhenEquals(field="c", value=3),
                             ]
@@ -414,9 +404,6 @@ class WhenConditionDispatchTests(unittest.TestCase):
 class CollectLeafConditionsTests(unittest.TestCase):
     """collect_leaf_conditions must yield exactly the When leaves of any tree."""
 
-    def test_none_yields_nothing(self):
-        self.assertEqual(list(collect_leaf_conditions(None)), [])
-
     def test_single_leaf(self):
         w = WhenEquals(field="f", value=1)
         leaves = list(collect_leaf_conditions(w))
@@ -425,13 +412,13 @@ class CollectLeafConditionsTests(unittest.TestCase):
     def test_and_group_yields_all_leaves(self):
         a = WhenEquals(field="a", value=1)
         b = WhenIn(field="b", value=[2, 3])
-        leaves = list(collect_leaf_conditions(WhenAnd(conditions=[a, b])))
+        leaves = list(collect_leaf_conditions(WhenAnd([a, b])))
         self.assertEqual(leaves, [a, b])
 
     def test_or_group_yields_all_leaves(self):
         a = WhenEquals(field="a", value=1)
         b = WhenEquals(field="a", value=2)
-        leaves = list(collect_leaf_conditions(WhenOr(conditions=[a, b])))
+        leaves = list(collect_leaf_conditions(WhenOr([a, b])))
         self.assertEqual(leaves, [a, b])
 
     def test_nested_tree_yields_all_leaves(self):
@@ -440,8 +427,8 @@ class CollectLeafConditionsTests(unittest.TestCase):
         c = WhenEquals(field="c", value=3)
         d = WhenEquals(field="d", value=4)
         tree = WhenAnd(
-            conditions=[
-                WhenOr(conditions=[a, WhenAnd(conditions=[b, c])]),
+            [
+                WhenOr([a, WhenAnd([b, c])]),
                 d,
             ]
         )
@@ -449,7 +436,7 @@ class CollectLeafConditionsTests(unittest.TestCase):
 
     def test_leaf_objects_are_when_instances(self):
         tree = WhenAnd(
-            conditions=[
+            [
                 WhenEquals(field="x", value=True),
                 WhenIn(field="y", value=["p", "q"]),
             ]

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -16,9 +16,13 @@ os.environ.setdefault("VFF_ONTOLOGY_CA", "1")
 from fiftyone.core.annotation.attributes import (
     AttributeSpec,
     When,
+    WhenAnd,
+    WhenCondition,
     WhenEquals,
     WhenIn,
     WhenOperator,
+    WhenOr,
+    collect_leaf_conditions,
 )
 from fiftyone.core.ontology import AnnotationOntology
 
@@ -178,6 +182,282 @@ class WhenInTests(unittest.TestCase):
         self.assertIn("WhenIn(", repr(WhenIn(field="f", value=[1])))
 
 
+class WhenAndTests(unittest.TestCase):
+    def test_create(self):
+        wa = WhenAnd(
+            conditions=[
+                WhenEquals(field="damage_present", value=True),
+                WhenIn(field="vehicle_type", value=["car", "truck"]),
+            ]
+        )
+        self.assertEqual(len(wa.conditions), 2)
+
+    def test_empty_conditions_raises(self):
+        with self.assertRaises(ValueError):
+            WhenAnd(conditions=[])
+
+    def test_non_list_conditions_raises(self):
+        with self.assertRaises(ValueError):
+            WhenAnd(conditions="not a list")
+
+    def test_accepts_mixed_condition_types(self):
+        # WhenAnd accepts any list of WhenCondition nodes without type-checking
+        # each element; type safety is enforced at the call site by type hints.
+        wa = WhenAnd(conditions=[WhenEquals(field="f", value=1)])
+        self.assertEqual(len(wa.conditions), 1)
+
+    def test_to_dict(self):
+        wa = WhenAnd(
+            conditions=[
+                WhenEquals(field="a", value=1),
+                WhenIn(field="b", value=[2, 3]),
+            ]
+        )
+        d = wa.to_dict()
+        self.assertEqual(d["operator"], "and")
+        self.assertIsInstance(d["conditions"], list)
+        self.assertEqual(len(d["conditions"]), 2)
+        self.assertEqual(d["conditions"][0]["operator"], "equals")
+        self.assertEqual(d["conditions"][1]["operator"], "in")
+
+    def test_from_dict(self):
+        d = {
+            "operator": "and",
+            "conditions": [
+                {"operator": "equals", "field": "a", "value": 1},
+                {"operator": "in", "field": "b", "value": [2, 3]},
+            ],
+        }
+        wa = WhenAnd.from_dict(d)
+        self.assertIsInstance(wa, WhenAnd)
+        self.assertEqual(len(wa.conditions), 2)
+        # from_dict always deserializes leaf conditions as When, not subclasses
+        self.assertIsInstance(wa.conditions[0], When)
+        self.assertIsInstance(wa.conditions[1], When)
+
+    def test_from_dict_missing_conditions_raises(self):
+        with self.assertRaises(ValueError):
+            WhenAnd.from_dict({"operator": "and"})
+
+    def test_roundtrip(self):
+        original = WhenAnd(
+            conditions=[
+                WhenEquals(field="flag", value=True),
+                WhenIn(field="type", value=["a", "b"]),
+            ]
+        )
+        restored = WhenAnd.from_dict(original.to_dict())
+        self.assertIsInstance(restored, WhenAnd)
+        self.assertEqual(len(restored.conditions), 2)
+        self.assertEqual(
+            restored.conditions[0].to_dict(),
+            original.conditions[0].to_dict(),
+        )
+
+    def test_repr(self):
+        self.assertIn(
+            "WhenAnd(",
+            repr(WhenAnd(conditions=[WhenEquals(field="f", value=1)])),
+        )
+
+
+class WhenOrTests(unittest.TestCase):
+    def test_create(self):
+        wo = WhenOr(
+            conditions=[
+                WhenEquals(field="category", value="mammal"),
+                WhenEquals(field="category", value="bird"),
+            ]
+        )
+        self.assertEqual(len(wo.conditions), 2)
+
+    def test_empty_conditions_raises(self):
+        with self.assertRaises(ValueError):
+            WhenOr(conditions=[])
+
+    def test_non_list_conditions_raises(self):
+        with self.assertRaises(ValueError):
+            WhenOr(conditions="not a list")
+
+    def test_to_dict(self):
+        wo = WhenOr(
+            conditions=[
+                WhenEquals(field="a", value=1),
+                WhenEquals(field="a", value=2),
+            ]
+        )
+        d = wo.to_dict()
+        self.assertEqual(d["operator"], "or")
+        self.assertIsInstance(d["conditions"], list)
+        self.assertEqual(len(d["conditions"]), 2)
+
+    def test_from_dict(self):
+        d = {
+            "operator": "or",
+            "conditions": [
+                {"operator": "equals", "field": "a", "value": 1},
+                {"operator": "equals", "field": "a", "value": 2},
+            ],
+        }
+        wo = WhenOr.from_dict(d)
+        self.assertIsInstance(wo, WhenOr)
+        self.assertEqual(len(wo.conditions), 2)
+
+    def test_roundtrip(self):
+        original = WhenOr(
+            conditions=[
+                WhenEquals(field="x", value="yes"),
+                WhenIn(field="y", value=["p", "q"]),
+            ]
+        )
+        restored = WhenOr.from_dict(original.to_dict())
+        self.assertIsInstance(restored, WhenOr)
+        self.assertEqual(
+            restored.conditions[1].to_dict(),
+            original.conditions[1].to_dict(),
+        )
+
+    def test_nested_and_inside_or(self):
+        """WhenOr may contain WhenAnd children."""
+        wo = WhenOr(
+            conditions=[
+                WhenEquals(field="priority", value="urgent"),
+                WhenAnd(
+                    conditions=[
+                        WhenEquals(field="category", value="mammal"),
+                        WhenEquals(field="size", value="large"),
+                    ]
+                ),
+            ]
+        )
+        d = wo.to_dict()
+        restored = WhenOr.from_dict(d)
+        self.assertIsInstance(restored.conditions[1], WhenAnd)
+
+
+class WhenConditionDispatchTests(unittest.TestCase):
+    """WhenCondition.from_dict must dispatch to the correct concrete class."""
+
+    def test_dispatch_equals(self):
+        d = {"operator": "equals", "field": "f", "value": 1}
+        cond = WhenCondition.from_dict(d)
+        # Deserialized leaves are When instances (not WhenEquals subclass)
+        self.assertIsInstance(cond, When)
+        self.assertEqual(cond.operator, WhenOperator.EQUALS)
+
+    def test_dispatch_in(self):
+        d = {"operator": "in", "field": "f", "value": [1, 2]}
+        cond = WhenCondition.from_dict(d)
+        # Deserialized leaves are When instances (not WhenIn subclass)
+        self.assertIsInstance(cond, When)
+        self.assertEqual(cond.operator, WhenOperator.IN)
+
+    def test_dispatch_and(self):
+        d = {
+            "operator": "and",
+            "conditions": [
+                {"operator": "equals", "field": "a", "value": 1},
+            ],
+        }
+        cond = WhenCondition.from_dict(d)
+        self.assertIsInstance(cond, WhenAnd)
+
+    def test_dispatch_or(self):
+        d = {
+            "operator": "or",
+            "conditions": [
+                {"operator": "equals", "field": "a", "value": 1},
+            ],
+        }
+        cond = WhenCondition.from_dict(d)
+        self.assertIsInstance(cond, WhenOr)
+
+    def test_dispatch_unknown_operator_raises(self):
+        with self.assertRaises(ValueError):
+            WhenCondition.from_dict(
+                {"operator": "contains", "field": "f", "value": 1}
+            )
+
+    def test_dispatch_not_a_dict_raises(self):
+        with self.assertRaises(ValueError):
+            WhenCondition.from_dict("not a dict")
+
+    def test_dispatch_missing_operator_raises(self):
+        with self.assertRaises((ValueError, KeyError)):
+            WhenCondition.from_dict({"field": "f", "value": 1})
+
+    def test_deeply_nested_roundtrip(self):
+        """AND(OR(leaf, AND(leaf, leaf)), leaf) survives a full to/from dict cycle."""
+        original = WhenAnd(
+            conditions=[
+                WhenOr(
+                    conditions=[
+                        WhenEquals(field="a", value=1),
+                        WhenAnd(
+                            conditions=[
+                                WhenEquals(field="b", value=2),
+                                WhenEquals(field="c", value=3),
+                            ]
+                        ),
+                    ]
+                ),
+                WhenEquals(field="d", value=4),
+            ]
+        )
+        restored = WhenCondition.from_dict(original.to_dict())
+        self.assertIsInstance(restored, WhenAnd)
+        self.assertIsInstance(restored.conditions[0], WhenOr)
+        self.assertIsInstance(restored.conditions[0].conditions[1], WhenAnd)
+        self.assertEqual(restored.to_dict(), original.to_dict())
+
+
+class CollectLeafConditionsTests(unittest.TestCase):
+    """collect_leaf_conditions must yield exactly the When leaves of any tree."""
+
+    def test_none_yields_nothing(self):
+        self.assertEqual(list(collect_leaf_conditions(None)), [])
+
+    def test_single_leaf(self):
+        w = WhenEquals(field="f", value=1)
+        leaves = list(collect_leaf_conditions(w))
+        self.assertEqual(leaves, [w])
+
+    def test_and_group_yields_all_leaves(self):
+        a = WhenEquals(field="a", value=1)
+        b = WhenIn(field="b", value=[2, 3])
+        leaves = list(collect_leaf_conditions(WhenAnd(conditions=[a, b])))
+        self.assertEqual(leaves, [a, b])
+
+    def test_or_group_yields_all_leaves(self):
+        a = WhenEquals(field="a", value=1)
+        b = WhenEquals(field="a", value=2)
+        leaves = list(collect_leaf_conditions(WhenOr(conditions=[a, b])))
+        self.assertEqual(leaves, [a, b])
+
+    def test_nested_tree_yields_all_leaves(self):
+        a = WhenEquals(field="a", value=1)
+        b = WhenEquals(field="b", value=2)
+        c = WhenEquals(field="c", value=3)
+        d = WhenEquals(field="d", value=4)
+        tree = WhenAnd(
+            conditions=[
+                WhenOr(conditions=[a, WhenAnd(conditions=[b, c])]),
+                d,
+            ]
+        )
+        self.assertEqual(list(collect_leaf_conditions(tree)), [a, b, c, d])
+
+    def test_leaf_objects_are_when_instances(self):
+        tree = WhenAnd(
+            conditions=[
+                WhenEquals(field="x", value=True),
+                WhenIn(field="y", value=["p", "q"]),
+            ]
+        )
+        for leaf in collect_leaf_conditions(tree):
+            self.assertIsInstance(leaf, When)
+
+
 class AttributeSpecTests(unittest.TestCase):
     def test_create_full(self):
         attr = AttributeSpec(
@@ -185,13 +465,13 @@ class AttributeSpecTests(unittest.TestCase):
             type="str",
             component="dropdown",
             values=["front", "rear"],
-            when=[WhenEquals(field="damage_present", value=True)],
+            when=WhenEquals(field="damage_present", value=True),
         )
         self.assertEqual(attr.name, "damage_location")
         self.assertEqual(attr.type, "str")
         self.assertEqual(attr.component, "dropdown")
         self.assertEqual(attr.values, ["front", "rear"])
-        self.assertEqual(len(attr.when), 1)
+        self.assertIsInstance(attr.when, WhenEquals)
 
     def test_create_unconditional(self):
         attr = AttributeSpec(
@@ -268,15 +548,15 @@ class AttributeSpecTests(unittest.TestCase):
             type="str",
             component="radio",
             values=["minor", "moderate", "severe"],
-            when=[WhenEquals(field="damage_present", value=True)],
+            when=WhenEquals(field="damage_present", value=True),
         )
         d = attr.to_dict()
         self.assertEqual(d["name"], "severity")
         self.assertEqual(d["type"], "str")
         self.assertEqual(d["component"], "radio")
         self.assertEqual(d["values"], ["minor", "moderate", "severe"])
-        self.assertEqual(len(d["when"]), 1)
-        self.assertEqual(d["when"][0]["operator"], "equals")
+        self.assertIsInstance(d["when"], dict)
+        self.assertEqual(d["when"]["operator"], "equals")
 
     def test_from_dict(self):
         d = {
@@ -284,21 +564,20 @@ class AttributeSpecTests(unittest.TestCase):
             "type": "str",
             "component": "dropdown",
             "values": ["front", "rear"],
-            "when": [
-                {
-                    "operator": "equals",
-                    "field": "damage_present",
-                    "value": True,
-                },
-            ],
+            "when": {
+                "operator": "equals",
+                "field": "damage_present",
+                "value": True,
+            },
         }
         attr = AttributeSpec.from_dict(d)
         self.assertEqual(attr.name, "damage_location")
         self.assertEqual(attr.type, "str")
         self.assertEqual(attr.component, "dropdown")
         self.assertEqual(attr.values, ["front", "rear"])
-        self.assertEqual(len(attr.when), 1)
-        self.assertEqual(attr.when[0].operator, WhenOperator.EQUALS)
+        # from_dict deserializes leaves as When (not WhenEquals subclass)
+        self.assertIsInstance(attr.when, When)
+        self.assertEqual(attr.when.operator, WhenOperator.EQUALS)
 
     def test_roundtrip(self):
         original = AttributeSpec(
@@ -306,17 +585,14 @@ class AttributeSpecTests(unittest.TestCase):
             type="str",
             component="dropdown",
             values=["front", "rear"],
-            when=[WhenEquals(field="damage_present", value=True)],
+            when=WhenEquals(field="damage_present", value=True),
         )
         restored = AttributeSpec.from_dict(original.to_dict())
         self.assertEqual(restored.name, original.name)
         self.assertEqual(restored.type, original.type)
         self.assertEqual(restored.component, original.component)
         self.assertEqual(restored.values, original.values)
-        self.assertEqual(len(restored.when), len(original.when))
-        self.assertEqual(
-            restored.when[0].to_dict(), original.when[0].to_dict()
-        )
+        self.assertEqual(restored.when.to_dict(), original.when.to_dict())
 
     def test_create_with_extended_fields(self):
         attr = AttributeSpec(
@@ -429,7 +705,7 @@ class AnnotationOntologyTests(unittest.TestCase):
                     type="str",
                     component="dropdown",
                     values=["front", "rear", "driver_side", "passenger_side"],
-                    when=[WhenEquals(field="damage_present", value=True)],
+                    when=WhenEquals(field="damage_present", value=True),
                 ),
             ],
         )
@@ -499,13 +775,11 @@ class AnnotationOntologyTests(unittest.TestCase):
                         "type": "str",
                         "component": "dropdown",
                         "values": ["a", "b"],
-                        "when": [
-                            {
-                                "operator": "equals",
-                                "field": "attr1",
-                                "value": True,
-                            }
-                        ],
+                        "when": {
+                            "operator": "equals",
+                            "field": "attr1",
+                            "value": True,
+                        },
                     },
                 ],
             },
@@ -515,7 +789,7 @@ class AnnotationOntologyTests(unittest.TestCase):
         self.assertEqual(ao.description, "A test")
         self.assertEqual(ao.taxonomies, ["tax1", "tax2"])
         self.assertEqual(len(ao.attributes), 2)
-        self.assertEqual(ao.attributes[1].when[0].field, "attr1")
+        self.assertEqual(ao.attributes[1].when.field, "attr1")
 
     def test_from_dict_with_none_root(self):
         ao = AnnotationOntology.from_dict(
@@ -547,13 +821,13 @@ class AnnotationOntologyTests(unittest.TestCase):
                     type="str",
                     component="dropdown",
                     values=["front", "rear"],
-                    when=[WhenEquals(field="damage_present", value=True)],
+                    when=WhenEquals(field="damage_present", value=True),
                 ),
                 AttributeSpec(
                     name="airbags_deployed",
                     type="bool",
                     component="checkbox",
-                    when=[WhenEquals(field="damage_location", value="front")],
+                    when=WhenEquals(field="damage_location", value="front"),
                 ),
             ],
         )
@@ -562,9 +836,7 @@ class AnnotationOntologyTests(unittest.TestCase):
         self.assertEqual(restored.description, original.description)
         self.assertEqual(restored.taxonomies, original.taxonomies)
         self.assertEqual(len(restored.attributes), 3)
-        self.assertEqual(
-            restored.attributes[2].when[0].field, "damage_location"
-        )
+        self.assertEqual(restored.attributes[2].when.field, "damage_location")
 
 
 class OntologySDKTests(unittest.TestCase):
@@ -604,7 +876,7 @@ class OntologySDKTests(unittest.TestCase):
                     type="str",
                     component="dropdown",
                     values=["front", "rear"],
-                    when=[WhenEquals(field="damage_present", value=True)],
+                    when=WhenEquals(field="damage_present", value=True),
                 ),
             ],
         )
@@ -624,7 +896,7 @@ class OntologySDKTests(unittest.TestCase):
         self.assertEqual(loaded.taxonomies, ["vehicle_classes"])
         self.assertEqual(len(loaded.attributes), 2)
         self.assertEqual(loaded.attributes[0].name, "damage_present")
-        self.assertEqual(loaded.attributes[1].when[0].field, "damage_present")
+        self.assertEqual(loaded.attributes[1].when.field, "damage_present")
 
     def test_save_and_reload(self):
         ao = self._make_ontology()

--- a/tests/unittests/ontology_validation_tests.py
+++ b/tests/unittests/ontology_validation_tests.py
@@ -15,7 +15,10 @@ os.environ.setdefault("VFF_ONTOLOGY_CA", "1")
 from fiftyone.core.annotation.attributes import (
     AttributeSpec,
     When,
+    WhenAnd,
+    WhenEquals,
     WhenOperator,
+    WhenOr,
 )
 from fiftyone.core.ontology import AnnotationOntology
 from fiftyone.core.ontology_validation import validate_annotation_ontology
@@ -34,7 +37,55 @@ class OperatorValidTests(unittest.TestCase):
                     name="location",
                     type="str",
                     component="dropdown",
-                    when=[w],
+                    when=w,
+                ),
+            ],
+        )
+        with self.assertRaises(ValueError):
+            validate_annotation_ontology(ao)
+
+    def test_rejects_invalid_operator_nested_inside_and_group(self):
+        # collect_leaf_conditions must recurse into WhenAnd to expose the
+        # mutated leaf; the group itself has no operator to validate.
+        bad_leaf = When(WhenOperator.EQUALS, field="flag", value=True)
+        bad_leaf.operator = "mock_operator"
+        ao = AnnotationOntology(
+            name="test",
+            attributes=[
+                AttributeSpec(name="flag", type="bool", component="checkbox"),
+                AttributeSpec(
+                    name="location",
+                    type="str",
+                    component="dropdown",
+                    when=WhenAnd(
+                        conditions=[
+                            WhenEquals(field="flag", value=True),
+                            bad_leaf,
+                        ]
+                    ),
+                ),
+            ],
+        )
+        with self.assertRaises(ValueError):
+            validate_annotation_ontology(ao)
+
+    def test_rejects_invalid_operator_nested_inside_or_group(self):
+        bad_leaf = When(WhenOperator.EQUALS, field="flag", value=True)
+        bad_leaf.operator = "mock_operator"
+        ao = AnnotationOntology(
+            name="test",
+            attributes=[
+                AttributeSpec(name="flag", type="bool", component="checkbox"),
+                AttributeSpec(
+                    name="location",
+                    type="str",
+                    component="dropdown",
+                    when=WhenOr(
+                        conditions=[
+                            WhenEquals(field="flag", value=True),
+                            bad_leaf,
+                        ]
+                    ),
                 ),
             ],
         )
@@ -78,13 +129,13 @@ class NoCyclesTests(unittest.TestCase):
                     name="a",
                     type="str",
                     component="dropdown",
-                    when=[When(WhenOperator.EQUALS, field="b", value="x")],
+                    when=WhenEquals(field="b", value="x"),
                 ),
                 AttributeSpec(
                     name="b",
                     type="str",
                     component="dropdown",
-                    when=[When(WhenOperator.EQUALS, field="a", value="y")],
+                    when=WhenEquals(field="a", value="y"),
                 ),
             ],
         )
@@ -104,7 +155,7 @@ class NoCyclesTests(unittest.TestCase):
                     name="a",
                     type="str",
                     component="dropdown",
-                    when=[When(WhenOperator.EQUALS, field="b", value="x")],
+                    when=WhenEquals(field="b", value="x"),
                 ),
                 # Same-name variant with no `when` — would have erased
                 # the cyclic edge from the first variant under the old
@@ -114,12 +165,100 @@ class NoCyclesTests(unittest.TestCase):
                     name="b",
                     type="str",
                     component="dropdown",
-                    when=[When(WhenOperator.EQUALS, field="a", value="y")],
+                    when=WhenEquals(field="a", value="y"),
                 ),
             ],
         )
         with self.assertRaises(ValueError):
             validate_annotation_ontology(ao)
+
+    def test_rejects_cycle_where_edge_is_inside_and_group(self):
+        # collect_leaf_conditions must traverse into WhenAnd so both
+        # leaf field references contribute edges to the cycle graph.
+        ao = AnnotationOntology(
+            name="test",
+            attributes=[
+                AttributeSpec(
+                    name="a",
+                    type="str",
+                    component="dropdown",
+                    when=WhenAnd(
+                        conditions=[
+                            WhenEquals(field="b", value="x"),
+                            WhenEquals(field="c", value="y"),
+                        ]
+                    ),
+                ),
+                AttributeSpec(
+                    name="b",
+                    type="str",
+                    component="dropdown",
+                ),
+                AttributeSpec(
+                    name="c",
+                    type="str",
+                    component="dropdown",
+                    when=WhenEquals(field="a", value="z"),
+                ),
+            ],
+        )
+        with self.assertRaises(ValueError):
+            validate_annotation_ontology(ao)
+
+    def test_rejects_cycle_where_edge_is_inside_or_group(self):
+        # Same as above but the back-edge lives inside a WhenOr.
+        ao = AnnotationOntology(
+            name="test",
+            attributes=[
+                AttributeSpec(
+                    name="a",
+                    type="str",
+                    component="dropdown",
+                    when=WhenOr(
+                        conditions=[
+                            WhenEquals(field="b", value="x"),
+                            WhenEquals(field="c", value="y"),
+                        ]
+                    ),
+                ),
+                AttributeSpec(
+                    name="b",
+                    type="str",
+                    component="dropdown",
+                ),
+                AttributeSpec(
+                    name="c",
+                    type="str",
+                    component="dropdown",
+                    when=WhenEquals(field="a", value="z"),
+                ),
+            ],
+        )
+        with self.assertRaises(ValueError):
+            validate_annotation_ontology(ao)
+
+    def test_accepts_valid_acyclic_and_group(self):
+        # A WhenAnd with two unrelated field references is not a cycle.
+        ao = AnnotationOntology(
+            name="test",
+            attributes=[
+                AttributeSpec(name="flag1", type="bool", component="checkbox"),
+                AttributeSpec(name="flag2", type="bool", component="checkbox"),
+                AttributeSpec(
+                    name="detail",
+                    type="str",
+                    component="dropdown",
+                    when=WhenAnd(
+                        conditions=[
+                            WhenEquals(field="flag1", value=True),
+                            WhenEquals(field="flag2", value=True),
+                        ]
+                    ),
+                ),
+            ],
+        )
+        # Should not raise
+        validate_annotation_ontology(ao)
 
 
 class ThenKeysValidTests(unittest.TestCase):
@@ -138,7 +277,82 @@ class ThenKeysValidTests(unittest.TestCase):
                     name="attr",
                     type="str",
                     component="dropdown",
-                    when=[w],
+                    when=w,
+                ),
+            ],
+        )
+        with self.assertRaises(ValueError):
+            validate_annotation_ontology(ao)
+
+    def test_accepts_then_with_allowed_keys(self):
+        ao = AnnotationOntology(
+            name="test",
+            attributes=[
+                AttributeSpec(
+                    name="vehicle_type", type="str", component="dropdown"
+                ),
+                AttributeSpec(
+                    name="model",
+                    type="str",
+                    component="dropdown",
+                    when=WhenEquals(
+                        field="vehicle_type",
+                        value="car",
+                        then={
+                            "values": ["sedan", "suv"],
+                            "component": "radio",
+                        },
+                    ),
+                ),
+            ],
+        )
+        # Should not raise
+        validate_annotation_ontology(ao)
+
+    def test_rejects_disallowed_then_key_inside_and_group(self):
+        # collect_leaf_conditions must recurse into WhenAnd to surface
+        # the bad `then` key on the nested leaf.
+        bad_leaf = WhenEquals(
+            field="other", value=True, then={"name": "renamed"}
+        )
+        ao = AnnotationOntology(
+            name="test",
+            attributes=[
+                AttributeSpec(name="flag", type="bool", component="checkbox"),
+                AttributeSpec(name="other", type="bool", component="checkbox"),
+                AttributeSpec(
+                    name="attr",
+                    type="str",
+                    component="dropdown",
+                    when=WhenAnd(
+                        conditions=[
+                            WhenEquals(field="flag", value=True),
+                            bad_leaf,
+                        ]
+                    ),
+                ),
+            ],
+        )
+        with self.assertRaises(ValueError):
+            validate_annotation_ontology(ao)
+
+    def test_rejects_disallowed_then_key_inside_or_group(self):
+        bad_leaf = WhenEquals(field="other", value=True, then={"type": "int"})
+        ao = AnnotationOntology(
+            name="test",
+            attributes=[
+                AttributeSpec(name="flag", type="bool", component="checkbox"),
+                AttributeSpec(name="other", type="bool", component="checkbox"),
+                AttributeSpec(
+                    name="attr",
+                    type="str",
+                    component="dropdown",
+                    when=WhenOr(
+                        conditions=[
+                            WhenEquals(field="flag", value=True),
+                            bad_leaf,
+                        ]
+                    ),
                 ),
             ],
         )
@@ -157,13 +371,13 @@ class SaveInvokesValidationTests(unittest.TestCase):
                     name="a",
                     type="str",
                     component="dropdown",
-                    when=[When(WhenOperator.EQUALS, field="b", value="x")],
+                    when=WhenEquals(field="b", value="x"),
                 ),
                 AttributeSpec(
                     name="b",
                     type="str",
                     component="dropdown",
-                    when=[When(WhenOperator.EQUALS, field="a", value="y")],
+                    when=WhenEquals(field="a", value="y"),
                 ),
             ],
         )

--- a/tests/unittests/ontology_validation_tests.py
+++ b/tests/unittests/ontology_validation_tests.py
@@ -58,7 +58,7 @@ class OperatorValidTests(unittest.TestCase):
                     type="str",
                     component="dropdown",
                     when=WhenAnd(
-                        conditions=[
+                        [
                             WhenEquals(field="flag", value=True),
                             bad_leaf,
                         ]
@@ -81,7 +81,7 @@ class OperatorValidTests(unittest.TestCase):
                     type="str",
                     component="dropdown",
                     when=WhenOr(
-                        conditions=[
+                        [
                             WhenEquals(field="flag", value=True),
                             bad_leaf,
                         ]
@@ -175,30 +175,34 @@ class NoCyclesTests(unittest.TestCase):
     def test_rejects_cycle_where_edge_is_inside_and_group(self):
         # collect_leaf_conditions must traverse into WhenAnd so both
         # leaf field references contribute edges to the cycle graph.
+        # Cycle: a → {b, c} (via WhenAnd), c → a (back-edge).
+        cycle_attr_a = "a"
+        cycle_attr_b = "b"
+        cycle_attr_c = "c"
         ao = AnnotationOntology(
             name="test",
             attributes=[
                 AttributeSpec(
-                    name="a",
+                    name=cycle_attr_a,
                     type="str",
                     component="dropdown",
                     when=WhenAnd(
-                        conditions=[
-                            WhenEquals(field="b", value="x"),
-                            WhenEquals(field="c", value="y"),
+                        [
+                            WhenEquals(field=cycle_attr_b, value="x"),
+                            WhenEquals(field=cycle_attr_c, value="y"),
                         ]
                     ),
                 ),
                 AttributeSpec(
-                    name="b",
+                    name=cycle_attr_b,
                     type="str",
                     component="dropdown",
                 ),
                 AttributeSpec(
-                    name="c",
+                    name=cycle_attr_c,
                     type="str",
                     component="dropdown",
-                    when=WhenEquals(field="a", value="z"),
+                    when=WhenEquals(field=cycle_attr_a, value="z"),
                 ),
             ],
         )
@@ -207,30 +211,34 @@ class NoCyclesTests(unittest.TestCase):
 
     def test_rejects_cycle_where_edge_is_inside_or_group(self):
         # Same as above but the back-edge lives inside a WhenOr.
+        # Cycle: a → {b, c} (via WhenOr), c → a (back-edge).
+        cycle_attr_a = "a"
+        cycle_attr_b = "b"
+        cycle_attr_c = "c"
         ao = AnnotationOntology(
             name="test",
             attributes=[
                 AttributeSpec(
-                    name="a",
+                    name=cycle_attr_a,
                     type="str",
                     component="dropdown",
                     when=WhenOr(
-                        conditions=[
-                            WhenEquals(field="b", value="x"),
-                            WhenEquals(field="c", value="y"),
+                        [
+                            WhenEquals(field=cycle_attr_b, value="x"),
+                            WhenEquals(field=cycle_attr_c, value="y"),
                         ]
                     ),
                 ),
                 AttributeSpec(
-                    name="b",
+                    name=cycle_attr_b,
                     type="str",
                     component="dropdown",
                 ),
                 AttributeSpec(
-                    name="c",
+                    name=cycle_attr_c,
                     type="str",
                     component="dropdown",
-                    when=WhenEquals(field="a", value="z"),
+                    when=WhenEquals(field=cycle_attr_a, value="z"),
                 ),
             ],
         )
@@ -249,7 +257,7 @@ class NoCyclesTests(unittest.TestCase):
                     type="str",
                     component="dropdown",
                     when=WhenAnd(
-                        conditions=[
+                        [
                             WhenEquals(field="flag1", value=True),
                             WhenEquals(field="flag2", value=True),
                         ]
@@ -325,7 +333,7 @@ class ThenKeysValidTests(unittest.TestCase):
                     type="str",
                     component="dropdown",
                     when=WhenAnd(
-                        conditions=[
+                        [
                             WhenEquals(field="flag", value=True),
                             bad_leaf,
                         ]
@@ -348,7 +356,7 @@ class ThenKeysValidTests(unittest.TestCase):
                     type="str",
                     component="dropdown",
                     when=WhenOr(
-                        conditions=[
+                        [
                             WhenEquals(field="flag", value=True),
                             bad_leaf,
                         ]


### PR DESCRIPTION
## 🔗 Related Issues

Attribute visibility in an Ontology is controlled by a when field on `AttributeConfig`. Previously this was an array of conditions with implicit `AND` semantics, making `OR` logic impossible — you couldn't, for example, show `expedite_delivery` when `is_member` or `has_coupon`.

This PR replaces the flat array with a composable WhenCondition tree. A when value is now either a leaf node (equals / in) or a group node (and / or) whose conditions array holds further WhenCondition nodes, allowing arbitrary nesting. The change updates the Python AttributeSpec dataclass, the TypeScript `AttributeConfig` type, condition evaluation and fulfillability logic, validation, and all existing call sites and tests.


## 📋 What changes are proposed in this pull request?

This PR replaces the flat array with a composable WhenCondition tree. A when value is now either a leaf node (equals / in) or a group node (and / or) whose conditions array holds further WhenCondition nodes, allowing arbitrary nesting. The change updates the Python AttributeSpec dataclass, the TypeScript `AttributeConfig` type, condition evaluation and fulfillability logic, validation, and all existing call sites and tests.

## 🧪 How is this patch tested? If it is not, please explain why.
Manual
Use this script to seed ontologies into your system. 
[seed_demo_ontologies.py](https://github.com/user-attachments/files/27652006/seed_demo_ontologies.py)

https://github.com/user-attachments/assets/bbca5653-ba9e-48cd-89db-b4693aac9453




## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for nested AND/OR conditional visibility for attributes, including deep nesting and stricter equality/in semantics.

* **Refactor**
  * Condition model and schema serialization changed from flat lists to recursive condition trees; validation and visibility resolution updated accordingly.
  * Preview text generation now summarizes tree-based conditions.

* **Tests**
  * Expanded unit tests for composite conditions, serialization round-trips, validation, fulfillment, and evaluation logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7511)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->