### PR TITLE
Fix/evaluate detections classes fn tagging

### DIFF
--- a/fiftyone/utils/eval/activitynet.py
+++ b/fiftyone/utils/eval/activitynet.py
@@ -97,7 +97,7 @@ class ActivityNetEvaluation(DetectionEvaluation):
                 "ActivityNet evaluation"
             )
 
-    def evaluate(self, sample, eval_key=None):
+    def evaluate(self, sample, eval_key=None, classes=None):
         """Performs ActivityNet-style evaluation on the given video.
 
         Predicted segments are matched to ground truth segments in descending
@@ -127,7 +127,7 @@ class ActivityNetEvaluation(DetectionEvaluation):
             preds = _copy_labels(preds)
 
         return _activitynet_evaluation_single_iou(
-            gts, preds, eval_key, self.config
+            gts, preds, eval_key, self.config, classes=classes
         )
 
     def generate_results(
@@ -517,7 +517,7 @@ _NO_MATCH_ID = ""
 _NO_MATCH_IOU = None
 
 
-def _activitynet_evaluation_single_iou(gts, preds, eval_key, config):
+def _activitynet_evaluation_single_iou(gts, preds, eval_key, config, classes=None):
     iou_thresh = min(config.iou, 1 - 1e-10)
     id_key = "%s_id" % eval_key
     iou_key = "%s_iou" % eval_key
@@ -533,6 +533,7 @@ def _activitynet_evaluation_single_iou(gts, preds, eval_key, config):
         eval_key=eval_key,
         id_key=id_key,
         iou_key=iou_key,
+        classes=classes,
     )
 
     return matches
@@ -614,7 +615,7 @@ def _activitynet_evaluation_setup(
     return cats, pred_ious
 
 
-def _compute_matches(cats, pred_ious, iou_thresh, eval_key, id_key, iou_key):
+def _compute_matches(cats, pred_ious, iou_thresh, eval_key, id_key, iou_key, classes=None):
     matches = []
 
     # Match preds to GT, highest confidence first
@@ -689,6 +690,8 @@ def _compute_matches(cats, pred_ious, iou_thresh, eval_key, id_key, iou_key):
         # Leftover GTs are false negatives
         for gt in segments["gts"]:
             if gt[id_key] == _NO_MATCH_ID:
+                if classes is not None and gt.label not in classes:
+                    continue
                 gt[eval_key] = "fn"
                 matches.append((gt.label, None, None, None, gt.id, None))
 

--- a/fiftyone/utils/eval/coco.py
+++ b/fiftyone/utils/eval/coco.py
@@ -140,7 +140,7 @@ class COCOEvaluation(DetectionEvaluation):
                 "evaluation"
             )
 
-    def evaluate(self, sample_or_frame, eval_key=None):
+    def evaluate(self, sample_or_frame, eval_key=None, classes=None):
         """Performs COCO-style evaluation on the given image.
 
         Predicted objects are matched to ground truth objects in descending
@@ -174,7 +174,7 @@ class COCOEvaluation(DetectionEvaluation):
             gts = _copy_labels(gts)
             preds = _copy_labels(preds)
 
-        return _coco_evaluation_single_iou(gts, preds, eval_key, self.config)
+        return _coco_evaluation_single_iou(gts, preds, eval_key, self.config, classes=classes)
 
     def generate_results(
         self,
@@ -483,7 +483,7 @@ _NO_MATCH_ID = ""
 _NO_MATCH_IOU = None
 
 
-def _coco_evaluation_single_iou(gts, preds, eval_key, config):
+def _coco_evaluation_single_iou(gts, preds, eval_key, config, classes=None):
     iou_thresh = min(config.iou, 1 - 1e-10)
     id_key = "%s_id" % eval_key
     iou_key = "%s_iou" % eval_key
@@ -500,6 +500,7 @@ def _coco_evaluation_single_iou(gts, preds, eval_key, config):
         eval_key=eval_key,
         id_key=id_key,
         iou_key=iou_key,
+        classes=classes,
     )
 
     # omit iscrowd
@@ -524,6 +525,7 @@ def _coco_evaluation_iou_sweep(gts, preds, config):
             eval_key="_eval",
             id_key=id_key,
             iou_key=iou_key,
+            classes=config.classes,
         )
         for iou_thresh, id_key in zip(iou_threshs, id_keys)
     ]
@@ -595,7 +597,7 @@ def _coco_evaluation_setup(
 
 
 def _compute_matches(
-    cats, pred_ious, iou_thresh, iscrowd, eval_key, id_key, iou_key
+    cats, pred_ious, iou_thresh, iscrowd, eval_key, id_key, iou_key, classes=None
 ):
     matches = []
 
@@ -699,6 +701,8 @@ def _compute_matches(
         # Leftover GTs are false negatives
         for gt in objects["gts"]:
             if gt[id_key] == _NO_MATCH_ID:
+                if classes is not None and gt.label not in classes:
+                    continue
                 gt[eval_key] = "fn"
                 matches.append(
                     (gt.label, None, None, None, gt.id, None, iscrowd(gt))

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -170,6 +170,7 @@ def evaluate_detections(
         is_temporal,
         iou=iou,
         classwise=classwise,
+        classes=classes,
         custom_metrics=custom_metrics,
         **kwargs,
     )
@@ -205,7 +206,7 @@ def evaluate_detections(
         sample_fp = 0
         sample_fn = 0
         for doc in docs:
-            doc_matches = eval_method.evaluate(doc, eval_key=eval_key)
+            doc_matches = eval_method.evaluate(doc, eval_key=eval_key, classes=config.classes)
             matches.extend(doc_matches)
             tp, fp, fn = _tally_matches(doc_matches)
             sample_tp += tp
@@ -266,6 +267,7 @@ class DetectionEvaluationConfig(BaseEvaluationMethodConfig):
         gt_field,
         iou=None,
         classwise=None,
+        classes=None,
         custom_metrics=None,
         **kwargs,
     ):
@@ -274,6 +276,7 @@ class DetectionEvaluationConfig(BaseEvaluationMethodConfig):
         self.gt_field = gt_field
         self.iou = iou
         self.classwise = classwise
+        self.classes = classes
         self.custom_metrics = custom_metrics
 
     @property
@@ -377,7 +380,7 @@ class DetectionEvaluation(BaseEvaluationMethod):
             dataset.add_sample_field(pred_id, fof.StringField)
             dataset.add_sample_field(pred_iou, fof.FloatField)
 
-    def evaluate(self, doc, eval_key=None):
+    def evaluate(self, doc, eval_key=None, classes=None):
         """Evaluates the ground truth and predictions in the given document.
 
         Args:

--- a/fiftyone/utils/eval/openimages.py
+++ b/fiftyone/utils/eval/openimages.py
@@ -163,7 +163,7 @@ class OpenImagesEvaluation(DetectionEvaluation):
                 "Open Images evaluation"
             )
 
-    def evaluate(self, sample_or_frame, eval_key=None):
+    def evaluate(self, sample_or_frame, eval_key=None, classes=None):
         """Performs Open Images-style evaluation on the given image.
 
         Predicted objects are matched to ground truth objects in descending
@@ -226,6 +226,7 @@ class OpenImagesEvaluation(DetectionEvaluation):
             self.config,
             pos_labs,
             neg_labs,
+            classes=classes,
         )
 
     def generate_results(
@@ -479,7 +480,7 @@ def _expand_detection_hierarchy(cats, obj, config, label_type):
 
 
 def _open_images_evaluation_single_iou(
-    gts, preds, eval_key, config, pos_labs, neg_labs
+    gts, preds, eval_key, config, pos_labs, neg_labs, classes=None
 ):
     iou_thresh = min(config.iou, 1 - 1e-10)
     id_key = "%s_id" % eval_key
@@ -504,6 +505,7 @@ def _open_images_evaluation_single_iou(
         eval_key=eval_key,
         id_key=id_key,
         iou_key=iou_key,
+        classes=classes,
     )
 
     return matches
@@ -588,7 +590,7 @@ def _open_images_evaluation_setup(
 
 
 def _compute_matches(
-    cats, pred_ious, iou_thresh, iscrowd, eval_key, id_key, iou_key
+    cats, pred_ious, iou_thresh, iscrowd, eval_key, id_key, iou_key, classes=None
 ):
     matches = []
 
@@ -718,6 +720,8 @@ def _compute_matches(
         # Leftover GTs are false negatives
         for gt in objects["gts"]:
             if gt[id_key] == _NO_MATCH_ID:
+                if classes is not None and gt.label not in classes:
+                    continue
                 gt[eval_key] = "fn"
                 matches.append((gt.label, None, None, None, gt.id, None))
 

--- a/tests/unittests/test_compute_matches_classes.py
+++ b/tests/unittests/test_compute_matches_classes.py
@@ -1,0 +1,178 @@
+"""
+Unit tests for _compute_matches classes-filter fix (issue #6707).
+
+Verifies that ground-truth objects whose label is not in the user-supplied
+``classes`` list are not tagged as false negatives during detection evaluation.
+
+No MongoDB connection required -- exercises the COCO matching helper directly.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import unittest
+from collections import defaultdict
+
+import fiftyone.utils.eval.coco as cocoe
+import fiftyone.utils.iou as foui
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_APPLE_GT = ("apple", "gt1", [0.10, 0.10, 0.30, 0.30])
+_ORANGE_GT = ("orange", "gt2", [0.60, 0.60, 0.30, 0.30])
+_BANANA_GT = ("banana", "gt3", [0.40, 0.10, 0.20, 0.20])
+_APPLE_PRED = ("apple", "p1", [0.10, 0.10, 0.30, 0.30], 0.99)
+
+_EVAL_KEY = "eval"
+_ID_KEY = "eval_id"
+_IOU_KEY = "eval_iou"
+_IOU_THRESH = 0.50
+
+
+# ---------------------------------------------------------------------------
+# Minimal Detection stub (no dataset / MongoDB required)
+# ---------------------------------------------------------------------------
+
+class _Det:
+    """Lightweight stand-in for a FiftyOne Detection label object."""
+
+    def __init__(self, label, det_id, bounding_box, confidence=None):
+        self.label = label
+        self.id = det_id
+        self.bounding_box = bounding_box
+        self.confidence = confidence
+        self._attrs = {}
+
+    def __getitem__(self, key):
+        sentinel = cocoe._NO_MATCH_ID if key.endswith("_id") else cocoe._NO_MATCH_IOU
+        return self._attrs.get(key, sentinel)
+
+    def __setitem__(self, key, value):
+        self._attrs[key] = value
+
+    def get(self, key, default=None):
+        return self._attrs.get(key, default)
+
+    def get_attribute_value(self, key, default=None):  # iscrowd support
+        return default
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+def _build_cats(gt_specs, pred_specs):
+    """
+    Construct the ``cats`` / ``pred_ious`` structures consumed by
+    ``_compute_matches``, initialising every object with the sentinel values
+    that the real COCO setup code would apply.
+    """
+    gts = [_Det(label, det_id, box) for label, det_id, box in gt_specs]
+    preds = [_Det(label, det_id, box, conf) for label, det_id, box, conf in pred_specs]
+
+    for obj in gts + preds:
+        obj[_ID_KEY] = cocoe._NO_MATCH_ID
+        obj[_IOU_KEY] = cocoe._NO_MATCH_IOU
+
+    iscrowd = lambda obj: False  # noqa: E731
+
+    cats = defaultdict(lambda: defaultdict(list))
+    for gt in gts:
+        cats[gt.label]["gts"].append(gt)
+    for pred in preds:
+        cats[pred.label]["preds"].append(pred)
+
+    pred_ious = {}
+    for objects in cats.values():
+        ious = foui.compute_ious(
+            objects["preds"], objects["gts"], sparse=True, iscrowd=iscrowd, error_level=1
+        )
+        pred_ious.update(ious)
+
+    return cats, pred_ious, iscrowd
+
+
+def _run_matches(cats, pred_ious, iscrowd, classes):
+    return cocoe._compute_matches(
+        cats,
+        pred_ious,
+        _IOU_THRESH,
+        iscrowd,
+        eval_key=_EVAL_KEY,
+        id_key=_ID_KEY,
+        iou_key=_IOU_KEY,
+        classes=classes,
+    )
+
+
+def _gt_map(cats):
+    return {gt.id: gt for objs in cats.values() for gt in objs["gts"]}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestComputeMatchesClassesFilter(unittest.TestCase):
+    """_compute_matches correctly applies the optional ``classes`` filter."""
+
+    def test_classes_none_preserves_existing_behaviour(self):
+        """classes=None: all unmatched GTs must still be tagged 'fn'."""
+        cats, pred_ious, iscrowd = _build_cats(
+            [_APPLE_GT, _ORANGE_GT], [_APPLE_PRED]
+        )
+        _run_matches(cats, pred_ious, iscrowd, classes=None)
+
+        gts = _gt_map(cats)
+        self.assertEqual(gts["gt1"][_EVAL_KEY], "tp")
+        self.assertEqual(gts["gt2"][_EVAL_KEY], "fn")
+
+    def test_excluded_class_gt_not_tagged_fn(self):
+        """classes=['apple']: orange GT must remain untagged."""
+        cats, pred_ious, iscrowd = _build_cats(
+            [_APPLE_GT, _ORANGE_GT], [_APPLE_PRED]
+        )
+        matches = _run_matches(cats, pred_ious, iscrowd, classes=["apple"])
+
+        gts = _gt_map(cats)
+        self.assertEqual(gts["gt1"][_EVAL_KEY], "tp")
+        self.assertIsNone(gts["gt2"].get(_EVAL_KEY))
+
+        fn_count = sum(1 for m in matches if m[1] is None)
+        self.assertEqual(fn_count, 0)
+
+    def test_multiple_excluded_classes_all_untagged(self):
+        """classes=['apple']: every non-apple GT must remain untagged."""
+        cats, pred_ious, iscrowd = _build_cats(
+            [_APPLE_GT, _ORANGE_GT, _BANANA_GT], [_APPLE_PRED]
+        )
+        _run_matches(cats, pred_ious, iscrowd, classes=["apple"])
+
+        gts = _gt_map(cats)
+        self.assertEqual(gts["gt1"][_EVAL_KEY], "tp")
+        self.assertIsNone(gts["gt2"].get(_EVAL_KEY))
+        self.assertIsNone(gts["gt3"].get(_EVAL_KEY))
+
+    def test_empty_classes_list_produces_no_tags(self):
+        """classes=[]: no GT should be tagged and the match list is empty."""
+        cats, pred_ious, iscrowd = _build_cats([_APPLE_GT, _ORANGE_GT], [])
+        matches = _run_matches(cats, pred_ious, iscrowd, classes=[])
+
+        self.assertEqual(matches, [])
+        for gt in _gt_map(cats).values():
+            self.assertIsNone(gt.get(_EVAL_KEY))
+
+    def test_explicit_full_class_list_equivalent_to_none(self):
+        """Passing all GT labels explicitly must equal the classes=None result."""
+        cats_a, pa, ica = _build_cats([_APPLE_GT, _ORANGE_GT], [_APPLE_PRED])
+        cats_b, pb, icb = _build_cats([_APPLE_GT, _ORANGE_GT], [_APPLE_PRED])
+
+        m_explicit = _run_matches(cats_a, pa, ica, classes=["apple", "orange"])
+        m_none = _run_matches(cats_b, pb, icb, classes=None)
+
+        fn_explicit = sum(1 for m in m_explicit if m[1] is None)
+        fn_none = sum(1 for m in m_none if m[1] is None)
+        self.assertEqual(fn_explicit, fn_none)
+


### PR DESCRIPTION
## 🔗 Related Issues

Fixes #6707

## 📋 What changes are proposed in this pull request?

Threads the `classes` filter through the proper `DetectionEvaluation.evaluate()` interface layer so all three backends respect class scope consistently.

**Changes:**
- `DetectionEvaluationConfig` stores `classes` for lifecycle access
- `evaluate_detections()` forwards `classes` into config and passes `config.classes` into `eval_method.evaluate()`
- `DetectionEvaluation.evaluate()` base signature accepts `classes=None`, consistent with `generate_results()` precedent
- All three backends propagate `classes` down:
  - COCO: `evaluate()` → `_coco_evaluation_single_iou()` → `_compute_matches()`
  - OpenImages: `evaluate()` → `_open_images_evaluation_single_iou()` → `_compute_matches()`
  - ActivityNet: `evaluate()` → `_activitynet_evaluation_single_iou()` → `_compute_matches()`
- Leftover-GT loop skips `fn` tagging for GT labels outside class scope
- `classes=None` (default) — zero behaviour change across all paths

## 🧪 How is this patch tested?

Added `tests/unittests/test_compute_matches_classes.py` with 5 unit tests:

| Test | Covers |
|---|---|
| `test_classes_none_preserves_existing_behaviour` | Regression guard |
| `test_excluded_class_gt_not_tagged_fn` | Core fix |
| `test_multiple_excluded_classes_all_untagged` | Multiple excluded classes |
| `test_empty_classes_list_produces_no_tags` | Empty list edge case |
| `test_explicit_full_class_list_equivalent_to_none` | Full list equivalence |

All 5 tests pass.

## 📝 Release Notes

- [x] Yes.

`evaluate_detections(classes=[...])` now correctly restricts per-sample `fn` tagging to the specified class scope. Previously, ground truth objects outside the `classes` filter were incorrectly tagged as false negatives.

### What areas of FiftyOne does this PR affect?

- [x] Core: Core `fiftyone` Python library changes