### PR TITLE
Tiling rework: drop tile sources, portal-based settings, playback consumer migrations

### DIFF
--- a/app/packages/playback/src/__tests__/tile-harness.tsx
+++ b/app/packages/playback/src/__tests__/tile-harness.tsx
@@ -1,24 +1,21 @@
 // Shared providers + tile-registry helper for PlaybackTiles tests.
-// Keeps each per-tile test file small.
 
+import { IconName } from "@voxel51/voodo";
 import {
   TileIdScope,
   TilingProvider,
   useTileRegistry,
+  type RegisteredTile,
 } from "@fiftyone/tiling";
 import { Provider as JotaiProvider, createStore } from "jotai";
 import React, { useEffect, useMemo } from "react";
 import { PlaybackProvider } from "../lib/playback/PlaybackProvider";
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 const DummyTile: React.FC = () => null;
 
 export interface TileRegistration {
-  streamId: string;
   type: string;
   typeLabel?: string;
-  title?: string;
   Tile?: React.ComponentType;
 }
 
@@ -29,16 +26,15 @@ export const RegisterTiles: React.FC<{ entries: TileRegistration[] }> = ({
   // registerTile is a stable jotai-backed setter — not in deps by design.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    const disposes = entries.map((e) =>
-      registerTile({
-        streamId: e.streamId,
+    const disposes = entries.map((e) => {
+      const entry: RegisteredTile = {
         type: e.type,
         typeLabel: e.typeLabel ?? e.type,
-        title: e.title ?? e.streamId,
-        icon: "icon",
+        icon: IconName.GridView,
         Tile: e.Tile ?? DummyTile,
-      })
-    );
+      };
+      return registerTile(entry);
+    });
     return () => {
       for (const d of disposes) d();
     };

--- a/app/packages/playback/src/stories/utils/TileStory.tsx
+++ b/app/packages/playback/src/stories/utils/TileStory.tsx
@@ -1,10 +1,5 @@
-import {
-  Tile,
-  TileIdScope,
-  TilingProvider,
-  useSetTileSourceFor,
-} from "@fiftyone/tiling";
-import React, { useEffect } from "react";
+import { Tile, TileIdScope, TilingProvider } from "@fiftyone/tiling";
+import React from "react";
 import { PlaybackProvider } from "../../lib/playback/PlaybackProvider";
 import { TrackProvider } from "../../lib/tracks/TrackProvider";
 import { useMockStreams, type MockStreamConfig } from "./use-mock-streams";
@@ -13,13 +8,10 @@ const TILE_ID = "story-tile";
 
 /**
  * Wraps a single per-tile story in the full provider stack
- * (`PlaybackProvider` + `TrackProvider` + `TilingProvider`) and registers
- * one mock stream. The bound tile id is fixed (`story-tile`) and pre-set
- * to the stream's id so `useStream` / `useTileSource` / `useTileSettings`
- * inside the tile body resolve to real data instead of placeholders.
- *
- * Per-tile stories should pass their tile body as `children`; the
- * standard chrome (header + bordered content) wraps it automatically.
+ * (`PlaybackProvider` + `TrackProvider` + `TilingProvider`) and
+ * registers one mock stream so the tile body's `useStream` resolves to
+ * real data. The caller is responsible for passing the stream id to
+ * its tile body (`config.id`) via the `children` slot.
  */
 export interface TileStoryProps {
   /** Stream config registered for the duration of the story. */
@@ -29,7 +21,7 @@ export interface TileStoryProps {
   /** Width × height of the tile container. */
   width?: number;
   height?: number;
-  /** The tile body (e.g. `<CameraTile />`). */
+  /** The tile body — typically `<CameraTile streamId={config.id} />`. */
   children: React.ReactNode;
 }
 
@@ -59,21 +51,10 @@ const Inner: React.FC<TileStoryProps> = ({
   children,
 }) => {
   useMockStreams([config]);
-  const setTileSource = useSetTileSourceFor();
-  // setTileSource is a stable jotai-backed setter — not in deps by design.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    setTileSource(TILE_ID, config.id);
-  }, [config.id]);
-
   return (
     <TileIdScope tileId={TILE_ID}>
       <div style={{ width, height }}>
-        <Tile
-          title={title}
-          onClose={() => {}}
-          onFullscreen={() => {}}
-        >
+        <Tile title={title} onClose={() => {}} onFullscreen={() => {}}>
           {children}
         </Tile>
       </div>

--- a/app/packages/playback/src/stories/utils/use-mock-streams.test.tsx
+++ b/app/packages/playback/src/stories/utils/use-mock-streams.test.tsx
@@ -1,5 +1,4 @@
 import { cleanup, render } from "@testing-library/react";
-import { TilingProvider, useRegisteredTiles } from "@fiftyone/tiling";
 import { Provider as JotaiProvider, createStore } from "jotai";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -18,96 +17,83 @@ import { useMockStreams, type MockStreamConfig } from "./use-mock-streams";
 
 const Probe: React.FC<{
   configs: MockStreamConfig[];
-  onReady: (state: {
-    duration: number;
-    tileTypes: string[];
-    tileStreamIds: string[];
-  }) => void;
+  onReady: (state: { duration: number; bundleIds: string[] }) => void;
 }> = ({ configs, onReady }) => {
-  useMockStreams(configs);
+  const bundles = useMockStreams(configs);
   const { duration } = usePlayback();
-  const tiles = useRegisteredTiles();
   React.useEffect(() => {
     onReady({
       duration,
-      tileTypes: tiles.map((t) => t.type),
-      tileStreamIds: tiles.map((t) => t.streamId),
+      bundleIds: bundles.map((b) => b.id),
     });
-  }, [duration, tiles, onReady]);
+  }, [duration, bundles, onReady]);
   return null;
 };
 
 describe("useMockStreams", () => {
   afterEach(() => cleanup());
 
-  it("registers each stream with the playback engine and each tile with the registry", () => {
+  it("registers each stream with the playback engine and returns the bundles", () => {
     const store = createStore();
-    const captured: Array<{
-      duration: number;
-      tileTypes: string[];
-      tileStreamIds: string[];
-    }> = [];
+    const captured: Array<{ duration: number; bundleIds: string[] }> = [];
     render(
       <JotaiProvider store={store}>
         <PlaybackProvider>
-          <TilingProvider>
-            <Probe
-              configs={[
-                { type: "camera", id: "cam_a", title: "Cam A", duration: 8 },
-                { type: "lidar", id: "lid_a", title: "Lid A", duration: 12 },
-              ]}
-              onReady={(s) => captured.push(s)}
-            />
-          </TilingProvider>
+          <Probe
+            configs={[
+              { type: "camera", id: "cam_a", title: "Cam A", duration: 8 },
+              { type: "lidar", id: "lid_a", title: "Lid A", duration: 12 },
+            ]}
+            onReady={(s) => captured.push(s)}
+          />
         </PlaybackProvider>
       </JotaiProvider>
     );
 
-    // The last captured snapshot reflects steady state.
     const last = captured[captured.length - 1];
     expect(last.duration).toBe(12); // max of registered streams
-    expect(last.tileStreamIds).toEqual(["cam_a", "lid_a"]);
-    expect(last.tileTypes).toEqual(["camera", "lidar"]);
+    expect(last.bundleIds).toEqual(["cam_a", "lid_a"]);
   });
 
-  it("unregisters tiles + streams on unmount", () => {
+  it("unregisters streams on unmount", () => {
     const store = createStore();
-    const snapshots: Array<{ tileStreamIds: string[]; duration: number }> = [];
+    const snapshots: Array<{ bundleIds: string[]; duration: number }> = [];
     const { unmount } = render(
       <JotaiProvider store={store}>
         <PlaybackProvider duration={3}>
-          <TilingProvider>
-            <Probe
-              configs={[
-                { type: "camera", id: "cam_a", title: "Cam A", duration: 8 },
-              ]}
-              onReady={(s) => snapshots.push(s)}
-            />
-          </TilingProvider>
+          <Probe
+            configs={[
+              { type: "camera", id: "cam_a", title: "Cam A", duration: 8 },
+            ]}
+            onReady={(s) => snapshots.push(s)}
+          />
         </PlaybackProvider>
       </JotaiProvider>
     );
-    expect(snapshots[snapshots.length - 1].tileStreamIds).toEqual(["cam_a"]);
+    expect(snapshots[snapshots.length - 1].bundleIds).toEqual(["cam_a"]);
 
     unmount();
 
-    // After unmount the tile registry on this store should be empty.
-    let postTiles: string[] = [];
+    // Re-mount a probe with no streams to confirm the engine duration
+    // collapses back to its fallback (no streams registered).
+    let postDuration = -1;
     render(
       <JotaiProvider store={store}>
-        <TilingProvider>
-          <Reader onReady={(t) => (postTiles = t)} />
-        </TilingProvider>
+        <PlaybackProvider duration={3}>
+          <DurationReader onReady={(d) => (postDuration = d)} />
+        </PlaybackProvider>
       </JotaiProvider>
     );
-    expect(postTiles).toEqual([]);
+    expect(postDuration).toBe(3);
   });
 });
 
-const Reader: React.FC<{ onReady: (ids: string[]) => void }> = ({ onReady }) => {
-  const tiles = useRegisteredTiles();
+const DurationReader: React.FC<{ onReady: (d: number) => void }> = ({
+  onReady,
+}) => {
+  const { duration } = usePlayback();
   React.useEffect(() => {
-    onReady(tiles.map((t) => t.streamId));
-  }, [tiles, onReady]);
+    onReady(duration);
+  }, [duration, onReady]);
   return null;
 };

--- a/app/packages/playback/src/stories/utils/use-mock-streams.ts
+++ b/app/packages/playback/src/stories/utils/use-mock-streams.ts
@@ -1,4 +1,3 @@
-import { useTileRegistry } from "@fiftyone/tiling";
 import { useEffect, useMemo } from "react";
 import { usePlayback } from "../../lib/playback/PlaybackProvider";
 import {
@@ -58,23 +57,20 @@ export function buildBundle(config: MockStreamConfig): MockStreamBundle {
 /**
  * Build mock-stream bundles from `configs` and register each one with
  * the surrounding `PlaybackProvider`. Returns the bundles so the caller
- * can:
+ * can build initial tiles or otherwise enumerate "what data exists".
  *
- * - seed `TilingProvider`'s `initialTiles` from them,
- * - drive the add-tile menu from them,
- * - or otherwise enumerate "what data exists right now".
+ * Tile registration is the caller's responsibility — the new tile
+ * model registers one entry per type, not per source, so this hook
+ * stays focused on stream-side wiring.
  *
  * The bundles are built **once on mount** — changing `configs` on
- * subsequent renders does NOT rebuild the streams. This mirrors how
- * `PlaybackProvider` treats its config: provider config is mount-time,
- * so the stream set should be too. Pass a stable configs array, or
- * remount the provider tree to swap streams.
+ * subsequent renders does NOT rebuild the streams. Pass a stable
+ * configs array, or remount the provider tree to swap streams.
  */
 export function useMockStreams(
   configs: MockStreamConfig[]
 ): MockStreamBundle[] {
   const { registerStream } = usePlayback();
-  const { registerTile } = useTileRegistry();
 
   // Built once at mount. The lint suppression is intentional — see the
   // doc comment above for the mount-time-only contract.
@@ -85,22 +81,12 @@ export function useMockStreams(
   );
 
   useEffect(() => {
-    const cleanups = bundles.flatMap((b) => [
-      registerStream(b.stream),
-      registerTile({
-        streamId: b.id,
-        type: b.type,
-        typeLabel: b.typeLabel,
-        title: b.title,
-        icon: b.icon,
-        Tile: b.Tile,
-      }),
-    ]);
+    const cleanups = bundles.map((b) => registerStream(b.stream));
     return () => {
       for (const c of cleanups) c();
     };
-    // registerStream / registerTile are stable hook callbacks; bundles is
-    // the only changing input.
+    // registerStream is a stable hook callback; bundles is the only
+    // changing input.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bundles]);
 

--- a/app/packages/playback/src/views/PlaybackTiles/CameraTile/CameraSettings.tsx
+++ b/app/packages/playback/src/views/PlaybackTiles/CameraTile/CameraSettings.tsx
@@ -1,49 +1,19 @@
-import { Checkbox, Select, Text, TextColor, TextVariant } from "@voxel51/voodo";
-import React, { useMemo } from "react";
-import {
-  useSetTileSource,
-  useTileSourcesByType,
-  useTileSource,
-} from "@fiftyone/tiling";
+import { Checkbox } from "@voxel51/voodo";
+import React from "react";
 import styles from "../tile-settings.module.css";
 
 /**
- * Source picker + per-tile toggles. The picker enumerates every
- * registered camera stream so the user can rebind the focused tile to
- * any of them without spawning a new tile.
+ * Decorative camera settings for the demo. The production MCAP tiles
+ * use `McapCameraSettings`, which sources its dropdown options from
+ * the scene inventory; demo tiles take their stream id via prop so
+ * there's nothing to pick here.
  */
-const CameraSettings: React.FC = () => {
-  const sources = useTileSourcesByType("camera");
-  const sourceId = useTileSource();
-  const setSource = useSetTileSource();
-
-  const options = useMemo(
-    () =>
-      sources.map((s) => ({
-        id: s.streamId,
-        data: { label: s.title },
-      })),
-    [sources]
-  );
-
-  return (
-    <div className={styles.root}>
-      <div className={styles.field}>
-        <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
-          Source
-        </Text>
-        <Select
-          options={options}
-          value={sourceId ?? ""}
-          onChange={(v) => setSource((v as string) || null)}
-        />
-      </div>
-
-      <Checkbox label="Show overlays" defaultChecked />
-      <Checkbox label="Show bounding boxes" />
-      <Checkbox label="Show track ids" />
-    </div>
-  );
-};
+const CameraSettings: React.FC = () => (
+  <div className={styles.root}>
+    <Checkbox label="Show overlays" defaultChecked />
+    <Checkbox label="Show bounding boxes" />
+    <Checkbox label="Show track ids" />
+  </div>
+);
 
 export default CameraSettings;

--- a/app/packages/playback/src/views/PlaybackTiles/CameraTile/CameraTile.stories.tsx
+++ b/app/packages/playback/src/views/PlaybackTiles/CameraTile/CameraTile.stories.tsx
@@ -17,7 +17,7 @@ export const Default: StoryObj = {
         fps: 30,
       }}
     >
-      <CameraTile />
+      <CameraTile streamId="camera_front" />
     </TileStory>
   ),
 };

--- a/app/packages/playback/src/views/PlaybackTiles/CameraTile/CameraTile.tsx
+++ b/app/packages/playback/src/views/PlaybackTiles/CameraTile/CameraTile.tsx
@@ -1,7 +1,6 @@
+import { TileSettingsContent } from "@fiftyone/tiling";
 import React from "react";
 import { useStream } from "../../../lib/playback/use-stream";
-import { useTileSource } from "@fiftyone/tiling";
-import { useTileSettings } from "@fiftyone/tiling";
 import CameraSettings from "./CameraSettings";
 import styles from "./CameraTile.module.css";
 
@@ -11,20 +10,24 @@ interface CameraFrame {
   label?: string;
 }
 
+export interface CameraTileProps {
+  /** Stream id this tile renders. Passed from the story / parent. */
+  streamId: string;
+}
+
 /**
- * Camera tile body — placeholder video pane plus an optional live
- * frame-number / label readout from the tile's bound source stream
- * (selected via the settings sidebar's source picker).
- *
- * Reads its source from the per-tile `tileSourceAtom` so the user can
- * swap which camera feed is bound without remounting the tile.
+ * Camera tile body — placeholder video pane plus a live label readout
+ * from the bound stream. Demo-only: the source is supplied by the
+ * caller (the production MCAP `McapCameraTile` manages its own source
+ * selection via the scene inventory).
  */
-const CameraTile: React.FC = () => {
-  useTileSettings(CameraSettings);
-  const sourceId = useTileSource();
-  const frame = useStream<CameraFrame>(sourceId ?? "");
+const CameraTile: React.FC<CameraTileProps> = ({ streamId }) => {
+  const frame = useStream<CameraFrame>(streamId);
   return (
     <div className={styles.body}>
+      <TileSettingsContent>
+        <CameraSettings />
+      </TileSettingsContent>
       <div className={styles.recIndicator}>
         <span className={styles.recDot} />
         REC
@@ -41,9 +44,7 @@ const CameraTile: React.FC = () => {
           <circle cx="13" cy="16" r="4" />
           <path d="M23 13 L29 9 L29 23 L23 19 Z" />
         </svg>
-        <span>
-          {sourceId && frame?.label ? frame.label : "Camera feed"}
-        </span>
+        <span>{frame?.label ?? "Camera feed"}</span>
       </div>
     </div>
   );

--- a/app/packages/playback/src/views/PlaybackTiles/GraphTile/GraphSettings.tsx
+++ b/app/packages/playback/src/views/PlaybackTiles/GraphTile/GraphSettings.tsx
@@ -1,49 +1,18 @@
-import { Checkbox, Select, Text, TextColor, TextVariant } from "@voxel51/voodo";
-import React, { useMemo } from "react";
-import {
-  useSetTileSource,
-  useTileSourcesByType,
-  useTileSource,
-} from "@fiftyone/tiling";
+import { Checkbox, Text, TextColor, TextVariant } from "@voxel51/voodo";
+import React from "react";
 import styles from "../tile-settings.module.css";
 
-const GraphSettings: React.FC = () => {
-  const sources = useTileSourcesByType("graph");
-  const sourceId = useTileSource();
-  const setSource = useSetTileSource();
+const GraphSettings: React.FC = () => (
+  <div className={styles.root}>
+    <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
+      Series
+    </Text>
+    <Checkbox label="velocity" defaultChecked />
+    <Checkbox label="accel" defaultChecked />
 
-  const options = useMemo(
-    () =>
-      sources.map((s) => ({
-        id: s.streamId,
-        data: { label: s.title },
-      })),
-    [sources]
-  );
-
-  return (
-    <div className={styles.root}>
-      <div className={styles.field}>
-        <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
-          Source
-        </Text>
-        <Select
-          options={options}
-          value={sourceId ?? ""}
-          onChange={(v) => setSource((v as string) || null)}
-        />
-      </div>
-
-      <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
-        Series
-      </Text>
-      <Checkbox label="velocity" defaultChecked />
-      <Checkbox label="accel" defaultChecked />
-
-      <Checkbox label="Show playhead" defaultChecked />
-      <Checkbox label="Smooth lines" />
-    </div>
-  );
-};
+    <Checkbox label="Show playhead" defaultChecked />
+    <Checkbox label="Smooth lines" />
+  </div>
+);
 
 export default GraphSettings;

--- a/app/packages/playback/src/views/PlaybackTiles/GraphTile/GraphTile.tsx
+++ b/app/packages/playback/src/views/PlaybackTiles/GraphTile/GraphTile.tsx
@@ -1,8 +1,7 @@
+import { TileSettingsContent, useSetTileSelection } from "@fiftyone/tiling";
 import React, { useMemo } from "react";
 import { usePlayback } from "../../../lib/playback/PlaybackProvider";
 import { usePlayhead } from "../../../lib/playback/use-playback-state";
-import { useSetTileSelection } from "@fiftyone/tiling";
-import { useTileSettings } from "@fiftyone/tiling";
 import GraphSettings from "./GraphSettings";
 import styles from "./GraphTile.module.css";
 
@@ -13,14 +12,20 @@ const SAMPLE_STEP = 4;
 const clamp = (v: number, lo: number, hi: number) =>
   Math.min(hi, Math.max(lo, v));
 
+export interface GraphTileProps {
+  /** Stream id (currently unused — the chart is closed-form). Accepted
+   *  so the demo story can render the graph tile through the same
+   *  `streamId`-prop interface as the others. */
+  streamId?: string;
+}
+
 /**
  * Graph tile body — two stylized line series with a vertical playhead
  * cursor synced to the current playback time. Clicking the chart both
  * seeks the playhead AND publishes the sample at that time to
  * `tileSelectionAtom` so the inspector sidebar can read it.
  */
-const GraphTile: React.FC = () => {
-  useTileSettings(GraphSettings);
+const GraphTile: React.FC<GraphTileProps> = () => {
   const { samples, path1, path2 } = useMemo(() => buildPaths(), []);
   const playhead = usePlayhead();
   const { duration, seek } = usePlayback();
@@ -54,6 +59,9 @@ const GraphTile: React.FC = () => {
 
   return (
     <div className={styles.body}>
+      <TileSettingsContent>
+        <GraphSettings />
+      </TileSettingsContent>
       <svg
         viewBox={`0 0 ${CHART_VIEWBOX_W} ${CHART_VIEWBOX_H}`}
         className={styles.chart}

--- a/app/packages/playback/src/views/PlaybackTiles/JsonDataTile/JsonDataSettings.tsx
+++ b/app/packages/playback/src/views/PlaybackTiles/JsonDataTile/JsonDataSettings.tsx
@@ -1,43 +1,12 @@
-import { Checkbox, Select, Text, TextColor, TextVariant } from "@voxel51/voodo";
-import React, { useMemo } from "react";
-import {
-  useSetTileSource,
-  useTileSourcesByType,
-  useTileSource,
-} from "@fiftyone/tiling";
+import { Checkbox } from "@voxel51/voodo";
+import React from "react";
 import styles from "../tile-settings.module.css";
 
-const JsonDataSettings: React.FC = () => {
-  const sources = useTileSourcesByType("json");
-  const sourceId = useTileSource();
-  const setSource = useSetTileSource();
-
-  const options = useMemo(
-    () =>
-      sources.map((s) => ({
-        id: s.streamId,
-        data: { label: s.title },
-      })),
-    [sources]
-  );
-
-  return (
-    <div className={styles.root}>
-      <div className={styles.field}>
-        <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
-          Source
-        </Text>
-        <Select
-          options={options}
-          value={sourceId ?? ""}
-          onChange={(v) => setSource((v as string) || null)}
-        />
-      </div>
-
-      <Checkbox label="Pretty-print" defaultChecked />
-      <Checkbox label="Show types" />
-    </div>
-  );
-};
+const JsonDataSettings: React.FC = () => (
+  <div className={styles.root}>
+    <Checkbox label="Pretty-print" defaultChecked />
+    <Checkbox label="Show types" />
+  </div>
+);
 
 export default JsonDataSettings;

--- a/app/packages/playback/src/views/PlaybackTiles/JsonDataTile/JsonDataTile.stories.tsx
+++ b/app/packages/playback/src/views/PlaybackTiles/JsonDataTile/JsonDataTile.stories.tsx
@@ -17,7 +17,7 @@ export const Default: StoryObj = {
         hz: 10,
       }}
     >
-      <JsonDataTile />
+      <JsonDataTile streamId="metadata" />
     </TileStory>
   ),
 };

--- a/app/packages/playback/src/views/PlaybackTiles/JsonDataTile/JsonDataTile.tsx
+++ b/app/packages/playback/src/views/PlaybackTiles/JsonDataTile/JsonDataTile.tsx
@@ -1,17 +1,17 @@
+import { TileSettingsContent } from "@fiftyone/tiling";
 import React from "react";
 import { useStream } from "../../../lib/playback/use-stream";
-import { useTileSource } from "@fiftyone/tiling";
-import { useTileSettings } from "@fiftyone/tiling";
 import JsonDataSettings from "./JsonDataSettings";
 import styles from "./JsonDataTile.module.css";
 
 export interface JsonDataTileProps {
   /**
    * Object to render as JSON. When provided, takes priority over the
-   * tile's bound stream — useful for the standalone story to pass a
-   * fixed sample.
+   * stream — useful for the standalone story to pass a fixed sample.
    */
   data?: unknown;
+  /** Stream id this tile renders when `data` is not provided. */
+  streamId?: string;
 }
 
 const PLACEHOLDER_DATA = {
@@ -30,17 +30,22 @@ const PLACEHOLDER_DATA = {
  * JSON tile body — syntax-colored render of an arbitrary object. Chrome
  * is provided externally (see `Tile` / `MosaicGrid`).
  */
-const JsonDataTile: React.FC<JsonDataTileProps> = ({ data }) => {
-  useTileSettings(JsonDataSettings);
-  const sourceId = useTileSource();
-  const streamValue = useStream<unknown>(sourceId ?? "");
+const JsonDataTile: React.FC<JsonDataTileProps> = ({ data, streamId }) => {
+  const streamValue = useStream<unknown>(streamId ?? "");
   const value =
     data !== undefined
       ? data
-      : sourceId && streamValue !== null
+      : streamValue !== null
         ? streamValue
         : PLACEHOLDER_DATA;
-  return <div className={styles.body}>{formatJson(value)}</div>;
+  return (
+    <div className={styles.body}>
+      <TileSettingsContent>
+        <JsonDataSettings />
+      </TileSettingsContent>
+      {formatJson(value)}
+    </div>
+  );
 };
 
 function formatJson(value: unknown, indent = 0): React.ReactNode {

--- a/app/packages/playback/src/views/PlaybackTiles/LidarTile/LidarSettings.tsx
+++ b/app/packages/playback/src/views/PlaybackTiles/LidarTile/LidarSettings.tsx
@@ -1,45 +1,14 @@
-import { Checkbox, Select, Text, TextColor, TextVariant } from "@voxel51/voodo";
-import React, { useMemo } from "react";
-import {
-  useSetTileSource,
-  useTileSourcesByType,
-  useTileSource,
-} from "@fiftyone/tiling";
+import { Checkbox } from "@voxel51/voodo";
+import React from "react";
 import styles from "../tile-settings.module.css";
 
-const LidarSettings: React.FC = () => {
-  const sources = useTileSourcesByType("lidar");
-  const sourceId = useTileSource();
-  const setSource = useSetTileSource();
-
-  const options = useMemo(
-    () =>
-      sources.map((s) => ({
-        id: s.streamId,
-        data: { label: s.title },
-      })),
-    [sources]
-  );
-
-  return (
-    <div className={styles.root}>
-      <div className={styles.field}>
-        <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
-          Source
-        </Text>
-        <Select
-          options={options}
-          value={sourceId ?? ""}
-          onChange={(v) => setSource((v as string) || null)}
-        />
-      </div>
-
-      <Checkbox label="Color by height" defaultChecked />
-      <Checkbox label="Show ground plane" />
-      <Checkbox label="Show intensity overlay" />
-      <Checkbox label="Cull behind sensor" defaultChecked />
-    </div>
-  );
-};
+const LidarSettings: React.FC = () => (
+  <div className={styles.root}>
+    <Checkbox label="Color by height" defaultChecked />
+    <Checkbox label="Show ground plane" />
+    <Checkbox label="Show intensity overlay" />
+    <Checkbox label="Cull behind sensor" defaultChecked />
+  </div>
+);
 
 export default LidarSettings;

--- a/app/packages/playback/src/views/PlaybackTiles/LidarTile/LidarTile.stories.tsx
+++ b/app/packages/playback/src/views/PlaybackTiles/LidarTile/LidarTile.stories.tsx
@@ -17,7 +17,7 @@ export const Default: StoryObj = {
         hz: 10,
       }}
     >
-      <LidarTile />
+      <LidarTile streamId="lidar_top" />
     </TileStory>
   ),
 };

--- a/app/packages/playback/src/views/PlaybackTiles/LidarTile/LidarTile.tsx
+++ b/app/packages/playback/src/views/PlaybackTiles/LidarTile/LidarTile.tsx
@@ -1,7 +1,6 @@
+import { TileSettingsContent } from "@fiftyone/tiling";
 import React, { useMemo } from "react";
 import { useStream } from "../../../lib/playback/use-stream";
-import { useTileSource } from "@fiftyone/tiling";
-import { useTileSettings } from "@fiftyone/tiling";
 import LidarSettings from "./LidarSettings";
 import styles from "./LidarTile.module.css";
 
@@ -9,28 +8,33 @@ interface LidarFrame {
   points?: Array<[number, number, number]>;
 }
 
-const LidarTile: React.FC = () => {
-  useTileSettings(LidarSettings);
+export interface LidarTileProps {
+  /** Stream id this tile renders. */
+  streamId: string;
+}
+
+const LidarTile: React.FC<LidarTileProps> = ({ streamId }) => {
   // Deterministic-ish scatter so the placeholder is stable across renders.
   const placeholder = useMemo(() => generatePoints(160), []);
-  const sourceId = useTileSource();
-  const frame = useStream<LidarFrame>(sourceId ?? "");
+  const frame = useStream<LidarFrame>(streamId);
 
-  // When a stream is connected and publishing, project its 3D points
-  // into the 2D placeholder viewBox so the live data drives the dots.
-  const livePoints =
-    sourceId && frame?.points
-      ? frame.points.map(([x, , z]) => ({
-          x: 50 + x * 8,
-          y: 50 + z * 8,
-          r: 0.5,
-          a: 0.8,
-        }))
-      : null;
+  // When the stream is publishing, project its 3D points into the 2D
+  // viewBox so the live data drives the dots.
+  const livePoints = frame?.points
+    ? frame.points.map(([x, , z]) => ({
+        x: 50 + x * 8,
+        y: 50 + z * 8,
+        r: 0.5,
+        a: 0.8,
+      }))
+    : null;
   const points = livePoints ?? placeholder;
 
   return (
     <div className={styles.body}>
+      <TileSettingsContent>
+        <LidarSettings />
+      </TileSettingsContent>
       <svg
         className={styles.points}
         viewBox="0 0 100 100"

--- a/app/packages/playback/src/views/PlaybackTiles/SceneTile/SceneSettings.tsx
+++ b/app/packages/playback/src/views/PlaybackTiles/SceneTile/SceneSettings.tsx
@@ -1,44 +1,13 @@
-import { Checkbox, Select, Text, TextColor, TextVariant } from "@voxel51/voodo";
-import React, { useMemo } from "react";
-import {
-  useSetTileSource,
-  useTileSourcesByType,
-  useTileSource,
-} from "@fiftyone/tiling";
+import { Checkbox } from "@voxel51/voodo";
+import React from "react";
 import styles from "../tile-settings.module.css";
 
-const SceneSettings: React.FC = () => {
-  const sources = useTileSourcesByType("scene");
-  const sourceId = useTileSource();
-  const setSource = useSetTileSource();
-
-  const options = useMemo(
-    () =>
-      sources.map((s) => ({
-        id: s.streamId,
-        data: { label: s.title },
-      })),
-    [sources]
-  );
-
-  return (
-    <div className={styles.root}>
-      <div className={styles.field}>
-        <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
-          Source
-        </Text>
-        <Select
-          options={options}
-          value={sourceId ?? ""}
-          onChange={(v) => setSource((v as string) || null)}
-        />
-      </div>
-
-      <Checkbox label="Show grid" defaultChecked />
-      <Checkbox label="Show path" defaultChecked />
-      <Checkbox label="Show axes" />
-    </div>
-  );
-};
+const SceneSettings: React.FC = () => (
+  <div className={styles.root}>
+    <Checkbox label="Show grid" defaultChecked />
+    <Checkbox label="Show path" defaultChecked />
+    <Checkbox label="Show axes" />
+  </div>
+);
 
 export default SceneSettings;

--- a/app/packages/playback/src/views/PlaybackTiles/SceneTile/SceneTile.stories.tsx
+++ b/app/packages/playback/src/views/PlaybackTiles/SceneTile/SceneTile.stories.tsx
@@ -16,7 +16,7 @@ export const Default: StoryObj = {
         duration: 12,
       }}
     >
-      <SceneTile />
+      <SceneTile streamId="scene_world" />
     </TileStory>
   ),
 };

--- a/app/packages/playback/src/views/PlaybackTiles/SceneTile/SceneTile.tsx
+++ b/app/packages/playback/src/views/PlaybackTiles/SceneTile/SceneTile.tsx
@@ -1,13 +1,9 @@
+import { TileSettingsContent, useSetTileSelection } from "@fiftyone/tiling";
 import { OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
 import React from "react";
-import { useStream } from "../../../lib/playback/use-stream";
 import { usePlayhead } from "../../../lib/playback/use-playback-state";
-import {
-  useSetTileSelection,
-  useTileSource,
-} from "@fiftyone/tiling";
-import { useTileSettings } from "@fiftyone/tiling";
+import { useStream } from "../../../lib/playback/use-stream";
 import SceneSettings from "./SceneSettings";
 import styles from "./SceneTile.module.css";
 
@@ -16,17 +12,23 @@ interface ScenePose {
   rotation?: number;
 }
 
+export interface SceneTileProps {
+  /** Stream id this tile renders. */
+  streamId: string;
+}
+
 /**
  * 3D scene tile body — a Three.js (via react-three-fiber) scene with a
- * box moving along a closed path. Reads its bound source from the
- * per-tile `tileSourceAtom`. The orange box is clickable: clicking it
- * publishes the current pose to `tileSelectionAtom` so the inspector
- * sidebar can show its data.
+ * box moving along a closed path. The orange box is clickable;
+ * clicking it publishes the current pose to `tileSelectionAtom` so
+ * the inspector sidebar can show its data.
  */
-const SceneTile: React.FC = () => {
-  useTileSettings(SceneSettings);
+const SceneTile: React.FC<SceneTileProps> = ({ streamId }) => {
   return (
     <div className={styles.body}>
+      <TileSettingsContent>
+        <SceneSettings />
+      </TileSettingsContent>
       <Canvas
         camera={{ position: [4, 3, 4], fov: 50 }}
         style={{ background: "#0f1115" }}
@@ -35,7 +37,7 @@ const SceneTile: React.FC = () => {
         <directionalLight position={[5, 5, 5]} intensity={1.2} />
         <PathReference />
         <FloorGrid />
-        <AnimatedBox />
+        <AnimatedBox streamId={streamId} />
         <OrbitControls enablePan={false} />
       </Canvas>
     </div>
@@ -57,26 +59,23 @@ function pathPoint(t: number): [number, number, number] {
 }
 
 /**
- * The animated box. Reads the tile's source via `useTileSource()` —
- * when bound to a stream that publishes a pose, the box tracks that
- * position; otherwise it falls back to the closed-form orbit driven
- * by `playheadAtom`. Clicking the box publishes its current pose to
+ * When the bound stream publishes a pose, the box tracks that
+ * position; otherwise it falls back to a closed-form orbit driven by
+ * `playheadAtom`. Clicking the box publishes its current pose to
  * `tileSelectionAtom` so the inspector can render it.
  */
-const AnimatedBox: React.FC = () => {
+const AnimatedBox: React.FC<{ streamId: string }> = ({ streamId }) => {
   const t = usePlayhead();
-  const sourceId = useTileSource();
-  const pose = useStream<ScenePose>(sourceId ?? "");
-  const [x, y, z] =
-    sourceId && pose?.position ? pose.position : pathPoint(t);
+  const pose = useStream<ScenePose>(streamId);
+  const [x, y, z] = pose?.position ?? pathPoint(t);
   const setSelection = useSetTileSelection();
   const handleClick = (e: { stopPropagation: () => void }) => {
     e.stopPropagation();
     setSelection({
       kind: "scene-object",
-      sourceId: sourceId ?? null,
+      sourceId: streamId,
       position: [x, y, z],
-      rotation: sourceId && pose?.rotation != null ? pose.rotation : null,
+      rotation: pose?.rotation ?? null,
       timestampSec: t,
     });
   };

--- a/app/packages/tiling/src/index.ts
+++ b/app/packages/tiling/src/index.ts
@@ -4,9 +4,9 @@
 export {
   TilingProvider,
   TileIdScope,
+  TileSettingsContent,
   useTiling,
   useTileId,
-  useTileSettings,
 } from "./lib/TilingProvider";
 export type { TilingProviderProps } from "./lib/TilingProvider";
 export type {
@@ -17,20 +17,12 @@ export type {
 } from "./lib/types";
 
 // --- Per-tile state -------------------------------------------------------
+export { registeredTilesAtom, tileSelectionAtom } from "./lib/atoms";
 export {
-  registeredTilesAtom,
-  tileSourceAtom,
-  tileSelectionAtom,
-} from "./lib/atoms";
-export {
-  useTileSource,
-  useSetTileSource,
-  useSetTileSourceFor,
   useTileSelection,
   useSetTileSelection,
   useTileSelectionFor,
   useTileTypes,
-  useTileSourcesByType,
 } from "./lib/use-tile-state";
 export { useRegisteredTiles } from "./lib/use-registered-tiles";
 export { useTileRegistry } from "./lib/use-tile-registry";

--- a/app/packages/tiling/src/lib/TilingProvider.test.tsx
+++ b/app/packages/tiling/src/lib/TilingProvider.test.tsx
@@ -1,11 +1,11 @@
 import { act, cleanup, render, renderHook } from "@testing-library/react";
-import React, { useState } from "react";
+import React from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  TileIdScope,
+  TileSettingsContent,
   TilingProvider,
   TilingTile,
-  TileIdScope,
-  useTileSettings,
   useTiling,
 } from "./TilingProvider";
 
@@ -262,122 +262,86 @@ describe("TilingProvider", () => {
     });
   });
 
-  describe("settings registry", () => {
-    function Camera() {
-      return <span data-testid="camera-settings">camera-settings</span>;
-    }
-    function Lidar() {
-      return <span data-testid="lidar-settings">lidar-settings</span>;
+  describe("settings portal", () => {
+    function Host({
+      initialFocus,
+    }: {
+      initialFocus?: string;
+    }) {
+      const tiling = useTiling();
+      // Bind the slot DOM element on mount so TileSettingsContent
+      // has somewhere to portal into.
+      React.useEffect(() => {
+        if (initialFocus) tiling.setFocusedTileId(initialFocus);
+      }, [tiling, initialFocus]);
+      return (
+        <>
+          <div data-testid="slot" ref={tiling.setSettingsSlotEl} />
+          <TileIdScope tileId="cam-1">
+            <TileSettingsContent>
+              <span data-testid="cam-settings">cam</span>
+            </TileSettingsContent>
+          </TileIdScope>
+          <TileIdScope tileId="lid-1">
+            <TileSettingsContent>
+              <span data-testid="lid-settings">lid</span>
+            </TileSettingsContent>
+          </TileIdScope>
+          <button
+            data-testid="focus-cam"
+            onClick={() => tiling.setFocusedTileId("cam-1")}
+          />
+          <button
+            data-testid="focus-lid"
+            onClick={() => tiling.setFocusedTileId("lid-1")}
+          />
+        </>
+      );
     }
 
-    it("exposes nothing when no tile is focused", () => {
-      const { result } = renderHook(() => useTiling(), { wrapper: Wrapper });
-      expect(result.current.FocusedTileSettings).toBeNull();
+    it("does not portal anything when no tile is focused", () => {
+      const utils = render(
+        <TilingProvider>
+          <Host />
+        </TilingProvider>
+      );
+      expect(utils.queryByTestId("cam-settings")).toBeNull();
+      expect(utils.queryByTestId("lid-settings")).toBeNull();
     });
 
-    it("returns the settings component for the focused tile", () => {
-      function TilePanel() {
-        useTileSettings(Camera);
-        return null;
-      }
-
-      const { result } = renderHook(() => useTiling(), {
-        wrapper: ({ children }) => (
-          <Wrapper initialTiles={{ "cam-1": makeTile("cam") }}>
-            <TileIdScope tileId="cam-1">
-              <TilePanel />
-            </TileIdScope>
-            {children}
-          </Wrapper>
-        ),
-      });
-
-      act(() => {
-        result.current.setFocusedTileId("cam-1");
-      });
-      expect(result.current.FocusedTileSettings).toBe(Camera);
-    });
-
-    it("clears its entry when the panel unmounts (effect cleanup runs)", () => {
-      function TilePanel() {
-        useTileSettings(Camera);
-        return null;
-      }
-
-      // Render a stateful wrapper that can toggle the panel on/off so
-      // we can verify the cleanup function deregisters the settings.
-      let setShow!: (v: boolean) => void;
-      function Host() {
-        const [show, set] = useState(true);
-        setShow = set;
-        const tiling = useTiling();
-        return (
-          <>
-            {show ? (
-              <TileIdScope tileId="cam-1">
-                <TilePanel />
-              </TileIdScope>
-            ) : null}
-            <button
-              data-testid="focus"
-              onClick={() => tiling.setFocusedTileId("cam-1")}
-            />
-            <span data-testid="settings">
-              {tiling.FocusedTileSettings ? "yes" : "no"}
-            </span>
-          </>
-        );
-      }
-
+    it("portals the focused tile's settings into the slot", () => {
       const utils = render(
         <TilingProvider initialTiles={{ "cam-1": makeTile("cam") }}>
           <Host />
         </TilingProvider>
       );
-      // Focus the tile — settings should resolve to "yes".
       act(() => {
-        utils.getByTestId("focus").click();
+        utils.getByTestId("focus-cam").click();
       });
-      expect(utils.getByTestId("settings").textContent).toBe("yes");
-
-      // Unmount the panel — registry should drop the entry.
-      act(() => setShow(false));
-      expect(utils.getByTestId("settings").textContent).toBe("no");
+      expect(utils.getByTestId("slot").contains(
+        utils.getByTestId("cam-settings")
+      )).toBe(true);
+      expect(utils.queryByTestId("lid-settings")).toBeNull();
     });
 
-    it("swapping the registered component replaces the entry", () => {
-      let setKind!: (k: "camera" | "lidar") => void;
-      function MultiPanel() {
-        const [kind, set] = useState<"camera" | "lidar">("camera");
-        setKind = set;
-        useTileSettings(kind === "camera" ? Camera : Lidar);
-        return null;
-      }
-      function FocusedReader({
-        onReady,
-      }: {
-        onReady: (r: ReturnType<typeof useTiling>) => void;
-      }) {
-        const t = useTiling();
-        onReady(t);
-        return null;
-      }
-
-      let api: ReturnType<typeof useTiling> | null = null;
-      render(
-        <TilingProvider initialTiles={{ "cam-1": makeTile("cam") }}>
-          <TileIdScope tileId="cam-1">
-            <MultiPanel />
-          </TileIdScope>
-          <FocusedReader onReady={(r) => (api = r)} />
+    it("swapping focus swaps which settings render in the slot", () => {
+      const utils = render(
+        <TilingProvider
+          initialTiles={{
+            "cam-1": makeTile("cam"),
+            "lid-1": makeTile("lid"),
+          }}
+        >
+          <Host />
         </TilingProvider>
       );
+      act(() => utils.getByTestId("focus-cam").click());
+      expect(utils.queryByTestId("cam-settings")).not.toBeNull();
+      expect(utils.queryByTestId("lid-settings")).toBeNull();
 
-      act(() => api!.setFocusedTileId("cam-1"));
-      expect(api!.FocusedTileSettings).toBe(Camera);
-
-      act(() => setKind("lidar"));
-      expect(api!.FocusedTileSettings).toBe(Lidar);
+      act(() => utils.getByTestId("focus-lid").click());
+      expect(utils.queryByTestId("cam-settings")).toBeNull();
+      expect(utils.queryByTestId("lid-settings")).not.toBeNull();
     });
   });
 });

--- a/app/packages/tiling/src/lib/TilingProvider.tsx
+++ b/app/packages/tiling/src/lib/TilingProvider.tsx
@@ -8,13 +8,14 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 import type { MosaicNode } from "react-mosaic-component";
 import {
   addTileToLayout,
   autoLayout as autoLayoutFn,
   collectTileIds,
 } from "../views/MosaicGrid/MosaicGrid";
-import { tileSelectionAtom, tileSourceAtom } from "./atoms";
+import { tileSelectionAtom } from "./atoms";
 import type {
   AddTileOptions,
   TilingContextValue,
@@ -70,9 +71,12 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
   // Per-instance Jotai store so multiple <TilingProvider>s on the same
   // page each get isolated atom state (sources, selections, registry).
   const jotaiStore = useMemo(() => createStore(), []);
-  const [settings, setSettings] = useState<
-    Record<string, React.ComponentType>
-  >({});
+  // Settings sidebar registers itself as a portal target here. Tile
+  // bodies render `<TileSettingsContent>` whose children portal into
+  // this element when the surrounding tile is focused.
+  const [settingsSlotEl, setSettingsSlotEl] = useState<HTMLElement | null>(
+    null
+  );
   // Seed the counter past any `<prefix>-<n>` suffix in the initial tiles,
   // so the first `addTile("camera", ...)` against `{ "camera-1": ... }`
   // produces `camera-2` instead of colliding with `camera-1`. Walks every
@@ -108,7 +112,6 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
         // Free per-tile atomFamily entries so dynamic tile ids don't
         // accumulate in the store across long sessions.
         for (const id of idsToRemove) {
-          tileSourceAtom.remove(id);
           tileSelectionAtom.remove(id);
         }
       }
@@ -153,9 +156,8 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
         return stripped;
       });
       setFocusedTileId((current) => (current === id ? null : current));
-      // Release the per-tile atomFamily entries so the store doesn't
+      // Release the per-tile atomFamily entry so the store doesn't
       // grow unbounded across long sessions.
-      tileSourceAtom.remove(id);
       tileSelectionAtom.remove(id);
     },
     []
@@ -169,27 +171,6 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
     setLayoutState(autoLayoutFn(Object.keys(tiles)));
   }, [tiles]);
 
-  const registerSettings = useCallback(
-    (tileId: string, Component: React.ComponentType) => {
-      setSettings((prev) =>
-        prev[tileId] === Component ? prev : { ...prev, [tileId]: Component }
-      );
-      return () => {
-        setSettings((prev) => {
-          if (!(tileId in prev)) return prev;
-          const next = { ...prev };
-          delete next[tileId];
-          return next;
-        });
-      };
-    },
-    []
-  );
-
-  const FocusedTileSettings = focusedTileId
-    ? (settings[focusedTileId] ?? null)
-    : null;
-
   const value = useMemo<TilingContextValue>(
     () => ({
       layout,
@@ -200,8 +181,8 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
       addTile,
       removeTile,
       autoLayout,
-      FocusedTileSettings,
-      registerSettings,
+      settingsSlotEl,
+      setSettingsSlotEl,
     }),
     [
       layout,
@@ -211,8 +192,7 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
       addTile,
       removeTile,
       autoLayout,
-      FocusedTileSettings,
-      registerSettings,
+      settingsSlotEl,
     ]
   );
 
@@ -267,19 +247,29 @@ export function useTileId(): string | null {
 }
 
 /**
- * Register a settings component for the surrounding tile. The component
- * is rendered (as `<Component />`) in the settings panel whenever this
- * tile is focused. Pass a module-level component reference, not an
- * inline JSX element — element identity changes every render and would
- * thrash the registry.
+ * Renders its children into the settings sidebar when the surrounding
+ * tile is focused. Lets a tile body share local React state with its
+ * settings UI via normal props — no atoms or shared stores required,
+ * since the settings JSX stays inside the tile body's React tree even
+ * though it appears in the sidebar's DOM.
+ *
+ *     function MyTile() {
+ *       const [x, setX] = useState(0);
+ *       return (
+ *         <>
+ *           <Body x={x} />
+ *           <TileSettingsContent>
+ *             <Settings x={x} onChange={setX} />
+ *           </TileSettingsContent>
+ *         </>
+ *       );
+ *     }
  */
-export function useTileSettings(Component: React.ComponentType): void {
+export const TileSettingsContent: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
   const tileId = useTileId();
-  const { registerSettings } = useTiling();
-  useEffect(() => {
-    if (!tileId) return undefined;
-    return registerSettings(tileId, Component);
-    // registerSettings is a useCallback([]) — stable across renders.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tileId, Component]);
-}
+  const { focusedTileId, settingsSlotEl } = useTiling();
+  if (!tileId || tileId !== focusedTileId || !settingsSlotEl) return null;
+  return createPortal(children, settingsSlotEl);
+};

--- a/app/packages/tiling/src/lib/atoms.ts
+++ b/app/packages/tiling/src/lib/atoms.ts
@@ -10,28 +10,11 @@ import { atomFamily } from "jotai/utils";
 import type { RegisteredTile } from "./types";
 
 /**
- * Flat list of every registered tile. Consumers call `registerTile`
- * (see `use-tile-registry.ts`) to push an entry; the tiling header /
- * settings UI reads it via `useTileTypes()` / `useTileSourcesByType()`.
- *
- * Held in registration order so the menu stays stable across renders.
+ * Flat list of every registered tile kind, in registration order.
+ * Consumers call `registerTile` (see `use-tile-registry.ts`) to push
+ * an entry; the "Add tile" menu reads it via `useTileTypes()`.
  */
 export const registeredTilesAtom = atom<RegisteredTile[]>([]);
-
-/**
- * Per-tile-id source binding. The value is the id of the source
- * (typically a playback stream) whose data this tile should render —
- * `null` when the tile is unbound (placeholder mode). Tiles read it
- * via `useTileSource()`; the settings panel writes it through
- * `useSetTileSource()`.
- */
-// `atom<string | null>(null)` should resolve to PrimitiveAtom, but jotai's
-// overloads narrow `Value` against the bare `null` argument and produce a
-// read-only `Atom<string>`. The cast preserves the writable shape so
-// `useSetAtom(tileSourceAtom(id))` keeps its setter signature.
-export const tileSourceAtom = atomFamily(
-  (_tileId: string) => atom<string | null>(null) as PrimitiveAtom<string | null>
-);
 
 /**
  * Per-tile-id "current selection". Tile bodies write into this when
@@ -40,7 +23,9 @@ export const tileSourceAtom = atomFamily(
  * to render its details. Shape is intentionally `unknown` — each tile
  * can publish its own payload schema.
  */
-// See note on `tileSourceAtom` — same `null`-initial-value inference quirk.
+// `atom<unknown>(null)` resolves to a read-only Atom under jotai's
+// null-narrowed overload; cast preserves the writable shape so callers
+// can `useSetAtom(tileSelectionAtom(id))`.
 export const tileSelectionAtom = atomFamily(
   (_tileId: string) => atom<unknown>(null) as PrimitiveAtom<unknown>
 );

--- a/app/packages/tiling/src/lib/types.ts
+++ b/app/packages/tiling/src/lib/types.ts
@@ -1,30 +1,21 @@
+import type { IconName } from "@voxel51/voodo";
 import type { ComponentType, ReactNode } from "react";
 import type { MosaicNode } from "react-mosaic-component";
 
 /**
- * One entry in the tile registry — links a data source (e.g. a
- * playback stream) to the tile component that should render it.
- *
- * Tiling is the owner here, not the data layer: the playback engine
- * (or any other source) calls `registerTile(...)` with this shape
- * whenever a source becomes available for spawning into a tile.
- *
- * The same `type` may be registered for multiple sources (e.g. several
- * camera streams). UIs that show "what kinds of tiles can I add" should
- * use `useTileTypes()` (deduplicated by `type`); UIs that show "which
- * source feeds this tile" should use `useTileSourcesByType(type)`.
+ * One entry in the tile registry — a renderable tile kind that the
+ * "Add tile" menu can spawn. Keyed by `type`; registering the same
+ * `type` again replaces the entry. The tile knows nothing about its
+ * data — picking a topic / stream / dataset is the tile's own
+ * concern, not tiling's.
  */
 export interface RegisteredTile {
-  /** Id of the source this tile renders — typically a playback stream id. */
-  streamId: string;
-  /** Discriminator used to group sources of the same kind. */
+  /** Stable key. One entry per `type`; the menu shows one item per type. */
   type: string;
-  /** Menu label for the type, shared across every source of this `type`. */
+  /** Menu label for the type. */
   typeLabel: string;
-  /** Per-source display name (used in the settings source picker). */
-  title: string;
-  /** Menu / chrome icon. Opaque to tiling — passed straight through to voodo. */
-  icon: unknown;
+  /** Menu / chrome icon. Passed straight to voodo's `<MenuIconTextItem>`. */
+  icon: IconName | ReactNode;
   /** Tile body component, mounted as `<Tile />` when a new tile spawns. */
   Tile: ComponentType;
 }
@@ -70,10 +61,12 @@ export interface TilingContextValue {
   removeTile: (id: string) => void;
   autoLayout: () => void;
 
-  // Settings registry
-  FocusedTileSettings: ComponentType | null;
-  registerSettings: (
-    tileId: string,
-    Component: ComponentType
-  ) => () => void;
+  /**
+   * Portal target for the focused tile's settings UI. `TileSettingsSidebar`
+   * writes the slot element via `setSettingsSlotEl`; tile bodies render
+   * `<TileSettingsContent>` whose children portal into this element
+   * when the surrounding tile is focused.
+   */
+  settingsSlotEl: HTMLElement | null;
+  setSettingsSlotEl: (el: HTMLElement | null) => void;
 }

--- a/app/packages/tiling/src/lib/use-tile-registry.test.tsx
+++ b/app/packages/tiling/src/lib/use-tile-registry.test.tsx
@@ -1,8 +1,10 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
+import { IconName } from "@voxel51/voodo";
 import { Provider as JotaiProvider, createStore } from "jotai";
 import React from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import { TilingProvider } from "./TilingProvider";
+import type { RegisteredTile } from "./types";
 import { useRegisteredTiles } from "./use-registered-tiles";
 import { useTileRegistry } from "./use-tile-registry";
 
@@ -20,12 +22,13 @@ const makeWrapper = (): React.FC<{ children: React.ReactNode }> => {
 
 const DummyTile: React.FC = () => null;
 
-const makeEntry = (streamId: string, type = "camera", title = streamId) => ({
-  streamId,
+const makeEntry = (
+  type: string,
+  typeLabel = type.charAt(0).toUpperCase() + type.slice(1)
+): RegisteredTile => ({
   type,
-  typeLabel: type.charAt(0).toUpperCase() + type.slice(1),
-  title,
-  icon: "icon",
+  typeLabel,
+  icon: IconName.GridView,
   Tile: DummyTile,
 });
 
@@ -43,27 +46,23 @@ describe("useTileRegistry", () => {
     expect(result.current.tiles).toEqual([]);
 
     act(() => {
-      result.current.registry.registerTile(makeEntry("camera_front"));
+      result.current.registry.registerTile(makeEntry("camera"));
     });
     expect(result.current.tiles).toHaveLength(1);
-    expect(result.current.tiles[0].streamId).toBe("camera_front");
+    expect(result.current.tiles[0].type).toBe("camera");
   });
 
-  it("replaces an existing entry with the same streamId rather than duplicating", () => {
+  it("replaces an existing entry with the same type rather than duplicating", () => {
     const { result } = renderHook(
       () => ({ registry: useTileRegistry(), tiles: useRegisteredTiles() }),
       { wrapper: makeWrapper() }
     );
     act(() => {
-      result.current.registry.registerTile(
-        makeEntry("camera_front", "camera", "Old title")
-      );
-      result.current.registry.registerTile(
-        makeEntry("camera_front", "camera", "New title")
-      );
+      result.current.registry.registerTile(makeEntry("camera", "Old label"));
+      result.current.registry.registerTile(makeEntry("camera", "New label"));
     });
     expect(result.current.tiles).toHaveLength(1);
-    expect(result.current.tiles[0].title).toBe("New title");
+    expect(result.current.tiles[0].typeLabel).toBe("New label");
   });
 
   it("returns a disposer that removes the entry", () => {
@@ -73,7 +72,7 @@ describe("useTileRegistry", () => {
     );
     let dispose = () => {};
     act(() => {
-      dispose = result.current.registry.registerTile(makeEntry("camera_front"));
+      dispose = result.current.registry.registerTile(makeEntry("camera"));
     });
     expect(result.current.tiles).toHaveLength(1);
     act(() => {
@@ -82,16 +81,20 @@ describe("useTileRegistry", () => {
     expect(result.current.tiles).toEqual([]);
   });
 
-  it("supports multiple distinct streamIds", () => {
+  it("supports multiple distinct types", () => {
     const { result } = renderHook(
       () => ({ registry: useTileRegistry(), tiles: useRegisteredTiles() }),
       { wrapper: makeWrapper() }
     );
     act(() => {
-      result.current.registry.registerTile(makeEntry("a"));
-      result.current.registry.registerTile(makeEntry("b"));
-      result.current.registry.registerTile(makeEntry("c"));
+      result.current.registry.registerTile(makeEntry("camera"));
+      result.current.registry.registerTile(makeEntry("lidar"));
+      result.current.registry.registerTile(makeEntry("graph"));
     });
-    expect(result.current.tiles.map((t) => t.streamId)).toEqual(["a", "b", "c"]);
+    expect(result.current.tiles.map((t) => t.type)).toEqual([
+      "camera",
+      "lidar",
+      "graph",
+    ]);
   });
 });

--- a/app/packages/tiling/src/lib/use-tile-registry.ts
+++ b/app/packages/tiling/src/lib/use-tile-registry.ts
@@ -4,23 +4,19 @@ import { registeredTilesAtom } from "./atoms";
 import type { RegisteredTile } from "./types";
 
 /**
- * Imperative tile-registry API. The integration layer (the code that
- * knows about your data sources — playback streams, server feeds,
- * whatever) calls `registerTile` for each spawnable source. The
- * returned function unregisters the entry — call it in a cleanup
- * effect on unmount.
+ * Imperative tile-registry API. Domains call `registerTile` to declare
+ * a renderable tile kind (one per `type`). The returned function
+ * unregisters the entry — call it in a cleanup effect on unmount.
  *
- * Tiling owns the registry; data layers don't have to know it exists.
- * UIs that consume the registry use `useTileTypes` (deduped) or
- * `useTileSourcesByType(type)` (filtered).
+ * Registering the same `type` twice replaces the previous entry so
+ * re-registers don't accumulate dupes. The tile itself owns its data
+ * binding — tiling never tracks per-tile sources.
  *
  *     const { registerTile } = useTileRegistry();
  *     useEffect(() => {
  *       const dispose = registerTile({
- *         streamId: "camera_front",
  *         type: "camera",
  *         typeLabel: "Camera",
- *         title: "Camera front",
  *         icon: IconName.GridView,
  *         Tile: CameraTile,
  *       });
@@ -33,15 +29,13 @@ export function useTileRegistry(): {
   const store = useStore();
   const registerTile = useCallback(
     (entry: RegisteredTile) => {
-      // Replace any existing entry with the same streamId so re-registers
-      // don't accumulate dupes.
       store.set(registeredTilesAtom, (prev) => [
-        ...prev.filter((t) => t.streamId !== entry.streamId),
+        ...prev.filter((t) => t.type !== entry.type),
         entry,
       ]);
       return () => {
         store.set(registeredTilesAtom, (prev) =>
-          prev.filter((t) => t.streamId !== entry.streamId)
+          prev.filter((t) => t.type !== entry.type)
         );
       };
     },

--- a/app/packages/tiling/src/lib/use-tile-state.test.tsx
+++ b/app/packages/tiling/src/lib/use-tile-state.test.tsx
@@ -1,17 +1,15 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
+import { IconName } from "@voxel51/voodo";
 import { Provider as JotaiProvider, createStore } from "jotai";
 import React from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import { TileIdScope, TilingProvider } from "./TilingProvider";
+import type { RegisteredTile } from "./types";
 import { useTileRegistry } from "./use-tile-registry";
 import {
   useSetTileSelection,
-  useSetTileSource,
-  useSetTileSourceFor,
   useTileSelection,
   useTileSelectionFor,
-  useTileSource,
-  useTileSourcesByType,
   useTileTypes,
 } from "./use-tile-state";
 
@@ -39,65 +37,11 @@ const makePlainWrap = () => {
 
 const DummyTile: React.FC = () => null;
 
-describe("useTileSource / useSetTileSource", () => {
-  afterEach(() => cleanup());
-
-  it("returns null until a source is set", () => {
-    const { result } = renderHook(() => useTileSource(), {
-      wrapper: wrap("camera-1"),
-    });
-    expect(result.current).toBeNull();
-  });
-
-  it("updates when useSetTileSource writes a new value", () => {
-    const { result } = renderHook(
-      () => ({ value: useTileSource(), set: useSetTileSource() }),
-      { wrapper: wrap("camera-1") }
-    );
-    act(() => {
-      result.current.set("camera_front");
-    });
-    expect(result.current.value).toBe("camera_front");
-    act(() => {
-      result.current.set(null);
-    });
-    expect(result.current.value).toBeNull();
-  });
-});
-
-describe("useSetTileSourceFor", () => {
-  afterEach(() => cleanup());
-
-  it("writes are visible to a scoped useTileSource reader for the same id", () => {
-    // Setter probe: captures the setter via a callback ref so the assertion
-    // can call it from outside the React tree.
-    function SourceWriter({
-      onReady,
-    }: {
-      onReady: (set: (id: string, src: string | null) => void) => void;
-    }) {
-      const set = useSetTileSourceFor();
-      React.useEffect(() => onReady(set), [onReady, set]);
-      return null;
-    }
-    let captured: (id: string, src: string | null) => void = () => {};
-    const store = createStore();
-    const { result } = renderHook(() => useTileSource(), {
-      wrapper: ({ children }) => (
-        <JotaiProvider store={store}>
-          <TilingProvider>
-            <SourceWriter onReady={(s) => (captured = s)} />
-            <TileIdScope tileId="lidar-1">{children}</TileIdScope>
-          </TilingProvider>
-        </JotaiProvider>
-      ),
-    });
-    expect(result.current).toBeNull();
-    act(() => {
-      captured("lidar-1", "lidar_top");
-    });
-    expect(result.current).toBe("lidar_top");
-  });
+const makeEntry = (type: string): RegisteredTile => ({
+  type,
+  typeLabel: type.charAt(0).toUpperCase() + type.slice(1),
+  icon: IconName.GridView,
+  Tile: DummyTile,
 });
 
 describe("useTileSelection / useTileSelectionFor / useSetTileSelection", () => {
@@ -166,7 +110,7 @@ describe("useTileSelection / useTileSelectionFor / useSetTileSelection", () => {
   });
 });
 
-describe("useTileTypes / useTileSourcesByType", () => {
+describe("useTileTypes", () => {
   afterEach(() => cleanup());
 
   function setup() {
@@ -174,40 +118,16 @@ describe("useTileTypes / useTileSourcesByType", () => {
       () => ({
         registry: useTileRegistry(),
         types: useTileTypes(),
-        cameras: useTileSourcesByType("camera"),
-        lidars: useTileSourcesByType("lidar"),
       }),
       { wrapper: makePlainWrap() }
     );
   }
 
-  const makeEntry = (streamId: string, type: string) => ({
-    streamId,
-    type,
-    typeLabel: type.charAt(0).toUpperCase() + type.slice(1),
-    title: streamId,
-    icon: "icon",
-    Tile: DummyTile,
-  });
-
-  it("dedupes types so each distinct type appears once", () => {
+  it("exposes registered tiles in registration order", () => {
     const { result } = setup();
     act(() => {
-      result.current.registry.registerTile(makeEntry("a", "camera"));
-      result.current.registry.registerTile(makeEntry("b", "camera"));
-      result.current.registry.registerTile(makeEntry("c", "lidar"));
-    });
-    expect(result.current.types.map((t) => t.type)).toEqual([
-      "camera",
-      "lidar",
-    ]);
-  });
-
-  it("preserves registration order in useTileTypes", () => {
-    const { result } = setup();
-    act(() => {
-      result.current.registry.registerTile(makeEntry("c", "lidar"));
-      result.current.registry.registerTile(makeEntry("a", "camera"));
+      result.current.registry.registerTile(makeEntry("lidar"));
+      result.current.registry.registerTile(makeEntry("camera"));
     });
     expect(result.current.types.map((t) => t.type)).toEqual([
       "lidar",
@@ -215,17 +135,17 @@ describe("useTileTypes / useTileSourcesByType", () => {
     ]);
   });
 
-  it("filters useTileSourcesByType to entries with the matching type", () => {
+  it("replacing a type keeps a single entry", () => {
     const { result } = setup();
     act(() => {
-      result.current.registry.registerTile(makeEntry("front", "camera"));
-      result.current.registry.registerTile(makeEntry("back", "camera"));
-      result.current.registry.registerTile(makeEntry("top", "lidar"));
+      result.current.registry.registerTile(makeEntry("camera"));
+      result.current.registry.registerTile(makeEntry("camera"));
+      result.current.registry.registerTile(makeEntry("lidar"));
     });
-    expect(result.current.cameras.map((c) => c.streamId)).toEqual([
-      "front",
-      "back",
+    expect(result.current.types).toHaveLength(2);
+    expect(result.current.types.map((t) => t.type)).toEqual([
+      "camera",
+      "lidar",
     ]);
-    expect(result.current.lidars.map((l) => l.streamId)).toEqual(["top"]);
   });
 });

--- a/app/packages/tiling/src/lib/use-tile-state.ts
+++ b/app/packages/tiling/src/lib/use-tile-state.ts
@@ -1,65 +1,13 @@
-import { useAtomValue, useSetAtom, useStore } from "jotai";
-import { useCallback, useMemo } from "react";
-import {
-  registeredTilesAtom,
-  tileSelectionAtom,
-  tileSourceAtom,
-} from "./atoms";
+import { useAtomValue, useSetAtom } from "jotai";
+import { useCallback } from "react";
+import { registeredTilesAtom, tileSelectionAtom } from "./atoms";
 import { useTileId } from "./TilingProvider";
 import type { RegisteredTile } from "./types";
 
-// We need a stable placeholder key so atomFamily doesn't create a new
-// atom on every render when the surrounding tile id is null (the
-// component is mounted outside a TileIdScope). The placeholder atom
-// stays null and writes against it are no-ops.
+// Stable placeholder so atomFamily doesn't churn when a component is
+// mounted outside a TileIdScope. The placeholder atom stays null and
+// writes against it are silently no-ops.
 const NO_TILE = "__no-tile__";
-
-/**
- * Read the current tile's bound source stream id. Reads `useTileId()`
- * internally, so call only inside a `TileIdScope`. Returns `null` when
- * the tile has no bound source (placeholder mode).
- */
-export function useTileSource(): string | null {
-  const tileId = useTileId();
-  return useAtomValue(tileSourceAtom(tileId ?? NO_TILE));
-}
-
-/**
- * Setter for the current tile's bound source stream id. Returned
- * function is stable.
- */
-export function useSetTileSource(): (sourceId: string | null) => void {
-  const tileId = useTileId();
-  const set = useSetAtom(tileSourceAtom(tileId ?? NO_TILE));
-  return useCallback(
-    (sourceId: string | null) => {
-      // Out-of-scope writes are real no-ops — don't touch the NO_TILE
-      // placeholder atom (state could otherwise survive across mounts).
-      if (!tileId) return;
-      set(sourceId);
-    },
-    // `set` is a Jotai setter (referentially stable from useSetAtom).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [tileId]
-  );
-}
-
-/**
- * Imperative setter for the source of an explicit tile id — used by
- * surfaces that bind a tile that doesn't yet exist at hook call time
- * (e.g. TilingHeader's "Add tile" menu defaulting a freshly-spawned
- * tile to the first registered source of its type).
- */
-export function useSetTileSourceFor(): (
-  tileId: string,
-  sourceId: string | null
-) => void {
-  const store = useStore();
-  return useCallback(
-    (tileId, sourceId) => store.set(tileSourceAtom(tileId), sourceId),
-    [store]
-  );
-}
 
 /**
  * Read the current tile's selection payload. Inspector / setting
@@ -83,6 +31,7 @@ export function useSetTileSelection(): (selection: unknown) => void {
       if (!tileId) return;
       set(selection);
     },
+    // `set` is a Jotai setter (referentially stable from useSetAtom).
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [tileId]
   );
@@ -101,27 +50,10 @@ export function useTileSelectionFor<T = unknown>(
 }
 
 /**
- * Distinct tile types among the currently-registered tiles, in
- * registration order. Each entry exposes the first registered source
- * as the type's exemplar (used for the icon + type label in
- * TilingHeader's add-tile menu).
+ * Every registered tile kind, in registration order. One entry per
+ * `type` since the registry is keyed by type. Used by the "Add tile"
+ * menu.
  */
 export function useTileTypes(): RegisteredTile[] {
-  const tiles = useAtomValue(registeredTilesAtom);
-  return useMemo(() => {
-    const seen = new Map<string, RegisteredTile>();
-    for (const entry of tiles) {
-      if (!seen.has(entry.type)) seen.set(entry.type, entry);
-    }
-    return Array.from(seen.values());
-  }, [tiles]);
-}
-
-/**
- * Registered tile sources matching the given `type`. Used by settings
- * source pickers ("which camera feed should this Camera tile show").
- */
-export function useTileSourcesByType(type: string): RegisteredTile[] {
-  const tiles = useAtomValue(registeredTilesAtom);
-  return useMemo(() => tiles.filter((t) => t.type === type), [tiles, type]);
+  return useAtomValue(registeredTilesAtom);
 }

--- a/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.module.css
+++ b/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.module.css
@@ -52,6 +52,15 @@
   background: transparent;
 }
 
+/* react-mosaic ships a `.mosaic-preview` drag thumbnail styled with
+   Blueprint icon classes (`bp3-icon-*`). Blueprint isn't loaded here,
+   so the icon is empty and the bare title + h4 show through under the
+   real tile body as a "ghost" layer. We don't use the drag preview —
+   hide it. */
+.root :global(.mosaic .mosaic-preview) {
+  display: none;
+}
+
 /* Pull the per-tile margin in (react-mosaic defaults to 3px on each
    side → 6px gap + 2px window borders ≈ 8px between tile contents).
    2px gives 4px gap + 2px borders ≈ 6px — visibly slim without making

--- a/app/packages/tiling/src/views/TileSettingsSidebar/TileSettingsSidebar.stories.tsx
+++ b/app/packages/tiling/src/views/TileSettingsSidebar/TileSettingsSidebar.stories.tsx
@@ -3,8 +3,8 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { useEffect } from "react";
 import {
   TileIdScope,
+  TileSettingsContent,
   TilingProvider,
-  useTileSettings,
   useTiling,
 } from "../../lib/TilingProvider";
 import TileSettingsSidebar from "./TileSettingsSidebar";
@@ -17,26 +17,22 @@ export default meta;
 
 type Story = StoryObj<typeof TileSettingsSidebar>;
 
-/** Stand-in tile-settings component, registered via useTileSettings. */
-const SampleSettings: React.FC = () => (
-  <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-    <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
-      Source
-    </Text>
-    <select defaultValue="camera_front">
-      <option value="camera_front">Camera front</option>
-      <option value="camera_back">Camera back</option>
-    </select>
-    <Checkbox label="Show overlays" defaultChecked />
-    <Checkbox label="Show bounding boxes" />
-  </div>
+/** Stand-in tile body — renders its settings JSX via the portal. */
+const TileBody: React.FC = () => (
+  <TileSettingsContent>
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
+        Source
+      </Text>
+      <select defaultValue="camera_front">
+        <option value="camera_front">Camera front</option>
+        <option value="camera_back">Camera back</option>
+      </select>
+      <Checkbox label="Show overlays" defaultChecked />
+      <Checkbox label="Show bounding boxes" />
+    </div>
+  </TileSettingsContent>
 );
-
-/** Mount the tile body (which registers its settings) so the sidebar has data. */
-const TileBody: React.FC = () => {
-  useTileSettings(SampleSettings);
-  return null;
-};
 
 function AutoFocus({ id }: { id: string }) {
   const { setFocusedTileId } = useTiling();

--- a/app/packages/tiling/src/views/TileSettingsSidebar/TileSettingsSidebar.test.tsx
+++ b/app/packages/tiling/src/views/TileSettingsSidebar/TileSettingsSidebar.test.tsx
@@ -2,23 +2,27 @@ import { act, cleanup, render, screen } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { TileIdScope, TilingProvider, useTileSettings, useTiling } from "../../lib/TilingProvider";
+import {
+  TileIdScope,
+  TileSettingsContent,
+  TilingProvider,
+  useTiling,
+} from "../../lib/TilingProvider";
 import TileSettingsSidebar from "./TileSettingsSidebar";
 
 const SETTINGS_LABEL = "camera-settings-panel";
 
-const Settings: React.FC = () => (
-  <div data-testid={SETTINGS_LABEL}>camera knobs</div>
-);
-
 /**
- * Mounts a tile body inside `TileIdScope` and registers the settings
- * panel — same shape a real PlaybackTile would use.
+ * Mounts a tile body inside `TileIdScope` and renders its settings JSX
+ * via the portal — same shape a real PlaybackTile would use.
  */
-const TileBody: React.FC = () => {
-  useTileSettings(Settings);
-  return <div data-testid="tile-body" />;
-};
+const TileBody: React.FC = () => (
+  <div data-testid="tile-body">
+    <TileSettingsContent>
+      <div data-testid={SETTINGS_LABEL}>camera knobs</div>
+    </TileSettingsContent>
+  </div>
+);
 
 const FocusButton: React.FC<{ id: string }> = ({ id }) => {
   const { setFocusedTileId } = useTiling();
@@ -40,7 +44,7 @@ describe("TileSettingsSidebar", () => {
     expect(screen.getByText("Focus a tile to edit its settings.")).toBeTruthy();
   });
 
-  it("renders the focused tile's registered settings when a tile is focused", () => {
+  it("portals the focused tile's settings into the sidebar", () => {
     render(
       <TilingProvider
         initialTiles={{

--- a/app/packages/tiling/src/views/TileSettingsSidebar/TileSettingsSidebar.tsx
+++ b/app/packages/tiling/src/views/TileSettingsSidebar/TileSettingsSidebar.tsx
@@ -1,28 +1,32 @@
 import { Text, TextColor, TextVariant } from "@voxel51/voodo";
-import React from "react";
+import React, { useCallback } from "react";
 import { useTiling } from "../../lib/TilingProvider";
 import SidebarPanel from "../SidebarPanel/SidebarPanel";
 
 /**
- * Left-hand sidebar that renders the focused tile's settings component,
- * if one was registered via `useTileSettings`. Otherwise shows an empty
- * state hint. Reads directly from the surrounding `TilingProvider`.
- *
- * The header reads "Settings: <tile title>" so it's obvious which tile
- * is being configured.
+ * Left-hand sidebar that hosts the focused tile's settings UI. Owns
+ * the portal target — the tile body's `<TileSettingsContent>` portals
+ * its children here when this tile is focused. Renders the empty
+ * state hint when no tile is focused or focused tile has no settings.
  */
 const TileSettingsSidebar: React.FC = () => {
-  const { focusedTileId, FocusedTileSettings, tiles } = useTiling();
+  const { focusedTileId, tiles, setSettingsSlotEl } = useTiling();
   // Defend against a stale focusedTileId — possible if a tile is removed
   // mid-render or the consumer's layout state races ahead of the registry.
   const focusedTile =
     focusedTileId && tiles[focusedTileId] ? tiles[focusedTileId] : null;
   const title = focusedTile ? `Settings: ${focusedTile.title}` : "Settings";
+
+  // Stable ref callback so `setSettingsSlotEl` isn't fired on every render.
+  const slotRef = useCallback(
+    (el: HTMLDivElement | null) => setSettingsSlotEl(el),
+    [setSettingsSlotEl]
+  );
+
   return (
     <SidebarPanel title={title}>
-      {focusedTile && FocusedTileSettings ? (
-        <FocusedTileSettings />
-      ) : (
+      <div ref={slotRef} />
+      {!focusedTile && (
         <Text variant={TextVariant.Sm} color={TextColor.Muted}>
           Focus a tile to edit its settings.
         </Text>

--- a/app/packages/tiling/src/views/TilingHeader/TilingHeader.stories.tsx
+++ b/app/packages/tiling/src/views/TilingHeader/TilingHeader.stories.tsx
@@ -32,26 +32,20 @@ function RegisterTiles() {
   useEffect(() => {
     const disposes = [
       registerTile({
-        streamId: "camera_front",
         type: "camera",
         typeLabel: "Camera",
-        title: "Camera front",
         icon: IconName.GridView,
         Tile: DummyTile,
       }),
       registerTile({
-        streamId: "lidar_top",
         type: "lidar",
         typeLabel: "Lidar",
-        title: "Lidar top",
         icon: IconName.Embeddings,
         Tile: DummyTile,
       }),
       registerTile({
-        streamId: "imu",
         type: "graph",
         typeLabel: "Graph",
-        title: "IMU",
         icon: IconName.Logs,
         Tile: DummyTile,
       }),

--- a/app/packages/tiling/src/views/TilingHeader/TilingHeader.test.tsx
+++ b/app/packages/tiling/src/views/TilingHeader/TilingHeader.test.tsx
@@ -1,32 +1,22 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { IconName } from "@voxel51/voodo";
 import React, { useEffect } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { TilingProvider } from "../../lib/TilingProvider";
+import type { RegisteredTile } from "../../lib/types";
 import { useTileRegistry } from "../../lib/use-tile-registry";
 import TilingHeader from "./TilingHeader";
 
 const CameraTile: React.FC = () => <div data-testid="camera-body" />;
 const LidarTile: React.FC = () => <div data-testid="lidar-body" />;
 
-/**
- * Mount inside the TilingProvider so it can register tile entries
- * exactly the way `useMockStreams` does in production stories.
- */
-const RegisterTiles: React.FC<{
-  entries: Array<{
-    streamId: string;
-    type: string;
-    typeLabel: string;
-    title: string;
-    Tile: React.ComponentType;
-  }>;
-}> = ({ entries }) => {
+const RegisterTiles: React.FC<{ entries: RegisteredTile[] }> = ({
+  entries,
+}) => {
   const { registerTile } = useTileRegistry();
   useEffect(() => {
-    const disposes = entries.map((e) =>
-      registerTile({ ...e, icon: "any" as unknown })
-    );
+    const disposes = entries.map((e) => registerTile(e));
     return () => {
       for (const d of disposes) d();
     };
@@ -91,17 +81,15 @@ describe("TilingHeader", () => {
         <RegisterTiles
           entries={[
             {
-              streamId: "camera_front",
               type: "camera",
               typeLabel: "Camera",
-              title: "Camera front",
+              icon: IconName.GridView,
               Tile: CameraTile,
             },
             {
-              streamId: "lidar_top",
               type: "lidar",
               typeLabel: "Lidar",
-              title: "Lidar top",
+              icon: IconName.Embeddings,
               Tile: LidarTile,
             },
           ]}

--- a/app/packages/tiling/src/views/TilingHeader/TilingHeader.tsx
+++ b/app/packages/tiling/src/views/TilingHeader/TilingHeader.tsx
@@ -13,11 +13,7 @@ import {
 } from "@voxel51/voodo";
 import clsx from "clsx";
 import React, { useMemo } from "react";
-import { useRegisteredTiles } from "../../lib/use-registered-tiles";
-import {
-  useSetTileSourceFor,
-  useTileTypes,
-} from "../../lib/use-tile-state";
+import { useTileTypes } from "../../lib/use-tile-state";
 import { useTiling } from "../../lib/TilingProvider";
 import { SidebarLeftIcon, SidebarRightIcon } from "./tiling-header-icons";
 import styles from "./TilingHeader.module.css";
@@ -37,12 +33,10 @@ export interface TilingHeaderProps {
  * Top-of-page chrome for a tiling layout:
  *
  * - Filename on the left (truncates with ellipsis when narrow)
- * - "Add tile" icon-button dropdown — items are inferred from the
- *   distinct tile *types* among the entries registered with the tile
- *   Spawning a Camera tile binds it to the first registered camera
- *   stream by default; the user can swap to any other registered
- *   camera through the tile's settings panel. Auto Layout is
- *   appended at the bottom.
+ * - "Add tile" icon-button dropdown — one item per registered tile
+ *   type. The spawned tile picks its own data binding (topic, stream,
+ *   etc.); tiling doesn't know or care. Auto Layout is appended at
+ *   the bottom.
  * - Two right-aligned sidebar toggles using mirrored "panel" icons that
  *   visually convey which side they control
  *
@@ -57,9 +51,7 @@ const TilingHeader: React.FC<TilingHeaderProps> = ({
   onToggleRightSidebar,
 }) => {
   const types = useTileTypes();
-  const allTiles = useRegisteredTiles();
   const { addTile, autoLayout } = useTiling();
-  const setTileSource = useSetTileSourceFor();
 
   const tileMenu = useMemo(() => {
     if (types.length === 0) return null;
@@ -73,22 +65,13 @@ const TilingHeader: React.FC<TilingHeaderProps> = ({
               icon={entry.icon}
               text={entry.typeLabel}
               onClick={() => {
-                const newTileId = addTile(
+                addTile(
                   {
                     title: entry.typeLabel,
                     render: () => <TileComponent />,
                   },
                   { idPrefix: entry.type }
                 );
-                // Default the spawn to the first registered source of
-                // this type, if any. The user can swap via the settings
-                // sidebar's source picker.
-                const firstSource = allTiles.find(
-                  (t) => t.type === entry.type
-                );
-                if (firstSource) {
-                  setTileSource(newTileId, firstSource.streamId);
-                }
               }}
             />
           );
@@ -101,10 +84,9 @@ const TilingHeader: React.FC<TilingHeaderProps> = ({
         />
       </>
     );
-    // addTile / autoLayout / setTileSource are stable callbacks from
-    // their providers; only re-build when types or registrations change.
+    // addTile / autoLayout are stable callbacks from their providers.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [types, allTiles]);
+  }, [types]);
 
   return (
     <div className={styles.root}>


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

Stacks on top of #7622 (\`feat/mmMcapMiddleware\`).

## 📋 What changes are proposed in this pull request?

Architectural cleanup of the tiling package — touches \`packages/tiling\` and \`packages/playback\` only, no \`packages/multimodal\` changes. Together with the parent PR (#7622), the stack rebuilds the multimodal POC on top of a cleaner tiling surface.

### Drop the "source" concept from tiling

\`packages/tiling\` no longer tracks anything about a tile's data binding. A tile is a kind (\`type\`), not a binding to a specific source.

- \`RegisteredTile\` is now \`{ type, typeLabel, icon, Tile }\` — keyed by \`type\`. One registry entry per kind, not one per source.
- Removed: \`streamId\` field, \`tileSourceAtom\`, \`useTileSource\`, \`useSetTileSource\`, \`useSetTileSourceFor\`, \`useTileSourcesByType\`.
- \`TilingHeader\`'s "Add tile" menu now shows one item per type and doesn't pre-bind sources on spawn.
- \`useTileTypes()\` just returns the deduped registry.

### Portal-based settings — kill the component registry

Tile bodies and their settings live in sibling React subtrees (mosaic grid vs. settings sidebar), so the old \`useTileSettings(Component)\` model required them to share state through a global atom keyed by tile id. Replaced with a portal:

- New \`<TileSettingsContent>{children}</TileSettingsContent>\` portals its children into the settings sidebar slot when the surrounding tile is focused.
- Tile body and settings JSX are in the **same React tree**, so per-tile state flows down as normal props — no atom, no atomFamily, no shared store.
- \`TileSettingsSidebar\` registers itself as the portal target via \`setSettingsSlotEl(el)\`.
- Removed: \`useTileSettings\`, \`registerSettings\`, \`FocusedTileSettings\`, the \`settings: Record<id, Component>\` provider state.

### Playback PlaybackTiles migration

The demo tiles in \`packages/playback/src/views/PlaybackTiles\` were the only other consumers of the deleted tiling APIs:

- Each tile (Camera, Lidar, Scene, Graph, JsonData) takes \`streamId\` as a prop instead of reading from tiling's deleted hook.
- Settings became decorative checkboxes — the source-picker pattern only lives in MCAP tiles (in #7622).
- \`useMockStreams\` no longer registers tile entries; stories build the initial-tile map themselves with \`streamId\` baked into the render closure.
- Stories + tests updated across tiling and playback.

### Bug fix along the way

- Mosaic drag-preview ghost (\`.mosaic-preview\`) was bleeding through under the spinner because Blueprint icon classes aren't loaded — hidden via CSS.

## 🧪 How is this patch tested? If it is not, please explain why.

- \`yarn check:types\` clean across tiling / playback / multimodal (when applied on top of #7622).
- 367/367 vitest tests pass across the three packages (tiling settings-registry tests rewritten as settings-portal tests; tile-registry tests dropped \`streamId\`).
- Manually verified end-to-end with a NuScenes \`.mcap\`.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No.
-   [ ] Yes.

N/A — internal multimodal POC; rides on top of #7622.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build
-   [ ] Core
-   [ ] Documentation
-   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tiles now accept explicit stream identifiers via props for clearer data binding.
  * Settings panels now render via portal mechanism for improved layout management.

* **Bug Fixes**
  * Simplified tile settings UI by removing redundant source selection controls.

* **Refactor**
  * Refactored tile architecture from hook-based source management to prop-driven design.
  * Removed internal tile-source tracking hooks from public API.
  * Streamlined tile registration system for cleaner setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7623?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->