### PR TITLE
first draft of mm project plan and job schema

### DIFF
--- a/fiftyone/factory/repo_factory.py
+++ b/fiftyone/factory/repo_factory.py
@@ -20,6 +20,10 @@ from fiftyone.factory.repos.execution_store import (
     ExecutionStoreRepo,
     MongoExecutionStoreRepo,
 )
+from fiftyone.factory.repos.projection_repo import (
+    ProjectionRepo,
+    MongoProjectionRepo,
+)
 from fiftyone.operators.store.notification_service import (
     ChangeStreamNotificationService,
 )
@@ -76,3 +80,14 @@ class RepositoryFactory(object):
             )
 
         return RepositoryFactory.repos[es_repo_key]
+
+    @staticmethod
+    def projection_repo() -> ProjectionRepo:
+        key = MongoProjectionRepo.PLANS_COLLECTION
+        if key not in RepositoryFactory.repos:
+            db = _get_db()
+            RepositoryFactory.repos[key] = MongoProjectionRepo(
+                plans_collection=db[MongoProjectionRepo.PLANS_COLLECTION],
+                jobs_collection=db[MongoProjectionRepo.JOBS_COLLECTION],
+            )
+        return RepositoryFactory.repos[key]

--- a/fiftyone/factory/repos/__init__.py
+++ b/fiftyone/factory/repos/__init__.py
@@ -8,3 +8,7 @@ FiftyOne repository factory.
 from fiftyone.factory.repos.delegated_operation_doc import (
     DelegatedOperationDocument,
 )
+from fiftyone.factory.repos.projection_plan_doc import (
+    ManifestPlanDocument,
+    ProjectionJobDocument,
+)

--- a/fiftyone/factory/repos/projection_plan_doc.py
+++ b/fiftyone/factory/repos/projection_plan_doc.py
@@ -1,0 +1,105 @@
+"""
+FiftyOne multimodal projection plan and job repository documents.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from __future__ import annotations
+
+import copy
+from datetime import datetime
+
+
+class ManifestPlanDocument(object):
+    """MongoDB document for a compiled MCAP projection manifest plan."""
+
+    def __init__(self):
+        self.id = None
+        self.plan_id: str | None = None
+        self.dataset_id: str | None = None
+        self.compiled_at: datetime | None = None
+        self.is_current: bool = False
+        self.manifest_source: str | None = None
+        self.channel_bindings: list = []
+        self.logical_streams: list = []
+        self.projections: list = []
+        self.dag: dict = {}
+        self._doc: dict | None = None
+
+    def from_pymongo(self, doc: dict) -> ManifestPlanDocument:
+        self.id = doc.get("_id", doc.get("id"))
+        self.plan_id = doc.get("plan_id")
+        self.dataset_id = doc.get("dataset_id")
+        self.compiled_at = doc.get("compiled_at")
+        self.is_current = doc.get("is_current", False)
+        self.manifest_source = doc.get("manifest_source")
+        self.channel_bindings = doc.get("channel_bindings", [])
+        self.logical_streams = doc.get("logical_streams", [])
+        self.projections = doc.get("projections", [])
+        self.dag = doc.get("dag", {})
+        self._doc = doc
+        return self
+
+    def to_pymongo(self) -> dict:
+        ignore_keys = {"id", "_doc"}
+        return {
+            k: copy.deepcopy(v)
+            for k, v in self.__dict__.items()
+            if k not in ignore_keys
+        }
+
+
+class ProjectionJobDocument(object):
+    """MongoDB document for one batched projection worker job."""
+
+    def __init__(self):
+        self.id = None
+        self.job_id: str | None = None
+        self.plan_id: str | None = None
+        self.dataset_id: str | None = None
+        self.batch_index: int = 0
+        self.episode_paths: list[str] = []
+        self.status: str = "pending"
+        self.episode_status: dict[str, str] = {}
+        self.output_paths: dict[str, str] = {}
+        self.created_at: datetime | None = None
+        self.started_at: datetime | None = None
+        self.completed_at: datetime | None = None
+        self.error: str | None = None
+        self.delegated_operation_id: str | None = None
+        self._doc: dict | None = None
+
+    def from_pymongo(self, doc: dict) -> ProjectionJobDocument:
+        self.id = doc.get("_id", doc.get("id"))
+        self.job_id = doc.get("job_id")
+        self.plan_id = doc.get("plan_id")
+        self.dataset_id = doc.get("dataset_id")
+        self.batch_index = doc.get("batch_index", 0)
+        self.episode_paths = doc.get("episode_paths", [])
+        self.status = doc.get("status", "pending")
+        # episode_status is stored as [{path, status}] in MongoDB.
+        raw_es = doc.get("episode_status", [])
+        if isinstance(raw_es, list):
+            self.episode_status = {
+                item["path"]: item["status"] for item in raw_es
+            }
+        else:
+            self.episode_status = raw_es
+        self.output_paths = doc.get("output_paths", {})
+        self.created_at = doc.get("created_at")
+        self.started_at = doc.get("started_at")
+        self.completed_at = doc.get("completed_at")
+        self.error = doc.get("error")
+        self.delegated_operation_id = doc.get("delegated_operation_id")
+        self._doc = doc
+        return self
+
+    def to_pymongo(self) -> dict:
+        ignore_keys = {"id", "_doc"}
+        return {
+            k: copy.deepcopy(v)
+            for k, v in self.__dict__.items()
+            if k not in ignore_keys
+        }

--- a/fiftyone/factory/repos/projection_repo.py
+++ b/fiftyone/factory/repos/projection_repo.py
@@ -1,0 +1,368 @@
+"""
+FiftyOne multimodal projection plan and job repository.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+import logging
+from typing import List, Optional
+
+import pymongo
+from pymongo import IndexModel
+from pymongo.collection import Collection
+
+from fiftyone.factory.repos.projection_plan_doc import (
+    ManifestPlanDocument,
+    ProjectionJobDocument,
+)
+from fiftyone.multimodal.projection.compiler.model import (
+    CompiledPlan,
+    JobStatus,
+    ProjectionJob,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Abstract base
+# ---------------------------------------------------------------------------
+
+
+class ProjectionRepo(object):
+    """Base class for the projection plan + job repository."""
+
+    # Plans
+
+    def save_plan(self, plan: CompiledPlan) -> ManifestPlanDocument:
+        raise NotImplementedError
+
+    def get_current_plan(
+        self, dataset_id: str
+    ) -> Optional[ManifestPlanDocument]:
+        raise NotImplementedError
+
+    def get_plan(self, plan_id: str) -> Optional[ManifestPlanDocument]:
+        raise NotImplementedError
+
+    def list_plans(self, dataset_id: str) -> List[ManifestPlanDocument]:
+        raise NotImplementedError
+
+    # Jobs
+
+    def save_jobs(
+        self, jobs: List[ProjectionJob]
+    ) -> List[ProjectionJobDocument]:
+        raise NotImplementedError
+
+    def get_job(self, job_id: str) -> Optional[ProjectionJobDocument]:
+        raise NotImplementedError
+
+    def list_jobs(
+        self,
+        plan_id: Optional[str] = None,
+        dataset_id: Optional[str] = None,
+        status: Optional[str] = None,
+    ) -> List[ProjectionJobDocument]:
+        raise NotImplementedError
+
+    def update_job_status(
+        self,
+        job_id: str,
+        status: JobStatus,
+        error: Optional[str] = None,
+    ) -> ProjectionJobDocument:
+        raise NotImplementedError
+
+    def update_episode_status(
+        self,
+        job_id: str,
+        episode_path: str,
+        status: str,
+    ) -> ProjectionJobDocument:
+        raise NotImplementedError
+
+    def set_delegated_operation_id(
+        self,
+        job_id: str,
+        delegated_operation_id: str,
+    ) -> ProjectionJobDocument:
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# MongoDB implementation
+# ---------------------------------------------------------------------------
+
+
+class MongoProjectionRepo(ProjectionRepo):
+    PLANS_COLLECTION = "multimodal_manifest_plans"
+    JOBS_COLLECTION = "multimodal_projection_jobs"
+
+    def __init__(
+        self,
+        plans_collection: Collection = None,
+        jobs_collection: Collection = None,
+    ):
+        self._plans = (
+            plans_collection
+            if plans_collection is not None
+            else self._get_collection(self.PLANS_COLLECTION)
+        )
+        self._jobs = (
+            jobs_collection
+            if jobs_collection is not None
+            else self._get_collection(self.JOBS_COLLECTION)
+        )
+        self._create_indexes()
+
+    def _get_collection(self, name: str) -> Collection:
+        import fiftyone.core.odm as foo
+
+        return foo.get_db_conn()[name]
+
+    def _create_indexes(self):
+        self._create_plan_indexes()
+        self._create_job_indexes()
+
+    def _create_plan_indexes(self):
+        existing = [idx["name"] for idx in self._plans.list_indexes()]
+        to_create = []
+
+        if "plan_id_1" not in existing:
+            to_create.append(
+                IndexModel(
+                    [("plan_id", pymongo.ASCENDING)],
+                    name="plan_id_1",
+                    unique=True,
+                )
+            )
+        if "dataset_id_1" not in existing:
+            to_create.append(
+                IndexModel(
+                    [("dataset_id", pymongo.ASCENDING)],
+                    name="dataset_id_1",
+                )
+            )
+        if "dataset_id_1_is_current_1" not in existing:
+            to_create.append(
+                IndexModel(
+                    [
+                        ("dataset_id", pymongo.ASCENDING),
+                        ("is_current", pymongo.ASCENDING),
+                    ],
+                    name="dataset_id_1_is_current_1",
+                )
+            )
+
+        if to_create:
+            self._plans.create_indexes(to_create)
+
+    def _create_job_indexes(self):
+        existing = [idx["name"] for idx in self._jobs.list_indexes()]
+        to_create = []
+
+        if "job_id_1" not in existing:
+            to_create.append(
+                IndexModel(
+                    [("job_id", pymongo.ASCENDING)],
+                    name="job_id_1",
+                    unique=True,
+                )
+            )
+        if "plan_id_1" not in existing:
+            to_create.append(
+                IndexModel(
+                    [("plan_id", pymongo.ASCENDING)],
+                    name="plan_id_1",
+                )
+            )
+        if "dataset_id_1" not in existing:
+            to_create.append(
+                IndexModel(
+                    [("dataset_id", pymongo.ASCENDING)],
+                    name="dataset_id_1",
+                )
+            )
+        if "plan_id_1_status_1" not in existing:
+            to_create.append(
+                IndexModel(
+                    [
+                        ("plan_id", pymongo.ASCENDING),
+                        ("status", pymongo.ASCENDING),
+                    ],
+                    name="plan_id_1_status_1",
+                )
+            )
+
+        if to_create:
+            self._jobs.create_indexes(to_create)
+
+    # ------------------------------------------------------------------
+    # Plan operations
+    # ------------------------------------------------------------------
+
+    def save_plan(self, plan: CompiledPlan) -> ManifestPlanDocument:
+        """Upsert the plan and mark it as the current plan for its dataset.
+
+        Any previously current plans for the same dataset_id are demoted
+        (is_current set to False) before the new plan is set as current.
+        """
+        # Demote all existing current plans for this dataset.
+        self._plans.update_many(
+            {"dataset_id": plan.dataset_id, "is_current": True},
+            {"$set": {"is_current": False}},
+        )
+
+        doc = plan.to_mongo_doc()
+        self._plans.update_one(
+            {"plan_id": plan.plan_id},
+            {"$set": doc},
+            upsert=True,
+        )
+
+        raw = self._plans.find_one({"plan_id": plan.plan_id})
+        return ManifestPlanDocument().from_pymongo(raw)
+
+    def get_current_plan(
+        self, dataset_id: str
+    ) -> Optional[ManifestPlanDocument]:
+        raw = self._plans.find_one(
+            {"dataset_id": dataset_id, "is_current": True}
+        )
+        if raw is None:
+            return None
+        return ManifestPlanDocument().from_pymongo(raw)
+
+    def get_plan(self, plan_id: str) -> Optional[ManifestPlanDocument]:
+        raw = self._plans.find_one({"plan_id": plan_id})
+        if raw is None:
+            return None
+        return ManifestPlanDocument().from_pymongo(raw)
+
+    def list_plans(self, dataset_id: str) -> List[ManifestPlanDocument]:
+        cursor = self._plans.find(
+            {"dataset_id": dataset_id},
+            sort=[("compiled_at", pymongo.DESCENDING)],
+        )
+        return [ManifestPlanDocument().from_pymongo(doc) for doc in cursor]
+
+    # ------------------------------------------------------------------
+    # Job operations
+    # ------------------------------------------------------------------
+
+    def save_jobs(
+        self, jobs: List[ProjectionJob]
+    ) -> List[ProjectionJobDocument]:
+        """Bulk-insert a list of projection jobs. Returns the persisted docs."""
+        if not jobs:
+            return []
+
+        docs = [job.to_mongo_doc() for job in jobs]
+        result = self._jobs.insert_many(docs)
+
+        cursor = self._jobs.find({"_id": {"$in": result.inserted_ids}})
+        return [ProjectionJobDocument().from_pymongo(doc) for doc in cursor]
+
+    def get_job(self, job_id: str) -> Optional[ProjectionJobDocument]:
+        raw = self._jobs.find_one({"job_id": job_id})
+        if raw is None:
+            return None
+        return ProjectionJobDocument().from_pymongo(raw)
+
+    def list_jobs(
+        self,
+        plan_id: Optional[str] = None,
+        dataset_id: Optional[str] = None,
+        status: Optional[str] = None,
+    ) -> List[ProjectionJobDocument]:
+        query: dict = {}
+        if plan_id is not None:
+            query["plan_id"] = plan_id
+        if dataset_id is not None:
+            query["dataset_id"] = dataset_id
+        if status is not None:
+            query["status"] = status
+
+        cursor = self._jobs.find(
+            query, sort=[("batch_index", pymongo.ASCENDING)]
+        )
+        return [ProjectionJobDocument().from_pymongo(doc) for doc in cursor]
+
+    def update_job_status(
+        self,
+        job_id: str,
+        status: JobStatus,
+        error: Optional[str] = None,
+    ) -> ProjectionJobDocument:
+        """Transition a job's status and stamp the appropriate timestamp."""
+        now = datetime.utcnow()
+        update: dict = {"status": status.value, "updated_at": now}
+
+        if status == JobStatus.RUNNING:
+            update["started_at"] = now
+        elif status in (
+            JobStatus.COMPLETED,
+            JobStatus.FAILED,
+            JobStatus.PARTIAL,
+        ):
+            update["completed_at"] = now
+
+        if error is not None:
+            update["error"] = error
+
+        doc = self._jobs.find_one_and_update(
+            {"job_id": job_id},
+            {"$set": update},
+            return_document=pymongo.ReturnDocument.AFTER,
+        )
+        if doc is None:
+            raise ValueError(f"No job found with job_id={job_id!r}")
+        return ProjectionJobDocument().from_pymongo(doc)
+
+    def update_episode_status(
+        self,
+        job_id: str,
+        episode_path: str,
+        status: str,
+    ) -> ProjectionJobDocument:
+        """Update the per-episode status within a batch job.
+
+        episode_status is stored as [{path, status}] in MongoDB so that
+        episode paths (which contain dots, slashes, etc.) are never used as
+        field names. arrayFilters targets the matching element by path.
+        """
+        doc = self._jobs.find_one_and_update(
+            {"job_id": job_id, "episode_status.path": episode_path},
+            {
+                "$set": {
+                    "episode_status.$[ep].status": status,
+                    "updated_at": datetime.utcnow(),
+                }
+            },
+            array_filters=[{"ep.path": episode_path}],
+            return_document=pymongo.ReturnDocument.AFTER,
+        )
+        if doc is None:
+            raise ValueError(f"No job found with job_id={job_id!r}")
+        return ProjectionJobDocument().from_pymongo(doc)
+
+    def set_delegated_operation_id(
+        self,
+        job_id: str,
+        delegated_operation_id: str,
+    ) -> ProjectionJobDocument:
+        """Attach a Teams delegated operation ID to a job document."""
+        doc = self._jobs.find_one_and_update(
+            {"job_id": job_id},
+            {"$set": {"delegated_operation_id": delegated_operation_id}},
+            return_document=pymongo.ReturnDocument.AFTER,
+        )
+        if doc is None:
+            raise ValueError(f"No job found with job_id={job_id!r}")
+        return ProjectionJobDocument().from_pymongo(doc)

--- a/fiftyone/factory/repos/projection_repo.py
+++ b/fiftyone/factory/repos/projection_repo.py
@@ -87,6 +87,12 @@ class ProjectionRepo(object):
     ) -> ProjectionJobDocument:
         raise NotImplementedError
 
+    def get_all_episode_paths(self, plan_id: str) -> set:
+        raise NotImplementedError
+
+    def get_next_batch_index(self, plan_id: str) -> int:
+        raise NotImplementedError
+
     def set_delegated_operation_id(
         self,
         job_id: str,
@@ -313,7 +319,13 @@ class MongoProjectionRepo(ProjectionRepo):
         ):
             update["completed_at"] = now
 
-        if error is not None:
+        # Always write the error field at terminal states so stale errors from
+        # a prior failed run are cleared when the job is re-run successfully.
+        if status in (
+            JobStatus.COMPLETED,
+            JobStatus.FAILED,
+            JobStatus.PARTIAL,
+        ):
             update["error"] = error
 
         doc = self._jobs.find_one_and_update(
@@ -351,6 +363,22 @@ class MongoProjectionRepo(ProjectionRepo):
         if doc is None:
             raise ValueError(f"No job found with job_id={job_id!r}")
         return ProjectionJobDocument().from_pymongo(doc)
+
+    def get_all_episode_paths(self, plan_id: str) -> set:
+        """Return the set of episode paths already assigned to any job for this plan."""
+        cursor = self._jobs.find({"plan_id": plan_id}, {"episode_paths": 1})
+        covered: set = set()
+        for doc in cursor:
+            covered.update(doc.get("episode_paths", []))
+        return covered
+
+    def get_next_batch_index(self, plan_id: str) -> int:
+        """Return the next available batch_index for a plan (max existing + 1, or 0)."""
+        doc = self._jobs.find_one(
+            {"plan_id": plan_id},
+            sort=[("batch_index", pymongo.DESCENDING)],
+        )
+        return (doc["batch_index"] + 1) if doc else 0
 
     def set_delegated_operation_id(
         self,

--- a/fiftyone/multimodal/projection/__init__.py
+++ b/fiftyone/multimodal/projection/__init__.py
@@ -1,5 +1,23 @@
 """
-Projection scaffolding for multimodal workflows.
+Multimodal projection compiler and sink infrastructure.
+
+The compiler converts MCAP projection manifests (YAML) into a
+:class:`~fiftyone.multimodal.projection.compiler.model.CompiledPlan` and
+batched :class:`~fiftyone.multimodal.projection.compiler.model.ProjectionJob`
+documents for MongoDB.
+
+Quick start::
+
+    from fiftyone.multimodal.projection import compiler
+
+    plan = compiler.compile(yaml_source, dataset_id="<mongo-object-id>")
+    jobs = compiler.dispatch(plan, episode_paths, base_path="gs://my-bucket")
+
+    # Persist to MongoDB
+    db["multimodal_manifest_plans"].insert_one(plan.to_mongo_doc())
+    db["multimodal_projection_jobs"].insert_many(
+        [job.to_mongo_doc() for job in jobs]
+    )
 
 | Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_

--- a/fiftyone/multimodal/projection/compiler/__init__.py
+++ b/fiftyone/multimodal/projection/compiler/__init__.py
@@ -23,11 +23,15 @@ Pipeline::
 
 from __future__ import annotations
 
+import logging
+
 from .emitter import dispatch, emit_plan
 from .expander import expand_manifest
 from .model import CompiledPlan, JobStatus, ProjectionJob
 from .parser import parse_manifest
 from .resolver import resolve_manifest
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "compile",
@@ -74,12 +78,17 @@ def save(
 ) -> tuple:
     """Compile a manifest, persist the plan and jobs to MongoDB, and return both.
 
-    This is the primary entry point for end-to-end ingestion. It:
-      1. Compiles the manifest YAML into a :class:`~.model.CompiledPlan`
-      2. Writes the plan to ``multimodal_manifest_plans`` (upsert by plan_id,
-         demoting any previously current plan for this dataset)
-      3. Batches ``episode_paths`` into jobs and inserts them into
-         ``multimodal_projection_jobs``
+    This is the primary entry point for end-to-end ingestion. It handles two
+    scenarios correctly:
+
+    **New manifest** — the compiled SHA-256 differs from the current plan, so a
+    new plan is created, the old one is demoted, and jobs are created for all
+    episode paths.
+
+    **New episodes, same manifest** — the compiled SHA-256 matches the existing
+    plan.  Only episode paths not already assigned to a job are dispatched;
+    batch indices continue from the highest existing batch so there are no
+    collisions.  If all paths are already covered, no new jobs are created.
 
     Args:
         yaml_source: raw manifest YAML string
@@ -89,16 +98,39 @@ def save(
         batch_size: episodes per worker job
 
     Returns:
-        ``(plan_doc, job_docs)`` — persisted MongoDB documents
+        ``(plan_doc, job_docs)`` — persisted MongoDB documents; ``job_docs``
+        is empty when all paths were already covered
     """
     from fiftyone.factory.repo_factory import RepositoryFactory
 
     plan = compile(yaml_source, dataset_id=dataset_id)
+    repo = RepositoryFactory.projection_repo()
+
+    # Filter out episode paths that already have jobs for this plan so that
+    # re-calling save() with new files doesn't re-queue already-processed ones.
+    covered = repo.get_all_episode_paths(plan.plan_id)
+    new_paths = [p for p in episode_paths if p not in covered]
+
+    if covered:
+        logger.info(
+            "plan %s: %d/%d episodes already covered, dispatching %d new",
+            plan.plan_id[:8],
+            len(covered),
+            len(episode_paths),
+            len(new_paths),
+        )
+
+    # New batch indices continue from the highest existing batch so they don't
+    # collide with already-inserted jobs for this plan.
+    start_idx = repo.get_next_batch_index(plan.plan_id) if new_paths else 0
     jobs = dispatch(
-        plan, episode_paths, base_path=base_path, batch_size=batch_size
+        plan,
+        new_paths,
+        base_path=base_path,
+        batch_size=batch_size,
+        start_batch_index=start_idx,
     )
 
-    repo = RepositoryFactory.projection_repo()
     plan_doc = repo.save_plan(plan)
     job_docs = repo.save_jobs(jobs)
 

--- a/fiftyone/multimodal/projection/compiler/__init__.py
+++ b/fiftyone/multimodal/projection/compiler/__init__.py
@@ -1,0 +1,105 @@
+"""
+MCAP projection manifest compiler.
+
+Converts a manifest YAML into a :class:`~.model.CompiledPlan` and emits
+:class:`~.model.ProjectionJob` documents ready for MongoDB insertion.
+
+Pipeline::
+
+    parse_manifest()   — YAML → raw validated dict
+        ↓
+    expand_manifest()  — expand {{var.field}} repeat blocks
+        ↓
+    resolve_manifest() — validate all cross-references
+        ↓
+    emit_plan()        — build CompiledPlan with content hash + DAG
+        ↓
+    dispatch()         — slice episodes into batched job documents
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from __future__ import annotations
+
+from .emitter import dispatch, emit_plan
+from .expander import expand_manifest
+from .model import CompiledPlan, JobStatus, ProjectionJob
+from .parser import parse_manifest
+from .resolver import resolve_manifest
+
+__all__ = [
+    "compile",
+    "dispatch",
+    "save",
+    "CompiledPlan",
+    "ProjectionJob",
+    "JobStatus",
+]
+
+
+def compile(yaml_source: str, dataset_id: str) -> CompiledPlan:
+    """Compile a manifest YAML string into a :class:`~.model.CompiledPlan`.
+
+    Runs all compiler phases in order: parse → expand → resolve → emit.
+
+    Args:
+        yaml_source: raw manifest YAML string
+        dataset_id: FiftyOne dataset ObjectId string that owns this plan
+
+    Returns:
+        a :class:`~.model.CompiledPlan` with a content-addressed ``plan_id``
+
+    Raises:
+        :class:`~.parser.ManifestParseError`: on invalid YAML structure
+        :class:`~.expander.TemplateExpansionError`: on bad template interpolation
+        :class:`~.resolver.ManifestResolveError`: on unknown cross-references
+        :class:`~.dag.CyclicDependencyError`: on circular projection dependencies
+    """
+    raw = parse_manifest(yaml_source)
+    expanded = expand_manifest(raw)
+    resolved = resolve_manifest(expanded)
+    return emit_plan(
+        resolved, dataset_id=dataset_id, manifest_source=yaml_source
+    )
+
+
+def save(
+    yaml_source: str,
+    dataset_id: str,
+    episode_paths: list,
+    base_path: str,
+    batch_size: int = 20,
+) -> tuple:
+    """Compile a manifest, persist the plan and jobs to MongoDB, and return both.
+
+    This is the primary entry point for end-to-end ingestion. It:
+      1. Compiles the manifest YAML into a :class:`~.model.CompiledPlan`
+      2. Writes the plan to ``multimodal_manifest_plans`` (upsert by plan_id,
+         demoting any previously current plan for this dataset)
+      3. Batches ``episode_paths`` into jobs and inserts them into
+         ``multimodal_projection_jobs``
+
+    Args:
+        yaml_source: raw manifest YAML string
+        dataset_id: FiftyOne dataset ObjectId string
+        episode_paths: GCS (or local) MCAP file paths to dispatch
+        base_path: output path root, e.g. ``gs://my-bucket``
+        batch_size: episodes per worker job
+
+    Returns:
+        ``(plan_doc, job_docs)`` — persisted MongoDB documents
+    """
+    from fiftyone.factory.repo_factory import RepositoryFactory
+
+    plan = compile(yaml_source, dataset_id=dataset_id)
+    jobs = dispatch(
+        plan, episode_paths, base_path=base_path, batch_size=batch_size
+    )
+
+    repo = RepositoryFactory.projection_repo()
+    plan_doc = repo.save_plan(plan)
+    job_docs = repo.save_jobs(jobs)
+
+    return plan_doc, job_docs

--- a/fiftyone/multimodal/projection/compiler/dag.py
+++ b/fiftyone/multimodal/projection/compiler/dag.py
@@ -1,0 +1,103 @@
+"""
+DAG construction, topological sort, and cycle detection for projections.
+
+Projections that source from other projections form a directed acyclic graph.
+This module builds that graph, assigns DAG levels, and returns a topological
+execution order. Circular dependencies raise immediately with a clear message.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from __future__ import annotations
+
+from collections import deque
+
+
+class CyclicDependencyError(ValueError):
+    pass
+
+
+def build_dag(
+    projections: list[dict],
+) -> tuple[list[str], dict[str, list[str]], dict[str, int]]:
+    """Build a DAG from a flat list of resolved projection dicts.
+
+    Args:
+        projections: resolved projection dicts, each with an ``id`` key and a
+            ``sources`` list whose entries may include a ``projections`` list
+            of upstream projection IDs
+
+    Returns:
+        A three-tuple of:
+        - ``order``: projection IDs in topological execution order
+        - ``levels``: mapping of level string ("0", "1", ...) to projection ID lists
+        - ``dep_map``: mapping of projection ID to list of upstream projection IDs
+    """
+    ids = [p["id"] for p in projections]
+    id_set = set(ids)
+
+    dep_map: dict[str, list[str]] = {}
+    for proj in projections:
+        upstream: list[str] = []
+        for source in proj.get("sources", []):
+            for pid in source.get("projections", []):
+                if pid not in id_set:
+                    raise ValueError(
+                        f"Projection '{proj['id']}' references unknown upstream "
+                        f"projection '{pid}'"
+                    )
+                upstream.append(pid)
+        dep_map[proj["id"]] = upstream
+
+    order = _topo_sort(ids, dep_map)
+    levels = _assign_levels(order, dep_map)
+    return order, levels, dep_map
+
+
+def _topo_sort(ids: list[str], dep_map: dict[str, list[str]]) -> list[str]:
+    """Kahn's algorithm. Raises CyclicDependencyError if a cycle is detected."""
+    in_degree: dict[str, int] = {pid: 0 for pid in ids}
+    dependents: dict[str, list[str]] = {pid: [] for pid in ids}
+
+    for pid, deps in dep_map.items():
+        for dep in deps:
+            in_degree[pid] += 1
+            dependents[dep].append(pid)
+
+    queue: deque[str] = deque(pid for pid in ids if in_degree[pid] == 0)
+    order: list[str] = []
+
+    while queue:
+        node = queue.popleft()
+        order.append(node)
+        for dependent in dependents[node]:
+            in_degree[dependent] -= 1
+            if in_degree[dependent] == 0:
+                queue.append(dependent)
+
+    if len(order) != len(ids):
+        remaining = [pid for pid in ids if pid not in set(order)]
+        raise CyclicDependencyError(
+            f"Circular dependency detected among projections: {remaining}"
+        )
+
+    return order
+
+
+def _assign_levels(
+    order: list[str], dep_map: dict[str, list[str]]
+) -> dict[str, list[str]]:
+    """Assign each projection to a DAG level based on its longest dependency chain."""
+    level_of: dict[str, int] = {}
+    for pid in order:
+        if not dep_map[pid]:
+            level_of[pid] = 0
+        else:
+            level_of[pid] = max(level_of[dep] for dep in dep_map[pid]) + 1
+
+    levels: dict[str, list[str]] = {}
+    for pid, lvl in level_of.items():
+        levels.setdefault(str(lvl), []).append(pid)
+    return levels

--- a/fiftyone/multimodal/projection/compiler/emitter.py
+++ b/fiftyone/multimodal/projection/compiler/emitter.py
@@ -1,0 +1,344 @@
+"""
+Compiled plan emitter and job dispatcher.
+
+``emit_plan`` converts a resolved + DAG-annotated manifest into a
+:class:`~.model.CompiledPlan`. ``dispatch`` slices a list of episode paths
+into batches and emits :class:`~.model.ProjectionJob` documents ready for
+MongoDB insertion.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from .dag import build_dag
+from .model import (
+    CompiledChannelBinding,
+    CompiledColumn,
+    CompiledLogicalStream,
+    CompiledPlan,
+    CompiledProjection,
+    CompiledProjectionSource,
+    ComputeParameter,
+    ComputeSpec,
+    Grain,
+    MatchSpec,
+    NormalizationSpec,
+    ProjectionJob,
+    StreamComponent,
+    TimestampCandidate,
+    ValueSource,
+)
+
+_GRAIN_KEYS = {
+    "observation": Grain.OBSERVATION,
+    "signal_chunk": Grain.SIGNAL_CHUNK,
+    "annotation": Grain.ANNOTATION,
+    "segment": Grain.SEGMENT,
+    "scene_summary": Grain.SCENE_SUMMARY,
+}
+
+
+def emit_plan(
+    resolved: dict,
+    dataset_id: str,
+    manifest_source: str,
+) -> CompiledPlan:
+    """Build a :class:`~.model.CompiledPlan` from a resolved manifest dict.
+
+    Args:
+        resolved: output of :func:`~.resolver.resolve_manifest`
+        dataset_id: FiftyOne dataset ObjectId string
+        manifest_source: raw YAML string stored for audit
+
+    Returns:
+        a fully compiled plan with content-hashed ``plan_id``
+    """
+    channel_bindings = [
+        _build_channel_binding(b) for b in resolved.get("channel_bindings", [])
+    ]
+    logical_streams = [
+        _build_logical_stream(s) for s in resolved.get("logical_streams", [])
+    ]
+
+    dag_order, dag_levels, dep_map = build_dag(resolved.get("projections", []))
+
+    level_of: dict[str, int] = {}
+    for lvl_str, pids in dag_levels.items():
+        for pid in pids:
+            level_of[pid] = int(lvl_str)
+
+    proj_by_id = {p["id"]: p for p in resolved.get("projections", [])}
+    projections = [
+        _build_projection(proj_by_id[pid], level_of[pid], dep_map[pid])
+        for pid in dag_order
+    ]
+
+    cb_dicts = [b.to_dict() for b in channel_bindings]
+    ls_dicts = [s.to_dict() for s in logical_streams]
+    proj_dicts = [p.to_dict() for p in projections]
+    plan_id = CompiledPlan.make_plan_id(cb_dicts, ls_dicts, proj_dicts)
+
+    return CompiledPlan(
+        plan_id=plan_id,
+        dataset_id=dataset_id,
+        compiled_at=datetime.utcnow(),
+        manifest_source=manifest_source,
+        channel_bindings=channel_bindings,
+        logical_streams=logical_streams,
+        projections=projections,
+        dag_order=dag_order,
+        dag_levels=dag_levels,
+    )
+
+
+def dispatch(
+    plan: CompiledPlan,
+    episode_paths: list[str],
+    base_path: str,
+    batch_size: int = 20,
+) -> list[ProjectionJob]:
+    """Slice episode paths into batches and emit one job document per batch.
+
+    Output parquet paths follow the pattern::
+
+        {base_path}/datasets/{dataset_id}/projections/{plan_id}/{projection_id}/part-{batch_index:04d}.parquet
+
+    Args:
+        plan: compiled plan to dispatch against
+        episode_paths: GCS (or local) paths to MCAP files
+        base_path: bucket/path root, e.g. ``gs://my-bucket``
+        batch_size: number of episodes per job document
+
+    Returns:
+        list of :class:`~.model.ProjectionJob` documents (not yet persisted)
+    """
+    batches = [
+        episode_paths[i : i + batch_size]
+        for i in range(0, len(episode_paths), batch_size)
+    ]
+    jobs: list[ProjectionJob] = []
+    for idx, batch in enumerate(batches):
+        output_paths = {
+            proj.id: (
+                f"{base_path}/datasets/{plan.dataset_id}"
+                f"/projections/{plan.plan_id}/{proj.id}/part-{idx:04d}.parquet"
+            )
+            for proj in plan.projections
+        }
+        jobs.append(
+            ProjectionJob(
+                plan_id=plan.plan_id,
+                dataset_id=plan.dataset_id,
+                batch_index=idx,
+                episode_paths=batch,
+                output_paths=output_paths,
+            )
+        )
+    return jobs
+
+
+# ---------------------------------------------------------------------------
+# Channel binding builder
+# ---------------------------------------------------------------------------
+
+
+def _build_channel_binding(raw: dict) -> CompiledChannelBinding:
+    match_raw = raw.get("match", {})
+    match = MatchSpec(
+        topic=match_raw.get("topic"),
+        schema_name=match_raw.get("schema_name"),
+        encoding=match_raw.get("encoding"),
+        channel_metadata=match_raw.get("channel_metadata", {}),
+    )
+
+    candidates = []
+    ts_spec = raw.get("timestamp_source", {})
+    for cand in ts_spec.get("candidates", []):
+        if "mcap" in cand:
+            candidates.append(TimestampCandidate(mcap=cand["mcap"]))
+        elif "decoded" in cand:
+            decoded = cand["decoded"]
+            candidates.append(
+                TimestampCandidate(
+                    decoded_path=decoded.get("path"),
+                    decoded_well_known=decoded.get("well_known"),
+                )
+            )
+
+    where_expr: str | None = None
+    if where := raw.get("where"):
+        where_expr = where.get("expr")
+
+    return CompiledChannelBinding(
+        id=raw["id"],
+        match=match,
+        codec=raw.get("codec"),
+        codec_options=raw.get("codec_options", {}),
+        where_expr=where_expr,
+        timestamp_candidates=candidates,
+        is_optional=raw.get("optional", False),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Logical stream builder
+# ---------------------------------------------------------------------------
+
+
+def _build_logical_stream(raw: dict) -> CompiledLogicalStream:
+    kind = raw.get("kind", "bundle")
+
+    components = []
+    for comp in raw.get("components", []):
+        source = comp.get("source", {})
+        components.append(
+            StreamComponent(
+                name=comp["name"],
+                channel_binding=source.get("channel_binding"),
+                logical_stream=source.get("logical_stream"),
+            )
+        )
+
+    sources = []
+    for src in raw.get("sources", []):
+        sources.append(
+            {
+                k: v
+                for k, v in src.items()
+                if k in ("channel_binding", "logical_stream", "projection")
+            }
+        )
+
+    where_expr: str | None = None
+    if where := raw.get("where"):
+        where_expr = where.get("expr")
+
+    return CompiledLogicalStream(
+        id=raw["id"],
+        kind=kind,
+        components=components,
+        sources=sources,
+        where_expr=where_expr,
+        metadata=raw.get("metadata", {}),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Projection builder
+# ---------------------------------------------------------------------------
+
+
+def _build_projection(
+    raw: dict, dag_level: int, depends_on: list[str]
+) -> CompiledProjection:
+    grain_key = next(k for k in _GRAIN_KEYS if k in raw)
+    grain = _GRAIN_KEYS[grain_key]
+
+    sources = [_build_source(s) for s in raw.get("sources", [])]
+
+    grain_spec = raw[grain_key]
+    columns = _extract_columns(grain_spec, grain)
+
+    return CompiledProjection(
+        id=raw["id"],
+        grain=grain,
+        dag_level=dag_level,
+        depends_on=depends_on,
+        sources=sources,
+        columns=columns,
+        grain_spec=grain_spec,
+        metadata=raw.get("metadata", {}),
+    )
+
+
+def _build_source(raw: dict) -> CompiledProjectionSource:
+    return CompiledProjectionSource(
+        name=raw["name"],
+        channel_bindings=raw.get("channel_bindings", []),
+        logical_streams=raw.get("logical_streams", []),
+        projections=raw.get("projections", []),
+    )
+
+
+def _extract_columns(grain_spec: dict, grain: Grain) -> list[CompiledColumn]:
+    """Pull the columns list out of whichever grain-specific sub-key holds it."""
+    raw_columns: list[dict] = []
+
+    if grain == Grain.OBSERVATION:
+        raw_columns = grain_spec.get("columns", [])
+    elif grain == Grain.SIGNAL_CHUNK:
+        raw_columns = grain_spec.get("columns", [])
+    elif grain == Grain.ANNOTATION:
+        raw_columns = grain_spec.get("columns", [])
+    elif grain == Grain.SEGMENT:
+        raw_columns = grain_spec.get("columns", [])
+    elif grain == Grain.SCENE_SUMMARY:
+        raw_columns = grain_spec.get("columns", [])
+
+    return [_build_column(c) for c in raw_columns]
+
+
+def _build_column(raw: dict) -> CompiledColumn:
+    value: ValueSource | None = None
+    if v := raw.get("value"):
+        value = ValueSource(path=v.get("path"), expr=v.get("expr"))
+
+    compute: ComputeSpec | None = None
+    if c := raw.get("compute"):
+        params = {
+            k: _build_compute_param(v)
+            for k, v in c.get("parameters", {}).items()
+        }
+        compute = ComputeSpec(
+            expr=c["expr"],
+            depends_on=c.get("depends_on", []),
+            parameters=params,
+        )
+
+    normalization: NormalizationSpec | None = None
+    if n := raw.get("normalization"):
+        normalization = NormalizationSpec(
+            kind=n.get("kind", "raw"),
+            source_unit=n.get("source_unit"),
+            target_unit=n.get("target_unit"),
+            scale=n.get("scale"),
+            offset=n.get("offset"),
+            range=n.get("range", []),
+            description=n.get("description"),
+        )
+
+    return CompiledColumn(
+        id=raw["id"],
+        type=raw.get("type", "string"),
+        value=value,
+        compute=compute,
+        name=raw.get("name"),
+        column=raw.get("column"),
+        quantity=raw.get("quantity"),
+        unit=raw.get("unit"),
+        normalization=normalization,
+        storage=raw.get("storage", "scalar"),
+        sample_set=raw.get("sample_set"),
+        metadata=raw.get("metadata", {}),
+    )
+
+
+def _build_compute_param(raw: dict) -> ComputeParameter:
+    normalization: NormalizationSpec | None = None
+    if n := raw.get("normalization"):
+        normalization = NormalizationSpec(
+            kind=n.get("kind", "raw"),
+            description=n.get("description"),
+        )
+    return ComputeParameter(
+        value=raw.get("value"),
+        quantity=raw.get("quantity"),
+        unit=raw.get("unit"),
+        normalization=normalization,
+        description=raw.get("description"),
+    )

--- a/fiftyone/multimodal/projection/compiler/emitter.py
+++ b/fiftyone/multimodal/projection/compiler/emitter.py
@@ -101,6 +101,7 @@ def dispatch(
     episode_paths: list[str],
     base_path: str,
     batch_size: int = 20,
+    start_batch_index: int = 0,
 ) -> list[ProjectionJob]:
     """Slice episode paths into batches and emit one job document per batch.
 
@@ -113,6 +114,9 @@ def dispatch(
         episode_paths: GCS (or local) paths to MCAP files
         base_path: bucket/path root, e.g. ``gs://my-bucket``
         batch_size: number of episodes per job document
+        start_batch_index: first batch_index to assign; pass the result of
+            ``repo.get_next_batch_index(plan_id)`` when adding episodes to an
+            existing plan so new jobs don't collide with existing batch numbers
 
     Returns:
         list of :class:`~.model.ProjectionJob` documents (not yet persisted)
@@ -122,7 +126,8 @@ def dispatch(
         for i in range(0, len(episode_paths), batch_size)
     ]
     jobs: list[ProjectionJob] = []
-    for idx, batch in enumerate(batches):
+    for offset, batch in enumerate(batches):
+        idx = start_batch_index + offset
         output_paths = {
             proj.id: (
                 f"{base_path}/datasets/{plan.dataset_id}"

--- a/fiftyone/multimodal/projection/compiler/expander.py
+++ b/fiftyone/multimodal/projection/compiler/expander.py
@@ -1,0 +1,120 @@
+"""
+Template expander for channel_binding_repeats and logical_stream_repeats.
+
+Expands repeat blocks into flat lists of bindings/streams using
+{{var.field}} interpolation. After expansion the manifest contains only
+`channel_bindings` and `logical_streams` (the repeat keys are removed).
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+
+_TEMPLATE_RE = re.compile(r"\{\{(\w+)\.(\w+)\}\}")
+
+
+class TemplateExpansionError(ValueError):
+    pass
+
+
+def expand_manifest(manifest: dict) -> dict:
+    """Expand all repeat blocks into flat binding/stream lists.
+
+    Args:
+        manifest: raw manifest dict from :func:`~.parser.parse_manifest`
+
+    Returns:
+        new dict with ``channel_binding_repeats`` and
+        ``logical_stream_repeats`` removed and their expansions merged into
+        ``channel_bindings`` and ``logical_streams``
+
+    Raises:
+        TemplateExpansionError: on duplicate IDs after expansion or bad templates
+    """
+    channel_bindings = list(manifest.get("channel_bindings", []))
+    logical_streams = list(manifest.get("logical_streams", []))
+
+    for repeat in manifest.get("channel_binding_repeats", []):
+        channel_bindings.extend(_expand_repeat(repeat))
+
+    for repeat in manifest.get("logical_stream_repeats", []):
+        logical_streams.extend(_expand_repeat(repeat))
+
+    _assert_unique_ids(channel_bindings, "channel_bindings")
+    _assert_unique_ids(logical_streams, "logical_streams")
+
+    return {
+        "channel_bindings": channel_bindings,
+        "logical_streams": logical_streams,
+        "projections": manifest.get("projections", []),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _expand_repeat(repeat: dict) -> list[dict]:
+    """Expand one repeat block into a flat list of concrete entries."""
+    var_name: str = repeat["var"]
+    values: list[dict] = repeat["values"]
+    templates: list[dict] = repeat["templates"]
+
+    expanded = []
+    for value_record in values:
+        if not isinstance(value_record, dict):
+            raise TemplateExpansionError(
+                f"Each entry in repeat 'values' must be a mapping, got {type(value_record).__name__}"
+            )
+        scope = {var_name: value_record}
+        for template in templates:
+            expanded.append(_interpolate(copy.deepcopy(template), scope))
+    return expanded
+
+
+def _interpolate(obj: object, scope: dict[str, dict]) -> object:
+    """Recursively interpolate {{var.field}} placeholders in all string values."""
+    if isinstance(obj, str):
+        return _interpolate_str(obj, scope)
+    if isinstance(obj, dict):
+        return {k: _interpolate(v, scope) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_interpolate(item, scope) for item in obj]
+    return obj
+
+
+def _interpolate_str(s: str, scope: dict[str, dict]) -> str:
+    def replace(match: re.Match) -> str:
+        var, attr = match.group(1), match.group(2)
+        if var not in scope:
+            raise TemplateExpansionError(
+                f"Template references unknown variable '{{{{{{var}}}}}}'; "
+                f"available: {list(scope)}"
+            )
+        record = scope[var]
+        if attr not in record:
+            raise TemplateExpansionError(
+                f"Template variable '{var}' has no field '{attr}'; "
+                f"available fields: {list(record)}"
+            )
+        return str(record[attr])
+
+    return _TEMPLATE_RE.sub(replace, s)
+
+
+def _assert_unique_ids(entries: list[dict], label: str) -> None:
+    seen: set[str] = set()
+    for entry in entries:
+        eid = entry.get("id")
+        if eid in seen:
+            raise TemplateExpansionError(
+                f"Duplicate id {eid!r} in {label} after template expansion"
+            )
+        if eid is not None:
+            seen.add(eid)

--- a/fiftyone/multimodal/projection/compiler/expression.py
+++ b/fiftyone/multimodal/projection/compiler/expression.py
@@ -1,0 +1,68 @@
+"""
+Expression engine stub for CEL expressions in projection manifests.
+
+CEL expressions appear in channel binding `where` clauses, column `value.expr`
+fields, and column `compute.expr` fields. This module captures them verbatim
+and defers evaluation to a future expression engine implementation.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class CapturedExpression:
+    """A CEL expression string captured at compile time."""
+
+    expr: str
+    # Source location hint for error reporting.
+    context_hint: str = ""
+    # Column/source IDs this expression depends on, if declared.
+    depends_on: list[str] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        return self.expr
+
+
+class ExpressionEngine(abc.ABC):
+    """Evaluates CEL expressions against a runtime context."""
+
+    @abc.abstractmethod
+    def evaluate(
+        self, expr: CapturedExpression, context: dict[str, Any]
+    ) -> Any:
+        """Evaluate a captured expression against the given context.
+
+        Args:
+            expr: the compiled expression to evaluate
+            context: name -> value bindings available to the expression
+
+        Returns:
+            the result of evaluating the expression
+        """
+        raise NotImplementedError
+
+
+class StubExpressionEngine(ExpressionEngine):
+    """Placeholder engine — raises at evaluation time.
+
+    Used by the PoC compiler so expression capture works end-to-end without
+    requiring a real CEL runtime. Replace with a concrete implementation once
+    the expression engine is ready.
+    """
+
+    def evaluate(
+        self, expr: CapturedExpression, context: dict[str, Any]
+    ) -> Any:
+        raise NotImplementedError(
+            f"Expression evaluation is not yet implemented. "
+            f"Expression: {expr.expr!r}"
+            + (f" (in {expr.context_hint})" if expr.context_hint else "")
+        )

--- a/fiftyone/multimodal/projection/compiler/model.py
+++ b/fiftyone/multimodal/projection/compiler/model.py
@@ -1,0 +1,413 @@
+"""
+Compiled projection plan data model.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+
+
+class JobStatus(str, Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    PARTIAL = "partial"
+
+
+class Grain(str, Enum):
+    OBSERVATION = "observation"
+    SIGNAL_CHUNK = "signal_chunk"
+    ANNOTATION = "annotation"
+    SEGMENT = "segment"
+    SCENE_SUMMARY = "scene_summary"
+
+
+# ---------------------------------------------------------------------------
+# Channel binding types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MatchSpec:
+    topic: str | None = None
+    schema_name: str | None = None
+    # Not yet in the proto schema; stored verbatim until proto bindings land.
+    encoding: str | None = None
+    channel_metadata: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        d: dict = {}
+        if self.topic is not None:
+            d["topic"] = self.topic
+        if self.schema_name is not None:
+            d["schema_name"] = self.schema_name
+        if self.encoding is not None:
+            d["encoding"] = self.encoding
+        if self.channel_metadata:
+            d["channel_metadata"] = self.channel_metadata
+        return d
+
+
+@dataclass
+class TimestampCandidate:
+    """One candidate in a timestamp resolution policy."""
+
+    # "log_time" | "publish_time"
+    mcap: str | None = None
+    decoded_path: str | None = None
+    decoded_well_known: str | None = None
+
+    def to_dict(self) -> dict:
+        if self.mcap is not None:
+            return {"mcap": self.mcap}
+        if self.decoded_path is not None:
+            return {"decoded": {"path": self.decoded_path}}
+        if self.decoded_well_known is not None:
+            return {"decoded": {"well_known": self.decoded_well_known}}
+        return {}
+
+
+@dataclass
+class CompiledChannelBinding:
+    id: str
+    match: MatchSpec
+    codec: str | None = None
+    codec_options: dict = field(default_factory=dict)
+    where_expr: str | None = None
+    timestamp_candidates: list[TimestampCandidate] = field(
+        default_factory=list
+    )
+    is_optional: bool = False
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "match": self.match.to_dict(),
+            "codec": self.codec,
+            "codec_options": self.codec_options,
+            "where_expr": self.where_expr,
+            "timestamp_candidates": [
+                c.to_dict() for c in self.timestamp_candidates
+            ],
+            "is_optional": self.is_optional,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Logical stream types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StreamComponent:
+    name: str
+    channel_binding: str | None = None
+    logical_stream: str | None = None
+
+    def to_dict(self) -> dict:
+        d: dict = {"name": self.name}
+        if self.channel_binding is not None:
+            d["source"] = {"channel_binding": self.channel_binding}
+        elif self.logical_stream is not None:
+            d["source"] = {"logical_stream": self.logical_stream}
+        return d
+
+
+@dataclass
+class CompiledLogicalStream:
+    id: str
+    kind: str  # "bundle" | "virtual"
+    components: list[StreamComponent] = field(default_factory=list)
+    # Virtual stream source refs: list of {"channel_binding"|"logical_stream": id}
+    sources: list[dict] = field(default_factory=list)
+    where_expr: str | None = None
+    metadata: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "kind": self.kind,
+            "components": [c.to_dict() for c in self.components],
+            "sources": self.sources,
+            "where_expr": self.where_expr,
+            "metadata": self.metadata,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Projection column types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ValueSource:
+    path: str | None = None
+    expr: str | None = None
+
+    def to_dict(self) -> dict:
+        if self.path is not None:
+            return {"path": self.path}
+        if self.expr is not None:
+            return {"expr": self.expr}
+        return {}
+
+
+@dataclass
+class NormalizationSpec:
+    kind: str = "raw"
+    source_unit: str | None = None
+    target_unit: str | None = None
+    scale: float | None = None
+    offset: float | None = None
+    range: list[float] = field(default_factory=list)
+    description: str | None = None
+
+    def to_dict(self) -> dict:
+        d: dict = {"kind": self.kind}
+        if self.source_unit is not None:
+            d["source_unit"] = self.source_unit
+        if self.target_unit is not None:
+            d["target_unit"] = self.target_unit
+        if self.scale is not None:
+            d["scale"] = self.scale
+        if self.offset is not None:
+            d["offset"] = self.offset
+        if self.range:
+            d["range"] = self.range
+        if self.description is not None:
+            d["description"] = self.description
+        return d
+
+
+@dataclass
+class ComputeParameter:
+    value: bool | float | str | int | None = None
+    quantity: str | None = None
+    unit: str | None = None
+    normalization: NormalizationSpec | None = None
+    description: str | None = None
+
+    def to_dict(self) -> dict:
+        d: dict = {"value": self.value}
+        if self.quantity is not None:
+            d["quantity"] = self.quantity
+        if self.unit is not None:
+            d["unit"] = self.unit
+        if self.normalization is not None:
+            d["normalization"] = self.normalization.to_dict()
+        if self.description is not None:
+            d["description"] = self.description
+        return d
+
+
+@dataclass
+class ComputeSpec:
+    """Structured compute expression. CEL string stored verbatim for now."""
+
+    expr: str
+    depends_on: list[str] = field(default_factory=list)
+    parameters: dict[str, ComputeParameter] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "expr": self.expr,
+            "depends_on": self.depends_on,
+            "parameters": {k: v.to_dict() for k, v in self.parameters.items()},
+        }
+
+
+@dataclass
+class CompiledColumn:
+    id: str
+    type: str
+    value: ValueSource | None = None
+    compute: ComputeSpec | None = None
+    name: str | None = None
+    column: str | None = None
+    quantity: str | None = None
+    unit: str | None = None
+    normalization: NormalizationSpec | None = None
+    storage: str = "scalar"
+    sample_set: str | None = None
+    metadata: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        d: dict = {"id": self.id, "type": self.type, "storage": self.storage}
+        if self.value is not None:
+            d["value"] = self.value.to_dict()
+        if self.compute is not None:
+            d["compute"] = self.compute.to_dict()
+        if self.name is not None:
+            d["name"] = self.name
+        if self.column is not None:
+            d["column"] = self.column
+        if self.quantity is not None:
+            d["quantity"] = self.quantity
+        if self.unit is not None:
+            d["unit"] = self.unit
+        if self.normalization is not None:
+            d["normalization"] = self.normalization.to_dict()
+        if self.sample_set is not None:
+            d["sample_set"] = self.sample_set
+        if self.metadata:
+            d["metadata"] = self.metadata
+        return d
+
+
+# ---------------------------------------------------------------------------
+# Projection types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CompiledProjectionSource:
+    name: str
+    channel_bindings: list[str] = field(default_factory=list)
+    logical_streams: list[str] = field(default_factory=list)
+    projections: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "channel_bindings": self.channel_bindings,
+            "logical_streams": self.logical_streams,
+            "projections": self.projections,
+        }
+
+
+@dataclass
+class CompiledProjection:
+    id: str
+    grain: Grain
+    dag_level: int
+    depends_on: list[str]
+    sources: list[CompiledProjectionSource]
+    columns: list[CompiledColumn]
+    # Raw grain-specific spec (rows/chunks/intervals/aggregate) stored verbatim.
+    # Workers consume this alongside columns. Expression fields within are
+    # captured as strings pending the expression engine.
+    grain_spec: dict
+    metadata: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "grain": self.grain.value,
+            "dag_level": self.dag_level,
+            "depends_on": self.depends_on,
+            "sources": [s.to_dict() for s in self.sources],
+            "columns": [c.to_dict() for c in self.columns],
+            "grain_spec": self.grain_spec,
+            "metadata": self.metadata,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Top-level compiled plan
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CompiledPlan:
+    plan_id: str
+    dataset_id: str
+    compiled_at: datetime
+    manifest_source: str
+    channel_bindings: list[CompiledChannelBinding]
+    logical_streams: list[CompiledLogicalStream]
+    projections: list[CompiledProjection]  # topologically sorted
+    dag_order: list[str]
+    dag_levels: dict[str, list[str]]  # "0" -> [proj_ids], "1" -> [...], ...
+
+    @staticmethod
+    def make_plan_id(
+        channel_bindings: list[dict],
+        logical_streams: list[dict],
+        projections: list[dict],
+    ) -> str:
+        payload = json.dumps(
+            {
+                "channel_bindings": channel_bindings,
+                "logical_streams": logical_streams,
+                "projections": projections,
+            },
+            sort_keys=True,
+        )
+        return hashlib.sha256(payload.encode()).hexdigest()
+
+    def to_mongo_doc(self) -> dict:
+        return {
+            "plan_id": self.plan_id,
+            "dataset_id": self.dataset_id,
+            "compiled_at": self.compiled_at,
+            "is_current": True,
+            "manifest_source": self.manifest_source,
+            "channel_bindings": [b.to_dict() for b in self.channel_bindings],
+            "logical_streams": [s.to_dict() for s in self.logical_streams],
+            "projections": [p.to_dict() for p in self.projections],
+            "dag": {
+                "order": self.dag_order,
+                "levels": self.dag_levels,
+            },
+        }
+
+
+# ---------------------------------------------------------------------------
+# Job document
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ProjectionJob:
+    plan_id: str
+    dataset_id: str
+    batch_index: int
+    episode_paths: list[str]
+    output_paths: dict[str, str]
+    job_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    status: JobStatus = JobStatus.PENDING
+    episode_status: dict[str, str] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    error: str | None = None
+    delegated_operation_id: str | None = None
+
+    def __post_init__(self):
+        if not self.episode_status:
+            self.episode_status = {
+                ep: JobStatus.PENDING.value for ep in self.episode_paths
+            }
+
+    def to_mongo_doc(self) -> dict:
+        # episode_status is stored as an array so that episode paths (which
+        # contain ".", "://", etc.) are never used as MongoDB field names.
+        episode_status_arr = [
+            {"path": path, "status": status}
+            for path, status in self.episode_status.items()
+        ]
+        return {
+            "job_id": self.job_id,
+            "plan_id": self.plan_id,
+            "dataset_id": self.dataset_id,
+            "batch_index": self.batch_index,
+            "episode_paths": self.episode_paths,
+            "status": self.status.value,
+            "episode_status": episode_status_arr,
+            "output_paths": self.output_paths,
+            "created_at": self.created_at,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+            "error": self.error,
+            "delegated_operation_id": self.delegated_operation_id,
+        }

--- a/fiftyone/multimodal/projection/compiler/parser.py
+++ b/fiftyone/multimodal/projection/compiler/parser.py
@@ -1,0 +1,186 @@
+"""
+YAML manifest parser.
+
+Reads a manifest YAML string and returns a raw dict that mirrors the
+top-level structure. Does not expand templates or resolve references —
+those are handled by subsequent compiler phases.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from __future__ import annotations
+
+try:
+    import yaml
+except ImportError:
+    raise ImportError(
+        "PyYAML is required for manifest parsing. "
+        "Install it via:\n\n    pip install pyyaml\n"
+    )
+
+_TOP_LEVEL_KEYS = frozenset(
+    {
+        "channel_bindings",
+        "channel_binding_repeats",
+        "logical_streams",
+        "logical_stream_repeats",
+        "projections",
+    }
+)
+
+_VALID_GRAINS = frozenset(
+    {
+        "observation",
+        "signal_chunk",
+        "annotation",
+        "segment",
+        "scene_summary",
+    }
+)
+
+
+class ManifestParseError(ValueError):
+    pass
+
+
+def parse_manifest(yaml_source: str) -> dict:
+    """Parse a manifest YAML string into a raw validated dict.
+
+    Validates top-level structure and that each projection declares exactly
+    one grain key. Does not expand templates or resolve cross-references.
+
+    Args:
+        yaml_source: raw YAML string
+
+    Returns:
+        dict with keys: channel_bindings, channel_binding_repeats,
+        logical_streams, logical_stream_repeats, projections (all lists,
+        defaulting to empty if absent)
+
+    Raises:
+        ManifestParseError: on structural problems
+    """
+    try:
+        raw = yaml.safe_load(yaml_source)
+    except yaml.YAMLError as exc:
+        raise ManifestParseError(f"Invalid YAML: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise ManifestParseError(
+            "Manifest must be a YAML mapping at the top level"
+        )
+
+    unknown = set(raw) - _TOP_LEVEL_KEYS
+    if unknown:
+        raise ManifestParseError(f"Unknown top-level keys: {sorted(unknown)}")
+
+    manifest = {
+        "channel_bindings": _require_list(raw, "channel_bindings"),
+        "channel_binding_repeats": _require_list(
+            raw, "channel_binding_repeats"
+        ),
+        "logical_streams": _require_list(raw, "logical_streams"),
+        "logical_stream_repeats": _require_list(raw, "logical_stream_repeats"),
+        "projections": _require_list(raw, "projections"),
+    }
+
+    _validate_channel_bindings(
+        manifest["channel_bindings"], label="channel_bindings"
+    )
+    for repeat in manifest["channel_binding_repeats"]:
+        _validate_repeat_block(repeat, "channel_binding_repeats")
+        _validate_channel_bindings(
+            repeat.get("templates", []),
+            label="channel_binding_repeats.templates",
+        )
+
+    _validate_logical_streams(
+        manifest["logical_streams"], label="logical_streams"
+    )
+    for repeat in manifest["logical_stream_repeats"]:
+        _validate_repeat_block(repeat, "logical_stream_repeats")
+        _validate_logical_streams(
+            repeat.get("templates", []),
+            label="logical_stream_repeats.templates",
+        )
+
+    _validate_projections(manifest["projections"])
+
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# Internal validators
+# ---------------------------------------------------------------------------
+
+
+def _require_list(raw: dict, key: str) -> list:
+    val = raw.get(key, [])
+    if val is None:
+        return []
+    if not isinstance(val, list):
+        raise ManifestParseError(
+            f"'{key}' must be a list, got {type(val).__name__}"
+        )
+    return val
+
+
+def _require_str_field(obj: dict, field: str, parent: str) -> str:
+    val = obj.get(field)
+    if not isinstance(val, str) or not val.strip():
+        raise ManifestParseError(
+            f"'{parent}' entry missing required string field '{field}'"
+        )
+    return val
+
+
+def _validate_channel_bindings(bindings: list, label: str) -> None:
+    for i, b in enumerate(bindings):
+        if not isinstance(b, dict):
+            raise ManifestParseError(f"{label}[{i}] must be a mapping")
+        _require_str_field(b, "id", f"{label}[{i}]")
+        if "match" in b and not isinstance(b["match"], dict):
+            raise ManifestParseError(f"{label}[{i}].match must be a mapping")
+
+
+def _validate_logical_streams(streams: list, label: str) -> None:
+    for i, s in enumerate(streams):
+        if not isinstance(s, dict):
+            raise ManifestParseError(f"{label}[{i}] must be a mapping")
+        _require_str_field(s, "id", f"{label}[{i}]")
+        kind = s.get("kind")
+        if kind is not None and kind not in ("bundle", "virtual"):
+            raise ManifestParseError(
+                f"{label}[{i}].kind must be 'bundle' or 'virtual', got {kind!r}"
+            )
+
+
+def _validate_repeat_block(repeat: dict, label: str) -> None:
+    if not isinstance(repeat, dict):
+        raise ManifestParseError(f"{label} entry must be a mapping")
+    if not isinstance(repeat.get("var"), str):
+        raise ManifestParseError(f"{label} entry missing string 'var'")
+    if not isinstance(repeat.get("values"), list):
+        raise ManifestParseError(f"{label} entry missing list 'values'")
+    if not isinstance(repeat.get("templates"), list):
+        raise ManifestParseError(f"{label} entry missing list 'templates'")
+
+
+def _validate_projections(projections: list) -> None:
+    for i, proj in enumerate(projections):
+        if not isinstance(proj, dict):
+            raise ManifestParseError(f"projections[{i}] must be a mapping")
+        _require_str_field(proj, "id", f"projections[{i}]")
+        grains = _VALID_GRAINS & set(proj)
+        if len(grains) == 0:
+            raise ManifestParseError(
+                f"projections[{i}] (id={proj.get('id')!r}) must declare exactly one "
+                f"grain key: {sorted(_VALID_GRAINS)}"
+            )
+        if len(grains) > 1:
+            raise ManifestParseError(
+                f"projections[{i}] (id={proj.get('id')!r}) declares multiple grain "
+                f"keys: {sorted(grains)}"
+            )

--- a/fiftyone/multimodal/projection/compiler/resolver.py
+++ b/fiftyone/multimodal/projection/compiler/resolver.py
@@ -1,0 +1,129 @@
+"""
+Reference resolver and manifest validator.
+
+Operates on an expanded manifest (all templates already applied) and verifies:
+  - All channel binding IDs are unique
+  - All logical stream IDs are unique
+  - All projection IDs are unique
+  - Every source reference in logical streams and projections points to a
+    declared channel binding, logical stream, or projection ID
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from __future__ import annotations
+
+
+class ManifestResolveError(ValueError):
+    pass
+
+
+def resolve_manifest(expanded: dict) -> dict:
+    """Validate all cross-references in an expanded manifest.
+
+    Args:
+        expanded: output of :func:`~.expander.expand_manifest`
+
+    Returns:
+        the same dict unchanged (validated in place)
+
+    Raises:
+        ManifestResolveError: on any unknown reference or duplicate ID
+    """
+    binding_ids = _collect_ids(
+        expanded.get("channel_bindings", []), "channel_bindings"
+    )
+    stream_ids = _collect_ids(
+        expanded.get("logical_streams", []), "logical_streams"
+    )
+    projection_ids = _collect_ids(
+        expanded.get("projections", []), "projections"
+    )
+
+    for stream in expanded.get("logical_streams", []):
+        _resolve_stream_refs(stream, binding_ids, stream_ids)
+
+    for proj in expanded.get("projections", []):
+        _resolve_projection_refs(proj, binding_ids, stream_ids, projection_ids)
+
+    return expanded
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _collect_ids(entries: list[dict], label: str) -> set[str]:
+    seen: set[str] = set()
+    for entry in entries:
+        eid = entry.get("id")
+        if eid is None:
+            raise ManifestResolveError(
+                f"{label} entry is missing an 'id' field"
+            )
+        if eid in seen:
+            raise ManifestResolveError(f"Duplicate id {eid!r} in {label}")
+        seen.add(eid)
+    return seen
+
+
+def _resolve_stream_refs(
+    stream: dict,
+    binding_ids: set[str],
+    stream_ids: set[str],
+) -> None:
+    sid = stream.get("id")
+    kind = stream.get("kind", "bundle")
+
+    for comp in stream.get("components", []):
+        source = comp.get("source", {})
+        if cb := source.get("channel_binding"):
+            _assert_exists(
+                cb, binding_ids, f"logical_stream '{sid}' component source"
+            )
+        if ls := source.get("logical_stream"):
+            _assert_exists(
+                ls, stream_ids, f"logical_stream '{sid}' component source"
+            )
+
+    if kind == "virtual":
+        for src in stream.get("sources", []):
+            if cb := src.get("channel_binding"):
+                _assert_exists(
+                    cb, binding_ids, f"logical_stream '{sid}' virtual source"
+                )
+            if ls := src.get("logical_stream"):
+                _assert_exists(
+                    ls, stream_ids, f"logical_stream '{sid}' virtual source"
+                )
+
+
+def _resolve_projection_refs(
+    proj: dict,
+    binding_ids: set[str],
+    stream_ids: set[str],
+    projection_ids: set[str],
+) -> None:
+    pid = proj.get("id")
+
+    for source in proj.get("sources", []):
+        for cb in source.get("channel_bindings", []):
+            _assert_exists(cb, binding_ids, f"projection '{pid}' source")
+        for ls in source.get("logical_streams", []):
+            _assert_exists(ls, stream_ids, f"projection '{pid}' source")
+        for up in source.get("projections", []):
+            _assert_exists(up, projection_ids, f"projection '{pid}' source")
+            if up == pid:
+                raise ManifestResolveError(
+                    f"Projection '{pid}' references itself as a source"
+                )
+
+
+def _assert_exists(ref_id: str, id_set: set[str], context: str) -> None:
+    if ref_id not in id_set:
+        raise ManifestResolveError(
+            f"{context} references unknown id '{ref_id}'"
+        )

--- a/fiftyone/multimodal/projection/sinks/__init__.py
+++ b/fiftyone/multimodal/projection/sinks/__init__.py
@@ -1,0 +1,49 @@
+"""
+Projection sink interface and built-in implementations.
+
+Sinks represent storage backends that workers write parquet output to.
+DuckDB is the query engine that reads from whatever the active sink wrote —
+it is not a sink itself.
+
+Available sinks:
+    :class:`~fiftyone.multimodal.projection.sinks.parquet.ParquetSink`
+        Writes parquet to a local path or cloud URI (GCS, S3, Azure).
+        This is the primary sink; DuckDB queries these files via a
+        glob resolved from the active ``plan_id`` in MongoDB.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from __future__ import annotations
+
+import abc
+
+try:
+    import pyarrow as pa
+except ImportError:
+    raise ImportError(
+        "pyarrow is required for multimodal projections. "
+        "Install it via:\n\n    pip install pyarrow\n"
+    )
+
+
+class ProjectionSink(abc.ABC):
+    """Abstract sink that receives projected scene rows as Arrow RecordBatches."""
+
+    @abc.abstractmethod
+    def write_batch(self, batch: pa.RecordBatch) -> None:
+        """Write a batch of projected scene rows."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def finalize(self) -> None:
+        """Flush and close the sink."""
+        raise NotImplementedError
+
+    def __enter__(self) -> ProjectionSink:
+        return self
+
+    def __exit__(self, *_) -> None:
+        self.finalize()

--- a/fiftyone/multimodal/projection/sinks/parquet.py
+++ b/fiftyone/multimodal/projection/sinks/parquet.py
@@ -1,0 +1,41 @@
+"""
+Parquet sink for multimodal scene projections.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from __future__ import annotations
+
+try:
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+except ImportError:
+    raise ImportError(
+        "pyarrow is required for the Parquet projection sink. "
+        "Install it via:\n\n    pip install pyarrow\n"
+    )
+
+from . import ProjectionSink
+
+
+class ParquetSink(ProjectionSink):
+    """Writes projected scenes to a Parquet file.
+
+    Accepts local paths or cloud URIs (``s3://``, ``gs://``, ``az://``);
+    PyArrow resolves the filesystem via ``fsspec``.
+
+    Args:
+        path: destination file path or cloud URI
+        schema: Arrow schema returned by :func:`~fiftyone.multimodal.projection.schema.build_schema`
+    """
+
+    def __init__(self, path: str, schema: pa.Schema) -> None:
+        self._writer = pq.ParquetWriter(path, schema)
+
+    def write_batch(self, batch: pa.RecordBatch) -> None:
+        self._writer.write_batch(batch)
+
+    def finalize(self) -> None:
+        self._writer.close()

--- a/fiftyone/multimodal/projection/sinks/parquet.py
+++ b/fiftyone/multimodal/projection/sinks/parquet.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 try:
     import pyarrow as pa
+    import pyarrow.fs as pafs
     import pyarrow.parquet as pq
 except ImportError:
     raise ImportError(
@@ -17,22 +18,29 @@ except ImportError:
         "Install it via:\n\n    pip install pyarrow\n"
     )
 
+import fiftyone.core.storage as fos
+
 from . import ProjectionSink
 
 
 class ParquetSink(ProjectionSink):
     """Writes projected scenes to a Parquet file.
 
-    Accepts local paths or cloud URIs (``s3://``, ``gs://``, ``az://``);
-    PyArrow resolves the filesystem via ``fsspec``.
+    Accepts local paths or cloud URIs (``gs://``, ``s3://``, ``az://``).
+    The filesystem is resolved via :func:`pyarrow.fs.FileSystem.from_uri` so
+    no manual cloud-vs-local branching is needed at the call site.  For local
+    paths the parent directory is created via :func:`fiftyone.core.storage.ensure_basedir`.
 
     Args:
         path: destination file path or cloud URI
-        schema: Arrow schema returned by :func:`~fiftyone.multimodal.projection.schema.build_schema`
+        schema: Arrow schema for the output table
     """
 
     def __init__(self, path: str, schema: pa.Schema) -> None:
-        self._writer = pq.ParquetWriter(path, schema)
+        fs, fs_path = pafs.FileSystem.from_uri(path)
+        if isinstance(fs, pafs.LocalFileSystem):
+            fos.ensure_basedir(path)
+        self._writer = pq.ParquetWriter(fs_path, schema, filesystem=fs)
 
     def write_batch(self, batch: pa.RecordBatch) -> None:
         self._writer.write_batch(batch)

--- a/pylintrc
+++ b/pylintrc
@@ -239,7 +239,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=torch.*,cv2.*
+generated-members=torch.*,cv2.*,abc.*
 
 # List of decorators that produce context managers, such as
 # contextlib.contextmanager. Add to this list to register other decorators that

--- a/tests/unittests/factory/projection_doc_tests.py
+++ b/tests/unittests/factory/projection_doc_tests.py
@@ -1,0 +1,191 @@
+"""
+Unit tests for ManifestPlanDocument and ProjectionJobDocument.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from datetime import datetime
+
+import pytest
+from bson import ObjectId
+
+from fiftyone.factory.repos.projection_plan_doc import (
+    ManifestPlanDocument,
+    ProjectionJobDocument,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def plan_raw():
+    return {
+        "_id": ObjectId(),
+        "plan_id": "abc123",
+        "dataset_id": "ds1",
+        "compiled_at": datetime(2026, 1, 1),
+        "is_current": True,
+        "manifest_source": "channel_bindings: []",
+        "channel_bindings": [{"id": "imu", "match": {"topic": "/imu"}}],
+        "logical_streams": [],
+        "projections": [{"id": "obs", "grain": "observation"}],
+        "dag": {"order": ["obs"], "levels": {"0": ["obs"]}},
+    }
+
+
+@pytest.fixture
+def job_raw():
+    return {
+        "_id": ObjectId(),
+        "job_id": "job-uuid-1",
+        "plan_id": "abc123",
+        "dataset_id": "ds1",
+        "batch_index": 2,
+        "episode_paths": ["ep1.mcap", "ep2.mcap"],
+        "status": "running",
+        "episode_status": [
+            {"path": "ep1.mcap", "status": "completed"},
+            {"path": "ep2.mcap", "status": "pending"},
+        ],
+        "output_paths": {"obs": "gs://bucket/obs/part-0002.parquet"},
+        "created_at": datetime(2026, 1, 1),
+        "started_at": datetime(2026, 1, 2),
+        "completed_at": None,
+        "error": None,
+        "delegated_operation_id": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# ManifestPlanDocument tests
+# ---------------------------------------------------------------------------
+
+
+class TestManifestPlanDocument:
+    def test_from_pymongo_populates_all_fields(self, plan_raw):
+        doc = ManifestPlanDocument().from_pymongo(plan_raw)
+        assert doc.plan_id == "abc123"
+        assert doc.dataset_id == "ds1"
+        assert doc.is_current is True
+        assert doc.manifest_source == "channel_bindings: []"
+        assert len(doc.channel_bindings) == 1
+        assert doc.channel_bindings[0]["id"] == "imu"
+        assert doc.projections[0]["id"] == "obs"
+        assert doc.dag["order"] == ["obs"]
+
+    def test_from_pymongo_uses_id_field(self, plan_raw):
+        doc = ManifestPlanDocument().from_pymongo(plan_raw)
+        assert doc.id == plan_raw["_id"]
+
+    def test_from_pymongo_defaults_missing_fields(self):
+        doc = ManifestPlanDocument().from_pymongo({"plan_id": "x"})
+        assert doc.dataset_id is None
+        assert doc.is_current is False
+        assert doc.channel_bindings == []
+        assert doc.logical_streams == []
+        assert doc.projections == []
+        assert doc.dag == {}
+
+    def test_to_pymongo_excludes_id_and_doc(self, plan_raw):
+        doc = ManifestPlanDocument().from_pymongo(plan_raw)
+        d = doc.to_pymongo()
+        assert "id" not in d
+        assert "_doc" not in d
+
+    def test_to_pymongo_includes_all_content_fields(self, plan_raw):
+        doc = ManifestPlanDocument().from_pymongo(plan_raw)
+        d = doc.to_pymongo()
+        assert d["plan_id"] == "abc123"
+        assert d["dataset_id"] == "ds1"
+        assert d["is_current"] is True
+        assert len(d["channel_bindings"]) == 1
+
+    def test_to_pymongo_is_a_deep_copy(self, plan_raw):
+        doc = ManifestPlanDocument().from_pymongo(plan_raw)
+        d = doc.to_pymongo()
+        d["channel_bindings"].append({"id": "new"})
+        assert len(doc.channel_bindings) == 1
+
+    def test_round_trip_preserves_dag(self, plan_raw):
+        doc = ManifestPlanDocument().from_pymongo(plan_raw)
+        d = doc.to_pymongo()
+        assert d["dag"]["order"] == ["obs"]
+        assert d["dag"]["levels"] == {"0": ["obs"]}
+
+
+# ---------------------------------------------------------------------------
+# ProjectionJobDocument tests
+# ---------------------------------------------------------------------------
+
+
+class TestProjectionJobDocument:
+    def test_from_pymongo_populates_all_fields(self, job_raw):
+        doc = ProjectionJobDocument().from_pymongo(job_raw)
+        assert doc.job_id == "job-uuid-1"
+        assert doc.plan_id == "abc123"
+        assert doc.dataset_id == "ds1"
+        assert doc.batch_index == 2
+        assert doc.episode_paths == ["ep1.mcap", "ep2.mcap"]
+        assert doc.status == "running"
+        assert doc.started_at == datetime(2026, 1, 2)
+        assert doc.delegated_operation_id is None
+
+    def test_from_pymongo_converts_episode_status_list_to_dict(self, job_raw):
+        doc = ProjectionJobDocument().from_pymongo(job_raw)
+        assert doc.episode_status == {
+            "ep1.mcap": "completed",
+            "ep2.mcap": "pending",
+        }
+
+    def test_from_pymongo_accepts_episode_status_as_dict(self, job_raw):
+        job_raw["episode_status"] = {"ep1.mcap": "completed"}
+        doc = ProjectionJobDocument().from_pymongo(job_raw)
+        assert doc.episode_status == {"ep1.mcap": "completed"}
+
+    def test_from_pymongo_episode_status_empty_list(self, job_raw):
+        job_raw["episode_status"] = []
+        doc = ProjectionJobDocument().from_pymongo(job_raw)
+        assert doc.episode_status == {}
+
+    def test_from_pymongo_defaults_missing_fields(self):
+        doc = ProjectionJobDocument().from_pymongo({"job_id": "x"})
+        assert doc.plan_id is None
+        assert doc.batch_index == 0
+        assert doc.episode_paths == []
+        assert doc.status == "pending"
+        assert doc.episode_status == {}
+        assert doc.output_paths == {}
+
+    def test_to_pymongo_excludes_private_fields(self, job_raw):
+        doc = ProjectionJobDocument().from_pymongo(job_raw)
+        d = doc.to_pymongo()
+        assert "id" not in d
+        assert "_doc" not in d
+
+    def test_to_pymongo_includes_all_job_fields(self, job_raw):
+        doc = ProjectionJobDocument().from_pymongo(job_raw)
+        d = doc.to_pymongo()
+        assert d["job_id"] == "job-uuid-1"
+        assert d["batch_index"] == 2
+        assert d["output_paths"] == {
+            "obs": "gs://bucket/obs/part-0002.parquet"
+        }
+
+    def test_from_pymongo_output_paths(self, job_raw):
+        doc = ProjectionJobDocument().from_pymongo(job_raw)
+        assert doc.output_paths == {"obs": "gs://bucket/obs/part-0002.parquet"}
+
+    def test_from_pymongo_with_error_field(self, job_raw):
+        job_raw["error"] = "something went wrong"
+        doc = ProjectionJobDocument().from_pymongo(job_raw)
+        assert doc.error == "something went wrong"
+
+    def test_from_pymongo_with_delegated_operation_id(self, job_raw):
+        job_raw["delegated_operation_id"] = "delegated-op-xyz"
+        doc = ProjectionJobDocument().from_pymongo(job_raw)
+        assert doc.delegated_operation_id == "delegated-op-xyz"

--- a/tests/unittests/factory/projection_repo_tests.py
+++ b/tests/unittests/factory/projection_repo_tests.py
@@ -1,0 +1,500 @@
+"""
+Unit tests for MongoProjectionRepo.
+
+The pymongo collections are replaced with MagicMocks so no real database is
+required.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock, call, patch
+
+import pymongo
+import pytest
+from bson import ObjectId
+
+from fiftyone.factory.repos.projection_plan_doc import (
+    ManifestPlanDocument,
+    ProjectionJobDocument,
+)
+from fiftyone.factory.repos.projection_repo import MongoProjectionRepo
+from fiftyone.multimodal.projection.compiler.model import (
+    JobStatus,
+    ProjectionJob,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_plan_doc(**kwargs):
+    base = {
+        "_id": ObjectId(),
+        "plan_id": "plan-sha256",
+        "dataset_id": "ds1",
+        "compiled_at": datetime(2026, 1, 1),
+        "is_current": True,
+        "manifest_source": "",
+        "channel_bindings": [],
+        "logical_streams": [],
+        "projections": [],
+        "dag": {"order": [], "levels": {}},
+    }
+    base.update(kwargs)
+    return base
+
+
+def _make_job_doc(**kwargs):
+    base = {
+        "_id": ObjectId(),
+        "job_id": "job-uuid-1",
+        "plan_id": "plan-sha256",
+        "dataset_id": "ds1",
+        "batch_index": 0,
+        "episode_paths": ["ep.mcap"],
+        "status": "pending",
+        "episode_status": [{"path": "ep.mcap", "status": "pending"}],
+        "output_paths": {},
+        "created_at": datetime(2026, 1, 1),
+        "started_at": None,
+        "completed_at": None,
+        "error": None,
+        "delegated_operation_id": None,
+    }
+    base.update(kwargs)
+    return base
+
+
+def _mock_collection():
+    col = MagicMock()
+    col.list_indexes.return_value = []
+    return col
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def plans_col():
+    return _mock_collection()
+
+
+@pytest.fixture
+def jobs_col():
+    return _mock_collection()
+
+
+@pytest.fixture
+def repo(plans_col, jobs_col):
+    return MongoProjectionRepo(
+        plans_collection=plans_col,
+        jobs_collection=jobs_col,
+    )
+
+
+@pytest.fixture
+def sample_job():
+    return ProjectionJob(
+        plan_id="plan-sha256",
+        dataset_id="ds1",
+        batch_index=0,
+        episode_paths=["ep.mcap"],
+        output_paths={"obs": "gs://bucket/obs/part-0000.parquet"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Index creation
+# ---------------------------------------------------------------------------
+
+
+class TestIndexCreation:
+    def test_creates_plan_indexes_on_init(self, plans_col, jobs_col):
+        MongoProjectionRepo(
+            plans_collection=plans_col,
+            jobs_collection=jobs_col,
+        )
+        plans_col.create_indexes.assert_called_once()
+        created_names = [
+            idx.document["name"]
+            for idx in plans_col.create_indexes.call_args[0][0]
+        ]
+        assert "plan_id_1" in created_names
+        assert "dataset_id_1" in created_names
+        assert "dataset_id_1_is_current_1" in created_names
+
+    def test_creates_job_indexes_on_init(self, plans_col, jobs_col):
+        MongoProjectionRepo(
+            plans_collection=plans_col,
+            jobs_collection=jobs_col,
+        )
+        jobs_col.create_indexes.assert_called_once()
+        created_names = [
+            idx.document["name"]
+            for idx in jobs_col.create_indexes.call_args[0][0]
+        ]
+        assert "job_id_1" in created_names
+        assert "plan_id_1" in created_names
+        assert "plan_id_1_status_1" in created_names
+
+    def test_skips_existing_indexes(self, jobs_col, plans_col):
+        plans_col.list_indexes.return_value = [
+            {"name": "plan_id_1"},
+            {"name": "dataset_id_1"},
+            {"name": "dataset_id_1_is_current_1"},
+        ]
+        jobs_col.list_indexes.return_value = [
+            {"name": "job_id_1"},
+            {"name": "plan_id_1"},
+            {"name": "dataset_id_1"},
+            {"name": "plan_id_1_status_1"},
+        ]
+        MongoProjectionRepo(
+            plans_collection=plans_col,
+            jobs_collection=jobs_col,
+        )
+        plans_col.create_indexes.assert_not_called()
+        jobs_col.create_indexes.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Plan operations
+# ---------------------------------------------------------------------------
+
+
+class TestSavePlan:
+    def test_demotes_existing_current_plans(self, repo, plans_col):
+        from fiftyone.multimodal.projection.compiler.emitter import emit_plan
+        from fiftyone.multimodal.projection.compiler.parser import (
+            parse_manifest,
+        )
+        from fiftyone.multimodal.projection.compiler.expander import (
+            expand_manifest,
+        )
+        from fiftyone.multimodal.projection.compiler.resolver import (
+            resolve_manifest,
+        )
+
+        yaml = "channel_bindings: []\nprojections: []"
+        resolved = resolve_manifest(expand_manifest(parse_manifest(yaml)))
+
+        # Silence the parse error by using a minimal valid plan via direct emit
+        plan_doc_raw = _make_plan_doc()
+        plans_col.find_one.return_value = plan_doc_raw
+
+        # Build a real CompiledPlan
+        import hashlib, json
+        from datetime import datetime
+        from fiftyone.multimodal.projection.compiler.model import CompiledPlan
+
+        compiled = CompiledPlan(
+            plan_id="plan-abc",
+            dataset_id="ds1",
+            compiled_at=datetime(2026, 1, 1),
+            manifest_source="",
+            channel_bindings=[],
+            logical_streams=[],
+            projections=[],
+            dag_order=[],
+            dag_levels={},
+        )
+        repo.save_plan(compiled)
+
+        plans_col.update_many.assert_called_once_with(
+            {"dataset_id": "ds1", "is_current": True},
+            {"$set": {"is_current": False}},
+        )
+
+    def test_upserts_plan_doc(self, repo, plans_col):
+        from fiftyone.multimodal.projection.compiler.model import CompiledPlan
+
+        compiled = CompiledPlan(
+            plan_id="plan-abc",
+            dataset_id="ds1",
+            compiled_at=datetime(2026, 1, 1),
+            manifest_source="",
+            channel_bindings=[],
+            logical_streams=[],
+            projections=[],
+            dag_order=[],
+            dag_levels={},
+        )
+        plans_col.find_one.return_value = _make_plan_doc(plan_id="plan-abc")
+        repo.save_plan(compiled)
+
+        plans_col.update_one.assert_called_once()
+        filter_doc, update_doc = plans_col.update_one.call_args[0]
+        assert filter_doc == {"plan_id": "plan-abc"}
+        assert update_doc["$set"]["plan_id"] == "plan-abc"
+
+    def test_returns_manifest_plan_document(self, repo, plans_col):
+        from fiftyone.multimodal.projection.compiler.model import CompiledPlan
+
+        compiled = CompiledPlan(
+            plan_id="plan-abc",
+            dataset_id="ds1",
+            compiled_at=datetime(2026, 1, 1),
+            manifest_source="",
+            channel_bindings=[],
+            logical_streams=[],
+            projections=[],
+            dag_order=[],
+            dag_levels={},
+        )
+        plans_col.find_one.return_value = _make_plan_doc(plan_id="plan-abc")
+        result = repo.save_plan(compiled)
+        assert isinstance(result, ManifestPlanDocument)
+        assert result.plan_id == "plan-abc"
+
+
+class TestGetPlan:
+    def test_returns_none_when_not_found(self, repo, plans_col):
+        plans_col.find_one.return_value = None
+        assert repo.get_plan("missing") is None
+
+    def test_returns_document_when_found(self, repo, plans_col):
+        plans_col.find_one.return_value = _make_plan_doc()
+        result = repo.get_plan("plan-sha256")
+        assert isinstance(result, ManifestPlanDocument)
+        assert result.plan_id == "plan-sha256"
+
+    def test_get_current_plan_queries_is_current(self, repo, plans_col):
+        plans_col.find_one.return_value = _make_plan_doc()
+        repo.get_current_plan("ds1")
+        plans_col.find_one.assert_called_once_with(
+            {"dataset_id": "ds1", "is_current": True}
+        )
+
+    def test_get_current_plan_returns_none_when_not_found(
+        self, repo, plans_col
+    ):
+        plans_col.find_one.return_value = None
+        assert repo.get_current_plan("ds1") is None
+
+
+class TestListPlans:
+    def test_returns_list_of_documents(self, repo, plans_col):
+        plans_col.find.return_value = [
+            _make_plan_doc(),
+            _make_plan_doc(plan_id="plan-2"),
+        ]
+        results = repo.list_plans("ds1")
+        assert len(results) == 2
+        assert all(isinstance(r, ManifestPlanDocument) for r in results)
+
+    def test_queries_by_dataset_id(self, repo, plans_col):
+        plans_col.find.return_value = []
+        repo.list_plans("ds1")
+        plans_col.find.assert_called_once_with(
+            {"dataset_id": "ds1"},
+            sort=[("compiled_at", pymongo.DESCENDING)],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Job operations
+# ---------------------------------------------------------------------------
+
+
+class TestSaveJobs:
+    def test_empty_list_returns_empty(self, repo):
+        result = repo.save_jobs([])
+        assert result == []
+
+    def test_inserts_all_jobs(self, repo, jobs_col, sample_job):
+        inserted_id = ObjectId()
+        jobs_col.insert_many.return_value = MagicMock(
+            inserted_ids=[inserted_id]
+        )
+        jobs_col.find.return_value = [_make_job_doc()]
+        repo.save_jobs([sample_job])
+        jobs_col.insert_many.assert_called_once()
+        inserted_docs = jobs_col.insert_many.call_args[0][0]
+        assert len(inserted_docs) == 1
+        assert inserted_docs[0]["plan_id"] == "plan-sha256"
+
+    def test_returns_job_documents(self, repo, jobs_col, sample_job):
+        inserted_id = ObjectId()
+        jobs_col.insert_many.return_value = MagicMock(
+            inserted_ids=[inserted_id]
+        )
+        jobs_col.find.return_value = [_make_job_doc()]
+        results = repo.save_jobs([sample_job])
+        assert len(results) == 1
+        assert isinstance(results[0], ProjectionJobDocument)
+
+    def test_episode_status_stored_as_array(self, repo, jobs_col, sample_job):
+        inserted_id = ObjectId()
+        jobs_col.insert_many.return_value = MagicMock(
+            inserted_ids=[inserted_id]
+        )
+        jobs_col.find.return_value = [_make_job_doc()]
+        repo.save_jobs([sample_job])
+        doc = jobs_col.insert_many.call_args[0][0][0]
+        assert isinstance(doc["episode_status"], list)
+
+
+class TestGetJob:
+    def test_returns_none_when_not_found(self, repo, jobs_col):
+        jobs_col.find_one.return_value = None
+        assert repo.get_job("missing") is None
+
+    def test_returns_document_when_found(self, repo, jobs_col):
+        jobs_col.find_one.return_value = _make_job_doc()
+        result = repo.get_job("job-uuid-1")
+        assert isinstance(result, ProjectionJobDocument)
+        assert result.job_id == "job-uuid-1"
+
+
+class TestListJobs:
+    def test_filters_by_plan_id(self, repo, jobs_col):
+        jobs_col.find.return_value = []
+        repo.list_jobs(plan_id="plan-sha256")
+        jobs_col.find.assert_called_once_with(
+            {"plan_id": "plan-sha256"},
+            sort=[("batch_index", pymongo.ASCENDING)],
+        )
+
+    def test_filters_by_status(self, repo, jobs_col):
+        jobs_col.find.return_value = []
+        repo.list_jobs(status="pending")
+        jobs_col.find.assert_called_once_with(
+            {"status": "pending"},
+            sort=[("batch_index", pymongo.ASCENDING)],
+        )
+
+    def test_filters_by_multiple_fields(self, repo, jobs_col):
+        jobs_col.find.return_value = []
+        repo.list_jobs(plan_id="p1", dataset_id="ds1", status="running")
+        jobs_col.find.assert_called_once_with(
+            {"plan_id": "p1", "dataset_id": "ds1", "status": "running"},
+            sort=[("batch_index", pymongo.ASCENDING)],
+        )
+
+    def test_no_filters_queries_all(self, repo, jobs_col):
+        jobs_col.find.return_value = []
+        repo.list_jobs()
+        jobs_col.find.assert_called_once_with(
+            {},
+            sort=[("batch_index", pymongo.ASCENDING)],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Status transitions
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateJobStatus:
+    def test_running_sets_started_at(self, repo, jobs_col):
+        jobs_col.find_one_and_update.return_value = _make_job_doc(
+            status="running"
+        )
+        repo.update_job_status("job-uuid-1", JobStatus.RUNNING)
+        _, update, *_ = jobs_col.find_one_and_update.call_args[0]
+        assert "started_at" in update["$set"]
+        assert "completed_at" not in update["$set"]
+
+    def test_completed_sets_completed_at(self, repo, jobs_col):
+        jobs_col.find_one_and_update.return_value = _make_job_doc(
+            status="completed"
+        )
+        repo.update_job_status("job-uuid-1", JobStatus.COMPLETED)
+        _, update, *_ = jobs_col.find_one_and_update.call_args[0]
+        assert "completed_at" in update["$set"]
+
+    def test_failed_sets_completed_at(self, repo, jobs_col):
+        jobs_col.find_one_and_update.return_value = _make_job_doc(
+            status="failed"
+        )
+        repo.update_job_status("job-uuid-1", JobStatus.FAILED)
+        _, update, *_ = jobs_col.find_one_and_update.call_args[0]
+        assert "completed_at" in update["$set"]
+
+    def test_partial_sets_completed_at(self, repo, jobs_col):
+        jobs_col.find_one_and_update.return_value = _make_job_doc(
+            status="partial"
+        )
+        repo.update_job_status("job-uuid-1", JobStatus.PARTIAL)
+        _, update, *_ = jobs_col.find_one_and_update.call_args[0]
+        assert "completed_at" in update["$set"]
+
+    def test_error_stored_when_provided(self, repo, jobs_col):
+        jobs_col.find_one_and_update.return_value = _make_job_doc(
+            status="failed", error="something broke"
+        )
+        repo.update_job_status(
+            "job-uuid-1", JobStatus.FAILED, error="something broke"
+        )
+        _, update, *_ = jobs_col.find_one_and_update.call_args[0]
+        assert update["$set"]["error"] == "something broke"
+
+    def test_no_error_key_when_error_is_none(self, repo, jobs_col):
+        jobs_col.find_one_and_update.return_value = _make_job_doc(
+            status="completed"
+        )
+        repo.update_job_status("job-uuid-1", JobStatus.COMPLETED)
+        _, update, *_ = jobs_col.find_one_and_update.call_args[0]
+        assert "error" not in update["$set"]
+
+    def test_raises_when_job_not_found(self, repo, jobs_col):
+        jobs_col.find_one_and_update.return_value = None
+        with pytest.raises(ValueError, match="No job found"):
+            repo.update_job_status("missing", JobStatus.RUNNING)
+
+    def test_returns_job_document(self, repo, jobs_col):
+        jobs_col.find_one_and_update.return_value = _make_job_doc(
+            status="running"
+        )
+        result = repo.update_job_status("job-uuid-1", JobStatus.RUNNING)
+        assert isinstance(result, ProjectionJobDocument)
+        assert result.status == "running"
+
+
+class TestUpdateEpisodeStatus:
+    def test_uses_array_filter(self, repo, jobs_col):
+        jobs_col.find_one_and_update.return_value = _make_job_doc()
+        repo.update_episode_status("job-uuid-1", "ep.mcap", "completed")
+        kwargs = jobs_col.find_one_and_update.call_args[1]
+        assert kwargs["array_filters"] == [{"ep.path": "ep.mcap"}]
+
+    def test_sets_episode_status_via_positional_filter(self, repo, jobs_col):
+        jobs_col.find_one_and_update.return_value = _make_job_doc()
+        repo.update_episode_status("job-uuid-1", "ep.mcap", "completed")
+        _, update, *_ = jobs_col.find_one_and_update.call_args[0]
+        assert update["$set"]["episode_status.$[ep].status"] == "completed"
+
+    def test_raises_when_job_not_found(self, repo, jobs_col):
+        jobs_col.find_one_and_update.return_value = None
+        with pytest.raises(ValueError, match="No job found"):
+            repo.update_episode_status("missing", "ep.mcap", "completed")
+
+
+class TestSetDelegatedOperationId:
+    def test_sets_field(self, repo, jobs_col):
+        jobs_col.find_one_and_update.return_value = _make_job_doc(
+            delegated_operation_id="op-xyz"
+        )
+        repo.set_delegated_operation_id("job-uuid-1", "op-xyz")
+        _, update, *_ = jobs_col.find_one_and_update.call_args[0]
+        assert update["$set"]["delegated_operation_id"] == "op-xyz"
+
+    def test_returns_job_document(self, repo, jobs_col):
+        jobs_col.find_one_and_update.return_value = _make_job_doc(
+            delegated_operation_id="op-xyz"
+        )
+        result = repo.set_delegated_operation_id("job-uuid-1", "op-xyz")
+        assert isinstance(result, ProjectionJobDocument)
+        assert result.delegated_operation_id == "op-xyz"
+
+    def test_raises_when_job_not_found(self, repo, jobs_col):
+        jobs_col.find_one_and_update.return_value = None
+        with pytest.raises(ValueError, match="No job found"):
+            repo.set_delegated_operation_id("missing", "op-xyz")

--- a/tests/unittests/multimodal/projection/compiler_tests.py
+++ b/tests/unittests/multimodal/projection/compiler_tests.py
@@ -1,0 +1,721 @@
+"""
+Unit tests for the MCAP projection manifest compiler pipeline.
+
+Covers: parser, expander, resolver, dag, emitter, model, expression, and the
+top-level compile() entrypoint.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import pytest
+
+from fiftyone.multimodal.projection.compiler.dag import (
+    CyclicDependencyError,
+    build_dag,
+)
+from fiftyone.multimodal.projection.compiler.emitter import dispatch, emit_plan
+from fiftyone.multimodal.projection.compiler.expander import (
+    TemplateExpansionError,
+    expand_manifest,
+)
+from fiftyone.multimodal.projection.compiler.expression import (
+    CapturedExpression,
+    StubExpressionEngine,
+)
+from fiftyone.multimodal.projection.compiler.model import (
+    CompiledPlan,
+    Grain,
+    JobStatus,
+    ProjectionJob,
+)
+from fiftyone.multimodal.projection.compiler.parser import (
+    ManifestParseError,
+    parse_manifest,
+)
+from fiftyone.multimodal.projection.compiler.resolver import (
+    ManifestResolveError,
+    resolve_manifest,
+)
+from fiftyone.multimodal.projection.compiler import compile as compiler_compile
+
+
+# ---------------------------------------------------------------------------
+# Shared YAML fixtures
+# ---------------------------------------------------------------------------
+
+_MINIMAL_YAML = """\
+channel_bindings:
+  - id: imu
+    match: { topic: /imu, schema_name: IMU, encoding: json }
+    codec: nuscenes_imu_json
+    timestamp_source:
+      candidates:
+        - mcap: log_time
+
+projections:
+  - id: obs
+    sources:
+      - name: sensor
+        channel_bindings: [imu]
+    observation:
+      rows:
+        for_each: sensor
+        time:
+          shape: point
+          timestamp: { path: sensor.timestamp }
+      columns:
+        - { id: ts, value: { path: sensor.timestamp }, type: int64 }
+"""
+
+_REPEAT_YAML = """\
+channel_binding_repeats:
+  - var: cam
+    values:
+      - { stream_id: front, topic: CAM_FRONT }
+      - { stream_id: back, topic: CAM_BACK }
+    templates:
+      - id: "{{cam.stream_id}}_image"
+        match: { topic: "/{{cam.topic}}/image" }
+        codec: image_codec
+
+logical_stream_repeats:
+  - var: cam
+    values:
+      - { stream_id: front, topic: CAM_FRONT }
+      - { stream_id: back, topic: CAM_BACK }
+    templates:
+      - id: "{{cam.stream_id}}"
+        kind: bundle
+        components:
+          - name: image
+            source: { channel_binding: "{{cam.stream_id}}_image" }
+
+projections:
+  - id: obs
+    sources:
+      - name: camera
+        logical_streams: [front]
+    observation:
+      rows:
+        for_each: camera
+        time: { shape: point, timestamp: { path: camera.timestamp } }
+      columns: []
+"""
+
+_DAG_YAML = """\
+channel_bindings:
+  - id: raw
+    match: { topic: /raw }
+
+projections:
+  - id: base
+    sources:
+      - name: src
+        channel_bindings: [raw]
+    observation:
+      rows: { for_each: src, time: { shape: point, timestamp: { path: src.ts } } }
+      columns: []
+
+  - id: derived
+    sources:
+      - name: up
+        projections: [base]
+    scene_summary:
+      aggregate:
+        time: { shape: interval }
+      columns: []
+"""
+
+
+# ---------------------------------------------------------------------------
+# Parser tests
+# ---------------------------------------------------------------------------
+
+
+class TestParser:
+    def test_minimal_valid_manifest(self):
+        result = parse_manifest(_MINIMAL_YAML)
+        assert len(result["channel_bindings"]) == 1
+        assert result["channel_bindings"][0]["id"] == "imu"
+        assert len(result["projections"]) == 1
+
+    def test_empty_sections_default_to_empty_lists(self):
+        result = parse_manifest("channel_bindings:\nprojections:\n")
+        assert result["channel_bindings"] == []
+        assert result["logical_streams"] == []
+
+    def test_missing_sections_default_to_empty_lists(self):
+        result = parse_manifest("projections: []")
+        assert result["channel_bindings"] == []
+        assert result["channel_binding_repeats"] == []
+        assert result["logical_stream_repeats"] == []
+
+    def test_invalid_yaml_raises(self):
+        with pytest.raises(ManifestParseError, match="Invalid YAML"):
+            parse_manifest("key: [unclosed")
+
+    def test_non_dict_root_raises(self):
+        with pytest.raises(ManifestParseError, match="mapping"):
+            parse_manifest("- item1\n- item2")
+
+    def test_unknown_top_level_key_raises(self):
+        with pytest.raises(ManifestParseError, match="Unknown top-level keys"):
+            parse_manifest("channel_bindings: []\nunknown_key: []")
+
+    def test_channel_binding_missing_id_raises(self):
+        yaml = "channel_bindings:\n  - match: { topic: /foo }\n"
+        with pytest.raises(
+            ManifestParseError, match="missing required string field 'id'"
+        ):
+            parse_manifest(yaml)
+
+    def test_channel_binding_invalid_match_raises(self):
+        yaml = "channel_bindings:\n  - id: foo\n    match: not_a_dict\n"
+        with pytest.raises(
+            ManifestParseError, match="match must be a mapping"
+        ):
+            parse_manifest(yaml)
+
+    def test_projection_missing_grain_raises(self):
+        yaml = "projections:\n  - id: p1\n    sources: []\n"
+        with pytest.raises(
+            ManifestParseError, match="must declare exactly one grain key"
+        ):
+            parse_manifest(yaml)
+
+    def test_projection_multiple_grains_raises(self):
+        yaml = (
+            "projections:\n"
+            "  - id: p1\n"
+            "    observation: {}\n"
+            "    annotation: {}\n"
+        )
+        with pytest.raises(
+            ManifestParseError, match="declares multiple grain keys"
+        ):
+            parse_manifest(yaml)
+
+    def test_logical_stream_invalid_kind_raises(self):
+        yaml = "logical_streams:\n  - id: s1\n    kind: unknown\n"
+        with pytest.raises(
+            ManifestParseError, match="kind must be 'bundle' or 'virtual'"
+        ):
+            parse_manifest(yaml)
+
+    def test_repeat_block_missing_var_raises(self):
+        yaml = (
+            "channel_binding_repeats:\n"
+            "  - values: []\n"
+            "    templates: []\n"
+        )
+        with pytest.raises(ManifestParseError, match="missing string 'var'"):
+            parse_manifest(yaml)
+
+    def test_repeat_block_missing_values_raises(self):
+        yaml = (
+            "channel_binding_repeats:\n" "  - var: cam\n" "    templates: []\n"
+        )
+        with pytest.raises(ManifestParseError, match="missing list 'values'"):
+            parse_manifest(yaml)
+
+
+# ---------------------------------------------------------------------------
+# Expander tests
+# ---------------------------------------------------------------------------
+
+
+class TestExpander:
+    def test_expands_channel_binding_repeats(self):
+        raw = parse_manifest(_REPEAT_YAML)
+        expanded = expand_manifest(raw)
+        ids = [b["id"] for b in expanded["channel_bindings"]]
+        assert "front_image" in ids
+        assert "back_image" in ids
+
+    def test_expands_logical_stream_repeats(self):
+        raw = parse_manifest(_REPEAT_YAML)
+        expanded = expand_manifest(raw)
+        ids = [s["id"] for s in expanded["logical_streams"]]
+        assert "front" in ids
+        assert "back" in ids
+
+    def test_removes_repeat_keys(self):
+        raw = parse_manifest(_REPEAT_YAML)
+        expanded = expand_manifest(raw)
+        assert "channel_binding_repeats" not in expanded
+        assert "logical_stream_repeats" not in expanded
+
+    def test_interpolates_nested_string_fields(self):
+        raw = parse_manifest(_REPEAT_YAML)
+        expanded = expand_manifest(raw)
+        front = next(
+            b for b in expanded["channel_bindings"] if b["id"] == "front_image"
+        )
+        assert front["match"]["topic"] == "/CAM_FRONT/image"
+
+    def test_duplicate_ids_after_expansion_raises(self):
+        yaml = (
+            "channel_binding_repeats:\n"
+            "  - var: cam\n"
+            "    values:\n"
+            "      - { stream_id: same }\n"
+            "      - { stream_id: same }\n"
+            "    templates:\n"
+            "      - id: '{{cam.stream_id}}'\n"
+            "        match: { topic: /x }\n"
+        )
+        raw = parse_manifest(yaml)
+        with pytest.raises(TemplateExpansionError, match="Duplicate id"):
+            expand_manifest(raw)
+
+    def test_unknown_template_variable_raises(self):
+        yaml = (
+            "channel_binding_repeats:\n"
+            "  - var: cam\n"
+            "    values:\n"
+            "      - { stream_id: front }\n"
+            "    templates:\n"
+            "      - id: '{{other.field}}'\n"
+            "        match: { topic: /x }\n"
+        )
+        raw = parse_manifest(yaml)
+        with pytest.raises(TemplateExpansionError, match="unknown variable"):
+            expand_manifest(raw)
+
+    def test_unknown_template_field_raises(self):
+        yaml = (
+            "channel_binding_repeats:\n"
+            "  - var: cam\n"
+            "    values:\n"
+            "      - { stream_id: front }\n"
+            "    templates:\n"
+            "      - id: '{{cam.no_such_field}}'\n"
+            "        match: { topic: /x }\n"
+        )
+        raw = parse_manifest(yaml)
+        with pytest.raises(TemplateExpansionError, match="no field"):
+            expand_manifest(raw)
+
+    def test_static_bindings_preserved(self):
+        raw = parse_manifest(_MINIMAL_YAML)
+        expanded = expand_manifest(raw)
+        assert expanded["channel_bindings"][0]["id"] == "imu"
+
+
+# ---------------------------------------------------------------------------
+# Resolver tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolver:
+    def _expanded(self, yaml_src):
+        return expand_manifest(parse_manifest(yaml_src))
+
+    def test_valid_manifest_passes(self):
+        expanded = self._expanded(_MINIMAL_YAML)
+        resolved = resolve_manifest(expanded)
+        assert resolved is expanded
+
+    def test_unknown_channel_binding_in_projection_raises(self):
+        yaml = (
+            "channel_bindings:\n"
+            "  - id: real\n"
+            "    match: { topic: /x }\n"
+            "projections:\n"
+            "  - id: p1\n"
+            "    sources:\n"
+            "      - name: src\n"
+            "        channel_bindings: [no_such_binding]\n"
+            "    observation:\n"
+            "      rows: { for_each: src, time: { shape: point, timestamp: { path: src.ts } } }\n"
+            "      columns: []\n"
+        )
+        with pytest.raises(
+            ManifestResolveError, match="unknown id 'no_such_binding'"
+        ):
+            resolve_manifest(self._expanded(yaml))
+
+    def test_unknown_projection_source_raises(self):
+        yaml = (
+            "channel_bindings:\n"
+            "  - id: raw\n"
+            "    match: { topic: /x }\n"
+            "projections:\n"
+            "  - id: p1\n"
+            "    sources:\n"
+            "      - name: up\n"
+            "        projections: [no_such_proj]\n"
+            "    scene_summary:\n"
+            "      aggregate: { time: { shape: interval } }\n"
+            "      columns: []\n"
+        )
+        with pytest.raises(
+            ManifestResolveError, match="unknown id 'no_such_proj'"
+        ):
+            resolve_manifest(self._expanded(yaml))
+
+    def test_self_referencing_projection_raises(self):
+        yaml = (
+            "channel_bindings:\n"
+            "  - id: raw\n"
+            "    match: { topic: /x }\n"
+            "projections:\n"
+            "  - id: loop\n"
+            "    sources:\n"
+            "      - name: up\n"
+            "        projections: [loop]\n"
+            "    scene_summary:\n"
+            "      aggregate: { time: { shape: interval } }\n"
+            "      columns: []\n"
+        )
+        with pytest.raises(ManifestResolveError, match="references itself"):
+            resolve_manifest(self._expanded(yaml))
+
+    def test_unknown_logical_stream_in_bundle_component_raises(self):
+        yaml = (
+            "channel_bindings:\n"
+            "  - id: raw\n"
+            "    match: { topic: /x }\n"
+            "logical_streams:\n"
+            "  - id: bundle\n"
+            "    kind: bundle\n"
+            "    components:\n"
+            "      - name: part\n"
+            "        source: { channel_binding: no_such }\n"
+            "projections:\n"
+            "  - id: p1\n"
+            "    sources: []\n"
+            "    observation: { rows: { for_each: x, time: { shape: point, timestamp: { path: x.ts } } }, columns: [] }\n"
+        )
+        with pytest.raises(ManifestResolveError, match="unknown id 'no_such'"):
+            resolve_manifest(self._expanded(yaml))
+
+
+# ---------------------------------------------------------------------------
+# DAG tests
+# ---------------------------------------------------------------------------
+
+
+class TestDag:
+    def _projs(self, *specs):
+        """Build minimal projection dicts from (id, upstream_ids) pairs."""
+        return [
+            {"id": pid, "sources": [{"name": "s", "projections": ups}]}
+            for pid, ups in specs
+        ]
+
+    def test_single_projection_level_zero(self):
+        order, levels, dep_map = build_dag(self._projs(("p1", [])))
+        assert order == ["p1"]
+        assert levels == {"0": ["p1"]}
+        assert dep_map == {"p1": []}
+
+    def test_linear_chain_order(self):
+        projs = self._projs(("a", []), ("b", ["a"]), ("c", ["b"]))
+        order, levels, _ = build_dag(projs)
+        assert order.index("a") < order.index("b") < order.index("c")
+        assert levels["0"] == ["a"]
+        assert levels["1"] == ["b"]
+        assert levels["2"] == ["c"]
+
+    def test_parallel_projections_same_level(self):
+        projs = self._projs(("x", []), ("y", []))
+        order, levels, _ = build_dag(projs)
+        assert set(order) == {"x", "y"}
+        assert set(levels["0"]) == {"x", "y"}
+
+    def test_diamond_dependency(self):
+        projs = self._projs(
+            ("a", []), ("b", ["a"]), ("c", ["a"]), ("d", ["b", "c"])
+        )
+        order, levels, _ = build_dag(projs)
+        assert order.index("a") < order.index("b")
+        assert order.index("a") < order.index("c")
+        assert order.index("b") < order.index("d")
+        assert order.index("c") < order.index("d")
+        assert levels["2"] == ["d"]
+
+    def test_cycle_detection_raises(self):
+        projs = self._projs(("a", ["b"]), ("b", ["a"]))
+        with pytest.raises(CyclicDependencyError, match="Circular dependency"):
+            build_dag(projs)
+
+    def test_unknown_upstream_raises(self):
+        projs = self._projs(("a", ["no_such"]))
+        with pytest.raises(ValueError, match="unknown upstream projection"):
+            build_dag(projs)
+
+
+# ---------------------------------------------------------------------------
+# Emitter tests
+# ---------------------------------------------------------------------------
+
+
+class TestEmitter:
+    def _resolved(self, yaml_src=_MINIMAL_YAML):
+        raw = parse_manifest(yaml_src)
+        expanded = expand_manifest(raw)
+        return resolve_manifest(expanded)
+
+    def test_emit_plan_returns_compiled_plan(self):
+        resolved = self._resolved()
+        plan = emit_plan(
+            resolved, dataset_id="ds1", manifest_source=_MINIMAL_YAML
+        )
+        assert isinstance(plan, CompiledPlan)
+        assert plan.dataset_id == "ds1"
+
+    def test_emit_plan_id_is_sha256_hex(self):
+        resolved = self._resolved()
+        plan = emit_plan(
+            resolved, dataset_id="ds1", manifest_source=_MINIMAL_YAML
+        )
+        assert len(plan.plan_id) == 64
+        assert all(c in "0123456789abcdef" for c in plan.plan_id)
+
+    def test_emit_plan_id_is_content_addressed(self):
+        resolved = self._resolved()
+        plan_a = emit_plan(
+            resolved, dataset_id="ds1", manifest_source=_MINIMAL_YAML
+        )
+        plan_b = emit_plan(
+            resolved, dataset_id="ds2", manifest_source="other source"
+        )
+        assert (
+            plan_a.plan_id == plan_b.plan_id
+        )  # dataset_id and source not in hash
+
+    def test_emit_plan_different_content_different_id(self):
+        resolved_a = self._resolved(_MINIMAL_YAML)
+        resolved_b = self._resolved(_DAG_YAML)
+        plan_a = emit_plan(resolved_a, dataset_id="ds1", manifest_source="")
+        plan_b = emit_plan(resolved_b, dataset_id="ds1", manifest_source="")
+        assert plan_a.plan_id != plan_b.plan_id
+
+    def test_emit_plan_dag_order_topo_sorted(self):
+        resolved = self._resolved(_DAG_YAML)
+        plan = emit_plan(resolved, dataset_id="ds1", manifest_source="")
+        ids = [p.id for p in plan.projections]
+        assert ids.index("base") < ids.index("derived")
+
+    def test_emit_plan_projection_grain(self):
+        resolved = self._resolved(_MINIMAL_YAML)
+        plan = emit_plan(resolved, dataset_id="ds1", manifest_source="")
+        assert plan.projections[0].grain == Grain.OBSERVATION
+
+    def test_emit_plan_channel_bindings_captured(self):
+        resolved = self._resolved(_MINIMAL_YAML)
+        plan = emit_plan(resolved, dataset_id="ds1", manifest_source="")
+        assert plan.channel_bindings[0].id == "imu"
+        assert plan.channel_bindings[0].codec == "nuscenes_imu_json"
+
+    def test_emit_plan_where_expr_captured(self):
+        yaml = (
+            "channel_bindings:\n"
+            "  - id: diag\n"
+            "    match: { topic: /diag }\n"
+            "    where: { expr: 'name == \"foo\"' }\n"
+            "    codec: nuscenes_diagnostics_json\n"
+            "projections:\n"
+            "  - id: p\n"
+            "    sources:\n"
+            "      - name: s\n"
+            "        channel_bindings: [diag]\n"
+            "    observation:\n"
+            "      rows: { for_each: s, time: { shape: point, timestamp: { path: s.ts } } }\n"
+            "      columns: []\n"
+        )
+        resolved = resolve_manifest(expand_manifest(parse_manifest(yaml)))
+        plan = emit_plan(resolved, dataset_id="ds1", manifest_source="")
+        assert plan.channel_bindings[0].where_expr == 'name == "foo"'
+
+    def test_dispatch_correct_batch_count(self):
+        resolved = self._resolved(_MINIMAL_YAML)
+        plan = emit_plan(resolved, dataset_id="ds1", manifest_source="")
+        episodes = [f"ep{i}.mcap" for i in range(45)]
+        jobs = dispatch(plan, episodes, base_path="gs://bucket", batch_size=20)
+        assert len(jobs) == 3  # ceil(45/20)
+
+    def test_dispatch_batch_contents(self):
+        resolved = self._resolved(_MINIMAL_YAML)
+        plan = emit_plan(resolved, dataset_id="ds1", manifest_source="")
+        episodes = [f"ep{i}.mcap" for i in range(5)]
+        jobs = dispatch(plan, episodes, base_path="gs://bucket", batch_size=3)
+        assert jobs[0].episode_paths == ["ep0.mcap", "ep1.mcap", "ep2.mcap"]
+        assert jobs[1].episode_paths == ["ep3.mcap", "ep4.mcap"]
+
+    def test_dispatch_output_paths_contain_plan_and_projection_ids(self):
+        resolved = self._resolved(_MINIMAL_YAML)
+        plan = emit_plan(resolved, dataset_id="ds1", manifest_source="")
+        jobs = dispatch(plan, ["ep.mcap"], base_path="gs://bucket")
+        path = jobs[0].output_paths["obs"]
+        assert plan.plan_id in path
+        assert "obs" in path
+        assert path.endswith(".parquet")
+
+    def test_dispatch_empty_episodes_returns_no_jobs(self):
+        resolved = self._resolved(_MINIMAL_YAML)
+        plan = emit_plan(resolved, dataset_id="ds1", manifest_source="")
+        jobs = dispatch(plan, [], base_path="gs://bucket")
+        assert jobs == []
+
+
+# ---------------------------------------------------------------------------
+# Model tests
+# ---------------------------------------------------------------------------
+
+
+class TestModel:
+    def test_compiled_plan_to_mongo_doc_has_required_keys(self):
+        resolved = resolve_manifest(
+            expand_manifest(parse_manifest(_MINIMAL_YAML))
+        )
+        plan = emit_plan(
+            resolved, dataset_id="ds1", manifest_source=_MINIMAL_YAML
+        )
+        doc = plan.to_mongo_doc()
+        assert doc["plan_id"] == plan.plan_id
+        assert doc["dataset_id"] == "ds1"
+        assert doc["is_current"] is True
+        assert "channel_bindings" in doc
+        assert "projections" in doc
+        assert "dag" in doc
+        assert "order" in doc["dag"]
+        assert "levels" in doc["dag"]
+
+    def test_make_plan_id_is_deterministic(self):
+        id1 = CompiledPlan.make_plan_id([], [], [])
+        id2 = CompiledPlan.make_plan_id([], [], [])
+        assert id1 == id2
+
+    def test_make_plan_id_changes_with_content(self):
+        id1 = CompiledPlan.make_plan_id([], [], [])
+        id2 = CompiledPlan.make_plan_id([{"id": "x"}], [], [])
+        assert id1 != id2
+
+    def test_projection_job_initialises_episode_status(self):
+        job = ProjectionJob(
+            plan_id="p1",
+            dataset_id="ds1",
+            batch_index=0,
+            episode_paths=["a.mcap", "b.mcap"],
+            output_paths={},
+        )
+        assert job.episode_status == {
+            "a.mcap": JobStatus.PENDING.value,
+            "b.mcap": JobStatus.PENDING.value,
+        }
+
+    def test_projection_job_to_mongo_doc_episode_status_is_array(self):
+        job = ProjectionJob(
+            plan_id="p1",
+            dataset_id="ds1",
+            batch_index=0,
+            episode_paths=["a.mcap"],
+            output_paths={},
+        )
+        doc = job.to_mongo_doc()
+        assert isinstance(doc["episode_status"], list)
+        assert doc["episode_status"][0]["path"] == "a.mcap"
+        assert doc["episode_status"][0]["status"] == JobStatus.PENDING.value
+
+    def test_projection_job_to_mongo_doc_status_is_string(self):
+        job = ProjectionJob(
+            plan_id="p1",
+            dataset_id="ds1",
+            batch_index=0,
+            episode_paths=[],
+            output_paths={},
+        )
+        doc = job.to_mongo_doc()
+        assert doc["status"] == "pending"
+
+    def test_job_status_enum_values(self):
+        assert JobStatus.PENDING.value == "pending"
+        assert JobStatus.RUNNING.value == "running"
+        assert JobStatus.COMPLETED.value == "completed"
+        assert JobStatus.FAILED.value == "failed"
+        assert JobStatus.PARTIAL.value == "partial"
+
+
+# ---------------------------------------------------------------------------
+# Expression tests
+# ---------------------------------------------------------------------------
+
+
+class TestExpression:
+    def test_captured_expression_str(self):
+        expr = CapturedExpression(expr="x > 0", context_hint="col 'foo'")
+        assert str(expr) == "x > 0"
+
+    def test_captured_expression_depends_on_defaults_empty(self):
+        expr = CapturedExpression(expr="x > 0")
+        assert expr.depends_on == []
+
+    def test_stub_engine_raises_not_implemented(self):
+        engine = StubExpressionEngine()
+        expr = CapturedExpression(expr="x > 0")
+        with pytest.raises(NotImplementedError, match="not yet implemented"):
+            engine.evaluate(expr, {"x": 1})
+
+    def test_stub_engine_includes_expr_in_message(self):
+        engine = StubExpressionEngine()
+        expr = CapturedExpression(expr="my_expr == 42")
+        with pytest.raises(NotImplementedError, match="my_expr == 42"):
+            engine.evaluate(expr, {})
+
+    def test_stub_engine_includes_context_hint_when_present(self):
+        engine = StubExpressionEngine()
+        expr = CapturedExpression(expr="x", context_hint="binding 'foo' where")
+        with pytest.raises(NotImplementedError, match="binding 'foo' where"):
+            engine.evaluate(expr, {})
+
+
+# ---------------------------------------------------------------------------
+# compile() integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestCompileEntrypoint:
+    def test_compile_minimal_yaml(self):
+        plan = compiler_compile(_MINIMAL_YAML, dataset_id="ds1")
+        assert plan.dataset_id == "ds1"
+        assert len(plan.projections) == 1
+
+    def test_compile_with_repeats(self):
+        plan = compiler_compile(_REPEAT_YAML, dataset_id="ds1")
+        binding_ids = [b.id for b in plan.channel_bindings]
+        assert "front_image" in binding_ids
+        assert "back_image" in binding_ids
+
+    def test_compile_with_dag(self):
+        plan = compiler_compile(_DAG_YAML, dataset_id="ds1")
+        ids = [p.id for p in plan.projections]
+        assert ids.index("base") < ids.index("derived")
+        derived = next(p for p in plan.projections if p.id == "derived")
+        assert derived.depends_on == ["base"]
+        assert derived.dag_level == 1
+
+    def test_compile_nuscenes_yaml(self):
+        import os
+
+        yaml_path = os.path.join(
+            os.path.dirname(__file__), "..", "..", "..", "..", "nuscenes.yaml"
+        )
+        if not os.path.exists(yaml_path):
+            pytest.skip("nuscenes.yaml not found")
+        with open(yaml_path) as f:
+            yaml_src = f.read()
+        plan = compiler_compile(yaml_src, dataset_id="nuscenes_ds")
+        assert len(plan.channel_bindings) > 0
+        assert len(plan.projections) > 0
+        # DAG order must be topologically valid
+        seen = set()
+        for proj in plan.projections:
+            assert all(dep in seen for dep in proj.depends_on), (
+                f"projection '{proj.id}' depends on {proj.depends_on} "
+                f"but only seen {seen} so far"
+            )
+            seen.add(proj.id)


### PR DESCRIPTION
## 🔗 Related Issues

https://voxel51.atlassian.net/browse/FOEPD-3793

## 📋 What changes are proposed in this pull request?

Given an mcap manifest convert it into a project plan and job to track the execution of that projection plan. These are both stored in mongo and will be acted on by a worker that can take a configurable batch of jobs. The executor is TODO but the end goal is something executable via an operator so that in a teams world we can delegate this process. In OSS the worker would just run in their app server or from the SDK process.

## 🧪 How is this patch tested? If it is not, please explain why.

Test script:

```
"""
Test script for the MCAP projection manifest compiler + MongoDB persistence.

Compiles nuscenes.yaml (expected at ../fiftyone/nuscenes.yaml relative to this
script), writes the plan and batch jobs to MongoDB, then exercises the repo
read/write API to verify everything round-trips correctly.

Run from anywhere:
    python scripts/test_projection_compiler.py

Optional args:
    --dataset-id   FiftyOne dataset ObjectId string to attach the plan to.
                   Defaults to a fixed test ID.
    --base-path    GCS (or local) output path root for parquet files.
    --batch-size   Episodes per worker job (default 3).
    --episodes     Number of fake episode paths to generate (default 10).
    --real-dataset Use an actual FiftyOne dataset named by --dataset-id as a
                   name (not an ObjectId) to resolve the real id.
"""

import argparse
import json
import os
import sys

# Ensure the fiftyone package is importable when running from the scripts dir.
_HERE = os.path.dirname(os.path.abspath(__file__))
_FO_ROOT = os.path.join(_HERE, "..", "fiftyone")
if _FO_ROOT not in sys.path:
    sys.path.insert(0, os.path.join(_HERE, ".."))

MANIFEST_PATH = os.path.join(_FO_ROOT, "nuscenes.yaml")


def parse_args():
    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
    p.add_argument("--dataset-id", default="507f1f77bcf86cd799439011", help="FiftyOne dataset ObjectId string")
    p.add_argument("--base-path", default="gs://voxel51-nuscenes-projections", help="Output parquet path root")
    p.add_argument("--batch-size", type=int, default=3, help="Episodes per job")
    p.add_argument("--episodes", type=int, default=10, help="Number of fake episode paths to generate")
    p.add_argument("--real-dataset", action="store_true", help="Treat --dataset-id as a dataset name and resolve its ObjectId")
    return p.parse_args()


def resolve_dataset_id(args) -> str:
    if args.real_dataset:
        import fiftyone as fo
        ds = fo.load_dataset(args.dataset_id)
        return str(ds._doc.id)
    return args.dataset_id


def separator(title=""):
    width = 60
    if title:
        print(f"\n{'─' * 4} {title} {'─' * (width - len(title) - 6)}")
    else:
        print("─" * width)


def main():
    args = parse_args()

    if not os.path.exists(MANIFEST_PATH):
        print(f"ERROR: manifest not found at {MANIFEST_PATH}", file=sys.stderr)
        sys.exit(1)

    with open(MANIFEST_PATH) as f:
        yaml_source = f.read()

    dataset_id = resolve_dataset_id(args)
    episodes = [
        f"gs://voxel51-nuscenes/scene{i:03d}.mcap"
        for i in range(args.episodes)
    ]

    # ------------------------------------------------------------------
    # 1. Compile + persist
    # ------------------------------------------------------------------
    separator("Compiling manifest")
    from fiftyone.multimodal.projection import compiler

    print(f"Manifest:   {MANIFEST_PATH}")
    print(f"Dataset ID: {dataset_id}")
    print(f"Episodes:   {len(episodes)} (fake paths)")
    print(f"Batch size: {args.batch_size}")
    print(f"Base path:  {args.base_path}")

    plan_doc, job_docs = compiler.save(
        yaml_source,
        dataset_id=dataset_id,
        episode_paths=episodes,
        base_path=args.base_path,
        batch_size=args.batch_size,
    )

    separator("Plan")
    print(f"plan_id:    {plan_doc.plan_id}")
    print(f"is_current: {plan_doc.is_current}")
    print(f"channel_bindings: {len(plan_doc.channel_bindings)}")
    print(f"logical_streams:  {len(plan_doc.logical_streams)}")
    print(f"projections:      {len(plan_doc.projections)}")

    separator("DAG")
    dag = plan_doc.dag
    for lvl, ids in sorted(dag.get("levels", {}).items(), key=lambda x: int(x[0])):
        print(f"  level {lvl}: {ids}")

    separator("Jobs created")
    for j in job_docs:
        print(f"  batch {j.batch_index}: {len(j.episode_paths)} episodes  status={j.status}  job_id={j.job_id[:8]}...")

    # ------------------------------------------------------------------
    # 2. Read-back via repo
    # ------------------------------------------------------------------
    separator("Read-back via repo")
    from fiftyone.factory.repo_factory import RepositoryFactory

    repo = RepositoryFactory.projection_repo()

    current = repo.get_current_plan(dataset_id)
    print(f"get_current_plan → plan_id matches: {current.plan_id == plan_doc.plan_id}")

    listed_jobs = repo.list_jobs(plan_id=plan_doc.plan_id)
    print(f"list_jobs → {len(listed_jobs)} jobs")

    pending = repo.list_jobs(plan_id=plan_doc.plan_id, status="pending")
    print(f"list_jobs(status=pending) → {len(pending)} jobs")

    # ------------------------------------------------------------------
    # 3. Simulate worker lifecycle on the first job
    # ------------------------------------------------------------------
    separator("Worker simulation (batch 0)")
    from fiftyone.multimodal.projection.compiler.model import JobStatus

    job = job_docs[0]
    print(f"job_id: {job.job_id}")
    print(f"episodes: {job.episode_paths}")

    updated = repo.update_job_status(job.job_id, JobStatus.RUNNING)
    print(f"→ RUNNING  started_at={updated.started_at is not None}")

    for ep in job.episode_paths:
        updated = repo.update_episode_status(job.job_id, ep, "completed")
        print(f"  episode {os.path.basename(ep)}: {updated.episode_status.get(ep)}")

    updated = repo.update_job_status(job.job_id, JobStatus.COMPLETED)
    print(f"→ COMPLETED  completed_at={updated.completed_at is not None}")

    remaining_pending = repo.list_jobs(plan_id=plan_doc.plan_id, status="pending")
    print(f"remaining pending jobs: {len(remaining_pending)}")

    # ------------------------------------------------------------------
    # 4. Show one full job document
    # ------------------------------------------------------------------
    separator("Sample job document (batch 0)")
    import fiftyone.core.odm as foo
    from bson import json_util

    raw = foo.get_db_conn()["multimodal_projection_jobs"].find_one(
        {"job_id": job.job_id}
    )
    raw.pop("_id", None)
    print(json.dumps(raw, default=json_util.default, indent=2))

    separator()
    print("Done.")


if __name__ == "__main__":
    main()
```

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
