### PR TITLE
chore(coderabbit): disable auto_assign_reviewers

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,7 +5,7 @@ reviews:
   profile: "assertive"
   request_changes_workflow: false
   changed_files_summary: false
-  auto_assign_reviewers: true
+  auto_assign_reviewers: false
   high_level_summary: true
   poem: false
   review_status: true


### PR DESCRIPTION
Flips `reviews.auto_assign_reviewers` from `true` to `false` in `.coderabbit.yaml` so CodeRabbit stops auto-adding reviewers to PRs.

## Summary by CodeRabbit

* **Chores**
  * Updated internal development configuration settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->