### PR TITLE
validate taxonomy and auto-validate on save

### DIFF
--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -37,6 +37,12 @@ class Ontology(abc.ABC):
 
     _TYPE: ClassVar[Optional[str]] = None
 
+    def _validate(self) -> None:
+        """Hook called by :meth:`save` to validate the ontology before
+        persisting. Default is a no-op; subclasses override to call
+        their type-specific validator.
+        """
+
     def __init__(
         self,
         name: str,
@@ -140,12 +146,6 @@ class Ontology(abc.ABC):
         cloned._doc = None
         cloned.save()
         return cloned
-
-    def _validate(self) -> None:
-        """Hook called by :meth:`save` to validate the ontology before
-        persisting. Default is a no-op; subclasses override to call
-        their type-specific validator.
-        """
 
     def _get_root(self) -> Any:
         """Returns the serialized root data for storage.
@@ -344,6 +344,13 @@ class Taxonomy(Ontology):
         if not isinstance(root, Node):
             raise ValueError("Taxonomy.root must be a Node instance")
         self.root = root
+
+    def _validate(self) -> None:
+        # Lazy import — ``ontology_validation`` imports ``Taxonomy`` for
+        # type hints, so a top-level import here would be circular.
+        from fiftyone.core.ontology_validation import validate_taxonomy
+
+        validate_taxonomy(self)
 
     def _get_root(self) -> dict:
         return self.root.to_dict()

--- a/fiftyone/core/ontology_validation.py
+++ b/fiftyone/core/ontology_validation.py
@@ -1,5 +1,5 @@
 """
-Validation for :class:`fiftyone.core.ontology.AnnotationOntology`.
+Validation for :mod:`fiftyone.core.ontology` SDK classes.
 
 | Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
@@ -11,7 +11,8 @@ from fiftyone.core.annotation.attributes import (
     WhenOperator,
     collect_leaf_conditions,
 )
-from fiftyone.core.ontology import AnnotationOntology
+from fiftyone.core.annotation.nodes import Node
+from fiftyone.core.ontology import AnnotationOntology, Taxonomy
 
 
 _ALLOWED_THEN_KEYS = {"values", "component"}
@@ -49,6 +50,27 @@ def validate_annotation_ontology(ontology: AnnotationOntology) -> None:
         raise ValueError(
             f"Invalid AnnotationOntology {ontology.name!r}:\n{bullet_list}"
         )
+
+
+def validate_taxonomy(taxonomy: Taxonomy) -> None:
+    """Validates a :class:`Taxonomy`.
+
+    Aggregates all taxonomy-level failures into a single error.
+
+    Args:
+        taxonomy: the taxonomy to validate
+
+    Raises:
+        ValueError: if any rule fails
+    """
+    errors: list[str] = [
+        *_validate_no_node_cycles(taxonomy),
+        *_validate_unique_node_names(taxonomy),
+    ]
+
+    if errors:
+        bullet_list = "\n".join(f"  - {e}" for e in errors)
+        raise ValueError(f"Invalid Taxonomy {taxonomy.name!r}:\n{bullet_list}")
 
 
 def _validate_when_operators(ontology: AnnotationOntology) -> list[str]:
@@ -159,3 +181,54 @@ def _validate_no_cycles(ontology: AnnotationOntology) -> list[str]:
             seen.add(node)
             to_visit.extend(graph[node])
     return errors
+
+
+def _validate_no_node_cycles(taxonomy: Taxonomy) -> list[str]:
+    """Detects cycles in the node tree.
+
+    Pathological — Node trees built via ``from_dict`` or normal Python
+    construction can't cycle, but a caller mutating ``values`` after
+    construction could create one. Catch it before downstream code
+    (serialization, traversal) recurses forever.
+    """
+    path_ids: set[int] = set()
+    cycles: list[str] = []
+
+    def visit(node: Node) -> None:
+        if id(node) in path_ids:
+            cycles.append(f"cycle detected at node {node.name!r}")
+            return
+        path_ids.add(id(node))
+        for child in node.values or []:
+            visit(child)
+        path_ids.remove(id(node))
+
+    visit(taxonomy.root)
+    return cycles
+
+
+def _validate_unique_node_names(taxonomy: Taxonomy) -> list[str]:
+    """Per the proposal, node names are unique within the taxonomy.
+
+    Uses an id-based visited set so a cyclic tree (which
+    ``_validate_no_node_cycles`` reports separately) doesn't loop forever
+    here.
+    """
+    seen_names: set[str] = set()
+    duplicates: set[str] = set()
+    visited_ids: set[int] = set()
+
+    def visit(node: Node) -> None:
+        if id(node) in visited_ids:
+            return
+        visited_ids.add(id(node))
+        if node.name in seen_names:
+            duplicates.add(node.name)
+        seen_names.add(node.name)
+        for child in node.values or []:
+            visit(child)
+
+    visit(taxonomy.root)
+    if duplicates:
+        return [f"duplicate node name(s): {sorted(duplicates)}"]
+    return []

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -22,6 +22,7 @@ from fiftyone.core.annotation.attributes import (
 )
 from fiftyone.core.annotation.nodes import Node
 from fiftyone.core.ontology import AnnotationOntology, Taxonomy, load_ontology
+from fiftyone.core.ontology_validation import validate_taxonomy
 
 
 class WhenTests(unittest.TestCase):
@@ -1157,6 +1158,107 @@ class TaxonomySDKTests(unittest.TestCase):
         self.assertTrue(ontology_exists("original"))
         self.assertTrue(ontology_exists("cloned"))
         self.assertEqual(cloned.root.name, "vehicles")
+
+
+class ValidateTaxonomyTests(unittest.TestCase):
+    def test_valid_passes(self):
+        t = Taxonomy(
+            name="vehicles",
+            root=Node(
+                name="root",
+                values=[Node(name="car"), Node(name="truck")],
+            ),
+        )
+        validate_taxonomy(t)
+
+    def test_single_node_passes(self):
+        t = Taxonomy(name="solo", root=Node(name="only_node"))
+        validate_taxonomy(t)
+
+    def test_deeply_nested_passes(self):
+        t = Taxonomy(
+            name="deep",
+            root=Node(
+                name="root",
+                values=[
+                    Node(
+                        name="vehicles",
+                        values=[
+                            Node(
+                                name="cars",
+                                values=[
+                                    Node(name="sedan"),
+                                    Node(name="coupe"),
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        )
+        validate_taxonomy(t)
+
+    def test_duplicate_sibling_names_fail(self):
+        t = Taxonomy(
+            name="dup",
+            root=Node(
+                name="root",
+                values=[Node(name="car"), Node(name="car")],
+            ),
+        )
+        with self.assertRaises(ValueError) as ctx:
+            validate_taxonomy(t)
+        self.assertIn("duplicate node name(s)", str(ctx.exception))
+        self.assertIn("car", str(ctx.exception))
+
+    def test_duplicate_across_subtrees_fail(self):
+        t = Taxonomy(
+            name="dup_across",
+            root=Node(
+                name="root",
+                values=[
+                    Node(name="vehicles", values=[Node(name="x")]),
+                    Node(name="animals", values=[Node(name="x")]),
+                ],
+            ),
+        )
+        with self.assertRaises(ValueError) as ctx:
+            validate_taxonomy(t)
+        self.assertIn("x", str(ctx.exception))
+
+    def test_root_name_collides_with_descendant_fails(self):
+        t = Taxonomy(
+            name="root_collides",
+            root=Node(
+                name="root",
+                values=[Node(name="root")],
+            ),
+        )
+        with self.assertRaises(ValueError) as ctx:
+            validate_taxonomy(t)
+        self.assertIn("root", str(ctx.exception))
+
+    def test_cycle_detected(self):
+        a = Node(name="a")
+        b = Node(name="b", values=[a])
+        a.values = [b]
+        t = Taxonomy(name="cyclic", root=a)
+        with self.assertRaises(ValueError) as ctx:
+            validate_taxonomy(t)
+        self.assertIn("cycle detected", str(ctx.exception))
+
+    def test_save_invokes_validation(self):
+        # Auto-validate hook in Ontology.save() — invalid taxonomies
+        # raise before any DB interaction.
+        t = Taxonomy(
+            name="bad",
+            root=Node(
+                name="root",
+                values=[Node(name="dup"), Node(name="dup")],
+            ),
+        )
+        with self.assertRaises(ValueError):
+            t.save()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🔗 Related Issues

https://github.com/voxel51/fiftyone/pull/7523
https://github.com/voxel51/fiftyone/pull/7524

## 📋 What changes are proposed in this pull request?

- Rejects taxonomies with duplicate node names or cycles before save, reporting all problems in a single error.
- Adds a _validate() hook on Ontology that save() runs pre-persist;

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Adds validation to taxonomy structure. 

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
