### PR TITLE
[HA] Prevent interpolation of mask edge pixels

### DIFF
--- a/app/packages/lighter/src/overlay/MaskCanvas.ts
+++ b/app/packages/lighter/src/overlay/MaskCanvas.ts
@@ -264,7 +264,11 @@ export class MaskCanvas {
     this.context = maskContext;
 
     if (this.maskBitmap) {
+      // Disable image smoothing to prevent feathering on fractional pixels
+      const prevSmoothing = this.context.imageSmoothingEnabled;
+      this.context.imageSmoothingEnabled = false;
       this.context.drawImage(this.maskBitmap, 0, 0, width, height);
+      this.context.imageSmoothingEnabled = prevSmoothing;
       this.maskBitmap.close();
       this.maskBitmap = undefined;
     }


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

Disables image smoothing when seeding a canvas with an existing mask to prevent edge pixels from being interpolated across multiple cells.

## 🧪 How is this patch tested? If it is not, please explain why.

local

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced mask rendering by preventing unwanted image smoothing artifacts on fractional pixels during canvas operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7609?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->