### PR TITLE
[FOEPD-3772] Parse MCAP files concurrently

### DIFF
--- a/fiftyone/multimodal/ingest/__init__.py
+++ b/fiftyone/multimodal/ingest/__init__.py
@@ -6,7 +6,7 @@ Ingest scaffolding for multimodal workflows.
 |
 """
 
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 from threading import Semaphore
 from typing import Generator
 
@@ -60,7 +60,7 @@ def _buffer_map(executor, fn, items, *, buffersize):
         future = executor.submit(call_and_release, item)
         futures.append(future)
 
-    return [future.result() for future in as_completed(futures)]
+    return [future.result() for future in futures]
 
 
 def _get_scene_inventories(

--- a/fiftyone/multimodal/ingest/__init__.py
+++ b/fiftyone/multimodal/ingest/__init__.py
@@ -6,6 +6,9 @@ Ingest scaffolding for multimodal workflows.
 |
 """
 
+import os
+from concurrent.futures import ThreadPoolExecutor
+
 from fiftyone.core import storage
 
 
@@ -50,8 +53,10 @@ def _get_scene_inventories(filepaths, *, adapter):
     Returns:
         a list of :class:`fiftyone.multimodal.SceneInventory` instances
     """
-    paths = _readable_paths(filepaths, adapter=adapter)
-    return [adapter.get_scene_inventory(path) for path in paths]
+    paths = list(_readable_paths(filepaths, adapter=adapter))
+    max_workers = max(1, min(8, (os.cpu_count() or 1) + 4, len(paths)))
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        return list(executor.map(adapter.get_scene_inventory, paths))
 
 
 __all__ = ["_get_scene_inventories"]

--- a/fiftyone/multimodal/ingest/__init__.py
+++ b/fiftyone/multimodal/ingest/__init__.py
@@ -9,6 +9,32 @@ Ingest scaffolding for multimodal workflows.
 from fiftyone.core import storage
 
 
+def _readable_paths(filepaths, *, adapter):
+    """
+    Returns a generator of filepaths in the given iterable that can be read by
+    the given adapter.
+
+    Args:
+        filepaths: an iterable of strings representing file paths or directory
+            locations to crawl
+        adapter: a subclass of :class:`MultimodalAdapter` that determines
+            whether a given file can be read
+
+    Returns:
+        a generator of strings representing the filepaths in the given iterable
+        that can be read by the given adapter
+    """
+    for filepath in filepaths:
+        if storage.isdir(filepath):
+            for path in storage.list_files(
+                filepath, abs_paths=True, recursive=True
+            ):
+                if adapter.can_read(path):
+                    yield path
+        elif storage.exists(filepath) and adapter.can_read(filepath):
+            yield filepath
+
+
 def _get_scene_inventories(filepaths, *, adapter):
     """
     Reads the given scene files using the given adapter class, and returns
@@ -24,19 +50,8 @@ def _get_scene_inventories(filepaths, *, adapter):
     Returns:
         a list of :class:`fiftyone.multimodal.SceneInventory` instances
     """
-    inventories = []
-
-    for filepath in filepaths:
-        if storage.isdir(filepath):
-            for path in storage.list_files(
-                filepath, abs_paths=True, recursive=True
-            ):
-                if adapter.can_read(path):
-                    inventories.append(adapter.get_scene_inventory(path))
-        elif storage.exists(filepath) and adapter.can_read(filepath):
-            inventories.append(adapter.get_scene_inventory(filepath))
-
-    return inventories
+    paths = _readable_paths(filepaths, adapter=adapter)
+    return [adapter.get_scene_inventory(path) for path in paths]
 
 
 __all__ = ["_get_scene_inventories"]

--- a/fiftyone/multimodal/ingest/__init__.py
+++ b/fiftyone/multimodal/ingest/__init__.py
@@ -6,13 +6,19 @@ Ingest scaffolding for multimodal workflows.
 |
 """
 
-import os
 from concurrent.futures import ThreadPoolExecutor
+import os
+from typing import Generator
 
+import fiftyone as fo
 from fiftyone.core import storage
+from fiftyone.multimodal.adapters import MultimodalAdapter
+from fiftyone.multimodal.schemas.v1 import SceneInventory
 
 
-def _readable_paths(filepaths, *, adapter):
+def _readable_paths(
+    filepaths: list[str], *, adapter: MultimodalAdapter
+) -> Generator[str, None, None]:
     """
     Returns a generator of filepaths in the given iterable that can be read by
     the given adapter.
@@ -38,7 +44,9 @@ def _readable_paths(filepaths, *, adapter):
             yield filepath
 
 
-def _get_scene_inventories(filepaths, *, adapter):
+def _get_scene_inventories(
+    filepaths: list[str], *, adapter: MultimodalAdapter
+) -> list[SceneInventory]:
     """
     Reads the given scene files using the given adapter class, and returns
     a list of scene inventories.

--- a/fiftyone/multimodal/ingest/__init__.py
+++ b/fiftyone/multimodal/ingest/__init__.py
@@ -61,8 +61,8 @@ def _get_scene_inventories(
     Returns:
         a list of :class:`fiftyone.multimodal.SceneInventory` instances
     """
-    paths = list(_readable_paths(filepaths, adapter=adapter))
-    max_workers = max(1, min(8, (os.cpu_count() or 1) + 4, len(paths)))
+    paths = _readable_paths(filepaths, adapter=adapter)
+    max_workers = max(1, min(8, (os.cpu_count() or 1) + 4))
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         return list(executor.map(adapter.get_scene_inventory, paths))
 

--- a/fiftyone/multimodal/ingest/__init__.py
+++ b/fiftyone/multimodal/ingest/__init__.py
@@ -7,13 +7,12 @@ Ingest scaffolding for multimodal workflows.
 """
 
 from concurrent.futures import ThreadPoolExecutor
-import os
 from typing import Generator
 
-import fiftyone as fo
 from fiftyone.core import storage
 from fiftyone.multimodal.adapters import MultimodalAdapter
 from fiftyone.multimodal.schemas.v1 import SceneInventory
+import fiftyone.core.utils as fou
 
 
 def _readable_paths(
@@ -62,7 +61,7 @@ def _get_scene_inventories(
         a list of :class:`fiftyone.multimodal.SceneInventory` instances
     """
     paths = _readable_paths(filepaths, adapter=adapter)
-    max_workers = min(8, (os.cpu_count() or 1) + 4)
+    max_workers = fou.recommend_thread_pool_workers(num_workers=8)
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         return list(executor.map(adapter.get_scene_inventory, paths))
 

--- a/fiftyone/multimodal/ingest/__init__.py
+++ b/fiftyone/multimodal/ingest/__init__.py
@@ -6,7 +6,8 @@ Ingest scaffolding for multimodal workflows.
 |
 """
 
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from threading import Semaphore
 from typing import Generator
 
 from fiftyone.core import storage
@@ -43,6 +44,25 @@ def _readable_paths(
             yield filepath
 
 
+def _buffer_map(executor, fn, items, *, buffersize):
+    semaphore = Semaphore(buffersize)
+
+    def call_and_release(item):
+        try:
+            return fn(item)
+        finally:
+            semaphore.release()
+
+    futures = []
+
+    for item in items:
+        semaphore.acquire()
+        future = executor.submit(call_and_release, item)
+        futures.append(future)
+
+    return [future.result() for future in as_completed(futures)]
+
+
 def _get_scene_inventories(
     filepaths: list[str], *, adapter: MultimodalAdapter
 ) -> list[SceneInventory]:
@@ -63,7 +83,12 @@ def _get_scene_inventories(
     paths = _readable_paths(filepaths, adapter=adapter)
     max_workers = fou.recommend_thread_pool_workers(num_workers=8)
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        return list(executor.map(adapter.get_scene_inventory, paths))
+        return _buffer_map(
+            executor,
+            adapter.get_scene_inventory,
+            paths,
+            buffersize=max_workers * 2,
+        )
 
 
 __all__ = ["_get_scene_inventories"]

--- a/fiftyone/multimodal/ingest/__init__.py
+++ b/fiftyone/multimodal/ingest/__init__.py
@@ -62,7 +62,7 @@ def _get_scene_inventories(
         a list of :class:`fiftyone.multimodal.SceneInventory` instances
     """
     paths = _readable_paths(filepaths, adapter=adapter)
-    max_workers = max(1, min(8, (os.cpu_count() or 1) + 4))
+    max_workers = min(8, (os.cpu_count() or 1) + 4)
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         return list(executor.map(adapter.get_scene_inventory, paths))
 


### PR DESCRIPTION
## 🔗 Related Issues

[FOEPD-3772](https://voxel51.atlassian.net/browse/FOEPD-3772)

## 📋 What changes are proposed in this pull request?

Updates `_get_scene_inventories` to use a thread pool to read and parse MCAP files in parallel.

## 🧪 How is this patch tested? If it is not, please explain why.

Benchmarked locally. In OSS where files are local, the overhead of adding a thread pool makes performance worse, because MCAP parsing is bottlenecked by the GIL, not by file I/O. In FiftyOne Enterprise where paths may be in cloud storage, read times do improve.

<img width="430" height="400" alt="visualization" src="https://github.com/user-attachments/assets/4ea1f355-074c-44d7-8dd0-bd02ef06e9c5" />

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [x] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

[FOEPD-3772]: https://voxel51.atlassian.net/browse/FOEPD-3772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Scene ingestion now runs in parallel to speed up data loading and improve throughput.
  * Input handling improved: directory inputs are expanded and unreadable paths are filtered before processing.
  * Concurrency is dynamically bounded based on available resources to make ingestion more efficient and robust.
  * Note: ingestion result ordering may differ from prior sequential behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7535)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->