### PR TITLE
Add SDK support for temporal tags

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -370,6 +370,13 @@ class SampleCollection(object):
         return self.concat(samples)
 
     @property
+    def temporal_tags(self):
+        """The multimodal temporal tags for this collection."""
+        import fiftyone.multimodal as fomm
+
+        return fomm.TemporalTags(self)
+
+    @property
     def _dataset(self):
         """The :class:`fiftyone.core.dataset.Dataset` that serves the samples
         in this collection.
@@ -7188,6 +7195,52 @@ class SampleCollection(object):
             a :class:`fiftyone.core.view.DatasetView`
         """
         return self._add_view_stage(fos.MatchTags(tags, bool=bool, all=all))
+
+    def match_temporal_tags(
+        self,
+        tags=None,
+        *,
+        anchors=None,
+        index_type=None,
+        start=None,
+        end=None,
+        bool=True,
+    ):
+        """Returns a view containing samples that match temporal tags.
+
+        Args:
+            tags (None): an optional temporal tag or iterable of tags
+            anchors (None): an optional anchor or iterable of anchors
+            index_type (None): an optional temporal tag index type
+            start (None): an optional inclusive lower bound for range overlap
+            end (None): an optional exclusive upper bound for range overlap
+            bool (True): whether to include (True) or exclude (False) matching
+                samples
+
+        Returns:
+            a :class:`fiftyone.core.view.DatasetView`
+        """
+        import fiftyone.multimodal as fomm
+
+        tag_filter = fomm.TemporalTagFilter(
+            tags=tags,
+            anchors=anchors,
+            index_type=index_type,
+            start=start,
+            end=end,
+        )
+        if bool is None:
+            bool = True
+
+        sample_ids = {
+            tag.sample_id
+            for tag in self.temporal_tags.values(filter=tag_filter)
+        }
+
+        if bool:
+            return self.select(sample_ids)
+
+        return self.exclude(sample_ids)
 
     @view_stage
     def mongo(self, pipeline, _needs_frames=None, _group_slices=None):

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -48,6 +48,7 @@ import fiftyone.core.runs as fors
 import fiftyone.core.sample as fosa
 import fiftyone.core.storage as fost
 import fiftyone.core.utils as fou
+from fiftyone.internal.docs import hide_from_docs
 
 fod = fou.lazy_import("fiftyone.core.dataset")
 fos = fou.lazy_import("fiftyone.core.stages")
@@ -370,6 +371,7 @@ class SampleCollection(object):
         return self.concat(samples)
 
     @property
+    @hide_from_docs
     def temporal_tags(self):
         """The multimodal temporal tags for this collection."""
         import fiftyone.multimodal as fomm
@@ -7196,6 +7198,7 @@ class SampleCollection(object):
         """
         return self._add_view_stage(fos.MatchTags(tags, bool=bool, all=all))
 
+    @hide_from_docs
     def match_temporal_tags(
         self,
         tags=None,

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -54,6 +54,7 @@ fot = fou.lazy_import("fiftyone.core.stages")
 foud = fou.lazy_import("fiftyone.utils.data")
 food = fou.lazy_import("fiftyone.operators.delegated")
 foos = fou.lazy_import("fiftyone.operators.store")
+fommtt = fou.lazy_import("fiftyone.multimodal.tags._temporal_tags")
 
 
 _SUMMARY_FIELD_KEY = "_summary_field"
@@ -6005,6 +6006,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             ops.append(DeleteMany({}))
 
         foo.bulk_write(ops, self._sample_collection)
+
+        if sample_ids is None:
+            fommtt.delete_for_dataset_id(self._doc.id)
+        else:
+            fommtt.delete_for_sample_ids(self._doc.id, sample_ids)
+
         self._update_last_deletion_at(now)
 
         fos.Sample._reset_docs(
@@ -10010,6 +10017,8 @@ def _delete_dataset_extras(dataset):
     svc = foos.ExecutionStoreService(dataset_id=dataset_id)
     svc.cleanup()
 
+    fommtt.delete_for_dataset_id(dataset_id)
+
 
 def _clone_collection(
     sample_collection,
@@ -10133,6 +10142,10 @@ def _clone_collection(
         foo.aggregate(coll, pipeline)
 
     clone_dataset = load_dataset(name)
+
+    fommtt.clone_tags(
+        dataset, clone_dataset, sample_collection=sample_collection, now=now
+    )
 
     # Clone extras (full datasets only)
     if view is None and (

--- a/fiftyone/core/odm/__init__.py
+++ b/fiftyone/core/odm/__init__.py
@@ -46,6 +46,7 @@ from .database import (
     drop_orphan_runs,
     drop_orphan_delegated_ops,
     drop_orphan_stores,
+    drop_orphan_temporal_tags,
     list_collections,
     get_collection_stats,
     get_indexed_values,

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -45,6 +45,7 @@ fob = fou.lazy_import("fiftyone.core.brain")
 fod = fou.lazy_import("fiftyone.core.dataset")
 foe = fou.lazy_import("fiftyone.core.evaluation")
 fors = fou.lazy_import("fiftyone.core.runs")
+fommtt = fou.lazy_import("fiftyone.multimodal.tags._temporal_tags")
 
 
 logger = logging.getLogger(__name__)
@@ -835,6 +836,35 @@ def drop_orphan_stores(dry_run=False):
             _delete_stores(conn, orphan_store_ids)
 
 
+def drop_orphan_temporal_tags(dry_run=False):
+    """Drops all orphan multimodal temporal tags from the database.
+
+    Orphan temporal tags are those that are associated with a dataset that no
+    longer exists in the database.
+
+    Args:
+        dry_run (False): whether to log the actions that would be taken but not
+            perform them
+    """
+    conn = get_db_conn()
+    _logger = _get_logger(dry_run=dry_run)
+
+    dataset_ids = set(conn.datasets.distinct("_id"))
+    orphan_dataset_ids = fommtt.get_orphan_dataset_ids(dataset_ids)
+    num_temporal_tags = fommtt.count_for_dataset_ids(orphan_dataset_ids)
+
+    if num_temporal_tags:
+        _logger.info(
+            "Deleting %d orphan multimodal temporal tag(s) for %d "
+            "dataset(s): %s",
+            num_temporal_tags,
+            len(orphan_dataset_ids),
+            orphan_dataset_ids,
+        )
+        if not dry_run:
+            fommtt.delete_for_dataset_ids(orphan_dataset_ids)
+
+
 def stream_collection(collection_name):
     """Streams the contents of the collection to stdout.
 
@@ -1416,6 +1446,15 @@ def delete_dataset(name, dry_run=False):
         _logger.info("Dropping collection '%s'", frame_collection_name)
         if not dry_run:
             conn.drop_collection(frame_collection_name)
+
+    _id = dataset_dict["_id"]
+    num_temporal_tags = fommtt.count_for_dataset_id(_id)
+    if num_temporal_tags > 0:
+        _logger.info(
+            "Deleting %d multimodal temporal tag(s)", num_temporal_tags
+        )
+        if not dry_run:
+            fommtt.delete_for_dataset_id(_id)
 
     view_ids = _get_saved_view_ids(dataset_dict)
 

--- a/fiftyone/multimodal/__init__.py
+++ b/fiftyone/multimodal/__init__.py
@@ -29,6 +29,7 @@ from .tags import (
     count_temporal_tags,
     delete_temporal_tags,
     list_temporal_tags,
+    update_temporal_tag,
 )
 
 __all__ = [
@@ -55,4 +56,5 @@ __all__ = [
     "schemas",
     "server",
     "tags",
+    "update_temporal_tag",
 ]

--- a/fiftyone/multimodal/__init__.py
+++ b/fiftyone/multimodal/__init__.py
@@ -6,7 +6,7 @@ Multimodal scaffolding for shared contracts and extension points.
 |
 """
 
-from . import decoders, resolver, server
+from . import decoders, resolver, server, tags
 from . import schemas
 from .decoders import (
     DecodedIngestFields,
@@ -20,6 +20,16 @@ from .decoders import (
     register_decoder,
 )
 from .resolver import PlaybackPlanBuilder
+from .tags import (
+    TemporalTag,
+    TemporalTagFilter,
+    TemporalTags,
+    TimeTrackType,
+    add_temporal_tags,
+    count_temporal_tags,
+    delete_temporal_tags,
+    list_temporal_tags,
+)
 
 __all__ = [
     "DecodedIngestFields",
@@ -28,12 +38,21 @@ __all__ = [
     "MultimodalPayload",
     "PayloadDescriptorKey",
     "PlaybackPlanBuilder",
+    "TemporalTag",
+    "TemporalTagFilter",
+    "TemporalTags",
+    "TimeTrackType",
+    "add_temporal_tags",
     "clear_decoders",
+    "count_temporal_tags",
     "decoders",
+    "delete_temporal_tags",
     "get_decoder",
+    "list_temporal_tags",
     "list_decoders",
     "register_decoder",
     "resolver",
     "schemas",
     "server",
+    "tags",
 ]

--- a/fiftyone/multimodal/server/__init__.py
+++ b/fiftyone/multimodal/server/__init__.py
@@ -10,12 +10,18 @@ from .routes import (
     MultimodalRoutes,
     PlaybackPlanEndpoint,
     PROTOBUF_MEDIA_TYPE,
+    SampleTemporalTagsEndpoint,
     SceneInventoryEndpoint,
+    TemporalTagCountsEndpoint,
+    TemporalTagsEndpoint,
 )
 
 __all__ = [
     "MultimodalRoutes",
     "PlaybackPlanEndpoint",
     "PROTOBUF_MEDIA_TYPE",
+    "SampleTemporalTagsEndpoint",
     "SceneInventoryEndpoint",
+    "TemporalTagCountsEndpoint",
+    "TemporalTagsEndpoint",
 ]

--- a/fiftyone/multimodal/server/routes.py
+++ b/fiftyone/multimodal/server/routes.py
@@ -12,6 +12,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 import fiftyone.multimodal.tags as fomt
+from fiftyone.multimodal.tags._temporal_tags import TemporalTagNotFoundError
 from fiftyone.multimodal.query import (
     resolve_playback_plan,
     resolve_scene_inventory,
@@ -102,6 +103,38 @@ class SampleTemporalTagsEndpoint(HTTPEndpoint):
                     tags=delete_request["tags"],
                     filter=delete_request["filter"],
                     delete_all=delete_request["delete_all"],
+                )
+            )
+        }
+
+
+class SampleTemporalTagEndpoint(HTTPEndpoint):
+    """Multimodal sample temporal tag item endpoint."""
+
+    @decorators.route
+    async def patch(self, request: Request, data: dict) -> dict:
+        """Updates a temporal tag for the sample."""
+
+        dataset = _get_dataset_from_request(request)
+        sample_id = _get_required_path_param(request, "sample_id")
+        temporal_tag_id = _get_required_path_param(request, "temporal_tag_id")
+        update = _temporal_tag_update_from_payload(
+            data,
+            sample_id=sample_id,
+            temporal_tag_id=temporal_tag_id,
+        )
+
+        return {
+            "temporal_tag": _serialize_temporal_tag(
+                _handle_temporal_tag_errors(
+                    lambda: fomt.update_temporal_tag(
+                        dataset.select([sample_id]),
+                        temporal_tag_id,
+                        start=update["start"],
+                        end=update["end"],
+                        tag=update["tag"],
+                        last_modified_by=update["last_modified_by"],
+                    )
                 )
             )
         }
@@ -270,6 +303,32 @@ def _delete_request_from_payload(data, sample_id: str) -> dict:
     }
 
 
+def _temporal_tag_update_from_payload(
+    data, *, sample_id: str, temporal_tag_id: str
+) -> dict:
+    _require_dict(data, "request body")
+    _reject_temporal_tag_update_fields(data)
+    _ensure_matching_sample_id(data.get("sample_id", None), sample_id)
+    _ensure_matching_temporal_tag_id(data.get("id", None), temporal_tag_id)
+
+    update = {
+        "start": data.get("start", None),
+        "end": data.get("end", None),
+        "tag": data.get("tag", None),
+        "last_modified_by": data.get("last_modified_by", None),
+    }
+    if all(value is None for value in update.values()):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Temporal tag update must include start, end, tag, or "
+                "last_modified_by"
+            ),
+        )
+
+    return update
+
+
 def _temporal_tag_filter_from_query(
     request: Request, sample_id: str | None = None
 ) -> fomt.TemporalTagFilter:
@@ -305,6 +364,8 @@ def _serialize_temporal_tag(tag: fomt.TemporalTag) -> dict:
 def _handle_temporal_tag_errors(callback):
     try:
         return callback()
+    except TemporalTagNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
     except (TypeError, ValueError) as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
@@ -366,6 +427,17 @@ def _ensure_matching_sample_id(value, sample_id: str) -> None:
         )
 
 
+def _ensure_matching_temporal_tag_id(value, temporal_tag_id: str) -> None:
+    if value is None:
+        return
+
+    if str(value) != temporal_tag_id:
+        raise HTTPException(
+            status_code=400,
+            detail="'id' must match the path temporal_tag_id",
+        )
+
+
 def _optional_query_int(params, field: str) -> int | None:
     value = params.get(field, None)
     if value is None or value == "":
@@ -405,23 +477,54 @@ def _reject_temporal_tag_timestamps(record: dict) -> None:
         )
 
 
+def _reject_temporal_tag_update_fields(record: dict) -> None:
+    fields = {
+        "anchor",
+        "created_at",
+        "created_by",
+        "index_type",
+        "last_modified_at",
+    } & set(record)
+    if fields:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Temporal tag %s %s not mutable through this route"
+                % (
+                    ", ".join(sorted(fields)),
+                    "is" if len(fields) == 1 else "are",
+                )
+            ),
+        )
+
+
 MultimodalRoutes = [
+    # Update one temporal tag scoped by sample.
+    (
+        "/dataset/{dataset_id}/sample/{sample_id}/multimodal/temporal-tags/{temporal_tag_id}",
+        SampleTemporalTagEndpoint,
+    ),
+    # Create, list, and delete temporal tags for one sample.
     (
         "/dataset/{dataset_id}/sample/{sample_id}/multimodal/temporal-tags",
         SampleTemporalTagsEndpoint,
     ),
+    # Count temporal tag values across a dataset.
     (
         "/dataset/{dataset_id}/multimodal/temporal-tags/counts",
         TemporalTagCountsEndpoint,
     ),
+    # List temporal tags across a dataset.
     (
         "/dataset/{dataset_id}/multimodal/temporal-tags",
         TemporalTagsEndpoint,
     ),
+    # Resolve playback timing for a scene inventory.
     (
         "/multimodal/playback-plan/{inventory_id}",
         PlaybackPlanEndpoint,
     ),
+    # Resolve multimodal scene inventory for one sample.
     (
         "/dataset/{dataset_id}/sample/{sample_id}/multimodal/scene-inventory",
         SceneInventoryEndpoint,

--- a/fiftyone/multimodal/server/routes.py
+++ b/fiftyone/multimodal/server/routes.py
@@ -180,6 +180,7 @@ def _temporal_tags_from_create_payload(
     tags = []
     for record in records:
         _require_dict(record, "temporal tag")
+        _reject_temporal_tag_timestamps(record)
         record_sample_id = record.get("sample_id", None)
         _ensure_matching_sample_id(record_sample_id, sample_id)
 
@@ -191,6 +192,8 @@ def _temporal_tags_from_create_payload(
                 tag=record.get("tag", None),
                 index_type=record.get("index_type", fomt.DEFAULT_INDEX_TYPE),
                 anchor=record.get("anchor", None),
+                created_by=record.get("created_by", None),
+                last_modified_by=record.get("last_modified_by", None),
             )
         )
 
@@ -379,6 +382,21 @@ def _require_dict(value, field: str) -> None:
         raise HTTPException(
             status_code=400,
             detail=f"'{field}' must be an object",
+        )
+
+
+def _reject_temporal_tag_timestamps(record: dict) -> None:
+    fields = {"created_at", "last_modified_at"} & set(record)
+    if fields:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Temporal tag %s %s response-only"
+                % (
+                    ", ".join(sorted(fields)),
+                    "is" if len(fields) == 1 else "are",
+                )
+            ),
         )
 
 

--- a/fiftyone/multimodal/server/routes.py
+++ b/fiftyone/multimodal/server/routes.py
@@ -84,7 +84,7 @@ class SampleTemporalTagsEndpoint(HTTPEndpoint):
             ]
         }
 
-    @decorators.route(parse_body=True)
+    @decorators.route(parse_body=True)  # pyright: ignore[reportCallIssue]
     async def delete(self, request: Request, data: dict) -> dict:
         """Deletes temporal tags for the sample."""
 

--- a/fiftyone/multimodal/server/routes.py
+++ b/fiftyone/multimodal/server/routes.py
@@ -203,6 +203,9 @@ def _temporal_tags_from_create_payload(
 def _delete_request_from_payload(data, sample_id: str) -> dict:
     _require_dict(data, "request body")
 
+    # Route deletes are always scoped by the path sample. Callers can delete by
+    # id/tag/filter, or opt into deleting all temporal tags for that sample via
+    # `delete_all`; dataset-wide deletes remain SDK-only.
     delete_all = data.get("delete_all", False)
     if not isinstance(delete_all, bool):
         raise HTTPException(
@@ -386,6 +389,8 @@ def _require_dict(value, field: str) -> None:
 
 
 def _reject_temporal_tag_timestamps(record: dict) -> None:
+    # Timestamps are system-managed in route CRUD. SDK/import callers can
+    # preserve provenance explicitly when they need to migrate existing records.
     fields = {"created_at", "last_modified_at"} & set(record)
     if fields:
         raise HTTPException(

--- a/fiftyone/multimodal/server/routes.py
+++ b/fiftyone/multimodal/server/routes.py
@@ -11,11 +11,13 @@ from starlette.exceptions import HTTPException
 from starlette.requests import Request
 from starlette.responses import Response
 
+import fiftyone.multimodal.tags as fomt
 from fiftyone.multimodal.query import (
     resolve_playback_plan,
     resolve_scene_inventory,
 )
 from fiftyone.server import decorators
+from fiftyone.server.utils.datasets import get_dataset
 
 PROTOBUF_MEDIA_TYPE = "application/x-protobuf"
 
@@ -23,7 +25,7 @@ PROTOBUF_MEDIA_TYPE = "application/x-protobuf"
 class SceneInventoryEndpoint(HTTPEndpoint):
     """Scene inventory query endpoint."""
 
-    @decorators.route(parse_body=False)
+    @decorators.route
     async def get(self, request: Request) -> Response:
         """Returns a serialized SceneInventory protobuf."""
 
@@ -55,6 +57,252 @@ class PlaybackPlanEndpoint(HTTPEndpoint):
         )
 
 
+class SampleTemporalTagsEndpoint(HTTPEndpoint):
+    """Multimodal sample temporal tag collection endpoint."""
+
+    @decorators.route
+    async def get(self, request: Request) -> dict:
+        """Lists temporal tags for the sample."""
+
+        sample_id = _get_required_path_param(request, "sample_id")
+        return _list_temporal_tags(request, sample_id=sample_id)
+
+    @decorators.route
+    async def post(self, request: Request, data: dict) -> dict:
+        """Creates one or more temporal tags for the sample."""
+
+        dataset = _get_dataset_from_request(request)
+        sample_id = _get_required_path_param(request, "sample_id")
+        tags = _temporal_tags_from_create_payload(data, sample_id=sample_id)
+
+        return {
+            "temporal_tags": [
+                _serialize_temporal_tag(tag)
+                for tag in _handle_temporal_tag_errors(
+                    lambda: fomt.add_temporal_tags(dataset, tags)
+                )
+            ]
+        }
+
+    @decorators.route(parse_body=True)
+    async def delete(self, request: Request, data: dict) -> dict:
+        """Deletes temporal tags for the sample."""
+
+        dataset = _get_dataset_from_request(request)
+        sample_id = _get_required_path_param(request, "sample_id")
+        delete_request = _delete_request_from_payload(
+            data, sample_id=sample_id
+        )
+
+        return {
+            "deleted": _handle_temporal_tag_errors(
+                lambda: fomt.delete_temporal_tags(
+                    dataset,
+                    ids=delete_request["ids"],
+                    tags=delete_request["tags"],
+                    filter=delete_request["filter"],
+                    delete_all=delete_request["delete_all"],
+                )
+            )
+        }
+
+
+class TemporalTagsEndpoint(HTTPEndpoint):
+    """Multimodal dataset temporal tag read endpoint."""
+
+    @decorators.route
+    async def get(self, request: Request) -> dict:
+        """Lists temporal tags for the dataset."""
+
+        return _list_temporal_tags(request)
+
+
+class TemporalTagCountsEndpoint(HTTPEndpoint):
+    """Multimodal temporal tag count endpoint."""
+
+    @decorators.route
+    async def get(self, request: Request) -> dict:
+        """Counts temporal tag values for the dataset."""
+
+        dataset = _get_dataset_from_request(request)
+        tag_filter = _temporal_tag_filter_from_query(request)
+
+        return {
+            "counts": _handle_temporal_tag_errors(
+                lambda: fomt.count_temporal_tags(dataset, filter=tag_filter)
+            )
+        }
+
+
+def _list_temporal_tags(
+    request: Request, sample_id: str | None = None
+) -> dict:
+    dataset = _get_dataset_from_request(request)
+    tag_filter = _temporal_tag_filter_from_query(request, sample_id=sample_id)
+
+    return {
+        "temporal_tags": [
+            _serialize_temporal_tag(tag)
+            for tag in _handle_temporal_tag_errors(
+                lambda: fomt.list_temporal_tags(dataset, filter=tag_filter)
+            )
+        ]
+    }
+
+
+def _get_dataset_from_request(request: Request):
+    dataset_id = _get_required_path_param(request, "dataset_id")
+
+    return get_dataset(dataset_id)
+
+
+def _temporal_tags_from_create_payload(
+    data, sample_id: str
+) -> list[fomt.TemporalTag]:
+    _require_dict(data, "request body")
+
+    records = data.get("temporal_tags", None)
+    if records is None:
+        records = data.get("tags", None)
+
+    if records is None:
+        records = data
+
+    if isinstance(records, dict):
+        records = [records]
+
+    if not isinstance(records, list) or not records:
+        raise HTTPException(
+            status_code=400,
+            detail="'temporal_tags' must contain at least one temporal tag",
+        )
+
+    tags = []
+    for record in records:
+        _require_dict(record, "temporal tag")
+        record_sample_id = record.get("sample_id", None)
+        _ensure_matching_sample_id(record_sample_id, sample_id)
+
+        tags.append(
+            fomt.TemporalTag(
+                sample_id=sample_id,
+                start=record.get("start", None),
+                end=record.get("end", None),
+                tag=record.get("tag", None),
+                index_type=record.get("index_type", fomt.DEFAULT_INDEX_TYPE),
+                anchor=record.get("anchor", None),
+            )
+        )
+
+    return tags
+
+
+def _delete_request_from_payload(data, sample_id: str) -> dict:
+    _require_dict(data, "request body")
+
+    delete_all = data.get("delete_all", False)
+    if not isinstance(delete_all, bool):
+        raise HTTPException(
+            status_code=400,
+            detail="'delete_all' must be a boolean",
+        )
+
+    ids = _first_present(data, "ids", "id")
+    tags = _first_present(data, "tags", "tag")
+    filter_payload = data.get("filter", None)
+
+    if filter_payload is None:
+        tag_filter = fomt.TemporalTagFilter(sample_ids=sample_id)
+        has_filter_selector = False
+    else:
+        _require_dict(filter_payload, "filter")
+        requested_sample_ids = _first_present(
+            filter_payload, "sample_ids", "sample_id"
+        )
+        _ensure_matching_sample_id(requested_sample_ids, sample_id)
+
+        tag_filter = fomt.TemporalTagFilter(
+            sample_ids=sample_id,
+            tags=_first_present(filter_payload, "tags", "tag"),
+            anchors=_first_present(filter_payload, "anchors", "anchor"),
+            index_type=filter_payload.get("index_type", None),
+            start=filter_payload.get("start", None),
+            end=filter_payload.get("end", None),
+        )
+        # The path sample scopes every delete, but should not count as a
+        # selector by itself; otherwise an empty request could delete the whole
+        # sample unless the caller opted into delete_all.
+        has_filter_selector = any(
+            field in filter_payload
+            for field in (
+                "tags",
+                "tag",
+                "anchors",
+                "anchor",
+                "index_type",
+                "start",
+                "end",
+            )
+        )
+
+    has_selector = ids is not None or tags is not None or has_filter_selector
+    if not has_selector and not delete_all:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Refusing to delete temporal tags with an empty selector; "
+                "pass delete_all=True to delete all temporal tags for the "
+                "sample"
+            ),
+        )
+
+    return {
+        "ids": ids,
+        "tags": tags,
+        "filter": tag_filter,
+        "delete_all": delete_all,
+    }
+
+
+def _temporal_tag_filter_from_query(
+    request: Request, sample_id: str | None = None
+) -> fomt.TemporalTagFilter:
+    params = request.query_params
+    sample_ids = _query_values(params, "sample_ids", "sample_id")
+    if sample_id is None:
+        if sample_ids is not None:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "'sample_id' is only supported in sample temporal tag "
+                    "routes"
+                ),
+            )
+    else:
+        _ensure_matching_sample_id(sample_ids, sample_id)
+        sample_ids = sample_id
+
+    return fomt.TemporalTagFilter(
+        sample_ids=sample_ids,
+        tags=_query_values(params, "tags", "tag"),
+        anchors=_query_values(params, "anchors", "anchor"),
+        index_type=_optional_query_int(params, "index_type"),
+        start=_optional_query_int(params, "start"),
+        end=_optional_query_int(params, "end"),
+    )
+
+
+def _serialize_temporal_tag(tag: fomt.TemporalTag) -> dict:
+    return tag.to_dict()
+
+
+def _handle_temporal_tag_errors(callback):
+    try:
+        return callback()
+    except (TypeError, ValueError) as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
 def _get_required_path_param(request: Request, field: str) -> str:
     value = request.path_params.get(field)
 
@@ -71,7 +319,82 @@ def _require_string(value, field: str) -> str:
     return value
 
 
+def _first_present(data: dict, *fields):
+    for field in fields:
+        if field in data:
+            return data[field]
+
+    return None
+
+
+def _query_values(params, *fields):
+    values = []
+
+    for field in fields:
+        if hasattr(params, "getlist"):
+            field_values = params.getlist(field)
+        else:
+            value = params.get(field, None)
+            field_values = [] if value is None else [value]
+
+        for value in field_values:
+            if isinstance(value, (list, tuple)):
+                values.extend(value)
+            elif isinstance(value, str):
+                values.extend(part for part in value.split(","))
+            else:
+                values.append(value)
+
+    return values or None
+
+
+def _ensure_matching_sample_id(value, sample_id: str) -> None:
+    if value is None:
+        return
+
+    values = value if isinstance(value, (list, tuple)) else [value]
+    if any(str(_value) != sample_id for _value in values):
+        raise HTTPException(
+            status_code=400,
+            detail="'sample_id' must match the path sample_id",
+        )
+
+
+def _optional_query_int(params, field: str) -> int | None:
+    value = params.get(field, None)
+    if value is None or value == "":
+        return None
+
+    try:
+        return int(value)
+    except (TypeError, ValueError) as e:
+        raise HTTPException(
+            status_code=400,
+            detail=f"'{field}' must be an integer",
+        ) from e
+
+
+def _require_dict(value, field: str) -> None:
+    if not isinstance(value, dict):
+        raise HTTPException(
+            status_code=400,
+            detail=f"'{field}' must be an object",
+        )
+
+
 MultimodalRoutes = [
+    (
+        "/dataset/{dataset_id}/sample/{sample_id}/multimodal/temporal-tags",
+        SampleTemporalTagsEndpoint,
+    ),
+    (
+        "/dataset/{dataset_id}/multimodal/temporal-tags/counts",
+        TemporalTagCountsEndpoint,
+    ),
+    (
+        "/dataset/{dataset_id}/multimodal/temporal-tags",
+        TemporalTagsEndpoint,
+    ),
     (
         "/multimodal/playback-plan/{inventory_id}",
         PlaybackPlanEndpoint,

--- a/fiftyone/multimodal/tags/__init__.py
+++ b/fiftyone/multimodal/tags/__init__.py
@@ -1,0 +1,40 @@
+"""
+Multimodal temporal tag SDK.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from fiftyone.multimodal.schemas import v1 as foms
+
+from .temporal_tags import (
+    DEFAULT_INDEX_TYPE,
+    SUPPORTED_INDEX_TYPES,
+    TEMPORAL_TAGS_COLLECTION_NAME,
+    TEMPORAL_TAGS_EXPORT_FILENAME,
+    TemporalTag,
+    TemporalTagFilter,
+    TemporalTags,
+    add_temporal_tags,
+    count_temporal_tags,
+    delete_temporal_tags,
+    list_temporal_tags,
+)
+
+TimeTrackType = foms.TimeTrackType
+
+__all__ = [
+    "DEFAULT_INDEX_TYPE",
+    "SUPPORTED_INDEX_TYPES",
+    "TEMPORAL_TAGS_COLLECTION_NAME",
+    "TEMPORAL_TAGS_EXPORT_FILENAME",
+    "TemporalTag",
+    "TemporalTagFilter",
+    "TemporalTags",
+    "TimeTrackType",
+    "add_temporal_tags",
+    "count_temporal_tags",
+    "delete_temporal_tags",
+    "list_temporal_tags",
+]

--- a/fiftyone/multimodal/tags/__init__.py
+++ b/fiftyone/multimodal/tags/__init__.py
@@ -20,6 +20,7 @@ from .temporal_tags import (
     count_temporal_tags,
     delete_temporal_tags,
     list_temporal_tags,
+    update_temporal_tag,
 )
 
 TimeTrackType = foms.TimeTrackType
@@ -37,4 +38,5 @@ __all__ = [
     "count_temporal_tags",
     "delete_temporal_tags",
     "list_temporal_tags",
+    "update_temporal_tag",
 ]

--- a/fiftyone/multimodal/tags/_temporal_tags.py
+++ b/fiftyone/multimodal/tags/_temporal_tags.py
@@ -1,0 +1,1043 @@
+"""
+Private implementation for multimodal temporal tags.
+
+Temporal tags are sample-scoped records stored in the dedicated
+``temporal_tags`` collection. Dataset/sample lifecycle hooks, import/export
+sidecars, and low-level orphan cleanup all flow through this module so the
+storage contract stays in one place.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import itertools
+import os
+from typing import Iterable
+
+from bson import ObjectId
+from pymongo import ASCENDING, InsertOne, UpdateOne
+
+import eta.core.utils as etau
+
+import fiftyone.core.odm as foo
+import fiftyone.core.utils as fou
+import fiftyone.core.view as fov
+from fiftyone.multimodal.schemas import v1 as foms
+
+TEMPORAL_TAGS_COLLECTION_NAME = "temporal_tags"
+TEMPORAL_TAGS_EXPORT_FILENAME = "temporal_tags.json"
+TEMPORAL_TAGS_EXPORT_KEY = "temporal_tags"
+
+DEFAULT_INDEX_TYPE = foms.TimeTrackType.TIME_TRACK_TYPE_DURATION_NS
+SUPPORTED_INDEX_TYPES = {
+    foms.TimeTrackType.TIME_TRACK_TYPE_SEQUENCE,
+    foms.TimeTrackType.TIME_TRACK_TYPE_DURATION_NS,
+    foms.TimeTrackType.TIME_TRACK_TYPE_TIMESTAMP_NS,
+}
+_TEMPORAL_TAG_SORT = [
+    ("_sample_id", ASCENDING),
+    ("index_type", ASCENDING),
+    ("start", ASCENDING),
+    ("end", ASCENDING),
+    ("tag", ASCENDING),
+    ("_id", ASCENDING),
+]
+
+
+class TemporalTag(object):
+    """A temporal tag interval on one multimodal sample.
+
+    Args:
+        sample_id: the sample ID this temporal tag applies to
+        start: the inclusive start value on the tag's index type
+        end: the exclusive end value on the tag's index type
+        tag: the tag value
+        index_type: a :class:`TimeTrackType` value describing the index
+            archetype. Defaults to ``TIME_TRACK_TYPE_DURATION_NS``
+        id: the persisted temporal tag ID, when available
+    """
+
+    def __init__(
+        self,
+        sample_id,
+        start,
+        end,
+        tag,
+        index_type=DEFAULT_INDEX_TYPE,
+        id=None,
+    ):
+        self.sample_id = sample_id
+        self.start = start
+        self.end = end
+        self.tag = tag
+        self.index_type = index_type
+        self.id = id
+
+    def __repr__(self):
+        return (
+            "%s(sample_id=%r, start=%r, end=%r, tag=%r, "
+            "index_type=%r, id=%r)"
+            % (
+                self.__class__.__name__,
+                self.sample_id,
+                self.start,
+                self.end,
+                self.tag,
+                self.index_type,
+                self.id,
+            )
+        )
+
+    def __eq__(self, other):
+        if not isinstance(other, TemporalTag):
+            return False
+
+        return self.to_dict() == other.to_dict()
+
+    def copy(self):
+        """Returns a copy of this temporal tag."""
+        return self.__class__(
+            self.sample_id,
+            self.start,
+            self.end,
+            self.tag,
+            index_type=self.index_type,
+            id=self.id,
+        )
+
+    def to_dict(self):
+        """Serializes the temporal tag to a JSON dictionary."""
+        d = {
+            "sample_id": self.sample_id,
+            "index_type": self.index_type,
+            "start": self.start,
+            "end": self.end,
+            "tag": self.tag,
+        }
+        if self.id is not None:
+            d["id"] = self.id
+
+        return d
+
+
+@dataclass(frozen=True)
+class TemporalTagFilter:
+    """Filter for multimodal temporal tag queries.
+
+    Range filters use half-open interval overlap semantics. For example,
+    ``start=10, end=20`` matches persisted intervals whose ``start < 20`` and
+    ``end > 10``.
+
+    Args:
+        sample_ids: an optional sample ID or iterable of sample IDs
+        tags: an optional tag or iterable of tags
+        index_type: an optional :class:`TimeTrackType` value
+        start: an optional inclusive lower bound for overlap queries
+        end: an optional exclusive upper bound for overlap queries
+    """
+
+    sample_ids: str | Iterable[str] | None = None
+    tags: str | Iterable[str] | None = None
+    index_type: int | None = None
+    start: int | None = None
+    end: int | None = None
+
+
+class TemporalTags(object):
+    """An ordered collection of temporal tags scoped to a sample collection.
+
+    Temporal tags are stored in a dedicated collection and linked to samples by
+    ID. Dataset/view scoping is applied by this facade: reads and deletes are
+    restricted to the provided sample collection, and adds reject sample IDs
+    outside the collection.
+
+    Args:
+        sample_collection: a :class:`fiftyone.Dataset` or
+            :class:`fiftyone.core.view.DatasetView`
+    """
+
+    def __init__(self, sample_collection):
+        dataset, sample_collection, sample_ids = _resolve_sample_collection(
+            sample_collection
+        )
+        self._dataset = dataset
+        self._sample_collection = sample_collection
+        self._sample_ids = sample_ids
+
+    def __str__(self):
+        return "<%s: %s>" % (
+            self.__class__.__name__,
+            fou.pformat(list(self.values())),
+        )
+
+    def __repr__(self):
+        return "<%s: %s>" % (self.__class__.__name__, len(self))
+
+    def __bool__(self):
+        return len(self) > 0
+
+    def __len__(self):
+        collection = _get_existing_collection()
+        if collection is None:
+            return 0
+
+        query = _build_query(
+            self._dataset._doc.id, None, sample_ids=self._sample_ids
+        )
+        return collection.count_documents(query)
+
+    def __iter__(self):
+        return self.keys()
+
+    def first(self):
+        """Returns the first temporal tag in this collection.
+
+        Returns:
+            a :class:`TemporalTag`
+        """
+        try:
+            return next(self.values())
+        except StopIteration:
+            raise ValueError("Sample collection has no temporal tags")
+
+    def head(self, num_tags=3):
+        """Returns a list of the first few temporal tags in this collection.
+
+        If fewer than ``num_tags`` temporal tags exist, only the available tags
+        are returned.
+
+        Args:
+            num_tags (3): the number of temporal tags
+
+        Returns:
+            a list of :class:`TemporalTag` instances
+        """
+        if num_tags <= 0:
+            return []
+
+        return list(itertools.islice(self.values(), num_tags))
+
+    def tail(self, num_tags=3):
+        """Returns a list of the last few temporal tags in this collection.
+
+        If fewer than ``num_tags`` temporal tags exist, only the available tags
+        are returned.
+
+        Args:
+            num_tags (3): the number of temporal tags
+
+        Returns:
+            a list of :class:`TemporalTag` instances
+        """
+        if num_tags <= 0:
+            return []
+
+        return list(self.values())[-num_tags:]
+
+    def keys(self):
+        """Returns an iterator over persisted temporal tag IDs."""
+        for temporal_tag in self.values():
+            yield temporal_tag.id
+
+    def items(self):
+        """Returns an iterator over persisted temporal tag ID/tag pairs."""
+        for temporal_tag in self.values():
+            yield temporal_tag.id, temporal_tag
+
+    def values(self, filter: TemporalTagFilter | None = None):
+        """Returns an iterator over temporal tags in this collection.
+
+        Args:
+            filter (None): an optional :class:`TemporalTagFilter`
+
+        Returns:
+            an iterator over :class:`TemporalTag` instances
+        """
+        query = _build_query(
+            self._dataset._doc.id, filter, sample_ids=self._sample_ids
+        )
+        collection = _get_existing_collection()
+        if collection is None:
+            return iter(())
+
+        docs = collection.find(query).sort(_TEMPORAL_TAG_SORT)
+        return (_from_storage_doc(doc) for doc in docs)
+
+    def add(self, tags: TemporalTag | Iterable[TemporalTag]):
+        """Adds temporal tags to this collection.
+
+        The tuple ``(dataset, sample_id, index_type, start, end, tag)`` is
+        unique, so adding the same tag interval multiple times is idempotent.
+
+        Args:
+            tags: a temporal tag or iterable of temporal tags
+
+        Returns:
+            a list of persisted :class:`TemporalTag` instances
+        """
+        tags = _ensure_temporal_tag_list(tags)
+        if not tags:
+            return []
+
+        sample_ids = _validate_sample_ids_exist(
+            self._sample_collection, [tag.sample_id for tag in tags]
+        )
+        now = _utcnow()
+        keys = []
+        ops_by_key = {}
+
+        for tag in tags:
+            doc = _to_storage_doc(
+                tag, self._dataset._doc.id, sample_ids[str(tag.sample_id)]
+            )
+            key = _unique_key(doc)
+            keys.append(key)
+            if key not in ops_by_key:
+                ops_by_key[key] = UpdateOne(
+                    _unique_query(doc),
+                    {
+                        "$setOnInsert": {
+                            "_dataset_id": doc["_dataset_id"],
+                            "_sample_id": doc["_sample_id"],
+                            "index_type": doc["index_type"],
+                            "start": doc["start"],
+                            "end": doc["end"],
+                            "tag": doc["tag"],
+                            "created_at": now,
+                        },
+                        "$set": {"last_modified_at": now},
+                    },
+                    upsert=True,
+                )
+
+        collection = _get_or_create_collection()
+        collection.bulk_write(list(ops_by_key.values()), ordered=False)
+
+        persisted_docs = collection.find(
+            {
+                "_dataset_id": self._dataset._doc.id,
+                "$or": [_query_from_unique_key(key) for key in set(keys)],
+            }
+        )
+        docs_by_key = {_unique_key(doc): doc for doc in persisted_docs}
+
+        return [_from_storage_doc(docs_by_key[key]) for key in keys]
+
+    def delete(
+        self,
+        *,
+        ids: str | Iterable[str] | None = None,
+        tags: str | Iterable[str] | None = None,
+        filter: TemporalTagFilter | None = None,
+        delete_all: bool = False,
+    ) -> int:
+        """Deletes temporal tags from this collection.
+
+        Args:
+            ids (None): an optional temporal tag ID or iterable of IDs
+            tags (None): an optional tag or iterable of tags
+            filter (None): an optional :class:`TemporalTagFilter`
+            delete_all (False): whether to allow an empty selector
+
+        Returns:
+            the number of deleted temporal tags
+        """
+        query = _build_query(
+            self._dataset._doc.id, filter, sample_ids=self._sample_ids
+        )
+        has_selector = filter is not None and not _is_empty_filter(filter)
+
+        if ids is not None:
+            query["_id"] = {"$in": _ensure_object_id_list(ids, "ids")}
+            has_selector = True
+
+        if tags is not None:
+            query["tag"] = _build_in_query(_ensure_string_list(tags, "tags"))
+            has_selector = True
+
+        if not has_selector and not delete_all:
+            raise ValueError(
+                "Refusing to delete temporal tags with an empty selector; "
+                "pass delete_all=True to delete all temporal tags for the "
+                "dataset"
+            )
+
+        collection = _get_existing_collection()
+        if collection is None:
+            return 0
+
+        return collection.delete_many(query).deleted_count
+
+    def clear(self):
+        """Deletes all temporal tags in this collection.
+
+        Returns:
+            the number of deleted temporal tags
+        """
+        return self.delete(delete_all=True)
+
+    def count(self, filter: TemporalTagFilter | None = None) -> dict[str, int]:
+        """Counts temporal tag occurrences in this collection.
+
+        Args:
+            filter (None): an optional :class:`TemporalTagFilter`
+
+        Returns:
+            a dict mapping tag values to counts
+        """
+        pipeline = [
+            {
+                "$match": _build_query(
+                    self._dataset._doc.id,
+                    filter,
+                    sample_ids=self._sample_ids,
+                )
+            },
+            {"$group": {"_id": "$tag", "count": {"$sum": 1}}},
+            {"$sort": {"_id": 1}},
+        ]
+
+        collection = _get_existing_collection()
+        if collection is None:
+            return {}
+
+        return {
+            result["_id"]: result["count"]
+            for result in collection.aggregate(pipeline)
+        }
+
+
+def add_temporal_tags(dataset, tags: TemporalTag | Iterable[TemporalTag]):
+    """Adds temporal tags to a dataset.
+
+    The tuple ``(dataset, sample_id, index_type, start, end, tag)`` is unique,
+    so adding the same tag interval multiple times is idempotent.
+    If a view is provided, all tag sample IDs must belong to the view.
+
+    Args:
+        dataset: a :class:`fiftyone.Dataset` or
+            :class:`fiftyone.core.view.DatasetView`
+        tags: a temporal tag or iterable of temporal tags
+
+    Returns:
+        a list of persisted :class:`TemporalTag` instances
+    """
+
+    return TemporalTags(dataset).add(tags)
+
+
+def list_temporal_tags(
+    dataset, filter: TemporalTagFilter | None = None
+) -> list[TemporalTag]:
+    """Lists temporal tags for a dataset.
+
+    If a view is provided, only temporal tags linked to the view's samples are
+    returned.
+
+    Args:
+        dataset: a :class:`fiftyone.Dataset` or
+            :class:`fiftyone.core.view.DatasetView`
+        filter (None): an optional :class:`TemporalTagFilter`
+
+    Returns:
+        a list of matching :class:`TemporalTag` instances
+    """
+
+    return list(TemporalTags(dataset).values(filter=filter))
+
+
+def delete_temporal_tags(
+    dataset,
+    *,
+    ids: str | Iterable[str] | None = None,
+    tags: str | Iterable[str] | None = None,
+    filter: TemporalTagFilter | None = None,
+    delete_all: bool = False,
+) -> int:
+    """Deletes temporal tags from a dataset.
+
+    If a view is provided, deletes are restricted to temporal tags linked to
+    the view's samples. Empty selectors are rejected unless ``delete_all=True``
+    is provided.
+
+    Args:
+        dataset: a :class:`fiftyone.Dataset` or
+            :class:`fiftyone.core.view.DatasetView`
+        ids (None): an optional temporal tag ID or iterable of IDs
+        tags (None): an optional tag or iterable of tags
+        filter (None): an optional :class:`TemporalTagFilter`
+        delete_all (False): whether to allow an empty selector
+
+    Returns:
+        the number of deleted temporal tags
+    """
+
+    return TemporalTags(dataset).delete(
+        ids=ids, tags=tags, filter=filter, delete_all=delete_all
+    )
+
+
+def count_temporal_tags(
+    dataset, filter: TemporalTagFilter | None = None
+) -> dict[str, int]:
+    """Counts temporal tag occurrences in a dataset.
+
+    If a view is provided, only temporal tags linked to the view's samples are
+    counted.
+
+    Args:
+        dataset: a :class:`fiftyone.Dataset` or
+            :class:`fiftyone.core.view.DatasetView`
+        filter (None): an optional :class:`TemporalTagFilter`
+
+    Returns:
+        a dict mapping tag values to counts
+    """
+
+    return TemporalTags(dataset).count(filter=filter)
+
+
+def delete_for_dataset_id(dataset_id) -> int:
+    collection = _get_existing_collection()
+    if collection is None:
+        return 0
+
+    return collection.delete_many({"_dataset_id": dataset_id}).deleted_count
+
+
+def delete_for_sample_ids(dataset_id, sample_ids) -> int:
+    collection = _get_existing_collection()
+    if collection is None:
+        return 0
+
+    sample_ids = list(sample_ids)
+    if not sample_ids:
+        return 0
+
+    batch_size = fou.recommend_batch_size_for_value(
+        ObjectId(), max_size=100000
+    )
+    num_deleted = 0
+
+    for _ids in fou.iter_batches(sample_ids, batch_size):
+        sample_oids = [_ensure_object_id(_id, "sample_ids") for _id in _ids]
+        num_deleted += collection.delete_many(
+            {"_dataset_id": dataset_id, "_sample_id": {"$in": sample_oids}}
+        ).deleted_count
+
+    return num_deleted
+
+
+def count_for_dataset_id(dataset_id) -> int:
+    collection = _get_existing_collection()
+    if collection is None:
+        return 0
+
+    return collection.count_documents({"_dataset_id": dataset_id})
+
+
+def get_orphan_dataset_ids(dataset_ids) -> list:
+    collection = _get_existing_collection()
+    if collection is None:
+        return []
+
+    dataset_ids = set(dataset_ids)
+    orphan_dataset_ids = [
+        dataset_id
+        for dataset_id in collection.distinct("_dataset_id")
+        if dataset_id not in dataset_ids
+    ]
+
+    return sorted(orphan_dataset_ids, key=str)
+
+
+def count_for_dataset_ids(dataset_ids) -> int:
+    dataset_ids = list(dataset_ids)
+    if not dataset_ids:
+        return 0
+
+    collection = _get_existing_collection()
+    if collection is None:
+        return 0
+
+    return collection.count_documents(
+        {"_dataset_id": _build_in_query(dataset_ids)}
+    )
+
+
+def delete_for_dataset_ids(dataset_ids) -> int:
+    dataset_ids = list(dataset_ids)
+    if not dataset_ids:
+        return 0
+
+    collection = _get_existing_collection()
+    if collection is None:
+        return 0
+
+    return collection.delete_many(
+        {"_dataset_id": _build_in_query(dataset_ids)}
+    ).deleted_count
+
+
+def clone_tags(
+    source_dataset, target_dataset, sample_collection=None, now=None
+) -> int:
+    if now is None:
+        now = _utcnow()
+
+    collection = _get_existing_collection()
+    if collection is None:
+        return 0
+
+    sample_ids = _get_sample_scope(source_dataset, sample_collection)
+    query = _build_query(source_dataset._doc.id, None, sample_ids=sample_ids)
+
+    ops = []
+    for doc in collection.find(query, {"_id": False}):
+        doc["_dataset_id"] = target_dataset._doc.id
+        doc["created_at"] = now
+        doc["last_modified_at"] = now
+        ops.append(InsertOne(doc))
+
+    if not ops:
+        return 0
+
+    return collection.bulk_write(ops, ordered=False).inserted_count
+
+
+def export_tags(sample_collection, export_path, progress=None) -> int:
+    dataset, _, sample_ids = _resolve_sample_collection(sample_collection)
+    query = _build_query(dataset._doc.id, None, sample_ids=sample_ids)
+
+    collection = _get_existing_collection()
+    if collection is None:
+        _delete_temporal_tags_export(export_path)
+        return 0
+
+    num_docs = collection.count_documents(query)
+    if num_docs == 0:
+        _delete_temporal_tags_export(export_path)
+        return 0
+
+    docs = collection.find(query).sort(
+        [
+            ("_sample_id", ASCENDING),
+            ("index_type", ASCENDING),
+            ("start", ASCENDING),
+            ("end", ASCENDING),
+            ("tag", ASCENDING),
+            ("_id", ASCENDING),
+        ]
+    )
+
+    foo.export_collection(
+        map(_to_export_doc, docs),
+        export_path,
+        key=TEMPORAL_TAGS_EXPORT_KEY,
+        progress=progress,
+        num_docs=num_docs,
+    )
+
+    return num_docs
+
+
+def import_tags(dataset, import_path, sample_ids=None, progress=None) -> int:
+    del progress  # reserved for future batched imports
+
+    if not os.path.isfile(import_path):
+        return 0
+
+    records, _ = foo.import_collection(
+        import_path, key=TEMPORAL_TAGS_EXPORT_KEY
+    )
+
+    if sample_ids is not None:
+        sample_ids = {str(sample_id) for sample_id in sample_ids}
+        records = [
+            record
+            for record in records
+            if str(record.get("sample_id", None)) in sample_ids
+        ]
+
+    tags = [_from_export_doc(record) for record in records]
+    if not tags:
+        return 0
+
+    return len(add_temporal_tags(dataset, tags))
+
+
+def _resolve_sample_collection(sample_collection):
+    if isinstance(sample_collection, fov.DatasetView):
+        dataset = sample_collection._dataset
+    else:
+        dataset = sample_collection
+
+    _validate_dataset(dataset)
+
+    if isinstance(sample_collection, fov.DatasetView):
+        sample_ids = _get_sample_scope(dataset, sample_collection)
+    else:
+        sample_ids = None
+
+    return dataset, sample_collection, sample_ids
+
+
+def _validate_dataset(dataset) -> None:
+    if not hasattr(dataset, "_doc") or not hasattr(
+        dataset, "_sample_collection"
+    ):
+        raise TypeError("Expected a FiftyOne Dataset or DatasetView")
+
+    if getattr(dataset, "deleted", False):
+        raise ValueError("Cannot access temporal tags for a deleted dataset")
+
+
+def _ensure_temporal_tag_list(tags) -> list[TemporalTag]:
+    if isinstance(tags, TemporalTag):
+        return [tags]
+
+    try:
+        tags = list(tags)
+    except TypeError as e:
+        raise TypeError(
+            "Expected a TemporalTag or iterable of TemporalTag instances"
+        ) from e
+
+    for tag in tags:
+        if not isinstance(tag, TemporalTag):
+            raise TypeError(
+                "Expected a TemporalTag or iterable of TemporalTag instances"
+            )
+
+    return tags
+
+
+def _get_sample_scope(dataset, sample_collection=None):
+    if sample_collection is None or sample_collection is dataset:
+        return None
+
+    return list(sample_collection.values("_id"))
+
+
+def _validate_sample_ids_exist(
+    sample_collection, sample_ids
+) -> dict[str, ObjectId]:
+    sample_id_map = {}
+    sample_oids = []
+
+    for sample_id in sample_ids:
+        sample_oid = _ensure_object_id(sample_id, "sample_id")
+        sample_id_map[str(sample_id)] = sample_oid
+        sample_oids.append(sample_oid)
+
+    if isinstance(sample_collection, fov.DatasetView):
+        found_values = sample_collection.values("_id")
+        if found_values is None:
+            found_values = []
+
+        found = set(found_values)
+    else:
+        found = set(
+            sample_collection._sample_collection.distinct(
+                "_id", {"_id": {"$in": sample_oids}}
+            )
+        )
+
+    missing = [
+        str(sample_id) for sample_id in sample_oids if sample_id not in found
+    ]
+    if missing:
+        raise ValueError(
+            "Temporal tag sample IDs not found in dataset: %s"
+            % ", ".join(missing)
+        )
+
+    return sample_id_map
+
+
+def _to_storage_doc(tag: TemporalTag, dataset_id, sample_id):
+    start = _ensure_integer(tag.start, "start")
+    end = _ensure_integer(tag.end, "end")
+
+    if start >= end:
+        raise ValueError("Temporal tag ranges must satisfy start < end")
+
+    return {
+        "_dataset_id": dataset_id,
+        "_sample_id": sample_id,
+        "index_type": _ensure_index_type(tag.index_type),
+        "start": start,
+        "end": end,
+        "tag": _ensure_tag(tag.tag),
+    }
+
+
+def _from_storage_doc(doc) -> TemporalTag:
+    return TemporalTag(
+        id=str(doc["_id"]),
+        sample_id=str(doc["_sample_id"]),
+        index_type=doc["index_type"],
+        start=doc["start"],
+        end=doc["end"],
+        tag=doc["tag"],
+    )
+
+
+def _to_export_doc(doc):
+    return {
+        "sample_id": str(doc["_sample_id"]),
+        "index_type": doc["index_type"],
+        "start": doc["start"],
+        "end": doc["end"],
+        "tag": doc["tag"],
+    }
+
+
+def _from_export_doc(doc) -> TemporalTag:
+    return TemporalTag(
+        sample_id=doc.get("sample_id", None),
+        index_type=doc.get("index_type", None),
+        start=doc.get("start", None),
+        end=doc.get("end", None),
+        tag=doc.get("tag", None),
+    )
+
+
+def _build_query(
+    dataset_id, filter: TemporalTagFilter | None, sample_ids=None
+):
+    query = {"_dataset_id": dataset_id}
+
+    if sample_ids is not None:
+        query["_sample_id"] = _build_in_query(list(sample_ids))
+
+    if filter is None:
+        return query
+
+    if filter.sample_ids is not None:
+        filter_sample_ids = _ensure_object_id_list(
+            filter.sample_ids, "sample_ids"
+        )
+        if sample_ids is not None:
+            filter_sample_ids = _intersect_sample_ids(
+                filter_sample_ids, sample_ids
+            )
+
+        query["_sample_id"] = _build_in_query(filter_sample_ids)
+
+    if filter.tags is not None:
+        query["tag"] = _build_in_query(
+            _ensure_string_list(filter.tags, "tags")
+        )
+
+    if filter.index_type is not None:
+        query["index_type"] = _ensure_index_type(filter.index_type)
+
+    start = None
+    end = None
+
+    if filter.start is not None:
+        start = _ensure_integer(filter.start, "start")
+        query["end"] = {"$gt": start}
+
+    if filter.end is not None:
+        end = _ensure_integer(filter.end, "end")
+        query["start"] = {"$lt": end}
+
+    if start is not None and end is not None and start >= end:
+        raise ValueError("Temporal tag filters must satisfy start < end")
+
+    return query
+
+
+def _intersect_sample_ids(filter_sample_ids, sample_ids):
+    sample_ids = set(sample_ids)
+    return [
+        sample_id for sample_id in filter_sample_ids if sample_id in sample_ids
+    ]
+
+
+def _is_empty_filter(filter: TemporalTagFilter) -> bool:
+    return (
+        filter.sample_ids is None
+        and filter.tags is None
+        and filter.index_type is None
+        and filter.start is None
+        and filter.end is None
+    )
+
+
+def _build_in_query(values):
+    if len(values) == 1:
+        return values[0]
+
+    return {"$in": values}
+
+
+def _ensure_string_list(value, field_name) -> list[str]:
+    if etau.is_str(value):
+        values = [value]
+    else:
+        values = list(value)
+
+    return [_ensure_non_empty_string(v, field_name) for v in values]
+
+
+def _ensure_object_id_list(value, field_name) -> list[ObjectId]:
+    if etau.is_str(value) or isinstance(value, ObjectId):
+        values = [value]
+    else:
+        values = list(value)
+
+    return [_ensure_object_id(v, field_name) for v in values]
+
+
+def _ensure_non_empty_string(value, field_name) -> str:
+    if not etau.is_str(value) or not value.strip():
+        raise ValueError(
+            "Temporal tag %s must be a non-empty string" % field_name
+        )
+
+    return value
+
+
+def _ensure_tag(value) -> str:
+    return _ensure_non_empty_string(value, "tag")
+
+
+def _ensure_object_id(value, field_name) -> ObjectId:
+    if isinstance(value, ObjectId):
+        return value
+
+    if not etau.is_str(value) or not ObjectId.is_valid(value):
+        raise ValueError(
+            "Temporal tag %s must be a valid ObjectId" % field_name
+        )
+
+    return ObjectId(value)
+
+
+def _ensure_integer(value, field_name) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError("Temporal tag %s must be an integer" % field_name)
+
+    return value
+
+
+def _ensure_index_type(value) -> int:
+    value = _ensure_integer(value, "index_type")
+
+    if value not in SUPPORTED_INDEX_TYPES:
+        raise ValueError(
+            "Unsupported temporal tag index_type %r; expected one of %s"
+            % (value, sorted(SUPPORTED_INDEX_TYPES))
+        )
+
+    return value
+
+
+def _unique_query(doc):
+    return {
+        "_dataset_id": doc["_dataset_id"],
+        "_sample_id": doc["_sample_id"],
+        "index_type": doc["index_type"],
+        "start": doc["start"],
+        "end": doc["end"],
+        "tag": doc["tag"],
+    }
+
+
+def _unique_key(doc):
+    return (
+        doc["_sample_id"],
+        doc["index_type"],
+        doc["start"],
+        doc["end"],
+        doc["tag"],
+    )
+
+
+def _query_from_unique_key(key):
+    sample_id, index_type, start, end, tag = key
+    return {
+        "_sample_id": sample_id,
+        "index_type": index_type,
+        "start": start,
+        "end": end,
+        "tag": tag,
+    }
+
+
+def _get_or_create_collection():
+    collection = foo.get_db_conn()[TEMPORAL_TAGS_COLLECTION_NAME]
+    _ensure_indexes(collection)
+    return collection
+
+
+def _get_existing_collection():
+    db = foo.get_db_conn()
+    if TEMPORAL_TAGS_COLLECTION_NAME not in db.list_collection_names():
+        return None
+
+    return db[TEMPORAL_TAGS_COLLECTION_NAME]
+
+
+def _delete_temporal_tags_export(export_path) -> None:
+    if os.path.isfile(export_path):
+        etau.delete_file(export_path)
+
+
+def _utcnow():
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _ensure_indexes(collection) -> None:
+    collection.create_index(
+        [
+            ("_dataset_id", ASCENDING),
+            ("_sample_id", ASCENDING),
+            ("index_type", ASCENDING),
+            ("start", ASCENDING),
+            ("end", ASCENDING),
+            ("tag", ASCENDING),
+        ],
+        unique=True,
+        name="unique_temporal_tag",
+    )
+    collection.create_index(
+        [
+            ("_dataset_id", ASCENDING),
+            ("_sample_id", ASCENDING),
+            ("index_type", ASCENDING),
+            ("start", ASCENDING),
+            ("end", ASCENDING),
+        ],
+        name="temporal_tag_overlap",
+    )
+    collection.create_index(
+        [
+            ("_dataset_id", ASCENDING),
+            ("tag", ASCENDING),
+        ],
+        name="temporal_tag_counts",
+    )
+
+
+__all__ = [
+    "DEFAULT_INDEX_TYPE",
+    "SUPPORTED_INDEX_TYPES",
+    "TEMPORAL_TAGS_EXPORT_FILENAME",
+    "TEMPORAL_TAGS_COLLECTION_NAME",
+    "TemporalTag",
+    "TemporalTagFilter",
+    "TemporalTags",
+    "add_temporal_tags",
+    "count_temporal_tags",
+    "delete_temporal_tags",
+    "list_temporal_tags",
+]

--- a/fiftyone/multimodal/tags/_temporal_tags.py
+++ b/fiftyone/multimodal/tags/_temporal_tags.py
@@ -24,7 +24,8 @@ import os
 from typing import Iterable
 
 from bson import ObjectId
-from pymongo import ASCENDING, InsertOne, UpdateMany, UpdateOne
+from pymongo import ASCENDING, InsertOne, ReturnDocument, UpdateMany, UpdateOne
+from pymongo.errors import DuplicateKeyError
 
 import eta.core.utils as etau
 
@@ -177,6 +178,10 @@ class TemporalTag(object):
             d["id"] = self.id
 
         return d
+
+
+class TemporalTagNotFoundError(ValueError):
+    """Raised when a temporal tag ID is not found in the current scope."""
 
 
 @dataclass(frozen=True)
@@ -401,6 +406,89 @@ class TemporalTags(object):
 
         return [_from_storage_doc(docs_by_key[key]) for key in keys]
 
+    def update(
+        self,
+        id,
+        *,
+        start=None,
+        end=None,
+        tag=None,
+        last_modified_by=None,
+    ) -> TemporalTag:
+        """Updates a persisted temporal tag by ID.
+
+        Args:
+            id: the temporal tag ID
+            start (None): an optional updated start value
+            end (None): an optional updated end value
+            tag (None): an optional updated tag value
+            last_modified_by (None): an optional actor that last modified the
+                temporal tag
+
+        Returns:
+            the updated :class:`TemporalTag`
+        """
+        tag_id = _ensure_object_id(id, "id")
+        collection = _get_existing_collection()
+        if collection is None:
+            raise TemporalTagNotFoundError(
+                "Temporal tag not found: %s" % tag_id
+            )
+
+        query = {"_dataset_id": self._dataset._doc.id, "_id": tag_id}
+        if self._sample_ids is not None:
+            query["_sample_id"] = _build_in_query(list(self._sample_ids))
+
+        existing_doc = collection.find_one(query)
+        if existing_doc is None:
+            raise TemporalTagNotFoundError(
+                "Temporal tag not found: %s" % tag_id
+            )
+
+        update_fields = _build_update_fields(
+            existing_doc,
+            start=start,
+            end=end,
+            tag=tag,
+            last_modified_by=last_modified_by,
+        )
+        now = _utcnow()
+        update_fields["last_modified_at"] = now
+
+        updated_doc = {**existing_doc, **update_fields}
+        duplicate = collection.find_one(
+            {
+                **_unique_query(updated_doc),
+                "_id": {"$ne": existing_doc["_id"]},
+            }
+        )
+        if duplicate is not None:
+            raise ValueError(
+                "Temporal tag update would duplicate an existing temporal tag"
+            )
+
+        try:
+            persisted_doc = collection.find_one_and_update(
+                query,
+                {"$set": update_fields},
+                return_document=ReturnDocument.AFTER,
+            )
+        except DuplicateKeyError as e:
+            raise ValueError(
+                "Temporal tag update would duplicate an existing temporal tag"
+            ) from e
+
+        if persisted_doc is None:
+            raise TemporalTagNotFoundError(
+                "Temporal tag not found: %s" % tag_id
+            )
+
+        _touch_parent_last_modified_at(
+            self._dataset, [persisted_doc["_sample_id"]], now
+        )
+
+        return _from_storage_doc(persisted_doc)
+
     def delete(
         self,
         *,
@@ -559,6 +647,42 @@ def delete_temporal_tags(
 
     return TemporalTags(dataset).delete(
         ids=ids, tags=tags, filter=filter, delete_all=delete_all
+    )
+
+
+def update_temporal_tag(
+    dataset,
+    id,
+    *,
+    start=None,
+    end=None,
+    tag=None,
+    last_modified_by=None,
+) -> TemporalTag:
+    """Updates a temporal tag in a dataset.
+
+    If a view is provided, the temporal tag ID must belong to the view.
+
+    Args:
+        dataset: a :class:`fiftyone.Dataset` or
+            :class:`fiftyone.core.view.DatasetView`
+        id: the temporal tag ID
+        start (None): an optional updated start value
+        end (None): an optional updated end value
+        tag (None): an optional updated tag value
+        last_modified_by (None): an optional actor that last modified the
+            temporal tag
+
+    Returns:
+        the updated :class:`TemporalTag`
+    """
+
+    return TemporalTags(dataset).update(
+        id,
+        start=start,
+        end=end,
+        tag=tag,
+        last_modified_by=last_modified_by,
     )
 
 
@@ -884,6 +1008,39 @@ def _to_storage_doc(tag: TemporalTag, dataset_id, sample_id):
         "tag": _ensure_tag(tag.tag),
         **_to_storage_provenance(tag),
     }
+
+
+def _build_update_fields(
+    doc, *, start=None, end=None, tag=None, last_modified_by=None
+):
+    fields = {}
+
+    if start is not None:
+        fields["start"] = _ensure_integer(start, "start")
+
+    if end is not None:
+        fields["end"] = _ensure_integer(end, "end")
+
+    if tag is not None:
+        fields["tag"] = _ensure_tag(tag)
+
+    if last_modified_by is not None:
+        fields["last_modified_by"] = _ensure_non_empty_string(
+            last_modified_by, "last_modified_by"
+        )
+
+    if not fields:
+        raise ValueError(
+            "Temporal tag update must include start, end, tag, or "
+            "last_modified_by"
+        )
+
+    updated_start = fields.get("start", doc["start"])
+    updated_end = fields.get("end", doc["end"])
+    if updated_start >= updated_end:
+        raise ValueError("Temporal tag ranges must satisfy start < end")
+
+    return fields
 
 
 def _from_storage_doc(doc) -> TemporalTag:
@@ -1309,4 +1466,5 @@ __all__ = [
     "count_temporal_tags",
     "delete_temporal_tags",
     "list_temporal_tags",
+    "update_temporal_tag",
 ]

--- a/fiftyone/multimodal/tags/_temporal_tags.py
+++ b/fiftyone/multimodal/tags/_temporal_tags.py
@@ -6,6 +6,10 @@ Temporal tags are sample-scoped records stored in the dedicated
 sidecars, and low-level orphan cleanup all flow through this module so the
 storage contract stays in one place.
 
+The collection and indexes are created lazily on first write. Public CRUD
+bumps linked sample and dataset ``last_modified_at`` values; lifecycle cleanup
+helpers rely on their own owning operations for freshness.
+
 | Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
@@ -20,7 +24,7 @@ import os
 from typing import Iterable
 
 from bson import ObjectId
-from pymongo import ASCENDING, InsertOne, UpdateOne
+from pymongo import ASCENDING, InsertOne, UpdateMany, UpdateOne
 
 import eta.core.utils as etau
 
@@ -385,6 +389,7 @@ class TemporalTags(object):
 
         collection = _get_or_create_collection()
         collection.bulk_write(list(ops_by_key.values()), ordered=False)
+        _touch_parent_last_modified_at(self._dataset, sample_ids.values(), now)
 
         persisted_docs = collection.find(
             {
@@ -439,7 +444,14 @@ class TemporalTags(object):
         if collection is None:
             return 0
 
-        return collection.delete_many(query).deleted_count
+        sample_ids = collection.distinct("_sample_id", query)
+        deleted_count = collection.delete_many(query).deleted_count
+        if deleted_count:
+            _touch_parent_last_modified_at(
+                self._dataset, sample_ids, _utcnow()
+            )
+
+        return deleted_count
 
     def clear(self):
         """Deletes all temporal tags in this collection.
@@ -828,6 +840,33 @@ def _validate_sample_ids_exist(
     return sample_id_map
 
 
+def _touch_parent_last_modified_at(dataset, sample_ids, last_modified_at):
+    sample_ids = sorted(
+        {
+            _ensure_object_id(sample_id, "sample_ids")
+            for sample_id in sample_ids
+        },
+        key=str,
+    )
+    if not sample_ids:
+        return
+
+    ops = []
+    batch_size = fou.recommend_batch_size_for_value(
+        ObjectId(), max_size=100000
+    )
+    for _ids in fou.iter_batches(sample_ids, batch_size):
+        ops.append(
+            UpdateMany(
+                {"_id": {"$in": _ids}},
+                {"$set": {"last_modified_at": last_modified_at}},
+            )
+        )
+
+    dataset._bulk_write(ops, ids=sample_ids)
+    dataset._update_last_modified_at(last_modified_at=last_modified_at)
+
+
 def _to_storage_doc(tag: TemporalTag, dataset_id, sample_id):
     start = _ensure_integer(tag.start, "start")
     end = _ensure_integer(tag.end, "end")
@@ -1196,9 +1235,7 @@ def _utcnow():
 
 
 def _ensure_indexes(collection) -> None:
-    _create_or_replace_index(
-        collection,
-        "unique_temporal_tag",
+    collection.create_index(
         [
             ("_dataset_id", ASCENDING),
             ("_sample_id", ASCENDING),
@@ -1208,11 +1245,10 @@ def _ensure_indexes(collection) -> None:
             ("end", ASCENDING),
             ("tag", ASCENDING),
         ],
+        name="unique_temporal_tag",
         unique=True,
     )
-    _create_or_replace_index(
-        collection,
-        "temporal_tag_overlap",
+    collection.create_index(
         [
             ("_dataset_id", ASCENDING),
             ("_sample_id", ASCENDING),
@@ -1221,12 +1257,11 @@ def _ensure_indexes(collection) -> None:
             ("start", ASCENDING),
             ("end", ASCENDING),
         ],
+        name="temporal_tag_overlap",
     )
     # Viewer reads usually pin one sample and optionally add a time window,
     # without necessarily knowing an index type or anchor up front.
-    _create_or_replace_index(
-        collection,
-        "temporal_tag_sample_range",
+    collection.create_index(
         [
             ("_dataset_id", ASCENDING),
             ("_sample_id", ASCENDING),
@@ -1236,12 +1271,11 @@ def _ensure_indexes(collection) -> None:
             ("anchor", ASCENDING),
             ("tag", ASCENDING),
         ],
+        name="temporal_tag_sample_range",
     )
     # Search and track-population flows start from tag values, then need the
     # matching sample IDs and ranges.
-    _create_or_replace_index(
-        collection,
-        "temporal_tag_tag_lookup",
+    collection.create_index(
         [
             ("_dataset_id", ASCENDING),
             ("tag", ASCENDING),
@@ -1251,24 +1285,16 @@ def _ensure_indexes(collection) -> None:
             ("index_type", ASCENDING),
             ("anchor", ASCENDING),
         ],
+        name="temporal_tag_tag_lookup",
     )
-    _create_or_replace_index(
-        collection,
-        "temporal_tag_counts",
+    collection.create_index(
         [
             ("_dataset_id", ASCENDING),
             ("anchor", ASCENDING),
             ("tag", ASCENDING),
         ],
+        name="temporal_tag_counts",
     )
-
-
-def _create_or_replace_index(collection, name, keys, **kwargs) -> None:
-    existing = collection.index_information().get(name, None)
-    if existing is not None and existing.get("key", None) != keys:
-        collection.drop_index(name)
-
-    collection.create_index(keys, name=name, **kwargs)
 
 
 __all__ = [

--- a/fiftyone/multimodal/tags/_temporal_tags.py
+++ b/fiftyone/multimodal/tags/_temporal_tags.py
@@ -62,6 +62,11 @@ class TemporalTag(object):
             archetype. Defaults to ``TIME_TRACK_TYPE_DURATION_NS``
         anchor (None): an optional opaque reference key that qualifies the
             context for ``start`` and ``end``
+        created_by (None): an optional actor that created the temporal tag
+        last_modified_by (None): an optional actor that last modified the
+            temporal tag
+        created_at (None): the creation timestamp, when available
+        last_modified_at (None): the last-modified timestamp, when available
         id: the persisted temporal tag ID, when available
     """
 
@@ -73,6 +78,10 @@ class TemporalTag(object):
         tag,
         index_type=DEFAULT_INDEX_TYPE,
         anchor=None,
+        created_by=None,
+        last_modified_by=None,
+        created_at=None,
+        last_modified_at=None,
         id=None,
     ):
         self.sample_id = sample_id
@@ -81,12 +90,19 @@ class TemporalTag(object):
         self.tag = tag
         self.index_type = index_type
         self.anchor = anchor
+        self.created_by = created_by
+        self.last_modified_by = last_modified_by
+        self.created_at = _coerce_optional_datetime(created_at, "created_at")
+        self.last_modified_at = _coerce_optional_datetime(
+            last_modified_at, "last_modified_at"
+        )
         self.id = id
 
     def __repr__(self):
         return (
             "%s(sample_id=%r, start=%r, end=%r, tag=%r, "
-            "index_type=%r, anchor=%r, id=%r)"
+            "index_type=%r, anchor=%r, created_by=%r, "
+            "last_modified_by=%r, created_at=%r, last_modified_at=%r, id=%r)"
             % (
                 self.__class__.__name__,
                 self.sample_id,
@@ -95,6 +111,10 @@ class TemporalTag(object):
                 self.tag,
                 self.index_type,
                 self.anchor,
+                self.created_by,
+                self.last_modified_by,
+                self.created_at,
+                self.last_modified_at,
                 self.id,
             )
         )
@@ -114,6 +134,10 @@ class TemporalTag(object):
             self.tag,
             index_type=self.index_type,
             anchor=self.anchor,
+            created_by=self.created_by,
+            last_modified_by=self.last_modified_by,
+            created_at=self.created_at,
+            last_modified_at=self.last_modified_at,
             id=self.id,
         )
 
@@ -128,6 +152,22 @@ class TemporalTag(object):
         }
         if self.anchor is not None:
             d["anchor"] = self.anchor
+
+        if self.created_by is not None:
+            d["created_by"] = self.created_by
+
+        if self.last_modified_by is not None:
+            d["last_modified_by"] = self.last_modified_by
+
+        if self.created_at is not None:
+            d["created_at"] = _serialize_datetime(
+                self.created_at, "created_at"
+            )
+
+        if self.last_modified_at is not None:
+            d["last_modified_at"] = _serialize_datetime(
+                self.last_modified_at, "last_modified_at"
+            )
 
         if self.id is not None:
             d["id"] = self.id
@@ -308,24 +348,38 @@ class TemporalTags(object):
             doc = _to_storage_doc(
                 tag, self._dataset._doc.id, sample_ids[str(tag.sample_id)]
             )
+            created_at, last_modified_at = _resolve_write_timestamps(doc, now)
             key = _unique_key(doc)
             keys.append(key)
             if key not in ops_by_key:
+                set_on_insert = {
+                    "_dataset_id": doc["_dataset_id"],
+                    "_sample_id": doc["_sample_id"],
+                    "index_type": doc["index_type"],
+                    "anchor": doc["anchor"],
+                    "start": doc["start"],
+                    "end": doc["end"],
+                    "tag": doc["tag"],
+                    "created_at": created_at,
+                }
+                update = {"$setOnInsert": set_on_insert}
+                set_fields = {"last_modified_at": last_modified_at}
+
+                created_by = doc.get("created_by", None)
+                if created_by is not None:
+                    set_on_insert["created_by"] = created_by
+
+                last_modified_by = doc.get("last_modified_by", None)
+                if last_modified_by is not None:
+                    set_fields["last_modified_by"] = last_modified_by
+                elif created_by is not None:
+                    set_on_insert["last_modified_by"] = created_by
+
+                update["$set"] = set_fields
+
                 ops_by_key[key] = UpdateOne(
                     _unique_query(doc),
-                    {
-                        "$setOnInsert": {
-                            "_dataset_id": doc["_dataset_id"],
-                            "_sample_id": doc["_sample_id"],
-                            "index_type": doc["index_type"],
-                            "anchor": doc["anchor"],
-                            "start": doc["start"],
-                            "end": doc["end"],
-                            "tag": doc["tag"],
-                            "created_at": now,
-                        },
-                        "$set": {"last_modified_at": now},
-                    },
+                    update,
                     upsert=True,
                 )
 
@@ -614,8 +668,7 @@ def clone_tags(
     ops = []
     for doc in collection.find(query, {"_id": False}):
         doc["_dataset_id"] = target_dataset._doc.id
-        doc["created_at"] = now
-        doc["last_modified_at"] = now
+        _fill_missing_timestamps(doc, now)
         ops.append(InsertOne(doc))
 
     if not ops:
@@ -790,6 +843,7 @@ def _to_storage_doc(tag: TemporalTag, dataset_id, sample_id):
         "start": start,
         "end": end,
         "tag": _ensure_tag(tag.tag),
+        **_to_storage_provenance(tag),
     }
 
 
@@ -802,10 +856,15 @@ def _from_storage_doc(doc) -> TemporalTag:
         start=doc["start"],
         end=doc["end"],
         tag=doc["tag"],
+        created_by=doc.get("created_by", None),
+        last_modified_by=doc.get("last_modified_by", None),
+        created_at=doc.get("created_at", None),
+        last_modified_at=doc.get("last_modified_at", None),
     )
 
 
 def _to_export_doc(doc):
+    _fill_missing_timestamps(doc, _utcnow())
     export_doc = {
         "sample_id": str(doc["_sample_id"]),
         "index_type": doc["index_type"],
@@ -816,6 +875,21 @@ def _to_export_doc(doc):
     anchor = doc.get("anchor", None)
     if anchor is not None:
         export_doc["anchor"] = anchor
+
+    for field_name in (
+        "created_by",
+        "last_modified_by",
+        "created_at",
+        "last_modified_at",
+    ):
+        value = doc.get(field_name, None)
+        if value is None:
+            continue
+
+        if field_name.endswith("_at"):
+            value = _serialize_datetime(value, field_name)
+
+        export_doc[field_name] = value
 
     return export_doc
 
@@ -828,6 +902,10 @@ def _from_export_doc(doc) -> TemporalTag:
         end=doc.get("end", None),
         tag=doc.get("tag", None),
         anchor=doc.get("anchor", None),
+        created_by=doc.get("created_by", None),
+        last_modified_by=doc.get("last_modified_by", None),
+        created_at=doc.get("created_at", None),
+        last_modified_at=doc.get("last_modified_at", None),
     )
 
 
@@ -944,6 +1022,88 @@ def _ensure_optional_anchor(value) -> str | None:
         return None
 
     return _ensure_non_empty_string(value, "anchor")
+
+
+def _to_storage_provenance(tag: TemporalTag) -> dict:
+    provenance = {}
+
+    if tag.created_by is not None:
+        provenance["created_by"] = _ensure_non_empty_string(
+            tag.created_by, "created_by"
+        )
+
+    if tag.last_modified_by is not None:
+        provenance["last_modified_by"] = _ensure_non_empty_string(
+            tag.last_modified_by, "last_modified_by"
+        )
+
+    if tag.created_at is not None:
+        provenance["created_at"] = _coerce_datetime(
+            tag.created_at, "created_at"
+        )
+
+    if tag.last_modified_at is not None:
+        provenance["last_modified_at"] = _coerce_datetime(
+            tag.last_modified_at, "last_modified_at"
+        )
+
+    return provenance
+
+
+def _resolve_write_timestamps(doc, now):
+    created_at = doc.get("created_at", None)
+    last_modified_at = doc.get("last_modified_at", None)
+
+    if created_at is None and last_modified_at is None:
+        created_at = now
+        last_modified_at = now
+    elif created_at is None:
+        created_at = last_modified_at
+    elif last_modified_at is None:
+        last_modified_at = created_at
+
+    return created_at, last_modified_at
+
+
+def _fill_missing_timestamps(doc, now) -> None:
+    created_at, last_modified_at = _resolve_write_timestamps(doc, now)
+    doc["created_at"] = created_at
+    doc["last_modified_at"] = last_modified_at
+
+
+def _coerce_optional_datetime(value, field_name):
+    if value is None:
+        return None
+
+    return _coerce_datetime(value, field_name)
+
+
+def _coerce_datetime(value, field_name):
+    if isinstance(value, datetime):
+        dt = value
+    elif etau.is_str(value):
+        value = value[:-1] + "+00:00" if value.endswith("Z") else value
+        try:
+            dt = datetime.fromisoformat(value)
+        except ValueError as e:
+            raise ValueError(
+                "Temporal tag %s must be a datetime or ISO datetime string"
+                % field_name
+            ) from e
+    else:
+        raise ValueError(
+            "Temporal tag %s must be a datetime or ISO datetime string"
+            % field_name
+        )
+
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+
+    return dt
+
+
+def _serialize_datetime(value, field_name) -> str:
+    return _coerce_datetime(value, field_name).isoformat()
 
 
 def _ensure_object_id(value, field_name) -> ObjectId:

--- a/fiftyone/multimodal/tags/_temporal_tags.py
+++ b/fiftyone/multimodal/tags/_temporal_tags.py
@@ -42,6 +42,7 @@ SUPPORTED_INDEX_TYPES = {
 _TEMPORAL_TAG_SORT = [
     ("_sample_id", ASCENDING),
     ("index_type", ASCENDING),
+    ("anchor", ASCENDING),
     ("start", ASCENDING),
     ("end", ASCENDING),
     ("tag", ASCENDING),
@@ -59,6 +60,8 @@ class TemporalTag(object):
         tag: the tag value
         index_type: a :class:`TimeTrackType` value describing the index
             archetype. Defaults to ``TIME_TRACK_TYPE_DURATION_NS``
+        anchor (None): an optional opaque reference key that qualifies the
+            context for ``start`` and ``end``
         id: the persisted temporal tag ID, when available
     """
 
@@ -69,6 +72,7 @@ class TemporalTag(object):
         end,
         tag,
         index_type=DEFAULT_INDEX_TYPE,
+        anchor=None,
         id=None,
     ):
         self.sample_id = sample_id
@@ -76,12 +80,13 @@ class TemporalTag(object):
         self.end = end
         self.tag = tag
         self.index_type = index_type
+        self.anchor = anchor
         self.id = id
 
     def __repr__(self):
         return (
             "%s(sample_id=%r, start=%r, end=%r, tag=%r, "
-            "index_type=%r, id=%r)"
+            "index_type=%r, anchor=%r, id=%r)"
             % (
                 self.__class__.__name__,
                 self.sample_id,
@@ -89,6 +94,7 @@ class TemporalTag(object):
                 self.end,
                 self.tag,
                 self.index_type,
+                self.anchor,
                 self.id,
             )
         )
@@ -107,6 +113,7 @@ class TemporalTag(object):
             self.end,
             self.tag,
             index_type=self.index_type,
+            anchor=self.anchor,
             id=self.id,
         )
 
@@ -119,6 +126,9 @@ class TemporalTag(object):
             "end": self.end,
             "tag": self.tag,
         }
+        if self.anchor is not None:
+            d["anchor"] = self.anchor
+
         if self.id is not None:
             d["id"] = self.id
 
@@ -136,6 +146,7 @@ class TemporalTagFilter:
     Args:
         sample_ids: an optional sample ID or iterable of sample IDs
         tags: an optional tag or iterable of tags
+        anchors: an optional anchor or iterable of anchors
         index_type: an optional :class:`TimeTrackType` value
         start: an optional inclusive lower bound for overlap queries
         end: an optional exclusive upper bound for overlap queries
@@ -143,6 +154,7 @@ class TemporalTagFilter:
 
     sample_ids: str | Iterable[str] | None = None
     tags: str | Iterable[str] | None = None
+    anchors: str | Iterable[str] | None = None
     index_type: int | None = None
     start: int | None = None
     end: int | None = None
@@ -271,8 +283,9 @@ class TemporalTags(object):
     def add(self, tags: TemporalTag | Iterable[TemporalTag]):
         """Adds temporal tags to this collection.
 
-        The tuple ``(dataset, sample_id, index_type, start, end, tag)`` is
-        unique, so adding the same tag interval multiple times is idempotent.
+        The tuple ``(dataset, sample_id, index_type, anchor, start, end, tag)``
+        is unique, so adding the same tag interval multiple times is
+        idempotent.
 
         Args:
             tags: a temporal tag or iterable of temporal tags
@@ -305,6 +318,7 @@ class TemporalTags(object):
                             "_dataset_id": doc["_dataset_id"],
                             "_sample_id": doc["_sample_id"],
                             "index_type": doc["index_type"],
+                            "anchor": doc["anchor"],
                             "start": doc["start"],
                             "end": doc["end"],
                             "tag": doc["tag"],
@@ -415,8 +429,8 @@ class TemporalTags(object):
 def add_temporal_tags(dataset, tags: TemporalTag | Iterable[TemporalTag]):
     """Adds temporal tags to a dataset.
 
-    The tuple ``(dataset, sample_id, index_type, start, end, tag)`` is unique,
-    so adding the same tag interval multiple times is idempotent.
+    The tuple ``(dataset, sample_id, index_type, anchor, start, end, tag)`` is
+    unique, so adding the same tag interval multiple times is idempotent.
     If a view is provided, all tag sample IDs must belong to the view.
 
     Args:
@@ -628,6 +642,7 @@ def export_tags(sample_collection, export_path, progress=None) -> int:
         [
             ("_sample_id", ASCENDING),
             ("index_type", ASCENDING),
+            ("anchor", ASCENDING),
             ("start", ASCENDING),
             ("end", ASCENDING),
             ("tag", ASCENDING),
@@ -771,6 +786,7 @@ def _to_storage_doc(tag: TemporalTag, dataset_id, sample_id):
         "_dataset_id": dataset_id,
         "_sample_id": sample_id,
         "index_type": _ensure_index_type(tag.index_type),
+        "anchor": _ensure_optional_anchor(tag.anchor),
         "start": start,
         "end": end,
         "tag": _ensure_tag(tag.tag),
@@ -782,6 +798,7 @@ def _from_storage_doc(doc) -> TemporalTag:
         id=str(doc["_id"]),
         sample_id=str(doc["_sample_id"]),
         index_type=doc["index_type"],
+        anchor=doc.get("anchor", None),
         start=doc["start"],
         end=doc["end"],
         tag=doc["tag"],
@@ -789,13 +806,18 @@ def _from_storage_doc(doc) -> TemporalTag:
 
 
 def _to_export_doc(doc):
-    return {
+    export_doc = {
         "sample_id": str(doc["_sample_id"]),
         "index_type": doc["index_type"],
         "start": doc["start"],
         "end": doc["end"],
         "tag": doc["tag"],
     }
+    anchor = doc.get("anchor", None)
+    if anchor is not None:
+        export_doc["anchor"] = anchor
+
+    return export_doc
 
 
 def _from_export_doc(doc) -> TemporalTag:
@@ -805,6 +827,7 @@ def _from_export_doc(doc) -> TemporalTag:
         start=doc.get("start", None),
         end=doc.get("end", None),
         tag=doc.get("tag", None),
+        anchor=doc.get("anchor", None),
     )
 
 
@@ -833,6 +856,11 @@ def _build_query(
     if filter.tags is not None:
         query["tag"] = _build_in_query(
             _ensure_string_list(filter.tags, "tags")
+        )
+
+    if filter.anchors is not None:
+        query["anchor"] = _build_in_query(
+            _ensure_string_list(filter.anchors, "anchors")
         )
 
     if filter.index_type is not None:
@@ -866,6 +894,7 @@ def _is_empty_filter(filter: TemporalTagFilter) -> bool:
     return (
         filter.sample_ids is None
         and filter.tags is None
+        and filter.anchors is None
         and filter.index_type is None
         and filter.start is None
         and filter.end is None
@@ -910,6 +939,13 @@ def _ensure_tag(value) -> str:
     return _ensure_non_empty_string(value, "tag")
 
 
+def _ensure_optional_anchor(value) -> str | None:
+    if value is None:
+        return None
+
+    return _ensure_non_empty_string(value, "anchor")
+
+
 def _ensure_object_id(value, field_name) -> ObjectId:
     if isinstance(value, ObjectId):
         return value
@@ -946,6 +982,7 @@ def _unique_query(doc):
         "_dataset_id": doc["_dataset_id"],
         "_sample_id": doc["_sample_id"],
         "index_type": doc["index_type"],
+        "anchor": doc["anchor"],
         "start": doc["start"],
         "end": doc["end"],
         "tag": doc["tag"],
@@ -956,6 +993,7 @@ def _unique_key(doc):
     return (
         doc["_sample_id"],
         doc["index_type"],
+        doc.get("anchor", None),
         doc["start"],
         doc["end"],
         doc["tag"],
@@ -963,10 +1001,11 @@ def _unique_key(doc):
 
 
 def _query_from_unique_key(key):
-    sample_id, index_type, start, end, tag = key
+    sample_id, index_type, anchor, start, end, tag = key
     return {
         "_sample_id": sample_id,
         "index_type": index_type,
+        "anchor": anchor,
         "start": start,
         "end": end,
         "tag": tag,
@@ -997,35 +1036,49 @@ def _utcnow():
 
 
 def _ensure_indexes(collection) -> None:
-    collection.create_index(
+    _create_or_replace_index(
+        collection,
+        "unique_temporal_tag",
         [
             ("_dataset_id", ASCENDING),
             ("_sample_id", ASCENDING),
             ("index_type", ASCENDING),
+            ("anchor", ASCENDING),
             ("start", ASCENDING),
             ("end", ASCENDING),
             ("tag", ASCENDING),
         ],
         unique=True,
-        name="unique_temporal_tag",
     )
-    collection.create_index(
+    _create_or_replace_index(
+        collection,
+        "temporal_tag_overlap",
         [
             ("_dataset_id", ASCENDING),
             ("_sample_id", ASCENDING),
             ("index_type", ASCENDING),
+            ("anchor", ASCENDING),
             ("start", ASCENDING),
             ("end", ASCENDING),
         ],
-        name="temporal_tag_overlap",
     )
-    collection.create_index(
+    _create_or_replace_index(
+        collection,
+        "temporal_tag_counts",
         [
             ("_dataset_id", ASCENDING),
+            ("anchor", ASCENDING),
             ("tag", ASCENDING),
         ],
-        name="temporal_tag_counts",
     )
+
+
+def _create_or_replace_index(collection, name, keys, **kwargs) -> None:
+    existing = collection.index_information().get(name, None)
+    if existing is not None and existing.get("key", None) != keys:
+        collection.drop_index(name)
+
+    collection.create_index(keys, name=name, **kwargs)
 
 
 __all__ = [

--- a/fiftyone/multimodal/tags/_temporal_tags.py
+++ b/fiftyone/multimodal/tags/_temporal_tags.py
@@ -1062,6 +1062,36 @@ def _ensure_indexes(collection) -> None:
             ("end", ASCENDING),
         ],
     )
+    # Viewer reads usually pin one sample and optionally add a time window,
+    # without necessarily knowing an index type or anchor up front.
+    _create_or_replace_index(
+        collection,
+        "temporal_tag_sample_range",
+        [
+            ("_dataset_id", ASCENDING),
+            ("_sample_id", ASCENDING),
+            ("start", ASCENDING),
+            ("end", ASCENDING),
+            ("index_type", ASCENDING),
+            ("anchor", ASCENDING),
+            ("tag", ASCENDING),
+        ],
+    )
+    # Search and track-population flows start from tag values, then need the
+    # matching sample IDs and ranges.
+    _create_or_replace_index(
+        collection,
+        "temporal_tag_tag_lookup",
+        [
+            ("_dataset_id", ASCENDING),
+            ("tag", ASCENDING),
+            ("_sample_id", ASCENDING),
+            ("start", ASCENDING),
+            ("end", ASCENDING),
+            ("index_type", ASCENDING),
+            ("anchor", ASCENDING),
+        ],
+    )
     _create_or_replace_index(
         collection,
         "temporal_tag_counts",

--- a/fiftyone/multimodal/tags/temporal_tags.py
+++ b/fiftyone/multimodal/tags/temporal_tags.py
@@ -2,8 +2,9 @@
 Temporal tagging support for multimodal samples.
 
 Use :func:`add_temporal_tags`, :func:`list_temporal_tags`,
-:func:`delete_temporal_tags`, and :func:`count_temporal_tags` for common SDK
-workflows. These helpers accept a dataset or view and delegate to
+:func:`update_temporal_tag`, :func:`delete_temporal_tags`, and
+:func:`count_temporal_tags` for common SDK workflows. These helpers accept a
+dataset or view and delegate to
 :class:`TemporalTags`, a small collection facade for ordered iteration and
 bulk operations.
 
@@ -39,6 +40,7 @@ from ._temporal_tags import (
     count_temporal_tags,
     delete_temporal_tags,
     list_temporal_tags,
+    update_temporal_tag,
 )
 
 for _public_obj in (
@@ -49,6 +51,7 @@ for _public_obj in (
     count_temporal_tags,
     delete_temporal_tags,
     list_temporal_tags,
+    update_temporal_tag,
 ):
     _public_obj.__module__ = __name__
 
@@ -66,4 +69,5 @@ __all__ = [
     "count_temporal_tags",
     "delete_temporal_tags",
     "list_temporal_tags",
+    "update_temporal_tag",
 ]

--- a/fiftyone/multimodal/tags/temporal_tags.py
+++ b/fiftyone/multimodal/tags/temporal_tags.py
@@ -11,7 +11,8 @@ Temporal tags are sample-scoped records stored in the dedicated
 ``temporal_tags`` collection. They are removed when linked samples or datasets
 are deleted, and FiftyOne dataset import/export preserves them through the
 ``temporal_tags.json`` sidecar. Tags may include an optional opaque ``anchor``
-string that qualifies the context for their ``start`` and ``end`` values.
+string that qualifies the context for their ``start`` and ``end`` values, plus
+optional provenance fields describing when and by whom records were written.
 
 | Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_

--- a/fiftyone/multimodal/tags/temporal_tags.py
+++ b/fiftyone/multimodal/tags/temporal_tags.py
@@ -14,6 +14,14 @@ are deleted, and FiftyOne dataset import/export preserves them through the
 string that qualifies the context for their ``start`` and ``end`` values, plus
 optional provenance fields describing when and by whom records were written.
 
+Adding a temporal tag is an upsert on
+``(dataset, sample, index_type, anchor, start, end, tag)``: repeated adds update
+``last_modified_at`` without changing ``created_at``. Range filters use
+half-open overlap semantics, so ``start=10, end=20`` matches records whose
+stored interval overlaps ``[10, 20)``. Anchors participate in identity and
+filtering, allowing the same tag and range to coexist under different reference
+contexts.
+
 | Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |

--- a/fiftyone/multimodal/tags/temporal_tags.py
+++ b/fiftyone/multimodal/tags/temporal_tags.py
@@ -10,7 +10,8 @@ bulk operations.
 Temporal tags are sample-scoped records stored in the dedicated
 ``temporal_tags`` collection. They are removed when linked samples or datasets
 are deleted, and FiftyOne dataset import/export preserves them through the
-``temporal_tags.json`` sidecar.
+``temporal_tags.json`` sidecar. Tags may include an optional opaque ``anchor``
+string that qualifies the context for their ``start`` and ``end`` values.
 
 | Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_

--- a/fiftyone/multimodal/tags/temporal_tags.py
+++ b/fiftyone/multimodal/tags/temporal_tags.py
@@ -1,0 +1,59 @@
+"""
+Temporal tagging support for multimodal samples.
+
+Use :func:`add_temporal_tags`, :func:`list_temporal_tags`,
+:func:`delete_temporal_tags`, and :func:`count_temporal_tags` for common SDK
+workflows. These helpers accept a dataset or view and delegate to
+:class:`TemporalTags`, a small collection facade for ordered iteration and
+bulk operations.
+
+Temporal tags are sample-scoped records stored in the dedicated
+``temporal_tags`` collection. They are removed when linked samples or datasets
+are deleted, and FiftyOne dataset import/export preserves them through the
+``temporal_tags.json`` sidecar.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from ._temporal_tags import (
+    DEFAULT_INDEX_TYPE,
+    SUPPORTED_INDEX_TYPES,
+    TEMPORAL_TAGS_COLLECTION_NAME,
+    TEMPORAL_TAGS_EXPORT_FILENAME,
+    TemporalTag,
+    TemporalTagFilter,
+    TemporalTags,
+    add_temporal_tags,
+    count_temporal_tags,
+    delete_temporal_tags,
+    list_temporal_tags,
+)
+
+for _public_obj in (
+    TemporalTag,
+    TemporalTagFilter,
+    TemporalTags,
+    add_temporal_tags,
+    count_temporal_tags,
+    delete_temporal_tags,
+    list_temporal_tags,
+):
+    _public_obj.__module__ = __name__
+
+del _public_obj
+
+__all__ = [
+    "DEFAULT_INDEX_TYPE",
+    "SUPPORTED_INDEX_TYPES",
+    "TEMPORAL_TAGS_EXPORT_FILENAME",
+    "TEMPORAL_TAGS_COLLECTION_NAME",
+    "TemporalTag",
+    "TemporalTagFilter",
+    "TemporalTags",
+    "add_temporal_tags",
+    "count_temporal_tags",
+    "delete_temporal_tags",
+    "list_temporal_tags",
+]

--- a/fiftyone/server/utils/datasets.py
+++ b/fiftyone/server/utils/datasets.py
@@ -6,16 +6,20 @@ Dataset and sample helper utilities for FiftyOne server routes.
 |
 """
 
-from typing import Any, Union
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING, Union
 import logging
 from starlette.exceptions import HTTPException
 
-import fiftyone as fo
 import fiftyone.core.odm as foo
 import fiftyone.core.labels as fol
 
 from fiftyone.server.utils.json.jsonpatch import apply as apply_jsonpatch
 from fiftyone.server.utils.json.serialization import deserialize
+
+if TYPE_CHECKING:
+    import fiftyone as fo
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -2172,11 +2172,14 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
         self._metadata_path = None
         self._samples_path = None
         self._frames_path = None
+        self._temporal_tags_path = None
         self._media_exporter = None
         self._media_fields = {}
         self._media_field_exporters = {}
 
     def setup(self):
+        import fiftyone.multimodal.tags._temporal_tags as fommtt
+
         self._data_dir = os.path.join(self.export_dir, "data")
         self._fields_dir = os.path.join(self.export_dir, "fields")
         self._anno_dir = os.path.join(self.export_dir, "annotations")
@@ -2184,6 +2187,9 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
         self._eval_dir = os.path.join(self.export_dir, "evaluations")
         self._runs_dir = os.path.join(self.export_dir, "runs")
         self._metadata_path = os.path.join(self.export_dir, "metadata.json")
+        self._temporal_tags_path = os.path.join(
+            self.export_dir, fommtt.TEMPORAL_TAGS_EXPORT_FILENAME
+        )
 
         if self.use_dirs:
             self._samples_path = os.path.join(self.export_dir, "samples")
@@ -2342,6 +2348,12 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
             ]
 
         foo.export_document(dataset_dict, self._metadata_path)
+
+        import fiftyone.multimodal.tags._temporal_tags as fommtt
+
+        fommtt.export_tags(
+            _sample_collection, self._temporal_tags_path, progress=progress
+        )
 
         self._media_exporter.close()
         for media_exporter in self._media_field_exporters.values():

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -5,6 +5,7 @@ Dataset importers.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from datetime import datetime
 import inspect
 import itertools
@@ -37,6 +38,7 @@ from fiftyone.core.sample import Sample
 import fiftyone.core.storage as fos
 import fiftyone.core.utils as fou
 import fiftyone.migrations as fomi
+import fiftyone.multimodal.tags._temporal_tags as fommtt
 import fiftyone.types as fot
 
 from .parsers import (
@@ -46,7 +48,6 @@ from .parsers import (
     FiftyOneImageLabelsSampleParser,
     FiftyOneVideoLabelsSampleParser,
 )
-
 
 logger = logging.getLogger(__name__)
 
@@ -1823,8 +1824,6 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
         self._media_fields = None
 
     def setup(self):
-        import fiftyone.multimodal.tags._temporal_tags as fommtt
-
         self._data_dir = os.path.join(self.dataset_dir, "data")
         self._fields_dir = os.path.join(self.dataset_dir, "fields")
         self._anno_dir = os.path.join(self.dataset_dir, "annotations")
@@ -1879,8 +1878,6 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
             sample_ids = self._import_samples(
                 dataset, dataset_dict, tags=tags, progress=progress
             )
-
-        import fiftyone.multimodal.tags._temporal_tags as fommtt
 
         fommtt.import_tags(
             dataset,

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -1818,10 +1818,13 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
         self._metadata_path = None
         self._samples_path = None
         self._frames_path = None
+        self._temporal_tags_path = None
         self._has_frames = None
         self._media_fields = None
 
     def setup(self):
+        import fiftyone.multimodal.tags._temporal_tags as fommtt
+
         self._data_dir = os.path.join(self.dataset_dir, "data")
         self._fields_dir = os.path.join(self.dataset_dir, "fields")
         self._anno_dir = os.path.join(self.dataset_dir, "annotations")
@@ -1829,6 +1832,9 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
         self._eval_dir = os.path.join(self.dataset_dir, "evaluations")
         self._runs_dir = os.path.join(self.dataset_dir, "runs")
         self._metadata_path = os.path.join(self.dataset_dir, "metadata.json")
+        self._temporal_tags_path = os.path.join(
+            self.dataset_dir, fommtt.TEMPORAL_TAGS_EXPORT_FILENAME
+        )
 
         if os.path.isdir(self._fields_dir):
             self._media_fields = {
@@ -1869,11 +1875,21 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
             finally:
                 tmp_dataset.delete()
 
-            return sample_ids
+        else:
+            sample_ids = self._import_samples(
+                dataset, dataset_dict, tags=tags, progress=progress
+            )
 
-        return self._import_samples(
-            dataset, dataset_dict, tags=tags, progress=progress
+        import fiftyone.multimodal.tags._temporal_tags as fommtt
+
+        fommtt.import_tags(
+            dataset,
+            self._temporal_tags_path,
+            sample_ids=sample_ids if self.max_samples is not None else None,
+            progress=progress,
         )
+
+        return sample_ids
 
     def _import_samples(self, dataset, dataset_dict, tags=None, progress=None):
         name = dataset.name

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -11,26 +11,34 @@ import random
 import string
 import tempfile
 import unittest
+from unittest import mock
 
 import cv2
 import numpy as np
 import pytest
 
+import eta.core.serial as etas
 import eta.core.utils as etau
 import eta.core.video as etav
 
 import fiftyone as fo
+import fiftyone.multimodal as fomm
 import fiftyone.utils.coco as fouc
 import fiftyone.utils.image as foui
 import fiftyone.utils.labels as foul
 import fiftyone.utils.yolo as fouy
 from fiftyone import ViewField as F
+from fiftyone.multimodal.tags import (
+    TEMPORAL_TAGS_COLLECTION_NAME,
+    TEMPORAL_TAGS_EXPORT_FILENAME,
+)
 
-from decorators import drop_datasets
+from decorators import drop_collection, drop_datasets
 
 skipwindows = pytest.mark.skipif(
     os.name == "nt", reason="Windows hangs in workflows, fix me"
 )
+drop_temporal_tags = drop_collection(TEMPORAL_TAGS_COLLECTION_NAME)
 
 
 class ImageDatasetTests(unittest.TestCase):
@@ -159,6 +167,155 @@ class DuplicateImageExportTests(ImageDatasetTests):
         )
 
         self.assertEqual(len(dataset2), 2)
+
+
+class TemporalTagsImportExportTests(ImageDatasetTests):
+    @drop_temporal_tags
+    @drop_datasets
+    def test_fiftyone_dataset_temporal_tags_round_trip(self):
+        dataset, sample_ids = self._make_temporal_tag_dataset()
+        export_dir = self._new_dir()
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.FiftyOneDataset,
+        )
+
+        tags_path = os.path.join(export_dir, TEMPORAL_TAGS_EXPORT_FILENAME)
+        self.assertTrue(os.path.isfile(tags_path))
+
+        exported = etas.read_json(tags_path)["temporal_tags"]
+        self.assertEqual(len(exported), 3)
+        for doc in exported:
+            self.assertEqual(
+                set(doc.keys()),
+                {"sample_id", "index_type", "start", "end", "tag"},
+            )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.FiftyOneDataset,
+        )
+
+        self.assertEqual(
+            fomm.count_temporal_tags(dataset2), {"drop": 1, "keep": 2}
+        )
+        self.assertEqual(
+            self._temporal_tag_tuples(dataset),
+            self._temporal_tag_tuples(dataset2),
+        )
+
+        etau.delete_file(tags_path)
+        dataset3 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.FiftyOneDataset,
+        )
+
+        self.assertEqual(fomm.count_temporal_tags(dataset3), {})
+
+        fomm.delete_temporal_tags(dataset, delete_all=True)
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.FiftyOneDataset,
+        )
+
+        self.assertFalse(os.path.isfile(tags_path))
+
+    @drop_temporal_tags
+    @drop_datasets
+    def test_fiftyone_dataset_temporal_tags_view_export(self):
+        dataset, sample_ids = self._make_temporal_tag_dataset()
+        view = dataset.select([sample_ids[0], sample_ids[2]])
+        export_dir = self._new_dir()
+
+        view.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.FiftyOneDataset,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.FiftyOneDataset,
+        )
+
+        self.assertEqual(fomm.count_temporal_tags(dataset2), {"keep": 2})
+        self.assertEqual(
+            {tag.sample_id for tag in fomm.list_temporal_tags(dataset2)},
+            {sample_ids[0], sample_ids[2]},
+        )
+
+    @drop_temporal_tags
+    @drop_datasets
+    def test_fiftyone_dataset_temporal_tags_max_samples(self):
+        dataset, sample_ids = self._make_temporal_tag_dataset()
+        export_dir = self._new_dir()
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.FiftyOneDataset,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.FiftyOneDataset,
+            max_samples=1,
+        )
+
+        self.assertEqual(len(dataset2), 1)
+        self.assertEqual(fomm.count_temporal_tags(dataset2), {"keep": 1})
+        self.assertEqual(
+            fomm.list_temporal_tags(dataset2)[0].sample_id, sample_ids[0]
+        )
+
+    @drop_temporal_tags
+    @drop_datasets
+    def test_fiftyone_dataset_temporal_tags_nonempty_migration_import(self):
+        dataset, _ = self._make_temporal_tag_dataset()
+        export_dir = self._new_dir()
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.FiftyOneDataset,
+        )
+
+        dataset2 = fo.Dataset()
+        dataset2.add_sample(fo.Sample(filepath=self._new_image()))
+
+        with mock.patch(
+            "fiftyone.utils.data.importers.fomi.needs_migration",
+            return_value=True,
+        ):
+            dataset2.add_dir(
+                dataset_dir=export_dir,
+                dataset_type=fo.types.FiftyOneDataset,
+            )
+
+        self.assertEqual(
+            fomm.count_temporal_tags(dataset2), {"drop": 1, "keep": 2}
+        )
+
+    def _make_temporal_tag_dataset(self):
+        dataset = fo.Dataset()
+        samples = [fo.Sample(filepath=self._new_image()) for _ in range(3)]
+        dataset.add_samples(samples)
+        sample_ids = dataset.values("id")
+
+        fomm.add_temporal_tags(
+            dataset,
+            [
+                fomm.TemporalTag(sample_ids[0], 0, 10, "keep"),
+                fomm.TemporalTag(sample_ids[1], 10, 20, "drop"),
+                fomm.TemporalTag(sample_ids[2], 20, 30, "keep"),
+            ],
+        )
+
+        return dataset, sample_ids
+
+    def _temporal_tag_tuples(self, dataset):
+        return [
+            (tag.sample_id, tag.index_type, tag.start, tag.end, tag.tag)
+            for tag in fomm.list_temporal_tags(dataset)
+        ]
 
 
 class ImageExportCoersionTests(ImageDatasetTests):

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -188,17 +188,48 @@ class TemporalTagsImportExportTests(ImageDatasetTests):
         exported = etas.read_json(tags_path)["temporal_tags"]
         self.assertEqual(len(exported), 3)
         for doc in exported:
-            expected_keys = {"sample_id", "index_type", "start", "end", "tag"}
+            expected_keys = {
+                "sample_id",
+                "index_type",
+                "start",
+                "end",
+                "tag",
+                "created_at",
+                "last_modified_at",
+            }
             if doc.get("anchor", None) is not None:
                 expected_keys.add("anchor")
+
+            if doc.get("created_by", None) is not None:
+                expected_keys.add("created_by")
+
+            if doc.get("last_modified_by", None) is not None:
+                expected_keys.add("last_modified_by")
 
             self.assertEqual(
                 set(doc.keys()),
                 expected_keys,
             )
+            self.assertIsInstance(doc["created_at"], str)
+            self.assertIsInstance(doc["last_modified_at"], str)
+
         self.assertEqual(
             {doc.get("anchor", None) for doc in exported},
             {None, "camera_front", "lidar_top"},
+        )
+        exported_by_tag = {
+            (doc["tag"], doc.get("anchor", None)): doc for doc in exported
+        }
+        self.assertEqual(
+            exported_by_tag[("keep", "camera_front")]["created_by"], "alice"
+        )
+        self.assertEqual(
+            exported_by_tag[("keep", "camera_front")]["last_modified_by"],
+            "alice",
+        )
+        self.assertEqual(
+            exported_by_tag[("drop", "lidar_top")]["last_modified_by"],
+            "carol",
         )
 
         dataset2 = fo.Dataset.from_dir(
@@ -245,6 +276,10 @@ class TemporalTagsImportExportTests(ImageDatasetTests):
         exported = etas.read_json(tags_path)
         for doc in exported["temporal_tags"]:
             doc.pop("anchor", None)
+            doc.pop("created_at", None)
+            doc.pop("last_modified_at", None)
+            doc.pop("created_by", None)
+            doc.pop("last_modified_by", None)
 
         exported["temporal_tags"][0]["anchor"] = None
         etas.write_json(exported, tags_path)
@@ -257,6 +292,10 @@ class TemporalTagsImportExportTests(ImageDatasetTests):
         tags = fomm.list_temporal_tags(dataset2)
         self.assertEqual(len(tags), 3)
         self.assertTrue(all(tag.anchor is None for tag in tags))
+        self.assertTrue(all(tag.created_at is not None for tag in tags))
+        self.assertTrue(all(tag.last_modified_at is not None for tag in tags))
+        self.assertTrue(all(tag.created_by is None for tag in tags))
+        self.assertTrue(all(tag.last_modified_by is None for tag in tags))
 
     @drop_temporal_tags
     @drop_datasets
@@ -310,6 +349,9 @@ class TemporalTagsImportExportTests(ImageDatasetTests):
         self.assertEqual(
             fomm.list_temporal_tags(dataset2)[0].anchor, "camera_front"
         )
+        self.assertEqual(
+            fomm.list_temporal_tags(dataset2)[0].created_by, "alice"
+        )
 
     @drop_temporal_tags
     @drop_datasets
@@ -348,10 +390,20 @@ class TemporalTagsImportExportTests(ImageDatasetTests):
             dataset,
             [
                 fomm.TemporalTag(
-                    sample_ids[0], 0, 10, "keep", anchor="camera_front"
+                    sample_ids[0],
+                    0,
+                    10,
+                    "keep",
+                    anchor="camera_front",
+                    created_by="alice",
                 ),
                 fomm.TemporalTag(
-                    sample_ids[1], 10, 20, "drop", anchor="lidar_top"
+                    sample_ids[1],
+                    10,
+                    20,
+                    "drop",
+                    anchor="lidar_top",
+                    last_modified_by="carol",
                 ),
                 fomm.TemporalTag(sample_ids[2], 20, 30, "keep"),
             ],
@@ -368,6 +420,10 @@ class TemporalTagsImportExportTests(ImageDatasetTests):
                 tag.start,
                 tag.end,
                 tag.tag,
+                tag.created_by,
+                tag.last_modified_by,
+                tag.created_at,
+                tag.last_modified_at,
             )
             for tag in fomm.list_temporal_tags(dataset)
         ]

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -5,6 +5,7 @@ FiftyOne import/export-related unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import os
 import pathlib
 import random
@@ -187,10 +188,18 @@ class TemporalTagsImportExportTests(ImageDatasetTests):
         exported = etas.read_json(tags_path)["temporal_tags"]
         self.assertEqual(len(exported), 3)
         for doc in exported:
+            expected_keys = {"sample_id", "index_type", "start", "end", "tag"}
+            if doc.get("anchor", None) is not None:
+                expected_keys.add("anchor")
+
             self.assertEqual(
                 set(doc.keys()),
-                {"sample_id", "index_type", "start", "end", "tag"},
+                expected_keys,
             )
+        self.assertEqual(
+            {doc.get("anchor", None) for doc in exported},
+            {None, "camera_front", "lidar_top"},
+        )
 
         dataset2 = fo.Dataset.from_dir(
             dataset_dir=export_dir,
@@ -223,6 +232,34 @@ class TemporalTagsImportExportTests(ImageDatasetTests):
 
     @drop_temporal_tags
     @drop_datasets
+    def test_fiftyone_dataset_temporal_tags_legacy_anchor_import(self):
+        dataset, _ = self._make_temporal_tag_dataset()
+        export_dir = self._new_dir()
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.FiftyOneDataset,
+        )
+
+        tags_path = os.path.join(export_dir, TEMPORAL_TAGS_EXPORT_FILENAME)
+        exported = etas.read_json(tags_path)
+        for doc in exported["temporal_tags"]:
+            doc.pop("anchor", None)
+
+        exported["temporal_tags"][0]["anchor"] = None
+        etas.write_json(exported, tags_path)
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.FiftyOneDataset,
+        )
+
+        tags = fomm.list_temporal_tags(dataset2)
+        self.assertEqual(len(tags), 3)
+        self.assertTrue(all(tag.anchor is None for tag in tags))
+
+    @drop_temporal_tags
+    @drop_datasets
     def test_fiftyone_dataset_temporal_tags_view_export(self):
         dataset, sample_ids = self._make_temporal_tag_dataset()
         view = dataset.select([sample_ids[0], sample_ids[2]])
@@ -239,6 +276,10 @@ class TemporalTagsImportExportTests(ImageDatasetTests):
         )
 
         self.assertEqual(fomm.count_temporal_tags(dataset2), {"keep": 2})
+        self.assertEqual(
+            {tag.anchor for tag in fomm.list_temporal_tags(dataset2)},
+            {None, "camera_front"},
+        )
         self.assertEqual(
             {tag.sample_id for tag in fomm.list_temporal_tags(dataset2)},
             {sample_ids[0], sample_ids[2]},
@@ -265,6 +306,9 @@ class TemporalTagsImportExportTests(ImageDatasetTests):
         self.assertEqual(fomm.count_temporal_tags(dataset2), {"keep": 1})
         self.assertEqual(
             fomm.list_temporal_tags(dataset2)[0].sample_id, sample_ids[0]
+        )
+        self.assertEqual(
+            fomm.list_temporal_tags(dataset2)[0].anchor, "camera_front"
         )
 
     @drop_temporal_tags
@@ -303,8 +347,12 @@ class TemporalTagsImportExportTests(ImageDatasetTests):
         fomm.add_temporal_tags(
             dataset,
             [
-                fomm.TemporalTag(sample_ids[0], 0, 10, "keep"),
-                fomm.TemporalTag(sample_ids[1], 10, 20, "drop"),
+                fomm.TemporalTag(
+                    sample_ids[0], 0, 10, "keep", anchor="camera_front"
+                ),
+                fomm.TemporalTag(
+                    sample_ids[1], 10, 20, "drop", anchor="lidar_top"
+                ),
                 fomm.TemporalTag(sample_ids[2], 20, 30, "keep"),
             ],
         )
@@ -313,7 +361,14 @@ class TemporalTagsImportExportTests(ImageDatasetTests):
 
     def _temporal_tag_tuples(self, dataset):
         return [
-            (tag.sample_id, tag.index_type, tag.start, tag.end, tag.tag)
+            (
+                tag.sample_id,
+                tag.index_type,
+                tag.anchor,
+                tag.start,
+                tag.end,
+                tag.tag,
+            )
             for tag in fomm.list_temporal_tags(dataset)
         ]
 

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -11,6 +11,7 @@ import pathlib
 import random
 import string
 import tempfile
+import time
 import unittest
 from unittest import mock
 
@@ -232,9 +233,18 @@ class TemporalTagsImportExportTests(ImageDatasetTests):
             "carol",
         )
 
+        source_tag_modified_at = max(
+            tag.last_modified_at for tag in fomm.list_temporal_tags(dataset)
+        )
+        time.sleep(0.05)
+
         dataset2 = fo.Dataset.from_dir(
             dataset_dir=export_dir,
             dataset_type=fo.types.FiftyOneDataset,
+        )
+        imported_tags = fomm.list_temporal_tags(dataset2)
+        sample_modified_at = dict(
+            zip(dataset2.values("id"), dataset2.values("last_modified_at"))
         )
 
         self.assertEqual(
@@ -243,6 +253,13 @@ class TemporalTagsImportExportTests(ImageDatasetTests):
         self.assertEqual(
             self._temporal_tag_tuples(dataset),
             self._temporal_tag_tuples(dataset2),
+        )
+        self.assertGreater(dataset2.last_modified_at, source_tag_modified_at)
+        self.assertTrue(
+            all(
+                sample_modified_at[tag.sample_id] > tag.last_modified_at
+                for tag in imported_tags
+            )
         )
 
         etau.delete_file(tags_path)
@@ -260,42 +277,6 @@ class TemporalTagsImportExportTests(ImageDatasetTests):
         )
 
         self.assertFalse(os.path.isfile(tags_path))
-
-    @drop_temporal_tags
-    @drop_datasets
-    def test_fiftyone_dataset_temporal_tags_legacy_anchor_import(self):
-        dataset, _ = self._make_temporal_tag_dataset()
-        export_dir = self._new_dir()
-
-        dataset.export(
-            export_dir=export_dir,
-            dataset_type=fo.types.FiftyOneDataset,
-        )
-
-        tags_path = os.path.join(export_dir, TEMPORAL_TAGS_EXPORT_FILENAME)
-        exported = etas.read_json(tags_path)
-        for doc in exported["temporal_tags"]:
-            doc.pop("anchor", None)
-            doc.pop("created_at", None)
-            doc.pop("last_modified_at", None)
-            doc.pop("created_by", None)
-            doc.pop("last_modified_by", None)
-
-        exported["temporal_tags"][0]["anchor"] = None
-        etas.write_json(exported, tags_path)
-
-        dataset2 = fo.Dataset.from_dir(
-            dataset_dir=export_dir,
-            dataset_type=fo.types.FiftyOneDataset,
-        )
-
-        tags = fomm.list_temporal_tags(dataset2)
-        self.assertEqual(len(tags), 3)
-        self.assertTrue(all(tag.anchor is None for tag in tags))
-        self.assertTrue(all(tag.created_at is not None for tag in tags))
-        self.assertTrue(all(tag.last_modified_at is not None for tag in tags))
-        self.assertTrue(all(tag.created_by is None for tag in tags))
-        self.assertTrue(all(tag.last_modified_by is None for tag in tags))
 
     @drop_temporal_tags
     @drop_datasets

--- a/tests/unittests/multimodal/temporal_tags_tests.py
+++ b/tests/unittests/multimodal/temporal_tags_tests.py
@@ -276,6 +276,106 @@ class TemporalTagTests(unittest.TestCase):
 
     @drop_temporal_tags
     @drop_datasets
+    def test_updates_preserve_identity_and_touch_parents(self):
+        dataset, sample_ids = _make_dataset(2)
+        first_id, second_id = sample_ids
+
+        inserted = fomm.add_temporal_tags(
+            dataset,
+            fomm.TemporalTag(first_id, 0, 10, "review", created_by="alice"),
+        )[0]
+        fomm.add_temporal_tags(
+            dataset,
+            fomm.TemporalTag(second_id, 0, 10, "other"),
+        )
+        before_dataset, before_first = _modified_timestamps(dataset, first_id)
+        _, before_second = _modified_timestamps(dataset, second_id)
+
+        time.sleep(0.05)
+        updated = fomm.update_temporal_tag(
+            dataset,
+            inserted.id,
+            start=2,
+            end=12,
+            tag="accepted",
+            last_modified_by="bob",
+        )
+        after_update_dataset, after_update_first = _modified_timestamps(
+            dataset, first_id
+        )
+        _, after_update_second = _modified_timestamps(dataset, second_id)
+
+        self.assertEqual(updated.id, inserted.id)
+        self.assertEqual(updated.sample_id, first_id)
+        self.assertEqual(updated.start, 2)
+        self.assertEqual(updated.end, 12)
+        self.assertEqual(updated.tag, "accepted")
+        self.assertEqual(updated.created_by, "alice")
+        self.assertEqual(updated.created_at, inserted.created_at)
+        self.assertEqual(updated.last_modified_by, "bob")
+        self.assertGreater(updated.last_modified_at, inserted.last_modified_at)
+        self.assertEqual(
+            fomm.count_temporal_tags(dataset), {"accepted": 1, "other": 1}
+        )
+        self.assertEqual(len(fomm.list_temporal_tags(dataset)), 2)
+        self.assertGreater(after_update_dataset, before_dataset)
+        self.assertGreater(after_update_first, before_first)
+        self.assertEqual(after_update_second, before_second)
+
+        time.sleep(0.05)
+        resized = fomm.TemporalTags(dataset).update(updated.id, end=14)
+
+        self.assertEqual(resized.id, inserted.id)
+        self.assertEqual(resized.start, 2)
+        self.assertEqual(resized.end, 14)
+        self.assertEqual(resized.created_at, inserted.created_at)
+        self.assertEqual(resized.last_modified_by, "bob")
+        self.assertGreater(resized.last_modified_at, updated.last_modified_at)
+
+    @drop_temporal_tags
+    @drop_datasets
+    def test_update_validation_and_scoping(self):
+        dataset, sample_ids = _make_dataset(2)
+        first_id, second_id = sample_ids
+
+        first = fomm.add_temporal_tags(
+            dataset, fomm.TemporalTag(first_id, 0, 10, "review")
+        )[0]
+        second = fomm.add_temporal_tags(
+            dataset, fomm.TemporalTag(first_id, 20, 30, "other")
+        )[0]
+
+        invalid_updates = [
+            {},
+            {"start": 10},
+            {"end": 0},
+            {"tag": ""},
+            {"last_modified_by": "   "},
+        ]
+        for update in invalid_updates:
+            with self.assertRaises(ValueError):
+                fomm.update_temporal_tag(dataset, first.id, **update)
+
+        with self.assertRaises(ValueError):
+            fomm.update_temporal_tag(dataset, str(ObjectId()), start=1)
+
+        with self.assertRaises(ValueError):
+            fomm.update_temporal_tag(
+                dataset, second.id, start=0, end=10, tag="review"
+            )
+
+        view = dataset.select([second_id])
+        with self.assertRaises(ValueError):
+            fomm.update_temporal_tag(view, first.id, start=1)
+
+        persisted = fomm.list_temporal_tags(dataset)
+        self.assertEqual(
+            [(tag.start, tag.end, tag.tag) for tag in persisted],
+            [(0, 10, "review"), (20, 30, "other")],
+        )
+
+    @drop_temporal_tags
+    @drop_datasets
     def test_storage_filtering_counts_and_deletion(self):
         dataset, sample_ids = _make_dataset(2)
         first = fomm.TemporalTag(sample_ids[0], 0, 10, "review")

--- a/tests/unittests/multimodal/temporal_tags_tests.py
+++ b/tests/unittests/multimodal/temporal_tags_tests.py
@@ -192,6 +192,90 @@ class TemporalTagTests(unittest.TestCase):
 
     @drop_temporal_tags
     @drop_datasets
+    def test_parent_timestamps_on_crud(self):
+        dataset, sample_ids = _make_dataset(2)
+        first_id, second_id = sample_ids
+
+        before_dataset, before_first = _modified_timestamps(dataset, first_id)
+        _, before_second = _modified_timestamps(dataset, second_id)
+
+        time.sleep(0.05)
+        inserted = fomm.add_temporal_tags(
+            dataset, fomm.TemporalTag(first_id, 0, 10, "review")
+        )[0]
+        after_add_dataset, after_add_first = _modified_timestamps(
+            dataset, first_id
+        )
+        _, after_add_second = _modified_timestamps(dataset, second_id)
+
+        self.assertGreater(after_add_dataset, before_dataset)
+        self.assertGreater(after_add_first, before_first)
+        self.assertEqual(after_add_second, before_second)
+
+        time.sleep(0.05)
+        repeated = fomm.add_temporal_tags(
+            dataset, fomm.TemporalTag(first_id, 0, 10, "review")
+        )[0]
+        after_repeat_dataset, after_repeat_first = _modified_timestamps(
+            dataset, first_id
+        )
+
+        self.assertEqual(repeated.id, inserted.id)
+        self.assertEqual(repeated.created_at, inserted.created_at)
+        self.assertGreater(
+            repeated.last_modified_at, inserted.last_modified_at
+        )
+        self.assertGreater(after_repeat_dataset, after_add_dataset)
+        self.assertGreater(after_repeat_first, after_add_first)
+
+        before_noop_dataset, before_noop_first = _modified_timestamps(
+            dataset, first_id
+        )
+        time.sleep(0.05)
+        self.assertEqual(fomm.delete_temporal_tags(dataset, tags="missing"), 0)
+        after_noop_dataset, after_noop_first = _modified_timestamps(
+            dataset, first_id
+        )
+
+        self.assertEqual(after_noop_dataset, before_noop_dataset)
+        self.assertEqual(after_noop_first, before_noop_first)
+
+        time.sleep(0.05)
+        self.assertEqual(
+            fomm.delete_temporal_tags(dataset, ids=inserted.id), 1
+        )
+        after_delete_dataset, after_delete_first = _modified_timestamps(
+            dataset, first_id
+        )
+
+        self.assertGreater(after_delete_dataset, after_noop_dataset)
+        self.assertGreater(after_delete_first, after_noop_first)
+
+        fomm.add_temporal_tags(
+            dataset,
+            [
+                fomm.TemporalTag(first_id, 20, 30, "clear"),
+                fomm.TemporalTag(second_id, 20, 30, "clear"),
+            ],
+        )
+        before_clear_dataset, before_clear_first = _modified_timestamps(
+            dataset, first_id
+        )
+        _, before_clear_second = _modified_timestamps(dataset, second_id)
+
+        time.sleep(0.05)
+        self.assertEqual(fomm.TemporalTags(dataset).clear(), 2)
+        after_clear_dataset, after_clear_first = _modified_timestamps(
+            dataset, first_id
+        )
+        _, after_clear_second = _modified_timestamps(dataset, second_id)
+
+        self.assertGreater(after_clear_dataset, before_clear_dataset)
+        self.assertGreater(after_clear_first, before_clear_first)
+        self.assertGreater(after_clear_second, before_clear_second)
+
+    @drop_temporal_tags
+    @drop_datasets
     def test_storage_filtering_counts_and_deletion(self):
         dataset, sample_ids = _make_dataset(2)
         first = fomm.TemporalTag(sample_ids[0], 0, 10, "review")
@@ -329,36 +413,6 @@ class TemporalTagTests(unittest.TestCase):
 
     @drop_temporal_tags
     @drop_datasets
-    def test_replaces_legacy_unique_index(self):
-        collection = foo.get_db_conn()[TEMPORAL_TAGS_COLLECTION_NAME]
-        collection.create_index(
-            [
-                ("_dataset_id", 1),
-                ("_sample_id", 1),
-                ("index_type", 1),
-                ("start", 1),
-                ("end", 1),
-                ("tag", 1),
-            ],
-            unique=True,
-            name="unique_temporal_tag",
-        )
-
-        dataset, sample_ids = _make_dataset()
-        fomm.add_temporal_tags(
-            dataset,
-            fomm.TemporalTag(
-                sample_ids[0], 0, 10, "review", anchor="camera_front"
-            ),
-        )
-
-        index_keys = collection.index_information()["unique_temporal_tag"][
-            "key"
-        ]
-        self.assertIn(("anchor", 1), index_keys)
-
-    @drop_temporal_tags
-    @drop_datasets
     def test_creates_query_indexes(self):
         dataset, sample_ids = _make_dataset()
         fomm.add_temporal_tags(
@@ -432,10 +486,39 @@ class TemporalTagTests(unittest.TestCase):
                 view, fomm.TemporalTag(sample_ids[1], 10, 20, "missing")
             )
 
+        (
+            before_view_delete_dataset,
+            before_view_delete_first,
+        ) = _modified_timestamps(dataset, sample_ids[0])
+        _, before_view_delete_second = _modified_timestamps(
+            dataset, sample_ids[1]
+        )
+        _, before_view_delete_third = _modified_timestamps(
+            dataset, sample_ids[2]
+        )
+
+        time.sleep(0.05)
         self.assertEqual(
             fomm.delete_temporal_tags(view, tags="shared"),
             1,
         )
+        (
+            after_view_delete_dataset,
+            after_view_delete_first,
+        ) = _modified_timestamps(dataset, sample_ids[0])
+        _, after_view_delete_second = _modified_timestamps(
+            dataset, sample_ids[1]
+        )
+        _, after_view_delete_third = _modified_timestamps(
+            dataset, sample_ids[2]
+        )
+
+        self.assertGreater(
+            after_view_delete_dataset, before_view_delete_dataset
+        )
+        self.assertGreater(after_view_delete_first, before_view_delete_first)
+        self.assertEqual(after_view_delete_second, before_view_delete_second)
+        self.assertEqual(after_view_delete_third, before_view_delete_third)
         self.assertEqual(
             fomm.count_temporal_tags(dataset),
             {"other": 1, "shared": 1, "view": 1},
@@ -641,6 +724,16 @@ def _temporal_tag_count_for_sample(dataset_id, sample_id):
     return foo.get_db_conn()[TEMPORAL_TAGS_COLLECTION_NAME].count_documents(
         {"_dataset_id": dataset_id, "_sample_id": ObjectId(sample_id)}
     )
+
+
+def _modified_timestamps(dataset, sample_id):
+    dataset.reload()
+    dataset_doc = foo.get_db_conn().datasets.find_one({"_id": dataset._doc.id})
+    sample_doc = dataset._sample_collection.find_one(
+        {"_id": ObjectId(sample_id)}
+    )
+
+    return dataset_doc["last_modified_at"], sample_doc["last_modified_at"]
 
 
 def _temporal_tag_provenance(tags):

--- a/tests/unittests/multimodal/temporal_tags_tests.py
+++ b/tests/unittests/multimodal/temporal_tags_tests.py
@@ -6,6 +6,7 @@ Multimodal temporal tag unit tests.
 |
 """
 
+import time
 import unittest
 
 from bson import ObjectId
@@ -47,7 +48,16 @@ class TemporalTagTests(unittest.TestCase):
             TimeTrackType.TIME_TRACK_TYPE_DURATION_NS,
         )
         self.assertIsNone(persisted[0].anchor)
+        self.assertIsNone(persisted[0].created_by)
+        self.assertIsNone(persisted[0].last_modified_by)
+        self.assertIsNotNone(persisted[0].created_at)
+        self.assertIsNotNone(persisted[0].last_modified_at)
+        self.assertEqual(
+            persisted[0].created_at, persisted[0].last_modified_at
+        )
         self.assertNotIn("anchor", persisted[0].to_dict())
+        self.assertIn("created_at", persisted[0].to_dict())
+        self.assertIn("last_modified_at", persisted[0].to_dict())
         self.assertEqual(persisted[0].copy(), persisted[0])
 
         temporal_tags = fomm.TemporalTags(dataset)
@@ -75,6 +85,24 @@ class TemporalTagTests(unittest.TestCase):
             fomm.TemporalTag(sample_id, 0, 1, "bad-anchor", anchor=3),
             fomm.TemporalTag(sample_id, 0, 1, "bool-anchor", anchor=False),
             fomm.TemporalTag(
+                sample_id, 0, 1, "empty-created-by", created_by=""
+            ),
+            fomm.TemporalTag(
+                sample_id,
+                0,
+                1,
+                "blank-last-modified-by",
+                last_modified_by="   ",
+            ),
+            fomm.TemporalTag(sample_id, 0, 1, "bad-created-by", created_by=3),
+            fomm.TemporalTag(
+                sample_id,
+                0,
+                1,
+                "bool-last-modified-by",
+                last_modified_by=False,
+            ),
+            fomm.TemporalTag(
                 sample_id,
                 0,
                 1,
@@ -92,6 +120,75 @@ class TemporalTagTests(unittest.TestCase):
         self.assertEqual(fomm.list_temporal_tags(dataset), [])
         with self.assertRaises(ValueError):
             temporal_tags.first()
+
+    @drop_temporal_tags
+    @drop_datasets
+    def test_provenance_upserts(self):
+        dataset, sample_ids = _make_dataset()
+        sample_id = sample_ids[0]
+
+        inserted = fomm.add_temporal_tags(
+            dataset,
+            fomm.TemporalTag(sample_id, 0, 10, "review", created_by="alice"),
+        )[0]
+
+        self.assertEqual(inserted.created_by, "alice")
+        self.assertEqual(inserted.last_modified_by, "alice")
+        self.assertEqual(inserted.created_at, inserted.last_modified_at)
+        self.assertEqual(
+            inserted.to_dict()["created_at"], inserted.created_at.isoformat()
+        )
+        self.assertEqual(
+            inserted.to_dict()["last_modified_at"],
+            inserted.last_modified_at.isoformat(),
+        )
+
+        time.sleep(0.02)
+        repeated = fomm.add_temporal_tags(
+            dataset,
+            fomm.TemporalTag(sample_id, 0, 10, "review", created_by="bob"),
+        )[0]
+
+        self.assertEqual(repeated.id, inserted.id)
+        self.assertEqual(repeated.created_by, "alice")
+        self.assertEqual(repeated.last_modified_by, "alice")
+        self.assertEqual(repeated.created_at, inserted.created_at)
+        self.assertGreater(
+            repeated.last_modified_at, inserted.last_modified_at
+        )
+
+        time.sleep(0.02)
+        modified = fomm.add_temporal_tags(
+            dataset,
+            fomm.TemporalTag(
+                sample_id, 0, 10, "review", last_modified_by="carol"
+            ),
+        )[0]
+
+        self.assertEqual(modified.id, inserted.id)
+        self.assertEqual(modified.created_by, "alice")
+        self.assertEqual(modified.last_modified_by, "carol")
+        self.assertEqual(modified.created_at, inserted.created_at)
+        self.assertGreater(
+            modified.last_modified_at, repeated.last_modified_at
+        )
+
+        manual = fomm.add_temporal_tags(
+            dataset,
+            fomm.TemporalTag(
+                sample_id,
+                20,
+                30,
+                "manual",
+                created_at="2026-01-01T00:00:00Z",
+                last_modified_at="2026-01-02T00:00:00+00:00",
+            ),
+        )[0]
+
+        self.assertEqual(manual.created_at.isoformat(), "2026-01-01T00:00:00")
+        self.assertEqual(
+            manual.last_modified_at.isoformat(), "2026-01-02T00:00:00"
+        )
 
     @drop_temporal_tags
     @drop_datasets
@@ -412,14 +509,31 @@ class TemporalTagTests(unittest.TestCase):
             dataset,
             [
                 fomm.TemporalTag(
-                    sample_ids[0], 0, 10, "first", anchor="camera_front"
+                    sample_ids[0],
+                    0,
+                    10,
+                    "first",
+                    anchor="camera_front",
+                    created_by="alice",
                 ),
-                fomm.TemporalTag(sample_ids[1], 10, 20, "second"),
+                fomm.TemporalTag(
+                    sample_ids[1],
+                    10,
+                    20,
+                    "second",
+                    last_modified_by="bob",
+                ),
             ],
         )
 
         full_clone = dataset.clone()
-        self.assertEqual(len(fomm.list_temporal_tags(full_clone)), 2)
+        source_tags = fomm.list_temporal_tags(dataset)
+        full_clone_tags = fomm.list_temporal_tags(full_clone)
+        self.assertEqual(len(full_clone_tags), 2)
+        self.assertEqual(
+            _temporal_tag_provenance(source_tags),
+            _temporal_tag_provenance(full_clone_tags),
+        )
         self.assertEqual(
             fomm.count_temporal_tags(
                 full_clone, fomm.TemporalTagFilter(anchors="camera_front")
@@ -527,3 +641,15 @@ def _temporal_tag_count_for_sample(dataset_id, sample_id):
     return foo.get_db_conn()[TEMPORAL_TAGS_COLLECTION_NAME].count_documents(
         {"_dataset_id": dataset_id, "_sample_id": ObjectId(sample_id)}
     )
+
+
+def _temporal_tag_provenance(tags):
+    return [
+        (
+            tag.created_by,
+            tag.last_modified_by,
+            tag.created_at,
+            tag.last_modified_at,
+        )
+        for tag in tags
+    ]

--- a/tests/unittests/multimodal/temporal_tags_tests.py
+++ b/tests/unittests/multimodal/temporal_tags_tests.py
@@ -632,6 +632,114 @@ class TemporalTagTests(unittest.TestCase):
 
     @drop_temporal_tags
     @drop_datasets
+    def test_sample_collection_temporal_tag_convenience(self):
+        dataset, sample_ids = _make_dataset(3)
+
+        persisted = dataset.temporal_tags.add(
+            [
+                fomm.TemporalTag(sample_ids[0], 0, 10, "shared"),
+                fomm.TemporalTag(sample_ids[1], 10, 20, "shared"),
+            ]
+        )
+
+        self.assertEqual(dataset.temporal_tags.count(), {"shared": 2})
+        self.assertEqual(
+            [tag.id for tag in dataset.temporal_tags.values()],
+            [tag.id for tag in persisted],
+        )
+
+        updated = dataset.temporal_tags.update(
+            persisted[0].id,
+            end=12,
+            tag="review",
+            last_modified_by="alice",
+        )
+        self.assertEqual(updated.end, 12)
+        self.assertEqual(updated.tag, "review")
+        self.assertEqual(updated.last_modified_by, "alice")
+        self.assertEqual(
+            dataset.temporal_tags.count(), {"review": 1, "shared": 1}
+        )
+
+        view = dataset.select([sample_ids[0], sample_ids[2]])
+        self.assertEqual(view.temporal_tags.count(), {"review": 1})
+
+        with self.assertRaises(ValueError):
+            view.temporal_tags.add(
+                fomm.TemporalTag(sample_ids[1], 20, 30, "outside")
+            )
+
+        self.assertEqual(view.temporal_tags.delete(tags="review"), 1)
+        self.assertEqual(dataset.temporal_tags.count(), {"shared": 1})
+
+    @drop_temporal_tags
+    @drop_datasets
+    def test_match_temporal_tags(self):
+        dataset, sample_ids = _make_dataset(4)
+        fomm.add_temporal_tags(
+            dataset,
+            [
+                fomm.TemporalTag(
+                    sample_ids[0],
+                    0,
+                    10,
+                    "review",
+                    anchor="camera_front",
+                ),
+                fomm.TemporalTag(
+                    sample_ids[1],
+                    5,
+                    15,
+                    "review",
+                    anchor="lidar_top",
+                ),
+                fomm.TemporalTag(sample_ids[2], 20, 30, "other"),
+            ],
+        )
+
+        self.assertEqual(
+            set(dataset.match_temporal_tags(tags="review").values("id")),
+            set(sample_ids[:2]),
+        )
+        self.assertEqual(
+            dataset.match_temporal_tags(
+                tags="review", start=10, end=11
+            ).values("id"),
+            [sample_ids[1]],
+        )
+        self.assertEqual(
+            dataset.match_temporal_tags(anchors="camera_front").values("id"),
+            [sample_ids[0]],
+        )
+        self.assertEqual(
+            set(
+                dataset.match_temporal_tags(tags="review", bool=False).values(
+                    "id"
+                )
+            ),
+            {sample_ids[2], sample_ids[3]},
+        )
+
+        view = dataset.select([sample_ids[0], sample_ids[2], sample_ids[3]])
+        self.assertEqual(
+            view.match_temporal_tags(tags="review").values("id"),
+            [sample_ids[0]],
+        )
+        self.assertEqual(
+            view.match_temporal_tags(tags="missing").values("id"),
+            [],
+        )
+        self.assertEqual(
+            set(
+                view.match_temporal_tags(tags="missing", bool=False).values(
+                    "id"
+                )
+            ),
+            {sample_ids[0], sample_ids[2], sample_ids[3]},
+        )
+
+    @drop_temporal_tags
+    @drop_datasets
     def test_generated_view_operations_use_backing_dataset(self):
         dataset = fo.Dataset()
         sample = fo.Sample(

--- a/tests/unittests/multimodal/temporal_tags_tests.py
+++ b/tests/unittests/multimodal/temporal_tags_tests.py
@@ -1,0 +1,385 @@
+"""
+Multimodal temporal tag unit tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+
+from bson import ObjectId
+from decorators import drop_collection, drop_datasets
+
+import fiftyone as fo
+import fiftyone.core.odm as foo
+import fiftyone.multimodal as fomm
+from fiftyone.multimodal.tags import (
+    TEMPORAL_TAGS_COLLECTION_NAME,
+    TimeTrackType,
+)
+
+drop_temporal_tags = drop_collection(TEMPORAL_TAGS_COLLECTION_NAME)
+
+
+class TemporalTagTests(unittest.TestCase):
+    @drop_temporal_tags
+    @drop_datasets
+    def test_validation_and_defaults(self):
+        dataset, sample_ids = _make_dataset()
+        sample_id = sample_ids[0]
+
+        self.assertEqual(fomm.list_temporal_tags(dataset), [])
+        self.assertEqual(fomm.count_temporal_tags(dataset), {})
+        self.assertEqual(fomm.delete_temporal_tags(dataset, tags="missing"), 0)
+        self.assertNotIn(
+            TEMPORAL_TAGS_COLLECTION_NAME,
+            foo.get_db_conn().list_collection_names(),
+        )
+
+        persisted = fomm.add_temporal_tags(
+            dataset, fomm.TemporalTag(sample_id, 0, 1, "review")
+        )
+
+        self.assertEqual(len(persisted), 1)
+        self.assertEqual(
+            persisted[0].index_type,
+            TimeTrackType.TIME_TRACK_TYPE_DURATION_NS,
+        )
+
+        temporal_tags = fomm.TemporalTags(dataset)
+        self.assertTrue(temporal_tags)
+        self.assertEqual(len(temporal_tags), 1)
+        self.assertEqual(list(temporal_tags), [persisted[0].id])
+        self.assertEqual(temporal_tags.first(), persisted[0])
+        self.assertEqual(temporal_tags.head(), persisted)
+        self.assertEqual(temporal_tags.tail(), persisted)
+        self.assertEqual(list(temporal_tags.keys()), [persisted[0].id])
+        self.assertEqual(
+            list(temporal_tags.items()), [(persisted[0].id, persisted[0])]
+        )
+        self.assertEqual(list(temporal_tags.values()), persisted)
+        self.assertEqual(temporal_tags.count(), {"review": 1})
+
+        invalid_tags = [
+            fomm.TemporalTag(str(ObjectId()), 0, 1, "missing"),
+            fomm.TemporalTag(sample_id, 1, 1, "same"),
+            fomm.TemporalTag(sample_id, 2, 1, "backwards"),
+            fomm.TemporalTag(sample_id, 0.5, 1, "fractional"),
+            fomm.TemporalTag(sample_id, 0, 1, ""),
+            fomm.TemporalTag(
+                sample_id,
+                0,
+                1,
+                "unsupported",
+                index_type=TimeTrackType.TIME_TRACK_TYPE_UNSPECIFIED,
+            ),
+        ]
+
+        for tag in invalid_tags:
+            with self.assertRaises(ValueError):
+                fomm.add_temporal_tags(dataset, tag)
+
+        self.assertEqual(temporal_tags.clear(), 1)
+        self.assertFalse(temporal_tags)
+        self.assertEqual(fomm.list_temporal_tags(dataset), [])
+        with self.assertRaises(ValueError):
+            temporal_tags.first()
+
+    @drop_temporal_tags
+    @drop_datasets
+    def test_storage_filtering_counts_and_deletion(self):
+        dataset, sample_ids = _make_dataset(2)
+        first = fomm.TemporalTag(sample_ids[0], 0, 10, "review")
+
+        inserted = fomm.add_temporal_tags(dataset, first)
+        repeated = fomm.add_temporal_tags(dataset, first)
+
+        self.assertEqual(inserted[0].id, repeated[0].id)
+        self.assertEqual(len(fomm.list_temporal_tags(dataset)), 1)
+
+        fomm.add_temporal_tags(
+            dataset,
+            [
+                fomm.TemporalTag(sample_ids[0], 5, 15, "review"),
+                fomm.TemporalTag(sample_ids[0], 0, 10, "keep"),
+                fomm.TemporalTag(
+                    sample_ids[1],
+                    0,
+                    1,
+                    "review",
+                    index_type=TimeTrackType.TIME_TRACK_TYPE_SEQUENCE,
+                ),
+            ],
+        )
+
+        self.assertEqual(len(fomm.list_temporal_tags(dataset)), 4)
+        self.assertEqual(
+            fomm.count_temporal_tags(dataset), {"keep": 1, "review": 3}
+        )
+
+        sample_tags = fomm.list_temporal_tags(
+            dataset, fomm.TemporalTagFilter(sample_ids=sample_ids[0])
+        )
+        self.assertEqual(len(sample_tags), 3)
+        self.assertTrue(
+            all(tag.sample_id == sample_ids[0] for tag in sample_tags)
+        )
+
+        overlap_at_boundary = fomm.list_temporal_tags(
+            dataset,
+            fomm.TemporalTagFilter(
+                index_type=TimeTrackType.TIME_TRACK_TYPE_DURATION_NS,
+                start=10,
+                end=11,
+            ),
+        )
+        self.assertEqual(
+            [(tag.start, tag.end, tag.tag) for tag in overlap_at_boundary],
+            [(5, 15, "review")],
+        )
+
+        self.assertEqual(
+            len(
+                fomm.list_temporal_tags(
+                    dataset, fomm.TemporalTagFilter(tags="review")
+                )
+            ),
+            3,
+        )
+
+        with self.assertRaises(ValueError):
+            fomm.delete_temporal_tags(dataset)
+
+        self.assertEqual(
+            fomm.delete_temporal_tags(dataset, ids=inserted[0].id), 1
+        )
+        self.assertEqual(
+            fomm.delete_temporal_tags(
+                dataset,
+                filter=fomm.TemporalTagFilter(sample_ids=sample_ids[1]),
+            ),
+            1,
+        )
+        self.assertEqual(fomm.delete_temporal_tags(dataset, tags="keep"), 1)
+        self.assertEqual(len(fomm.list_temporal_tags(dataset)), 1)
+        self.assertEqual(
+            fomm.delete_temporal_tags(dataset, delete_all=True), 1
+        )
+
+    @drop_temporal_tags
+    @drop_datasets
+    def test_view_scoped_operations(self):
+        dataset, sample_ids = _make_dataset(3)
+        fomm.add_temporal_tags(
+            dataset,
+            [
+                fomm.TemporalTag(sample_ids[0], 0, 10, "shared"),
+                fomm.TemporalTag(sample_ids[1], 0, 10, "shared"),
+                fomm.TemporalTag(sample_ids[2], 0, 10, "other"),
+            ],
+        )
+
+        view = dataset.select([sample_ids[0], sample_ids[2]])
+
+        self.assertEqual(
+            fomm.count_temporal_tags(dataset), {"other": 1, "shared": 2}
+        )
+        self.assertEqual(
+            fomm.count_temporal_tags(view), {"other": 1, "shared": 1}
+        )
+
+        view_tags = fomm.list_temporal_tags(view)
+        self.assertEqual(
+            {tag.sample_id for tag in view_tags},
+            {sample_ids[0], sample_ids[2]},
+        )
+
+        self.assertEqual(
+            fomm.list_temporal_tags(
+                view, fomm.TemporalTagFilter(sample_ids=sample_ids[1])
+            ),
+            [],
+        )
+
+        fomm.add_temporal_tags(
+            view, fomm.TemporalTag(sample_ids[2], 10, 20, "view")
+        )
+        with self.assertRaises(ValueError):
+            fomm.add_temporal_tags(
+                view, fomm.TemporalTag(sample_ids[1], 10, 20, "missing")
+            )
+
+        self.assertEqual(
+            fomm.delete_temporal_tags(view, tags="shared"),
+            1,
+        )
+        self.assertEqual(
+            fomm.count_temporal_tags(dataset),
+            {"other": 1, "shared": 1, "view": 1},
+        )
+
+        with self.assertRaises(ValueError):
+            fomm.delete_temporal_tags(view)
+
+        self.assertEqual(fomm.TemporalTags(view).clear(), 2)
+        self.assertEqual(fomm.count_temporal_tags(dataset), {"shared": 1})
+
+    @drop_temporal_tags
+    @drop_datasets
+    def test_generated_view_operations_use_backing_dataset(self):
+        dataset = fo.Dataset()
+        sample = fo.Sample(
+            filepath="/tmp/multimodal-temporal-tag-patches.jpg",
+            detections=fo.Detections(
+                detections=[
+                    fo.Detection(label="object", bounding_box=[0, 0, 1, 1])
+                ]
+            ),
+        )
+        dataset.add_sample(sample)
+
+        patches = dataset.to_patches("detections")
+        patch_id = patches.values("id")[0]
+
+        fomm.add_temporal_tags(
+            patches, fomm.TemporalTag(patch_id, 0, 1, "patch")
+        )
+
+        self.assertEqual(fomm.count_temporal_tags(patches), {"patch": 1})
+        self.assertEqual(fomm.count_temporal_tags(dataset), {})
+
+    @drop_temporal_tags
+    @drop_datasets
+    def test_sample_delete_and_clear_lifecycle(self):
+        dataset, sample_ids = _make_dataset(3)
+        fomm.add_temporal_tags(
+            dataset,
+            [
+                fomm.TemporalTag(sample_ids[0], 0, 10, "first"),
+                fomm.TemporalTag(sample_ids[1], 10, 20, "second"),
+                fomm.TemporalTag(sample_ids[2], 20, 30, "third"),
+            ],
+        )
+
+        dataset.delete_samples(sample_ids[1])
+
+        self.assertEqual(
+            fomm.count_temporal_tags(dataset), {"first": 1, "third": 1}
+        )
+        self.assertEqual(
+            _temporal_tag_count_for_sample(dataset._doc.id, sample_ids[1]), 0
+        )
+
+        dataset.clear()
+
+        self.assertEqual(_temporal_tag_count(dataset._doc.id), 0)
+
+    @drop_temporal_tags
+    @drop_datasets
+    def test_dataset_delete_and_clone_lifecycle(self):
+        dataset, sample_ids = _make_dataset(2)
+        fomm.add_temporal_tags(
+            dataset,
+            [
+                fomm.TemporalTag(sample_ids[0], 0, 10, "first"),
+                fomm.TemporalTag(sample_ids[1], 10, 20, "second"),
+            ],
+        )
+
+        full_clone = dataset.clone()
+        self.assertEqual(len(fomm.list_temporal_tags(full_clone)), 2)
+
+        view_clone = dataset.select([sample_ids[0]]).clone()
+        view_clone_tags = fomm.list_temporal_tags(view_clone)
+        self.assertEqual(len(view_clone_tags), 1)
+        self.assertEqual(view_clone_tags[0].sample_id, sample_ids[0])
+
+        dataset_id = dataset._doc.id
+        self.assertEqual(_temporal_tag_count(dataset_id), 2)
+
+        dataset.delete()
+
+        self.assertEqual(_temporal_tag_count(dataset_id), 0)
+
+    @drop_temporal_tags
+    @drop_datasets
+    def test_low_level_dataset_delete_lifecycle(self):
+        dataset, sample_ids = _make_dataset(2)
+        fomm.add_temporal_tags(
+            dataset,
+            [
+                fomm.TemporalTag(sample_ids[0], 0, 10, "first"),
+                fomm.TemporalTag(sample_ids[1], 10, 20, "second"),
+            ],
+        )
+
+        dataset_name = dataset.name
+        dataset_id = dataset._doc.id
+
+        foo.delete_dataset(dataset_name, dry_run=True)
+
+        self.assertIn(dataset_name, fo.list_datasets())
+        self.assertEqual(_temporal_tag_count(dataset_id), 2)
+
+        foo.delete_dataset(dataset_name)
+
+        self.assertNotIn(dataset_name, fo.list_datasets())
+        self.assertEqual(_temporal_tag_count(dataset_id), 0)
+
+    @drop_temporal_tags
+    @drop_datasets
+    def test_drop_orphan_temporal_tags(self):
+        orphan_dataset, orphan_sample_ids = _make_dataset(1)
+        active_dataset, active_sample_ids = _make_dataset(1)
+        orphan_sample_collection_name = orphan_dataset._sample_collection_name
+        self.addCleanup(foo.drop_collection, orphan_sample_collection_name)
+        self.addCleanup(
+            foo.drop_collection, "frames." + orphan_sample_collection_name
+        )
+
+        fomm.add_temporal_tags(
+            orphan_dataset,
+            fomm.TemporalTag(orphan_sample_ids[0], 0, 10, "orphan"),
+        )
+        fomm.add_temporal_tags(
+            active_dataset,
+            fomm.TemporalTag(active_sample_ids[0], 0, 10, "active"),
+        )
+
+        orphan_dataset_id = orphan_dataset._doc.id
+        active_dataset_id = active_dataset._doc.id
+        foo.get_db_conn().datasets.delete_one({"_id": orphan_dataset_id})
+
+        foo.drop_orphan_temporal_tags(dry_run=True)
+
+        self.assertEqual(_temporal_tag_count(orphan_dataset_id), 1)
+        self.assertEqual(_temporal_tag_count(active_dataset_id), 1)
+
+        foo.drop_orphan_temporal_tags()
+
+        self.assertEqual(_temporal_tag_count(orphan_dataset_id), 0)
+        self.assertEqual(_temporal_tag_count(active_dataset_id), 1)
+
+
+def _make_dataset(num_samples=1):
+    dataset = fo.Dataset()
+    samples = [
+        fo.Sample(filepath="/tmp/multimodal-temporal-tag-%d.jpg" % idx)
+        for idx in range(num_samples)
+    ]
+    dataset.add_samples(samples)
+
+    return dataset, [str(sample.id) for sample in samples]
+
+
+def _temporal_tag_count(dataset_id):
+    return foo.get_db_conn()[TEMPORAL_TAGS_COLLECTION_NAME].count_documents(
+        {"_dataset_id": dataset_id}
+    )
+
+
+def _temporal_tag_count_for_sample(dataset_id, sample_id):
+    return foo.get_db_conn()[TEMPORAL_TAGS_COLLECTION_NAME].count_documents(
+        {"_dataset_id": dataset_id, "_sample_id": ObjectId(sample_id)}
+    )

--- a/tests/unittests/multimodal/temporal_tags_tests.py
+++ b/tests/unittests/multimodal/temporal_tags_tests.py
@@ -46,6 +46,9 @@ class TemporalTagTests(unittest.TestCase):
             persisted[0].index_type,
             TimeTrackType.TIME_TRACK_TYPE_DURATION_NS,
         )
+        self.assertIsNone(persisted[0].anchor)
+        self.assertNotIn("anchor", persisted[0].to_dict())
+        self.assertEqual(persisted[0].copy(), persisted[0])
 
         temporal_tags = fomm.TemporalTags(dataset)
         self.assertTrue(temporal_tags)
@@ -67,6 +70,10 @@ class TemporalTagTests(unittest.TestCase):
             fomm.TemporalTag(sample_id, 2, 1, "backwards"),
             fomm.TemporalTag(sample_id, 0.5, 1, "fractional"),
             fomm.TemporalTag(sample_id, 0, 1, ""),
+            fomm.TemporalTag(sample_id, 0, 1, "empty-anchor", anchor=""),
+            fomm.TemporalTag(sample_id, 0, 1, "blank-anchor", anchor="   "),
+            fomm.TemporalTag(sample_id, 0, 1, "bad-anchor", anchor=3),
+            fomm.TemporalTag(sample_id, 0, 1, "bool-anchor", anchor=False),
             fomm.TemporalTag(
                 sample_id,
                 0,
@@ -169,6 +176,92 @@ class TemporalTagTests(unittest.TestCase):
 
     @drop_temporal_tags
     @drop_datasets
+    def test_anchor_identity_filtering_counts_and_deletion(self):
+        dataset, sample_ids = _make_dataset()
+        sample_id = sample_ids[0]
+
+        unanchored = fomm.TemporalTag(sample_id, 0, 10, "review")
+        camera = fomm.TemporalTag(
+            sample_id, 0, 10, "review", anchor="camera_front"
+        )
+        lidar = fomm.TemporalTag(
+            sample_id, 0, 10, "review", anchor="lidar_top"
+        )
+
+        inserted = fomm.add_temporal_tags(dataset, [unanchored, camera, lidar])
+        repeated = fomm.add_temporal_tags(dataset, camera)
+
+        self.assertEqual(len(inserted), 3)
+        self.assertEqual(inserted[1].id, repeated[0].id)
+        self.assertEqual(
+            [tag.anchor for tag in inserted],
+            [None, "camera_front", "lidar_top"],
+        )
+        self.assertEqual(inserted[1].to_dict()["anchor"], "camera_front")
+        self.assertEqual(fomm.count_temporal_tags(dataset), {"review": 3})
+        self.assertEqual(
+            fomm.count_temporal_tags(
+                dataset, fomm.TemporalTagFilter(anchors="camera_front")
+            ),
+            {"review": 1},
+        )
+
+        anchored_tags = fomm.list_temporal_tags(
+            dataset,
+            fomm.TemporalTagFilter(anchors=["camera_front", "lidar_top"]),
+        )
+        self.assertEqual(
+            {tag.anchor for tag in anchored_tags},
+            {"camera_front", "lidar_top"},
+        )
+
+        self.assertEqual(
+            fomm.delete_temporal_tags(
+                dataset,
+                filter=fomm.TemporalTagFilter(anchors="camera_front"),
+            ),
+            1,
+        )
+        self.assertEqual(fomm.count_temporal_tags(dataset), {"review": 2})
+        self.assertEqual(
+            fomm.list_temporal_tags(
+                dataset, fomm.TemporalTagFilter(anchors="camera_front")
+            ),
+            [],
+        )
+
+    @drop_temporal_tags
+    @drop_datasets
+    def test_replaces_legacy_unique_index(self):
+        collection = foo.get_db_conn()[TEMPORAL_TAGS_COLLECTION_NAME]
+        collection.create_index(
+            [
+                ("_dataset_id", 1),
+                ("_sample_id", 1),
+                ("index_type", 1),
+                ("start", 1),
+                ("end", 1),
+                ("tag", 1),
+            ],
+            unique=True,
+            name="unique_temporal_tag",
+        )
+
+        dataset, sample_ids = _make_dataset()
+        fomm.add_temporal_tags(
+            dataset,
+            fomm.TemporalTag(
+                sample_ids[0], 0, 10, "review", anchor="camera_front"
+            ),
+        )
+
+        index_keys = collection.index_information()["unique_temporal_tag"][
+            "key"
+        ]
+        self.assertIn(("anchor", 1), index_keys)
+
+    @drop_temporal_tags
+    @drop_datasets
     def test_view_scoped_operations(self):
         dataset, sample_ids = _make_dataset(3)
         fomm.add_temporal_tags(
@@ -256,8 +349,12 @@ class TemporalTagTests(unittest.TestCase):
         fomm.add_temporal_tags(
             dataset,
             [
-                fomm.TemporalTag(sample_ids[0], 0, 10, "first"),
-                fomm.TemporalTag(sample_ids[1], 10, 20, "second"),
+                fomm.TemporalTag(
+                    sample_ids[0], 0, 10, "first", anchor="camera_front"
+                ),
+                fomm.TemporalTag(
+                    sample_ids[1], 10, 20, "second", anchor="lidar_top"
+                ),
                 fomm.TemporalTag(sample_ids[2], 20, 30, "third"),
             ],
         )
@@ -282,18 +379,27 @@ class TemporalTagTests(unittest.TestCase):
         fomm.add_temporal_tags(
             dataset,
             [
-                fomm.TemporalTag(sample_ids[0], 0, 10, "first"),
+                fomm.TemporalTag(
+                    sample_ids[0], 0, 10, "first", anchor="camera_front"
+                ),
                 fomm.TemporalTag(sample_ids[1], 10, 20, "second"),
             ],
         )
 
         full_clone = dataset.clone()
         self.assertEqual(len(fomm.list_temporal_tags(full_clone)), 2)
+        self.assertEqual(
+            fomm.count_temporal_tags(
+                full_clone, fomm.TemporalTagFilter(anchors="camera_front")
+            ),
+            {"first": 1},
+        )
 
         view_clone = dataset.select([sample_ids[0]]).clone()
         view_clone_tags = fomm.list_temporal_tags(view_clone)
         self.assertEqual(len(view_clone_tags), 1)
         self.assertEqual(view_clone_tags[0].sample_id, sample_ids[0])
+        self.assertEqual(view_clone_tags[0].anchor, "camera_front")
 
         dataset_id = dataset._doc.id
         self.assertEqual(_temporal_tag_count(dataset_id), 2)
@@ -309,7 +415,9 @@ class TemporalTagTests(unittest.TestCase):
         fomm.add_temporal_tags(
             dataset,
             [
-                fomm.TemporalTag(sample_ids[0], 0, 10, "first"),
+                fomm.TemporalTag(
+                    sample_ids[0], 0, 10, "first", anchor="camera_front"
+                ),
                 fomm.TemporalTag(sample_ids[1], 10, 20, "second"),
             ],
         )
@@ -340,11 +448,15 @@ class TemporalTagTests(unittest.TestCase):
 
         fomm.add_temporal_tags(
             orphan_dataset,
-            fomm.TemporalTag(orphan_sample_ids[0], 0, 10, "orphan"),
+            fomm.TemporalTag(
+                orphan_sample_ids[0], 0, 10, "orphan", anchor="camera_front"
+            ),
         )
         fomm.add_temporal_tags(
             active_dataset,
-            fomm.TemporalTag(active_sample_ids[0], 0, 10, "active"),
+            fomm.TemporalTag(
+                active_sample_ids[0], 0, 10, "active", anchor="lidar_top"
+            ),
         )
 
         orphan_dataset_id = orphan_dataset._doc.id

--- a/tests/unittests/multimodal/temporal_tags_tests.py
+++ b/tests/unittests/multimodal/temporal_tags_tests.py
@@ -262,6 +262,38 @@ class TemporalTagTests(unittest.TestCase):
 
     @drop_temporal_tags
     @drop_datasets
+    def test_creates_query_indexes(self):
+        dataset, sample_ids = _make_dataset()
+        fomm.add_temporal_tags(
+            dataset,
+            fomm.TemporalTag(
+                sample_ids[0], 0, 10, "review", anchor="camera_front"
+            ),
+        )
+
+        collection = foo.get_db_conn()[TEMPORAL_TAGS_COLLECTION_NAME]
+        indexes = collection.index_information()
+
+        self.assertEqual(
+            indexes["temporal_tag_sample_range"]["key"][:4],
+            [
+                ("_dataset_id", 1),
+                ("_sample_id", 1),
+                ("start", 1),
+                ("end", 1),
+            ],
+        )
+        self.assertEqual(
+            indexes["temporal_tag_tag_lookup"]["key"][:3],
+            [
+                ("_dataset_id", 1),
+                ("tag", 1),
+                ("_sample_id", 1),
+            ],
+        )
+
+    @drop_temporal_tags
+    @drop_datasets
     def test_view_scoped_operations(self):
         dataset, sample_ids = _make_dataset(3)
         fomm.add_temporal_tags(

--- a/tests/unittests/server/routes/test_multimodal_temporal_tags.py
+++ b/tests/unittests/server/routes/test_multimodal_temporal_tags.py
@@ -71,6 +71,14 @@ def fixture_sample_temporal_tags_endpoint():
     )
 
 
+@pytest.fixture(name="sample_temporal_tag_endpoint")
+def fixture_sample_temporal_tag_endpoint():
+    """Returns the sample temporal tag item endpoint instance."""
+    return fomr.SampleTemporalTagEndpoint(
+        scope={"type": "http"}, receive=AsyncMock(), send=AsyncMock()
+    )
+
+
 @pytest.fixture(name="temporal_tags_endpoint")
 def fixture_temporal_tags_endpoint():
     """Returns the dataset temporal tags endpoint instance."""
@@ -87,11 +95,19 @@ def fixture_temporal_tag_counts_endpoint():
     )
 
 
-def _make_request(dataset_id, sample_id=None, query_params=None, body=None):
+def _make_request(
+    dataset_id,
+    sample_id=None,
+    temporal_tag_id=None,
+    query_params=None,
+    body=None,
+):
     request = MagicMock()
     request.path_params = {"dataset_id": dataset_id}
     if sample_id is not None:
         request.path_params["sample_id"] = sample_id
+    if temporal_tag_id is not None:
+        request.path_params["temporal_tag_id"] = temporal_tag_id
 
     request.query_params = QueryParams(query_params or {})
     payload = {} if body is None else body
@@ -223,6 +239,59 @@ class TestMultimodalTemporalTagsRoute:
         assert len(temporal_tags) == 1
         assert temporal_tags[0]["sample_id"] == sample_ids[0]
         assert temporal_tags[0]["tag"] == "clip"
+
+    @pytest.mark.asyncio
+    async def test_updates_sample_temporal_tag(
+        self,
+        sample_temporal_tag_endpoint,
+        sample_temporal_tags_endpoint,
+        dataset,
+        dataset_id,
+        sample_ids,
+    ):
+        created = fomt.add_temporal_tags(
+            dataset,
+            fomt.TemporalTag(
+                sample_ids[0], 0, 10, "review", created_by="alice"
+            ),
+        )[0]
+        before_patch = _modified_timestamps(dataset, sample_ids[0])
+
+        time.sleep(0.05)
+        request = _make_request(
+            dataset_id,
+            sample_id=sample_ids[0],
+            temporal_tag_id=created.id,
+            body={
+                "id": created.id,
+                "start": 5,
+                "end": 15,
+                "tag": "accepted",
+                "last_modified_by": "bob",
+            },
+        )
+        response = await sample_temporal_tag_endpoint.patch(request)
+        updated = _json_body(response)["temporal_tag"]
+        after_patch = _modified_timestamps(dataset, sample_ids[0])
+
+        assert updated["id"] == created.id
+        assert updated["sample_id"] == sample_ids[0]
+        assert updated["start"] == 5
+        assert updated["end"] == 15
+        assert updated["tag"] == "accepted"
+        assert updated["created_by"] == "alice"
+        assert updated["last_modified_by"] == "bob"
+        assert updated["created_at"] == created.created_at.isoformat()
+        assert (
+            updated["last_modified_at"] > created.last_modified_at.isoformat()
+        )
+        assert after_patch[0] > before_patch[0]
+        assert after_patch[1] > before_patch[1]
+
+        request = _make_request(dataset_id, sample_id=sample_ids[0])
+        response = await sample_temporal_tags_endpoint.get(request)
+
+        assert _json_body(response)["temporal_tags"] == [updated]
 
     @pytest.mark.asyncio
     async def test_lists_scene_temporal_tags_with_optional_range(
@@ -395,11 +464,17 @@ class TestMultimodalTemporalTagsRoute:
     async def test_validation_errors_return_400(
         self,
         sample_temporal_tags_endpoint,
+        sample_temporal_tag_endpoint,
         temporal_tags_endpoint,
         temporal_tag_counts_endpoint,
+        dataset,
         dataset_id,
         sample_ids,
     ):
+        temporal_tag = fomt.add_temporal_tags(
+            dataset,
+            fomt.TemporalTag(sample_ids[0], 0, 10, "review"),
+        )[0]
         cases = [
             (
                 sample_temporal_tags_endpoint.post,
@@ -477,6 +552,62 @@ class TestMultimodalTemporalTagsRoute:
                 _make_request(dataset_id, sample_id=sample_ids[0]),
             ),
             (
+                sample_temporal_tag_endpoint.patch,
+                _make_request(
+                    dataset_id,
+                    sample_id=sample_ids[0],
+                    temporal_tag_id=temporal_tag.id,
+                ),
+            ),
+            (
+                sample_temporal_tag_endpoint.patch,
+                _make_request(
+                    dataset_id,
+                    sample_id=sample_ids[0],
+                    temporal_tag_id=temporal_tag.id,
+                    body={
+                        "id": str(ObjectId()),
+                        "start": 1,
+                    },
+                ),
+            ),
+            (
+                sample_temporal_tag_endpoint.patch,
+                _make_request(
+                    dataset_id,
+                    sample_id=sample_ids[0],
+                    temporal_tag_id=temporal_tag.id,
+                    body={
+                        "sample_id": sample_ids[1],
+                        "start": 1,
+                    },
+                ),
+            ),
+            (
+                sample_temporal_tag_endpoint.patch,
+                _make_request(
+                    dataset_id,
+                    sample_id=sample_ids[0],
+                    temporal_tag_id=temporal_tag.id,
+                    body={
+                        "created_by": "alice",
+                        "start": 1,
+                    },
+                ),
+            ),
+            (
+                sample_temporal_tag_endpoint.patch,
+                _make_request(
+                    dataset_id,
+                    sample_id=sample_ids[0],
+                    temporal_tag_id=temporal_tag.id,
+                    body={
+                        "anchor": "camera_front",
+                        "start": 1,
+                    },
+                ),
+            ),
+            (
                 temporal_tags_endpoint.get,
                 _make_request(dataset_id, query_params={"start": "soon"}),
             ),
@@ -503,6 +634,41 @@ class TestMultimodalTemporalTagsRoute:
             assert exc_info.value.status_code == 400
 
     @pytest.mark.asyncio
+    async def test_temporal_tag_update_not_found_returns_404(
+        self, sample_temporal_tag_endpoint, dataset, dataset_id, sample_ids
+    ):
+        temporal_tag = fomt.add_temporal_tags(
+            dataset,
+            fomt.TemporalTag(sample_ids[0], 0, 10, "review"),
+        )[0]
+
+        cases = [
+            _make_request(
+                dataset_id,
+                sample_id=sample_ids[0],
+                temporal_tag_id=str(ObjectId()),
+                body={"start": 1},
+            ),
+            _make_request(
+                dataset_id,
+                sample_id=sample_ids[1],
+                temporal_tag_id=temporal_tag.id,
+                body={"start": 1},
+            ),
+        ]
+
+        for request in cases:
+            with pytest.raises(HTTPException) as exc_info:
+                await sample_temporal_tag_endpoint.patch(request)
+
+            assert exc_info.value.status_code == 404
+
+        persisted = fomt.list_temporal_tags(dataset)
+        assert [(tag.start, tag.end, tag.tag) for tag in persisted] == [
+            (0, 10, "review")
+        ]
+
+    @pytest.mark.asyncio
     async def test_dataset_not_found_returns_404(self, temporal_tags_endpoint):
         request = _make_request("missing-dataset")
 
@@ -521,6 +687,10 @@ class TestMultimodalTemporalTagsRoute:
         ]
 
         assert temporal_routes == [
+            (
+                "/dataset/{dataset_id}/sample/{sample_id}/multimodal/temporal-tags/{temporal_tag_id}",
+                fomr.SampleTemporalTagEndpoint,
+            ),
             (
                 "/dataset/{dataset_id}/sample/{sample_id}/multimodal/temporal-tags",
                 fomr.SampleTemporalTagsEndpoint,

--- a/tests/unittests/server/routes/test_multimodal_temporal_tags.py
+++ b/tests/unittests/server/routes/test_multimodal_temporal_tags.py
@@ -120,6 +120,7 @@ class TestMultimodalTemporalTagsRoute:
                 "end": 10,
                 "tag": "review",
                 "anchor": "camera_front",
+                "created_by": "alice",
             },
         )
 
@@ -131,6 +132,10 @@ class TestMultimodalTemporalTagsRoute:
         assert created[0]["sample_id"] == sample_ids[0]
         assert created[0]["tag"] == "review"
         assert created[0]["anchor"] == "camera_front"
+        assert created[0]["created_by"] == "alice"
+        assert created[0]["last_modified_by"] == "alice"
+        assert isinstance(created[0]["created_at"], str)
+        assert isinstance(created[0]["last_modified_at"], str)
 
         request = _make_request(
             dataset_id,
@@ -382,6 +387,19 @@ class TestMultimodalTemporalTagsRoute:
                         "start": 0,
                         "end": 10,
                         "tag": "wrong-sample",
+                    },
+                ),
+            ),
+            (
+                sample_temporal_tags_endpoint.post,
+                _make_request(
+                    dataset_id,
+                    sample_id=sample_ids[0],
+                    body={
+                        "created_at": "2026-01-01T00:00:00",
+                        "start": 0,
+                        "end": 10,
+                        "tag": "response-only-created-at",
                     },
                 ),
             ),

--- a/tests/unittests/server/routes/test_multimodal_temporal_tags.py
+++ b/tests/unittests/server/routes/test_multimodal_temporal_tags.py
@@ -6,8 +6,8 @@ Multimodal temporal tag route unit tests.
 |
 """
 
+import asyncio
 import json
-import time
 from unittest.mock import AsyncMock, MagicMock
 
 from bson import ObjectId
@@ -148,7 +148,7 @@ class TestMultimodalTemporalTagsRoute:
         sample_ids,
     ):
         before_post = _modified_timestamps(dataset, sample_ids[0])
-        time.sleep(0.05)
+        await asyncio.sleep(0.05)
 
         request = _make_request(
             dataset_id,
@@ -185,7 +185,7 @@ class TestMultimodalTemporalTagsRoute:
                 "anchor": "camera_front",
             },
         )
-        time.sleep(0.05)
+        await asyncio.sleep(0.05)
         response = await sample_temporal_tags_endpoint.get(request)
         listed = _json_body(response)["temporal_tags"]
         after_get = _modified_timestamps(dataset, sample_ids[0])
@@ -198,7 +198,7 @@ class TestMultimodalTemporalTagsRoute:
             sample_id=sample_ids[0],
             body={"ids": [created[0]["id"]]},
         )
-        time.sleep(0.05)
+        await asyncio.sleep(0.05)
         response = await sample_temporal_tags_endpoint.delete(request)
         after_delete = _modified_timestamps(dataset, sample_ids[0])
 
@@ -257,7 +257,7 @@ class TestMultimodalTemporalTagsRoute:
         )[0]
         before_patch = _modified_timestamps(dataset, sample_ids[0])
 
-        time.sleep(0.05)
+        await asyncio.sleep(0.05)
         request = _make_request(
             dataset_id,
             sample_id=sample_ids[0],
@@ -312,7 +312,7 @@ class TestMultimodalTemporalTagsRoute:
         )
 
         before_get = _dataset_last_modified_at(dataset)
-        time.sleep(0.05)
+        await asyncio.sleep(0.05)
         request = _make_request(
             dataset_id,
             query_params={"start": "5", "end": "15"},
@@ -325,7 +325,7 @@ class TestMultimodalTemporalTagsRoute:
         assert [tag["tag"] for tag in temporal_tags] == ["clip", "clip"]
         assert after_get == before_get
 
-        time.sleep(0.05)
+        await asyncio.sleep(0.05)
         request = _make_request(
             dataset_id,
             query_params={"start": "5", "end": "15"},

--- a/tests/unittests/server/routes/test_multimodal_temporal_tags.py
+++ b/tests/unittests/server/routes/test_multimodal_temporal_tags.py
@@ -1,0 +1,460 @@
+"""
+Multimodal temporal tag route unit tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+from bson import ObjectId
+import pytest
+from starlette.datastructures import QueryParams
+from starlette.exceptions import HTTPException
+
+import fiftyone as fo
+import fiftyone.core.odm as foo
+import fiftyone.multimodal.server.routes as fomr
+import fiftyone.multimodal.tags as fomt
+
+
+@pytest.fixture(autouse=True)
+def clean_temporal_tags():
+    """Ensures each test starts with an empty temporal tag collection."""
+    foo.get_db_conn().drop_collection(fomt.TEMPORAL_TAGS_COLLECTION_NAME)
+
+    yield
+
+    foo.get_db_conn().drop_collection(fomt.TEMPORAL_TAGS_COLLECTION_NAME)
+
+
+@pytest.fixture(name="dataset")
+def fixture_dataset():
+    """Creates a dataset with a few multimodal samples."""
+    dataset = fo.Dataset()
+    dataset.add_samples(
+        [
+            fo.Sample(filepath="/tmp/temporal-tags-1.mp4"),
+            fo.Sample(filepath="/tmp/temporal-tags-2.mp4"),
+            fo.Sample(filepath="/tmp/temporal-tags-3.mp4"),
+        ]
+    )
+
+    try:
+        yield dataset
+    finally:
+        if fo.dataset_exists(dataset.name):
+            fo.delete_dataset(dataset.name)
+
+
+@pytest.fixture(name="dataset_id")
+def fixture_dataset_id(dataset):
+    """Returns the dataset ID as it appears in route paths."""
+    # pylint: disable-next=protected-access
+    return str(dataset._doc.id)
+
+
+@pytest.fixture(name="sample_ids")
+def fixture_sample_ids(dataset):
+    """Returns sample IDs in deterministic insertion order."""
+    return [str(sample.id) for sample in dataset.iter_samples()]
+
+
+@pytest.fixture(name="sample_temporal_tags_endpoint")
+def fixture_sample_temporal_tags_endpoint():
+    """Returns the sample temporal tags endpoint instance."""
+    return fomr.SampleTemporalTagsEndpoint(
+        scope={"type": "http"}, receive=AsyncMock(), send=AsyncMock()
+    )
+
+
+@pytest.fixture(name="temporal_tags_endpoint")
+def fixture_temporal_tags_endpoint():
+    """Returns the dataset temporal tags endpoint instance."""
+    return fomr.TemporalTagsEndpoint(
+        scope={"type": "http"}, receive=AsyncMock(), send=AsyncMock()
+    )
+
+
+@pytest.fixture(name="temporal_tag_counts_endpoint")
+def fixture_temporal_tag_counts_endpoint():
+    """Returns the temporal tag counts endpoint instance."""
+    return fomr.TemporalTagCountsEndpoint(
+        scope={"type": "http"}, receive=AsyncMock(), send=AsyncMock()
+    )
+
+
+def _make_request(dataset_id, sample_id=None, query_params=None, body=None):
+    request = MagicMock()
+    request.path_params = {"dataset_id": dataset_id}
+    if sample_id is not None:
+        request.path_params["sample_id"] = sample_id
+
+    request.query_params = QueryParams(query_params or {})
+    payload = {} if body is None else body
+    request.body = AsyncMock(return_value=json.dumps(payload).encode())
+    return request
+
+
+def _json_body(response):
+    return json.loads(response.body.decode("utf-8"))
+
+
+class TestMultimodalTemporalTagsRoute:
+    """Tests for the multimodal temporal tag collection route."""
+
+    @pytest.mark.asyncio
+    async def test_sample_scoped_create_list_and_delete_temporal_tags(
+        self,
+        sample_temporal_tags_endpoint,
+        dataset_id,
+        sample_ids,
+    ):
+        request = _make_request(
+            dataset_id,
+            sample_id=sample_ids[0],
+            body={
+                "start": 0,
+                "end": 10,
+                "tag": "review",
+                "anchor": "camera_front",
+            },
+        )
+
+        response = await sample_temporal_tags_endpoint.post(request)
+        created = _json_body(response)["temporal_tags"]
+
+        assert len(created) == 1
+        assert created[0]["id"]
+        assert created[0]["sample_id"] == sample_ids[0]
+        assert created[0]["tag"] == "review"
+        assert created[0]["anchor"] == "camera_front"
+
+        request = _make_request(
+            dataset_id,
+            sample_id=sample_ids[0],
+            query_params={
+                "anchor": "camera_front",
+            },
+        )
+        response = await sample_temporal_tags_endpoint.get(request)
+        listed = _json_body(response)["temporal_tags"]
+
+        assert listed == created
+
+        request = _make_request(
+            dataset_id,
+            sample_id=sample_ids[0],
+            body={"ids": [created[0]["id"]]},
+        )
+        response = await sample_temporal_tags_endpoint.delete(request)
+
+        assert _json_body(response) == {"deleted": 1}
+
+        request = _make_request(dataset_id, sample_id=sample_ids[0])
+        response = await sample_temporal_tags_endpoint.get(request)
+
+        assert _json_body(response)["temporal_tags"] == []
+
+    @pytest.mark.asyncio
+    async def test_lists_sample_temporal_tags_with_optional_range(
+        self,
+        sample_temporal_tags_endpoint,
+        dataset,
+        dataset_id,
+        sample_ids,
+    ):
+        fomt.add_temporal_tags(
+            dataset,
+            [
+                fomt.TemporalTag(sample_ids[0], 0, 10, "clip"),
+                fomt.TemporalTag(sample_ids[0], 30, 40, "outside"),
+                fomt.TemporalTag(sample_ids[1], 5, 15, "other-sample"),
+            ],
+        )
+
+        request = _make_request(
+            dataset_id,
+            sample_id=sample_ids[0],
+            query_params={"start": "5", "end": "15"},
+        )
+        response = await sample_temporal_tags_endpoint.get(request)
+        temporal_tags = _json_body(response)["temporal_tags"]
+
+        assert len(temporal_tags) == 1
+        assert temporal_tags[0]["sample_id"] == sample_ids[0]
+        assert temporal_tags[0]["tag"] == "clip"
+
+    @pytest.mark.asyncio
+    async def test_lists_scene_temporal_tags_with_optional_range(
+        self,
+        temporal_tags_endpoint,
+        temporal_tag_counts_endpoint,
+        dataset,
+        dataset_id,
+        sample_ids,
+    ):
+        fomt.add_temporal_tags(
+            dataset,
+            [
+                fomt.TemporalTag(sample_ids[0], 0, 10, "clip"),
+                fomt.TemporalTag(sample_ids[1], 10, 20, "clip"),
+                fomt.TemporalTag(sample_ids[2], 30, 40, "outside"),
+            ],
+        )
+
+        request = _make_request(
+            dataset_id,
+            query_params={"start": "5", "end": "15"},
+        )
+        response = await temporal_tags_endpoint.get(request)
+        temporal_tags = _json_body(response)["temporal_tags"]
+
+        assert [tag["sample_id"] for tag in temporal_tags] == sample_ids[:2]
+        assert [tag["tag"] for tag in temporal_tags] == ["clip", "clip"]
+
+        request = _make_request(
+            dataset_id,
+            query_params={"start": "5", "end": "15"},
+        )
+        response = await temporal_tag_counts_endpoint.get(request)
+
+        assert _json_body(response)["counts"] == {"clip": 2}
+
+    @pytest.mark.asyncio
+    async def test_lists_tag_hits_across_samples_and_counts_all_tags(
+        self,
+        temporal_tags_endpoint,
+        temporal_tag_counts_endpoint,
+        dataset,
+        dataset_id,
+        sample_ids,
+    ):
+        fomt.add_temporal_tags(
+            dataset,
+            [
+                fomt.TemporalTag(sample_ids[0], 0, 10, "candidate"),
+                fomt.TemporalTag(sample_ids[1], 10, 20, "candidate"),
+                fomt.TemporalTag(sample_ids[2], 20, 30, "review"),
+                fomt.TemporalTag(sample_ids[2], 30, 40, "other"),
+            ],
+        )
+
+        request = _make_request(
+            dataset_id,
+            query_params={"tags": "candidate,review"},
+        )
+        response = await temporal_tags_endpoint.get(request)
+        temporal_tags = _json_body(response)["temporal_tags"]
+
+        assert [
+            (tag["sample_id"], tag["start"], tag["end"], tag["tag"])
+            for tag in temporal_tags
+        ] == [
+            (sample_ids[0], 0, 10, "candidate"),
+            (sample_ids[1], 10, 20, "candidate"),
+            (sample_ids[2], 20, 30, "review"),
+        ]
+
+        request = _make_request(dataset_id)
+        response = await temporal_tag_counts_endpoint.get(request)
+
+        assert _json_body(response)["counts"] == {
+            "candidate": 2,
+            "other": 1,
+            "review": 1,
+        }
+
+    @pytest.mark.asyncio
+    async def test_bulk_create_and_delete_by_filter(
+        self, sample_temporal_tags_endpoint, dataset_id, sample_ids
+    ):
+        request = _make_request(
+            dataset_id,
+            sample_id=sample_ids[0],
+            body={
+                "temporal_tags": [
+                    {
+                        "start": 0,
+                        "end": 10,
+                        "tag": "candidate",
+                        "anchor": "camera_front",
+                    },
+                    {
+                        "start": 0,
+                        "end": 10,
+                        "tag": "candidate",
+                        "anchor": "camera_rear",
+                    },
+                ]
+            },
+        )
+
+        response = await sample_temporal_tags_endpoint.post(request)
+
+        assert len(_json_body(response)["temporal_tags"]) == 2
+
+        request = _make_request(
+            dataset_id,
+            sample_id=sample_ids[0],
+            body={
+                "filter": {
+                    "anchors": "camera_front",
+                }
+            },
+        )
+        response = await sample_temporal_tags_endpoint.delete(request)
+
+        assert _json_body(response) == {"deleted": 1}
+
+        request = _make_request(dataset_id, sample_id=sample_ids[0])
+        response = await sample_temporal_tags_endpoint.get(request)
+        remaining = _json_body(response)["temporal_tags"]
+
+        assert len(remaining) == 1
+        assert remaining[0]["sample_id"] == sample_ids[0]
+        assert remaining[0]["anchor"] == "camera_rear"
+
+    @pytest.mark.asyncio
+    async def test_validation_errors_return_400(
+        self,
+        sample_temporal_tags_endpoint,
+        temporal_tags_endpoint,
+        temporal_tag_counts_endpoint,
+        dataset_id,
+        sample_ids,
+    ):
+        cases = [
+            (
+                sample_temporal_tags_endpoint.post,
+                _make_request(
+                    dataset_id,
+                    sample_id=sample_ids[0],
+                    body={"temporal_tags": []},
+                ),
+            ),
+            (
+                sample_temporal_tags_endpoint.post,
+                _make_request(
+                    dataset_id,
+                    sample_id=str(ObjectId()),
+                    body={
+                        "start": 0,
+                        "end": 10,
+                        "tag": "missing-sample",
+                    },
+                ),
+            ),
+            (
+                sample_temporal_tags_endpoint.post,
+                _make_request(
+                    dataset_id,
+                    sample_id=sample_ids[0],
+                    body={
+                        "start": 10,
+                        "end": 10,
+                        "tag": "bad-range",
+                    },
+                ),
+            ),
+            (
+                sample_temporal_tags_endpoint.post,
+                _make_request(
+                    dataset_id,
+                    sample_id=sample_ids[0],
+                    body={
+                        "index_type": 0,
+                        "start": 0,
+                        "end": 10,
+                        "tag": "bad-index-type",
+                    },
+                ),
+            ),
+            (
+                sample_temporal_tags_endpoint.post,
+                _make_request(
+                    dataset_id,
+                    sample_id=sample_ids[0],
+                    body={
+                        "sample_id": sample_ids[1],
+                        "start": 0,
+                        "end": 10,
+                        "tag": "wrong-sample",
+                    },
+                ),
+            ),
+            (
+                sample_temporal_tags_endpoint.delete,
+                _make_request(dataset_id, sample_id=sample_ids[0]),
+            ),
+            (
+                temporal_tags_endpoint.get,
+                _make_request(dataset_id, query_params={"start": "soon"}),
+            ),
+            (
+                sample_temporal_tags_endpoint.get,
+                _make_request(
+                    dataset_id,
+                    sample_id=sample_ids[0],
+                    query_params={"sample_id": sample_ids[1]},
+                ),
+            ),
+            (
+                temporal_tag_counts_endpoint.get,
+                _make_request(
+                    dataset_id, query_params={"sample_id": sample_ids[0]}
+                ),
+            ),
+        ]
+
+        for endpoint, request in cases:
+            with pytest.raises(HTTPException) as exc_info:
+                await endpoint(request)
+
+            assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_dataset_not_found_returns_404(self, temporal_tags_endpoint):
+        request = _make_request("missing-dataset")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await temporal_tags_endpoint.get(request)
+
+        assert exc_info.value.status_code == 404
+        assert "Dataset 'missing-dataset' not found" in exc_info.value.detail
+
+    def test_multimodal_routes_register_temporal_tag_endpoints(self):
+        routes = dict(fomr.MultimodalRoutes)
+        temporal_routes = [
+            (path, endpoint)
+            for path, endpoint in fomr.MultimodalRoutes
+            if "temporal-tags" in path
+        ]
+
+        assert temporal_routes == [
+            (
+                "/dataset/{dataset_id}/sample/{sample_id}/multimodal/temporal-tags",
+                fomr.SampleTemporalTagsEndpoint,
+            ),
+            (
+                "/dataset/{dataset_id}/multimodal/temporal-tags/counts",
+                fomr.TemporalTagCountsEndpoint,
+            ),
+            (
+                "/dataset/{dataset_id}/multimodal/temporal-tags",
+                fomr.TemporalTagsEndpoint,
+            ),
+        ]
+        assert (
+            routes["/dataset/{dataset_id}/multimodal/temporal-tags"]
+            is fomr.TemporalTagsEndpoint
+        )
+        assert (
+            routes["/dataset/{dataset_id}/multimodal/temporal-tags/counts"]
+            is fomr.TemporalTagCountsEndpoint
+        )
+        assert not hasattr(fomr.TemporalTagsEndpoint, "post")
+        assert not hasattr(fomr.TemporalTagsEndpoint, "delete")
+        assert not hasattr(fomr.TemporalTagCountsEndpoint, "post")

--- a/tests/unittests/server/routes/test_multimodal_temporal_tags.py
+++ b/tests/unittests/server/routes/test_multimodal_temporal_tags.py
@@ -7,6 +7,7 @@ Multimodal temporal tag route unit tests.
 """
 
 import json
+import time
 from unittest.mock import AsyncMock, MagicMock
 
 from bson import ObjectId
@@ -102,6 +103,23 @@ def _json_body(response):
     return json.loads(response.body.decode("utf-8"))
 
 
+def _modified_timestamps(dataset, sample_id):
+    dataset.reload()
+    dataset_doc = foo.get_db_conn().datasets.find_one({"_id": dataset._doc.id})
+    sample_doc = dataset._sample_collection.find_one(
+        {"_id": ObjectId(sample_id)}
+    )
+
+    return dataset_doc["last_modified_at"], sample_doc["last_modified_at"]
+
+
+def _dataset_last_modified_at(dataset):
+    dataset.reload()
+    dataset_doc = foo.get_db_conn().datasets.find_one({"_id": dataset._doc.id})
+
+    return dataset_doc["last_modified_at"]
+
+
 class TestMultimodalTemporalTagsRoute:
     """Tests for the multimodal temporal tag collection route."""
 
@@ -109,9 +127,13 @@ class TestMultimodalTemporalTagsRoute:
     async def test_sample_scoped_create_list_and_delete_temporal_tags(
         self,
         sample_temporal_tags_endpoint,
+        dataset,
         dataset_id,
         sample_ids,
     ):
+        before_post = _modified_timestamps(dataset, sample_ids[0])
+        time.sleep(0.05)
+
         request = _make_request(
             dataset_id,
             sample_id=sample_ids[0],
@@ -126,6 +148,7 @@ class TestMultimodalTemporalTagsRoute:
 
         response = await sample_temporal_tags_endpoint.post(request)
         created = _json_body(response)["temporal_tags"]
+        after_post = _modified_timestamps(dataset, sample_ids[0])
 
         assert len(created) == 1
         assert created[0]["id"]
@@ -136,6 +159,8 @@ class TestMultimodalTemporalTagsRoute:
         assert created[0]["last_modified_by"] == "alice"
         assert isinstance(created[0]["created_at"], str)
         assert isinstance(created[0]["last_modified_at"], str)
+        assert after_post[0] > before_post[0]
+        assert after_post[1] > before_post[1]
 
         request = _make_request(
             dataset_id,
@@ -144,19 +169,26 @@ class TestMultimodalTemporalTagsRoute:
                 "anchor": "camera_front",
             },
         )
+        time.sleep(0.05)
         response = await sample_temporal_tags_endpoint.get(request)
         listed = _json_body(response)["temporal_tags"]
+        after_get = _modified_timestamps(dataset, sample_ids[0])
 
         assert listed == created
+        assert after_get == after_post
 
         request = _make_request(
             dataset_id,
             sample_id=sample_ids[0],
             body={"ids": [created[0]["id"]]},
         )
+        time.sleep(0.05)
         response = await sample_temporal_tags_endpoint.delete(request)
+        after_delete = _modified_timestamps(dataset, sample_ids[0])
 
         assert _json_body(response) == {"deleted": 1}
+        assert after_delete[0] > after_get[0]
+        assert after_delete[1] > after_get[1]
 
         request = _make_request(dataset_id, sample_id=sample_ids[0])
         response = await sample_temporal_tags_endpoint.get(request)
@@ -210,23 +242,30 @@ class TestMultimodalTemporalTagsRoute:
             ],
         )
 
+        before_get = _dataset_last_modified_at(dataset)
+        time.sleep(0.05)
         request = _make_request(
             dataset_id,
             query_params={"start": "5", "end": "15"},
         )
         response = await temporal_tags_endpoint.get(request)
         temporal_tags = _json_body(response)["temporal_tags"]
+        after_get = _dataset_last_modified_at(dataset)
 
         assert [tag["sample_id"] for tag in temporal_tags] == sample_ids[:2]
         assert [tag["tag"] for tag in temporal_tags] == ["clip", "clip"]
+        assert after_get == before_get
 
+        time.sleep(0.05)
         request = _make_request(
             dataset_id,
             query_params={"start": "5", "end": "15"},
         )
         response = await temporal_tag_counts_endpoint.get(request)
+        after_counts = _dataset_last_modified_at(dataset)
 
         assert _json_body(response)["counts"] == {"clip": 2}
+        assert after_counts == after_get
 
     @pytest.mark.asyncio
     async def test_lists_tag_hits_across_samples_and_counts_all_tags(
@@ -321,6 +360,36 @@ class TestMultimodalTemporalTagsRoute:
         assert len(remaining) == 1
         assert remaining[0]["sample_id"] == sample_ids[0]
         assert remaining[0]["anchor"] == "camera_rear"
+
+    @pytest.mark.asyncio
+    async def test_delete_all_is_sample_scoped(
+        self,
+        sample_temporal_tags_endpoint,
+        dataset,
+        dataset_id,
+        sample_ids,
+    ):
+        fomt.add_temporal_tags(
+            dataset,
+            [
+                fomt.TemporalTag(sample_ids[0], 0, 10, "first"),
+                fomt.TemporalTag(sample_ids[0], 10, 20, "second"),
+                fomt.TemporalTag(sample_ids[1], 0, 10, "other"),
+            ],
+        )
+
+        request = _make_request(
+            dataset_id,
+            sample_id=sample_ids[0],
+            body={"delete_all": True},
+        )
+        response = await sample_temporal_tags_endpoint.delete(request)
+
+        assert _json_body(response) == {"deleted": 2}
+        assert fomt.count_temporal_tags(dataset) == {"other": 1}
+        assert [tag.sample_id for tag in fomt.list_temporal_tags(dataset)] == [
+            sample_ids[1]
+        ]
 
     @pytest.mark.asyncio
     async def test_validation_errors_return_400(


### PR DESCRIPTION
## 🔗 Related Issues

https://voxel51.atlassian.net/browse/FOEPD-3881

## 📋 What changes are proposed in this pull request?

Adds backend support for multimodal temporal tags: sample-scoped time ranges stored in a dedicated `temporal_tags` collection.

This includes:

- SDK helpers under `fiftyone.multimodal`: `add_temporal_tags`, `list_temporal_tags`, `update_temporal_tag`, `delete_temporal_tags`, and `count_temporal_tags`
- `dataset.temporal_tags` / `view.temporal_tags` convenience accessors
- `dataset.match_temporal_tags(...)` / `view.match_temporal_tags(...)` for creating views from temporal tag matches
- A small `TemporalTags` collection facade with view-scoped behavior
- Optional `anchor` support for qualifying the reference frame/context of `start` and `end`
- Optional provenance fields: `created_by`, `last_modified_by`, `created_at`, and `last_modified_at`
- Import/export support through `temporal_tags.json`
- Dataset/sample lifecycle cleanup, clone support, orphan cleanup, and query indexes
- JSON routes for sample-scoped CRUD/update and dataset-scoped reads/counts

Minimal local SDK smoke test:

```python
import os
import tempfile

import fiftyone as fo
import fiftyone.multimodal as fomm

tmpdir = tempfile.mkdtemp()
mcap_path = os.path.join(tmpdir, "example.mcap")

with open(mcap_path, "wb") as f:
    f.write(b"\x89MCAP\r\n")

dataset = fo.Dataset(name="temporal-tags-mcap-smoke-test")

try:
    sample = fo.Sample(filepath=mcap_path)
    dataset.add_sample(sample)

    tag = dataset.temporal_tags.add(
        fomm.TemporalTag(
            sample_id=sample.id,
            start=0,
            end=5_000_000_000,
            tag="interesting-window",
            anchor="lidar_top",
            created_by="local-smoke",
        )
    )[0]

    dataset.temporal_tags.update(
        tag.id,
        end=6_000_000_000,
        tag="reviewed-window",
        last_modified_by="local-smoke",
    )

    view = dataset.match_temporal_tags(tags="reviewed-window")

    for tag in view.temporal_tags.values():
        print(tag.to_dict())

    print(dataset.temporal_tags.count())
finally:
    dataset.delete()
```

## 🧪 How is this patch tested? If it is not, please explain why.

Unit tests.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Adds multimodal temporal tags for annotating time ranges on samples, including SDK helpers, view matching, update support, import/export persistence, anchors, and provenance metadata.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive temporal tagging system for multimodal samples with full lifecycle support.
  * New APIs for adding, updating, deleting, listing, and counting temporal tags on datasets and samples.
  * Added temporal tag filtering and matching capabilities to query datasets by temporal properties.
  * Temporal tags now automatically persist across dataset import/export operations.
  * New HTTP endpoints for managing temporal tags via the multimodal server.

* **Bug Fixes**
  * Ensured orphaned temporal tags are properly cleaned up during dataset deletion and clearing operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7644?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->