### PR TITLE
[AS-1090] Remove support for Python 3.9

### DIFF
--- a/.github/workflows/build-db.yml
+++ b/.github/workflows/build-db.yml
@@ -25,10 +25,10 @@ jobs:
     steps:
       - name: Clone fiftyone
         uses: actions/checkout@v6
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel build
@@ -90,10 +90,10 @@ jobs:
         with:
           name: dist-sdist
           path: downloads
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install fiftyone-db
         run: |
           pip install downloads/fiftyone_db-*.tar.gz

--- a/.github/workflows/build-db.yml
+++ b/.github/workflows/build-db.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel build
@@ -93,7 +93,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install fiftyone-db
         run: |
           pip install downloads/fiftyone_db-*.tar.gz

--- a/.github/workflows/build-graphql.yml
+++ b/.github/workflows/build-graphql.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel build

--- a/.github/workflows/build-graphql.yml
+++ b/.github/workflows/build-graphql.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - name: Clone fiftyone
         uses: actions/checkout@v6
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: true
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,6 @@ jobs:
         os:
           - ubuntu-latest
         python:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -16,7 +16,6 @@ jobs:
         os:
           - windows-latest
         python:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ pip install fiftyone
 
 ### Installation options
 
-FiftyOne supports Python 3.9 - 3.12.
+FiftyOne supports Python 3.10 - 3.12.
 
 For most users, we recommend installing the latest release version of FiftyOne
 via `pip` as shown above.
@@ -96,7 +96,7 @@ App.
 
 You'll need the following tools installed:
 
--   [Python](https://www.python.org) (3.9 - 3.12)
+-   [Python](https://www.python.org) (3.10 - 3.12)
 -   [Node.js](https://nodejs.org) - on Linux, we recommend using
     [nvm](https://github.com/nvm-sh/nvm) to install an up-to-date version.
 -   [Yarn](https://yarnpkg.com) - once Node.js is installed, you can
@@ -295,7 +295,7 @@ complete the Homebrew installation.
 #### 3. Install Python
 
 ```shell
-brew install python@3.9
+brew install python@3.10
 brew install protobuf
 ```
 
@@ -327,7 +327,7 @@ brew install ffmpeg
 ⚠️ The version of Python that is available in the Microsoft Store is **not
 recommended** ⚠️
 
-Download a Python 3.9 - 3.12 installer from
+Download a Python 3.10 - 3.12 installer from
 [python.org](https://www.python.org/downloads/). Make sure to pick a 64-bit
 version. For example, this
 [Python 3.10.11 installer](https://www.python.org/ftp/python/3.10.11/python-3.10.11-amd64.exe).

--- a/docs/source/getting_started/depth_estimation/index.rst
+++ b/docs/source/getting_started/depth_estimation/index.rst
@@ -60,7 +60,7 @@ Each notebook contains the necessary `pip install` commands at the beginning, so
 **System Requirements**
 
 - **Operating System:** Linux (Ubuntu 24.04), macOS
-- **Python:** 3.10, 3.11
+- **Python:** 3.10, 3.11, 3.12
 - **Memory:** 8GB RAM recommended (16GB for larger models)
 - **Storage:** 10GB free space for datasets and models
 - **GPU:** Optional but recommended for faster inference (CUDA-capable GPU)

--- a/docs/source/getting_started/depth_estimation/index.rst
+++ b/docs/source/getting_started/depth_estimation/index.rst
@@ -60,7 +60,7 @@ Each notebook contains the necessary `pip install` commands at the beginning, so
 **System Requirements**
 
 - **Operating System:** Linux (Ubuntu 24.04), macOS
-- **Python:** 3.9, 3.11
+- **Python:** 3.10, 3.11
 - **Memory:** 8GB RAM recommended (16GB for larger models)
 - **Storage:** 10GB free space for datasets and models
 - **GPU:** Optional but recommended for faster inference (CUDA-capable GPU)

--- a/docs/source/getting_started/manufacturing/index.rst
+++ b/docs/source/getting_started/manufacturing/index.rst
@@ -81,7 +81,7 @@ Each notebook contains the necessary `pip install` commands at the beginning, so
 **System Requirements**
 
 - **Operating System:** Linux (Ubuntu 20.04+), macOS
-- **Python:** 3.10, 3.11
+- **Python:** 3.10, 3.11, 3.12
 - **Memory:** 8GB RAM recommended for manufacturing dataset operations
 - **Storage:** 10GB free space for manufacturing datasets and models
 - **GPU:** Optional but recommended for faster model inference

--- a/docs/source/getting_started/manufacturing/index.rst
+++ b/docs/source/getting_started/manufacturing/index.rst
@@ -81,7 +81,7 @@ Each notebook contains the necessary `pip install` commands at the beginning, so
 **System Requirements**
 
 - **Operating System:** Linux (Ubuntu 20.04+), macOS
-- **Python:** 3.9, 3.10, 3.11
+- **Python:** 3.10, 3.11
 - **Memory:** 8GB RAM recommended for manufacturing dataset operations
 - **Storage:** 10GB free space for manufacturing datasets and models
 - **GPU:** Optional but recommended for faster model inference

--- a/docs/source/getting_started/medical_imaging/index.rst
+++ b/docs/source/getting_started/medical_imaging/index.rst
@@ -56,7 +56,7 @@ Each notebook contains the necessary `pip install` commands at the beginning, so
 **System Requirements**
 
 - **Operating System:** Linux (Ubuntu 24.04), macOS
-- **Python:** 3.9, 3.11
+- **Python:** 3.10, 3.11
 - **Memory:** 8GB RAM recommended for medical imaging operations
 - **Storage:** 5GB free space for medical datasets
 - **Notebook Environment:** Jupyter, Google Colab, VS Code notebooks (all validated)

--- a/docs/source/getting_started/medical_imaging/index.rst
+++ b/docs/source/getting_started/medical_imaging/index.rst
@@ -56,7 +56,7 @@ Each notebook contains the necessary `pip install` commands at the beginning, so
 **System Requirements**
 
 - **Operating System:** Linux (Ubuntu 24.04), macOS
-- **Python:** 3.10, 3.11
+- **Python:** 3.10, 3.11, 3.12
 - **Memory:** 8GB RAM recommended for medical imaging operations
 - **Storage:** 5GB free space for medical datasets
 - **Notebook Environment:** Jupyter, Google Colab, VS Code notebooks (all validated)

--- a/docs/source/getting_started/model_evaluation/index.rst
+++ b/docs/source/getting_started/model_evaluation/index.rst
@@ -51,7 +51,7 @@ Each notebook contains the necessary `pip install` commands at the beginning, so
 **System Requirements**
 
 - **Operating System:** Linux (Ubuntu 24.04), macOS
-- **Python:** 3.9, 3.11
+- **Python:** 3.10, 3.11
 - **Memory:** 8GB RAM recommended for evaluation operations
 - **Storage:** 2GB free space for datasets and models
 - **Notebook Environment:** Jupyter, Google Colab, VS Code notebooks (all validated)

--- a/docs/source/getting_started/model_evaluation/index.rst
+++ b/docs/source/getting_started/model_evaluation/index.rst
@@ -51,7 +51,7 @@ Each notebook contains the necessary `pip install` commands at the beginning, so
 **System Requirements**
 
 - **Operating System:** Linux (Ubuntu 24.04), macOS
-- **Python:** 3.10, 3.11
+- **Python:** 3.10, 3.11, 3.12
 - **Memory:** 8GB RAM recommended for evaluation operations
 - **Storage:** 2GB free space for datasets and models
 - **Notebook Environment:** Jupyter, Google Colab, VS Code notebooks (all validated)

--- a/docs/source/getting_started/object_detection/index.rst
+++ b/docs/source/getting_started/object_detection/index.rst
@@ -53,7 +53,7 @@ Each notebook contains the necessary `pip install` commands at the beginning, so
 **System Requirements**
 
 - **Operating System:** Linux (Ubuntu 24.04), macOS
-- **Python:** 3.10, 3.11
+- **Python:** 3.10, 3.11, 3.12
 - **Memory:** 8GB RAM recommended for COCO dataset operations
 - **Storage:** 2GB free space for datasets and models
 - **Notebook Environment:** Jupyter, Google Colab, VS Code notebooks (all validated)

--- a/docs/source/getting_started/object_detection/index.rst
+++ b/docs/source/getting_started/object_detection/index.rst
@@ -53,7 +53,7 @@ Each notebook contains the necessary `pip install` commands at the beginning, so
 **System Requirements**
 
 - **Operating System:** Linux (Ubuntu 24.04), macOS
-- **Python:** 3.9, 3.11
+- **Python:** 3.10, 3.11
 - **Memory:** 8GB RAM recommended for COCO dataset operations
 - **Storage:** 2GB free space for datasets and models
 - **Notebook Environment:** Jupyter, Google Colab, VS Code notebooks (all validated)

--- a/docs/source/getting_started/threed_visual_ai/index.rst
+++ b/docs/source/getting_started/threed_visual_ai/index.rst
@@ -54,7 +54,7 @@ Each notebook contains the necessary `pip install` commands at the beginning, so
 **System Requirements**
 
 - **Operating System:** Linux (Ubuntu 24.04), macOS
-- **Python:** 3.10, 3.11
+- **Python:** 3.10, 3.11, 3.12
 - **Memory:** 8GB RAM recommended for 3D operations
 - **Storage:** 5GB free space for 3D datasets
 - **Graphics:** GPU recommended for large point cloud visualization

--- a/docs/source/getting_started/threed_visual_ai/index.rst
+++ b/docs/source/getting_started/threed_visual_ai/index.rst
@@ -54,7 +54,7 @@ Each notebook contains the necessary `pip install` commands at the beginning, so
 **System Requirements**
 
 - **Operating System:** Linux (Ubuntu 24.04), macOS
-- **Python:** 3.9, 3.11
+- **Python:** 3.10, 3.11
 - **Memory:** 8GB RAM recommended for 3D operations
 - **Storage:** 5GB free space for 3D datasets
 - **Graphics:** GPU recommended for large point cloud visualization

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -15,7 +15,7 @@ Prerequisites
 -------------
 
 You will need a working Python installation. FiftyOne currently requires
-**Python 3.9 - 3.12**.
+**Python 3.10 - 3.12**.
 
 On Linux, we recommend installing Python through your system package manager
 (APT, YUM, etc.) if it is available. On other platforms, Python can be

--- a/docs/source/installation/troubleshooting.rst
+++ b/docs/source/installation/troubleshooting.rst
@@ -44,9 +44,9 @@ old, you may encounter errors like these:
 
 .. code-block:: text
 
-    fiftyone requires Python '>=3.9' but the running Python is 3.4.10
+    fiftyone requires Python '>=3.10' but the running Python is 3.4.10
 
-To resolve this, you will need to use Python 3.9 or newer, and pip 19.3 or
+To resolve this, you will need to use Python 3.10 or newer, and pip 19.3 or
 newer. See the :ref:`installation guide <installing-fiftyone>` for details. If
 you have installed a suitable version of Python in a virtual environment and
 still encounter this error, ensure that the virtual environment is activated.

--- a/docs/source/installation/virtualenv.rst
+++ b/docs/source/installation/virtualenv.rst
@@ -26,7 +26,7 @@ these commands:
    $ python --version
    Python 2.7.17
    $ python3 --version
-   Python 3.9.20
+   Python 3.10.18
 
 In this case, `python3` should be used in the next step.
 
@@ -71,7 +71,7 @@ of this guide. For example:
 .. code-block:: text
 
    $ python --version
-   Python 3.9.20
+   Python 3.10.18
 
 Also note that `python` and `pip` live inside the `env` folder (in this output,
 the path to the current folder is replaced with `...`):

--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -6,6 +6,7 @@ Installs the ``fiftyone-db`` package.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import csv
 import os
 import pathlib
@@ -345,10 +346,9 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     cmdclass=cmdclass,
 )

--- a/package/desktop/setup.py
+++ b/package/desktop/setup.py
@@ -6,6 +6,7 @@ Installs the ``fiftyone-desktop`` package.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import glob
 import os
 import shutil
@@ -14,7 +15,6 @@ from wheel.bdist_wheel import bdist_wheel
 
 import os
 import shutil
-
 
 VERSION = "0.35.0"
 
@@ -187,10 +187,9 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     cmdclass=cmdclass,
 )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ Installs FiftyOne.
 import os
 from setuptools import setup, find_packages
 
-
 VERSION = "1.17.0"
 
 
@@ -116,11 +115,10 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
     ],
     entry_points={"console_scripts": ["fiftyone=fiftyone.core.cli:main"]},
-    python_requires=">=3.9",
+    python_requires=">=3.10",
 )


### PR DESCRIPTION
## 🔗 Related Issues

[AS-1090](https://voxel51.atlassian.net/browse/AS-1090)

## 📋 What changes are proposed in this pull request?

Remove support for Python 3.9, update documentation, and configure CI not to test on Python 3.9.

## 🧪 How is this patch tested? If it is not, please explain why.

CI

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Python 3.9 is no longer supported.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [x] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

[AS-1090]: https://voxel51.atlassian.net/browse/AS-1090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Raised minimum Python requirement from 3.9 to 3.10 across the project, updated packaging metadata accordingly.
  * CI/CD workflows and Docker build matrix now target Python 3.10, 3.11, 3.12; Python 3.9 entries removed.

* **Documentation**
  * Installation guides and system requirements updated to reflect Python 3.10 as the minimum supported version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->