### PR TITLE
taxonomy endpoints

### DIFF
--- a/fiftyone/core/annotation/nodes.py
+++ b/fiftyone/core/annotation/nodes.py
@@ -94,60 +94,6 @@ class Node:
             d["values"] = [v.to_dict() for v in self.values]
         return d
 
-    def find(self, name: str) -> Optional["Node"]:
-        """Returns the descendant (or self) with the given name, or
-        ``None``.
-
-        Node names are unique within a taxonomy (enforced by
-        :func:`fiftyone.core.ontology_validation.validate_taxonomy`),
-        so the first match is the only match.
-
-        Args:
-            name: the node name to search for
-
-        Returns:
-            the matching :class:`Node` or ``None``
-        """
-        if self.name == name:
-            return self
-        for child in self.values or []:
-            match = child.find(name)
-            if match is not None:
-                return match
-        return None
-
-    def truncated(self, depth: int) -> "Node":
-        """Returns a copy of this node with descendants limited to
-        ``depth`` levels below.
-
-        At the truncation boundary, nodes that had children in the
-        source are returned with ``values=[]`` so the wire format
-        distinguishes them from real leaves (which have no ``values``
-        key).
-
-        Args:
-            depth: non-negative recursion depth. ``0`` returns just this
-                node with no descendants.
-
-        Returns:
-            a new :class:`Node`
-        """
-        if depth <= 0:
-            return Node(
-                name=self.name,
-                description=self.description,
-                can_select=self.can_select,
-                deprecated=self.deprecated,
-                values=[] if self.values else None,
-            )
-        return Node(
-            name=self.name,
-            description=self.description,
-            can_select=self.can_select,
-            deprecated=self.deprecated,
-            values=[c.truncated(depth - 1) for c in (self.values or [])],
-        )
-
     @classmethod
     def from_dict(cls, d: dict) -> "Node":
         """Creates a :class:`Node` from a dict.
@@ -176,3 +122,61 @@ class Node:
     def __repr__(self) -> str:
         n = len(self.values) if self.values is not None else 0
         return f"Node(name={self.name!r}, values={n})"
+
+
+# The functions below walk the dict form of a node tree (as produced by
+# ``Node.to_dict`` and stored in ``OntologyDocument.root``) without
+# hydrating into :class:`Node` instances. Large taxonomies (~50k nodes)
+# pay a ~400ms cost for the recursive dataclass construction in
+# ``Node.from_dict``; read-only consumers that just need to slice or
+# project a subtree skip that entirely by operating on dicts.
+
+
+def find_in_dict(root: dict, name: str) -> Optional[dict]:
+    """Returns the first descendant (or ``root`` itself) whose ``name``
+    matches, or ``None``.
+
+    Node names are unique within a taxonomy (enforced by
+    :func:`fiftyone.core.ontology_validation.validate_taxonomy`), so the
+    first match is the only match.
+
+    Args:
+        root: a node-shaped dict
+        name: the node name to search for
+
+    Returns:
+        the matching dict (a reference into ``root``) or ``None``
+    """
+    if root.get("name") == name:
+        return root
+    for child in root.get("values") or []:
+        match = find_in_dict(child, name)
+        if match is not None:
+            return match
+    return None
+
+
+def truncate_dict(node: dict, depth: int) -> dict:
+    """Returns a copy of ``node`` truncated to ``depth`` levels below.
+
+    At the truncation boundary, nodes that had children in the source
+    are returned with ``values=[]`` so the wire format distinguishes
+    them from real leaves (which have no ``values`` key).
+
+    Args:
+        node: a node-shaped dict
+        depth: non-negative recursion depth. ``0`` returns just
+            ``node`` with no descendants.
+
+    Returns:
+        a new dict; the input is not mutated
+    """
+    if depth <= 0:
+        truncated = {k: v for k, v in node.items() if k != "values"}
+        if node.get("values"):
+            truncated["values"] = []
+        return truncated
+    out = dict(node)
+    if "values" in node:
+        out["values"] = [truncate_dict(c, depth - 1) for c in node["values"]]
+    return out

--- a/fiftyone/core/annotation/nodes.py
+++ b/fiftyone/core/annotation/nodes.py
@@ -94,6 +94,60 @@ class Node:
             d["values"] = [v.to_dict() for v in self.values]
         return d
 
+    def find(self, name: str) -> Optional["Node"]:
+        """Returns the descendant (or self) with the given name, or
+        ``None``.
+
+        Node names are unique within a taxonomy (enforced by
+        :func:`fiftyone.core.ontology_validation.validate_taxonomy`),
+        so the first match is the only match.
+
+        Args:
+            name: the node name to search for
+
+        Returns:
+            the matching :class:`Node` or ``None``
+        """
+        if self.name == name:
+            return self
+        for child in self.values or []:
+            match = child.find(name)
+            if match is not None:
+                return match
+        return None
+
+    def truncated(self, depth: int) -> "Node":
+        """Returns a copy of this node with descendants limited to
+        ``depth`` levels below.
+
+        At the truncation boundary, nodes that had children in the
+        source are returned with ``values=[]`` so the wire format
+        distinguishes them from real leaves (which have no ``values``
+        key).
+
+        Args:
+            depth: non-negative recursion depth. ``0`` returns just this
+                node with no descendants.
+
+        Returns:
+            a new :class:`Node`
+        """
+        if depth <= 0:
+            return Node(
+                name=self.name,
+                description=self.description,
+                can_select=self.can_select,
+                deprecated=self.deprecated,
+                values=[] if self.values else None,
+            )
+        return Node(
+            name=self.name,
+            description=self.description,
+            can_select=self.can_select,
+            deprecated=self.deprecated,
+            values=[c.truncated(depth - 1) for c in (self.values or [])],
+        )
+
     @classmethod
     def from_dict(cls, d: dict) -> "Node":
         """Creates a :class:`Node` from a dict.

--- a/fiftyone/server/routes/__init__.py
+++ b/fiftyone/server/routes/__init__.py
@@ -21,7 +21,7 @@ from .geo import GeoPoints
 from .get_similar_labels_frames import GetSimilarLabelsFrameCollection
 from .groups import GroupsRoutes
 from .media import Media
-from .ontology import OntologyAttributes, Ontologies
+from .ontology import OntologyAttributes, OntologyTaxonomy, Ontologies
 from .plugins import Plugins
 from .runtime_assets import RuntimeAssetRoutes
 from .sample import SampleRoutes
@@ -50,6 +50,7 @@ routes = (
         ("/geo", GeoPoints),
         ("/media", Media),
         ("/ontologies/{name}/attributes", OntologyAttributes),
+        ("/ontologies/{name}/taxonomy", OntologyTaxonomy),
         ("/ontologies", Ontologies),
         ("/plugins", Plugins),
         ("/sort", Sort),

--- a/fiftyone/server/routes/ontology.py
+++ b/fiftyone/server/routes/ontology.py
@@ -33,6 +33,55 @@ class Ontologies(HTTPEndpoint):
         )
 
 
+class OntologyTaxonomy(HTTPEndpoint):
+    """Returns the tree for a taxonomy.
+
+    ``GET /ontologies/{name}/taxonomy`` — path parameter ``name`` is a
+    :class:`fiftyone.core.ontology.Taxonomy`'s human-readable name.
+
+    Optional query parameters:
+        node: if set, root the response at this named node. 404 when no
+            node with that name exists in the taxonomy.
+        depth: if set, limit the response to this many levels below the
+            response root. ``depth=0`` returns the root node with no
+            children; truncated branches that had children in the source
+            are serialized with ``"values": []`` so the caller can
+            distinguish them from real leaves (no ``values`` key).
+
+    Returns 404 when the named ontology does not exist or is not a
+    taxonomy.
+    """
+
+    async def get(self, request: Request) -> JSONResponse:
+        name = request.path_params["name"]
+        node_name = request.query_params.get("node") or None
+
+        depth_str = request.query_params.get("depth")
+        if depth_str is None:
+            depth = None
+        else:
+            try:
+                depth = int(depth_str)
+            except ValueError as e:
+                raise HTTPException(
+                    status_code=400,
+                    detail="'depth' must be a non-negative integer",
+                ) from e
+            if depth < 0:
+                raise HTTPException(
+                    status_code=400,
+                    detail="'depth' must be a non-negative integer",
+                )
+
+        body, error = await fou.run_sync_task(
+            _load_taxonomy_response, name, node_name, depth
+        )
+        if error is not None:
+            raise HTTPException(status_code=404, detail=error)
+
+        return JSONResponse({"taxonomy": body})
+
+
 class OntologyAttributes(HTTPEndpoint):
     """Returns the attributes list for a single annotation ontology.
 
@@ -100,6 +149,49 @@ async def _list_ontology_summaries(
         dt = s.get("last_modified_at")
         s["last_modified_at"] = dt.isoformat() if dt is not None else None
     return summaries
+
+
+def _load_taxonomy_response(
+    name: str, node_name: Optional[str], depth: Optional[int]
+) -> tuple[Optional[dict[str, Any]], Optional[str]]:
+    """Resolves a taxonomy name and serializes the requested subtree.
+
+    Returns a ``(body, error)`` pair: ``body`` is the response dict on
+    success and ``error`` is the 404 detail string on failure. Exactly
+    one is ``None``.
+    """
+    from fiftyone.core.ontology import Ontology, load_ontology
+
+    try:
+        target_taxonomy = load_ontology(name)
+    except ValueError:
+        return None, f"Taxonomy '{name}' not found"
+
+    if not target_taxonomy.is_taxonomy:
+        return None, f"Ontology '{name}' is not a taxonomy"
+
+    # Narrow the response to the named subtree when requested.
+    if node_name is not None:
+        target_node = target_taxonomy.root.find(node_name)
+        if target_node is None:
+            return (
+                None,
+                f"Node '{node_name}' not found in taxonomy "
+                f"'{target_taxonomy.name}'",
+            )
+    else:
+        target_node = target_taxonomy.root
+
+    # Truncate the subtree when a depth cap is requested.
+    if depth is not None:
+        target_node = target_node.truncated(depth)
+
+    # Build the response from ontology metadata + the filtered subtree.
+    # Calling the base ``Ontology.to_dict`` skips the subclass override
+    # that would re-serialize the full root tree we just filtered.
+    body = Ontology.to_dict(target_taxonomy)
+    body["root"] = target_node.to_dict()
+    return body, None
 
 
 def _load_attributes(name: str) -> Optional[list[dict[str, Any]]]:

--- a/fiftyone/server/routes/ontology.py
+++ b/fiftyone/server/routes/ontology.py
@@ -14,6 +14,7 @@ from starlette.requests import Request
 
 import fiftyone.core.odm as foo
 import fiftyone.core.utils as fou
+from fiftyone.core.annotation.nodes import find_in_dict, truncate_dict
 from fiftyone.server.utils.json import JSONResponse
 
 
@@ -73,9 +74,7 @@ class OntologyTaxonomy(HTTPEndpoint):
                     detail="'depth' must be a non-negative integer",
                 )
 
-        body, error = await fou.run_sync_task(
-            _load_taxonomy_response, name, node_name, depth
-        )
+        body, error = await _load_taxonomy_response(name, node_name, depth)
         if error is not None:
             raise HTTPException(status_code=404, detail=error)
 
@@ -151,46 +150,90 @@ async def _list_ontology_summaries(
     return summaries
 
 
-def _load_taxonomy_response(
+def _select_subtree(
+    root_dict: dict[str, Any],
+    taxonomy_name: str,
+    node_name: Optional[str],
+    depth: Optional[int],
+) -> tuple[Optional[dict[str, Any]], Optional[str]]:
+    """Applies the ``?node=`` and ``?depth=`` filters to a taxonomy root.
+
+    Order matters: subtree selection happens before depth truncation so
+    ``depth`` counts levels below the requested node, not below the
+    original root.
+
+    Returns a ``(subtree, error)`` pair with exactly one ``None``.
+    """
+    if node_name is not None:
+        subtree = find_in_dict(root_dict, node_name)
+        if subtree is None:
+            return (
+                None,
+                f"Node '{node_name}' not found in taxonomy "
+                f"'{taxonomy_name}'",
+            )
+    else:
+        subtree = root_dict
+
+    if depth is not None:
+        subtree = truncate_dict(subtree, depth)
+
+    return subtree, None
+
+
+async def _load_taxonomy_doc(
+    name: str,
+) -> tuple[Optional[dict[str, Any]], Optional[str]]:
+    """Fetches the latest version of a Taxonomy ontology document by
+    name. Returns a ``(doc, error)`` pair with exactly one ``None``.
+    """
+    collection = foo.get_async_db_conn()["ontologies"]
+    pipeline = [
+        {"$match": {"slug": fou.to_slug(name)}},
+        {"$sort": {"version": -1}},
+        {"$limit": 1},
+    ]
+    docs = await foo.aggregate(collection, pipeline).to_list(1)
+    if not docs:
+        return None, f"Taxonomy '{name}' not found"
+
+    doc = docs[0]
+    if doc.get("type") != "taxonomy":
+        return None, f"Ontology '{name}' is not a taxonomy"
+
+    return doc, None
+
+
+async def _load_taxonomy_response(
     name: str, node_name: Optional[str], depth: Optional[int]
 ) -> tuple[Optional[dict[str, Any]], Optional[str]]:
     """Resolves a taxonomy name and serializes the requested subtree.
 
-    Returns a ``(body, error)`` pair: ``body`` is the response dict on
-    success and ``error`` is the 404 detail string on failure. Exactly
-    one is ``None``.
+    Returns a ``(body, error)`` pair with exactly one ``None``.
     """
-    from fiftyone.core.ontology import Ontology, load_ontology
+    doc, error = await _load_taxonomy_doc(name)
+    if error is not None:
+        return None, error
 
-    try:
-        target_taxonomy = load_ontology(name)
-    except ValueError:
-        return None, f"Taxonomy '{name}' not found"
+    root_dict = doc.get("root") or {}
+    subtree, error = _select_subtree(
+        root_dict, doc["name"], node_name, depth
+    )
+    if error is not None:
+        return None, error
 
-    if not target_taxonomy.is_taxonomy:
-        return None, f"Ontology '{name}' is not a taxonomy"
-
-    # Narrow the response to the named subtree when requested.
-    if node_name is not None:
-        target_node = target_taxonomy.root.find(node_name)
-        if target_node is None:
-            return (
-                None,
-                f"Node '{node_name}' not found in taxonomy "
-                f"'{target_taxonomy.name}'",
-            )
-    else:
-        target_node = target_taxonomy.root
-
-    # Truncate the subtree when a depth cap is requested.
-    if depth is not None:
-        target_node = target_node.truncated(depth)
-
-    # Build the response from ontology metadata + the filtered subtree.
-    # Calling the base ``Ontology.to_dict`` skips the subclass override
-    # that would re-serialize the full root tree we just filtered.
-    body = Ontology.to_dict(target_taxonomy)
-    body["root"] = target_node.to_dict()
+    body: dict[str, Any] = {
+        "name": doc["name"],
+        "type": doc["type"],
+        "version": doc.get("version"),
+    }
+    if doc.get("description") is not None:
+        body["description"] = doc["description"]
+    for field_name in ("created_at", "last_modified_at"):
+        dt = doc.get(field_name)
+        if dt is not None:
+            body[field_name] = dt.isoformat()
+    body["root"] = subtree
     return body, None
 
 

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -1125,6 +1125,51 @@ class NodeTests(unittest.TestCase):
         self.assertNotIn("deprecated", d)
         self.assertNotIn("description", d)
 
+    def test_find_returns_self_on_match(self):
+        n = Node(name="car")
+        self.assertIs(n.find("car"), n)
+
+    def test_find_returns_descendant(self):
+        sedan = Node(name="sedan")
+        cars = Node(name="cars", values=[sedan])
+        root = Node(name="root", values=[cars])
+        self.assertIs(root.find("sedan"), sedan)
+
+    def test_find_returns_none_when_missing(self):
+        root = Node(name="root", values=[Node(name="car")])
+        self.assertIsNone(root.find("missing"))
+
+    def test_truncated_zero_drops_children_marks_truncated(self):
+        # Branch with children → values=[] indicates truncation.
+        n = Node(name="cars", values=[Node(name="sedan")]).truncated(0)
+        self.assertEqual(n.values, [])
+
+    def test_truncated_zero_real_leaf_keeps_no_values(self):
+        # Real leaf → values=None (omitted in dict).
+        n = Node(name="car").truncated(0)
+        self.assertIsNone(n.values)
+
+    def test_truncated_one_keeps_direct_children_only(self):
+        deep = Node(
+            name="root",
+            values=[
+                Node(
+                    name="cars",
+                    values=[Node(name="sedan", values=[Node(name="camry")])],
+                ),
+            ],
+        )
+        out = deep.truncated(1)
+        # root has cars; cars is truncated → values=[]
+        self.assertEqual(out.values[0].name, "cars")
+        self.assertEqual(out.values[0].values, [])
+
+    def test_truncated_returns_copy(self):
+        original = Node(name="cars", values=[Node(name="sedan")])
+        out = original.truncated(0)
+        self.assertIsNot(out, original)
+        self.assertEqual(original.values[0].name, "sedan")
+
 
 class TaxonomyTests(unittest.TestCase):
     def _tree(self):

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -1125,50 +1125,70 @@ class NodeTests(unittest.TestCase):
         self.assertNotIn("deprecated", d)
         self.assertNotIn("description", d)
 
-    def test_find_returns_self_on_match(self):
-        n = Node(name="car")
-        self.assertIs(n.find("car"), n)
 
-    def test_find_returns_descendant(self):
-        sedan = Node(name="sedan")
-        cars = Node(name="cars", values=[sedan])
-        root = Node(name="root", values=[cars])
-        self.assertIs(root.find("sedan"), sedan)
+class FindInDictTests(unittest.TestCase):
+    def test_returns_root_on_match(self):
+        from fiftyone.core.annotation.nodes import find_in_dict
 
-    def test_find_returns_none_when_missing(self):
-        root = Node(name="root", values=[Node(name="car")])
-        self.assertIsNone(root.find("missing"))
+        d = {"name": "car"}
+        self.assertIs(find_in_dict(d, "car"), d)
 
-    def test_truncated_zero_drops_children_marks_truncated(self):
-        # Branch with children → values=[] indicates truncation.
-        n = Node(name="cars", values=[Node(name="sedan")]).truncated(0)
-        self.assertEqual(n.values, [])
+    def test_returns_descendant(self):
+        from fiftyone.core.annotation.nodes import find_in_dict
 
-    def test_truncated_zero_real_leaf_keeps_no_values(self):
-        # Real leaf → values=None (omitted in dict).
-        n = Node(name="car").truncated(0)
-        self.assertIsNone(n.values)
+        sedan = {"name": "sedan"}
+        cars = {"name": "cars", "values": [sedan]}
+        root = {"name": "root", "values": [cars]}
+        self.assertIs(find_in_dict(root, "sedan"), sedan)
 
-    def test_truncated_one_keeps_direct_children_only(self):
-        deep = Node(
-            name="root",
-            values=[
-                Node(
-                    name="cars",
-                    values=[Node(name="sedan", values=[Node(name="camry")])],
-                ),
-            ],
+    def test_returns_none_when_missing(self):
+        from fiftyone.core.annotation.nodes import find_in_dict
+
+        root = {"name": "root", "values": [{"name": "car"}]}
+        self.assertIsNone(find_in_dict(root, "missing"))
+
+
+class TruncateDictTests(unittest.TestCase):
+    def test_zero_marks_branch_with_empty_values(self):
+        from fiftyone.core.annotation.nodes import truncate_dict
+
+        out = truncate_dict(
+            {"name": "cars", "values": [{"name": "sedan"}]}, 0
         )
-        out = deep.truncated(1)
-        # root has cars; cars is truncated → values=[]
-        self.assertEqual(out.values[0].name, "cars")
-        self.assertEqual(out.values[0].values, [])
+        self.assertEqual(out["values"], [])
 
-    def test_truncated_returns_copy(self):
-        original = Node(name="cars", values=[Node(name="sedan")])
-        out = original.truncated(0)
+    def test_zero_real_leaf_keeps_no_values_key(self):
+        from fiftyone.core.annotation.nodes import truncate_dict
+
+        out = truncate_dict({"name": "car"}, 0)
+        self.assertNotIn("values", out)
+
+    def test_one_keeps_direct_children_only(self):
+        from fiftyone.core.annotation.nodes import truncate_dict
+
+        deep = {
+            "name": "root",
+            "values": [
+                {
+                    "name": "cars",
+                    "values": [
+                        {"name": "sedan", "values": [{"name": "camry"}]}
+                    ],
+                }
+            ],
+        }
+        out = truncate_dict(deep, 1)
+        # root has cars; cars is truncated → values=[]
+        self.assertEqual(out["values"][0]["name"], "cars")
+        self.assertEqual(out["values"][0]["values"], [])
+
+    def test_does_not_mutate_input(self):
+        from fiftyone.core.annotation.nodes import truncate_dict
+
+        original = {"name": "cars", "values": [{"name": "sedan"}]}
+        out = truncate_dict(original, 0)
         self.assertIsNot(out, original)
-        self.assertEqual(original.values[0].name, "sedan")
+        self.assertEqual(original["values"], [{"name": "sedan"}])
 
 
 class TaxonomyTests(unittest.TestCase):

--- a/tests/unittests/server/routes/test_ontology.py
+++ b/tests/unittests/server/routes/test_ontology.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from starlette.exceptions import HTTPException
 
 import fiftyone.core.odm as foo
 from fiftyone.core.odm.ontology import OntologyDocument, OntologyType
@@ -168,3 +169,250 @@ class TestOntologiesRoute:
 
         body = json.loads(response.body)
         assert body == {"ontologies": []}
+
+
+@pytest.fixture(name="taxonomy_endpoint")
+def fixture_taxonomy_endpoint():
+    return foro.OntologyTaxonomy(
+        scope={"type": "http"}, receive=AsyncMock(), send=AsyncMock()
+    )
+
+
+@pytest.fixture(name="taxonomy_request")
+def fixture_taxonomy_request():
+    def _make(name, query_params=None):
+        request = MagicMock()
+        request.path_params = {"name": name}
+        request.query_params = query_params or {}
+        return request
+
+    return _make
+
+
+def _save_taxonomy(name, root_dict):
+    """Saves a Taxonomy by name with the given root tree (a Node dict)."""
+    from fiftyone.core.annotation.nodes import Node
+    from fiftyone.core.ontology import Taxonomy
+
+    Taxonomy(name=name, root=Node.from_dict(root_dict)).save()
+
+
+class TestOntologyTaxonomyRoute:
+    @pytest.mark.asyncio
+    async def test_unknown_name_404(
+        self, taxonomy_endpoint, taxonomy_request
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await taxonomy_endpoint.get(taxonomy_request("does_not_exist"))
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_non_taxonomy_404(
+        self, taxonomy_endpoint, taxonomy_request
+    ):
+        from fiftyone.core.ontology import AnnotationOntology
+
+        AnnotationOntology(name="some_ao").save()
+
+        with pytest.raises(HTTPException) as exc:
+            await taxonomy_endpoint.get(taxonomy_request("some_ao"))
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_returns_full_tree(
+        self, taxonomy_endpoint, taxonomy_request
+    ):
+        _save_taxonomy(
+            "vehicle_classes",
+            {
+                "name": "root",
+                "values": [
+                    {"name": "car"},
+                    {"name": "truck"},
+                ],
+            },
+        )
+
+        response = await taxonomy_endpoint.get(
+            taxonomy_request("vehicle_classes")
+        )
+
+        body = json.loads(response.body)
+        assert body["taxonomy"]["name"] == "vehicle_classes"
+        assert body["taxonomy"]["type"] == "taxonomy"
+        assert body["taxonomy"]["root"]["name"] == "root"
+        child_names = [
+            c["name"] for c in body["taxonomy"]["root"]["values"]
+        ]
+        assert child_names == ["car", "truck"]
+
+    @pytest.mark.asyncio
+    async def test_node_query_returns_subtree(
+        self, taxonomy_endpoint, taxonomy_request
+    ):
+        _save_taxonomy(
+            "vehicle_classes",
+            {
+                "name": "root",
+                "values": [
+                    {
+                        "name": "cars",
+                        "values": [{"name": "sedan"}, {"name": "suv"}],
+                    },
+                    {"name": "trucks"},
+                ],
+            },
+        )
+
+        response = await taxonomy_endpoint.get(
+            taxonomy_request("vehicle_classes", query_params={"node": "cars"})
+        )
+
+        body = json.loads(response.body)
+        # `root` is reframed at the requested node.
+        assert body["taxonomy"]["root"]["name"] == "cars"
+        names = [c["name"] for c in body["taxonomy"]["root"]["values"]]
+        assert names == ["sedan", "suv"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_node_404(
+        self, taxonomy_endpoint, taxonomy_request
+    ):
+        _save_taxonomy(
+            "vehicle_classes", {"name": "root", "values": [{"name": "car"}]}
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            await taxonomy_endpoint.get(
+                taxonomy_request(
+                    "vehicle_classes", query_params={"node": "missing"}
+                )
+            )
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_depth_zero_returns_root_only(
+        self, taxonomy_endpoint, taxonomy_request
+    ):
+        _save_taxonomy(
+            "vehicle_classes",
+            {"name": "root", "values": [{"name": "car"}]},
+        )
+
+        response = await taxonomy_endpoint.get(
+            taxonomy_request(
+                "vehicle_classes", query_params={"depth": "0"}
+            )
+        )
+
+        body = json.loads(response.body)
+        # had children → values=[] marks truncation
+        assert body["taxonomy"]["root"]["values"] == []
+
+    @pytest.mark.asyncio
+    async def test_depth_one_returns_root_and_direct_children(
+        self, taxonomy_endpoint, taxonomy_request
+    ):
+        _save_taxonomy(
+            "vehicle_classes",
+            {
+                "name": "root",
+                "values": [
+                    {
+                        "name": "cars",
+                        "values": [{"name": "sedan"}],
+                    },
+                ],
+            },
+        )
+
+        response = await taxonomy_endpoint.get(
+            taxonomy_request(
+                "vehicle_classes", query_params={"depth": "1"}
+            )
+        )
+
+        body = json.loads(response.body)
+        assert body["taxonomy"]["root"]["name"] == "root"
+        cars = body["taxonomy"]["root"]["values"][0]
+        assert cars["name"] == "cars"
+        # depth=1 truncated below cars; cars had children so values=[]
+        assert cars["values"] == []
+
+    @pytest.mark.asyncio
+    async def test_depth_truncated_leaf_has_no_values_key(
+        self, taxonomy_endpoint, taxonomy_request
+    ):
+        # A real leaf at the truncation boundary keeps no ``values``
+        # key (distinguishes it from a truncated branch).
+        _save_taxonomy(
+            "vehicle_classes",
+            {"name": "root", "values": [{"name": "car"}]},
+        )
+
+        response = await taxonomy_endpoint.get(
+            taxonomy_request(
+                "vehicle_classes", query_params={"depth": "1"}
+            )
+        )
+
+        body = json.loads(response.body)
+        car = body["taxonomy"]["root"]["values"][0]
+        assert car["name"] == "car"
+        assert "values" not in car
+
+    @pytest.mark.asyncio
+    async def test_node_and_depth_combined(
+        self, taxonomy_endpoint, taxonomy_request
+    ):
+        _save_taxonomy(
+            "vehicle_classes",
+            {
+                "name": "root",
+                "values": [
+                    {
+                        "name": "cars",
+                        "values": [
+                            {
+                                "name": "sedan",
+                                "values": [{"name": "camry"}],
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+
+        response = await taxonomy_endpoint.get(
+            taxonomy_request(
+                "vehicle_classes",
+                query_params={"node": "cars", "depth": "1"},
+            )
+        )
+
+        body = json.loads(response.body)
+        # rooted at cars, one level below (sedan but not camry).
+        assert body["taxonomy"]["root"]["name"] == "cars"
+        sedan = body["taxonomy"]["root"]["values"][0]
+        assert sedan["name"] == "sedan"
+        assert sedan["values"] == []
+
+    @pytest.mark.asyncio
+    async def test_invalid_depth_400(
+        self, taxonomy_endpoint, taxonomy_request
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await taxonomy_endpoint.get(
+                taxonomy_request("x", query_params={"depth": "not_a_number"})
+            )
+        assert exc.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_negative_depth_400(
+        self, taxonomy_endpoint, taxonomy_request
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await taxonomy_endpoint.get(
+                taxonomy_request("x", query_params={"depth": "-1"})
+            )
+        assert exc.value.status_code == 400


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

adds an endpoint for retrieving taxonomies, including optional query parameters `node`, and `depth` that allow for retrieving partials of the node tree.  

## 🧪 How is this patch tested? If it is not, please explain why.

Tested locally and with unit tests. Also did some integration tests and benchmarking:


<img width="1069" height="797" alt="image" src="https://github.com/user-attachments/assets/0910fd8a-c948-4870-98dd-20ff628cf7e5" />



## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New ontology taxonomy endpoint enables efficient querying of specific taxonomy nodes with depth-based tree truncation. Includes comprehensive query parameter validation and proper error handling for unknown ontologies and malformed requests.

* **Tests**
  * Added extensive test coverage for the taxonomy endpoint: node selection, depth-based filtering and truncation, parameter validation, error handling, and edge case verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2826
<!-- enterprise-sync-pr:end -->