### PR TITLE
[HA] Fix floating toolbar tooltip styling

### DIFF
--- a/app/packages/components/src/components/ActionToolbar/ActionToolbar.tsx
+++ b/app/packages/components/src/components/ActionToolbar/ActionToolbar.tsx
@@ -9,17 +9,22 @@
  * those concerns.
  */
 
-import { Box, Typography, styled } from "@mui/material";
+import { styled, Typography } from "@mui/material";
 import {
+  Align,
   Anchor,
   Orientation,
+  Spacing,
+  Stack,
+  Text,
+  TextColor,
   Toolbar,
   ToolbarAction,
   ToolbarGroup,
   Tooltip,
   ZIndex,
 } from "@voxel51/voodo";
-import type { ToolbarActionItem, ToolbarActionGroup } from "./types";
+import type { ToolbarActionGroup, ToolbarActionItem } from "./types";
 
 const GroupLabel = styled(Typography)(({ theme }) => ({
   fontSize: "9px",
@@ -68,18 +73,22 @@ const ActionButton = ({ action }: { action: ToolbarActionItem }) => {
     <Tooltip
       portal
       content={
-        <Box>
+        <Stack
+          orientation={Orientation.Row}
+          spacing={Spacing.Sm}
+          align={Align.Center}
+        >
+          {action.shortcut && (
+            <Text color={TextColor.Tertiary} style={{ fontWeight: 600 }}>
+              ({action.shortcut})
+            </Text>
+          )}
           {typeof action.tooltip === "string" ? (
-            <Typography variant="body2">{action.tooltip}</Typography>
+            <Text color={TextColor.Secondary}>{action.tooltip}</Text>
           ) : (
             action.tooltip
           )}
-          {action.shortcut && (
-            <Typography variant="caption" sx={{ opacity: 0.7 }}>
-              {action.shortcut}
-            </Typography>
-          )}
-        </Box>
+        </Stack>
       }
       anchor={Anchor.Right}
     >

--- a/app/packages/looker-3d/src/annotation/annotation-toolbar/AnnotationPlaneTooltip.tsx
+++ b/app/packages/looker-3d/src/annotation/annotation-toolbar/AnnotationPlaneTooltip.tsx
@@ -1,9 +1,8 @@
-import { useTheme } from "@fiftyone/components";
-import { Box, Typography, styled } from "@mui/material";
+import { Box, styled } from "@mui/material";
+import { Orientation, Spacing, Stack, Text, TextColor } from "@voxel51/voodo";
 
-const TooltipContainer = styled(Box)(({ theme }) => ({
+const TooltipContainer = styled(Box)(() => ({
   maxWidth: "300px",
-  lineHeight: "1.4",
 }));
 
 /**
@@ -11,29 +10,19 @@ const TooltipContainer = styled(Box)(({ theme }) => ({
  * Provides detailed explanation of the annotation plane concept.
  */
 export const AnnotationPlaneTooltip = () => {
-  const theme = useTheme() as any;
-
   return (
     <TooltipContainer>
-      <Typography
-        variant="subtitle2"
-        sx={{
-          fontWeight: "bold",
-          marginBottom: "8px",
-        }}
-      >
-        Toggle annotation plane visibility
-      </Typography>
-      <Typography
-        variant="body2"
-        sx={{
-          fontSize: "13px",
-        }}
-      >
-        The transformable annotation plane solves the z-depth problem by
-        providing a reference surface for drawing vertices. Vertices snap to the
-        plane by default.
-      </Typography>
+      <Stack orientation={Orientation.Column} spacing={Spacing.Sm}>
+        <Text color={TextColor.Secondary}>
+          Toggle annotation plane visibility
+        </Text>
+
+        <Text color={TextColor.Secondary}>
+          The transformable annotation plane solves the z-depth problem by
+          providing a reference surface for drawing vertices. Vertices snap to
+          the plane by default.
+        </Text>
+      </Stack>
     </TooltipContainer>
   );
 };


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

Migrates tooltip content to use voodo's `Text` component to ensure consistent theming/styling. Update 3D tooltips to match `ActionBar` semantics.

## 🧪 How is this patch tested? If it is not, please explain why.

local

<img width="233" height="357" alt="image" src="https://github.com/user-attachments/assets/dc274b48-3d13-4459-a800-e295d6063bbc" />

<img width="438" height="326" alt="image" src="https://github.com/user-attachments/assets/ea370599-1760-42ed-8ca7-c7c6caf1cd41" />


## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated tooltip rendering in action and annotation toolbar components to use consistent design system components for improved visual consistency and maintainability across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7559)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->