### PR TITLE
[HA] update polyline mode to use two-stage mode deactivation

### DIFF
--- a/app/packages/core/src/components/Modal/Lighter/useBridge.ts
+++ b/app/packages/core/src/components/Modal/Lighter/useBridge.ts
@@ -32,6 +32,7 @@ import {
   savedLabel,
 } from "../Sidebar/Annotate/Edit/state";
 import { useDetectionMode } from "../Sidebar/Annotate/Edit/useDetectionMode";
+import { usePolylineMode } from "../Sidebar/Annotate/Edit/usePolylineMode";
 import {
   SegmentationTool,
   useSegmentationMode,
@@ -76,6 +77,7 @@ export const useBridge = (scene: Scene2D | null) => {
 
   const segmentationMode = useSegmentationMode();
   const detectionMode = useDetectionMode();
+  const polylineMode = usePolylineMode();
   const focus = useFocus();
 
   useAnnotationEventHandler(
@@ -180,10 +182,7 @@ export const useBridge = (scene: Scene2D | null) => {
       const f = focusRef.current;
       const s = sceneRef.current;
 
-      if (
-        sm.segmentationModeActive &&
-        sm.tool === SegmentationTool.Merge
-      ) {
+      if (sm.segmentationModeActive && sm.tool === SegmentationTool.Merge) {
         const overlay = s?.getOverlay(payload.id);
         if (overlay instanceof DetectionOverlay) {
           // Merge tool consumes the click; `true` means we should skip the
@@ -209,10 +208,7 @@ export const useBridge = (scene: Scene2D | null) => {
     useCallback((payload) => {
       const sm = segmentationModeRef.current;
 
-      if (
-        sm.segmentationModeActive &&
-        sm.tool === SegmentationTool.Merge
-      ) {
+      if (sm.segmentationModeActive && sm.tool === SegmentationTool.Merge) {
         return;
       }
 
@@ -229,10 +225,7 @@ export const useBridge = (scene: Scene2D | null) => {
     useCallback((payload) => {
       const sm = segmentationModeRef.current;
 
-      if (
-        sm.segmentationModeActive &&
-        sm.tool === SegmentationTool.Merge
-      ) {
+      if (sm.segmentationModeActive && sm.tool === SegmentationTool.Merge) {
         sm.mergeTool.clearMergeTarget();
         focusRef.current.deselectOverlay({
           ignoreSideEffects: payload.ignoreSideEffects,
@@ -390,6 +383,29 @@ export const useBridge = (scene: Scene2D | null) => {
     useCallback(() => {
       detectionMode.deactivateDetectionMode();
     }, [detectionMode])
+  );
+
+  // Generic "quit the active mode" request from global gestures (e.g.
+  // right-click on empty canvas). Each mode self-filters on its own active
+  // state so InteractionManager doesn't need to know about modes.
+  useEventHandler(
+    "lighter:active-mode-quit-requested",
+    useCallback(() => {
+      if (detectionMode.detectionModeActive) {
+        detectionMode.deactivateDetectionMode();
+        return;
+      }
+
+      if (segmentationMode.segmentationModeActive) {
+        segmentationMode.deactivateSegmentationMode();
+        return;
+      }
+
+      if (polylineMode.polylineModeActive) {
+        polylineMode.deactivatePolylineMode();
+        return;
+      }
+    }, [detectionMode, polylineMode, segmentationMode])
   );
 
   useEventHandler(

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/usePolylineMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/usePolylineMode.ts
@@ -65,8 +65,12 @@ const resolveEmptyHit = (ctx: PolylineEmptyHitContext) =>
  *
  * The mode exits when:
  *
- * - The deactivation function is called explicitly, or
- * - Selection moves from a 2D polyline to a different label, or to nothing.
+ * - The deactivation function is called explicitly (toolbar toggle, generic
+ *   mode-quit gesture, etc.), or
+ * - Selection moves from a 2D polyline to a different (non-polyline) label.
+ *
+ * Deselecting entirely does NOT exit the mode — the user is still in polyline
+ * mode, just without an active edit target, ready to draw a new one.
  */
 export const usePolylineMode = () => {
   const [polylineModeActive, setPolylineModeActive] = useAtom(
@@ -94,7 +98,7 @@ export const usePolylineMode = () => {
     ? "No active fields"
     : polylineModeActive
     ? "Exit polyline mode"
-    : "Edit polylines";
+    : "Create new polylines";
 
   const exitInstalledHandler = useCallback(() => {
     if (!installedHandlerRef.current) {
@@ -106,9 +110,10 @@ export const usePolylineMode = () => {
   }, [scene]);
 
   // Selection drives the mode. Selecting a 2D polyline activates polyline
-  // mode; selecting a non-polyline (or deselecting) exits it.
-  // Toolbar activations with no selection are preserved (the previous selection
-  // ref lets us distinguish "no change" from "user deselected").
+  // mode; switching from a polyline to a *different* non-polyline label
+  // exits it. Deselecting entirely leaves the mode active so the user can
+  // immediately draw another polyline — exiting requires an explicit gesture
+  // (toolbar toggle or generic mode-quit).
   const prevSelectedLabelRef = useRef(selectedLabel);
   useEffect(() => {
     const prev = prevSelectedLabelRef.current;
@@ -119,12 +124,10 @@ export const usePolylineMode = () => {
 
     if (isPolyline2d) {
       setPolylineModeActive(true);
-    } else if (wasPolyline2d) {
-      // Selection moved away from a polyline (different label or deselect).
+    } else if (wasPolyline2d && selectedLabel) {
+      // Switched from a polyline to a different non-polyline label.
       setPolylineModeActive(false);
     }
-    // Otherwise the selection isn't (and wasn't) a polyline — leave the mode
-    // alone so toolbar-driven activations stick around for creation.
   }, [selectedLabel, setPolylineModeActive]);
 
   // Stable ref so the creation handler's `onCreate` always sees the latest

--- a/app/packages/lighter/src/events/index.ts
+++ b/app/packages/lighter/src/events/index.ts
@@ -136,6 +136,12 @@ export type LighterEventGroup = {
   "lighter:detection-mode-quit": { eventId: string };
   /** Emitted when user clicks without dragging in segmentation mode to close out the current detection */
   "lighter:segmentation-mode-quit": { eventId: string };
+  /**
+   * Generic "quit the active annotation mode" request, fired by global gestures
+   * (e.g. right-click on empty canvas). Listeners are expected to no-op unless
+   * their own mode is active, in which case they deactivate it.
+   */
+  "lighter:active-mode-quit-requested": { eventId: string };
   /** Emitted when the AI mask should be established and point selection ended (e.g. right-click). */
   "lighter:point-selection-finalize": { eventId: string };
 

--- a/app/packages/lighter/src/interaction/InteractionManager.ts
+++ b/app/packages/lighter/src/interaction/InteractionManager.ts
@@ -1135,19 +1135,12 @@ export class InteractionManager {
     }
 
     // ---- Tier 3: Exit the current mode ----
-
-    if (detectionModeBridge.isActive()) {
-      this.eventBus.dispatch("lighter:detection-mode-quit", {
-        eventId: generateUUID(),
-      });
-      return;
-    }
-
-    if (segmentationModeBridge.isActive()) {
-      this.eventBus.dispatch("lighter:segmentation-mode-quit", {
-        eventId: generateUUID(),
-      });
-    }
+    //
+    // Mode-agnostic dispatch; mode-specific handlers can decide whether they
+    // should deactivate
+    this.eventBus.dispatch("lighter:active-mode-quit-requested", {
+      eventId: generateUUID(),
+    });
   };
 
   private handleHover(point: Point, event: PointerEvent): void {


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

Migrates right-click behavior to match two-stage deactivation consistent with other modes. First right click deselects the current label, but leaves the mode active. Second right click deactivates the mode.

## 🧪 How is this patch tested? If it is not, please explain why.

local

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Polyline mode now remains active when deselecting, only exiting when switching to a different annotation type or explicitly deactivating via the quit gesture.
  * Right-click behavior now consistently deactivates the current annotation mode across all mode types using a unified gesture system.
  * Updated tooltip text for polyline creation functionality to better reflect its purpose.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->