### PR TITLE
Video annotation surface for video datasets

### DIFF
--- a/app/packages/app/package.json
+++ b/app/packages/app/package.json
@@ -22,6 +22,7 @@
         "@fiftyone/relay": "*",
         "@fiftyone/state": "*",
         "@fiftyone/utilities": "*",
+        "@fiftyone/video-annotation": "workspace:*",
         "@material-ui/core": "4.12.4",
         "@use-gesture/react": "10.1.1",
         "classnames": "^2.2.6",

--- a/app/packages/core/src/components/Modal/ModalLooker.tsx
+++ b/app/packages/core/src/components/Modal/ModalLooker.tsx
@@ -2,6 +2,7 @@ import { useTheme } from "@fiftyone/components";
 import type { ImageLooker } from "@fiftyone/looker";
 import { isNativeMediaType } from "@fiftyone/looker/src/util";
 import * as fos from "@fiftyone/state";
+import { VideoAnnotationSurface } from "@fiftyone/video-annotation";
 import { useAtomValue } from "jotai";
 import React from "react";
 import { useRecoilCallback, useRecoilValue } from "recoil";
@@ -97,7 +98,11 @@ const ModalLookerContent = React.memo(
     }
 
     if (video) {
-      return <VideoLookerReact sample={sample} showControls={!isAnnotate} />;
+      return isAnnotate ? (
+        <VideoAnnotationSurface sample={sample} />
+      ) : (
+        <VideoLookerReact sample={sample} showControls />
+      );
     }
 
     if (isNative) {

--- a/app/packages/lighter/src/events/index.ts
+++ b/app/packages/lighter/src/events/index.ts
@@ -193,6 +193,14 @@ export type LighterEventGroup = {
   "lighter:selection-changed": {
     selectedIds: string[];
     deselectedIds: string[];
+    /**
+     * True when the selection state change was driven by something other than
+     * a user gesture — currently set when an overlay is removed from the
+     * scene (its selection is dropped as a side effect of removal, not because
+     * the user picked something else). Listeners that care about user intent
+     * should skip deselect entries when this is true.
+     */
+    ignoreSideEffects?: boolean;
   };
   /** Emitted when all overlays are deselected */
   "lighter:selection-cleared": {

--- a/app/packages/lighter/src/index.ts
+++ b/app/packages/lighter/src/index.ts
@@ -121,7 +121,12 @@ export type {
   ViewportState,
 } from "./types";
 
-export { getOverlayColor } from "./utils/colorMapping";
+// Utilities
+export {
+  getLabelColorFromContext,
+  getOverlayColor,
+  type ColorMappingContext,
+} from "./utils/colorMapping";
 export { decodeMaskPath } from "./utils/maskPathDecoding";
 
 // Constants

--- a/app/packages/lighter/src/selection/SelectionManage.test.ts
+++ b/app/packages/lighter/src/selection/SelectionManage.test.ts
@@ -74,12 +74,13 @@ describe("SelectionManager", () => {
 
     expect(deselectDetail).toStrictEqual({
       id: "id",
-      ignoreSideEffects: false,
+      ignoreSideEffects: true,
     });
 
     expect(selectionChangedDetail).toStrictEqual({
       selectedIds: [],
       deselectedIds: ["id"],
+      ignoreSideEffects: true,
     });
 
     expect(manager.getSelectedIds()).not.toContain("id");

--- a/app/packages/lighter/src/selection/SelectionManager.ts
+++ b/app/packages/lighter/src/selection/SelectionManager.ts
@@ -48,7 +48,9 @@ export class SelectionManager {
    * @param id - The ID of the overlay to unregister.
    */
   removeSelectable(id: string): void {
-    this.deselect(id);
+    // Removal-driven deselect; flag it so listeners can distinguish it from a
+    // user-driven deselect
+    this.deselect(id, { ignoreSideEffects: true });
     this.selectableOverlays.delete(id);
   }
 
@@ -112,7 +114,7 @@ export class SelectionManager {
       ignoreSideEffects,
     });
 
-    this.emitSelectionChanged([], [id]);
+    this.emitSelectionChanged([], [id], ignoreSideEffects);
   }
 
   /**
@@ -152,7 +154,7 @@ export class SelectionManager {
       previouslySelectedIds: previouslySelected,
     });
 
-    this.emitSelectionChanged([], previouslySelected);
+    this.emitSelectionChanged([], previouslySelected, ignoreSideEffects);
   }
 
   /**
@@ -192,13 +194,15 @@ export class SelectionManager {
 
   private emitSelectionChanged(
     selectedIds: string[],
-    deselectedIds: string[]
+    deselectedIds: string[],
+    ignoreSideEffects = false
   ): void {
     if (selectedIds.length === 0 && deselectedIds.length === 0) return;
 
     this.eventBus.dispatch("lighter:selection-changed", {
       selectedIds,
       deselectedIds,
+      ignoreSideEffects,
     });
   }
 

--- a/app/packages/lighter/src/utils/colorMapping.ts
+++ b/app/packages/lighter/src/utils/colorMapping.ts
@@ -26,13 +26,17 @@ export interface StrokeStyles {
 }
 
 /**
- * Maps Lighter / Annotation overlay information to a color using FiftyOne's color scheme system.
+ * Resolve a color for a label under the given color-mapping context.
  *
- * This is a lightweight adapter around Looker's getLabelColor function, while making some key assumptions:
- * 1. Label tags are not accounted for.
+ * Lightweight adapter around Looker's `getLabelColor`, with the same
+ * assumption as {@link getOverlayColor}: label tags are not accounted for.
+ *
+ * Use this when you need to color a UI element by the same rules the
+ * overlay would use but don't have a {@link BaseOverlay} instance.
  */
-export function getOverlayColor(
-  overlay: BaseOverlay,
+export function getLabelColorFromContext(
+  path: string,
+  label: unknown,
   context: ColorMappingContext
 ): string {
   // Convert ColorSchemeInput to Coloring interface
@@ -54,15 +58,12 @@ export function getOverlayColor(
     targets: [],
   };
 
-  // Map overlay properties to getLabelColor parameters
-  const path = overlay.field;
-  const label = overlay.label as any;
-
-  // Handle case when overlay.label is null or undefined
+  // Handle case when label is null or undefined
   if (!label) {
-    // Return a default color when no label is available
     return getColor(context.colorScheme.colorPool, context.seed, path);
   }
+
+  const typedLabel = label as Record<string, unknown>;
 
   // Sensible defaults for missing parameters (lean towards false or undefined)
   const isTagged = false;
@@ -81,30 +82,44 @@ export function getOverlayColor(
       valueColors: field.valueColors ? [...field.valueColors] : undefined,
     })
   );
-  const embeddedDocType = label["_cls"];
+  const embeddedDocType = typedLabel["_cls"];
   const isPolyline3D =
-    "points3d" in label &&
-    Array.isArray(label["points3d"]) &&
-    label["points3d"].length > 0;
+    "points3d" in typedLabel &&
+    Array.isArray(typedLabel["points3d"]) &&
+    (typedLabel["points3d"] as unknown[]).length > 0;
   const isDetection3D =
-    "location" in label &&
-    Array.isArray(label["location"]) &&
-    label["location"].length > 0 &&
-    "dimensions" in label &&
-    Array.isArray(label["dimensions"]) &&
-    label["dimensions"].length > 0;
+    "location" in typedLabel &&
+    Array.isArray(typedLabel["location"]) &&
+    (typedLabel["location"] as unknown[]).length > 0 &&
+    "dimensions" in typedLabel &&
+    Array.isArray(typedLabel["dimensions"]) &&
+    (typedLabel["dimensions"] as unknown[]).length > 0;
   const is3D = isPolyline3D || isDetection3D;
 
   return getLabelColor({
     coloring,
     path,
-    label,
+    label: typedLabel as any,
     isTagged,
     labelTagColors,
     customizeColorSetting,
     is3D,
     embeddedDocType,
   });
+}
+
+/**
+ * Maps Lighter / Annotation overlay information to a color using FiftyOne's
+ * color scheme system.
+ *
+ * Thin wrapper around {@link getLabelColorFromContext} that extracts the
+ * field + label from an overlay instance.
+ */
+export function getOverlayColor(
+  overlay: BaseOverlay,
+  context: ColorMappingContext
+): string {
+  return getLabelColorFromContext(overlay.field, overlay.label, context);
 }
 
 /**

--- a/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.tsx
+++ b/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.tsx
@@ -102,7 +102,7 @@ const MultiModalPlayback: React.FC<MultiModalPlaybackProps> = ({
   return (
     <PlaybackProvider>
       <TrackProvider
-        initialTracks={tracks}
+        tracks={tracks}
         initialPinnedIds={defaultPinnedTrackIds}
       >
         <TilingProvider initialTiles={initialTiles}>

--- a/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.tsx
+++ b/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.tsx
@@ -101,10 +101,7 @@ const MultiModalPlayback: React.FC<MultiModalPlaybackProps> = ({
 }) => {
   return (
     <PlaybackProvider>
-      <TrackProvider
-        tracks={tracks}
-        initialPinnedIds={defaultPinnedTrackIds}
-      >
+      <TrackProvider tracks={tracks} initialPinnedIds={defaultPinnedTrackIds}>
         <TilingProvider initialTiles={initialTiles}>
           {children}
           <Layout

--- a/app/packages/playback/src/lib/playback/types.ts
+++ b/app/packages/playback/src/lib/playback/types.ts
@@ -145,6 +145,44 @@ export interface PlaybackStream {
 }
 
 // ---------------------------------------------------------------------------
+// Pluggable clock source
+// ---------------------------------------------------------------------------
+
+/**
+ * An override for the engine's RAF tick: when registered (via
+ * `setClockSource`), the engine consults `read()` each tick and, if
+ * it returns a number, uses that as the next target time instead of
+ * computing `playhead + dt` from wallclock.
+ *
+ * Use this when a specific data source already has the authoritative
+ * clock for the timeline — the canonical case is a single `<video>`
+ * whose `requestVideoFrameCallback` reports the actually-presented
+ * frame's mediaTime. Letting that drive the engine sidesteps the
+ * two-clock race between the engine's wallclock RAF and the video's
+ * decoder pace.
+ *
+ * For label-only timelines, image-sequence playback, sensor data,
+ * and multi-stream coordinated playback, do *not* register a clock
+ * source. The engine's wallclock-driven barrier sync is the right
+ * model there: streams gate the engine via `bufferState`, and the
+ * engine advances `dt`-by-`dt` regardless of any single source.
+ *
+ * Multi-video: register a clock source whose `read()` returns
+ * the *minimum* presented mediaTime across the participating videos,
+ * so the engine waits for the slowest. The clock-source contract is
+ * deliberately a single number rather than a per-stream presented
+ * time so the coordination strategy is the integrator's choice.
+ *
+ * `read()` may return `null` to mean "no opinion this tick" — the
+ * engine then falls through to its `dt` advance. Use this for the
+ * pre-first-frame window where a video stream hasn't reported any
+ * presented frame yet.
+ */
+export interface PlaybackClockSource {
+  read: () => number | null;
+}
+
+// ---------------------------------------------------------------------------
 // Config passed to PlaybackProvider
 // ---------------------------------------------------------------------------
 
@@ -211,4 +249,17 @@ export interface PlaybackContextValue {
    * directly — the hook handles subscribe/unsubscribe in a useEffect.
    */
   subscribeStream: (id: string) => () => void;
+
+  /**
+   * Install (or remove with `null`) a clock source that overrides the
+   * engine's RAF `dt` advance. See {@link PlaybackClockSource}. Only
+   * one clock source is active at a time; setting a new one replaces
+   * any prior installation.
+   *
+   * Returns a teardown function for ergonomic use inside a useEffect:
+   * ```ts
+   * useEffect(() => setClockSource({ read: () => ref.current }), [setClockSource]);
+   * ```
+   */
+  setClockSource: (source: PlaybackClockSource | null) => () => void;
 }

--- a/app/packages/playback/src/lib/playback/use-playback-engine.ts
+++ b/app/packages/playback/src/lib/playback/use-playback-engine.ts
@@ -15,6 +15,7 @@ import {
   viewStartAtom,
 } from "./atoms";
 import type {
+  PlaybackClockSource,
   PlaybackConfig,
   PlaybackContextValue,
   PlaybackStore,
@@ -23,6 +24,26 @@ import type {
 
 const clamp = (v: number, lo: number, hi: number) =>
   Math.min(hi, Math.max(lo, v));
+
+/**
+ * Cap on per-tick `dt` (sec) in the engine's wallclock-driven advance.
+ * When the main thread is blocked (memory pressure, GC pause, throttled
+ * tab) RAF callbacks pile up and the next `timestamp - lastTimestamp`
+ * can be huge. Without a cap, the engine teleports `targetTime`
+ * forward by seconds in a single tick — past where any blocking stream
+ * has caught up to. The cap turns that into "advance one cap-step,
+ * then wait for the barrier to refresh."
+ *
+ * 0.133s ≈ 4 frames at 30fps. Generous enough to absorb a 100ms GC
+ * pause without throttling smooth playback; tight enough that a
+ * post-stall tick doesn't overshoot beyond what `bufferState` could
+ * meaningfully gate.
+ *
+ * Only applies in the dt-driven path. When a clock source is
+ * registered (e.g. video-anchored playback), the cap is irrelevant
+ * because `targetTime` comes from the source directly.
+ */
+const MAX_TICK_DT_S = 0.133;
 
 export function usePlaybackEngine({
   duration = 0,
@@ -70,7 +91,14 @@ export function usePlaybackEngine({
   const streamsRef = useRef<Map<string, PlaybackStream>>(new Map());
   const subscribersRef = useRef<Map<string, number>>(new Map());
   const rafIdRef = useRef<number | null>(null);
+  // Wallclock at the previous tick. Used for `dt`-driven advance when
+  // no clock source is registered. Reset to `null` on play() so the
+  // first tick after pause doesn't see a huge gap.
   const lastTimestampRef = useRef<number | null>(null);
+  // Optional override for the engine's wallclock advance. When non-null and
+  // `read()` returns a number, the engine uses that as the next target time;
+  // when `null` or `read()` returns `null`, the engine falls back to dt.
+  const clockSourceRef = useRef<PlaybackClockSource | null>(null);
   const seekDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const seekSeqRef = useRef(0);
 
@@ -149,38 +177,82 @@ export function usePlaybackEngine({
     [store, isActive]
   );
 
+  /**
+   * Engine RAF tick. Two modes, chosen per tick based on whether a
+   * `PlaybackClockSource` has been registered via `setClockSource`:
+   *
+   * - **Default (wallclock-driven, no clock source)**: advance
+   *   `playhead` by capped `dt`. Gate the commit on all blocking
+   *   subscribed streams reporting ready at `targetTime`. This is the
+   *   general-purpose model — label-only timelines, image-sequence
+   *   playback, sensor data, multi-stream coordinated playback all
+   *   live here. The engine is the authority on time; streams
+   *   contribute readiness.
+   *
+   * - **External clock (with registered clock source)**: `targetTime`
+   *   comes from `clockSourceRef.current.read()`. The engine doesn't
+   *   compute `dt`; it observes whatever time the source reports and
+   *   commits gated on the same barrier check. Use this for the
+   *   video-anchored case where the `<video>` element's actual
+   *   presentation time should drive the timeline (avoids the
+   *   wallclock-vs-decoder race).
+   *
+   * If a registered clock source returns `null` (no opinion this
+   * tick — e.g. video hasn't presented a first frame yet), we fall
+   * back to the dt path for that tick. So the modes compose: the
+   * presence of a source doesn't disable dt; only an actual value
+   * does.
+   */
   const tick = useCallback(
     (timestamp: number) => {
-      // Capture first timestamp to avoid a large dt spike on the first frame.
+      // Capture first timestamp so the first tick after a pause/seek
+      // doesn't see a huge dt spike.
       if (lastTimestampRef.current === null) {
         lastTimestampRef.current = timestamp;
         rafIdRef.current = requestAnimationFrame(tick);
         return;
       }
 
-      const dt = ((timestamp - lastTimestampRef.current) / 1000) * store.get(speedAtom);
-      lastTimestampRef.current = timestamp;
-
+      const speed = store.get(speedAtom);
       const currentTime = store.get(playheadAtom);
       const loopStart = store.get(loopStartAtom);
       const loopEnd = store.get(loopEndAtom);
+      const duration = store.get(durationAtom);
 
-      const rawNext = currentTime + dt;
+      const externalTime = clockSourceRef.current?.read() ?? null;
+
+      let rawNext: number;
+      if (externalTime !== null) {
+        // External clock owns the timeline
+        rawNext = externalTime;
+        lastTimestampRef.current = timestamp;
+      } else {
+        // dt-driven advance. Cap to absorb main-thread blocks.
+        const rawDt = (timestamp - lastTimestampRef.current) / 1000;
+        const cappedDt = Math.min(rawDt, MAX_TICK_DT_S);
+        const dt = cappedDt * speed;
+        lastTimestampRef.current = timestamp;
+        rawNext = currentTime + dt;
+      }
+
       const willWrap = rawNext >= loopEnd;
       const targetTime = willWrap ? loopStart : rawNext;
 
-      const duration = store.get(durationAtom);
+      // Barrier: every blocking, subscribed stream must be ready at
+      // `targetTime` before we commit. Streams that report `missing`
+      // get a prefetch nudge; `loading` is already in flight.
       let isBuffering = false;
-
       for (const s of streamsRef.current.values()) {
         if (!s.blocking) continue;
-        if (!isActive(s.id)) continue; // dormant — no subscribers
+        if (!isActive(s.id)) continue;
         const state = s.bufferState(targetTime);
         if (state === "ready") continue;
         isBuffering = true;
-        // "loading" means fetch already in flight — don't re-request.
         if (state === "missing") {
-          s.prefetch?.([targetTime, Math.min(duration, targetTime + (s.lookaheadSeconds ?? 3))]);
+          s.prefetch?.([
+            targetTime,
+            Math.min(duration, targetTime + (s.lookaheadSeconds ?? 3)),
+          ]);
         }
       }
 
@@ -189,8 +261,8 @@ export function usePlaybackEngine({
       if (!isBuffering) {
         store.set(playheadAtom, targetTime);
         doCommit(targetTime);
-        // Loop-wrap is a discontinuous jump — fire immediately so streams
-        // can flush their cache and buffer around loopStart.
+        // Loop-wrap is a discontinuous jump — fire immediately so
+        // streams can flush their cache and buffer around loopStart.
         if (willWrap) fireSeekEvent(loopStart, true);
       }
 
@@ -298,10 +370,14 @@ export function usePlaybackEngine({
         store.set(loopEndAtom, le);
       },
       setSpeed: (speed: number) => {
-        // NaN / Infinity / non-positive values would corrupt `dt` in the
-        // RAF tick and produce invalid playhead progression.
+        // NaN / Infinity / non-positive values would corrupt `dt` in
+        // the RAF tick and produce invalid playhead progression.
         if (!Number.isFinite(speed) || speed <= 0) return;
         store.set(speedAtom, speed);
+        // When a clock source is registered, the engine's `dt` arithmetic
+        // isn't running — the source already paces the timeline. Speed in that
+        // mode has to be applied at the source (e.g. `v.playbackRate` for a
+        // video clock source).
       },
       registerStream: (stream: PlaybackStream) => {
         streamsRef.current.set(stream.id, stream);
@@ -318,7 +394,10 @@ export function usePlaybackEngine({
         };
       },
       subscribeStream: (id: string) => {
-        subscribersRef.current.set(id, (subscribersRef.current.get(id) ?? 0) + 1);
+        subscribersRef.current.set(
+          id,
+          (subscribersRef.current.get(id) ?? 0) + 1
+        );
         // One-shot cleanup. StrictMode's setup→cleanup→setup cycle (and
         // any consumer that retains a stale cleanup) would otherwise
         // double-decrement and drop a still-mounted stream.
@@ -331,6 +410,21 @@ export function usePlaybackEngine({
             subscribersRef.current.delete(id);
           } else {
             subscribersRef.current.set(id, next);
+          }
+        };
+      },
+      setClockSource: (source: PlaybackClockSource | null) => {
+        clockSourceRef.current = source;
+        // Reset the dt anchor so a switch back to wallclock mode
+        // doesn't see a huge gap accumulated while the source was
+        // driving.
+        lastTimestampRef.current = null;
+        return () => {
+          // Identity guard: a stale cleanup from a previous source
+          // shouldn't yank out a newer one.
+          if (clockSourceRef.current === source) {
+            clockSourceRef.current = null;
+            lastTimestampRef.current = null;
           }
         };
       },

--- a/app/packages/playback/src/lib/playback/use-video-stream.ts
+++ b/app/packages/playback/src/lib/playback/use-video-stream.ts
@@ -1,30 +1,71 @@
-import { useEffect, useState, type RefObject } from "react";
+import { useEffect, useRef, useState, type RefObject } from "react";
 import type { PlaybackStream } from "./types";
 import { usePlayback } from "./PlaybackProvider";
+
+/**
+ * Maximum drift (sec) between the engine's target time and the video's
+ * last-presented frame time before `bufferState` reports "loading".
+ *
+ * The engine's wallclock RAF can drift past the video's decoder pace
+ * under stress (memory pressure, throttled tab, decoder starvation).
+ * The bytes are in `buffered` and `currentTime` keeps incrementing
+ * from the element's internal clock, but no new frame is being
+ * painted — so the byte-level check says "ready" while the picture is
+ * stale. Stalling closes the loop: engine pauses, decoder catches up,
+ * `presented` returns, engine resumes.
+ *
+ * ~1.5 frames at 30fps. Tight because we measure presentation, not
+ * bookkeeping. See {@link usePresentedMediaTime}.
+ *
+ * Not used when a `PlaybackClockSource` is registered (e.g. video-
+ * anchored playback) — in that mode the engine reads time from the
+ * source directly, so it can't drift past presentation.
+ */
+const VIDEO_DRIFT_TOLERANCE_S = 0.05;
 
 /**
  * Registers a video element as a `PlaybackStream` with the surrounding
  * `PlaybackProvider`. The stream contributes:
  *
- * - `duration` — the engine's overall timeline length follows the video's
- *   metadata-reported duration. The provider doesn't need a fallback
- *   `duration` prop for the video to drive the clock.
+ * - `duration` — the engine's overall timeline length follows the
+ *   video's metadata-reported duration. The provider doesn't need a
+ *   fallback `duration` prop for the video to drive the clock.
  * - `bufferState` — "ready" if the time is inside one of the video's
- *   `buffered` ranges, "loading" if the element is still fetching but
- *   isn't ready at the target time, "missing" otherwise. The engine
- *   stalls the clock while the video is buffering at the target time.
+ *   `buffered` ranges *and* the picture has been presented within
+ *   `VIDEO_DRIFT_TOLERANCE_S` of the target; "loading" if the element
+ *   is still fetching or the picture is behind; "missing" otherwise.
  *
  * Doesn't drive `play()` / `pause()` / scrubs — pair with `useVideoSync`
  * for that. Streams are "what data is there"; the sync hook is "what
  * the data does about it".
+ *
+ * `options.blocking` defaults to true: the engine's RAF won't advance
+ * past a target the video hasn't caught up to. Pass `false` when a
+ * `PlaybackClockSource` is going to drive the engine — the source is
+ * already the authority on presentation time, so gating again on the
+ * stream is redundant.
+ *
+ * Note on `blocking: false` without a clock source: the engine runs its
+ * wallclock `dt` independently of the video, and nothing pulls them
+ * back into sync (no `bufferState` gating, no `timeupdate` mirror).
+ * They drift sub-percent over long sessions. Acceptable for decorative
+ * video paired with another authoritative timeline; not acceptable for
+ * overlay-on-video. If sync matters, register a clock source.
  */
 export function useVideoStream(
   id: string,
   videoRef: RefObject<HTMLVideoElement | null>,
   options: { blocking?: boolean } = {}
 ): void {
+  const blocking = options.blocking ?? true;
   const { registerStream } = usePlayback();
   const [duration, setDuration] = useState(0);
+  // The presented-frame ref only feeds the drift check inside
+  // `bufferState`, which the engine never calls on a non-blocking
+  // stream. Skip the vfc loop entirely in that mode so we don't
+  // duplicate it with `useVfcClockSource` (which mounts its own loop
+  // on the same element).
+  const presentedMediaTimeRef = usePresentedMediaTime(videoRef, blocking);
 
   // Track the video's reported duration. The stream isn't registered until
   // metadata loads — `durationAtom` stays at the provider's fallback (0 by
@@ -51,20 +92,40 @@ export function useVideoStream(
     if (duration <= 0) return undefined;
     const stream: PlaybackStream = {
       id,
-      blocking: options.blocking ?? true,
+      blocking,
       duration,
       bufferState: (t) => {
         const v = videoRef.current;
         if (!v) return "missing";
+
+        // Decoder can't promise the next displayable frame — stall the
+        // engine so it doesn't commit a playhead the on-screen video
+        // isn't actually at. Covers seeks (readyState drops while the
+        // element resyncs) and decoder starvation.
+        if (v.readyState < v.HAVE_FUTURE_DATA) return "loading";
+
         // Per HTML spec, `TimeRanges.end(i)` is the first moment NOT
         // buffered — use an exclusive upper bound.
+        let inBuffered = false;
         for (let i = 0; i < v.buffered.length; i++) {
-          if (t >= v.buffered.start(i) && t < v.buffered.end(i)) return "ready";
+          if (t >= v.buffered.start(i) && t < v.buffered.end(i)) {
+            inBuffered = true;
+            break;
+          }
         }
-        // `readyState >= 3` only guarantees playback can proceed from
-        // `currentTime`, not that an arbitrary `t` is buffered — return
-        // "loading" so the engine stalls until the target range is fetched.
-        return "loading";
+        if (!inBuffered) return "loading";
+
+        // Compare against the most recently *presented* frame time —
+        // `currentTime` keeps incrementing from the element's internal
+        // clock even when no frame is being painted, so it can't be
+        // trusted as a sync signal. `presentedMediaTimeRef` is updated
+        // from `requestVideoFrameCallback`, which fires exactly when a
+        // new frame reaches the compositor. Falls back to `currentTime`
+        // before the first vfc tick lands or on browsers without
+        // support.
+        const presented = presentedMediaTimeRef.current ?? v.currentTime;
+        if (Math.abs(t - presented) > VIDEO_DRIFT_TOLERANCE_S) return "loading";
+        return "ready";
       },
       bufferedRanges: () => {
         const v = videoRef.current;
@@ -77,9 +138,87 @@ export function useVideoStream(
       },
     };
     return registerStream(stream);
-  }, [id, duration, options.blocking, registerStream, videoRef]);
+  }, [id, duration, blocking, registerStream, videoRef]);
 }
 
 function isFiniteDuration(d: number): boolean {
   return Number.isFinite(d) && d > 0;
+}
+
+/**
+ * Tracks the `mediaTime` of the most recently presented video frame.
+ *
+ * `HTMLVideoElement.requestVideoFrameCallback` fires once per frame
+ * that actually reaches the compositor — unlike `currentTime`, which
+ * the element keeps advancing from its internal clock even when the
+ * decoder is starved and no frame is being painted. Comparing the
+ * engine's target time against `presentedMediaTimeRef` therefore
+ * measures *visual* lag, which is what we want when deciding whether
+ * to stall the engine to keep streams in sync visually.
+ *
+ * Falls back to `null` on browsers without `requestVideoFrameCallback`
+ * (legacy Safari, Firefox before 132); consumers should fall back to
+ * `currentTime` in that case.
+ *
+ * Exported so callers outside of `useVideoStream` (e.g. a video-
+ * anchored `PlaybackClockSource`) can read the same signal. Each call
+ * site mounts its own vfc loop — pass `enabled: false` from callers
+ * that don't need the ref so we don't run a loop whose output goes
+ * unread.
+ */
+export function usePresentedMediaTime(
+  videoRef: RefObject<HTMLVideoElement | null>,
+  enabled = true
+): RefObject<number | null> {
+  const ref = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
+
+    const v = videoRef.current;
+    if (!v) {
+      return undefined;
+    }
+
+    // `requestVideoFrameCallback` exists on HTMLVideoElement but isn't
+    // in lib.dom.d.ts on older TS targets — cast through to call it.
+    type VFC = (
+      cb: (now: number, metadata: { mediaTime: number }) => void
+    ) => number;
+    const rvfc = (v as unknown as { requestVideoFrameCallback?: VFC })
+      .requestVideoFrameCallback;
+    const cvfc = (
+      v as unknown as { cancelVideoFrameCallback?: (handle: number) => void }
+    ).cancelVideoFrameCallback;
+
+    if (typeof rvfc !== "function") {
+      return undefined;
+    }
+
+    let cancelled = false;
+    let handle: number | null = null;
+
+    const onFrame = (_now: number, metadata: { mediaTime: number }) => {
+      if (cancelled) {
+        return;
+      }
+
+      ref.current = metadata.mediaTime;
+      handle = rvfc.call(v, onFrame);
+    };
+    handle = rvfc.call(v, onFrame);
+
+    return () => {
+      cancelled = true;
+      if (handle != null && typeof cvfc === "function") {
+        cvfc.call(v, handle);
+      }
+
+      ref.current = null;
+    };
+  }, [videoRef, enabled]);
+
+  return ref;
 }

--- a/app/packages/playback/src/lib/playback/use-video-sync.ts
+++ b/app/packages/playback/src/lib/playback/use-video-sync.ts
@@ -1,25 +1,27 @@
 import { useAtomValue, useSetAtom } from "jotai";
 import { useEffect, type RefObject } from "react";
-import { currentTimeAtom, isPlayingAtom, playheadAtom } from "./atoms";
+import { isBufferingAtom, isPlayingAtom, seekEventAtom } from "./atoms";
 import { usePlaybackStore } from "./playback-store-context";
 
 /**
- * Seek tolerance in seconds. If the playhead and the video's currentTime
- * drift more than this, we re-sync the video. Lower than the typical
- * `timeupdate` event granularity so a normal play cycle never triggers
- * a sync (avoiding feedback loops with our own RAF updates).
- */
-const SEEK_TOLERANCE_S = 0.15;
-
-/**
- * Bidirectional sync between an HTMLVideoElement and the playback atoms.
+ * Bind an `<video>` element to the playback atoms. Three responsibilities:
  *
- * - `isPlayingAtom` drives `video.play()` / `video.pause()`.
- * - User scrubs (changes to `playheadAtom` that diverge from the video's
- *   currentTime) seek the video.
- * - The video's own `timeupdate` events update `playheadAtom` and
- *   `currentTimeAtom` so the rest of the UI follows the video's natural
- *   playback rate.
+ * - `isPlayingAtom` → `v.play()` / `v.pause()`. When buffering
+ *   (`isBufferingAtom = true`), the video stays paused even if
+ *   `isPlayingAtom` is true. This is how non-video blocking streams
+ *   (label fetches, etc.) backpressure the timeline: the engine sets
+ *   `isBufferingAtom`, the video freezes, and the rest of the system
+ *   waits for the data to land.
+ * - `seekEventAtom` → `v.currentTime`. Explicit seeks (UI scrub, step
+ *   actions, loop wrap) drive the video.
+ * - `ended` → flip `isPlayingAtom` false so the bar's play button is
+ *   correct after natural end-of-stream.
+ *
+ * This hook does **not** read the video's clock back into the
+ * playhead. In the engine's default wallclock mode, the engine owns
+ * the playhead and the video follows. For video-anchored playback,
+ * pair this with the `useVfcClockSource` hook (in `video-annotation`)
+ * which registers a `PlaybackClockSource` with the engine.
  *
  * Pass the ref of a `<video>` element. Every atom read/write and the
  * `store.sub` subscription below target the playback store explicitly
@@ -32,61 +34,52 @@ export function useVideoSync(
 ): void {
   const store = usePlaybackStore();
   const isPlaying = useAtomValue(isPlayingAtom, { store });
-  const setPlayhead = useSetAtom(playheadAtom, { store });
-  const setCurrentTime = useSetAtom(currentTimeAtom, { store });
+  const isBuffering = useAtomValue(isBufferingAtom, { store });
   const setIsPlaying = useSetAtom(isPlayingAtom, { store });
 
-  // play / pause
+  // play / pause / buffering. The buffering gate takes precedence:
+  // while a blocking stream is loading, the video stays paused even
+  // if `isPlayingAtom` is true. Pausing also stops vfc, which freezes
+  // any registered video clock source — so labels-fetch-in-progress
+  // can't be raced by a video that keeps advancing on its own.
   useEffect(() => {
     const v = videoRef.current;
     if (!v) return undefined;
-    if (isPlaying) {
+    if (isPlaying && !isBuffering) {
       v.play().catch(() => {
         // Autoplay policy may reject — caller can show a click-to-play UI.
       });
     } else {
       v.pause();
     }
-  }, [isPlaying, videoRef]);
+  }, [isPlaying, isBuffering, videoRef]);
 
-  // Subscribe to the playhead via the store (not useAtomValue) so this
-  // effect doesn't tear down and re-run on every tick. When the playhead
-  // changes for a reason OTHER than the video itself (a scrub), the video
-  // is out of sync — seek it.
+  // Explicit seeks (UI scrub, step actions, loop wrap) come through
+  // `seekEventAtom`. Drive the video element here.
   useEffect(() => {
-    return store.sub(playheadAtom, () => {
+    return store.sub(seekEventAtom, () => {
       const v = videoRef.current;
       if (!v) return;
-      const target = store.get(playheadAtom);
-      if (Math.abs(v.currentTime - target) > SEEK_TOLERANCE_S) {
-        v.currentTime = target;
-      }
+      const ev = store.get(seekEventAtom);
+      if (!ev) return;
+      v.currentTime = ev.time;
     });
   }, [store, videoRef]);
 
-  // Mirror the video's authoritative time into the atoms.
+  // Surface the video's natural end-of-stream as paused so the bar's
+  // play button matches reality. `isPlayingAtom` normally drives the
+  // video; here the video drove itself to a stop, so we have to push
+  // the state back up.
   useEffect(() => {
     const v = videoRef.current;
     if (!v) return undefined;
-    const onTimeUpdate = () => {
-      setPlayhead(v.currentTime);
-      setCurrentTime(v.currentTime);
-    };
     const onEnded = () => {
-      // Video reached its end — surface that as paused so the bar's
-      // play button is correct. `isPlayingAtom` normally drives the
-      // video; here the video drove itself to a stop, so we have to
-      // push the state back up.
       v.pause();
       setIsPlaying(false);
     };
-    v.addEventListener("timeupdate", onTimeUpdate);
     v.addEventListener("ended", onEnded);
-    return () => {
-      v.removeEventListener("timeupdate", onTimeUpdate);
-      v.removeEventListener("ended", onEnded);
-    };
-    // setPlayhead / setCurrentTime / setIsPlaying are stable Jotai setters.
+    return () => v.removeEventListener("ended", onEnded);
+    // setIsPlaying is a stable Jotai setter.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [videoRef]);
 }

--- a/app/packages/playback/src/lib/tracks/TrackProvider.test.tsx
+++ b/app/packages/playback/src/lib/tracks/TrackProvider.test.tsx
@@ -18,11 +18,12 @@ const TRACKS: Track[] = [
 
 const wrap =
   (tracks: Track[] = TRACKS, initialPinnedIds: string[] = []) =>
-  ({ children }: { children: React.ReactNode }) => (
-    <TrackProvider tracks={tracks} initialPinnedIds={initialPinnedIds}>
-      {children}
-    </TrackProvider>
-  );
+  ({ children }: { children: React.ReactNode }) =>
+    (
+      <TrackProvider tracks={tracks} initialPinnedIds={initialPinnedIds}>
+        {children}
+      </TrackProvider>
+    );
 
 describe("TrackProvider", () => {
   afterEach(() => cleanup());

--- a/app/packages/playback/src/lib/tracks/TrackProvider.test.tsx
+++ b/app/packages/playback/src/lib/tracks/TrackProvider.test.tsx
@@ -17,12 +17,9 @@ const TRACKS: Track[] = [
 ];
 
 const wrap =
-  (initialTracks: Track[] = TRACKS, initialPinnedIds: string[] = []) =>
+  (tracks: Track[] = TRACKS, initialPinnedIds: string[] = []) =>
   ({ children }: { children: React.ReactNode }) => (
-    <TrackProvider
-      initialTracks={initialTracks}
-      initialPinnedIds={initialPinnedIds}
-    >
+    <TrackProvider tracks={tracks} initialPinnedIds={initialPinnedIds}>
       {children}
     </TrackProvider>
   );

--- a/app/packages/playback/src/lib/tracks/TrackProvider.tsx
+++ b/app/packages/playback/src/lib/tracks/TrackProvider.tsx
@@ -3,7 +3,6 @@ import React, {
   useCallback,
   useContext,
   useMemo,
-  useRef,
   useState,
 } from "react";
 
@@ -60,11 +59,17 @@ export interface TrackContextValue {
 const TrackContext = createContext<TrackContextValue | null>(null);
 
 export interface TrackProviderProps {
-  /** Tracks to broadcast. Treated as mount-time config (no churn). */
-  initialTracks?: Track[];
+  /**
+   * Tracks to broadcast. Reactive; callers should provide a stable reference
+   * so a new identity is a signal that the track list changed.
+   */
+  tracks?: Track[];
   /**
    * Track ids that should start pinned to the timeline. Anything else
-   * sits in the "unpinned" pool, browsable but not rendered.
+   * sits in the "unpinned" pool, browsable but not rendered. **Mount-time
+   * only** — captured into local state on the first render and never read
+   * again. To mutate pin state after mount, call `togglePin` / `setPinned`
+   * from `useTrackPinning()`.
    */
   initialPinnedIds?: string[];
   children: React.ReactNode;
@@ -86,14 +91,10 @@ export interface TrackProviderProps {
  * provider when the user opens that recording.
  */
 export const TrackProvider: React.FC<TrackProviderProps> = ({
-  initialTracks = [],
+  tracks = [],
   initialPinnedIds = [],
   children,
 }) => {
-  // Tracks are mount-time config — no setter exposed. Capture in a ref so
-  // a parent passing a fresh `initialTracks` array on every render doesn't
-  // bust the context's memoization.
-  const tracksRef = useRef(initialTracks);
   const [pinnedIds, setPinnedSet] = useState<Set<string>>(
     () => new Set(initialPinnedIds)
   );
@@ -121,13 +122,13 @@ export const TrackProvider: React.FC<TrackProviderProps> = ({
 
   const value = useMemo<TrackContextValue>(
     () => ({
-      tracks: tracksRef.current,
+      tracks,
       pinnedIds,
       togglePin,
       setPinned,
     }),
     // togglePin / setPinned are useCallback([]) — referentially stable.
-    [pinnedIds]
+    [tracks, pinnedIds]
   );
 
   return (

--- a/app/packages/playback/src/stories/TimelineComposed.stories.tsx
+++ b/app/packages/playback/src/stories/TimelineComposed.stories.tsx
@@ -47,7 +47,7 @@ export const Default: StoryObj = {
   render: () => (
     <PlaybackProvider duration={12} stepInterval={1 / 30}>
       <TrackProvider
-        initialTracks={DEFAULT_TRACKS}
+        tracks={DEFAULT_TRACKS}
         initialPinnedIds={DEFAULT_PINNED_TRACK_IDS}
       >
         <StoryShell>

--- a/app/packages/playback/src/views/TimelineTrack/TimelineTrack.tsx
+++ b/app/packages/playback/src/views/TimelineTrack/TimelineTrack.tsx
@@ -65,6 +65,16 @@ export interface TimelineTrackProps {
   onPinClick?: () => void;
   onContextMenu?: (e: React.MouseEvent<HTMLDivElement>) => void;
   className?: string;
+  /** Fired on the row root. Used for cross-component hover linking. */
+  onMouseEnter?: (e: React.MouseEvent<HTMLDivElement>) => void;
+  /** Fired on the row root. Used for cross-component hover linking. */
+  onMouseLeave?: (e: React.MouseEvent<HTMLDivElement>) => void;
+  /**
+   * Fired when the track row is clicked anywhere except the pin button
+   * or an event marker / interval bar. Lane clicks still seek.
+   * `onTrackClick` runs alongside the seek, not in place of it.
+   */
+  onTrackClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
 }
 
 const TimelineTrack: React.FC<TimelineTrackProps> = ({
@@ -82,6 +92,9 @@ const TimelineTrack: React.FC<TimelineTrackProps> = ({
   onPinClick,
   onContextMenu,
   className,
+  onMouseEnter,
+  onMouseLeave,
+  onTrackClick,
 }) => {
   const viewStart = useViewStart();
   const viewEnd = useViewEnd();
@@ -93,8 +106,7 @@ const TimelineTrack: React.FC<TimelineTrackProps> = ({
   // Degenerate view (zero/negative width) — would produce NaN/Infinity
   // CSS values and break layout for every bar/marker below.
   if (viewDuration <= 0) return null;
-  const pct = (t: number) =>
-    `${((t - viewStart) / viewDuration) * 100}%`;
+  const pct = (t: number) => `${((t - viewStart) / viewDuration) * 100}%`;
 
   // Background bar is rendered only when both start/end are provided.
   const hasBackground = start !== undefined && end !== undefined;
@@ -107,8 +119,15 @@ const TimelineTrack: React.FC<TimelineTrackProps> = ({
   return (
     <div
       className={clsx(styles.root, className)}
-      style={{ height }}
+      style={{
+        height,
+        ...(onTrackClick ? { cursor: "pointer" } : null),
+      }}
       onContextMenu={onContextMenu}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onClick={onTrackClick}
+      data-track-id={id}
     >
       {labelWidth > 0 && (
         <div className={styles.label} style={{ width: labelWidth }}>
@@ -182,13 +201,19 @@ const TimelineTrack: React.FC<TimelineTrackProps> = ({
           )
           .map((e, i) => {
             const handleClick = (ev: React.MouseEvent) => {
-              ev.stopPropagation();
+              // Deliberately no stopPropagation. The click bubbles to
+              // the row root so `onTrackClick` fires for marker / interval-bar
+              // clicks too. The lane's onClick filters by target class so seek
+              // doesn't double-fire.
               const lane = laneRef.current;
               if (lane) {
                 const rect = lane.getBoundingClientRect();
                 const t =
                   viewStart +
-                  Math.max(0, Math.min(1, (ev.clientX - rect.left) / rect.width)) *
+                  Math.max(
+                    0,
+                    Math.min(1, (ev.clientX - rect.left) / rect.width)
+                  ) *
                     viewDuration;
                 seek(t);
               }
@@ -219,8 +244,7 @@ const TimelineTrack: React.FC<TimelineTrackProps> = ({
               const left = pct(Math.max(e.startSec, viewStart));
               const right = Math.min(e.endSec!, viewEnd);
               const width = `${
-                ((right - Math.max(e.startSec, viewStart)) / viewDuration) *
-                100
+                ((right - Math.max(e.startSec, viewStart)) / viewDuration) * 100
               }%`;
               return (
                 <ContextMenu key={i} menu={menu}>
@@ -234,8 +258,12 @@ const TimelineTrack: React.FC<TimelineTrackProps> = ({
                     }}
                     title={
                       e.label
-                        ? `${e.label}  (${e.startSec.toFixed(2)}–${e.endSec!.toFixed(2)}s)`
-                        : `${labelText}  (${e.startSec.toFixed(2)}–${e.endSec!.toFixed(2)}s)`
+                        ? `${e.label}  (${e.startSec.toFixed(
+                            2
+                          )}–${e.endSec!.toFixed(2)}s)`
+                        : `${labelText}  (${e.startSec.toFixed(
+                            2
+                          )}–${e.endSec!.toFixed(2)}s)`
                     }
                     onClick={handleClick}
                   />

--- a/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.stories.tsx
+++ b/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.stories.tsx
@@ -47,7 +47,7 @@ export const WithTracks: Story = {
   render: () => (
     <PlaybackProvider duration={12} stepInterval={1 / 30}>
       <TrackProvider
-        initialTracks={DEFAULT_TRACKS}
+        tracks={DEFAULT_TRACKS}
         initialPinnedIds={DEFAULT_PINNED_TRACK_IDS}
       >
         <StoryShell>

--- a/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.tsx
+++ b/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.tsx
@@ -15,7 +15,9 @@ import {
 import LoopOverlays from "../Loop/LoopOverlays";
 import PlayheadLine from "../Playhead/PlayheadLine";
 import TimelineHeader from "../TimelineHeader/TimelineHeader";
-import TimelineTrack from "../TimelineTrack/TimelineTrack";
+import TimelineTrack, {
+  type TimelineTrackProps,
+} from "../TimelineTrack/TimelineTrack";
 import styles from "./TimelineWithTracks.module.css";
 
 export interface TimelineWithTracksProps {
@@ -32,6 +34,14 @@ export interface TimelineWithTracksProps {
    */
   maxSize?: number;
   className?: string;
+  /**
+   * Per-row prop override. Returned partial is merged onto the props
+   * passed to each {@link TimelineTrack}.
+   */
+  decorateTrack?: (
+    track: Track,
+    pinned: boolean
+  ) => Partial<TimelineTrackProps>;
 }
 
 /**
@@ -51,6 +61,7 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
   defaultSize = TIMELINE_DEFAULT_DRAWER_SIZE,
   maxSize = TIMELINE_DRAWER_MAX_SIZE,
   className,
+  decorateTrack,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const tracks = useTracks();
@@ -104,6 +115,7 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
       pinned
       onPinClick={() => togglePin(track.id)}
       onEventClick={(e) => seek(e.startSec)}
+      {...(decorateTrack ? decorateTrack(track, true) : null)}
     />
   );
 
@@ -164,20 +176,26 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
               {pinned.map(renderPinnedTrack)}
             </div>
             <div ref={unpinnedSectionRef}>
-              {unpinned.map((track) => (
-                <TimelineTrack
-                  key={track.id}
-                  id={track.id}
-                  label={track.label}
-                  color={track.color}
-                  events={track.events}
-                  labelWidth={labelWidth}
-                  pinned={false}
-                  onPinClick={() => togglePin(track.id)}
-                  onEventClick={(e) => seek(e.startSec)}
-                  className={styles.unpinnedTrack}
-                />
-              ))}
+              {unpinned.map((track) => {
+                const extra = decorateTrack
+                  ? decorateTrack(track, false)
+                  : null;
+                return (
+                  <TimelineTrack
+                    key={track.id}
+                    id={track.id}
+                    label={track.label}
+                    color={track.color}
+                    events={track.events}
+                    labelWidth={labelWidth}
+                    pinned={false}
+                    onPinClick={() => togglePin(track.id)}
+                    onEventClick={(e) => seek(e.startSec)}
+                    {...extra}
+                    className={clsx(styles.unpinnedTrack, extra?.className)}
+                  />
+                );
+              })}
             </div>
           </div>
 

--- a/app/packages/utilities/src/media.ts
+++ b/app/packages/utilities/src/media.ts
@@ -8,7 +8,7 @@ import { PathType, determinePathType, getBasename } from "./paths";
 export const isAnnotationSupported = (
   mediaType: string | null | undefined
 ): boolean => {
-  return !!mediaType && !["video", "group"].includes(mediaType);
+  return !!mediaType && !["group"].includes(mediaType);
 };
 
 const DIRECT_3D_SAMPLE_EXTENSIONS = new Set([

--- a/app/packages/utilities/src/paths.test.ts
+++ b/app/packages/utilities/src/paths.test.ts
@@ -16,9 +16,9 @@ describe("paths", () => {
       expect(
         paths.determinePathType("data:image/png;base64,iVBORw0KGgo=")
       ).toBe(paths.PathType.URL);
-      expect(
-        paths.determinePathType("blob:https://example.com/abc-123")
-      ).toBe(paths.PathType.URL);
+      expect(paths.determinePathType("blob:https://example.com/abc-123")).toBe(
+        paths.PathType.URL
+      );
     });
 
     it("should detect Linux paths", () => {

--- a/app/packages/utilities/src/paths.test.ts
+++ b/app/packages/utilities/src/paths.test.ts
@@ -13,6 +13,12 @@ describe("paths", () => {
       expect(paths.determinePathType("s3://example.com")).toBe(
         paths.PathType.URL
       );
+      expect(
+        paths.determinePathType("data:image/png;base64,iVBORw0KGgo=")
+      ).toBe(paths.PathType.URL);
+      expect(
+        paths.determinePathType("blob:https://example.com/abc-123")
+      ).toBe(paths.PathType.URL);
     });
 
     it("should detect Linux paths", () => {

--- a/app/packages/utilities/src/paths.ts
+++ b/app/packages/utilities/src/paths.ts
@@ -11,6 +11,12 @@ export function determinePathType(path: string): PathType {
   if (/^\w+:\/\//.test(path)) {
     return PathType.URL;
   }
+  // data: and blob: URLs don't use `//` after the scheme but are URLs in
+  // every other sense — let them through so callers like `getSampleSrc`
+  // don't wrap them in `/media?filepath=...`.
+  if (/^(data|blob):/.test(path)) {
+    return PathType.URL;
+  }
   // backslashes = windows
   if (path?.includes("\\")) {
     return PathType.WINDOWS;

--- a/app/packages/video-annotation/index.ts
+++ b/app/packages/video-annotation/index.ts
@@ -1,0 +1,7 @@
+export { VideoAnnotationSurface } from "./src/VideoAnnotationSurface";
+export { SyntheticLabelStream } from "./src/SyntheticLabelStream";
+export type {
+  FrameLabelSnapshot,
+  SyntheticBox,
+} from "./src/SyntheticLabelStream";
+export { VIDEO_STREAM_ID, LABELS_STREAM_ID, MAIN_TILE_ID } from "./src/ids";

--- a/app/packages/video-annotation/package.json
+++ b/app/packages/video-annotation/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "@fiftyone/video-annotation",
+    "main": "./index.ts",
+    "packageManager": "yarn@4.9.1",
+    "dependencies": {
+        "@fiftyone/lighter": "workspace:*",
+        "@fiftyone/playback": "workspace:*",
+        "@fiftyone/state": "workspace:*",
+        "@fiftyone/tiling": "workspace:*",
+        "@voxel51/voodo": "^0.0.30",
+        "clsx": "^2.1.0",
+        "jotai": "^2.9.3"
+    },
+    "devDependencies": {
+        "vite": "^7.3.2"
+    }
+}

--- a/app/packages/video-annotation/src/FrameLabels.tsx
+++ b/app/packages/video-annotation/src/FrameLabels.tsx
@@ -1,0 +1,220 @@
+import { getLabelColorFromContext } from "@fiftyone/lighter";
+import {
+  colorScheme,
+  colorSeed,
+  datasetName,
+  groupSlice,
+  modalSampleId,
+  view as viewAtom,
+} from "@fiftyone/state";
+import type { ModalSample } from "@fiftyone/state";
+import type { Stage } from "@fiftyone/utilities";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useRecoilValue } from "recoil";
+import { usePlayback } from "../../playback/src/lib/playback/PlaybackProvider";
+import { useDuration } from "../../playback/src/lib/playback/use-playback-state";
+import { usePlaybackStream } from "../../playback/src/lib/playback/use-playback-stream";
+import {
+  TrackProvider,
+  type Track,
+} from "../../playback/src/lib/tracks/TrackProvider";
+import TimelineWithTracks from "../../playback/src/views/TimelineWithTracks/TimelineWithTracks";
+import { FrameLabelsContext, useFrameLabelsStream } from "./FrameLabelsContext";
+import { buildPerInstanceTracks, type PerInstanceLabel } from "./frameTracks";
+import { LABELS_STREAM_ID } from "./ids";
+import { useLinkedTrackDecorator } from "./linkedTracks";
+import { VideoFrameLabelsStream } from "./VideoFrameLabelsStream";
+
+// todo - hardcoded for demo
+export const FRAME_FIELD = "frames.detections";
+
+/**
+ * Reads the params needed to construct a real `/frames`-backed labels
+ * stream from recoil + the modal sample, waits until duration is known
+ * (so we can derive `frameCount`), then mounts the registration child
+ * with a key that changes if the underlying sample / view changes — so
+ * a fresh stream cleanly replaces the old one through usePlaybackStream's
+ * standard lifecycle.
+ *
+ * Wraps its children in a `FrameLabelsContext.Provider` so downstream
+ * consumers (e.g. {@link FrameLabelsTracks}) can read the same stream
+ * without issuing duplicate fetches.
+ */
+export const RegisterFrameLabels: React.FC<{
+  sample: ModalSample;
+  children: React.ReactNode;
+}> = ({ sample, children }) => {
+  const duration = useDuration();
+  const dataset = useRecoilValue(datasetName);
+  const view = useRecoilValue(viewAtom);
+  const slice = useRecoilValue(groupSlice);
+  const sampleId = useRecoilValue(modalSampleId);
+
+  const frameRate = sample.frameRate;
+  const ready =
+    duration > 0 && !!sampleId && !!dataset && Number.isFinite(frameRate);
+
+  if (!ready) {
+    // Stream params aren't all available yet; expose a null stream so
+    // consumers render their loading/placeholder state.
+    return (
+      <FrameLabelsContext.Provider value={null}>
+        {children}
+      </FrameLabelsContext.Provider>
+    );
+  }
+
+  const frameCount = Math.max(1, Math.round(duration * frameRate));
+
+  // Include every input that affects the stream's identity in the key so
+  // changing sample / view re-mounts the registrar with a fresh stream
+  // and `usePlaybackStream`'s effect cleanup unregisters the old one.
+  const key = `${sampleId}|${dataset}|${
+    slice ?? ""
+  }|${frameRate}|${frameCount}`;
+
+  return (
+    <FrameLabelsRegistration
+      key={key}
+      sampleId={sampleId}
+      dataset={dataset}
+      view={view ?? []}
+      groupSlice={slice ?? null}
+      frameCount={frameCount}
+      frameRate={frameRate}
+    >
+      {children}
+    </FrameLabelsRegistration>
+  );
+};
+
+interface FrameLabelsRegistrationProps {
+  sampleId: string;
+  dataset: string;
+  view: Stage[];
+  groupSlice: string | null;
+  frameCount: number;
+  frameRate: number;
+  children: React.ReactNode;
+}
+
+const FrameLabelsRegistration: React.FC<FrameLabelsRegistrationProps> = ({
+  children,
+  ...props
+}) => {
+  // Construct once per mount — the parent re-mounts us on identity
+  // changes via `key`.
+  const streamRef = useRef<VideoFrameLabelsStream | null>(null);
+  if (streamRef.current === null) {
+    streamRef.current = new VideoFrameLabelsStream({
+      id: LABELS_STREAM_ID,
+      sampleId: props.sampleId,
+      dataset: props.dataset,
+      view: props.view,
+      groupSlice: props.groupSlice,
+      frameCount: props.frameCount,
+      frameRate: props.frameRate,
+    });
+  }
+  usePlaybackStream(streamRef.current);
+
+  // Prefetch the chunk containing t=0 and then seek(0). The engine's
+  // `seek` only commits when every blocking stream is already ready, so
+  // without the warmup the engine queues the seek silently and overlays
+  // stay blank until the user presses play. With it, overlays paint as
+  // soon as the first chunk lands.
+  const { seek } = usePlayback();
+  useEffect(() => {
+    let cancelled = false;
+    void streamRef.current!.warmup(0).then(() => {
+      if (!cancelled) seek(0);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [seek]);
+
+  return (
+    <FrameLabelsContext.Provider value={streamRef.current}>
+      {children}
+    </FrameLabelsContext.Provider>
+  );
+};
+
+/**
+ * Labels track timeline — one row per tracked instance observed in
+ * the clip (grouped by `index`), with intervals showing when
+ * that instance is present. Untracked labels still paint as overlays
+ * but don't get rows. Triggers a one-shot `warmupAll` so the cache covers
+ * every frame, then walks it to build the tracks.
+ *
+ * Rebuilds (and re-broadcasts through `TrackProvider`) whenever the
+ * color scheme or seed changes so row colors stay in lock-step with the
+ * overlays — `getLabelColorFromContext` returns different colors under
+ * the same input when the palette, seed, or `colorBy` mode changes.
+ *
+ * One-shot re-key on the empty→ready transition so `initialPinnedIds`
+ * (which the provider only reads at mount) bootstraps from the real
+ * track list. Subsequent recolors update through the live `tracks`
+ * prop and don't trip the key, so the user's pin state is preserved.
+ */
+export const FrameLabelsTracks: React.FC = () => {
+  const stream = useFrameLabelsStream();
+  const scheme = useRecoilValue(colorScheme);
+  const seed = useRecoilValue(colorSeed);
+
+  // useState so we can re-render once warmupAll resolves, but keep the
+  // build deterministic in the deps (stream identity changes when the
+  // sample changes, which is the trigger we care about).
+  const [tracks, setTracks] = useState<Track[]>([]);
+
+  const resolveColor = useCallback(
+    (label: PerInstanceLabel) =>
+      getLabelColorFromContext(FRAME_FIELD, label, {
+        colorScheme: scheme,
+        seed,
+      }),
+    [scheme, seed]
+  );
+
+  useEffect(() => {
+    if (!stream) {
+      setTracks([]);
+      return;
+    }
+
+    let cancelled = false;
+
+    void stream.warmupAll().then(() => {
+      if (cancelled) {
+        return;
+      }
+
+      setTracks(buildPerInstanceTracks({ stream, resolveColor }));
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [stream, resolveColor]);
+
+  const pinned = useMemo(() => tracks.map((t) => t.id), [tracks]);
+  const ready = tracks.length > 0;
+  const decorateTrack = useLinkedTrackDecorator();
+
+  return (
+    <TrackProvider
+      key={ready ? "ready" : "init"}
+      tracks={tracks}
+      initialPinnedIds={pinned}
+    >
+      <TimelineWithTracks decorateTrack={decorateTrack} />
+    </TrackProvider>
+  );
+};

--- a/app/packages/video-annotation/src/FrameLabelsContext.ts
+++ b/app/packages/video-annotation/src/FrameLabelsContext.ts
@@ -1,0 +1,19 @@
+import { createContext, useContext } from "react";
+import type { VideoFrameLabelsStream } from "./VideoFrameLabelsStream";
+
+/**
+ * Shares the active frame-labels stream from the registrar component
+ * down to downstream consumers (e.g. the per-class track builder) so we
+ * don't issue duplicate `/frames` fetches against the same sample.
+ *
+ * Value is `null` while the stream's params (sampleId, duration, etc.)
+ * aren't all available yet — consumers should treat that as "no data
+ * available; render placeholder."
+ */
+export const FrameLabelsContext = createContext<VideoFrameLabelsStream | null>(
+  null
+);
+
+export function useFrameLabelsStream(): VideoFrameLabelsStream | null {
+  return useContext(FrameLabelsContext);
+}

--- a/app/packages/video-annotation/src/SyntheticLabelStream.ts
+++ b/app/packages/video-annotation/src/SyntheticLabelStream.ts
@@ -1,0 +1,271 @@
+import { PlaybackStreamBase } from "../../playback/src/lib/playback/stream-base";
+
+export interface SyntheticBox {
+  id: string;
+  label: string;
+  /** Normalized [x, y, w, h] in [0, 1]. */
+  bounding_box: [number, number, number, number];
+  /**
+   * FiftyOne track index, when present. Carried so downstream color-
+   * mapping can use `COLOR_BY.INSTANCE`'s `${label}-${index}-...` hash
+   * (otherwise instance mode would collapse tracked detections of the
+   * same class to one color).
+   */
+  index?: number;
+  /**
+   * Mirrors {@link BaseLabel.instance} from `@fiftyone/looker`. Used as
+   * the fallback `COLOR_BY.INSTANCE` hash seed for untracked detections,
+   * and as a stable instance id for the synthetic stream (which has no
+   * numeric index).
+   */
+  instance?: { _cls: "Instance"; _id?: string };
+}
+
+export interface FrameLabelSnapshot {
+  frameNumber: number;
+  detections: SyntheticBox[];
+}
+
+export interface SyntheticActor {
+  id: string;
+  label: string;
+  width: number;
+  height: number;
+  /** Cycle length in seconds for x and y trajectories. */
+  xPeriodSec: number;
+  yPeriodSec: number;
+  xPhase: number;
+  yPhase: number;
+  /**
+   * Presence schedule: the actor is in frame for `presenceDuty` fraction
+   * of each `presenceCycleSec`-long cycle, starting at `presencePhase`
+   * (0–1) of the way through that cycle at t=0. Same shape as the
+   * trajectory oscillators so the math composes the same way.
+   */
+  presenceCycleSec: number;
+  presenceDuty: number;
+  presencePhase: number;
+}
+
+/**
+ * Clip-relative actor spec — cycle counts are expressed per-clip so the
+ * motion / presence rhythms scale to whatever video length is loaded.
+ * Resolve to concrete time-domain {@link SyntheticActor}s via
+ * {@link resolveActor} once the clip duration is known.
+ */
+export interface SyntheticActorSpec {
+  id: string;
+  label: string;
+  width: number;
+  height: number;
+  /** Number of x/y trajectory oscillations across the full clip. */
+  xCyclesPerClip: number;
+  yCyclesPerClip: number;
+  xPhase: number;
+  yPhase: number;
+  /** Number of presence (enter/exit) cycles across the full clip. */
+  presenceCyclesPerClip: number;
+  presenceDuty: number;
+  presencePhase: number;
+}
+
+export interface PresenceInterval {
+  startSec: number;
+  endSec: number;
+}
+
+/**
+ * Project a clip-relative {@link SyntheticActorSpec} onto an absolute-time
+ * {@link SyntheticActor} for the given clip duration.
+ */
+export function resolveActor(
+  spec: SyntheticActorSpec,
+  duration: number
+): SyntheticActor {
+  const safeDuration = duration > 0 ? duration : 1;
+  return {
+    id: spec.id,
+    label: spec.label,
+    width: spec.width,
+    height: spec.height,
+    xPeriodSec: safeDuration / Math.max(spec.xCyclesPerClip, 1e-3),
+    yPeriodSec: safeDuration / Math.max(spec.yCyclesPerClip, 1e-3),
+    xPhase: spec.xPhase,
+    yPhase: spec.yPhase,
+    presenceCycleSec: safeDuration / Math.max(spec.presenceCyclesPerClip, 1e-3),
+    presenceDuty: spec.presenceDuty,
+    presencePhase: spec.presencePhase,
+  };
+}
+
+export const DEFAULT_ACTOR_SPECS: SyntheticActorSpec[] = [
+  {
+    id: "actor-a",
+    label: "person",
+    width: 0.18,
+    height: 0.32,
+    // Two slow sweeps across the clip horizontally, ~1.3 vertically.
+    xCyclesPerClip: 1,
+    yCyclesPerClip: 0.5,
+    xPhase: 0,
+    yPhase: 0.25,
+    // In ~60% of the time, two enter/exit cycles.
+    presenceCyclesPerClip: 2,
+    presenceDuty: 0.6,
+    presencePhase: 0,
+  },
+  {
+    id: "actor-b",
+    label: "car",
+    width: 0.22,
+    height: 0.14,
+    // Faster horizontal motion (cars move).
+    xCyclesPerClip: 1.2,
+    yCyclesPerClip: 1,
+    xPhase: 0.5,
+    yPhase: 0.6,
+    // Starts in-frame briefly, then a longer middle appearance.
+    presenceCyclesPerClip: 1.5,
+    presenceDuty: 0.5,
+    presencePhase: 0.4,
+  },
+  {
+    id: "actor-c",
+    label: "dog",
+    width: 0.12,
+    height: 0.12,
+    xCyclesPerClip: 0.8,
+    yCyclesPerClip: 1.3,
+    xPhase: 0.8,
+    yPhase: 0.1,
+    // Starts out-of-frame, several short visits.
+    presenceCyclesPerClip: 2.5,
+    presenceDuty: 0.4,
+    presencePhase: 0.6,
+  },
+];
+
+const TWO_PI = Math.PI * 2;
+
+function oscillate(t: number, periodSec: number, phase: number): number {
+  // sine in [-1, 1] -> [0, 1]
+  return 0.5 + 0.5 * Math.sin(TWO_PI * (t / periodSec + phase));
+}
+
+/** Position in the current presence cycle, normalized to [0, 1). */
+function presenceOffset(time: number, actor: SyntheticActor): number {
+  const raw = time / actor.presenceCycleSec + actor.presencePhase;
+  return raw - Math.floor(raw);
+}
+
+/** True when the actor's presence cycle says it's in frame at `time`. */
+export function isPresent(time: number, actor: SyntheticActor): boolean {
+  return presenceOffset(time, actor) < actor.presenceDuty;
+}
+
+/**
+ * Enumerate the presence intervals (start, end pairs) for an actor over
+ * `[0, duration]`. Intervals are clipped to the duration; the actor may
+ * be in mid-interval at t=0 or at t=duration.
+ */
+export function getPresenceIntervals(
+  actor: SyntheticActor,
+  duration: number
+): PresenceInterval[] {
+  if (!(duration > 0)) return [];
+
+  const {
+    presenceCycleSec: cycle,
+    presenceDuty: duty,
+    presencePhase: phase,
+  } = actor;
+  const intervalLen = cycle * duty;
+  const out: PresenceInterval[] = [];
+
+  // Cycle n starts at t = cycle * (n - phase). Walk forward until we pass
+  // duration, including n=-1 so a cycle straddling t=0 is captured.
+  for (let n = -1; ; n++) {
+    const cycleStart = cycle * (n - phase);
+    if (cycleStart >= duration) break;
+    const intervalEnd = cycleStart + intervalLen;
+    const start = Math.max(0, cycleStart);
+    const end = Math.min(duration, intervalEnd);
+    if (end > start) out.push({ startSec: start, endSec: end });
+  }
+  return out;
+}
+
+function snapshotAtTime(
+  time: number,
+  fps: number,
+  actors: SyntheticActor[]
+): FrameLabelSnapshot {
+  const frameNumber = Math.max(0, Math.floor(time * fps));
+  const detections: SyntheticBox[] = [];
+  for (const actor of actors) {
+    if (!isPresent(time, actor)) continue;
+    // Position the bbox top-left so the whole box stays inside [0, 1].
+    const maxX = 1 - actor.width;
+    const maxY = 1 - actor.height;
+    const x = oscillate(time, actor.xPeriodSec, actor.xPhase) * maxX;
+    const y = oscillate(time, actor.yPeriodSec, actor.yPhase) * maxY;
+    detections.push({
+      id: actor.id,
+      label: actor.label,
+      bounding_box: [x, y, actor.width, actor.height],
+      // Per-actor stable instance so COLOR_BY.INSTANCE produces distinct
+      // colors per synthetic actor (the index path doesn't apply here
+      // — synthetic actors have no numeric index by design).
+      instance: { _cls: "Instance", _id: actor.id },
+    });
+  }
+  return { frameNumber, detections };
+}
+
+/**
+ * Demo / test stream that emits a deterministic moving set of bboxes as a
+ * function of time. Synchronous — no fetch, never stalls the clock. Useful
+ * for exercising the playback → overlay diff path without real label data.
+ */
+export class SyntheticLabelStream extends PlaybackStreamBase<FrameLabelSnapshot> {
+  private readonly fps: number;
+  private actors: SyntheticActor[];
+
+  constructor(
+    id: string,
+    opts: { fps: number; duration?: number; actors?: SyntheticActor[] }
+  ) {
+    super(id, {
+      blocking: false,
+      duration: opts.duration,
+      nativeStepSeconds: 1 / opts.fps,
+      lookupPolicy: {
+        type: "nearestPrevious",
+        thresholdSeconds: 1 / opts.fps,
+      },
+    });
+    this.fps = opts.fps;
+    this.actors = opts.actors ?? [];
+  }
+
+  /**
+   * Replace the actor set. Callers typically resolve clip-relative specs
+   * to absolute actors once the video duration is known and call this.
+   * The next commit (seek or RAF tick) will reflect the new actors.
+   */
+  setActors(actors: SyntheticActor[]): void {
+    this.actors = actors;
+  }
+
+  bufferState(): "ready" {
+    return "ready";
+  }
+
+  prefetch(): void {
+    // no-op — generation is synchronous
+  }
+
+  getValue(time: number): FrameLabelSnapshot {
+    return snapshotAtTime(time, this.fps, this.actors);
+  }
+}

--- a/app/packages/video-annotation/src/SyntheticLabels.tsx
+++ b/app/packages/video-annotation/src/SyntheticLabels.tsx
@@ -1,0 +1,102 @@
+import { getLabelColorFromContext } from "@fiftyone/lighter";
+import { colorScheme, colorSeed } from "@fiftyone/state";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import { useRecoilValue } from "recoil";
+import { usePlayback } from "../../playback/src/lib/playback/PlaybackProvider";
+import { useDuration } from "../../playback/src/lib/playback/use-playback-state";
+import { usePlaybackStream } from "../../playback/src/lib/playback/use-playback-stream";
+import { TrackProvider } from "../../playback/src/lib/tracks/TrackProvider";
+import TimelineWithTracks from "../../playback/src/views/TimelineWithTracks/TimelineWithTracks";
+import { LABELS_STREAM_ID } from "./ids";
+import { useLinkedTrackDecorator } from "./linkedTracks";
+import {
+  DEFAULT_ACTOR_SPECS,
+  resolveActor,
+  SyntheticLabelStream,
+} from "./SyntheticLabelStream";
+import {
+  buildSyntheticTracks,
+  type SyntheticActorLabel,
+} from "./syntheticTracks";
+
+// todo - hardcoded for demo
+export const SYNTHETIC_FIELD = "synthetic_detections";
+export const SYNTHETIC_FPS = 30;
+
+/**
+ * Synthetic labels stream — used for testing the rendering path without
+ * real labels. Mirrors the lifecycle of `RegisterFrameLabels`:
+ * construct once, push actors in once duration is known, nudge `seek(0)`.
+ */
+export const RegisterSyntheticLabels: React.FC = () => {
+  const duration = useDuration();
+  const { seek } = usePlayback();
+
+  const streamRef = useRef<SyntheticLabelStream | null>(null);
+  if (streamRef.current === null) {
+    streamRef.current = new SyntheticLabelStream(LABELS_STREAM_ID, {
+      fps: SYNTHETIC_FPS,
+    });
+  }
+  usePlaybackStream(streamRef.current);
+
+  useEffect(() => {
+    if (duration <= 0) return;
+    const actors = DEFAULT_ACTOR_SPECS.map((spec) =>
+      resolveActor(spec, duration)
+    );
+    streamRef.current!.setActors(actors);
+    seek(0);
+  }, [duration, seek]);
+
+  return null;
+};
+
+/**
+ * Synthetic track timeline — one row per actor with the color resolved
+ * against the same color scheme the overlays use. Mirrors
+ * `FrameLabelsTracks`: live recolor through the reactive `tracks` prop,
+ * plus a one-shot empty→ready key flip so `initialPinnedIds` bootstraps
+ * when the real track list lands.
+ */
+export const SyntheticTrackTimeline: React.FC = () => {
+  const duration = useDuration();
+  const scheme = useRecoilValue(colorScheme);
+  const seed = useRecoilValue(colorSeed);
+
+  const resolveColor = useCallback(
+    (label: SyntheticActorLabel) =>
+      getLabelColorFromContext(SYNTHETIC_FIELD, label, {
+        colorScheme: scheme,
+        seed,
+      }),
+    [scheme, seed]
+  );
+
+  const actors = useMemo(
+    () =>
+      duration > 0
+        ? DEFAULT_ACTOR_SPECS.map((spec) => resolveActor(spec, duration))
+        : [],
+    [duration]
+  );
+
+  const tracks = useMemo(
+    () => buildSyntheticTracks(actors, duration, resolveColor),
+    [actors, duration, resolveColor]
+  );
+
+  const pinned = useMemo(() => tracks.map((t) => t.id), [tracks]);
+  const ready = tracks.length > 0;
+  const decorateTrack = useLinkedTrackDecorator();
+
+  return (
+    <TrackProvider
+      key={ready ? "ready" : "init"}
+      tracks={tracks}
+      initialPinnedIds={pinned}
+    >
+      <TimelineWithTracks decorateTrack={decorateTrack} />
+    </TrackProvider>
+  );
+};

--- a/app/packages/video-annotation/src/VideoAnnotationSurface.module.css
+++ b/app/packages/video-annotation/src/VideoAnnotationSurface.module.css
@@ -1,30 +1,30 @@
 .root {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    height: 100%;
-    min-height: 0;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
 }
 
 .media {
-    flex: 1 1 auto;
-    min-height: 0;
-    position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  position: relative;
 }
 
 .timeline {
-    flex: 0 0 auto;
-    border-top: 1px solid rgba(255, 255, 255, 0.08);
-    background: var(--bg-panel, #1a1a1a);
+  flex: 0 0 auto;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--bg-panel, #1a1a1a);
 }
 
 .empty {
-    width: 100%;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: rgba(255, 255, 255, 0.6);
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.6);
 }
 
 /* Linked-state classes applied to a timeline track row whose matching
@@ -32,14 +32,14 @@
    over the row itself) is handled by the row's normal :hover styles —
    these only need to cover the external (overlay-side) trigger. */
 .linkHovered {
-    background: var(--color-background-level-1, rgba(255, 255, 255, 0.06));
+  background: var(--color-background-level-1, rgba(255, 255, 255, 0.06));
 }
 
 .linkSelected {
-    box-shadow: inset 4px 0 0 var(--color-brand-primary, #fb923c);
+  box-shadow: inset 4px 0 0 var(--color-brand-primary, #fb923c);
 }
 
 /* When both are set, the box-shadow accent stays on top of the bg. */
 .linkSelected.linkHovered {
-    background: var(--color-background-level-1, rgba(255, 255, 255, 0.06));
+  background: var(--color-background-level-1, rgba(255, 255, 255, 0.06));
 }

--- a/app/packages/video-annotation/src/VideoAnnotationSurface.module.css
+++ b/app/packages/video-annotation/src/VideoAnnotationSurface.module.css
@@ -1,0 +1,45 @@
+.root {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+}
+
+.media {
+    flex: 1 1 auto;
+    min-height: 0;
+    position: relative;
+}
+
+.timeline {
+    flex: 0 0 auto;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    background: var(--bg-panel, #1a1a1a);
+}
+
+.empty {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+/* Linked-state classes applied to a timeline track row whose matching
+   overlay is currently hovered / selected. Self-hover (the user's cursor
+   over the row itself) is handled by the row's normal :hover styles —
+   these only need to cover the external (overlay-side) trigger. */
+.linkHovered {
+    background: var(--color-background-level-1, rgba(255, 255, 255, 0.06));
+}
+
+.linkSelected {
+    box-shadow: inset 4px 0 0 var(--color-brand-primary, #fb923c);
+}
+
+/* When both are set, the box-shadow accent stays on top of the bg. */
+.linkSelected.linkHovered {
+    background: var(--color-background-level-1, rgba(255, 255, 255, 0.06));
+}

--- a/app/packages/video-annotation/src/VideoAnnotationSurface.tsx
+++ b/app/packages/video-annotation/src/VideoAnnotationSurface.tsx
@@ -3,7 +3,11 @@ import type { ModalSample } from "@fiftyone/state";
 import { TilingProvider } from "@fiftyone/tiling";
 import React, { useMemo, useState } from "react";
 import { PlaybackProvider } from "../../playback/src/lib/playback/PlaybackProvider";
-import { FRAME_FIELD, FrameLabelsTracks, RegisterFrameLabels } from "./FrameLabels";
+import {
+  FRAME_FIELD,
+  FrameLabelsTracks,
+  RegisterFrameLabels,
+} from "./FrameLabels";
 import { LinkedOverlayStateBridge } from "./linkedTracks";
 import {
   RegisterSyntheticLabels,

--- a/app/packages/video-annotation/src/VideoAnnotationSurface.tsx
+++ b/app/packages/video-annotation/src/VideoAnnotationSurface.tsx
@@ -1,0 +1,98 @@
+import { getSampleSrc } from "@fiftyone/state";
+import type { ModalSample } from "@fiftyone/state";
+import { TilingProvider } from "@fiftyone/tiling";
+import React, { useMemo, useState } from "react";
+import { PlaybackProvider } from "../../playback/src/lib/playback/PlaybackProvider";
+import { FRAME_FIELD, FrameLabelsTracks, RegisterFrameLabels } from "./FrameLabels";
+import { LinkedOverlayStateBridge } from "./linkedTracks";
+import {
+  RegisterSyntheticLabels,
+  SYNTHETIC_FIELD,
+  SyntheticTrackTimeline,
+} from "./SyntheticLabels";
+import { VideoLighterTile } from "./VideoLighterTile";
+import styles from "./VideoAnnotationSurface.module.css";
+
+/**
+ * Switch between the synthetic stream (for testing the rendering path
+ * without real labels) and the real `/frames`-backed stream.
+ *
+ * - default: real
+ * - `?labels=synthetic`: synthetic
+ *
+ * Read once at mount; flipping requires reopening the modal.
+ */
+type LabelsMode = "real" | "synthetic";
+
+function useLabelsMode(): LabelsMode {
+  const [mode] = useState<LabelsMode>(() => {
+    if (typeof window === "undefined") {
+      return "real";
+    }
+
+    const param = new URLSearchParams(window.location.search).get("labels");
+    return param === "synthetic" ? "synthetic" : "real";
+  });
+
+  return mode;
+}
+
+export interface VideoAnnotationSurfaceProps {
+  sample: ModalSample;
+}
+
+/**
+ * Composition root for the video annotation surface. Wires
+ * PlaybackProvider + TrackProvider + TilingProvider, registers a labels
+ * stream (real `/frames` by default; synthetic when `?labels=synthetic`),
+ * and renders media (top) + timeline (bottom).
+ *
+ * Lives inside the modal's media region — the existing right-side
+ * annotation sidebar continues to render outside this component.
+ */
+export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
+  sample,
+}) => {
+  const mode = useLabelsMode();
+  const videoSrc = useMemo(() => {
+    const url = sample.urls?.[0]?.url;
+    return url ? getSampleSrc(url) : null;
+  }, [sample]);
+
+  const field = mode === "synthetic" ? SYNTHETIC_FIELD : FRAME_FIELD;
+
+  const layout = (
+    <div className={styles.root}>
+      <LinkedOverlayStateBridge />
+      <div className={styles.media}>
+        {videoSrc ? (
+          <VideoLighterTile videoSrc={videoSrc} field={field} />
+        ) : (
+          <div className={styles.empty}>No media URL on this sample.</div>
+        )}
+      </div>
+      <div className={styles.timeline}>
+        {mode === "synthetic" ? (
+          <SyntheticTrackTimeline />
+        ) : (
+          <FrameLabelsTracks />
+        )}
+      </div>
+    </div>
+  );
+
+  return (
+    <PlaybackProvider>
+      <TilingProvider initialTiles={{}}>
+        {mode === "synthetic" ? (
+          <>
+            <RegisterSyntheticLabels />
+            {layout}
+          </>
+        ) : (
+          <RegisterFrameLabels sample={sample}>{layout}</RegisterFrameLabels>
+        )}
+      </TilingProvider>
+    </PlaybackProvider>
+  );
+};

--- a/app/packages/video-annotation/src/VideoCanonicalMedia.ts
+++ b/app/packages/video-annotation/src/VideoCanonicalMedia.ts
@@ -1,0 +1,146 @@
+import type {
+  CanonicalMedia,
+  Dimensions,
+  Rect,
+  Renderer2D,
+} from "@fiftyone/lighter";
+import { BaseOverlay } from "@fiftyone/lighter/src/overlay/BaseOverlay";
+
+/**
+ * Minimal CanonicalMedia for the video tile. Provides coordinate-space
+ * bounds (intrinsic video dimensions + container-fitted rendered bounds)
+ * so Lighter overlays can position themselves correctly, but draws no
+ * pixels of its own — the <video> element behind the Lighter canvas
+ * supplies the visible image.
+ *
+ * We don't use `ImageOverlay` as a stand-in for two reasons:
+ *  - It sizes itself from the loaded image's natural dimensions. A
+ *    transparent stand-in would collapse every overlay's coordinate
+ *    space to whatever 1×1 placeholder we fed it; here we want the
+ *    canonical dimensions to be the video's intrinsic resolution.
+ *  - `renderImpl` decodes and paints a sprite every frame. We don't
+ *    need that — the `<video>` element behind the canvas is the
+ *    visible media.
+ *
+ * The right long-term fix is a `VideoOverlay` (or generic
+ * `MediaCanonicalMedia`) upstream in `@fiftyone/lighter`.
+ */
+export class VideoCanonicalMedia extends BaseOverlay implements CanonicalMedia {
+  private originalDimensions: Dimensions;
+  private currentBounds: Rect = { x: 0, y: 0, width: 0, height: 0 };
+  private resizeObserver?: ResizeObserver;
+  private detach?: () => void;
+
+  constructor(opts: { width: number; height: number }) {
+    super(
+      `video-canonical-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      "",
+      null as never
+    );
+    this.originalDimensions = { width: opts.width, height: opts.height };
+  }
+
+  override getOverlayType(): string {
+    return "VideoCanonicalMedia";
+  }
+
+  override setRenderer(renderer: Renderer2D): void {
+    super.setRenderer(renderer);
+
+    const canvas = renderer.getCanvas();
+    const parent = canvas?.parentElement;
+    if (!parent) return;
+
+    this.updateBoundsFromContainer(parent.clientWidth, parent.clientHeight);
+
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const { width, height } = entry.contentRect;
+      this.updateBoundsFromContainer(width, height);
+    });
+    this.resizeObserver.observe(parent);
+
+    this.detach = () => {
+      this.resizeObserver?.disconnect();
+      this.resizeObserver = undefined;
+    };
+  }
+
+  protected renderImpl(): void {
+    // No-op: the <video> element drawn behind the Lighter canvas is the
+    // visible media. We exist only to anchor the coordinate system.
+  }
+
+  getOriginalDimensions(): Dimensions {
+    return this.originalDimensions;
+  }
+
+  getRenderedBounds(): Rect {
+    return this.currentBounds;
+  }
+
+  getAspectRatio(): number {
+    const { width, height } = this.originalDimensions;
+    return height > 0 ? width / height : 1;
+  }
+
+  updateBounds(): void {
+    if (!this.renderer) {
+      return;
+    }
+
+    const parent = this.renderer.getCanvas()?.parentElement;
+    if (!parent) {
+      return;
+    }
+
+    this.updateBoundsFromContainer(parent.clientWidth, parent.clientHeight);
+  }
+
+  private updateBoundsFromContainer(width: number, height: number): void {
+    if (width <= 0 || height <= 0) {
+      return;
+    }
+
+    this.currentBounds = this.fitAspect(width, height);
+    this.markDirty();
+
+    // Tell Scene2D to update its coordinate-system transform. Without this
+    // event the coord system stays at the default identity and overlays
+    // collapse to (0,0) — relativeToAbsolute([0..1]) returns ~0.
+    this.eventBus.dispatch("lighter:canonical-media-bounds-changed", {
+      bounds: this.currentBounds,
+    });
+  }
+
+  /** Letterbox the canonical media to fit `container` while keeping aspect. */
+  private fitAspect(containerW: number, containerH: number): Rect {
+    const { width: ow, height: oh } = this.originalDimensions;
+    const origAspect = ow / oh;
+    const targetAspect = containerW / containerH;
+
+    let w: number;
+    let h: number;
+    let x = 0;
+    let y = 0;
+
+    if (origAspect > targetAspect) {
+      w = containerW;
+      h = containerW / origAspect;
+      y = (containerH - h) / 2;
+    } else {
+      h = containerH;
+      w = containerH * origAspect;
+      x = (containerW - w) / 2;
+    }
+
+    return { x, y, width: w, height: h };
+  }
+
+  /** Caller cleanup (also runs on Scene2D.removeOverlay -> overlay.destroy). */
+  override destroy(): void {
+    this.detach?.();
+  }
+}

--- a/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
+++ b/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
@@ -1,0 +1,408 @@
+import { getFetchFunction, type Stage } from "@fiftyone/utilities";
+import { PlaybackStreamBase } from "../../playback/src/lib/playback/stream-base";
+import { streamValueAtom } from "../../playback/src/lib/playback/atoms";
+import type {
+  BufferReadiness,
+  PlaybackStore,
+} from "../../playback/src/lib/playback/types";
+import type { FrameLabelSnapshot, SyntheticBox } from "./SyntheticLabelStream";
+
+/**
+ * One per-frame document returned by `POST /frames`. We only model the
+ * shape we touch; everything else is read through the dynamic indexer.
+ */
+interface FrameSample {
+  frame_number: number;
+  [key: string]: unknown;
+}
+
+interface FrameChunkResponse {
+  frames: FrameSample[];
+  range: [number, number];
+}
+
+// todo - adapter pattern for other label types
+interface RawDetection {
+  _id?: string;
+  id?: string;
+  index?: number;
+  label?: string;
+  bounding_box?: [number, number, number, number];
+  instance?: { _cls: "Instance"; _id?: string } | null;
+}
+
+interface RawDetectionsField {
+  detections?: RawDetection[];
+}
+
+export interface VideoFrameLabelsStreamOptions {
+  id: string;
+  /** Sample id for the parent video document. */
+  sampleId: string;
+  /** Current dataset name (POST /frames requires it). */
+  dataset: string;
+  /** Active view stages — same shape sent on every dataset query. */
+  view: Stage[];
+  /** Group slice name, when the dataset is grouped. */
+  groupSlice?: string | null;
+  /** Total frame count of the clip (1-indexed up to this number). */
+  frameCount: number;
+  /** Frame rate in frames per second. */
+  frameRate: number;
+  /**
+   * todo - multiple fields
+   * Field on the per-frame document that carries `Detections`. Strip the
+   * `frames.` prefix that lives in the parent video schema — the per-frame
+   * samples returned by `/frames` are already frame-relative.
+   *
+   * @default "detections"
+   */
+  frameField?: string;
+  /**
+   * Number of frames to request in a single `/frames` chunk. Larger
+   * values mean fewer round trips but larger payloads.
+   *
+   * @default 60
+   */
+  chunkSize?: number;
+}
+
+const DEFAULT_CHUNK_SIZE = 60;
+const DEFAULT_FRAME_FIELD = "detections";
+
+/**
+ * Labels stream backed by the `POST /frames` endpoint.
+ *
+ * Caches per-frame samples by 1-indexed frame number. `bufferState`
+ * reports readiness for a given time; `prefetch` issues a chunk fetch
+ * starting at the first missing frame in the requested range; `getValue`
+ * reads the cached frame and pulls labels out as overlays so the existing
+ * diff path in `VideoLighterTile` can consume them unchanged.
+ *
+ * Label identity prefers FiftyOne's track `index` when present (so
+ * tracked instances mutate in place across frames); falls back to `_id`
+ * for un-tracked labels (which will churn each frame).
+ */
+export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapshot> {
+  private readonly sampleId: string;
+  private readonly dataset: string;
+  private readonly view: Stage[];
+  private readonly groupSlice: string | null;
+  private readonly frameCount: number;
+  private readonly frameRate: number;
+  private readonly frameField: string;
+  private readonly chunkSize: number;
+
+  private readonly cache = new Map<number, FrameSample>();
+  private readonly inflight = new Map<number, Promise<void>>();
+  private readonly fetchedRanges: Array<[number, number]> = [];
+
+  constructor(opts: VideoFrameLabelsStreamOptions) {
+    super(opts.id, {
+      blocking: true,
+      duration: opts.frameCount / opts.frameRate,
+      nativeStepSeconds: 1 / opts.frameRate,
+      lookupPolicy: {
+        type: "nearestPrevious",
+        thresholdSeconds: 1 / opts.frameRate,
+      },
+    });
+
+    this.sampleId = opts.sampleId;
+    this.dataset = opts.dataset;
+    this.view = opts.view;
+    this.groupSlice = opts.groupSlice ?? null;
+    this.frameCount = opts.frameCount;
+    this.frameRate = opts.frameRate;
+    this.frameField = opts.frameField ?? DEFAULT_FRAME_FIELD;
+    this.chunkSize = opts.chunkSize ?? DEFAULT_CHUNK_SIZE;
+  }
+
+  /**
+   * Resolve once the frame containing `time` is cached. Coalesces against
+   * any in-flight chunk covering that frame; otherwise kicks one off.
+   *
+   * Intended for "show overlays before the user plays" — call this after
+   * registering the stream, then `seek(time)` once it resolves so the
+   * engine commits with the frame in hand.
+   */
+  async warmup(time = 0): Promise<void> {
+    const frame = this.timeToFrame(time);
+    if (this.cache.has(frame)) {
+      return;
+    }
+
+    const inflight = this.inflight.get(frame);
+    if (inflight) {
+      await inflight;
+      return;
+    }
+
+    await this.fetchChunk(frame);
+  }
+
+  /**
+   * Resolve once every frame in [1, frameCount] is cached. Coalesces
+   * against any in-flight chunks; otherwise walks the range in chunk-
+   * sized strides and dispatches fetches in parallel.
+   *
+   * Use for one-shot analyses over the full clip (e.g. building
+   * per-class timeline tracks). For long clips this is expensive — a
+   * future aggregation endpoint would be preferable.
+   */
+  async warmupAll(): Promise<void> {
+    const promises: Promise<void>[] = [];
+    let f = 1;
+
+    while (f <= this.frameCount) {
+      if (this.cache.has(f)) {
+        f++;
+        continue;
+      }
+
+      const inflight = this.inflight.get(f);
+      if (inflight) {
+        promises.push(inflight);
+        f += this.chunkSize;
+        continue;
+      }
+
+      promises.push(this.fetchChunk(f));
+      f += this.chunkSize;
+    }
+
+    await Promise.all(promises);
+  }
+
+  /** Total frames in the clip — useful for callers iterating the cache. */
+  get totalFrames(): number {
+    return this.frameCount;
+  }
+
+  /** Frame rate the stream was constructed with, in fps. */
+  get fps(): number {
+    return this.frameRate;
+  }
+
+  bufferState(time: number): BufferReadiness {
+    const frame = this.timeToFrame(time);
+
+    if (this.cache.has(frame)) {
+      return "ready";
+    }
+
+    if (this.isInflight(frame)) {
+      return "loading";
+    }
+
+    return "missing";
+  }
+
+  prefetch(range: [number, number]): void {
+    const [startSec, endSec] = range;
+    const startFrame = this.timeToFrame(startSec);
+    const endFrame = this.timeToFrame(endSec);
+
+    // Find the first missing frame in the range and issue one chunk
+    // starting there. The engine calls prefetch again as the playhead
+    // advances — we don't need to fan out multiple requests here.
+    for (let f = startFrame; f <= endFrame; f++) {
+      if (this.cache.has(f) || this.isInflight(f)) {
+        continue;
+      }
+
+      void this.fetchChunk(f);
+
+      return;
+    }
+  }
+
+  getValue(time: number): FrameLabelSnapshot | null {
+    const frame = this.timeToFrame(time);
+    const sample = this.cache.get(frame);
+    if (!sample) {
+      return null;
+    }
+
+    return {
+      frameNumber: frame,
+      // todo - adapter pattern for other label types
+      detections: extractDetections(sample, this.frameField),
+    };
+  }
+
+  /**
+   * Custom `onCommit`: dedupe by `frameNumber`. The engine ticks 5–8×
+   * within a single frame; default `onCommit` would build a fresh
+   * detections array and re-publish on every tick, kicking every
+   * `useStream` consumer into a re-render and re-running the overlay
+   * diff with identical content. We only need to publish when the frame
+   * actually changes — or when transitioning to/from `null` (cache
+   * miss → hit when a chunk lands).
+   */
+  override onCommit(time: number, store: PlaybackStore): void {
+    const next = this.getValue(time);
+    const prev = store.get(
+      streamValueAtom(this.id)
+    ) as FrameLabelSnapshot | null;
+
+    if (prev && next && prev.frameNumber === next.frameNumber) {
+      return;
+    }
+
+    if (prev === null && next === null) {
+      return;
+    }
+
+    store.set(streamValueAtom(this.id), next);
+  }
+
+  bufferedRanges(): Array<[number, number]> {
+    return this.fetchedRanges.map(
+      ([start, end]) =>
+        [(start - 1) / this.frameRate, end / this.frameRate] as [number, number]
+    );
+  }
+
+  private timeToFrame(time: number): number {
+    // Mirror @fiftyone/looker's getFrameNumber semantics: 1-indexed,
+    // clamped to [1, frameCount].
+    const frame = Math.floor(time * this.frameRate) + 1;
+    if (frame < 1) {
+      return 1;
+    }
+
+    if (frame > this.frameCount) {
+      return this.frameCount;
+    }
+
+    return frame;
+  }
+
+  private isInflight(frame: number): boolean {
+    return this.inflight.has(frame);
+  }
+
+  private async fetchChunk(startFrame: number): Promise<void> {
+    const numFrames = Math.min(
+      this.chunkSize,
+      this.frameCount - startFrame + 1
+    );
+
+    if (numFrames <= 0) {
+      return;
+    }
+
+    const promise = this.doFetch(startFrame, numFrames).finally(() => {
+      for (let f = startFrame; f < startFrame + numFrames; f++) {
+        if (this.inflight.get(f) === promise) {
+          this.inflight.delete(f);
+        }
+      }
+    });
+
+    for (let f = startFrame; f < startFrame + numFrames; f++) {
+      this.inflight.set(f, promise);
+    }
+
+    return promise;
+  }
+
+  private async doFetch(startFrame: number, numFrames: number): Promise<void> {
+    try {
+      const result = (await getFetchFunction()(
+        "POST",
+        "/frames",
+        {
+          frameNumber: startFrame,
+          numFrames,
+          frameCount: this.frameCount,
+          sampleId: this.sampleId,
+          dataset: this.dataset,
+          view: this.view,
+          slice: this.groupSlice ?? undefined,
+        },
+        "json",
+        2
+      )) as FrameChunkResponse;
+
+      for (const frame of result.frames) {
+        this.cache.set(frame.frame_number, frame);
+      }
+
+      mergeRange(this.fetchedRanges, result.range);
+    } catch (error) {
+      // Surface but don't crash — the engine will keep asking; subsequent
+      // prefetch calls will retry the missing frames.
+      console.error(
+        `[VideoFrameLabelsStream] fetch failed for [${startFrame}, +${numFrames})`,
+        error
+      );
+    }
+  }
+}
+
+/**
+ * Pull detections off a per-frame sample and convert them into the
+ * `SyntheticBox` shape the existing overlay-diff path consumes.
+ *
+ * Prefers FiftyOne's track `index` for stable cross-frame identity; falls
+ * back to `_id` so un-tracked detections still render (with the caveat
+ * that they will churn add/remove on every frame).
+ */
+function extractDetections(
+  sample: FrameSample,
+  frameField: string
+): SyntheticBox[] {
+  const raw = sample[frameField] as RawDetectionsField | undefined;
+  const detections = raw?.detections;
+  if (!Array.isArray(detections)) {
+    return [];
+  }
+
+  const out: SyntheticBox[] = [];
+  for (const det of detections) {
+    if (!det.bounding_box || det.bounding_box.length !== 4) {
+      continue;
+    }
+
+    const detId = det._id ?? det.id ?? null;
+    const id = det.index !== undefined ? `track-${det.index}` : detId;
+
+    if (!id) {
+      continue;
+    }
+
+    out.push({
+      id,
+      label: det.label ?? "",
+      bounding_box: det.bounding_box,
+      index: det.index,
+      instance: det.instance ?? undefined,
+    });
+  }
+
+  return out;
+}
+
+/**
+ * Merge a newly-fetched `[start, end]` range into a sorted, disjoint list
+ * of contiguous ranges.
+ */
+function mergeRange(
+  ranges: Array<[number, number]>,
+  add: [number, number]
+): void {
+  ranges.push(add);
+  ranges.sort((a, b) => a[0] - b[0]);
+
+  for (let i = ranges.length - 1; i > 0; i--) {
+    const prev = ranges[i - 1];
+    const cur = ranges[i];
+
+    if (cur[0] <= prev[1] + 1) {
+      prev[1] = Math.max(prev[1], cur[1]);
+      ranges.splice(i, 1);
+    }
+  }
+}

--- a/app/packages/video-annotation/src/VideoLighterTile.module.css
+++ b/app/packages/video-annotation/src/VideoLighterTile.module.css
@@ -1,23 +1,23 @@
 .body {
-    position: relative;
-    width: 100%;
-    height: 100%;
-    background: black;
-    overflow: hidden;
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: black;
+  overflow: hidden;
 }
 
 .video {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-    z-index: 0;
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  z-index: 0;
 }
 
 .lighterHost {
-    position: absolute;
-    inset: 0;
-    z-index: 1;
-    display: flex;
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: flex;
 }

--- a/app/packages/video-annotation/src/VideoLighterTile.module.css
+++ b/app/packages/video-annotation/src/VideoLighterTile.module.css
@@ -1,0 +1,23 @@
+.body {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    background: black;
+    overflow: hidden;
+}
+
+.video {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    z-index: 0;
+}
+
+.lighterHost {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    display: flex;
+}

--- a/app/packages/video-annotation/src/VideoLighterTile.tsx
+++ b/app/packages/video-annotation/src/VideoLighterTile.tsx
@@ -1,0 +1,289 @@
+import {
+  type DetectionOverlayOptions,
+  type DetectionLabel,
+  DetectionOverlay,
+  overlayFactory,
+  UNDEFINED_LIGHTER_SCENE_ID,
+  useLighterEventHandler,
+  useLighterSetupWithPixi,
+} from "@fiftyone/lighter";
+import { VideoCanonicalMedia } from "./VideoCanonicalMedia";
+import { colorScheme, colorSeed, useModalLookerOptions } from "@fiftyone/state";
+import { singletonCanvas } from "../../core/src/components/Modal/Lighter/SharedCanvas";
+import { usePlayback } from "../../playback/src/lib/playback/PlaybackProvider";
+import { useStream } from "../../playback/src/lib/playback/use-stream";
+import { useVideoStream } from "../../playback/src/lib/playback/use-video-stream";
+import { useVideoSync } from "../../playback/src/lib/playback/use-video-sync";
+import { useVfcClockSource } from "./useVfcClockSource";
+import { useTileSource } from "@fiftyone/tiling";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useRecoilValue } from "recoil";
+import { LABELS_STREAM_ID, VIDEO_STREAM_ID } from "./ids";
+import type { FrameLabelSnapshot, SyntheticBox } from "./SyntheticLabelStream";
+import styles from "./VideoLighterTile.module.css";
+
+export interface VideoLighterTileProps {
+  /** Resolved media URL for the video. */
+  videoSrc: string;
+  /**
+   * // todo - multiple fields
+   * Schema field name the labels are reported under. Should match a real
+   * field on the dataset so activePaths / color-mapping flow through.
+   */
+  field?: string;
+}
+
+// todo - annotation state
+const DEFAULT_FIELD = "synthetic_detections";
+
+/**
+ * <video> bound to the playback engine, Lighter overlaid on top,
+ * Overlays diffed in from the labels stream each commit.
+ */
+export const VideoLighterTile: React.FC<VideoLighterTileProps> = ({
+  videoSrc,
+  field = DEFAULT_FIELD,
+}) => {
+  const sourceId = useTileSource() ?? VIDEO_STREAM_ID;
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const lighterHostRef = useRef<HTMLDivElement | null>(null);
+  const [canvas, setCanvas] = useState<HTMLCanvasElement | null>(null);
+  const [videoDims, setVideoDims] = useState<{ w: number; h: number } | null>(
+    null
+  );
+
+  // Bind <video> -> playback engine. The video-annotation tile uses
+  // video-anchored playback: `useVfcClockSource` registers the
+  // element's vfc-presented mediaTime as the engine's clock source,
+  // so the engine commits exactly where the picture is. We pass
+  // `blocking: false` to `useVideoStream` because the clock source
+  // already owns presentation time — gating the engine again on the
+  // stream's bufferState would produce spurious stalls.
+  useVideoStream(sourceId, videoRef, { blocking: false });
+  useVideoSync(videoRef);
+  useVfcClockSource(videoRef);
+  const { seek } = usePlayback();
+
+  // Attach the SINGLETON Lighter canvas into our host. There is one
+  // SharedPixiApplication per page bound to the first canvas it ever sees;
+  // creating a fresh canvas for the video tile would leave Pixi rendering
+  // to the old (image-modal) canvas instead. singletonCanvas detaches
+  // cleanly from any previous container and reattaches here.
+  useEffect(() => {
+    const host = lighterHostRef.current;
+    if (!host) {
+      return;
+    }
+
+    setCanvas(singletonCanvas.getCanvas(host));
+
+    return () => {
+      singletonCanvas.detach();
+    };
+  }, []);
+
+  // Modal options so activePaths / showOverlays / alpha match the
+  // sidebar and overlays.
+  const options = useModalLookerOptions();
+  const sceneId = useMemo(
+    () => `video-anno-${Math.random().toString(36).slice(2, 9)}`,
+    [videoSrc]
+  );
+  const { scene } = useLighterSetupWithPixi(canvas!, options, sceneId);
+
+  // Wire the FiftyOne color scheme so overlays match the rest of the UI.
+  const scheme = useRecoilValue(colorScheme);
+  const seed = useRecoilValue(colorSeed);
+  useEffect(() => {
+    if (!scene || scene.getSceneId() !== sceneId) {
+      return;
+    }
+
+    scene.updateColorMappingContext({ colorScheme: scheme, seed });
+  }, [scene, sceneId, scheme, seed]);
+
+  // Tracks whether the *current* scene has its canonical media installed.
+  // The overlay diff effect (`useFrameOverlaySync`) gates on this — without
+  // canonical media, overlays added to the scene have no coordinate
+  // context to position against, so they render with broken bounds and a
+  // later in-place `relativeBounds` update doesn't fix them. We reset the
+  // flag whenever `sceneId` changes (new scene → not installed yet) and set
+  // it true at the bottom of the install effect.
+  const [canonicalMediaReady, setCanonicalMediaReady] = useState(false);
+  useEffect(() => {
+    setCanonicalMediaReady(false);
+  }, [sceneId]);
+
+  // Install a no-pixel canonical-media overlay sized to the video's intrinsic
+  // resolution. Lighter draws overlays relative to it; the <video>
+  // behind the canvas provides the visible pixels.
+  useEffect(() => {
+    if (!scene || !videoDims) {
+      return;
+    }
+
+    if (scene.getSceneId() !== sceneId) {
+      return;
+    }
+
+    const media = new VideoCanonicalMedia({
+      width: videoDims.w,
+      height: videoDims.h,
+    });
+
+    scene.addOverlay(media);
+    scene.setCanonicalMedia(media);
+    setCanonicalMediaReady(true);
+  }, [scene, sceneId, videoDims]);
+
+  // Viewport init — without this the pixi-viewport never gets framed and
+  // overlays render with zero / wrong coordinate transforms. We wait for
+  // both renderer-ready and canonical media before fitting.
+  const [rendererReady, setRendererReady] = useState(false);
+  const useEventHandler = useLighterEventHandler(
+    scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
+  );
+
+  useEventHandler(
+    "lighter:renderer-ready",
+    useCallback(() => setRendererReady(true), []),
+    { once: true }
+  );
+
+  useEffect(() => {
+    if (!scene || !rendererReady || !videoDims) {
+      return;
+    }
+
+    if (scene.getSceneId() !== sceneId) {
+      return;
+    }
+
+    scene.fitToContent();
+  }, [scene, sceneId, rendererReady, videoDims]);
+
+  // Stream-driven overlay diff. Gate on canonical media being installed
+  // on the current scene — see `canonicalMediaReady` above.
+  const snapshot = useStream<FrameLabelSnapshot>(LABELS_STREAM_ID);
+  useFrameOverlaySync(scene, snapshot, field, canonicalMediaReady);
+
+  return (
+    <div className={styles.body}>
+      <video
+        ref={videoRef}
+        className={styles.video}
+        src={videoSrc}
+        preload="auto"
+        playsInline
+        muted
+        onLoadedMetadata={(e) => {
+          const v = e.currentTarget;
+          setVideoDims({ w: v.videoWidth, h: v.videoHeight });
+        }}
+        onLoadedData={() => {
+          // Force the engine to commit once now that the video stream is
+          // ready. The engine's RAF loop is dormant while paused — without
+          // a seek the label stream never gets `onCommit` called
+          // and `useStream` stays at null, so no overlays paint on first
+          // load.
+          seek(0);
+        }}
+      />
+      <div ref={lighterHostRef} className={styles.lighterHost} />
+    </div>
+  );
+};
+
+/**
+ * Diff the latest snapshot into Lighter overlays. Add unseen
+ * ids, update moved ones in place, remove ids that fell out. Overlay
+ * identity is preserved across commits — important during playback,
+ * otherwise the remove-then-add churn races the Pixi render loop and
+ * the overlays disappear between frames.
+ */
+function useFrameOverlaySync(
+  scene: ReturnType<typeof useLighterSetupWithPixi>["scene"],
+  snapshot: FrameLabelSnapshot | null,
+  field: string,
+  canonicalMediaReady: boolean
+) {
+  const trackedRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    // Skip the diff until the current scene has its canonical media —
+    // overlays added before then get burned in with a bad coordinate
+    // context, and a later in-place `relativeBounds` mutation doesn't
+    // fix them. The effect re-runs once `canonicalMediaReady` flips.
+    if (!scene || !snapshot || !canonicalMediaReady) return;
+
+    const next = new Set<string>();
+    // todo - adapter pattern for other label types
+    for (const det of snapshot.detections) {
+      next.add(det.id);
+      const existing = scene.getOverlay(det.id) as DetectionOverlay | undefined;
+      const bounds = {
+        x: det.bounding_box[0],
+        y: det.bounding_box[1],
+        width: det.bounding_box[2],
+        height: det.bounding_box[3],
+      };
+      if (existing) {
+        existing.relativeBounds = bounds;
+      } else {
+        const overlay = overlayFactory.create<
+          DetectionOverlayOptions,
+          DetectionOverlay
+        >("detection", {
+          id: det.id,
+          label: toDetectionLabel(det),
+          relativeBounds: bounds,
+          field,
+          draggable: false,
+          resizeable: false,
+          selectable: false,
+        });
+        scene.addOverlay(overlay);
+        trackedRef.current.add(det.id);
+      }
+    }
+
+    for (const id of Array.from(trackedRef.current)) {
+      if (!next.has(id)) {
+        scene.removeOverlay(id);
+        trackedRef.current.delete(id);
+      }
+    }
+  }, [scene, snapshot, field, canonicalMediaReady]);
+
+  useEffect(() => {
+    return () => {
+      if (!scene) {
+        return;
+      }
+
+      for (const id of trackedRef.current) {
+        scene.removeOverlay(id);
+      }
+
+      trackedRef.current.clear();
+    };
+  }, [scene]);
+}
+
+function toDetectionLabel(box: SyntheticBox): DetectionLabel {
+  return {
+    label: box.label,
+    bounding_box: box.bounding_box,
+    // `index` and `instance` are what `COLOR_BY.INSTANCE` hashes on —
+    // without them every detection of the same class would collapse to
+    // a single color in instance mode.
+    index: box.index,
+    instance: box.instance,
+  } as DetectionLabel;
+}

--- a/app/packages/video-annotation/src/frameTracks.ts
+++ b/app/packages/video-annotation/src/frameTracks.ts
@@ -1,0 +1,168 @@
+import type {
+  Track,
+  TrackEvent,
+} from "../../playback/src/lib/tracks/TrackProvider";
+import type { VideoFrameLabelsStream } from "./VideoFrameLabelsStream";
+
+/**
+ * Prefix the stream uses for label ids when a FiftyOne track `index`
+ * is present.
+ */
+const TRACK_ID_PREFIX = "track-";
+
+interface InstanceState {
+  /** Class label observed for this instance (e.g. "person"). */
+  classLabel: string;
+  /** Numeric track index, used for sorting and as the instance-hash key. */
+  trackIndex: number;
+  /** Whether the instance was present in the most recent frame. */
+  inFrame: boolean;
+  /** Start time (sec) of the currently-open interval, if any. */
+  currentStart: number | null;
+  /** Closed presence intervals. */
+  intervals: Array<{ start: number; end: number }>;
+}
+
+/**
+ * Minimal label-shape passed to {@link BuildPerInstanceTracksInput.resolveColor}.
+ * Mirrors the fields `getLabelColorFromContext` reads, so the color resolves
+ * the same way it would for the matching label.
+ */
+export interface PerInstanceLabel {
+  label: string;
+  index: number;
+}
+
+export interface BuildPerInstanceTracksInput {
+  stream: VideoFrameLabelsStream;
+  resolveColor: (label: PerInstanceLabel) => string;
+}
+
+/**
+ * Walk every frame in `[1, stream.totalFrames]`, group labels by
+ * track id, and emit one {@link Track} per tracked instance whose events are
+ * the contiguous presence intervals.
+ *
+ * Row labels combine the class with the track index (e.g. "person 5");
+ * row color is resolved from the class so each row matches the colour
+ * of its bbox overlay in the media tile.
+ *
+ * Labels without a track index (untracked) are ignored here — they
+ * still render as overlays during playback but don't contribute rows.
+ *
+ * Requires the stream's cache to cover the full range; call
+ * {@link VideoFrameLabelsStream#warmupAll} and `await` it first.
+ */
+export function buildPerInstanceTracks({
+  stream,
+  resolveColor,
+}: BuildPerInstanceTracksInput): Track[] {
+  const { totalFrames, fps } = stream;
+  if (totalFrames < 1 || !Number.isFinite(fps) || fps <= 0) {
+    return [];
+  }
+
+  const states = new Map<string, InstanceState>();
+  const closeInterval = (state: InstanceState, endSec: number) => {
+    if (state.currentStart === null) {
+      return;
+    }
+
+    state.intervals.push({ start: state.currentStart, end: endSec });
+    state.currentStart = null;
+    state.inFrame = false;
+  };
+
+  for (let frame = 1; frame <= totalFrames; frame++) {
+    const frameStartSec = (frame - 1) / fps;
+    const snapshot = stream.getValue(frameStartSec);
+    const present = new Set<string>();
+    if (snapshot) {
+      // todo - adapter pattern to handle other label types
+      for (const det of snapshot.detections) {
+        if (!det.id.startsWith(TRACK_ID_PREFIX)) {
+          continue;
+        }
+
+        present.add(det.id);
+
+        let state = states.get(det.id);
+        if (!state) {
+          // Prefer the parsed-back-from-id index, but fall back to the
+          // structured `index` field on the box so we still get a usable
+          // sort key / instance hash if the id format ever drifts.
+          const suffix = det.id.slice(TRACK_ID_PREFIX.length);
+          const fromSuffix = Number(suffix);
+          const idx = Number.isFinite(fromSuffix) ? fromSuffix : det.index ?? 0;
+
+          state = {
+            classLabel: det.label || "unknown",
+            trackIndex: idx,
+            inFrame: false,
+            currentStart: null,
+            intervals: [],
+          };
+
+          states.set(det.id, state);
+        }
+        if (!state.inFrame) {
+          state.currentStart = frameStartSec;
+          state.inFrame = true;
+        }
+      }
+    }
+
+    // Close any instance that was present last frame but not now.
+    for (const [id, state] of states) {
+      if (!present.has(id) && state.inFrame) {
+        closeInterval(state, frameStartSec);
+      }
+    }
+  }
+
+  // Close any intervals still open at clip end.
+  const clipEndSec = totalFrames / fps;
+  for (const state of states.values()) {
+    closeInterval(state, clipEndSec);
+  }
+
+  const tracks: Track[] = [];
+  for (const [id, state] of states) {
+    if (state.intervals.length === 0) {
+      continue;
+    }
+
+    const events: TrackEvent[] = state.intervals.map(({ start, end }) => ({
+      startSec: start,
+      endSec: end,
+      label: "in frame",
+    }));
+
+    const suffix = id.slice(TRACK_ID_PREFIX.length);
+    tracks.push({
+      id,
+      label: `${state.classLabel} ${suffix}`,
+      description: `Tracked "${state.classLabel}" (track ${suffix})`,
+      color: resolveColor({
+        label: state.classLabel,
+        index: state.trackIndex,
+      }),
+      events,
+    });
+  }
+
+  // Sort by class then by numeric track index — keeps instances of the
+  // same class adjacent and the row order reproducible across runs.
+  tracks.sort((a, b) => {
+    const sa = states.get(a.id)!;
+    const sb = states.get(b.id)!;
+
+    if (sa.classLabel !== sb.classLabel) {
+      return sa.classLabel.localeCompare(sb.classLabel);
+    }
+
+    return sa.trackIndex - sb.trackIndex;
+  });
+
+  return tracks;
+}

--- a/app/packages/video-annotation/src/ids.ts
+++ b/app/packages/video-annotation/src/ids.ts
@@ -1,0 +1,3 @@
+export const VIDEO_STREAM_ID = "video";
+export const LABELS_STREAM_ID = "frame-labels";
+export const MAIN_TILE_ID = "main";

--- a/app/packages/video-annotation/src/linkedTracks.tsx
+++ b/app/packages/video-annotation/src/linkedTracks.tsx
@@ -1,0 +1,130 @@
+import {
+  UNDEFINED_LIGHTER_SCENE_ID,
+  useLighter,
+  useLighterEventBus,
+  useLighterEventHandler,
+} from "@fiftyone/lighter";
+import clsx from "clsx";
+import { useAtomValue } from "jotai";
+import React, { useCallback, useRef } from "react";
+import { type Track } from "../../playback/src/lib/tracks/TrackProvider";
+import {
+  hoveredOverlayIds,
+  selectedOverlayIds,
+  useLinkedOverlayState,
+  useScrollTrackOnSelect,
+} from "./useLinkedOverlayState";
+import styles from "./VideoAnnotationSurface.module.css";
+
+/**
+ * Side-effect component that runs {@link useLinkedOverlayState} so the
+ * `hoveredOverlayIds` / `selectedOverlayIds` atoms reflect the current
+ * Lighter scene. Rendered as a null component just to host the hook
+ * inside the surface tree.
+ */
+export const LinkedOverlayStateBridge: React.FC = () => {
+  useLinkedOverlayState();
+  useScrollTrackOnSelect();
+  return null;
+};
+
+/**
+ * Builds a `decorateTrack` for `TimelineWithTracks` that wires each row
+ * to its matching overlay (track.id == overlay.id for our datasets):
+ *
+ *  - row gets the `linkHovered` class when the overlay is hovered
+ *  - row gets the `linkSelected` class when the overlay is selected
+ *  - hovering the row itself fires `lighter:do-overlay-hover` on the
+ *    scene bus, so the overlay's hover state matches in real time. The
+ *    row's own visual hover is handled by ordinary CSS `:hover` — only
+ *    the cross-component direction needs an atom.
+ */
+export function useLinkedTrackDecorator(): (track: Track) => Partial<{
+  className: string;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+  onTrackClick: () => void;
+}> {
+  const hovered = useAtomValue(hoveredOverlayIds);
+  const selected = useAtomValue(selectedOverlayIds);
+  const { scene } = useLighter();
+  const eventBus = useLighterEventBus(
+    scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
+  );
+
+  // "Pending select" — the id the user just clicked whose overlay
+  // wasn't in the scene yet. Clicking an interval bar seeks to that
+  // frame; the matching overlay enters the scene a moment later when
+  // `useFrameOverlaySync` lands it. We watch `lighter:overlay-added`
+  // for that id and call `selectOverlay` then.
+  const useEventHandler = useLighterEventHandler(
+    scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
+  );
+  const pendingSelectRef = useRef<string | null>(null);
+
+  useEventHandler(
+    "lighter:overlay-added",
+    useCallback(
+      (payload) => {
+        if (!scene || pendingSelectRef.current !== payload.id) {
+          return;
+        }
+
+        scene.selectOverlay(payload.id);
+        pendingSelectRef.current = null;
+      },
+      [scene]
+    )
+  );
+
+  // Any select clears the pending intent — the user (or our own
+  // synchronous select below) picked something, so stale pendings
+  // shouldn't override a later choice if the original instance re-
+  // enters frame.
+  useEventHandler(
+    "lighter:overlay-select",
+    useCallback(() => {
+      pendingSelectRef.current = null;
+    }, [])
+  );
+
+  return useCallback(
+    (track: Track) => ({
+      className: clsx({
+        [styles.linkHovered]: hovered.has(track.id),
+        [styles.linkSelected]: selected.has(track.id),
+      }),
+      onMouseEnter: () => {
+        if (!scene) {
+          return;
+        }
+
+        eventBus.dispatch("lighter:do-overlay-hover", {
+          id: track.id,
+          tooltip: false,
+        });
+      },
+      onMouseLeave: () => {
+        if (!scene) {
+          return;
+        }
+
+        eventBus.dispatch("lighter:do-overlay-unhover", { id: track.id });
+      },
+      onTrackClick: () => {
+        // Record the intent first, then try a synchronous select. If
+        // the overlay is already in the scene, `selectOverlay` fires
+        // `:overlay-select` which clears `pendingSelectRef` via the
+        // listener above. If the label isn't in the current frame —
+        // typical when clicking an interval bar that the playhead is
+        // about to seek into — the synchronous call no-ops, the seek
+        // (already in flight from the bar's own click handler) lands
+        // the right frame, the overlay enters the scene, the
+        // `:overlay-added` listener fires, and we select then.
+        pendingSelectRef.current = track.id;
+        scene?.selectOverlay(track.id);
+      },
+    }),
+    [hovered, selected, scene, eventBus]
+  );
+}

--- a/app/packages/video-annotation/src/syntheticTracks.ts
+++ b/app/packages/video-annotation/src/syntheticTracks.ts
@@ -1,4 +1,7 @@
-import type { Track, TrackEvent } from "../../playback/src/lib/tracks/TrackProvider";
+import type {
+  Track,
+  TrackEvent,
+} from "../../playback/src/lib/tracks/TrackProvider";
 import {
   getPresenceIntervals,
   type PresenceInterval,

--- a/app/packages/video-annotation/src/syntheticTracks.ts
+++ b/app/packages/video-annotation/src/syntheticTracks.ts
@@ -1,0 +1,109 @@
+import type { Track, TrackEvent } from "../../playback/src/lib/tracks/TrackProvider";
+import {
+  getPresenceIntervals,
+  type PresenceInterval,
+  type SyntheticActor,
+} from "./SyntheticLabelStream";
+
+/**
+ * Minimal label-shape passed to {@link buildSyntheticTracks}' resolver.
+ * Mirrors the fields the overlay's color resolution reads, so a row's
+ * color matches its bboxes — including under `COLOR_BY.INSTANCE`, which
+ * hashes on `${label}-${instance._id}` when no numeric index is present
+ * (the case for synthetic actors).
+ */
+export interface SyntheticActorLabel {
+  label: string;
+  instance: { _cls: "Instance"; _id: string };
+}
+
+const MAX_HIGHLIGHTS = 3;
+
+function isInsideAny(t: number, intervals: PresenceInterval[]): boolean {
+  for (const { startSec, endSec } of intervals) {
+    if (t >= startSec && t <= endSec) return true;
+  }
+  return false;
+}
+
+/**
+ * Times in [0, duration] at which the oscillator
+ *   f(t) = 0.5 + 0.5 * sin(2π * (t / periodSec + phase))
+ * hits its maximum (= 1). Each maximum corresponds to the actor being at
+ * the rightmost (or topmost) edge of its trajectory.
+ */
+function maximaTimes(
+  periodSec: number,
+  phase: number,
+  duration: number,
+  limit: number
+): number[] {
+  // sin is maximal when its argument is π/2 + 2πn → t/period + phase = 0.25 + n
+  const out: number[] = [];
+  // Start n at the first integer for which t >= 0.
+  const firstN = Math.ceil(phase - 0.25);
+  for (let n = firstN; out.length < limit; n++) {
+    const t = periodSec * (0.25 - phase + n);
+    if (t < 0) continue;
+    if (t > duration) break;
+    out.push(t);
+  }
+  return out;
+}
+
+/**
+ * Build per-actor timeline tracks from the synthetic stream's actor model.
+ *
+ * Each actor becomes one row: a full-duration interval (the actor is
+ * "in frame" the whole clip) plus a handful of point events marking
+ * deterministic moments along its trajectory (when the actor reaches
+ * the right edge of the frame).
+ *
+ * Colors are resolved through the caller-supplied function so the rows
+ * match whatever scheme the overlays use.
+ */
+export function buildSyntheticTracks(
+  actors: SyntheticActor[],
+  duration: number,
+  resolveColor: (label: SyntheticActorLabel) => string
+): Track[] {
+  if (!(duration > 0)) return [];
+
+  return actors.map((actor) => {
+    const intervals = getPresenceIntervals(actor, duration);
+
+    const presenceEvents: TrackEvent[] = intervals.map(
+      ({ startSec, endSec }) => ({
+        startSec,
+        endSec,
+        label: "in frame",
+      })
+    );
+
+    // Only highlight x-maxima that fall inside a presence interval — a
+    // "right edge" marker during a gap would be misleading.
+    const highlights: TrackEvent[] = maximaTimes(
+      actor.xPeriodSec,
+      actor.xPhase,
+      duration,
+      MAX_HIGHLIGHTS * 2
+    )
+      .filter((t) => isInsideAny(t, intervals))
+      .slice(0, MAX_HIGHLIGHTS)
+      .map((t) => ({
+        startSec: t,
+        label: `${actor.label} → right edge`,
+      }));
+
+    return {
+      id: actor.id,
+      label: actor.label,
+      description: `Synthetic actor "${actor.label}"`,
+      color: resolveColor({
+        label: actor.label,
+        instance: { _cls: "Instance", _id: actor.id },
+      }),
+      events: [...presenceEvents, ...highlights],
+    };
+  });
+}

--- a/app/packages/video-annotation/src/useLinkedOverlayState.ts
+++ b/app/packages/video-annotation/src/useLinkedOverlayState.ts
@@ -1,0 +1,185 @@
+import {
+  UNDEFINED_LIGHTER_SCENE_ID,
+  useLighter,
+  useLighterEventHandler,
+} from "@fiftyone/lighter";
+import { atom, useStore } from "jotai";
+import { useCallback } from "react";
+
+/**
+ * IDs of overlays currently in hover state on the live Lighter scene.
+ * Reflects the set of `lighter:overlay-hover` / `:overlay-unhover`
+ * events; cleared in bulk by `lighter:overlay-all-unhover`.
+ */
+export const hoveredOverlayIds = atom<Set<string>>(new Set<string>());
+
+/**
+ * IDs the user has *intentionally* selected. Mirrors the scene's
+ * selection set but filters out removal-driven deselects so the row
+ * decoration outlives a tracked instance exiting frame.
+ *
+ * Driven by `:selection-changed`. Deselect entries are applied only
+ * when the payload's `ignoreSideEffects` flag is false — that flag is
+ * set by `SelectionManager.removeSelectable`, which we treat as "the
+ * overlay went away, not a user action".
+ */
+export const selectedOverlayIds = atom<Set<string>>(new Set<string>());
+
+/**
+ * Link hover and selection states between overlays and object tracks.
+ *
+ * The video-annotation timeline relies on track.id == overlay.id for
+ * tracked instances (both are `track-${index}`), so a hovered/selected
+ * label lights up its row and vice versa with no extra mapping.
+ *
+ * Mount once near the top of the video-annotation surface. Re-mounts
+ * automatically follow the active scene through `useLighter()`. Uses
+ * `useStore()` rather than `getDefaultStore()` so writes land in the
+ * same store consumers read from — `TilingProvider` mounts its own
+ * Jotai `<Provider>`, and reads inside that subtree would otherwise
+ * miss writes made to the default store.
+ */
+export function useLinkedOverlayState(): void {
+  const { scene } = useLighter();
+  const store = useStore();
+  const useEventHandler = useLighterEventHandler(
+    scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
+  );
+
+  useEventHandler(
+    "lighter:overlay-hover",
+    useCallback(
+      (payload) => {
+        const current = store.get(hoveredOverlayIds);
+        if (current.has(payload.id)) {
+          return;
+        }
+
+        const next = new Set(current);
+        next.add(payload.id);
+
+        store.set(hoveredOverlayIds, next);
+      },
+      [store]
+    )
+  );
+
+  useEventHandler(
+    "lighter:overlay-unhover",
+    useCallback(
+      (payload) => {
+        const current = store.get(hoveredOverlayIds);
+        if (!current.has(payload.id)) {
+          return;
+        }
+
+        const next = new Set(current);
+        next.delete(payload.id);
+
+        store.set(hoveredOverlayIds, next);
+      },
+      [store]
+    )
+  );
+
+  useEventHandler(
+    "lighter:overlay-all-unhover",
+    useCallback(() => {
+      if (store.get(hoveredOverlayIds).size === 0) {
+        return;
+      }
+
+      store.set(hoveredOverlayIds, new Set<string>());
+    }, [store])
+  );
+
+  useEventHandler(
+    "lighter:selection-changed",
+    useCallback(
+      (payload) => {
+        const prev = store.get(selectedOverlayIds);
+        let mutated = false;
+        const next = new Set(prev);
+        for (const id of payload.selectedIds) {
+          if (!next.has(id)) {
+            next.add(id);
+            mutated = true;
+          }
+        }
+
+        // Skip deselects flagged as side-effect-only — those fire when
+        // the overlay is removed from the scene (e.g. a tracked
+        // instance exiting frame) and the user-intent atom should
+        // carry through.
+        if (!payload.ignoreSideEffects) {
+          for (const id of payload.deselectedIds) {
+            if (next.has(id)) {
+              next.delete(id);
+              mutated = true;
+            }
+          }
+        }
+
+        if (mutated) {
+          store.set(selectedOverlayIds, next);
+        }
+      },
+      [store]
+    )
+  );
+
+  useEventHandler(
+    "lighter:selection-cleared",
+    useCallback(
+      (payload) => {
+        if (payload.ignoreSideEffects) {
+          return;
+        }
+
+        if (store.get(selectedOverlayIds).size === 0) {
+          return;
+        }
+
+        store.set(selectedOverlayIds, new Set<string>());
+      },
+      [store]
+    )
+  );
+}
+
+/**
+ * When the user selects an overlay, bring its matching track row into
+ * view. Relies on `data-track-id={id}` rendered by {@link TimelineTrack}
+ * (track id == overlay id for our datasets).
+ *
+ * Pinned tracks appear twice in the DOM (the header copy when the
+ * drawer is closed, the body copy when open). `querySelector` returns
+ * the first match — usually the visible copy — and `scrollIntoView`
+ * with `block: "nearest"` no-ops when the row is already visible, so
+ * pinned rows generate no scroll. Only off-screen unpinned rows move.
+ */
+export function useScrollTrackOnSelect(): void {
+  const { scene } = useLighter();
+  const useEventHandler = useLighterEventHandler(
+    scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
+  );
+
+  useEventHandler(
+    "lighter:overlay-select",
+    useCallback((payload) => {
+      // Defer to the next frame so any layout shift triggered by the
+      // selection itself settles before scrolling.
+      requestAnimationFrame(() => {
+        const row = document.querySelector(
+          `[data-track-id="${CSS.escape(payload.id)}"]`
+        );
+
+        row?.scrollIntoView({
+          behavior: "smooth",
+          block: "nearest",
+          inline: "nearest",
+        });
+      });
+    }, [])
+  );
+}

--- a/app/packages/video-annotation/src/useVfcClockSource.ts
+++ b/app/packages/video-annotation/src/useVfcClockSource.ts
@@ -1,0 +1,50 @@
+import { useEffect, type RefObject } from "react";
+import { usePlayback } from "../../playback/src/lib/playback/PlaybackProvider";
+import { usePresentedMediaTime } from "../../playback/src/lib/playback/use-video-stream";
+
+/**
+ * Register a `<video>` element's vfc-reported presentation time as
+ * the playback engine's clock source.
+ *
+ * This is the video-annotation opt-in into video-anchored playback.
+ * The default engine model — wallclock RAF + barrier sync over
+ * blocking streams — is the right design for label-only timelines,
+ * image sequences, sensor data, and multi-stream coordinated
+ * playback. But when a single `<video>` is the visual ground truth
+ * for the timeline (one camera, one annotation pass), letting that
+ * video's actual presentation time drive the engine avoids the
+ * two-clock race between wallclock and the video's decoder pace.
+ *
+ * The clock source reads from a vfc-driven ref:
+ * `requestVideoFrameCallback` fires once per frame the compositor
+ * actually paints, so its `mediaTime` is exactly where the picture
+ * is. The engine reads that each tick and commits at it.
+ *
+ * Returns `null` before the first vfc tick lands; the engine
+ * gracefully falls back to its dt advance for that pre-first-frame
+ * window. That's typically a single tick during initial decode and
+ * doesn't matter.
+ *
+ * When you use this hook, also pass `blocking: false` to the
+ * corresponding `useVideoStream` call — the clock source is already
+ * the authority on presentation time, so the bufferState drift check
+ * has nothing to add and would just produce spurious stalls.
+ *
+ * Multi-video extension: this is single-source. For coordinated
+ * playback across N videos, write a hook that combines
+ * multiple `presentedMediaTimeRef`s into one `read()` (typically
+ * via `Math.min` across non-null refs so the engine waits on the
+ * slowest video).
+ */
+export function useVfcClockSource(
+  videoRef: RefObject<HTMLVideoElement | null>
+): void {
+  const { setClockSource } = usePlayback();
+  const presentedMediaTimeRef = usePresentedMediaTime(videoRef);
+
+  useEffect(() => {
+    return setClockSource({
+      read: () => presentedMediaTimeRef.current,
+    });
+  }, [presentedMediaTimeRef, setClockSource]);
+}

--- a/app/packages/video-annotation/tsconfig.json
+++ b/app/packages/video-annotation/tsconfig.json
@@ -1,0 +1,4 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "include": ["./src", "./index.ts"]
+}

--- a/app/packages/video-annotation/vite.config.ts
+++ b/app/packages/video-annotation/vite.config.ts
@@ -1,0 +1,12 @@
+import { UserConfig } from "vite";
+
+export default <UserConfig>{
+  rollupOptions: {
+    external: ["react", "react-dom"],
+  },
+  resolve: {
+    alias: {
+      "@fiftyone/video-annotation": "@fiftyone/video-annotation/index.ts",
+    },
+  },
+};

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3034,6 +3034,7 @@ __metadata:
     "@fiftyone/relay": "npm:*"
     "@fiftyone/state": "npm:*"
     "@fiftyone/utilities": "npm:*"
+    "@fiftyone/video-annotation": "workspace:*"
     "@material-ui/core": "npm:4.12.4"
     "@types/lodash": "npm:^4.14.182"
     "@types/mime": "npm:^2.0.3"
@@ -3349,7 +3350,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fiftyone/lighter@workspace:packages/lighter":
+"@fiftyone/lighter@workspace:*, @fiftyone/lighter@workspace:packages/lighter":
   version: 0.0.0-use.local
   resolution: "@fiftyone/lighter@workspace:packages/lighter"
   dependencies:
@@ -3491,7 +3492,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fiftyone/playback@workspace:packages/playback":
+"@fiftyone/playback@workspace:*, @fiftyone/playback@workspace:packages/playback":
   version: 0.0.0-use.local
   resolution: "@fiftyone/playback@workspace:packages/playback"
   dependencies:
@@ -3589,7 +3590,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fiftyone/state@npm:*, @fiftyone/state@workspace:packages/state":
+"@fiftyone/state@npm:*, @fiftyone/state@workspace:*, @fiftyone/state@workspace:packages/state":
   version: 0.0.0-use.local
   resolution: "@fiftyone/state@workspace:packages/state"
   dependencies:
@@ -3613,7 +3614,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fiftyone/tiling@npm:*, @fiftyone/tiling@workspace:packages/tiling":
+"@fiftyone/tiling@npm:*, @fiftyone/tiling@workspace:*, @fiftyone/tiling@workspace:packages/tiling":
   version: 0.0.0-use.local
   resolution: "@fiftyone/tiling@workspace:packages/tiling"
   dependencies:
@@ -3643,6 +3644,20 @@ __metadata:
     vite: "npm:^7.3.2"
   peerDependencies:
     react: "*"
+  languageName: unknown
+  linkType: soft
+
+"@fiftyone/video-annotation@workspace:*, @fiftyone/video-annotation@workspace:packages/video-annotation":
+  version: 0.0.0-use.local
+  resolution: "@fiftyone/video-annotation@workspace:packages/video-annotation"
+  dependencies:
+    "@fiftyone/lighter": "workspace:*"
+    "@fiftyone/playback": "workspace:*"
+    "@fiftyone/state": "workspace:*"
+    "@fiftyone/tiling": "workspace:*"
+    "@voxel51/voodo": "npm:^0.0.30"
+    jotai: "npm:^2.9.3"
+    vite: "npm:^7.3.2"
   languageName: unknown
   linkType: soft
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3656,6 +3656,7 @@ __metadata:
     "@fiftyone/state": "workspace:*"
     "@fiftyone/tiling": "workspace:*"
     "@voxel51/voodo": "npm:^0.0.30"
+    clsx: "npm:^2.1.0"
     jotai: "npm:^2.9.3"
     vite: "npm:^7.3.2"
   languageName: unknown


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

Introduces a modal-based annotation surface for video datasets, plus the playback and Lighter primitives it builds on. This is the base of a stack; subsequent PRs layer the frame stream, persistence, keyframes, and tracking on top.

- **Annotation surface** — a new video annotation surface mounted as a modal entry point.
- **Playback** — reactive track list with per-row decoration and bubbling marker clicks; pluggable clock source + dt cap for the RAF tick; the video element is driven from explicit seek events with play gated on buffering; tightened stream readiness with a presented-frame ref.
- **Lighter** — `getLabelColorFromContext` extracted for non-overlay callers; side-effect deselects are flagged on selection-changed events so consumers can distinguish them from user deselects.
- **Utilities** — `determinePathType` forwards `data:` and `blob:` URLs.

## 🧪 How is this patch tested? If it is not, please explain why.

Tested locally in the app.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

In-app annotation now supports video datasets.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
