### PR TITLE
Dynamic tile titles + camera source dropdown + per-(tick, topic) prefetch

### DIFF
--- a/app/packages/multimodal/src/adapters/mcap/react/McapCameraTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapCameraTile.tsx
@@ -1,14 +1,17 @@
-import { TileSettingsContent } from "@fiftyone/tiling";
+import { TileSettingsContent, useSetTileTitle } from "@fiftyone/tiling";
 import {
   Checkbox,
-  Select,
+  Dropdown,
+  DropdownAnchor,
+  DropdownTrigger,
+  MenuTextItem,
   Size,
   Spinner,
   Text,
   TextColor,
   TextVariant,
 } from "@voxel51/voodo";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
 import type { EncodedImageVisualization } from "../../../decoders";
 import { useSceneSourcesByType } from "../../../scene-inventory";
 import { ImagePanel } from "../../../visualization/panels/image";
@@ -19,19 +22,21 @@ import { useMcapTopicStream } from "./use-mcap-topic-stream";
 const McapCameraTile: React.FC = () => {
   const [topic, setTopic] = useState<string | null>(null);
   const cameras = useSceneSourcesByType("camera");
+  const setTileTitle = useSetTileTitle();
 
   // Auto-bind to the first available camera the first time we render
   // with one available and nothing chosen yet.
   useEffect(() => {
     if (topic !== null || cameras.length === 0) return;
-    setTopic(cameras[0]?.id ?? null);
-  }, [cameras, topic]);
+    const first = cameras[0];
+    if (!first) return;
+    setTopic(first.id);
+    setTileTitle(first.label);
+  }, [cameras, topic, setTileTitle]);
 
   const frame = useMcapTopicStream<EncodedImageVisualization>(topic ?? "");
-  const options = useMemo(
-    () => cameras.map((c) => ({ id: c.id, data: { label: c.label } })),
-    [cameras]
-  );
+  const currentLabel =
+    cameras.find((c) => c.id === topic)?.label ?? "Select source";
 
   return (
     <>
@@ -41,11 +46,22 @@ const McapCameraTile: React.FC = () => {
             <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
               Source
             </Text>
-            <Select
-              options={options}
-              value={topic ?? ""}
-              onChange={(v) => setTopic((v as string) || null)}
-            />
+            <Dropdown
+              anchor={DropdownAnchor.BottomStart}
+              trigger={<DropdownTrigger>{currentLabel}</DropdownTrigger>}
+            >
+              {cameras.map((c) => (
+                <MenuTextItem
+                  key={c.id}
+                  onClick={() => {
+                    setTopic(c.id);
+                    setTileTitle(c.label);
+                  }}
+                >
+                  {c.label}
+                </MenuTextItem>
+              ))}
+            </Dropdown>
           </div>
           <Checkbox label="Show overlays" defaultChecked />
           <Checkbox label="Show bounding boxes" />

--- a/app/packages/multimodal/src/adapters/mcap/react/McapLidarTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapLidarTile.tsx
@@ -1,14 +1,17 @@
-import { TileSettingsContent } from "@fiftyone/tiling";
+import { TileSettingsContent, useSetTileTitle } from "@fiftyone/tiling";
 import {
   Checkbox,
-  Select,
+  Dropdown,
+  DropdownAnchor,
+  DropdownTrigger,
+  MenuTextItem,
   Size,
   Spinner,
   Text,
   TextColor,
   TextVariant,
 } from "@voxel51/voodo";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
 import type { PointCloudVisualization } from "../../../decoders";
 import { useSceneSourcesByType } from "../../../scene-inventory";
 import { PointCloudPanel } from "../../../visualization/panels/point-cloud";
@@ -19,17 +22,19 @@ import { useMcapTopicStream } from "./use-mcap-topic-stream";
 const McapLidarTile: React.FC = () => {
   const [topic, setTopic] = useState<string | null>(null);
   const lidars = useSceneSourcesByType("lidar");
+  const setTileTitle = useSetTileTitle();
 
   useEffect(() => {
     if (topic !== null || lidars.length === 0) return;
-    setTopic(lidars[0]?.id ?? null);
-  }, [lidars, topic]);
+    const first = lidars[0];
+    if (!first) return;
+    setTopic(first.id);
+    setTileTitle(first.label);
+  }, [lidars, topic, setTileTitle]);
 
   const frame = useMcapTopicStream<PointCloudVisualization>(topic ?? "");
-  const options = useMemo(
-    () => lidars.map((l) => ({ id: l.id, data: { label: l.label } })),
-    [lidars]
-  );
+  const currentLabel =
+    lidars.find((l) => l.id === topic)?.label ?? "Select source";
 
   return (
     <>
@@ -39,11 +44,22 @@ const McapLidarTile: React.FC = () => {
             <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
               Source
             </Text>
-            <Select
-              options={options}
-              value={topic ?? ""}
-              onChange={(v) => setTopic((v as string) || null)}
-            />
+            <Dropdown
+              anchor={DropdownAnchor.BottomStart}
+              trigger={<DropdownTrigger>{currentLabel}</DropdownTrigger>}
+            >
+              {lidars.map((l) => (
+                <MenuTextItem
+                  key={l.id}
+                  onClick={() => {
+                    setTopic(l.id);
+                    setTileTitle(l.label);
+                  }}
+                >
+                  {l.label}
+                </MenuTextItem>
+              ))}
+            </Dropdown>
           </div>
           <Checkbox label="Color by height" defaultChecked />
           <Checkbox label="Show ground plane" />

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-data-stream.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-data-stream.ts
@@ -62,10 +62,44 @@ export function useMcapDataStream({
 
   // Stable refs — read in RAF/subscribe callbacks without closure capture.
   const topicCachesRef = useRef<Map<string, McapTopicCache>>(new Map());
-  const pendingTicksRef = useRef<Set<string>>(new Set());
+  // Pending fetches keyed by tick → set of topics each in-flight request
+  // is covering. Per-topic so a request that omits a newly-subscribed
+  // topic doesn't make collectMissingTicks think that topic is in flight.
+  const pendingTicksRef = useRef<Map<string, Set<string>>>(new Map());
   const lastFrameRef = useRef<Map<string, unknown>>(new Map());
   const indexRef = useRef<McapTimelineIndex | null>(null);
   indexRef.current = index;
+
+  // Pending helpers — wrap the per-tick topic sets so call sites read
+  // like simple predicates instead of repeating the get/has dance.
+  const isTopicPending = (tickKey: string, topic: string): boolean =>
+    pendingTicksRef.current.get(tickKey)?.has(topic) ?? false;
+  const markTopicsPending = (
+    tickKeys: readonly string[],
+    topics: readonly string[]
+  ): void => {
+    const pending = pendingTicksRef.current;
+    for (const key of tickKeys) {
+      let covered = pending.get(key);
+      if (!covered) {
+        covered = new Set();
+        pending.set(key, covered);
+      }
+      for (const t of topics) covered.add(t);
+    }
+  };
+  const clearTopicsPending = (
+    tickKeys: readonly string[],
+    topics: readonly string[]
+  ): void => {
+    const pending = pendingTicksRef.current;
+    for (const key of tickKeys) {
+      const covered = pending.get(key);
+      if (!covered) continue;
+      for (const t of topics) covered.delete(t);
+      if (covered.size === 0) pending.delete(key);
+    }
+  };
 
   // Ensure a cache exists for every known topic.
   useEffect(() => {
@@ -109,14 +143,19 @@ export function useMcapDataStream({
   const fetchBatch = useCallback(
     (ticks: bigint[], activeTopics: string[]) => {
       if (ticks.length === 0 || activeTopics.length === 0 || !source) return;
-      const pending = pendingTicksRef.current;
       const caches = topicCachesRef.current;
 
-      const toFetch = ticks.filter((t) => !pending.has(t.toString()));
+      // Only include a tick if at least one active topic needs it (not
+      // already pending for that topic). A tick that's fully covered by
+      // in-flight requests across every active topic is dropped.
+      const toFetch = ticks.filter((tick) => {
+        const tickKey = tick.toString();
+        return activeTopics.some((t) => !isTopicPending(tickKey, t));
+      });
       if (toFetch.length === 0) return;
 
       const keys = toFetch.map((t) => t.toString());
-      for (const key of keys) pending.add(key);
+      markTopicsPending(keys, activeTopics);
 
       client
         .readSynchronizedMessageBatch({
@@ -145,7 +184,7 @@ export function useMcapDataStream({
         })
         .catch(noop)
         .finally(() => {
-          for (const key of keys) pending.delete(key);
+          clearTopicsPending(keys, activeTopics);
         });
     },
     // streamPolicies is mount-time config — read fresh on every call.
@@ -153,9 +192,9 @@ export function useMcapDataStream({
     [client, source, store]
   );
 
-  // Collect uncached, non-pending ticks in [startSec, endSec] for the active
-  // topic set, capped at MAX_PREFETCH_BATCH. Reads from refs so this works
-  // before/after the engine stream registers.
+  // Collect ticks in [startSec, endSec] where at least one active topic
+  // still needs the data — i.e. not cached and not already pending for
+  // that specific topic. Capped at MAX_PREFETCH_BATCH.
   const collectMissingTicks = useCallback(
     (startSec: number, endSec: number): bigint[] => {
       const currentIndex = indexRef.current;
@@ -163,15 +202,17 @@ export function useMcapDataStream({
       const activeTopics = getActiveTopics();
       if (activeTopics.length === 0) return [];
       const caches = topicCachesRef.current;
-      const pending = pendingTicksRef.current;
       const startNs = currentIndex.secToNs(startSec);
       const endNs = currentIndex.secToNs(endSec);
       const toFetch: bigint[] = [];
       for (const tick of currentIndex.ticks) {
         if (tick < startNs) continue;
         if (tick > endNs) break;
-        const allCached = activeTopics.every((t) => caches.get(t)?.has(tick));
-        if (!allCached && !pending.has(tick.toString())) toFetch.push(tick);
+        const tickKey = tick.toString();
+        const needsFetch = activeTopics.some(
+          (t) => !caches.get(t)?.has(tick) && !isTopicPending(tickKey, t)
+        );
+        if (needsFetch) toFetch.push(tick);
         if (toFetch.length >= MAX_PREFETCH_BATCH) break;
       }
       return toFetch;
@@ -212,7 +253,6 @@ export function useMcapDataStream({
 
     const nativeStep = 1 / DEFAULT_MCAP_TIMELINE_TICK_RATE_HZ;
     const caches = topicCachesRef.current;
-    const pending = pendingTicksRef.current;
     const lastFrame = lastFrameRef.current;
 
     const stream: PlaybackStream = {
@@ -227,9 +267,19 @@ export function useMcapDataStream({
         if (!tick) return "missing";
         const activeTopics = getActiveTopics();
         if (activeTopics.length === 0) return "ready";
-        if (activeTopics.every((t) => caches.get(t)?.has(tick))) return "ready";
-        if (pending.has(tick.toString())) return "loading";
-        return "missing";
+        const tickKey = tick.toString();
+        let allCached = true;
+        let everyMissingIsPending = true;
+        for (const t of activeTopics) {
+          if (caches.get(t)?.has(tick)) continue;
+          allCached = false;
+          if (!isTopicPending(tickKey, t)) {
+            everyMissingIsPending = false;
+            break;
+          }
+        }
+        if (allCached) return "ready";
+        return everyMissingIsPending ? "loading" : "missing";
       },
 
       prefetch: ([startSec, endSec]) => {

--- a/app/packages/tiling/src/index.ts
+++ b/app/packages/tiling/src/index.ts
@@ -19,9 +19,12 @@ export type {
 // --- Per-tile state -------------------------------------------------------
 export { registeredTilesAtom, tileSelectionAtom } from "./lib/atoms";
 export {
-  useTileSelection,
   useSetTileSelection,
+  useSetTileTitle,
+  useTileSelection,
   useTileSelectionFor,
+  useTileTitle,
+  useTileTitleFor,
   useTileTypes,
 } from "./lib/use-tile-state";
 export { useRegisteredTiles } from "./lib/use-registered-tiles";

--- a/app/packages/tiling/src/lib/TilingProvider.tsx
+++ b/app/packages/tiling/src/lib/TilingProvider.tsx
@@ -77,6 +77,27 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
   const [settingsSlotEl, setSettingsSlotEl] = useState<HTMLElement | null>(
     null
   );
+  // Per-tile title overrides — published by tile bodies (via
+  // `useSetTileTitle`) when they want their chrome/sidebar header to
+  // reflect runtime state instead of the static config title.
+  const [titleOverrides, setTitleOverrides] = useState<
+    Record<string, string>
+  >({});
+  const setTileTitleOverride = useCallback(
+    (tileId: string, title: string | null) => {
+      setTitleOverrides((prev) => {
+        if (title === null) {
+          if (!(tileId in prev)) return prev;
+          const next = { ...prev };
+          delete next[tileId];
+          return next;
+        }
+        if (prev[tileId] === title) return prev;
+        return { ...prev, [tileId]: title };
+      });
+    },
+    []
+  );
   // Seed the counter past any `<prefix>-<n>` suffix in the initial tiles,
   // so the first `addTile("camera", ...)` against `{ "camera-1": ... }`
   // produces `camera-2` instead of colliding with `camera-1`. Walks every
@@ -87,6 +108,10 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
       return m ? Math.max(max, Number(m[1])) : max;
     }, 0) + 1
   );
+  // Always-current ref so autoLayout stays referentially stable — avoids
+  // stale captures in useMemo dependency-suppressed consumers (TilingHeader).
+  const tilesRef = useRef(tiles);
+  tilesRef.current = tiles;
 
   /**
    * Layout setter that also reconciles the entries map (drops orphans
@@ -114,6 +139,18 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
         for (const id of idsToRemove) {
           tileSelectionAtom.remove(id);
         }
+        // Also drop any title overrides for removed tiles.
+        setTitleOverrides((prev) => {
+          const next = { ...prev };
+          let changed = false;
+          for (const id of idsToRemove) {
+            if (id in next) {
+              delete next[id];
+              changed = true;
+            }
+          }
+          return changed ? next : prev;
+        });
       }
       setFocusedTileId((current) =>
         current && presentIds.has(current) ? current : null
@@ -159,6 +196,8 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
       // Release the per-tile atomFamily entry so the store doesn't
       // grow unbounded across long sessions.
       tileSelectionAtom.remove(id);
+      // Drop any title override for the removed tile too.
+      setTileTitleOverride(id, null);
     },
     []
   );
@@ -168,8 +207,10 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
     // entry can exist in `tiles` without being placed in the tree
     // yet (e.g. when `initialLayout` is null or partial), and we
     // don't want auto-layout to silently drop it.
-    setLayoutState(autoLayoutFn(Object.keys(tiles)));
-  }, [tiles]);
+    // Read from ref so this callback stays stable across tile additions,
+    // avoiding stale captures in useMemo consumers that suppress deps.
+    setLayoutState(autoLayoutFn(Object.keys(tilesRef.current)));
+  }, []);
 
   const value = useMemo<TilingContextValue>(
     () => ({
@@ -183,6 +224,8 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
       autoLayout,
       settingsSlotEl,
       setSettingsSlotEl,
+      titleOverrides,
+      setTileTitleOverride,
     }),
     [
       layout,
@@ -192,6 +235,8 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
       addTile,
       removeTile,
       autoLayout,
+      titleOverrides,
+      setTileTitleOverride,
       settingsSlotEl,
     ]
   );

--- a/app/packages/tiling/src/lib/types.ts
+++ b/app/packages/tiling/src/lib/types.ts
@@ -69,4 +69,14 @@ export interface TilingContextValue {
    */
   settingsSlotEl: HTMLElement | null;
   setSettingsSlotEl: (el: HTMLElement | null) => void;
+
+  /**
+   * Per-tile title overrides. A tile body calls `useSetTileTitle(...)`
+   * when its content makes the static `MosaicTileConfig.title` stale —
+   * for example, when the user picks a different source in settings.
+   * Header consumers (the tile chrome + the settings sidebar header)
+   * read the override and fall back to the static title when absent.
+   */
+  titleOverrides: Record<string, string>;
+  setTileTitleOverride: (tileId: string, title: string | null) => void;
 }

--- a/app/packages/tiling/src/lib/use-tile-state.ts
+++ b/app/packages/tiling/src/lib/use-tile-state.ts
@@ -1,7 +1,7 @@
 import { useAtomValue, useSetAtom } from "jotai";
 import { useCallback } from "react";
 import { registeredTilesAtom, tileSelectionAtom } from "./atoms";
-import { useTileId } from "./TilingProvider";
+import { useTileId, useTiling } from "./TilingProvider";
 import type { RegisteredTile } from "./types";
 
 // Stable placeholder so atomFamily doesn't churn when a component is
@@ -47,6 +47,45 @@ export function useTileSelectionFor<T = unknown>(
   tileId: string | null
 ): T | null {
   return useAtomValue(tileSelectionAtom(tileId ?? NO_TILE)) as T | null;
+}
+
+/**
+ * Read the title override for the surrounding tile. Returns `null`
+ * when nothing has been published — callers fall back to the static
+ * `MosaicTileConfig.title`.
+ */
+export function useTileTitle(): string | null {
+  const tileId = useTileId();
+  const { titleOverrides } = useTiling();
+  return tileId ? (titleOverrides[tileId] ?? null) : null;
+}
+
+/**
+ * Read the title override for an explicit `tileId` — used by surfaces
+ * outside a `TileIdScope` (the header in `TileSettingsSidebar`).
+ * Pass `null` when no tile is focused.
+ */
+export function useTileTitleFor(tileId: string | null): string | null {
+  const { titleOverrides } = useTiling();
+  return tileId ? (titleOverrides[tileId] ?? null) : null;
+}
+
+/**
+ * Setter for the surrounding tile's title override. Pass `null` to
+ * revert the header back to the static `MosaicTileConfig.title`. Use
+ * this from a tile body when its content makes the original title
+ * stale (e.g. the user picks a different source in the settings UI).
+ */
+export function useSetTileTitle(): (title: string | null) => void {
+  const tileId = useTileId();
+  const { setTileTitleOverride } = useTiling();
+  return useCallback(
+    (title: string | null) => {
+      if (!tileId) return;
+      setTileTitleOverride(tileId, title);
+    },
+    [tileId, setTileTitleOverride]
+  );
 }
 
 /**

--- a/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.tsx
+++ b/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.tsx
@@ -44,7 +44,6 @@ export interface MosaicGridProps {
 }
 
 interface TileWindowProps {
-  id: string;
   path: MosaicBranch[];
   tile: MosaicTileConfig;
   isFocused: boolean;
@@ -54,7 +53,6 @@ interface TileWindowProps {
 }
 
 const TileWindow: React.FC<TileWindowProps> = ({
-  id,
   path,
   tile,
   isFocused,
@@ -179,7 +177,6 @@ const MosaicGrid: React.FC<MosaicGridProps> = ({
     return (
       <TileIdScope tileId={id}>
         <TileWindow
-          id={id}
           path={path}
           tile={tile}
           isFocused={isFocused}

--- a/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.tsx
+++ b/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.tsx
@@ -11,6 +11,7 @@ import {
 } from "react-mosaic-component";
 import "react-mosaic-component/react-mosaic-component.css";
 import { TileIdScope } from "../../lib/TilingProvider";
+import { useTileTitle } from "../../lib/use-tile-state";
 import { TileHeader } from "../Tile/Tile";
 import styles from "./MosaicGrid.module.css";
 
@@ -41,6 +42,53 @@ export interface MosaicGridProps {
   onFocusTile?: (id: string) => void;
   className?: string;
 }
+
+interface TileWindowProps {
+  id: string;
+  path: MosaicBranch[];
+  tile: MosaicTileConfig;
+  isFocused: boolean;
+  onFocus: () => void;
+  onClose: () => void;
+  onFullscreen: () => void;
+}
+
+const TileWindow: React.FC<TileWindowProps> = ({
+  id,
+  path,
+  tile,
+  isFocused,
+  onFocus,
+  onClose,
+  onFullscreen,
+}) => {
+  const titleOverride = useTileTitle();
+  const title = titleOverride ?? tile.title;
+  return (
+    <MosaicWindow<string>
+      path={path}
+      title={title}
+      toolbarControls={[]}
+      className={isFocused ? styles.focused : undefined}
+      renderToolbar={() => (
+        // react-mosaic's react-dnd integration needs a native DOM node at
+        // the toolbar root to attach the drag source ref. TileHeader is a
+        // React FC, so we wrap it in a plain div the connector can grab.
+        <div className={styles.toolbarHeader}>
+          <TileHeader
+            title={title}
+            onClose={onClose}
+            onFullscreen={onFullscreen}
+          />
+        </div>
+      )}
+    >
+      <div className={styles.bodyWrapper} onPointerDown={onFocus}>
+        {tile.render()}
+      </div>
+    </MosaicWindow>
+  );
+};
 
 /**
  * Draggable, resizable grid layout wrapping `react-mosaic-component`.
@@ -129,30 +177,17 @@ const MosaicGrid: React.FC<MosaicGridProps> = ({
     };
 
     return (
-      <MosaicWindow<string>
-        path={path}
-        title={tile.title}
-        toolbarControls={[]}
-        className={isFocused ? styles.focused : undefined}
-        renderToolbar={() => (
-          // react-mosaic's react-dnd integration needs a native DOM node at
-          // the toolbar root to attach the drag source ref. TileHeader is a
-          // React FC, so we wrap it in a plain div the connector can grab.
-          <div className={styles.toolbarHeader}>
-            <TileHeader
-              title={tile.title}
-              onClose={handleClose}
-              onFullscreen={handleFullscreen}
-            />
-          </div>
-        )}
-      >
-        <TileIdScope tileId={id}>
-          <div className={styles.bodyWrapper} onPointerDown={focus}>
-            {tile.render()}
-          </div>
-        </TileIdScope>
-      </MosaicWindow>
+      <TileIdScope tileId={id}>
+        <TileWindow
+          id={id}
+          path={path}
+          tile={tile}
+          isFocused={isFocused}
+          onFocus={focus}
+          onClose={handleClose}
+          onFullscreen={handleFullscreen}
+        />
+      </TileIdScope>
     );
   };
 

--- a/app/packages/tiling/src/views/TileSettingsSidebar/TileSettingsSidebar.tsx
+++ b/app/packages/tiling/src/views/TileSettingsSidebar/TileSettingsSidebar.tsx
@@ -1,13 +1,18 @@
 import { Text, TextColor, TextVariant } from "@voxel51/voodo";
 import React, { useCallback } from "react";
 import { useTiling } from "../../lib/TilingProvider";
+import { useTileTitleFor } from "../../lib/use-tile-state";
 import SidebarPanel from "../SidebarPanel/SidebarPanel";
 
 /**
  * Left-hand sidebar that hosts the focused tile's settings UI. Owns
  * the portal target — the tile body's `<TileSettingsContent>` portals
  * its children here when this tile is focused. Renders the empty
- * state hint when no tile is focused or focused tile has no settings.
+ * state hint when no tile is focused.
+ *
+ * The header reflects the tile's runtime title — if the body has
+ * published an override via `useSetTileTitle`, the override wins;
+ * otherwise the static `tile.title` is used.
  */
 const TileSettingsSidebar: React.FC = () => {
   const { focusedTileId, tiles, setSettingsSlotEl } = useTiling();
@@ -15,7 +20,10 @@ const TileSettingsSidebar: React.FC = () => {
   // mid-render or the consumer's layout state races ahead of the registry.
   const focusedTile =
     focusedTileId && tiles[focusedTileId] ? tiles[focusedTileId] : null;
-  const title = focusedTile ? `Settings: ${focusedTile.title}` : "Settings";
+  const titleOverride = useTileTitleFor(focusedTileId);
+  const title = focusedTile
+    ? `Settings: ${titleOverride ?? focusedTile.title}`
+    : "Settings";
 
   // Stable ref callback so `setSettingsSlotEl` isn't fired on every render.
   const slotRef = useCallback(


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

Stacks on top of #7620 (`feat/mmTimelineWithMiddleware`).

## 📋 What changes are proposed in this pull request?

Three threads of follow-up work on top of the multimodal MCAP middleware PR. Each fixes something I hit while actually using the playback view with a real scene.

### Dynamic tile titles

The tile chrome (and the settings sidebar header) was stuck on the static `MosaicTileConfig.title` set when the tile was spawned. Picking a different camera in settings left the header saying "Camera" forever.

- Tiling holds a per-tile `titleOverrides: Record<string, string>` as plain React state on `TilingProvider` (no atom — title swaps aren't realtime).
- `useSetTileTitle()` / `useTileTitle()` / `useTileTitleFor(tileId)` read/write the override; the `MosaicGrid` `TileWindow` and `TileSettingsSidebar` use the override before falling back to `tile.title`.
- Title overrides are dropped automatically when the tile is removed (via the same path that frees `tileSelectionAtom`).
- `McapCameraTile` / `McapLidarTile` call `useSetTileTitle(label)` on auto-bind and on every dropdown selection so the chrome stays in sync with the chosen source.

### Camera/Lidar source dropdown

The voodo `<Select>` we were using crashed (`x.some is not a function`) under certain combinations and broke source switching. Replaced with `<Dropdown>` + `<MenuTextItem>` from voodo:

- `currentLabel` mirrors the chosen source as the dropdown trigger.
- Each menu item sets the topic and pushes a title override in one click.
- Same shape on both `McapCameraTile` and `McapLidarTile`.

### `autoLayout` stale-closure fix

`autoLayout` captured `tiles` directly, so any consumer pinning it via a dep-suppressed `useMemo` (e.g. the `TilingHeader` add-tile menu) saw a stale tile set after subsequent additions. Switched to a `tilesRef` so the callback is referentially stable and reads the live tile map at call time.

### Per-(tick, topic) prefetch tracking

When switching camera source mid-stream the new topic wasn't being prefetched. Root cause: pending-fetch tracking in `useMcapDataStream` was keyed only by tick, so if a fetch was already in flight covering the *previous* active topic set, `collectMissingTicks` would skip those ticks and never queue them for the newly-subscribed topic.

- `pendingTicksRef` is now `Map<tickKey, Set<topic>>` — each in-flight request marks every topic it's covering.
- `collectMissingTicks` includes a tick if any active topic is *neither* cached *nor* pending *for that topic*.
- `bufferState` keeps the same semantics (`"ready"` / `"loading"` / `"missing"`) but evaluated per-topic.
- `fetchBatch` marks/clears pending per topic alongside the actual fetch lifecycle.

Net effect: switching source fires a fresh prefetch for the new topic regardless of in-flight requests for older topics.

## 🧪 How is this patch tested? If it is not, please explain why.

- Manually verified with a NuScenes `.mcap`: switching cameras updates the tile header to the new label, the dropdown reflects the active source, the new feed prefetches immediately even mid-playback, and lidar source switches behave the same way.
- `yarn check:types` clean across tiling / playback / multimodal.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes.

N/A — internal multimodal POC; rides on top of #7620.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tiles support runtime title overrides with APIs to read/set per-tile titles
  * Camera and LIDAR tiles auto-select the first available source on initial load and update tile titles

* **UI/UX Improvements**
  * Source selector changed to a menu-style dropdown for camera and LIDAR tiles
  * Mosaic windows and settings now surface overridden titles
  * Improved per-topic loading behavior for more accurate stream states

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->