### PR TITLE
chore: Bump version from 1.16.0 to 1.17.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import os
 from setuptools import setup, find_packages
 
 
-VERSION = "1.16.0"
+VERSION = "1.17.0"
 
 
 def get_version():


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

Bumps `VERSION` in `setup.py` from `1.16.0` to `1.17.0` to open the next development cycle on `develop`, following the cut of `release/v1.16.0`.

## 🧪 How is this patch tested? If it is not, please explain why.

N/A — version bump only.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

## Related

- Release branch: `release/v1.16.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.17.0

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7521)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->