### PR TITLE
[FOEPD-3783] Remove storage.py's `get_file_size`

### DIFF
--- a/fiftyone/core/storage.py
+++ b/fiftyone/core/storage.py
@@ -1036,16 +1036,3 @@ def _to_bytes(val, encoding="utf-8"):
         raise TypeError("Failed to convert %s to bytes" % type(b))
 
     return b
-
-
-def get_file_size(path):
-    """
-    Returns the size of the file at the given path in bytes.
-
-    Args:
-        path: the filepath
-
-    Returns:
-        the file size in bytes
-    """
-    return os.path.getsize(path)

--- a/fiftyone/multimodal/adapters/mcap.py
+++ b/fiftyone/multimodal/adapters/mcap.py
@@ -77,7 +77,7 @@ class McapAdapter(MultimodalAdapter):
                     return cls._read_scene_inventory(
                         summary=summary,
                         scene_id=filepath,
-                        size=storage.get_file_size(filepath),
+                        size=0,
                         first_chunk_crc=chunk_crc(f, chunk_indices[0]),
                         last_chunk_crc=chunk_crc(f, chunk_indices[-1]),
                     )
@@ -85,7 +85,7 @@ class McapAdapter(MultimodalAdapter):
             return cls._read_scene_inventory(
                 summary=summary,
                 scene_id=filepath,
-                size=storage.get_file_size(filepath),
+                size=0,
                 first_chunk_crc=None,
                 last_chunk_crc=None,
             )


### PR DESCRIPTION
## 🔗 Related Issues

[FOEPD-3783](https://voxel51.atlassian.net/browse/FOEPD-3783)

## 📋 What changes are proposed in this pull request?

Remove storage.py's `get_file_size` function, which is only used to fingerprint multimodal scene inventories, which is [being removed](https://github.com/voxel51/fiftyone/pull/7577) from FiftyOne and doesn't need to be included in the release.

## 🧪 How is this patch tested? If it is not, please explain why.

n/a

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [x] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

[FOEPD-3783]: https://voxel51.atlassian.net/browse/FOEPD-3783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of MCAP files with empty chunk indexes to ensure proper CRC32 checksum computation and accurate file size information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->