### PR TITLE
select a detection before issuing any edits

### DIFF
--- a/app/packages/lighter/src/interaction/InteractionManager.ts
+++ b/app/packages/lighter/src/interaction/InteractionManager.ts
@@ -338,6 +338,13 @@ export class InteractionManager {
 
       if (isUnselectedOverlay) {
         this.selectionManager.select(handler!.id);
+
+        // Select an overlay before issuing any edits. The cursor at this point
+        // is a 'pointer' indicating selection, not painting/erasing/keypoint.
+        if (segmentationModeBridge.isActive()) {
+          event.preventDefault();
+          return;
+        }
       }
 
       // Detection mode: defer overlay creation until we confirm this is a drag.


### PR DESCRIPTION
## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

In Brush or Pen mode with no detection selected, hovering over a detection sets the mouse cursor to 'pointer' indicating selection. If the user clicks at this point the detection will be selected but if, for instance, the Brush is set to Erase the click to select will also punch a hole in the mask (the Pen would drop a keypoint). This change short-circuits the `pointerdown` handler so that it only selects the detection which can then be edited.

## 🧪 How is this patch tested? If it is not, please explain why.

Locally

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pointer interaction handling in segmentation mode. Clicking an unselected element now correctly selects it while preventing subsequent interaction flows from executing in the same action.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->