### PR TITLE
Serve temporal tags to app clients

### DIFF
--- a/app/packages/multimodal/package.json
+++ b/app/packages/multimodal/package.json
@@ -10,6 +10,7 @@
         "./query/bytes": "./src/query/bytes/index.ts",
         "./query/decode": "./src/query/decode/index.ts",
         "./decoders": "./src/decoders/index.ts",
+        "./temporal-tags": "./src/temporal-tags/index.ts",
         "./inject": "./src/inject/index.ts",
         "./adapters/mcap": "./src/adapters/mcap/index.ts",
         "./schemas/v1": "./src/schemas/v1/index.ts",
@@ -21,6 +22,9 @@
         "*": {
             "decoders": [
                 "src/decoders/index.ts"
+            ],
+            "temporal-tags": [
+                "src/temporal-tags/index.ts"
             ],
             "query": [
                 "src/query/index.ts"

--- a/app/packages/multimodal/src/temporal-tags/client.test.ts
+++ b/app/packages/multimodal/src/temporal-tags/client.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTemporalTagsClient } from "./client";
+
+type FetchConfig = {
+  readonly body?: unknown;
+  readonly method: string;
+  readonly path: string;
+};
+
+describe("createTemporalTagsClient", () => {
+  it("builds canonical route paths for every operation", async () => {
+    const fetchFunction = createFetch(responseForRoute);
+    const client = createTemporalTagsClient({
+      fetchFunction: fetchFunction as never,
+    });
+
+    await client.listSampleTemporalTags({
+      datasetId: "dataset-id",
+      sampleId: "sample-id",
+    });
+    await client.createSampleTemporalTags({
+      datasetId: "dataset-id",
+      sampleId: "sample-id",
+      temporalTags: [createTemporalTagInput()],
+    });
+    await client.updateSampleTemporalTag({
+      datasetId: "dataset-id",
+      sampleId: "sample-id",
+      temporalTagId: "tag-id",
+      update: { end: 4 },
+    });
+    await client.deleteSampleTemporalTags({
+      datasetId: "dataset-id",
+      sampleId: "sample-id",
+      ids: ["tag-id"],
+    });
+    await client.clearSampleTemporalTags({
+      datasetId: "dataset-id",
+      sampleId: "sample-id",
+    });
+    await client.listDatasetTemporalTags({ datasetId: "dataset-id" });
+    await client.countDatasetTemporalTags({ datasetId: "dataset-id" });
+
+    expect(
+      fetchFunction.mock.calls.map(([config]) => routeKey(config))
+    ).toEqual([
+      "GET /dataset/dataset-id/sample/sample-id/multimodal/temporal-tags",
+      "POST /dataset/dataset-id/sample/sample-id/multimodal/temporal-tags",
+      "PATCH /dataset/dataset-id/sample/sample-id/multimodal/temporal-tags/tag-id",
+      "DELETE /dataset/dataset-id/sample/sample-id/multimodal/temporal-tags",
+      "DELETE /dataset/dataset-id/sample/sample-id/multimodal/temporal-tags",
+      "GET /dataset/dataset-id/multimodal/temporal-tags",
+      "GET /dataset/dataset-id/multimodal/temporal-tags/counts",
+    ]);
+  });
+
+  it("serializes repeated filter query params", async () => {
+    const fetchFunction = createFetch({ temporal_tags: [] });
+    const client = createTemporalTagsClient({
+      fetchFunction: fetchFunction as never,
+    });
+
+    await client.listSampleTemporalTags({
+      datasetId: "dataset id",
+      filter: {
+        anchors: ["lidar_top", "camera_front"],
+        end: 20,
+        indexType: 2,
+        start: 10,
+        tags: ["review", "interesting"],
+      },
+      sampleId: "sample/id",
+    });
+
+    const url = routeUrl(fetchFunction.mock.calls[0][0].path);
+    expect(url.pathname).toBe(
+      "/dataset/dataset%20id/sample/sample%2Fid/multimodal/temporal-tags"
+    );
+    expect(url.searchParams.getAll("anchors")).toEqual([
+      "lidar_top",
+      "camera_front",
+    ]);
+    expect(url.searchParams.get("end")).toBe("20");
+    expect(url.searchParams.get("index_type")).toBe("2");
+    expect(url.searchParams.get("start")).toBe("10");
+    expect(url.searchParams.getAll("tags")).toEqual(["review", "interesting"]);
+  });
+
+  it("converts create bodies and response tags between app and route shapes", async () => {
+    const fetchFunction = createFetch({
+      temporal_tags: [createTemporalTagDto()],
+    });
+    const client = createTemporalTagsClient({
+      fetchFunction: fetchFunction as never,
+    });
+
+    const tags = await client.createSampleTemporalTags({
+      datasetId: "dataset-id",
+      sampleId: "sample-id",
+      temporalTags: [createTemporalTagInput()],
+    });
+
+    expect(fetchFunction.mock.calls[0][0].body).toEqual({
+      temporal_tags: [
+        {
+          anchor: "lidar_top",
+          created_by: "sashank",
+          end: 10,
+          index_type: 2,
+          last_modified_by: "kacey",
+          start: 5,
+          tag: "review",
+        },
+      ],
+    });
+    expect(JSON.stringify(fetchFunction.mock.calls[0][0].body)).not.toContain(
+      "sample_id"
+    );
+    expect(tags[0]).toEqual({
+      anchor: "lidar_top",
+      createdAt: "2026-05-26T12:00:00Z",
+      createdBy: "sashank",
+      end: 10,
+      id: "temporal-tag-id",
+      indexType: 2,
+      lastModifiedAt: "2026-05-26T12:01:00Z",
+      lastModifiedBy: "kacey",
+      sampleId: "sample-id",
+      start: 5,
+      tag: "review",
+    });
+  });
+
+  it("converts update bodies without route-owned identity fields", async () => {
+    const fetchFunction = createFetch({
+      temporal_tag: createTemporalTagDto({ end: 15, tag: "moved" }),
+    });
+    const client = createTemporalTagsClient({
+      fetchFunction: fetchFunction as never,
+    });
+
+    const tag = await client.updateSampleTemporalTag({
+      datasetId: "dataset-id",
+      sampleId: "sample-id",
+      temporalTagId: "temporal-tag-id",
+      update: {
+        end: 15,
+        lastModifiedBy: "sashank",
+        tag: "moved",
+      },
+    });
+
+    expect(fetchFunction.mock.calls[0][0].body).toEqual({
+      end: 15,
+      last_modified_by: "sashank",
+      tag: "moved",
+    });
+    expect(JSON.stringify(fetchFunction.mock.calls[0][0].body)).not.toContain(
+      "sample_id"
+    );
+    expect(tag.tag).toBe("moved");
+  });
+
+  it("supports deleting explicit temporal tag ids", async () => {
+    const fetchFunction = createFetch({ deleted: 2 });
+    const client = createTemporalTagsClient({
+      fetchFunction: fetchFunction as never,
+    });
+
+    await expect(
+      client.deleteSampleTemporalTags({
+        datasetId: "dataset-id",
+        sampleId: "sample-id",
+        ids: ["temporal-tag-id"],
+      })
+    ).resolves.toBe(2);
+
+    expect(fetchFunction.mock.calls[0][0].body).toEqual({
+      ids: ["temporal-tag-id"],
+    });
+  });
+
+  it("supports clearing all sample tags with an optional filter", async () => {
+    const fetchFunction = createFetch({ deleted: 2 });
+    const client = createTemporalTagsClient({
+      fetchFunction: fetchFunction as never,
+    });
+
+    await expect(
+      client.clearSampleTemporalTags({
+        datasetId: "dataset-id",
+        filter: {
+          anchors: ["lidar_top"],
+          end: 20,
+          indexType: 2,
+          start: 10,
+          tags: ["review"],
+        },
+        sampleId: "sample-id",
+      })
+    ).resolves.toBe(2);
+
+    expect(fetchFunction.mock.calls[0][0].body).toEqual({
+      delete_all: true,
+      filter: {
+        anchors: ["lidar_top"],
+        end: 20,
+        index_type: 2,
+        start: 10,
+        tags: ["review"],
+      },
+    });
+  });
+});
+
+function createFetch(response: unknown | ((config: FetchConfig) => unknown)) {
+  return vi.fn(async (config: FetchConfig) => ({
+    headers: new Headers(),
+    response: typeof response === "function" ? response(config) : response,
+  }));
+}
+
+function responseForRoute(config: FetchConfig) {
+  if (config.method === "DELETE") {
+    return { deleted: 1 };
+  }
+
+  if (config.path.endsWith("/counts")) {
+    return { counts: { review: 1 } };
+  }
+
+  if (config.method === "PATCH") {
+    return { temporal_tag: createTemporalTagDto() };
+  }
+
+  return { temporal_tags: [createTemporalTagDto()] };
+}
+
+function routeKey(config: FetchConfig) {
+  const url = routeUrl(config.path);
+
+  return `${config.method} ${url.pathname}`;
+}
+
+function routeUrl(path: string) {
+  return new URL(path, "http://fiftyone.test");
+}
+
+function createTemporalTagInput() {
+  return {
+    anchor: "lidar_top",
+    createdBy: "sashank",
+    end: 10,
+    indexType: 2,
+    lastModifiedBy: "kacey",
+    start: 5,
+    tag: "review",
+  };
+}
+
+function createTemporalTagDto(
+  overrides: Partial<ReturnType<typeof createTemporalTagDtoBase>> = {}
+) {
+  return {
+    ...createTemporalTagDtoBase(),
+    ...overrides,
+  };
+}
+
+function createTemporalTagDtoBase() {
+  return {
+    anchor: "lidar_top",
+    created_at: "2026-05-26T12:00:00Z",
+    created_by: "sashank",
+    end: 10,
+    id: "temporal-tag-id",
+    index_type: 2,
+    last_modified_at: "2026-05-26T12:01:00Z",
+    last_modified_by: "kacey",
+    sample_id: "sample-id",
+    start: 5,
+    tag: "review",
+  };
+}

--- a/app/packages/multimodal/src/temporal-tags/client.ts
+++ b/app/packages/multimodal/src/temporal-tags/client.ts
@@ -1,0 +1,309 @@
+import { getFetchFunctionExtended } from "@fiftyone/utilities";
+import type {
+  ClearSampleTemporalTagsRequest,
+  CountDatasetTemporalTagsRequest,
+  CreateSampleTemporalTagsRequest,
+  DeleteSampleTemporalTagsRequest,
+  ListDatasetTemporalTagsRequest,
+  ListSampleTemporalTagsRequest,
+  TemporalTag,
+  TemporalTagCreate,
+  TemporalTagFilter,
+  TemporalTagsClient,
+  TemporalTagUpdate,
+  UpdateSampleTemporalTagRequest,
+} from "./types";
+
+type TemporalTagsFetch = ReturnType<typeof getFetchFunctionExtended>;
+
+type TemporalTagDto = {
+  readonly end: number;
+  readonly id: string;
+  readonly index_type: number;
+  readonly sample_id: string;
+  readonly start: number;
+  readonly tag: string;
+  readonly anchor?: string;
+  readonly created_at?: string;
+  readonly created_by?: string;
+  readonly last_modified_at?: string;
+  readonly last_modified_by?: string;
+};
+
+type TemporalTagsResponseDto = {
+  readonly temporal_tags: readonly TemporalTagDto[];
+};
+
+type TemporalTagResponseDto = {
+  readonly temporal_tag: TemporalTagDto;
+};
+
+type TemporalTagCountsResponseDto = {
+  readonly counts: Readonly<Record<string, number>>;
+};
+
+type DeleteTemporalTagsResponseDto = {
+  readonly deleted: number;
+};
+
+/**
+ * Options for constructing the temporal-tags route client.
+ */
+export interface CreateTemporalTagsClientOptions {
+  readonly fetchFunction?: TemporalTagsFetch;
+}
+
+/**
+ * Creates a typed client for the multimodal temporal-tag HTTP routes.
+ */
+export function createTemporalTagsClient(
+  options: CreateTemporalTagsClientOptions = {}
+): TemporalTagsClient {
+  const fetchFunction = options.fetchFunction ?? getFetchFunctionExtended();
+
+  return {
+    async createSampleTemporalTags({
+      datasetId,
+      sampleId,
+      temporalTags,
+    }: CreateSampleTemporalTagsRequest) {
+      const response = await fetchFunction<
+        { temporal_tags: readonly ReturnType<typeof temporalTagCreateDto>[] },
+        TemporalTagsResponseDto
+      >({
+        body: {
+          temporal_tags: temporalTags.map(temporalTagCreateDto),
+        },
+        method: "POST",
+        path: `/dataset/${encodeURIComponent(
+          datasetId
+        )}/sample/${encodeURIComponent(sampleId)}/multimodal/temporal-tags`,
+      });
+
+      return response.response.temporal_tags.map(temporalTagFromDto);
+    },
+
+    async clearSampleTemporalTags({
+      datasetId,
+      sampleId,
+      filter,
+    }: ClearSampleTemporalTagsRequest) {
+      const response = await fetchFunction<
+        ReturnType<typeof clearTemporalTagsDto>,
+        DeleteTemporalTagsResponseDto
+      >({
+        body: clearTemporalTagsDto(filter),
+        method: "DELETE",
+        path: `/dataset/${encodeURIComponent(
+          datasetId
+        )}/sample/${encodeURIComponent(sampleId)}/multimodal/temporal-tags`,
+      });
+
+      return response.response.deleted;
+    },
+
+    async countDatasetTemporalTags({
+      datasetId,
+      filter,
+    }: CountDatasetTemporalTagsRequest) {
+      const response = await fetchFunction<
+        undefined,
+        TemporalTagCountsResponseDto
+      >({
+        method: "GET",
+        path: withFilterQuery(
+          `/dataset/${encodeURIComponent(
+            datasetId
+          )}/multimodal/temporal-tags/counts`,
+          filter
+        ),
+      });
+
+      return response.response.counts;
+    },
+
+    async deleteSampleTemporalTags({
+      datasetId,
+      sampleId,
+      ids,
+    }: DeleteSampleTemporalTagsRequest) {
+      const response = await fetchFunction<
+        ReturnType<typeof deleteTemporalTagsDto>,
+        DeleteTemporalTagsResponseDto
+      >({
+        body: deleteTemporalTagsDto(ids),
+        method: "DELETE",
+        path: `/dataset/${encodeURIComponent(
+          datasetId
+        )}/sample/${encodeURIComponent(sampleId)}/multimodal/temporal-tags`,
+      });
+
+      return response.response.deleted;
+    },
+
+    async listDatasetTemporalTags({
+      datasetId,
+      filter,
+    }: ListDatasetTemporalTagsRequest) {
+      const response = await fetchFunction<undefined, TemporalTagsResponseDto>({
+        method: "GET",
+        path: withFilterQuery(
+          `/dataset/${encodeURIComponent(datasetId)}/multimodal/temporal-tags`,
+          filter
+        ),
+      });
+
+      return response.response.temporal_tags.map(temporalTagFromDto);
+    },
+
+    async listSampleTemporalTags({
+      datasetId,
+      sampleId,
+      filter,
+    }: ListSampleTemporalTagsRequest) {
+      const response = await fetchFunction<undefined, TemporalTagsResponseDto>({
+        method: "GET",
+        path: withFilterQuery(
+          `/dataset/${encodeURIComponent(
+            datasetId
+          )}/sample/${encodeURIComponent(sampleId)}/multimodal/temporal-tags`,
+          filter
+        ),
+      });
+
+      return response.response.temporal_tags.map(temporalTagFromDto);
+    },
+
+    async updateSampleTemporalTag({
+      datasetId,
+      sampleId,
+      temporalTagId,
+      update,
+    }: UpdateSampleTemporalTagRequest) {
+      const response = await fetchFunction<
+        ReturnType<typeof temporalTagUpdateDto>,
+        TemporalTagResponseDto
+      >({
+        body: temporalTagUpdateDto(update),
+        method: "PATCH",
+        path: `/dataset/${encodeURIComponent(
+          datasetId
+        )}/sample/${encodeURIComponent(
+          sampleId
+        )}/multimodal/temporal-tags/${encodeURIComponent(temporalTagId)}`,
+      });
+
+      return temporalTagFromDto(response.response.temporal_tag);
+    },
+  };
+}
+
+function withFilterQuery(path: string, filter: TemporalTagFilter | undefined) {
+  const params = filterQueryParams(filter);
+  const queryString = params.toString();
+
+  return queryString ? `${path}?${queryString}` : path;
+}
+
+function filterQueryParams(filter: TemporalTagFilter | undefined) {
+  const params = new URLSearchParams();
+  if (!filter) {
+    return params;
+  }
+
+  appendValues(params, "anchors", filter.anchors);
+  appendNumber(params, "end", filter.end);
+  appendNumber(params, "index_type", filter.indexType);
+  appendNumber(params, "start", filter.start);
+  appendValues(params, "tags", filter.tags);
+
+  return params;
+}
+
+function appendNumber(
+  params: URLSearchParams,
+  field: string,
+  value: number | undefined
+) {
+  if (value !== undefined) {
+    params.append(field, value.toString());
+  }
+}
+
+function appendValues(
+  params: URLSearchParams,
+  field: string,
+  value: readonly string[] | undefined
+) {
+  if (value === undefined) {
+    return;
+  }
+
+  for (const item of value) {
+    params.append(field, item);
+  }
+}
+
+function temporalTagCreateDto(tag: TemporalTagCreate) {
+  return stripUndefined({
+    anchor: tag.anchor,
+    created_by: tag.createdBy,
+    end: tag.end,
+    index_type: tag.indexType,
+    last_modified_by: tag.lastModifiedBy,
+    start: tag.start,
+    tag: tag.tag,
+  });
+}
+
+function temporalTagUpdateDto(update: TemporalTagUpdate) {
+  return stripUndefined({
+    end: update.end,
+    last_modified_by: update.lastModifiedBy,
+    start: update.start,
+    tag: update.tag,
+  });
+}
+
+function deleteTemporalTagsDto(ids: readonly string[]) {
+  return { ids };
+}
+
+function clearTemporalTagsDto(filter: TemporalTagFilter | undefined) {
+  return stripUndefined({
+    delete_all: true,
+    filter: filter ? filterDto(filter) : undefined,
+  });
+}
+
+function filterDto(filter: TemporalTagFilter) {
+  return stripUndefined({
+    anchors: filter.anchors,
+    end: filter.end,
+    index_type: filter.indexType,
+    start: filter.start,
+    tags: filter.tags,
+  });
+}
+
+function temporalTagFromDto(dto: TemporalTagDto): TemporalTag {
+  return stripUndefined({
+    anchor: dto.anchor,
+    createdAt: dto.created_at,
+    createdBy: dto.created_by,
+    end: dto.end,
+    id: dto.id,
+    indexType: dto.index_type,
+    lastModifiedAt: dto.last_modified_at,
+    lastModifiedBy: dto.last_modified_by,
+    sampleId: dto.sample_id,
+    start: dto.start,
+    tag: dto.tag,
+  }) as TemporalTag;
+}
+
+function stripUndefined<T extends Record<string, unknown>>(value: T) {
+  return Object.fromEntries(
+    Object.entries(value).filter((entry) => entry[1] !== undefined)
+  ) as Partial<T>;
+}

--- a/app/packages/multimodal/src/temporal-tags/client.ts
+++ b/app/packages/multimodal/src/temporal-tags/client.ts
@@ -287,7 +287,7 @@ function filterDto(filter: TemporalTagFilter) {
 }
 
 function temporalTagFromDto(dto: TemporalTagDto): TemporalTag {
-  return stripUndefined({
+  return {
     anchor: dto.anchor,
     createdAt: dto.created_at,
     createdBy: dto.created_by,
@@ -299,7 +299,7 @@ function temporalTagFromDto(dto: TemporalTagDto): TemporalTag {
     sampleId: dto.sample_id,
     start: dto.start,
     tag: dto.tag,
-  }) as TemporalTag;
+  };
 }
 
 function stripUndefined<T extends Record<string, unknown>>(value: T) {

--- a/app/packages/multimodal/src/temporal-tags/hooks.test.tsx
+++ b/app/packages/multimodal/src/temporal-tags/hooks.test.tsx
@@ -1,0 +1,341 @@
+import type { SampleRendererProps } from "@fiftyone/plugins";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { useEffect } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useSampleRendererTemporalTags, useSampleTemporalTags } from "./hooks";
+import type {
+  TemporalTag,
+  TemporalTagCreate,
+  TemporalTagsClient,
+  UseSampleTemporalTagsOptions,
+  UseSampleTemporalTagsResult,
+} from "./types";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useSampleTemporalTags", () => {
+  it("stays idle without a sample scope", () => {
+    const client = createTemporalTagsClient();
+
+    render(
+      <TemporalTagsHarness
+        options={{ client, datasetId: "dataset-id", sampleId: undefined }}
+      />
+    );
+
+    expect(screen.getByTestId("temporal-tags").textContent).toBe("idle::");
+    expect(client.listSampleTemporalTags).not.toHaveBeenCalled();
+  });
+
+  it("loads sample temporal tags", async () => {
+    const client = createTemporalTagsClient({
+      listSampleTemporalTags: vi.fn(async () => [createTemporalTag("tag-a")]),
+    });
+
+    render(
+      <TemporalTagsHarness
+        options={{
+          client,
+          datasetId: "dataset-id",
+          sampleId: "sample-id",
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("temporal-tags").textContent).toBe(
+        "ready:tag-a:"
+      );
+    });
+    expect(client.listSampleTemporalTags).toHaveBeenCalledWith({
+      datasetId: "dataset-id",
+      filter: undefined,
+      sampleId: "sample-id",
+    });
+  });
+
+  it("refetches when the sample id or filter changes", async () => {
+    const client = createTemporalTagsClient({
+      listSampleTemporalTags: vi.fn(async ({ filter, sampleId }) => [
+        createTemporalTag(`${sampleId}-${filter?.start ?? 0}`),
+      ]),
+    });
+
+    const { rerender } = render(
+      <TemporalTagsHarness
+        options={{
+          client,
+          datasetId: "dataset-id",
+          filter: { start: 1 },
+          sampleId: "sample-a",
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("temporal-tags").textContent).toBe(
+        "ready:sample-a-1:"
+      );
+    });
+
+    rerender(
+      <TemporalTagsHarness
+        options={{
+          client,
+          datasetId: "dataset-id",
+          filter: { start: 2 },
+          sampleId: "sample-b",
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("temporal-tags").textContent).toBe(
+        "ready:sample-b-2:"
+      );
+    });
+    expect(client.listSampleTemporalTags).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores stale async responses after a rerender", async () => {
+    const first = deferred<readonly TemporalTag[]>();
+    const second = deferred<readonly TemporalTag[]>();
+    const client = createTemporalTagsClient({
+      listSampleTemporalTags: vi.fn(({ sampleId }) =>
+        sampleId === "sample-a" ? first.promise : second.promise
+      ),
+    });
+
+    const { rerender } = render(
+      <TemporalTagsHarness
+        options={{
+          client,
+          datasetId: "dataset-id",
+          sampleId: "sample-a",
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(client.listSampleTemporalTags).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(
+      <TemporalTagsHarness
+        options={{
+          client,
+          datasetId: "dataset-id",
+          sampleId: "sample-b",
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(client.listSampleTemporalTags).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      second.resolve([createTemporalTag("sample-b")]);
+      await second.promise;
+    });
+    expect(screen.getByTestId("temporal-tags").textContent).toBe(
+      "ready:sample-b:"
+    );
+
+    await act(async () => {
+      first.resolve([createTemporalTag("sample-a")]);
+      await first.promise;
+    });
+    expect(screen.getByTestId("temporal-tags").textContent).toBe(
+      "ready:sample-b:"
+    );
+  });
+
+  it("exposes mutation helpers and reloads after successful mutations", async () => {
+    const client = createTemporalTagsClient();
+    const createInput: TemporalTagCreate = {
+      end: 2,
+      start: 1,
+      tag: "review",
+    };
+    let latest!: UseSampleTemporalTagsResult;
+
+    render(
+      <TemporalTagsHarness
+        onState={(state) => {
+          latest = state;
+        }}
+        options={{
+          client,
+          datasetId: "dataset-id",
+          sampleId: "sample-id",
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(latest.status).toBe("ready");
+    });
+
+    await act(async () => {
+      await latest.create([createInput]);
+    });
+    expect(client.createSampleTemporalTags).toHaveBeenCalledWith({
+      datasetId: "dataset-id",
+      sampleId: "sample-id",
+      temporalTags: [createInput],
+    });
+    expect(client.listSampleTemporalTags).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await latest.update("temporal-tag-id", { end: 3 });
+    });
+    expect(client.updateSampleTemporalTag).toHaveBeenCalledWith({
+      datasetId: "dataset-id",
+      sampleId: "sample-id",
+      temporalTagId: "temporal-tag-id",
+      update: { end: 3 },
+    });
+    expect(client.listSampleTemporalTags).toHaveBeenCalledTimes(3);
+
+    await act(async () => {
+      await latest.delete(["temporal-tag-id"]);
+    });
+    expect(client.deleteSampleTemporalTags).toHaveBeenCalledWith({
+      datasetId: "dataset-id",
+      ids: ["temporal-tag-id"],
+      sampleId: "sample-id",
+    });
+    expect(client.listSampleTemporalTags).toHaveBeenCalledTimes(4);
+
+    await act(async () => {
+      await latest.clear({ tags: ["review"] });
+    });
+    expect(client.clearSampleTemporalTags).toHaveBeenCalledWith({
+      datasetId: "dataset-id",
+      filter: { tags: ["review"] },
+      sampleId: "sample-id",
+    });
+    expect(client.listSampleTemporalTags).toHaveBeenCalledTimes(5);
+  });
+
+  it("surfaces client errors", async () => {
+    const client = createTemporalTagsClient({
+      listSampleTemporalTags: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    });
+
+    render(
+      <TemporalTagsHarness
+        options={{
+          client,
+          datasetId: "dataset-id",
+          sampleId: "sample-id",
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("temporal-tags").textContent).toBe(
+        "error::boom"
+      );
+    });
+  });
+});
+
+describe("useSampleRendererTemporalTags", () => {
+  it("derives the sample scope from a sample renderer context", async () => {
+    const client = createTemporalTagsClient();
+    const ctx = {
+      dataset: { datasetId: "dataset-id" },
+      sample: { sample: { _id: "sample-id" } },
+    } as SampleRendererProps["ctx"];
+
+    render(<SampleRendererTemporalTagsHarness client={client} ctx={ctx} />);
+
+    await waitFor(() => {
+      expect(client.listSampleTemporalTags).toHaveBeenCalledWith({
+        datasetId: "dataset-id",
+        filter: undefined,
+        sampleId: "sample-id",
+      });
+    });
+  });
+});
+
+function TemporalTagsHarness({
+  onState,
+  options,
+}: {
+  readonly onState?: (state: UseSampleTemporalTagsResult) => void;
+  readonly options: UseSampleTemporalTagsOptions;
+}) {
+  const state = useSampleTemporalTags(options);
+
+  useEffect(() => {
+    onState?.(state);
+  }, [onState, state]);
+
+  return (
+    <div data-testid="temporal-tags">
+      {state.status}:{state.temporalTags.map((tag) => tag.id).join(",")}:
+      {state.error ?? ""}
+    </div>
+  );
+}
+
+function SampleRendererTemporalTagsHarness({
+  client,
+  ctx,
+}: {
+  readonly client: TemporalTagsClient;
+  readonly ctx: SampleRendererProps["ctx"];
+}) {
+  useSampleRendererTemporalTags(ctx, { client });
+
+  return null;
+}
+
+function createTemporalTagsClient(
+  overrides: Partial<TemporalTagsClient> = {}
+): TemporalTagsClient {
+  return {
+    clearSampleTemporalTags: vi.fn(async () => 1),
+    countDatasetTemporalTags: vi.fn(async () => ({})),
+    createSampleTemporalTags: vi.fn(async () => [createTemporalTag("created")]),
+    deleteSampleTemporalTags: vi.fn(async () => 1),
+    listDatasetTemporalTags: vi.fn(async () => []),
+    listSampleTemporalTags: vi.fn(async () => []),
+    updateSampleTemporalTag: vi.fn(async () => createTemporalTag("updated")),
+    ...overrides,
+  };
+}
+
+function createTemporalTag(id: string): TemporalTag {
+  return {
+    end: 2,
+    id,
+    indexType: 2,
+    sampleId: "sample-id",
+    start: 1,
+    tag: "review",
+  };
+}
+
+function deferred<Value>() {
+  let resolve!: (value: Value) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<Value>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return {
+    promise,
+    reject,
+    resolve,
+  };
+}

--- a/app/packages/multimodal/src/temporal-tags/hooks.ts
+++ b/app/packages/multimodal/src/temporal-tags/hooks.ts
@@ -1,0 +1,218 @@
+import type { SampleRendererProps } from "@fiftyone/plugins";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createTemporalTagsClient } from "./client";
+import type {
+  TemporalTag,
+  TemporalTagCreate,
+  TemporalTagFilter,
+  TemporalTagsClient,
+  TemporalTagsStatus,
+  TemporalTagUpdate,
+  UseSampleTemporalTagsOptions,
+  UseSampleTemporalTagsResult,
+} from "./types";
+
+type TemporalTagsState = {
+  readonly error: string | null;
+  readonly status: TemporalTagsStatus;
+  readonly temporalTags: readonly TemporalTag[];
+};
+
+const IDLE_STATE: TemporalTagsState = {
+  error: null,
+  status: "idle",
+  temporalTags: [],
+};
+let defaultTemporalTagsClient: TemporalTagsClient | undefined;
+
+/**
+ * Loads and mutates temporal tags for one dataset sample.
+ */
+export function useSampleTemporalTags({
+  client,
+  datasetId,
+  filter,
+  sampleId,
+}: UseSampleTemporalTagsOptions): UseSampleTemporalTagsResult {
+  const temporalTagsClient = client ?? getDefaultTemporalTagsClient();
+  const filterKey = temporalTagFilterKey(filter);
+  const [state, setState] = useState<TemporalTagsState>(IDLE_STATE);
+  const filterRef = useRef(filter);
+  const mountedRef = useRef(true);
+  const requestIdRef = useRef(0);
+  filterRef.current = filter;
+
+  const reload = useCallback(async () => {
+    if (!datasetId || !sampleId) {
+      requestIdRef.current += 1;
+      if (mountedRef.current) {
+        setState(IDLE_STATE);
+      }
+      return [];
+    }
+
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    if (mountedRef.current) {
+      setState((current) => ({
+        error: null,
+        status: "loading",
+        temporalTags: current.temporalTags,
+      }));
+    }
+
+    try {
+      const currentFilter = filterKey ? filterRef.current : undefined;
+      const temporalTags = await temporalTagsClient.listSampleTemporalTags({
+        datasetId,
+        filter: currentFilter,
+        sampleId,
+      });
+      if (mountedRef.current && requestIdRef.current === requestId) {
+        setState({
+          error: null,
+          status: "ready",
+          temporalTags,
+        });
+      }
+      return temporalTags;
+    } catch (error) {
+      if (mountedRef.current && requestIdRef.current === requestId) {
+        setState({
+          error: errorMessage(error),
+          status: "error",
+          temporalTags: [],
+        });
+      }
+      throw error;
+    }
+  }, [datasetId, filterKey, sampleId, temporalTagsClient]);
+
+  useEffect(() => {
+    void reload().catch(() => undefined);
+  }, [reload]);
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+      requestIdRef.current += 1;
+    };
+  }, []);
+
+  const create = useCallback(
+    async (temporalTags: readonly TemporalTagCreate[]) => {
+      const ids = requireSampleScope(datasetId, sampleId);
+      const created = await temporalTagsClient.createSampleTemporalTags({
+        ...ids,
+        temporalTags,
+      });
+      await reload();
+
+      return created;
+    },
+    [datasetId, reload, sampleId, temporalTagsClient]
+  );
+
+  const update = useCallback(
+    async (temporalTagId: string, update: TemporalTagUpdate) => {
+      const ids = requireSampleScope(datasetId, sampleId);
+      const updated = await temporalTagsClient.updateSampleTemporalTag({
+        ...ids,
+        temporalTagId,
+        update,
+      });
+      await reload();
+
+      return updated;
+    },
+    [datasetId, reload, sampleId, temporalTagsClient]
+  );
+
+  const deleteTags = useCallback(
+    async (idsToDelete: readonly string[]) => {
+      const ids = requireSampleScope(datasetId, sampleId);
+      const deleted = await temporalTagsClient.deleteSampleTemporalTags({
+        ...ids,
+        ids: idsToDelete,
+      });
+      await reload();
+
+      return deleted;
+    },
+    [datasetId, reload, sampleId, temporalTagsClient]
+  );
+
+  const clear = useCallback(
+    async (clearFilter?: TemporalTagFilter) => {
+      const ids = requireSampleScope(datasetId, sampleId);
+      const deleted = await temporalTagsClient.clearSampleTemporalTags({
+        ...ids,
+        filter: clearFilter,
+      });
+      await reload();
+
+      return deleted;
+    },
+    [datasetId, reload, sampleId, temporalTagsClient]
+  );
+
+  return {
+    ...state,
+    clear,
+    create,
+    delete: deleteTags,
+    reload,
+    update,
+  };
+}
+
+/**
+ * Loads temporal tags for a sample renderer context.
+ */
+export function useSampleRendererTemporalTags(
+  ctx: SampleRendererProps["ctx"],
+  options: {
+    readonly client?: TemporalTagsClient;
+    readonly filter?: TemporalTagFilter;
+  } = {}
+) {
+  return useSampleTemporalTags({
+    client: options.client,
+    datasetId: ctx.dataset.datasetId,
+    filter: options.filter,
+    sampleId: ctx.sample.sample._id,
+  });
+}
+
+function requireSampleScope(
+  datasetId: string | undefined,
+  sampleId: string | undefined
+) {
+  if (!datasetId || !sampleId) {
+    throw new Error("datasetId and sampleId are required");
+  }
+
+  return { datasetId, sampleId };
+}
+
+function temporalTagFilterKey(filter: TemporalTagFilter | undefined) {
+  if (!filter) {
+    return "";
+  }
+
+  return JSON.stringify(filter);
+}
+
+function errorMessage(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+function getDefaultTemporalTagsClient() {
+  defaultTemporalTagsClient ??= createTemporalTagsClient();
+
+  return defaultTemporalTagsClient;
+}

--- a/app/packages/multimodal/src/temporal-tags/hooks.ts
+++ b/app/packages/multimodal/src/temporal-tags/hooks.ts
@@ -37,10 +37,8 @@ export function useSampleTemporalTags({
   const temporalTagsClient = client ?? getDefaultTemporalTagsClient();
   const filterKey = temporalTagFilterKey(filter);
   const [state, setState] = useState<TemporalTagsState>(IDLE_STATE);
-  const filterRef = useRef(filter);
   const mountedRef = useRef(true);
   const requestIdRef = useRef(0);
-  filterRef.current = filter;
 
   const reload = useCallback(async () => {
     if (!datasetId || !sampleId) {
@@ -62,10 +60,9 @@ export function useSampleTemporalTags({
     }
 
     try {
-      const currentFilter = filterKey ? filterRef.current : undefined;
       const temporalTags = await temporalTagsClient.listSampleTemporalTags({
         datasetId,
-        filter: currentFilter,
+        filter,
         sampleId,
       });
       if (mountedRef.current && requestIdRef.current === requestId) {
@@ -86,6 +83,9 @@ export function useSampleTemporalTags({
       }
       throw error;
     }
+    // `filterKey` captures filter content changes while avoiding callback churn
+    // when callers pass a new object with the same filter values.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [datasetId, filterKey, sampleId, temporalTagsClient]);
 
   useEffect(() => {

--- a/app/packages/multimodal/src/temporal-tags/index.ts
+++ b/app/packages/multimodal/src/temporal-tags/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Temporal-tag route client and React hooks.
+ */
+export { createTemporalTagsClient } from "./client";
+export { useSampleRendererTemporalTags, useSampleTemporalTags } from "./hooks";
+export type { CreateTemporalTagsClientOptions } from "./client";
+export type {
+  CountDatasetTemporalTagsRequest,
+  ClearSampleTemporalTagsRequest,
+  CreateSampleTemporalTagsRequest,
+  DeleteSampleTemporalTagsRequest,
+  ListDatasetTemporalTagsRequest,
+  ListSampleTemporalTagsRequest,
+  SampleTemporalTagsRequest,
+  TemporalTag,
+  TemporalTagCreate,
+  TemporalTagFilter,
+  TemporalTagsClient,
+  TemporalTagsStatus,
+  TemporalTagUpdate,
+  UpdateSampleTemporalTagRequest,
+  UseSampleTemporalTagsOptions,
+  UseSampleTemporalTagsResult,
+} from "./types";

--- a/app/packages/multimodal/src/temporal-tags/types.ts
+++ b/app/packages/multimodal/src/temporal-tags/types.ts
@@ -1,0 +1,149 @@
+/** Load state for temporal-tag React hooks. */
+export type TemporalTagsStatus = "idle" | "loading" | "ready" | "error";
+
+/** Filter for temporal-tag list/count/delete queries. */
+export interface TemporalTagFilter {
+  readonly anchors?: readonly string[];
+  readonly end?: number;
+  readonly indexType?: number;
+  readonly start?: number;
+  readonly tags?: readonly string[];
+}
+
+/** Persisted temporal tag returned by the backend. */
+export interface TemporalTag {
+  readonly end: number;
+  readonly id: string;
+  readonly indexType: number;
+  readonly sampleId: string;
+  readonly start: number;
+  readonly tag: string;
+  readonly anchor?: string;
+  readonly createdAt?: string;
+  readonly createdBy?: string;
+  readonly lastModifiedAt?: string;
+  readonly lastModifiedBy?: string;
+}
+
+/** Temporal tag payload accepted by sample-scoped create routes. */
+export interface TemporalTagCreate {
+  readonly end: number;
+  readonly start: number;
+  readonly tag: string;
+  readonly anchor?: string;
+  readonly createdBy?: string;
+  readonly indexType?: number;
+  readonly lastModifiedBy?: string;
+}
+
+/** Mutable temporal tag fields accepted by sample-scoped update routes. */
+export interface TemporalTagUpdate {
+  readonly end?: number;
+  readonly start?: number;
+  readonly tag?: string;
+  readonly lastModifiedBy?: string;
+}
+
+/** Common request shape for sample-scoped temporal-tag operations. */
+export interface SampleTemporalTagsRequest {
+  readonly datasetId: string;
+  readonly sampleId: string;
+}
+
+/** Request for listing temporal tags for one sample. */
+export interface ListSampleTemporalTagsRequest
+  extends SampleTemporalTagsRequest {
+  readonly filter?: TemporalTagFilter;
+}
+
+/** Request for creating temporal tags for one sample. */
+export interface CreateSampleTemporalTagsRequest
+  extends SampleTemporalTagsRequest {
+  readonly temporalTags: readonly TemporalTagCreate[];
+}
+
+/** Request for updating one persisted temporal tag for one sample. */
+export interface UpdateSampleTemporalTagRequest
+  extends SampleTemporalTagsRequest {
+  readonly temporalTagId: string;
+  readonly update: TemporalTagUpdate;
+}
+
+/** Request for deleting persisted temporal tags by ID for one sample. */
+export interface DeleteSampleTemporalTagsRequest
+  extends SampleTemporalTagsRequest {
+  readonly ids: readonly string[];
+}
+
+/** Request for clearing temporal tags for one sample. */
+export interface ClearSampleTemporalTagsRequest
+  extends SampleTemporalTagsRequest {
+  readonly filter?: TemporalTagFilter;
+}
+
+/** Request for listing temporal tags across a dataset. */
+export interface ListDatasetTemporalTagsRequest {
+  readonly datasetId: string;
+  readonly filter?: TemporalTagFilter;
+}
+
+/** Request for counting temporal tag values across a dataset. */
+export interface CountDatasetTemporalTagsRequest {
+  readonly datasetId: string;
+  readonly filter?: TemporalTagFilter;
+}
+
+/**
+ * Client for the multimodal temporal-tag route surface.
+ */
+export interface TemporalTagsClient {
+  createSampleTemporalTags(
+    request: CreateSampleTemporalTagsRequest
+  ): Promise<readonly TemporalTag[]>;
+  clearSampleTemporalTags(
+    request: ClearSampleTemporalTagsRequest
+  ): Promise<number>;
+  countDatasetTemporalTags(
+    request: CountDatasetTemporalTagsRequest
+  ): Promise<Readonly<Record<string, number>>>;
+  deleteSampleTemporalTags(
+    request: DeleteSampleTemporalTagsRequest
+  ): Promise<number>;
+  listDatasetTemporalTags(
+    request: ListDatasetTemporalTagsRequest
+  ): Promise<readonly TemporalTag[]>;
+  listSampleTemporalTags(
+    request: ListSampleTemporalTagsRequest
+  ): Promise<readonly TemporalTag[]>;
+  updateSampleTemporalTag(
+    request: UpdateSampleTemporalTagRequest
+  ): Promise<TemporalTag>;
+}
+
+/**
+ * Hook options for sample-scoped temporal-tag loading.
+ */
+export interface UseSampleTemporalTagsOptions
+  extends Partial<SampleTemporalTagsRequest> {
+  readonly client?: TemporalTagsClient;
+  readonly filter?: TemporalTagFilter;
+}
+
+/**
+ * Hook result for sample-scoped temporal-tag loading and mutations.
+ */
+export interface UseSampleTemporalTagsResult {
+  readonly error: string | null;
+  readonly status: TemporalTagsStatus;
+  readonly temporalTags: readonly TemporalTag[];
+  readonly clear: (filter?: TemporalTagFilter) => Promise<number>;
+  readonly create: (
+    temporalTags: readonly TemporalTagCreate[]
+  ) => Promise<readonly TemporalTag[]>;
+  readonly delete: (ids: readonly string[]) => Promise<number>;
+  readonly reload: () => Promise<readonly TemporalTag[]>;
+  readonly update: (
+    temporalTagId: string,
+    update: TemporalTagUpdate
+  ) => Promise<TemporalTag>;
+}


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Adds a typed app-side temporal tags client under `@fiftyone/multimodal/temporal-tags`.

This includes:

- A route client for sample-scoped create/list/update/delete/clear and dataset-scoped list/count
- CamelCase app types with private snake_case route DTO conversion
- Sample-modal-oriented React hooks for loading, reloading, and mutating temporal tags
- Focused client and hook tests

## 🧪 How is this patch tested? If it is not, please explain why.

Ran:

```sh
yarn test
yarn workspace @fiftyone/multimodal check
```

Minimal client usage:

```ts
import { createTemporalTagsClient } from "@fiftyone/multimodal/temporal-tags";

const client = createTemporalTagsClient();
const tags = await client.listSampleTemporalTags({ datasetId, sampleId });

await client.createSampleTemporalTags({
  datasetId,
  sampleId,
  temporalTags: [{ start: 0, end: 1_000_000_000, tag: "review" }],
});
```

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added temporal tags management for multimodal datasets: create, list, update, delete, clear, and count temporal tags with flexible filtering (including multi-value filters).
  * Exposed high-level hooks for loading and mutating sample temporal tags with automatic reloads and status/error reporting.

* **Tests**
  * Added comprehensive unit tests covering client request/response shapes, query serialization, and hook behaviors (load, mutations, refetching, and error handling).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->