### PR TITLE
fix compute_embeddings e2e test

### DIFF
--- a/e2e-pw/src/oss/specs/MISSING-embeddings.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-embeddings.spec.ts
@@ -33,40 +33,47 @@ test.beforeAll(async ({ fiftyoneLoader, foWebServer }, testInfo) => {
   await foWebServer.startWebServer();
   await fiftyoneLoader.executePythonCode(
     `
+
+      # TF_INTRA/INTER_OP=1 forces single-threaded init, which sidesteps the
+      # Abseil mutex deadlock seen.
+      import os
+      os.environ["TF_INTRA_OP_PARALLELISM_THREADS"] = "1"
+      os.environ["TF_INTER_OP_PARALLELISM_THREADS"] = "1"
+
       import sys, types
+
+      # Block umap.parametric_umap from triggering \`import tensorflow\` during
+      # umap/__init__.py load (causes an Abseil mutex deadlock on macOS during
+      # TF's C++ static init). compute_visualization only uses umap.UMAP, never
+      # ParametricUMAP, so a stub is fine.
+      if "umap.parametric_umap" not in sys.modules:
+          _stub = types.ModuleType("umap.parametric_umap")
+
+          class _ParametricUMAPDisabled:
+              def __init__(self, *a, **kw):
+                  raise NotImplementedError(
+                      "ParametricUMAP disabled to avoid TensorFlow deadlock"
+                  )
+
+          _stub.ParametricUMAP = _ParametricUMAPDisabled
+          sys.modules["umap.parametric_umap"] = _stub
+
       import fiftyone.core.utils as fou
+      umap = fou.lazy_import("umap.umap_")
+      import fiftyone as fo
+      import fiftyone.zoo as foz
+      import fiftyone.brain as fob
+      import numpy as np
+      np.random.seed(42)
 
-        # Block umap.parametric_umap from triggering \`import tensorflow\` during
-        # umap/__init__.py load (causes an Abseil mutex deadlock on macOS during
-        # TF's C++ static init). compute_visualization only uses umap.UMAP, never
-        # ParametricUMAP, so a stub is fine.
-        if "umap.parametric_umap" not in sys.modules:
-            _stub = types.ModuleType("umap.parametric_umap")
-        
-            class _ParametricUMAPDisabled:
-                def __init__(self, *a, **kw):
-                    raise NotImplementedError(
-                        "ParametricUMAP disabled to avoid TensorFlow deadlock"
-                    )
-        
-            _stub.ParametricUMAP = _ParametricUMAPDisabled
-            sys.modules["umap.parametric_umap"] = _stub
-        
-        umap = fou.lazy_import("umap.umap_")
-        import fiftyone as fo
-        import fiftyone.zoo as foz
-        import fiftyone.brain as fob
-        import numpy as np
-        np.random.seed(42)
+      dataset = foz.load_zoo_dataset("quickstart", max_samples=5, dataset_name="${datasetName}")
+      dataset.persistent = True
 
-        dataset = foz.load_zoo_dataset("quickstart", max_samples=5, dataset_name="${datasetName}")
-        dataset.persistent = True
+      embeddings = np.random.random((5, 512))
+      # umap is default
+      fob.compute_visualization(dataset, brain_key="img_viz", embeddings=embeddings)
 
-        embeddings = np.random.random((5, 512))
-        # umap is default
-        fob.compute_visualization(dataset, brain_key="img_viz", embeddings=embeddings)
-
-        dataset.save()
+      dataset.save()
     `
   );
 });

--- a/e2e-pw/src/oss/specs/MISSING-embeddings.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-embeddings.spec.ts
@@ -33,6 +33,25 @@ test.beforeAll(async ({ fiftyoneLoader, foWebServer }, testInfo) => {
   await foWebServer.startWebServer();
   await fiftyoneLoader.executePythonCode(
     `
+      import sys, types
+
+        # Block umap.parametric_umap from triggering \`import tensorflow\` during
+        # umap/__init__.py load (causes an Abseil mutex deadlock on macOS during
+        # TF's C++ static init). compute_visualization only uses umap.UMAP, never
+        # ParametricUMAP, so a stub is fine.
+        if "umap.parametric_umap" not in sys.modules:
+            _stub = types.ModuleType("umap.parametric_umap")
+        
+            class _ParametricUMAPDisabled:
+                def __init__(self, *a, **kw):
+                    raise NotImplementedError(
+                        "ParametricUMAP disabled to avoid TensorFlow deadlock"
+                    )
+        
+            _stub.ParametricUMAP = _ParametricUMAPDisabled
+            sys.modules["umap.parametric_umap"] = _stub
+        
+        umap = fou.lazy_import("umap.umap_")
         import fiftyone as fo
         import fiftyone.zoo as foz
         import fiftyone.brain as fob
@@ -44,7 +63,7 @@ test.beforeAll(async ({ fiftyoneLoader, foWebServer }, testInfo) => {
 
         embeddings = np.random.random((5, 512))
         #
-        # fob.compute_visualization(dataset, brain_key="img_viz", embeddings=embeddings)
+        fob.compute_visualization(dataset, brain_key="img_viz", embeddings=embeddings)
         #
         # TODO: revert to the line above (i.e. no method="pca").
         # fob.compute_visualization segfaults on # CI's Linux runner.

--- a/e2e-pw/src/oss/specs/MISSING-embeddings.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-embeddings.spec.ts
@@ -34,6 +34,7 @@ test.beforeAll(async ({ fiftyoneLoader, foWebServer }, testInfo) => {
   await fiftyoneLoader.executePythonCode(
     `
       import sys, types
+      import fiftyone.core.utils as fou
 
         # Block umap.parametric_umap from triggering \`import tensorflow\` during
         # umap/__init__.py load (causes an Abseil mutex deadlock on macOS during
@@ -62,16 +63,8 @@ test.beforeAll(async ({ fiftyoneLoader, foWebServer }, testInfo) => {
         dataset.persistent = True
 
         embeddings = np.random.random((5, 512))
-        #
+        # umap is default
         fob.compute_visualization(dataset, brain_key="img_viz", embeddings=embeddings)
-        #
-        # TODO: revert to the line above (i.e. no method="pca").
-        # fob.compute_visualization segfaults on # CI's Linux runner.
-        # TensorFlow loads during import and crashes the Python process.
-        # Suspected to coincide with the brain version bump in #7455.
-        fob.compute_visualization(
-            dataset, brain_key="img_viz", embeddings=embeddings, method="pca"
-        )
 
         dataset.save()
     `


### PR DESCRIPTION
## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

Stub umap.parametric_umap and set TF single-threaded env vars in the embeddings spec's Python loader to avoid the Abseil static-init deadlock 

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by preventing unintended heavy ML library initialization during embedded Python execution, reducing flakiness from optional native dependencies.
  * Expanded smoke-test coverage to exercise the default UMAP-based image visualization path by invoking the standard visualization compute step, ensuring output generation for the default workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7554)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->