### PR TITLE
crop bounds to mask

### DIFF
--- a/app/packages/lighter/src/overlay/DetectionOverlay.ts
+++ b/app/packages/lighter/src/overlay/DetectionOverlay.ts
@@ -829,9 +829,12 @@ export class DetectionOverlay
     const wasPainting = this.interactionState === "PAINTING";
 
     this.interactionState = "NONE";
-    this.mask?.paintEnd(this.bounds, () => {
+    const croppedBounds = this.mask?.paintEnd(this.bounds, () => {
       this.markDirty();
     });
+    if (croppedBounds) {
+      this.bounds = croppedBounds;
+    }
     this.moveStartPoint = undefined;
     this.moveStartPosition = undefined;
     this.moveStartBounds = undefined;
@@ -1201,7 +1204,7 @@ export class DetectionOverlay
       this.bounds = updatedBounds;
     }
 
-    this.mask.paintEnd(this.bounds, () => {
+    this.bounds = this.mask.paintEnd(this.bounds, () => {
       this.markDirty();
     });
 

--- a/app/packages/lighter/src/overlay/MaskCanvas.test.ts
+++ b/app/packages/lighter/src/overlay/MaskCanvas.test.ts
@@ -7,9 +7,19 @@ import {
   SegmentationToolMode,
   SegmentationToolShape,
 } from "@fiftyone/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { MaskCanvas } from "./MaskCanvas";
 import type { Rect } from "../types";
+import { maskBounds } from "../utils";
+
+// Stub maskBounds so tests can drive paintEnd's post-stroke crop directly —
+// the jsdom canvas mock in vitest.setup.ts has no real pixel storage, so we
+// can't compute a tight bbox from painted pixels at runtime.
+vi.mock("../utils", async () => {
+  const actual = await vi.importActual<typeof import("../utils")>("../utils");
+  return { ...actual, maskBounds: vi.fn() };
+});
+const mockedMaskBounds = vi.mocked(maskBounds);
 
 const WHITE = "#ffffff";
 
@@ -74,7 +84,9 @@ describe("MaskCanvas.mergeFrom", () => {
       targetBounds
     );
 
-    // Union: (0,0) → (18,18)
+    // Union: (0,0) → (18,18). The post-merge crop is a no-op here because
+    // the jsdom canvas mock has no real pixel storage — see paintEnd suite
+    // below for shrink coverage with maskBounds mocked.
     expect(newBounds.x).toBe(0);
     expect(newBounds.y).toBe(0);
     expect(newBounds.width).toBe(18);
@@ -133,10 +145,53 @@ describe("MaskCanvas.mergeFrom", () => {
       targetBounds
     );
 
-    // Source is inside target; bounds shouldn't grow.
+    // Source is inside target; bounds shouldn't grow. (Crop is a no-op in
+    // the mocked canvas env.)
     expect(newBounds.x).toBe(targetBounds.x);
     expect(newBounds.y).toBe(targetBounds.y);
     expect(newBounds.width).toBe(targetBounds.width);
     expect(newBounds.height).toBe(targetBounds.height);
+  });
+});
+
+describe("MaskCanvas.paintEnd shrink", () => {
+  it("snaps bounds down to the painted region reported by maskBounds", () => {
+    const bounds: Rect = { x: 0, y: 0, width: 20, height: 20 };
+    const mc = seedCanvas(bounds, bounds);
+
+    // Pretend the painted region tight-bounds to pixels (3,4)-(7,8).
+    mockedMaskBounds.mockReturnValueOnce({
+      minX: 3,
+      minY: 4,
+      maxX: 7,
+      maxY: 8,
+    });
+
+    const newBounds = mc.paintEnd(bounds);
+
+    expect(newBounds).toEqual({ x: 3, y: 4, width: 5, height: 5 });
+  });
+
+  it("returns bounds unchanged when the canvas is already tight", () => {
+    const bounds: Rect = { x: 0, y: 0, width: 5, height: 5 };
+    const mc = seedCanvas(bounds, bounds);
+
+    mockedMaskBounds.mockReturnValueOnce({
+      minX: 0,
+      minY: 0,
+      maxX: 4,
+      maxY: 4,
+    });
+
+    expect(mc.paintEnd(bounds)).toEqual(bounds);
+  });
+
+  it("returns bounds unchanged when maskBounds reports no opaque pixels", () => {
+    const bounds: Rect = { x: 0, y: 0, width: 10, height: 10 };
+    const mc = seedCanvas(bounds, bounds);
+
+    mockedMaskBounds.mockReturnValueOnce(null);
+
+    expect(mc.paintEnd(bounds)).toEqual(bounds);
   });
 });

--- a/app/packages/lighter/src/overlay/MaskCanvas.ts
+++ b/app/packages/lighter/src/overlay/MaskCanvas.ts
@@ -546,21 +546,22 @@ export class MaskCanvas {
       this.context.imageSmoothingEnabled = prevSmoothing;
     }
 
-    this.paintEnd(newBounds, onEncoded);
-
-    return newBounds;
+    return this.paintEnd(newBounds, onEncoded);
   }
 
-  paintEnd(bounds: Rect, onEncoded?: () => void) {
-    if (!this.canvas) return;
+  paintEnd(bounds: Rect, onEncoded?: () => void): Rect {
+    if (!this.canvas) return bounds;
 
     this.lastPoint = undefined;
 
     // Rebuild the canvas to recolor + threshold anti-aliased edge pixels
-    // before the snapshot and encode.
+    // before computing tight bounds and snapshotting.
     this.updateCanvas(this.canvas.width, this.canvas.height);
 
-    this.postStrokeBounds = { ...bounds };
+    // Snap bounds down to the painted region.
+    const finalBounds = this.cropToContent(bounds) ?? bounds;
+
+    this.postStrokeBounds = { ...finalBounds };
     this.postStrokeSnapshot = this.takeSnapshot();
 
     // Refresh single-channel mask data so hit-testing reflects the edit.
@@ -576,6 +577,8 @@ export class MaskCanvas {
       .catch((err) => {
         console.error("[MaskCanvas] paintEnd encode failed:", err);
       });
+
+    return finalBounds;
   }
 
   getPaintStrokeData(): PaintStrokeData {
@@ -725,6 +728,43 @@ export class MaskCanvas {
       y: minY,
       width: newWidth,
       height: newHeight,
+    };
+  }
+
+  /**
+   * Crops the editing canvas to the tight bbox of opaque pixels and returns
+   * the corresponding world-space bounds. Returns `undefined` when the canvas
+   * is already tight, or when it is fully transparent (nothing to crop to).
+   */
+  private cropToContent(bounds: Rect): Rect | undefined {
+    if (!this.canvas || !this.context) return undefined;
+
+    const tight = this.getBounds();
+    if (!tight) return undefined;
+
+    const { width, height } = this.canvas;
+    const tightW = tight.maxX - tight.minX + 1;
+    const tightH = tight.maxY - tight.minY + 1;
+
+    if (
+      tight.minX === 0 &&
+      tight.minY === 0 &&
+      tightW === width &&
+      tightH === height
+    ) {
+      return undefined;
+    }
+
+    const pxW = bounds.width / width;
+    const pxH = bounds.height / height;
+
+    this.updateCanvas(tightW, tightH, -tight.minX, -tight.minY);
+
+    return {
+      x: bounds.x + tight.minX * pxW,
+      y: bounds.y + tight.minY * pxH,
+      width: tightW * pxW,
+      height: tightH * pxH,
     };
   }
 


### PR DESCRIPTION
## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

After editing, crop bounds of detection to mask. e.g. after erasing

## 🧪 How is this patch tested? If it is not, please explain why.

Unit test

https://github.com/user-attachments/assets/583eb77d-6a09-4210-a5a3-242db4f5dc44


## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed mask painting operations to correctly update and crop bounds to the tight bounding box of edited content, improving accuracy in undo/redo functionality and preventing unnecessary empty space in saved canvas regions.

* **Tests**
  * Enhanced test coverage for canvas cropping behavior during mask painting operations with deterministic bounds validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7578?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->