### PR TITLE
Docs/plugin skills name resolution docs

### DIFF
--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -37,11 +37,13 @@ FiftyOne plugins can be written in Python or JavaScript (JS), or a combination
 of both.
 
 Python plugins are built using the `fiftyone` package, pip packages, and your
-own Python. They can consist of panels and operators.
+own Python. They can consist of panels and operators. Plugins can also bundle
+skills via a `skills/` directory and `fiftyone.yml` registration.
 
 JS plugins are built using the `@fiftyone` TypeScript packages, npm packages,
 and your own TypeScript. They can consist of panels, operators, and custom
-components.
+components. Plugins can also bundle skills via a `skills/` directory and
+`fiftyone.yml` registration.
 
 .. _plugins-design-panels:
 

--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -37,13 +37,11 @@ FiftyOne plugins can be written in Python or JavaScript (JS), or a combination
 of both.
 
 Python plugins are built using the `fiftyone` package, pip packages, and your
-own Python. They can consist of panels and operators. Plugins can also bundle
-skills via a `skills/` directory and `fiftyone.yml` registration.
+own Python. They can consist of panels, operators, and skills.
 
 JS plugins are built using the `@fiftyone` TypeScript packages, npm packages,
-and your own TypeScript. They can consist of panels, operators, and custom
-components. Plugins can also bundle skills via a `skills/` directory and
-`fiftyone.yml` registration.
+and your own TypeScript. They can consist of panels, operators, skills, and custom
+components.
 
 .. _plugins-design-panels:
 
@@ -110,7 +108,7 @@ agent follows to complete the workflow autonomously.
 
 .. note::
 
-    Jump to :ref:`this section <developing-skills-from-plugins>` for more
+    Jump to :ref:`this section <developing-plugins-skills>` for more
     information about developing skills.
 
 .. _plugins-design-components:
@@ -272,7 +270,7 @@ The following fields are available:
     +------------------------------+-----------+-----------------------------------------------------------------------------+
     | `panels`                     |           | A list of panel names registered by the plugin, if any                      |
     +------------------------------+-----------+-----------------------------------------------------------------------------+
-    | `skills`                     |           | A list of :ref:`skill <developing-skills-from-plugins>` names registered by |
+    | `skills`                     |           | A list of :ref:`skill <developing-plugins-skills>` names registered by |
     |                              |           | the plugin, if any                                                          |
     +------------------------------+-----------+-----------------------------------------------------------------------------+
     | `secrets`                    |           | A list of secret keys that may be used by the plugin, if any                |
@@ -3175,7 +3173,7 @@ subsequent sections.
                 allow_multiple=False,
 
                 # Whether the panel should be available in the grid, modal, or both
-                # Possible values: "grid", "modal", "grid modal"       
+                # Possible values: "grid", "modal", "grid modal"
                 surfaces="grid",  # default = "grid"
 
                 # Markdown-formatted text that describes the panel. This is
@@ -3409,7 +3407,7 @@ subsequent sections.
             }
             ctx.panel.set_state("event", "on_change_extended_selection")
             ctx.panel.set_data("event_data", event)
-        
+
         def on_change_group_slice(self, ctx):
             """Implement this method to set panel state/data when the current
             group slice changes.
@@ -4111,7 +4109,7 @@ On the JavaScript side, register a component whose ``name`` matches the
         type: PluginComponentType.Component,
         activator: () => true,
     });
-    
+
 .. note::
 
     Check out the `Hybrid Panel Plugin <https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/hybrid-panel>`_
@@ -4139,7 +4137,7 @@ and programmatically modify the current state.
 
 .. warning::
 
-    The return value of all panel events—including builtin events (such as 
+    The return value of all panel events—including builtin events (such as
     `on_load`, `on_unload`, `on_change_ctx`, etc.) and custom events (such as
     `on_change_brain_key`, `on_click_start`, etc.)—must be JSON-serializable.
 
@@ -4735,7 +4733,7 @@ you to reveal all of its available methods during development:
         ctx.
         ...
 
-.. _developing-skills-from-plugins:
+.. _developing-plugins-skills:
 
 Developing skills
 _________________
@@ -4770,13 +4768,13 @@ This section describes how to develop JS-specific plugin components.
 Getting Started
 ---------------
 
-To start building your own JS plugin, refer to the 
-`hello-world-plugin-js <https://github.com/voxel51/hello-world-plugin-js>`_ 
-repository. This repo serves as a starting point, providing examples of a build 
+To start building your own JS plugin, refer to the
+`hello-world-plugin-js <https://github.com/voxel51/hello-world-plugin-js>`_
+repository. This repo serves as a starting point, providing examples of a build
 process, a JS panel, and a JS operator.
 
-The `fiftyone-js-plugin-build <https://github.com/voxel51/fiftyone-js-plugin-build>`_ 
-package offers a utility for configuring `vite <https://vite.dev>`_ to build your 
+The `fiftyone-js-plugin-build <https://github.com/voxel51/fiftyone-js-plugin-build>`_
+package offers a utility for configuring `vite <https://vite.dev>`_ to build your
 JS plugin bundle.
 
 Component types

--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -17,7 +17,7 @@ This page describes how to write your own FiftyOne plugins.
 Design overview
 _______________
 
-Plugins are composed of one or more panels, operators, and components.
+Plugins are composed of one or more panels, operators, skills, and components.
 
 Together these building blocks enable you to build full-featured interactive
 data applications that tailor FiftyOne to your specific use case and workflow.
@@ -95,6 +95,21 @@ plugin use.
 
     Jump to :ref:`this section <developing-operators>` for more information
     about developing operators.
+
+.. _plugins-design-skills:
+
+Skills
+------
+
+Skills are Markdown files that teach AI agents how to perform complex
+FiftyOne workflows using natural language. Each skill describes a task that
+an agent can be asked to perform, providing step-by-step guidance that the
+agent follows to complete the workflow autonomously.
+
+.. note::
+
+    Jump to :ref:`this section <developing-skills-from-plugins>` for more
+    information about developing skills.
 
 .. _plugins-design-components:
 
@@ -254,6 +269,9 @@ The following fields are available:
     | `operators`                  |           | A list of operator names registered by the plugin, if any                   |
     +------------------------------+-----------+-----------------------------------------------------------------------------+
     | `panels`                     |           | A list of panel names registered by the plugin, if any                      |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `skills`                     |           | A list of :ref:`skill <developing-skills-from-plugins>` names registered by |
+    |                              |           | the plugin, if any                                                          |
     +------------------------------+-----------+-----------------------------------------------------------------------------+
     | `secrets`                    |           | A list of secret keys that may be used by the plugin, if any                |
     +------------------------------+-----------+-----------------------------------------------------------------------------+
@@ -4714,6 +4732,31 @@ you to reveal all of its available methods during development:
         # Reveals the remaining methods available to ctx
         ctx.
         ...
+
+.. _developing-skills-from-plugins:
+
+Developing skills
+_________________
+
+Skills are Markdown files that teach AI agents how to perform complex
+FiftyOne workflows using natural language. A skill describes a task that
+an agent can be asked to perform — such as importing a dataset, running
+inference, or finding duplicates — and provides step-by-step guidance
+that the agent follows to complete the workflow autonomously.
+
+You can bundle skills inside any FiftyOne plugin by placing them in a
+`skills/` subdirectory and declaring their names in your `fiftyone.yml`:
+
+.. code-block:: yaml
+
+    skills:
+      - my-skill-name
+
+.. note::
+
+    See :ref:`Developing skills <developing-skills-authoring>` for a full
+    guide on authoring skills, including the required file structure, YAML
+    frontmatter fields, and how to contribute skills to the community.
 
 .. _developing-js-plugins:
 

--- a/fiftyone/plugins/skills.py
+++ b/fiftyone/plugins/skills.py
@@ -118,27 +118,34 @@ def list_skills(enabled=True, plugin=None, category=None):
 
 
 def _iter_plugin_skills(plugin_definition):
+    declared = set(plugin_definition.skills)
+    if not declared:
+        return
+
     plugin_dir = os.path.realpath(plugin_definition.directory)
-    for rel_path in plugin_definition.skills:
-        skill_path = os.path.realpath(os.path.join(plugin_dir, rel_path))
-        try:
-            outside = (
-                os.path.commonpath([plugin_dir, skill_path]) != plugin_dir
+    skills_dir = os.path.join(plugin_dir, "skills")
+    if not os.path.isdir(skills_dir):
+        return
+
+    skill_map = {}
+    with os.scandir(skills_dir) as it:
+        for entry in it:
+            if not entry.is_dir():
+                continue
+            skill_path = os.path.join(entry.path, "SKILL.md")
+            if not os.path.isfile(skill_path):
+                continue
+            metadata = _parse_skill_frontmatter(skill_path)
+            skill_map[metadata.get("name", entry.name)] = (
+                skill_path,
+                metadata,
             )
-        except ValueError:
-            outside = True
 
-        if outside:
-            logger.warning(
-                "Ignoring skill path outside plugin directory: %s", rel_path
-            )
+    for name in declared:
+        if name not in skill_map:
+            logger.debug("Skill '%s' declared but not found in skills/", name)
             continue
-
-        if not os.path.isfile(skill_path):
-            logger.debug(f"Skill file not found: '{skill_path}'")
-            continue
-
-        metadata = _parse_skill_frontmatter(skill_path)
+        skill_path, metadata = skill_map[name]
         yield SkillDefinition(skill_path, metadata, plugin_definition.name)
 
 


### PR DESCRIPTION
## 🔗 Related Issues

Addresses reviewer feedback from @brimoor, [PR](https://github.com/voxel51/fiftyone/pull/7509#pullrequestreview-4282255195) 
## 📋 What changes are proposed in this pull request?

This PR updates plugin skill registration and documentation to make skills a first-class plugin building block alongside panels, operators, and components.

* `_iter_plugin_skills()` now resolves skills by `name` instead of relative file path
* The loader scans the plugin `skills/` directory, parses `SKILL.md` frontmatter, and matches against the names declared in `fiftyone.yml`
* Makes skill registration consistent with `operators:` and `panels:`
* Added skills to the plugin architecture overview -> Pending to get a formal design from design team.
Draft:
<img width="738" height="448" alt="Screenshot 2026-05-14 at 4 05 54 PM" src="https://github.com/user-attachments/assets/a42e9089-7b16-4ce1-a36a-032820e255f9" />


* Added a dedicated **Skills** subsection
* Added a `skills:` row to the `fiftyone.yml` reference table
* Added a new **Developing skills** section with links to the authoring guide

## 🧪 How is this patch tested? If it is not, please explain why.

* Manually tested skill discovery with multiple plugin skills
* Built and reviewed docs locally

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [X] No. You can skip the rest of this section.

### What areas of FiftyOne does this PR affect?

* [ ] App: FiftyOne application changes
* [ ] Build: Build and test infrastructure changes
* [x] Core: Core `fiftyone` Python library changes
* [x] Documentation: FiftyOne documentation changes
* [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugins can bundle and expose skills—Markdown-guided agent workflows—discoverable in a plugin's skills/ directory and registered by name in fiftyone.yml.

* **Documentation**
  * Added a "Developing skills" section and updated plugin docs to show how to author, bundle, and declare skills in fiftyone.yml.
  * Clarified panel development guidance and minor formatting fixes.

* **Bug Fixes / Improvements**
  * Improved skill discovery to resolve declared skill names for more reliable plugin behavior.
* **Behavior Change**
  * Panel event handlers must return JSON-serializable values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7552?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->