### PR TITLE
[FOEPD-3725] Update Pillow version requirement to explicitly require 12.2+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         "jsonpatch>=1,<2",
         "mongoengine~=0.29.1",  # Keep small bounds on mongo-related libraries
         "motor~=3.6.0",  # Keep small bounds on mongo-related libraries
-        "Pillow>=6.2,!=11.2.*",  # Pillow 11.2.0 introduced CVE 2025-48379 that is fixed in 11.3.0
+        "Pillow>=12.2",
         "plotly>=6.1.1,<7",
         "pprintpp>=0.1,<0.5",
         "protobuf==6.33.6",


### PR DESCRIPTION
## 🔗 Related Issues

[FOEPD-3725](https://voxel51.atlassian.net/browse/FOEPD-3725)

## 📋 What changes are proposed in this pull request?

Require Pillow 12.2+. Technically this isn't needed so long as Python 3.9 isn't allowed, because Pillow 12.2 [requires](https://pypi.org/project/pillow/) Python 3.10+ so dependency resolution will install Pillow 12.2+, but probably better to be explicit about not allowing prior, vulnerable versions.

## 🧪 How is this patch tested? If it is not, please explain why.

Built Docker image locally with `make python && docker build . --no-cache --tag fo-cve-test`, then ran `docker scout cves fo-cve-test`, confirmed output did not list CVE-2026-40192.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [x] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

[FOEPD-3725]: https://voxel51.atlassian.net/browse/FOEPD-3725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Pillow dependency requirement from version 6.2+ to 12.2+

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7596?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->