### PR TITLE
[FOEPD-3825] Fix SAM2 Mask Offsets

### DIFF
--- a/app/packages/annotation/src/providers/math.test.ts
+++ b/app/packages/annotation/src/providers/math.test.ts
@@ -11,65 +11,34 @@ import {
 const SZ = SAM2_INPUT_SIZE;
 
 function makeImg(width: number, height: number): ProcessedImage {
-  const scale = Math.min(SZ / width, SZ / height);
-  const scaledW = Math.round(width * scale);
-  const scaledH = Math.round(height * scale);
-
   return {
     tensor: new Float32Array(0),
     originalWidth: width,
     originalHeight: height,
-    scale,
-    padX: Math.floor((SZ - scaledW) / 2),
-    padY: Math.floor((SZ - scaledH) / 2),
   };
 }
 
 describe("transformPoint", () => {
-  const square = makeImg(512, 512);
-  const landscape = makeImg(1920, 1080);
-  const portrait = makeImg(1080, 1920);
+  const cases: Array<[string, ProcessedImage]> = [
+    ["square", makeImg(512, 512)],
+    ["landscape", makeImg(1920, 1080)],
+    ["portrait", makeImg(1080, 1920)],
+  ];
 
-  it("Square image: no padding, maps cleanly to SZ", () => {
-    expect(square.padX).toBe(0);
-    expect(square.padY).toBe(0);
-    expect(transformPoint(0, 0, square)).toEqual([0, 0]);
+  it.each(cases)(
+    "Normalized [0,1] coords map directly to [0, SZ] for %s images",
+    () => {
+      expect(transformPoint(0, 0)).toEqual([0, 0]);
 
-    const [cx, cy] = transformPoint(0.5, 0.5, square);
-    expect(cx).toBeCloseTo(SZ / 2, 5);
-    expect(cy).toBeCloseTo(SZ / 2, 5);
+      const [cx, cy] = transformPoint(0.5, 0.5);
+      expect(cx).toBeCloseTo(SZ / 2, 5);
+      expect(cy).toBeCloseTo(SZ / 2, 5);
 
-    const [ex, ey] = transformPoint(1, 1, square);
-    expect(ex).toBeCloseTo(SZ, 5);
-    expect(ey).toBeCloseTo(SZ, 5);
-  });
-
-  it("Non-square images: padding, center, and corner", () => {
-    // Origin
-    expect(landscape.padX).toBe(0);
-    expect(landscape.padY).toBeGreaterThan(0);
-
-    expect(portrait.padX).toBeGreaterThan(0);
-    expect(portrait.padY).toBe(0);
-
-    // Center point
-    const [lcx, lcy] = transformPoint(0.5, 0.5, landscape);
-    expect(lcx).toBeCloseTo(SZ / 2, 5);
-    expect(lcy).toBeCloseTo(0.5 * landscape.originalHeight * landscape.scale + landscape.padY, 5);
-
-    const [pcx, pcy] = transformPoint(0.5, 0.5, portrait);
-    expect(pcx).toBeCloseTo(0.5 * portrait.originalWidth * portrait.scale + portrait.padX, 5);
-    expect(pcy).toBeCloseTo(SZ / 2, 5);
-
-    // (1,1) -> scaled size + padding
-    const [lx, ly] = transformPoint(1, 1, landscape);
-    expect(lx).toBeCloseTo(landscape.originalWidth * landscape.scale + landscape.padX, 5);
-    expect(ly).toBeCloseTo(landscape.originalHeight * landscape.scale + landscape.padY, 5);
-
-    const [px, py] = transformPoint(1, 1, portrait);
-    expect(px).toBeCloseTo(portrait.originalWidth * portrait.scale + portrait.padX, 5);
-    expect(py).toBeCloseTo(portrait.originalHeight * portrait.scale + portrait.padY, 5);
-  });
+      const [ex, ey] = transformPoint(1, 1);
+      expect(ex).toBeCloseTo(SZ, 5);
+      expect(ey).toBeCloseTo(SZ, 5);
+    }
+  );
 });
 
 describe("computeMaskBbox", () => {
@@ -102,16 +71,12 @@ describe("computeMaskBbox", () => {
 
     // Derive expected bbox using the same mapping as computeMaskBbox
     const W = 100, H = 50;
-    const msx = SAM2_OUTPUT_SIZE / SZ;
-    const msy = SAM2_OUTPUT_SIZE / SZ;
-    const mpx = Math.floor(img.padX * msx);
-    const mpy = Math.floor(img.padY * msy);
-    const mw = Math.round(W * img.scale * msx);
-    const mh = Math.round(H * img.scale * msy);
-    const x1 = Math.max(0, Math.floor(((regionX - mpx) / mw) * W));
-    const y1 = Math.max(0, Math.floor(((regionY - mpy) / mh) * H));
-    const x2 = Math.min(W - 1, Math.ceil(((regionX + regionW - 1 - mpx) / mw) * W));
-    const y2 = Math.min(H - 1, Math.ceil(((regionY + regionH - 1 - mpy) / mh) * H));
+    const maskW = SAM2_OUTPUT_SIZE;
+    const maskH = SAM2_OUTPUT_SIZE;
+    const x1 = Math.max(0, Math.floor((regionX / maskW) * W));
+    const y1 = Math.max(0, Math.floor((regionY / maskH) * H));
+    const x2 = Math.min(W - 1, Math.ceil(((regionX + regionW - 1) / maskW) * W));
+    const y2 = Math.min(H - 1, Math.ceil(((regionY + regionH - 1) / maskH) * H));
 
     const bbox = computeMaskBbox(mask, img)!;
     expect(bbox).not.toBeNull();

--- a/app/packages/annotation/src/providers/math.test.ts
+++ b/app/packages/annotation/src/providers/math.test.ts
@@ -60,30 +60,13 @@ describe("computeMaskBbox", () => {
 
   it("Returns localized bbox for localized mask", () => {
     const mask = mask256().fill(-5);
-    // Small positive region in mask space
-    const regionX = 15;
-    const regionY = 80;
-    const regionW = 10;
-    const regionH = 20;
-    for (let y = regionY; y < regionY + regionH; y++)
-      for (let x = regionX; x < regionX + regionW; x++)
+    for (let y = 80; y < 100; y++)
+      for (let x = 15; x < 25; x++)
         mask[y * SAM2_OUTPUT_SIZE + x] = 5;
-
-    // Derive expected bbox using the same mapping as computeMaskBbox
-    const W = 100, H = 50;
-    const maskW = SAM2_OUTPUT_SIZE;
-    const maskH = SAM2_OUTPUT_SIZE;
-    const x1 = Math.max(0, Math.floor((regionX / maskW) * W));
-    const y1 = Math.max(0, Math.floor((regionY / maskH) * H));
-    const x2 = Math.min(W - 1, Math.ceil(((regionX + regionW - 1) / maskW) * W));
-    const y2 = Math.min(H - 1, Math.ceil(((regionY + regionH - 1) / maskH) * H));
 
     const bbox = computeMaskBbox(mask, img)!;
     expect(bbox).not.toBeNull();
-    expect(bbox.x).toBe(x1);
-    expect(bbox.y).toBe(y1);
-    expect(bbox.w).toBe(x2 - x1 + 1);
-    expect(bbox.h).toBe(y2 - y1 + 1);
+    expect(bbox).toEqual({ x: 5, y: 15, w: 6, h: 6 });
   });
 });
 

--- a/app/packages/annotation/src/providers/math.ts
+++ b/app/packages/annotation/src/providers/math.ts
@@ -5,12 +5,11 @@ export const SAM2_INPUT_SIZE = 1024;
 export const SAM2_OUTPUT_SIZE = 256;
 
 // Geometric metadata from preprocessing (shared by encoder, decoder, and cache).
+// SAM2's reference preprocessing is a direct (non-aspect-preserving) resize to
+// SAM2_INPUT_SIZE x SAM2_INPUT_SIZE.
 export interface ImageGeometry {
   originalWidth: number;
   originalHeight: number;
-  scale: number;
-  padX: number;
-  padY: number;
 }
 
 export interface ProcessedImage extends ImageGeometry {
@@ -18,23 +17,16 @@ export interface ProcessedImage extends ImageGeometry {
 }
 
 /**
- * Map normalized [0,1] coordinates to the SAM2_INPUT_SIZE x SAM2_INPUT_SIZE padded/scaled
- * encoder input space.
+ * Map normalized [0,1] coordinates to the SAM2_INPUT_SIZE x SAM2_INPUT_SIZE
+ * encoder input space. Since the image is stretched to fill the full input,
+ * normalized coords map straight to [0, SAM2_INPUT_SIZE] on each axis.
  *
  * @param x Normalized x coordinate in [0,1]
  * @param y Normalized y coordinate in [0,1]
- * @param img The preprocessing metadata (scale, padding) from {@link preprocessImage}
  * @returns Pixel coordinates in encoder input space
  */
-export function transformPoint(
-  x: number,
-  y: number,
-  img: ImageGeometry
-): [number, number] {
-  return [
-    x * img.originalWidth * img.scale + img.padX,
-    y * img.originalHeight * img.scale + img.padY,
-  ];
+export function transformPoint(x: number, y: number): [number, number] {
+  return [x * SAM2_INPUT_SIZE, y * SAM2_INPUT_SIZE];
 }
 
 /**
@@ -72,13 +64,9 @@ export function computeMaskBbox(
   maskH = SAM2_OUTPUT_SIZE,
   maskW = SAM2_OUTPUT_SIZE
 ): { x: number; y: number; w: number; h: number } | null {
-  const { originalWidth: W, originalHeight: H, scale, padX, padY } = img;
-  const msx = maskW / SAM2_INPUT_SIZE;
-  const msy = maskH / SAM2_INPUT_SIZE;
-  const mpx = Math.floor(padX * msx);
-  const mpy = Math.floor(padY * msy);
-  const mw = Math.round(W * scale * msx);
-  const mh = Math.round(H * scale * msy);
+  const { originalWidth: W, originalHeight: H } = img;
+  // The image fills the full mask (SAM2 stretches to 1024x1024), so the
+  // mask-space coords map directly to normalized [0,1] image coords.
 
   // Find exact bbox of positive logits in mask space
   let mx0 = maskW, my0 = maskH, mx1 = -1, my1 = -1;
@@ -97,10 +85,10 @@ export function computeMaskBbox(
     return null;
 
   // Map mask-space bbox to original image coordinates
-  const x1 = Math.max(0, Math.floor(((mx0 - mpx) / mw) * W));
-  const y1 = Math.max(0, Math.floor(((my0 - mpy) / mh) * H));
-  const x2 = Math.min(W - 1, Math.ceil(((mx1 - mpx) / mw) * W));
-  const y2 = Math.min(H - 1, Math.ceil(((my1 - mpy) / mh) * H));
+  const x1 = Math.max(0, Math.floor((mx0 / maskW) * W));
+  const y1 = Math.max(0, Math.floor((my0 / maskH) * H));
+  const x2 = Math.min(W - 1, Math.ceil((mx1 / maskW) * W));
+  const y2 = Math.min(H - 1, Math.ceil((my1 / maskH) * H));
 
   return { x: x1, y: y1, w: x2 - x1 + 1, h: y2 - y1 + 1 };
 }
@@ -124,21 +112,17 @@ export function postprocessMask(
   maskH = SAM2_OUTPUT_SIZE,
   maskW = SAM2_OUTPUT_SIZE
 ): Float32Array {
-  const { originalWidth: W, originalHeight: H, scale, padX, padY } = img;
-  const msx = maskW / SAM2_INPUT_SIZE;
-  const msy = maskH / SAM2_INPUT_SIZE;
-  const mpx = Math.floor(padX * msx);
-  const mpy = Math.floor(padY * msy);
-  const mw = Math.round(W * scale * msx);
-  const mh = Math.round(H * scale * msy);
+  const { originalWidth: W, originalHeight: H } = img;
+  // The image fills the full mask: map image-space (ox, oy) directly to
+  // mask coords (ox/W * maskW, oy/H * maskH).
   const out = new Float32Array(bbox.w * bbox.h);
 
   for (let iy = 0; iy < bbox.h; iy++) {
     for (let ix = 0; ix < bbox.w; ix++) {
       const ox = bbox.x + ix;
       const oy = bbox.y + iy;
-      const mx = (ox / W) * mw + mpx;
-      const my = (oy / H) * mh + mpy;
+      const mx = (ox / W) * maskW;
+      const my = (oy / H) * maskH;
       const x0 = Math.max(0, Math.min(Math.floor(mx), maskW - 1));
       const x1 = Math.min(x0 + 1, maskW - 1);
       const y0 = Math.max(0, Math.min(Math.floor(my), maskH - 1));

--- a/app/packages/annotation/src/providers/worker.ts
+++ b/app/packages/annotation/src/providers/worker.ts
@@ -153,25 +153,20 @@ async function loadImageData(url: string): Promise<ImageData> {
  */
 function preprocessImage(imageData: ImageData): ProcessedImage {
   const { width, height } = imageData;
-  const scale = Math.min(SAM2_INPUT_SIZE / width, SAM2_INPUT_SIZE / height);
-  const scaledWidth = Math.round(width * scale);
-  const scaledHeight = Math.round(height * scale);
-  const padX = Math.floor((SAM2_INPUT_SIZE - scaledWidth) / 2);
-  const padY = Math.floor((SAM2_INPUT_SIZE - scaledHeight) / 2);
 
+  // SAM2 reference preprocessing is a direct (non-aspect-preserving) resize
+  // to 1024x1024. No padding; just stretch the image to fill the input.
   const canvas = new OffscreenCanvas(SAM2_INPUT_SIZE, SAM2_INPUT_SIZE);
   const ctx = canvas.getContext("2d");
   if (!ctx)
     throw new Error("Failed to get 2d context");
-  ctx.fillStyle = "black";
-  ctx.fillRect(0, 0, SAM2_INPUT_SIZE, SAM2_INPUT_SIZE);
 
   const tmp = new OffscreenCanvas(width, height);
   const tmpCtx = tmp.getContext("2d");
   if (!tmpCtx)
     throw new Error("Failed to get 2d context");
   tmpCtx.putImageData(imageData, 0, 0);
-  ctx.drawImage(tmp, padX, padY, scaledWidth, scaledHeight);
+  ctx.drawImage(tmp, 0, 0, SAM2_INPUT_SIZE, SAM2_INPUT_SIZE);
 
   const pixels = ctx.getImageData(0, 0, SAM2_INPUT_SIZE, SAM2_INPUT_SIZE).data;
   const N = SAM2_INPUT_SIZE * SAM2_INPUT_SIZE;
@@ -183,7 +178,7 @@ function preprocessImage(imageData: ImageData): ProcessedImage {
     tensor[i + 2 * N] = (pixels[j + 2] / 255 - IMAGE_MEAN[2]) / IMAGE_STD[2];
   }
 
-  return { tensor, originalWidth: width, originalHeight: height, scale, padX, padY };
+  return { tensor, originalWidth: width, originalHeight: height };
 }
 
 /**
@@ -289,9 +284,6 @@ async function embedAndDecode(
       processedImage: {
         originalWidth: geometry.originalWidth,
         originalHeight: geometry.originalHeight,
-        scale: geometry.scale,
-        padX: geometry.padX,
-        padY: geometry.padY,
       },
     }, postWarningNotification);
   }
@@ -301,7 +293,7 @@ async function embedAndDecode(
   const coords = new Float32Array(n * 2);
   const labels = new Float32Array(n);
   for (let i = 0; i < n; i++) {
-    const [sx, sy] = transformPoint(points[i].x, points[i].y, geometry);
+    const [sx, sy] = transformPoint(points[i].x, points[i].y);
     coords[i * 2] = sx;
     coords[i * 2 + 1] = sy;
     labels[i] = points[i].label;


### PR DESCRIPTION
## 🔗 Related Issues

FOEPD-3825

## 📋 What changes are proposed in this pull request?

Coordinate transformation was preserving image aspect ratio which is not required (and therefore incorrect) for SAM2 inference..

Note: previous embeddings cache on the browser needs to be purged before re-running the new inference.

Before/After:

<img width="1240" height="479" alt="Screenshot 2026-05-15 at 17 09 46" src="https://github.com/user-attachments/assets/1a67ab62-6295-4cd3-9850-997587a51dab" />
<img width="1344" height="590" alt="Screenshot 2026-05-15 at 17 10 08" src="https://github.com/user-attachments/assets/da2bb68c-76a8-4189-b0d2-29d6a38c5192" />

<img width="430" height="233" alt="Screenshot 2026-05-15 at 17 11 01" src="https://github.com/user-attachments/assets/246b3d94-d3e6-460b-af54-58a803c106b6" />
<img width="593" height="313" alt="Screenshot 2026-05-15 at 17 11 36" src="https://github.com/user-attachments/assets/1e6d53ed-c252-454e-8a42-b5ff6a61bbbb" />

## 🧪 How is this patch tested? If it is not, please explain why.

- Unit tests
- Local compared to rc deployment

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.



### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Image preprocessing now stretches images to a fixed encoder size instead of using aspect-preserving resize with padding.
  * Coordinate transforms and mask postprocessing simplified to use only original image dimensions (removed padding/scale adjustments).
  * Mask bounding box mapping now derives image coordinates directly from normalized mask coordinates.
* **Tests**
  * Simplified and table-driven tests for point transforms and mask bbox expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->