### PR TITLE
Add Miris Streams Support to Voxel51

### DIFF
--- a/app/packages/looker-3d/package.json
+++ b/app/packages/looker-3d/package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
-        "@miris-inc/three": "latest",
+        "@miris-inc/three": "0.0.8-ec1b54d",
         "@react-three/drei": "^10.7.6",
         "@react-three/fiber": "catalog:",
         "@sparkjsdev/spark": "2.1.0",

--- a/app/packages/looker-3d/package.json
+++ b/app/packages/looker-3d/package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
-        "@miris-inc/three": "0.0.8-ec1b54d",
+        "@miris-inc/three": "0.0.8-25565b3",
         "@react-three/drei": "^10.7.6",
         "@react-three/fiber": "catalog:",
         "@sparkjsdev/spark": "2.1.0",

--- a/app/packages/looker-3d/package.json
+++ b/app/packages/looker-3d/package.json
@@ -15,6 +15,7 @@
     "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
+        "@miris-inc/three": "latest",
         "@react-three/drei": "^10.7.6",
         "@react-three/fiber": "catalog:",
         "@sparkjsdev/spark": "2.1.0",

--- a/app/packages/looker-3d/package.json
+++ b/app/packages/looker-3d/package.json
@@ -15,8 +15,8 @@
     "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
-        "@miris-inc/core": "0.0.8-25565b3",
-        "@miris-inc/three": "0.0.8-25565b3",
+        "@miris-inc/core": "latest",
+        "@miris-inc/three": "latest",
         "@react-three/drei": "^10.7.6",
         "@react-three/fiber": "catalog:",
         "@sparkjsdev/spark": "2.1.0",

--- a/app/packages/looker-3d/package.json
+++ b/app/packages/looker-3d/package.json
@@ -15,6 +15,7 @@
     "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
+        "@miris-inc/core": "0.0.8-25565b3",
         "@miris-inc/three": "0.0.8-25565b3",
         "@react-three/drei": "^10.7.6",
         "@react-three/fiber": "catalog:",

--- a/app/packages/looker-3d/src/fo3d/FoScene.tsx
+++ b/app/packages/looker-3d/src/fo3d/FoScene.tsx
@@ -18,6 +18,7 @@ import { Fo3dBackground } from "./Background";
 import { useFo3dContext } from "./context";
 import { Fbx } from "./mesh/Fbx";
 import { Gltf } from "./mesh/Gltf";
+import { MirisStream } from "./mesh/MirisStream";
 import { Obj } from "./mesh/Obj";
 import { Ply } from "./mesh/Ply";
 import { Stl } from "./mesh/Stl";
@@ -30,6 +31,7 @@ import {
   type FoScene,
   type FoSceneNode,
   GltfAsset,
+  MirisStreamAsset,
   ObjAsset,
   PcdAsset,
   PlaneGeometryAsset,
@@ -262,6 +264,19 @@ const getAssetJsx = (
       >
         {children}
       </Plane>
+    );
+  } else if (node.asset instanceof MirisStreamAsset) {
+    return (
+      <MirisStream
+        key={key}
+        name={node.name}
+        asset={node.asset as MirisStreamAsset}
+        position={node.position}
+        quaternion={node.quaternion}
+        scale={node.scale}
+      >
+        {children}
+      </MirisStream>
     );
   }
 

--- a/app/packages/looker-3d/src/fo3d/mesh/MirisStream.tsx
+++ b/app/packages/looker-3d/src/fo3d/mesh/MirisStream.tsx
@@ -10,7 +10,10 @@ import type { MirisStreamAsset } from "../render-types";
 let _mirisPromise: Promise<unknown> | null = null;
 const ensureMirisRuntime = () => {
   if (!_mirisPromise) {
-    _mirisPromise = import("@miris-inc/three")
+    _mirisPromise = import("@miris-inc/three").catch((err) => {
+      _mirisPromise = null;
+      throw err;
+    });
   }
   return _mirisPromise as Promise<{ MirisStream: unknown }>;
 };
@@ -33,7 +36,9 @@ export const MirisStream = ({
   const ds = useRecoilValue(dataset as never) as {
     info?: Record<string, unknown>;
   } | null;
-  const datasetViewerKey = ds?.info?.["miris_viewer_key"] as string | undefined;
+  const rawDatasetViewerKey = ds?.info?.["miris_viewer_key"];
+  const datasetViewerKey =
+    typeof rawDatasetViewerKey === "string" ? rawDatasetViewerKey : undefined;
   const viewerKey = asset.viewerKey ?? datasetViewerKey;
 
   const [stream, setStream] = useState<Group | null>(null);

--- a/app/packages/looker-3d/src/fo3d/mesh/MirisStream.tsx
+++ b/app/packages/looker-3d/src/fo3d/mesh/MirisStream.tsx
@@ -1,0 +1,89 @@
+import { dataset } from "@fiftyone/state";
+import { useEffect, useState } from "react";
+import { useRecoilValue } from "recoil";
+import type { Group, Quaternion, Vector3 } from "three";
+import type { MirisStreamAsset } from "../render-types";
+
+// Cached promise for the Miris WASM runtime. Resolves once per page, shared
+// across all MirisStream nodes. Dynamic-imported so the SDK (and its WASM
+// blob) only ships if a fo3d scene actually contains a Miris stream.
+let _mirisPromise: Promise<unknown> | null = null;
+const ensureMirisRuntime = () => {
+  if (!_mirisPromise) {
+    _mirisPromise = import("@miris-inc/three")
+  }
+  return _mirisPromise as Promise<{ MirisStream: unknown }>;
+};
+
+export const MirisStream = ({
+  name,
+  asset,
+  position,
+  quaternion,
+  scale,
+  children,
+}: {
+  name: string;
+  asset: MirisStreamAsset;
+  position: Vector3;
+  quaternion: Quaternion;
+  scale: Vector3;
+  children?: React.ReactNode;
+}) => {
+  const ds = useRecoilValue(dataset as never) as {
+    info?: Record<string, unknown>;
+  } | null;
+  const datasetViewerKey = ds?.info?.["miris_viewer_key"] as string | undefined;
+  const viewerKey = asset.viewerKey ?? datasetViewerKey;
+
+  const [stream, setStream] = useState<Group | null>(null);
+
+  useEffect(() => {
+    let constructed: Group | null = null;
+    let cancelled = false;
+
+    if (asset.assetUuid && viewerKey) {
+      (async () => {
+        try {
+          const { MirisStream: MirisStreamSDK } = await ensureMirisRuntime() as any;
+          if (cancelled) return;
+          constructed = new MirisStreamSDK({
+            uuid: asset.assetUuid,
+            viewerKey,
+          }) as unknown as Group;
+          constructed.name = name;
+          setStream(constructed);
+        } catch (err) {
+          console.error("[MirisStream] Failed to construct stream:", err);
+        }
+      })();
+    } else if (asset.assetUuid && !viewerKey) {
+      console.warn(
+        "[MirisStream] No viewer key resolved (checked asset.viewerKey and " +
+          "dataset.info.miris_viewer_key); skipping stream construction."
+      );
+    }
+
+    return () => {
+      cancelled = true;
+      constructed?.removeFromParent();
+      setStream(null);
+    };
+  }, [asset.assetUuid, viewerKey, name]);
+
+  if (!stream) {
+    return null;
+  }
+
+  return (
+    <primitive
+      object={stream}
+      position={position}
+      quaternion={quaternion}
+      scale={scale}
+      dispose={null}
+    >
+      {children ?? null}
+    </primitive>
+  );
+};

--- a/app/packages/looker-3d/src/fo3d/mesh/MirisStream.tsx
+++ b/app/packages/looker-3d/src/fo3d/mesh/MirisStream.tsx
@@ -50,7 +50,8 @@ export const MirisStream = ({
     if (asset.assetUuid && viewerKey) {
       (async () => {
         try {
-          const { MirisStream: MirisStreamSDK } = await ensureMirisRuntime() as any;
+          const { MirisStream: MirisStreamSDK } =
+            (await ensureMirisRuntime()) as any;
           if (cancelled) return;
           constructed = new MirisStreamSDK({
             uuid: asset.assetUuid,
@@ -65,7 +66,7 @@ export const MirisStream = ({
     } else if (asset.assetUuid && !viewerKey) {
       console.warn(
         "[MirisStream] No viewer key resolved (checked asset.viewerKey and " +
-          "dataset.info.miris_viewer_key); skipping stream construction."
+          "dataset.info.miris_viewer_key); skipping stream construction.",
       );
     }
 

--- a/app/packages/looker-3d/src/fo3d/render-types.ts
+++ b/app/packages/looker-3d/src/fo3d/render-types.ts
@@ -127,7 +127,7 @@ export class StlAsset {
 export class MirisStreamAsset {
   constructor(
     readonly assetUuid: string,
-    readonly viewerKey?: string
+    readonly viewerKey?: string,
   ) {}
 }
 

--- a/app/packages/looker-3d/src/fo3d/render-types.ts
+++ b/app/packages/looker-3d/src/fo3d/render-types.ts
@@ -124,6 +124,13 @@ export class StlAsset {
   ) {}
 }
 
+export class MirisStreamAsset {
+  constructor(
+    readonly assetUuid: string,
+    readonly viewerKey?: string
+  ) {}
+}
+
 export type MeshAsset =
   | FbxAsset
   | GaussianSplatAsset
@@ -135,7 +142,8 @@ export type MeshAsset =
   | BoxGeometryAsset
   | CylinderGeometryAsset
   | PlaneGeometryAsset
-  | SphereGeometryAsset;
+  | SphereGeometryAsset
+  | MirisStreamAsset;
 
 export type FoMaterial3D = {
   opacity: number;
@@ -198,6 +206,7 @@ export type FoPointcloudMaterialProps = FoMaterial3D & {
 };
 
 export type FoSceneNode = {
+  uuid?: string;
   name: string;
   asset?: MeshAsset;
   position: Vector3;

--- a/app/packages/looker-3d/src/hooks/use-fo3d-scene-parser.ts
+++ b/app/packages/looker-3d/src/hooks/use-fo3d-scene-parser.ts
@@ -10,6 +10,7 @@ import {
   type FoSceneNode,
   GltfAsset,
   type MeshAsset,
+  MirisStreamAsset,
   ObjAsset,
   PcdAsset,
   PlaneGeometryAsset,
@@ -117,6 +118,13 @@ const parseAsset = (node: FoSceneRawNode): MeshAsset | undefined => {
       getOptionalBooleanField(node, "centerGeometry") ?? true,
       getOptionalNumberField(node, "opacity"),
       getOptionalStringField(node, "tint"),
+    );
+  }
+
+  if (nodeType === "mirisstream" && hasStringField(node, "assetUuid")) {
+    return new MirisStreamAsset(
+      node.assetUuid,
+      getOptionalStringField(node, "viewerKey"),
     );
   }
 
@@ -254,6 +262,7 @@ const parseAsset = (node: FoSceneRawNode): MeshAsset | undefined => {
 
 const buildSceneNode = (node: FoSceneRawNode): FoSceneNode => {
   return {
+    uuid: node.uuid,
     asset: parseAsset(node),
     name: node.name,
     visible: node.visible,

--- a/app/packages/looker-3d/src/types/miris-three.d.ts
+++ b/app/packages/looker-3d/src/types/miris-three.d.ts
@@ -1,0 +1,52 @@
+declare module "@miris-inc/three" {
+  import { Object3D, Scene as ThreeScene } from "three";
+
+  export class Miris {
+    static instance(): Promise<Miris>;
+  }
+
+  export class MirisScene extends ThreeScene {
+    constructor(init?: { miris?: Miris; viewerKey?: string | null });
+    viewerKey: string | null;
+    readonly ready: Promise<MirisScene>;
+    readonly pending: boolean;
+    dispose(): void;
+    fetchAssets(tags?: string | string[]): Promise<unknown[]>;
+  }
+
+  interface MirisStreamBounds {
+    min: [number, number, number];
+    max: [number, number, number];
+    size: [number, number, number];
+    center: [number, number, number];
+  }
+
+  export class MirisStream extends Object3D {
+    constructor(init: {
+      uuid: string;
+      viewerKey?: string;
+      authToken?: string;
+      drmKey?: string;
+    });
+    readonly isStream: true;
+    static viewerKey: string;
+    getBounds(): MirisStreamBounds;
+    addEventListener(
+      type: "streamloaded" | "rootloaded",
+      listener: (event: unknown) => void
+    ): void;
+    removeEventListener(
+      type: "streamloaded" | "rootloaded",
+      listener: (event: unknown) => void
+    ): void;
+  }
+
+  export class MirisControls {
+    constructor(
+      objects: Object3D | Iterable<Object3D> | null,
+      camera: import("three").Camera,
+      domElement: HTMLElement
+    );
+    dispose(): void;
+  }
+}

--- a/app/packages/looker-3d/src/types/miris-three.d.ts
+++ b/app/packages/looker-3d/src/types/miris-three.d.ts
@@ -33,11 +33,11 @@ declare module "@miris-inc/three" {
     getBounds(): MirisStreamBounds;
     addEventListener(
       type: "streamloaded" | "rootloaded",
-      listener: (event: unknown) => void
+      listener: (event: unknown) => void,
     ): void;
     removeEventListener(
       type: "streamloaded" | "rootloaded",
-      listener: (event: unknown) => void
+      listener: (event: unknown) => void,
     ): void;
   }
 
@@ -45,7 +45,7 @@ declare module "@miris-inc/three" {
     constructor(
       objects: Object3D | Iterable<Object3D> | null,
       camera: import("three").Camera,
-      domElement: HTMLElement
+      domElement: HTMLElement,
     );
     dispose(): void;
   }

--- a/app/packages/plugins/package.json
+++ b/app/packages/plugins/package.json
@@ -22,5 +22,9 @@
         "@fiftyone/utilities": "workspace:^",
         "prettier": "catalog:",
         "vite": "catalog:"
+    },
+    "dependencies": {
+        "moment": "^2.29.4",
+        "three": "^0.182.0"
     }
 }

--- a/app/packages/plugins/package.json
+++ b/app/packages/plugins/package.json
@@ -24,7 +24,6 @@
         "vite": "catalog:"
     },
     "dependencies": {
-        "moment": "^2.29.4",
-        "three": "^0.182.0"
+        "moment": "^2.29.4"
     }
 }

--- a/app/packages/plugins/src/externalize.ts
+++ b/app/packages/plugins/src/externalize.ts
@@ -14,6 +14,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import * as recoil from "recoil";
 import styled from "styled-components";
+import * as three from "three";
 
 declare global {
   interface Window {
@@ -33,6 +34,7 @@ declare global {
     __fof__: typeof fof;
     __mui__: typeof mui;
     __styled__: typeof styled;
+    __three__: typeof three;
 
     // todo: the following cannot be externalized because of unknown reason
     // __focore__: typeof focore;
@@ -61,6 +63,7 @@ if (typeof window !== "undefined") {
   window.__fosl__ = fosl;
   window.__fof__ = fof;
   window.__styled__ = styled;
+  window.__three__ = three;
   // todo: the following cannot be externalized because of unknown reason
   // window.__fol3d__ = fol3d;
   // window.__foe__ = foe;

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2174,7 +2174,6 @@ __metadata:
     "@fiftyone/utilities": "workspace:^"
     moment: "npm:^2.29.4"
     prettier: "catalog:"
-    three: "npm:^0.182.0"
     vite: "catalog:"
   languageName: unknown
   linkType: soft

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2010,6 +2010,7 @@ __metadata:
   dependencies:
     "@emotion/react": "npm:^11.14.0"
     "@emotion/styled": "npm:^11.14.0"
+    "@miris-inc/three": "npm:latest"
     "@react-three/drei": "npm:^10.7.6"
     "@react-three/fiber": "catalog:"
     "@sparkjsdev/spark": "npm:2.1.0"
@@ -2171,7 +2172,9 @@ __metadata:
   resolution: "@fiftyone/plugins@workspace:packages/plugins"
   dependencies:
     "@fiftyone/utilities": "workspace:^"
+    moment: "npm:^2.29.4"
     prettier: "catalog:"
+    three: "npm:^0.182.0"
     vite: "catalog:"
   languageName: unknown
   linkType: soft
@@ -3180,6 +3183,13 @@ __metadata:
   version: 2.0.1
   resolution: "@microsoft/fetch-event-source@npm:2.0.1"
   checksum: 10/c147055fafe83801efb9834136ba4b7944406a0bba3517afcea6ceeb56714b5ef78c2e89544bd9c1426ad1d2f964a087e3a719169ae04855836a23fb53269f8d
+  languageName: node
+  linkType: hard
+
+"@miris-inc/three@npm:latest":
+  version: 0.0.7-86c2ee0
+  resolution: "@miris-inc/three@npm:0.0.7-86c2ee0"
+  checksum: 10/24f0fb237e5a695280e0ba2c14ec75f98733d4f6e638bdb4d845a7b51184f77a5d701c3bfd99d9a04e7a7b2c02b2a56650128d1edf97e17b5d4151fb26f11a4d
   languageName: node
   linkType: hard
 
@@ -14855,6 +14865,13 @@ __metadata:
   bin:
     mkdirp: bin/cmd.js
   checksum: 10/d71b8dcd4b5af2fe13ecf3bd24070263489404fe216488c5ba7e38ece1f54daf219e72a833a3a2dc404331e870e9f44963a33399589490956bff003a3404d3b2
+  languageName: node
+  linkType: hard
+
+"moment@npm:^2.29.4":
+  version: 2.30.1
+  resolution: "moment@npm:2.30.1"
+  checksum: 10/ae42d876d4ec831ef66110bdc302c0657c664991e45cf2afffc4b0f6cd6d251dde11375c982a5c0564ccc0fa593fc564576ddceb8c8845e87c15f58aa6baca69
   languageName: node
   linkType: hard
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2010,8 +2010,8 @@ __metadata:
   dependencies:
     "@emotion/react": "npm:^11.14.0"
     "@emotion/styled": "npm:^11.14.0"
-    "@miris-inc/core": "npm:0.0.8-25565b3"
-    "@miris-inc/three": "npm:0.0.8-25565b3"
+    "@miris-inc/core": "npm:latest"
+    "@miris-inc/three": "npm:latest"
     "@react-three/drei": "npm:^10.7.6"
     "@react-three/fiber": "catalog:"
     "@sparkjsdev/spark": "npm:2.1.0"
@@ -3186,20 +3186,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@miris-inc/core@npm:0.0.8-25565b3":
-  version: 0.0.8-25565b3
-  resolution: "@miris-inc/core@npm:0.0.8-25565b3"
-  checksum: 10/4b4c627f67ffa7e922a82e9935ffec909281fcb4d121700cf9ebbe3e2a20c391ada2bf11b57f9c4ca2ca14f20113ef0efaf35f345b713b3d285390d5fdcb973c
+"@miris-inc/core@npm:latest":
+  version: 0.0.8-a1b9846
+  resolution: "@miris-inc/core@npm:0.0.8-a1b9846"
+  checksum: 10/6e99f8cdb3e580b5905daa241327f821361aa1054e844b6add10718fe4f48c297d5b27839cc204b0fc7dad71142ace2b41957b6cd8cc271e9d9c52bb859be88b
   languageName: node
   linkType: hard
 
-"@miris-inc/three@npm:0.0.8-25565b3":
-  version: 0.0.8-25565b3
-  resolution: "@miris-inc/three@npm:0.0.8-25565b3"
+"@miris-inc/three@npm:latest":
+  version: 0.0.8-a1b9846
+  resolution: "@miris-inc/three@npm:0.0.8-a1b9846"
   peerDependencies:
-    "@miris-inc/core": 0.0.8-25565b3
+    "@miris-inc/core": 0.0.8-a1b9846
     three: ^0.182.0
-  checksum: 10/7024956baeb3da20ff3e602f70ab07c1b8b9f8575bf7048a8fc1a0283d16c12a8f2fa9c70bdc318647a2210c7bc745b71bc348e23fa6de86d31f58c93eadde96
+  checksum: 10/d34c36e2463e1b68cb006768e83195cec915e2f21df8548b03ccd6bd14348a8082f253f42f6cc41445adef02d8093a24c48089c905c5c9fbd0257973841cb54f
   languageName: node
   linkType: hard
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2010,7 +2010,8 @@ __metadata:
   dependencies:
     "@emotion/react": "npm:^11.14.0"
     "@emotion/styled": "npm:^11.14.0"
-    "@miris-inc/three": "npm:0.0.8-ec1b54d"
+    "@miris-inc/core": "npm:0.0.8-25565b3"
+    "@miris-inc/three": "npm:0.0.8-25565b3"
     "@react-three/drei": "npm:^10.7.6"
     "@react-three/fiber": "catalog:"
     "@sparkjsdev/spark": "npm:2.1.0"
@@ -3185,10 +3186,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@miris-inc/three@npm:0.0.8-ec1b54d":
-  version: 0.0.8-ec1b54d
-  resolution: "@miris-inc/three@npm:0.0.8-ec1b54d"
-  checksum: 10/48b7c600122c1f8f0efbf4569de00ab351ab89f0ac9388b156c7b37b2d29c256122ddbeb9ed0ccc74227957eb13ba4d8fdefed86bba395f7ad77886143e233a6
+"@miris-inc/core@npm:0.0.8-25565b3":
+  version: 0.0.8-25565b3
+  resolution: "@miris-inc/core@npm:0.0.8-25565b3"
+  checksum: 10/4b4c627f67ffa7e922a82e9935ffec909281fcb4d121700cf9ebbe3e2a20c391ada2bf11b57f9c4ca2ca14f20113ef0efaf35f345b713b3d285390d5fdcb973c
+  languageName: node
+  linkType: hard
+
+"@miris-inc/three@npm:0.0.8-25565b3":
+  version: 0.0.8-25565b3
+  resolution: "@miris-inc/three@npm:0.0.8-25565b3"
+  peerDependencies:
+    "@miris-inc/core": 0.0.8-25565b3
+    three: ^0.182.0
+  checksum: 10/7024956baeb3da20ff3e602f70ab07c1b8b9f8575bf7048a8fc1a0283d16c12a8f2fa9c70bdc318647a2210c7bc745b71bc348e23fa6de86d31f58c93eadde96
   languageName: node
   linkType: hard
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2010,7 +2010,7 @@ __metadata:
   dependencies:
     "@emotion/react": "npm:^11.14.0"
     "@emotion/styled": "npm:^11.14.0"
-    "@miris-inc/three": "npm:latest"
+    "@miris-inc/three": "npm:0.0.8-ec1b54d"
     "@react-three/drei": "npm:^10.7.6"
     "@react-three/fiber": "catalog:"
     "@sparkjsdev/spark": "npm:2.1.0"
@@ -3185,10 +3185,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@miris-inc/three@npm:latest":
-  version: 0.0.7-86c2ee0
-  resolution: "@miris-inc/three@npm:0.0.7-86c2ee0"
-  checksum: 10/24f0fb237e5a695280e0ba2c14ec75f98733d4f6e638bdb4d845a7b51184f77a5d701c3bfd99d9a04e7a7b2c02b2a56650128d1edf97e17b5d4151fb26f11a4d
+"@miris-inc/three@npm:0.0.8-ec1b54d":
+  version: 0.0.8-ec1b54d
+  resolution: "@miris-inc/three@npm:0.0.8-ec1b54d"
+  checksum: 10/48b7c600122c1f8f0efbf4569de00ab351ab89f0ac9388b156c7b37b2d29c256122ddbeb9ed0ccc74227957eb13ba4d8fdefed86bba395f7ad77886143e233a6
   languageName: node
   linkType: hard
 

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -210,6 +210,7 @@ from .core.threed import (
     SphereGeometry,
     FbxMesh,
     GltfMesh,
+    MirisStream,
     ObjMesh,
     PlyMesh,
     StlMesh,

--- a/fiftyone/core/threed/__init__.py
+++ b/fiftyone/core/threed/__init__.py
@@ -16,6 +16,7 @@ from .material_3d import (
     PointCloudMaterial,
 )
 from .mesh import FbxMesh, GltfMesh, ObjMesh, PlyMesh, StlMesh
+from .miris_stream import MirisStream
 from .object_3d import Object3D
 from .pointcloud import *
 from .scene_3d import *

--- a/fiftyone/core/threed/miris_stream.py
+++ b/fiftyone/core/threed/miris_stream.py
@@ -37,6 +37,7 @@ class MirisStream(Object3D):
         scale: Optional[Vec3UnionType] = None,
         quaternion: Optional[Quaternion] = None,
     ):
+        """Initializes a :class:`MirisStream`."""
         super().__init__(
             name=name,
             visible=visible,
@@ -52,6 +53,7 @@ class MirisStream(Object3D):
         self.viewer_key = viewer_key
 
     def _to_dict_extra(self):
+        """Extra properties to include in dictionary representation."""
         return {
             "assetUuid": self.asset_uuid,
             "viewerKey": self.viewer_key,

--- a/fiftyone/core/threed/miris_stream.py
+++ b/fiftyone/core/threed/miris_stream.py
@@ -1,0 +1,58 @@
+"""
+Miris stream definitions for 3D visualization.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from typing import Optional
+
+from .object_3d import Object3D
+from .transformation import Quaternion, Vec3UnionType
+
+
+class MirisStream(Object3D):
+    """Represents a Miris stream rendered via the ``@miris-inc/three`` SDK.
+
+    Args:
+        name (str): the name of the stream
+        asset_uuid (str): the Miris asset UUID identifying the stream
+        viewer_key (str, optional): the Miris viewer key used to authorize
+            playback. If ``None``, the App must supply a viewer key by
+            another means (e.g. ``dataset.info["miris_viewer_key"]``)
+        visible (True): default visibility of the stream in the scene
+        position (None): the position of the stream in object space
+        quaternion (None): the quaternion of the stream in object space
+        scale (None): the scale of the stream in object space
+    """
+
+    def __init__(
+        self,
+        name: str,
+        asset_uuid: str,
+        viewer_key: Optional[str] = None,
+        visible: bool = True,
+        position: Optional[Vec3UnionType] = None,
+        scale: Optional[Vec3UnionType] = None,
+        quaternion: Optional[Quaternion] = None,
+    ):
+        super().__init__(
+            name=name,
+            visible=visible,
+            position=position,
+            scale=scale,
+            quaternion=quaternion,
+        )
+
+        if not asset_uuid:
+            raise ValueError("MirisStream requires an asset_uuid")
+
+        self.asset_uuid = asset_uuid
+        self.viewer_key = viewer_key
+
+    def _to_dict_extra(self):
+        return {
+            "assetUuid": self.asset_uuid,
+            "viewerKey": self.viewer_key,
+        }

--- a/fiftyone/core/threed/scene_3d.py
+++ b/fiftyone/core/threed/scene_3d.py
@@ -17,6 +17,7 @@ import fiftyone.core.storage as fos
 from .camera import PerspectiveCamera
 from .lights import Light
 from .mesh import FbxMesh, GltfMesh, ObjMesh, PlyMesh, StlMesh
+from .miris_stream import MirisStream
 from .object_3d import Object3D
 from .pointcloud import PointCloud
 from .shape_3d import Shape3D
@@ -316,6 +317,7 @@ class Scene(Object3D):
             "stls": node_types[StlMesh],
             "plys": node_types[PlyMesh],
             "gaussian splats": node_types[GaussianSplat],
+            "miris streams": node_types[MirisStream],
             "shapes": node_types[Shape3D],
         }
 

--- a/tests/unittests/threed/scene_3d_tests.py
+++ b/tests/unittests/threed/scene_3d_tests.py
@@ -157,6 +157,7 @@ class TestScene(unittest.TestCase):
                 "shapes": 1,
                 "stls": 1,
                 "gaussian splats": 1,
+                "miris streams": 0,
             },
         )
 


### PR DESCRIPTION
## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

This PR adds Miris 3D Streams as a first class datatype to the fo3d scene format. Users can stream Miris assets into the fiftyone canvas and annotate/label them just like any other 3d dataset. We recommend users pair the [Miris Plugin](https://github.com/Miris-Inc/MirisSDK/tree/latest/fiftyone) with fiftyone to automatically generate datasets from their miris assets - although it isn't strictly required. 

## 🧪 How is this patch tested? If it is not, please explain why.

Manual builds of this fork were tested along side the plugin to verify the install and functionality of the proposed changes. We can add unit tests if requested - but wanted to keep the surface area of this change fairly light weight

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [X] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

Added support for adding Miris Streams within fo3d datasets. 

### What areas of FiftyOne does this PR affect?

-   [X] App: FiftyOne application changes
-   [X] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for MirisStream assets in the 3D viewer so MirisStream asset types can be rendered alongside other meshes.
  * Introduced a MirisStream 3D object in the Python API and exported it for user code.
  * Scene summaries now report counts for MirisStream nodes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->