### PR TITLE
Show pre-filled paths in FileExplorerView inputs

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileExplorer.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileExplorer.tsx
@@ -31,6 +31,7 @@ export default function FileExplorer({
   chooseButtonLabel,
   chooseMode,
   onChoose,
+  initialPath,
 }) {
   const fsInfo = useAvailableFileSystems();
   const {
@@ -60,7 +61,7 @@ export default function FileExplorer({
     hasNextPage,
     customPath,
     handleCustomPathChange,
-  } = useFileExplorer(fsInfo, chooseMode, onChoose);
+  } = useFileExplorer(fsInfo, chooseMode, onChoose, initialPath);
 
   const hasValue = customPath || chosenFile?.absolute_path;
   const fsReady = fsInfo?.ready;

--- a/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileExplorerView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileExplorerView.tsx
@@ -31,6 +31,7 @@ export default function FileExplorerView(props) {
           chooseButtonLabel={choose_button_label}
           chooseMode={chooseMode}
           onChoose={handleChoose}
+          initialPath={data?.absolute_path}
         />
       )}
     </FieldWrapper>

--- a/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/state.ts
+++ b/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/state.ts
@@ -111,7 +111,7 @@ export function useSelectedFile(currentPath, chooseMode) {
   return { selectedFile, handleSelectFile, showOpenButton, enableChooseButton };
 }
 
-export function useFileExplorer(fsInfo, chooseMode, onChoose) {
+export function useFileExplorer(fsInfo, chooseMode, onChoose, initialPath?) {
   const [open, setOpen] = useState(false);
   const {
     abort,
@@ -124,12 +124,14 @@ export function useFileExplorer(fsInfo, chooseMode, onChoose) {
     loading,
     nextPage,
     hasNextPage,
-  } = useCurrentFiles(fsInfo.defaultFile?.absolute_path);
+  } = useCurrentFiles(initialPath ?? fsInfo.defaultFile?.absolute_path);
   const { selectedFile, handleSelectFile, showOpenButton, enableChooseButton } =
     useSelectedFile(currentPath, chooseMode);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [chosenFile, setChosenFile] = useState(null);
-  const [customPath, setCustomPath] = useState<string | null>(null);
+  const [customPath, setCustomPath] = useState<string | null>(
+    initialPath ?? null
+  );
   const [initialized, setInitialized] = useState(false);
   const [customPathChanged, setCustomPathChanged] = useState(false);
 


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link in Jira.

## 📋 What changes are proposed in this pull request?

This PR fixes `FileExplorerView` so paths set programmatically are shown correctly in the file explorer by passing `initialPath` into `FileExplorer`.

## 🧪 How is this patch tested? If it is not, please explain why.

Manually tested by setting a path programmatically and confirming that `FileExplorerView` opens with the expected initial path.

Enterprise vs FO version with my change:

https://github.com/user-attachments/assets/fd8055ca-f7b3-4179-9b3b-eb6922f72a91


## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [x] No. You can skip the rest of this section.
* [ ] Yes. Give a description of this change to be included in the release
  notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

* [x] App: FiftyOne application changes
* [ ] Build: Build and test infrastructure changes
* [ ] Core: Core `fiftyone` Python library changes
* [ ] Documentation: FiftyOne documentation changes
* [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File explorer now supports opening at a specified initial path, enabling direct navigation to predetermined directories or files when appropriate context is available. This enhancement allows users to start browsing from relevant locations rather than always defaulting to standard directories, improving navigation efficiency and overall workflow continuity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7632?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->