### PR TITLE
[HA] update polyline extension to use sticky endpoints

### DIFF
--- a/app/packages/lighter/src/interaction/InteractivePolylineHandler.ts
+++ b/app/packages/lighter/src/interaction/InteractivePolylineHandler.ts
@@ -294,7 +294,9 @@ export class InteractivePolylineHandler implements InteractionHandler {
     worldPoint: Point,
     modifiers: ClickEventModifiers
   ): void {
-    this.overlay.setPreviewAnchorFlipped(modifiers.metaKey);
+    this.overlay.setPreviewAnchorFlipped(
+      modifiers.metaKey || modifiers.ctrlKey
+    );
 
     // hide preview if:
     //   - creating a new segment (holding shift key)

--- a/app/packages/lighter/src/interaction/InteractivePolylineHandler.ts
+++ b/app/packages/lighter/src/interaction/InteractivePolylineHandler.ts
@@ -2,7 +2,7 @@
  * Copyright 2017-2026, Voxel51, Inc.
  */
 
-import { CommandContextManager } from "@fiftyone/commands";
+import { CommandContextManager, type Undoable } from "@fiftyone/commands";
 import { ClickEventModifiers, getClickModifiers } from "@fiftyone/utilities";
 import { AddPolylinePointCommand } from "../commands/AddPolylinePointCommand";
 import { MoveKeypointPointCommand } from "../commands/MoveKeypointPointCommand";
@@ -120,6 +120,15 @@ export class InteractivePolylineHandler implements InteractionHandler {
   private readonly priorIsDeletable: boolean;
 
   private setActiveSegmentIdx(segmentIdx: number | null): void {
+    // Invariant: sticky is only ever set on the active segment. When the
+    // user shifts focus to a segment that doesn't house the sticky point,
+    // clear sticky so reads don't need a segment-mismatch gate.
+    if (this.lastExtensionPointId !== null && segmentIdx !== null) {
+      const loc = this.overlay.findPointLocationById(this.lastExtensionPointId);
+      if (loc && loc.segmentIdx !== segmentIdx) {
+        this.setLastExtensionPointId(null);
+      }
+    }
     this.activeSegmentIdx = segmentIdx;
     this.overlay.setPreviewAnchorSegmentIdx(segmentIdx);
   }
@@ -127,6 +136,33 @@ export class InteractivePolylineHandler implements InteractionHandler {
   private setLastExtensionPointId(pointId: string | null): void {
     this.lastExtensionPointId = pointId;
     this.overlay.setPreviewAnchorPointId(pointId);
+  }
+
+  /**
+   * Pushes `cmd` onto the active undo context, wrapping execute/undo so the
+   * sticky pointer follows the command's lifecycle.
+   */
+  private pushWithStickyTracking(
+    cmd: Undoable,
+    stickyAfter: string | null
+  ): void {
+    const stickyBefore = this.lastExtensionPointId;
+    this.setLastExtensionPointId(stickyAfter);
+
+    const wrapped: Undoable = {
+      id: cmd.id,
+      execute: () => {
+        cmd.execute();
+        this.setLastExtensionPointId(stickyAfter);
+      },
+      undo: () => {
+        cmd.undo();
+        this.setLastExtensionPointId(stickyBefore);
+      },
+    };
+
+    CommandContextManager.instance().getActiveContext().pushUndoable(wrapped);
+    this.pushedCommandIds.add(cmd.id);
   }
 
   constructor(
@@ -441,14 +477,18 @@ export class InteractivePolylineHandler implements InteractionHandler {
     }
 
     const segCountBefore = this.overlay.getSegmentCount();
+    // If the deleted point is the current sticky, clear sticky on
+    // execute/redo and restore it on undo
+    const stickyAfter =
+      this.lastExtensionPointId === pointId ? null : this.lastExtensionPointId;
+
     const cmd = new RemovePolylinePointCommand(
       this.overlay,
       loc.segmentIdx,
       loc.indexInSegment
     );
     cmd.execute();
-    CommandContextManager.instance().getActiveContext().pushUndoable(cmd);
-    this.pushedCommandIds.add(cmd.id);
+    this.pushWithStickyTracking(cmd, stickyAfter);
 
     // If the segment was emptied, indices for following segments shift down.
     if (this.overlay.getSegmentCount() < segCountBefore) {
@@ -504,11 +544,8 @@ export class InteractivePolylineHandler implements InteractionHandler {
       undefined,
       true
     );
-    CommandContextManager.instance().getActiveContext().pushUndoable(cmd);
-    this.pushedCommandIds.add(cmd.id);
-
     this.setActiveSegmentIdx(newSegIdx);
-    this.setLastExtensionPointId(newId);
+    this.pushWithStickyTracking(cmd, newId);
 
     return newId;
   }
@@ -546,11 +583,15 @@ export class InteractivePolylineHandler implements InteractionHandler {
    * descriptor, or `null` if sticky should not apply. Returns `null` when:
    *
    *   - sticky was never set (no extends yet), or
-   *   - the sticky point was removed (undo, alt-delete), or
-   *   - the sticky point is no longer an endpoint (e.g. edge insert
-   *     turned it into an interior point), or
-   *   - the user shifted focus to a different segment (point/edge click on
-   *     another segment), so sticky shouldn't override that intent.
+   *   - the sticky point was removed, or
+   *   - the sticky point is no longer an endpoint (e.g. inserting a point
+   *     on a closed polyline's closing edge pushes the old tail to an
+   *     interior position).
+   *
+   * Invariant: sticky is kept on the active segment by
+   * {@link setActiveSegmentIdx} (which clears it on segment switch) and is
+   * cleared on point removal at command-push time via
+   * {@link pushWithStickyTracking}.
    */
   private getStickyEndpoint(): {
     segmentIdx: number;
@@ -562,13 +603,6 @@ export class InteractivePolylineHandler implements InteractionHandler {
 
     const loc = this.overlay.findPointLocationById(this.lastExtensionPointId);
     if (!loc) {
-      return null;
-    }
-
-    if (
-      this.activeSegmentIdx !== null &&
-      loc.segmentIdx !== this.activeSegmentIdx
-    ) {
       return null;
     }
 
@@ -641,10 +675,7 @@ export class InteractivePolylineHandler implements InteractionHandler {
       newId,
       relativePoint
     );
-    CommandContextManager.instance().getActiveContext().pushUndoable(cmd);
-    this.pushedCommandIds.add(cmd.id);
-
-    this.setLastExtensionPointId(newId);
+    this.pushWithStickyTracking(cmd, newId);
 
     return newId;
   }

--- a/app/packages/lighter/src/interaction/InteractivePolylineHandler.ts
+++ b/app/packages/lighter/src/interaction/InteractivePolylineHandler.ts
@@ -100,6 +100,18 @@ export class InteractivePolylineHandler implements InteractionHandler {
   private activeSegmentIdx: number | null = null;
 
   /**
+   * Sticky endpoint for empty-space EXTEND clicks. Updated to the new point
+   * id after each extend so subsequent extends keep appending from the same
+   * end of the segment, rather than re-picking the nearest endpoint to the
+   * cursor each time. Validated on use against {@link PolylineOverlay} —
+   * if the point has been removed (undo, alt-delete) or is no longer an
+   * endpoint (edge insert), EXTEND falls back to the nearest-endpoint
+   * behavior. Meta-key still overrides to extend from the opposite end,
+   * which then becomes the new sticky.
+   */
+  private lastExtensionPointId: string | null = null;
+
+  /**
    * Saved `isDeletable` value from before the handler installed. Polyline
    * overlays are typically constructed with `deletable: false` so deletes are
    * blocked in non-edit contexts; an active editing session needs point
@@ -110,6 +122,11 @@ export class InteractivePolylineHandler implements InteractionHandler {
   private setActiveSegmentIdx(segmentIdx: number | null): void {
     this.activeSegmentIdx = segmentIdx;
     this.overlay.setPreviewAnchorSegmentIdx(segmentIdx);
+  }
+
+  private setLastExtensionPointId(pointId: string | null): void {
+    this.lastExtensionPointId = pointId;
+    this.overlay.setPreviewAnchorPointId(pointId);
   }
 
   constructor(
@@ -219,13 +236,17 @@ export class InteractivePolylineHandler implements InteractionHandler {
       return true;
     }
 
-    // connect to the farthest endpoint when holding meta key,
-    // otherwise the nearest endpoint
-    if (modifiers.metaKey) {
-      this.extendFarthestEndpoint(worldPoint, rp);
-    } else {
+    // Meta/ctrl-click swaps from sticky to the opposite endpoint of the same
+    // segment. When sticky is absent or stale, fall back to farthest from
+    // cursor. Non-meta clicks prefer sticky, falling back to nearest.
+    if (modifiers.metaKey || modifiers.ctrlKey) {
+      if (this.tryExtendOppositeOfSticky(rp) === null) {
+        this.extendFarthestEndpoint(worldPoint, rp);
+      }
+    } else if (this.tryExtendFromSticky(rp) === null) {
       this.extendNearestEndpoint(worldPoint, rp);
     }
+
     return true;
   }
 
@@ -348,6 +369,7 @@ export class InteractivePolylineHandler implements InteractionHandler {
     this.overlay.setPreviewPoint(null);
     this.overlay.setPreviewAnchorSegmentIdx(null);
     this.overlay.setPreviewAnchorFlipped(false);
+    this.overlay.setPreviewAnchorPointId(null);
     this.overlay.setDeletable(this.priorIsDeletable);
   }
 
@@ -484,6 +506,7 @@ export class InteractivePolylineHandler implements InteractionHandler {
     this.pushedCommandIds.add(cmd.id);
 
     this.setActiveSegmentIdx(newSegIdx);
+    this.setLastExtensionPointId(newId);
 
     return newId;
   }
@@ -516,6 +539,78 @@ export class InteractivePolylineHandler implements InteractionHandler {
     );
   }
 
+  /**
+   * Resolves the sticky last-extended point to a `{segmentIdx, end}`
+   * descriptor, or `null` if sticky should not apply. Returns `null` when:
+   *
+   *   - sticky was never set (no extends yet), or
+   *   - the sticky point was removed (undo, alt-delete), or
+   *   - the sticky point is no longer an endpoint (e.g. edge insert
+   *     turned it into an interior point), or
+   *   - the user shifted focus to a different segment (point/edge click on
+   *     another segment), so sticky shouldn't override that intent.
+   */
+  private getStickyEndpoint(): {
+    segmentIdx: number;
+    end: "head" | "tail";
+  } | null {
+    if (!this.lastExtensionPointId) {
+      return null;
+    }
+
+    const loc = this.overlay.findPointLocationById(this.lastExtensionPointId);
+    if (!loc) {
+      return null;
+    }
+
+    if (
+      this.activeSegmentIdx !== null &&
+      loc.segmentIdx !== this.activeSegmentIdx
+    ) {
+      return null;
+    }
+
+    const segLen = this.overlay.getSegmentLength(loc.segmentIdx);
+    if (loc.indexInSegment === 0) {
+      return { segmentIdx: loc.segmentIdx, end: "head" };
+    }
+    if (loc.indexInSegment === segLen - 1) {
+      return { segmentIdx: loc.segmentIdx, end: "tail" };
+    }
+    return null;
+  }
+
+  /**
+   * Sticky EXTEND — appends to the last-extended endpoint. Returns the new
+   * point id on success, or `null` so callers can fall back to
+   * nearest-endpoint behavior.
+   */
+  private tryExtendFromSticky(relativePoint: [number, number]): string | null {
+    const ep = this.getStickyEndpoint();
+    return ep ? this.extendFromEndpoint(relativePoint, ep) : null;
+  }
+
+  /**
+   * Meta-swap EXTEND — appends to the endpoint *opposite* the sticky one.
+   * The previous sticky might already be the geometric far endpoint from
+   * the cursor, so falling through to "farthest from cursor" would no-op;
+   * swapping by endpoint identity instead guarantees a real toggle.
+   * Returns `null` when no valid sticky exists, so callers can fall back
+   * to the unanchored farthest-endpoint behavior.
+   */
+  private tryExtendOppositeOfSticky(
+    relativePoint: [number, number]
+  ): string | null {
+    const ep = this.getStickyEndpoint();
+    if (!ep) {
+      return null;
+    }
+    return this.extendFromEndpoint(relativePoint, {
+      segmentIdx: ep.segmentIdx,
+      end: ep.end === "head" ? "tail" : "head",
+    });
+  }
+
   private extendFromEndpoint(
     relativePoint: [number, number],
     target: SegmentEndpoint
@@ -546,6 +641,8 @@ export class InteractivePolylineHandler implements InteractionHandler {
     );
     CommandContextManager.instance().getActiveContext().pushUndoable(cmd);
     this.pushedCommandIds.add(cmd.id);
+
+    this.setLastExtensionPointId(newId);
 
     return newId;
   }

--- a/app/packages/lighter/src/interaction/InteractivePolylineHandler.ts
+++ b/app/packages/lighter/src/interaction/InteractivePolylineHandler.ts
@@ -330,7 +330,7 @@ export class InteractivePolylineHandler implements InteractionHandler {
     return "crosshair";
   }
 
-  onPointerUp(_point: Point, _event: PointerEvent): boolean {
+  onPointerUp(_params: OverlayEvent): boolean {
     if (this.dragPointId === null) {
       return true;
     }

--- a/app/packages/lighter/src/overlay/PolylineOverlay.ts
+++ b/app/packages/lighter/src/overlay/PolylineOverlay.ts
@@ -104,6 +104,16 @@ export class PolylineOverlay extends KeypointOverlay {
    */
   private previewAnchorFlipped = false;
 
+  /**
+   * Sticky-extension override: when set, the preview line anchors against
+   * this specific point instead of the segment's nearest endpoint. Mirrors
+   * the {@link InteractivePolylineHandler}'s last-extended point id so the
+   * dashed preview matches the click target. The meta-flip flag takes
+   * precedence — pressing meta still telegraphs (and produces) a swap to
+   * the opposite endpoint of the active segment.
+   */
+  private previewAnchorPointId: string | null = null;
+
   constructor(options: PolylineOptions) {
     const { flatPoints, connections, segmentBoundaries } =
       flattenPolylinePoints(options.label.points ?? []);
@@ -716,10 +726,31 @@ export class PolylineOverlay extends KeypointOverlay {
   }
 
   /**
-   * Anchors the preview line to whichever endpoint of the active segment
-   * (or globally, if no active segment) is closest to the cursor — so the
-   * dashed line previews the actual point that EXTEND will produce. The
-   * meta-flip flag inverts that to the far endpoint instead.
+   * Sets the sticky-anchor point id for the preview line. When set (and the
+   * point still exists, and meta-flip is off), the preview anchors against
+   * this point instead of the segment's nearest endpoint. Pass `null` to
+   * clear and fall back to nearest-endpoint anchoring.
+   */
+  setPreviewAnchorPointId(pointId: string | null): void {
+    if (this.previewAnchorPointId === pointId) {
+      return;
+    }
+
+    this.previewAnchorPointId = pointId;
+    this.markDirty();
+  }
+
+  /**
+   * Anchors the preview line so the dashed telegraph matches the point that
+   * EXTEND will actually produce on click.
+   *
+   *   - **Sticky set, no meta-flip** — anchor to the sticky point.
+   *   - **Sticky set, meta-flip on** — anchor to the opposite endpoint of
+   *     the sticky's segment (matches the swap-by-identity logic in
+   *     {@link InteractivePolylineHandler}).
+   *   - **No sticky (or sticky is stale/no longer an endpoint)** — fall
+   *     back to `findNearestEndpoint` against the active segment, with
+   *     meta-flip selecting farthest-from-cursor.
    */
   protected override renderPreviewLine(
     renderer: Renderer2D,
@@ -729,30 +760,61 @@ export class PolylineOverlay extends KeypointOverlay {
       return;
     }
 
-    const nearest = this.findNearestEndpoint(
-      this.previewPoint,
-      this.previewAnchorSegmentIdx ?? undefined,
-      this.previewAnchorFlipped
-    );
-    if (!nearest) {
-      return;
+    // Sticky-aware anchor resolution: when a sticky point id is set and the
+    // point is still an endpoint of its segment, anchor to that point — or,
+    // when meta-flip is active, to the opposite endpoint of the same
+    // segment (matching the meta-swap behavior in
+    // InteractivePolylineHandler, which toggles by endpoint identity rather
+    // than by cursor distance).
+    let entry: ReturnType<typeof this.getPointById> | null = null;
+
+    if (this.previewAnchorPointId) {
+      const loc = this.findPointLocationById(this.previewAnchorPointId);
+      if (loc) {
+        const segLen = this.getSegmentLength(loc.segmentIdx);
+        let anchorIndexInSegment: number | null = null;
+        if (loc.indexInSegment === 0) {
+          anchorIndexInSegment = this.previewAnchorFlipped ? segLen - 1 : 0;
+        } else if (loc.indexInSegment === segLen - 1) {
+          anchorIndexInSegment = this.previewAnchorFlipped ? 0 : segLen - 1;
+        }
+        if (anchorIndexInSegment !== null) {
+          const anchorId = this.getPointIdInSegment(
+            loc.segmentIdx,
+            anchorIndexInSegment
+          );
+          entry = anchorId ? this.getPointById(anchorId) : null;
+        }
+      }
     }
 
-    const segLen = this.getSegmentLength(nearest.segmentIdx);
-    if (segLen === 0) {
-      return;
+    if (!entry) {
+      const nearest = this.findNearestEndpoint(
+        this.previewPoint,
+        this.previewAnchorSegmentIdx ?? undefined,
+        this.previewAnchorFlipped
+      );
+      if (!nearest) {
+        return;
+      }
+
+      const segLen = this.getSegmentLength(nearest.segmentIdx);
+      if (segLen === 0) {
+        return;
+      }
+
+      const indexInSegment = nearest.end === "head" ? 0 : segLen - 1;
+      const anchorId = this.getPointIdInSegment(
+        nearest.segmentIdx,
+        indexInSegment
+      );
+      if (!anchorId) {
+        return;
+      }
+
+      entry = this.getPointById(anchorId);
     }
 
-    const indexInSegment = nearest.end === "head" ? 0 : segLen - 1;
-    const anchorId = this.getPointIdInSegment(
-      nearest.segmentIdx,
-      indexInSegment
-    );
-    if (!anchorId) {
-      return;
-    }
-
-    const entry = this.getPointById(anchorId);
     if (!entry) {
       return;
     }


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

Current polyline extension always prefers the nearest segment endpoint, with a keybind to swap to the farthest endpoint. This PR updates the behavior to make extension "sticky" - the last used endpoint is preferred regardless of proximity. Holding cmd/ctrl will still allow for swapping to the opposite endpoint

## 🧪 How is this patch tested? If it is not, please explain why.

local

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Polyline extensions retain a "sticky" endpoint that subsequent extensions reference by default; meta/ctrl-click extends from the opposite endpoint.
  * Preview line anchoring now targets the remembered extension point and treats meta and ctrl as flip toggles for the preview.

* **Bug Fixes**
  * Sticky endpoint is validated and falls back gracefully if removed or no longer valid; undo/redo and deletion restore or clear sticky state appropriately.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7564?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->