### PR TITLE
[HA] fix drag state inconsistency across handlers

### DIFF
--- a/app/packages/lighter/src/interaction/InteractivePolylineHandler.ts
+++ b/app/packages/lighter/src/interaction/InteractivePolylineHandler.ts
@@ -409,6 +409,12 @@ export class InteractivePolylineHandler implements InteractionHandler {
     this.overlay.setPreviewAnchorFlipped(false);
     this.overlay.setPreviewAnchorPointId(null);
     this.overlay.setDeletable(this.priorIsDeletable);
+    // The select-click that triggered handler install ran the overlay's own
+    // onPointerDown (setting per-point drag state) before this handler took
+    // over dispatch. Pointer-up then routed to the handler, not the overlay,
+    // so that state would otherwise outlive the handler and re-engage drag
+    // on the next hover.
+    this.overlay.cancelPointDrag();
   }
 
   /**

--- a/app/packages/lighter/src/overlay/KeypointOverlay.ts
+++ b/app/packages/lighter/src/overlay/KeypointOverlay.ts
@@ -753,7 +753,6 @@ export class KeypointOverlay
    * on subsequent hover once the handler is uninstalled.
    */
   cancelPointDrag(): void {
-    if (this.dragPointIndex === null) return;
     this.dragPointIndex = null;
     this.moveStartScreenPoint = undefined;
     this.moveStartRelativePoint = undefined;

--- a/app/packages/lighter/src/overlay/KeypointOverlay.ts
+++ b/app/packages/lighter/src/overlay/KeypointOverlay.ts
@@ -744,6 +744,22 @@ export class KeypointOverlay
     return true;
   }
 
+  /**
+   * Resets per-point drag tracking. For use by interactive handlers that take
+   * over drag ownership (e.g. {@link InteractivePolylineHandler}): the click
+   * that selects an overlay enters this overlay's own onPointerDown and sets
+   * drag state, but the matching pointer-up may dispatch to the now-installed
+   * handler instead, leaving drag state stranded. Stranded state re-engages
+   * on subsequent hover once the handler is uninstalled.
+   */
+  cancelPointDrag(): void {
+    if (this.dragPointIndex === null) return;
+    this.dragPointIndex = null;
+    this.moveStartScreenPoint = undefined;
+    this.moveStartRelativePoint = undefined;
+    this.renderer?.enableZoomPan();
+  }
+
   // ---------------------------------------------------------------------------
   // Public mutation API
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

Fixes a bug where polyline points can be dragged erroneously due to drag state inconsistency across handlers.

## 🧪 How is this patch tested? If it is not, please explain why.

local

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where point-drag state could persist after an interaction ended, which could cause unintended dragging in subsequent pointer actions.
  * Ensured zoom and pan controls are re-enabled when interaction handlers finish, preventing stuck zoom/pan behavior after dragging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->