### PR TITLE
Auto-download BDD100K from Internet Archive mirror

### DIFF
--- a/fiftyone/utils/bdd.py
+++ b/fiftyone/utils/bdd.py
@@ -13,6 +13,7 @@ import warnings
 
 import eta.core.serial as etas
 import eta.core.utils as etau
+import eta.core.web as etaw
 
 import fiftyone as fo
 import fiftyone.core.labels as fol
@@ -22,6 +23,11 @@ import fiftyone.utils.data as foud
 
 
 logger = logging.getLogger(__name__)
+
+
+_BDD100K_IA_BASE = "https://archive.org/download/bdd100k"
+_BDD100K_IMAGES_ZIP = "bdd100k_images.zip"
+_BDD100K_LABELS_ZIP = "bdd100k_labels.zip"
 
 
 class BDDDatasetImporter(
@@ -374,6 +380,155 @@ def load_bdd_annotations(json_path):
     """
     annotations = etas.load_json(json_path)
     return {d["name"]: d for d in annotations}
+
+
+def download_bdd100k_dataset(
+    dataset_dir, scratch_dir=None, source_dir=None, copy_files=True
+):
+    """Downloads the BDD100K dataset from the Internet Archive mirror.
+
+    If ``source_dir`` is provided, an existing download in the legacy 2018
+    layout is used instead of fetching from the network.
+
+    Args:
+        dataset_dir: the directory in which to construct the dataset
+        scratch_dir (None): a scratch directory for downloads and extraction
+        source_dir (None): an existing BDD100K source directory in the
+            legacy 2018 layout
+        copy_files (True): whether to copy (True) or move (False) source
+            files when populating ``dataset_dir``
+
+    Returns:
+        the number of samples added across all splits
+    """
+    if source_dir is not None:
+        parse_bdd100k_dataset(source_dir, dataset_dir, copy_files=copy_files)
+        return _count_split_samples(dataset_dir)
+
+    if scratch_dir is None:
+        scratch_dir = os.path.join(dataset_dir, "scratch")
+
+    etau.ensure_dir(scratch_dir)
+
+    images_zip = os.path.join(scratch_dir, _BDD100K_IMAGES_ZIP)
+    labels_zip = os.path.join(scratch_dir, _BDD100K_LABELS_ZIP)
+
+    extracted_dir = os.path.join(scratch_dir, "bdd100k")
+    extracted_val_images = os.path.join(
+        extracted_dir, "images", "100k", "val"
+    )
+    extracted_val_labels = os.path.join(
+        extracted_dir, "labels", "100k", "val"
+    )
+
+    if not os.path.isfile(images_zip):
+        logger.info("Downloading BDD100K images from %s...", _BDD100K_IA_BASE)
+        etaw.download_file(
+            "%s/%s" % (_BDD100K_IA_BASE, _BDD100K_IMAGES_ZIP),
+            path=images_zip,
+        )
+    else:
+        logger.info("Using existing archive '%s'", images_zip)
+
+    if not os.path.isfile(labels_zip):
+        logger.info("Downloading BDD100K labels from %s...", _BDD100K_IA_BASE)
+        etaw.download_file(
+            "%s/%s" % (_BDD100K_IA_BASE, _BDD100K_LABELS_ZIP),
+            path=labels_zip,
+        )
+    else:
+        logger.info("Using existing archive '%s'", labels_zip)
+
+    if not os.path.isdir(extracted_val_images):
+        logger.info("Extracting images archive...")
+        etau.extract_archive(images_zip, outdir=scratch_dir)
+
+    if not os.path.isdir(extracted_val_labels):
+        logger.info("Extracting labels archive...")
+        etau.extract_archive(labels_zip, outdir=scratch_dir)
+
+    for split in ("train", "val"):
+        mot_dir = os.path.join(extracted_dir, "labels", "100k", split)
+        out_path = os.path.join(
+            extracted_dir,
+            "labels",
+            "bdd100k_labels_images_%s.json" % split,
+        )
+        if os.path.isfile(out_path):
+            logger.info("Using existing consolidated labels '%s'", out_path)
+            continue
+        if not os.path.isdir(mot_dir):
+            logger.warning("MOT labels directory '%s' not found", mot_dir)
+            continue
+        logger.info(
+            "Converting %s per-image labels to legacy layout...", split
+        )
+        _convert_mot_to_legacy_labels(mot_dir, out_path)
+
+    parse_bdd100k_dataset(extracted_dir, dataset_dir, copy_files=copy_files)
+
+    return _count_split_samples(dataset_dir)
+
+
+def _convert_mot_to_legacy_labels(mot_dir, out_path):
+    """Consolidates per-image MOT-style label JSONs at ``mot_dir`` into a
+    single legacy-format JSON at ``out_path``.
+    """
+    entries = []
+    for filename in sorted(etau.list_files(mot_dir)):
+        if not filename.endswith(".json"):
+            continue
+        mot = etas.load_json(os.path.join(mot_dir, filename))
+
+        name = mot.get("name", "")
+        if name and not name.endswith(".jpg"):
+            name = name + ".jpg"
+
+        frames = mot.get("frames") or []
+        raw_objects = frames[0].get("objects", []) if frames else []
+
+        labels = []
+        for obj in raw_objects:
+            converted = {k: v for k, v in obj.items() if k != "poly2d"}
+            if "poly2d" in obj:
+                converted["poly2d"] = _convert_mot_poly2d(
+                    obj["poly2d"], obj.get("category", "")
+                )
+            labels.append(converted)
+
+        entries.append({
+            "name": name,
+            "attributes": mot.get("attributes", {}) or {},
+            "labels": labels,
+        })
+
+    etas.write_json(entries, out_path)
+
+
+def _convert_mot_poly2d(mot_poly2d, category):
+    """Wraps a MOT-style poly2d (list of ``[x, y, type]`` triples) in the
+    legacy structure: ``[{"vertices": [...], "types": "...", "closed": bool}]``.
+
+    ``closed`` is inferred from the category prefix: drivable / alternative
+    areas (``area/*``) are closed polygons; lane markings (``lane/*``) are
+    open polylines.
+    """
+    vertices = [[pt[0], pt[1]] for pt in mot_poly2d]
+    types = "".join(pt[2] for pt in mot_poly2d if len(pt) >= 3)
+    return [{
+        "vertices": vertices,
+        "types": types,
+        "closed": category.startswith("area/"),
+    }]
+
+
+def _count_split_samples(dataset_dir):
+    total = 0
+    for split in ("train", "validation", "test"):
+        split_data_dir = os.path.join(dataset_dir, split, "data")
+        if os.path.isdir(split_data_dir):
+            total += len(etau.list_files(split_data_dir))
+    return total
 
 
 def parse_bdd100k_dataset(

--- a/fiftyone/utils/bdd.py
+++ b/fiftyone/utils/bdd.py
@@ -13,6 +13,7 @@ import warnings
 
 import eta.core.serial as etas
 import eta.core.utils as etau
+import eta.core.web as etaw
 
 import fiftyone as fo
 import fiftyone.core.labels as fol
@@ -22,6 +23,11 @@ import fiftyone.utils.data as foud
 
 
 logger = logging.getLogger(__name__)
+
+
+_BDD100K_IA_BASE = "https://archive.org/download/bdd100k"
+_BDD100K_IMAGES_ZIP = "bdd100k_images.zip"
+_BDD100K_LABELS_ZIP = "bdd100k_labels.zip"
 
 
 class BDDDatasetImporter(
@@ -374,6 +380,182 @@ def load_bdd_annotations(json_path):
     """
     annotations = etas.load_json(json_path)
     return {d["name"]: d for d in annotations}
+
+
+def download_bdd100k_dataset(
+    dataset_dir, scratch_dir=None, source_dir=None, copy_files=True
+):
+    """Downloads the BDD100K dataset from the Internet Archive mirror.
+
+    If ``source_dir`` is provided, an existing download in the legacy 2018
+    layout is used instead of fetching from the network.
+
+    Args:
+        dataset_dir: the directory in which to construct the dataset
+        scratch_dir (None): a scratch directory for downloads and extraction
+        source_dir (None): an existing BDD100K source directory in the
+            legacy 2018 layout
+        copy_files (True): whether to copy (True) or move (False) source
+            files when populating ``dataset_dir``
+
+    Returns:
+        the number of samples added across all splits
+    """
+    if source_dir is not None:
+        try:
+            parse_bdd100k_dataset(
+                source_dir, dataset_dir, copy_files=copy_files
+            )
+        except OSError as e:
+            # The underlying error advises a manual download, which no longer
+            # applies; the chained cause carries its detail
+            raise OSError(
+                "Failed to parse the BDD100K source directory '%s'. Expected "
+                "the legacy 2018 layout described by `fiftyone zoo datasets "
+                "info bdd100k`." % source_dir
+            ) from e
+
+        return _count_split_samples(dataset_dir)
+
+    if scratch_dir is None:
+        scratch_dir = os.path.join(dataset_dir, "scratch")
+
+    etau.ensure_dir(scratch_dir)
+
+    images_zip = os.path.join(scratch_dir, _BDD100K_IMAGES_ZIP)
+    labels_zip = os.path.join(scratch_dir, _BDD100K_LABELS_ZIP)
+
+    extracted_dir = os.path.join(scratch_dir, "bdd100k")
+    extracted_val_images = os.path.join(
+        extracted_dir, "images", "100k", "val"
+    )
+    extracted_val_labels = os.path.join(
+        extracted_dir, "labels", "100k", "val"
+    )
+
+    if not os.path.isfile(images_zip):
+        logger.info("Downloading BDD100K images from %s...", _BDD100K_IA_BASE)
+        etaw.download_file(
+            "%s/%s" % (_BDD100K_IA_BASE, _BDD100K_IMAGES_ZIP),
+            path=images_zip,
+        )
+    else:
+        logger.info("Using existing archive '%s'", images_zip)
+
+    if not os.path.isfile(labels_zip):
+        logger.info("Downloading BDD100K labels from %s...", _BDD100K_IA_BASE)
+        etaw.download_file(
+            "%s/%s" % (_BDD100K_IA_BASE, _BDD100K_LABELS_ZIP),
+            path=labels_zip,
+        )
+    else:
+        logger.info("Using existing archive '%s'", labels_zip)
+
+    if not os.path.isdir(extracted_val_images):
+        logger.info("Extracting images archive...")
+        etau.extract_archive(images_zip, outdir=scratch_dir)
+
+    if not os.path.isdir(extracted_val_labels):
+        logger.info("Extracting labels archive...")
+        etau.extract_archive(labels_zip, outdir=scratch_dir)
+
+    for split in ("train", "val"):
+        mot_dir = os.path.join(extracted_dir, "labels", "100k", split)
+        out_path = os.path.join(
+            extracted_dir,
+            "labels",
+            "bdd100k_labels_images_%s.json" % split,
+        )
+        if os.path.isfile(out_path):
+            logger.info("Using existing consolidated labels '%s'", out_path)
+            continue
+        if not os.path.isdir(mot_dir):
+            # Both splits are required by the parse below, so failing here
+            # names the missing directory instead of surfacing later
+            raise OSError(
+                "Expected %s labels at '%s', but that directory does not "
+                "exist. The extracted archive at '%s' does not have the "
+                "expected layout" % (split, mot_dir, extracted_dir)
+            )
+        logger.info(
+            "Converting %s per-image labels to legacy layout...", split
+        )
+        _convert_mot_to_legacy_labels(mot_dir, out_path)
+
+    try:
+        parse_bdd100k_dataset(
+            extracted_dir, dataset_dir, copy_files=copy_files
+        )
+    except OSError as e:
+        raise OSError(
+            "Failed to parse BDD100K from the archives extracted to '%s'. "
+            "The download may be incomplete or the mirror layout may have "
+            "changed; delete '%s' to force a fresh download."
+            % (extracted_dir, scratch_dir)
+        ) from e
+
+    return _count_split_samples(dataset_dir)
+
+
+def _convert_mot_to_legacy_labels(mot_dir, out_path):
+    """Consolidates per-image MOT-style label JSONs at ``mot_dir`` into a
+    single legacy-format JSON at ``out_path``.
+    """
+    entries = []
+    for filename in sorted(etau.list_files(mot_dir)):
+        if not filename.endswith(".json"):
+            continue
+        mot = etas.load_json(os.path.join(mot_dir, filename))
+
+        name = mot.get("name", "")
+        if name and not name.endswith(".jpg"):
+            name = name + ".jpg"
+
+        frames = mot.get("frames") or []
+        raw_objects = frames[0].get("objects", []) if frames else []
+
+        labels = []
+        for obj in raw_objects:
+            converted = {k: v for k, v in obj.items() if k != "poly2d"}
+            if "poly2d" in obj:
+                converted["poly2d"] = _convert_mot_poly2d(
+                    obj["poly2d"], obj.get("category", "")
+                )
+            labels.append(converted)
+
+        entries.append({
+            "name": name,
+            "attributes": mot.get("attributes", {}) or {},
+            "labels": labels,
+        })
+
+    etas.write_json(entries, out_path)
+
+
+def _convert_mot_poly2d(mot_poly2d, category):
+    """Wraps a MOT-style poly2d (list of ``[x, y, type]`` triples) in the
+    legacy structure: ``[{"vertices": [...], "types": "...", "closed": bool}]``.
+
+    ``closed`` is inferred from the category prefix: drivable / alternative
+    areas (``area/*``) are closed polygons; lane markings (``lane/*``) are
+    open polylines.
+    """
+    vertices = [[pt[0], pt[1]] for pt in mot_poly2d if len(pt) >= 2]
+    types = "".join(pt[2] for pt in mot_poly2d if len(pt) >= 3)
+    return [{
+        "vertices": vertices,
+        "types": types,
+        "closed": category.startswith("area/"),
+    }]
+
+
+def _count_split_samples(dataset_dir):
+    total = 0
+    for split in ("train", "validation", "test"):
+        split_data_dir = os.path.join(dataset_dir, split, "data")
+        if os.path.isdir(split_data_dir):
+            total += len(etau.list_files(split_data_dir))
+    return total
 
 
 def parse_bdd100k_dataset(

--- a/fiftyone/utils/bdd.py
+++ b/fiftyone/utils/bdd.py
@@ -6,6 +6,7 @@ Utilities for working with datasets in
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from copy import deepcopy
 import logging
 import os
@@ -20,7 +21,6 @@ import fiftyone.core.labels as fol
 import fiftyone.core.metadata as fom
 import fiftyone.core.storage as fos
 import fiftyone.utils.data as foud
-
 
 logger = logging.getLogger(__name__)
 
@@ -426,12 +426,8 @@ def download_bdd100k_dataset(
     labels_zip = os.path.join(scratch_dir, _BDD100K_LABELS_ZIP)
 
     extracted_dir = os.path.join(scratch_dir, "bdd100k")
-    extracted_val_images = os.path.join(
-        extracted_dir, "images", "100k", "val"
-    )
-    extracted_val_labels = os.path.join(
-        extracted_dir, "labels", "100k", "val"
-    )
+    extracted_val_images = os.path.join(extracted_dir, "images", "100k", "val")
+    extracted_val_labels = os.path.join(extracted_dir, "labels", "100k", "val")
 
     if not os.path.isfile(images_zip):
         logger.info("Downloading BDD100K images from %s...", _BDD100K_IA_BASE)
@@ -523,11 +519,13 @@ def _convert_mot_to_legacy_labels(mot_dir, out_path):
                 )
             labels.append(converted)
 
-        entries.append({
-            "name": name,
-            "attributes": mot.get("attributes", {}) or {},
-            "labels": labels,
-        })
+        entries.append(
+            {
+                "name": name,
+                "attributes": mot.get("attributes", {}) or {},
+                "labels": labels,
+            }
+        )
 
     etas.write_json(entries, out_path)
 
@@ -542,11 +540,13 @@ def _convert_mot_poly2d(mot_poly2d, category):
     """
     vertices = [[pt[0], pt[1]] for pt in mot_poly2d if len(pt) >= 2]
     types = "".join(pt[2] for pt in mot_poly2d if len(pt) >= 3)
-    return [{
-        "vertices": vertices,
-        "types": types,
-        "closed": category.startswith("area/"),
-    }]
+    return [
+        {
+            "vertices": vertices,
+            "types": types,
+            "closed": category.startswith("area/"),
+        }
+    ]
 
 
 def _count_split_samples(dataset_dir):

--- a/fiftyone/zoo/datasets/base.py
+++ b/fiftyone/zoo/datasets/base.py
@@ -425,8 +425,10 @@ class BDD100KDataset(FiftyOneDataset):
     the videos as described above, together with the image classification,
     detection, and segmentation labels.
 
-    In order to load the BDD100K dataset, you must download the source data
-    manually. The directory should be organized in the following format::
+    The dataset is downloaded automatically from the Internet Archive
+    mirror (the original Berkeley host has been offline). If you have an
+    existing BDD100K download in the legacy 2018 layout, you can pass
+    ``source_dir`` to skip the network fetch::
 
         source_dir/
             labels/
@@ -438,22 +440,12 @@ class BDD100KDataset(FiftyOneDataset):
                     test/
                     val/
 
-    You can register at http://bdd-data.berkeley.edu in order to get links to
-    download the data.
-
     Example usage::
 
         import fiftyone as fo
         import fiftyone.zoo as foz
 
-        # The path to the source files that you manually downloaded
-        source_dir = "/path/to/dir-with-bdd100k-files"
-
-        dataset = foz.load_zoo_dataset(
-            "bdd100k",
-            split="validation",
-            source_dir=source_dir,
-        )
+        dataset = foz.load_zoo_dataset("bdd100k", split="validation")
 
         session = fo.launch_app(dataset)
 
@@ -461,11 +453,12 @@ class BDD100KDataset(FiftyOneDataset):
         7.10 GB
 
     Source
-        http://bdd-data.berkeley.edu
+        https://archive.org/details/bdd100k
 
     Args:
-        source_dir (None): the directory containing the manually downloaded
-            BDD100K files
+        source_dir (None): an optional directory containing a pre-downloaded
+            BDD100K source tree in the legacy 2018 layout. If omitted, the
+            dataset is downloaded automatically from the Internet Archive
         copy_files (True): whether to move (False) or create copies (True) of
             the source files when populating the dataset directory
     """
@@ -480,32 +473,26 @@ class BDD100KDataset(FiftyOneDataset):
 
     @property
     def license(self):
-        return "http://bdd-data.berkeley.edu/download.html"
+        return "https://doc.bdd100k.com/license.html"
 
     @property
     def tags(self):
-        return ("image", "multilabel", "automotive", "manual")
+        return ("image", "multilabel", "automotive")
 
     @property
     def supported_splits(self):
         return ("train", "validation", "test")
 
-    @property
-    def requires_manual_download(self):
-        return True
-
     def _download_and_prepare(self, dataset_dir, scratch_dir, split):
-        #
-        # BDD100K must be manually downloaded by the user in `source_dir`
-        #
-        # The download contains all splits, so we remove the split from
-        # `dataset_dir` here and wrangle the whole dataset (if necessary)
-        #
-        dataset_dir = os.path.dirname(dataset_dir)  # remove split dir
-        split_dir = os.path.join(dataset_dir, split)
+        parent_dir = os.path.dirname(dataset_dir)
+        split_dir = os.path.join(parent_dir, split)
+
         if not os.path.isdir(split_dir):
-            foub.parse_bdd100k_dataset(
-                self.source_dir, dataset_dir, copy_files=self.copy_files
+            foub.download_bdd100k_dataset(
+                parent_dir,
+                scratch_dir=scratch_dir,
+                source_dir=self.source_dir,
+                copy_files=self.copy_files,
             )
 
         logger.info("Parsing dataset metadata")

--- a/fiftyone/zoo/datasets/base.py
+++ b/fiftyone/zoo/datasets/base.py
@@ -431,8 +431,10 @@ class BDD100KDataset(FiftyOneDataset):
     the videos as described above, together with the image classification,
     detection, and segmentation labels.
 
-    In order to load the BDD100K dataset, you must download the source data
-    manually. The directory should be organized in the following format::
+    The dataset is downloaded automatically from the Internet Archive
+    mirror (the original Berkeley host has been offline). If you have an
+    existing BDD100K download in the legacy 2018 layout, you can pass
+    ``source_dir`` to skip the network fetch::
 
         source_dir/
             labels/
@@ -444,22 +446,12 @@ class BDD100KDataset(FiftyOneDataset):
                     test/
                     val/
 
-    You can register at http://bdd-data.berkeley.edu in order to get links to
-    download the data.
-
     Example usage::
 
         import fiftyone as fo
         import fiftyone.zoo as foz
 
-        # The path to the source files that you manually downloaded
-        source_dir = "/path/to/dir-with-bdd100k-files"
-
-        dataset = foz.load_zoo_dataset(
-            "bdd100k",
-            split="validation",
-            source_dir=source_dir,
-        )
+        dataset = foz.load_zoo_dataset("bdd100k", split="validation")
 
         session = fo.launch_app(dataset)
 
@@ -467,11 +459,12 @@ class BDD100KDataset(FiftyOneDataset):
         7.10 GB
 
     Source
-        http://bdd-data.berkeley.edu
+        https://archive.org/details/bdd100k
 
     Args:
-        source_dir (None): the directory containing the manually downloaded
-            BDD100K files
+        source_dir (None): an optional directory containing a pre-downloaded
+            BDD100K source tree in the legacy 2018 layout. If omitted, the
+            dataset is downloaded automatically from the Internet Archive
         copy_files (True): whether to move (False) or create copies (True) of
             the source files when populating the dataset directory
     """
@@ -486,32 +479,26 @@ class BDD100KDataset(FiftyOneDataset):
 
     @property
     def license(self):
-        return "http://bdd-data.berkeley.edu/download.html"
+        return "https://doc.bdd100k.com/license.html"
 
     @property
     def tags(self):
-        return ("image", "multilabel", "automotive", "manual")
+        return ("image", "multilabel", "automotive")
 
     @property
     def supported_splits(self):
         return ("train", "validation", "test")
 
-    @property
-    def requires_manual_download(self):
-        return True
-
     def _download_and_prepare(self, dataset_dir, scratch_dir, split):
-        #
-        # BDD100K must be manually downloaded by the user in `source_dir`
-        #
-        # The download contains all splits, so we remove the split from
-        # `dataset_dir` here and wrangle the whole dataset (if necessary)
-        #
-        dataset_dir = os.path.dirname(dataset_dir)  # remove split dir
-        split_dir = os.path.join(dataset_dir, split)
+        parent_dir = os.path.dirname(dataset_dir)
+        split_dir = os.path.join(parent_dir, split)
+
         if not os.path.isdir(split_dir):
-            foub.parse_bdd100k_dataset(
-                self.source_dir, dataset_dir, copy_files=self.copy_files
+            foub.download_bdd100k_dataset(
+                parent_dir,
+                scratch_dir=scratch_dir,
+                source_dir=self.source_dir,
+                copy_files=self.copy_files,
             )
 
         logger.info("Parsing dataset metadata")

--- a/tests/unittests/utils/test_bdd.py
+++ b/tests/unittests/utils/test_bdd.py
@@ -1,0 +1,58 @@
+"""
+Tests for fiftyone/utils/bdd.py BDD100K download and parsing helpers.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import os
+
+import pytest
+
+import fiftyone.utils.bdd as foub
+
+
+class TestConvertMotPoly2d:
+    """Conversion of MOT-style poly2d points to legacy polylines."""
+
+    def test_triples_produce_vertices_and_types(self) -> None:
+        out = foub._convert_mot_poly2d(
+            [[1.0, 2.0, "L"], [3.0, 4.0, "C"]], "lane/road_curb"
+        )
+
+        assert out[0]["vertices"] == [[1.0, 2.0], [3.0, 4.0]]
+        assert out[0]["types"] == "LC"
+        assert out[0]["closed"] is False
+
+    def test_area_category_is_closed(self) -> None:
+        out = foub._convert_mot_poly2d([[0.0, 0.0, "L"]], "area/drivable")
+
+        assert out[0]["closed"] is True
+
+    def test_short_points_are_skipped(self) -> None:
+        """A point with fewer than two values is dropped rather than
+        raising IndexError."""
+        out = foub._convert_mot_poly2d(
+            [[1.0, 2.0, "L"], [9.0], [3.0, 4.0, "C"]], "lane/road_curb"
+        )
+
+        assert out[0]["vertices"] == [[1.0, 2.0], [3.0, 4.0]]
+        assert out[0]["types"] == "LC"
+
+
+class TestDownloadErrorRemediation:
+    """Parser failures name the actual failing path."""
+
+    def test_bad_source_dir_names_the_source_dir(self, tmp_path) -> None:
+        source_dir = str(tmp_path / "not-bdd")
+        os.makedirs(source_dir)
+
+        with pytest.raises(OSError, match="not-bdd") as excinfo:
+            foub.download_bdd100k_dataset(
+                str(tmp_path / "dataset"), source_dir=source_dir
+            )
+
+        message = str(excinfo.value)
+        assert "legacy 2018 layout" in message
+        assert "download the source files" not in message

--- a/tests/unittests/utils/test_bdd.py
+++ b/tests/unittests/utils/test_bdd.py
@@ -16,7 +16,7 @@ import fiftyone.utils.bdd as foub
 class TestConvertMotPoly2d:
     """Conversion of MOT-style poly2d points to legacy polylines."""
 
-    def test_triples_produce_vertices_and_types(self) -> None:
+    def test_triples_produce_vertices_and_types(self):
         out = foub._convert_mot_poly2d(
             [[1.0, 2.0, "L"], [3.0, 4.0, "C"]], "lane/road_curb"
         )
@@ -25,12 +25,12 @@ class TestConvertMotPoly2d:
         assert out[0]["types"] == "LC"
         assert out[0]["closed"] is False
 
-    def test_area_category_is_closed(self) -> None:
+    def test_area_category_is_closed(self):
         out = foub._convert_mot_poly2d([[0.0, 0.0, "L"]], "area/drivable")
 
         assert out[0]["closed"] is True
 
-    def test_short_points_are_skipped(self) -> None:
+    def test_short_points_are_skipped(self):
         """A point with fewer than two values is dropped rather than
         raising IndexError."""
         out = foub._convert_mot_poly2d(
@@ -44,7 +44,7 @@ class TestConvertMotPoly2d:
 class TestDownloadErrorRemediation:
     """Parser failures name the actual failing path."""
 
-    def test_bad_source_dir_names_the_source_dir(self, tmp_path) -> None:
+    def test_bad_source_dir_names_the_source_dir(self, tmp_path):
         source_dir = str(tmp_path / "not-bdd")
         os.makedirs(source_dir)
 


### PR DESCRIPTION
## Summary

- Auto-download BDD100K from the Internet Archive; the Berkeley host is
  offline
- Convert the IA mirror's per-image MOT label JSONs to the legacy
  consolidated layout that `BDDDatasetImporter` consumes, including the
  per-label `poly2d` reshape
- `source_dir` still works for callers with an existing 2018-layout
  tree

## What changes are proposed in this pull request?

`fiftyone/utils/bdd.py` gets `download_bdd100k_dataset` and a converter
(`_convert_mot_to_legacy_labels` + `_convert_mot_poly2d`);
`BDD100KDataset._download_and_prepare` in
`fiftyone/zoo/datasets/base.py` calls it. MOT puts objects under
`frames[0].objects` and stores `poly2d` as flat `[[x, y, type], ...]`;
the converter rewrites both into the legacy shape, inferring `closed`
from the category prefix (`area/*` closed, `lane/*` open).
`requires_manual_download` and the `"manual"` tag drop; docstring and
license URLs repointed at the IA mirror.

## How is this patch tested?

- [x] `foz.load_zoo_dataset("bdd100k", split="validation")` end-to-end:
  10,000 samples, 185,578 detections across 10 classes, polylines and
  scene attributes populated.
- [x] `source_dir` branch via a real legacy-layout tree: importer
  produces correct detections + polylines on the prepared output.
- [x] Converter unit check on synthetic MOT input.

## Release Notes

- [x] Yes.

`foz.load_zoo_dataset("bdd100k")` now downloads automatically from the
Internet Archive mirror; manual `source_dir` is no longer required.

### What areas of FiftyOne does this PR affect?

- [x] Core: Core `fiftyone` Python library changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * BDD100K can now be downloaded automatically from an Internet Archive mirror.
  * Existing legacy-layout BDD100K downloads can be reused through a source directory.
  * Dataset archives are extracted, annotations converted, and train/validation splits prepared automatically.
  * Added support for parsing and validating downloaded BDD100K data.

* **Documentation**
  * Updated BDD100K documentation, usage examples, and license information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3762
<!-- enterprise-sync-pr:end -->