### PR TITLE
fix: preserve hex string keys in mask_targets label schema sanitizer

### DIFF
--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -1940,7 +1940,8 @@ class AnnotationBackendConfig(foa.AnnotationMethodConfig):
             mask_targets = label_info.get("mask_targets", None)
             if isinstance(mask_targets, dict):
                 label_info["mask_targets"] = {
-                    int(k): v for k, v in mask_targets.items()
+                    int(k) if fof.is_integer_target(k) else k: v
+                    for k, v in mask_targets.items()
                 }
 
     def serialize(self, *args, **kwargs):


### PR DESCRIPTION
## Summary

Fixes #6186

## Root Cause

`_sanitize_label_schema` in `annotations.py` unconditionally cast all
`mask_targets` keys with `int(k)`, crashing when keys are RGB hex
strings like `"#3f0a44"`.

The rest of the codebase already handles both formats correctly —
`MaskTargetsField` in `fields.py` validates grayscale vs. RGB targets
separately, and `labels.py` uses `is_rgb_mask_targets()` + `_hex_to_int()`
for rendering and export. The sanitizer was the only place that didn't
respect this distinction.

## Changes

- `fiftyone/utils/annotations.py`: cast to `int` only when key is a digit string; preserve hex string keys as-is

## Testing

```
tests/unittests/annotation/dataset_label_schemas_tests.py     12 passed
```

## What areas of FiftyOne does this PR affect?
- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [x] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved annotation schema handling for mask targets: numeric string keys are now correctly interpreted as integers while non-numeric string keys are left unchanged, preventing parsing errors and unintended conversions. This change avoids failures when loading or processing annotations and preserves compatibility with existing numeric-keyed mask targets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->