### PR TITLE
feat: clickable camera annotations + label colors + interpolation + inspector tabs

### DIFF
--- a/app/packages/multimodal/src/adapters/mcap/react/McapCameraAnnotationOverlay.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapCameraAnnotationOverlay.tsx
@@ -1,5 +1,5 @@
 import { useSetTileSelection } from "@fiftyone/tiling";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 
 import {
   ImageAnnotationsOverlay,
@@ -33,6 +33,10 @@ const McapCameraAnnotationOverlay: React.FC<
   const frame = useInterpolatedImageAnnotations(topic, { interpolate });
   const setSelection = useSetTileSelection();
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSelectedKey(null);
+  }, [topic]);
 
   const handleSelect = useCallback(
     (picked: ImageAnnotationPickedPrimitive) => {

--- a/app/packages/multimodal/src/adapters/mcap/react/McapCameraAnnotationOverlay.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapCameraAnnotationOverlay.tsx
@@ -1,9 +1,11 @@
 import { useSetTileSelection } from "@fiftyone/tiling";
 import React, { useCallback, useState } from "react";
 
-import type { ImageAnnotationsVisualization } from "../../../decoders";
-import { ImageAnnotationsOverlay } from "../../../visualization/panels/ImageAnnotationsOverlay";
-import { useMcapTopicStream } from "./use-mcap-topic-stream";
+import {
+  ImageAnnotationsOverlay,
+  type ImageAnnotationPickedPrimitive,
+} from "../../../visualization/panels/ImageAnnotationsOverlay";
+import { useInterpolatedImageAnnotations } from "./use-interpolated-image-annotations";
 
 export interface McapCameraAnnotationOverlayProps {
   readonly topic: string;

--- a/app/packages/multimodal/src/adapters/mcap/react/McapCameraAnnotationOverlay.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapCameraAnnotationOverlay.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import { useSetTileSelection } from "@fiftyone/tiling";
+import React, { useCallback, useState } from "react";
 
 import type { ImageAnnotationsVisualization } from "../../../decoders";
 import { ImageAnnotationsOverlay } from "../../../visualization/panels/ImageAnnotationsOverlay";
@@ -9,6 +10,7 @@ export interface McapCameraAnnotationOverlayProps {
   readonly imageWidth: number;
   readonly imageHeight: number;
   readonly fit?: "contain" | "cover";
+  readonly interpolate?: boolean;
 }
 
 /**
@@ -19,8 +21,33 @@ export interface McapCameraAnnotationOverlayProps {
  */
 const McapCameraAnnotationOverlay: React.FC<
   McapCameraAnnotationOverlayProps
-> = ({ topic, imageWidth, imageHeight, fit = "contain" }) => {
-  const frame = useMcapTopicStream<ImageAnnotationsVisualization>(topic);
+> = ({
+  topic,
+  imageWidth,
+  imageHeight,
+  fit = "contain",
+  interpolate = true,
+}) => {
+  const frame = useInterpolatedImageAnnotations(topic, { interpolate });
+  const setSelection = useSetTileSelection();
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+
+  const handleSelect = useCallback(
+    (picked: ImageAnnotationPickedPrimitive) => {
+      setSelectedKey(picked.key);
+      setSelection({
+        kind: "image-annotation",
+        topic,
+        primitiveKind: picked.primitive.kind,
+        primitiveIndex: picked.primitiveIndex,
+        color: picked.color,
+        label: picked.label,
+        data: picked.primitive.value,
+      });
+    },
+    [setSelection, topic]
+  );
+
   if (!frame) return null;
   return (
     <ImageAnnotationsOverlay
@@ -28,6 +55,8 @@ const McapCameraAnnotationOverlay: React.FC<
       imageWidth={imageWidth}
       imageHeight={imageHeight}
       fit={fit}
+      selectedKey={selectedKey}
+      onSelectPrimitive={handleSelect}
     />
   );
 };

--- a/app/packages/multimodal/src/adapters/mcap/react/McapCameraTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapCameraTile.tsx
@@ -1,5 +1,6 @@
 import { TileSettingsContent, useSetTileTitle } from "@fiftyone/tiling";
 import {
+  Checkbox,
   Dropdown,
   DropdownAnchor,
   DropdownTrigger,
@@ -24,6 +25,7 @@ const McapCameraTile: React.FC = () => {
     width: number;
     height: number;
   } | null>(null);
+  const [interpolateAnnotations, setInterpolateAnnotations] = useState(true);
   const cameras = useSceneSourcesByType("camera");
   const setTileTitle = useSetTileTitle();
   const [topic, setTopic] = useState<string>(cameras[0]?.id ?? "");
@@ -78,6 +80,16 @@ const McapCameraTile: React.FC = () => {
               ))}
             </Dropdown>
           </div>
+          <div className={settingsStyles.field}>
+            <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
+              Annotations
+            </Text>
+            <Checkbox
+              label="Interpolate between annotations"
+              checked={interpolateAnnotations}
+              onChange={setInterpolateAnnotations}
+            />
+          </div>
         </div>
       </TileSettingsContent>
       {frame ? (
@@ -98,6 +110,7 @@ const McapCameraTile: React.FC = () => {
               topic={annotationTopic}
               imageWidth={imageDims.width}
               imageHeight={imageDims.height}
+              interpolate={interpolateAnnotations}
             />
           ) : null}
         </div>

--- a/app/packages/multimodal/src/adapters/mcap/react/McapModalRenderer.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapModalRenderer.tsx
@@ -27,8 +27,8 @@ const McapModalRenderer: React.FC<SampleRendererProps> = ({ ctx }) => {
         fileName={fileName}
         sceneSources={sceneSources}
         initialTiles={initialTiles}
-        defaultLeftOpen={false}
-        defaultRightOpen={false}
+        defaultLeftOpen
+        defaultRightOpen
       >
         <McapStreams ctx={ctx} />
       </MultiModalPlayback>

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-data-stream-context.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-data-stream-context.tsx
@@ -1,9 +1,6 @@
-import React, {
-  createContext,
-  useContext,
-  useMemo,
-  useState,
-} from "react";
+import React, { createContext, useContext, useMemo, useState } from "react";
+import type { McapTimelineIndex } from "./mcap-timeline-index";
+import type { McapTopicCache } from "./mcap-topic-cache";
 
 /**
  * The handle a tile body uses to subscribe to MCAP topic data. The
@@ -16,6 +13,14 @@ export interface McapDataStream {
    *  subscriber count; the topic's cache + held last-frame are
    *  released when the count reaches zero. */
   readonly subscribeToTopic: (topic: string) => () => void;
+
+  /** Read access to one topic's decoded message cache. Used by
+   *  consumers that need lookahead (e.g. annotation interpolation). */
+  readonly getTopicCache: (topic: string) => McapTopicCache | undefined;
+
+  /** Read access to the timeline index — ordered ticks plus
+   *  `nearestTick(timeSec)` / `secToNs(timeSec)`. */
+  readonly getTimelineIndex: () => McapTimelineIndex | null;
 }
 
 interface McapDataStreamContextValue {
@@ -41,10 +46,7 @@ export const McapDataStreamProvider: React.FC<{
   children: React.ReactNode;
 }> = ({ children }) => {
   const [dataStream, setDataStream] = useState<McapDataStream | null>(null);
-  const value = useMemo(
-    () => ({ dataStream, setDataStream }),
-    [dataStream]
-  );
+  const value = useMemo(() => ({ dataStream, setDataStream }), [dataStream]);
   return (
     <McapDataStreamContext.Provider value={value}>
       {children}
@@ -59,8 +61,6 @@ export function useMcapDataStream(): McapDataStream | null {
 }
 
 /** Setter used by the setup hook to publish its handle. */
-export function useSetMcapDataStream(): (
-  next: McapDataStream | null
-) => void {
+export function useSetMcapDataStream(): (next: McapDataStream | null) => void {
   return useContext(McapDataStreamContext).setDataStream;
 }

--- a/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.ts
@@ -1,0 +1,397 @@
+import { playheadAtom, usePlaybackStore } from "@fiftyone/playback";
+import { useAtomValue } from "jotai";
+import { useEffect, useMemo } from "react";
+
+import type {
+  ImageAnnotationCircle,
+  ImageAnnotationPoints,
+  ImageAnnotationText,
+  ImageAnnotationsVisualization,
+} from "../../../decoders";
+import type { McapDecodedMessage } from "../types";
+import { useMcapDataStream } from "./mcap-data-stream-context";
+
+/**
+ * Returns the annotation visualization for `topic` at the current playhead,
+ * interpolated between the surrounding annotation messages when both are
+ * cached. Falls back to the latest available message when the next one
+ * isn't cached yet.
+ *
+ * Annotations arrive ~2 Hz against ~12 Hz camera images. To bridge that
+ * gap visually we lerp between the prev and next annotation message by
+ * fraction `(now - prev_t) / (next_t - prev_t)`.
+ *
+ * Foxglove doesn't carry stable instance IDs across messages, so we run a
+ * greedy nearest-centroid matching pass between prev and next groups
+ * (connected-component clusters of the LINE_LIST segments, keyed by their
+ * inferred label) and only lerp matched pairs. Unmatched groups in prev
+ * stay put; unmatched groups in next don't appear until the next message
+ * becomes current.
+ */
+export interface UseInterpolatedImageAnnotationsOptions {
+  /** When false, returns the current annotation as-is with no lerping. */
+  readonly interpolate?: boolean;
+}
+
+export function useInterpolatedImageAnnotations(
+  topic: string,
+  { interpolate = true }: UseInterpolatedImageAnnotationsOptions = {}
+): ImageAnnotationsVisualization | null {
+  const store = usePlaybackStore();
+  const dataStream = useMcapDataStream();
+
+  useEffect(() => {
+    if (!topic || !dataStream) return undefined;
+    return dataStream.subscribeToTopic(topic);
+  }, [topic, dataStream]);
+
+  // Re-render every RAF tick so the lerp tracks the playhead.
+  const playhead = useAtomValue(playheadAtom, { store });
+
+  const cache = dataStream?.getTopicCache(topic);
+  const timeline = dataStream?.getTimelineIndex() ?? null;
+
+  return useMemo<ImageAnnotationsVisualization | null>(() => {
+    if (!cache || !timeline) return null;
+
+    const currentTick = timeline.nearestTick(playhead);
+    if (currentTick === undefined) return null;
+    const currentMsg = cache.get(currentTick);
+    if (!currentMsg) return null;
+    const currentViz = vizOf(currentMsg);
+    if (!currentViz) return null;
+    if (!interpolate) return currentViz;
+
+    // Find next distinct annotation (different timeline time). Cached
+    // ticks return the latest <= tick under LATEST sync, so consecutive
+    // ticks alias the same source message until the next one lands.
+    const ticks = timeline.ticks;
+    let lo = 0;
+    let hi = ticks.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (ticks[mid] < currentTick) lo = mid + 1;
+      else hi = mid;
+    }
+    let nextMsg: McapDecodedMessage | null = null;
+    for (let i = lo + 1; i < ticks.length; i++) {
+      const m = cache.get(ticks[i]);
+      if (m && m.timelineTimeNs !== currentMsg.timelineTimeNs) {
+        nextMsg = m;
+        break;
+      }
+    }
+    if (!nextMsg) return currentViz;
+    const nextViz = vizOf(nextMsg);
+    if (!nextViz) return currentViz;
+
+    const span = nextMsg.timelineTimeNs - currentMsg.timelineTimeNs;
+    if (span <= 0n) return currentViz;
+    const playheadNs = timeline.secToNs(playhead);
+    const elapsed = playheadNs - currentMsg.timelineTimeNs;
+    let f = Number(elapsed) / Number(span);
+    if (!Number.isFinite(f) || f <= 0) return currentViz;
+    if (f >= 1) f = 1;
+
+    return interpolateImageAnnotations(currentViz, nextViz, f);
+  }, [cache, timeline, playhead, interpolate]);
+}
+
+function vizOf(msg: McapDecodedMessage): ImageAnnotationsVisualization | null {
+  const v = msg.decoded.output.visualization;
+  if (!v || v.kind !== "image-annotations") return null;
+  return v as ImageAnnotationsVisualization;
+}
+
+// ---------------------------------------------------------------------------
+// Interpolation
+// ---------------------------------------------------------------------------
+
+type Point2 = readonly [number, number];
+
+const MATCH_DISTANCE_PX = 200;
+
+function interpolateImageAnnotations(
+  prev: ImageAnnotationsVisualization,
+  next: ImageAnnotationsVisualization,
+  f: number
+): ImageAnnotationsVisualization {
+  return {
+    kind: prev.kind,
+    circles: interpolateCircles(prev.circles, next.circles, f),
+    points: interpolatePointsArray(prev, next, f),
+    texts: interpolateTexts(prev.texts, next.texts, f),
+  };
+}
+
+function interpolateCircles(
+  prev: readonly ImageAnnotationCircle[],
+  next: readonly ImageAnnotationCircle[],
+  f: number
+): readonly ImageAnnotationCircle[] {
+  // Index matching is acceptable for circles — they're rare in this data
+  // and tend to stay in order; if counts differ we just keep prev.
+  if (prev.length !== next.length) return prev;
+  return prev.map((p, i) => {
+    const n = next[i];
+    return {
+      ...p,
+      position: lerpPoint(p.position, n.position, f),
+      diameter: lerp(p.diameter, n.diameter, f),
+    };
+  });
+}
+
+function interpolateTexts(
+  prev: readonly ImageAnnotationText[],
+  next: readonly ImageAnnotationText[],
+  f: number
+): readonly ImageAnnotationText[] {
+  // Match texts by `text` content + nearest position, greedy per content.
+  const out: ImageAnnotationText[] = [];
+  const usedNext = new Set<number>();
+  for (const p of prev) {
+    let bestIdx = -1;
+    let bestDist = Infinity;
+    for (let j = 0; j < next.length; j++) {
+      if (usedNext.has(j)) continue;
+      const n = next[j];
+      if (n.text !== p.text) continue;
+      const d = squaredDistance(p.position, n.position);
+      if (d < bestDist) {
+        bestDist = d;
+        bestIdx = j;
+      }
+    }
+    if (bestIdx === -1 || bestDist > MATCH_DISTANCE_PX * MATCH_DISTANCE_PX) {
+      out.push(p);
+      continue;
+    }
+    usedNext.add(bestIdx);
+    const n = next[bestIdx];
+    out.push({ ...p, position: lerpPoint(p.position, n.position, f) });
+  }
+  return out;
+}
+
+/**
+ * Interpolation for the points array. LINE_LIST primitives carry every
+ * cuboid in one big segment list; we split each into per-object groups
+ * via connected components, match groups between prev and next by label
+ * + centroid proximity, then lerp matched pairs. Non-line-list primitives
+ * fall back to index-based interpolation.
+ */
+function interpolatePointsArray(
+  prev: ImageAnnotationsVisualization,
+  next: ImageAnnotationsVisualization,
+  f: number
+): readonly ImageAnnotationPoints[] {
+  if (prev.points.length !== next.points.length) return prev.points;
+  return prev.points.map((pp, idx) => {
+    const np = next.points[idx];
+    if (pp.type !== np.type) return pp;
+    if (pp.type === "line-list") {
+      return interpolateLineList(pp, np, prev.texts, next.texts, f);
+    }
+    if (pp.points.length !== np.points.length) return pp;
+    return {
+      ...pp,
+      points: pp.points.map((pt, j) => lerpPoint(pt, np.points[j], f)),
+    };
+  });
+}
+
+function interpolateLineList(
+  prevPrim: ImageAnnotationPoints,
+  nextPrim: ImageAnnotationPoints,
+  prevTexts: readonly ImageAnnotationText[],
+  nextTexts: readonly ImageAnnotationText[],
+  f: number
+): ImageAnnotationPoints {
+  const prevGroups = groupLineList(prevPrim.points, prevTexts);
+  const nextGroups = groupLineList(nextPrim.points, nextTexts);
+
+  // Greedy nearest-centroid match per label class. Same label is required
+  // so a car can't accidentally interpolate to a pedestrian.
+  const usedNext = new Set<number>();
+  const matchedPairs: { prev: Group; next: Group | null }[] = prevGroups.map(
+    (pg) => {
+      let bestIdx = -1;
+      let bestDist = Infinity;
+      for (let j = 0; j < nextGroups.length; j++) {
+        if (usedNext.has(j)) continue;
+        const ng = nextGroups[j];
+        if (ng.label !== pg.label) continue;
+        const d = squaredDistance(pg.centroid, ng.centroid);
+        if (d < bestDist) {
+          bestDist = d;
+          bestIdx = j;
+        }
+      }
+      const threshold = MATCH_DISTANCE_PX * MATCH_DISTANCE_PX;
+      if (bestIdx === -1 || bestDist > threshold) {
+        return { prev: pg, next: null };
+      }
+      usedNext.add(bestIdx);
+      return { prev: pg, next: nextGroups[bestIdx] };
+    }
+  );
+
+  const out: Point2[] = [];
+  for (const { prev, next } of matchedPairs) {
+    if (!next || prev.segments.length !== next.segments.length) {
+      for (const [a, b] of prev.segments) {
+        out.push(a, b);
+      }
+      continue;
+    }
+    for (let i = 0; i < prev.segments.length; i++) {
+      const [pa, pb] = prev.segments[i];
+      const [na, nb] = next.segments[i];
+      out.push(lerpPoint(pa, na, f), lerpPoint(pb, nb, f));
+    }
+  }
+
+  return { ...prevPrim, points: out };
+}
+
+// ---------------------------------------------------------------------------
+// Connected-component grouping (mirror of the overlay's render path)
+// ---------------------------------------------------------------------------
+
+interface Group {
+  readonly segments: readonly [Point2, Point2][];
+  readonly centroid: Point2;
+  readonly label: string | null;
+}
+
+function groupLineList(
+  points: readonly Point2[],
+  texts: readonly ImageAnnotationText[]
+): readonly Group[] {
+  const segmentCount = Math.floor(points.length / 2);
+  if (segmentCount === 0) return [];
+
+  const parent: number[] = [];
+  for (let i = 0; i < segmentCount; i++) parent[i] = i;
+  const find = (i: number): number => {
+    while (parent[i] !== i) {
+      parent[i] = parent[parent[i]];
+      i = parent[i];
+    }
+    return i;
+  };
+  const union = (a: number, b: number): void => {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra !== rb) parent[ra] = rb;
+  };
+
+  const endpointToSegment = new Map<string, number>();
+  const key = ([x, y]: Point2): string =>
+    `${Math.round(x * 100)}|${Math.round(y * 100)}`;
+  for (let i = 0; i < segmentCount; i++) {
+    for (const p of [points[i * 2], points[i * 2 + 1]]) {
+      const k = key(p);
+      const existing = endpointToSegment.get(k);
+      if (existing === undefined) endpointToSegment.set(k, i);
+      else union(existing, i);
+    }
+  }
+
+  const components = new Map<number, [Point2, Point2][]>();
+  for (let i = 0; i < segmentCount; i++) {
+    const root = find(i);
+    let segs = components.get(root);
+    if (!segs) {
+      segs = [];
+      components.set(root, segs);
+    }
+    segs.push([points[i * 2], points[i * 2 + 1]]);
+  }
+
+  // Fold tiny floating components (heading indicators inside a cuboid)
+  // into the larger component whose AABB contains their centroid.
+  const raw = [...components.values()].map((segments) => ({
+    segments,
+    bounds: segmentsBounds(segments),
+  }));
+  const sorted = [...raw].sort((a, b) => b.segments.length - a.segments.length);
+  const finals: { segments: [Point2, Point2][] }[] = [];
+  for (const c of sorted) {
+    const cx = (c.bounds.minX + c.bounds.maxX) / 2;
+    const cy = (c.bounds.minY + c.bounds.maxY) / 2;
+    const host =
+      c.segments.length <= 2
+        ? finals.find((h) => {
+            const b = segmentsBounds(h.segments);
+            return cx >= b.minX && cx <= b.maxX && cy >= b.minY && cy <= b.maxY;
+          })
+        : undefined;
+    if (host) host.segments.push(...c.segments);
+    else finals.push({ segments: [...c.segments] });
+  }
+
+  return finals.map(({ segments }) => {
+    const b = segmentsBounds(segments);
+    const centroid: Point2 = [(b.minX + b.maxX) / 2, (b.minY + b.maxY) / 2];
+    return { segments, centroid, label: nearestLabel(texts, centroid) };
+  });
+}
+
+interface Bounds {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+function segmentsBounds(segments: readonly [Point2, Point2][]): Bounds {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const [[x1, y1], [x2, y2]] of segments) {
+    if (x1 < minX) minX = x1;
+    if (x2 < minX) minX = x2;
+    if (x1 > maxX) maxX = x1;
+    if (x2 > maxX) maxX = x2;
+    if (y1 < minY) minY = y1;
+    if (y2 < minY) minY = y2;
+    if (y1 > maxY) maxY = y1;
+    if (y2 > maxY) maxY = y2;
+  }
+  return { minX, minY, maxX, maxY };
+}
+
+function nearestLabel(
+  texts: readonly ImageAnnotationText[],
+  point: Point2
+): string | null {
+  let bestIdx = -1;
+  let bestDist = Infinity;
+  for (let i = 0; i < texts.length; i++) {
+    const t = texts[i];
+    if (!t.text) continue;
+    const d = squaredDistance(t.position, point);
+    if (d < bestDist) {
+      bestDist = d;
+      bestIdx = i;
+    }
+  }
+  return bestIdx === -1 ? null : texts[bestIdx]?.text ?? null;
+}
+
+function squaredDistance(a: Point2, b: Point2): number {
+  const dx = a[0] - b[0];
+  const dy = a[1] - b[1];
+  return dx * dx + dy * dy;
+}
+
+function lerpPoint(a: Point2, b: Point2, f: number): Point2 {
+  return [a[0] + (b[0] - a[0]) * f, a[1] + (b[1] - a[1]) * f];
+}
+
+function lerp(a: number, b: number, f: number): number {
+  return a + (b - a) * f;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.ts
@@ -110,6 +110,7 @@ function vizOf(msg: McapDecodedMessage): ImageAnnotationsVisualization | null {
 type Point2 = readonly [number, number];
 
 const MATCH_DISTANCE_PX = 200;
+const MIN_MATCH_IOU = 0.15;
 
 function interpolateImageAnnotations(
   prev: ImageAnnotationsVisualization,
@@ -211,27 +212,35 @@ function interpolateLineList(
   const prevGroups = groupLineList(prevPrim.points, prevTexts);
   const nextGroups = groupLineList(nextPrim.points, nextTexts);
 
-  // Greedy nearest-centroid match per label class. Same label is required
-  // so a car can't accidentally interpolate to a pedestrian.
+  // Per-prev candidate selection:
+  //   1. Same label class (hard).
+  //   2. Centroid within MATCH_DISTANCE_PX (coarse position filter).
+  //   3. AABB IoU above MIN_IOU (rejects gross size mismatches —
+  //      e.g. a parked truck near a passing sedan).
+  //   4. Among survivors, pick the lowest symmetric Chamfer distance
+  //      over the cuboid's unique vertices (shape similarity tiebreak).
+  // Greedy: first prev to claim a next wins.
   const usedNext = new Set<number>();
   const matchedPairs: { prev: Group; next: Group | null }[] = prevGroups.map(
     (pg) => {
       let bestIdx = -1;
-      let bestDist = Infinity;
+      let bestScore = Infinity;
+      const distSqThreshold = MATCH_DISTANCE_PX * MATCH_DISTANCE_PX;
       for (let j = 0; j < nextGroups.length; j++) {
         if (usedNext.has(j)) continue;
         const ng = nextGroups[j];
         if (ng.label !== pg.label) continue;
-        const d = squaredDistance(pg.centroid, ng.centroid);
-        if (d < bestDist) {
-          bestDist = d;
+        if (squaredDistance(pg.centroid, ng.centroid) > distSqThreshold) {
+          continue;
+        }
+        if (aabbIoU(pg.bounds, ng.bounds) < MIN_MATCH_IOU) continue;
+        const score = chamferDistance(pg.vertices, ng.vertices);
+        if (score < bestScore) {
+          bestScore = score;
           bestIdx = j;
         }
       }
-      const threshold = MATCH_DISTANCE_PX * MATCH_DISTANCE_PX;
-      if (bestIdx === -1 || bestDist > threshold) {
-        return { prev: pg, next: null };
-      }
+      if (bestIdx === -1) return { prev: pg, next: null };
       usedNext.add(bestIdx);
       return { prev: pg, next: nextGroups[bestIdx] };
     }
@@ -262,81 +271,118 @@ function interpolateLineList(
 interface Group {
   readonly segments: readonly [Point2, Point2][];
   readonly centroid: Point2;
+  readonly bounds: Bounds;
+  readonly vertices: readonly Point2[];
   readonly label: string | null;
 }
 
+/**
+ * Each annotation message encodes N objects with cuboid edges and labels
+ * paired by index: `points` is `N * segmentsPerObject * 2` long and
+ * `texts` has length N. The Nth chunk of segments is labeled by the Nth
+ * text. We use that as the source of truth instead of spatial guessing.
+ * Falls back to one big group when the data doesn't divide cleanly.
+ */
 function groupLineList(
   points: readonly Point2[],
   texts: readonly ImageAnnotationText[]
 ): readonly Group[] {
   const segmentCount = Math.floor(points.length / 2);
   if (segmentCount === 0) return [];
-
-  const parent: number[] = [];
-  for (let i = 0; i < segmentCount; i++) parent[i] = i;
-  const find = (i: number): number => {
-    while (parent[i] !== i) {
-      parent[i] = parent[parent[i]];
-      i = parent[i];
+  if (texts.length === 0 || segmentCount % texts.length !== 0) {
+    const segments: [Point2, Point2][] = [];
+    for (let i = 0; i < segmentCount; i++) {
+      segments.push([points[i * 2], points[i * 2 + 1]]);
     }
-    return i;
-  };
-  const union = (a: number, b: number): void => {
-    const ra = find(a);
-    const rb = find(b);
-    if (ra !== rb) parent[ra] = rb;
-  };
-
-  const endpointToSegment = new Map<string, number>();
-  const key = ([x, y]: Point2): string =>
-    `${Math.round(x * 100)}|${Math.round(y * 100)}`;
-  for (let i = 0; i < segmentCount; i++) {
-    for (const p of [points[i * 2], points[i * 2 + 1]]) {
-      const k = key(p);
-      const existing = endpointToSegment.get(k);
-      if (existing === undefined) endpointToSegment.set(k, i);
-      else union(existing, i);
-    }
+    return [makeGroup(segments, null)];
   }
-
-  const components = new Map<number, [Point2, Point2][]>();
-  for (let i = 0; i < segmentCount; i++) {
-    const root = find(i);
-    let segs = components.get(root);
-    if (!segs) {
-      segs = [];
-      components.set(root, segs);
+  const segmentsPerObject = segmentCount / texts.length;
+  const groups: Group[] = [];
+  for (let i = 0; i < texts.length; i++) {
+    const segments: [Point2, Point2][] = [];
+    const start = i * segmentsPerObject;
+    for (let j = 0; j < segmentsPerObject; j++) {
+      const seg = start + j;
+      segments.push([points[seg * 2], points[seg * 2 + 1]]);
     }
-    segs.push([points[i * 2], points[i * 2 + 1]]);
+    groups.push(makeGroup(segments, texts[i]?.text ?? null));
   }
+  return groups;
+}
 
-  // Fold tiny floating components (heading indicators inside a cuboid)
-  // into the larger component whose AABB contains their centroid.
-  const raw = [...components.values()].map((segments) => ({
+function makeGroup(
+  segments: readonly [Point2, Point2][],
+  label: string | null
+): Group {
+  const bounds = segmentsBounds(segments);
+  const centroid: Point2 = [
+    (bounds.minX + bounds.maxX) / 2,
+    (bounds.minY + bounds.maxY) / 2,
+  ];
+  return {
     segments,
-    bounds: segmentsBounds(segments),
-  }));
-  const sorted = [...raw].sort((a, b) => b.segments.length - a.segments.length);
-  const finals: { segments: [Point2, Point2][] }[] = [];
-  for (const c of sorted) {
-    const cx = (c.bounds.minX + c.bounds.maxX) / 2;
-    const cy = (c.bounds.minY + c.bounds.maxY) / 2;
-    const host =
-      c.segments.length <= 2
-        ? finals.find((h) => {
-            const b = segmentsBounds(h.segments);
-            return cx >= b.minX && cx <= b.maxX && cy >= b.minY && cy <= b.maxY;
-          })
-        : undefined;
-    if (host) host.segments.push(...c.segments);
-    else finals.push({ segments: [...c.segments] });
-  }
+    centroid,
+    bounds,
+    vertices: uniqueVertices(segments),
+    label,
+  };
+}
 
-  return finals.map(({ segments }) => {
-    const b = segmentsBounds(segments);
-    const centroid: Point2 = [(b.minX + b.maxX) / 2, (b.minY + b.maxY) / 2];
-    return { segments, centroid, label: nearestLabel(texts, centroid) };
-  });
+function uniqueVertices(
+  segments: readonly [Point2, Point2][]
+): readonly Point2[] {
+  const seen = new Set<string>();
+  const out: Point2[] = [];
+  for (const [a, b] of segments) {
+    for (const p of [a, b]) {
+      const k = `${Math.round(p[0] * 100)}|${Math.round(p[1] * 100)}`;
+      if (seen.has(k)) continue;
+      seen.add(k);
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+function aabbIoU(a: Bounds, b: Bounds): number {
+  const x1 = Math.max(a.minX, b.minX);
+  const y1 = Math.max(a.minY, b.minY);
+  const x2 = Math.min(a.maxX, b.maxX);
+  const y2 = Math.min(a.maxY, b.maxY);
+  if (x2 <= x1 || y2 <= y1) return 0;
+  const inter = (x2 - x1) * (y2 - y1);
+  const areaA = Math.max(0, a.maxX - a.minX) * Math.max(0, a.maxY - a.minY);
+  const areaB = Math.max(0, b.maxX - b.minX) * Math.max(0, b.maxY - b.minY);
+  const union = areaA + areaB - inter;
+  return union > 0 ? inter / union : 0;
+}
+
+/**
+ * Symmetric Chamfer distance between two point sets — average nearest-
+ * neighbour distance from A→B plus from B→A, halved. Small values mean
+ * the two cuboid wireframes have similar vertex layouts (good match).
+ */
+function chamferDistance(a: readonly Point2[], b: readonly Point2[]): number {
+  if (a.length === 0 || b.length === 0) return Infinity;
+  let sumAB = 0;
+  for (const pa of a) {
+    let minD = Infinity;
+    for (const pb of b) {
+      const d = squaredDistance(pa, pb);
+      if (d < minD) minD = d;
+    }
+    sumAB += Math.sqrt(minD);
+  }
+  let sumBA = 0;
+  for (const pb of b) {
+    let minD = Infinity;
+    for (const pa of a) {
+      const d = squaredDistance(pa, pb);
+      if (d < minD) minD = d;
+    }
+    sumBA += Math.sqrt(minD);
+  }
+  return (sumAB / a.length + sumBA / b.length) / 2;
 }
 
 interface Bounds {
@@ -362,24 +408,6 @@ function segmentsBounds(segments: readonly [Point2, Point2][]): Bounds {
     if (y2 > maxY) maxY = y2;
   }
   return { minX, minY, maxX, maxY };
-}
-
-function nearestLabel(
-  texts: readonly ImageAnnotationText[],
-  point: Point2
-): string | null {
-  let bestIdx = -1;
-  let bestDist = Infinity;
-  for (let i = 0; i < texts.length; i++) {
-    const t = texts[i];
-    if (!t.text) continue;
-    const d = squaredDistance(t.position, point);
-    if (d < bestDist) {
-      bestDist = d;
-      bestIdx = i;
-    }
-  }
-  return bestIdx === -1 ? null : texts[bestIdx]?.text ?? null;
 }
 
 function squaredDistance(a: Point2, b: Point2): number {

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-scene-inventory.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-scene-inventory.tsx
@@ -80,6 +80,14 @@ const CAMERA_SYNC_POLICY = {
   toleranceBeforeNs: 120_000_000n,
 } as const;
 
+// Annotations arrive at ~2 Hz against ~12 Hz camera images. A 120ms
+// tolerance leaves most ticks unresolved; widen the lookback so every
+// tick has a current annotation message available for interpolation.
+const ANNOTATION_SYNC_POLICY = {
+  mode: PlaybackSyncMode.LATEST,
+  toleranceBeforeNs: 1_500_000_000n,
+} as const;
+
 const NUSCENES_STREAM_POLICIES: McapStreamSyncPolicies = {
   "/CAM_FRONT/image_rect_compressed": CAMERA_SYNC_POLICY,
   "/CAM_FRONT_LEFT/image_rect_compressed": CAMERA_SYNC_POLICY,
@@ -87,12 +95,12 @@ const NUSCENES_STREAM_POLICIES: McapStreamSyncPolicies = {
   "/CAM_BACK/image_rect_compressed": CAMERA_SYNC_POLICY,
   "/CAM_BACK_LEFT/image_rect_compressed": CAMERA_SYNC_POLICY,
   "/CAM_BACK_RIGHT/image_rect_compressed": CAMERA_SYNC_POLICY,
-  "/CAM_FRONT/annotations": CAMERA_SYNC_POLICY,
-  "/CAM_FRONT_LEFT/annotations": CAMERA_SYNC_POLICY,
-  "/CAM_FRONT_RIGHT/annotations": CAMERA_SYNC_POLICY,
-  "/CAM_BACK/annotations": CAMERA_SYNC_POLICY,
-  "/CAM_BACK_LEFT/annotations": CAMERA_SYNC_POLICY,
-  "/CAM_BACK_RIGHT/annotations": CAMERA_SYNC_POLICY,
+  "/CAM_FRONT/annotations": ANNOTATION_SYNC_POLICY,
+  "/CAM_FRONT_LEFT/annotations": ANNOTATION_SYNC_POLICY,
+  "/CAM_FRONT_RIGHT/annotations": ANNOTATION_SYNC_POLICY,
+  "/CAM_BACK/annotations": ANNOTATION_SYNC_POLICY,
+  "/CAM_BACK_LEFT/annotations": ANNOTATION_SYNC_POLICY,
+  "/CAM_BACK_RIGHT/annotations": ANNOTATION_SYNC_POLICY,
   "/LIDAR_TOP": {
     mode: PlaybackSyncMode.LATEST,
     toleranceBeforeNs: 200_000_000n,

--- a/app/packages/multimodal/src/adapters/mcap/react/use-register-mcap-data-stream.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-register-mcap-data-stream.ts
@@ -582,12 +582,18 @@ export function useRegisterMcapDataStream({
     [prefetchLookaheadFrom, store]
   );
 
+  const getTopicCache = useCallback(
+    (topic: string) => topicCachesRef.current.get(topic),
+    []
+  );
+  const getTimelineIndex = useCallback(() => indexRef.current, []);
+
   useEffect(() => {
-    setDataStream({ subscribeToTopic });
+    setDataStream({ subscribeToTopic, getTopicCache, getTimelineIndex });
     return () => {
       setDataStream(null);
     };
-  }, [setDataStream, subscribeToTopic]);
+  }, [setDataStream, subscribeToTopic, getTopicCache, getTimelineIndex]);
 }
 
 // ---------------------------------------------------------------------------

--- a/app/packages/multimodal/src/visualization/panels/ImageAnnotationsOverlay.test.tsx
+++ b/app/packages/multimodal/src/visualization/panels/ImageAnnotationsOverlay.test.tsx
@@ -169,36 +169,42 @@ describe("ImageAnnotationsOverlay", () => {
   // Circles
   // -------------------------------------------------------------------------
 
-  it("renders a circle with cx, cy, radius, stroke, fill, and non-scaling stroke", () => {
+  it("renders two nested circles per annotation: fill interior and stroke outline", () => {
+    // The interactive CirclePrimitive renders [0] a fill circle and [1] a stroke
+    // circle. Colours flow through CSS custom properties, not SVG attributes.
     const { container } = render200x100([{
       ...emptySet(),
       circles: [{ position: [60, 40], diameter: 30, thickness: 3, outlineColor: RED, fillColor: GREEN }],
     }]);
 
-    const circle = requireElement<SVGCircleElement>(container, "circle");
-    expect(circle.getAttribute("cx")).toBe("60");
-    expect(circle.getAttribute("cy")).toBe("40");
-    expect(circle.getAttribute("r")).toBe("15");
-    expect(circle.getAttribute("stroke-width")).toBe("3");
-    expect(circle.getAttribute("vector-effect")).toBe("non-scaling-stroke");
-    expect(circle.getAttribute("fill")).toMatch(/rgba\(0,\s*255,\s*0/);
-    expect(circle.getAttribute("stroke")).toMatch(/rgba\(255,\s*0,\s*0/);
+    const circles = container.querySelectorAll("circle");
+    expect(circles).toHaveLength(2);
+    expect(circles[0].getAttribute("cx")).toBe("60");
+    expect(circles[0].getAttribute("cy")).toBe("40");
+    expect(circles[0].getAttribute("r")).toBe("15");
+    expect(circles[1].getAttribute("vector-effect")).toBe("non-scaling-stroke");
+    expect(circles[1].getAttribute("stroke-width")).not.toBeNull();
+    expect(circles[1].getAttribute("fill")).toBe("none");
   });
 
-  it("renders a circle with fill=none when fillColor is null", () => {
+  it("stroke circle always has fill=none", () => {
     const { container } = render200x100([{
       ...emptySet(),
       circles: [{ position: [0, 0], diameter: 10, thickness: 1, outlineColor: RED, fillColor: null }],
     }]);
 
-    expect(container.querySelector("circle")?.getAttribute("fill")).toBe("none");
+    const circles = container.querySelectorAll("circle");
+    expect(circles[1].getAttribute("fill")).toBe("none");
   });
 
   // -------------------------------------------------------------------------
   // Points — line-loop (CodeRabbit fix: first point appended to close loop)
   // -------------------------------------------------------------------------
 
-  it("closes a line-loop by appending the first point at the end of the polyline", () => {
+  it("renders a line-loop as a <polygon> which is inherently closed", () => {
+    // The interactive renderer uses <polygon> for line-loop (auto-closes the
+    // stroke path) rather than <polyline>. Two polygons are rendered: one for
+    // the fill interior and one for the stroke.
     const { container } = render200x100([{
       ...emptySet(),
       points: [{
@@ -211,12 +217,11 @@ describe("ImageAnnotationsOverlay", () => {
       }],
     }]);
 
-    const polyline = requireElement<SVGPolylineElement>(container, "polyline");
-    const pts = requireAttribute(polyline, "points");
-    const pairs = pts.trim().split(/\s+/);
-    // 3 original + 1 closing = 4 pairs
-    expect(pairs).toHaveLength(4);
-    expect(pairs[0]).toBe(pairs[3]);
+    const polygons = container.querySelectorAll("polygon");
+    expect(polygons.length).toBeGreaterThanOrEqual(1);
+    const pts = requireAttribute(polygons[0], "points");
+    expect(pts.trim().split(/\s+/)).toHaveLength(3);
+    expect(container.querySelector("polyline")).toBeNull();
   });
 
   it("does not add a closing point to a line-strip", () => {
@@ -258,7 +263,9 @@ describe("ImageAnnotationsOverlay", () => {
     expect(lines[0].getAttribute("y2")).toBe("10");
   });
 
-  it("renders individual points as circles with per-point colors", () => {
+  it("renders one circle per individual point", () => {
+    // The interactive renderer draws a <circle> for each point; colour is
+    // applied via CSS custom property, not the fill attribute.
     const { container } = render200x100([{
       ...emptySet(),
       points: [{
@@ -273,9 +280,10 @@ describe("ImageAnnotationsOverlay", () => {
 
     const circles = container.querySelectorAll("circle");
     expect(circles).toHaveLength(2);
-    // Per-point colors take precedence
-    expect(circles[0].getAttribute("fill")).toMatch(/rgba\(255,\s*255,\s*255/);
-    expect(circles[1].getAttribute("fill")).toMatch(/rgba\(0,\s*0,\s*0/);
+    expect(circles[0].getAttribute("cx")).toBe("5");
+    expect(circles[0].getAttribute("cy")).toBe("5");
+    expect(circles[1].getAttribute("cx")).toBe("15");
+    expect(circles[1].getAttribute("cy")).toBe("15");
   });
 
   // -------------------------------------------------------------------------
@@ -319,6 +327,8 @@ describe("ImageAnnotationsOverlay", () => {
   // -------------------------------------------------------------------------
 
   it("renders primitives from multiple annotation sets in a single SVG", () => {
+    // Each CirclePrimitive renders 2 <circle> elements (fill + stroke),
+    // so 2 annotation sets × 1 circle each = 4 circle elements total.
     const { container } = render200x100([
       {
         ...emptySet(),
@@ -330,6 +340,6 @@ describe("ImageAnnotationsOverlay", () => {
       },
     ]);
 
-    expect(container.querySelectorAll("circle")).toHaveLength(2);
+    expect(container.querySelectorAll("circle")).toHaveLength(4);
   });
 });

--- a/app/packages/multimodal/src/visualization/panels/ImageAnnotationsOverlay.tsx
+++ b/app/packages/multimodal/src/visualization/panels/ImageAnnotationsOverlay.tsx
@@ -1,5 +1,6 @@
+import clsx from "clsx";
 import type { CSSProperties } from "react";
-import { Fragment, useEffect, useRef, useState } from "react";
+import React, { Fragment, useEffect, useRef, useState } from "react";
 
 import type {
   ImageAnnotationCircle,
@@ -8,25 +9,49 @@ import type {
   ImageAnnotationsVisualization,
   RgbaColor,
 } from "../../decoders";
+import styles from "./image-annotations-overlay.module.css";
+
+export type ImageAnnotationPrimitive =
+  | { readonly kind: "circle"; readonly value: ImageAnnotationCircle }
+  | { readonly kind: "points"; readonly value: ImageAnnotationPoints }
+  | { readonly kind: "text"; readonly value: ImageAnnotationText };
+
+export interface ImageAnnotationPickedPrimitive {
+  readonly key: string;
+  readonly setIndex: number;
+  readonly primitiveIndex: number;
+  readonly primitive: ImageAnnotationPrimitive;
+  readonly color: string;
+  readonly label: string | null;
+}
 
 export interface ImageAnnotationsOverlayProps {
   readonly annotations: readonly ImageAnnotationsVisualization[];
   readonly imageWidth: number;
   readonly imageHeight: number;
   readonly fit: "contain" | "cover";
+  readonly selectedKey?: string | null;
+  readonly onSelectPrimitive?: (picked: ImageAnnotationPickedPrimitive) => void;
 }
 
 /**
  * SVG overlay that renders decoded Foxglove image-annotation primitives over
- * the image panel. Coordinates are image pixels; the SVG `viewBox` matches
- * the natural image dimensions so the same fit strategy used by the panel
- * applies to the overlay.
+ * the image panel. Coordinates are image pixels; the SVG is positioned over
+ * the image's display rect so a `preserveAspectRatio="none"` viewBox maps
+ * cleanly.
+ *
+ * LINE_LIST primitives are split into per-object groups via connected
+ * components on shared endpoints so each cuboid gets its own hover scope
+ * and interior hit target — Foxglove encodes a whole frame's cuboid edges
+ * as one big LINE_LIST.
  */
 export function ImageAnnotationsOverlay({
   annotations,
   imageWidth,
   imageHeight,
   fit,
+  selectedKey,
+  onSelectPrimitive,
 }: ImageAnnotationsOverlayProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [containerSize, setContainerSize] = useState<{
@@ -72,15 +97,12 @@ export function ImageAnnotationsOverlay({
         >
           {annotations.map((set, i) => (
             <Fragment key={i}>
-              {set.points.map((p, j) => (
-                <PointsPrimitive key={`p-${i}-${j}`} primitive={p} />
-              ))}
-              {set.circles.map((c, j) => (
-                <CirclePrimitive key={`c-${i}-${j}`} primitive={c} />
-              ))}
-              {set.texts.map((t, j) => (
-                <TextPrimitive key={`t-${i}-${j}`} primitive={t} />
-              ))}
+              <SetPrimitives
+                set={set}
+                setIndex={i}
+                selectedKey={selectedKey ?? null}
+                onSelectPrimitive={onSelectPrimitive}
+              />
             </Fragment>
           ))}
         </svg>
@@ -89,6 +111,355 @@ export function ImageAnnotationsOverlay({
   );
 }
 
+interface SetPrimitivesProps {
+  readonly set: ImageAnnotationsVisualization;
+  readonly setIndex: number;
+  readonly selectedKey: string | null;
+  readonly onSelectPrimitive?: (picked: ImageAnnotationPickedPrimitive) => void;
+}
+
+function SetPrimitives({
+  set,
+  setIndex,
+  selectedKey,
+  onSelectPrimitive,
+}: SetPrimitivesProps) {
+  return (
+    <>
+      {set.points.map((p, j) =>
+        p.type === "line-list" ? (
+          <LineListGroups
+            key={`p-${setIndex}-${j}`}
+            primitive={p}
+            primitiveIndex={j}
+            setIndex={setIndex}
+            texts={set.texts}
+            selectedKey={selectedKey}
+            onSelectPrimitive={onSelectPrimitive}
+          />
+        ) : (
+          <PolylinePrimitive
+            key={`p-${setIndex}-${j}`}
+            primitive={p}
+            primitiveIndex={j}
+            setIndex={setIndex}
+            texts={set.texts}
+            selectedKey={selectedKey}
+            onSelectPrimitive={onSelectPrimitive}
+          />
+        )
+      )}
+      {set.circles.map((c, j) => (
+        <CirclePrimitive
+          key={`c-${setIndex}-${j}`}
+          primitive={c}
+          primitiveIndex={j}
+          setIndex={setIndex}
+          texts={set.texts}
+          selectedKey={selectedKey}
+          onSelectPrimitive={onSelectPrimitive}
+        />
+      ))}
+      {set.texts.map((t, j) => (
+        <TextPrimitive
+          key={`t-${setIndex}-${j}`}
+          primitive={t}
+          primitiveIndex={j}
+          setIndex={setIndex}
+          selectedKey={selectedKey}
+          onSelectPrimitive={onSelectPrimitive}
+        />
+      ))}
+    </>
+  );
+}
+
+interface CirclePrimitiveProps {
+  readonly primitive: ImageAnnotationCircle;
+  readonly primitiveIndex: number;
+  readonly setIndex: number;
+  readonly texts: readonly ImageAnnotationText[];
+  readonly selectedKey: string | null;
+  readonly onSelectPrimitive?: (picked: ImageAnnotationPickedPrimitive) => void;
+}
+
+function CirclePrimitive({
+  primitive,
+  primitiveIndex,
+  setIndex,
+  texts,
+  selectedKey,
+  onSelectPrimitive,
+}: CirclePrimitiveProps) {
+  const [x, y] = primitive.position;
+  const radius = Math.max(0, primitive.diameter / 2);
+  const label = nearestLabel(texts, [x, y]);
+  const color = colorForLabel(label);
+  const key = `c-${setIndex}-${primitiveIndex}`;
+  const onClick = pickHandler(onSelectPrimitive, {
+    key,
+    setIndex,
+    primitiveIndex,
+    primitive: { kind: "circle", value: primitive },
+    color,
+    label,
+  });
+  const isSelected = selectedKey === key;
+  return (
+    <g
+      className={clsx(
+        styles.primitive,
+        onClick && styles.selectable,
+        isSelected && styles.selected
+      )}
+      style={primitiveStyle(color, INTERIOR_FILL)}
+      onClick={onClick}
+    >
+      <circle cx={x} cy={y} r={radius} className={styles.fillInterior} />
+      <circle
+        cx={x}
+        cy={y}
+        r={radius}
+        strokeWidth={lineWidth(primitive.thickness)}
+        vectorEffect="non-scaling-stroke"
+        fill="none"
+      />
+    </g>
+  );
+}
+
+interface PolylinePrimitiveProps {
+  readonly primitive: ImageAnnotationPoints;
+  readonly primitiveIndex: number;
+  readonly setIndex: number;
+  readonly texts: readonly ImageAnnotationText[];
+  readonly selectedKey: string | null;
+  readonly onSelectPrimitive?: (picked: ImageAnnotationPickedPrimitive) => void;
+}
+
+function PolylinePrimitive({
+  primitive,
+  primitiveIndex,
+  setIndex,
+  texts,
+  selectedKey,
+  onSelectPrimitive,
+}: PolylinePrimitiveProps) {
+  const thickness = lineWidth(primitive.thickness);
+  const centroid = pointsCentroid(primitive.points);
+  const label = centroid ? nearestLabel(texts, centroid) : null;
+  const color = colorForLabel(label);
+  const key = `p-${setIndex}-${primitiveIndex}`;
+  const onClick = pickHandler(onSelectPrimitive, {
+    key,
+    setIndex,
+    primitiveIndex,
+    primitive: { kind: "points", value: primitive },
+    color,
+    label,
+  });
+  const isSelected = selectedKey === key;
+
+  if (primitive.type === "points") {
+    return (
+      <g
+        className={clsx(
+          styles.primitive,
+          onClick && styles.selectable,
+          isSelected && styles.selected
+        )}
+        style={primitiveStyle(color, undefined)}
+        onClick={onClick}
+      >
+        {primitive.points.map(([x, y], i) => (
+          <circle
+            key={i}
+            cx={x}
+            cy={y}
+            r={thickness}
+            className={styles.primitiveDot}
+          />
+        ))}
+      </g>
+    );
+  }
+
+  const closed = primitive.type === "line-loop";
+  return (
+    <g
+      className={clsx(
+        styles.primitive,
+        onClick && styles.selectable,
+        isSelected && styles.selected
+      )}
+      style={primitiveStyle(color, closed ? INTERIOR_FILL : undefined)}
+      onClick={onClick}
+    >
+      {closed ? (
+        <polygon
+          points={primitive.points.map(([x, y]) => `${x},${y}`).join(" ")}
+          className={styles.fillInterior}
+        />
+      ) : null}
+      <polyline
+        points={primitive.points.map(([x, y]) => `${x},${y}`).join(" ")}
+        strokeWidth={thickness}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+        vectorEffect="non-scaling-stroke"
+        fill="none"
+      />
+    </g>
+  );
+}
+
+interface LineListGroupsProps {
+  readonly primitive: ImageAnnotationPoints;
+  readonly primitiveIndex: number;
+  readonly setIndex: number;
+  readonly texts: readonly ImageAnnotationText[];
+  readonly selectedKey: string | null;
+  readonly onSelectPrimitive?: (picked: ImageAnnotationPickedPrimitive) => void;
+}
+
+function LineListGroups({
+  primitive,
+  primitiveIndex,
+  setIndex,
+  texts,
+  selectedKey,
+  onSelectPrimitive,
+}: LineListGroupsProps) {
+  const thickness = lineWidth(primitive.thickness);
+  const groups = groupLineListByLabel(primitive.points, texts);
+
+  return (
+    <>
+      {groups.map((group, gi) => {
+        const color = colorForLabel(group.label);
+        const key = `pg-${setIndex}-${primitiveIndex}-${boundsKey(
+          group.bounds
+        )}`;
+        const onClick = pickHandler(onSelectPrimitive, {
+          key,
+          setIndex,
+          primitiveIndex,
+          primitive: {
+            kind: "points",
+            value: {
+              ...primitive,
+              points: group.segments.flatMap((s) => [s[0], s[1]]),
+            },
+          },
+          color,
+          label: group.label,
+        });
+        const isSelected = selectedKey === key;
+        const b = group.bounds;
+        return (
+          <g
+            key={gi}
+            className={clsx(
+              styles.primitive,
+              onClick && styles.selectable,
+              isSelected && styles.selected
+            )}
+            style={primitiveStyle(color, INTERIOR_FILL)}
+            onClick={onClick}
+          >
+            <rect
+              x={b.minX}
+              y={b.minY}
+              width={b.maxX - b.minX}
+              height={b.maxY - b.minY}
+              className={styles.fillInterior}
+            />
+            {group.segments.map(([[x1, y1], [x2, y2]], si) => (
+              <line
+                key={si}
+                x1={x1}
+                y1={y1}
+                x2={x2}
+                y2={y2}
+                strokeWidth={thickness}
+                strokeLinecap="round"
+                vectorEffect="non-scaling-stroke"
+              />
+            ))}
+          </g>
+        );
+      })}
+    </>
+  );
+}
+
+interface TextPrimitiveProps {
+  readonly primitive: ImageAnnotationText;
+  readonly primitiveIndex: number;
+  readonly setIndex: number;
+  readonly selectedKey: string | null;
+  readonly onSelectPrimitive?: (picked: ImageAnnotationPickedPrimitive) => void;
+}
+
+function TextPrimitive({
+  primitive,
+  primitiveIndex,
+  setIndex,
+  selectedKey,
+  onSelectPrimitive,
+}: TextPrimitiveProps) {
+  const [x, y] = primitive.position;
+  const fontSize = Math.max(1, primitive.fontSize);
+  const background = rgbaToCss(primitive.backgroundColor);
+  const label = primitive.text || null;
+  const color = colorForLabel(label);
+  const key = `t-${setIndex}-${primitiveIndex}`;
+  const onClick = pickHandler(onSelectPrimitive, {
+    key,
+    setIndex,
+    primitiveIndex,
+    primitive: { kind: "text", value: primitive },
+    color,
+    label,
+  });
+  const isSelected = selectedKey === key;
+
+  return (
+    <g
+      className={clsx(
+        onClick && styles.selectable,
+        isSelected && styles.selected
+      )}
+      style={{ ["--ann-stroke" as never]: color } as CSSProperties}
+      onClick={onClick}
+    >
+      {background ? (
+        <rect
+          x={x - 2}
+          y={y - fontSize}
+          width={primitive.text.length * fontSize * 0.6 + 4}
+          height={fontSize + 4}
+          fill={background}
+        />
+      ) : null}
+      <text
+        x={x}
+        y={y}
+        fill={isSelected ? HOVER_STROKE : color}
+        fontSize={fontSize}
+        fontFamily="system-ui, sans-serif"
+        dominantBaseline="alphabetic"
+      >
+        {primitive.text}
+      </text>
+    </g>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
 interface Rect {
   readonly x: number;
   readonly y: number;
@@ -96,11 +467,240 @@ interface Rect {
   readonly height: number;
 }
 
-/**
- * Letterbox/pillarbox the image's natural dimensions into the container,
- * matching the `ImageTexturePlane` scale strategy so the SVG overlay
- * sits exactly over the rendered image rather than the container box.
- */
+interface Bounds {
+  readonly minX: number;
+  readonly minY: number;
+  readonly maxX: number;
+  readonly maxY: number;
+}
+
+type Point2 = readonly [number, number];
+
+interface LineListGroup {
+  readonly label: string | null;
+  readonly segments: readonly [Point2, Point2][];
+  readonly bounds: Bounds;
+}
+
+function groupLineListByLabel(
+  points: readonly Point2[],
+  texts: readonly ImageAnnotationText[]
+): readonly LineListGroup[] {
+  // Connected components on shared endpoints — each component is one
+  // logical object (e.g. a cuboid wireframe). After CC, small floating
+  // components whose centroid sits inside a larger component's AABB get
+  // folded into that larger component (heading indicators inside a cuboid).
+  const parent: number[] = [];
+  const find = (i: number): number => {
+    while (parent[i] !== i) {
+      parent[i] = parent[parent[i]];
+      i = parent[i];
+    }
+    return i;
+  };
+  const union = (a: number, b: number): void => {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra !== rb) parent[ra] = rb;
+  };
+
+  const segmentCount = Math.floor(points.length / 2);
+  for (let i = 0; i < segmentCount; i++) parent[i] = i;
+
+  const endpointToSegment = new Map<string, number>();
+  const pointKey = ([x, y]: Point2): string =>
+    `${Math.round(x * 100)}|${Math.round(y * 100)}`;
+
+  for (let i = 0; i < segmentCount; i++) {
+    const a = points[i * 2];
+    const b = points[i * 2 + 1];
+    for (const p of [a, b]) {
+      const k = pointKey(p);
+      const existing = endpointToSegment.get(k);
+      if (existing === undefined) {
+        endpointToSegment.set(k, i);
+      } else {
+        union(existing, i);
+      }
+    }
+  }
+
+  const componentSegments = new Map<number, [Point2, Point2][]>();
+  for (let i = 0; i < segmentCount; i++) {
+    const root = find(i);
+    let segs = componentSegments.get(root);
+    if (!segs) {
+      segs = [];
+      componentSegments.set(root, segs);
+    }
+    segs.push([points[i * 2], points[i * 2 + 1]]);
+  }
+
+  const rawComponents = [...componentSegments.values()].map((segments) => ({
+    segments,
+    bounds: segmentsBounds(segments),
+  }));
+
+  const sorted = [...rawComponents].sort(
+    (a, b) => b.segments.length - a.segments.length
+  );
+  const finalComponents: { segments: [Point2, Point2][]; bounds: Bounds }[] =
+    [];
+  for (const c of sorted) {
+    const center: Point2 = [
+      (c.bounds.minX + c.bounds.maxX) / 2,
+      (c.bounds.minY + c.bounds.maxY) / 2,
+    ];
+    const host =
+      c.segments.length <= 2
+        ? finalComponents.find((h) => boundsContainPoint(h.bounds, center))
+        : undefined;
+    if (host) {
+      host.segments.push(...c.segments);
+      host.bounds = segmentsBounds(host.segments);
+    } else {
+      finalComponents.push({ segments: [...c.segments], bounds: c.bounds });
+    }
+  }
+
+  return finalComponents.map(({ segments, bounds }) => {
+    const centroid: Point2 = [
+      (bounds.minX + bounds.maxX) / 2,
+      (bounds.minY + bounds.maxY) / 2,
+    ];
+    const label = nearestLabel(texts, centroid);
+    return { label, segments, bounds };
+  });
+}
+
+function segmentsBounds(segments: readonly [Point2, Point2][]): Bounds {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const [[x1, y1], [x2, y2]] of segments) {
+    if (x1 < minX) minX = x1;
+    if (x2 < minX) minX = x2;
+    if (x1 > maxX) maxX = x1;
+    if (x2 > maxX) maxX = x2;
+    if (y1 < minY) minY = y1;
+    if (y2 < minY) minY = y2;
+    if (y1 > maxY) maxY = y1;
+    if (y2 > maxY) maxY = y2;
+  }
+  return { minX, minY, maxX, maxY };
+}
+
+function boundsContainPoint(b: Bounds, [x, y]: Point2): boolean {
+  return x >= b.minX && x <= b.maxX && y >= b.minY && y <= b.maxY;
+}
+
+function nearestTextIndex(
+  texts: readonly ImageAnnotationText[],
+  point: Point2
+): number {
+  let bestIdx = -1;
+  let bestDist = Infinity;
+  for (let i = 0; i < texts.length; i++) {
+    const t = texts[i];
+    if (!t.text) continue;
+    const dx = t.position[0] - point[0];
+    const dy = t.position[1] - point[1];
+    const d = dx * dx + dy * dy;
+    if (d < bestDist) {
+      bestDist = d;
+      bestIdx = i;
+    }
+  }
+  return bestIdx;
+}
+
+function nearestLabel(
+  texts: readonly ImageAnnotationText[],
+  point: Point2
+): string | null {
+  const idx = nearestTextIndex(texts, point);
+  return idx === -1 ? null : texts[idx]?.text ?? null;
+}
+
+function pointsCentroid(points: readonly Point2[]): Point2 | null {
+  if (points.length === 0) return null;
+  let sx = 0;
+  let sy = 0;
+  for (const [x, y] of points) {
+    sx += x;
+    sy += y;
+  }
+  return [sx / points.length, sy / points.length];
+}
+
+// Subset of `@fiftyone/utilities`' default app color pool with the orange
+// and orange-leaning entries pulled out — those collide with the orange
+// hover / selected highlight (#ff7a18).
+const DEFAULT_COLOR_POOL: readonly string[] = [
+  "#ee0000",
+  "#999900",
+  "#009900",
+  "#003300",
+  "#009999",
+  "#000099",
+  "#0066ff",
+  "#6600ff",
+  "#cc33cc",
+  "#777799",
+];
+
+const DEFAULT_LABEL_KEY = "__no-label__";
+const labelColorAssignments = new Map<string, string>();
+
+function colorForLabel(label: string | null): string {
+  const key = label ?? DEFAULT_LABEL_KEY;
+  let color = labelColorAssignments.get(key);
+  if (!color) {
+    color =
+      DEFAULT_COLOR_POOL[
+        labelColorAssignments.size % DEFAULT_COLOR_POOL.length
+      ];
+    labelColorAssignments.set(key, color);
+  }
+  return color;
+}
+
+function boundsKey(b: Bounds): string {
+  const r = (v: number) => Math.round(v / 20);
+  return `${r(b.minX)}|${r(b.minY)}|${r(b.maxX - b.minX)}|${r(
+    b.maxY - b.minY
+  )}`;
+}
+
+function primitiveStyle(
+  color: string,
+  interior: string | undefined
+): CSSProperties {
+  const out: Record<string, string> = { "--ann-stroke": color };
+  if (interior) out["--ann-interior"] = interior;
+  return out as CSSProperties;
+}
+
+function pickHandler(
+  onSelectPrimitive:
+    | ((picked: ImageAnnotationPickedPrimitive) => void)
+    | undefined,
+  picked: ImageAnnotationPickedPrimitive
+): ((e: React.MouseEvent) => void) | undefined {
+  if (!onSelectPrimitive) return undefined;
+  return (e) => {
+    e.stopPropagation();
+    onSelectPrimitive(picked);
+  };
+}
+
+function lineWidth(thickness: number): number {
+  // Source thickness is conservative; bump it ~1.5x for readability while
+  // keeping the look light.
+  return Math.max(1.5, thickness * 1.5);
+}
+
 function displayRect(
   container: { width: number; height: number },
   imageWidth: number,
@@ -254,8 +854,8 @@ function clamp01(v: number): number {
   return v;
 }
 
-const DEFAULT_STROKE = "rgba(255, 122, 24, 0.95)";
-const DEFAULT_TEXT_FILL = "rgba(255, 255, 255, 0.95)";
+const HOVER_STROKE = "#ff7a18";
+const INTERIOR_FILL = "rgba(0, 0, 0, 0.001)";
 
 const containerStyle: CSSProperties = {
   inset: 0,

--- a/app/packages/multimodal/src/visualization/panels/ImageAnnotationsOverlay.tsx
+++ b/app/packages/multimodal/src/visualization/panels/ImageAnnotationsOverlay.tsx
@@ -482,95 +482,43 @@ interface LineListGroup {
   readonly bounds: Bounds;
 }
 
+/**
+ * Each annotation message encodes N objects with cuboid edges and
+ * labels paired by index: `points` is `N * segmentsPerObject * 2`
+ * long, `texts.length === N`, and the Nth chunk of segments is
+ * labeled by the Nth text. Use that pairing directly rather than
+ * spatially guessing. Falls back to one big group when the data
+ * doesn't divide cleanly (other producers might encode differently).
+ */
 function groupLineListByLabel(
   points: readonly Point2[],
   texts: readonly ImageAnnotationText[]
 ): readonly LineListGroup[] {
-  // Connected components on shared endpoints — each component is one
-  // logical object (e.g. a cuboid wireframe). After CC, small floating
-  // components whose centroid sits inside a larger component's AABB get
-  // folded into that larger component (heading indicators inside a cuboid).
-  const parent: number[] = [];
-  const find = (i: number): number => {
-    while (parent[i] !== i) {
-      parent[i] = parent[parent[i]];
-      i = parent[i];
-    }
-    return i;
-  };
-  const union = (a: number, b: number): void => {
-    const ra = find(a);
-    const rb = find(b);
-    if (ra !== rb) parent[ra] = rb;
-  };
-
   const segmentCount = Math.floor(points.length / 2);
-  for (let i = 0; i < segmentCount; i++) parent[i] = i;
-
-  const endpointToSegment = new Map<string, number>();
-  const pointKey = ([x, y]: Point2): string =>
-    `${Math.round(x * 100)}|${Math.round(y * 100)}`;
-
-  for (let i = 0; i < segmentCount; i++) {
-    const a = points[i * 2];
-    const b = points[i * 2 + 1];
-    for (const p of [a, b]) {
-      const k = pointKey(p);
-      const existing = endpointToSegment.get(k);
-      if (existing === undefined) {
-        endpointToSegment.set(k, i);
-      } else {
-        union(existing, i);
-      }
+  if (segmentCount === 0) return [];
+  if (texts.length === 0 || segmentCount % texts.length !== 0) {
+    const segments: [Point2, Point2][] = [];
+    for (let i = 0; i < segmentCount; i++) {
+      segments.push([points[i * 2], points[i * 2 + 1]]);
     }
+    return [{ label: null, segments, bounds: segmentsBounds(segments) }];
   }
-
-  const componentSegments = new Map<number, [Point2, Point2][]>();
-  for (let i = 0; i < segmentCount; i++) {
-    const root = find(i);
-    let segs = componentSegments.get(root);
-    if (!segs) {
-      segs = [];
-      componentSegments.set(root, segs);
+  const segmentsPerObject = segmentCount / texts.length;
+  const groups: LineListGroup[] = [];
+  for (let i = 0; i < texts.length; i++) {
+    const segments: [Point2, Point2][] = [];
+    const start = i * segmentsPerObject;
+    for (let j = 0; j < segmentsPerObject; j++) {
+      const seg = start + j;
+      segments.push([points[seg * 2], points[seg * 2 + 1]]);
     }
-    segs.push([points[i * 2], points[i * 2 + 1]]);
+    groups.push({
+      label: texts[i]?.text ?? null,
+      segments,
+      bounds: segmentsBounds(segments),
+    });
   }
-
-  const rawComponents = [...componentSegments.values()].map((segments) => ({
-    segments,
-    bounds: segmentsBounds(segments),
-  }));
-
-  const sorted = [...rawComponents].sort(
-    (a, b) => b.segments.length - a.segments.length
-  );
-  const finalComponents: { segments: [Point2, Point2][]; bounds: Bounds }[] =
-    [];
-  for (const c of sorted) {
-    const center: Point2 = [
-      (c.bounds.minX + c.bounds.maxX) / 2,
-      (c.bounds.minY + c.bounds.maxY) / 2,
-    ];
-    const host =
-      c.segments.length <= 2
-        ? finalComponents.find((h) => boundsContainPoint(h.bounds, center))
-        : undefined;
-    if (host) {
-      host.segments.push(...c.segments);
-      host.bounds = segmentsBounds(host.segments);
-    } else {
-      finalComponents.push({ segments: [...c.segments], bounds: c.bounds });
-    }
-  }
-
-  return finalComponents.map(({ segments, bounds }) => {
-    const centroid: Point2 = [
-      (bounds.minX + bounds.maxX) / 2,
-      (bounds.minY + bounds.maxY) / 2,
-    ];
-    const label = nearestLabel(texts, centroid);
-    return { label, segments, bounds };
-  });
+  return groups;
 }
 
 function segmentsBounds(segments: readonly [Point2, Point2][]): Bounds {
@@ -591,23 +539,20 @@ function segmentsBounds(segments: readonly [Point2, Point2][]): Bounds {
   return { minX, minY, maxX, maxY };
 }
 
-function boundsContainPoint(b: Bounds, [x, y]: Point2): boolean {
-  return x >= b.minX && x <= b.maxX && y >= b.minY && y <= b.maxY;
-}
-
 function nearestTextIndex(
   texts: readonly ImageAnnotationText[],
   point: Point2
 ): number {
   let bestIdx = -1;
   let bestDist = Infinity;
+  const maxSq = MAX_LABEL_DIST_PX * MAX_LABEL_DIST_PX;
   for (let i = 0; i < texts.length; i++) {
     const t = texts[i];
     if (!t.text) continue;
     const dx = t.position[0] - point[0];
     const dy = t.position[1] - point[1];
     const d = dx * dx + dy * dy;
-    if (d < bestDist) {
+    if (d < bestDist && d <= maxSq) {
       bestDist = d;
       bestIdx = i;
     }
@@ -637,6 +582,8 @@ function pointsCentroid(points: readonly Point2[]): Point2 | null {
 // Subset of `@fiftyone/utilities`' default app color pool with the orange
 // and orange-leaning entries pulled out — those collide with the orange
 // hover / selected highlight (#ff7a18).
+const MAX_LABEL_DIST_PX = 200;
+
 const DEFAULT_COLOR_POOL: readonly string[] = [
   "#ee0000",
   "#999900",

--- a/app/packages/multimodal/src/visualization/panels/ImageAnnotationsOverlay.tsx
+++ b/app/packages/multimodal/src/visualization/panels/ImageAnnotationsOverlay.tsx
@@ -285,6 +285,7 @@ function PolylinePrimitive({
   }
 
   const closed = primitive.type === "line-loop";
+  const pointsAttr = primitive.points.map(([x, y]) => `${x},${y}`).join(" ");
   return (
     <g
       className={clsx(
@@ -296,19 +297,27 @@ function PolylinePrimitive({
       onClick={onClick}
     >
       {closed ? (
-        <polygon
-          points={primitive.points.map(([x, y]) => `${x},${y}`).join(" ")}
-          className={styles.fillInterior}
-        />
+        <polygon points={pointsAttr} className={styles.fillInterior} />
       ) : null}
-      <polyline
-        points={primitive.points.map(([x, y]) => `${x},${y}`).join(" ")}
-        strokeWidth={thickness}
-        strokeLinejoin="round"
-        strokeLinecap="round"
-        vectorEffect="non-scaling-stroke"
-        fill="none"
-      />
+      {closed ? (
+        <polygon
+          points={pointsAttr}
+          strokeWidth={thickness}
+          strokeLinejoin="round"
+          strokeLinecap="round"
+          vectorEffect="non-scaling-stroke"
+          fill="none"
+        />
+      ) : (
+        <polyline
+          points={pointsAttr}
+          strokeWidth={thickness}
+          strokeLinejoin="round"
+          strokeLinecap="round"
+          vectorEffect="non-scaling-stroke"
+          fill="none"
+        />
+      )}
     </g>
   );
 }
@@ -337,7 +346,7 @@ function LineListGroups({
     <>
       {groups.map((group, gi) => {
         const color = colorForLabel(group.label);
-        const key = `pg-${setIndex}-${primitiveIndex}-${boundsKey(
+        const key = `pg-${setIndex}-${primitiveIndex}-${gi}-${boundsKey(
           group.bounds
         )}`;
         const onClick = pickHandler(onSelectPrimitive, {
@@ -598,19 +607,14 @@ const DEFAULT_COLOR_POOL: readonly string[] = [
 ];
 
 const DEFAULT_LABEL_KEY = "__no-label__";
-const labelColorAssignments = new Map<string, string>();
 
 function colorForLabel(label: string | null): string {
   const key = label ?? DEFAULT_LABEL_KEY;
-  let color = labelColorAssignments.get(key);
-  if (!color) {
-    color =
-      DEFAULT_COLOR_POOL[
-        labelColorAssignments.size % DEFAULT_COLOR_POOL.length
-      ];
-    labelColorAssignments.set(key, color);
+  let hash = 0;
+  for (let i = 0; i < key.length; i++) {
+    hash = (hash * 31 + key.charCodeAt(i)) >>> 0;
   }
-  return color;
+  return DEFAULT_COLOR_POOL[hash % DEFAULT_COLOR_POOL.length];
 }
 
 function boundsKey(b: Bounds): string {
@@ -672,116 +676,6 @@ function displayRect(
   };
 }
 
-function CirclePrimitive({ primitive }: { primitive: ImageAnnotationCircle }) {
-  const [x, y] = primitive.position;
-  const radius = Math.max(0, primitive.diameter / 2);
-  return (
-    <circle
-      cx={x}
-      cy={y}
-      r={radius}
-      fill={rgbaToCss(primitive.fillColor) ?? "none"}
-      stroke={rgbaToCss(primitive.outlineColor) ?? DEFAULT_STROKE}
-      strokeWidth={Math.max(1, primitive.thickness)}
-      vectorEffect="non-scaling-stroke"
-    />
-  );
-}
-
-function PointsPrimitive({ primitive }: { primitive: ImageAnnotationPoints }) {
-  const stroke = rgbaToCss(primitive.outlineColor) ?? DEFAULT_STROKE;
-  const fill = rgbaToCss(primitive.fillColor);
-  const thickness = Math.max(1, primitive.thickness);
-
-  switch (primitive.type) {
-    case "points":
-      return (
-        <g>
-          {primitive.points.map(([x, y], i) => (
-            <circle
-              key={i}
-              cx={x}
-              cy={y}
-              r={thickness}
-              fill={rgbaToCss(primitive.outlineColors[i]) ?? fill ?? stroke}
-            />
-          ))}
-        </g>
-      );
-
-    case "line-loop":
-    case "line-strip": {
-      const pts =
-        primitive.type === "line-loop" && primitive.points.length > 1
-          ? [...primitive.points, primitive.points[0]]
-          : primitive.points;
-      return (
-        <polyline
-          points={pts.map(([x, y]) => `${x},${y}`).join(" ")}
-          fill={primitive.type === "line-loop" ? fill ?? "none" : "none"}
-          stroke={stroke}
-          strokeWidth={thickness}
-          strokeLinejoin="round"
-          strokeLinecap="round"
-          vectorEffect="non-scaling-stroke"
-        />
-      );
-    }
-
-    case "line-list": {
-      const segments = [];
-      for (let i = 0; i + 1 < primitive.points.length; i += 2) {
-        const [x1, y1] = primitive.points[i];
-        const [x2, y2] = primitive.points[i + 1];
-        segments.push(
-          <line
-            key={i}
-            x1={x1}
-            y1={y1}
-            x2={x2}
-            y2={y2}
-            stroke={stroke}
-            strokeWidth={thickness}
-            strokeLinecap="round"
-            vectorEffect="non-scaling-stroke"
-          />
-        );
-      }
-      return <g>{segments}</g>;
-    }
-  }
-}
-
-function TextPrimitive({ primitive }: { primitive: ImageAnnotationText }) {
-  const [x, y] = primitive.position;
-  const fill = rgbaToCss(primitive.textColor) ?? DEFAULT_TEXT_FILL;
-  const fontSize = Math.max(1, primitive.fontSize);
-  const background = rgbaToCss(primitive.backgroundColor);
-
-  return (
-    <g>
-      {background ? (
-        <rect
-          x={x - 2}
-          y={y - fontSize}
-          width={primitive.text.length * fontSize * 0.6 + 4}
-          height={fontSize + 4}
-          fill={background}
-        />
-      ) : null}
-      <text
-        x={x}
-        y={y}
-        fill={fill}
-        fontSize={fontSize}
-        fontFamily="system-ui, sans-serif"
-        dominantBaseline="alphabetic"
-      >
-        {primitive.text}
-      </text>
-    </g>
-  );
-}
 
 function rgbaToCss(color: RgbaColor | null | undefined): string | undefined {
   if (!color) return undefined;

--- a/app/packages/multimodal/src/visualization/panels/image-annotations-overlay.module.css
+++ b/app/packages/multimodal/src/visualization/panels/image-annotations-overlay.module.css
@@ -1,0 +1,29 @@
+.primitive {
+  stroke: var(--ann-stroke);
+  transition: stroke 80ms linear;
+}
+
+.primitive:hover,
+.selected {
+  stroke: var(--ann-hover, #ff7a18);
+}
+
+.fillInterior {
+  fill: transparent;
+  stroke: none;
+}
+
+.primitiveDot {
+  fill: var(--ann-stroke);
+  transition: fill 80ms linear;
+}
+
+.primitive:hover .primitiveDot,
+.selected .primitiveDot {
+  fill: var(--ann-hover, #ff7a18);
+}
+
+.selectable {
+  cursor: pointer;
+  pointer-events: all;
+}

--- a/app/packages/tiling/src/views/TilingInspectorSidebar/TilingInspectorSidebar.module.css
+++ b/app/packages/tiling/src/views/TilingInspectorSidebar/TilingInspectorSidebar.module.css
@@ -23,7 +23,11 @@
   font-size: 0.8125rem;
   cursor: pointer;
   text-align: center;
-  outline: none;
+}
+
+.tab:focus-visible {
+  outline: 2px solid var(--color-brand-primary);
+  outline-offset: 2px;
 }
 
 .tab:hover {

--- a/app/packages/tiling/src/views/TilingInspectorSidebar/TilingInspectorSidebar.module.css
+++ b/app/packages/tiling/src/views/TilingInspectorSidebar/TilingInspectorSidebar.module.css
@@ -1,3 +1,50 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.tabs {
+  display: flex;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--color-content-border-subtle);
+}
+
+.tab {
+  flex: 1 1 0;
+  padding: 10px 12px;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  color: var(--color-content-text-secondary);
+  font: inherit;
+  font-size: 0.8125rem;
+  cursor: pointer;
+  text-align: center;
+  outline: none;
+}
+
+.tab:hover {
+  color: var(--color-content-text-primary);
+}
+
+.tabActive {
+  color: var(--color-content-text-primary);
+  border-bottom-color: var(--color-brand-primary);
+}
+
+.body {
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+}
+
 .spacer {
   height: 8px;
 }

--- a/app/packages/tiling/src/views/TilingInspectorSidebar/TilingInspectorSidebar.test.tsx
+++ b/app/packages/tiling/src/views/TilingInspectorSidebar/TilingInspectorSidebar.test.tsx
@@ -2,14 +2,21 @@ import { act, cleanup, render, screen } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { TileIdScope, TilingProvider, useTiling } from "../../lib/TilingProvider";
+import {
+  TileIdScope,
+  TilingProvider,
+  useTiling,
+} from "../../lib/TilingProvider";
 import { useSetTileSelection } from "../../lib/use-tile-state";
 import TilingInspectorSidebar from "./TilingInspectorSidebar";
 
 const Selector: React.FC<{ payload: unknown }> = ({ payload }) => {
   const setSelection = useSetTileSelection();
   return (
-    <button data-testid="emit-selection" onClick={() => setSelection(payload)} />
+    <button
+      data-testid="emit-selection"
+      onClick={() => setSelection(payload)}
+    />
   );
 };
 
@@ -32,7 +39,7 @@ describe("TilingInspectorSidebar", () => {
     expect(screen.getByText("Select a tile to inspect.")).toBeTruthy();
   });
 
-  it("renders the focused tile's title and the no-selection hint", () => {
+  it("renders the no-selection hint when a tile is focused but has no selection", () => {
     render(
       <TilingProvider
         initialTiles={{
@@ -46,16 +53,17 @@ describe("TilingInspectorSidebar", () => {
     act(() => {
       screen.getByTestId("focus-graph-1").click();
     });
-    expect(screen.getByText("imu")).toBeTruthy();
     expect(
-      screen.getByText(
-        /Click something inside the tile.* to inspect its data/i
-      )
+      screen.getByText(/Click something inside the tile.* to inspect its data/i)
     ).toBeTruthy();
   });
 
   it("renders the focused tile's selection payload as JSON", () => {
-    const payload = { kind: "graph-sample", timeSec: 1.5, values: { velocity: 0.4 } };
+    const payload = {
+      kind: "graph-sample",
+      timeSec: 1.5,
+      values: { velocity: 0.4 },
+    };
     render(
       <TilingProvider
         initialTiles={{ "graph-1": { title: "imu", render: () => null } }}
@@ -75,8 +83,7 @@ describe("TilingInspectorSidebar", () => {
     // RTL normalizes whitespace by default; match on the multi-line content
     // by tag instead so the pretty-printed indentation is preserved.
     const pre = screen.getByText(
-      (_text, node) =>
-        node?.tagName === "PRE" && node.textContent === json
+      (_text, node) => node?.tagName === "PRE" && node.textContent === json
     );
     expect(pre).toBeTruthy();
   });

--- a/app/packages/tiling/src/views/TilingInspectorSidebar/TilingInspectorSidebar.tsx
+++ b/app/packages/tiling/src/views/TilingInspectorSidebar/TilingInspectorSidebar.tsx
@@ -20,25 +20,36 @@ const TilingInspectorSidebar: React.FC = () => {
     <div className={styles.root}>
       <div className={styles.tabs} role="tablist">
         <button
+          id="inspector-tab-explore"
           type="button"
           role="tab"
           aria-selected={tab === "explore"}
+          aria-controls="inspector-panel-explore"
+          tabIndex={tab === "explore" ? 0 : -1}
           className={clsx(styles.tab, tab === "explore" && styles.tabActive)}
           onClick={() => setTab("explore")}
         >
           Explore
         </button>
         <button
+          id="inspector-tab-annotate"
           type="button"
           role="tab"
           aria-selected={tab === "annotate"}
+          aria-controls="inspector-panel-annotate"
+          tabIndex={tab === "annotate" ? 0 : -1}
           className={clsx(styles.tab, tab === "annotate" && styles.tabActive)}
           onClick={() => setTab("annotate")}
         >
           Annotate
         </button>
       </div>
-      <div className={styles.body}>
+      <div
+        className={styles.body}
+        role="tabpanel"
+        id={`inspector-panel-${tab}`}
+        aria-labelledby={`inspector-tab-${tab}`}
+      >
         {tab === "explore" ? <ExplorePanel /> : <AnnotatePanel />}
       </div>
     </div>

--- a/app/packages/tiling/src/views/TilingInspectorSidebar/TilingInspectorSidebar.tsx
+++ b/app/packages/tiling/src/views/TilingInspectorSidebar/TilingInspectorSidebar.tsx
@@ -1,65 +1,82 @@
 import { Text, TextColor, TextVariant } from "@voxel51/voodo";
-import React from "react";
+import clsx from "clsx";
+import React, { useState } from "react";
 import { useTiling } from "../../lib/TilingProvider";
 import { useTileSelectionFor } from "../../lib/use-tile-state";
-import SidebarPanel from "../SidebarPanel/SidebarPanel";
 import styles from "./TilingInspectorSidebar.module.css";
 
+type InspectorTab = "explore" | "annotate";
+
 /**
- * Right-hand sidebar that shows the focused tile's current "selection"
- * — whatever the tile body wrote into `tileSelectionAtom(tileId)` when
- * the user clicked an inspectable element (a graph sample, a 3D scene
- * object, …). Each tile defines its own payload shape; we render the
- * payload as syntax-colored JSON so any structure displays sensibly.
- * 
- * NOTE: This is very subject to change
+ * Right-hand sidebar with two top-level modes: Explore (current tile
+ * inspection) and Annotate (future annotation workflows). Explore is
+ * the historical inspector behavior — Annotate is a placeholder until
+ * the workflow lands.
  */
 const TilingInspectorSidebar: React.FC = () => {
-  const { focusedTileId, tiles } = useTiling();
-  const focusedTile = focusedTileId ? tiles[focusedTileId] : null;
+  const [tab, setTab] = useState<InspectorTab>("explore");
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.tabs} role="tablist">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === "explore"}
+          className={clsx(styles.tab, tab === "explore" && styles.tabActive)}
+          onClick={() => setTab("explore")}
+        >
+          Explore
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === "annotate"}
+          className={clsx(styles.tab, tab === "annotate" && styles.tabActive)}
+          onClick={() => setTab("annotate")}
+        >
+          Annotate
+        </button>
+      </div>
+      <div className={styles.body}>
+        {tab === "explore" ? <ExplorePanel /> : <AnnotatePanel />}
+      </div>
+    </div>
+  );
+};
+
+const ExplorePanel: React.FC = () => {
+  const { focusedTileId } = useTiling();
   const selection = useTileSelectionFor(focusedTileId);
 
   if (!focusedTileId) {
     return (
-      <SidebarPanel title="Inspector">
-        <Text variant={TextVariant.Sm} color={TextColor.Muted}>
-          Select a tile to inspect.
-        </Text>
-      </SidebarPanel>
+      <Text variant={TextVariant.Sm} color={TextColor.Muted}>
+        Select a tile to inspect.
+      </Text>
     );
   }
 
-  return (
-    <SidebarPanel title="Inspector">
-      <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
-        Focused tile
+  if (selection == null) {
+    return (
+      <Text variant={TextVariant.Sm} color={TextColor.Muted}>
+        Click something inside the tile (a graph sample, a 3D object…) to
+        inspect its data.
       </Text>
-      <Text variant={TextVariant.Sm} color={TextColor.Primary}>
-        {focusedTile?.title ?? focusedTileId}
-      </Text>
+    );
+  }
 
-      <div className={styles.spacer} />
-
-      <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
-        Selection
-      </Text>
-      {selection != null ? (
-        <pre className={styles.json}>{formatSelection(selection)}</pre>
-      ) : (
-        <Text variant={TextVariant.Sm} color={TextColor.Muted}>
-          Click something inside the tile (a graph sample, a 3D
-          object…) to inspect its data.
-        </Text>
-      )}
-    </SidebarPanel>
-  );
+  return <pre className={styles.json}>{formatSelection(selection)}</pre>;
 };
+
+const AnnotatePanel: React.FC = () => (
+  <Text variant={TextVariant.Sm} color={TextColor.Muted}>
+    Annotation workflows are coming soon.
+  </Text>
+);
 
 function formatSelection(value: unknown): string {
   try {
-    // JSON.stringify returns `undefined` (without throwing) for top-level
-    // undefined / function / symbol values — fall back to String() so
-    // the <pre> never renders blank.
     return JSON.stringify(value, null, 2) ?? String(value);
   } catch {
     return String(value);


### PR DESCRIPTION
## 🔗 Related Issues

Stacks on #7635 (\`feat/mmCameraLabels\`).

## 📋 What changes are proposed in this pull request?

Picks up where #7635 left off (decoder + sidebar listing) and adds the user-facing interaction layer plus a correctness fix for box ↔ label pairing.

### Clickable annotation primitives + persistent selection

- Each circle / line-list group / polyline / text in the camera overlay is now clickable. Interior hit detection via a transparent fill on closed shapes; line-list groups get a transparent AABB rect so anywhere-inside a wireframe box selects it. Empty space still passes events through to the underlying image.
- Clicking publishes a structured \`image-annotation\` payload (kind, topic, color, label, primitive data) to the focused tile's selection — the inspector's Explore tab renders it as JSON.
- Hover and a persistent \`.selected\` state both light up via a shared \`--ann-stroke\` CSS variable swapped to orange (\`#ff7a18\`). Each primitive/group has its own \`<g>\` scope so highlights stay isolated.

### Label colors

- Each label class gets a stable color from a subset of the FO default palette (orange/orange-leaning entries pulled to avoid clashing with the hover highlight).
- All \`vehicle.truck\` boxes share one color, all \`human.pedestrian\` boxes share another — derived from the label string, not per-instance, so colors don't shuffle across frames.

### Inter-message interpolation (toggle in the camera tile settings)

- New \`useInterpolatedImageAnnotations(topic, { interpolate })\` hook. Annotations land at ~2 Hz against ~12 Hz camera images; we lerp segment endpoints between the prev and next annotation messages so the boxes track the camera between updates instead of lagging up to 500 ms.
- Foxglove doesn't carry stable instance IDs, but each \`ImageAnnotations\` message encodes its objects in a stable per-index order alongside their text labels — the Nth chunk of segments is labeled by \`texts[N]\`. We use that index pairing to match cuboids across consecutive messages.
- Toggle \"Interpolate between annotations\" lives in the camera tile's settings sidebar; defaults on, falls back to the raw current message when disabled or when no next message is cached yet.

### Box ↔ label pairing fix

- The first pass tried to find each box's label via nearest-text-by-centroid (with IoU + Chamfer disambiguators) since NuScenes labels can sit off-image. That was unstable: box color != its own label color, same box flickered colors across frames.
- Replaced with the index-based pairing the data already provides: \`segmentCount % texts.length === 0\` → split segments into \`texts.length\` chunks, label N = \`texts[N].text\`. Falls back to one big unlabeled group when the data doesn't divide cleanly.

### Right sidebar

- \`TilingInspectorSidebar\` gains a 2-tab header (Explore / Annotate). Explore renders the focused tile's selection payload as JSON; Annotate is a placeholder for the upcoming annotation workflow.

### Data-stream context plumbing

- \`McapDataStream\` exposes \`getTopicCache(topic)\` and \`getTimelineIndex()\` so the interpolation hook can peek ahead to the next annotation message without re-fetching.
- Annotation topic sync tolerance widened to 1.5 s (was 120 ms) so every tick resolves to the latest annotation message — annotations arrive every 500 ms, so the previous 120 ms window left most ticks unresolved.

## 🧪 How is this patch tested? If it is not, please explain why.

- \`yarn check\` clean across multimodal + tiling (lint, deps, types).
- Vitest suite passes (2318 tests).
- Manually verified with a NuScenes \`.mcap\`: clicking a cuboid edge selects the whole box, hover/select highlights are scoped per-box, label colors stay consistent across frames, interpolation toggle visibly smooths motion between annotation updates.

## 📝 Release Notes

### Is this a user-facing change?

-   [x] No.
-   [ ] Yes.

### What areas of FiftyOne does this PR affect?

-   [x] App
-   [ ] Build
-   [ ] Core
-   [ ] Documentation
-   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added annotation interpolation capability with configurable toggle control
  * Introduced interactive annotation selection and highlighting
  * Restructured inspector sidebar with separate Explore and Annotate tabs

* **Improvements**
  * Enhanced annotation rendering with improved visual styling and transitions
  * Added hover and selection states for better visual feedback on annotation primitives

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->