### PR TITLE
[HA] Add default value setting for boolean attributes

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useCreate.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useCreate.ts
@@ -200,10 +200,10 @@ export function buildNewLabelData(
 
   if (type === POLYLINE) {
     return {
-      ...data,
-      points: options?.origin ? [[options.origin]] : [],
       closed: false,
       filled: false,
+      ...data,
+      points: options?.origin ? [[options.origin]] : [],
     };
   }
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/AttributeFormContent.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/AttributeFormContent.tsx
@@ -17,7 +17,11 @@ import {
   TextVariant,
   Toggle,
 } from "@voxel51/voodo";
-import { ATTRIBUTE_TYPE_LABELS, ATTRIBUTE_TYPE_OPTIONS } from "../../constants";
+import {
+  ATTRIBUTE_TYPE_LABELS,
+  ATTRIBUTE_TYPE_OPTIONS,
+  BOOL_DEFAULT_OPTIONS,
+} from "../../constants";
 import { type AttributeFormData } from "../../utils";
 import ComponentTypeButton from "./ComponentTypeButton";
 import ListDefaultInput from "./ListDefaultInput";
@@ -259,6 +263,19 @@ const AttributeFormContent = ({
                     isNumeric={isNumericType}
                     error={defaultError}
                     readOnly={isFromOntology}
+                  />
+                ) : formState.type === "bool" ? (
+                  <Select
+                    exclusive
+                    portal
+                    value={formState.default}
+                    onChange={(value) => {
+                      if (typeof value === "string") {
+                        handleDefaultChange(value);
+                      }
+                    }}
+                    options={BOOL_DEFAULT_OPTIONS}
+                    disabled={isFromOntology}
                   />
                 ) : (
                   <Input

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/constants.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/constants.ts
@@ -216,7 +216,14 @@ export const COMPONENT_OPTIONS: Record<
 export const NUMERIC_TYPES = ["int", "float", "list<int>", "list<float>"];
 
 // Types that don't need/support a default value
-export const NO_DEFAULT_TYPES = ["bool", "date", "datetime", "dict", "id"];
+export const NO_DEFAULT_TYPES = ["date", "datetime", "dict", "id"];
+
+// Options for the bool default Select (empty id = no default)
+export const BOOL_DEFAULT_OPTIONS = [
+  { id: "", data: { label: "(none)" } },
+  { id: "true", data: { label: "True" } },
+  { id: "false", data: { label: "False" } },
+];
 
 // List types
 export const LIST_TYPES = ["list<str>", "list<int>", "list<float>"];

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/utils.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/utils.ts
@@ -77,7 +77,7 @@ export interface AttributeConfig {
   component?: string;
   values?: (string | number)[];
   range?: [number, number];
-  default?: string | number | (string | number)[]; // Array for list types
+  default?: string | number | boolean | (string | number)[]; // Array for list types
   read_only?: boolean;
   when?: AttributeCondition;
   _source?: string;
@@ -308,7 +308,7 @@ export const toFormData = (config: AttributeConfig): AttributeFormData => {
   if (config.default !== undefined) {
     if (Array.isArray(config.default)) {
       listDefault = config.default;
-    } else if (isListType) {
+    } else if (isListType && typeof config.default !== "boolean") {
       // Single value for list type - wrap in array
       listDefault = [config.default];
     } else {
@@ -360,12 +360,16 @@ export const toAttributeConfig = (data: AttributeFormData): AttributeConfig => {
   }
 
   // Convert default to appropriate type
-  let defaultValue: string | number | (string | number)[] | undefined;
+  let defaultValue: string | number | boolean | (string | number)[] | undefined;
   if (isListType) {
     // For list types, use listDefault array
     if (data.listDefault && data.listDefault.length > 0) {
       defaultValue = data.listDefault;
     }
+  } else if (data.type === "bool") {
+    // For bool, map the tri-state form value to a real boolean (or undefined)
+    if (data.default === "true") defaultValue = true;
+    else if (data.default === "false") defaultValue = false;
   } else if (data.default) {
     // For non-list types, convert to number if numeric
     defaultValue = isNumeric ? parseFloat(data.default) : data.default;


### PR DESCRIPTION
## 🔗 Related Issues

FOEPD-3817

Polylines should be able to set `filled` and `closed` attribute value prior to annotation. 

## 📋 What changes are proposed in this pull request?

- Boolean attributes in schema forms now support setting default values (True, False, or None) via a dedicated dropdown selector.
- Boolean defaults are now properly stored and managed in schema configuration.

## 🧪 How is this patch tested? If it is not, please explain why.

1. go to schema manager, add default value for `closed` and `filled` attributes on polyline type labels
2. create new label, it should follow the default value

https://github.com/user-attachments/assets/3aa51c48-e0ac-43b3-8e45-c6b2912b12ae


## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Boolean attributes in schema forms now support setting default values (True, False, or None) via a dedicated dropdown selector.
  * Boolean defaults are now properly stored and managed in schema configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7555)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->