### PR TITLE
taxonomy delete functionality

### DIFF
--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -638,7 +638,13 @@ def delete_ontology(name: str, force: bool = False) -> None:
     elif ontology.is_taxonomy:
         _delete_taxonomy(ontology, force=force)
     else:
-        _objects_by_slug(name).delete()
+        # Defensive: load_ontology only returns known types today, but a
+        # new OntologyType added without a cascade handler must not fall
+        # through to a silent delete.
+        raise ValueError(
+            f"Cannot delete ontology {name!r}: no cascade handler for "
+            f"type {type(ontology).__name__}"
+        )
 
 
 def _delete_annotation_ontology(

--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -607,33 +607,48 @@ def _find_label_schema_refs_by_ontology(
 def delete_ontology(name: str, force: bool = False) -> None:
     """Deletes an ontology and all its versions from the database.
 
-    If any label schema references this ontology (via
-    ``applied_ontology`` on a field), the default behavior is to raise
-    rather than silently break those schemas. Pass ``force=True`` to
-    inline the ontology's attributes into each affected schema as
-    permanent local copies and then delete the ontology.
+    Behavior depends on the ontology's type:
 
-    Inlining and deletion run as two phases: every affected schema is
-    inlined and saved first, and the ontology is deleted only if every
-    save succeeds. If something fails mid-inline, the ontology still
-    exists and the call is safely re-runnable — already-inlined
-    schemas no longer match the lookup.
+    - **AnnotationOntology**: if any label schema references this ontology
+      via ``applied_ontology``, raises unless ``force=True``. With force,
+      the ontology's attributes are inlined into each affected schema as
+      permanent local copies before deletion.
+    - **Taxonomy**: if any annotation ontology references this taxonomy
+      via its ``taxonomy`` field, raises unless ``force=True``. With
+      force, the reference is unset on each affected annotation ontology
+      (saving appends a new version). Label schemas are not scanned —
+      ``applied_taxonomy`` is a hydration-time output, never persisted.
+
+    Cascade writes run before the ontology itself is deleted, so a
+    mid-cascade failure leaves the call safely re-runnable.
 
     Args:
         name: the ontology name
-        force: if False (default), raise if any label schema references
-            the ontology. If True, inline the ontology's attributes
-            into each affected schema as local copies before deleting.
+        force: if False (default), raise if anything references the
+            ontology. If True, cascade as described above before deleting.
 
     Raises:
         ValueError: if the ontology does not exist, or if it is in use
             and ``force=False``
     """
-    # Late imports to avoid circular dependency with annotation/dataset.
+    ontology = load_ontology(name)
+
+    if ontology.is_annotation_ontology:
+        _delete_annotation_ontology(ontology, force=force)
+    elif ontology.is_taxonomy:
+        _delete_taxonomy(ontology, force=force)
+    else:
+        _objects_by_slug(name).delete()
+
+
+def _delete_annotation_ontology(
+    ontology: "AnnotationOntology", force: bool
+) -> None:
+    # Late imports to avoid a circular dependency with annotation/dataset.
     from fiftyone.core.annotation import inline_applied_ontology
     from fiftyone.core.odm.dataset import DatasetDocument
 
-    ontology = load_ontology(name)
+    name = ontology.name
     affected = _find_label_schema_refs_by_ontology(name)
 
     if affected and not force:
@@ -656,6 +671,55 @@ def delete_ontology(name: str, force: bool = False) -> None:
         dataset_doc.save()
 
     _objects_by_slug(name).delete()
+
+
+def _delete_taxonomy(ontology: "Taxonomy", force: bool) -> None:
+    name = ontology.name
+    referencing_ao_names = _find_annotation_ontology_refs_by_taxonomy(name)
+
+    if referencing_ao_names and not force:
+        raise ValueError(
+            f"Taxonomy '{name}' is bundled by "
+            f"{len(referencing_ao_names)} annotation ontology(ies). "
+            f"Pass force=True to unset the reference on each before "
+            f"deleting."
+        )
+
+    # Each save appends a new AO version, so a re-run finds no matches.
+    for ao_name in referencing_ao_names:
+        ao = load_ontology(ao_name)
+        ao.taxonomy = None
+        ao.save()
+
+    _objects_by_slug(name).delete()
+
+
+def _find_annotation_ontology_refs_by_taxonomy(
+    taxonomy_name: str,
+) -> list[str]:
+    """Returns names of annotation ontologies whose latest version
+    bundles the given taxonomy. Older versions may still reference it
+    after an unset; we only act on the latest version per slug.
+    """
+    # ``root.taxonomy`` is stored as a slug; normalize the input so
+    # callers can pass either the name or slug form.
+    taxonomy_slug = fou.to_slug(taxonomy_name)
+    pipeline = [
+        {"$match": {"type": OntologyType.ANNOTATION_ONTOLOGY.value}},
+        {"$sort": {"slug": 1, "version": -1}},
+        {
+            "$group": {
+                "_id": "$slug",
+                "name": {"$first": "$name"},
+                "root": {"$first": "$root"},
+            }
+        },
+        {"$match": {"root.taxonomy": taxonomy_slug}},
+        {"$project": {"name": 1, "_id": 0}},
+    ]
+    # pylint: disable-next=no-member
+    matches = OntologyDocument.objects.aggregate(pipeline)
+    return [m["name"] for m in matches]
 
 
 def apply_ontology(

--- a/tests/unittests/ontology_delete_tests.py
+++ b/tests/unittests/ontology_delete_tests.py
@@ -13,8 +13,10 @@ import fiftyone.core.odm as foo
 from fiftyone.core.annotation.attributes import AttributeSpec
 from fiftyone.core.ontology import (
     AnnotationOntology,
+    _find_annotation_ontology_refs_by_taxonomy,
     _find_label_schema_refs_by_ontology,
     delete_ontology,
+    load_ontology,
 )
 
 
@@ -343,6 +345,147 @@ class FindLabelSchemaRefsTests(unittest.TestCase):
         result = _find_label_schema_refs_by_ontology(_ONTOLOGY_NAME)
 
         self.assertEqual(result, [])
+
+
+_TAXONOMY_NAME = "test_taxonomy"
+_TAXONOMY_SLUG = "test-taxonomy"
+
+
+def _make_taxonomy(name: str = _TAXONOMY_NAME) -> None:
+    from fiftyone.core.annotation.nodes import Node
+    from fiftyone.core.ontology import Taxonomy
+
+    Taxonomy(
+        name=name,
+        root=Node(name="root", values=[Node(name="a"), Node(name="b")]),
+    ).save()
+
+
+def _make_ao_bundling_taxonomy(
+    ao_name: str, taxonomy_name: str = _TAXONOMY_NAME
+) -> None:
+    tax = load_ontology(taxonomy_name)
+    AnnotationOntology(name=ao_name, taxonomy=tax).save()
+
+
+class DeleteTaxonomyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        db = foo.get_db_conn()
+        db.drop_collection("ontologies")
+        fo.delete_non_persistent_datasets()
+
+    def tearDown(self) -> None:
+        db = foo.get_db_conn()
+        db.drop_collection("ontologies")
+        fo.delete_non_persistent_datasets()
+
+    def test_delete_unreferenced_taxonomy_succeeds(self) -> None:
+        _make_taxonomy()
+
+        delete_ontology(_TAXONOMY_NAME)
+
+        self.assertFalse(fo.ontology_exists(_TAXONOMY_NAME))
+
+    def test_delete_referenced_taxonomy_without_force_raises(self) -> None:
+        _make_taxonomy()
+        _make_ao_bundling_taxonomy("my_ao")
+
+        with self.assertRaises(ValueError):
+            delete_ontology(_TAXONOMY_NAME)
+
+        # Taxonomy and AO ref should be untouched.
+        self.assertTrue(fo.ontology_exists(_TAXONOMY_NAME))
+        self.assertEqual(load_ontology("my_ao").taxonomy, _TAXONOMY_SLUG)
+
+    def test_force_delete_taxonomy_unsets_ao_ref_and_deletes(self) -> None:
+        _make_taxonomy()
+        _make_ao_bundling_taxonomy("my_ao")
+
+        delete_ontology(_TAXONOMY_NAME, force=True)
+
+        # Taxonomy gone.
+        self.assertFalse(fo.ontology_exists(_TAXONOMY_NAME))
+        # AO survives without its bundled taxonomy.
+        self.assertIsNone(load_ontology("my_ao").taxonomy)
+
+    def test_force_delete_taxonomy_unsets_via_new_ao_version(self) -> None:
+        # Append-only: the unset is an appended version, not an in-place
+        # mutation. The latest AO version no longer carries the ref;
+        # whether prior versions still do is unspecified by this API.
+        _make_taxonomy()
+        _make_ao_bundling_taxonomy("my_ao")
+        ao_before = load_ontology("my_ao")
+
+        delete_ontology(_TAXONOMY_NAME, force=True)
+
+        ao_after = load_ontology("my_ao")
+        self.assertGreater(ao_after.version, ao_before.version)
+        self.assertIsNone(ao_after.taxonomy)
+
+    def test_force_delete_taxonomy_does_not_touch_label_schemas(
+        self,
+    ) -> None:
+        # applied_taxonomy is a hydration-time output, never persisted.
+        # The cascade scans AOs, not label schemas.
+        _make_taxonomy()
+        ds = fo.Dataset()
+        ds._doc.label_schemas = {
+            "ground_truth": {
+                "type": "detections",
+                "applied_ontology": "some_ao",
+            }
+        }
+        ds._doc.save()
+        snapshot = dict(ds._doc.label_schemas)
+
+        delete_ontology(_TAXONOMY_NAME, force=True)
+
+        ds.reload()
+        self.assertEqual(dict(ds._doc.label_schemas), snapshot)
+
+
+class FindAnnotationOntologyRefsByTaxonomyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        db = foo.get_db_conn()
+        db.drop_collection("ontologies")
+
+    def tearDown(self) -> None:
+        db = foo.get_db_conn()
+        db.drop_collection("ontologies")
+
+    def test_no_ontologies_returns_empty(self) -> None:
+        self.assertEqual(
+            _find_annotation_ontology_refs_by_taxonomy(_TAXONOMY_NAME), []
+        )
+
+    def test_unrelated_ao_excluded(self) -> None:
+        AnnotationOntology(name="no_tax_ao").save()
+        self.assertEqual(
+            _find_annotation_ontology_refs_by_taxonomy(_TAXONOMY_NAME), []
+        )
+
+    def test_finds_ao_bundling_taxonomy(self) -> None:
+        _make_taxonomy()
+        _make_ao_bundling_taxonomy("my_ao")
+
+        self.assertEqual(
+            _find_annotation_ontology_refs_by_taxonomy(_TAXONOMY_NAME),
+            ["my_ao"],
+        )
+
+    def test_latest_version_only(self) -> None:
+        # If the latest AO version no longer references the taxonomy
+        # (older versions did), the AO should NOT appear in the result.
+        _make_taxonomy()
+        _make_ao_bundling_taxonomy("my_ao")
+
+        ao = load_ontology("my_ao")
+        ao.taxonomy = None
+        ao.save()
+
+        self.assertEqual(
+            _find_annotation_ontology_refs_by_taxonomy(_TAXONOMY_NAME), []
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unittests/ontology_delete_tests.py
+++ b/tests/unittests/ontology_delete_tests.py
@@ -11,8 +11,10 @@ import unittest
 import fiftyone as fo
 import fiftyone.core.odm as foo
 from fiftyone.core.annotation.attributes import AttributeSpec
+from fiftyone.core.annotation.nodes import Node
 from fiftyone.core.ontology import (
     AnnotationOntology,
+    Taxonomy,
     _find_annotation_ontology_refs_by_taxonomy,
     _find_label_schema_refs_by_ontology,
     delete_ontology,
@@ -352,9 +354,6 @@ _TAXONOMY_SLUG = "test-taxonomy"
 
 
 def _make_taxonomy(name: str = _TAXONOMY_NAME) -> None:
-    from fiftyone.core.annotation.nodes import Node
-    from fiftyone.core.ontology import Taxonomy
-
     Taxonomy(
         name=name,
         root=Node(name="root", values=[Node(name="a"), Node(name="b")]),
@@ -408,6 +407,19 @@ class DeleteTaxonomyTests(unittest.TestCase):
         # AO survives without its bundled taxonomy.
         self.assertIsNone(load_ontology("my_ao").taxonomy)
 
+    def test_force_delete_taxonomy_unsets_ref_on_all_bundling_aos(
+        self,
+    ) -> None:
+        _make_taxonomy()
+        _make_ao_bundling_taxonomy("ao_one")
+        _make_ao_bundling_taxonomy("ao_two")
+
+        delete_ontology(_TAXONOMY_NAME, force=True)
+
+        self.assertFalse(fo.ontology_exists(_TAXONOMY_NAME))
+        self.assertIsNone(load_ontology("ao_one").taxonomy)
+        self.assertIsNone(load_ontology("ao_two").taxonomy)
+
     def test_force_delete_taxonomy_unsets_via_new_ao_version(self) -> None:
         # Append-only: the unset is an appended version, not an in-place
         # mutation. The latest AO version no longer carries the ref;
@@ -426,13 +438,16 @@ class DeleteTaxonomyTests(unittest.TestCase):
         self,
     ) -> None:
         # applied_taxonomy is a hydration-time output, never persisted.
-        # The cascade scans AOs, not label schemas.
+        # The cascade scans AOs, not label schemas: even when a label
+        # schema points at an AO whose taxonomy is being cascade-unset,
+        # the schema entry itself must stay byte-identical.
         _make_taxonomy()
+        _make_ao_bundling_taxonomy("my_ao")
         ds = fo.Dataset()
         ds._doc.label_schemas = {
             "ground_truth": {
                 "type": "detections",
-                "applied_ontology": "some_ao",
+                "applied_ontology": "my_ao",
             }
         }
         ds._doc.save()
@@ -440,6 +455,9 @@ class DeleteTaxonomyTests(unittest.TestCase):
 
         delete_ontology(_TAXONOMY_NAME, force=True)
 
+        # Cascade actually ran: AO's taxonomy ref is gone.
+        self.assertIsNone(load_ontology("my_ao").taxonomy)
+        # But the label schema dict is untouched.
         ds.reload()
         self.assertEqual(dict(ds._doc.label_schemas), snapshot)
 


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

This has delete handling to taxonomies. 

- If a taxonomy is not referenced, it is just deleted. 
- If a taxonomy is referenced and force is not passed, it raises an error. 
- If a taxonomy is referenced and force IS passed it removes the references and then deletes the taxonomy. 

## 🧪 How is this patch tested? If it is not, please explain why.

Tested locally and with unit tests. 

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Taxonomy deletion is now supported. When deleting a taxonomy, referencing annotation ontologies can optionally be automatically updated to remove the taxonomy reference.

* **Improvements**
  * Enhanced error handling for ontology deletion operations with explicit validation of ontology types.

* **Tests**
  * Expanded test coverage for taxonomy deletion and cascading behavior across annotation ontologies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2827
<!-- enterprise-sync-pr:end -->