### PR TITLE
fix(app): stabilize dynamic group carousel navigation

### DIFF
--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/carousel/DynamicGroupCarousel.tsx
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/carousel/DynamicGroupCarousel.tsx
@@ -2,8 +2,8 @@ import { useTheme } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
 import { useBrowserStorage } from "@fiftyone/state";
 import { Resizable } from "re-resizable";
-import React, { useEffect, useState } from "react";
-import { useRecoilCallback, useRecoilValue } from "recoil";
+import React from "react";
+import { useRecoilValue } from "recoil";
 import { DynamicGroupsFlashlightWrapper } from "./DynamicGroupsFlashlightWrapper";
 
 const MAX_CAROUSEL_HEIGHT = 600;
@@ -18,36 +18,6 @@ export const DynamicGroupCarousel = React.memo(() => {
   const isMainVisible = useRecoilValue(
     fos.groupMediaIsMain2DViewerVisibleSetting
   );
-
-  /**
-   * BIG HACK: TODO: FIX ME
-   *
-   * Problem = flashlight is not re-rendering when group by field changes.
-   * Solution was to key it by groupByValue, but when the component
-   * subscribes to the groupByFieldValue using useRecoilValue(fos.groupByFieldValue),
-   * while it solves the problem, it causes flashlight to behave weirdly.
-   * (try scrolling carousel and selecting samples, flashlight will reset to the front)
-   *
-   */
-  const getGroupByFieldValue = useRecoilCallback(({ snapshot }) => () => {
-    const groupByField = snapshot.getLoadable(fos.groupByFieldValue).getValue();
-    return groupByField;
-  });
-
-  const [groupByValue, setGroupByValue] = useState(getGroupByFieldValue());
-  const groupByValueRef = React.useRef(groupByValue);
-  groupByValueRef.current = groupByValue;
-
-  useEffect(() => {
-    const intervalId = window.setInterval(() => {
-      const groupByFieldValue = getGroupByFieldValue();
-      if (groupByFieldValue !== groupByValueRef.current) {
-        setGroupByValue(groupByFieldValue);
-      }
-    }, 50);
-
-    return () => window.clearInterval(intervalId);
-  }, []);
 
   return (
     <Resizable
@@ -73,7 +43,7 @@ export const DynamicGroupCarousel = React.memo(() => {
       }}
       data-cy={"group-carousel"}
     >
-      <DynamicGroupsFlashlightWrapper key={groupByValue} />
+      <DynamicGroupsFlashlightWrapper />
     </Resizable>
   );
 });

--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/carousel/DynamicGroupsFlashlightWrapper.tsx
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/carousel/DynamicGroupsFlashlightWrapper.tsx
@@ -1,17 +1,9 @@
-import Flashlight from "@fiftyone/flashlight";
+import Flashlight, { Response } from "@fiftyone/flashlight";
 import { Sample, freeVideos } from "@fiftyone/looker";
 import * as fos from "@fiftyone/state";
-import { selectedSamples } from "@fiftyone/state";
 import { get } from "lodash";
-import React, {
-  useCallback,
-  useEffect,
-  useId,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
-import { selector, useRecoilValue, useRecoilValueLoadable } from "recoil";
+import React, { useCallback, useEffect, useId, useRef, useState } from "react";
+import { selector, useRecoilValue } from "recoil";
 import useFlashlightPager from "../../../../../useFlashlightPager";
 import useSetDynamicGroupSample from "./useSetDynamicGroupSample";
 
@@ -20,6 +12,150 @@ export const DYNAMIC_GROUPS_FLASHLIGHT_CONTAINER_ID =
 export const DYNAMIC_GROUPS_FLASHLIGHT_ELEMENT_ID =
   "dynamic-groups-flashlight-element";
 
+/**
+ * Returns a stable Flashlight render callback that manages looker lifecycle
+ * for a single sample slot.
+ *
+ * Re-attaches or disables an existing looker when the slot is revisited, and
+ * creates a new one (wiring up thumbnail-selection events) the first time a
+ * sample is rendered.
+ */
+const useLookerRender = (
+  store: fos.LookerStore<fos.Lookers>,
+  createLooker: ReturnType<typeof fos.useCreateLooker>,
+  selectSample: React.MutableRefObject<ReturnType<typeof fos.useSelectSample>>
+) =>
+  useCallback(
+    (
+      sampleId: string,
+      element: HTMLElement,
+      dimensions: [number, number],
+      soft: boolean,
+      hide: boolean
+    ) => {
+      const result = store.samples.get(sampleId);
+      const looker = store.lookers.get(sampleId);
+
+      if (looker) {
+        hide ? looker.disable() : looker.attach(element, dimensions);
+        return;
+      }
+
+      if (!soft && createLooker.current && result) {
+        const newLooker = createLooker.current(result);
+        newLooker.addEventListener(
+          "selectthumbnail",
+          ({ detail }: CustomEvent) => {
+            selectSample.current(detail.id, detail.altKey);
+          }
+        );
+        store.lookers.set(sampleId, newLooker);
+        newLooker.attach(element, dimensions);
+      }
+    },
+    [createLooker, selectSample, store]
+  );
+
+/**
+ * Keeps all carousel lookers' display options in sync whenever selection,
+ * highlight, or other looker option state changes.
+ */
+const useUpdateItems = (
+  flashlight: Flashlight<number> | null,
+  store: fos.LookerStore<fos.Lookers>,
+  options: ReturnType<typeof fos.useLookerOptions>,
+  highlight: (sample: fos.Sample) => boolean,
+  selected: Set<string>,
+  style: fos.SelectionStyle
+) => {
+  const updateItem = useCallback(
+    async (id: string) => {
+      const isSelected = selected.has(id);
+      const { selectionType, selectionIcon } = fos.resolveSelectionIcon(
+        selected,
+        style,
+        id,
+        isSelected
+      );
+      store.lookers.get(id)?.updateOptions({
+        ...options,
+        selected: isSelected,
+        selectionType,
+        selectionIcon,
+        highlight: highlight(store.samples.get(id)!.sample as Sample),
+      });
+    },
+    [highlight, options, selected, store, style]
+  );
+
+  useEffect(() => {
+    if (flashlight?.isAttached()) {
+      flashlight.updateItems(updateItem);
+    }
+  }, [flashlight, updateItem]);
+};
+
+/**
+ * Creates and configures a Flashlight instance for the dynamic groups carousel.
+ *
+ * Wires up looker creation, thumbnail titles (derived from the orderBy field),
+ * and thumbnail selection events. Returns the factory alongside the highlight
+ * predicate and looker options so the outer component can keep looker state in
+ * sync with selection changes.
+ */
+const useCreateFlashlight = (
+  page: (page: number) => Promise<Response<number>>,
+  store: fos.LookerStore<fos.Lookers>
+) => {
+  const modalSampleId = useRecoilValue(fos.modalSampleId);
+  const highlight = useCallback(
+    (sample) => sample._id === modalSampleId,
+    [modalSampleId]
+  );
+  const select = fos.useSelectSample();
+  const selectSample = useRef(select);
+  selectSample.current = select;
+  const options = fos.useLookerOptions(true);
+  const field = useRecoilValue(fos.dynamicGroupParameters);
+  const setSample = useSetDynamicGroupSample();
+  const createLooker = fos.useCreateLooker(
+    true,
+    true,
+    {
+      ...options,
+      thumbnailTitle: (sample) =>
+        field?.orderBy ? get(sample, field.orderBy) : null,
+    },
+    highlight
+  );
+  const render = useLookerRender(store, createLooker, selectSample);
+
+  return {
+    createFlashlight: useCallback(() => {
+      return new Flashlight({
+        horizontal: true,
+        containerId: DYNAMIC_GROUPS_FLASHLIGHT_CONTAINER_ID,
+        elementId: DYNAMIC_GROUPS_FLASHLIGHT_ELEMENT_ID,
+        initialRequestKey: 0,
+        onItemClick: (_, id) => setSample(id),
+        options: {
+          rowAspectRatioThreshold: 0,
+        },
+        get: page,
+        render,
+      });
+    }, [page, render, setSample]),
+    highlight,
+    options,
+  };
+};
+
+/**
+ * Recoil selector that builds the paginator callback for the dynamic groups
+ * carousel. Captures dataset name at selector evaluation time and reads view
+ * and groupByFieldValue from a snapshot at page-fetch time so the pager always
+ * uses the current view without becoming a stale closure.
+ */
 const pageParams = selector({
   key: "paginateDynamicGroupVariables",
   get: ({ get, getCallback }) => {
@@ -47,133 +183,48 @@ const pageParams = selector({
   },
 });
 
+/**
+ * Horizontal Flashlight carousel for a dynamic group's samples.
+ *
+ * Recreates the Flashlight instance whenever the active group key
+ * (groupByFieldValue) or selected media field changes, ensuring stale lookers
+ * from a previous group are never displayed. Selection and highlight state are
+ * kept in sync via a separate updateItems effect.
+ */
 export const DynamicGroupsFlashlightWrapper = React.memo(() => {
   const id = useId();
 
   const store = fos.useLookerStore();
-  const opts = fos.useLookerOptions(true);
-  const modalSampleId = useRecoilValue(fos.modalSampleId);
-  const field = useRecoilValue(fos.dynamicGroupParameters);
-  const highlight = useCallback(
-    (sample) => sample._id === modalSampleId,
-    [modalSampleId]
-  );
-
-  const createLooker = fos.useCreateLooker(
-    true,
-    true,
-    {
-      ...opts,
-      thumbnailTitle: (sample) =>
-        field?.orderBy ? get(sample, field.orderBy) : null,
-    },
-    highlight
-  );
-
-  const select = fos.useSelectSample();
-  const selectSample = useRef(select);
-  const flashlightRef = useRef<Flashlight<number>>();
-  selectSample.current = select;
-
-  const setSample = useSetDynamicGroupSample();
-  const { init, deferred } = fos.useDeferrer();
-
   const { page, reset } = useFlashlightPager(store, pageParams);
+  const { createFlashlight, highlight, options } = useCreateFlashlight(
+    page,
+    store
+  );
 
-  const [flashlight] = useState(() => {
-    const flashlight = new Flashlight({
-      horizontal: true,
-      containerId: DYNAMIC_GROUPS_FLASHLIGHT_CONTAINER_ID,
-      elementId: DYNAMIC_GROUPS_FLASHLIGHT_ELEMENT_ID,
-      initialRequestKey: 0,
-      onItemClick: (_, id) => setSample(id),
-      options: {
-        rowAspectRatioThreshold: 0,
-      },
-      get: page,
-      render: (sampleId, element, dimensions, soft, hide) => {
-        const result = store.samples.get(sampleId);
-
-        const looker = store.lookers.get(sampleId);
-        if (looker) {
-          hide ? looker.disable() : looker.attach(element, dimensions);
-          return;
-        }
-
-        if (!soft && createLooker.current && result) {
-          const looker = createLooker.current(result);
-          looker.addEventListener(
-            "selectthumbnail",
-            ({ detail }: CustomEvent) => {
-              selectSample.current(detail.id, detail.altKey);
-            }
-          );
-
-          store.lookers.set(sampleId, looker);
-
-          looker.attach(element, dimensions);
-        }
-      },
-    });
-
-    return flashlight;
-  });
-
+  const key = fos.useGroupByFieldValue();
+  const lastKey = useRef<string | null | undefined>(undefined);
+  const [flashlight, setFlashlight] = useState<Flashlight<number> | null>(null);
   const mediaField = useRecoilValue(fos.selectedMediaField(true));
-  useLayoutEffect(() => {
-    deferred(() => {
-      if (!flashlight.isAttached()) {
-        return;
-      }
-
-      flashlight.reset();
-
-      freeVideos();
-    });
-  }, [deferred, reset, flashlight, mediaField]);
-
-  useLayoutEffect(() => {
-    flashlight.attach(id);
-    flashlightRef.current = flashlight;
-
-    return () => flashlight.detach();
-  }, [flashlight, id]);
-
-  const selected = useRecoilValue(selectedSamples);
-  const style = useRecoilValue(fos.sampleSelectionStyle);
-
-  const updateItem = useCallback(
-    async (id: string) => {
-      const isSelected = selected.has(id);
-      const { selectionType, selectionIcon } = fos.resolveSelectionIcon(
-        selected,
-        style,
-        id,
-        isSelected
-      );
-      store.lookers.get(id)?.updateOptions({
-        ...opts,
-        selected: isSelected,
-        selectionType,
-        selectionIcon,
-        highlight: highlight(store.samples.get(id)!.sample as Sample),
-      });
-    },
-    [highlight, opts, selected, store, style]
-  );
-
-  const options = useRecoilValueLoadable(
-    fos.lookerOptions({ modal: true, withFilter: true })
-  );
-  useLayoutEffect(() => {
-    deferred(() => {
-      flashlight.updateItems(updateItem);
-    });
-  }, [deferred, flashlight, updateItem, options, selected]);
 
   useEffect(() => {
-    init();
-  }, [init]);
+    if (key === undefined || lastKey.current === key) return;
+    lastKey.current = key;
+    setFlashlight(createFlashlight());
+  }, [createFlashlight, key, reset, mediaField]);
+
+  useEffect(() => {
+    if (flashlight && !flashlight.isAttached()) {
+      flashlight.attach(id);
+      return () => {
+        flashlight.detach();
+        freeVideos();
+      };
+    }
+  }, [flashlight, id]);
+
+  const selected = useRecoilValue(fos.selectedSamples);
+  const style = useRecoilValue(fos.sampleSelectionStyle);
+  useUpdateItems(flashlight, store, options, highlight, selected, style);
 
   return (
     <div
@@ -184,6 +235,6 @@ export const DynamicGroupsFlashlightWrapper = React.memo(() => {
         position: "relative",
       }}
       id={id}
-    ></div>
+    />
   );
 });

--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/carousel/DynamicGroupsFlashlightWrapper.tsx
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/carousel/DynamicGroupsFlashlightWrapper.tsx
@@ -202,13 +202,16 @@ export const DynamicGroupsFlashlightWrapper = React.memo(() => {
   );
 
   const key = fos.useGroupByFieldValue();
-  const lastKey = useRef<string | null | undefined>(undefined);
+  const lastIdentity = useRef<string | undefined>(undefined);
   const [flashlight, setFlashlight] = useState<Flashlight<number> | null>(null);
   const mediaField = useRecoilValue(fos.selectedMediaField(true));
 
   useEffect(() => {
-    if (key === undefined || lastKey.current === key) return;
-    lastKey.current = key;
+    if (key === undefined) return;
+    const identity = `${mediaField}::${key ?? "null"}`;
+    if (lastIdentity.current === identity) return;
+    lastIdentity.current = identity;
+    reset();
     setFlashlight(createFlashlight());
   }, [createFlashlight, key, reset, mediaField]);
 

--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/index.tsx
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/index.tsx
@@ -1,5 +1,5 @@
 import * as fos from "@fiftyone/state";
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import { NestedGroup } from "./NestedGroup";
 import { NonNestedDynamicGroup } from "./NonNestedGroup";

--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/useDynamicGroupSamples.ts
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/useDynamicGroupSamples.ts
@@ -31,6 +31,11 @@ export const useDynamicGroupSamples = () => {
         return null;
       }
 
+      // group key hasn't settled yet — skip the query
+      if (dynamicGroup === undefined) {
+        return null;
+      }
+
       return loadQuery<foq.paginateSamplesQuery>(
         environment,
         foq.paginateSamples,

--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/useDynamicGroupSamples.ts
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/useDynamicGroupSamples.ts
@@ -9,7 +9,7 @@ export const useDynamicGroupSamples = () => {
   const slice = useRecoilValue(fos.groupSlice);
   const modalSlice = useRecoilValue(fos.modalGroupSlice);
   const view = useRecoilValue(fos.view);
-  const dynamicGroup = useRecoilValue(fos.groupByFieldValue);
+  const dynamicGroup = fos.useGroupByFieldValue();
   const dataset = useRecoilValue(fos.datasetName);
   const dynamicGroupIndex = useRecoilValue(fos.dynamicGroupIndex);
   const shouldRenderImavid = useRecoilValue(fos.shouldRenderImaVidLooker(true));

--- a/app/packages/state/src/accessors/modal/dynamicGroups.test.ts
+++ b/app/packages/state/src/accessors/modal/dynamicGroups.test.ts
@@ -103,6 +103,18 @@ describe("useGroupByFieldValue", () => {
 });
 
 describe("useElementsCount", () => {
+  it("surfaces errors from the count selector as a render error", () => {
+    stateStore.loadables = {
+      groupByFieldValue: { state: "hasValue", contents: "cat" },
+      "dynamicGroupsElementCount-true-cat": {
+        state: "hasError",
+        contents: new Error("count failed"),
+      },
+    };
+    const { result } = renderHook(() => useElementsCount(true));
+    expect(result.error).toEqual(new Error("count failed"));
+  });
+
   it("returns 0 before the count settles", () => {
     stateStore.loadables = {
       groupByFieldValue: { state: "hasValue", contents: "cat" },

--- a/app/packages/state/src/accessors/modal/dynamicGroups.test.ts
+++ b/app/packages/state/src/accessors/modal/dynamicGroups.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ * @vitest-environment jsdom
+ */
+import { renderHook } from "@testing-library/react-hooks";
+import { describe, expect, it, vi } from "vitest";
+
+const mockSelectors = vi.hoisted(() => ({
+  groupByFieldValue: { key: "groupByFieldValue" },
+}));
+
+const mockPathData = vi.hoisted(() => ({
+  dynamicGroupsElementCount: ({
+    modal,
+    value,
+  }: {
+    modal: boolean;
+    value: string | null;
+  }) => ({ key: `dynamicGroupsElementCount-${modal}-${value}` }),
+}));
+
+const stateStore = vi.hoisted(() => ({
+  loadables: {} as Record<string, { state: string; contents: unknown }>,
+}));
+
+vi.mock("../../recoil/dynamicGroups", () => mockSelectors);
+vi.mock("../../recoil/pathData/groups", () => mockPathData);
+
+vi.mock("recoil", async () => {
+  const actual = await vi.importActual<typeof import("recoil")>("recoil");
+  return {
+    ...actual,
+    useRecoilValueLoadable: (node: { key: string }) =>
+      stateStore.loadables[node.key] ?? { state: "loading" },
+  };
+});
+
+import { useElementsCount, useGroupByFieldValue } from "./dynamicGroups";
+
+describe("useGroupByFieldValue", () => {
+  it("returns undefined before the first value settles", () => {
+    stateStore.loadables = {};
+    const { result } = renderHook(() => useGroupByFieldValue());
+    expect(result.current).toBeUndefined();
+  });
+
+  it("returns the settled value", () => {
+    stateStore.loadables = {
+      groupByFieldValue: { state: "hasValue", contents: "cat" },
+    };
+    const { result } = renderHook(() => useGroupByFieldValue());
+    expect(result.current).toBe("cat");
+  });
+
+  it("returns null when the group field is absent", () => {
+    stateStore.loadables = {
+      groupByFieldValue: { state: "hasValue", contents: null },
+    };
+    const { result } = renderHook(() => useGroupByFieldValue());
+    expect(result.current).toBeNull();
+  });
+
+  it("holds the last settled value while the next value is loading", () => {
+    stateStore.loadables = {
+      groupByFieldValue: { state: "hasValue", contents: "cat" },
+    };
+    const { result, rerender } = renderHook(() => useGroupByFieldValue());
+    expect(result.current).toBe("cat");
+
+    stateStore.loadables = {};
+    rerender();
+
+    expect(result.current).toBe("cat");
+  });
+
+  it("updates once a new value settles after a loading transition", () => {
+    stateStore.loadables = {
+      groupByFieldValue: { state: "hasValue", contents: "cat" },
+    };
+    const { result, rerender } = renderHook(() => useGroupByFieldValue());
+
+    stateStore.loadables = {};
+    rerender();
+    expect(result.current).toBe("cat");
+
+    stateStore.loadables = {
+      groupByFieldValue: { state: "hasValue", contents: "dog" },
+    };
+    rerender();
+    expect(result.current).toBe("dog");
+  });
+
+  it("surfaces errors from the selector as a render error", () => {
+    stateStore.loadables = {
+      groupByFieldValue: {
+        state: "hasError",
+        contents: new Error("fetch failed"),
+      },
+    };
+    const { result } = renderHook(() => useGroupByFieldValue());
+    expect(result.error).toEqual(new Error("fetch failed"));
+  });
+});
+
+describe("useElementsCount", () => {
+  it("returns 0 before the count settles", () => {
+    stateStore.loadables = {
+      groupByFieldValue: { state: "hasValue", contents: "cat" },
+    };
+    const { result } = renderHook(() => useElementsCount(true));
+    expect(result.current).toBe(0);
+  });
+
+  it("returns the settled element count", () => {
+    stateStore.loadables = {
+      groupByFieldValue: { state: "hasValue", contents: "cat" },
+      "dynamicGroupsElementCount-true-cat": {
+        state: "hasValue",
+        contents: 42,
+      },
+    };
+    const { result } = renderHook(() => useElementsCount(true));
+    expect(result.current).toBe(42);
+  });
+
+  it("holds the last count while groupByFieldValue transitions between groups", () => {
+    stateStore.loadables = {
+      groupByFieldValue: { state: "hasValue", contents: "cat" },
+      "dynamicGroupsElementCount-true-cat": {
+        state: "hasValue",
+        contents: 42,
+      },
+    };
+    const { result, rerender } = renderHook(() => useElementsCount(true));
+    expect(result.current).toBe(42);
+
+    // group key transitions — both selectors go back to loading
+    stateStore.loadables = {};
+    rerender();
+
+    expect(result.current).toBe(42);
+  });
+
+  it("updates the count once the new group's count settles", () => {
+    stateStore.loadables = {
+      groupByFieldValue: { state: "hasValue", contents: "cat" },
+      "dynamicGroupsElementCount-true-cat": {
+        state: "hasValue",
+        contents: 42,
+      },
+    };
+    const { result, rerender } = renderHook(() => useElementsCount(true));
+
+    stateStore.loadables = {};
+    rerender();
+
+    stateStore.loadables = {
+      groupByFieldValue: { state: "hasValue", contents: "dog" },
+      "dynamicGroupsElementCount-true-dog": {
+        state: "hasValue",
+        contents: 7,
+      },
+    };
+    rerender();
+
+    expect(result.current).toBe(7);
+  });
+
+  it("respects the modal flag when keying the count selector", () => {
+    stateStore.loadables = {
+      groupByFieldValue: { state: "hasValue", contents: "cat" },
+      "dynamicGroupsElementCount-false-cat": {
+        state: "hasValue",
+        contents: 99,
+      },
+    };
+    const { result } = renderHook(() => useElementsCount(false));
+    expect(result.current).toBe(99);
+  });
+});

--- a/app/packages/state/src/accessors/modal/dynamicGroups.ts
+++ b/app/packages/state/src/accessors/modal/dynamicGroups.ts
@@ -39,6 +39,9 @@ export const useElementsCount = (modal: boolean): number => {
   const ref = useRef<number>(
     loadable.state === "hasValue" ? loadable.contents : 0
   );
+  if (loadable.state === "hasError") {
+    throw loadable.contents;
+  }
   if (loadable.state === "hasValue") {
     ref.current = loadable.contents;
   }

--- a/app/packages/state/src/accessors/modal/dynamicGroups.ts
+++ b/app/packages/state/src/accessors/modal/dynamicGroups.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+import { useRef } from "react";
+import { useRecoilValueLoadable } from "recoil";
+import { groupByFieldValue } from "../../recoil/dynamicGroups";
+import { dynamicGroupsElementCount } from "../../recoil/pathData/groups";
+
+/**
+ * Returns the last settled groupByFieldValue without ever suspending.
+ *
+ * groupByFieldValue derives from modalSample (a graphQLSelector) and suspends
+ * during sample transitions. This hook holds the previous value steady while
+ * the next one loads, preventing Suspense boundaries from triggering on every
+ * sample navigation. Returns undefined until the first value has settled.
+ */
+export const useGroupByFieldValue = (): string | null | undefined => {
+  const loadable = useRecoilValueLoadable(groupByFieldValue);
+  const ref = useRef<string | null | undefined>(
+    loadable.state === "hasValue" ? loadable.contents : undefined
+  );
+  if (loadable.state === "hasValue") {
+    ref.current = loadable.contents;
+  }
+  if (loadable.state === "hasError") throw loadable.contents;
+  return ref.current;
+};
+
+/**
+ * Returns the last settled element count for the current dynamic group without
+ * suspending. Uses the stable groupByFieldValue so the count stays frozen while
+ * modalSample is transitioning between pages.
+ */
+export const useElementsCount = (modal: boolean): number => {
+  const value = useGroupByFieldValue() ?? null;
+  const loadable = useRecoilValueLoadable(
+    dynamicGroupsElementCount({ modal, value })
+  );
+  const ref = useRef<number>(
+    loadable.state === "hasValue" ? loadable.contents : 0
+  );
+  if (loadable.state === "hasValue") {
+    ref.current = loadable.contents;
+  }
+  return ref.current;
+};

--- a/app/packages/state/src/accessors/modal/index.ts
+++ b/app/packages/state/src/accessors/modal/index.ts
@@ -1,12 +1,14 @@
+export * from "./dynamicGroups";
+
 import type { Schema } from "@fiftyone/utilities";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useMemo } from "react";
 import { useRecoilState, useRecoilValue, useRecoilValueLoadable } from "recoil";
-import { ModalMode, modalMode } from "../jotai";
-import { preferredGroupAnnotationSliceAtom } from "../jotai/group-annotation";
-import type { ModalViewportState } from "../jotai/modal";
-import { __unsafeModalViewportAtom } from "../jotai/modal";
-import type { ModalSample } from "../recoil";
+import { ModalMode, modalMode } from "../../jotai";
+import { preferredGroupAnnotationSliceAtom } from "../../jotai/group-annotation";
+import type { ModalViewportState } from "../../jotai/modal";
+import { __unsafeModalViewportAtom } from "../../jotai/modal";
+import type { ModalSample } from "../../recoil";
 import {
   State,
   activeFields,
@@ -15,7 +17,7 @@ import {
   lookerOptions,
   modalSample,
   selectedMediaField,
-} from "../recoil";
+} from "../../recoil";
 
 /**
  * Hook which provides the modal's current active paths,


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Adds `useGroupByFieldValue` and `useElementsCount` — stable hooks that hold the last settled Recoil value in a ref rather than suspending during sample transitions. The dynamic group carousel uses these to stay stable while groups load.

### Before

https://github.com/user-attachments/assets/ce4a5670-6afb-4cdf-8ed6-39a5c8166010


### After


https://github.com/user-attachments/assets/652e6ef1-bd35-48f0-a8af-7ad434a36bc8



## 🧪 How is this patch tested? If it is not, please explain why.

Unit tests cover: initial undefined state, settled value, null (no group field), hold-during-transition, update-after-transition, error propagation, and the modal flag

```python
import fiftyone as fo
import fiftyone.zoo as foz
dataset = foz.load_zoo_dataset("cifar10")
view = dataset.group_by("ground_truth.label", order_by=True)
dataset.save_view("labels", view)

session = fo.Session(view)
``` 

## 📝 Release Notes

Fixed flickering in the dynamic group carousel during group navigation

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added non‑suspending hooks to read dynamic group value and element counts.

* **Bug Fixes**
  * Improved carousel stability and responsiveness when switching group-by values.
  * Fixed redundant carousel reloads during group transitions.

* **Refactor**
  * Simplified carousel and flashlight lifecycle and state synchronization; removed polling-based updates.

* **Tests**
  * Added test coverage for dynamic group state management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7516)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->