### PR TITLE
Fix/pen tool

### DIFF
--- a/app/packages/lighter/src/overlay/DetectionOverlay.ts
+++ b/app/packages/lighter/src/overlay/DetectionOverlay.ts
@@ -1228,7 +1228,10 @@ export class DetectionOverlay
    * Updates the pen cursor position for live preview rendering.
    */
   updatePenMousePosition(worldPoint: Point | null): void {
-    this.maskKeypoints?.setPreviewPoint(worldPoint);
+    if (!this.maskKeypoints) return;
+
+    this.maskKeypoints.setPreviewPoint(worldPoint);
+    this.markDirty();
   }
 
   /**

--- a/app/packages/lighter/src/overlay/MaskKeypoints.ts
+++ b/app/packages/lighter/src/overlay/MaskKeypoints.ts
@@ -156,7 +156,7 @@ export class MaskKeypoints extends KeypointOverlay {
 
     // 1b. Preview-state closing edge (last -> first) at reduced opacity so it
     // reads as in-progress, distinct from the committed edges above.
-    if (absPoints.length >= 2) {
+    if (absPoints.length > 2) {
       renderer.drawLine(
         absPoints[absPoints.length - 1],
         absPoints[0],

--- a/app/packages/lighter/src/overlay/MaskKeypoints.ts
+++ b/app/packages/lighter/src/overlay/MaskKeypoints.ts
@@ -127,11 +127,7 @@ export class MaskKeypoints extends KeypointOverlay {
     const points = this.getAbsolutePoints();
     const connections = points.reduce(
       (memo, _point, index) =>
-        index === 0
-          ? memo
-          : index === points.length - 1
-          ? [...memo, [index - 1, index], [index, 0]]
-          : [...memo, [index - 1, index]],
+        index === 0 ? memo : [...memo, [index - 1, index]],
       []
     );
     this.setConnections(connections);
@@ -154,6 +150,21 @@ export class MaskKeypoints extends KeypointOverlay {
       renderer.drawLines(
         edgeSegments,
         { strokeStyle: strokeColor, lineWidth },
+        this.containerId
+      );
+    }
+
+    // 1b. Preview-state closing edge (last -> first) at reduced opacity so it
+    // reads as in-progress, distinct from the committed edges above.
+    if (absPoints.length >= 2) {
+      renderer.drawLine(
+        absPoints[absPoints.length - 1],
+        absPoints[0],
+        {
+          strokeStyle: strokeColor,
+          lineWidth,
+          opacity: PREVIEW_LINE_OPACITY,
+        },
         this.containerId
       );
     }

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -4603,10 +4603,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@protobufjs/codegen@npm:^2.0.5":
-  version: 2.0.5
-  resolution: "@protobufjs/codegen@npm:2.0.5"
-  checksum: 10/290335fa114f26202abc0695f279d53e2fd516b01cfd8298923591e0bda011295ff40e3582a1cda0a0f27cbc5039a0292082d5ad08872bb5d6243a614ac15c88
+"@protobufjs/codegen@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "@protobufjs/codegen@npm:2.0.4"
+  checksum: 10/c6ee5fa172a8464f5253174d3c2353ea520c2573ad7b6476983d9b1346f4d8f2b44aa29feb17a949b83c1816bc35286a5ea265ed9d8fdd2865acfa09668c0447
   languageName: node
   linkType: hard
 
@@ -4641,13 +4641,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@protobufjs/inquire@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@protobufjs/inquire@npm:1.1.1"
-  checksum: 10/504740e8ac348f70b33bcf6a20c83d5b9679901654c1a96b18c0491ec2f2f7ac580e74019b6d1bce16113bfb9746bc6e7dfd4e12a717deed699675b7f230ce9e
-  languageName: node
-  linkType: hard
-
 "@protobufjs/path@npm:^1.1.2":
   version: 1.1.2
   resolution: "@protobufjs/path@npm:1.1.2"
@@ -4662,7 +4655,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@protobufjs/utf8@npm:^1.1.1":
+"@protobufjs/utf8@npm:^1.1.0":
   version: 1.1.1
   resolution: "@protobufjs/utf8@npm:1.1.1"
   checksum: 10/ed0c3f9ff1afd602a0aed54c4c03a0b8f641686a5587d8949e088dcac653fb2019d15691ed92eef23dfdf9f4293249532d0508ecd15cef810acf026917719a19
@@ -17584,22 +17577,22 @@ __metadata:
   linkType: hard
 
 "protobufjs@npm:^7.2.4":
-  version: 7.5.8
-  resolution: "protobufjs@npm:7.5.8"
+  version: 7.5.5
+  resolution: "protobufjs@npm:7.5.5"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
-    "@protobufjs/codegen": "npm:^2.0.5"
+    "@protobufjs/codegen": "npm:^2.0.4"
     "@protobufjs/eventemitter": "npm:^1.1.0"
     "@protobufjs/fetch": "npm:^1.1.0"
     "@protobufjs/float": "npm:^1.0.2"
-    "@protobufjs/inquire": "npm:^1.1.1"
+    "@protobufjs/inquire": "npm:^1.1.0"
     "@protobufjs/path": "npm:^1.1.2"
     "@protobufjs/pool": "npm:^1.1.0"
-    "@protobufjs/utf8": "npm:^1.1.1"
+    "@protobufjs/utf8": "npm:^1.1.0"
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
-  checksum: 10/2beb69b88a5c0a8420d0d5934f2358d417ecd6446f4c0d7c8a9ba5fc0e62ec1631938c0ab083258c14f15b87d39d559b49b398779638df57b2f3a3238cc0be1c
+  checksum: 10/048898023a38d22f5fc9a1bcf0dcce5cfbcd37fb00753bd72283720eee7e2cb6055b23957542e5bcdc136379af66203a2ddb8d8c39d11f73169bacf07885fedd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- get preview lines working again (i.e. dashed lines to the cursor)
- add a "closed" preview line from the last point to the first at half opacity

https://github.com/user-attachments/assets/c90c6666-d73f-4401-bb14-87d023d7cc78



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overlay handling to avoid updating when no in-progress polygon exists and to force redraws during preview for smoother responsiveness.
  * Made the polygon preview closing edge render independently, providing clearer visual feedback when drawing mask polygons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7536)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->