### PR TITLE
Bugfix/clip tokenizer file for sam3

### DIFF
--- a/fiftyone/utils/sam3.py
+++ b/fiftyone/utils/sam3.py
@@ -9,6 +9,7 @@ wrapper for the FiftyOne Model Zoo.
 
 import logging
 import os
+import shutil
 from PIL import Image
 
 import fiftyone.core.utils as fou
@@ -16,6 +17,8 @@ import fiftyone.utils.torch as fout
 import fiftyone.utils.sam as fosam
 import fiftyone.utils.sam2 as fosam2
 import fiftyone.zoo.models as fozm
+
+import eta.core.web as etaw
 
 fou.ensure_torch()
 import torch
@@ -28,6 +31,61 @@ sam3misc = fou.lazy_import("sam3.model.utils.misc")
 sam2ip = fou.lazy_import("sam2.sam2_image_predictor")
 
 logger = logging.getLogger(__name__)
+
+
+_SAM3_BPE_FILENAME = "bpe_simple_vocab_16e6.txt.gz"
+_SAM3_BPE_URL = (
+    "https://raw.githubusercontent.com/openai/CLIP/main/clip/"
+    + _SAM3_BPE_FILENAME
+)
+
+
+def _ensure_sam3_bpe_vocab_path():
+    """Ensures SAM3 has a valid BPE vocab file and returns its path.
+
+    The upstream `sam3` package defaults to a relative `../assets/` location
+    that is not always present in packaged wheels, so we store/download this
+    file in FiftyOne's model zoo directory.
+    """
+
+    import fiftyone as fo
+
+    bpe_dir = os.path.join(fo.config.model_zoo_dir, "sam3")
+    os.makedirs(bpe_dir, exist_ok=True)
+    bpe_path = os.path.join(bpe_dir, _SAM3_BPE_FILENAME)
+
+    if os.path.isfile(bpe_path):
+        return bpe_path
+
+    # Best-effort: copy from installed `sam3` package if it ships the asset
+    try:
+        import sam3 as _sam3_pkg
+
+        sam3_pkg_dir = os.path.dirname(os.path.abspath(_sam3_pkg.__file__))
+        candidates = (
+            os.path.join(
+                os.path.dirname(sam3_pkg_dir), "assets", _SAM3_BPE_FILENAME
+            ),
+            os.path.join(sam3_pkg_dir, "assets", _SAM3_BPE_FILENAME),
+        )
+        for candidate in candidates:
+            if os.path.isfile(candidate):
+                shutil.copyfile(candidate, bpe_path)
+                return bpe_path
+    except Exception:
+        pass
+
+    logger.info("Downloading SAM3 tokenizer vocab (%s)...", _SAM3_BPE_FILENAME)
+    try:
+        etaw.download_file(_SAM3_BPE_URL, path=bpe_path)
+    except Exception as e:
+        raise RuntimeError(
+            "Failed to download SAM3 tokenizer vocab. "
+            "You can manually download '%s' from %s and save it to %s"
+            % (_SAM3_BPE_FILENAME, _SAM3_BPE_URL, bpe_path)
+        ) from e
+
+    return bpe_path
 
 
 class SegmentAnything3ImageModelConfig(
@@ -311,6 +369,12 @@ class SegmentAnything3ImageModel(fosam2.SegmentAnything2ImageModel):
     def _load_model(self, config):
         if "device" not in config.entrypoint_args:
             config.entrypoint_args["device"] = str(self._device)
+
+        # Ensure the upstream `sam3` entrypoint has a valid BPE vocab path
+        bpe_path = config.entrypoint_args.get("bpe_path", None)
+        if not bpe_path or not os.path.isfile(bpe_path):
+            config.entrypoint_args["bpe_path"] = _ensure_sam3_bpe_vocab_path()
+
         model = super()._load_model(config)
         return model
 

--- a/fiftyone/utils/sam3.py
+++ b/fiftyone/utils/sam3.py
@@ -34,23 +34,18 @@ sam2ip = fou.lazy_import("sam2.sam2_image_predictor")
 logger = logging.getLogger(__name__)
 
 
-def _ensure_sam3_bpe_vocab_path(
-    tokenizer_base_filename: str,
+def _download_sam3_bpe_vocab_file(
     tokenizer_base_url: str,
+    bpe_path: str,
 ):
-    """Ensures SAM3 has a valid BPE vocab file and returns its path.
+    """Downloads SAM3 BPE vocab file if it does not exist at the specified path.
 
     The upstream `sam3` package defaults to a relative `../assets/` location
     that is not always present in packaged wheels, so we store/download this
     file in FiftyOne's model zoo directory.
     """
 
-    bpe_dir = os.path.join(fo.config.model_zoo_dir, "sam3")
-    os.makedirs(bpe_dir, exist_ok=True)
-    bpe_path = os.path.join(bpe_dir, tokenizer_base_filename)
-
-    if os.path.isfile(bpe_path):
-        return bpe_path
+    asset_filename = os.path.basename(bpe_path)
 
     # Best-effort: copy from installed `sam3` package if it ships the asset
     try:
@@ -61,9 +56,9 @@ def _ensure_sam3_bpe_vocab_path(
             os.path.join(
                 os.path.dirname(sam3_pkg_dir),
                 "assets",
-                tokenizer_base_filename,
+                asset_filename,
             ),
-            os.path.join(sam3_pkg_dir, "assets", tokenizer_base_filename),
+            os.path.join(sam3_pkg_dir, "assets", asset_filename),
         )
         for candidate in candidates:
             if os.path.isfile(candidate):
@@ -73,19 +68,15 @@ def _ensure_sam3_bpe_vocab_path(
     except Exception as e:
         logger.debug("Could not copy SAM3 vocab from installed package: %s", e)
 
-    logger.info(
-        "Downloading SAM3 tokenizer vocab (%s)...", tokenizer_base_filename
-    )
+    logger.info("Downloading SAM3 tokenizer vocab (%s)...", asset_filename)
     try:
         etaw.download_file(tokenizer_base_url, path=bpe_path)
     except Exception as e:
         raise RuntimeError(
             "Failed to download SAM3 tokenizer vocab. "
             "You can manually download '%s' from %s and save it to %s"
-            % (tokenizer_base_filename, tokenizer_base_url, bpe_path)
+            % (asset_filename, tokenizer_base_url, bpe_path)
         ) from e
-
-    return bpe_path
 
 
 class SegmentAnything3ImageModelConfig(
@@ -104,6 +95,8 @@ class SegmentAnything3ImageModelConfig(
             :class:`GetItem` to use for SAM
         get_item_args (None): a dictionary of arguments for
             ``get_item_cls(field_mapping=field_mapping, **kwargs)``
+        tokenizer_base_filename (None): the filename of the SAM3 tokenizer BPE vocab
+        tokenizer_base_url (None): the URL to download the SAM3 tokenizer BPE vocab
         operation_mode ("concept"): concept or visual mode of operation for inference
     """
 
@@ -136,6 +129,21 @@ class SegmentAnything3ImageModelConfig(
         self.tokenizer_base_url = self.parse_string(
             d, "tokenizer_base_url", default=None
         )
+
+        # Ensure the upstream `sam3` entrypoint gets an absolute, stable BPE
+        # vocab path (avoids upstream defaulting to a relative `../assets/`)
+        if self.entrypoint_args is None:
+            self.entrypoint_args = {}
+
+        if (
+            "bpe_path" not in self.entrypoint_args
+            and self.tokenizer_base_filename
+        ):
+            self.entrypoint_args["bpe_path"] = os.path.join(
+                fo.config.model_zoo_dir,
+                "sam3",
+                self.tokenizer_base_filename,
+            )
 
         self.operation_mode = self.parse_string(
             d, "operation_mode", default="concept"
@@ -378,6 +386,25 @@ class SegmentAnything3ImageModel(fosam2.SegmentAnything2ImageModel):
         if "device" not in config.entrypoint_args:
             config.entrypoint_args["device"] = str(self._device)
 
+        if not config.tokenizer_base_filename or not config.tokenizer_base_url:
+            raise ValueError(
+                "Missing required SAM3 tokenizer vocab configuration. "
+                "Provide 'tokenizer_base_filename' and 'tokenizer_base_url' "
+                "in the model config (typically via the model zoo manifest)."
+            )
+
+        # Ensure the upstream `sam3` entrypoint has a valid BPE vocab path
+        if config.entrypoint_args is None:
+            config.entrypoint_args = {}
+
+        bpe_path = config.entrypoint_args.get("bpe_path", None)
+        if not bpe_path:
+            bpe_path = os.path.join(
+                os.path.dirname(config.model_path),
+                config.tokenizer_base_filename,
+            )
+            config.entrypoint_args["bpe_path"] = bpe_path
+
         model = super()._load_model(config)
         return model
 
@@ -391,22 +418,11 @@ class SegmentAnything3ImageModel(fosam2.SegmentAnything2ImageModel):
             local_dir=os.path.dirname(config.model_path),
         )
 
-        if (
-            not self.config.tokenizer_base_filename
-            or not self.config.tokenizer_base_url
-        ):
-            raise ValueError(
-                "Missing required SAM3 tokenizer vocab configuration. "
-                "Provide 'tokenizer_base_filename' and 'tokenizer_base_url' "
-                "in the model config (typically via the model zoo manifest)."
-            )
-
-        # Ensure the upstream `sam3` entrypoint has a valid BPE vocab path
-        bpe_path = config.entrypoint_args.get("bpe_path", None)
-        if not bpe_path or not os.path.isfile(bpe_path):
-            config.entrypoint_args["bpe_path"] = _ensure_sam3_bpe_vocab_path(
-                tokenizer_base_filename=self.config.tokenizer_base_filename,
-                tokenizer_base_url=self.config.tokenizer_base_url,
+        bpe_path = config.entrypoint_args["bpe_path"]
+        if not os.path.isfile(bpe_path):
+            _download_sam3_bpe_vocab_file(
+                tokenizer_base_url=config.tokenizer_base_url,
+                bpe_path=bpe_path,
             )
 
     def _build_concept_output_processor(self, config):

--- a/fiftyone/utils/sam3.py
+++ b/fiftyone/utils/sam3.py
@@ -35,8 +35,8 @@ logger = logging.getLogger(__name__)
 
 
 def _download_sam3_bpe_vocab_file(
-    tokenizer_base_url: str,
-    bpe_path: str,
+    tokenizer_source,
+    bpe_path,
 ):
     """Downloads SAM3 BPE vocab file if it does not exist at the specified path.
 
@@ -47,35 +47,14 @@ def _download_sam3_bpe_vocab_file(
 
     asset_filename = os.path.basename(bpe_path)
 
-    # Best-effort: copy from installed `sam3` package if it ships the asset
-    try:
-        import sam3 as _sam3_pkg
-
-        sam3_pkg_dir = os.path.dirname(os.path.abspath(_sam3_pkg.__file__))
-        candidates = (
-            os.path.join(
-                os.path.dirname(sam3_pkg_dir),
-                "assets",
-                asset_filename,
-            ),
-            os.path.join(sam3_pkg_dir, "assets", asset_filename),
-        )
-        for candidate in candidates:
-            if os.path.isfile(candidate):
-                shutil.copyfile(candidate, bpe_path)
-                return
-
-    except Exception as e:
-        logger.debug("Could not copy SAM3 vocab from installed package: %s", e)
-
     logger.info("Downloading SAM3 tokenizer vocab (%s)...", asset_filename)
     try:
-        etaw.download_file(tokenizer_base_url, path=bpe_path)
+        etaw.download_file(tokenizer_source, path=bpe_path)
     except Exception as e:
         raise RuntimeError(
             "Failed to download SAM3 tokenizer vocab. "
             "You can manually download '%s' from %s and save it to %s"
-            % (asset_filename, tokenizer_base_url, bpe_path)
+            % (asset_filename, tokenizer_source, bpe_path)
         ) from e
 
 
@@ -95,8 +74,7 @@ class SegmentAnything3ImageModelConfig(
             :class:`GetItem` to use for SAM
         get_item_args (None): a dictionary of arguments for
             ``get_item_cls(field_mapping=field_mapping, **kwargs)``
-        tokenizer_base_filename (None): the filename of the SAM3 tokenizer BPE vocab
-        tokenizer_base_url (None): the URL to download the SAM3 tokenizer BPE vocab
+        tokenizer_source (None): the URL to download the SAM3 tokenizer BPE vocab
         operation_mode ("concept"): concept or visual mode of operation for inference
     """
 
@@ -122,28 +100,9 @@ class SegmentAnything3ImageModelConfig(
         )
         self.get_item_args = self.parse_dict(d, "get_item_args", default=None)
 
-        # Tokenizer vocab settings (provided by the model zoo manifest)
-        self.tokenizer_base_filename = self.parse_string(
-            d, "tokenizer_base_filename", default=None
+        self.tokenizer_source = self.parse_string(
+            d, "tokenizer_source", default=None
         )
-        self.tokenizer_base_url = self.parse_string(
-            d, "tokenizer_base_url", default=None
-        )
-
-        # Ensure the upstream `sam3` entrypoint gets an absolute, stable BPE
-        # vocab path (avoids upstream defaulting to a relative `../assets/`)
-        if self.entrypoint_args is None:
-            self.entrypoint_args = {}
-
-        if (
-            "bpe_path" not in self.entrypoint_args
-            and self.tokenizer_base_filename
-        ):
-            self.entrypoint_args["bpe_path"] = os.path.join(
-                fo.config.model_zoo_dir,
-                "sam3",
-                self.tokenizer_base_filename,
-            )
 
         self.operation_mode = self.parse_string(
             d, "operation_mode", default="concept"
@@ -367,6 +326,15 @@ class SegmentAnything3ImageModel(fosam2.SegmentAnything2ImageModel):
             # Always set to True for easy switching of operation modes in a loaded zoo model.
             config.entrypoint_args["enable_inst_interactivity"] = True
 
+        if (
+            "bpe_path" not in config.entrypoint_args
+            and config.tokenizer_source
+        ):
+            config.entrypoint_args["bpe_path"] = os.path.join(
+                os.path.dirname(config.model_path),
+                os.path.basename(config.tokenizer_source),
+            )
+
         fout.TorchImageModelWithPrompts.__init__(self, config)
         self._sam_auto_generator = None
         self._sam_predictor = self._load_predictor()
@@ -385,26 +353,6 @@ class SegmentAnything3ImageModel(fosam2.SegmentAnything2ImageModel):
     def _load_model(self, config):
         if "device" not in config.entrypoint_args:
             config.entrypoint_args["device"] = str(self._device)
-
-        if not config.tokenizer_base_filename or not config.tokenizer_base_url:
-            raise ValueError(
-                "Missing required SAM3 tokenizer vocab configuration. "
-                "Provide 'tokenizer_base_filename' and 'tokenizer_base_url' "
-                "in the model config (typically via the model zoo manifest)."
-            )
-
-        # Ensure the upstream `sam3` entrypoint has a valid BPE vocab path
-        if config.entrypoint_args is None:
-            config.entrypoint_args = {}
-
-        bpe_path = config.entrypoint_args.get("bpe_path", None)
-        if not bpe_path:
-            bpe_path = os.path.join(
-                os.path.dirname(config.model_path),
-                config.tokenizer_base_filename,
-            )
-            config.entrypoint_args["bpe_path"] = bpe_path
-
         model = super()._load_model(config)
         return model
 
@@ -420,8 +368,14 @@ class SegmentAnything3ImageModel(fosam2.SegmentAnything2ImageModel):
 
         bpe_path = config.entrypoint_args["bpe_path"]
         if not os.path.isfile(bpe_path):
+            if not config.tokenizer_source:
+                raise ValueError(
+                    "Missing BPE vocabulary tokenizer. Either provide 'tokenizer_source'"
+                    "in the model config for downloading or set 'bpe_path' in the model config"
+                    "'entrypoint_args' to a pre-downloaded file."
+                )
             _download_sam3_bpe_vocab_file(
-                tokenizer_base_url=config.tokenizer_base_url,
+                tokenizer_source=config.tokenizer_source,
                 bpe_path=bpe_path,
             )
 

--- a/fiftyone/utils/sam3.py
+++ b/fiftyone/utils/sam3.py
@@ -38,12 +38,7 @@ def _download_sam3_bpe_vocab_file(
     tokenizer_source,
     bpe_path,
 ):
-    """Downloads SAM3 BPE vocab file if it does not exist at the specified path.
-
-    The upstream `sam3` package defaults to a relative `../assets/` location
-    that is not always present in packaged wheels, so we store/download this
-    file in FiftyOne's model zoo directory.
-    """
+    """Downloads SAM3 BPE vocab file from the source URL."""
 
     asset_filename = os.path.basename(bpe_path)
 

--- a/fiftyone/utils/sam3.py
+++ b/fiftyone/utils/sam3.py
@@ -33,14 +33,10 @@ sam2ip = fou.lazy_import("sam2.sam2_image_predictor")
 logger = logging.getLogger(__name__)
 
 
-_SAM3_BPE_FILENAME = "bpe_simple_vocab_16e6.txt.gz"
-_SAM3_BPE_URL = (
-    "https://raw.githubusercontent.com/openai/CLIP/main/clip/"
-    + _SAM3_BPE_FILENAME
-)
-
-
-def _ensure_sam3_bpe_vocab_path():
+def _ensure_sam3_bpe_vocab_path(
+    tokenizer_base_filename: str,
+    tokenizer_base_url: str,
+):
     """Ensures SAM3 has a valid BPE vocab file and returns its path.
 
     The upstream `sam3` package defaults to a relative `../assets/` location
@@ -52,7 +48,7 @@ def _ensure_sam3_bpe_vocab_path():
 
     bpe_dir = os.path.join(fo.config.model_zoo_dir, "sam3")
     os.makedirs(bpe_dir, exist_ok=True)
-    bpe_path = os.path.join(bpe_dir, _SAM3_BPE_FILENAME)
+    bpe_path = os.path.join(bpe_dir, tokenizer_base_filename)
 
     if os.path.isfile(bpe_path):
         return bpe_path
@@ -64,9 +60,11 @@ def _ensure_sam3_bpe_vocab_path():
         sam3_pkg_dir = os.path.dirname(os.path.abspath(_sam3_pkg.__file__))
         candidates = (
             os.path.join(
-                os.path.dirname(sam3_pkg_dir), "assets", _SAM3_BPE_FILENAME
+                os.path.dirname(sam3_pkg_dir),
+                "assets",
+                tokenizer_base_filename,
             ),
-            os.path.join(sam3_pkg_dir, "assets", _SAM3_BPE_FILENAME),
+            os.path.join(sam3_pkg_dir, "assets", tokenizer_base_filename),
         )
         for candidate in candidates:
             if os.path.isfile(candidate):
@@ -75,14 +73,16 @@ def _ensure_sam3_bpe_vocab_path():
     except Exception:
         pass
 
-    logger.info("Downloading SAM3 tokenizer vocab (%s)...", _SAM3_BPE_FILENAME)
+    logger.info(
+        "Downloading SAM3 tokenizer vocab (%s)...", tokenizer_base_filename
+    )
     try:
-        etaw.download_file(_SAM3_BPE_URL, path=bpe_path)
+        etaw.download_file(tokenizer_base_url, path=bpe_path)
     except Exception as e:
         raise RuntimeError(
             "Failed to download SAM3 tokenizer vocab. "
             "You can manually download '%s' from %s and save it to %s"
-            % (_SAM3_BPE_FILENAME, _SAM3_BPE_URL, bpe_path)
+            % (tokenizer_base_filename, tokenizer_base_url, bpe_path)
         ) from e
 
     return bpe_path
@@ -128,6 +128,14 @@ class SegmentAnything3ImageModelConfig(
             default="fiftyone.utils.sam3.SegmentAnything3ImageGetItem",
         )
         self.get_item_args = self.parse_dict(d, "get_item_args", default=None)
+
+        # Tokenizer vocab settings (provided by the model zoo manifest)
+        self.tokenizer_base_filename = self.parse_string(
+            d, "tokenizer_base_filename", default=None
+        )
+        self.tokenizer_base_url = self.parse_string(
+            d, "tokenizer_base_url", default=None
+        )
 
         self.operation_mode = self.parse_string(
             d, "operation_mode", default="concept"
@@ -370,10 +378,23 @@ class SegmentAnything3ImageModel(fosam2.SegmentAnything2ImageModel):
         if "device" not in config.entrypoint_args:
             config.entrypoint_args["device"] = str(self._device)
 
+        if (
+            not self.config.tokenizer_base_filename
+            or not self.config.tokenizer_base_url
+        ):
+            raise ValueError(
+                "Missing required SAM3 tokenizer vocab configuration. "
+                "Provide 'tokenizer_base_filename' and 'tokenizer_base_url' "
+                "in the model config (typically via the model zoo manifest)."
+            )
+
         # Ensure the upstream `sam3` entrypoint has a valid BPE vocab path
         bpe_path = config.entrypoint_args.get("bpe_path", None)
         if not bpe_path or not os.path.isfile(bpe_path):
-            config.entrypoint_args["bpe_path"] = _ensure_sam3_bpe_vocab_path()
+            config.entrypoint_args["bpe_path"] = _ensure_sam3_bpe_vocab_path(
+                tokenizer_base_filename=self.config.tokenizer_base_filename,
+                tokenizer_base_url=self.config.tokenizer_base_url,
+            )
 
         model = super()._load_model(config)
         return model

--- a/fiftyone/utils/sam3.py
+++ b/fiftyone/utils/sam3.py
@@ -12,6 +12,7 @@ import os
 import shutil
 from PIL import Image
 
+import fiftyone as fo
 import fiftyone.core.utils as fou
 import fiftyone.utils.torch as fout
 import fiftyone.utils.sam as fosam
@@ -44,8 +45,6 @@ def _ensure_sam3_bpe_vocab_path(
     file in FiftyOne's model zoo directory.
     """
 
-    import fiftyone as fo
-
     bpe_dir = os.path.join(fo.config.model_zoo_dir, "sam3")
     os.makedirs(bpe_dir, exist_ok=True)
     bpe_path = os.path.join(bpe_dir, tokenizer_base_filename)
@@ -70,8 +69,9 @@ def _ensure_sam3_bpe_vocab_path(
             if os.path.isfile(candidate):
                 shutil.copyfile(candidate, bpe_path)
                 return bpe_path
-    except Exception:
-        pass
+
+    except Exception as e:
+        logger.debug("Could not copy SAM3 vocab from installed package: %s", e)
 
     logger.info(
         "Downloading SAM3 tokenizer vocab (%s)...", tokenizer_base_filename
@@ -378,6 +378,19 @@ class SegmentAnything3ImageModel(fosam2.SegmentAnything2ImageModel):
         if "device" not in config.entrypoint_args:
             config.entrypoint_args["device"] = str(self._device)
 
+        model = super()._load_model(config)
+        return model
+
+    def _download_model(self, config):
+        # Download sam3 to fo.config.model_zoo_dir from HF hub.
+        from huggingface_hub import hf_hub_download
+
+        hf_hub_download(
+            repo_id="facebook/sam3",
+            filename=os.path.basename(config.model_path),
+            local_dir=os.path.dirname(config.model_path),
+        )
+
         if (
             not self.config.tokenizer_base_filename
             or not self.config.tokenizer_base_url
@@ -395,19 +408,6 @@ class SegmentAnything3ImageModel(fosam2.SegmentAnything2ImageModel):
                 tokenizer_base_filename=self.config.tokenizer_base_filename,
                 tokenizer_base_url=self.config.tokenizer_base_url,
             )
-
-        model = super()._load_model(config)
-        return model
-
-    def _download_model(self, config):
-        # Download sam3 to fo.config.model_zoo_dir from HF hub.
-        from huggingface_hub import hf_hub_download
-
-        hf_hub_download(
-            repo_id="facebook/sam3",
-            filename=os.path.basename(config.model_path),
-            local_dir=os.path.dirname(config.model_path),
-        )
 
     def _build_concept_output_processor(self, config):
         kwargs = config.output_processor_args or {}

--- a/fiftyone/utils/sam3.py
+++ b/fiftyone/utils/sam3.py
@@ -63,7 +63,7 @@ def _download_sam3_bpe_vocab_file(
         for candidate in candidates:
             if os.path.isfile(candidate):
                 shutil.copyfile(candidate, bpe_path)
-                return bpe_path
+                return
 
     except Exception as e:
         logger.debug("Could not copy SAM3 vocab from installed package: %s", e)

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -668,8 +668,7 @@
                 "config": {
                     "entrypoint_fcn": "sam3.model_builder.build_sam3_image_model",
                     "entrypoint_args": {},
-                    "tokenizer_base_filename": "bpe_simple_vocab_16e6.txt.gz",
-                    "tokenizer_base_url": "https://raw.githubusercontent.com/openai/CLIP/main/clip/bpe_simple_vocab_16e6.txt.gz"
+                    "tokenizer_source": "https://raw.githubusercontent.com/openai/CLIP/main/clip/bpe_simple_vocab_16e6.txt.gz"
                 }
             },
             "requirements": {

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -667,7 +667,9 @@
                 "type": "fiftyone.utils.sam3.SegmentAnything3ImageModel",
                 "config": {
                     "entrypoint_fcn": "sam3.model_builder.build_sam3_image_model",
-                    "entrypoint_args": {}
+                    "entrypoint_args": {},
+                    "tokenizer_base_filename": "bpe_simple_vocab_16e6.txt.gz",
+                    "tokenizer_base_url": "https://raw.githubusercontent.com/openai/CLIP/main/clip/bpe_simple_vocab_16e6.txt.gz"
                 }
             },
             "requirements": {

--- a/tests/intensive/sam_parity_tests.py
+++ b/tests/intensive/sam_parity_tests.py
@@ -1345,7 +1345,8 @@ class TestSAM3ConceptParity(unittest.TestCase):
         from sam3.model_builder import build_sam3_image_model
         from sam3.model.sam3_image_processor import Sam3Processor
 
-        cls.sam3_model = build_sam3_image_model()
+        bpe_path = cls.fo_model.config.entrypoint_args.get("bpe_path")
+        cls.sam3_model = build_sam3_image_model(bpe_path=bpe_path)
         cls.processor = Sam3Processor(cls.sam3_model)
 
         cls.device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -1452,8 +1453,10 @@ class TestSAM3VisualParity(unittest.TestCase):
 
         from sam3.model_builder import build_sam3_image_model
 
+        bpe_path = cls.fo_model.config.entrypoint_args.get("bpe_path")
         sam3_model = build_sam3_image_model(
             enable_inst_interactivity=True,
+            bpe_path=bpe_path,
         )
         tracker_model = sam3_model.inst_interactive_predictor.model
         if getattr(tracker_model, "backbone", None) is None:


### PR DESCRIPTION
## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

Without this fix, I get: 

Traceback (most recent call last):
  File "/home/peter/code/zcore/zero-shot-coreset-selection/eval_open_vocab_models.py", line 541, in <module>
    main()
  File "/home/peter/code/zcore/zero-shot-coreset-selection/eval_open_vocab_models.py", line 490, in main
    model = _load_model(base_name, device=args.device, classes=classes)
  File "/home/peter/code/zcore/zero-shot-coreset-selection/eval_open_vocab_models.py", line 187, in _load_model
    return foz.load_zoo_model(base_name, device=device, classes=classes)
  File "/home/peter/code/fo/fiftyone/fiftyone/zoo/models/__init__.py", line 325, in load_zoo_model
    model = fom.load_model(config_dict, model_path=model_path, **kwargs)
  File "/home/peter/code/fo/fiftyone/fiftyone/core/models.py", line 2239, in load_model
    return config.build()
  File "/home/peter/code/.fo_env/lib/python3.10/site-packages/eta/core/learning.py", line 284, in build
    return self._model_cls(self.config)
  File "/home/peter/code/fo/fiftyone/fiftyone/utils/sam3.py", line 296, in __init__
    fout.TorchImageModelWithPrompts.__init__(self, config)
  File "/home/peter/code/fo/fiftyone/fiftyone/utils/torch.py", line 688, in __init__
    self._model = self._load_model(config)
  File "/home/peter/code/fo/fiftyone/fiftyone/utils/sam3.py", line 314, in _load_model
    model = super()._load_model(config)
  File "/home/peter/code/fo/fiftyone/fiftyone/utils/sam2.py", line 354, in _load_model
    model = super()._load_model(config)
  File "/home/peter/code/fo/fiftyone/fiftyone/utils/torch.py", line 1009, in _load_model
    model = entrypoint_fcn(**kwargs)
  File "/home/peter/code/.fo_env/lib/python3.10/site-packages/sam3/model_builder.py", line 593, in build_sam3_image_model
    text_encoder = _create_text_encoder(bpe_path)
  File "/home/peter/code/.fo_env/lib/python3.10/site-packages/sam3/model_builder.py", line 488, in _create_text_encoder
    tokenizer = SimpleTokenizer(bpe_path=bpe_path)
  File "/home/peter/code/.fo_env/lib/python3.10/site-packages/sam3/model/tokenizer_ve.py", line 138, in __init__
    with g_pathmgr.open(bpe_path, "rb") as fh:
  File "/home/peter/code/.fo_env/lib/python3.10/site-packages/iopath/common/file_io.py", line 1062, in open
    bret = handler._open(path, mode, buffering=buffering, **kwargs)  # type: ignore
  File "/home/peter/code/.fo_env/lib/python3.10/site-packages/iopath/common/file_io.py", line 645, in _open
    return open(  # type: ignore
FileNotFoundError: [Errno 2] No such file or directory: '/home/peter/code/.fo_env/lib/python3.10/site-packages/assets/bpe_simple_vocab_16e6.txt.gz'

## 🧪 How is this patch tested? If it is not, please explain why.

Tested with local `foz.load_zoo_model()` and  `apply_model()`



## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SAM3 tokenizer BPE vocab is now located automatically: reuse a local copy, extract from an installed package when available, or download from a configured URL and store under the model zoo; model config now accepts tokenizer base filename and URL.

* **Bug Fixes**
  * Added validation and clearer errors when tokenizer configuration or vocab file is missing, preventing incomplete model initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7515)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2891
<!-- enterprise-sync-pr:end -->