### PR TITLE
[FOEPD-3738] Add SDK entrypoint for multimodal ingestion

### DIFF
--- a/fiftyone/multimodal/ingest/__init__.py
+++ b/fiftyone/multimodal/ingest/__init__.py
@@ -19,6 +19,14 @@ def ingest_files(
 
     Args:
         dataset: a :class:`fiftyone.core.dataset.Dataset` to ingest
+        filepaths: an iterable of strings representing the locations of the
+            scene files to ingest
+        adapter: a subclass of
+            :class:`fiftyone.multimodal.adapters.MultimodalAdapter` that
+            determines how the given sources are ingested
+        manifest: a :class:`fiftyone.multimodal.manifest.Manifest` that
+            describes the mapping between scene inventories and samples in the
+            dataset
     """
     inventories = _get_scene_inventories(filepaths, adapter=adapter)
     sample_and_inventory_pairs = [

--- a/fiftyone/multimodal/ingest/__init__.py
+++ b/fiftyone/multimodal/ingest/__init__.py
@@ -11,7 +11,7 @@ from .read import _get_scene_inventories
 from fiftyone.multimodal.db.mongo import MongoAdapter
 
 
-def ingest_filepaths(
+def ingest_files(
     dataset: fo.Dataset, filepaths: list[str], *, adapter, manifest
 ) -> None:
     """
@@ -37,4 +37,4 @@ def ingest_filepaths(
     dataset.save()
 
 
-__all__ = ["_get_scene_inventories", "ingest_filepaths"]
+__all__ = ["_get_scene_inventories", "ingest_files"]

--- a/fiftyone/multimodal/ingest/__init__.py
+++ b/fiftyone/multimodal/ingest/__init__.py
@@ -6,66 +6,9 @@ Ingest scaffolding for multimodal workflows.
 |
 """
 
-from concurrent.futures import ThreadPoolExecutor
-import os
-from typing import Generator
-
 import fiftyone as fo
-from fiftyone.core import media, storage
-from fiftyone.multimodal.adapters import MultimodalAdapter
+from .read import _get_scene_inventories
 from fiftyone.multimodal.db.mongo import MongoAdapter
-from fiftyone.multimodal.schemas.v1 import SceneInventory
-
-
-def _readable_paths(
-    filepaths: list[str], *, adapter: MultimodalAdapter
-) -> Generator[str, None, None]:
-    """
-    Returns a generator of filepaths in the given iterable that can be read by
-    the given adapter.
-
-    Args:
-        filepaths: an iterable of strings representing file paths or directory
-            locations to crawl
-        adapter: a subclass of :class:`MultimodalAdapter` that determines
-            whether a given file can be read
-
-    Returns:
-        a generator of strings representing the filepaths in the given iterable
-        that can be read by the given adapter
-    """
-    for filepath in filepaths:
-        if storage.isdir(filepath):
-            for path in storage.list_files(
-                filepath, abs_paths=True, recursive=True
-            ):
-                if adapter.can_read(path):
-                    yield path
-        elif storage.exists(filepath) and adapter.can_read(filepath):
-            yield filepath
-
-
-def _get_scene_inventories(
-    filepaths: list[str], *, adapter: MultimodalAdapter
-) -> list[SceneInventory]:
-    """
-    Reads the given scene files using the given adapter class, and returns
-    a list of scene inventories.
-
-    Args:
-        filepaths: an iterable of strings representing the locations of the
-            scene files to ingest
-        adapter: a subclass of
-            :class:`fiftyone.multimodal.adapters.MultimodalAdapter` that
-            determines how the given sources are ingested
-
-    Returns:
-        a list of :class:`fiftyone.multimodal.SceneInventory` instances
-    """
-    paths = list(_readable_paths(filepaths, adapter=adapter))
-    max_workers = max(1, min(8, (os.cpu_count() or 1) + 4, len(paths)))
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        return list(executor.map(adapter.get_scene_inventory, paths))
 
 
 def ingest_filepaths(
@@ -84,7 +27,7 @@ def ingest_filepaths(
                 # TODO the actual mapping of inventory to filepath should be
                 # derived from the manifest
                 filepath=inventory.scene_id,
-                media_type=media.MULTIMODAL,
+                media_type=fo.core.media.MULTIMODAL,
             ),
             inventory,
         )

--- a/fiftyone/multimodal/ingest/__init__.py
+++ b/fiftyone/multimodal/ingest/__init__.py
@@ -6,6 +6,9 @@ Ingest scaffolding for multimodal workflows.
 |
 """
 
+import os
+from concurrent.futures import ThreadPoolExecutor
+
 from fiftyone.core import storage
 
 
@@ -50,8 +53,10 @@ def _get_scene_inventories(filepaths, *, adapter):
     Returns:
         a list of :class:`fiftyone.multimodal.SceneInventory` instances
     """
-    paths = _readable_paths(filepaths, adapter=adapter)
-    return [adapter.get_scene_inventory(path) for path in paths]
+    paths = list(_readable_paths(filepaths, adapter=adapter))
+    max_workers = max(1, min(8, (os.cpu_count() or 1) + 4, len(paths)))
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        return list(executor.map(adapter.get_scene_inventory, paths))
 
 
 __all__ = ["_get_scene_inventories"]

--- a/fiftyone/multimodal/ingest/__init__.py
+++ b/fiftyone/multimodal/ingest/__init__.py
@@ -9,6 +9,32 @@ Ingest scaffolding for multimodal workflows.
 from fiftyone.core import storage
 
 
+def _readable_paths(filepaths, *, adapter):
+    """
+    Returns a generator of filepaths in the given iterable that can be read by
+    the given adapter.
+
+    Args:
+        filepaths: an iterable of strings representing file paths or directory
+            locations to crawl
+        adapter: a subclass of :class:`MultimodalAdapter` that determines
+            whether a given file can be read
+
+    Returns:
+        a generator of strings representing the filepaths in the given iterable
+        that can be read by the given adapter
+    """
+    for filepath in filepaths:
+        if storage.isdir(filepath):
+            for path in storage.list_files(
+                filepath, abs_paths=True, recursive=True
+            ):
+                if adapter.can_read(path):
+                    yield path
+        elif storage.exists(filepath) and adapter.can_read(filepath):
+            yield filepath
+
+
 def _get_scene_inventories(filepaths, *, adapter):
     """
     Reads the given scene files using the given adapter class, and returns
@@ -24,19 +50,8 @@ def _get_scene_inventories(filepaths, *, adapter):
     Returns:
         a list of :class:`fiftyone.multimodal.SceneInventory` instances
     """
-    inventories = []
-
-    for filepath in filepaths:
-        if storage.isdir(filepath):
-            for path in storage.list_files(
-                filepath, abs_paths=True, recursive=True
-            ):
-                if adapter.can_read(path):
-                    inventories.append(adapter.get_scene_inventory(path))
-        elif storage.exists(filepath) and adapter.can_read(filepath):
-            inventories.append(adapter.get_scene_inventory(filepath))
-
-    return inventories
+    paths = _readable_paths(filepaths, adapter=adapter)
+    return [adapter.get_scene_inventory(path) for path in paths]
 
 
 __all__ = ["_get_scene_inventories"]

--- a/fiftyone/multimodal/ingest/__init__.py
+++ b/fiftyone/multimodal/ingest/__init__.py
@@ -6,13 +6,19 @@ Ingest scaffolding for multimodal workflows.
 |
 """
 
-import os
 from concurrent.futures import ThreadPoolExecutor
+import os
+from typing import Generator
 
+import fiftyone as fo
 from fiftyone.core import storage
+from fiftyone.multimodal.adapters import MultimodalAdapter
+from fiftyone.multimodal.schemas.v1 import SceneInventory
 
 
-def _readable_paths(filepaths, *, adapter):
+def _readable_paths(
+    filepaths: list[str], *, adapter: MultimodalAdapter
+) -> Generator[str, None, None]:
     """
     Returns a generator of filepaths in the given iterable that can be read by
     the given adapter.
@@ -38,7 +44,9 @@ def _readable_paths(filepaths, *, adapter):
             yield filepath
 
 
-def _get_scene_inventories(filepaths, *, adapter):
+def _get_scene_inventories(
+    filepaths: list[str], *, adapter: MultimodalAdapter
+) -> list[SceneInventory]:
     """
     Reads the given scene files using the given adapter class, and returns
     a list of scene inventories.

--- a/fiftyone/multimodal/ingest/__init__.py
+++ b/fiftyone/multimodal/ingest/__init__.py
@@ -11,8 +11,9 @@ import os
 from typing import Generator
 
 import fiftyone as fo
-from fiftyone.core import storage
+from fiftyone.core import media, storage
 from fiftyone.multimodal.adapters import MultimodalAdapter
+from fiftyone.multimodal.db.mongo import MongoAdapter
 from fiftyone.multimodal.schemas.v1 import SceneInventory
 
 
@@ -67,4 +68,30 @@ def _get_scene_inventories(
         return list(executor.map(adapter.get_scene_inventory, paths))
 
 
-__all__ = ["_get_scene_inventories"]
+def ingest_filepaths(
+    dataset: fo.Dataset, filepaths: list[str], *, adapter, manifest
+) -> None:
+    """
+    Runs the multimodal ingestion pipeline on the given dataset.
+
+    Args:
+        dataset: a :class:`fiftyone.core.dataset.Dataset` to ingest
+    """
+    inventories = _get_scene_inventories(filepaths, adapter=adapter)
+    sample_and_inventory_pairs = [
+        (
+            fo.Sample(
+                # TODO the actual mapping of inventory to filepath should be
+                # derived from the manifest
+                filepath=inventory.scene_id,
+                media_type=media.MULTIMODAL,
+            ),
+            inventory,
+        )
+        for inventory in inventories
+    ]
+    MongoAdapter.write_scene_inventories(dataset, sample_and_inventory_pairs)
+    dataset.save()
+
+
+__all__ = ["_get_scene_inventories", "ingest_filepaths"]

--- a/fiftyone/multimodal/ingest/__init__.py
+++ b/fiftyone/multimodal/ingest/__init__.py
@@ -10,6 +10,8 @@ import fiftyone as fo
 from .read import _get_scene_inventories
 from fiftyone.multimodal.db.mongo import MongoAdapter
 
+__all__ = ["ingest_files"]
+
 
 def ingest_files(
     dataset: fo.Dataset, filepaths: list[str], *, adapter, manifest
@@ -43,6 +45,3 @@ def ingest_files(
     ]
     MongoAdapter.write_scene_inventories(dataset, sample_and_inventory_pairs)
     dataset.save()
-
-
-__all__ = ["_get_scene_inventories", "ingest_files"]

--- a/fiftyone/multimodal/ingest/read.py
+++ b/fiftyone/multimodal/ingest/read.py
@@ -1,0 +1,64 @@
+"""
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+import os
+from typing import Generator
+
+from fiftyone.core import storage
+from fiftyone.multimodal.adapters import MultimodalAdapter
+from fiftyone.multimodal.schemas.v1 import SceneInventory
+
+
+def _readable_paths(
+    filepaths: list[str], *, adapter: MultimodalAdapter
+) -> Generator[str, None, None]:
+    """
+    Returns a generator of filepaths in the given iterable that can be read by
+    the given adapter.
+
+    Args:
+        filepaths: an iterable of strings representing file paths or directory
+            locations to crawl
+        adapter: a subclass of :class:`MultimodalAdapter` that determines
+            whether a given file can be read
+
+    Returns:
+        a generator of strings representing the filepaths in the given iterable
+        that can be read by the given adapter
+    """
+    for filepath in filepaths:
+        if storage.isdir(filepath):
+            for path in storage.list_files(
+                filepath, abs_paths=True, recursive=True
+            ):
+                if adapter.can_read(path):
+                    yield path
+        elif storage.exists(filepath) and adapter.can_read(filepath):
+            yield filepath
+
+
+def _get_scene_inventories(
+    filepaths: list[str], *, adapter: MultimodalAdapter
+) -> list[SceneInventory]:
+    """
+    Reads the given scene files using the given adapter class, and returns
+    a list of scene inventories.
+
+    Args:
+        filepaths: an iterable of strings representing the locations of the
+            scene files to ingest
+        adapter: a subclass of
+            :class:`fiftyone.multimodal.adapters.MultimodalAdapter` that
+            determines how the given sources are ingested
+
+    Returns:
+        a list of :class:`fiftyone.multimodal.SceneInventory` instances
+    """
+    paths = list(_readable_paths(filepaths, adapter=adapter))
+    max_workers = max(1, min(8, (os.cpu_count() or 1) + 4, len(paths)))
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        return list(executor.map(adapter.get_scene_inventory, paths))

--- a/tests/unittests/multimodal/ingest/ingest_tests.py
+++ b/tests/unittests/multimodal/ingest/ingest_tests.py
@@ -4,6 +4,7 @@
 |
 """
 
+from pathlib import Path
 from unittest.mock import Mock, call, patch
 
 import pytest
@@ -162,9 +163,9 @@ class TestIngestFilepaths:
         assert len(sample_inventory_pairs) == 2
 
         sample1 = sample_inventory_pairs[0][0]
-        assert sample1.filepath.endswith("/scene 1")
+        assert Path(sample1.filepath).name == "scene 1"
         assert sample1.media_type == fo.core.media.MULTIMODAL
 
         sample2 = sample_inventory_pairs[1][0]
-        assert sample2.filepath.endswith("/scene 2")
+        assert Path(sample2.filepath).name == "scene 2"
         assert sample2.media_type == fo.core.media.MULTIMODAL

--- a/tests/unittests/multimodal/ingest/ingest_tests.py
+++ b/tests/unittests/multimodal/ingest/ingest_tests.py
@@ -150,7 +150,7 @@ class TestIngestFilepaths:
                 manifest=None,
             )
 
-        mock_get_inventories.assert_called_with(
+        mock_get_inventories.assert_called_once_with(
             ["/some/path", "/another/path"], adapter=adapter
         )
         mock_write.assert_called_once()

--- a/tests/unittests/multimodal/ingest/ingest_tests.py
+++ b/tests/unittests/multimodal/ingest/ingest_tests.py
@@ -162,9 +162,9 @@ class TestIngestFilepaths:
         assert len(sample_inventory_pairs) == 2
 
         sample1 = sample_inventory_pairs[0][0]
-        assert sample1.filepath.endswith("scene 1")
+        assert sample1.filepath.endswith("/scene 1")
         assert sample1.media_type == fo.core.media.MULTIMODAL
 
         sample2 = sample_inventory_pairs[1][0]
-        assert sample2.filepath.endswith("scene 2")
+        assert sample2.filepath.endswith("/scene 2")
         assert sample2.media_type == fo.core.media.MULTIMODAL

--- a/tests/unittests/multimodal/ingest/ingest_tests.py
+++ b/tests/unittests/multimodal/ingest/ingest_tests.py
@@ -158,13 +158,16 @@ class TestIngestFilepaths:
         mock_write.assert_called_once()
         dataset.save.assert_called_once()
 
-        args = mock_write.mock_calls[0][1]
-        assert args[0] == dataset
+        write_args, _ = mock_write.call_args
+        assert write_args[0] is dataset
 
-        sample1 = args[1][0][0]
+        sample_inventory_pairs = write_args[1]
+        assert len(sample_inventory_pairs) == 2
+
+        sample1 = sample_inventory_pairs[0][0]
         assert sample1.filepath.endswith("scene 1")
         assert sample1.media_type == fo.core.media.MULTIMODAL
 
-        sample2 = args[1][1][0]
+        sample2 = sample_inventory_pairs[1][0]
         assert sample2.filepath.endswith("scene 2")
         assert sample2.media_type == fo.core.media.MULTIMODAL

--- a/tests/unittests/multimodal/ingest/ingest_tests.py
+++ b/tests/unittests/multimodal/ingest/ingest_tests.py
@@ -9,7 +9,8 @@ from unittest.mock import Mock, call, patch
 import pytest
 
 import fiftyone as fo
-from fiftyone.multimodal import ingest
+from fiftyone.multimodal.ingest import ingest_files
+from fiftyone.multimodal.ingest.read import _get_scene_inventories
 
 
 @pytest.fixture(name="adapter")
@@ -26,7 +27,7 @@ def mock_storage():
 class TestGetSceneInventories:
     def test_empty_input(self, adapter):
         ###
-        result = ingest._get_scene_inventories([], adapter=adapter)
+        result = _get_scene_inventories([], adapter=adapter)
         ###
 
         assert result == []
@@ -39,9 +40,7 @@ class TestGetSceneInventories:
         adapter.get_scene_inventory.return_value = "scene inventory"
 
         ###
-        result = ingest._get_scene_inventories(
-            ["/path/to/file"], adapter=adapter
-        )
+        result = _get_scene_inventories(["/path/to/file"], adapter=adapter)
         ###
 
         assert result == ["scene inventory"]
@@ -54,9 +53,7 @@ class TestGetSceneInventories:
         adapter.get_scene_inventory.return_value = "scene inventory"
 
         ###
-        result = ingest._get_scene_inventories(
-            ["/path/to/file"], adapter=adapter
-        )
+        result = _get_scene_inventories(["/path/to/file"], adapter=adapter)
         ###
 
         assert result == []
@@ -73,7 +70,7 @@ class TestGetSceneInventories:
         adapter.get_scene_inventory.return_value = "scene inventory"
 
         ###
-        result = ingest._get_scene_inventories(
+        result = _get_scene_inventories(
             ["/path/to/directory"], adapter=adapter
         )
         ###
@@ -99,7 +96,7 @@ class TestGetSceneInventories:
         adapter.get_scene_inventory.return_value = "scene inventory"
 
         ###
-        result = ingest._get_scene_inventories(
+        result = _get_scene_inventories(
             ["/path/to/directory"], adapter=adapter
         )
         ###
@@ -120,7 +117,7 @@ class TestGetSceneInventories:
         adapter.get_scene_inventory.return_value = "scene inventory"
 
         ###
-        result = ingest._get_scene_inventories(
+        result = _get_scene_inventories(
             ["/path/to/directory"], adapter=adapter
         )
         ###
@@ -145,7 +142,7 @@ class TestIngestFilepaths:
         ) as mock_get_inventories, patch(
             "fiftyone.multimodal.db.mongo.MongoAdapter.write_scene_inventories"
         ) as mock_write:
-            ingest.ingest_files(
+            ingest_files(
                 dataset,
                 ["/some/path", "/another/path"],
                 adapter=adapter,

--- a/tests/unittests/multimodal/ingest/ingest_tests.py
+++ b/tests/unittests/multimodal/ingest/ingest_tests.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, call, patch
 
 import pytest
 
+import fiftyone as fo
 from fiftyone.multimodal import ingest
 
 
@@ -131,3 +132,52 @@ class TestGetSceneInventories:
         adapter.get_scene_inventory.assert_has_calls(
             [call("/path/to/file"), call("/path/to/another_file")]
         )
+
+
+class SampleMatcher:
+    def __init__(self, expected_filepath, expected_media_type):
+        self.expected_filepath = expected_filepath
+        self.expected_media_type = expected_media_type
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, fo.Sample)
+            and other.filepath == self.expected_filepath
+            and other.media_type == self.expected_media_type
+        )
+
+
+class TestIngestFilepaths:
+    def test_success(self, adapter):
+        dataset = Mock()
+        adapter = Mock()
+
+        with patch(
+            "fiftyone.multimodal.ingest._get_scene_inventories",
+            return_value=[Mock(scene_id="scene 1"), Mock(scene_id="scene 2")],
+        ) as mock_get_inventories, patch(
+            "fiftyone.multimodal.db.mongo.MongoAdapter.write_scene_inventories"
+        ) as mock_write:
+            ingest.ingest_files(
+                dataset,
+                ["/some/path", "/another/path"],
+                adapter=adapter,
+                manifest=None,
+            )
+
+        mock_get_inventories.assert_called_with(
+            ["/some/path", "/another/path"], adapter=adapter
+        )
+        mock_write.assert_called_once()
+        dataset.save.assert_called_once()
+
+        args = mock_write.mock_calls[0][1]
+        assert args[0] == dataset
+
+        sample1 = args[1][0][0]
+        assert sample1.filepath.endswith("scene 1")
+        assert sample1.media_type == fo.core.media.MULTIMODAL
+
+        sample2 = args[1][1][0]
+        assert sample2.filepath.endswith("scene 2")
+        assert sample2.media_type == fo.core.media.MULTIMODAL

--- a/tests/unittests/multimodal/ingest/ingest_tests.py
+++ b/tests/unittests/multimodal/ingest/ingest_tests.py
@@ -18,7 +18,7 @@ def mock_adapter():
 
 @pytest.fixture(name="storage")
 def mock_storage():
-    with patch("fiftyone.multimodal.ingest.storage") as mock:
+    with patch("fiftyone.multimodal.ingest.read.storage") as mock:
         yield mock
 
 

--- a/tests/unittests/multimodal/ingest/ingest_tests.py
+++ b/tests/unittests/multimodal/ingest/ingest_tests.py
@@ -134,21 +134,8 @@ class TestGetSceneInventories:
         )
 
 
-class SampleMatcher:
-    def __init__(self, expected_filepath, expected_media_type):
-        self.expected_filepath = expected_filepath
-        self.expected_media_type = expected_media_type
-
-    def __eq__(self, other):
-        return (
-            isinstance(other, fo.Sample)
-            and other.filepath == self.expected_filepath
-            and other.media_type == self.expected_media_type
-        )
-
-
 class TestIngestFilepaths:
-    def test_success(self, adapter):
+    def test_success(self):
         dataset = Mock()
         adapter = Mock()
 


### PR DESCRIPTION
## 🔗 Related Issues

[FOEPD-3738](https://voxel51.atlassian.net/browse/FOEPD-3738)

## 📋 What changes are proposed in this pull request?

Adds a function `fiftyone.multimodal.ingest.ingest_files` that serves as the SDK entrypoint for ingesting multimodal files. Given a dataset and a list of file paths, it parses multimodal files (currently only MCAP files), creates samples for each scene inventory (currently uses the scene inventory's scene ID as the sample's filepath), and writes the samples to the dataset.

## 🧪 How is this patch tested? If it is not, please explain why.

Unit tests.

Also tested manually with a script like this:
```python
from fiftyone.multimodal import ingest
from fiftyone.multimodal.adapters.mcap import McapAdapter

name = "my_dataset"
paths = [...]

dataset = fo.load_dataset(name) if fo.dataset_exists(name) else fo.Dataset(name, persistent=True)
ingest.ingest_files(dataset, paths, adapter=McapAdapter, manifest=None)
```

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Adds a function `fiftyone.multimodal.ingest.ingest_files` that serves as the SDK entrypoint for ingesting multimodal files. Given a dataset and a list of file paths, it parses multimodal files (currently only MCAP files), creates samples for each scene inventory (currently uses the scene inventory's scene ID as the sample's filepath), and writes the samples to the dataset.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [x] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

[FOEPD-3738]: https://voxel51.atlassian.net/browse/FOEPD-3738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a high-level multimodal ingestion API to import files into datasets, create samples, attach per-scene inventories, and persist changes (accepts an optional manifest parameter).

* **Refactor**
  * Reorganized ingestion internals and moved path-reading and inventory fetching into a concurrent processing helper for improved performance.

* **Tests**
  * Added unit tests covering the ingestion flow and verifying created sample properties and persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7545)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->