### PR TITLE
[HA] fix undo bug for first point in polyline

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useCreate.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useCreate.ts
@@ -108,7 +108,8 @@ const useCreateAnnotationLabel = () => {
             selectable: true,
           }
         );
-        addOverlay(overlay);
+        // needs to pass in true, so that first point is undo-able. Otherwise, the overlay doesn't exist in the store until after the first point is placed, so the initial state isn't captured in the undo stack
+        addOverlay(overlay, true);
 
         // Selecting the new overlay triggers `usePolylineMode`'s effect to
         // install an `InteractivePolylineHandler` for editing. Creation


### PR DESCRIPTION
## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

<!--
Provide a clear, concise description of what this PR does and why.
-->

## 🧪 How is this patch tested? If it is not, please explain why.


https://github.com/user-attachments/assets/7f7fd580-ec8c-4a48-ad3d-1f2611a5130e



## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Polyline annotations now maintain full undo/redo history starting from the initial point placement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->