### PR TITLE
fixed device allocation for qwen3vl model such that it uses user-sele…

### DIFF
--- a/fiftyone/utils/qwen3_vl.py
+++ b/fiftyone/utils/qwen3_vl.py
@@ -180,7 +180,9 @@ class Qwen3VLModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
             raise ValueError(
                 f"video_fps must be positive, got {self.video_fps}"
             )
-        self.max_video_frames = self.parse_int(d, "max_video_frames", default=128)
+        self.max_video_frames = self.parse_int(
+            d, "max_video_frames", default=128
+        )
         if self.max_video_frames <= 0:
             raise ValueError(
                 f"max_video_frames must be positive, got {self.max_video_frames}"
@@ -275,11 +277,22 @@ class Qwen3VLModel(fout.TorchImageModel, fom.EmbeddingsMixin, fom.PromptMixin):
         model_cls = transformers.Qwen3VLForConditionalGeneration
         dtype = torch.bfloat16 if self._using_gpu else torch.float32
 
+        # HuggingFace models loaded with `device_map="auto"` may end up on an
+        # unexpected GPU in multi-GPU environments. If the user explicitly
+        # requested a device via `device=...`, honor it by disabling auto
+        # device mapping and moving the model to `self._device`.
+        device_map = None
+        if self._using_gpu:
+            device_map = "auto" if config.device is None else None
+
         model = model_cls.from_pretrained(
             config.name_or_path,
             torch_dtype=dtype,
-            device_map="auto" if self._using_gpu else None,
+            device_map=device_map,
         )
+
+        if device_map is None:
+            model = model.to(self._device)
         model.eval()
 
         self._processor = transformers.AutoProcessor.from_pretrained(
@@ -346,7 +359,7 @@ class Qwen3VLModel(fout.TorchImageModel, fom.EmbeddingsMixin, fom.PromptMixin):
             )
 
             generated_ids_trimmed = [
-                out_ids[len(in_ids):]
+                out_ids[len(in_ids) :]
                 for in_ids, out_ids in zip(inputs["input_ids"], generated_ids)
             ]
 
@@ -416,7 +429,9 @@ class Qwen3VLModel(fout.TorchImageModel, fom.EmbeddingsMixin, fom.PromptMixin):
             if img.shape[0] in (1, 3, 4) and img.shape[2] not in (1, 3, 4):
                 img = np.transpose(img, (1, 2, 0))
 
-        if isinstance(img, np.ndarray) and np.issubdtype(img.dtype, np.floating):
+        if isinstance(img, np.ndarray) and np.issubdtype(
+            img.dtype, np.floating
+        ):
             if img.max() <= 1.0:
                 img = img * 255.0
             img = np.clip(img, 0, 255).astype(np.uint8)
@@ -567,7 +582,9 @@ class Qwen3VLModel(fout.TorchImageModel, fom.EmbeddingsMixin, fom.PromptMixin):
             }
         ]
 
-        image_inputs, video_inputs = qwen_vl_utils.process_vision_info(messages)
+        image_inputs, video_inputs = qwen_vl_utils.process_vision_info(
+            messages
+        )
         text = self._processor.apply_chat_template(
             messages,
             tokenize=False,


### PR DESCRIPTION
…cted device

## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

<!--
Provide a clear, concise description of what this PR does and why.
-->

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device mapping for GPU utilization in model loading.
  * Enhanced handling of floating-point numpy image arrays in media preprocessing.
  * Refined video embedding processing workflow.

* **Refactor**
  * Updated parameter parsing formatting for internal configuration structures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7512)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->