### PR TITLE
Adding skills CLI methods to docs

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -64,7 +64,7 @@ The FiftyOne command-line interface.
 .. code-block:: text
 
     fiftyone [-h] [-v] [--all-help]
-             {quickstart,annotation,brain,evaluation,app,config,constants,convert,datasets,migrate,operators,delegated,plugins,utils,zoo,labs}
+             {quickstart,annotation,brain,evaluation,app,config,constants,convert,datasets,migrate,operators,skills,delegated,plugins,utils,zoo,labs}
              ...
 
 **Arguments**
@@ -77,7 +77,8 @@ The FiftyOne command-line interface.
       --all-help            show help recursively and exit
 
     available commands:
-      {quickstart,annotation,brain,evaluation,app,config,constants,convert,datasets,migrate,operators,delegated,plugins,utils,zoo,labs}
+      {quickstart,annotation,brain,evaluation,app,config,constants,convert,datasets,migrate,operators,skills,delegated,plugins,utils,zoo,labs}
+
         quickstart          Launch a FiftyOne quickstart.
         annotation          Tools for working with the FiftyOne annotation API.
         brain               Tools for working with the FiftyOne Brain.
@@ -88,7 +89,8 @@ The FiftyOne command-line interface.
         convert             Convert datasets on disk between supported formats.
         datasets            Tools for working with FiftyOne datasets.
         migrate             Tools for migrating the FiftyOne database.
-        operators           Tools for working with FiftyOne operators.
+        operators           Tools for working with FiftyOne operators and panels.
+        skills              Tools for working with FiftyOne skills.
         delegated           Tools for working with FiftyOne delegated operations.
         plugins             Tools for working with FiftyOne plugins.
         utils               FiftyOne utilities.
@@ -921,6 +923,81 @@ Prints information about operators and panels that are installed locally.
 
     # Prints information about an operator or panel
     fiftyone operators info <uri>
+
+.. _cli-fiftyone-skills:
+
+FiftyOne skills
+------------------
+
+Tools for working with FiftyOne skills.
+
+.. code-block:: text
+
+    fiftyone skills [-h] [--all-help] {list} ...
+
+**Arguments**
+
+.. code-block:: text
+
+    optional arguments:
+      -h, --help   show this help message and exit
+      --all-help   show help recursively and exit
+
+    available commands:
+      {list}
+        list      List skills provided by installed plugins.
+
+.. _cli-fiftyone-skills-list:
+
+List skills
+~~~~~~~~~~~
+
+List skills provided by installed plugins.
+
+.. code-block:: text
+
+    fiftyone skills list [-h] [-p PLUGIN [PLUGIN ...]] [-c CATEGORY [CATEGORY ...]] [-e] [-d] [-n]
+
+**Arguments**
+
+.. code-block:: text
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -p PLUGIN [PLUGIN ...], --plugin PLUGIN [PLUGIN ...]
+                            only show skills from this plugin(s)
+      -c CATEGORY [CATEGORY ...], --category CATEGORY [CATEGORY ...]
+                            only show skills in this category(s)
+      -e, --enabled         only show skills from enabled plugins
+      -d, --disabled        only show skills from disabled plugins
+      -n, --names-only      only show names
+
+**Examples**
+
+.. code-block:: shell
+
+    # List all available skills
+    fiftyone skills list
+
+.. code-block:: shell
+
+    # List skills from a specific plugin
+    fiftyone skills list --plugin @voxel51/my-plugin
+
+.. code-block:: shell
+
+    # List skills in a specific category
+    fiftyone skills list --category data-ingestion
+
+.. code-block:: shell
+
+    # List enabled skills
+    fiftyone skills list --enabled
+
+.. code-block:: shell
+
+    # List skill names only
+    fiftyone skills list --names-only
 
 .. _cli-fiftyone-delegated:
 


### PR DESCRIPTION
Adds the CLI methods introduced in https://github.com/voxel51/fiftyone/pull/7289 to the [CLI docs](https://docs.voxel51.com/cli/index.html).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI documentation to include a new `skills` command and its `list` subcommand, with supported options and usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7558)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->