### PR TITLE
Docs: add section for custom weights endpoint

### DIFF
--- a/docs/source/enterprise/app.rst
+++ b/docs/source/enterprise/app.rst
@@ -228,7 +228,7 @@ the modal to confirm this action.
 
 .. note::
 
-   The Enterprise App ships with AI-assisted mask segmentation for
+   The FiftyOne Enterprise App ships with AI-assisted mask segmentation for
    annotation workflows. The feature works out of the box with no
    configuration. Deployments that prefer to serve the model weights from
    their own infrastructure can do so via the

--- a/docs/source/enterprise/app.rst
+++ b/docs/source/enterprise/app.rst
@@ -225,3 +225,11 @@ the modal to confirm this action.
 .. warning::
 
    Deleting a dataset is permanent!
+
+.. note::
+
+   The Enterprise App ships with AI-assisted mask segmentation for
+   annotation workflows. The feature works out of the box with no
+   configuration. Deployments that prefer to serve the model weights from
+   their own infrastructure can do so via the
+   :ref:`AI model weights <enterprise-ai-model-weights>` setting.

--- a/docs/source/enterprise/installation.rst
+++ b/docs/source/enterprise/installation.rst
@@ -700,3 +700,40 @@ default, so that local SDK usage will download credentials from the Enterprise
 server, and there is no need to configure credentials locally. To enable
 downloading of credentials to machines, set the environment variable
 `FEATURE_FLAG_ENABLE_CREDS_LOCAL_USE` to `True` in the `teams-api` container.
+
+.. _enterprise-ai-model-weights:
+
+AI Model Weights
+________________
+
+The Enterprise App ships with AI-assisted mask segmentation for annotation
+workflows. By default, the required model weights are served from Voxel51's
+CDN and no configuration is required.
+
+Deployments that prefer to serve the weights from their own infrastructure
+can set the optional `FIFTYONE_MODEL_WEIGHTS_BASE_SAM2` environment
+variable on the `fiftyone-app` container. The value is a base URL or
+cloud path that hosts the weights. The App appends the specific weight
+file to it at request time.
+
+The base location must host the two files that the App fetches:
+
+* `encoder.with_runtime_opt.ort`
+* `decoder.onnx`
+
+The SAM2 tiny variant is recommended for optimal user experience.
+
+.. code-block:: shell
+
+    # Private GCS bucket
+    FIFTYONE_MODEL_WEIGHTS_BASE_SAM2=gs://my-bucket/sam2
+
+    # Private S3 bucket
+    FIFTYONE_MODEL_WEIGHTS_BASE_SAM2=s3://my-bucket/sam2
+
+    # Private HTTPS endpoint
+    FIFTYONE_MODEL_WEIGHTS_BASE_SAM2=https://cdn.internal.example.com/sam2
+
+When a cloud path is used, URLs are signed automatically using the
+deployment's :ref:`cloud credentials <enterprise-cloud-credentials>`, so
+the `fiftyone-app` container must have access to the bucket.

--- a/docs/source/enterprise/installation.rst
+++ b/docs/source/enterprise/installation.rst
@@ -749,4 +749,4 @@ Then upload both files to the location referenced by
 
 When a cloud path is used, URLs are signed automatically using the
 deployment's :ref:`cloud credentials <enterprise-cloud-credentials>`, so
-the `fiftyone-app` container must have access to the bucket.
+the `fiftyone-app` container must have read access to the bucket.

--- a/docs/source/enterprise/installation.rst
+++ b/docs/source/enterprise/installation.rst
@@ -721,7 +721,20 @@ The base location must host the two files that the App fetches:
 * `encoder.with_runtime_opt.ort`
 * `decoder.onnx`
 
-The SAM2 tiny variant is recommended for optimal user experience.
+The SAM2 tiny variant is recommended for optimal user experience. The
+simplest way to populate your own location is to mirror the files Voxel51
+serves from its CDN, which are the canonical artifacts that the App is
+built against:
+
+.. code-block:: shell
+
+    curl -sSL -o encoder.with_runtime_opt.ort \
+        https://models-cdn.voxel51.com/sam2/encoder.with_runtime_opt.ort
+    curl -sSL -o decoder.onnx \
+        https://models-cdn.voxel51.com/sam2/decoder.onnx
+
+Then upload both files to the location referenced by
+`FIFTYONE_MODEL_WEIGHTS_BASE_SAM2`.
 
 .. code-block:: shell
 

--- a/docs/source/enterprise/installation.rst
+++ b/docs/source/enterprise/installation.rst
@@ -706,7 +706,7 @@ downloading of credentials to machines, set the environment variable
 AI Model Weights
 ________________
 
-The Enterprise App ships with AI-assisted mask segmentation for annotation
+The FiftyOne Enterprise App ships with AI-assisted mask segmentation for annotation
 workflows. By default, the required model weights are served from Voxel51's
 CDN and no configuration is required.
 


### PR DESCRIPTION
## 🔗 Related Issues


## 📋 What changes are proposed in this pull request?

Docs: add section for custom weights endpoint

## 🧪 How is this patch tested? If it is not, please explain why.

N/A

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

N/A (handled separately)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Danger Zone note describing the Enterprise App's built-in AI-assisted mask segmentation for annotation workflows (enabled by default).
  * Added an “AI Model Weights” guide explaining the default CDN-hosted SAM2 model weights, how to point the App to custom cloud/storage locations, recommended SAM2 variant, required model weight files (names omitted), example base paths, and access/signing considerations for cloud-hosted weights.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->