### PR TITLE
update mode on add/remove mask of new Label

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useDetectionMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useDetectionMode.ts
@@ -111,7 +111,6 @@ export const useDetectionMode = () => {
 
   const isEditingDetection =
     editingLabelType === DETECTION &&
-    !selectedLabel?.isNew &&
     !selectedLabel?.data?.mask &&
     !selectedLabel?.data?.mask_path &&
     !isEditingMask;
@@ -197,10 +196,7 @@ export const useDetectionMode = () => {
 
   // Auto-activate detection mode when a pre-existing bbox detection is selected,
   // auto-deactivate when a pre-existing label of a different type is selected.
-  // New labels are ignored — the mode was set intentionally via the toolbar button.
   useEffect(() => {
-    if (selectedLabel?.isNew) return;
-
     if (isEditingDetection && !detectionModeActive) {
       setDetectionModeActive(true);
     } else if (editingLabelType && !isEditingDetection && detectionModeActive) {
@@ -210,7 +206,6 @@ export const useDetectionMode = () => {
     detectionModeActive,
     editingLabelType,
     isEditingDetection,
-    selectedLabel?.isNew,
     setDetectionModeActive,
   ]);
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode.ts
@@ -252,13 +252,7 @@ export const useSegmentationMode = () => {
 
   // Auto-enable segmentation mode when a pre-existing mask detection is selected,
   // auto-disable when a pre-existing label of a different type is selected.
-  //
-  // New labels are ignored — the mode was set intentionally via the toolbar button.
   useEffect(() => {
-    if (selectedLabel?.isNew) {
-      return;
-    }
-
     if (isEditingSegmentation && !segmentationModeActive) {
       setSegmentationModeActive(true);
     } else if (
@@ -269,7 +263,6 @@ export const useSegmentationMode = () => {
       setSegmentationModeActive(false);
     }
   }, [
-    selectedLabel?.isNew,
     selectedLabel?.overlay,
     editingLabelType,
     isEditingSegmentation,


### PR DESCRIPTION
## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

For a newly-created detection add/remove mask via the kabob menu now properly updates the "mode" (i.e. Detection/Segmentation).

## 🧪 How is this patch tested? If it is not, please explain why.

Locally

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of newly created labels in detection and segmentation mode. Auto-activation of these modes now works consistently regardless of whether a label is new or existing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->