### PR TITLE
[HA] Remove feature flags for segmentation and polylines

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Actions.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Actions.tsx
@@ -38,7 +38,6 @@ import { usePolylineMode } from "./Edit/usePolylineMode";
 import { useSegmentationMode } from "./Edit/useSegmentationMode";
 import { useDeactivateAllModes } from "./useDeactivateAllModes";
 import { Anchor, Text, Tooltip } from "@voxel51/voodo";
-import { FeatureFlag, FeatureFlagged } from "@fiftyone/feature-flags";
 
 const ActionsDiv = styled.div`
   align-items: center;
@@ -465,12 +464,8 @@ const Actions = () => {
             ) : (
               <>
                 <Detection />
-                <FeatureFlagged feature={FeatureFlag.VFF_AI_SEGMENTATION}>
-                  <Segmentation />
-                </FeatureFlagged>
-                <FeatureFlagged feature={FeatureFlag.VFF_POLYLINE_ANNOTATION}>
-                  <Polyline />
-                </FeatureFlagged>
+                <Segmentation />
+                <Polyline />
               </>
             )}
           </ItemLeft>

--- a/app/packages/feature-flags/src/client/flags.ts
+++ b/app/packages/feature-flags/src/client/flags.ts
@@ -2,7 +2,5 @@
  * Enumeration of active feature flags.
  */
 export enum FeatureFlag {
-  VFF_AI_SEGMENTATION = "VFF_AI_SEGMENTATION",
   VFF_MULTIMODAL = "VFF_MULTIMODAL",
-  VFF_POLYLINE_ANNOTATION = "VFF_POLYLINE_ANNOTATION",
 }

--- a/fiftyone/internal/features/flags.py
+++ b/fiftyone/internal/features/flags.py
@@ -10,8 +10,6 @@ from typing import Literal
 
 
 FeatureFlag = Literal[
-    "VFF_AI_SEGMENTATION",
     "VFF_MULTIMODAL",
-    "VFF_POLYLINE_ANNOTATION",
 ]
 """Enumeration of active feature flags."""


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

Remove feature flags for segmentation + polyline annotation; features are fully enabled.

## 🧪 How is this patch tested? If it is not, please explain why.

👀 

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Segmentation and Polyline annotation features are now universally available (removed conditional feature flag restrictions)
  * Simplified feature flag infrastructure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7591?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->