### PR TITLE
Optimize MCAP playback buffering

### DIFF
--- a/app/packages/multimodal/src/adapters/mcap/react/McapCameraTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapCameraTile.tsx
@@ -1,5 +1,5 @@
 import { Size, Spinner } from "@voxel51/voodo";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import type { EncodedImageVisualization } from "../../../decoders";
 import { useSceneSourcesByType } from "../../../scene-inventory";
 import { ImagePanel } from "../../../visualization/panels/image";
@@ -7,23 +7,9 @@ import styles from "./McapTile.module.css";
 import { useMcapTopicStream } from "./use-mcap-topic-stream";
 
 const McapCameraTile: React.FC = () => {
-  const [topic, setTopic] = useState<string | null>(null);
   const cameras = useSceneSourcesByType("camera");
-
-  useEffect(() => {
-    // Re-bind when the inventory changes — covers both "no selection
-    // yet" and "previous selection disappeared after a source/file
-    // change". Without this, a stale topic keeps the tile in loading.
-    if (cameras.length === 0) {
-      if (topic !== null) setTopic(null);
-      return;
-    }
-    if (topic === null || !cameras.some((c) => c.id === topic)) {
-      setTopic(cameras[0].id);
-    }
-  }, [cameras, topic]);
-
-  const frame = useMcapTopicStream<EncodedImageVisualization>(topic ?? "");
+  const topic = cameras[0]?.id ?? "";
+  const frame = useMcapTopicStream<EncodedImageVisualization>(topic);
 
   if (!frame) {
     return (

--- a/app/packages/multimodal/src/adapters/mcap/react/McapLidarTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapLidarTile.tsx
@@ -1,5 +1,5 @@
 import { Size, Spinner } from "@voxel51/voodo";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import type { PointCloudVisualization } from "../../../decoders";
 import { useSceneSourcesByType } from "../../../scene-inventory";
 import { PointCloudPanel } from "../../../visualization/panels/point-cloud";
@@ -7,23 +7,9 @@ import styles from "./McapTile.module.css";
 import { useMcapTopicStream } from "./use-mcap-topic-stream";
 
 const McapLidarTile: React.FC = () => {
-  const [topic, setTopic] = useState<string | null>(null);
   const lidars = useSceneSourcesByType("lidar");
-
-  useEffect(() => {
-    // Re-bind when the inventory changes — covers both "no selection
-    // yet" and "previous selection disappeared after a source/file
-    // change". Without this, a stale topic keeps the tile in loading.
-    if (lidars.length === 0) {
-      if (topic !== null) setTopic(null);
-      return;
-    }
-    if (topic === null || !lidars.some((l) => l.id === topic)) {
-      setTopic(lidars[0].id);
-    }
-  }, [lidars, topic]);
-
-  const frame = useMcapTopicStream<PointCloudVisualization>(topic ?? "");
+  const topic = lidars[0]?.id ?? "";
+  const frame = useMcapTopicStream<PointCloudVisualization>(topic);
 
   if (!frame) {
     return (

--- a/app/packages/multimodal/src/adapters/mcap/react/use-register-mcap-data-stream.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-register-mcap-data-stream.test.tsx
@@ -101,16 +101,69 @@ describe("useRegisterMcapDataStream", () => {
     });
     expect(playbackStore?.get(streamValueAtom(TOPIC))).toBeNull();
   });
+
+  it("ignores in-flight batch results after topic unsubscribe", async () => {
+    const source = createSource("source");
+    const oldBatch = deferred<readonly McapSynchronizedMessageWindow[]>();
+    let playbackStore: PlaybackStore | undefined;
+    const client = createClient({
+      readSynchronizedMessageBatch: vi.fn(() => oldBatch.promise),
+      readTimelineRange: vi.fn(async () => createTimelineRange()),
+    });
+
+    const { rerender } = render(
+      <Harness
+        client={client}
+        onStore={(store) => {
+          playbackStore = store;
+        }}
+        source={source}
+      />,
+      { wrapper: TestProviders }
+    );
+
+    await waitFor(() => {
+      expect(client.readSynchronizedMessageBatch).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(
+      <Harness
+        client={client}
+        onStore={(store) => {
+          playbackStore = store;
+        }}
+        source={source}
+        subscribe={false}
+      />
+    );
+
+    await act(async () => {
+      oldBatch.resolve([
+        createWindow({
+          timeNs: 0n,
+          visualization: {
+            bytes: new Uint8Array([1, 2, 3]),
+            kind: VISUALIZATION_KIND.ENCODED_IMAGE,
+          },
+        }),
+      ]);
+      await Promise.resolve();
+    });
+
+    expect(playbackStore?.get(streamValueAtom(TOPIC))).toBeNull();
+  });
 });
 
 function Harness({
   client,
   onStore,
   source,
+  subscribe = true,
 }: {
   readonly client: McapResourceClient;
   readonly onStore: (store: PlaybackStore) => void;
   readonly source: ByteSourceDescriptor | null;
+  readonly subscribe?: boolean;
 }) {
   const dataStream = useMcapDataStream();
   const store = usePlaybackStore();
@@ -126,8 +179,10 @@ function Harness({
   }, [onStore, store]);
 
   useEffect(() => {
+    if (!subscribe) return undefined;
+
     return dataStream?.subscribeToTopic(TOPIC);
-  }, [dataStream]);
+  }, [dataStream, subscribe]);
 
   return null;
 }

--- a/app/packages/multimodal/src/adapters/mcap/react/use-register-mcap-data-stream.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-register-mcap-data-stream.ts
@@ -22,9 +22,73 @@ import type { McapTimelineIndex } from "./mcap-timeline-index";
 import { createMcapTimelineIndex } from "./mcap-timeline-index";
 import { McapTopicCache } from "./mcap-topic-cache";
 
+// One engine stream owns all MCAP topics so camera/lidar tiles stay on the
+// same synchronized timeline and fetch in shared batches.
 const STREAM_ID = "mcap-data-stream";
-const LOOKAHEAD_SECONDS = 15;
-const MAX_PREFETCH_BATCH = 32;
+
+interface McapPlaybackPolicy {
+  /**
+   * Target buffer horizon. This should be long enough to hide normal worker
+   * decode latency and short enough that a seek/topic switch does not overfetch
+   * a large part of the file.
+   */
+  readonly lookaheadSeconds: number;
+
+  /**
+   * Per-worker-request time cap. A single full-lookahead request can decode too
+   * much at once and create a large response, so the lookahead is filled by
+   * multiple bounded requests.
+   */
+  readonly prefetchBatchSeconds: number;
+
+  /**
+   * Cadence for topping up lookahead while playback advances. This should be
+   * much slower than RAF but comfortably faster than the buffer can drain.
+   */
+  readonly prefetchRefreshSeconds: number;
+
+  /**
+   * Cache room relative to one full lookahead window. Values above 1 leave room
+   * for overlap during refreshes, seeks, and in-flight batch completion, so
+   * future prefetches do not evict near-playhead ticks before playback reaches
+   * them.
+   */
+  readonly topicCacheLookaheadMultiplier: number;
+}
+
+/**
+ * Playback policy after converting human-scale seconds/multipliers into the
+ * concrete tick counts used by the prefetch loop and per-topic caches.
+ */
+interface DerivedMcapPlaybackPolicy extends McapPlaybackPolicy {
+  /**
+   * Maximum number of timeline ticks to request in one worker batch, derived
+   * from the timeline tick rate and `prefetchBatchSeconds`.
+   */
+  readonly maxPrefetchBatch: number;
+
+  /**
+   * Number of bounded worker batches needed to cover one full lookahead window,
+   * derived from `lookaheadSeconds / prefetchBatchSeconds`.
+   */
+  readonly prefetchBatchesPerLookahead: number;
+
+  /**
+   * Maximum entries retained per topic cache, derived from tick rate,
+   * lookahead window, and `topicCacheLookaheadMultiplier`.
+   */
+  readonly topicCacheMaxEntries: number;
+}
+
+const DEFAULT_MCAP_PLAYBACK_POLICY: McapPlaybackPolicy = {
+  lookaheadSeconds: 15,
+  prefetchBatchSeconds: 5,
+  prefetchRefreshSeconds: 1,
+  topicCacheLookaheadMultiplier: 2,
+} as const;
+
+const PLAYBACK_POLICY = deriveMcapPlaybackPolicy(DEFAULT_MCAP_PLAYBACK_POLICY);
+
 const noop = (): void => undefined;
 
 export interface UseMcapDataStreamOptions {
@@ -67,6 +131,7 @@ export function useRegisterMcapDataStream({
   // topic doesn't make collectMissingTicks think that topic is in flight.
   const pendingTicksRef = useRef<Map<string, Set<string>>>(new Map());
   const lastFrameRef = useRef<Map<string, unknown>>(new Map());
+  const nextLookaheadRefreshTimeRef = useRef(0);
   const indexRef = useRef<McapTimelineIndex | null>(null);
   const sourceEpochRef = useRef(0);
   indexRef.current = index;
@@ -117,7 +182,10 @@ export function useRegisterMcapDataStream({
   useEffect(() => {
     for (const topic of allTopics) {
       if (!topicCachesRef.current.has(topic)) {
-        topicCachesRef.current.set(topic, new McapTopicCache());
+        topicCachesRef.current.set(
+          topic,
+          new McapTopicCache(PLAYBACK_POLICY.topicCacheMaxEntries)
+        );
       }
     }
   }, [allTopics]);
@@ -132,6 +200,7 @@ export function useRegisterMcapDataStream({
     setIndex(null);
     pendingTicksRef.current.clear();
     lastFrameRef.current.clear();
+    nextLookaheadRefreshTimeRef.current = 0;
     for (const cache of topicCachesRef.current.values()) {
       cache.clear();
     }
@@ -170,7 +239,9 @@ export function useRegisterMcapDataStream({
   // tiles render their first frame as soon as the network resolves.
   const fetchBatch = useCallback(
     (ticks: bigint[], activeTopics: string[]) => {
-      if (ticks.length === 0 || activeTopics.length === 0 || !source) return;
+      if (ticks.length === 0 || activeTopics.length === 0 || !source) {
+        return false;
+      }
       const sourceEpoch = sourceEpochRef.current;
       const caches = topicCachesRef.current;
 
@@ -181,10 +252,20 @@ export function useRegisterMcapDataStream({
         const tickKey = tick.toString();
         return activeTopics.some((t) => !isTopicPending(tickKey, t));
       });
-      if (toFetch.length === 0) return;
+      if (toFetch.length === 0) return false;
 
       const keys = toFetch.map((t) => t.toString());
-      markTopicsPending(keys, activeTopics);
+      const topicsToFetch = activeTopics.filter((topic) =>
+        toFetch.some((tick) => {
+          const tickKey = tick.toString();
+          return (
+            !caches.get(topic)?.has(tick) && !isTopicPending(tickKey, topic)
+          );
+        })
+      );
+      if (topicsToFetch.length === 0) return false;
+
+      markTopicsPending(keys, topicsToFetch);
 
       client
         .readSynchronizedMessageBatch({
@@ -192,13 +273,13 @@ export function useRegisterMcapDataStream({
           source,
           streamPolicies: streamPoliciesRef.current,
           timeNs: toFetch,
-          topics: activeTopics,
+          topics: topicsToFetch,
         })
         .then((windows) => {
           if (sourceEpochRef.current !== sourceEpoch) return;
 
           for (const window of windows) {
-            distributeWindowToCaches(window, caches, activeTopics);
+            distributeWindowToCaches(window, caches, topicsToFetch);
           }
           const currentIndex = indexRef.current;
           if (!currentIndex) return;
@@ -217,15 +298,17 @@ export function useRegisterMcapDataStream({
         .finally(() => {
           if (sourceEpochRef.current !== sourceEpoch) return;
 
-          clearTopicsPending(keys, activeTopics);
+          clearTopicsPending(keys, topicsToFetch);
         });
+
+      return true;
     },
     [client, source, store]
   );
 
   // Collect ticks in [startSec, endSec] where at least one active topic
   // still needs the data — i.e. not cached and not already pending for
-  // that specific topic. Capped at MAX_PREFETCH_BATCH.
+  // that specific topic. Capped by the resolved playback policy.
   const collectMissingTicks = useCallback(
     (startSec: number, endSec: number): bigint[] => {
       const currentIndex = indexRef.current;
@@ -248,7 +331,7 @@ export function useRegisterMcapDataStream({
           (t) => !caches.get(t)?.has(tick) && !isTopicPending(tickKey, t)
         );
         if (needsFetch) toFetch.push(tick);
-        if (toFetch.length >= MAX_PREFETCH_BATCH) break;
+        if (toFetch.length >= PLAYBACK_POLICY.maxPrefetchBatch) break;
       }
       return toFetch;
     },
@@ -257,13 +340,14 @@ export function useRegisterMcapDataStream({
 
   // Push cached current frame for the active set AND kick off a batch
   // prefetch of [timeSec, timeSec+LOOKAHEAD] so the buffer starts filling
-  // immediately (mount, tile subscribe, seek, every playhead tick).
+  // immediately (mount, tile subscribe, seek).
   const prefetchLookaheadFrom = useCallback(
     (timeSec: number) => {
       const currentIndex = indexRef.current;
       if (!currentIndex) return;
       const activeTopics = getActiveTopics();
       if (activeTopics.length === 0) return;
+      nextLookaheadRefreshTimeRef.current = timeSec;
 
       const tick = currentIndex.nearestTick(timeSec);
       if (tick) {
@@ -276,8 +360,13 @@ export function useRegisterMcapDataStream({
         );
       }
 
-      const missing = collectMissingTicks(timeSec, timeSec + LOOKAHEAD_SECONDS);
-      if (missing.length > 0) fetchBatch(missing, activeTopics);
+      fillMissingLookaheadFrom({
+        activeTopics,
+        collectMissingTicks,
+        fetchBatch,
+        policy: PLAYBACK_POLICY,
+        timeSec,
+      });
     },
     [collectMissingTicks, fetchBatch, getActiveTopics, store]
   );
@@ -289,13 +378,14 @@ export function useRegisterMcapDataStream({
     const nativeStep = 1 / DEFAULT_MCAP_TIMELINE_TICK_RATE_HZ;
     const caches = topicCachesRef.current;
     const lastFrame = lastFrameRef.current;
+    let lastCommittedTickKey: string | null = null;
 
     const stream: PlaybackStream = {
       id: STREAM_ID,
       blocking: true,
       duration: index.durationSec,
       nativeStepSeconds: nativeStep,
-      lookaheadSeconds: LOOKAHEAD_SECONDS,
+      lookaheadSeconds: PLAYBACK_POLICY.lookaheadSeconds,
 
       bufferState: (timeSec) => {
         const tick = index.nearestTick(timeSec);
@@ -325,6 +415,9 @@ export function useRegisterMcapDataStream({
       onCommit: (timeSec, commitStore) => {
         const tick = index.nearestTick(timeSec);
         if (!tick) return;
+        const tickKey = tick.toString();
+        if (lastCommittedTickKey === tickKey) return;
+        lastCommittedTickKey = tickKey;
         pushTickToStore(
           getActiveTopics(),
           tick,
@@ -340,10 +433,24 @@ export function useRegisterMcapDataStream({
     // per-topic via McapTopicCache, not at the engine stream level.
     const unsubscribe = subscribeStream(STREAM_ID);
 
-    // Proactive lookahead: fill the buffer ahead of the playhead on every
-    // RAF tick so subsequent frames are ready before the engine needs them.
+    // Proactive lookahead: fill the buffer ahead of the playhead in larger
+    // chunks instead of creating one tiny worker request per source tick.
     const unsubPlayhead = store.sub(playheadAtom, () => {
-      prefetchLookaheadFrom(store.get(playheadAtom));
+      const timeSec = store.get(playheadAtom);
+      if (timeSec < nextLookaheadRefreshTimeRef.current) return;
+      nextLookaheadRefreshTimeRef.current =
+        timeSec + PLAYBACK_POLICY.prefetchRefreshSeconds;
+      const activeTopics = getActiveTopics();
+      if (activeTopics.length === 0) return;
+      // Periodic top-up only fills missing lookahead; current-frame publication
+      // stays in prefetchLookaheadFrom for mount, seek, and subscription paths.
+      fillMissingLookaheadFrom({
+        activeTopics,
+        collectMissingTicks,
+        fetchBatch,
+        policy: PLAYBACK_POLICY,
+        timeSec,
+      });
     });
 
     return () => {
@@ -360,7 +467,6 @@ export function useRegisterMcapDataStream({
     fetchBatch,
     collectMissingTicks,
     getActiveTopics,
-    prefetchLookaheadFrom,
   ]);
 
   // Paused-seek: scrub while paused → push or fetch the seeked tick + window.
@@ -409,6 +515,45 @@ export function useRegisterMcapDataStream({
 // Module-level helpers (no React dependency)
 // ---------------------------------------------------------------------------
 
+function deriveMcapPlaybackPolicy(
+  policy: McapPlaybackPolicy,
+  tickRateHz = DEFAULT_MCAP_TIMELINE_TICK_RATE_HZ
+): DerivedMcapPlaybackPolicy {
+  return {
+    ...policy,
+    maxPrefetchBatch: Math.ceil(tickRateHz * policy.prefetchBatchSeconds),
+    prefetchBatchesPerLookahead: Math.ceil(
+      policy.lookaheadSeconds / policy.prefetchBatchSeconds
+    ),
+    topicCacheMaxEntries: Math.ceil(
+      tickRateHz *
+        policy.lookaheadSeconds *
+        policy.topicCacheLookaheadMultiplier
+    ),
+  };
+}
+
+function fillMissingLookaheadFrom({
+  activeTopics,
+  collectMissingTicks,
+  fetchBatch,
+  policy,
+  timeSec,
+}: {
+  activeTopics: string[];
+  collectMissingTicks: (startSec: number, endSec: number) => bigint[];
+  fetchBatch: (ticks: bigint[], activeTopics: string[]) => boolean;
+  policy: DerivedMcapPlaybackPolicy;
+  timeSec: number;
+}): void {
+  const endSec = timeSec + policy.lookaheadSeconds;
+  for (let i = 0; i < policy.prefetchBatchesPerLookahead; i++) {
+    const missing = collectMissingTicks(timeSec, endSec);
+    if (missing.length === 0) return;
+    if (!fetchBatch(missing, activeTopics)) return;
+  }
+}
+
 function distributeWindowToCaches(
   window: McapSynchronizedMessageWindow,
   caches: Map<string, McapTopicCache>,
@@ -436,11 +581,12 @@ function pushTickToStore(
     const msg = cache.get(tick);
     const viz = msg?.decoded.output.visualization ?? null;
     if (viz !== null) lastFrame.set(topic, viz);
-    // Write unconditionally — including `null` — so re-subscribing to a
-    // topic that previously held data doesn't briefly show the prior
-    // session's last frame before a fresh fetch lands.
+    // Still publish `null` when the current atom holds data, but avoid
+    // waking subscribers when the selected source tick hasn't changed.
     const toWrite = lastFrame.get(topic) ?? null;
-    store.set(streamValueAtom(topic), toWrite);
+    const atom = streamValueAtom(topic);
+    if (store.get(atom) === toWrite) continue;
+    store.set(atom, toWrite);
   }
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/react/use-register-mcap-data-stream.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-register-mcap-data-stream.ts
@@ -287,15 +287,22 @@ export function useRegisterMcapDataStream({
         .then((windows) => {
           if (sourceEpochRef.current !== sourceEpoch) return;
 
+          const activeFetchedTopics = activeTopicsInCaches(
+            caches,
+            topicsToFetch
+          );
+          if (activeFetchedTopics.length === 0) return;
+
           for (const window of windows) {
-            distributeWindowToCaches(window, caches, topicsToFetch);
+            distributeWindowToCaches(window, caches, activeFetchedTopics);
           }
           const currentIndex = indexRef.current;
           if (!currentIndex) return;
           const tick = currentIndex.nearestTick(store.get(playheadAtom));
+          const stillActiveTopics = activeTopicsInCaches(caches, activeTopics);
           if (tick) {
             pushTickToStore(
-              activeTopics,
+              stillActiveTopics,
               tick,
               caches,
               lastFrameRef.current,
@@ -324,6 +331,7 @@ export function useRegisterMcapDataStream({
         return false;
       }
 
+      const sourceEpoch = sourceEpochRef.current;
       const caches = topicCachesRef.current;
       const tickKey = tick.toString();
       const topicsToFetch = activeTopics.filter(
@@ -343,9 +351,17 @@ export function useRegisterMcapDataStream({
           topics: topicsToFetch,
         })
         .then((window) => {
-          distributeWindowToCaches(window, caches, topicsToFetch);
+          if (sourceEpochRef.current !== sourceEpoch) return;
+
+          const activeFetchedTopics = activeTopicsInCaches(
+            caches,
+            topicsToFetch
+          );
+          if (activeFetchedTopics.length === 0) return;
+
+          distributeWindowToCaches(window, caches, activeFetchedTopics);
           pushTickToStore(
-            activeTopics,
+            activeTopicsInCaches(caches, activeTopics),
             tick,
             caches,
             lastFrameRef.current,
@@ -354,6 +370,8 @@ export function useRegisterMcapDataStream({
         })
         .catch(noop)
         .finally(() => {
+          if (sourceEpochRef.current !== sourceEpoch) return;
+
           clearTopicsPending([tickKey], topicsToFetch);
         });
 
@@ -617,6 +635,13 @@ function fillMissingLookaheadFrom({
     if (missing.length === 0) return;
     if (!fetchBatch(missing, activeTopics)) return;
   }
+}
+
+function activeTopicsInCaches(
+  caches: Map<string, McapTopicCache>,
+  topics: readonly string[]
+): string[] {
+  return topics.filter((topic) => caches.get(topic)?.isActive);
 }
 
 function distributeWindowToCaches(

--- a/app/packages/multimodal/src/adapters/mcap/react/use-register-mcap-data-stream.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-register-mcap-data-stream.ts
@@ -42,6 +42,14 @@ interface McapPlaybackPolicy {
   readonly prefetchBatchSeconds: number;
 
   /**
+   * Maximum number of background prefetch batches to enqueue in one pass.
+   * Keeping this lower than the full lookahead lets the current-frame request
+   * win worker time on mount, seek, and subscription while still filling the
+   * buffer through periodic top-ups.
+   */
+  readonly prefetchBatchesPerPass: number;
+
+  /**
    * Cadence for topping up lookahead while playback advances. This should be
    * much slower than RAF but comfortably faster than the buffer can drain.
    */
@@ -83,6 +91,7 @@ interface DerivedMcapPlaybackPolicy extends McapPlaybackPolicy {
 const DEFAULT_MCAP_PLAYBACK_POLICY: McapPlaybackPolicy = {
   lookaheadSeconds: 15,
   prefetchBatchSeconds: 5,
+  prefetchBatchesPerPass: 1,
   prefetchRefreshSeconds: 1,
   topicCacheLookaheadMultiplier: 2,
 } as const;
@@ -306,6 +315,53 @@ export function useRegisterMcapDataStream({
     [client, source, store]
   );
 
+  // Fetch the nearest target frame through the worker's current-frame lane so
+  // mount, seek, subscription, and buffering recovery do not wait behind a
+  // larger background lookahead batch.
+  const fetchCurrentFrame = useCallback(
+    (tick: bigint, activeTopics: string[]) => {
+      if (activeTopics.length === 0 || !source) {
+        return false;
+      }
+
+      const caches = topicCachesRef.current;
+      const tickKey = tick.toString();
+      const topicsToFetch = activeTopics.filter(
+        (topic) =>
+          !caches.get(topic)?.has(tick) && !isTopicPending(tickKey, topic)
+      );
+      if (topicsToFetch.length === 0) return false;
+
+      markTopicsPending([tickKey], topicsToFetch);
+
+      client
+        .readSynchronizedMessages({
+          activeTimeline: MCAP_ACTIVE_TIMELINE.LOG,
+          source,
+          streamPolicies: streamPoliciesRef.current,
+          timeNs: tick,
+          topics: topicsToFetch,
+        })
+        .then((window) => {
+          distributeWindowToCaches(window, caches, topicsToFetch);
+          pushTickToStore(
+            activeTopics,
+            tick,
+            caches,
+            lastFrameRef.current,
+            store
+          );
+        })
+        .catch(noop)
+        .finally(() => {
+          clearTopicsPending([tickKey], topicsToFetch);
+        });
+
+      return true;
+    },
+    [client, source, store]
+  );
+
   // Collect ticks in [startSec, endSec] where at least one active topic
   // still needs the data — i.e. not cached and not already pending for
   // that specific topic. Capped by the resolved playback policy.
@@ -338,9 +394,9 @@ export function useRegisterMcapDataStream({
     [getActiveTopics]
   );
 
-  // Push cached current frame for the active set AND kick off a batch
-  // prefetch of [timeSec, timeSec+LOOKAHEAD] so the buffer starts filling
-  // immediately (mount, tile subscribe, seek).
+  // Push cached current frame for the active set, request a missing current
+  // frame on the priority lane, and then enqueue bounded background lookahead
+  // so mount, tile subscribe, and seek paint before bulk prefetch completes.
   const prefetchLookaheadFrom = useCallback(
     (timeSec: number) => {
       const currentIndex = indexRef.current;
@@ -358,6 +414,7 @@ export function useRegisterMcapDataStream({
           lastFrameRef.current,
           store
         );
+        fetchCurrentFrame(tick, activeTopics);
       }
 
       fillMissingLookaheadFrom({
@@ -368,7 +425,7 @@ export function useRegisterMcapDataStream({
         timeSec,
       });
     },
-    [collectMissingTicks, fetchBatch, getActiveTopics, store]
+    [collectMissingTicks, fetchBatch, fetchCurrentFrame, getActiveTopics, store]
   );
 
   // Register the single engine stream and the proactive lookahead subscription.
@@ -408,8 +465,11 @@ export function useRegisterMcapDataStream({
       },
 
       prefetch: ([startSec, endSec]) => {
+        const activeTopics = getActiveTopics();
+        const tick = index.nearestTick(startSec);
+        if (tick) fetchCurrentFrame(tick, activeTopics);
         const missing = collectMissingTicks(startSec, endSec);
-        if (missing.length > 0) fetchBatch(missing, getActiveTopics());
+        if (missing.length > 0) fetchBatch(missing, activeTopics);
       },
 
       onCommit: (timeSec, commitStore) => {
@@ -465,6 +525,7 @@ export function useRegisterMcapDataStream({
     subscribeStream,
     store,
     fetchBatch,
+    fetchCurrentFrame,
     collectMissingTicks,
     getActiveTopics,
   ]);
@@ -547,7 +608,11 @@ function fillMissingLookaheadFrom({
   timeSec: number;
 }): void {
   const endSec = timeSec + policy.lookaheadSeconds;
-  for (let i = 0; i < policy.prefetchBatchesPerLookahead; i++) {
+  const batchesToQueue = Math.min(
+    policy.prefetchBatchesPerPass,
+    policy.prefetchBatchesPerLookahead
+  );
+  for (let i = 0; i < batchesToQueue; i++) {
     const missing = collectMissingTicks(timeSec, endSec);
     if (missing.length === 0) return;
     if (!fetchBatch(missing, activeTopics)) return;

--- a/app/packages/multimodal/src/visualization/panels/webgpu-canvas.tsx
+++ b/app/packages/multimodal/src/visualization/panels/webgpu-canvas.tsx
@@ -17,7 +17,9 @@ type RendererWithDreiCompat = THREE.WebGPURenderer & {
   }>;
 };
 
-const DEFAULT_DPR: Dpr = [1, 2];
+// Playback canvases redraw frequently; default to CSS pixel density and let
+// inspection surfaces opt into higher DPR explicitly when they need it.
+const DEFAULT_DPR: Dpr = 1;
 const OPAQUE_CLEAR_ALPHA = 1;
 const DEFAULT_MAX_ANISOTROPY = 1;
 


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Optimizes MCAP playback by batching lookahead less aggressively, prioritizing the current frame, reducing redundant frame publishes, binding default camera/lidar topics during render, and lowering the shared WebGPU canvas default DPR for playback-heavy panels.

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn check:strict`
- `yarn test packages/multimodal/src/adapters/mcap/worker/worker-client.test.ts packages/multimodal/src/adapters/mcap/worker/playback-worker-scheduler.test.ts`
- `git diff --check origin/feat/tf-mcap...HEAD`

## Notes to Reviewer

Best reviewed commit-by-commit. The first commit contains the main playback policy and lookahead cadence change; the last two commits prioritize current-frame fetches and lighten panel startup/render cost.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified camera and lidar topic selection to reduce rebinding delays and improve responsiveness
  * Reworked MCAP playback to use a configurable playback policy with adaptive lookahead, bounded prefetching, prioritized current-frame fetches, and reduced redundant updates
  * Set a fixed default canvas DPR for more consistent rendering

* **Tests**
  * Added a test ensuring in-flight batch results are ignored after a topic is unsubscribed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7646?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->