### PR TITLE
[HA] Deactivate all annotation modes when leaving annotation context

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Actions.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Actions.tsx
@@ -36,6 +36,7 @@ import { useClassificationMode } from "./Edit/useClassificationMode";
 import { useDetectionMode } from "./Edit/useDetectionMode";
 import { usePolylineMode } from "./Edit/usePolylineMode";
 import { useSegmentationMode } from "./Edit/useSegmentationMode";
+import { useDeactivateAllModes } from "./useDeactivateAllModes";
 import { Anchor, Text, Tooltip } from "@voxel51/voodo";
 import { FeatureFlag, FeatureFlagged } from "@fiftyone/feature-flags";
 
@@ -433,14 +434,11 @@ const Actions = () => {
   // This checks if a 3d sample is pinned - is true when media type is `group` with a 3d slice pinned
   const { isPinned: is3dSamplePinned } = useRenderConfig3dState();
 
-  const { classificationModeActive, deactivateClassificationMode } =
-    useClassificationMode();
-  const { detectionModeActive, deactivateDetectionMode } = useDetectionMode();
-  const { segmentationModeActive, deactivateSegmentationMode } =
-    useSegmentationMode();
-  const { polylineModeActive, deactivatePolylineMode } = usePolylineMode();
+  const { classificationModeActive } = useClassificationMode();
+  const { detectionModeActive } = useDetectionMode();
+  const { segmentationModeActive } = useSegmentationMode();
+  const { polylineModeActive } = usePolylineMode();
   const current3dAnnotationMode = useCurrent3dAnnotationMode();
-  const setCurrent3dAnnotationMode = useSetCurrent3dAnnotationMode();
 
   const noActiveActions =
     !classificationModeActive &&
@@ -450,19 +448,7 @@ const Actions = () => {
     !current3dAnnotationMode;
   const areThreeDActionsVisible = is3dDataset || is3dSamplePinned;
 
-  const deactivateAll = useCallback(() => {
-    deactivateClassificationMode();
-    deactivateDetectionMode();
-    deactivateSegmentationMode();
-    setCurrent3dAnnotationMode(null);
-    deactivatePolylineMode();
-  }, [
-    deactivateClassificationMode,
-    deactivateDetectionMode,
-    deactivatePolylineMode,
-    deactivateSegmentationMode,
-    setCurrent3dAnnotationMode,
-  ]);
+  const deactivateAll = useDeactivateAllModes();
 
   return (
     <DeactivateAllContext.Provider value={deactivateAll}>

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/RequiredFieldPrompt.test.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/RequiredFieldPrompt.test.tsx
@@ -20,6 +20,10 @@ vi.mock("./useCanManageSchema", () => ({
   default: vi.fn(() => true),
 }));
 
+vi.mock("./useDeactivateAllModes", () => ({
+  useDeactivateAllModes: () => vi.fn(),
+}));
+
 vi.mock("./useAnnotationContextManager", async (importOriginal) => {
   const actual = await importOriginal<
     typeof import("./useAnnotationContextManager")

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useAnnotationContextManager.test.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useAnnotationContextManager.test.ts
@@ -44,6 +44,7 @@ vi.mock("@fiftyone/state", () => ({
   })),
   useActiveModalFields: () => [[], vi.fn()],
   useQueryPerformanceSampleLimit: () => 1000,
+  useUnboundStateRef: (val: unknown) => ({ current: val }),
 }));
 
 vi.mock("@fiftyone/state/src/jotai", () => ({
@@ -72,6 +73,10 @@ vi.mock("./state", () => ({
 
 vi.mock("./useCanManageSchema", () => ({
   default: vi.fn(() => mockCanManageSchema),
+}));
+
+vi.mock("./useDeactivateAllModes", () => ({
+  useDeactivateAllModes: () => vi.fn(),
 }));
 
 vi.mock("./useSchemaResolver", async () => {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useAnnotationContextManager.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useAnnotationContextManager.ts
@@ -4,6 +4,7 @@ import {
   DefaultContextManager,
   useActiveModalFields,
   useQueryPerformanceSampleLimit,
+  useUnboundStateRef,
 } from "@fiftyone/state";
 import { atom, useAtom, useAtomValue, useSetAtom } from "jotai";
 import { jotaiStore } from "@fiftyone/state/src/jotai";
@@ -12,6 +13,7 @@ import { usePrimitiveController } from "./Edit/useActivePrimitive";
 import useSave from "./Edit/useSave";
 import { useAnnotationSchemaContext } from "./state";
 import useCanManageSchema from "./useCanManageSchema";
+import { useDeactivateAllModes } from "./useDeactivateAllModes";
 import {
   schemaManagementOpsAtom,
   useSchemaResolver,
@@ -110,6 +112,9 @@ export const useAnnotationContextManager = (): AnnotationContextManager => {
   const schemaResolver = useSchemaResolver();
   const { isPrimitive, setActivePrimitive } = usePrimitiveController();
   const { reset: clearStaleMutations } = useSampleMutationManager();
+  // Held in a ref so exit() invokes the most recent deactivator chain
+  // even when the captured `exit` closure was snapshotted at mount.
+  const deactivateAllModesRef = useUnboundStateRef(useDeactivateAllModes());
 
   const activateField = useCallback(
     async (field: string): Promise<EnterResult> => {
@@ -225,9 +230,10 @@ export const useAnnotationContextManager = (): AnnotationContextManager => {
     if (contextManager.isActive()) {
       saveChanges();
       clearStaleMutations();
+      deactivateAllModesRef.current();
       contextManager.exit();
     }
-  }, [clearStaleMutations, contextManager, saveChanges]);
+  }, [clearStaleMutations, contextManager, deactivateAllModesRef, saveChanges]);
 
   return useMemo(
     () => ({

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useDeactivateAllModes.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useDeactivateAllModes.ts
@@ -1,0 +1,34 @@
+import { useSetCurrent3dAnnotationMode } from "@fiftyone/looker-3d/src/state/accessors";
+import { useCallback } from "react";
+import { useClassificationMode } from "./Edit/useClassificationMode";
+import { useDetectionMode } from "./Edit/useDetectionMode";
+import { usePolylineMode } from "./Edit/usePolylineMode";
+import { useSegmentationMode } from "./Edit/useSegmentationMode";
+
+/**
+ * Returns a callback that deactivates every annotation mode (2D + 3D).
+ *
+ * Used to switch between modes and to clear mode state on exit, so modes do
+ * not leak out of the Annotate tab.
+ */
+export const useDeactivateAllModes = () => {
+  const { deactivateClassificationMode } = useClassificationMode();
+  const { deactivateDetectionMode } = useDetectionMode();
+  const { deactivateSegmentationMode } = useSegmentationMode();
+  const { deactivatePolylineMode } = usePolylineMode();
+  const setCurrent3dAnnotationMode = useSetCurrent3dAnnotationMode();
+
+  return useCallback(() => {
+    deactivateClassificationMode();
+    deactivateDetectionMode();
+    deactivateSegmentationMode();
+    deactivatePolylineMode();
+    setCurrent3dAnnotationMode(null);
+  }, [
+    deactivateClassificationMode,
+    deactivateDetectionMode,
+    deactivatePolylineMode,
+    deactivateSegmentationMode,
+    setCurrent3dAnnotationMode,
+  ]);
+};


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

Fixes a bug where annotation modes could "leak" outside of the annotation experience (e.g. a floating toolbar showing while on the explore tab). This PR adds mode deactivation logic when leaving the annotation context to prevent leakage.

## 🧪 How is this patch tested? If it is not, please explain why.

local

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated annotation-mode deactivation into a single, reusable mechanism used across components.
  * Ensures all annotation modes, including 3D, are reliably deactivated when exiting annotation context.
  * Updated components to consume the centralized deactivation behavior for consistent state handling.

* **Tests**
  * Adjusted mocks to support the new deactivation hook and related state refs for stable testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->