### PR TITLE
[HA] disable image smoothing when merging masks

### DIFF
--- a/app/packages/lighter/src/overlay/MaskCanvas.ts
+++ b/app/packages/lighter/src/overlay/MaskCanvas.ts
@@ -534,8 +534,16 @@ export class MaskCanvas {
       const dw = (otherBounds.width / newBounds.width) * this.canvas.width;
       const dh = (otherBounds.height / newBounds.height) * this.canvas.height;
 
+      // Disable smoothing so the source's binary edge pixels don't get
+      // bilinear-spread across two destination pixels at fractional offsets.
+      // updateCanvas thresholds any non-zero alpha to fully opaque, so without
+      // this the anti-aliased fringe would be promoted to solid pixels and
+      // the mask would grow by ~1 pixel on each edge.
+      const prevSmoothing = this.context.imageSmoothingEnabled;
+      this.context.imageSmoothingEnabled = false;
       this.context.globalCompositeOperation = "source-over";
       this.context.drawImage(otherSource, dx, dy, dw, dh);
+      this.context.imageSmoothingEnabled = prevSmoothing;
     }
 
     this.paintEnd(newBounds, onEncoded);


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

When merging masks, we leverage canvas primitives to draw masks into a shared canvas. By default, this interpolates fractional pixels. In our case, we want to preserve pixel boundaries to prevent mask feathering during a merge. This PR disables image smoothing when drawing the mask into the shared canvas.

## 🧪 How is this patch tested? If it is not, please explain why.

local

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mask compositing to prevent anti-aliasing artifacts from affecting edge quality, resulting in cleaner and more precise mask rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->