### PR TITLE
[HA] Add support for annotating masks stored in mask_path

### DIFF
--- a/app/packages/annotation/src/persistence/useLighterDeltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/useLighterDeltaSupplier.ts
@@ -49,6 +49,10 @@ const buildAnnotationLabel = (overlay: BaseOverlay): LabelProxy | undefined => {
         ? {
             ...(_mask && { mask: _mask }),
             ...(pendingMask && { mask: pendingMask }),
+            // Edits to a `mask_path`-sourced detection are persisted as an
+            // inline `mask`; null the path so the backend doesn't end up
+            // with both fields pointing at divergent data.
+            ...(pendingMask && _maskPath && { mask_path: null }),
           }
         : hadMask
         ? { mask: null, mask_path: null }

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Edit.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Edit.tsx
@@ -55,7 +55,7 @@ export default function Edit() {
   const data = useAtomValue(currentData);
   const isReadOnly = useAtomValue(currentFieldIsReadOnlyAtom);
   const { isEditingMask } = useSegmentationMode();
-  const isMaskDetection = !!(data?.mask || isEditingMask);
+  const isMaskDetection = !!(data?.mask || data?.mask_path || isEditingMask);
   const [activePrimitivePath] = useActivePrimitive();
 
   const clear = useClearModal();

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Header.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Header.tsx
@@ -53,7 +53,7 @@ const LabelHamburgerMenu = () => {
   const setData = useSetAtom(currentData);
   const { isEditingMask } = useSegmentationMode();
 
-  const isMaskDetection = !!(data?.mask || isEditingMask);
+  const isMaskDetection = !!(data?.mask || data?.mask_path || isEditingMask);
   const isDetection = type === DETECTION;
 
   const handleAddMask = useCallback(() => {
@@ -66,7 +66,7 @@ const LabelHamburgerMenu = () => {
   const handleRemoveMask = useCallback(() => {
     if (overlay instanceof DetectionOverlay) {
       overlay.removeMask();
-      setData({ mask: undefined });
+      setData({ mask: undefined, mask_path: undefined });
       setOpen(false);
     }
   }, [overlay, setData]);

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useDetectionMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useDetectionMode.ts
@@ -113,6 +113,7 @@ export const useDetectionMode = () => {
     editingLabelType === DETECTION &&
     !selectedLabel?.isNew &&
     !selectedLabel?.data?.mask &&
+    !selectedLabel?.data?.mask_path &&
     !isEditingMask;
 
   const noActiveFields = fields.length === 0;

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useMergeTool.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useMergeTool.ts
@@ -54,11 +54,8 @@ export const useMergeTool = (): MergeTool => {
   const [mergeTargetId, setMergeTargetId] = useAtom(mergeTargetIdAtom);
   const commandBus = useCommandBus();
   const { scene, removeOverlay } = useLighter();
-  const {
-    addLabelToSidebar,
-    getLabelById,
-    removeLabelFromSidebar,
-  } = useLabelsContext();
+  const { addLabelToSidebar, getLabelById, removeLabelFromSidebar } =
+    useLabelsContext();
   const fieldSchema = useRecoilValue(
     fos.fieldSchema({ space: fos.State.SPACE.SAMPLE })
   );
@@ -66,9 +63,12 @@ export const useMergeTool = (): MergeTool => {
   const sidebarLabels = useAtomValue(labels);
   const disabled = useMemo(() => {
     const maskCount = sidebarLabels.reduce((count, label) => {
+      const data = label.data as {
+        mask?: unknown;
+        mask_path?: unknown;
+      };
       const hasMask =
-        label.type === "Detection" &&
-        !!(label.data as { mask?: unknown })?.mask;
+        label.type === "Detection" && !!(data?.mask || data?.mask_path);
 
       return hasMask ? count + 1 : count;
     }, 0);

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
@@ -125,7 +125,9 @@ export const useSegmentationMode = () => {
 
   const isEditingSegmentation =
     editingLabelType === DETECTION &&
-    (!!selectedLabel?.data?.mask || isEditingMask);
+    (!!selectedLabel?.data?.mask ||
+      !!selectedLabel?.data?.mask_path ||
+      isEditingMask);
 
   const noActiveFields = fields.length === 0;
   const disabled = isPatchView || noActiveFields;

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
@@ -221,9 +221,12 @@ export const useSegmentationMode = () => {
         // selected, deselect it — the Merge tool only operates on masks.
         const selected = selectedLabelRef.current;
         const overlayId = selected?.overlay?.id;
+        const data = selected?.data as {
+          mask?: unknown;
+          mask_path?: unknown;
+        };
         const hasMask =
-          selected?.type === "Detection" &&
-          !!(selected.data as { mask?: unknown })?.mask;
+          selected?.type === "Detection" && !!(data?.mask || data?.mask_path);
 
         if (hasMask && overlayId) {
           mergeTool.setMergeTarget(overlayId);

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useCreateAnnotationLabel.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useCreateAnnotationLabel.ts
@@ -36,7 +36,14 @@ export const useCreateAnnotationLabel = () => {
     async (
       field: string,
       type: LabelType,
-      data: AnnotationLabel["data"]
+      data: AnnotationLabel["data"],
+      options?: {
+        /**
+         * Callback to resolve media URLs for a sub-field of this label
+         * (e.g. `mask_path`).
+         */
+        resolveUrl?: (subField: string) => string | undefined;
+      }
     ): Promise<AnnotationLabel> => {
       if (type === CLASSIFICATION) {
         const overlay = overlayFactory.create<
@@ -60,10 +67,14 @@ export const useCreateAnnotationLabel = () => {
         const fieldSchema = store.get(labelSchemaData(field));
         const isReadOnly = isFieldReadOnly(fieldSchema);
 
-        // Pre-decode `mask_path` masks.
+        // Pre-decode `mask_path` masks. The caller-provided resolver maps
+        // the structural path to a fetchable URL; we don't fetch
+        // `label.mask_path` directly because the raw value is not always
+        // a fetchable URL on its own.
+        const maskUrl = options?.resolveUrl?.("mask_path");
         const preDecodedMask =
-          !label?.mask && label?.mask_path
-            ? await decodeMaskPath(label.mask_path, field, DETECTION)
+          !label?.mask && label?.mask_path && maskUrl
+            ? await decodeMaskPath(maskUrl, field, DETECTION)
             : undefined;
 
         const overlay = overlayFactory.create<

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useCreateAnnotationLabel.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useCreateAnnotationLabel.ts
@@ -15,6 +15,7 @@ import {
   KeypointOverlay,
   PolylineOptions,
   PolylineOverlay,
+  decodeMaskPath,
   useLighter,
 } from "@fiftyone/lighter";
 import { PolylineLabel } from "@fiftyone/looker/src/overlays/polyline";
@@ -32,11 +33,11 @@ export const useCreateAnnotationLabel = () => {
   const getSkeletonForField = useGetKeypointSkeleton();
 
   return useCallback(
-    (
+    async (
       field: string,
       type: LabelType,
       data: AnnotationLabel["data"]
-    ): AnnotationLabel => {
+    ): Promise<AnnotationLabel> => {
       if (type === CLASSIFICATION) {
         const overlay = overlayFactory.create<
           ClassificationOptions,
@@ -59,6 +60,12 @@ export const useCreateAnnotationLabel = () => {
         const fieldSchema = store.get(labelSchemaData(field));
         const isReadOnly = isFieldReadOnly(fieldSchema);
 
+        // Pre-decode `mask_path` masks.
+        const preDecodedMask =
+          !label?.mask && label?.mask_path
+            ? await decodeMaskPath(label.mask_path, field, DETECTION)
+            : undefined;
+
         const overlay = overlayFactory.create<
           DetectionOverlayOptions,
           DetectionOverlay
@@ -75,6 +82,7 @@ export const useCreateAnnotationLabel = () => {
             width: boundingBox[2],
             height: boundingBox[3],
           },
+          preDecodedMask,
         });
 
         return { data, overlay, path: field, type };

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useCreateAnnotationLabel.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useCreateAnnotationLabel.ts
@@ -88,8 +88,7 @@ export const useCreateAnnotationLabel = () => {
         ) {
           console.warn(
             `[mask-path] detection ${data._id} in field "${field}" has ` +
-              `mask_path but the caller did not provide a resolvable URL; ` +
-              `the mask will render as a placeholder.`
+              "mask_path but the caller did not provide a resolvable URL"
           );
         }
         const preDecodedMask =
@@ -99,7 +98,7 @@ export const useCreateAnnotationLabel = () => {
         if (label?.mask_path && !label?.mask && maskUrl && !preDecodedMask) {
           console.warn(
             `[mask-path] decode failed for detection ${data._id} in field ` +
-              `"${field}" (url=${maskUrl}); the mask will render as a placeholder.`
+              `"${field}" (url=${maskUrl})`
           );
         }
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useCreateAnnotationLabel.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useCreateAnnotationLabel.ts
@@ -43,6 +43,12 @@ export const useCreateAnnotationLabel = () => {
          * (e.g. `mask_path`).
          */
         resolveUrl?: (subField: string) => string | undefined;
+        /**
+         * When true, skip the `mask_path` pre-decode. Used by the refresh
+         * path in `useLabels`, where the existing scene overlay is reused
+         * and any newly-decoded mask would be discarded.
+         */
+        skipMaskDecode?: boolean;
       }
     ): Promise<AnnotationLabel> => {
       if (type === CLASSIFICATION) {
@@ -71,11 +77,31 @@ export const useCreateAnnotationLabel = () => {
         // the structural path to a fetchable URL; we don't fetch
         // `label.mask_path` directly because the raw value is not always
         // a fetchable URL on its own.
-        const maskUrl = options?.resolveUrl?.("mask_path");
+        const maskUrl = options?.skipMaskDecode
+          ? undefined
+          : options?.resolveUrl?.("mask_path");
+        if (
+          !options?.skipMaskDecode &&
+          label?.mask_path &&
+          !label?.mask &&
+          !maskUrl
+        ) {
+          console.warn(
+            `[mask-path] detection ${data._id} in field "${field}" has ` +
+              `mask_path but the caller did not provide a resolvable URL; ` +
+              `the mask will render as a placeholder.`
+          );
+        }
         const preDecodedMask =
           !label?.mask && label?.mask_path && maskUrl
             ? await decodeMaskPath(maskUrl, field, DETECTION)
             : undefined;
+        if (label?.mask_path && !label?.mask && maskUrl && !preDecodedMask) {
+          console.warn(
+            `[mask-path] decode failed for detection ${data._id} in field ` +
+              `"${field}" (url=${maskUrl}); the mask will render as a placeholder.`
+          );
+        }
 
         const overlay = overlayFactory.create<
           DetectionOverlayOptions,

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
@@ -58,6 +58,32 @@ const LABEL_LIST_INFO: Record<string, { listKey: string; type: LabelType }> = {
  * downstream factory can just ask by sub-field name without knowing where
  * its label lives in the sample tree.
  */
+
+/**
+ * Pulls fulfilled values out of a `Promise.allSettled` batch and logs
+ * rejected ones. Used so one bad label decode doesn't abort the entire
+ * sample's label hydration.
+ */
+const collectFulfilled = <T>(
+  results: PromiseSettledResult<T>[],
+  context: string
+): T[] => {
+  const values: T[] = [];
+
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      values.push(result.value);
+    } else {
+      console.warn(
+        `Skipping label in ${context}: failed to create annotation label`,
+        result.reason
+      );
+    }
+  }
+
+  return values;
+};
+
 const buildLabelResolveUrl = (
   sources: { [key: string]: string },
   expandedPath: string,
@@ -129,24 +155,24 @@ const handleSample = async ({
     const array = isList ? result : result ? [result] : [];
     const expandedPath = paths[path];
 
-    labels.push(
-      ...(await Promise.all(
-        array.map((item, idx) =>
-          createLabel(path, type, item, {
-            resolveUrl: buildLabelResolveUrl(
-              sources,
-              expandedPath,
-              isList,
-              idx,
-              item
-            ),
-            skipMaskDecode: hasExistingOverlay(
-              (item as { _id?: string })?._id ?? ""
-            ),
-          })
-        )
-      ))
+    const settled = await Promise.allSettled(
+      array.map((item, idx) =>
+        createLabel(path, type, item, {
+          resolveUrl: buildLabelResolveUrl(
+            sources,
+            expandedPath,
+            isList,
+            idx,
+            item
+          ),
+          skipMaskDecode: hasExistingOverlay(
+            (item as { _id?: string })?._id ?? ""
+          ),
+        })
+      )
     );
+
+    labels.push(...collectFulfilled(settled, `path "${path}"`));
   }
 
   // Process fields in activeLabelSchemas that aren't in Recoil's activeFields
@@ -175,40 +201,47 @@ const handleSample = async ({
 
       if (Array.isArray(items)) {
         const expandedPath = `${schemaPath}.${listInfo.listKey}`;
-        labels.push(
-          ...(await Promise.all(
-            items.map((item, idx) =>
-              createLabel(schemaPath, listInfo.type, item, {
-                resolveUrl: buildLabelResolveUrl(
-                  sources,
-                  expandedPath,
-                  true,
-                  idx,
-                  item
-                ),
-                skipMaskDecode: hasExistingOverlay(
-                  (item as { _id?: string })?._id ?? ""
-                ),
-              })
-            )
-          ))
+        const settled = await Promise.allSettled(
+          items.map((item, idx) =>
+            createLabel(schemaPath, listInfo.type, item, {
+              resolveUrl: buildLabelResolveUrl(
+                sources,
+                expandedPath,
+                true,
+                idx,
+                item
+              ),
+              skipMaskDecode: hasExistingOverlay(
+                (item as { _id?: string })?._id ?? ""
+              ),
+            })
+          )
         );
+
+        labels.push(...collectFulfilled(settled, `schema "${schemaPath}"`));
       }
     } else if (KNOWN_SINGULAR_TYPES.has(cls)) {
-      labels.push(
-        await createLabel(schemaPath, cls as LabelType, fieldData, {
-          resolveUrl: buildLabelResolveUrl(
-            sources,
-            schemaPath,
-            false,
-            0,
-            fieldData
-          ),
-          skipMaskDecode: hasExistingOverlay(
-            (fieldData as { _id?: string })?._id ?? ""
-          ),
-        })
-      );
+      try {
+        labels.push(
+          await createLabel(schemaPath, cls as LabelType, fieldData, {
+            resolveUrl: buildLabelResolveUrl(
+              sources,
+              schemaPath,
+              false,
+              0,
+              fieldData
+            ),
+            skipMaskDecode: hasExistingOverlay(
+              (fieldData as { _id?: string })?._id ?? ""
+            ),
+          })
+        );
+      } catch (err) {
+        console.warn(
+          `Skipping label at "${schemaPath}": failed to create annotation label`,
+          err
+        );
+      }
     } else {
       console.warn(`Unsupported label _cls "${cls}" for field "${schemaPath}"`);
     }

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
@@ -70,30 +70,64 @@ const buildLabelResolveUrl = (
       ? `${expandedPath}[${idx}].${subField}`
       : `${expandedPath}.${subField}`;
 
-    if (sources[key]) {
-      return sources[key];
+    // Resolve the raw value: sources[key] takes precedence (server-provided,
+    // structurally keyed), falling back to the label's own sub-field.
+    const raw = sources[key] ?? get(item, subField);
+    if (typeof raw !== "string") {
+      console.debug(
+        `[mask-path] no URL for "${key}" (no source entry, raw value not a string)`
+      );
+      return undefined;
     }
 
-    const raw = get(item, subField);
-    return typeof raw === "string" ? getSampleSrc(raw) : undefined;
+    // `getSampleSrc` rewrites local-style paths into a `/media`-shaped URL;
+    // returns URL-shaped values unchanged. If it returns the value
+    // unchanged, the raw value isn't directly fetchable on its own and
+    // we'd just generate a request that 404s — return undefined and let
+    // the caller skip the decode.
+    const transformed = getSampleSrc(raw);
+    if (transformed === raw) {
+      console.warn(
+        `[mask-path] no URL for "${key}" — value "${raw}" is not fetchable on its own.`
+      );
+      return undefined;
+    }
+
+    console.debug(
+      `[mask-path] resolved "${key}" → ${transformed} (source: ${
+        sources[key] ? "sources" : "raw label"
+      })`
+    );
+    return transformed;
   };
 };
 
 const handleSample = async ({
   createLabel,
   getFieldType,
+  hasExistingOverlay,
   paths,
   sample,
   schemas,
 }: {
   createLabel: ReturnType<typeof useCreateAnnotationLabel>;
   getFieldType: (path: string) => Promise<LabelType>;
+  /**
+   * Returns true if the scene already holds an overlay for the given
+   * label id. Used to skip redundant `mask_path` decodes during refresh —
+   * the existing overlay's mask is reused.
+   */
+  hasExistingOverlay: (id: string) => boolean;
   paths: { [key: string]: string };
   sample: ModalSample;
   schemas: string[];
 }) => {
   const data = sample.sample;
   const sources = getNormalizedUrls(sample.urls ?? {});
+  console.debug(
+    `[mask-path] handleSample: ${Object.keys(sources).length} sources entries`,
+    sources
+  );
   const labels: AnnotationLabel[] = [];
 
   for (const path in paths) {
@@ -128,6 +162,9 @@ const handleSample = async ({
               isList,
               idx,
               item
+            ),
+            skipMaskDecode: hasExistingOverlay(
+              (item as { _id?: string })?._id ?? ""
             ),
           })
         )
@@ -172,6 +209,9 @@ const handleSample = async ({
                   idx,
                   item
                 ),
+                skipMaskDecode: hasExistingOverlay(
+                  (item as { _id?: string })?._id ?? ""
+                ),
               })
             )
           ))
@@ -186,6 +226,9 @@ const handleSample = async ({
             false,
             0,
             fieldData
+          ),
+          skipMaskDecode: hasExistingOverlay(
+            (fieldData as { _id?: string })?._id ?? ""
           ),
         })
       );
@@ -462,6 +505,7 @@ export default function useLabels() {
           sample: modalSample,
           getFieldType,
           schemas: active,
+          hasExistingOverlay: (id) => !!id && !!scene?.getOverlay(id),
         });
 
       if (loadingRef.current === LabelsState.UNSET) {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
@@ -74,7 +74,9 @@ const handleSample = async ({
 
     const array = Array.isArray(result) ? result : result ? [result] : [];
 
-    labels.push(...array.map((data) => createLabel(path, type, data)));
+    labels.push(
+      ...(await Promise.all(array.map((data) => createLabel(path, type, data))))
+    );
   }
 
   // Process fields in activeLabelSchemas that aren't in Recoil's activeFields
@@ -103,11 +105,13 @@ const handleSample = async ({
 
       if (Array.isArray(items)) {
         labels.push(
-          ...items.map((item) => createLabel(schemaPath, listInfo.type, item))
+          ...(await Promise.all(
+            items.map((item) => createLabel(schemaPath, listInfo.type, item))
+          ))
         );
       }
     } else if (KNOWN_SINGULAR_TYPES.has(cls)) {
-      labels.push(createLabel(schemaPath, cls as LabelType, fieldData));
+      labels.push(await createLabel(schemaPath, cls as LabelType, fieldData));
     } else {
       console.warn(`Unsupported label _cls "${cls}" for field "${schemaPath}"`);
     }

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
@@ -9,6 +9,8 @@ import {
   useCurrentSampleId,
   useModalSample,
 } from "@fiftyone/state";
+import { getNormalizedUrls } from "@fiftyone/state/src/utils";
+import { getSampleSrc } from "@fiftyone/state/src/recoil/utils";
 import { DETECTION } from "@fiftyone/utilities";
 import { atom, getDefaultStore, useAtomValue, useSetAtom } from "jotai";
 import { splitAtom, useAtomCallback } from "jotai/utils";
@@ -38,6 +40,45 @@ const LABEL_LIST_INFO: Record<string, { listKey: string; type: LabelType }> = {
   Keypoints: { listKey: "keypoints", type: "Keypoint" },
 };
 
+/**
+ * Builds a per-label URL resolver that maps sub-field names (e.g.
+ * `"mask_path"`) to fetchable media URLs.
+ *
+ * Resolution order:
+ *   1. Look up the sub-field's structural key (e.g.
+ *      `"ground_truth.detections[0].mask_path"`) in the sample's `sources`
+ *      map. Mirrors looker's key construction in
+ *      `app/packages/looker/src/worker/disk-overlay-decoder.ts`.
+ *   2. Fall back to `getSampleSrc(rawValue)` on the sub-field's raw value.
+ *
+ * Returns `undefined` if neither path produces a usable URL.
+ *
+ * The closure captures the label's structural context — the expanded
+ * sample path, whether the label is a list item, and its index — so the
+ * downstream factory can just ask by sub-field name without knowing where
+ * its label lives in the sample tree.
+ */
+const buildLabelResolveUrl = (
+  sources: { [key: string]: string },
+  expandedPath: string,
+  isList: boolean,
+  idx: number,
+  item: unknown
+): ((subField: string) => string | undefined) => {
+  return (subField: string) => {
+    const key = isList
+      ? `${expandedPath}[${idx}].${subField}`
+      : `${expandedPath}.${subField}`;
+
+    if (sources[key]) {
+      return sources[key];
+    }
+
+    const raw = get(item, subField);
+    return typeof raw === "string" ? getSampleSrc(raw) : undefined;
+  };
+};
+
 const handleSample = async ({
   createLabel,
   getFieldType,
@@ -52,6 +93,7 @@ const handleSample = async ({
   schemas: string[];
 }) => {
   const data = sample.sample;
+  const sources = getNormalizedUrls(sample.urls ?? {});
   const labels: AnnotationLabel[] = [];
 
   for (const path in paths) {
@@ -72,10 +114,24 @@ const handleSample = async ({
     }
     const result = get(data, paths[path]);
 
-    const array = Array.isArray(result) ? result : result ? [result] : [];
+    const isList = Array.isArray(result);
+    const array = isList ? result : result ? [result] : [];
+    const expandedPath = paths[path];
 
     labels.push(
-      ...(await Promise.all(array.map((data) => createLabel(path, type, data))))
+      ...(await Promise.all(
+        array.map((item, idx) =>
+          createLabel(path, type, item, {
+            resolveUrl: buildLabelResolveUrl(
+              sources,
+              expandedPath,
+              isList,
+              idx,
+              item
+            ),
+          })
+        )
+      ))
     );
   }
 
@@ -104,14 +160,35 @@ const handleSample = async ({
       ] as unknown[];
 
       if (Array.isArray(items)) {
+        const expandedPath = `${schemaPath}.${listInfo.listKey}`;
         labels.push(
           ...(await Promise.all(
-            items.map((item) => createLabel(schemaPath, listInfo.type, item))
+            items.map((item, idx) =>
+              createLabel(schemaPath, listInfo.type, item, {
+                resolveUrl: buildLabelResolveUrl(
+                  sources,
+                  expandedPath,
+                  true,
+                  idx,
+                  item
+                ),
+              })
+            )
           ))
         );
       }
     } else if (KNOWN_SINGULAR_TYPES.has(cls)) {
-      labels.push(await createLabel(schemaPath, cls as LabelType, fieldData));
+      labels.push(
+        await createLabel(schemaPath, cls as LabelType, fieldData, {
+          resolveUrl: buildLabelResolveUrl(
+            sources,
+            schemaPath,
+            false,
+            0,
+            fieldData
+          ),
+        })
+      );
     } else {
       console.warn(`Unsupported label _cls "${cls}" for field "${schemaPath}"`);
     }

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
@@ -41,25 +41,6 @@ const LABEL_LIST_INFO: Record<string, { listKey: string; type: LabelType }> = {
 };
 
 /**
- * Builds a per-label URL resolver that maps sub-field names (e.g.
- * `"mask_path"`) to fetchable media URLs.
- *
- * Resolution order:
- *   1. Look up the sub-field's structural key (e.g.
- *      `"ground_truth.detections[0].mask_path"`) in the sample's `sources`
- *      map. Mirrors looker's key construction in
- *      `app/packages/looker/src/worker/disk-overlay-decoder.ts`.
- *   2. Fall back to `getSampleSrc(rawValue)` on the sub-field's raw value.
- *
- * Returns `undefined` if neither path produces a usable URL.
- *
- * The closure captures the label's structural context — the expanded
- * sample path, whether the label is a list item, and its index — so the
- * downstream factory can just ask by sub-field name without knowing where
- * its label lives in the sample tree.
- */
-
-/**
  * Pulls fulfilled values out of a `Promise.allSettled` batch and logs
  * rejected ones. Used so one bad label decode doesn't abort the entire
  * sample's label hydration.
@@ -84,6 +65,24 @@ const collectFulfilled = <T>(
   return values;
 };
 
+/**
+ * Builds a per-label URL resolver that maps sub-field names (e.g.
+ * `"mask_path"`) to fetchable media URLs.
+ *
+ * Resolution order:
+ *   1. Look up the sub-field's structural key (e.g.
+ *      `"ground_truth.detections[0].mask_path"`) in the sample's `sources`
+ *      map. Mirrors looker's key construction in
+ *      `app/packages/looker/src/worker/disk-overlay-decoder.ts`.
+ *   2. Fall back to `getSampleSrc(rawValue)` on the sub-field's raw value.
+ *
+ * Returns `undefined` if neither path produces a usable URL.
+ *
+ * The closure captures the label's structural context — the expanded
+ * sample path, whether the label is a list item, and its index — so the
+ * downstream factory can just ask by sub-field name without knowing where
+ * its label lives in the sample tree.
+ */
 const buildLabelResolveUrl = (
   sources: { [key: string]: string },
   expandedPath: string,

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
@@ -396,12 +396,15 @@ export default function useLabels() {
             return;
           }
 
-          setLabels(result);
+          // Attach overlays to the scene before exposing them to the app.
+          // This ensures that geometry is grounded in some frame of reference.
           const initialOverlayIds = new Set<string>();
           for (const annotationLabel of result) {
             addLabelToRenderer(annotationLabel);
             initialOverlayIds.add(annotationLabel.data._id);
           }
+
+          setLabels(result);
           setInitialOverlayIds(initialOverlayIds);
 
           // In patches view with a single label, activate it for editing
@@ -436,10 +439,12 @@ export default function useLabels() {
               annotationLabel.data
             );
 
-            // new label, add it
+            // new label, add it. Attach to the scene first so the overlay
+            // has its coordinate system before any sidebar subscriber tries
+            // to read bounds off it.
             if (!updated) {
-              addLabelToStore(annotationLabel);
               addLabelToRenderer(annotationLabel);
+              addLabelToStore(annotationLabel);
             }
           });
         });

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
@@ -1,11 +1,11 @@
 import { DetectionOverlay, useLighter } from "@fiftyone/lighter";
 import {
+  activeFields,
   AnnotationLabel,
   AnnotationLabelData,
-  ModalSample,
-  activeFields,
   field,
   isPatchesView,
+  ModalSample,
   useCurrentSampleId,
   useModalSample,
 } from "@fiftyone/state";
@@ -74,31 +74,12 @@ const buildLabelResolveUrl = (
     // structurally keyed), falling back to the label's own sub-field.
     const raw = sources[key] ?? get(item, subField);
     if (typeof raw !== "string") {
-      console.debug(
-        `[mask-path] no URL for "${key}" (no source entry, raw value not a string)`
-      );
       return undefined;
     }
 
-    // `getSampleSrc` rewrites local-style paths into a `/media`-shaped URL;
-    // returns URL-shaped values unchanged. If it returns the value
-    // unchanged, the raw value isn't directly fetchable on its own and
-    // we'd just generate a request that 404s — return undefined and let
-    // the caller skip the decode.
-    const transformed = getSampleSrc(raw);
-    if (transformed === raw) {
-      console.warn(
-        `[mask-path] no URL for "${key}" — value "${raw}" is not fetchable on its own.`
-      );
-      return undefined;
-    }
-
-    console.debug(
-      `[mask-path] resolved "${key}" → ${transformed} (source: ${
-        sources[key] ? "sources" : "raw label"
-      })`
-    );
-    return transformed;
+    // `getSampleSrc` rewrites local-style paths into a `/media`-shaped URL
+    // and returns URL-shaped values unchanged
+    return getSampleSrc(raw);
   };
 };
 
@@ -124,10 +105,6 @@ const handleSample = async ({
 }) => {
   const data = sample.sample;
   const sources = getNormalizedUrls(sample.urls ?? {});
-  console.debug(
-    `[mask-path] handleSample: ${Object.keys(sources).length} sources entries`,
-    sources
-  );
   const labels: AnnotationLabel[] = [];
 
   for (const path in paths) {

--- a/app/packages/lighter/package.json
+++ b/app/packages/lighter/package.json
@@ -17,6 +17,7 @@
         "type-check": "tsc --noEmit"
     },
     "dependencies": {
+        "lru-cache": "^11.0.1",
         "pixi.js": "^8.13.1"
     },
     "devDependencies": {

--- a/app/packages/lighter/src/index.ts
+++ b/app/packages/lighter/src/index.ts
@@ -122,6 +122,7 @@ export type {
 } from "./types";
 
 export { getOverlayColor } from "./utils/colorMapping";
+export { decodeMaskPath } from "./utils/maskPathDecoding";
 
 // Constants
 export { DEFAULT_ZOOM_PAD } from "./constants";

--- a/app/packages/lighter/src/overlay/DetectionOverlay.ts
+++ b/app/packages/lighter/src/overlay/DetectionOverlay.ts
@@ -111,6 +111,14 @@ export class DetectionOverlay
   private textBounds?: Rect;
 
   private mask?: MaskCanvas;
+  /**
+   * The mask source picked at construction time — inline `SerializedMask`
+   * if present, otherwise a pre-decoded `OverlayMask` from `mask_path`.
+   * Retained so {@link rehydrateMask} can reseed `MaskCanvas` after a
+   * destroy/re-add cycle (e.g. undoing a deletion) without depending on
+   * `label.mask`, which is `undefined` for `mask_path`-sourced overlays.
+   */
+  private maskSource?: SerializedMask | OverlayMask;
   private segmentationTool?: SegmentationToolState;
 
   // Pen tool state
@@ -125,9 +133,9 @@ export class DetectionOverlay
     this.isResizeable = options.resizeable !== false;
     this.#relativeBounds = options.relativeBounds || NO_BOUNDS;
 
-    const maskSource = options.preDecodedMask ?? this.label.mask;
-    if (maskSource) {
-      this.mask = new MaskCanvas(maskSource);
+    this.maskSource = options.preDecodedMask ?? this.label.mask;
+    if (this.maskSource) {
+      this.mask = new MaskCanvas(this.maskSource);
     } else if (this.label.mask_path) {
       // `mask_path` was present on the label but the caller didn't supply
       // a decoded source (e.g. the URL couldn't be resolved). Construct an
@@ -156,6 +164,9 @@ export class DetectionOverlay
     }
 
     if (label.mask) {
+      // Inline mask takes precedence over any `mask_path`-sourced
+      // `OverlayMask` we may have been carrying.
+      this.maskSource = label.mask;
       if (this.mask) {
         this.mask.updateSource(label.mask);
       } else {
@@ -166,6 +177,7 @@ export class DetectionOverlay
       // null — explicit removal
       // `undefined` can be cases when mask has not been saved yet - leave it alone
       const hadMask = !!this.mask;
+      this.maskSource = undefined;
       this.mask?.destroy();
       this.mask = undefined;
       if (hadMask) this.markDirty();
@@ -1121,6 +1133,7 @@ export class DetectionOverlay
    */
   removeMask(): void {
     const hadMask = !!this.mask;
+    this.maskSource = undefined;
     this.mask?.destroy();
     this.mask = undefined;
     this.markDirty();
@@ -1351,9 +1364,9 @@ export class DetectionOverlay
    */
   rehydrateMask(): void {
     if (this.mask) return;
-    if (!this.label.mask) return;
+    if (!this.maskSource) return;
 
-    this.mask = new MaskCanvas(this.label.mask);
+    this.mask = new MaskCanvas(this.maskSource);
 
     this.forceHoverLeave();
     this.markDirty();

--- a/app/packages/lighter/src/overlay/DetectionOverlay.ts
+++ b/app/packages/lighter/src/overlay/DetectionOverlay.ts
@@ -128,6 +128,13 @@ export class DetectionOverlay
     const maskSource = options.preDecodedMask ?? this.label.mask;
     if (maskSource) {
       this.mask = new MaskCanvas(maskSource);
+    } else if (this.label.mask_path) {
+      // `mask_path` was present on the label but the caller didn't supply
+      // a decoded source (e.g. the URL couldn't be resolved). Construct an
+      // empty placeholder so `hasMask()` correctly reports "yes" — without
+      // it, the save flow would treat the missing canvas as a user
+      // deletion and wipe the mask_path on the backend.
+      this.mask = new MaskCanvas();
     }
   }
 

--- a/app/packages/lighter/src/overlay/DetectionOverlay.ts
+++ b/app/packages/lighter/src/overlay/DetectionOverlay.ts
@@ -39,6 +39,7 @@ import type { MaskSnapshot, PaintStrokeData } from "./MaskCanvas";
 import { MaskKeypoints } from "./MaskKeypoints";
 import type { SerializedMask } from "@fiftyone/utilities";
 import { BASE_ALPHA } from "@fiftyone/looker/src/constants";
+import type { OverlayMask } from "@fiftyone/looker/src/numpy";
 
 export type DetectionLabel = RawLookerLabel & {
   label: string;
@@ -60,6 +61,12 @@ export interface DetectionOverlayOptions {
   draggable?: boolean;
   resizeable?: boolean;
   selectable?: boolean;
+  /**
+   * A mask decoded out-of-band — typically from `label.mask_path` — that
+   * seeds the editing canvas without touching `label.mask`. When set, this
+   * takes precedence over `label.mask` for the initial mask source.
+   */
+  preDecodedMask?: OverlayMask;
 }
 
 export type ResizeRegion =
@@ -118,8 +125,9 @@ export class DetectionOverlay
     this.isResizeable = options.resizeable !== false;
     this.#relativeBounds = options.relativeBounds || NO_BOUNDS;
 
-    if (this.label.mask) {
-      this.mask = new MaskCanvas(this.label.mask);
+    const maskSource = options.preDecodedMask ?? this.label.mask;
+    if (maskSource) {
+      this.mask = new MaskCanvas(maskSource);
     }
   }
 

--- a/app/packages/lighter/src/overlay/DetectionOverlay.ts
+++ b/app/packages/lighter/src/overlay/DetectionOverlay.ts
@@ -860,6 +860,12 @@ export class DetectionOverlay
    * @returns True if current bounds are valid
    */
   hasValidBounds(): boolean {
+    // An overlay without a coordinate system isn't attached to a scene yet
+    // (or has been detached); no way to validate bounds.
+    if (!this.coordinateSystem) {
+      return false;
+    }
+
     return BaseOverlay.validBounds(this.bounds);
   }
 

--- a/app/packages/lighter/src/overlay/MaskCanvas.ts
+++ b/app/packages/lighter/src/overlay/MaskCanvas.ts
@@ -7,6 +7,7 @@ import {
   SegmentationToolShape,
   type SegmentationToolState,
 } from "@fiftyone/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode";
+import type { OverlayMask } from "@fiftyone/looker/src/numpy";
 import type { SerializedMask } from "@fiftyone/utilities";
 import type { Renderer2D } from "../renderer/Renderer2D";
 import type { DrawStyle, Point, Rect } from "../types";
@@ -53,10 +54,14 @@ export interface PaintStrokeData {
  * ```
  */
 export class MaskCanvas {
-  // Cached decoded mask bitmap, keyed by the raw mask string to detect changes.
+  // Cached decoded mask bitmap, keyed by the raw mask source to detect changes.
   private maskBitmap?: ImageBitmap;
-  /** Raw mask data awaiting decode (deferred until color is known). */
-  private rawMaskData?: string;
+  /**
+   * Raw mask source awaiting decode (deferred until color is known). Either
+   * a base64-encoded numpy string (inline `mask` field) or a pre-decoded
+   * {@link OverlayMask} produced from a `mask_path` fetch.
+   */
+  private rawMaskData?: string | OverlayMask;
   /** True while an async decode is in flight. */
   private decoding = false;
   /** The color used for the current decoded bitmap, so we can re-decode on color change. */
@@ -81,18 +86,22 @@ export class MaskCanvas {
   private postStrokeSnapshot?: MaskSnapshot;
   private postStrokeBounds?: Rect;
 
-  constructor(maskData?: SerializedMask) {
-    this.rawMaskData = MaskCanvas.extractB64(maskData);
+  constructor(maskData?: SerializedMask | OverlayMask) {
+    this.rawMaskData = MaskCanvas.extractSource(maskData);
   }
 
   /**
-   * Extracts the base64 string from a SerializedMask, which may be a plain
-   * string or a `{ $binary: { base64: string } }` wrapper.
+   * Normalizes the input mask source to either a base64 string (for inline
+   * `mask` data) or a pre-decoded {@link OverlayMask} (for `mask_path` data).
+   * Plain `undefined` and `{ $binary: { base64 } }` wrappers are unwrapped.
    */
-  private static extractB64(mask?: SerializedMask): string | undefined {
+  private static extractSource(
+    mask?: SerializedMask | OverlayMask
+  ): string | OverlayMask | undefined {
     if (!mask) return undefined;
     if (typeof mask === "string") return mask;
-    return mask.$binary.base64;
+    if ("$binary" in mask) return mask.$binary.base64;
+    return mask;
   }
 
   /**
@@ -101,12 +110,12 @@ export class MaskCanvas {
    * bitmap, raw pixels, editing canvas, undo snapshots — so that subsequent
    * renders / hit-tests reflect the new source rather than a stale canvas.
    */
-  updateSource(mask?: SerializedMask): boolean {
-    const b64 = MaskCanvas.extractB64(mask);
-    if (b64 === this.rawMaskData) return false;
+  updateSource(mask?: SerializedMask | OverlayMask): boolean {
+    const source = MaskCanvas.extractSource(mask);
+    if (source === this.rawMaskData) return false;
 
     this.reset();
-    this.rawMaskData = b64;
+    this.rawMaskData = source;
     return true;
   }
 

--- a/app/packages/lighter/src/utils/index.ts
+++ b/app/packages/lighter/src/utils/index.ts
@@ -3,3 +3,4 @@ export { decodeMask } from "./maskDecoding";
 export { encodeMask } from "./maskEncoding";
 export { maskBounds } from "./maskBounds";
 export type { MaskBounds } from "./maskBounds";
+export { decodeMaskPath } from "./maskPathDecoding";

--- a/app/packages/lighter/src/utils/maskDecoding.ts
+++ b/app/packages/lighter/src/utils/maskDecoding.ts
@@ -16,20 +16,25 @@ export interface DecodedMask {
 }
 
 /**
- * Decodes a base64-encoded numpy mask string and paints it with the given
- * color, returning an ImageBitmap ready for rendering alongside the raw
- * single-channel pixel data for hit-testing.
+ * Decodes a mask source and paints it with the given color, returning an
+ * ImageBitmap ready for rendering alongside the raw single-channel pixel
+ * data for hit-testing.
  *
- * Pipeline: base64 → inflate → numpy parse → paint RGBA → ImageBitmap
+ * Accepts either a base64-encoded numpy string (inline `mask` field) or a
+ * pre-decoded {@link OverlayMask} (e.g. produced from a `mask_path` fetch).
+ * The string path runs the full base64 → inflate → numpy parse pipeline; the
+ * `OverlayMask` path skips straight to painting.
  *
- * @param maskData - Base64-encoded, zlib-compressed numpy array
- * @param color - CSS color string for non-zero mask pixels
+ * @param maskData - Base64-encoded compressed numpy string, or a decoded
+ *   {@link OverlayMask}.
+ * @param color - CSS color string for non-zero mask pixels.
  */
 export async function decodeMask(
-  maskData: string,
+  maskData: string | OverlayMask,
   color: string
 ): Promise<DecodedMask> {
-  const overlayMask = deserialize(maskData);
+  const overlayMask =
+    typeof maskData === "string" ? deserialize(maskData) : maskData;
   const rgbaBuffer = paintMask(overlayMask, color);
   const [height, width] = overlayMask.shape;
   const imageData = new ImageData(

--- a/app/packages/lighter/src/utils/maskPathDecodeWorker.ts
+++ b/app/packages/lighter/src/utils/maskPathDecodeWorker.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Web worker that fetches a `mask_path` URL and decodes the response into an
+ * {@link OverlayMask}. Runs as a sibling to the main thread so dense samples
+ * with many large masks don't block the UI on decode.
+ *
+ * Pairs with `maskPathDecoding.ts` (the pool manager).
+ */
+
+import type { Coloring } from "@fiftyone/looker";
+import type { OverlayMask } from "@fiftyone/looker/src/numpy";
+import { decodeMaskOnDisk } from "@fiftyone/looker/src/worker/mask-decoder";
+
+interface DecodeRequest {
+  uuid: string;
+  url: string;
+  field: string;
+  cls: string;
+}
+
+interface DecodeSuccess {
+  uuid: string;
+  ok: true;
+  mask: OverlayMask;
+}
+
+interface DecodeFailure {
+  uuid: string;
+  ok: false;
+  error: string;
+}
+
+export type DecodeResponse = DecodeSuccess | DecodeFailure;
+
+// `decodeMaskOnDisk` only consults `coloring` in its SEGMENTATION branch;
+// detection masks fall through to the default canvas decode path, so a stub
+// is sufficient and keeps the worker free of state/recoil dependencies.
+const STUB_COLORING = {} as Coloring;
+
+self.onmessage = async (event: MessageEvent<DecodeRequest>) => {
+  const { uuid, url, field, cls } = event.data;
+
+  try {
+    const response = await fetch(url);
+    const blob = await response.blob();
+    const mask = await decodeMaskOnDisk(blob, cls, field, STUB_COLORING);
+
+    if (!mask) {
+      const payload: DecodeFailure = {
+        uuid,
+        ok: false,
+        error: "decodeMaskOnDisk returned no mask",
+      };
+
+      (self as DedicatedWorkerGlobalScope).postMessage(payload);
+      return;
+    }
+
+    const payload: DecodeSuccess = { uuid, ok: true, mask };
+
+    (self as DedicatedWorkerGlobalScope).postMessage(payload, [mask.buffer]);
+  } catch (err) {
+    const payload: DecodeFailure = {
+      uuid,
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+
+    (self as DedicatedWorkerGlobalScope).postMessage(payload);
+  }
+};

--- a/app/packages/lighter/src/utils/maskPathDecodeWorker.ts
+++ b/app/packages/lighter/src/utils/maskPathDecodeWorker.ts
@@ -40,9 +40,20 @@ const STUB_COLORING = {} as Coloring;
 
 self.onmessage = async (event: MessageEvent<DecodeRequest>) => {
   const { uuid, url, field, cls } = event.data;
+  console.debug(`[mask-path worker] fetch ${url} (field=${field})`);
 
   try {
     const response = await fetch(url);
+    if (!response.ok) {
+      const payload: DecodeFailure = {
+        uuid,
+        ok: false,
+        error: `fetch ${url} → HTTP ${response.status}`,
+      };
+
+      (self as DedicatedWorkerGlobalScope).postMessage(payload);
+      return;
+    }
     const blob = await response.blob();
     const mask = await decodeMaskOnDisk(blob, cls, field, STUB_COLORING);
 

--- a/app/packages/lighter/src/utils/maskPathDecodeWorker.ts
+++ b/app/packages/lighter/src/utils/maskPathDecodeWorker.ts
@@ -41,6 +41,19 @@ const STUB_COLORING = {} as Coloring;
 self.onmessage = async (event: MessageEvent<DecodeRequest>) => {
   const { uuid, url, field, cls } = event.data;
 
+  // Defensive: callers should never reach the worker with a non-string URL,
+  // but if they do, `fetch(undefined)` coerces to `fetch("undefined")` and
+  // produces phantom requests against the page origin. Fail fast instead.
+  if (typeof url !== "string" || url.length === 0) {
+    const payload: DecodeFailure = {
+      uuid,
+      ok: false,
+      error: `invalid url: ${String(url)}`,
+    };
+    (self as DedicatedWorkerGlobalScope).postMessage(payload);
+    return;
+  }
+
   try {
     const response = await fetch(url);
     if (!response.ok) {

--- a/app/packages/lighter/src/utils/maskPathDecodeWorker.ts
+++ b/app/packages/lighter/src/utils/maskPathDecodeWorker.ts
@@ -40,7 +40,6 @@ const STUB_COLORING = {} as Coloring;
 
 self.onmessage = async (event: MessageEvent<DecodeRequest>) => {
   const { uuid, url, field, cls } = event.data;
-  console.debug(`[mask-path worker] fetch ${url} (field=${field})`);
 
   try {
     const response = await fetch(url);

--- a/app/packages/lighter/src/utils/maskPathDecoding.ts
+++ b/app/packages/lighter/src/utils/maskPathDecoding.ts
@@ -83,13 +83,20 @@ const bindWorker = (slot: Slot, worker: Worker): void => {
   });
 
   worker.addEventListener("error", (event) => {
+    // Guard against stale error events from a worker we've already replaced.
+    // Without this, a late-arriving error from the old instance would
+    // terminate the healthy replacement bound to the same slot.
+    if (slot.worker !== worker) {
+      return;
+    }
+
     console.error("[decodeMaskPath] worker crashed; respawning slot:", event);
     // Fail the in-flight job so one bad payload doesn't hang the caller.
     const failed = slot.job;
     slot.job = null;
     failed?.resolve(undefined);
 
-    slot.worker.terminate();
+    worker.terminate();
     bindWorker(slot, new MaskPathDecodeWorker());
 
     drain();
@@ -198,6 +205,15 @@ async function decodeMaskPathImpl(
 
     try {
       const response = await fetch(url);
+
+      if (!response.ok) {
+        console.error(
+          `[decodeMaskPath] fallback fetch failed: HTTP ${response.status} ` +
+            `${response.statusText} (${url})`
+        );
+        return undefined;
+      }
+
       const blob = await response.blob();
 
       const mask = await decodeMaskOnDisk(blob, cls, field, {} as never);

--- a/app/packages/lighter/src/utils/maskPathDecoding.ts
+++ b/app/packages/lighter/src/utils/maskPathDecoding.ts
@@ -163,13 +163,11 @@ export async function decodeMaskPath(
 ): Promise<OverlayMask | undefined> {
   const cached = cache.get(url);
   if (cached) {
-    console.debug(`[mask-path] cache hit for ${url}`);
     return cached;
   }
 
   const existing = inFlight.get(url);
   if (existing) {
-    console.debug(`[mask-path] dedupe in-flight fetch for ${url}`);
     return existing;
   }
 

--- a/app/packages/lighter/src/utils/maskPathDecoding.ts
+++ b/app/packages/lighter/src/utils/maskPathDecoding.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import type { Coloring } from "@fiftyone/looker";
+import type { OverlayMask } from "@fiftyone/looker/src/numpy";
+import { decodeMaskOnDisk } from "@fiftyone/looker/src/worker/mask-decoder";
+import { getSampleSrc } from "@fiftyone/state/src/recoil/utils";
+
+// `decodeMaskOnDisk` only consults `coloring` in its SEGMENTATION branch.
+// Detection masks fall through to the default canvas decode path, so a stub
+// is sufficient — keeps the call site free of recoil/state dependencies.
+const STUB_COLORING = {} as Coloring;
+
+/**
+ * Fetches a mask image referenced by `mask_path` and decodes it into an
+ * {@link OverlayMask} on the main thread by reusing looker's
+ * `decodeMaskOnDisk` pipeline. The result is suitable for handing directly
+ * to {@link MaskCanvas} via the pre-decoded mask path.
+ *
+ * Returns `undefined` if the fetch or decode fails — callers should treat
+ * this as "no mask available yet" and proceed without one.
+ */
+export async function decodeMaskPath(
+  maskPath: string,
+  field: string,
+  cls: string
+): Promise<OverlayMask | undefined> {
+  try {
+    const url = getSampleSrc(maskPath);
+    const response = await fetch(url);
+    const blob = await response.blob();
+
+    const overlayMask = await decodeMaskOnDisk(blob, cls, field, STUB_COLORING);
+
+    return overlayMask ?? undefined;
+  } catch (err) {
+    console.error("[decodeMaskPath] failed to decode mask_path:", err);
+    return undefined;
+  }
+}

--- a/app/packages/lighter/src/utils/maskPathDecoding.ts
+++ b/app/packages/lighter/src/utils/maskPathDecoding.ts
@@ -1,24 +1,136 @@
 /**
  * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Off-main-thread `mask_path` decode. URL resolution stays on the main thread
+ * (so we can reuse `getSampleSrc` without porting state plumbing into the
+ * worker), and a small pool of workers handles fetch + decode.
  */
 
-import type { Coloring } from "@fiftyone/looker";
 import type { OverlayMask } from "@fiftyone/looker/src/numpy";
-import { decodeMaskOnDisk } from "@fiftyone/looker/src/worker/mask-decoder";
 import { getSampleSrc } from "@fiftyone/state/src/recoil/utils";
+import { v4 as uuidv4 } from "uuid";
 
-// `decodeMaskOnDisk` only consults `coloring` in its SEGMENTATION branch.
-// Detection masks fall through to the default canvas decode path, so a stub
-// is sufficient — keeps the call site free of recoil/state dependencies.
-const STUB_COLORING = {} as Coloring;
+import MaskPathDecodeWorker from "./maskPathDecodeWorker?worker&inline";
+import type { DecodeResponse } from "./maskPathDecodeWorker";
+
+// Minimum of 1 worker, maximum of 4 workers
+const MAX_WORKERS = (() => {
+  const hw =
+    typeof navigator !== "undefined" && navigator.hardwareConcurrency
+      ? navigator.hardwareConcurrency
+      : 2;
+  return Math.max(1, Math.min(4, hw));
+})();
+
+interface PendingJob {
+  uuid: string;
+  url: string;
+  field: string;
+  cls: string;
+  resolve: (mask: OverlayMask | undefined) => void;
+}
+
+interface Slot {
+  worker: Worker;
+  job: PendingJob | null;
+}
+
+let slots: Slot[] | undefined;
+const queue: PendingJob[] = [];
+
+const supportsWorkers = (): boolean =>
+  typeof Worker !== "undefined" && typeof window !== "undefined";
+
+const bindWorker = (slot: Slot, worker: Worker): void => {
+  slot.worker = worker;
+
+  worker.addEventListener("message", (event: MessageEvent<DecodeResponse>) => {
+    const job = slot.job;
+    if (!job || job.uuid !== event.data.uuid) {
+      // Stale message (e.g. after a respawn). Ignore.
+      return;
+    }
+    slot.job = null;
+
+    if (event.data.ok) {
+      job.resolve(event.data.mask);
+    } else {
+      console.error("[decodeMaskPath] worker decode failed:", event.data.error);
+      job.resolve(undefined);
+    }
+
+    drain();
+  });
+
+  worker.addEventListener("error", (event) => {
+    console.error("[decodeMaskPath] worker crashed; respawning slot:", event);
+    // Fail the in-flight job so one bad payload doesn't hang the caller.
+    const failed = slot.job;
+    slot.job = null;
+    failed?.resolve(undefined);
+
+    slot.worker.terminate();
+    bindWorker(slot, new MaskPathDecodeWorker());
+
+    drain();
+  });
+};
+
+const createSlot = (): Slot => {
+  const slot: Slot = { worker: undefined as unknown as Worker, job: null };
+
+  bindWorker(slot, new MaskPathDecodeWorker());
+
+  return slot;
+};
+
+const ensurePool = (): Slot[] | undefined => {
+  if (slots) {
+    return slots;
+  }
+
+  if (!supportsWorkers()) {
+    return undefined;
+  }
+
+  slots = Array.from({ length: MAX_WORKERS }, () => createSlot());
+  return slots;
+};
+
+const dispatch = (slot: Slot, job: PendingJob): void => {
+  slot.job = job;
+  slot.worker.postMessage({
+    uuid: job.uuid,
+    url: job.url,
+    field: job.field,
+    cls: job.cls,
+  });
+};
+
+const drain = (): void => {
+  if (!slots || queue.length === 0) {
+    return;
+  }
+
+  for (const slot of slots) {
+    if (queue.length === 0) {
+      break;
+    }
+
+    if (slot.job) {
+      continue;
+    }
+
+    const next = queue.shift()!;
+    dispatch(slot, next);
+  }
+};
 
 /**
  * Fetches a mask image referenced by `mask_path` and decodes it into an
- * {@link OverlayMask} on the main thread by reusing looker's
- * `decodeMaskOnDisk` pipeline. The result is suitable for handing directly
- * to {@link MaskCanvas} via the pre-decoded mask path.
+ * {@link OverlayMask}.
  *
- * Returns `undefined` if the fetch or decode fails — callers should treat
+ * Returns `undefined` if the fetch or decode fails; callers should treat
  * this as "no mask available yet" and proceed without one.
  */
 export async function decodeMaskPath(
@@ -26,16 +138,43 @@ export async function decodeMaskPath(
   field: string,
   cls: string
 ): Promise<OverlayMask | undefined> {
-  try {
-    const url = getSampleSrc(maskPath);
-    const response = await fetch(url);
-    const blob = await response.blob();
+  const url = getSampleSrc(maskPath);
+  const pool = ensurePool();
 
-    const overlayMask = await decodeMaskOnDisk(blob, cls, field, STUB_COLORING);
+  if (!pool) {
+    // No worker support (SSR, tests). Fall back to a direct fetch+decode on
+    // whatever thread we're on so callers still get a result.
+    const { decodeMaskOnDisk } = await import(
+      "@fiftyone/looker/src/worker/mask-decoder"
+    );
 
-    return overlayMask ?? undefined;
-  } catch (err) {
-    console.error("[decodeMaskPath] failed to decode mask_path:", err);
-    return undefined;
+    try {
+      const response = await fetch(url);
+      const blob = await response.blob();
+
+      const mask = await decodeMaskOnDisk(blob, cls, field, {} as never);
+
+      return mask ?? undefined;
+    } catch (err) {
+      console.error("[decodeMaskPath] fallback decode failed:", err);
+      return undefined;
+    }
   }
+
+  return new Promise<OverlayMask | undefined>((resolve) => {
+    const job: PendingJob = {
+      uuid: uuidv4(),
+      url,
+      field,
+      cls,
+      resolve,
+    };
+
+    const free = pool.find((s) => !s.job);
+    if (free) {
+      dispatch(free, job);
+    } else {
+      queue.push(job);
+    }
+  });
 }

--- a/app/packages/lighter/src/utils/maskPathDecoding.ts
+++ b/app/packages/lighter/src/utils/maskPathDecoding.ts
@@ -7,6 +7,7 @@
  */
 
 import type { OverlayMask } from "@fiftyone/looker/src/numpy";
+import { LRUCache } from "lru-cache";
 import { v4 as uuidv4 } from "uuid";
 
 import MaskPathDecodeWorker from "./maskPathDecodeWorker?worker&inline";
@@ -36,6 +37,26 @@ interface Slot {
 
 let slots: Slot[] | undefined;
 const queue: PendingJob[] = [];
+
+// Dedupe concurrent decodes for the same URL. Useful when two callers
+// overlap — e.g. a slow cloud fetch with a re-entering effect.
+const inFlight = new Map<string, Promise<OverlayMask | undefined>>();
+
+// Cache resolved decodes. Sequential repeats of the same URL (the common
+// case for fast local fetches where in-flight dedupe misses) get the
+// cached `OverlayMask` instead of a fresh worker fetch.
+//
+// LRU-bounded so the cache stays memory-safe across long sessions with
+// many unique masks. Sized by buffer byte count.
+//
+// The buffer is read-only from `MaskCanvas`'s perspective; multiple
+// instances can share it safely.
+const CACHE_MAX_BYTES = 128 * 1024 * 1024;
+const cache = new LRUCache<string, OverlayMask>({
+  maxSize: CACHE_MAX_BYTES,
+  sizeCalculation: (mask) => mask.buffer.byteLength,
+  ttl: 30_000, // 30 seconds; allow for frequent refresh
+});
 
 const supportsWorkers = (): boolean =>
   typeof Worker !== "undefined" && typeof window !== "undefined";
@@ -136,6 +157,34 @@ const drain = (): void => {
  * this as "no mask available yet" and proceed without one.
  */
 export async function decodeMaskPath(
+  url: string,
+  field: string,
+  cls: string
+): Promise<OverlayMask | undefined> {
+  const cached = cache.get(url);
+  if (cached) {
+    console.debug(`[mask-path] cache hit for ${url}`);
+    return cached;
+  }
+
+  const existing = inFlight.get(url);
+  if (existing) {
+    console.debug(`[mask-path] dedupe in-flight fetch for ${url}`);
+    return existing;
+  }
+
+  const promise = decodeMaskPathImpl(url, field, cls);
+  inFlight.set(url, promise);
+  void promise
+    .then((mask) => {
+      if (mask) cache.set(url, mask);
+    })
+    .finally(() => inFlight.delete(url));
+
+  return promise;
+}
+
+async function decodeMaskPathImpl(
   url: string,
   field: string,
   cls: string

--- a/app/packages/lighter/src/utils/maskPathDecoding.ts
+++ b/app/packages/lighter/src/utils/maskPathDecoding.ts
@@ -7,7 +7,6 @@
  */
 
 import type { OverlayMask } from "@fiftyone/looker/src/numpy";
-import { getSampleSrc } from "@fiftyone/state/src/recoil/utils";
 import { v4 as uuidv4 } from "uuid";
 
 import MaskPathDecodeWorker from "./maskPathDecodeWorker?worker&inline";
@@ -127,18 +126,20 @@ const drain = (): void => {
 };
 
 /**
- * Fetches a mask image referenced by `mask_path` and decodes it into an
- * {@link OverlayMask}.
+ * Fetches a pre-resolved mask URL and decodes it into an {@link OverlayMask}.
+ *
+ * URL resolution is the caller's responsibility; the raw `mask_path` value
+ * on a label is not always directly fetchable and must be mapped to a real
+ * URL by the integration layer before reaching here.
  *
  * Returns `undefined` if the fetch or decode fails; callers should treat
  * this as "no mask available yet" and proceed without one.
  */
 export async function decodeMaskPath(
-  maskPath: string,
+  url: string,
   field: string,
   cls: string
 ): Promise<OverlayMask | undefined> {
-  const url = getSampleSrc(maskPath);
   const pool = ensurePool();
 
   if (!pool) {

--- a/app/packages/lighter/src/utils/maskPathDecoding.ts
+++ b/app/packages/lighter/src/utils/maskPathDecoding.ts
@@ -61,6 +61,17 @@ const cache = new LRUCache<string, OverlayMask>({
 const supportsWorkers = (): boolean =>
   typeof Worker !== "undefined" && typeof window !== "undefined";
 
+/** Worker factory. */
+const spawnWorker = (): Worker => {
+  try {
+    return new MaskPathDecodeWorker();
+  } catch {
+    return new Worker(new URL("./maskPathDecodeWorker.ts", import.meta.url), {
+      type: "module",
+    });
+  }
+};
+
 const bindWorker = (slot: Slot, worker: Worker): void => {
   slot.worker = worker;
 
@@ -97,7 +108,7 @@ const bindWorker = (slot: Slot, worker: Worker): void => {
     failed?.resolve(undefined);
 
     worker.terminate();
-    bindWorker(slot, new MaskPathDecodeWorker());
+    bindWorker(slot, spawnWorker());
 
     drain();
   });
@@ -106,7 +117,7 @@ const bindWorker = (slot: Slot, worker: Worker): void => {
 const createSlot = (): Slot => {
   const slot: Slot = { worker: undefined as unknown as Worker, job: null };
 
-  bindWorker(slot, new MaskPathDecodeWorker());
+  bindWorker(slot, spawnWorker());
 
   return slot;
 };
@@ -168,6 +179,14 @@ export async function decodeMaskPath(
   field: string,
   cls: string
 ): Promise<OverlayMask | undefined> {
+  // Defensive: callers should never pass a non-string URL, but if they do,
+  // a downstream `fetch(undefined)` would resolve to a phantom request
+  // against the page origin. Treat as "no mask" and bail.
+  if (typeof url !== "string" || url.length === 0) {
+    console.warn("[decodeMaskPath] called with invalid url:", url);
+    return undefined;
+  }
+
   const cached = cache.get(url);
   if (cached) {
     return cached;

--- a/app/packages/lighter/src/vite-env.d.ts
+++ b/app/packages/lighter/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2984,6 +2984,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^6.0.0"
     "@typescript-eslint/parser": "npm:^6.0.0"
     eslint: "npm:^8.0.0"
+    lru-cache: "npm:^11.0.1"
     pixi.js: "npm:^8.13.1"
   peerDependencies:
     "@fiftyone/commands": "*"


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

Current mask annotation supports the `mask` attribute, but not masks stored in `mask_path`. This PR fills that gap.

`mask_path` masks are now decoded on a worker thread before being passed to the detection overlay. Any modifications made to the mask are then stored in `mask`, while `mask_path` is cleared to prevent the sample from having conflicting mask data.

## 🧪 How is this patch tested? If it is not, please explain why.

local

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background worker-based decoding of masks from external URLs with caching/deduplication; overlays can be seeded with pre-decoded masks.
  * Label creation now supports async pre-decoding and per-field URL resolution so externally-stored masks are prepared before use.
  * Mask handling accepts pre-decoded mask objects for preview/editing.

* **Bug Fixes**
  * Prevent persisting both inline mask data and a conflicting external mask reference; removing a mask clears both sources.

* **UI**
  * Editing, preview, merge and tool enable/disable now treat external mask references the same as inline masks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7581?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->