### PR TITLE
[HA] fix point offset when resizing mask canvas

### DIFF
--- a/app/packages/lighter/src/overlay/MaskCanvas.ts
+++ b/app/packages/lighter/src/overlay/MaskCanvas.ts
@@ -702,6 +702,16 @@ export class MaskCanvas {
 
     this.updateCanvas(newWidth, newHeight, offsetX, offsetY);
 
+    // Existing pixels were shifted by (offsetX, offsetY); the cached lastPoint
+    // is in canvas-pixel coords and must be shifted in lockstep so paintLine
+    // continues to interpolate from the correct origin after a resize.
+    if (this.lastPoint) {
+      this.lastPoint = {
+        x: this.lastPoint.x + offsetX,
+        y: this.lastPoint.y + offsetY,
+      };
+    }
+
     return {
       x: minX,
       y: minY,


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

Fixes a bug where last paint location was not being translated to new canvas coordinates in some cases. This manifested as
* gaps in painted line when moving cursor quickly
* erroneous bounding box dimensions due to stacking offset gaps

## 🧪 How is this patch tested? If it is not, please explain why.

local

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where drawing strokes would continue from incorrect positions after resizing the canvas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->