### PR TITLE
Fix/null values in smart form

### DIFF
--- a/app/packages/components/src/components/SmartForm/RJSF/index.tsx
+++ b/app/packages/components/src/components/SmartForm/RJSF/index.tsx
@@ -116,7 +116,13 @@ export default function RJSF(props: SmartFormProps) {
       onChange={handleChange}
       onSubmit={handleSubmit}
       showErrorList={false}
-      transformErrors={(errors) => transformErrors(errors, uiSchema)}
+      transformErrors={(errors) =>
+        transformErrors(
+          errors,
+          uiSchema,
+          deserializeFormData(data) as Record<string, unknown>
+        )
+      }
       {...props.formProps}
     />
   );

--- a/app/packages/components/src/components/SmartForm/RJSF/utils.ts
+++ b/app/packages/components/src/components/SmartForm/RJSF/utils.ts
@@ -39,9 +39,18 @@ function isLabelValueWidgetPath(property: string, uiSchema: UiSchema): boolean {
 
 export function transformErrors(
   errors: RJSFValidationError[],
-  uiSchema?: UiSchema
+  uiSchema?: UiSchema,
+  formData?: Record<string, unknown>
 ) {
   const filteredErrors = errors.filter((error) => {
+    // Drop type/enum errors whose value is null
+    if (
+      formData &&
+      (error.name === "type" || error.name === "enum") &&
+      _valueAt(formData, error.property) === null
+    ) {
+      return false;
+    }
     if (!uiSchema) return true; // can't filter without the schema
     // We don't need to show validation errors on read-only fields.
     if (isLabelValueWidgetPath(error?.property ?? "", uiSchema)) {
@@ -60,4 +69,15 @@ export function transformErrors(
     }
     return error;
   });
+}
+
+function _valueAt(data: Record<string, unknown>, property?: string): unknown {
+  if (!property) return undefined;
+  const path = property.replace(/^\./, "").split(".");
+  let value: unknown = data;
+  for (const key of path) {
+    if (value === null || value === undefined) return value;
+    value = (value as Record<string, unknown>)[key];
+  }
+  return value;
 }

--- a/app/packages/components/src/components/SmartForm/RJSF/utils.ts
+++ b/app/packages/components/src/components/SmartForm/RJSF/utils.ts
@@ -37,13 +37,21 @@ function isLabelValueWidgetPath(property: string, uiSchema: UiSchema): boolean {
   return isWidgetPath(property, uiSchema, "LabelValueWidget");
 }
 
+function _valueAt(data: Record<string, unknown>, property?: string): unknown {
+  if (!property) return undefined;
+  // RJSF property paths may have a leading "." (e.g. ".region"); strip it
+  // if present, then look up the (flat) key on the form data.
+  return data[property.replace(/^\./, "")];
+}
+
 export function transformErrors(
   errors: RJSFValidationError[],
   uiSchema?: UiSchema,
   formData?: Record<string, unknown>
 ) {
   const filteredErrors = errors.filter((error) => {
-    // Drop type/enum errors whose value is null
+    // Drop type/enum errors whose value is null - if it is explicity
+    // set null we should respect it.
     if (
       formData &&
       (error.name === "type" || error.name === "enum") &&
@@ -69,15 +77,4 @@ export function transformErrors(
     }
     return error;
   });
-}
-
-function _valueAt(data: Record<string, unknown>, property?: string): unknown {
-  if (!property) return undefined;
-  const path = property.replace(/^\./, "").split(".");
-  let value: unknown = data;
-  for (const key of path) {
-    if (value === null || value === undefined) return value;
-    value = (value as Record<string, unknown>)[key];
-  }
-  return value;
 }

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/ApplyOntologySection.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/ApplyOntologySection.tsx
@@ -60,7 +60,7 @@ const ApplyOntologySection = ({ field }: ApplyOntologySectionProps) => {
         spacing={Spacing.Sm}
         style={{ alignItems: "center", justifyContent: "space-between" }}
       >
-        <Text variant={TextVariant.Lg}>Apply Ontology</Text>
+        <Text variant={TextVariant.Lg}>Ontology</Text>
         <Toggle size={Size.Md} checked={expanded} onChange={handleToggle} />
       </Stack>
       <Text variant={TextVariant.Lg} color={TextColor.Secondary}>


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Fixes a bug where null values could show incorrect error messages 

Apply Ontology -> Ontology

## 🧪 How is this patch tested? If it is not, please explain why.

Tested locally - before:

<img width="281" height="391" alt="Screenshot from 2026-05-15 17-08-50" src="https://github.com/user-attachments/assets/b2831eeb-4f0b-4ace-81f9-8327055f9659" />


After:

<img width="271" height="293" alt="Screenshot from 2026-05-15 17-08-18" src="https://github.com/user-attachments/assets/6e1de13c-aa0b-48ae-8864-cf5412b725c5" />


## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form error messaging to accurately reflect current form state, particularly when fields contain null values.

* **Style**
  * Updated ontology section label for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7561?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->