### PR TITLE
Fix navigation and carousel view in sample modal for dynamic groups

### DIFF
--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/pagination/index.tsx
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/pagination/index.tsx
@@ -18,6 +18,7 @@ import { usePreloadedQuery } from "react-relay";
 import {
   useRecoilCallback,
   useRecoilState,
+  useRecoilTransaction_UNSTABLE,
   useRecoilValue,
   useSetRecoilState,
 } from "recoil";
@@ -80,6 +81,16 @@ export const GroupElementsLinkBar = React.memo(() => {
     [groupByFieldValue]
   );
 
+  const populateSampleCache = useRecoilTransaction_UNSTABLE(
+    ({ set }) =>
+      (samples: fos.ModalSample[]) => {
+        for (const sample of samples) {
+          set(fos.cachedSampleById(sample.sample._id as string), sample);
+        }
+      },
+    []
+  );
+
   const map = useMemo(() => {
     if (data?.samples?.edges?.length) {
       for (const { cursor, node } of data.samples.edges) {
@@ -88,6 +99,11 @@ export const GroupElementsLinkBar = React.memo(() => {
     }
     return new Map(mapRef);
   }, [data, mapRef]);
+
+  useEffect(() => {
+    if (map.size === 0) return;
+    populateSampleCache(Array.from(map.values()));
+  }, [map, populateSampleCache]);
 
   useEffect(() => {
     if (map.size === 0) {

--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/useDynamicGroupSamples.ts
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/useDynamicGroupSamples.ts
@@ -1,6 +1,6 @@
 import * as foq from "@fiftyone/relay";
 import * as fos from "@fiftyone/state";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { loadQuery, useRelayEnvironment } from "react-relay";
 import { useRecoilValue } from "recoil";
 
@@ -9,10 +9,22 @@ export const useDynamicGroupSamples = () => {
   const slice = useRecoilValue(fos.groupSlice);
   const modalSlice = useRecoilValue(fos.modalGroupSlice);
   const view = useRecoilValue(fos.view);
-  const dynamicGroup = fos.useGroupByFieldValue();
+  const rawDynamicGroup = fos.useGroupByFieldValue();
   const dataset = useRecoilValue(fos.datasetName);
   const dynamicGroupIndex = useRecoilValue(fos.dynamicGroupIndex);
   const shouldRenderImavid = useRecoilValue(fos.shouldRenderImaVidLooker(true));
+
+  // Stabilize by-value so identical group keys don't refetch on every modal nav.
+  const lastGroup = useRef<{
+    key: string;
+    value: typeof rawDynamicGroup;
+  } | null>(null);
+  const dynamicGroup = useMemo(() => {
+    const key = JSON.stringify(rawDynamicGroup ?? null);
+    if (lastGroup.current?.key === key) return lastGroup.current.value;
+    lastGroup.current = { key, value: rawDynamicGroup };
+    return rawDynamicGroup;
+  }, [rawDynamicGroup]);
 
   const filter = useMemo(
     // slice is how the group was accessed, i.e. from the grid

--- a/app/packages/core/src/useFlashlightPager.ts
+++ b/app/packages/core/src/useFlashlightPager.ts
@@ -6,7 +6,12 @@ import { Schema } from "@fiftyone/utilities";
 import { useMemo, useRef, useState } from "react";
 import { useErrorHandler } from "react-error-boundary";
 import { VariablesOf, fetchQuery, useRelayEnvironment } from "react-relay";
-import { RecoilValueReadOnly, selector, useRecoilValue } from "recoil";
+import {
+  RecoilValueReadOnly,
+  selector,
+  useRecoilTransaction_UNSTABLE,
+  useRecoilValue,
+} from "recoil";
 
 const PAGE_SIZE = 20;
 
@@ -15,9 +20,11 @@ const processSamplePageData = (
   store: fos.LookerStore<fos.Lookers>,
   data: fos.ResponseFrom<foq.paginateSamplesQuery>,
   schema: Schema,
-  zoom?: boolean
+  zoom: boolean | undefined,
+  cacheSamples: (samples: fos.ModalSample[]) => void
 ) => {
-  return data.samples.edges.map((edge, i) => {
+  const cached: fos.ModalSample[] = [];
+  const items = data.samples.edges.map((edge, i) => {
     if (edge.node.__typename === "%other") {
       throw new Error("unexpected sample type");
     }
@@ -25,6 +32,7 @@ const processSamplePageData = (
     const node = edge.node as fos.ModalSample;
     store.samples.set(node.sample._id, node);
     store.indices.set(offset + i, node.sample._id);
+    cached.push(node);
 
     return {
       aspectRatio: zoom
@@ -33,6 +41,8 @@ const processSamplePageData = (
       id: edge.node.id,
     };
   });
+  if (cached.length) cacheSamples(cached);
+  return items;
 };
 
 export const defaultZoom = selector({
@@ -59,6 +69,16 @@ const useFlashlightPager = (
     fos.fieldSchema({ space: fos.State.SPACE.SAMPLE })
   );
 
+  const cacheSamples = useRecoilTransaction_UNSTABLE(
+    ({ set }) =>
+      (samples: fos.ModalSample[]) => {
+        for (const sample of samples) {
+          set(fos.cachedSampleById(sample.sample._id as string), sample);
+        }
+      },
+    []
+  );
+
   const pager = useMemo(() => {
     return async (pageNumber: number) => {
       const variables = await page(pageNumber, PAGE_SIZE);
@@ -75,7 +95,8 @@ const useFlashlightPager = (
               store,
               data,
               schema,
-              zoomValue
+              zoomValue,
+              cacheSamples
             );
 
             subscription.unsubscribe();
@@ -92,7 +113,7 @@ const useFlashlightPager = (
         });
       });
     };
-  }, [environment, handleError, page, schema, store, zoom]);
+  }, [cacheSamples, environment, handleError, page, schema, store, zoom]);
 
   const ref = useRef<FlashlightConfig<number>["get"]>(pager);
   ref.current = pager;

--- a/app/packages/state/src/recoil/aggregations.test.ts
+++ b/app/packages/state/src/recoil/aggregations.test.ts
@@ -93,3 +93,250 @@ describe("test aggregation path accumulation", () => {
     expect(testAggregations()).toStrictEqual([]);
   });
 });
+
+describe("deriveAggregation", () => {
+  const FLOAT = { ftype: "fiftyone.core.fields.FloatField" };
+  const INT = { ftype: "fiftyone.core.fields.IntField" };
+  const STRING = { ftype: "fiftyone.core.fields.StringField" };
+  const OBJECT_ID = { ftype: "fiftyone.core.fields.ObjectIdField" };
+  const BOOL = { ftype: "fiftyone.core.fields.BooleanField" };
+  const EMB_DOC = {
+    ftype: "fiftyone.core.fields.EmbeddedDocumentField",
+  };
+  const LIST_STR = {
+    ftype: "fiftyone.core.fields.ListField",
+    subfield: "fiftyone.core.fields.StringField",
+  };
+
+  it("scalar Classification: count=1, derives label/confidence", () => {
+    const sample = {
+      alexnet: { label: "car", confidence: 0.42 },
+    };
+    expect(aggregations.deriveAggregation("alexnet", sample, EMB_DOC)).toEqual({
+      __typename: "DataAggregation",
+      path: "alexnet",
+      count: 1,
+    });
+    expect(
+      aggregations.deriveAggregation("alexnet.label", sample, STRING)
+    ).toEqual({
+      __typename: "StringAggregation",
+      path: "alexnet.label",
+      count: 1,
+      exists: 1,
+      values: [{ value: "car", count: 1 }],
+    });
+    expect(
+      aggregations.deriveAggregation("alexnet.confidence", sample, FLOAT)
+    ).toEqual({
+      __typename: "FloatAggregation",
+      path: "alexnet.confidence",
+      count: 1,
+      exists: 1,
+      inf: 0,
+      ninf: 0,
+      nan: 0,
+      min: 0.42,
+      max: 0.42,
+    });
+  });
+
+  it("list of embedded docs: count=list length; nested leaf agg traverses list", () => {
+    const sample = {
+      detections: {
+        detections: [
+          { label: "car", confidence: 0.8 },
+          { label: "truck", confidence: 0.6 },
+          { label: "car", confidence: 0.5 },
+        ],
+      },
+    };
+    expect(
+      aggregations.deriveAggregation("detections.detections", sample, {
+        ftype: "fiftyone.core.fields.ListField",
+        subfield: "fiftyone.core.fields.EmbeddedDocumentField",
+      })
+    ).toEqual({
+      __typename: "DataAggregation",
+      path: "detections.detections",
+      count: 3,
+    });
+    expect(
+      aggregations.deriveAggregation(
+        "detections.detections.label",
+        sample,
+        STRING
+      )
+    ).toEqual({
+      __typename: "StringAggregation",
+      path: "detections.detections.label",
+      count: 3,
+      exists: 3,
+      values: [
+        { value: "car", count: 2 },
+        { value: "truck", count: 1 },
+      ],
+    });
+    expect(
+      aggregations.deriveAggregation(
+        "detections.detections.confidence",
+        sample,
+        FLOAT
+      )
+    ).toMatchObject({
+      __typename: "FloatAggregation",
+      count: 3,
+      min: 0.5,
+      max: 0.8,
+    });
+  });
+
+  it("ListField<StringField> like top-level tags", () => {
+    expect(
+      aggregations.deriveAggregation("tags", { tags: [] }, LIST_STR)
+    ).toEqual({
+      __typename: "StringAggregation",
+      path: "tags",
+      count: 0,
+      exists: 0,
+      values: [],
+    });
+    expect(
+      aggregations.deriveAggregation(
+        "tags",
+        { tags: ["a", "b", "a"] },
+        LIST_STR
+      )
+    ).toEqual({
+      __typename: "StringAggregation",
+      path: "tags",
+      count: 3,
+      exists: 3,
+      values: [
+        { value: "a", count: 2 },
+        { value: "b", count: 1 },
+      ],
+    });
+  });
+
+  it("FloatAggregation: NaN/Inf/-Inf are counted separately and excluded from min/max", () => {
+    const sample = {
+      detections: {
+        detections: [
+          { score: 1.0 },
+          { score: Number.NaN },
+          { score: Number.POSITIVE_INFINITY },
+          { score: Number.NEGATIVE_INFINITY },
+          { score: 3.5 },
+        ],
+      },
+    };
+    expect(
+      aggregations.deriveAggregation(
+        "detections.detections.score",
+        sample,
+        FLOAT
+      )
+    ).toEqual({
+      __typename: "FloatAggregation",
+      path: "detections.detections.score",
+      count: 5,
+      exists: 5,
+      inf: 1,
+      ninf: 1,
+      nan: 1,
+      min: 1.0,
+      max: 3.5,
+    });
+  });
+
+  it("IntAggregation: tracks min/max across leaves", () => {
+    const sample = {
+      detections: {
+        detections: [{ index: 0 }, { index: 5 }, { index: 2 }],
+      },
+    };
+    expect(
+      aggregations.deriveAggregation("detections.detections.index", sample, INT)
+    ).toEqual({
+      __typename: "IntAggregation",
+      path: "detections.detections.index",
+      count: 3,
+      exists: 3,
+      min: 0,
+      max: 5,
+    });
+  });
+
+  it("BooleanAggregation: counts true vs false", () => {
+    const sample = {
+      detections: {
+        detections: [{ flag: true }, { flag: false }, { flag: true }],
+      },
+    };
+    expect(
+      aggregations.deriveAggregation("detections.detections.flag", sample, BOOL)
+    ).toEqual({
+      __typename: "BooleanAggregation",
+      path: "detections.detections.flag",
+      count: 3,
+      exists: 3,
+      true: 2,
+      false: 1,
+    });
+  });
+
+  it("ObjectIdField is aggregated as StringAggregation", () => {
+    const sample = {
+      detections: {
+        detections: [{ _id: "abc" }, { _id: "def" }, { _id: "abc" }],
+      },
+    };
+    expect(
+      aggregations.deriveAggregation(
+        "detections.detections._id",
+        sample,
+        OBJECT_ID
+      )
+    ).toMatchObject({
+      __typename: "StringAggregation",
+      count: 3,
+      values: [
+        { value: "abc", count: 2 },
+        { value: "def", count: 1 },
+      ],
+    });
+  });
+
+  it("missing intermediate doc yields zero counts (not throwing)", () => {
+    const sample = { other_field: "x" };
+    expect(aggregations.deriveAggregation("alexnet", sample, EMB_DOC)).toEqual({
+      __typename: "DataAggregation",
+      path: "alexnet",
+      count: 0,
+    });
+    expect(
+      aggregations.deriveAggregation("alexnet.confidence", sample, FLOAT)
+    ).toEqual({
+      __typename: "FloatAggregation",
+      path: "alexnet.confidence",
+      count: 0,
+      exists: 0,
+      inf: 0,
+      ninf: 0,
+      nan: 0,
+      min: null,
+      max: null,
+    });
+  });
+
+  it("null field info defaults to DataAggregation", () => {
+    expect(
+      aggregations.deriveAggregation("custom_field", { custom_field: 42 }, null)
+    ).toEqual({
+      __typename: "DataAggregation",
+      path: "custom_field",
+      count: 1,
+    });
+  });
+});

--- a/app/packages/state/src/recoil/aggregations.ts
+++ b/app/packages/state/src/recoil/aggregations.ts
@@ -1,4 +1,17 @@
 import * as foq from "@fiftyone/relay";
+import {
+  BOOLEAN_FIELD,
+  DATE_FIELD,
+  DATE_TIME_FIELD,
+  DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
+  EMBEDDED_DOCUMENT_FIELD,
+  FLOAT_FIELD,
+  FRAME_NUMBER_FIELD,
+  INT_FIELD,
+  LIST_FIELD,
+  OBJECT_ID_FIELD,
+  STRING_FIELD,
+} from "@fiftyone/utilities";
 import type { VariablesOf } from "react-relay";
 import type { SerializableParam } from "recoil";
 import { selectorFamily } from "recoil";
@@ -8,6 +21,7 @@ import { refresher } from "./atoms";
 import { config } from "./config";
 import * as filterAtoms from "./filters";
 import {
+  activeModalSidebarSample,
   currentSlices,
   groupId,
   groupSlice,
@@ -81,6 +95,16 @@ export const aggregationQuery = graphQLSelectorFamily<
         return null;
       }
 
+      if (
+        useSidebarSampleId &&
+        sampleIds.length === 1 &&
+        sampleIds[0] &&
+        get(activeModalSidebarSample) &&
+        paths.every((p) => !p.startsWith("frames."))
+      ) {
+        return null;
+      }
+
       mixed =
         (mixed || get(groupStatistics(modal)) === "group") && useSelection;
 
@@ -119,6 +143,183 @@ export const aggregationQuery = graphQLSelectorFamily<
     },
 });
 
+const collectLeaves = (
+  value: unknown,
+  parts: string[],
+  i: number
+): unknown[] => {
+  if (value === null || value === undefined) return [];
+  if (Array.isArray(value)) {
+    return value.flatMap((v) => collectLeaves(v, parts, i));
+  }
+  if (i >= parts.length) return [value];
+  if (typeof value !== "object") return [];
+  return collectLeaves(
+    (value as Record<string, unknown>)[parts[i]],
+    parts,
+    i + 1
+  );
+};
+
+const pickAggType = (ftype?: string, subfield?: string | null): string => {
+  const t = ftype === LIST_FIELD && subfield ? subfield : ftype;
+  switch (t) {
+    case BOOLEAN_FIELD:
+      return "BooleanAggregation";
+    case INT_FIELD:
+    case FRAME_NUMBER_FIELD:
+      return "IntAggregation";
+    case FLOAT_FIELD:
+      return "FloatAggregation";
+    case STRING_FIELD:
+    case OBJECT_ID_FIELD:
+    case DATE_FIELD:
+    case DATE_TIME_FIELD:
+      return "StringAggregation";
+    case EMBEDDED_DOCUMENT_FIELD:
+    case DYNAMIC_EMBEDDED_DOCUMENT_FIELD:
+      return "DataAggregation";
+    default:
+      return "DataAggregation";
+  }
+};
+
+export const deriveAggregation = (
+  path: string,
+  sample: Record<string, unknown>,
+  fieldInfo: { ftype?: string; subfield?: string | null } | null
+): Aggregation => {
+  const parts = path.split(".");
+  const leaves = collectLeaves(sample[parts[0]], parts, 1);
+  const typename = pickAggType(fieldInfo?.ftype, fieldInfo?.subfield ?? null);
+
+  switch (typename) {
+    case "BooleanAggregation": {
+      let count = 0;
+      let trueN = 0;
+      let falseN = 0;
+      for (const v of leaves) {
+        if (typeof v === "boolean") {
+          count++;
+          if (v) trueN++;
+          else falseN++;
+        }
+      }
+      return {
+        __typename: "BooleanAggregation",
+        path,
+        count,
+        exists: count,
+        true: trueN,
+        false: falseN,
+      } as unknown as Aggregation;
+    }
+    case "IntAggregation": {
+      let count = 0;
+      let min: number | null = null;
+      let max: number | null = null;
+      for (const v of leaves) {
+        if (typeof v === "number" && Number.isFinite(v)) {
+          count++;
+          if (min === null || v < min) min = v;
+          if (max === null || v > max) max = v;
+        }
+      }
+      return {
+        __typename: "IntAggregation",
+        path,
+        count,
+        exists: count,
+        min,
+        max,
+      } as unknown as Aggregation;
+    }
+    case "FloatAggregation": {
+      let count = 0;
+      let inf = 0;
+      let ninf = 0;
+      let nan = 0;
+      let min: number | null = null;
+      let max: number | null = null;
+      for (const v of leaves) {
+        if (typeof v !== "number") continue;
+        count++;
+        if (Number.isNaN(v)) nan++;
+        else if (v === Infinity) inf++;
+        else if (v === -Infinity) ninf++;
+        else {
+          if (min === null || v < min) min = v;
+          if (max === null || v > max) max = v;
+        }
+      }
+      return {
+        __typename: "FloatAggregation",
+        path,
+        count,
+        exists: count,
+        inf,
+        ninf,
+        nan,
+        min,
+        max,
+      } as unknown as Aggregation;
+    }
+    case "StringAggregation": {
+      const counts = new Map<string, number>();
+      let count = 0;
+      for (const v of leaves) {
+        if (typeof v === "string") {
+          count++;
+          counts.set(v, (counts.get(v) ?? 0) + 1);
+        }
+      }
+      return {
+        __typename: "StringAggregation",
+        path,
+        count,
+        exists: count,
+        values: Array.from(counts.entries()).map(([value, c]) => ({
+          count: c,
+          value,
+        })),
+      } as unknown as Aggregation;
+    }
+    default: {
+      let cur: unknown = sample;
+      for (const part of parts) {
+        if (cur === null || cur === undefined) {
+          cur = undefined;
+          break;
+        }
+        if (Array.isArray(cur)) {
+          cur = cur.flatMap((x) =>
+            x &&
+            typeof x === "object" &&
+            (x as Record<string, unknown>)[part] !== undefined
+              ? [(x as Record<string, unknown>)[part]]
+              : []
+          );
+        } else if (typeof cur === "object") {
+          cur = (cur as Record<string, unknown>)[part];
+        } else {
+          cur = undefined;
+          break;
+        }
+      }
+      let count = 0;
+      if (cur !== null && cur !== undefined) {
+        if (Array.isArray(cur)) count = cur.length;
+        else count = 1;
+      }
+      return {
+        __typename: "DataAggregation",
+        path,
+        count,
+      } as unknown as Aggregation;
+    }
+  }
+};
+
 export const aggregations = selectorFamily({
   key: "aggregations",
   get:
@@ -134,6 +335,25 @@ export const aggregations = selectorFamily({
         let extended = params.extended;
         if (extended && !get(filterAtoms.hasFilters(params.modal))) {
           extended = false;
+        }
+
+        const useSidebarSampleId =
+          params.modal && !get(groupId) && !params.mixed;
+        if (
+          useSidebarSampleId &&
+          params.paths.every((p) => !p.startsWith("frames."))
+        ) {
+          const sid = get(sidebarSampleId);
+          const sampleDoc = sid ? get(activeModalSidebarSample) : null;
+          if (sampleDoc) {
+            return params.paths.map((path) =>
+              deriveAggregation(
+                path,
+                sampleDoc as unknown as Record<string, unknown>,
+                get(schemaAtoms.field(path))
+              )
+            );
+          }
         }
 
         return get(aggregationQuery({ ...params, extended })) ?? [];

--- a/app/packages/state/src/recoil/dynamicGroups.test.ts
+++ b/app/packages/state/src/recoil/dynamicGroups.test.ts
@@ -57,3 +57,51 @@ describe("handles dynamic groups", () => {
     });
   });
 });
+
+describe("groupByFieldValue reconstruction", () => {
+  const testGroupByFieldValue = <
+    TestSelector<typeof dynamicGroups.groupByFieldValue>
+  >(<unknown>dynamicGroups.groupByFieldValue);
+
+  it("returns server-provided _group as-is", () => {
+    setMockAtoms({
+      modalSample: { sample: { _group: ["scene-1", "CAM_BACK"] } },
+      dynamicGroupParameters: { groupBy: ["scene_id", "sensor_name"] },
+    });
+    expect(testGroupByFieldValue()).toEqual(["scene-1", "CAM_BACK"]);
+  });
+
+  it("reconstructs from array groupBy when _group missing (pagination edge case)", () => {
+    setMockAtoms({
+      modalSample: {
+        sample: { scene_id: "scene-7", sensor_name: "CAM_FRONT" },
+      },
+      dynamicGroupParameters: { groupBy: ["scene_id", "sensor_name"] },
+    });
+    expect(testGroupByFieldValue()).toEqual(["scene-7", "CAM_FRONT"]);
+  });
+
+  it("reconstructs from string groupBy when _group missing", () => {
+    setMockAtoms({
+      modalSample: { sample: { scene_id: "scene-7" } },
+      dynamicGroupParameters: { groupBy: "scene_id" },
+    });
+    expect(testGroupByFieldValue()).toEqual("scene-7");
+  });
+
+  it("returns null when no dynamicGroupParameters present", () => {
+    setMockAtoms({
+      modalSample: { sample: { _id: "abc" } },
+      dynamicGroupParameters: null,
+    });
+    expect(testGroupByFieldValue()).toBeNull();
+  });
+
+  it("returns null when modalSample is unavailable", () => {
+    setMockAtoms({
+      modalSample: null,
+      dynamicGroupParameters: { groupBy: "scene_id" },
+    });
+    expect(testGroupByFieldValue()).toBeNull();
+  });
+});

--- a/app/packages/state/src/recoil/dynamicGroups.ts
+++ b/app/packages/state/src/recoil/dynamicGroups.ts
@@ -138,7 +138,18 @@ export const imaVidLookerState = atomFamily<any, string>({
 export const groupByFieldValue = selector({
   key: "groupByFieldValue",
   get: ({ get }) => {
-    return get(modalSample)?.sample?._group ?? null;
+    const sample = get(modalSample)?.sample;
+    if (!sample) return null;
+    const grp = sample._group;
+    if (grp !== undefined && grp !== null) return grp;
+    // Pagination edges omit server-derived _group; reconstruct from groupBy spec.
+    const params = get(dynamicGroupParameters);
+    const groupBy = (params as { groupBy?: string | string[] } | null)?.groupBy;
+    if (!groupBy) return null;
+    if (Array.isArray(groupBy)) {
+      return groupBy.map((f) => (sample as Record<string, unknown>)[f]);
+    }
+    return (sample as Record<string, unknown>)[groupBy] ?? null;
   },
 });
 

--- a/app/packages/state/src/recoil/modal.ts
+++ b/app/packages/state/src/recoil/modal.ts
@@ -1,6 +1,6 @@
 import { PointInfo, type Sample } from "@fiftyone/looker";
 import { mainSample, mainSampleQuery } from "@fiftyone/relay";
-import { atom, selector } from "recoil";
+import { atom, atomFamily, selector } from "recoil";
 import { graphQLSelector } from "recoil-relay";
 import { VariablesOf } from "relay-runtime";
 import type { Lookers } from "../hooks";
@@ -148,12 +148,19 @@ export const nullableModalSampleId = selector<string>({
   },
 });
 
-export const modalSample = graphQLSelector<
+// Lets modalSample skip mainSampleQuery when pagination already has the doc.
+export const cachedSampleById = atomFamily<ModalSample | null, string>({
+  key: "cachedSampleById",
+  default: null,
+  dangerouslyAllowMutability: true,
+});
+
+const modalSampleFromQuery = graphQLSelector<
   VariablesOf<mainSampleQuery>,
-  ModalSample
+  ModalSample | null
 >({
   environment: RelayEnvironmentKey,
-  key: "modalSample",
+  key: "modalSampleFromQuery",
   query: mainSample,
   mapResponse: (data: ModalSampleResponse, { variables }) => {
     if (!data.sample) {
@@ -175,6 +182,9 @@ export const modalSample = graphQLSelector<
 
     if (current === null) return null;
 
+    // Cache hit: skip network entirely.
+    if (get(cachedSampleById(current.id))) return null;
+
     const slice = get(groupSlice);
     const sliceSelect = get(modalGroupSlice);
 
@@ -193,6 +203,25 @@ export const modalSample = graphQLSelector<
       },
     };
   },
+});
+
+export const modalSample = selector<ModalSample>({
+  key: "modalSample",
+  get: ({ get }) => {
+    const current = get(modalSelector);
+    if (!current) {
+      throw new Error("modal sample is not defined");
+    }
+    const cached = get(cachedSampleById(current.id));
+    if (cached) return cached;
+
+    const fromQuery = get(modalSampleFromQuery);
+    if (!fromQuery) {
+      throw new SampleNotFound(`sample with id ${current.id} not found`);
+    }
+    return fromQuery;
+  },
+  dangerouslyAllowMutability: true,
 });
 
 export const tooltipCoordinates = atom<ComputeCoordinatesReturnType | null>({


### PR DESCRIPTION
## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

  Eliminate redundant GraphQL requests when navigating samples in the dynamic-group / imavid sample modal. Previously, every click in the carousel or "next sample" arrow fired 4 GraphQL requests (mainSampleQuery, aggregationsQuery, and two paginateSamplesQuery calls) — even when the clicked sample's data was already in the pagination cache. After
  this change, navigating to a sample whose data is already loaded fires 0 GraphQL requests.


## 🧪 How is this patch tested? If it is not, please explain why.

- Before

https://github.com/user-attachments/assets/ba3576d6-1b93-4a2d-b024-5ea32be9ec63



- After

https://github.com/user-attachments/assets/22f25645-ca98-45f4-be2c-48559244b1ce



## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added client-side sample caching to optimize pagination and modal loading performance.
  * Implemented client-side aggregation calculations for faster, more responsive result filtering.

* **Improvements**
  * Enhanced modal navigation stability and responsiveness when working with dynamic groups.
  * Reduced unnecessary network requests through intelligent cache utilization.

* **Tests**
  * Expanded test coverage for aggregation logic and dynamic group selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->