### PR TITLE
[HA] Improve visibility of modal status content

### DIFF
--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -77,16 +77,6 @@ const SpacesContainer = styled.div`
   z-index: 1501;
 `;
 
-// Fills the remaining height under the status row. `min-height: 0` lets the
-// flex child shrink properly so the inner Space (height: 100%) doesn't push
-// past the parent.
-const SpaceFill = styled.div`
-  position: relative;
-  flex: 1;
-  min-height: 0;
-  width: 100%;
-`;
-
 const AnnotationHandlerRegistration = () => {
   // Sparse groups can have no sample on the active slice; the annotation
   // hooks below read modalSample and would throw GroupSampleNotFound. Skip
@@ -354,10 +344,8 @@ const Modal = () => {
             <ModalNavigation closePanels={closePanels} />
             <SegmentationToolbar />
             <SpacesContainer>
+              <ModalSpace />
               <ModalStatusBar />
-              <SpaceFill>
-                <ModalSpace />
-              </SpaceFill>
             </SpacesContainer>
             {isSidebarVisible && <Sidebar />}
             <OperatorPromptArea area={OPERATOR_PROMPT_AREAS.DRAWER_RIGHT} />

--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -77,6 +77,16 @@ const SpacesContainer = styled.div`
   z-index: 1501;
 `;
 
+// Fills the remaining height under the status row. `min-height: 0` lets the
+// flex child shrink properly so the inner Space (height: 100%) doesn't push
+// past the parent.
+const SpaceFill = styled.div`
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+`;
+
 const AnnotationHandlerRegistration = () => {
   // Sparse groups can have no sample on the active slice; the annotation
   // hooks below read modalSample and would throw GroupSampleNotFound. Skip
@@ -344,8 +354,10 @@ const Modal = () => {
             <ModalNavigation closePanels={closePanels} />
             <SegmentationToolbar />
             <SpacesContainer>
-              <ModalSpace />
               <ModalStatusBar />
+              <SpaceFill>
+                <ModalSpace />
+              </SpaceFill>
             </SpacesContainer>
             {isSidebarVisible && <Sidebar />}
             <OperatorPromptArea area={OPERATOR_PROMPT_AREAS.DRAWER_RIGHT} />

--- a/app/packages/core/src/components/Modal/ModalStatusBar.tsx
+++ b/app/packages/core/src/components/Modal/ModalStatusBar.tsx
@@ -16,17 +16,22 @@ export type StatusContent = ReactElement | null;
 const initialContent: StatusContent = null;
 const statusContentAtom: PrimitiveAtom<StatusContent> = atom(initialContent);
 
+// Overlay anchored to the top of the sample pane. `position: absolute` keeps
+// it out of the flex flow so it never shrinks the sample canvas (which would
+// change canvas dimensions and break e2e screenshots). `pointer-events: none`
+// lets clicks pass through to the canvas during annotation.
 const Container = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
   display: flex;
-  align-items: center;
-  flex: 0 0 auto;
-  width: 100%;
-  min-width: 0;
-  padding: 2px 8px;
+  align-items: flex-start;
   user-select: none;
   white-space: nowrap;
   overflow-x: auto;
   overflow-y: hidden;
+  pointer-events: none;
   z-index: 1502;
 `;
 

--- a/app/packages/core/src/components/Modal/ModalStatusBar.tsx
+++ b/app/packages/core/src/components/Modal/ModalStatusBar.tsx
@@ -17,14 +17,25 @@ const initialContent: StatusContent = null;
 const statusContentAtom: PrimitiveAtom<StatusContent> = atom(initialContent);
 
 const Container = styled.div`
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 1502;
-  pointer-events: none;
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  width: 100%;
+  min-width: 0;
+  padding: 2px 8px;
   user-select: none;
   white-space: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+  z-index: 1502;
+`;
+
+// Auto margins center the content when it fits and collapse to 0 when it
+// overflows, so the scrollable region starts at the leftmost character
+// instead of clipping it off.
+const Inner = styled.div`
+  margin: 0 auto;
+  flex-shrink: 0;
 `;
 
 const IconWrap = styled.span`
@@ -48,7 +59,11 @@ const IconWrap = styled.span`
 export const ModalStatusBar = () => {
   const content = useAtomValue(statusContentAtom);
   if (!content) return null;
-  return <Container data-cy="modal-status-bar">{content}</Container>;
+  return (
+    <Container data-cy="modal-status-bar">
+      <Inner>{content}</Inner>
+    </Container>
+  );
 };
 
 /**

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/annotationStatusContent.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/annotationStatusContent.tsx
@@ -53,10 +53,22 @@ export const PenStatus = (): ReactElement => (
 );
 
 export const PolylineEntryStatus = (): ReactElement => (
-  <StatusItem
-    icon={<Timeline fontSize="small" />}
-    label="Click to start a new polyline"
-  />
+  <Stack
+    orientation={Orientation.Row}
+    align={Align.Center}
+    spacing={Spacing.Md}
+  >
+    <StatusItem
+      icon={<Timeline fontSize="small" />}
+      label="Click to start a new polyline"
+    />
+
+    <Separator />
+
+    <Text variant={TextVariant.Md} color={TextColor.Secondary}>
+      Right click to exit
+    </Text>
+  </Stack>
 );
 
 export const PolylineProgressStatus = ({
@@ -90,8 +102,8 @@ export const MergeInitialStatus = (): ReactElement => (
     icon={<CallMerge fontSize="small" />}
     label={
       <>
-        Click the <strong>primary</strong> polygon first · its properties will
-        be kept
+        Click the <strong>primary</strong> mask first · its properties will be
+        kept
       </>
     }
   />
@@ -182,9 +194,21 @@ const AIErrorStatus = ({ error }: { error: InferenceError }): ReactElement => (
 );
 
 const AIFirstClickStatus = (): ReactElement => (
-  <Text variant={TextVariant.Md} color={TextColor.Secondary}>
-    Click on an object to segment it
-  </Text>
+  <Stack
+    orientation={Orientation.Row}
+    align={Align.Center}
+    spacing={Spacing.Md}
+  >
+    <Text variant={TextVariant.Md} color={TextColor.Secondary}>
+      Click on an object to segment it
+    </Text>
+
+    <Separator />
+
+    <Text variant={TextVariant.Md} color={TextColor.Secondary}>
+      Right click to exit
+    </Text>
+  </Stack>
 );
 
 const Marker = ({ color, label }: { color: TextColor; label: string }) => (
@@ -223,6 +247,10 @@ const AIPromptStatus = (): ReactElement => (
     <Separator />
     <Text variant={TextVariant.Md} color={TextColor.Secondary}>
       Click marker to remove
+    </Text>
+    <Separator />
+    <Text variant={TextVariant.Md} color={TextColor.Secondary}>
+      Right click to exit
     </Text>
   </Stack>
 );


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

Moves the modal status content to its own row to prevent overlap with other elements. Status container is horizontally-scrollable to allow for short- and long-form content.

## 🧪 How is this patch tested? If it is not, please explain why.

local

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the annotation tool's status messages with additional "Right click to exit" instructions across multiple interaction states for improved user guidance
  * Refined merge instruction wording for clearer messaging

* **Style**
  * Improved modal overlay layout by refactoring the positioning system for better content alignment and horizontal scrolling behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->