### PR TITLE
Ontology allow save overwrites

### DIFF
--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -72,6 +72,7 @@ from .core.ontology import (
     list_ontologies,
     load_ontology,
     ontology_exists,
+    save_ontology,
 )
 from .core.fields import (
     flatten_schema,

--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -354,6 +354,19 @@ def _objects_by_slug(name: str):
     )
 
 
+def save_ontology(ontology: Ontology, overwrite: bool = False) -> None:
+    """Saves the given ontology to the database.
+
+    Module-level mirror of :meth:`Ontology.save`, paired with
+    :func:`load_ontology` and :func:`delete_ontology`.
+
+    Args:
+        ontology: an :class:`Ontology` to save
+        overwrite: see :meth:`Ontology.save`
+    """
+    ontology.save(overwrite=overwrite)
+
+
 def load_ontology(name: str) -> Ontology:
     """Loads the latest version of an ontology by name.
 

--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -88,9 +88,22 @@ class Ontology(abc.ABC):
         """Whether this ontology is a taxonomy."""
         return self._TYPE == OntologyType.TAXONOMY.value
 
-    def save(self) -> None:
-        """Saves this ontology to the database."""
+    def save(self, overwrite: bool = False) -> None:
+        """Saves this ontology to the database.
+
+        Args:
+            overwrite: if True and an ontology with this name already exists
+                in the database, adopt its lineage and append a new version.
+                Enables JSON/git-driven workflows where an instance built via
+                :meth:`from_dict` is saved without first calling
+                :func:`load_ontology`. With the default ``False``, saving an
+                in-memory instance whose slug collides with a persisted
+                ontology is rejected.
+        """
         self._validate()
+        if self._doc is None and overwrite:
+            self._doc = self._find_latest_doc()
+
         if self._doc is None:
             self._doc = OntologyDocument(
                 name=self.name,
@@ -104,6 +117,14 @@ class Ontology(abc.ABC):
             self._doc.root = self._get_root()
 
         self._doc.save()
+
+    def _find_latest_doc(self) -> Optional[OntologyDocument]:
+        slug = fou.to_slug(self.name)
+        return (
+            OntologyDocument.objects(slug=slug, type=self._TYPE)
+            .order_by("-version")
+            .first()
+        )
 
     def reload(self) -> None:
         """Reloads this ontology from the database."""

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -994,6 +994,40 @@ class OntologySDKTests(unittest.TestCase):
         original = load_ontology("original")
         self.assertEqual(original.name, "original")
 
+    def test_save_overwrite_appends_new_version(self):
+        from fiftyone.core.ontology import load_ontology
+
+        self._make_ontology("versioned").save()
+
+        fresh = AnnotationOntology(
+            name="versioned",
+            description="rev 2",
+            attributes=[
+                AttributeSpec(name="x", type="bool", component="checkbox"),
+            ],
+        )
+        fresh.save(overwrite=True)
+
+        self.assertEqual(fresh.version, 2)
+
+        loaded = load_ontology("versioned")
+        self.assertEqual(loaded.version, 2)
+        self.assertEqual(loaded.description, "rev 2")
+        self.assertEqual(len(loaded.attributes), 1)
+        self.assertEqual(loaded.attributes[0].name, "x")
+
+    def test_save_without_overwrite_rejects_collision(self):
+        self._make_ontology("collide").save()
+
+        with self.assertRaises(ValueError):
+            self._make_ontology("collide").save()
+
+    def test_save_overwrite_no_existing_doc_creates_version_1(self):
+        fresh = self._make_ontology("brand_new")
+        fresh.save(overwrite=True)
+
+        self.assertEqual(fresh.version, 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -1028,6 +1028,32 @@ class OntologySDKTests(unittest.TestCase):
 
         self.assertEqual(fresh.version, 1)
 
+    def test_save_ontology_function_mirrors_instance_save(self):
+        from fiftyone.core.ontology import load_ontology, save_ontology
+
+        ao = self._make_ontology("via_module_fn")
+        save_ontology(ao)
+
+        self.assertEqual(ao.version, 1)
+        self.assertEqual(load_ontology("via_module_fn").name, "via_module_fn")
+
+    def test_save_ontology_function_forwards_overwrite(self):
+        from fiftyone.core.ontology import load_ontology, save_ontology
+
+        save_ontology(self._make_ontology("forwarded"))
+
+        fresh = AnnotationOntology(
+            name="forwarded",
+            description="rev 2",
+            attributes=[
+                AttributeSpec(name="x", type="bool", component="checkbox"),
+            ],
+        )
+        save_ontology(fresh, overwrite=True)
+
+        self.assertEqual(fresh.version, 2)
+        self.assertEqual(load_ontology("forwarded").description, "rev 2")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

This adds a overwrite parameter to the ontology save. This allows workflows where an ontology was loaded through `from_dict` or in just Python data classes to save without first loading from the database. 

## 🧪 How is this patch tested? If it is not, please explain why.

Tested locally, unit tests. 

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ontologies can be saved with an overwrite option to update existing ontologies (applies versioning) instead of creating duplicates.
  * A top-level public save function for ontologies was added to the API.

* **Tests**
  * Added tests validating ontology versioning, overwrite behavior, collision rejection, and the new public save function.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7594?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->