### PR TITLE
fix(tiling): keep autoLayout stable via tilesRef

### DIFF
--- a/app/packages/tiling/src/lib/TilingProvider.tsx
+++ b/app/packages/tiling/src/lib/TilingProvider.tsx
@@ -83,6 +83,10 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
       return m ? Math.max(max, Number(m[1])) : max;
     }, 0) + 1
   );
+  // Always-current ref so autoLayout stays referentially stable — avoids
+  // stale captures in useMemo dependency-suppressed consumers (TilingHeader).
+  const tilesRef = useRef(tiles);
+  tilesRef.current = tiles;
 
   /**
    * Layout setter that also reconciles the entries map (drops orphans
@@ -166,8 +170,10 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
     // entry can exist in `tiles` without being placed in the tree
     // yet (e.g. when `initialLayout` is null or partial), and we
     // don't want auto-layout to silently drop it.
-    setLayoutState(autoLayoutFn(Object.keys(tiles)));
-  }, [tiles]);
+    // Read from ref so this callback stays stable across tile additions,
+    // avoiding stale captures in useMemo consumers that suppress deps.
+    setLayoutState(autoLayoutFn(Object.keys(tilesRef.current)));
+  }, []);
 
   const registerSettings = useCallback(
     (tileId: string, Component: React.ComponentType) => {


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

\`TilingProvider.autoLayout\` was defined as \`useCallback([tiles])\` — i.e. it captured the current \`tiles\` map and got a fresh identity every time a tile was added or removed. That broke any consumer that intentionally suppressed \`autoLayout\` from its dependency array (e.g. \`TilingHeader\`'s \`useMemo\`-cached add-tile menu): once the callback identity changed, the consumer's pinned reference kept pointing at the version that captured the pre-add \`tiles\`, and \"Auto Layout\" silently dropped any tile added after the menu mounted.

Fix: mirror \`tiles\` into a ref (\`tilesRef\`) and have \`autoLayout\` read from the ref instead of the captured value. Callback identity is now stable, and dep-suppressed consumers always see the live tile set at call time.

## 🧪 How is this patch tested? If it is not, please explain why.

- Manually verified: spawn several tiles via the add-tile menu, then click \"Auto Layout\". Before: only the originally-spawned tiles get included. After: every tile is in the layout.
- No tests changed; this is a single \`useCallback\` deps change in \`TilingProvider\`.

## 📝 Release Notes

### Is this a user-facing change?

-   [x] No.
-   [ ] Yes.

### What areas of FiftyOne does this PR affect?

-   [x] App
-   [ ] Build
-   [ ] Core
-   [ ] Documentation
-   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where auto-layout could reference outdated tile information when tiles are added dynamically, ensuring proper layout updates in all scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->