### PR TITLE
feat: 3D bounding boxes in the lidar tile (Foxglove SceneUpdate + TF tree)

### DIFF
--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/frame-transform.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/frame-transform.ts
@@ -1,0 +1,81 @@
+import {
+  type Decoder,
+  type FrameTransformVisualization,
+  type Quat,
+  type Vec3,
+} from "../../../../decoders";
+import { VISUALIZATION_KIND } from "../../../../visualization";
+import { decodeProtobufMessage } from "./protobuf";
+import { FOXGLOVE_FRAME_TRANSFORM_PAYLOAD } from "./protobuf/payloads";
+import { optionalRecord, optionalString } from "./protobuf/records";
+import { timestampNs, timingFromContext } from "./protobuf/timing";
+
+/**
+ * Decoder for Foxglove FrameTransform protobuf messages. Emits the
+ * structured transform as a visualization payload so the TF tree
+ * consumer can typed-access it without re-decoding.
+ */
+export const foxgloveFrameTransformDecoder: Decoder = {
+  id: "foxglove.frame-transform",
+  payload: FOXGLOVE_FRAME_TRANSFORM_PAYLOAD,
+  version: "1",
+
+  decode(bytes, context) {
+    const message = decodeProtobufMessage(
+      bytes,
+      FOXGLOVE_FRAME_TRANSFORM_PAYLOAD,
+      context
+    );
+
+    const parentFrameId =
+      optionalString(message, "parentFrameId", "parent_frame_id") ?? "";
+    const childFrameId =
+      optionalString(message, "childFrameId", "child_frame_id") ?? "";
+    const ts = optionalRecord(message, "timestamp");
+    const tsNs = ts ? timestampNs(ts) : undefined;
+    const translation = decodeVec3(optionalRecord(message, "translation"));
+    const rotation = decodeQuat(optionalRecord(message, "rotation"));
+
+    const visualization: FrameTransformVisualization = {
+      kind: VISUALIZATION_KIND.FRAME_TRANSFORM,
+      parentFrameId,
+      childFrameId,
+      timestampNs: tsNs ?? 0n,
+      translation,
+      rotation,
+    };
+
+    return {
+      attributes: { parent: parentFrameId, child: childFrameId },
+      resourceHints: { sizeBytes: bytes.byteLength },
+      timing: timingFromContext(context, tsNs),
+      visualization,
+    };
+  },
+};
+
+function decodeVec3(record: Record<string, unknown> | undefined): Vec3 {
+  if (!record) return [0, 0, 0];
+  return [num(record, "x"), num(record, "y"), num(record, "z")];
+}
+
+function decodeQuat(record: Record<string, unknown> | undefined): Quat {
+  if (!record) return [0, 0, 0, 1];
+  return [
+    num(record, "x"),
+    num(record, "y"),
+    num(record, "z"),
+    num(record, "w", 1),
+  ];
+}
+
+function num(
+  record: Record<string, unknown>,
+  field: string,
+  defaultValue = 0
+): number {
+  const value = record[field];
+  if (typeof value === "number") return value;
+  if (typeof value === "bigint") return Number(value);
+  return defaultValue;
+}

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/index.ts
@@ -1,28 +1,23 @@
 import type { Decoder } from "../../../../decoders";
 import { foxgloveCompressedImageDecoder } from "./compressed-image";
+import { foxgloveFrameTransformDecoder } from "./frame-transform";
 import { foxgloveImageAnnotationsDecoder } from "./image-annotations";
 import { foxglovePointCloudDecoder } from "./point-cloud";
+import { foxgloveSceneUpdateDecoder } from "./scene-update";
 
-/**
- * Foxglove compressed image decoder export.
- */
 export { foxgloveCompressedImageDecoder } from "./compressed-image";
-
-/**
- * Foxglove image annotations decoder export.
- */
+export { foxgloveFrameTransformDecoder } from "./frame-transform";
 export { foxgloveImageAnnotationsDecoder } from "./image-annotations";
-
-/**
- * Foxglove point cloud decoder export.
- */
 export { foxglovePointCloudDecoder } from "./point-cloud";
+export { foxgloveSceneUpdateDecoder } from "./scene-update";
 
 /**
  * Built-in Foxglove decoders for the MCAP adapter.
  */
 export const foxgloveDecoders: readonly Decoder[] = [
   foxgloveCompressedImageDecoder,
+  foxgloveFrameTransformDecoder,
   foxgloveImageAnnotationsDecoder,
   foxglovePointCloudDecoder,
+  foxgloveSceneUpdateDecoder,
 ];

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/protobuf/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/protobuf/payloads.ts
@@ -29,3 +29,21 @@ export const FOXGLOVE_IMAGE_ANNOTATIONS_PAYLOAD: PayloadDescriptor = {
   schema: "foxglove.ImageAnnotations",
   schemaEncoding: "protobuf",
 };
+
+/**
+ * Payload identity for foxglove.SceneUpdate messages.
+ */
+export const FOXGLOVE_SCENE_UPDATE_PAYLOAD: PayloadDescriptor = {
+  encoding: "protobuf",
+  schema: "foxglove.SceneUpdate",
+  schemaEncoding: "protobuf",
+};
+
+/**
+ * Payload identity for foxglove.FrameTransform messages.
+ */
+export const FOXGLOVE_FRAME_TRANSFORM_PAYLOAD: PayloadDescriptor = {
+  encoding: "protobuf",
+  schema: "foxglove.FrameTransform",
+  schemaEncoding: "protobuf",
+};

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/scene-update.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/scene-update.ts
@@ -1,0 +1,155 @@
+import {
+  type DecodedAttributeValue,
+  type Decoder,
+  type Quat,
+  type RgbaColor,
+  type SceneUpdateCube,
+  type SceneUpdateEntity,
+  type SceneUpdateVisualization,
+  type Vec3,
+} from "../../../../decoders";
+import { VISUALIZATION_KIND } from "../../../../visualization";
+import { decodeProtobufMessage } from "./protobuf";
+import { FOXGLOVE_SCENE_UPDATE_PAYLOAD } from "./protobuf/payloads";
+import {
+  asRecord,
+  optionalRecord,
+  optionalString,
+} from "./protobuf/records";
+import { timingFromContext, timestampNs } from "./protobuf/timing";
+
+/**
+ * Decoder for Foxglove SceneUpdate protobuf messages. Only the cube
+ * primitive is surfaced today — spheres, lines, arrows, triangles,
+ * models, and texts are ignored until we render them.
+ */
+export const foxgloveSceneUpdateDecoder: Decoder = {
+  id: "foxglove.scene-update",
+  payload: FOXGLOVE_SCENE_UPDATE_PAYLOAD,
+  version: "1",
+
+  decode(bytes, context) {
+    const message = decodeProtobufMessage(
+      bytes,
+      FOXGLOVE_SCENE_UPDATE_PAYLOAD,
+      context
+    );
+
+    const rawEntities = optionalArray(message, "entities");
+    const entities = rawEntities.map(decodeEntity);
+
+    const firstEntityTs = entities[0]?.timestampNs;
+
+    const visualization: SceneUpdateVisualization = {
+      kind: VISUALIZATION_KIND.SCENE_UPDATE,
+      entities,
+    };
+
+    const attributes: Record<string, DecodedAttributeValue> = {
+      entityCount: entities.length,
+      cubeCount: entities.reduce((sum, e) => sum + e.cubes.length, 0),
+    };
+
+    return {
+      attributes,
+      resourceHints: { sizeBytes: bytes.byteLength },
+      timing: timingFromContext(context, firstEntityTs),
+      visualization,
+    };
+  },
+};
+
+function decodeEntity(value: unknown): SceneUpdateEntity {
+  const record = asRecord(value);
+  const id = optionalString(record, "id") ?? "";
+  const frameId =
+    optionalString(record, "frameId", "frame_id") ?? "";
+  const timestampRaw = optionalRecord(record, "timestamp");
+  const timestampNsValue = timestampRaw ? timestampNs(timestampRaw) : undefined;
+  const cubes = optionalArray(record, "cubes").map(decodeCube);
+  const metadata = decodeMetadata(optionalArray(record, "metadata"));
+  return {
+    id,
+    frameId,
+    timestampNs: timestampNsValue ?? 0n,
+    cubes,
+    metadata,
+  };
+}
+
+function decodeCube(value: unknown): SceneUpdateCube {
+  const record = asRecord(value);
+  const pose = optionalRecord(record, "pose");
+  const position = decodeVec3(optionalRecord(pose ?? {}, "position"));
+  const orientation = decodeQuat(optionalRecord(pose ?? {}, "orientation"));
+  const size = decodeVec3(optionalRecord(record, "size"));
+  const color = decodeColor(optionalRecord(record, "color"));
+  return { position, orientation, size, color };
+}
+
+function decodeMetadata(
+  entries: readonly unknown[]
+): Readonly<Record<string, string>> {
+  const out: Record<string, string> = {};
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") continue;
+    const record = entry as Record<string, unknown>;
+    const k = record["key"];
+    const v = record["value"];
+    if (typeof k === "string" && typeof v === "string") out[k] = v;
+  }
+  return out;
+}
+
+function decodeVec3(record: Record<string, unknown> | undefined): Vec3 {
+  if (!record) return [0, 0, 0];
+  return [numberField(record, "x"), numberField(record, "y"), numberField(record, "z")];
+}
+
+function decodeQuat(record: Record<string, unknown> | undefined): Quat {
+  if (!record) return [0, 0, 0, 1];
+  return [
+    numberField(record, "x"),
+    numberField(record, "y"),
+    numberField(record, "z"),
+    numberField(record, "w", undefined, 1),
+  ];
+}
+
+function decodeColor(
+  record: Record<string, unknown> | undefined
+): RgbaColor | null {
+  if (!record) return null;
+  return [
+    numberField(record, "r"),
+    numberField(record, "g"),
+    numberField(record, "b"),
+    numberField(record, "a"),
+  ];
+}
+
+function optionalArray(
+  record: Record<string, unknown>,
+  field: string
+): readonly unknown[] {
+  const value = record[field];
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    throw new Error(`Field '${field}' is not an array`);
+  }
+  return value;
+}
+
+function numberField(
+  record: Record<string, unknown>,
+  field: string,
+  fallbackField?: string,
+  defaultValue = 0
+): number {
+  const value =
+    record[field] ?? (fallbackField ? record[fallbackField] : undefined);
+  if (typeof value === "number") return value;
+  if (typeof value === "bigint") return Number(value);
+  return defaultValue;
+}
+

--- a/app/packages/multimodal/src/adapters/mcap/react/McapCameraAnnotationOverlay.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapCameraAnnotationOverlay.tsx
@@ -1,10 +1,11 @@
 import { useSetTileSelection } from "@fiftyone/tiling";
-import React, { useCallback, useState } from "react";
+import React, { useCallback } from "react";
 
 import {
   ImageAnnotationsOverlay,
   type ImageAnnotationPickedPrimitive,
 } from "../../../visualization/panels/image-annotations-overlay";
+import { useMcapAnnotationSelection } from "./mcap-annotation-selection-context";
 import { useInterpolatedImageAnnotations } from "./use-interpolated-image-annotations";
 
 export interface McapCameraAnnotationOverlayProps {
@@ -32,7 +33,7 @@ const McapCameraAnnotationOverlay: React.FC<
 }) => {
   const frame = useInterpolatedImageAnnotations(topic, { interpolate });
   const setSelection = useSetTileSelection();
-  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const { selectedKey, setSelectedKey } = useMcapAnnotationSelection();
 
   const handleSelect = useCallback(
     (picked: ImageAnnotationPickedPrimitive) => {

--- a/app/packages/multimodal/src/adapters/mcap/react/McapCameraAnnotationOverlay.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapCameraAnnotationOverlay.tsx
@@ -1,10 +1,10 @@
 import { useSetTileSelection } from "@fiftyone/tiling";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useState } from "react";
 
 import {
   ImageAnnotationsOverlay,
   type ImageAnnotationPickedPrimitive,
-} from "../../../visualization/panels/ImageAnnotationsOverlay";
+} from "../../../visualization/panels/image-annotations-overlay";
 import { useInterpolatedImageAnnotations } from "./use-interpolated-image-annotations";
 
 export interface McapCameraAnnotationOverlayProps {
@@ -33,10 +33,6 @@ const McapCameraAnnotationOverlay: React.FC<
   const frame = useInterpolatedImageAnnotations(topic, { interpolate });
   const setSelection = useSetTileSelection();
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
-
-  useEffect(() => {
-    setSelectedKey(null);
-  }, [topic]);
 
   const handleSelect = useCallback(
     (picked: ImageAnnotationPickedPrimitive) => {

--- a/app/packages/multimodal/src/adapters/mcap/react/McapLidarBoxes.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapLidarBoxes.tsx
@@ -1,0 +1,88 @@
+import { useSetTileSelection } from "@fiftyone/tiling";
+import React, { useCallback, useState } from "react";
+
+import type { SceneUpdateVisualization } from "../../../decoders";
+import {
+  SceneUpdateBoxes,
+  type SceneUpdatePickedEntity,
+} from "../../../visualization/panels/scene-update-boxes";
+import { useMcapDataStream } from "./mcap-data-stream-context";
+import { useMcapTopicStream } from "./use-mcap-topic-stream";
+import { useMcapTfTree, useTfTransformMatrix } from "./use-tf-tree";
+
+export interface McapLidarBoxesProps {
+  /** Topic to subscribe to for scene-update messages. */
+  readonly topic: string;
+  /**
+   * The frame the surrounding 3D scene renders in. Cubes from
+   * `entity.frameId` get transformed into this frame via the TF tree.
+   */
+  readonly renderFrame: string;
+}
+
+/**
+ * Lidar tile overlay: subscribes to a `foxglove.SceneUpdate` topic,
+ * looks up the TF chain from the entity's frame to the render frame
+ * at the current playhead, and draws the cubes inside the surrounding
+ * R3F scene. Mounting kicks off the topic subscription and the
+ * one-shot `/tf` history fetch; unmounting drops both.
+ */
+const McapLidarBoxes: React.FC<McapLidarBoxesProps> = ({
+  topic,
+  renderFrame,
+}) => {
+  const frame = useMcapTopicStream<SceneUpdateVisualization>(topic);
+  const { tree, ready } = useMcapTfTree();
+  const dataStream = useMcapDataStream();
+  const timelineStartNs =
+    dataStream?.getTimelineIndex()?.startTimeNs ?? 0n;
+
+  // All entities in a single message share the same frameId in practice,
+  // but the schema doesn't promise it. We pull from the first entity and
+  // accept that mixed-frame messages won't be handled in this pass.
+  const sourceFrame = frame?.entities[0]?.frameId ?? "";
+  const matrix = useTfTransformMatrix(
+    ready ? tree : null,
+    sourceFrame,
+    renderFrame,
+    timelineStartNs
+  );
+
+  const setSelection = useSetTileSelection();
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+
+  const handleSelect = useCallback(
+    (picked: SceneUpdatePickedEntity) => {
+      setSelectedKey(picked.key);
+      setSelection({
+        kind: "scene-annotation",
+        topic,
+        entityId: picked.entityId,
+        cubeIndex: picked.cubeIndex,
+        color: picked.color,
+        label: picked.label,
+        frameId: picked.entity.frameId,
+        metadata: picked.entity.metadata,
+        cube: picked.cube,
+      });
+    },
+    [setSelection, topic]
+  );
+
+  if (!frame) return null;
+  // Until TF is ready we'd render boxes at world origin (wrong place),
+  // which is more confusing than just waiting. Skip until we have a
+  // matrix.
+  if (sourceFrame && !matrix) return null;
+
+  return (
+    <SceneUpdateBoxes
+      visualization={frame}
+      worldMatrix={matrix ?? null}
+      selectedKey={selectedKey}
+      onSelectPrimitive={handleSelect}
+    />
+  );
+};
+
+export default McapLidarBoxes;

--- a/app/packages/multimodal/src/adapters/mcap/react/McapLidarBoxes.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapLidarBoxes.tsx
@@ -1,11 +1,12 @@
 import { useSetTileSelection } from "@fiftyone/tiling";
-import React, { useCallback, useState } from "react";
+import React, { useCallback } from "react";
 
 import type { SceneUpdateVisualization } from "../../../decoders";
 import {
   SceneUpdateBoxes,
   type SceneUpdatePickedEntity,
 } from "../../../visualization/panels/scene-update-boxes";
+import { useMcapAnnotationSelection } from "./mcap-annotation-selection-context";
 import { useMcapDataStream } from "./mcap-data-stream-context";
 import { useMcapTopicStream } from "./use-mcap-topic-stream";
 import { useMcapTfTree, useTfTransformMatrix } from "./use-tf-tree";
@@ -49,7 +50,7 @@ const McapLidarBoxes: React.FC<McapLidarBoxesProps> = ({
   );
 
   const setSelection = useSetTileSelection();
-  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const { selectedKey, setSelectedKey } = useMcapAnnotationSelection();
 
   const handleSelect = useCallback(
     (picked: SceneUpdatePickedEntity) => {

--- a/app/packages/multimodal/src/adapters/mcap/react/McapLidarTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapLidarTile.tsx
@@ -15,11 +15,17 @@ import React, { useEffect, useState } from "react";
 import type { PointCloudVisualization } from "../../../decoders";
 import { useSceneSourcesByType } from "../../../scene-inventory";
 import { PointCloudPanel } from "../../../visualization/panels/point-cloud";
+import McapLidarBoxes from "./McapLidarBoxes";
 import settingsStyles from "./McapTile.settings.module.css";
 import styles from "./McapTile.module.css";
 import { useMcapTopicStream } from "./use-mcap-topic-stream";
+import { useMcapTfTree } from "./use-tf-tree";
+
+const SCENE_ANNOTATION_TOPIC = "/markers/annotations";
 
 const McapLidarTile: React.FC = () => {
+  const [showAnnotations, setShowAnnotations] = useState(false);
+  const [tfReady, setTfReady] = useState(false);
   const lidars = useSceneSourcesByType("lidar");
   const setTileTitle = useSetTileTitle();
   // Initialize from the first available source — develop's auto-pick
@@ -43,6 +49,11 @@ const McapLidarTile: React.FC = () => {
   const frame = useMcapTopicStream<PointCloudVisualization>(topic);
   const currentLabel =
     lidars.find((l) => l.id === topic)?.label ?? "Select source";
+
+  // Use the selected lidar's frame_id as the render frame. The topic
+  // doubles as the TF frame name (`/LIDAR_TOP`-style names → frame
+  // `LIDAR_TOP`).
+  const renderFrame = topic ? topic.replace(/^\//, "") : "";
 
   return (
     <>
@@ -69,14 +80,34 @@ const McapLidarTile: React.FC = () => {
               ))}
             </Dropdown>
           </div>
-          <Checkbox label="Color by height" defaultChecked />
-          <Checkbox label="Show ground plane" />
-          <Checkbox label="Show intensity overlay" />
-          <Checkbox label="Cull behind sensor" defaultChecked />
+          <div className={settingsStyles.field}>
+            <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
+              Annotations
+            </Text>
+            <Checkbox
+              label={
+                showAnnotations && !tfReady
+                  ? "Show 3D annotations (loading…)"
+                  : "Show 3D annotations"
+              }
+              checked={showAnnotations}
+              onChange={setShowAnnotations}
+            />
+          </div>
         </div>
       </TileSettingsContent>
+      {showAnnotations ? (
+        <TfReadyReporter onReady={setTfReady} />
+      ) : null}
       {frame ? (
-        <PointCloudPanel frame={frame} className={styles.panel} />
+        <PointCloudPanel frame={frame} className={styles.panel}>
+          {showAnnotations && renderFrame ? (
+            <McapLidarBoxes
+              topic={SCENE_ANNOTATION_TOPIC}
+              renderFrame={renderFrame}
+            />
+          ) : null}
+        </PointCloudPanel>
       ) : (
         <div className={styles.loading}>
           <Spinner size={Size.Lg} />
@@ -84,6 +115,22 @@ const McapLidarTile: React.FC = () => {
       )}
     </>
   );
+};
+
+/**
+ * Headless: subscribes to the TF tree only while mounted (i.e. while
+ * the lidar annotations toggle is on), and reports ready state up so
+ * the tile can show a loading status next to the checkbox.
+ */
+const TfReadyReporter: React.FC<{ onReady: (ready: boolean) => void }> = ({
+  onReady,
+}) => {
+  const { ready } = useMcapTfTree();
+  useEffect(() => {
+    onReady(ready);
+    return () => onReady(false);
+  }, [ready, onReady]);
+  return null;
 };
 
 export default McapLidarTile;

--- a/app/packages/multimodal/src/adapters/mcap/react/McapModalRenderer.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapModalRenderer.tsx
@@ -1,6 +1,7 @@
 import type { SampleRendererProps } from "@fiftyone/plugins";
 import React from "react";
 import MultiModalPlayback from "../../../components/MultiModalPlayback/MultiModalPlayback";
+import { McapAnnotationSelectionProvider } from "./mcap-annotation-selection-context";
 import { McapDataStreamProvider } from "./mcap-data-stream-context";
 import { McapStreams } from "./McapStreams";
 import {
@@ -23,15 +24,17 @@ const McapModalRenderer: React.FC<SampleRendererProps> = ({ ctx }) => {
 
   return (
     <McapDataStreamProvider>
-      <MultiModalPlayback
-        fileName={fileName}
-        sceneSources={sceneSources}
-        initialTiles={initialTiles}
-        defaultLeftOpen
-        defaultRightOpen
-      >
-        <McapStreams ctx={ctx} />
-      </MultiModalPlayback>
+      <McapAnnotationSelectionProvider>
+        <MultiModalPlayback
+          fileName={fileName}
+          sceneSources={sceneSources}
+          initialTiles={initialTiles}
+          defaultLeftOpen
+          defaultRightOpen
+        >
+          <McapStreams ctx={ctx} />
+        </MultiModalPlayback>
+      </McapAnnotationSelectionProvider>
     </McapDataStreamProvider>
   );
 };

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-annotation-selection-context.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-annotation-selection-context.tsx
@@ -1,0 +1,44 @@
+import React, { createContext, useContext, useMemo, useState } from "react";
+
+/**
+ * Shared "currently selected annotation" key across all annotation
+ * surfaces in one MCAP modal (camera image overlays + lidar 3D boxes).
+ * Clicking a primitive on any surface sets this key; each overlay
+ * highlights only the primitive whose own key matches. Selecting on
+ * one surface therefore implicitly deselects whatever was selected on
+ * the other.
+ *
+ * Selection keys are opaque strings — each overlay generates its own
+ * (e.g. line-list groups keyed by bounds fingerprint, SceneUpdate cubes
+ * keyed by `entityId#cubeIndex`). They're disjoint by construction so
+ * the single string is sufficient.
+ */
+interface McapAnnotationSelectionContextValue {
+  readonly selectedKey: string | null;
+  readonly setSelectedKey: (next: string | null) => void;
+}
+
+const McapAnnotationSelectionContext =
+  createContext<McapAnnotationSelectionContextValue>({
+    selectedKey: null,
+    setSelectedKey: () => undefined,
+  });
+
+export const McapAnnotationSelectionProvider: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const value = useMemo(
+    () => ({ selectedKey, setSelectedKey }),
+    [selectedKey]
+  );
+  return (
+    <McapAnnotationSelectionContext.Provider value={value}>
+      {children}
+    </McapAnnotationSelectionContext.Provider>
+  );
+};
+
+export function useMcapAnnotationSelection(): McapAnnotationSelectionContextValue {
+  return useContext(McapAnnotationSelectionContext);
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-data-stream-context.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-data-stream-context.tsx
@@ -1,4 +1,6 @@
 import React, { createContext, useContext, useMemo, useState } from "react";
+import type { ByteSourceDescriptor } from "../../../query/bytes";
+import type { McapResourceClient } from "../types";
 import type { McapTimelineIndex } from "./mcap-timeline-index";
 import type { McapTopicCache } from "./mcap-topic-cache";
 
@@ -21,6 +23,13 @@ export interface McapDataStream {
   /** Read access to the timeline index — ordered ticks plus
    *  `nearestTick(timeSec)` / `secToNs(timeSec)`. */
   readonly getTimelineIndex: () => McapTimelineIndex | null;
+
+  /** Resource client used by the data stream. Exposed so tile bodies
+   *  can issue out-of-band reads (e.g. one-shot TF history). */
+  readonly client: McapResourceClient;
+
+  /** Current byte source descriptor. `null` until a sample is open. */
+  readonly source: ByteSourceDescriptor | null;
 }
 
 interface McapDataStreamContextValue {

--- a/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.ts
@@ -110,7 +110,6 @@ function vizOf(msg: McapDecodedMessage): ImageAnnotationsVisualization | null {
 type Point2 = readonly [number, number];
 
 const MATCH_DISTANCE_PX = 200;
-const MIN_MATCH_IOU = 0.15;
 
 function interpolateImageAnnotations(
   prev: ImageAnnotationsVisualization,
@@ -212,35 +211,27 @@ function interpolateLineList(
   const prevGroups = groupLineList(prevPrim.points, prevTexts);
   const nextGroups = groupLineList(nextPrim.points, nextTexts);
 
-  // Per-prev candidate selection:
-  //   1. Same label class (hard).
-  //   2. Centroid within MATCH_DISTANCE_PX (coarse position filter).
-  //   3. AABB IoU above MIN_IOU (rejects gross size mismatches —
-  //      e.g. a parked truck near a passing sedan).
-  //   4. Among survivors, pick the lowest symmetric Chamfer distance
-  //      over the cuboid's unique vertices (shape similarity tiebreak).
-  // Greedy: first prev to claim a next wins.
+  // Greedy nearest-centroid match per label class. Same label is required
+  // so a car can't accidentally interpolate to a pedestrian.
   const usedNext = new Set<number>();
   const matchedPairs: { prev: Group; next: Group | null }[] = prevGroups.map(
     (pg) => {
       let bestIdx = -1;
-      let bestScore = Infinity;
-      const distSqThreshold = MATCH_DISTANCE_PX * MATCH_DISTANCE_PX;
+      let bestDist = Infinity;
       for (let j = 0; j < nextGroups.length; j++) {
         if (usedNext.has(j)) continue;
         const ng = nextGroups[j];
         if (ng.label !== pg.label) continue;
-        if (squaredDistance(pg.centroid, ng.centroid) > distSqThreshold) {
-          continue;
-        }
-        if (aabbIoU(pg.bounds, ng.bounds) < MIN_MATCH_IOU) continue;
-        const score = chamferDistance(pg.vertices, ng.vertices);
-        if (score < bestScore) {
-          bestScore = score;
+        const d = squaredDistance(pg.centroid, ng.centroid);
+        if (d < bestDist) {
+          bestDist = d;
           bestIdx = j;
         }
       }
-      if (bestIdx === -1) return { prev: pg, next: null };
+      const threshold = MATCH_DISTANCE_PX * MATCH_DISTANCE_PX;
+      if (bestIdx === -1 || bestDist > threshold) {
+        return { prev: pg, next: null };
+      }
       usedNext.add(bestIdx);
       return { prev: pg, next: nextGroups[bestIdx] };
     }
@@ -271,118 +262,81 @@ function interpolateLineList(
 interface Group {
   readonly segments: readonly [Point2, Point2][];
   readonly centroid: Point2;
-  readonly bounds: Bounds;
-  readonly vertices: readonly Point2[];
   readonly label: string | null;
 }
 
-/**
- * Each annotation message encodes N objects with cuboid edges and labels
- * paired by index: `points` is `N * segmentsPerObject * 2` long and
- * `texts` has length N. The Nth chunk of segments is labeled by the Nth
- * text. We use that as the source of truth instead of spatial guessing.
- * Falls back to one big group when the data doesn't divide cleanly.
- */
 function groupLineList(
   points: readonly Point2[],
   texts: readonly ImageAnnotationText[]
 ): readonly Group[] {
   const segmentCount = Math.floor(points.length / 2);
   if (segmentCount === 0) return [];
-  if (texts.length === 0 || segmentCount % texts.length !== 0) {
-    const segments: [Point2, Point2][] = [];
-    for (let i = 0; i < segmentCount; i++) {
-      segments.push([points[i * 2], points[i * 2 + 1]]);
-    }
-    return [makeGroup(segments, null)];
-  }
-  const segmentsPerObject = segmentCount / texts.length;
-  const groups: Group[] = [];
-  for (let i = 0; i < texts.length; i++) {
-    const segments: [Point2, Point2][] = [];
-    const start = i * segmentsPerObject;
-    for (let j = 0; j < segmentsPerObject; j++) {
-      const seg = start + j;
-      segments.push([points[seg * 2], points[seg * 2 + 1]]);
-    }
-    groups.push(makeGroup(segments, texts[i]?.text ?? null));
-  }
-  return groups;
-}
 
-function makeGroup(
-  segments: readonly [Point2, Point2][],
-  label: string | null
-): Group {
-  const bounds = segmentsBounds(segments);
-  const centroid: Point2 = [
-    (bounds.minX + bounds.maxX) / 2,
-    (bounds.minY + bounds.maxY) / 2,
-  ];
-  return {
-    segments,
-    centroid,
-    bounds,
-    vertices: uniqueVertices(segments),
-    label,
+  const parent: number[] = [];
+  for (let i = 0; i < segmentCount; i++) parent[i] = i;
+  const find = (i: number): number => {
+    while (parent[i] !== i) {
+      parent[i] = parent[parent[i]];
+      i = parent[i];
+    }
+    return i;
   };
-}
+  const union = (a: number, b: number): void => {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra !== rb) parent[ra] = rb;
+  };
 
-function uniqueVertices(
-  segments: readonly [Point2, Point2][]
-): readonly Point2[] {
-  const seen = new Set<string>();
-  const out: Point2[] = [];
-  for (const [a, b] of segments) {
-    for (const p of [a, b]) {
-      const k = `${Math.round(p[0] * 100)}|${Math.round(p[1] * 100)}`;
-      if (seen.has(k)) continue;
-      seen.add(k);
-      out.push(p);
+  const endpointToSegment = new Map<string, number>();
+  const key = ([x, y]: Point2): string =>
+    `${Math.round(x * 100)}|${Math.round(y * 100)}`;
+  for (let i = 0; i < segmentCount; i++) {
+    for (const p of [points[i * 2], points[i * 2 + 1]]) {
+      const k = key(p);
+      const existing = endpointToSegment.get(k);
+      if (existing === undefined) endpointToSegment.set(k, i);
+      else union(existing, i);
     }
   }
-  return out;
-}
 
-function aabbIoU(a: Bounds, b: Bounds): number {
-  const x1 = Math.max(a.minX, b.minX);
-  const y1 = Math.max(a.minY, b.minY);
-  const x2 = Math.min(a.maxX, b.maxX);
-  const y2 = Math.min(a.maxY, b.maxY);
-  if (x2 <= x1 || y2 <= y1) return 0;
-  const inter = (x2 - x1) * (y2 - y1);
-  const areaA = Math.max(0, a.maxX - a.minX) * Math.max(0, a.maxY - a.minY);
-  const areaB = Math.max(0, b.maxX - b.minX) * Math.max(0, b.maxY - b.minY);
-  const union = areaA + areaB - inter;
-  return union > 0 ? inter / union : 0;
-}
+  const components = new Map<number, [Point2, Point2][]>();
+  for (let i = 0; i < segmentCount; i++) {
+    const root = find(i);
+    let segs = components.get(root);
+    if (!segs) {
+      segs = [];
+      components.set(root, segs);
+    }
+    segs.push([points[i * 2], points[i * 2 + 1]]);
+  }
 
-/**
- * Symmetric Chamfer distance between two point sets — average nearest-
- * neighbour distance from A→B plus from B→A, halved. Small values mean
- * the two cuboid wireframes have similar vertex layouts (good match).
- */
-function chamferDistance(a: readonly Point2[], b: readonly Point2[]): number {
-  if (a.length === 0 || b.length === 0) return Infinity;
-  let sumAB = 0;
-  for (const pa of a) {
-    let minD = Infinity;
-    for (const pb of b) {
-      const d = squaredDistance(pa, pb);
-      if (d < minD) minD = d;
-    }
-    sumAB += Math.sqrt(minD);
+  // Fold tiny floating components (heading indicators inside a cuboid)
+  // into the larger component whose AABB contains their centroid.
+  const raw = [...components.values()].map((segments) => ({
+    segments,
+    bounds: segmentsBounds(segments),
+  }));
+  const sorted = [...raw].sort((a, b) => b.segments.length - a.segments.length);
+  const finals: { segments: [Point2, Point2][] }[] = [];
+  for (const c of sorted) {
+    const cx = (c.bounds.minX + c.bounds.maxX) / 2;
+    const cy = (c.bounds.minY + c.bounds.maxY) / 2;
+    const host =
+      c.segments.length <= 2
+        ? finals.find((h) => {
+            const b = segmentsBounds(h.segments);
+            return cx >= b.minX && cx <= b.maxX && cy >= b.minY && cy <= b.maxY;
+          })
+        : undefined;
+    if (host) host.segments.push(...c.segments);
+    else finals.push({ segments: [...c.segments] });
   }
-  let sumBA = 0;
-  for (const pb of b) {
-    let minD = Infinity;
-    for (const pa of a) {
-      const d = squaredDistance(pa, pb);
-      if (d < minD) minD = d;
-    }
-    sumBA += Math.sqrt(minD);
-  }
-  return (sumAB / a.length + sumBA / b.length) / 2;
+
+  return finals.map(({ segments }) => {
+    const b = segmentsBounds(segments);
+    const centroid: Point2 = [(b.minX + b.maxX) / 2, (b.minY + b.maxY) / 2];
+    return { segments, centroid, label: nearestLabel(texts, centroid) };
+  });
 }
 
 interface Bounds {
@@ -408,6 +362,24 @@ function segmentsBounds(segments: readonly [Point2, Point2][]): Bounds {
     if (y2 > maxY) maxY = y2;
   }
   return { minX, minY, maxX, maxY };
+}
+
+function nearestLabel(
+  texts: readonly ImageAnnotationText[],
+  point: Point2
+): string | null {
+  let bestIdx = -1;
+  let bestDist = Infinity;
+  for (let i = 0; i < texts.length; i++) {
+    const t = texts[i];
+    if (!t.text) continue;
+    const d = squaredDistance(t.position, point);
+    if (d < bestDist) {
+      bestDist = d;
+      bestIdx = i;
+    }
+  }
+  return bestIdx === -1 ? null : texts[bestIdx]?.text ?? null;
 }
 
 function squaredDistance(a: Point2, b: Point2): number {

--- a/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.ts
@@ -110,6 +110,7 @@ function vizOf(msg: McapDecodedMessage): ImageAnnotationsVisualization | null {
 type Point2 = readonly [number, number];
 
 const MATCH_DISTANCE_PX = 200;
+const MIN_MATCH_IOU = 0.15;
 
 function interpolateImageAnnotations(
   prev: ImageAnnotationsVisualization,
@@ -211,27 +212,35 @@ function interpolateLineList(
   const prevGroups = groupLineList(prevPrim.points, prevTexts);
   const nextGroups = groupLineList(nextPrim.points, nextTexts);
 
-  // Greedy nearest-centroid match per label class. Same label is required
-  // so a car can't accidentally interpolate to a pedestrian.
+  // Per-prev candidate selection:
+  //   1. Same label class (hard).
+  //   2. Centroid within MATCH_DISTANCE_PX (coarse position filter).
+  //   3. AABB IoU above MIN_IOU (rejects gross size mismatches —
+  //      e.g. a parked truck near a passing sedan).
+  //   4. Among survivors, pick the lowest symmetric Chamfer distance
+  //      over the cuboid's unique vertices (shape similarity tiebreak).
+  // Greedy: first prev to claim a next wins.
   const usedNext = new Set<number>();
   const matchedPairs: { prev: Group; next: Group | null }[] = prevGroups.map(
     (pg) => {
       let bestIdx = -1;
-      let bestDist = Infinity;
+      let bestScore = Infinity;
+      const distSqThreshold = MATCH_DISTANCE_PX * MATCH_DISTANCE_PX;
       for (let j = 0; j < nextGroups.length; j++) {
         if (usedNext.has(j)) continue;
         const ng = nextGroups[j];
         if (ng.label !== pg.label) continue;
-        const d = squaredDistance(pg.centroid, ng.centroid);
-        if (d < bestDist) {
-          bestDist = d;
+        if (squaredDistance(pg.centroid, ng.centroid) > distSqThreshold) {
+          continue;
+        }
+        if (aabbIoU(pg.bounds, ng.bounds) < MIN_MATCH_IOU) continue;
+        const score = chamferDistance(pg.vertices, ng.vertices);
+        if (score < bestScore) {
+          bestScore = score;
           bestIdx = j;
         }
       }
-      const threshold = MATCH_DISTANCE_PX * MATCH_DISTANCE_PX;
-      if (bestIdx === -1 || bestDist > threshold) {
-        return { prev: pg, next: null };
-      }
+      if (bestIdx === -1) return { prev: pg, next: null };
       usedNext.add(bestIdx);
       return { prev: pg, next: nextGroups[bestIdx] };
     }
@@ -262,81 +271,118 @@ function interpolateLineList(
 interface Group {
   readonly segments: readonly [Point2, Point2][];
   readonly centroid: Point2;
+  readonly bounds: Bounds;
+  readonly vertices: readonly Point2[];
   readonly label: string | null;
 }
 
+/**
+ * Each annotation message encodes N objects with cuboid edges and labels
+ * paired by index: `points` is `N * segmentsPerObject * 2` long and
+ * `texts` has length N. The Nth chunk of segments is labeled by the Nth
+ * text. We use that as the source of truth instead of spatial guessing.
+ * Falls back to one big group when the data doesn't divide cleanly.
+ */
 function groupLineList(
   points: readonly Point2[],
   texts: readonly ImageAnnotationText[]
 ): readonly Group[] {
   const segmentCount = Math.floor(points.length / 2);
   if (segmentCount === 0) return [];
-
-  const parent: number[] = [];
-  for (let i = 0; i < segmentCount; i++) parent[i] = i;
-  const find = (i: number): number => {
-    while (parent[i] !== i) {
-      parent[i] = parent[parent[i]];
-      i = parent[i];
+  if (texts.length === 0 || segmentCount % texts.length !== 0) {
+    const segments: [Point2, Point2][] = [];
+    for (let i = 0; i < segmentCount; i++) {
+      segments.push([points[i * 2], points[i * 2 + 1]]);
     }
-    return i;
-  };
-  const union = (a: number, b: number): void => {
-    const ra = find(a);
-    const rb = find(b);
-    if (ra !== rb) parent[ra] = rb;
-  };
-
-  const endpointToSegment = new Map<string, number>();
-  const key = ([x, y]: Point2): string =>
-    `${Math.round(x * 100)}|${Math.round(y * 100)}`;
-  for (let i = 0; i < segmentCount; i++) {
-    for (const p of [points[i * 2], points[i * 2 + 1]]) {
-      const k = key(p);
-      const existing = endpointToSegment.get(k);
-      if (existing === undefined) endpointToSegment.set(k, i);
-      else union(existing, i);
-    }
+    return [makeGroup(segments, null)];
   }
-
-  const components = new Map<number, [Point2, Point2][]>();
-  for (let i = 0; i < segmentCount; i++) {
-    const root = find(i);
-    let segs = components.get(root);
-    if (!segs) {
-      segs = [];
-      components.set(root, segs);
+  const segmentsPerObject = segmentCount / texts.length;
+  const groups: Group[] = [];
+  for (let i = 0; i < texts.length; i++) {
+    const segments: [Point2, Point2][] = [];
+    const start = i * segmentsPerObject;
+    for (let j = 0; j < segmentsPerObject; j++) {
+      const seg = start + j;
+      segments.push([points[seg * 2], points[seg * 2 + 1]]);
     }
-    segs.push([points[i * 2], points[i * 2 + 1]]);
+    groups.push(makeGroup(segments, texts[i]?.text ?? null));
   }
+  return groups;
+}
 
-  // Fold tiny floating components (heading indicators inside a cuboid)
-  // into the larger component whose AABB contains their centroid.
-  const raw = [...components.values()].map((segments) => ({
+function makeGroup(
+  segments: readonly [Point2, Point2][],
+  label: string | null
+): Group {
+  const bounds = segmentsBounds(segments);
+  const centroid: Point2 = [
+    (bounds.minX + bounds.maxX) / 2,
+    (bounds.minY + bounds.maxY) / 2,
+  ];
+  return {
     segments,
-    bounds: segmentsBounds(segments),
-  }));
-  const sorted = [...raw].sort((a, b) => b.segments.length - a.segments.length);
-  const finals: { segments: [Point2, Point2][] }[] = [];
-  for (const c of sorted) {
-    const cx = (c.bounds.minX + c.bounds.maxX) / 2;
-    const cy = (c.bounds.minY + c.bounds.maxY) / 2;
-    const host =
-      c.segments.length <= 2
-        ? finals.find((h) => {
-            const b = segmentsBounds(h.segments);
-            return cx >= b.minX && cx <= b.maxX && cy >= b.minY && cy <= b.maxY;
-          })
-        : undefined;
-    if (host) host.segments.push(...c.segments);
-    else finals.push({ segments: [...c.segments] });
-  }
+    centroid,
+    bounds,
+    vertices: uniqueVertices(segments),
+    label,
+  };
+}
 
-  return finals.map(({ segments }) => {
-    const b = segmentsBounds(segments);
-    const centroid: Point2 = [(b.minX + b.maxX) / 2, (b.minY + b.maxY) / 2];
-    return { segments, centroid, label: nearestLabel(texts, centroid) };
-  });
+function uniqueVertices(
+  segments: readonly [Point2, Point2][]
+): readonly Point2[] {
+  const seen = new Set<string>();
+  const out: Point2[] = [];
+  for (const [a, b] of segments) {
+    for (const p of [a, b]) {
+      const k = `${Math.round(p[0] * 100)}|${Math.round(p[1] * 100)}`;
+      if (seen.has(k)) continue;
+      seen.add(k);
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+function aabbIoU(a: Bounds, b: Bounds): number {
+  const x1 = Math.max(a.minX, b.minX);
+  const y1 = Math.max(a.minY, b.minY);
+  const x2 = Math.min(a.maxX, b.maxX);
+  const y2 = Math.min(a.maxY, b.maxY);
+  if (x2 <= x1 || y2 <= y1) return 0;
+  const inter = (x2 - x1) * (y2 - y1);
+  const areaA = Math.max(0, a.maxX - a.minX) * Math.max(0, a.maxY - a.minY);
+  const areaB = Math.max(0, b.maxX - b.minX) * Math.max(0, b.maxY - b.minY);
+  const union = areaA + areaB - inter;
+  return union > 0 ? inter / union : 0;
+}
+
+/**
+ * Symmetric Chamfer distance between two point sets — average nearest-
+ * neighbour distance from A→B plus from B→A, halved. Small values mean
+ * the two cuboid wireframes have similar vertex layouts (good match).
+ */
+function chamferDistance(a: readonly Point2[], b: readonly Point2[]): number {
+  if (a.length === 0 || b.length === 0) return Infinity;
+  let sumAB = 0;
+  for (const pa of a) {
+    let minD = Infinity;
+    for (const pb of b) {
+      const d = squaredDistance(pa, pb);
+      if (d < minD) minD = d;
+    }
+    sumAB += Math.sqrt(minD);
+  }
+  let sumBA = 0;
+  for (const pb of b) {
+    let minD = Infinity;
+    for (const pa of a) {
+      const d = squaredDistance(pa, pb);
+      if (d < minD) minD = d;
+    }
+    sumBA += Math.sqrt(minD);
+  }
+  return (sumAB / a.length + sumBA / b.length) / 2;
 }
 
 interface Bounds {
@@ -362,24 +408,6 @@ function segmentsBounds(segments: readonly [Point2, Point2][]): Bounds {
     if (y2 > maxY) maxY = y2;
   }
   return { minX, minY, maxX, maxY };
-}
-
-function nearestLabel(
-  texts: readonly ImageAnnotationText[],
-  point: Point2
-): string | null {
-  let bestIdx = -1;
-  let bestDist = Infinity;
-  for (let i = 0; i < texts.length; i++) {
-    const t = texts[i];
-    if (!t.text) continue;
-    const d = squaredDistance(t.position, point);
-    if (d < bestDist) {
-      bestDist = d;
-      bestIdx = i;
-    }
-  }
-  return bestIdx === -1 ? null : texts[bestIdx]?.text ?? null;
 }
 
 function squaredDistance(a: Point2, b: Point2): number {

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-scene-inventory.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-scene-inventory.tsx
@@ -44,6 +44,11 @@ const NUSCENES_SOURCES: readonly SceneSource[] = [
   },
   { id: "/LIDAR_TOP", type: "lidar", label: "Top lidar" },
   {
+    id: "/markers/annotations",
+    type: "scene-annotation",
+    label: "Scene annotations",
+  },
+  {
     id: "/CAM_FRONT/annotations",
     type: "image-annotation",
     label: "Front camera annotations",
@@ -105,6 +110,7 @@ const NUSCENES_STREAM_POLICIES: McapStreamSyncPolicies = {
     mode: PlaybackSyncMode.LATEST,
     toleranceBeforeNs: 200_000_000n,
   },
+  "/markers/annotations": ANNOTATION_SYNC_POLICY,
 };
 
 const NUSCENES_INITIAL_TILES: Record<string, TilingTile> = {

--- a/app/packages/multimodal/src/adapters/mcap/react/use-register-mcap-data-stream.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-register-mcap-data-stream.ts
@@ -589,11 +589,24 @@ export function useRegisterMcapDataStream({
   const getTimelineIndex = useCallback(() => indexRef.current, []);
 
   useEffect(() => {
-    setDataStream({ subscribeToTopic, getTopicCache, getTimelineIndex });
+    setDataStream({
+      subscribeToTopic,
+      getTopicCache,
+      getTimelineIndex,
+      client,
+      source,
+    });
     return () => {
       setDataStream(null);
     };
-  }, [setDataStream, subscribeToTopic, getTopicCache, getTimelineIndex]);
+  }, [
+    setDataStream,
+    subscribeToTopic,
+    getTopicCache,
+    getTimelineIndex,
+    client,
+    source,
+  ]);
 }
 
 // ---------------------------------------------------------------------------

--- a/app/packages/multimodal/src/adapters/mcap/react/use-tf-tree.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-tf-tree.ts
@@ -1,0 +1,152 @@
+import { playheadAtom, usePlaybackStore } from "@fiftyone/playback";
+import { useAtomValue } from "jotai";
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  byteSourceCacheKey,
+  type ByteSourceDescriptor,
+} from "../../../query/bytes";
+import type { FrameTransformVisualization } from "../../../decoders";
+import { MCAP_ACTIVE_TIMELINE } from "../types";
+import type { McapResourceClient } from "../types";
+import { useMcapDataStream } from "./mcap-data-stream-context";
+import type { Mat4 } from "../tf/tf-tree";
+import { TfTree } from "../tf/tf-tree";
+
+const TF_TOPIC = "/tf";
+
+interface TfTreeState {
+  readonly tree: TfTree | null;
+  readonly ready: boolean;
+}
+
+// Module-level cache so toggling the lidar annotations off/on doesn't
+// re-fetch /tf. Keyed by the source's stable cache key.
+const tfTreeCache = new Map<
+  string,
+  { promise: Promise<TfTree>; tree?: TfTree }
+>();
+
+/**
+ * One-shot loader: reads every `/tf` message via the resource client,
+ * builds a `TfTree`. The data-stream cache stores one message per
+ * (tick, topic), which can't represent the latest-per-edge tree we
+ * need, so `/tf` is fetched out-of-band here.
+ *
+ * Mounting kicks off the read; unmounting cancels. Re-runs only when
+ * client or source identity changes.
+ */
+export function useTfTree(
+  client: McapResourceClient | null,
+  source: ByteSourceDescriptor | null
+): TfTreeState {
+  const [state, setState] = useState<TfTreeState>({
+    tree: null,
+    ready: false,
+  });
+
+  useEffect(() => {
+    if (!client || !source) {
+      setState({ tree: null, ready: false });
+      return;
+    }
+    const key = byteSourceCacheKey(source);
+    let cancelled = false;
+    const entry = ensureCacheEntry(key, client, source);
+    if (entry.tree) {
+      // Cached — synchronous-equivalent state update.
+      setState({ tree: entry.tree, ready: true });
+      return;
+    }
+    setState({ tree: null, ready: false });
+    entry.promise
+      .then((tree) => {
+        if (cancelled) return;
+        setState({ tree, ready: true });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setState({ tree: null, ready: false });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client, source]);
+
+  return state;
+}
+
+function ensureCacheEntry(
+  key: string,
+  client: McapResourceClient,
+  source: ByteSourceDescriptor
+): { promise: Promise<TfTree>; tree?: TfTree } {
+  const cached = tfTreeCache.get(key);
+  if (cached) return cached;
+  const entry: { promise: Promise<TfTree>; tree?: TfTree } = {
+    promise: loadTfTree(client, source).then((tree) => {
+      entry.tree = tree;
+      return tree;
+    }),
+  };
+  tfTreeCache.set(key, entry);
+  return entry;
+}
+
+async function loadTfTree(
+  client: McapResourceClient,
+  source: ByteSourceDescriptor
+): Promise<TfTree> {
+  const tree = new TfTree();
+  for await (const msg of client.readDecodedMessages({
+    source,
+    topics: [TF_TOPIC],
+    activeTimeline: MCAP_ACTIVE_TIMELINE.LOG,
+  })) {
+    const v = msg.decoded.output.visualization;
+    if (!v || v.kind !== "frame-transform") continue;
+    const ft = v as FrameTransformVisualization;
+    tree.addTransform(
+      ft.parentFrameId,
+      ft.childFrameId,
+      ft.timestampNs,
+      ft.translation,
+      ft.rotation
+    );
+  }
+  tree.finalize();
+  return tree;
+}
+
+/**
+ * Returns the 4x4 column-major matrix that maps a point in `fromFrame`
+ * coordinates into `toFrame` coordinates at the current playhead.
+ * Returns `null` until the TF tree is loaded or when the frames aren't
+ * connected by any TF chain.
+ */
+/**
+ * Convenience: reads `client` + `source` from the data-stream context
+ * and forwards to `useTfTree`. Most consumers should use this — only
+ * call `useTfTree` directly when you have client/source from somewhere
+ * other than the context (e.g. tests).
+ */
+export function useMcapTfTree(): TfTreeState {
+  const dataStream = useMcapDataStream();
+  return useTfTree(dataStream?.client ?? null, dataStream?.source ?? null);
+}
+
+export function useTfTransformMatrix(
+  tree: TfTree | null,
+  fromFrame: string,
+  toFrame: string,
+  timelineStartNs: bigint
+): Mat4 | null {
+  const store = usePlaybackStore();
+  const playhead = useAtomValue(playheadAtom, { store });
+  return useMemo(() => {
+    if (!tree) return null;
+    const timeNs =
+      timelineStartNs + BigInt(Math.round(playhead * 1_000_000_000));
+    return tree.lookupChain(fromFrame, toFrame, timeNs);
+  }, [tree, fromFrame, toFrame, playhead, timelineStartNs]);
+}

--- a/app/packages/multimodal/src/adapters/mcap/tf/tf-tree.ts
+++ b/app/packages/multimodal/src/adapters/mcap/tf/tf-tree.ts
@@ -1,0 +1,317 @@
+import type { Quat, Vec3 } from "../../../decoders";
+
+/**
+ * 4x4 column-major transformation matrix represented as a row-major
+ * Float32Array of 16 elements. Three.js's `Matrix4.fromArray()` accepts
+ * either convention; we standardize on column-major to match WebGL math
+ * libraries.
+ */
+export type Mat4 = Float32Array;
+
+interface TransformSample {
+  readonly timeNs: bigint;
+  readonly translation: Vec3;
+  readonly rotation: Quat;
+}
+
+/**
+ * Coordinate-frame graph built from a stream of `foxglove.FrameTransform`
+ * messages. Each (parent → child) pair holds a time-sorted history of
+ * (translation, rotation) samples; lookups binary-search the latest
+ * sample at or before the requested time.
+ *
+ * `lookupChain(from, to, t)` walks the graph from `from` to `to` (BFS
+ * since the graph is small) and composes the per-edge matrices at time
+ * `t`. Returns `null` when no path connects the two frames or when one
+ * of the edges has no sample at or before `t`.
+ */
+export class TfTree {
+  /**
+   * Forward edges: `forward.get(parent)[child]` is the history of
+   * transforms that take a point in child-frame coordinates and return
+   * the corresponding parent-frame coordinates. (Foxglove's
+   * `FrameTransform` semantics.)
+   */
+  private readonly forward = new Map<string, Map<string, TransformSample[]>>();
+
+  /**
+   * Reverse edges (auto-populated): present so a BFS can traverse the
+   * graph in either direction. A reverse-edge transform is the inverse
+   * of the forward transform at the same timestamp.
+   */
+  private readonly reverse = new Map<string, Map<string, TransformSample[]>>();
+
+  /** All frame ids ever observed. */
+  private readonly frames = new Set<string>();
+
+  addTransform(
+    parent: string,
+    child: string,
+    timeNs: bigint,
+    translation: Vec3,
+    rotation: Quat
+  ): void {
+    if (!parent || !child) return;
+    this.frames.add(parent);
+    this.frames.add(child);
+
+    appendSample(this.forward, parent, child, {
+      timeNs,
+      translation,
+      rotation,
+    });
+    appendSample(this.reverse, child, parent, {
+      timeNs,
+      translation,
+      rotation,
+    });
+  }
+
+  /**
+   * Sort every per-edge history by timestamp. Call once after bulk
+   * loading; subsequent `addTransform` calls keep order if you feed
+   * them in time order.
+   */
+  finalize(): void {
+    for (const inner of this.forward.values())
+      for (const history of inner.values())
+        history.sort(compareSamples);
+    for (const inner of this.reverse.values())
+      for (const history of inner.values())
+        history.sort(compareSamples);
+  }
+
+  hasFrame(frame: string): boolean {
+    return this.frames.has(frame);
+  }
+
+  /**
+   * Resolves the 4x4 matrix `M` such that `point_in_to = M * point_in_from`
+   * at time `timeNs`. Returns `null` if `from` and `to` aren't connected
+   * or any edge along the path lacks a sample at or before `timeNs`.
+   */
+  lookupChain(from: string, to: string, timeNs: bigint): Mat4 | null {
+    if (from === to) return identityMatrix();
+    if (!this.frames.has(from) || !this.frames.has(to)) return null;
+
+    const path = this.findPath(from, to);
+    if (!path) return null;
+
+    // Compose edge transforms left-to-right.
+    let m = identityMatrix();
+    for (let i = 0; i < path.length - 1; i++) {
+      const a = path[i];
+      const b = path[i + 1];
+      const edge = this.lookupEdge(a, b, timeNs);
+      if (!edge) return null;
+      m = multiplyMatrices(edge, m);
+    }
+    return m;
+  }
+
+  private findPath(from: string, to: string): string[] | null {
+    if (from === to) return [from];
+    const queue: string[] = [from];
+    const cameFrom = new Map<string, string>();
+    cameFrom.set(from, from);
+    while (queue.length > 0) {
+      const cur = queue.shift() as string;
+      if (cur === to) {
+        const path: string[] = [];
+        let n = to;
+        while (n !== from) {
+          path.unshift(n);
+          n = cameFrom.get(n) as string;
+        }
+        path.unshift(from);
+        return path;
+      }
+      for (const neighbor of this.neighborsOf(cur)) {
+        if (cameFrom.has(neighbor)) continue;
+        cameFrom.set(neighbor, cur);
+        queue.push(neighbor);
+      }
+    }
+    return null;
+  }
+
+  private *neighborsOf(frame: string): Generator<string, void, void> {
+    const fwd = this.forward.get(frame);
+    if (fwd) for (const k of fwd.keys()) yield k;
+    const rev = this.reverse.get(frame);
+    if (rev) for (const k of rev.keys()) yield k;
+  }
+
+  /**
+   * Returns the 4x4 matrix that maps a point expressed in frame `a`
+   * into frame `b`'s coordinates at time `timeNs`. Walks one edge of
+   * the graph in either direction (forward or reverse).
+   */
+  private lookupEdge(a: string, b: string, timeNs: bigint): Mat4 | null {
+    // Foxglove's FrameTransform parent→child entry means "point in
+    // child coords → point in parent coords". To go FROM frame `a` TO
+    // frame `b`, we need the inverse of the parent→child transform
+    // when `a` is the parent.
+    const fwd = this.forward.get(a)?.get(b);
+    if (fwd) {
+      // a→b means a is parent, b is child. We want point-in-a → point-in-b
+      // which is the INVERSE of the stored parent→child matrix.
+      const sample = latestSampleAtOrBefore(fwd, timeNs);
+      if (sample) return invertRigid(sampleToMatrix(sample));
+    }
+    const rev = this.reverse.get(a)?.get(b);
+    if (rev) {
+      // Reverse map: stored as (parent=b, child=a). We want
+      // point-in-a → point-in-b, which IS the stored matrix (parent←child).
+      const sample = latestSampleAtOrBefore(rev, timeNs);
+      if (sample) return sampleToMatrix(sample);
+    }
+    return null;
+  }
+}
+
+function appendSample(
+  table: Map<string, Map<string, TransformSample[]>>,
+  parent: string,
+  child: string,
+  sample: TransformSample
+): void {
+  let inner = table.get(parent);
+  if (!inner) {
+    inner = new Map();
+    table.set(parent, inner);
+  }
+  let history = inner.get(child);
+  if (!history) {
+    history = [];
+    inner.set(child, history);
+  }
+  history.push(sample);
+}
+
+function compareSamples(a: TransformSample, b: TransformSample): number {
+  if (a.timeNs < b.timeNs) return -1;
+  if (a.timeNs > b.timeNs) return 1;
+  return 0;
+}
+
+function latestSampleAtOrBefore(
+  history: readonly TransformSample[],
+  timeNs: bigint
+): TransformSample | null {
+  if (history.length === 0) return null;
+  // Binary search for the largest index whose timeNs <= timeNs.
+  let lo = 0;
+  let hi = history.length - 1;
+  if (history[0].timeNs > timeNs) return history[0]; // earliest known wins
+  if (history[hi].timeNs <= timeNs) return history[hi];
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (history[mid].timeNs <= timeNs) lo = mid;
+    else hi = mid - 1;
+  }
+  return history[lo];
+}
+
+// ---------------------------------------------------------------------------
+// 4x4 matrix math (column-major). Three.js' `Matrix4.fromArray()` reads
+// column-major Float32Array; that's what we produce.
+// ---------------------------------------------------------------------------
+
+function identityMatrix(): Mat4 {
+  const m = new Float32Array(16);
+  m[0] = 1;
+  m[5] = 1;
+  m[10] = 1;
+  m[15] = 1;
+  return m;
+}
+
+/**
+ * Compose a parent←child rigid transform from a quaternion rotation
+ * and a translation vector. Returns a column-major Float32Array(16).
+ */
+function sampleToMatrix(sample: TransformSample): Mat4 {
+  const [tx, ty, tz] = sample.translation;
+  const [qx, qy, qz, qw] = sample.rotation;
+  // Normalize the quaternion defensively.
+  const n = Math.hypot(qx, qy, qz, qw) || 1;
+  const x = qx / n;
+  const y = qy / n;
+  const z = qz / n;
+  const w = qw / n;
+  const xx = x * x;
+  const yy = y * y;
+  const zz = z * z;
+  const xy = x * y;
+  const xz = x * z;
+  const yz = y * z;
+  const wx = w * x;
+  const wy = w * y;
+  const wz = w * z;
+
+  const m = new Float32Array(16);
+  m[0] = 1 - 2 * (yy + zz);
+  m[1] = 2 * (xy + wz);
+  m[2] = 2 * (xz - wy);
+  m[3] = 0;
+
+  m[4] = 2 * (xy - wz);
+  m[5] = 1 - 2 * (xx + zz);
+  m[6] = 2 * (yz + wx);
+  m[7] = 0;
+
+  m[8] = 2 * (xz + wy);
+  m[9] = 2 * (yz - wx);
+  m[10] = 1 - 2 * (xx + yy);
+  m[11] = 0;
+
+  m[12] = tx;
+  m[13] = ty;
+  m[14] = tz;
+  m[15] = 1;
+  return m;
+}
+
+/**
+ * Inverse of a rigid (rotation + translation, no scale/shear) transform.
+ * Transposes the rotation block and reflects the translation.
+ */
+function invertRigid(m: Mat4): Mat4 {
+  const out = new Float32Array(16);
+  // Transpose rotation.
+  out[0] = m[0];
+  out[1] = m[4];
+  out[2] = m[8];
+  out[4] = m[1];
+  out[5] = m[5];
+  out[6] = m[9];
+  out[8] = m[2];
+  out[9] = m[6];
+  out[10] = m[10];
+  // -R^T * t
+  const tx = m[12];
+  const ty = m[13];
+  const tz = m[14];
+  out[12] = -(out[0] * tx + out[4] * ty + out[8] * tz);
+  out[13] = -(out[1] * tx + out[5] * ty + out[9] * tz);
+  out[14] = -(out[2] * tx + out[6] * ty + out[10] * tz);
+  out[15] = 1;
+  return out;
+}
+
+/**
+ * Right-multiplies `b` by `a` — column-major: `result = a · b`.
+ * Allocates a new matrix.
+ */
+function multiplyMatrices(a: Mat4, b: Mat4): Mat4 {
+  const out = new Float32Array(16);
+  for (let row = 0; row < 4; row++) {
+    for (let col = 0; col < 4; col++) {
+      let s = 0;
+      for (let k = 0; k < 4; k++) s += a[row + k * 4] * b[k + col * 4];
+      out[row + col * 4] = s;
+    }
+  }
+  return out;
+}

--- a/app/packages/multimodal/src/decoders/types.ts
+++ b/app/packages/multimodal/src/decoders/types.ts
@@ -108,13 +108,72 @@ export interface ImageAnnotationsVisualization {
 }
 
 /**
+ * 3D Cartesian vector — used for positions and sizes in scene primitives.
+ */
+export type Vec3 = readonly [number, number, number];
+
+/**
+ * Quaternion in (x, y, z, w) order — matches Foxglove + Three.js convention.
+ */
+export type Quat = readonly [number, number, number, number];
+
+/**
+ * Single 3D cuboid primitive from a scene-update entity.
+ */
+export interface SceneUpdateCube {
+  readonly position: Vec3;
+  readonly orientation: Quat;
+  readonly size: Vec3;
+  readonly color: RgbaColor | null;
+}
+
+/**
+ * One scene-update entity. Carries a stable string id so consumers can
+ * track the same logical object across messages without spatial matching.
+ */
+export interface SceneUpdateEntity {
+  readonly id: string;
+  readonly frameId: string;
+  readonly timestampNs: bigint;
+  readonly cubes: readonly SceneUpdateCube[];
+  readonly metadata: Readonly<Record<string, string>>;
+}
+
+/**
+ * Renderer-neutral 3D scene-update snapshot decoded from a
+ * foxglove.SceneUpdate message. Other primitive types (spheres, lines,
+ * arrows, triangles, models, texts) are intentionally omitted until we
+ * need them.
+ */
+export interface SceneUpdateVisualization {
+  readonly kind: typeof VISUALIZATION_KIND.SCENE_UPDATE;
+  readonly entities: readonly SceneUpdateEntity[];
+}
+
+/**
+ * One frame-to-frame coordinate transform decoded from a
+ * foxglove.FrameTransform message. The TF tree consumer aggregates
+ * these into a graph for per-tick transform lookups.
+ */
+export interface FrameTransformVisualization {
+  readonly kind: typeof VISUALIZATION_KIND.FRAME_TRANSFORM;
+  readonly parentFrameId: string;
+  readonly childFrameId: string;
+  readonly timestampNs: bigint;
+  readonly translation: Vec3;
+  readonly rotation: Quat;
+}
+
+/**
  * Decoder-owned visual artifact. Decoders may omit this for messages that only
  * contribute metadata, transforms, annotations, or other nonvisual state.
  */
 export type DecodedVisualization =
   | EncodedImageVisualization
+  | FrameTransformVisualization
   | ImageAnnotationsVisualization
-  | PointCloudVisualization;
+  | PointCloudVisualization
+  | SceneUpdateVisualization;
 
 /**
  * Encoded payload identity used by frontend decoder selection.

--- a/app/packages/multimodal/src/visualization/panels/ImageAnnotationsOverlay.tsx
+++ b/app/packages/multimodal/src/visualization/panels/ImageAnnotationsOverlay.tsx
@@ -647,9 +647,7 @@ function pickHandler(
 }
 
 function lineWidth(thickness: number): number {
-  // Source thickness is conservative; bump it ~1.5x for readability while
-  // keeping the look light.
-  return Math.max(1.5, thickness * 1.5);
+  return Math.max(1, thickness);
 }
 
 function displayRect(

--- a/app/packages/multimodal/src/visualization/panels/point-cloud.tsx
+++ b/app/packages/multimodal/src/visualization/panels/point-cloud.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-unknown-property */
 import { useThree } from "@react-three/fiber";
-import type { CSSProperties } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
 import * as THREE from "three";
 
@@ -74,6 +74,7 @@ export interface PointCloudFrameTransform {
  * Props for rendering one decoded point-cloud visualization frame.
  */
 export interface PointCloudPanelProps {
+  readonly children?: ReactNode;
   readonly className?: string;
   readonly fit?: "initial" | "frame" | "never";
   readonly frame: PointCloudVisualization;
@@ -89,6 +90,7 @@ export interface PointCloudPanelProps {
  * Production point-cloud visualization panel backed by a stable Three.js canvas.
  */
 export function PointCloudPanel({
+  children,
   className,
   fit = "initial",
   frame,
@@ -110,8 +112,11 @@ export function PointCloudPanel({
         pointSize={pointSize}
         positions={frame.positions}
         transform={frameTransform}
-      />
+      >
+        {children}
+      </PointCloudSceneContent>
     ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [fit, frame.positions, frameTransform, maxRenderedPoints, pointSize]
   );
 
@@ -141,6 +146,7 @@ export function PointCloudPanel({
 }
 
 function PointCloudSceneContent({
+  children,
   fit: _fit,
   maxRenderedPoints,
   onFinitePointCount,
@@ -148,6 +154,7 @@ function PointCloudSceneContent({
   positions,
   transform,
 }: {
+  readonly children?: ReactNode;
   readonly fit: "initial" | "frame" | "never";
   readonly maxRenderedPoints: number;
   readonly onFinitePointCount: (count: number) => void;
@@ -181,6 +188,7 @@ function PointCloudSceneContent({
       >
         <PointCloudPoints data={data} pointSize={pointSize} />
       </group>
+      {children}
     </Base3DScene>
   );
 }

--- a/app/packages/multimodal/src/visualization/panels/scene-update-boxes.tsx
+++ b/app/packages/multimodal/src/visualization/panels/scene-update-boxes.tsx
@@ -1,0 +1,243 @@
+/* eslint-disable react/no-unknown-property */
+import { useMemo, useState } from "react";
+import * as THREE from "three";
+
+import type {
+  SceneUpdateCube,
+  SceneUpdateEntity,
+  SceneUpdateVisualization,
+} from "../../decoders";
+
+export interface SceneUpdatePickedEntity {
+  readonly key: string;
+  readonly entityId: string;
+  readonly cubeIndex: number;
+  readonly entity: SceneUpdateEntity;
+  readonly cube: SceneUpdateCube;
+  readonly color: string;
+  readonly label: string | null;
+}
+
+export interface SceneUpdateBoxesProps {
+  readonly visualization: SceneUpdateVisualization;
+  /**
+   * 4x4 column-major transform applied to every entity before its own
+   * pose. Use this to map entities from their authoring frame (e.g.
+   * `"map"`) into the surrounding scene's frame (e.g. lidar). When
+   * null, entities render at their native positions.
+   */
+  readonly worldMatrix?: Float32Array | null;
+  readonly selectedKey?: string | null;
+  readonly onSelectPrimitive?: (picked: SceneUpdatePickedEntity) => void;
+}
+
+/**
+ * Renders the cubes of a decoded `foxglove.SceneUpdate` as wireframe
+ * boxes inside the surrounding R3F scene. Each entity gets its own
+ * group keyed by its stable id; hover and selection use that id, so
+ * highlights persist across messages without any spatial matching.
+ */
+export function SceneUpdateBoxes({
+  visualization,
+  worldMatrix,
+  selectedKey,
+  onSelectPrimitive,
+}: SceneUpdateBoxesProps) {
+  const worldMat = useMemo(() => {
+    if (!worldMatrix) return null;
+    const m = new THREE.Matrix4();
+    m.fromArray(worldMatrix);
+    return m;
+  }, [worldMatrix]);
+
+  const cubes = useMemo(() => collectCubes(visualization), [visualization]);
+
+  return (
+    // Foxglove uses Z-up; the surrounding lidar scene renders raw XYZ
+    // into Three.js's Y-up world, so the cuboids would otherwise stand
+    // on their sides. Rotate the whole overlay -90° around X so the
+    // boxes (positions + orientations) match the lidar's rendering.
+    <group rotation={[-Math.PI / 2, 0, 0]}>
+      <group
+        matrixAutoUpdate={false}
+        matrix={worldMat ?? IDENTITY_MATRIX}
+      >
+        {cubes.map((c) => (
+          <CubeOverlay
+            key={c.key}
+            entity={c.entity}
+            cube={c.cube}
+            cubeIndex={c.cubeIndex}
+            selected={selectedKey === c.key}
+            onSelect={onSelectPrimitive}
+          />
+        ))}
+      </group>
+    </group>
+  );
+}
+
+interface CollectedCube {
+  readonly key: string;
+  readonly entity: SceneUpdateEntity;
+  readonly cube: SceneUpdateCube;
+  readonly cubeIndex: number;
+}
+
+function collectCubes(viz: SceneUpdateVisualization): readonly CollectedCube[] {
+  const out: CollectedCube[] = [];
+  for (const entity of viz.entities) {
+    for (let i = 0; i < entity.cubes.length; i++) {
+      out.push({
+        key: cubeKey(entity.id, i),
+        entity,
+        cube: entity.cubes[i],
+        cubeIndex: i,
+      });
+    }
+  }
+  return out;
+}
+
+function cubeKey(entityId: string, cubeIndex: number): string {
+  return `${entityId}#${cubeIndex}`;
+}
+
+interface CubeOverlayProps {
+  readonly entity: SceneUpdateEntity;
+  readonly cube: SceneUpdateCube;
+  readonly cubeIndex: number;
+  readonly selected: boolean;
+  readonly onSelect?: (picked: SceneUpdatePickedEntity) => void;
+}
+
+const HOVER_STROKE = "#ff7a18";
+
+function CubeOverlay({
+  entity,
+  cube,
+  cubeIndex,
+  selected,
+  onSelect,
+}: CubeOverlayProps) {
+  const [hovered, setHovered] = useState(false);
+  const label = labelOf(entity);
+  const baseColor = colorForLabel(label ?? entity.id);
+  const highlight = selected || hovered;
+  const strokeColor = highlight ? HOVER_STROKE : baseColor;
+
+  const position = cube.position as readonly [number, number, number];
+  const orientation = cube.orientation as readonly [
+    number,
+    number,
+    number,
+    number,
+  ];
+  const size = cube.size as readonly [number, number, number];
+
+  const key = cubeKey(entity.id, cubeIndex);
+  const handleClick = onSelect
+    ? (e: { stopPropagation: () => void }) => {
+        e.stopPropagation();
+        onSelect({
+          key,
+          entityId: entity.id,
+          cubeIndex,
+          entity,
+          cube,
+          color: baseColor,
+          label,
+        });
+      }
+    : undefined;
+
+  // BoxGeometry is unit-sized; we scale to the cube's size. Edges
+  // geometry is built once per render pass — fine at this scale.
+  return (
+    <group
+      position={[position[0], position[1], position[2]]}
+      quaternion={[
+        orientation[0],
+        orientation[1],
+        orientation[2],
+        orientation[3],
+      ]}
+      scale={[
+        Math.max(0.001, size[0]),
+        Math.max(0.001, size[1]),
+        Math.max(0.001, size[2]),
+      ]}
+    >
+      <mesh
+        onClick={handleClick}
+        onPointerOver={(e) => {
+          e.stopPropagation();
+          setHovered(true);
+        }}
+        onPointerOut={() => setHovered(false)}
+      >
+        <boxGeometry args={[1, 1, 1]} />
+        <meshBasicMaterial transparent opacity={0} depthWrite={false} />
+      </mesh>
+      <lineSegments>
+        <edgesGeometry args={[unitBoxGeometry]} />
+        <lineBasicMaterial
+          color={strokeColor}
+          linewidth={highlight ? 2 : 1}
+          transparent
+          opacity={highlight ? 1 : 0.95}
+          depthTest
+        />
+      </lineSegments>
+    </group>
+  );
+}
+
+// Shared unit box geometry feeds edgesGeometry for every cube; the
+// per-cube scale handles size.
+const unitBoxGeometry = new THREE.BoxGeometry(1, 1, 1);
+
+const IDENTITY_MATRIX = new THREE.Matrix4();
+
+function labelOf(entity: SceneUpdateEntity): string | null {
+  return (
+    entity.metadata["category"] ??
+    entity.metadata["class"] ??
+    entity.metadata["label"] ??
+    null
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Label → palette color (mirrors the image-annotations overlay so the same
+// label class gets the same color on both surfaces).
+// ---------------------------------------------------------------------------
+
+const DEFAULT_COLOR_POOL: readonly string[] = [
+  "#ee0000",
+  "#999900",
+  "#009900",
+  "#003300",
+  "#009999",
+  "#000099",
+  "#0066ff",
+  "#6600ff",
+  "#cc33cc",
+  "#777799",
+];
+
+const labelColorAssignments = new Map<string, string>();
+const DEFAULT_LABEL_KEY = "__no-label__";
+
+function colorForLabel(label: string | null): string {
+  const key = label ?? DEFAULT_LABEL_KEY;
+  let color = labelColorAssignments.get(key);
+  if (!color) {
+    color =
+      DEFAULT_COLOR_POOL[
+        labelColorAssignments.size % DEFAULT_COLOR_POOL.length
+      ];
+    labelColorAssignments.set(key, color);
+  }
+  return color;
+}

--- a/app/packages/multimodal/src/visualization/visualization-registry.ts
+++ b/app/packages/multimodal/src/visualization/visualization-registry.ts
@@ -5,8 +5,10 @@
  */
 export const VISUALIZATION_KIND = Object.freeze({
   ENCODED_IMAGE: "encoded-image",
+  FRAME_TRANSFORM: "frame-transform",
   IMAGE_ANNOTATIONS: "image-annotations",
   POINT_CLOUD: "point-cloud",
+  SCENE_UPDATE: "scene-update",
 } as const);
 
 /**
@@ -37,6 +39,8 @@ export const VISUALIZATION_PANEL_REGISTRY: Readonly<
   Record<VisualizationKind, PanelType>
 > = Object.freeze({
   [VISUALIZATION_KIND.ENCODED_IMAGE]: PANEL_TYPE.IMAGE,
+  [VISUALIZATION_KIND.FRAME_TRANSFORM]: PANEL_TYPE.THREE_D,
   [VISUALIZATION_KIND.IMAGE_ANNOTATIONS]: PANEL_TYPE.IMAGE,
   [VISUALIZATION_KIND.POINT_CLOUD]: PANEL_TYPE.THREE_D,
+  [VISUALIZATION_KIND.SCENE_UPDATE]: PANEL_TYPE.THREE_D,
 });

--- a/app/packages/tiling/src/views/TilingInspectorSidebar/TilingInspectorSidebar.module.css
+++ b/app/packages/tiling/src/views/TilingInspectorSidebar/TilingInspectorSidebar.module.css
@@ -23,11 +23,7 @@
   font-size: 0.8125rem;
   cursor: pointer;
   text-align: center;
-}
-
-.tab:focus-visible {
-  outline: 2px solid var(--color-brand-primary);
-  outline-offset: 2px;
+  outline: none;
 }
 
 .tab:hover {

--- a/app/packages/tiling/src/views/TilingInspectorSidebar/TilingInspectorSidebar.tsx
+++ b/app/packages/tiling/src/views/TilingInspectorSidebar/TilingInspectorSidebar.tsx
@@ -20,36 +20,25 @@ const TilingInspectorSidebar: React.FC = () => {
     <div className={styles.root}>
       <div className={styles.tabs} role="tablist">
         <button
-          id="inspector-tab-explore"
           type="button"
           role="tab"
           aria-selected={tab === "explore"}
-          aria-controls="inspector-panel-explore"
-          tabIndex={tab === "explore" ? 0 : -1}
           className={clsx(styles.tab, tab === "explore" && styles.tabActive)}
           onClick={() => setTab("explore")}
         >
           Explore
         </button>
         <button
-          id="inspector-tab-annotate"
           type="button"
           role="tab"
           aria-selected={tab === "annotate"}
-          aria-controls="inspector-panel-annotate"
-          tabIndex={tab === "annotate" ? 0 : -1}
           className={clsx(styles.tab, tab === "annotate" && styles.tabActive)}
           onClick={() => setTab("annotate")}
         >
           Annotate
         </button>
       </div>
-      <div
-        className={styles.body}
-        role="tabpanel"
-        id={`inspector-panel-${tab}`}
-        aria-labelledby={`inspector-tab-${tab}`}
-      >
+      <div className={styles.body}>
         {tab === "explore" ? <ExplorePanel /> : <AnnotatePanel />}
       </div>
     </div>


### PR DESCRIPTION
## 🔗 Related Issues

Top of the multimodal annotation stack. Stacks on #7647.

## 📋 What changes are proposed in this pull request?

Adds 3D bounding boxes to the lidar tile, sourced from the MCAP's \`foxglove.SceneUpdate\` channel and aligned to the lidar point cloud through a TF tree.

### Decoder layer

- New \`foxglove.SceneUpdate\` decoder. Emits a \`SceneUpdateVisualization\` with \`entities[]\` carrying stable string IDs, per-entity \`frameId\`, and \`cubes[]\` (pose + orientation quaternion + size + color + metadata). Only cubes are surfaced today — spheres / lines / arrows / triangles / models / texts are intentionally deferred until we render them.
- New \`foxglove.FrameTransform\` decoder. Emits a structured \`FrameTransformVisualization\` (parent → child + translation + rotation + timestamp) so the TF tree consumer can typed-access cached transforms without re-decoding.
- Adds the \`SCENE_UPDATE\` and \`FRAME_TRANSFORM\` visualization kinds plus payload descriptors.

### TF tree

- New \`TfTree\` class: frame graph keyed by (parent, child) with a time-sorted history per edge, BFS path-finding between any two frames, quaternion → matrix composition, rigid-transform inverse, and \`lookupChain(from, to, timeNs)\` that binary-searches the latest sample per edge and composes the chain.
- New \`useMcapTfTree()\` hook: one-shot reads every \`/tf\` message via \`client.readDecodedMessages\` (the data-stream cache stores one message per (tick, topic), which can't represent the latest-per-edge tree we need, so \`/tf\` is fetched out-of-band). Builds the tree, caches it at module level by source key so re-toggling is instant.
- New \`useTfTransformMatrix(tree, from, to, timelineStartNs)\` recomputes the 4×4 transform every RAF tick by combining the latest map-frame ego pose with the (effectively static) sensor mounting.

### 3D rendering

- New \`SceneUpdateBoxes\` R3F component: wireframe cubes via \`lineSegments\` + \`edgesGeometry\` on a unit \`boxGeometry\` scaled by the cube's size. Interior pointer-event capture via a transparent \`mesh\` + \`boxGeometry\` sibling so anywhere-inside a wireframe selects it. Mounts as a child of \`Base3DScene\` — same Three.js world as the lidar point cloud.
- The outer group applies a -90° X rotation so the Foxglove Z-up cuboids stand upright in the lidar tile's Y-up Three.js view, matching the existing point-cloud rendering.

### Lidar tile integration

- New \`McapLidarBoxes\` adapter component: subscribes to a \`SceneUpdate\` topic, looks up \`entityFrame → lidarFrame\` at the current playhead, draws the cubes inside the surrounding R3F scene.
- Lidar tile gains a \"Show 3D annotations\" checkbox in its settings sidebar. **Defaults off** — when off, neither the \`/markers/annotations\` subscription nor the one-shot \`/tf\` history fetch runs. When on, the toggle label briefly says \"(loading…)\" until the TF tree finishes loading.
- \`PointCloudPanel\` accepts \`children\` so consumers can mount additional R3F scene content.

### Shared selection across surfaces

- New \`McapAnnotationSelectionProvider\` holds a single \`selectedKey\` shared between the camera image overlay and the lidar 3D boxes. Clicking either surface implicitly deselects whatever was selected on the other.
- Selection keys are disjoint by construction (camera uses bounds-fingerprint keys, lidar uses \`entityId#cubeIndex\`), so the single string is sufficient.

### Inspector + miscellany

- Sidebars default to open in the modal.
- Clicking a lidar box publishes a \`scene-annotation\` payload (entity id, color, label, full cube data, metadata) into the focused tile's selection — Explore tab renders it.
- Camera lines reverted to source thickness (the 1.5× bump felt too heavy).

## 🧪 How is this patch tested? If it is not, please explain why.

- \`yarn check\` clean across multimodal + tiling (lint, deps, types).
- Vitest suite passes (2318 tests).
- Manually verified with a NuScenes \`.mcap\`: toggling on triggers exactly one \`/tf\` fetch, cubes appear correctly oriented relative to the lidar cloud, clicking a cube publishes its metadata to the inspector and unselects any prior camera-overlay selection, re-toggling is instant (cached).

## 📝 Release Notes

### Is this a user-facing change?

-   [x] No.
-   [ ] Yes.

### What areas of FiftyOne does this PR affect?

-   [x] App
-   [ ] Build
-   [ ] Core
-   [ ] Documentation
-   [ ] Other