### PR TITLE
chore(ci): skip CodeRabbit review on automated release-merge PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -33,11 +33,12 @@ reviews:
   auto_review:
     enabled: true
     ignore_title_keywords:
-      - "WIP"
+      - "AUTOMATED MERGE"
       - "DO NOT MERGE"
       - "DRAFT"
       - "MERGE OSS"
       - "OSS MERGE"
+      - "WIP"
     drafts: false
     base_branches:
       - "develop"

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -31,6 +31,6 @@ jobs:
           author: voxel51-bot <bot@voxel51.com>
           token: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
           base: develop
-          body: Merge `${{ inputs.ref_name || github.ref_name }}` to `develop`
+          body: AUTOMATED MERGE `${{ inputs.ref_name || github.ref_name }}` to `develop`
           branch: merge/${{ inputs.ref_name || github.ref_name }}
-          title: Merge `${{ inputs.ref_name || github.ref_name }}` to `develop`
+          title: AUTOMATED MERGE `${{ inputs.ref_name || github.ref_name }}` to `develop`


### PR DESCRIPTION
## Summary

CodeRabbit was reviewing the bot-created release→develop merge PRs (e.g. #7612) because they target `develop`, which matches `auto_review.base_branches` in `.coderabbit.yaml`. The existing `ignore_title_keywords` list didn't cover the auto-generated title.

- `.github/workflows/push-release.yml`: prefix the auto PR title/body with `AUTOMATED MERGE`.
- `.coderabbit.yaml`: add `AUTOMATED MERGE` to `ignore_title_keywords` and alphabetize the list.

## Test plan
- [ ] Next push to a `release/v*` branch (or manual `workflow_dispatch` of `Push Release`) creates a PR titled `AUTOMATED MERGE \`release/vX.Y.Z\` to \`develop\``.
- [ ] CodeRabbit does not auto-review that PR (no walkthrough/summary comment).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation configuration for improved merge process handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7618?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->