### PR TITLE
fix(modal): remove sample-bound suspension in useCanAnnotate

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Annotate.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Annotate.tsx
@@ -28,9 +28,9 @@ const DISABLED_MESSAGES: Record<
       Annotation isn&rsquo;t supported for frames, clips, or materialized views.
     </p>
   ),
-  groupedDatasetNoSupportedSlices: (
+  groupDatasetNoSupportedSlices: (
     <p>
-      This grouped dataset has no slices that support annotation. Only image and
+      This group dataset has no slices that support annotation. Only image and
       3D slices can be annotated.
     </p>
   ),

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useCanAnnotate.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useCanAnnotate.ts
@@ -1,18 +1,26 @@
 import {
   canAnnotate,
   isGeneratedView,
-  isGroup,
   isPatchesView,
   mediaType,
   readOnly,
+  useGroupSlices,
+  useIsGroupDataset,
 } from "@fiftyone/state";
 import { isAnnotationSupported } from "@fiftyone/utilities";
 import { useRecoilValue } from "recoil";
-import { useGroupAnnotationSlices } from "./useGroupAnnotationSlices";
+
+/**
+ * Returns true if the current group dataset has at least one slice with a
+ * media type that supports annotation (image or 3D).
+ */
+function useHasAnnotationSupportedSlices(): boolean {
+  return useGroupSlices(["image", "3d"]).length > 0;
+}
 
 export type AnnotationDisabledReason =
   | "generatedView"
-  | "groupedDatasetNoSupportedSlices"
+  | "groupDatasetNoSupportedSlices"
   | "videoDataset"
   | null;
 
@@ -21,38 +29,6 @@ export interface CanAnnotateResult {
   showAnnotationTab: boolean;
   /** If tab is shown but disabled, the reason why */
   disabledReason: AnnotationDisabledReason;
-  /** Whether this is a grouped dataset (to show slice selector) */
-  isGroupedDataset: boolean;
-}
-
-const MEDIA_TYPE_TO_DISABLED_REASON: Partial<
-  Record<
-    string,
-    Exclude<
-      AnnotationDisabledReason,
-      "generatedView" | "groupedDatasetNoSupportedSlices" | null
-    >
-  >
-> = {
-  video: "videoDataset",
-};
-
-export function getDisabledReason(
-  currentMediaType: string | null | undefined,
-  isGenerated: boolean,
-  isGrouped: boolean,
-  hasSupportedSlices: boolean
-): AnnotationDisabledReason {
-  if (isGenerated) return "generatedView";
-
-  if (isGrouped) {
-    return hasSupportedSlices ? null : "groupedDatasetNoSupportedSlices";
-  }
-
-  if (currentMediaType && !isAnnotationSupported(currentMediaType)) {
-    return MEDIA_TYPE_TO_DISABLED_REASON[currentMediaType] ?? null;
-  }
-  return null;
 }
 
 export default function useCanAnnotate(): CanAnnotateResult {
@@ -60,30 +36,43 @@ export default function useCanAnnotate(): CanAnnotateResult {
   const { enabled: canAnnotateEnabled } = useRecoilValue(canAnnotate);
   const currentMediaType = useRecoilValue(mediaType);
   const isGenerated = useRecoilValue(isGeneratedView);
-  const isGroupedDataset = useRecoilValue(isGroup);
-  const { supportedSlices } = useGroupAnnotationSlices();
 
-  const hasSupportedSlices = supportedSlices.length > 0;
   const isPatches = useRecoilValue(isPatchesView);
   const isUnsupportedGeneratedView = isGenerated && !isPatches;
+  const hasSlices = useHasAnnotationSupportedSlices();
+  const isGroup = useIsGroupDataset();
 
   // hide tab entirely if user lacks edit permission or feature disabled
   if (isReadOnlySnapshot || !canAnnotateEnabled) {
     return {
       showAnnotationTab: false,
       disabledReason: null,
-      isGroupedDataset: isGroupedDataset,
+    };
+  }
+
+  if (isGroup && !hasSlices) {
+    return {
+      showAnnotationTab: true,
+      disabledReason: "groupDatasetNoSupportedSlices",
+    };
+  }
+
+  if (!isGroup && !isAnnotationSupported(currentMediaType)) {
+    return {
+      showAnnotationTab: true,
+      disabledReason: "videoDataset",
+    };
+  }
+
+  if (isGenerated && isUnsupportedGeneratedView) {
+    return {
+      showAnnotationTab: true,
+      disabledReason: "generatedView",
     };
   }
 
   return {
-    isGroupedDataset,
     showAnnotationTab: true,
-    disabledReason: getDisabledReason(
-      currentMediaType,
-      isUnsupportedGeneratedView,
-      isGroupedDataset,
-      hasSupportedSlices
-    ),
+    disabledReason: null,
   };
 }

--- a/app/packages/core/src/components/Modal/Sidebar/Sidebar.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Sidebar.tsx
@@ -5,6 +5,7 @@ import {
   datasetName,
   modalMode,
   useDisabledCheckboxPaths,
+  useIsGroupDataset,
   useModalExplorEntries,
 } from "@fiftyone/state";
 import { useAtomValue, useSetAtom } from "jotai";
@@ -38,8 +39,8 @@ const Explore = () => {
 
 const Sidebar = () => {
   const mode = useAtomValue(modalMode);
-  const { showAnnotationTab, disabledReason, isGroupedDataset } =
-    useCanAnnotate();
+  const { showAnnotationTab, disabledReason } = useCanAnnotate();
+  const isGroupDataset = useIsGroupDataset();
   const datasetNameValue = useRecoilValue(datasetName);
   const exploreFields = useRecoilValue(
     activeFields({ modal: true, expanded: false })
@@ -63,13 +64,10 @@ const Sidebar = () => {
   }, [showAnnotationTab, disabledReason, loadSchemas, datasetNameValue]);
 
   const showSliceSelector =
-    showAnnotationTab &&
-    mode === ANNOTATE &&
-    isGroupedDataset &&
-    !disabledReason;
+    showAnnotationTab && mode === ANNOTATE && isGroupDataset && !disabledReason;
 
   const showTransitionManager =
-    showAnnotationTab && isGroupedDataset && !disabledReason;
+    showAnnotationTab && isGroupDataset && !disabledReason;
 
   return (
     <SidebarContainer modal={true}>

--- a/app/packages/state/src/accessors/dataset.ts
+++ b/app/packages/state/src/accessors/dataset.ts
@@ -1,9 +1,12 @@
+import { is3d } from "@fiftyone/utilities";
 import { useRecoilCallback, useRecoilValue } from "recoil";
 import {
   dataset,
   datasetId,
   datasetName,
   fieldSchema,
+  groupMediaTypes,
+  isGroup,
   selectedMediaField,
   skeleton,
   State,
@@ -50,6 +53,17 @@ export const useSelectedMediaFieldGrid = () => {
 };
 
 /**
+ * Whether the current dataset is a group dataset.
+ *
+ * @returns True if the current dataset is a group dataset
+ */
+export const useIsGroupDataset = () => {
+  return useRecoilValue(isGroup);
+};
+
+export type GroupSliceMediaType = "video" | "3d" | "image";
+
+/**
  * Hook which provides a function to get the default keypoint skeleton for a
  * given field.
  */
@@ -60,4 +74,25 @@ export const useGetKeypointSkeleton = () => {
         snapshot.getLoadable(skeleton(field)).getValue(),
     []
   );
+};
+
+/**
+ * Returns the names of dataset-level group slices whose media type matches
+ * any of the provided types.
+ *
+ * @param mediaTypes - The media types to filter by. "3d" matches all 3D
+ *   types (fo3d, point-cloud, etc.).
+ * @returns Slice names matching the requested media types, in dataset order.
+ */
+export const useGroupSlices = (mediaTypes: GroupSliceMediaType[]): string[] => {
+  const slices = useRecoilValue(groupMediaTypes);
+
+  return slices
+    .filter(({ mediaType }) =>
+      mediaTypes.some((type) => {
+        if (type === "3d") return is3d(mediaType);
+        return mediaType === type;
+      })
+    )
+    .map(({ name }) => name);
 };


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

wip

## 🧪 How is this patch tested? If it is not, please explain why.

wip

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

wip

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
