### PR TITLE
refactor(tiling): drop tile-source concept; portal-based settings

### DIFF
--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-tiles.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-tiles.ts
@@ -46,10 +46,8 @@ export function useMcapTiles({ presentTypes }: UseMcapTilesOptions): void {
       const entry = TILE_BY_TYPE[type];
       return [
         registerTile({
-          streamId: type,
           type,
           typeLabel: entry.typeLabel,
-          title: entry.typeLabel,
           icon: entry.icon,
           Tile: entry.Tile,
         }),

--- a/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.test.tsx
+++ b/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.test.tsx
@@ -2,6 +2,15 @@ import { cleanup, render, screen } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+// The MCAP tile components transitively import three.js, which evaluates
+// WebGPU constants at module load and crashes in jsdom. Stub the
+// inventory hooks so the shell test doesn't drag those in.
+vi.mock("../../adapters/mcap/react/use-mcap-scene-inventory", () => ({
+  useMcapSceneInventory: () => [],
+  useMcapStreamPolicies: () => ({}),
+  useMcapInitialTiles: () => ({}),
+}));
+
 // react-mosaic-component uses react-dnd which needs a DnD context; in
 // jsdom we just need the layout to mount, so stub MosaicGrid to a
 // passthrough that renders each tile's body.

--- a/app/packages/playback/src/__tests__/tile-harness.tsx
+++ b/app/packages/playback/src/__tests__/tile-harness.tsx
@@ -1,24 +1,21 @@
 // Shared providers + tile-registry helper for PlaybackTiles tests.
-// Keeps each per-tile test file small.
 
+import { IconName } from "@voxel51/voodo";
 import {
   TileIdScope,
   TilingProvider,
   useTileRegistry,
+  type RegisteredTile,
 } from "@fiftyone/tiling";
 import { Provider as JotaiProvider, createStore } from "jotai";
 import React, { useEffect, useMemo } from "react";
 import { PlaybackProvider } from "../lib/playback/PlaybackProvider";
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 const DummyTile: React.FC = () => null;
 
 export interface TileRegistration {
-  streamId: string;
   type: string;
   typeLabel?: string;
-  title?: string;
   Tile?: React.ComponentType;
 }
 
@@ -29,16 +26,15 @@ export const RegisterTiles: React.FC<{ entries: TileRegistration[] }> = ({
   // registerTile is a stable jotai-backed setter — not in deps by design.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    const disposes = entries.map((e) =>
-      registerTile({
-        streamId: e.streamId,
+    const disposes = entries.map((e) => {
+      const entry: RegisteredTile = {
         type: e.type,
         typeLabel: e.typeLabel ?? e.type,
-        title: e.title ?? e.streamId,
-        icon: "icon",
+        icon: IconName.GridView,
         Tile: e.Tile ?? DummyTile,
-      })
-    );
+      };
+      return registerTile(entry);
+    });
     return () => {
       for (const d of disposes) d();
     };

--- a/app/packages/tiling/src/index.ts
+++ b/app/packages/tiling/src/index.ts
@@ -4,9 +4,9 @@
 export {
   TilingProvider,
   TileIdScope,
+  TileSettingsContent,
   useTiling,
   useTileId,
-  useTileSettings,
 } from "./lib/TilingProvider";
 export type { TilingProviderProps } from "./lib/TilingProvider";
 export type {
@@ -17,20 +17,12 @@ export type {
 } from "./lib/types";
 
 // --- Per-tile state -------------------------------------------------------
+export { registeredTilesAtom, tileSelectionAtom } from "./lib/atoms";
 export {
-  registeredTilesAtom,
-  tileSourceAtom,
-  tileSelectionAtom,
-} from "./lib/atoms";
-export {
-  useTileSource,
-  useSetTileSource,
-  useSetTileSourceFor,
   useTileSelection,
   useSetTileSelection,
   useTileSelectionFor,
   useTileTypes,
-  useTileSourcesByType,
 } from "./lib/use-tile-state";
 export { useRegisteredTiles } from "./lib/use-registered-tiles";
 export { useTileRegistry } from "./lib/use-tile-registry";

--- a/app/packages/tiling/src/lib/TilingProvider.test.tsx
+++ b/app/packages/tiling/src/lib/TilingProvider.test.tsx
@@ -1,11 +1,11 @@
 import { act, cleanup, render, renderHook } from "@testing-library/react";
-import React, { useState } from "react";
+import React from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  TileIdScope,
+  TileSettingsContent,
   TilingProvider,
   TilingTile,
-  TileIdScope,
-  useTileSettings,
   useTiling,
 } from "./TilingProvider";
 
@@ -262,122 +262,86 @@ describe("TilingProvider", () => {
     });
   });
 
-  describe("settings registry", () => {
-    function Camera() {
-      return <span data-testid="camera-settings">camera-settings</span>;
-    }
-    function Lidar() {
-      return <span data-testid="lidar-settings">lidar-settings</span>;
+  describe("settings portal", () => {
+    function Host({
+      initialFocus,
+    }: {
+      initialFocus?: string;
+    }) {
+      const tiling = useTiling();
+      // Bind the slot DOM element on mount so TileSettingsContent
+      // has somewhere to portal into.
+      React.useEffect(() => {
+        if (initialFocus) tiling.setFocusedTileId(initialFocus);
+      }, [tiling, initialFocus]);
+      return (
+        <>
+          <div data-testid="slot" ref={tiling.setSettingsSlotEl} />
+          <TileIdScope tileId="cam-1">
+            <TileSettingsContent>
+              <span data-testid="cam-settings">cam</span>
+            </TileSettingsContent>
+          </TileIdScope>
+          <TileIdScope tileId="lid-1">
+            <TileSettingsContent>
+              <span data-testid="lid-settings">lid</span>
+            </TileSettingsContent>
+          </TileIdScope>
+          <button
+            data-testid="focus-cam"
+            onClick={() => tiling.setFocusedTileId("cam-1")}
+          />
+          <button
+            data-testid="focus-lid"
+            onClick={() => tiling.setFocusedTileId("lid-1")}
+          />
+        </>
+      );
     }
 
-    it("exposes nothing when no tile is focused", () => {
-      const { result } = renderHook(() => useTiling(), { wrapper: Wrapper });
-      expect(result.current.FocusedTileSettings).toBeNull();
+    it("does not portal anything when no tile is focused", () => {
+      const utils = render(
+        <TilingProvider>
+          <Host />
+        </TilingProvider>
+      );
+      expect(utils.queryByTestId("cam-settings")).toBeNull();
+      expect(utils.queryByTestId("lid-settings")).toBeNull();
     });
 
-    it("returns the settings component for the focused tile", () => {
-      function TilePanel() {
-        useTileSettings(Camera);
-        return null;
-      }
-
-      const { result } = renderHook(() => useTiling(), {
-        wrapper: ({ children }) => (
-          <Wrapper initialTiles={{ "cam-1": makeTile("cam") }}>
-            <TileIdScope tileId="cam-1">
-              <TilePanel />
-            </TileIdScope>
-            {children}
-          </Wrapper>
-        ),
-      });
-
-      act(() => {
-        result.current.setFocusedTileId("cam-1");
-      });
-      expect(result.current.FocusedTileSettings).toBe(Camera);
-    });
-
-    it("clears its entry when the panel unmounts (effect cleanup runs)", () => {
-      function TilePanel() {
-        useTileSettings(Camera);
-        return null;
-      }
-
-      // Render a stateful wrapper that can toggle the panel on/off so
-      // we can verify the cleanup function deregisters the settings.
-      let setShow!: (v: boolean) => void;
-      function Host() {
-        const [show, set] = useState(true);
-        setShow = set;
-        const tiling = useTiling();
-        return (
-          <>
-            {show ? (
-              <TileIdScope tileId="cam-1">
-                <TilePanel />
-              </TileIdScope>
-            ) : null}
-            <button
-              data-testid="focus"
-              onClick={() => tiling.setFocusedTileId("cam-1")}
-            />
-            <span data-testid="settings">
-              {tiling.FocusedTileSettings ? "yes" : "no"}
-            </span>
-          </>
-        );
-      }
-
+    it("portals the focused tile's settings into the slot", () => {
       const utils = render(
         <TilingProvider initialTiles={{ "cam-1": makeTile("cam") }}>
           <Host />
         </TilingProvider>
       );
-      // Focus the tile — settings should resolve to "yes".
       act(() => {
-        utils.getByTestId("focus").click();
+        utils.getByTestId("focus-cam").click();
       });
-      expect(utils.getByTestId("settings").textContent).toBe("yes");
-
-      // Unmount the panel — registry should drop the entry.
-      act(() => setShow(false));
-      expect(utils.getByTestId("settings").textContent).toBe("no");
+      expect(utils.getByTestId("slot").contains(
+        utils.getByTestId("cam-settings")
+      )).toBe(true);
+      expect(utils.queryByTestId("lid-settings")).toBeNull();
     });
 
-    it("swapping the registered component replaces the entry", () => {
-      let setKind!: (k: "camera" | "lidar") => void;
-      function MultiPanel() {
-        const [kind, set] = useState<"camera" | "lidar">("camera");
-        setKind = set;
-        useTileSettings(kind === "camera" ? Camera : Lidar);
-        return null;
-      }
-      function FocusedReader({
-        onReady,
-      }: {
-        onReady: (r: ReturnType<typeof useTiling>) => void;
-      }) {
-        const t = useTiling();
-        onReady(t);
-        return null;
-      }
-
-      let api: ReturnType<typeof useTiling> | null = null;
-      render(
-        <TilingProvider initialTiles={{ "cam-1": makeTile("cam") }}>
-          <TileIdScope tileId="cam-1">
-            <MultiPanel />
-          </TileIdScope>
-          <FocusedReader onReady={(r) => (api = r)} />
+    it("swapping focus swaps which settings render in the slot", () => {
+      const utils = render(
+        <TilingProvider
+          initialTiles={{
+            "cam-1": makeTile("cam"),
+            "lid-1": makeTile("lid"),
+          }}
+        >
+          <Host />
         </TilingProvider>
       );
+      act(() => utils.getByTestId("focus-cam").click());
+      expect(utils.queryByTestId("cam-settings")).not.toBeNull();
+      expect(utils.queryByTestId("lid-settings")).toBeNull();
 
-      act(() => api!.setFocusedTileId("cam-1"));
-      expect(api!.FocusedTileSettings).toBe(Camera);
-
-      act(() => setKind("lidar"));
-      expect(api!.FocusedTileSettings).toBe(Lidar);
+      act(() => utils.getByTestId("focus-lid").click());
+      expect(utils.queryByTestId("cam-settings")).toBeNull();
+      expect(utils.queryByTestId("lid-settings")).not.toBeNull();
     });
   });
 });

--- a/app/packages/tiling/src/lib/TilingProvider.tsx
+++ b/app/packages/tiling/src/lib/TilingProvider.tsx
@@ -8,13 +8,14 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 import type { MosaicNode } from "react-mosaic-component";
 import {
   addTileToLayout,
   autoLayout as autoLayoutFn,
   collectTileIds,
 } from "../views/MosaicGrid/MosaicGrid";
-import { tileSelectionAtom, tileSourceAtom } from "./atoms";
+import { tileSelectionAtom } from "./atoms";
 import type {
   AddTileOptions,
   TilingContextValue,
@@ -70,9 +71,11 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
   // Per-instance Jotai store so multiple <TilingProvider>s on the same
   // page each get isolated atom state (sources, selections, registry).
   const jotaiStore = useMemo(() => createStore(), []);
-  const [settings, setSettings] = useState<
-    Record<string, React.ComponentType>
-  >({});
+  // Portal target the settings sidebar registers; `<TileSettingsContent>`
+  // children render here when their tile is focused.
+  const [settingsSlotEl, setSettingsSlotEl] = useState<HTMLElement | null>(
+    null
+  );
   // Seed the counter past any `<prefix>-<n>` suffix in the initial tiles,
   // so the first `addTile("camera", ...)` against `{ "camera-1": ... }`
   // produces `camera-2` instead of colliding with `camera-1`. Walks every
@@ -112,7 +115,6 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
         // Free per-tile atomFamily entries so dynamic tile ids don't
         // accumulate in the store across long sessions.
         for (const id of idsToRemove) {
-          tileSourceAtom.remove(id);
           tileSelectionAtom.remove(id);
         }
       }
@@ -157,9 +159,8 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
         return stripped;
       });
       setFocusedTileId((current) => (current === id ? null : current));
-      // Release the per-tile atomFamily entries so the store doesn't
+      // Release the per-tile atomFamily entry so the store doesn't
       // grow unbounded across long sessions.
-      tileSourceAtom.remove(id);
       tileSelectionAtom.remove(id);
     },
     []
@@ -175,27 +176,6 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
     setLayoutState(autoLayoutFn(Object.keys(tilesRef.current)));
   }, []);
 
-  const registerSettings = useCallback(
-    (tileId: string, Component: React.ComponentType) => {
-      setSettings((prev) =>
-        prev[tileId] === Component ? prev : { ...prev, [tileId]: Component }
-      );
-      return () => {
-        setSettings((prev) => {
-          if (!(tileId in prev)) return prev;
-          const next = { ...prev };
-          delete next[tileId];
-          return next;
-        });
-      };
-    },
-    []
-  );
-
-  const FocusedTileSettings = focusedTileId
-    ? (settings[focusedTileId] ?? null)
-    : null;
-
   const value = useMemo<TilingContextValue>(
     () => ({
       layout,
@@ -206,8 +186,8 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
       addTile,
       removeTile,
       autoLayout,
-      FocusedTileSettings,
-      registerSettings,
+      settingsSlotEl,
+      setSettingsSlotEl,
     }),
     [
       layout,
@@ -217,8 +197,7 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
       addTile,
       removeTile,
       autoLayout,
-      FocusedTileSettings,
-      registerSettings,
+      settingsSlotEl,
     ]
   );
 
@@ -273,19 +252,15 @@ export function useTileId(): string | null {
 }
 
 /**
- * Register a settings component for the surrounding tile. The component
- * is rendered (as `<Component />`) in the settings panel whenever this
- * tile is focused. Pass a module-level component reference, not an
- * inline JSX element — element identity changes every render and would
- * thrash the registry.
+ * Portals its children into the settings sidebar when the surrounding
+ * tile is focused. State flows through normal React props from the
+ * tile body — no shared store needed.
  */
-export function useTileSettings(Component: React.ComponentType): void {
+export const TileSettingsContent: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
   const tileId = useTileId();
-  const { registerSettings } = useTiling();
-  useEffect(() => {
-    if (!tileId) return undefined;
-    return registerSettings(tileId, Component);
-    // registerSettings is a useCallback([]) — stable across renders.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tileId, Component]);
-}
+  const { focusedTileId, settingsSlotEl } = useTiling();
+  if (!tileId || tileId !== focusedTileId || !settingsSlotEl) return null;
+  return createPortal(children, settingsSlotEl);
+};

--- a/app/packages/tiling/src/lib/atoms.ts
+++ b/app/packages/tiling/src/lib/atoms.ts
@@ -1,46 +1,16 @@
-// ---------------------------------------------------------------------------
-// Tiling-scoped Jotai atoms. The `TilingProvider` mounts a Jotai
-// `Provider` with its own `createStore()`, so multiple independent
-// tiling instances on the same page each get their own copy of these
-// values.
-// ---------------------------------------------------------------------------
-
 import { atom, type PrimitiveAtom } from "jotai";
 import { atomFamily } from "jotai/utils";
 import type { RegisteredTile } from "./types";
 
-/**
- * Flat list of every registered tile. Consumers call `registerTile`
- * (see `use-tile-registry.ts`) to push an entry; the tiling header /
- * settings UI reads it via `useTileTypes()` / `useTileSourcesByType()`.
- *
- * Held in registration order so the menu stays stable across renders.
- */
+/** Registered tile kinds, in registration order. Consumed by the
+ *  "Add tile" menu via `useTileTypes()`. */
 export const registeredTilesAtom = atom<RegisteredTile[]>([]);
 
-/**
- * Per-tile-id source binding. The value is the id of the source
- * (typically a playback stream) whose data this tile should render —
- * `null` when the tile is unbound (placeholder mode). Tiles read it
- * via `useTileSource()`; the settings panel writes it through
- * `useSetTileSource()`.
- */
-// `atom<string | null>(null)` should resolve to PrimitiveAtom, but jotai's
-// overloads narrow `Value` against the bare `null` argument and produce a
-// read-only `Atom<string>`. The cast preserves the writable shape so
-// `useSetAtom(tileSourceAtom(id))` keeps its setter signature.
-export const tileSourceAtom = atomFamily(
-  (_tileId: string) => atom<string | null>(null) as PrimitiveAtom<string | null>
-);
-
-/**
- * Per-tile-id "current selection". Tile bodies write into this when
- * the user clicks something inspectable (a graph point, a scene
- * object, etc.); the inspector sidebar reads the focused tile's value
- * to render its details. Shape is intentionally `unknown` — each tile
- * can publish its own payload schema.
- */
-// See note on `tileSourceAtom` — same `null`-initial-value inference quirk.
+/** Per-tile selection payload — whatever the tile body publishes when
+ *  the user clicks something inspectable. The inspector sidebar reads
+ *  the focused tile's value. */
+// Cast preserves the writable shape; jotai's null-narrowed overload
+// resolves to a read-only Atom otherwise.
 export const tileSelectionAtom = atomFamily(
   (_tileId: string) => atom<unknown>(null) as PrimitiveAtom<unknown>
 );

--- a/app/packages/tiling/src/lib/types.ts
+++ b/app/packages/tiling/src/lib/types.ts
@@ -1,31 +1,15 @@
+import type { IconName } from "@voxel51/voodo";
 import type { ComponentType, ReactNode } from "react";
 import type { MosaicNode } from "react-mosaic-component";
 
 /**
- * One entry in the tile registry — links a data source (e.g. a
- * playback stream) to the tile component that should render it.
- *
- * Tiling is the owner here, not the data layer: the playback engine
- * (or any other source) calls `registerTile(...)` with this shape
- * whenever a source becomes available for spawning into a tile.
- *
- * The same `type` may be registered for multiple sources (e.g. several
- * camera streams). UIs that show "what kinds of tiles can I add" should
- * use `useTileTypes()` (deduplicated by `type`); UIs that show "which
- * source feeds this tile" should use `useTileSourcesByType(type)`.
+ * A renderable tile kind for the "Add tile" menu. Keyed by `type` —
+ * registering the same `type` replaces the entry.
  */
 export interface RegisteredTile {
-  /** Id of the source this tile renders — typically a playback stream id. */
-  streamId: string;
-  /** Discriminator used to group sources of the same kind. */
   type: string;
-  /** Menu label for the type, shared across every source of this `type`. */
   typeLabel: string;
-  /** Per-source display name (used in the settings source picker). */
-  title: string;
-  /** Menu / chrome icon. Opaque to tiling — passed straight through to voodo. */
-  icon: unknown;
-  /** Tile body component, mounted as `<Tile />` when a new tile spawns. */
+  icon: IconName | ReactNode;
   Tile: ComponentType;
 }
 
@@ -70,10 +54,7 @@ export interface TilingContextValue {
   removeTile: (id: string) => void;
   autoLayout: () => void;
 
-  // Settings registry
-  FocusedTileSettings: ComponentType | null;
-  registerSettings: (
-    tileId: string,
-    Component: ComponentType
-  ) => () => void;
+  // Portal target for the focused tile's settings UI.
+  settingsSlotEl: HTMLElement | null;
+  setSettingsSlotEl: (el: HTMLElement | null) => void;
 }

--- a/app/packages/tiling/src/lib/use-tile-registry.test.tsx
+++ b/app/packages/tiling/src/lib/use-tile-registry.test.tsx
@@ -1,8 +1,10 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
+import { IconName } from "@voxel51/voodo";
 import { Provider as JotaiProvider, createStore } from "jotai";
 import React from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import { TilingProvider } from "./TilingProvider";
+import type { RegisteredTile } from "./types";
 import { useRegisteredTiles } from "./use-registered-tiles";
 import { useTileRegistry } from "./use-tile-registry";
 
@@ -20,12 +22,13 @@ const makeWrapper = (): React.FC<{ children: React.ReactNode }> => {
 
 const DummyTile: React.FC = () => null;
 
-const makeEntry = (streamId: string, type = "camera", title = streamId) => ({
-  streamId,
+const makeEntry = (
+  type: string,
+  typeLabel = type.charAt(0).toUpperCase() + type.slice(1)
+): RegisteredTile => ({
   type,
-  typeLabel: type.charAt(0).toUpperCase() + type.slice(1),
-  title,
-  icon: "icon",
+  typeLabel,
+  icon: IconName.GridView,
   Tile: DummyTile,
 });
 
@@ -43,27 +46,23 @@ describe("useTileRegistry", () => {
     expect(result.current.tiles).toEqual([]);
 
     act(() => {
-      result.current.registry.registerTile(makeEntry("camera_front"));
+      result.current.registry.registerTile(makeEntry("camera"));
     });
     expect(result.current.tiles).toHaveLength(1);
-    expect(result.current.tiles[0].streamId).toBe("camera_front");
+    expect(result.current.tiles[0].type).toBe("camera");
   });
 
-  it("replaces an existing entry with the same streamId rather than duplicating", () => {
+  it("replaces an existing entry with the same type rather than duplicating", () => {
     const { result } = renderHook(
       () => ({ registry: useTileRegistry(), tiles: useRegisteredTiles() }),
       { wrapper: makeWrapper() }
     );
     act(() => {
-      result.current.registry.registerTile(
-        makeEntry("camera_front", "camera", "Old title")
-      );
-      result.current.registry.registerTile(
-        makeEntry("camera_front", "camera", "New title")
-      );
+      result.current.registry.registerTile(makeEntry("camera", "Old label"));
+      result.current.registry.registerTile(makeEntry("camera", "New label"));
     });
     expect(result.current.tiles).toHaveLength(1);
-    expect(result.current.tiles[0].title).toBe("New title");
+    expect(result.current.tiles[0].typeLabel).toBe("New label");
   });
 
   it("returns a disposer that removes the entry", () => {
@@ -73,7 +72,7 @@ describe("useTileRegistry", () => {
     );
     let dispose = () => {};
     act(() => {
-      dispose = result.current.registry.registerTile(makeEntry("camera_front"));
+      dispose = result.current.registry.registerTile(makeEntry("camera"));
     });
     expect(result.current.tiles).toHaveLength(1);
     act(() => {
@@ -82,16 +81,20 @@ describe("useTileRegistry", () => {
     expect(result.current.tiles).toEqual([]);
   });
 
-  it("supports multiple distinct streamIds", () => {
+  it("supports multiple distinct types", () => {
     const { result } = renderHook(
       () => ({ registry: useTileRegistry(), tiles: useRegisteredTiles() }),
       { wrapper: makeWrapper() }
     );
     act(() => {
-      result.current.registry.registerTile(makeEntry("a"));
-      result.current.registry.registerTile(makeEntry("b"));
-      result.current.registry.registerTile(makeEntry("c"));
+      result.current.registry.registerTile(makeEntry("camera"));
+      result.current.registry.registerTile(makeEntry("lidar"));
+      result.current.registry.registerTile(makeEntry("graph"));
     });
-    expect(result.current.tiles.map((t) => t.streamId)).toEqual(["a", "b", "c"]);
+    expect(result.current.tiles.map((t) => t.type)).toEqual([
+      "camera",
+      "lidar",
+      "graph",
+    ]);
   });
 });

--- a/app/packages/tiling/src/lib/use-tile-registry.test.tsx
+++ b/app/packages/tiling/src/lib/use-tile-registry.test.tsx
@@ -81,6 +81,27 @@ describe("useTileRegistry", () => {
     expect(result.current.tiles).toEqual([]);
   });
 
+  it("disposing the older registration leaves the replacement intact", () => {
+    const { result } = renderHook(
+      () => ({ registry: useTileRegistry(), tiles: useRegisteredTiles() }),
+      { wrapper: makeWrapper() }
+    );
+    let disposeA = () => {};
+    act(() => {
+      disposeA = result.current.registry.registerTile(makeEntry("camera", "A"));
+      result.current.registry.registerTile(makeEntry("camera", "B"));
+    });
+    expect(result.current.tiles).toHaveLength(1);
+    expect(result.current.tiles[0].typeLabel).toBe("B");
+
+    act(() => {
+      disposeA();
+    });
+    // Stale disposer must not strip the newer same-type entry.
+    expect(result.current.tiles).toHaveLength(1);
+    expect(result.current.tiles[0].typeLabel).toBe("B");
+  });
+
   it("supports multiple distinct types", () => {
     const { result } = renderHook(
       () => ({ registry: useTileRegistry(), tiles: useRegisteredTiles() }),

--- a/app/packages/tiling/src/lib/use-tile-registry.ts
+++ b/app/packages/tiling/src/lib/use-tile-registry.ts
@@ -14,13 +14,19 @@ export function useTileRegistry(): {
   const store = useStore();
   const registerTile = useCallback(
     (entry: RegisteredTile) => {
-      store.set(registeredTilesAtom, (prev) => [
-        ...prev.filter((t) => t.type !== entry.type),
-        entry,
-      ]);
+      store.set(registeredTilesAtom, (prev) => {
+        const index = prev.findIndex((t) => t.type === entry.type);
+        if (index === -1) return [...prev, entry];
+        const next = [...prev];
+        next[index] = entry;
+        return next;
+      });
+      // Filter by identity, not by type — otherwise an older disposer
+      // could remove a newer same-type registration that has since
+      // replaced this one.
       return () => {
         store.set(registeredTilesAtom, (prev) =>
-          prev.filter((t) => t.type !== entry.type)
+          prev.filter((t) => t !== entry)
         );
       };
     },

--- a/app/packages/tiling/src/lib/use-tile-registry.ts
+++ b/app/packages/tiling/src/lib/use-tile-registry.ts
@@ -4,28 +4,9 @@ import { registeredTilesAtom } from "./atoms";
 import type { RegisteredTile } from "./types";
 
 /**
- * Imperative tile-registry API. The integration layer (the code that
- * knows about your data sources — playback streams, server feeds,
- * whatever) calls `registerTile` for each spawnable source. The
- * returned function unregisters the entry — call it in a cleanup
- * effect on unmount.
- *
- * Tiling owns the registry; data layers don't have to know it exists.
- * UIs that consume the registry use `useTileTypes` (deduped) or
- * `useTileSourcesByType(type)` (filtered).
- *
- *     const { registerTile } = useTileRegistry();
- *     useEffect(() => {
- *       const dispose = registerTile({
- *         streamId: "camera_front",
- *         type: "camera",
- *         typeLabel: "Camera",
- *         title: "Camera front",
- *         icon: IconName.GridView,
- *         Tile: CameraTile,
- *       });
- *       return dispose;
- *     }, [registerTile]);
+ * Register a tile kind (one per `type`). Returns a disposer; call it
+ * from a cleanup effect. Re-registering the same `type` replaces the
+ * previous entry.
  */
 export function useTileRegistry(): {
   registerTile: (entry: RegisteredTile) => () => void;
@@ -33,15 +14,13 @@ export function useTileRegistry(): {
   const store = useStore();
   const registerTile = useCallback(
     (entry: RegisteredTile) => {
-      // Replace any existing entry with the same streamId so re-registers
-      // don't accumulate dupes.
       store.set(registeredTilesAtom, (prev) => [
-        ...prev.filter((t) => t.streamId !== entry.streamId),
+        ...prev.filter((t) => t.type !== entry.type),
         entry,
       ]);
       return () => {
         store.set(registeredTilesAtom, (prev) =>
-          prev.filter((t) => t.streamId !== entry.streamId)
+          prev.filter((t) => t.type !== entry.type)
         );
       };
     },

--- a/app/packages/tiling/src/lib/use-tile-state.test.tsx
+++ b/app/packages/tiling/src/lib/use-tile-state.test.tsx
@@ -1,17 +1,15 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
+import { IconName } from "@voxel51/voodo";
 import { Provider as JotaiProvider, createStore } from "jotai";
 import React from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import { TileIdScope, TilingProvider } from "./TilingProvider";
+import type { RegisteredTile } from "./types";
 import { useTileRegistry } from "./use-tile-registry";
 import {
   useSetTileSelection,
-  useSetTileSource,
-  useSetTileSourceFor,
   useTileSelection,
   useTileSelectionFor,
-  useTileSource,
-  useTileSourcesByType,
   useTileTypes,
 } from "./use-tile-state";
 
@@ -39,65 +37,11 @@ const makePlainWrap = () => {
 
 const DummyTile: React.FC = () => null;
 
-describe("useTileSource / useSetTileSource", () => {
-  afterEach(() => cleanup());
-
-  it("returns null until a source is set", () => {
-    const { result } = renderHook(() => useTileSource(), {
-      wrapper: wrap("camera-1"),
-    });
-    expect(result.current).toBeNull();
-  });
-
-  it("updates when useSetTileSource writes a new value", () => {
-    const { result } = renderHook(
-      () => ({ value: useTileSource(), set: useSetTileSource() }),
-      { wrapper: wrap("camera-1") }
-    );
-    act(() => {
-      result.current.set("camera_front");
-    });
-    expect(result.current.value).toBe("camera_front");
-    act(() => {
-      result.current.set(null);
-    });
-    expect(result.current.value).toBeNull();
-  });
-});
-
-describe("useSetTileSourceFor", () => {
-  afterEach(() => cleanup());
-
-  it("writes are visible to a scoped useTileSource reader for the same id", () => {
-    // Setter probe: captures the setter via a callback ref so the assertion
-    // can call it from outside the React tree.
-    function SourceWriter({
-      onReady,
-    }: {
-      onReady: (set: (id: string, src: string | null) => void) => void;
-    }) {
-      const set = useSetTileSourceFor();
-      React.useEffect(() => onReady(set), [onReady, set]);
-      return null;
-    }
-    let captured: (id: string, src: string | null) => void = () => {};
-    const store = createStore();
-    const { result } = renderHook(() => useTileSource(), {
-      wrapper: ({ children }) => (
-        <JotaiProvider store={store}>
-          <TilingProvider>
-            <SourceWriter onReady={(s) => (captured = s)} />
-            <TileIdScope tileId="lidar-1">{children}</TileIdScope>
-          </TilingProvider>
-        </JotaiProvider>
-      ),
-    });
-    expect(result.current).toBeNull();
-    act(() => {
-      captured("lidar-1", "lidar_top");
-    });
-    expect(result.current).toBe("lidar_top");
-  });
+const makeEntry = (type: string): RegisteredTile => ({
+  type,
+  typeLabel: type.charAt(0).toUpperCase() + type.slice(1),
+  icon: IconName.GridView,
+  Tile: DummyTile,
 });
 
 describe("useTileSelection / useTileSelectionFor / useSetTileSelection", () => {
@@ -166,7 +110,7 @@ describe("useTileSelection / useTileSelectionFor / useSetTileSelection", () => {
   });
 });
 
-describe("useTileTypes / useTileSourcesByType", () => {
+describe("useTileTypes", () => {
   afterEach(() => cleanup());
 
   function setup() {
@@ -174,40 +118,16 @@ describe("useTileTypes / useTileSourcesByType", () => {
       () => ({
         registry: useTileRegistry(),
         types: useTileTypes(),
-        cameras: useTileSourcesByType("camera"),
-        lidars: useTileSourcesByType("lidar"),
       }),
       { wrapper: makePlainWrap() }
     );
   }
 
-  const makeEntry = (streamId: string, type: string) => ({
-    streamId,
-    type,
-    typeLabel: type.charAt(0).toUpperCase() + type.slice(1),
-    title: streamId,
-    icon: "icon",
-    Tile: DummyTile,
-  });
-
-  it("dedupes types so each distinct type appears once", () => {
+  it("exposes registered tiles in registration order", () => {
     const { result } = setup();
     act(() => {
-      result.current.registry.registerTile(makeEntry("a", "camera"));
-      result.current.registry.registerTile(makeEntry("b", "camera"));
-      result.current.registry.registerTile(makeEntry("c", "lidar"));
-    });
-    expect(result.current.types.map((t) => t.type)).toEqual([
-      "camera",
-      "lidar",
-    ]);
-  });
-
-  it("preserves registration order in useTileTypes", () => {
-    const { result } = setup();
-    act(() => {
-      result.current.registry.registerTile(makeEntry("c", "lidar"));
-      result.current.registry.registerTile(makeEntry("a", "camera"));
+      result.current.registry.registerTile(makeEntry("lidar"));
+      result.current.registry.registerTile(makeEntry("camera"));
     });
     expect(result.current.types.map((t) => t.type)).toEqual([
       "lidar",
@@ -215,17 +135,17 @@ describe("useTileTypes / useTileSourcesByType", () => {
     ]);
   });
 
-  it("filters useTileSourcesByType to entries with the matching type", () => {
+  it("replacing a type keeps a single entry", () => {
     const { result } = setup();
     act(() => {
-      result.current.registry.registerTile(makeEntry("front", "camera"));
-      result.current.registry.registerTile(makeEntry("back", "camera"));
-      result.current.registry.registerTile(makeEntry("top", "lidar"));
+      result.current.registry.registerTile(makeEntry("camera"));
+      result.current.registry.registerTile(makeEntry("camera"));
+      result.current.registry.registerTile(makeEntry("lidar"));
     });
-    expect(result.current.cameras.map((c) => c.streamId)).toEqual([
-      "front",
-      "back",
+    expect(result.current.types).toHaveLength(2);
+    expect(result.current.types.map((t) => t.type)).toEqual([
+      "camera",
+      "lidar",
     ]);
-    expect(result.current.lidars.map((l) => l.streamId)).toEqual(["top"]);
   });
 });

--- a/app/packages/tiling/src/lib/use-tile-state.ts
+++ b/app/packages/tiling/src/lib/use-tile-state.ts
@@ -1,80 +1,17 @@
-import { useAtomValue, useSetAtom, useStore } from "jotai";
-import { useCallback, useMemo } from "react";
-import {
-  registeredTilesAtom,
-  tileSelectionAtom,
-  tileSourceAtom,
-} from "./atoms";
+import { useAtomValue, useSetAtom } from "jotai";
+import { useCallback } from "react";
+import { registeredTilesAtom, tileSelectionAtom } from "./atoms";
 import { useTileId } from "./TilingProvider";
 import type { RegisteredTile } from "./types";
 
-// We need a stable placeholder key so atomFamily doesn't create a new
-// atom on every render when the surrounding tile id is null (the
-// component is mounted outside a TileIdScope). The placeholder atom
-// stays null and writes against it are no-ops.
+// Stable placeholder for use outside a TileIdScope; writes no-op.
 const NO_TILE = "__no-tile__";
 
-/**
- * Read the current tile's bound source stream id. Reads `useTileId()`
- * internally, so call only inside a `TileIdScope`. Returns `null` when
- * the tile has no bound source (placeholder mode).
- */
-export function useTileSource(): string | null {
-  const tileId = useTileId();
-  return useAtomValue(tileSourceAtom(tileId ?? NO_TILE));
-}
-
-/**
- * Setter for the current tile's bound source stream id. Returned
- * function is stable.
- */
-export function useSetTileSource(): (sourceId: string | null) => void {
-  const tileId = useTileId();
-  const set = useSetAtom(tileSourceAtom(tileId ?? NO_TILE));
-  return useCallback(
-    (sourceId: string | null) => {
-      // Out-of-scope writes are real no-ops — don't touch the NO_TILE
-      // placeholder atom (state could otherwise survive across mounts).
-      if (!tileId) return;
-      set(sourceId);
-    },
-    // `set` is a Jotai setter (referentially stable from useSetAtom).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [tileId]
-  );
-}
-
-/**
- * Imperative setter for the source of an explicit tile id — used by
- * surfaces that bind a tile that doesn't yet exist at hook call time
- * (e.g. TilingHeader's "Add tile" menu defaulting a freshly-spawned
- * tile to the first registered source of its type).
- */
-export function useSetTileSourceFor(): (
-  tileId: string,
-  sourceId: string | null
-) => void {
-  const store = useStore();
-  return useCallback(
-    (tileId, sourceId) => store.set(tileSourceAtom(tileId), sourceId),
-    [store]
-  );
-}
-
-/**
- * Read the current tile's selection payload. Inspector / setting
- * surfaces use this to render details about whatever the user picked
- * inside the tile.
- */
 export function useTileSelection<T = unknown>(): T | null {
   const tileId = useTileId();
   return useAtomValue(tileSelectionAtom(tileId ?? NO_TILE)) as T | null;
 }
 
-/**
- * Setter for the current tile's selection payload. Tile bodies call
- * this when the user clicks something inspectable.
- */
 export function useSetTileSelection(): (selection: unknown) => void {
   const tileId = useTileId();
   const set = useSetAtom(tileSelectionAtom(tileId ?? NO_TILE));
@@ -88,40 +25,12 @@ export function useSetTileSelection(): (selection: unknown) => void {
   );
 }
 
-/**
- * Read the selection payload for an explicit `tileId` — used by surfaces
- * that aren't inside a `TileIdScope` but know which tile to inspect
- * (e.g. the global inspector sidebar reading the focused tile's data).
- * Pass `null` when no tile is focused.
- */
 export function useTileSelectionFor<T = unknown>(
   tileId: string | null
 ): T | null {
   return useAtomValue(tileSelectionAtom(tileId ?? NO_TILE)) as T | null;
 }
 
-/**
- * Distinct tile types among the currently-registered tiles, in
- * registration order. Each entry exposes the first registered source
- * as the type's exemplar (used for the icon + type label in
- * TilingHeader's add-tile menu).
- */
 export function useTileTypes(): RegisteredTile[] {
-  const tiles = useAtomValue(registeredTilesAtom);
-  return useMemo(() => {
-    const seen = new Map<string, RegisteredTile>();
-    for (const entry of tiles) {
-      if (!seen.has(entry.type)) seen.set(entry.type, entry);
-    }
-    return Array.from(seen.values());
-  }, [tiles]);
-}
-
-/**
- * Registered tile sources matching the given `type`. Used by settings
- * source pickers ("which camera feed should this Camera tile show").
- */
-export function useTileSourcesByType(type: string): RegisteredTile[] {
-  const tiles = useAtomValue(registeredTilesAtom);
-  return useMemo(() => tiles.filter((t) => t.type === type), [tiles, type]);
+  return useAtomValue(registeredTilesAtom);
 }

--- a/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.module.css
+++ b/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.module.css
@@ -24,8 +24,6 @@
   pointer-events: none;
 }
 
-/* Strip react-mosaic's default chrome — we provide our own via TileHeader
-   in renderToolbar and our tile bodies as the window children. */
 .root :global(.mosaic) {
   background: transparent;
 }
@@ -37,9 +35,6 @@
   background: var(--color-content-bg-card-2);
 }
 
-/* react-mosaic auto-wires the toolbar as the drag source; we render a
-   TileHeader inside via renderToolbar. Strip default padding/border so
-   the TileHeader is the only thing styling that row. */
 .root :global(.mosaic .mosaic-window-toolbar) {
   padding: 0;
   background: transparent;
@@ -57,6 +52,7 @@
    so the icon is empty and the bare title + h4 show through under the
    real tile body as a "ghost" layer. We don't use the drag preview —
    hide it. */
+/* Blueprint-styled drag preview leaks through as a ghost — hide it. */
 .root :global(.mosaic .mosaic-preview) {
   display: none;
 }
@@ -69,10 +65,6 @@
   margin: 2px;
 }
 
-/* Split hit area: still draggable, but its width matches the tile
-   margins on each side so it sits in the gap without overlapping the
-   tile body. Vertical splits use width + horizontal margin; horizontal
-   splits use the column variant. */
 .root :global(.mosaic .mosaic-split) {
   background: transparent;
 }
@@ -91,21 +83,15 @@
   background: var(--color-brand-primary);
 }
 
-/* TileHeader fills the full toolbar width so the whole row is draggable. */
 .toolbarHeader {
   width: 100%;
 }
 
-/* Wraps tile.render() output so we can attach pointer-down for focus
-   without each tile having to opt in. */
 .bodyWrapper {
   width: 100%;
   height: 100%;
 }
 
-/* Focused window — inset accent outline so the user sees which tile new
-   spawns will split. Outline (rather than border) avoids fighting the
-   base .mosaic-window border specificity. */
 .focused {
   outline: 2px solid var(--color-brand-primary);
   outline-offset: -2px;

--- a/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.module.css
+++ b/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.module.css
@@ -53,6 +53,7 @@
    real tile body as a "ghost" layer. We don't use the drag preview —
    hide it. */
 /* Blueprint-styled drag preview leaks through as a ghost — hide it. */
+/* stylelint-disable-next-line selector-pseudo-class-no-unknown */
 .root :global(.mosaic .mosaic-preview) {
   display: none;
 }

--- a/app/packages/tiling/src/views/TileSettingsSidebar/TileSettingsSidebar.stories.tsx
+++ b/app/packages/tiling/src/views/TileSettingsSidebar/TileSettingsSidebar.stories.tsx
@@ -3,8 +3,8 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { useEffect } from "react";
 import {
   TileIdScope,
+  TileSettingsContent,
   TilingProvider,
-  useTileSettings,
   useTiling,
 } from "../../lib/TilingProvider";
 import TileSettingsSidebar from "./TileSettingsSidebar";
@@ -17,26 +17,22 @@ export default meta;
 
 type Story = StoryObj<typeof TileSettingsSidebar>;
 
-/** Stand-in tile-settings component, registered via useTileSettings. */
-const SampleSettings: React.FC = () => (
-  <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-    <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
-      Source
-    </Text>
-    <select defaultValue="camera_front">
-      <option value="camera_front">Camera front</option>
-      <option value="camera_back">Camera back</option>
-    </select>
-    <Checkbox label="Show overlays" defaultChecked />
-    <Checkbox label="Show bounding boxes" />
-  </div>
+/** Stand-in tile body — renders its settings JSX via the portal. */
+const TileBody: React.FC = () => (
+  <TileSettingsContent>
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
+        Source
+      </Text>
+      <select defaultValue="camera_front">
+        <option value="camera_front">Camera front</option>
+        <option value="camera_back">Camera back</option>
+      </select>
+      <Checkbox label="Show overlays" defaultChecked />
+      <Checkbox label="Show bounding boxes" />
+    </div>
+  </TileSettingsContent>
 );
-
-/** Mount the tile body (which registers its settings) so the sidebar has data. */
-const TileBody: React.FC = () => {
-  useTileSettings(SampleSettings);
-  return null;
-};
 
 function AutoFocus({ id }: { id: string }) {
   const { setFocusedTileId } = useTiling();

--- a/app/packages/tiling/src/views/TileSettingsSidebar/TileSettingsSidebar.test.tsx
+++ b/app/packages/tiling/src/views/TileSettingsSidebar/TileSettingsSidebar.test.tsx
@@ -2,23 +2,27 @@ import { act, cleanup, render, screen } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { TileIdScope, TilingProvider, useTileSettings, useTiling } from "../../lib/TilingProvider";
+import {
+  TileIdScope,
+  TileSettingsContent,
+  TilingProvider,
+  useTiling,
+} from "../../lib/TilingProvider";
 import TileSettingsSidebar from "./TileSettingsSidebar";
 
 const SETTINGS_LABEL = "camera-settings-panel";
 
-const Settings: React.FC = () => (
-  <div data-testid={SETTINGS_LABEL}>camera knobs</div>
-);
-
 /**
- * Mounts a tile body inside `TileIdScope` and registers the settings
- * panel — same shape a real PlaybackTile would use.
+ * Mounts a tile body inside `TileIdScope` and renders its settings JSX
+ * via the portal — same shape a real PlaybackTile would use.
  */
-const TileBody: React.FC = () => {
-  useTileSettings(Settings);
-  return <div data-testid="tile-body" />;
-};
+const TileBody: React.FC = () => (
+  <div data-testid="tile-body">
+    <TileSettingsContent>
+      <div data-testid={SETTINGS_LABEL}>camera knobs</div>
+    </TileSettingsContent>
+  </div>
+);
 
 const FocusButton: React.FC<{ id: string }> = ({ id }) => {
   const { setFocusedTileId } = useTiling();
@@ -40,7 +44,7 @@ describe("TileSettingsSidebar", () => {
     expect(screen.getByText("Focus a tile to edit its settings.")).toBeTruthy();
   });
 
-  it("renders the focused tile's registered settings when a tile is focused", () => {
+  it("portals the focused tile's settings into the sidebar", () => {
     render(
       <TilingProvider
         initialTiles={{

--- a/app/packages/tiling/src/views/TileSettingsSidebar/TileSettingsSidebar.tsx
+++ b/app/packages/tiling/src/views/TileSettingsSidebar/TileSettingsSidebar.tsx
@@ -1,28 +1,23 @@
 import { Text, TextColor, TextVariant } from "@voxel51/voodo";
-import React from "react";
+import React, { useCallback } from "react";
 import { useTiling } from "../../lib/TilingProvider";
 import SidebarPanel from "../SidebarPanel/SidebarPanel";
 
-/**
- * Left-hand sidebar that renders the focused tile's settings component,
- * if one was registered via `useTileSettings`. Otherwise shows an empty
- * state hint. Reads directly from the surrounding `TilingProvider`.
- *
- * The header reads "Settings: <tile title>" so it's obvious which tile
- * is being configured.
- */
 const TileSettingsSidebar: React.FC = () => {
-  const { focusedTileId, FocusedTileSettings, tiles } = useTiling();
-  // Defend against a stale focusedTileId — possible if a tile is removed
-  // mid-render or the consumer's layout state races ahead of the registry.
+  const { focusedTileId, tiles, setSettingsSlotEl } = useTiling();
   const focusedTile =
     focusedTileId && tiles[focusedTileId] ? tiles[focusedTileId] : null;
   const title = focusedTile ? `Settings: ${focusedTile.title}` : "Settings";
+
+  const slotRef = useCallback(
+    (el: HTMLDivElement | null) => setSettingsSlotEl(el),
+    [setSettingsSlotEl]
+  );
+
   return (
     <SidebarPanel title={title}>
-      {focusedTile && FocusedTileSettings ? (
-        <FocusedTileSettings />
-      ) : (
+      <div ref={slotRef} />
+      {!focusedTile && (
         <Text variant={TextVariant.Sm} color={TextColor.Muted}>
           Focus a tile to edit its settings.
         </Text>

--- a/app/packages/tiling/src/views/TilingHeader/TilingHeader.stories.tsx
+++ b/app/packages/tiling/src/views/TilingHeader/TilingHeader.stories.tsx
@@ -32,26 +32,20 @@ function RegisterTiles() {
   useEffect(() => {
     const disposes = [
       registerTile({
-        streamId: "camera_front",
         type: "camera",
         typeLabel: "Camera",
-        title: "Camera front",
         icon: IconName.GridView,
         Tile: DummyTile,
       }),
       registerTile({
-        streamId: "lidar_top",
         type: "lidar",
         typeLabel: "Lidar",
-        title: "Lidar top",
         icon: IconName.Embeddings,
         Tile: DummyTile,
       }),
       registerTile({
-        streamId: "imu",
         type: "graph",
         typeLabel: "Graph",
-        title: "IMU",
         icon: IconName.Logs,
         Tile: DummyTile,
       }),

--- a/app/packages/tiling/src/views/TilingHeader/TilingHeader.test.tsx
+++ b/app/packages/tiling/src/views/TilingHeader/TilingHeader.test.tsx
@@ -1,32 +1,22 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { IconName } from "@voxel51/voodo";
 import React, { useEffect } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { TilingProvider } from "../../lib/TilingProvider";
+import type { RegisteredTile } from "../../lib/types";
 import { useTileRegistry } from "../../lib/use-tile-registry";
 import TilingHeader from "./TilingHeader";
 
 const CameraTile: React.FC = () => <div data-testid="camera-body" />;
 const LidarTile: React.FC = () => <div data-testid="lidar-body" />;
 
-/**
- * Mount inside the TilingProvider so it can register tile entries
- * exactly the way `useMockStreams` does in production stories.
- */
-const RegisterTiles: React.FC<{
-  entries: Array<{
-    streamId: string;
-    type: string;
-    typeLabel: string;
-    title: string;
-    Tile: React.ComponentType;
-  }>;
-}> = ({ entries }) => {
+const RegisterTiles: React.FC<{ entries: RegisteredTile[] }> = ({
+  entries,
+}) => {
   const { registerTile } = useTileRegistry();
   useEffect(() => {
-    const disposes = entries.map((e) =>
-      registerTile({ ...e, icon: "any" as unknown })
-    );
+    const disposes = entries.map((e) => registerTile(e));
     return () => {
       for (const d of disposes) d();
     };
@@ -91,17 +81,15 @@ describe("TilingHeader", () => {
         <RegisterTiles
           entries={[
             {
-              streamId: "camera_front",
               type: "camera",
               typeLabel: "Camera",
-              title: "Camera front",
+              icon: IconName.GridView,
               Tile: CameraTile,
             },
             {
-              streamId: "lidar_top",
               type: "lidar",
               typeLabel: "Lidar",
-              title: "Lidar top",
+              icon: IconName.Embeddings,
               Tile: LidarTile,
             },
           ]}

--- a/app/packages/tiling/src/views/TilingHeader/TilingHeader.tsx
+++ b/app/packages/tiling/src/views/TilingHeader/TilingHeader.tsx
@@ -13,42 +13,19 @@ import {
 } from "@voxel51/voodo";
 import clsx from "clsx";
 import React, { useMemo } from "react";
-import { useRegisteredTiles } from "../../lib/use-registered-tiles";
-import {
-  useSetTileSourceFor,
-  useTileTypes,
-} from "../../lib/use-tile-state";
+import { useTileTypes } from "../../lib/use-tile-state";
 import { useTiling } from "../../lib/TilingProvider";
 import { SidebarLeftIcon, SidebarRightIcon } from "./tiling-header-icons";
 import styles from "./TilingHeader.module.css";
 
 export interface TilingHeaderProps {
-  /** Displayed on the left — usually the current dataset / session filename. */
   fileName: string;
-  /** Current left sidebar visibility. Toggle button reflects this in its label. */
   leftSidebarOpen?: boolean;
-  /** Current right sidebar visibility. */
   rightSidebarOpen?: boolean;
   onToggleLeftSidebar?: () => void;
   onToggleRightSidebar?: () => void;
 }
 
-/**
- * Top-of-page chrome for a tiling layout:
- *
- * - Filename on the left (truncates with ellipsis when narrow)
- * - "Add tile" icon-button dropdown — items are inferred from the
- *   distinct tile *types* among the entries registered with the tile
- *   Spawning a Camera tile binds it to the first registered camera
- *   stream by default; the user can swap to any other registered
- *   camera through the tile's settings panel. Auto Layout is
- *   appended at the bottom.
- * - Two right-aligned sidebar toggles using mirrored "panel" icons that
- *   visually convey which side they control
- *
- * Must be rendered inside a `TilingProvider` — the menu depends on
- * tiling context for type discovery and tile spawning.
- */
 const TilingHeader: React.FC<TilingHeaderProps> = ({
   fileName,
   leftSidebarOpen,
@@ -57,9 +34,7 @@ const TilingHeader: React.FC<TilingHeaderProps> = ({
   onToggleRightSidebar,
 }) => {
   const types = useTileTypes();
-  const allTiles = useRegisteredTiles();
   const { addTile, autoLayout } = useTiling();
-  const setTileSource = useSetTileSourceFor();
 
   const tileMenu = useMemo(() => {
     if (types.length === 0) return null;
@@ -73,22 +48,13 @@ const TilingHeader: React.FC<TilingHeaderProps> = ({
               icon={entry.icon}
               text={entry.typeLabel}
               onClick={() => {
-                const newTileId = addTile(
+                addTile(
                   {
                     title: entry.typeLabel,
                     render: () => <TileComponent />,
                   },
                   { idPrefix: entry.type }
                 );
-                // Default the spawn to the first registered source of
-                // this type, if any. The user can swap via the settings
-                // sidebar's source picker.
-                const firstSource = allTiles.find(
-                  (t) => t.type === entry.type
-                );
-                if (firstSource) {
-                  setTileSource(newTileId, firstSource.streamId);
-                }
               }}
             />
           );
@@ -101,10 +67,8 @@ const TilingHeader: React.FC<TilingHeaderProps> = ({
         />
       </>
     );
-    // addTile / autoLayout / setTileSource are stable callbacks from
-    // their providers; only re-build when types or registrations change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [types, allTiles]);
+  }, [types]);
 
   return (
     <div className={styles.root}>
@@ -146,7 +110,6 @@ const TilingHeader: React.FC<TilingHeaderProps> = ({
             variant={Variant.Borderless}
             size={Size.Xs}
             data-testid="tiling-header-toggle-left-sidebar"
-            // React 18/19 type mismatch on FC<{}>.
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             leadingIcon={SidebarLeftIcon as any}
             aria-label={leftSidebarOpen ? "Hide settings" : "Show settings"}
@@ -162,7 +125,6 @@ const TilingHeader: React.FC<TilingHeaderProps> = ({
             variant={Variant.Borderless}
             size={Size.Xs}
             data-testid="tiling-header-toggle-right-sidebar"
-            // React 18/19 type mismatch on FC<{}>.
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             leadingIcon={SidebarRightIcon as any}
             aria-label={rightSidebarOpen ? "Hide inspector" : "Show inspector"}


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

Stacked on #7628 (\`feat/mmMcapMiddleware\`).

## 📋 What changes are proposed in this pull request?

Architectural cleanup of the tiling package. Touches \`packages/tiling\` + \`packages/playback\` + the MCAP tile bodies in \`packages/multimodal\` (consumer migration). No multimodal-side feature work — that's the next PR in the stack.

### Drop the \"source\" concept from tiling

\`packages/tiling\` no longer tracks anything about a tile's data binding. A tile is a kind (\`type\`), not a binding to a specific source.

- \`RegisteredTile\` is now \`{ type, typeLabel, icon, Tile }\` — keyed by \`type\`. One registry entry per kind, not per source.
- Removed: \`streamId\` field, \`tileSourceAtom\`, \`useTileSource\`, \`useSetTileSource\`, \`useSetTileSourceFor\`, \`useTileSourcesByType\`.
- \`TilingHeader\`'s \"Add tile\" menu shows one item per type and doesn't pre-bind sources on spawn.
- \`useTileTypes()\` just returns the deduped registry.

### Portal-based settings — kill the component registry

Tile bodies and their settings live in sibling React subtrees (mosaic grid vs. settings sidebar), so the old \`useTileSettings(Component)\` model required them to share state through a global atom keyed by tile id. Replaced with a portal:

- New \`<TileSettingsContent>{children}</TileSettingsContent>\` portals its children into the settings sidebar slot when the surrounding tile is focused.
- Tile body and settings JSX are in the **same React tree**, so per-tile state flows down as normal props — no atom, no atomFamily, no shared store.
- \`TileSettingsSidebar\` registers itself as the portal target via \`setSettingsSlotEl(el)\`.
- Removed: \`useTileSettings\`, \`registerSettings\`, \`FocusedTileSettings\`, the \`settings: Record<id, Component>\` provider state.

### Playback PlaybackTiles migration

The demo tiles in \`packages/playback/src/views/PlaybackTiles\` were the only other consumers of the deleted tiling APIs:

- Each tile (Camera, Lidar, Scene, Graph, JsonData) takes \`streamId\` as a prop instead of reading from tiling's deleted hook.
- Settings became decorative checkboxes — source-picker UX lives in the MCAP tiles.
- \`useMockStreams\` no longer registers tile entries; stories build the initial-tile map themselves with \`streamId\` baked into the render closure.
- Stories + tests updated across tiling and playback.

### MCAP tile migration

- \`McapCameraTile\` / \`McapLidarTile\` accept \`topic\` as a prop and render their settings inline via \`<TileSettingsContent>\`. Source-picker UX is intentionally absent — that lands once the scene-inventory abstraction exists (#5 in the stack).
- \`useMcapTiles\` registers one tile per kind from a \`presentTypes\` list.
- \`McapStreams\` computes \`presentTypes\` from its props.

## 🧪 How is this patch tested? If it is not, please explain why.

- \`yarn check:types\` clean across tiling / playback / multimodal.
- 367/367 vitest tests pass across the three packages (tiling settings-registry tests rewritten as settings-portal tests; tile-registry tests dropped \`streamId\`).
- Manually verified end-to-end with a NuScenes \`.mcap\` — initial layout opens, settings sidebar tracks focus, switching tile via the chrome works.

## 📝 Release Notes

### Is this a user-facing change?

-   [x] No.
-   [ ] Yes.

### What areas of FiftyOne does this PR affect?

-   [x] App
-   [ ] Build
-   [ ] Core
-   [ ] Documentation
-   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Tile registration now keys by tile type (stream/title removed) and icons/use of a named icon enum introduced.
  * Tile settings now render via a portal into a sidebar slot; provider exposes a settings slot element setter.
  * Tile-source tracking and source-binding APIs removed.

* **Bug Fixes**
  * Hidden unwanted drag-preview visuals in the mosaic grid.

* **Tests**
  * Updated tests and mocks to register/assert tiles by type and to stub an adapter to prevent environment crashes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7629?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->