### PR TITLE
[HA] Fix masks not being restored after undoing a merge

### DIFF
--- a/app/packages/lighter/src/overlay/DetectionOverlay.ts
+++ b/app/packages/lighter/src/overlay/DetectionOverlay.ts
@@ -856,7 +856,8 @@ export class DetectionOverlay
     const wasPainting = this.interactionState === "PAINTING";
 
     this.interactionState = "NONE";
-    const croppedBounds = this.mask?.paintEnd(this.bounds, () => {
+    const croppedBounds = this.mask?.paintEnd(this.bounds, (encoded) => {
+      this.maskSource = encoded;
       this.markDirty();
     });
     if (croppedBounds) {
@@ -1238,7 +1239,8 @@ export class DetectionOverlay
       this.bounds = updatedBounds;
     }
 
-    this.bounds = this.mask.paintEnd(this.bounds, () => {
+    this.bounds = this.mask.paintEnd(this.bounds, (encoded) => {
+      this.maskSource = encoded;
       this.markDirty();
     });
 
@@ -1318,7 +1320,10 @@ export class DetectionOverlay
     const newBounds = this.mask.mergeFrom(
       sourceSource,
       source.bounds,
-      this.bounds
+      this.bounds,
+      (encoded) => {
+        this.maskSource = encoded;
+      }
     );
 
     this.bounds = newBounds;
@@ -1355,7 +1360,16 @@ export class DetectionOverlay
   ): void {
     this.mask ??= new MaskCanvas();
 
-    this.mask.restoreSnapshot(snapshot);
+    if (snapshot) {
+      this.mask.restoreSnapshot(snapshot, (encoded) => {
+        this.maskSource = encoded;
+      });
+    } else {
+      // Clearing to "no mask" — drop the rehydration source too so a later
+      // destroy/re-add doesn't resurrect a stale serialized payload.
+      this.mask.restoreSnapshot(undefined);
+      this.maskSource = undefined;
+    }
     this.bounds = bounds;
     this.markDirty();
   }

--- a/app/packages/lighter/src/overlay/MaskCanvas.test.ts
+++ b/app/packages/lighter/src/overlay/MaskCanvas.test.ts
@@ -14,10 +14,15 @@ import { maskBounds } from "../utils";
 
 // Stub maskBounds so tests can drive paintEnd's post-stroke crop directly —
 // the jsdom canvas mock in vitest.setup.ts has no real pixel storage, so we
-// can't compute a tight bbox from painted pixels at runtime.
+// can't compute a tight bbox from painted pixels at runtime. encodeMask is
+// stubbed to a known string so tests can observe what onEncoded receives.
 vi.mock("../utils", async () => {
   const actual = await vi.importActual<typeof import("../utils")>("../utils");
-  return { ...actual, maskBounds: vi.fn() };
+  return {
+    ...actual,
+    maskBounds: vi.fn(),
+    encodeMask: vi.fn().mockResolvedValue("encoded-mask"),
+  };
 });
 const mockedMaskBounds = vi.mocked(maskBounds);
 
@@ -193,5 +198,110 @@ describe("MaskCanvas.paintEnd shrink", () => {
     mockedMaskBounds.mockReturnValueOnce(null);
 
     expect(mc.paintEnd(bounds)).toEqual(bounds);
+  });
+});
+
+describe("MaskCanvas onEncoded plumbing", () => {
+  // Drives DetectionOverlay.maskSource: callers need the freshly encoded mask
+  // so a destroy/re-add cycle can rehydrate without depending on a save
+  // round-trip back through label.mask.
+
+  it("paintEnd invokes onEncoded with the encoded mask once encode resolves", async () => {
+    const bounds: Rect = { x: 0, y: 0, width: 5, height: 5 };
+    const mc = seedCanvas(bounds, bounds);
+    mockedMaskBounds.mockReturnValueOnce({
+      minX: 0,
+      minY: 0,
+      maxX: 4,
+      maxY: 4,
+    });
+
+    const onEncoded = vi.fn();
+    mc.paintEnd(bounds, onEncoded);
+
+    // Allow the encodeMask Promise to settle.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onEncoded).toHaveBeenCalledTimes(1);
+    expect(onEncoded).toHaveBeenCalledWith("encoded-mask");
+  });
+
+  it("mergeFrom plumbs onEncoded through to paintEnd", async () => {
+    const targetBounds: Rect = { x: 0, y: 0, width: 10, height: 10 };
+    const target = seedCanvas(targetBounds, {
+      x: 0,
+      y: 0,
+      width: 4,
+      height: 4,
+    });
+    const sourceBounds: Rect = { x: 8, y: 8, width: 10, height: 10 };
+    const source = seedCanvas(sourceBounds, {
+      x: 12,
+      y: 12,
+      width: 4,
+      height: 4,
+    });
+
+    const onEncoded = vi.fn();
+    target.mergeFrom(
+      source.getPreviewSource() as HTMLCanvasElement,
+      sourceBounds,
+      targetBounds,
+      onEncoded
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onEncoded).toHaveBeenCalledWith("encoded-mask");
+  });
+
+  it("restoreSnapshot invokes onEncoded after replaying a snapshot", async () => {
+    const bounds: Rect = { x: 0, y: 0, width: 5, height: 5 };
+    const mc = seedCanvas(bounds, bounds);
+    mockedMaskBounds.mockReturnValueOnce({
+      minX: 0,
+      minY: 0,
+      maxX: 4,
+      maxY: 4,
+    });
+    mc.paintEnd(bounds);
+    // Wait for the paintEnd encode so the snapshot below has a canvas to
+    // capture from; the subsequent restoreSnapshot call is what we're testing.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const snapshot = mc.getPaintStrokeData().afterSnapshot;
+    expect(snapshot).toBeDefined();
+
+    const onEncoded = vi.fn();
+    mc.restoreSnapshot(snapshot, onEncoded);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onEncoded).toHaveBeenCalledWith("encoded-mask");
+  });
+
+  it("restoreSnapshot(undefined) skips onEncoded (cleared to empty mask)", async () => {
+    const bounds: Rect = { x: 0, y: 0, width: 5, height: 5 };
+    const mc = seedCanvas(bounds, bounds);
+    mockedMaskBounds.mockReturnValueOnce({
+      minX: 0,
+      minY: 0,
+      maxX: 4,
+      maxY: 4,
+    });
+    mc.paintEnd(bounds);
+    await Promise.resolve();
+
+    const onEncoded = vi.fn();
+    mc.restoreSnapshot(undefined, onEncoded);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onEncoded).not.toHaveBeenCalled();
   });
 });

--- a/app/packages/lighter/src/overlay/MaskCanvas.ts
+++ b/app/packages/lighter/src/overlay/MaskCanvas.ts
@@ -516,7 +516,7 @@ export class MaskCanvas {
     otherSource: HTMLCanvasElement | ImageBitmap,
     otherBounds: Rect,
     ourBounds: Rect,
-    onEncoded?: () => void
+    onEncoded?: (encoded: string) => void
   ): Rect {
     this.ensureCanvas(ourBounds);
     this.paintStart(ourBounds);
@@ -558,7 +558,7 @@ export class MaskCanvas {
     return this.paintEnd(newBounds, onEncoded);
   }
 
-  paintEnd(bounds: Rect, onEncoded?: () => void): Rect {
+  paintEnd(bounds: Rect, onEncoded?: (encoded: string) => void): Rect {
     if (!this.canvas) return bounds;
 
     this.lastPoint = undefined;
@@ -581,7 +581,7 @@ export class MaskCanvas {
       .then((encoded) => {
         if (this.canvas !== capturedCanvas) return;
         this.pendingMask = encoded;
-        onEncoded?.();
+        onEncoded?.(encoded);
       })
       .catch((err) => {
         console.error("[MaskCanvas] paintEnd encode failed:", err);
@@ -821,9 +821,13 @@ export class MaskCanvas {
   /**
    * Replaces the current canvas contents with a previously captured snapshot.
    * If `snapshot` is `undefined`, clears the canvas entirely (restoring the
-   * "no mask" state). Kicks off `encodeMask` so `pendingMask` stays in sync.
+   * "no mask" state). Kicks off `encodeMask` so `pendingMask` stays in sync;
+   * `onEncoded` fires once with the encoded payload when that completes.
    */
-  restoreSnapshot(snapshot: MaskSnapshot | undefined): void {
+  restoreSnapshot(
+    snapshot: MaskSnapshot | undefined,
+    onEncoded?: (encoded: string) => void
+  ): void {
     if (!snapshot) {
       this.canvas = undefined;
       this.context = undefined;
@@ -851,6 +855,7 @@ export class MaskCanvas {
       .then((encoded) => {
         if (this.canvas !== capturedCanvas) return;
         this.pendingMask = encoded;
+        onEncoded?.(encoded);
       })
       .catch((err) => {
         console.error("[MaskCanvas] restoreSnapshot encode failed:", err);


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

Adds logic to synchronize internal mask state when mask (re)-encoding occurs; fixes a bug where masks were not being retained correctly after undoing a merge.

## 🧪 How is this patch tested? If it is not, please explain why.

local, unit tests

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of mask editing, merging, and undo operations by ensuring mask data is consistently captured and preserved across editing workflows.

* **Tests**
  * Added test coverage for mask encoding callback functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7608?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->