### PR TITLE
Ontology mutation delta persist

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
@@ -181,7 +181,9 @@ const useHandleSchemaChange = (readOnly: boolean) => {
         );
 
         if (!currentOwner || prevOwner !== currentOwner) {
-          delete value[name];
+          // null, not `delete`: the auto-save delta must carry an explicit
+          // unset, otherwise the existing-detection merge resurrects the value.
+          value[name] = null;
         }
       }
 


### PR DESCRIPTION

## 📋 What changes are proposed in this pull request?

Fixes a bug that caused deleted state to not persist on on conditionally rendered attributes.

Our sample endpoints use PATCH - When incomplete data is sent to the back end the server assumes that we are not changing it. Therefore, while the front end thinks it is deleted, the back end Resurrects it on the next save. 

## 🧪 How is this patch tested? If it is not, please explain why.

Before:

[before.webm](https://github.com/user-attachments/assets/41699889-cedd-4274-bcda-9cb2876ff1cc)


After:

[after.webm](https://github.com/user-attachments/assets/abd15290-27fb-4f26-96e4-4e28ae3062db)



## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where conditional form fields could be unintentionally restored when their visibility or ownership was modified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7542)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->