### PR TITLE
[feat] Add MultiModalPlayback shell (4/4)

### DIFF
--- a/app/packages/multimodal/package.json
+++ b/app/packages/multimodal/package.json
@@ -37,6 +37,7 @@
     "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",
         "@fiftyone/plugins": "*",
+        "@fiftyone/tiling": "*",
         "@fiftyone/utilities": "*"
     }
 }

--- a/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.module.css
+++ b/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.module.css
@@ -1,0 +1,18 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--color-content-bg-background);
+  overflow: hidden;
+}
+
+.body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+.main {
+  flex: 1;
+  min-width: 0;
+}

--- a/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.stories.tsx
+++ b/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.stories.tsx
@@ -11,8 +11,13 @@ import {
 } from "../../../../playback/src/stories/utils";
 import MultiModalPlayback from "./MultiModalPlayback";
 
-const meta: Meta = { title: "Multimodal/Demos/MultiModalPlayback" };
+const meta = {
+  title: "Multimodal/Demos/MultiModalPlayback",
+  component: MultiModalPlayback,
+} satisfies Meta<typeof MultiModalPlayback>;
 export default meta;
+
+type Story = StoryObj<typeof MultiModalPlayback>;
 
 const STREAM_CONFIGS: MockStreamConfig[] = DEFAULT_STREAM_CONFIGS;
 
@@ -42,15 +47,17 @@ const INITIAL_TILES: Record<string, TilingTile> = Object.fromEntries(
 function MockSetup() {
   const bundles = useMockStreams(STREAM_CONFIGS);
   const setTileSource = useSetTileSourceFor();
+  // setTileSource is a stable jotai-backed setter — not in deps by design.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     for (const b of bundles) {
       setTileSource(`${b.id}-1`, b.id);
     }
-  }, [bundles, setTileSource]);
+  }, [bundles]);
   return null;
 }
 
-export const Default: StoryObj = {
+export const Default: Story = {
   render: () => (
     <div style={{ height: "calc(100vh - 32px)" }}>
       <MultiModalPlayback

--- a/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.stories.tsx
+++ b/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useEffect } from "react";
+import { useSetTileSourceFor, type TilingTile } from "@fiftyone/tiling";
+import {
+  buildBundle,
+  DEFAULT_PINNED_TRACK_IDS,
+  DEFAULT_STREAM_CONFIGS,
+  DEFAULT_TRACKS,
+  useMockStreams,
+  type MockStreamConfig,
+} from "../../../../playback/src/stories/utils";
+import MultiModalPlayback from "./MultiModalPlayback";
+
+const meta: Meta = { title: "Multimodal/Demos/MultiModalPlayback" };
+export default meta;
+
+const STREAM_CONFIGS: MockStreamConfig[] = DEFAULT_STREAM_CONFIGS;
+
+/**
+ * Initial tile entries derived from the stream configs at module level
+ * (the bundle factories are pure functions of their config). One tile
+ * per stream, id `<streamId>-1` so subsequent TilingProvider adds get
+ * `-2`, `-3`, …
+ */
+const INITIAL_TILES: Record<string, TilingTile> = Object.fromEntries(
+  STREAM_CONFIGS.map((config) => {
+    const bundle = buildBundle(config);
+    const TileComponent = bundle.Tile;
+    return [
+      `${bundle.id}-1`,
+      { title: bundle.title, render: () => <TileComponent /> },
+    ];
+  })
+);
+
+/**
+ * Mounts inside MultiModalPlayback's providers. Registers the mock
+ * streams with the playback engine, then binds each pre-seeded initial
+ * tile (`<streamId>-1`) to its matching stream id so its body resolves
+ * the right data out of the gate.
+ */
+function MockSetup() {
+  const bundles = useMockStreams(STREAM_CONFIGS);
+  const setTileSource = useSetTileSourceFor();
+  useEffect(() => {
+    for (const b of bundles) {
+      setTileSource(`${b.id}-1`, b.id);
+    }
+  }, [bundles, setTileSource]);
+  return null;
+}
+
+export const Default: StoryObj = {
+  render: () => (
+    <div style={{ height: "calc(100vh - 32px)" }}>
+      <MultiModalPlayback
+        fileName="multimodal_demo.fo"
+        tracks={DEFAULT_TRACKS}
+        defaultPinnedTrackIds={DEFAULT_PINNED_TRACK_IDS}
+        initialTiles={INITIAL_TILES}
+      >
+        <MockSetup />
+      </MultiModalPlayback>
+    </div>
+  ),
+};

--- a/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.stories.tsx
+++ b/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.stories.tsx
@@ -47,12 +47,12 @@ const INITIAL_TILES: Record<string, TilingTile> = Object.fromEntries(
 function MockSetup() {
   const bundles = useMockStreams(STREAM_CONFIGS);
   const setTileSource = useSetTileSourceFor();
-  // setTileSource is a stable jotai-backed setter — not in deps by design.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     for (const b of bundles) {
       setTileSource(`${b.id}-1`, b.id);
     }
+    // setTileSource is a stable jotai-backed setter — not in deps by design.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bundles]);
   return null;
 }

--- a/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.test.tsx
+++ b/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.test.tsx
+++ b/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.test.tsx
@@ -60,15 +60,6 @@ describe("MultiModalPlayback shell", () => {
     expect(screen.getByText("Select a tile to inspect.")).toBeTruthy();
   });
 
-  it("hides the left sidebar after the toggle is clicked", () => {
-    render(<MultiModalPlayback fileName="x" />);
-    // Both sidebars start open → both drawers render.
-    expect(screen.getAllByTestId("drawer")).toHaveLength(2);
-    fireEvent.click(screen.getByTestId("tiling-header-toggle-left-sidebar"));
-    // The Drawer mock unmounts when `open` flips to false.
-    expect(screen.getAllByTestId("drawer")).toHaveLength(1);
-  });
-
   it("respects defaultLeftOpen / defaultRightOpen=false", () => {
     render(
       <MultiModalPlayback

--- a/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.test.tsx
+++ b/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// react-mosaic-component uses react-dnd which needs a DnD context; in
+// jsdom we just need the layout to mount, so stub MosaicGrid to a
+// passthrough that renders each tile's body.
+vi.mock("@fiftyone/tiling", async () => {
+  const actual = await vi.importActual<typeof import("@fiftyone/tiling")>(
+    "@fiftyone/tiling"
+  );
+  return {
+    ...actual,
+    MosaicGrid: ({
+      tiles,
+    }: {
+      tiles: Record<string, { title: string; render: () => React.ReactNode }>;
+    }) => (
+      <div data-testid="mosaic-stub">
+        {Object.entries(tiles).map(([id, t]) => (
+          <div key={id} data-testid={`stub-${id}`}>
+            {t.title}
+          </div>
+        ))}
+      </div>
+    ),
+  };
+});
+
+import MultiModalPlayback from "./MultiModalPlayback";
+
+describe("MultiModalPlayback shell", () => {
+  afterEach(() => cleanup());
+
+  it("renders the filename in the header", () => {
+    render(<MultiModalPlayback fileName="session.fo" />);
+    expect(screen.getByText("session.fo")).toBeTruthy();
+  });
+
+  it("seeds the mosaic with the provided initialTiles", () => {
+    render(
+      <MultiModalPlayback
+        fileName="session.fo"
+        initialTiles={{
+          "camera-1": { title: "camera_front", render: () => null },
+          "lidar-1": { title: "lidar_top", render: () => null },
+        }}
+      />
+    );
+    expect(screen.getByTestId("stub-camera-1").textContent).toBe(
+      "camera_front"
+    );
+    expect(screen.getByTestId("stub-lidar-1").textContent).toBe("lidar_top");
+  });
+
+  it("renders the default sidebars (settings + inspector empty states)", () => {
+    render(<MultiModalPlayback fileName="x" />);
+    expect(screen.getByText("Settings")).toBeTruthy();
+    expect(screen.getByText("Focus a tile to edit its settings.")).toBeTruthy();
+    expect(screen.getByText("Select a tile to inspect.")).toBeTruthy();
+  });
+
+  it("hides the left sidebar after the toggle is clicked", () => {
+    render(<MultiModalPlayback fileName="x" />);
+    // Both sidebars start open → both drawers render.
+    expect(screen.getAllByTestId("drawer")).toHaveLength(2);
+    fireEvent.click(screen.getByTestId("tiling-header-toggle-left-sidebar"));
+    // The Drawer mock unmounts when `open` flips to false.
+    expect(screen.getAllByTestId("drawer")).toHaveLength(1);
+  });
+
+  it("respects defaultLeftOpen / defaultRightOpen=false", () => {
+    render(
+      <MultiModalPlayback
+        fileName="x"
+        defaultLeftOpen={false}
+        defaultRightOpen={false}
+      />
+    );
+    expect(screen.queryByTestId("drawer")).toBeNull();
+  });
+});

--- a/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.tsx
+++ b/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.tsx
@@ -60,7 +60,7 @@ export interface MultiModalPlaybackProps {
 }
 
 /**
- * Production-ready multi-modal playback shell. Composes the three
+ * Multi-modal playback shell. Composes the three
  * providers we always need — `PlaybackProvider`, `TrackProvider`,
  * `TilingProvider` — and the standard four-region layout:
  *

--- a/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.tsx
+++ b/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.tsx
@@ -1,0 +1,197 @@
+import {
+  MosaicGrid,
+  TileSettingsSidebar,
+  TilingHeader,
+  TilingInspectorSidebar,
+  TilingProvider,
+  useTiling,
+  type TilingTile,
+} from "@fiftyone/tiling";
+import { Drawer } from "@voxel51/voodo";
+import clsx from "clsx";
+import React, { useState, type ReactNode } from "react";
+import { PlaybackProvider } from "../../../../playback/src/lib/playback/PlaybackProvider";
+import {
+  TrackProvider,
+  type Track,
+} from "../../../../playback/src/lib/tracks/TrackProvider";
+import TimelineWithTracks from "../../../../playback/src/views/TimelineWithTracks/TimelineWithTracks";
+import styles from "./MultiModalPlayback.module.css";
+
+export interface MultiModalPlaybackProps {
+  /** Filename rendered on the left of the top bar. */
+  fileName: string;
+
+  /** Tracks broadcast through the embedded TrackProvider. */
+  tracks?: Track[];
+  /** Track ids that should start pinned to the timeline. */
+  defaultPinnedTrackIds?: string[];
+
+  /** Initial tile entries seeded into the embedded TilingProvider. */
+  initialTiles?: Record<string, TilingTile>;
+
+  /**
+   * Override for the left sidebar. Defaults to {@link TileSettingsSidebar}
+   * (focused tile's settings).
+   */
+  leftSidebar?: ReactNode;
+  /**
+   * Override for the right sidebar. Defaults to {@link TilingInspectorSidebar}
+   * (focused tile's selection payload as JSON).
+   */
+  rightSidebar?: ReactNode;
+  /** Whether the left sidebar starts open. @default true */
+  defaultLeftOpen?: boolean;
+  /** Whether the right sidebar starts open. @default true */
+  defaultRightOpen?: boolean;
+
+  /**
+   * Rendered inside the providers this component owns. Use it for
+   * one-time setup that needs to call into the playback engine, the
+   * tiling provider, or the track provider — e.g. registering streams
+   * from a real source (or `useMockStreams(configs)` from a story).
+   *
+   * Rendered before the visible chrome, so non-visual children stay
+   * out of the layout flow.
+   */
+  children?: ReactNode;
+
+  className?: string;
+}
+
+/**
+ * Production-ready multi-modal playback shell. Composes the three
+ * providers we always need — `PlaybackProvider`, `TrackProvider`,
+ * `TilingProvider` — and the standard four-region layout:
+ *
+ *     ┌──────────── TilingHeader ────────────┐
+ *     │  filename · add-tile · ← sidebar →    │
+ *     ├──────┬───────────────────────┬───────┤
+ *     │ left │     MosaicGrid        │ right │
+ *     ├──────┴───────────────────────┴───────┤
+ *     │       TimelineWithTracks             │
+ *     └──────────────────────────────────────┘
+ *
+ * Pass the data via props (`tracks`, `defaultPinnedTrackIds`,
+ * `initialTiles`); pass setup hooks via `children` (stream
+ * registration, source seeding, anything else that needs the
+ * providers in scope). Override the sidebars per app surface via
+ * `leftSidebar` / `rightSidebar`.
+ *
+ *     <MultiModalPlayback
+ *       fileName="…"
+ *       tracks={TRACKS}
+ *       defaultPinnedTrackIds={PINNED}
+ *       initialTiles={INITIAL_TILES}
+ *     >
+ *       <RegisterMyStreams />
+ *     </MultiModalPlayback>
+ */
+const MultiModalPlayback: React.FC<MultiModalPlaybackProps> = ({
+  fileName,
+  tracks,
+  defaultPinnedTrackIds,
+  initialTiles,
+  leftSidebar = <TileSettingsSidebar />,
+  rightSidebar = <TilingInspectorSidebar />,
+  defaultLeftOpen = true,
+  defaultRightOpen = true,
+  children,
+  className,
+}) => {
+  return (
+    <PlaybackProvider>
+      <TrackProvider
+        initialTracks={tracks}
+        initialPinnedIds={defaultPinnedTrackIds}
+      >
+        <TilingProvider initialTiles={initialTiles}>
+          {children}
+          <Layout
+            fileName={fileName}
+            leftSidebar={leftSidebar}
+            rightSidebar={rightSidebar}
+            defaultLeftOpen={defaultLeftOpen}
+            defaultRightOpen={defaultRightOpen}
+            className={className}
+          />
+        </TilingProvider>
+      </TrackProvider>
+    </PlaybackProvider>
+  );
+};
+
+interface LayoutProps {
+  fileName: string;
+  leftSidebar: ReactNode;
+  rightSidebar: ReactNode;
+  defaultLeftOpen: boolean;
+  defaultRightOpen: boolean;
+  className?: string;
+}
+
+function Layout({
+  fileName,
+  leftSidebar,
+  rightSidebar,
+  defaultLeftOpen,
+  defaultRightOpen,
+  className,
+}: LayoutProps) {
+  const { layout, tiles, focusedTileId, setLayout, setFocusedTileId } =
+    useTiling();
+  const [leftOpen, setLeftOpen] = useState(defaultLeftOpen);
+  const [rightOpen, setRightOpen] = useState(defaultRightOpen);
+
+  return (
+    <div className={clsx(styles.root, className)}>
+      <TilingHeader
+        fileName={fileName}
+        leftSidebarOpen={leftOpen}
+        rightSidebarOpen={rightOpen}
+        onToggleLeftSidebar={() => setLeftOpen((v) => !v)}
+        onToggleRightSidebar={() => setRightOpen((v) => !v)}
+      />
+
+      <div className={styles.body}>
+        <Drawer
+          side="left"
+          mode="push"
+          defaultSize={280}
+          minSize={200}
+          maxSize={500}
+          open={leftOpen}
+          onOpenChange={setLeftOpen}
+        >
+          {leftSidebar}
+        </Drawer>
+
+        <div className={styles.main}>
+          <MosaicGrid
+            tiles={tiles}
+            value={layout}
+            onChange={setLayout}
+            focusedTileId={focusedTileId}
+            onFocusTile={setFocusedTileId}
+          />
+        </div>
+
+        <Drawer
+          side="right"
+          mode="push"
+          defaultSize={280}
+          minSize={200}
+          maxSize={500}
+          open={rightOpen}
+          onOpenChange={setRightOpen}
+        >
+          {rightSidebar}
+        </Drawer>
+      </div>
+
+      <TimelineWithTracks />
+    </div>
+  );
+}
+
+export default MultiModalPlayback;

--- a/app/packages/multimodal/vitest.config.ts
+++ b/app/packages/multimodal/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    dedupe: ["react", "react-dom"],
+  },
+  test: {
+    environment: "jsdom",
+    setupFiles: ["../../vitest.setup.ts"],
+    css: {
+      modules: {
+        classNameStrategy: "non-scoped",
+      },
+    },
+  },
+});

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3457,6 +3457,7 @@ __metadata:
   dependencies:
     "@bufbuild/protobuf": "npm:^2.11.0"
     "@fiftyone/plugins": "npm:*"
+    "@fiftyone/tiling": "npm:*"
     "@fiftyone/utilities": "npm:*"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

`MultiModalPlayback`: the production shell that composes `PlaybackProvider` + `TrackProvider` + `TilingProvider` into the standard four-region layout (header, left + right sidebars, mosaic grid, timeline). Apps pass `fileName`, `tracks`, `defaultPinnedTrackIds`, and `initialTiles` plus an optional setup `children` (e.g. for stream registration).

Surfaces in Storybook as `Multimodal/Demos/MultiModalPlayback`.

This is **PR 4 of 4** in the stack:

```
develop
└── feat/tiling-pkg
    └── feat/playback-engine
        └── feat/playback-timeline
            └── feat/multimodal-shell ← this PR
```

**Blocked on landing**: same voodo release as the upstream PRs (`Drawer` and the new dropdown plumbing).

**Follow-ups:**
- Layout persistence.
- Pixel-alignment polish in the timeline chrome.

## 🧪 How is this patch tested? If it is not, please explain why.

- Unit tests on the shell composition: header renders, default sidebars surface their empty states, `initialTiles` seeds the mosaic, sidebar toggles flip drawer visibility, `defaultLeftOpen` / `defaultRightOpen` are respected.
- Manually exercised via the `Multimodal/Demos/MultiModalPlayback` Storybook entry.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes.

N/A — foundational shell; not yet wired into any user-facing surface.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build
-   [ ] Core
-   [ ] Documentation
-   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MultiModalPlayback component with configurable tracks, tile-based layout, and collapsible sidebars.
  * Added a Storybook demo that seeds mock streams for immediate preview.

* **Style**
  * Added layout-focused CSS for responsive flex behavior of the playback UI.

* **Tests**
  * Added tests validating header, mosaic tile rendering, and sidebar open/close behavior.

* **Chores**
  * Added Vitest configuration for the multimodal package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7532)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->