### PR TITLE
Taxonomy data classes

### DIFF
--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -65,8 +65,12 @@ from .core.annotation.attributes import (
     WhenOperator,
     WhenOr,
 )
+from .core.annotation.nodes import (
+    Node,
+)
 from .core.ontology import (
     AnnotationOntology,
+    Taxonomy,
     apply_ontology,
     delete_ontology,
     list_ontologies,

--- a/fiftyone/core/annotation/nodes.py
+++ b/fiftyone/core/annotation/nodes.py
@@ -85,6 +85,7 @@ class Node:
         """
         d: dict[str, Any] = {"name": self.name}
         attr_insert_to_dict(d, "description", self)
+        # omit default-valued fields to keep serialized trees compact at scale
         if self.can_select is not True:
             d["can_select"] = self.can_select
         if self.deprecated is not False:

--- a/fiftyone/core/annotation/nodes.py
+++ b/fiftyone/core/annotation/nodes.py
@@ -1,0 +1,123 @@
+"""
+Taxonomy node primitive.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from fiftyone.core.annotation.attributes import (
+    _require_keys,
+    attr_insert_to_dict,
+)
+
+
+@dataclass(repr=False)
+class Node:
+    """A node in a :class:`fiftyone.core.ontology.Taxonomy` tree.
+
+    There is a single node type: every node has the same shape regardless
+    of whether it represents a leaf class, a sub-class, or a group header.
+    The role of a node is determined by its position in the tree and by
+    the ``can_select`` flag.
+
+    Args:
+        name: required label for this node — a class name, sub-class
+            name, or group header. Must be unique within the taxonomy
+            (uniqueness is enforced by ``validate_taxonomy``, not at
+            construction time).
+        description: optional context for the user (tooltip / guidance
+            text in the UI)
+        can_select: if ``False``, the node is a group header — it
+            expands to show child nodes but is not itself selectable as
+            a class. Defaults to ``True``.
+        deprecated: if ``True``, the node is hidden from the UI for new
+            selections but remains valid on existing labels. Defaults to
+            ``False``.
+        values: optional list of child :class:`Node` instances. A leaf
+            node has no ``values``; a node with children has ``values``.
+
+    Example::
+
+        Node(
+            name="vehicles",
+            can_select=False,
+            values=[
+                Node(name="car"),
+                Node(name="truck"),
+            ],
+        )
+    """
+
+    name: str
+    description: Optional[str] = None
+    can_select: bool = True
+    deprecated: bool = False
+    values: Optional[list["Node"]] = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not self.name:
+            raise ValueError("Node.name must be a non-empty string")
+        if self.description is not None and not isinstance(
+            self.description, str
+        ):
+            raise ValueError("Node.description must be a string if provided")
+        if not isinstance(self.can_select, bool):
+            raise ValueError("Node.can_select must be a bool")
+        if not isinstance(self.deprecated, bool):
+            raise ValueError("Node.deprecated must be a bool")
+        if self.values is not None:
+            if not isinstance(self.values, list):
+                raise ValueError("Node.values must be a list if provided")
+            if not all(isinstance(v, Node) for v in self.values):
+                raise ValueError(
+                    "Node.values must be a list of Node instances"
+                )
+
+    def to_dict(self) -> dict:
+        """Serializes this node to a dict.
+
+        Returns:
+            a dict
+        """
+        d: dict[str, Any] = {"name": self.name}
+        attr_insert_to_dict(d, "description", self)
+        if self.can_select is not True:
+            d["can_select"] = self.can_select
+        if self.deprecated is not False:
+            d["deprecated"] = self.deprecated
+        if self.values is not None:
+            d["values"] = [v.to_dict() for v in self.values]
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Node":
+        """Creates a :class:`Node` from a dict.
+
+        Args:
+            d: a node dict
+
+        Returns:
+            a :class:`Node`
+        """
+        _require_keys(d, ("name",), cls)
+        values_raw = d.get("values")
+        values = (
+            [cls.from_dict(v) for v in values_raw]
+            if values_raw is not None
+            else None
+        )
+        return cls(
+            name=d["name"],
+            description=d.get("description"),
+            can_select=d.get("can_select", True),
+            deprecated=d.get("deprecated", False),
+            values=values,
+        )
+
+    def __repr__(self) -> str:
+        n = len(self.values) if self.values is not None else 0
+        return f"Node(name={self.name!r}, values={n})"

--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -10,7 +10,7 @@ import abc
 import copy
 import fnmatch
 from datetime import datetime
-from typing import Any, NamedTuple, Optional
+from typing import Any, ClassVar, NamedTuple, Optional
 
 import fiftyone.core.annotation.constants as foac
 import fiftyone.core.utils as fou
@@ -18,6 +18,7 @@ from fiftyone.core.annotation.attributes import (
     AttributeSpec,
     attr_insert_to_dict,
 )
+from fiftyone.core.annotation.nodes import Node
 from fiftyone.core.odm.ontology import OntologyDocument, OntologyType
 
 
@@ -34,7 +35,7 @@ class Ontology(abc.ABC):
         description: optional description
     """
 
-    _TYPE: Optional[str] = None
+    _TYPE: ClassVar[Optional[str]] = None
 
     def __init__(
         self,
@@ -302,10 +303,89 @@ class AnnotationOntology(Ontology):
         )
 
 
+class Taxonomy(Ontology):
+    """Ontology for defining a hierarchical class structure.
+
+    A taxonomy is a named, versioned, self-contained class hierarchy.
+    Label schema fields reference a taxonomy by ``name`` instead of
+    inlining a flat class list, so the same hierarchy can be shared
+    across multiple datasets.
+
+    Args:
+        name: the taxonomy name
+        description: optional description
+        root: the root :class:`Node` of the hierarchy. Required.
+
+    Example::
+
+        Taxonomy(
+            name="vehicle_classes",
+            root=Node(
+                name="vehicles",
+                can_select=False,
+                values=[
+                    Node(name="car"),
+                    Node(name="truck"),
+                    Node(name="motorcycle"),
+                ],
+            ),
+        )
+    """
+
+    _TYPE = OntologyType.TAXONOMY.value
+
+    def __init__(
+        self,
+        name: str,
+        root: Node,
+        description: Optional[str] = None,
+    ):
+        super().__init__(name=name, description=description)
+        if not isinstance(root, Node):
+            raise ValueError("Taxonomy.root must be a Node instance")
+        self.root = root
+
+    def _get_root(self) -> dict:
+        return self.root.to_dict()
+
+    def _apply_doc(self, doc: OntologyDocument) -> None:
+        self.name = doc.name
+        self.description = doc.description
+        self.root = Node.from_dict(doc.root)
+
+    def to_dict(self) -> dict:
+        """Serializes this taxonomy to a dict.
+
+        Returns:
+            a dict
+        """
+        d = super().to_dict()
+        d["root"] = self._get_root()
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Taxonomy":
+        """Creates a :class:`Taxonomy` from a dict.
+
+        Args:
+            d: a taxonomy dict
+
+        Returns:
+            a :class:`Taxonomy`
+        """
+        root = d.get("root") or {}
+        return cls(
+            name=d["name"],
+            description=d.get("description"),
+            root=Node.from_dict(root),
+        )
+
+
 # ---- Type dispatch --------------------------------------------------------
 
 _TYPE_TO_CLS: dict[str, type[Ontology]] = {
     OntologyType.ANNOTATION_ONTOLOGY.value: AnnotationOntology,
+    OntologyType.TAXONOMY.value: Taxonomy,
 }
 
 

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -20,7 +20,8 @@ from fiftyone.core.annotation.attributes import (
     WhenOr,
     collect_leaf_conditions,
 )
-from fiftyone.core.ontology import AnnotationOntology
+from fiftyone.core.annotation.nodes import Node
+from fiftyone.core.ontology import AnnotationOntology, Taxonomy, load_ontology
 
 
 class WhenTests(unittest.TestCase):
@@ -993,6 +994,169 @@ class OntologySDKTests(unittest.TestCase):
 
         original = load_ontology("original")
         self.assertEqual(original.name, "original")
+
+
+class NodeTests(unittest.TestCase):
+    def test_create_leaf(self):
+        n = Node(name="car")
+        self.assertEqual(n.name, "car")
+        self.assertIsNone(n.description)
+        self.assertTrue(n.can_select)
+        self.assertFalse(n.deprecated)
+        self.assertIsNone(n.values)
+
+    def test_create_with_children(self):
+        n = Node(
+            name="vehicles",
+            description="any vehicle",
+            can_select=False,
+            values=[Node(name="car"), Node(name="truck")],
+        )
+        self.assertEqual(len(n.values), 2)
+        self.assertFalse(n.can_select)
+
+    def test_empty_name_raises(self):
+        with self.assertRaises(ValueError):
+            Node(name="")
+
+    def test_round_trip_leaf(self):
+        n = Node(name="car")
+        round_tripped = Node.from_dict(n.to_dict())
+        self.assertEqual(round_tripped.to_dict(), n.to_dict())
+        self.assertNotIn("values", n.to_dict())
+
+    def test_round_trip_nested(self):
+        n = Node(
+            name="vehicles",
+            description="anything that moves",
+            can_select=False,
+            values=[
+                Node(name="car"),
+                Node(
+                    name="truck",
+                    values=[
+                        Node(name="pickup"),
+                        Node(name="semi", deprecated=True),
+                    ],
+                ),
+            ],
+        )
+        d = n.to_dict()
+        round_tripped = Node.from_dict(d)
+        self.assertEqual(round_tripped.to_dict(), d)
+
+    def test_default_flags_omitted_from_dict(self):
+        d = Node(name="car").to_dict()
+        self.assertNotIn("can_select", d)
+        self.assertNotIn("deprecated", d)
+        self.assertNotIn("description", d)
+
+
+class TaxonomyTests(unittest.TestCase):
+    def _tree(self):
+        return Node(
+            name="vehicles",
+            can_select=False,
+            values=[Node(name="car"), Node(name="truck")],
+        )
+
+    def test_create(self):
+        t = Taxonomy(name="vehicle_classes", root=self._tree())
+        self.assertEqual(t.name, "vehicle_classes")
+        self.assertEqual(t.root.name, "vehicles")
+        self.assertTrue(t.is_taxonomy)
+        self.assertFalse(t.is_annotation_ontology)
+
+    def test_root_must_be_node(self):
+        with self.assertRaises(ValueError):
+            Taxonomy(name="x", root={"name": "vehicles"})
+
+    def test_round_trip(self):
+        t = Taxonomy(
+            name="vehicle_classes",
+            description="cars and trucks",
+            root=self._tree(),
+        )
+        d = t.to_dict()
+        round_tripped = Taxonomy.from_dict(d)
+        self.assertEqual(round_tripped.to_dict(), d)
+
+
+class TaxonomySDKTests(unittest.TestCase):
+    """Integration tests for Taxonomy CRUD against MongoDB."""
+
+    def setUp(self):
+        import fiftyone.core.odm as foo
+
+        db = foo.get_db_conn()
+        db.drop_collection("ontologies")
+
+        from fiftyone.core.odm.ontology import OntologyDocument
+
+        OntologyDocument.ensure_indexes()
+
+    def tearDown(self):
+        import fiftyone.core.odm as foo
+
+        db = foo.get_db_conn()
+        db.drop_collection("ontologies")
+
+    def _make_taxonomy(self, name: str = "test_taxonomy") -> Taxonomy:
+        return Taxonomy(
+            name=name,
+            description="Test taxonomy",
+            root=Node(
+                name="vehicles",
+                can_select=False,
+                values=[
+                    Node(name="car"),
+                    Node(name="truck", values=[Node(name="pickup")]),
+                ],
+            ),
+        )
+
+    def test_save_and_load(self):
+        t = self._make_taxonomy()
+        t.save()
+
+        self.assertIsNotNone(t.version)
+        self.assertIsNotNone(t.created_at)
+
+        loaded = load_ontology("test_taxonomy")
+        self.assertIsInstance(loaded, Taxonomy)
+        self.assertEqual(loaded.name, "test_taxonomy")
+        self.assertEqual(loaded.root.name, "vehicles")
+        self.assertEqual(loaded.root.values[1].values[0].name, "pickup")
+
+    def test_save_and_reload(self):
+        t = self._make_taxonomy()
+        t.save()
+
+        t.description = "updated"
+        t.reload()
+        self.assertEqual(t.description, "Test taxonomy")
+
+    def test_delete(self):
+        from fiftyone.core.ontology import ontology_exists
+
+        t = self._make_taxonomy()
+        t.save()
+        t.delete()
+
+        self.assertIsNone(t._doc)
+        self.assertFalse(ontology_exists("test_taxonomy"))
+
+    def test_clone(self):
+        from fiftyone.core.ontology import ontology_exists
+
+        t = self._make_taxonomy("original")
+        t.save()
+
+        cloned = t.clone("cloned")
+        self.assertIsInstance(cloned, Taxonomy)
+        self.assertTrue(ontology_exists("original"))
+        self.assertTrue(ontology_exists("cloned"))
+        self.assertEqual(cloned.root.name, "vehicles")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🔗 Related Issues

https://github.com/voxel51/fiftyone/pull/7523

## 📋 What changes are proposed in this pull request?

- Splits ontology feature-flag gating so the taxonomy track is governed independently of conditional attributes — enabling VFF_ONTOLOGY_TX alone unlocks just taxonomy CRUD, with no implicit coupling to VFF_ONTOLOGY_CA.
- Introduces the Taxonomy ontology type with a single uniform Node primitive that serves as leaf, sub-class, or group header depending on its position in the tree and its can_select flag.
- Surfaces Taxonomy and Node on the public fo.* namespace alongside AnnotationOntology.

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added taxonomy ontology support with hierarchical node structures
  * Taxonomy ontologies now support full serialization and persistence, enabling save/load workflows
  * Introduced public API exports for working with taxonomy nodes and ontologies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7524?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->