### PR TITLE
fix(tiling): hide react-mosaic drag-preview ghost

### DIFF
--- a/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.module.css
+++ b/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.module.css
@@ -52,6 +52,15 @@
   background: transparent;
 }
 
+/* react-mosaic ships a `.mosaic-preview` drag thumbnail styled with
+   Blueprint icon classes (`bp3-icon-*`). Blueprint isn't loaded here,
+   so the icon is empty and the bare title + h4 show through under the
+   real tile body as a "ghost" layer. We don't use the drag preview —
+   hide it. */
+.root :global(.mosaic .mosaic-preview) {
+  display: none;
+}
+
 /* Pull the per-tile margin in (react-mosaic defaults to 3px on each
    side → 6px gap + 2px window borders ≈ 8px between tile contents).
    2px gives 4px gap + 2px borders ≈ 6px — visibly slim without making


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

\`react-mosaic-component\` ships a \`.mosaic-preview\` drag-thumbnail element inside every window. It's intended as the floating image rendered next to the cursor during drag-and-drop, styled with Blueprint icon classes (\`bp3-icon-application\`, etc.) for the icon glyph.

We don't load Blueprint in this app, so the icon glyph is empty and the bare \`<h4>Title</h4>\` text inside \`.mosaic-preview\` shows through underneath the actual tile body — looks like a \"ghost\" layer with a phantom title.

Fix is one CSS rule: hide \`.mosaic-preview\` entirely. We don't use the drag-preview UX (react-dnd captures the drag image before the element is hidden anyway), so dropping it has no functional cost.

## 🧪 How is this patch tested? If it is not, please explain why.

Visually verified — the spurious \"Camera\" / \"Lidar\" text that previously appeared under the tile body is gone. No test changes needed (pure CSS).

## 📝 Release Notes

### Is this a user-facing change?

-   [x] No.
-   [ ] Yes.

### What areas of FiftyOne does this PR affect?

-   [x] App
-   [ ] Build
-   [ ] Core
-   [ ] Documentation
-   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved the visual experience when dragging tiles by removing an unwanted preview element that appeared during interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7626?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->