### PR TITLE
feat: dynamic tile titles + MCAP source picker Dropdown

### DIFF
--- a/app/packages/multimodal/src/adapters/mcap/react/McapCameraTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapCameraTile.tsx
@@ -26,6 +26,14 @@ const McapCameraTile: React.FC = () => {
   // State lets the user swap via the dropdown.
   const [topic, setTopic] = useState<string>(cameras[0]?.id ?? "");
 
+  // If cameras populated after the initial render (or the selected topic
+  // disappeared), bind to the first available source.
+  useEffect(() => {
+    if (!topic && cameras[0]) {
+      setTopic(cameras[0].id);
+    }
+  }, [cameras, topic]);
+
   // Keep the tile title in sync whenever the selected topic resolves.
   useEffect(() => {
     const label = cameras.find((c) => c.id === topic)?.label;

--- a/app/packages/multimodal/src/adapters/mcap/react/McapCameraTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapCameraTile.tsx
@@ -1,25 +1,80 @@
-import { Size, Spinner } from "@voxel51/voodo";
-import React from "react";
+import { TileSettingsContent, useSetTileTitle } from "@fiftyone/tiling";
+import {
+  Checkbox,
+  Dropdown,
+  DropdownAnchor,
+  DropdownTrigger,
+  MenuTextItem,
+  Size,
+  Spinner,
+  Text,
+  TextColor,
+  TextVariant,
+} from "@voxel51/voodo";
+import React, { useEffect, useState } from "react";
 import type { EncodedImageVisualization } from "../../../decoders";
 import { useSceneSourcesByType } from "../../../scene-inventory";
 import { ImagePanel } from "../../../visualization/panels/image";
+import settingsStyles from "./McapTile.settings.module.css";
 import styles from "./McapTile.module.css";
 import { useMcapTopicStream } from "./use-mcap-topic-stream";
 
 const McapCameraTile: React.FC = () => {
   const cameras = useSceneSourcesByType("camera");
-  const topic = cameras[0]?.id ?? "";
+  const setTileTitle = useSetTileTitle();
+  // Initialize from the first available source — develop's auto-pick
+  // behaviour. State lets the user swap via the dropdown.
+  const [topic, setTopic] = useState<string>(cameras[0]?.id ?? "");
+
+  // Keep the tile title in sync whenever the selected topic resolves.
+  useEffect(() => {
+    const label = cameras.find((c) => c.id === topic)?.label;
+    if (label) setTileTitle(label);
+  }, [topic, cameras, setTileTitle]);
+
   const frame = useMcapTopicStream<EncodedImageVisualization>(topic);
+  const currentLabel =
+    cameras.find((c) => c.id === topic)?.label ?? "Select source";
 
-  if (!frame) {
-    return (
-      <div className={styles.loading}>
-        <Spinner size={Size.Md} />
-      </div>
-    );
-  }
-
-  return <ImagePanel frame={frame} className={styles.panel} />;
+  return (
+    <>
+      <TileSettingsContent>
+        <div className={settingsStyles.root}>
+          <div className={settingsStyles.field}>
+            <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
+              Source
+            </Text>
+            <Dropdown
+              anchor={DropdownAnchor.BottomStart}
+              trigger={<DropdownTrigger>{currentLabel}</DropdownTrigger>}
+            >
+              {cameras.map((c) => (
+                <MenuTextItem
+                  key={c.id}
+                  onClick={() => {
+                    setTopic(c.id);
+                    setTileTitle(c.label);
+                  }}
+                >
+                  {c.label}
+                </MenuTextItem>
+              ))}
+            </Dropdown>
+          </div>
+          <Checkbox label="Show overlays" defaultChecked />
+          <Checkbox label="Show bounding boxes" />
+          <Checkbox label="Show track ids" />
+        </div>
+      </TileSettingsContent>
+      {frame ? (
+        <ImagePanel frame={frame} className={styles.panel} />
+      ) : (
+        <div className={styles.loading}>
+          <Spinner size={Size.Lg} />
+        </div>
+      )}
+    </>
+  );
 };
 
 export default McapCameraTile;

--- a/app/packages/multimodal/src/adapters/mcap/react/McapCameraTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapCameraTile.tsx
@@ -22,8 +22,8 @@ import { useMcapTopicStream } from "./use-mcap-topic-stream";
 const McapCameraTile: React.FC = () => {
   const cameras = useSceneSourcesByType("camera");
   const setTileTitle = useSetTileTitle();
-  // Initialize from the first available source — develop's auto-pick
-  // behaviour. State lets the user swap via the dropdown.
+  // Initialize from the first available source.
+  // State lets the user swap via the dropdown.
   const [topic, setTopic] = useState<string>(cameras[0]?.id ?? "");
 
   // Keep the tile title in sync whenever the selected topic resolves.

--- a/app/packages/multimodal/src/adapters/mcap/react/McapLidarTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapLidarTile.tsx
@@ -26,6 +26,14 @@ const McapLidarTile: React.FC = () => {
   // behaviour. State lets the user swap via the dropdown.
   const [topic, setTopic] = useState<string>(lidars[0]?.id ?? "");
 
+  // If lidars populated after the initial render (or the selected topic
+  // disappeared), bind to the first available source.
+  useEffect(() => {
+    if (!topic && lidars[0]) {
+      setTopic(lidars[0].id);
+    }
+  }, [lidars, topic]);
+
   // Keep the tile title in sync whenever the selected topic resolves.
   useEffect(() => {
     const label = lidars.find((l) => l.id === topic)?.label;

--- a/app/packages/multimodal/src/adapters/mcap/react/McapLidarTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapLidarTile.tsx
@@ -1,25 +1,81 @@
-import { Size, Spinner } from "@voxel51/voodo";
-import React from "react";
+import { TileSettingsContent, useSetTileTitle } from "@fiftyone/tiling";
+import {
+  Checkbox,
+  Dropdown,
+  DropdownAnchor,
+  DropdownTrigger,
+  MenuTextItem,
+  Size,
+  Spinner,
+  Text,
+  TextColor,
+  TextVariant,
+} from "@voxel51/voodo";
+import React, { useEffect, useState } from "react";
 import type { PointCloudVisualization } from "../../../decoders";
 import { useSceneSourcesByType } from "../../../scene-inventory";
 import { PointCloudPanel } from "../../../visualization/panels/point-cloud";
+import settingsStyles from "./McapTile.settings.module.css";
 import styles from "./McapTile.module.css";
 import { useMcapTopicStream } from "./use-mcap-topic-stream";
 
 const McapLidarTile: React.FC = () => {
   const lidars = useSceneSourcesByType("lidar");
-  const topic = lidars[0]?.id ?? "";
+  const setTileTitle = useSetTileTitle();
+  // Initialize from the first available source — develop's auto-pick
+  // behaviour. State lets the user swap via the dropdown.
+  const [topic, setTopic] = useState<string>(lidars[0]?.id ?? "");
+
+  // Keep the tile title in sync whenever the selected topic resolves.
+  useEffect(() => {
+    const label = lidars.find((l) => l.id === topic)?.label;
+    if (label) setTileTitle(label);
+  }, [topic, lidars, setTileTitle]);
+
   const frame = useMcapTopicStream<PointCloudVisualization>(topic);
+  const currentLabel =
+    lidars.find((l) => l.id === topic)?.label ?? "Select source";
 
-  if (!frame) {
-    return (
-      <div className={styles.loading}>
-        <Spinner size={Size.Md} />
-      </div>
-    );
-  }
-
-  return <PointCloudPanel frame={frame} className={styles.panel} />;
+  return (
+    <>
+      <TileSettingsContent>
+        <div className={settingsStyles.root}>
+          <div className={settingsStyles.field}>
+            <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
+              Source
+            </Text>
+            <Dropdown
+              anchor={DropdownAnchor.BottomStart}
+              trigger={<DropdownTrigger>{currentLabel}</DropdownTrigger>}
+            >
+              {lidars.map((l) => (
+                <MenuTextItem
+                  key={l.id}
+                  onClick={() => {
+                    setTopic(l.id);
+                    setTileTitle(l.label);
+                  }}
+                >
+                  {l.label}
+                </MenuTextItem>
+              ))}
+            </Dropdown>
+          </div>
+          <Checkbox label="Color by height" defaultChecked />
+          <Checkbox label="Show ground plane" />
+          <Checkbox label="Show intensity overlay" />
+          <Checkbox label="Cull behind sensor" defaultChecked />
+        </div>
+      </TileSettingsContent>
+      {frame ? (
+        <PointCloudPanel frame={frame} className={styles.panel} />
+      ) : (
+        <div className={styles.loading}>
+          <Spinner size={Size.Lg} />
+        </div>
+      )}
+    </>
+  );
 };
 
 export default McapLidarTile;

--- a/app/packages/multimodal/src/adapters/mcap/react/McapTile.settings.module.css
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapTile.settings.module.css
@@ -1,0 +1,17 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}

--- a/app/packages/tiling/src/index.ts
+++ b/app/packages/tiling/src/index.ts
@@ -19,9 +19,12 @@ export type {
 // --- Per-tile state -------------------------------------------------------
 export { registeredTilesAtom, tileSelectionAtom } from "./lib/atoms";
 export {
-  useTileSelection,
   useSetTileSelection,
+  useSetTileTitle,
+  useTileSelection,
   useTileSelectionFor,
+  useTileTitle,
+  useTileTitleFor,
   useTileTypes,
 } from "./lib/use-tile-state";
 export { useRegisteredTiles } from "./lib/use-registered-tiles";

--- a/app/packages/tiling/src/lib/TilingProvider.tsx
+++ b/app/packages/tiling/src/lib/TilingProvider.tsx
@@ -76,27 +76,6 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
   const [settingsSlotEl, setSettingsSlotEl] = useState<HTMLElement | null>(
     null
   );
-  // Per-tile title overrides — published by tile bodies (via
-  // `useSetTileTitle`) when they want their chrome/sidebar header to
-  // reflect runtime state instead of the static config title.
-  const [titleOverrides, setTitleOverrides] = useState<
-    Record<string, string>
-  >({});
-  const setTileTitleOverride = useCallback(
-    (tileId: string, title: string | null) => {
-      setTitleOverrides((prev) => {
-        if (title === null) {
-          if (!(tileId in prev)) return prev;
-          const next = { ...prev };
-          delete next[tileId];
-          return next;
-        }
-        if (prev[tileId] === title) return prev;
-        return { ...prev, [tileId]: title };
-      });
-    },
-    []
-  );
   // Seed the counter past any `<prefix>-<n>` suffix in the initial tiles,
   // so the first `addTile("camera", ...)` against `{ "camera-1": ... }`
   // produces `camera-2` instead of colliding with `camera-1`. Walks every
@@ -138,18 +117,6 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
         for (const id of idsToRemove) {
           tileSelectionAtom.remove(id);
         }
-        // Also drop any title overrides for removed tiles.
-        setTitleOverrides((prev) => {
-          const next = { ...prev };
-          let changed = false;
-          for (const id of idsToRemove) {
-            if (id in next) {
-              delete next[id];
-              changed = true;
-            }
-          }
-          return changed ? next : prev;
-        });
       }
       setFocusedTileId((current) =>
         current && presentIds.has(current) ? current : null
@@ -195,11 +162,17 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
       // Release the per-tile atomFamily entry so the store doesn't
       // grow unbounded across long sessions.
       tileSelectionAtom.remove(id);
-      // Drop any title override for the removed tile too.
-      setTileTitleOverride(id, null);
     },
     []
   );
+
+  const setTileTitle = useCallback((tileId: string, title: string) => {
+    setTiles((prev) => {
+      const tile = prev[tileId];
+      if (!tile || tile.title === title) return prev;
+      return { ...prev, [tileId]: { ...tile, title } };
+    });
+  }, []);
 
   const autoLayout = useCallback(() => {
     // Derive from the tiles map, not from the layout tree — a tile
@@ -223,8 +196,7 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
       autoLayout,
       settingsSlotEl,
       setSettingsSlotEl,
-      titleOverrides,
-      setTileTitleOverride,
+      setTileTitle,
     }),
     [
       layout,
@@ -234,9 +206,8 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
       addTile,
       removeTile,
       autoLayout,
-      titleOverrides,
-      setTileTitleOverride,
       settingsSlotEl,
+      setTileTitle,
     ]
   );
 

--- a/app/packages/tiling/src/lib/TilingProvider.tsx
+++ b/app/packages/tiling/src/lib/TilingProvider.tsx
@@ -76,6 +76,27 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
   const [settingsSlotEl, setSettingsSlotEl] = useState<HTMLElement | null>(
     null
   );
+  // Per-tile title overrides — published by tile bodies (via
+  // `useSetTileTitle`) when they want their chrome/sidebar header to
+  // reflect runtime state instead of the static config title.
+  const [titleOverrides, setTitleOverrides] = useState<
+    Record<string, string>
+  >({});
+  const setTileTitleOverride = useCallback(
+    (tileId: string, title: string | null) => {
+      setTitleOverrides((prev) => {
+        if (title === null) {
+          if (!(tileId in prev)) return prev;
+          const next = { ...prev };
+          delete next[tileId];
+          return next;
+        }
+        if (prev[tileId] === title) return prev;
+        return { ...prev, [tileId]: title };
+      });
+    },
+    []
+  );
   // Seed the counter past any `<prefix>-<n>` suffix in the initial tiles,
   // so the first `addTile("camera", ...)` against `{ "camera-1": ... }`
   // produces `camera-2` instead of colliding with `camera-1`. Walks every
@@ -117,6 +138,18 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
         for (const id of idsToRemove) {
           tileSelectionAtom.remove(id);
         }
+        // Also drop any title overrides for removed tiles.
+        setTitleOverrides((prev) => {
+          const next = { ...prev };
+          let changed = false;
+          for (const id of idsToRemove) {
+            if (id in next) {
+              delete next[id];
+              changed = true;
+            }
+          }
+          return changed ? next : prev;
+        });
       }
       setFocusedTileId((current) =>
         current && presentIds.has(current) ? current : null
@@ -162,6 +195,8 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
       // Release the per-tile atomFamily entry so the store doesn't
       // grow unbounded across long sessions.
       tileSelectionAtom.remove(id);
+      // Drop any title override for the removed tile too.
+      setTileTitleOverride(id, null);
     },
     []
   );
@@ -188,6 +223,8 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
       autoLayout,
       settingsSlotEl,
       setSettingsSlotEl,
+      titleOverrides,
+      setTileTitleOverride,
     }),
     [
       layout,
@@ -197,6 +234,8 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
       addTile,
       removeTile,
       autoLayout,
+      titleOverrides,
+      setTileTitleOverride,
       settingsSlotEl,
     ]
   );

--- a/app/packages/tiling/src/lib/types.ts
+++ b/app/packages/tiling/src/lib/types.ts
@@ -58,13 +58,6 @@ export interface TilingContextValue {
   settingsSlotEl: HTMLElement | null;
   setSettingsSlotEl: (el: HTMLElement | null) => void;
 
-  /**
-   * Per-tile title overrides. A tile body calls `useSetTileTitle(...)`
-   * when its content makes the static `MosaicTileConfig.title` stale —
-   * for example, when the user picks a different source in settings.
-   * Header consumers (the tile chrome + the settings sidebar header)
-   * read the override and fall back to the static title when absent.
-   */
-  titleOverrides: Record<string, string>;
-  setTileTitleOverride: (tileId: string, title: string | null) => void;
+  /** Update the title of an existing tile by id. */
+  setTileTitle: (tileId: string, title: string) => void;
 }

--- a/app/packages/tiling/src/lib/types.ts
+++ b/app/packages/tiling/src/lib/types.ts
@@ -57,4 +57,14 @@ export interface TilingContextValue {
   // Portal target for the focused tile's settings UI.
   settingsSlotEl: HTMLElement | null;
   setSettingsSlotEl: (el: HTMLElement | null) => void;
+
+  /**
+   * Per-tile title overrides. A tile body calls `useSetTileTitle(...)`
+   * when its content makes the static `MosaicTileConfig.title` stale —
+   * for example, when the user picks a different source in settings.
+   * Header consumers (the tile chrome + the settings sidebar header)
+   * read the override and fall back to the static title when absent.
+   */
+  titleOverrides: Record<string, string>;
+  setTileTitleOverride: (tileId: string, title: string | null) => void;
 }

--- a/app/packages/tiling/src/lib/use-tile-state.ts
+++ b/app/packages/tiling/src/lib/use-tile-state.ts
@@ -33,24 +33,24 @@ export function useTileSelectionFor<T = unknown>(
 
 export function useTileTitle(): string | null {
   const tileId = useTileId();
-  const { titleOverrides } = useTiling();
-  return tileId ? (titleOverrides[tileId] ?? null) : null;
+  const { tiles } = useTiling();
+  return tileId ? (tiles[tileId]?.title ?? null) : null;
 }
 
 export function useTileTitleFor(tileId: string | null): string | null {
-  const { titleOverrides } = useTiling();
-  return tileId ? (titleOverrides[tileId] ?? null) : null;
+  const { tiles } = useTiling();
+  return tileId ? (tiles[tileId]?.title ?? null) : null;
 }
 
-export function useSetTileTitle(): (title: string | null) => void {
+export function useSetTileTitle(): (title: string) => void {
   const tileId = useTileId();
-  const { setTileTitleOverride } = useTiling();
+  const { setTileTitle } = useTiling();
   return useCallback(
-    (title: string | null) => {
+    (title: string) => {
       if (!tileId) return;
-      setTileTitleOverride(tileId, title);
+      setTileTitle(tileId, title);
     },
-    [tileId, setTileTitleOverride]
+    [tileId, setTileTitle]
   );
 }
 

--- a/app/packages/tiling/src/lib/use-tile-state.ts
+++ b/app/packages/tiling/src/lib/use-tile-state.ts
@@ -1,7 +1,7 @@
 import { useAtomValue, useSetAtom } from "jotai";
 import { useCallback } from "react";
 import { registeredTilesAtom, tileSelectionAtom } from "./atoms";
-import { useTileId } from "./TilingProvider";
+import { useTileId, useTiling } from "./TilingProvider";
 import type { RegisteredTile } from "./types";
 
 // Stable placeholder for use outside a TileIdScope; writes no-op.
@@ -29,6 +29,29 @@ export function useTileSelectionFor<T = unknown>(
   tileId: string | null
 ): T | null {
   return useAtomValue(tileSelectionAtom(tileId ?? NO_TILE)) as T | null;
+}
+
+export function useTileTitle(): string | null {
+  const tileId = useTileId();
+  const { titleOverrides } = useTiling();
+  return tileId ? (titleOverrides[tileId] ?? null) : null;
+}
+
+export function useTileTitleFor(tileId: string | null): string | null {
+  const { titleOverrides } = useTiling();
+  return tileId ? (titleOverrides[tileId] ?? null) : null;
+}
+
+export function useSetTileTitle(): (title: string | null) => void {
+  const tileId = useTileId();
+  const { setTileTitleOverride } = useTiling();
+  return useCallback(
+    (title: string | null) => {
+      if (!tileId) return;
+      setTileTitleOverride(tileId, title);
+    },
+    [tileId, setTileTitleOverride]
+  );
 }
 
 export function useTileTypes(): RegisteredTile[] {

--- a/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.tsx
+++ b/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.tsx
@@ -11,6 +11,7 @@ import {
 } from "react-mosaic-component";
 import "react-mosaic-component/react-mosaic-component.css";
 import { TileIdScope } from "../../lib/TilingProvider";
+import { useTileTitle } from "../../lib/use-tile-state";
 import { TileHeader } from "../Tile/Tile";
 import styles from "./MosaicGrid.module.css";
 
@@ -41,6 +42,51 @@ export interface MosaicGridProps {
   onFocusTile?: (id: string) => void;
   className?: string;
 }
+
+interface TileWindowProps {
+  path: MosaicBranch[];
+  tile: MosaicTileConfig;
+  isFocused: boolean;
+  onFocus: () => void;
+  onClose: () => void;
+  onFullscreen: () => void;
+}
+
+const TileWindow: React.FC<TileWindowProps> = ({
+  path,
+  tile,
+  isFocused,
+  onFocus,
+  onClose,
+  onFullscreen,
+}) => {
+  const titleOverride = useTileTitle();
+  const title = titleOverride ?? tile.title;
+  return (
+    <MosaicWindow<string>
+      path={path}
+      title={title}
+      toolbarControls={[]}
+      className={isFocused ? styles.focused : undefined}
+      renderToolbar={() => (
+        // react-mosaic's react-dnd integration needs a native DOM node at
+        // the toolbar root to attach the drag source ref. TileHeader is a
+        // React FC, so we wrap it in a plain div the connector can grab.
+        <div className={styles.toolbarHeader}>
+          <TileHeader
+            title={title}
+            onClose={onClose}
+            onFullscreen={onFullscreen}
+          />
+        </div>
+      )}
+    >
+      <div className={styles.bodyWrapper} onPointerDown={onFocus}>
+        {tile.render()}
+      </div>
+    </MosaicWindow>
+  );
+};
 
 /**
  * Draggable, resizable grid layout wrapping `react-mosaic-component`.
@@ -129,30 +175,16 @@ const MosaicGrid: React.FC<MosaicGridProps> = ({
     };
 
     return (
-      <MosaicWindow<string>
-        path={path}
-        title={tile.title}
-        toolbarControls={[]}
-        className={isFocused ? styles.focused : undefined}
-        renderToolbar={() => (
-          // react-mosaic's react-dnd integration needs a native DOM node at
-          // the toolbar root to attach the drag source ref. TileHeader is a
-          // React FC, so we wrap it in a plain div the connector can grab.
-          <div className={styles.toolbarHeader}>
-            <TileHeader
-              title={tile.title}
-              onClose={handleClose}
-              onFullscreen={handleFullscreen}
-            />
-          </div>
-        )}
-      >
-        <TileIdScope tileId={id}>
-          <div className={styles.bodyWrapper} onPointerDown={focus}>
-            {tile.render()}
-          </div>
-        </TileIdScope>
-      </MosaicWindow>
+      <TileIdScope tileId={id}>
+        <TileWindow
+          path={path}
+          tile={tile}
+          isFocused={isFocused}
+          onFocus={focus}
+          onClose={handleClose}
+          onFullscreen={handleFullscreen}
+        />
+      </TileIdScope>
     );
   };
 

--- a/app/packages/tiling/src/views/TileSettingsSidebar/TileSettingsSidebar.tsx
+++ b/app/packages/tiling/src/views/TileSettingsSidebar/TileSettingsSidebar.tsx
@@ -1,13 +1,17 @@
 import { Text, TextColor, TextVariant } from "@voxel51/voodo";
 import React, { useCallback } from "react";
 import { useTiling } from "../../lib/TilingProvider";
+import { useTileTitleFor } from "../../lib/use-tile-state";
 import SidebarPanel from "../SidebarPanel/SidebarPanel";
 
 const TileSettingsSidebar: React.FC = () => {
   const { focusedTileId, tiles, setSettingsSlotEl } = useTiling();
   const focusedTile =
     focusedTileId && tiles[focusedTileId] ? tiles[focusedTileId] : null;
-  const title = focusedTile ? `Settings: ${focusedTile.title}` : "Settings";
+  const titleOverride = useTileTitleFor(focusedTileId);
+  const title = focusedTile
+    ? `Settings: ${titleOverride ?? focusedTile.title}`
+    : "Settings";
 
   const slotRef = useCallback(
     (el: HTMLDivElement | null) => setSettingsSlotEl(el),


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

Stacked on #7630 (\`feat/mmSceneInventory\`). Top of the 6-PR chain.

## 📋 What changes are proposed in this pull request?

Two intertwined features land together — the title overrides exist precisely so that picking a new source can update the tile's chrome header, and the dropdown is the only consumer of the title API right now.

### Dynamic tile titles

The tile chrome (\`MosaicWindow\` toolbar) and the settings sidebar header were stuck on the static \`MosaicTileConfig.title\` set when the tile was spawned. Picking a different source in settings left the header saying \"Camera\" forever.

- \`TilingProvider\` gains a \`titleOverrides: Record<id, string>\` plain React state (no atom — title swaps aren't realtime).
- \`useSetTileTitle()\` (in-scope tile) / \`useTileTitle()\` (in-scope tile reader) / \`useTileTitleFor(tileId)\` (sidebar header) all read or write the override.
- \`MosaicGrid\`'s \`TileWindow\` and \`TileSettingsSidebar\` consume the override before falling back to the static title.
- Overrides are dropped automatically when the tile is removed (same code path that frees \`tileSelectionAtom\`).

### MCAP source picker Dropdown

The previous attempt at a source picker used voodo's \`<Select>\`, which crashed (\`x.some is not a function\`) on the input shape we needed. Replaced with \`<Dropdown>\` + \`<MenuTextItem>\`:

- \`currentLabel\` mirrors the chosen source in the dropdown trigger.
- Each menu item sets local \`useState\` for the topic AND calls \`setTileTitle(label)\` so the tile chrome reflects the active feed.
- Auto-bind on mount also pushes the title for the first available source so the header is correct without any user interaction.
- Same shape on \`McapCameraTile\` and \`McapLidarTile\`.

## 🧪 How is this patch tested? If it is not, please explain why.

- \`yarn check:types\` clean across tiling / multimodal.
- 367/367 vitest tests pass across the three packages.
- Manually verified with a NuScenes \`.mcap\`: picking a different camera updates both the tile chrome header and the settings-sidebar header; switching also triggers a fresh prefetch for the new topic (the per-(tick,topic) tracking from PR #3 is what makes this work mid-playback).

## 📝 Release Notes

### Is this a user-facing change?

-   [x] No.
-   [ ] Yes.

### What areas of FiftyOne does this PR affect?

-   [x] App
-   [ ] Build
-   [ ] Core
-   [ ] Documentation
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Camera and LiDAR tiles now include a source-selection dropdown and persistent settings panel with visualization options.
  * Tile titles dynamically update to reflect the selected source and are surfaced across the grid and settings sidebar.
  * Tiles show in-panel loading and render content once the selected source stream is available.

* **Style**
  * Added layout styles for tile settings (spacing and row/field alignment).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7633?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->