### PR TITLE
Video annotation: ImaVid image-stream playback (worker-backed frame fetch + decode)

### DIFF
--- a/app/packages/core/src/client/framesClient.ts
+++ b/app/packages/core/src/client/framesClient.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import {
+  FetchFunctionConfig,
+  FetchFunctionResult,
+  getFetchFunctionExtended,
+} from "@fiftyone/utilities";
+
+export type GetFramesRequest = {
+  /** Sample id for the parent video document. */
+  sampleId: string;
+  /** Current dataset name. */
+  dataset: string;
+  /**
+   * Active view stages — same opaque array sent on every dataset
+   * query. Typed `unknown[]` because the server treats it as JSON
+   * and the client doesn't introspect; callers usually pass the
+   * `Stage[]` from `@fiftyone/utilities`.
+   */
+  view: unknown[];
+  /** First frame to fetch (1-indexed, inclusive). */
+  frameNumber: number;
+  /** Maximum number of frames to fetch starting at `frameNumber`. */
+  numFrames: number;
+  /** Total frame count of the clip; used to clamp the upper end. */
+  frameCount: number;
+  /** Group slice name, when the dataset is grouped. */
+  slice?: string | null;
+  /** Optional extended view stages. */
+  extended?: unknown;
+};
+
+/**
+ * Per-frame document returned by `POST /frames`. The shape mirrors the
+ * frame's MongoDB document — `frame_number` is always present and the
+ * remaining fields depend on the dataset's frame-level schema. For
+ * `to_frames(sample_frames=True)` datasets, `filepath` is also present
+ * at the top level alongside any label fields.
+ *
+ * We don't enumerate label fields here — the server may return any
+ * shape based on the dataset. Callers project into the fields they
+ * care about.
+ */
+export type FrameDoc = {
+  frame_number: number;
+  filepath?: string;
+  [key: string]: unknown;
+};
+
+export type GetFramesResponse = {
+  frames: FrameDoc[];
+  /** Server-clamped `[startFrame, endFrame]` of the returned chunk. */
+  range: [number, number];
+};
+
+/**
+ * `fetch` with the standard FiftyOne fetch plumbing. No specialized
+ * error handling — `/frames` returns generic HTTP errors and callers
+ * coalesce / retry at a higher level (see e.g. `VideoFrameLabelsStream`'s
+ * inflight bookkeeping).
+ */
+const doFetch = <A, R>(
+  config: FetchFunctionConfig<A>
+): Promise<FetchFunctionResult<R>> => {
+  return getFetchFunctionExtended()(config);
+};
+
+/**
+ * Fetch a contiguous chunk of per-frame documents from the source
+ * video sample's `frames` sub-collection.
+ *
+ * The server clamps `frameNumber + numFrames` against `frameCount` and
+ * returns the actually-served range in `response.range`, so callers can
+ * use the response to track which frames are now cached.
+ *
+ * This is a thin wrapper around `POST /frames` — the same endpoint
+ * powers per-frame label loading (`VideoFrameLabelsStream`) and ImaVid
+ * per-frame image loading (`ImaVidImageStream`). Two parallel calls
+ * against the same chunk are fine; HTTP/2 multiplexes and the server
+ * doesn't keep state between them. Coalescing them into a single
+ * request is on the fast-follow list.
+ *
+ * @param request Frame-chunk request
+ */
+export const getFrames = async (
+  request: GetFramesRequest
+): Promise<GetFramesResponse> => {
+  const { response } = await doFetch<GetFramesRequest, GetFramesResponse>({
+    method: "POST",
+    path: "/frames",
+    body: request,
+    result: "json",
+    retries: 2,
+  });
+
+  return response;
+};

--- a/app/packages/core/src/client/index.ts
+++ b/app/packages/core/src/client/index.ts
@@ -1,2 +1,3 @@
 export * from "./annotationClient";
+export * from "./framesClient";
 export * from "./transformer";

--- a/app/packages/playback/src/lib/playback/utils.test.ts
+++ b/app/packages/playback/src/lib/playback/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveAtTime } from "./utils";
+import { frameAt, resolveAtTime } from "./utils";
 
 const NEAREST = { type: "nearest" as const, thresholdSeconds: 0.1 };
 const NEAREST_PREVIOUS = {
@@ -65,9 +65,9 @@ describe("resolveAtTime", () => {
       [1.5, "after"],
     ]);
     // Both within 0.5s — but "after" is past `time` and should be skipped.
-    expect(resolveAtTime(cache, 1, { ...NEAREST_PREVIOUS, thresholdSeconds: 0.5 })).toBe(
-      "before"
-    );
+    expect(
+      resolveAtTime(cache, 1, { ...NEAREST_PREVIOUS, thresholdSeconds: 0.5 })
+    ).toBe("before");
   });
 
   it("returns null for nearestPrevious when only future entries exist", () => {
@@ -100,5 +100,28 @@ describe("resolveAtTime", () => {
     const cache = new Map([[1, "v"]]);
     // |1.05 - 1| = 0.05 < 0.1 threshold → hit.
     expect(resolveAtTime(cache, 1.05, NEAREST)).toBe("v");
+  });
+});
+
+describe("frameAt", () => {
+  it("returns 1 at time 0 (1-indexed)", () => {
+    expect(frameAt(0, 30)).toBe(1);
+  });
+
+  it("floors to the nearest preceding frame boundary", () => {
+    // 1/30s exactly → frame 2; just under → still frame 1.
+    expect(frameAt(1 / 30, 30)).toBe(2);
+    expect(frameAt(1 / 30 - 1e-9, 30)).toBe(1);
+  });
+
+  it("returns the raw frame when no frameCount is provided", () => {
+    // 100s @ 30fps → 3001 — no clamping without an upper bound.
+    expect(frameAt(100, 30)).toBe(3001);
+  });
+
+  it("clamps to [1, frameCount] when frameCount is provided", () => {
+    expect(frameAt(-1, 30, 100)).toBe(1);
+    expect(frameAt(1000, 30, 100)).toBe(100);
+    expect(frameAt(1, 30, 100)).toBe(31);
   });
 });

--- a/app/packages/playback/src/lib/playback/utils.ts
+++ b/app/packages/playback/src/lib/playback/utils.ts
@@ -1,6 +1,30 @@
 import type { StreamLookupPolicy } from "./types";
 
 /**
+ * Convert a continuous playback time to a 1-indexed frame number. When
+ * `frameCount` is provided, clamps the result to `[1, frameCount]`;
+ * otherwise returns the raw `floor(time * fps) + 1`.
+ *
+ * Shared by streams, server-query helpers, and (eventually) hotkeys so
+ * everyone agrees on which frame a given `time` belongs to. 1-indexed
+ * because that is the convention `/frames` uses and the labels coming
+ * back from the server are keyed on.
+ */
+export function frameAt(
+  time: number,
+  fps: number,
+  frameCount?: number
+): number {
+  const raw = Math.floor(time * fps) + 1;
+  if (frameCount === undefined) {
+    return raw;
+  }
+  if (raw < 1) return 1;
+  if (raw > frameCount) return frameCount;
+  return raw;
+}
+
+/**
  * Resolves the best cached entry for a given time from a Map<number, T>.
  *
  * "nearest"         — closest entry in either direction within threshold.

--- a/app/packages/video-annotation/index.ts
+++ b/app/packages/video-annotation/index.ts
@@ -4,4 +4,11 @@ export type {
   FrameLabelSnapshot,
   SyntheticBox,
 } from "./src/SyntheticLabelStream";
-export { VIDEO_STREAM_ID, LABELS_STREAM_ID, MAIN_TILE_ID } from "./src/ids";
+export {
+  IMAVID_STREAM_ID,
+  LABELS_STREAM_ID,
+  MAIN_TILE_ID,
+  VIDEO_STREAM_ID,
+} from "./src/ids";
+export { ImaVidImageStream } from "./src/ImaVidImageStream";
+export type { ImaVidImageFrame } from "./src/ImaVidImageStream";

--- a/app/packages/video-annotation/package.json
+++ b/app/packages/video-annotation/package.json
@@ -7,9 +7,11 @@
         "@fiftyone/playback": "workspace:*",
         "@fiftyone/state": "workspace:*",
         "@fiftyone/tiling": "workspace:*",
+        "@fiftyone/utilities": "workspace:*",
         "@voxel51/voodo": "^0.0.30",
         "clsx": "^2.1.0",
-        "jotai": "^2.9.3"
+        "jotai": "^2.9.3",
+        "lru-cache": "^11.0.1"
     },
     "devDependencies": {
         "vite": "^7.3.2"

--- a/app/packages/video-annotation/src/ExternalCanonicalMedia.ts
+++ b/app/packages/video-annotation/src/ExternalCanonicalMedia.ts
@@ -7,25 +7,28 @@ import type {
 import { BaseOverlay } from "@fiftyone/lighter/src/overlay/BaseOverlay";
 
 /**
- * Minimal CanonicalMedia for the video tile. Provides coordinate-space
- * bounds (intrinsic video dimensions + container-fitted rendered bounds)
- * so Lighter overlays can position themselves correctly, but draws no
- * pixels of its own — the <video> element behind the Lighter canvas
- * supplies the visible image.
+ * Minimal CanonicalMedia for tiles whose visible pixels come from a
+ * non-Lighter element layered behind the canvas — a `<video>` for the
+ * native-video tile, an `<img>` for the ImaVid (image-per-frame) tile.
+ * Provides coordinate-space bounds (intrinsic media dimensions +
+ * container-fitted rendered bounds) so Lighter overlays position
+ * correctly, but draws no pixels of its own.
  *
  * We don't use `ImageOverlay` as a stand-in for two reasons:
  *  - It sizes itself from the loaded image's natural dimensions. A
  *    transparent stand-in would collapse every overlay's coordinate
  *    space to whatever 1×1 placeholder we fed it; here we want the
- *    canonical dimensions to be the video's intrinsic resolution.
+ *    canonical dimensions to be the media's intrinsic resolution.
  *  - `renderImpl` decodes and paints a sprite every frame. We don't
- *    need that — the `<video>` element behind the canvas is the
- *    visible media.
+ *    need that — the element behind the canvas is the visible media.
  *
- * The right long-term fix is a `VideoOverlay` (or generic
- * `MediaCanonicalMedia`) upstream in `@fiftyone/lighter`.
+ * The right long-term fix is for `@fiftyone/lighter` to ship a
+ * first-class no-pixel canonical of its own.
  */
-export class VideoCanonicalMedia extends BaseOverlay implements CanonicalMedia {
+export class ExternalCanonicalMedia
+  extends BaseOverlay
+  implements CanonicalMedia
+{
   private originalDimensions: Dimensions;
   private currentBounds: Rect = { x: 0, y: 0, width: 0, height: 0 };
   private resizeObserver?: ResizeObserver;
@@ -33,7 +36,9 @@ export class VideoCanonicalMedia extends BaseOverlay implements CanonicalMedia {
 
   constructor(opts: { width: number; height: number }) {
     super(
-      `video-canonical-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      `external-canonical-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2, 7)}`,
       "",
       null as never
     );
@@ -41,7 +46,7 @@ export class VideoCanonicalMedia extends BaseOverlay implements CanonicalMedia {
   }
 
   override getOverlayType(): string {
-    return "VideoCanonicalMedia";
+    return "ExternalCanonicalMedia";
   }
 
   override setRenderer(renderer: Renderer2D): void {
@@ -69,7 +74,7 @@ export class VideoCanonicalMedia extends BaseOverlay implements CanonicalMedia {
   }
 
   protected renderImpl(): void {
-    // No-op: the <video> element drawn behind the Lighter canvas is the
+    // No-op: the element drawn behind the Lighter canvas is the
     // visible media. We exist only to anchor the coordinate system.
   }
 

--- a/app/packages/video-annotation/src/ImaVidImageStream.ts
+++ b/app/packages/video-annotation/src/ImaVidImageStream.ts
@@ -1,0 +1,339 @@
+import { getSampleSrc } from "@fiftyone/state";
+import { type Stage } from "@fiftyone/utilities";
+import { LRUCache } from "lru-cache";
+import { getFrames, type FrameDoc } from "../../core/src/client/framesClient";
+import { streamValueAtom } from "../../playback/src/lib/playback/atoms";
+import { PlaybackStreamBase } from "../../playback/src/lib/playback/stream-base";
+import type {
+  BufferReadiness,
+  PlaybackStore,
+} from "../../playback/src/lib/playback/types";
+import { frameAt } from "../../playback/src/lib/playback/utils";
+
+/**
+ * What the stream publishes per tick. Consumers (the ImaVid tile)
+ * bind `<img src={value.src}>`; `sampleId` and `frameNumber` are exposed
+ * for commands / persistence that need to know which frame this is.
+ */
+export interface ImaVidImageFrame {
+  src: string;
+  sampleId: string;
+  frameNumber: number;
+}
+
+/**
+ * What we keep in the LRU. We hold the decoded `HTMLImageElement` alive
+ * (not just the src) so a frame reuse doesn't trigger a fresh network
+ * + decode.
+ */
+interface CachedFrame extends ImaVidImageFrame {
+  image: HTMLImageElement;
+  sizeBytes: number;
+}
+
+export interface ImaVidImageStreamOptions {
+  id: string;
+  /** Sample id for the parent video document. */
+  sampleId: string;
+  /** Current dataset name (POST /frames requires it). */
+  dataset: string;
+  /** Active view stages — same shape sent on every dataset query. */
+  view: Stage[];
+  /** Group slice name, when the dataset is grouped. */
+  groupSlice?: string | null;
+  /** Total frame count of the clip (1-indexed up to this number). */
+  frameCount: number;
+  /** Frame rate in frames per second. */
+  frameRate: number;
+  /**
+   * Number of frames to request in a single `/frames` chunk. Larger
+   * values mean fewer round trips but larger payloads.
+   *
+   * @default 60
+   */
+  chunkSize?: number;
+  /**
+   * Cap on cached pixel bytes. Defaults to 1 GB which matches looker's
+   * ImaVid path. The LRU evicts the oldest frames first once this is
+   * exceeded.
+   *
+   * @default 1e9
+   */
+  maxBytes?: number;
+}
+
+const DEFAULT_CHUNK_SIZE = 60;
+const DEFAULT_MAX_BYTES = 1e9;
+
+/**
+ * Image stream backed by `POST /frames` for ImaVid-style playback
+ * (i.e. `to_frames(sample_frames=True)` data, one materialized image
+ * per frame). Reads `filepath` off each per-frame doc, resolves it
+ * via `getSampleSrc`, decodes via `new Image()`, and caches the
+ * decoded image in an LRU sized by pixel bytes.
+ *
+ * `bufferState` returns `ready` only after a frame has fully decoded,
+ * so the engine never tries to render half-loaded frames.
+ */
+export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
+  private readonly sampleId: string;
+  private readonly dataset: string;
+  private readonly view: Stage[];
+  private readonly groupSlice: string | null;
+  private readonly frameCount: number;
+  private readonly frameRate: number;
+  private readonly chunkSize: number;
+
+  private readonly cache: LRUCache<number, CachedFrame>;
+  /** Per-frame decode promises — one slot per frame, shared across callers. */
+  private readonly inflight = new Map<number, Promise<void>>();
+  private readonly fetchedRanges: Array<[number, number]> = [];
+
+  constructor(opts: ImaVidImageStreamOptions) {
+    super(opts.id, {
+      blocking: true,
+      duration: opts.frameCount / opts.frameRate,
+      nativeStepSeconds: 1 / opts.frameRate,
+      lookupPolicy: {
+        type: "nearestPrevious",
+        thresholdSeconds: 1 / opts.frameRate,
+      },
+    });
+
+    this.sampleId = opts.sampleId;
+    this.dataset = opts.dataset;
+    this.view = opts.view;
+    this.groupSlice = opts.groupSlice ?? null;
+    this.frameCount = opts.frameCount;
+    this.frameRate = opts.frameRate;
+    this.chunkSize = opts.chunkSize ?? DEFAULT_CHUNK_SIZE;
+
+    this.cache = new LRUCache<number, CachedFrame>({
+      maxSize: opts.maxBytes ?? DEFAULT_MAX_BYTES,
+      sizeCalculation: (entry) => entry.sizeBytes,
+    });
+  }
+
+  /**
+   * Resolve once the frame containing `time` has been fetched and decoded.
+   * Use in tandem with `seek(time)` on mount so the first paint isn't a
+   * blank `<img>` waiting for the network.
+   */
+  async warmup(time = 0): Promise<void> {
+    const frame = this.timeToFrame(time);
+    if (this.cache.has(frame)) {
+      return;
+    }
+
+    const inflight = this.inflight.get(frame);
+    if (inflight) {
+      await inflight;
+      return;
+    }
+
+    await this.fetchAndDecodeChunk(frame);
+  }
+
+  /** Total frames in the clip. */
+  get totalFrames(): number {
+    return this.frameCount;
+  }
+
+  /** Frame rate in fps. */
+  get fps(): number {
+    return this.frameRate;
+  }
+
+  bufferState(time: number): BufferReadiness {
+    const frame = this.timeToFrame(time);
+
+    if (this.cache.has(frame)) {
+      return "ready";
+    }
+
+    if (this.inflight.has(frame)) {
+      return "loading";
+    }
+
+    return "missing";
+  }
+
+  prefetch(range: [number, number]): void {
+    const [startSec, endSec] = range;
+    const startFrame = this.timeToFrame(startSec);
+    const endFrame = this.timeToFrame(endSec);
+
+    // First missing frame wins — the engine re-calls prefetch as the
+    // playhead advances, so we don't need to fan out here.
+    for (let f = startFrame; f <= endFrame; f++) {
+      if (this.cache.has(f) || this.inflight.has(f)) {
+        continue;
+      }
+
+      void this.fetchAndDecodeChunk(f);
+      return;
+    }
+  }
+
+  getValue(time: number): ImaVidImageFrame | null {
+    const frame = this.timeToFrame(time);
+    const entry = this.cache.get(frame);
+    if (!entry) {
+      return null;
+    }
+
+    return {
+      src: entry.src,
+      sampleId: entry.sampleId,
+      frameNumber: entry.frameNumber,
+    };
+  }
+
+  /**
+   * Custom `onCommit`: dedupe by `frameNumber`. The engine ticks several
+   * times per frame; without dedupe each tick republishes an identical
+   * value and kicks every `useStream` consumer into a re-render.
+   */
+  override onCommit(time: number, store: PlaybackStore): void {
+    const next = this.getValue(time);
+    const prev = store.get(streamValueAtom(this.id)) as ImaVidImageFrame | null;
+
+    if (prev && next && prev.frameNumber === next.frameNumber) {
+      return;
+    }
+
+    if (prev === null && next === null) {
+      return;
+    }
+
+    store.set(streamValueAtom(this.id), next);
+  }
+
+  bufferedRanges(): Array<[number, number]> {
+    return this.fetchedRanges.map(
+      ([start, end]) =>
+        [(start - 1) / this.frameRate, end / this.frameRate] as [number, number]
+    );
+  }
+
+  private timeToFrame(time: number): number {
+    return frameAt(time, this.frameRate, this.frameCount);
+  }
+
+  private async fetchAndDecodeChunk(startFrame: number): Promise<void> {
+    const numFrames = Math.min(
+      this.chunkSize,
+      this.frameCount - startFrame + 1
+    );
+    if (numFrames <= 0) {
+      return;
+    }
+
+    // One Promise covers fetch + decode for every frame in the chunk.
+    // Each frame's `inflight` slot points at this same promise so
+    // bufferState reports "loading" uniformly across the range.
+    const promise = this.runChunk(startFrame, numFrames).finally(() => {
+      for (let f = startFrame; f < startFrame + numFrames; f++) {
+        if (this.inflight.get(f) === promise) {
+          this.inflight.delete(f);
+        }
+      }
+    });
+
+    for (let f = startFrame; f < startFrame + numFrames; f++) {
+      this.inflight.set(f, promise);
+    }
+
+    return promise;
+  }
+
+  private async runChunk(startFrame: number, numFrames: number): Promise<void> {
+    let result: Awaited<ReturnType<typeof getFrames>>;
+    try {
+      result = await getFrames({
+        frameNumber: startFrame,
+        numFrames,
+        frameCount: this.frameCount,
+        sampleId: this.sampleId,
+        dataset: this.dataset,
+        view: this.view,
+        slice: this.groupSlice ?? undefined,
+      });
+    } catch (error) {
+      // Subsequent prefetch calls retry the same range; leaving the
+      // cache untouched lets that happen naturally.
+      console.error(
+        `[ImaVidImageStream] fetch failed for [${startFrame}, +${numFrames})`,
+        error
+      );
+      return;
+    }
+
+    mergeRange(this.fetchedRanges, result.range);
+
+    // Decode in parallel; one slow image shouldn't block the rest of
+    // the chunk from becoming ready.
+    await Promise.all(result.frames.map((frame) => this.decodeAndCache(frame)));
+  }
+
+  private async decodeAndCache(frame: FrameDoc): Promise<void> {
+    if (!frame.filepath || typeof frame.filepath !== "string") {
+      return;
+    }
+
+    const src = getSampleSrc(frame.filepath);
+    const image = new Image();
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        image.addEventListener("load", () => resolve(), { once: true });
+        image.addEventListener(
+          "error",
+          () => reject(new Error(`image load failed: ${src}`)),
+          { once: true }
+        );
+        image.src = src;
+      });
+    } catch (error) {
+      console.error(
+        `[ImaVidImageStream] decode failed for frame ${frame.frame_number}`,
+        error
+      );
+      return;
+    }
+
+    // RGBA pixel bytes — close enough for LRU sizing without holding
+    // an offscreen canvas open to count exact decoded bytes.
+    const sizeBytes = Math.max(1, image.naturalWidth * image.naturalHeight * 4);
+
+    this.cache.set(frame.frame_number, {
+      src,
+      sampleId: this.sampleId,
+      frameNumber: frame.frame_number,
+      image,
+      sizeBytes,
+    });
+  }
+}
+
+/**
+ * Merge a newly-fetched `[start, end]` range into a sorted, disjoint
+ * list of contiguous ranges.
+ */
+function mergeRange(
+  ranges: Array<[number, number]>,
+  add: [number, number]
+): void {
+  ranges.push(add);
+  ranges.sort((a, b) => a[0] - b[0]);
+
+  for (let i = ranges.length - 1; i > 0; i--) {
+    const prev = ranges[i - 1];
+    const cur = ranges[i];
+
+    if (cur[0] <= prev[1] + 1) {
+      prev[1] = Math.max(prev[1], cur[1]);
+      ranges.splice(i, 1);
+    }
+  }
+}

--- a/app/packages/video-annotation/src/ImaVidImageStream.ts
+++ b/app/packages/video-annotation/src/ImaVidImageStream.ts
@@ -1,7 +1,5 @@
-import { getSampleSrc } from "@fiftyone/state";
-import { type Stage } from "@fiftyone/utilities";
+import { getFetchParameters, type Stage } from "@fiftyone/utilities";
 import { LRUCache } from "lru-cache";
-import { getFrames, type FrameDoc } from "../../core/src/client/framesClient";
 import { streamValueAtom } from "../../playback/src/lib/playback/atoms";
 import { PlaybackStreamBase } from "../../playback/src/lib/playback/stream-base";
 import type {
@@ -9,25 +7,33 @@ import type {
   PlaybackStore,
 } from "../../playback/src/lib/playback/types";
 import { frameAt } from "../../playback/src/lib/playback/utils";
+import type {
+  ChunkDoneMessage,
+  ChunkFailedMessage,
+  FrameReadyMessage,
+  OutboundMessage,
+} from "./framesWorker";
 
 /**
- * What the stream publishes per tick. Consumers (the ImaVid tile)
- * bind `<img src={value.src}>`; `sampleId` and `frameNumber` are exposed
- * for commands / persistence that need to know which frame this is.
+ * What the stream publishes per tick. Consumers (the ImaVid tile) draw
+ * `bitmap` into a canvas; `sampleId` and `frameNumber` are exposed for
+ * commands / persistence that need to know which frame this is. `src`
+ * is kept for debugging / dev-tools inspection — production rendering
+ * does not use it.
  */
 export interface ImaVidImageFrame {
+  bitmap: ImageBitmap;
   src: string;
   sampleId: string;
   frameNumber: number;
 }
 
 /**
- * What we keep in the LRU. We hold the decoded `HTMLImageElement` alive
- * (not just the src) so a frame reuse doesn't trigger a fresh network
- * + decode.
+ * What we keep in the LRU. Decoded `ImageBitmap`s are sized by pixel
+ * bytes; on eviction we call `.close()` to free the underlying GPU /
+ * native memory immediately rather than waiting on GC.
  */
 interface CachedFrame extends ImaVidImageFrame {
-  image: HTMLImageElement;
   sizeBytes: number;
 }
 
@@ -68,12 +74,16 @@ const DEFAULT_MAX_BYTES = 1e9;
 /**
  * Image stream backed by `POST /frames` for ImaVid-style playback
  * (i.e. `to_frames(sample_frames=True)` data, one materialized image
- * per frame). Reads `filepath` off each per-frame doc, resolves it
- * via `getSampleSrc`, decodes via `new Image()`, and caches the
- * decoded image in an LRU sized by pixel bytes.
+ * per frame).
  *
- * `bufferState` returns `ready` only after a frame has fully decoded,
- * so the engine never tries to render half-loaded frames.
+ * Both the JSON fetch and the per-image fetch+decode run inside a
+ * `framesWorker` so the main thread never has to parse a `/frames`
+ * response or decode an image. The worker transfers `ImageBitmap`s
+ * back zero-copy; the tile renders them via `<canvas>` + `drawImage`.
+ *
+ * `bufferState` reports `ready` only after a frame's bitmap has landed
+ * in the cache — so the engine never tries to render a half-decoded
+ * frame.
  */
 export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
   private readonly sampleId: string;
@@ -85,9 +95,14 @@ export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
   private readonly chunkSize: number;
 
   private readonly cache: LRUCache<number, CachedFrame>;
-  /** Per-frame decode promises — one slot per frame, shared across callers. */
-  private readonly inflight = new Map<number, Promise<void>>();
+  private readonly inflight = new Map<number, InflightEntry>();
+  /** reqId → frame numbers that request asked for. */
+  private readonly requestFrames = new Map<number, number[]>();
   private readonly fetchedRanges: Array<[number, number]> = [];
+
+  private readonly worker: Worker;
+  private nextReqId = 1;
+  private destroyed = false;
 
   constructor(opts: ImaVidImageStreamOptions) {
     super(opts.id, {
@@ -111,13 +126,37 @@ export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
     this.cache = new LRUCache<number, CachedFrame>({
       maxSize: opts.maxBytes ?? DEFAULT_MAX_BYTES,
       sizeCalculation: (entry) => entry.sizeBytes,
+      dispose: (entry) => {
+        // Free the underlying decoded pixels immediately. Without
+        // .close(), the bitmap sits in GPU / native memory until GC
+        // runs, which can push us well past the byte cap before
+        // memory is actually reclaimed.
+        entry.bitmap.close();
+      },
+    });
+
+    this.worker = new Worker(new URL("./framesWorker.ts", import.meta.url), {
+      type: "module",
+    });
+    this.worker.addEventListener("message", this.handleWorkerMessage);
+
+    // Hand the worker the same fetch context the main thread uses.
+    // Normalize HeadersInit → Record<string, string> so it's structured-
+    // cloneable (Headers objects and arrays both serialize fine, but
+    // the worker side is simpler if it can spread headers verbatim).
+    const params = getFetchParameters();
+    this.worker.postMessage({
+      type: "init",
+      origin: params.origin,
+      pathPrefix: params.pathPrefix,
+      headers: normalizeHeaders(params.headers),
     });
   }
 
   /**
-   * Resolve once the frame containing `time` has been fetched and decoded.
-   * Use in tandem with `seek(time)` on mount so the first paint isn't a
-   * blank `<img>` waiting for the network.
+   * Resolve once the frame containing `time` has been fetched and
+   * decoded. Use in tandem with `seek(time)` on mount so the first
+   * paint isn't a blank tile waiting for the network.
    */
   async warmup(time = 0): Promise<void> {
     const frame = this.timeToFrame(time);
@@ -125,13 +164,37 @@ export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
       return;
     }
 
-    const inflight = this.inflight.get(frame);
-    if (inflight) {
-      await inflight;
+    const existing = this.inflight.get(frame);
+    if (existing) {
+      await existing.promise;
       return;
     }
 
-    await this.fetchAndDecodeChunk(frame);
+    this.requestChunkStartingAt(frame);
+    const entry = this.inflight.get(frame);
+    if (entry) {
+      await entry.promise;
+    }
+  }
+
+  /** Terminate the worker. Call when the stream is being replaced. */
+  destroy(): void {
+    if (this.destroyed) {
+      return;
+    }
+
+    this.destroyed = true;
+
+    this.worker.removeEventListener("message", this.handleWorkerMessage);
+    this.worker.terminate();
+
+    // Settle anyone awaiting a frame that will never arrive.
+    for (const entry of this.inflight.values()) {
+      entry.resolve();
+    }
+    this.inflight.clear();
+    this.requestFrames.clear();
+    this.cache.clear();
   }
 
   /** Total frames in the clip. */
@@ -170,7 +233,7 @@ export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
         continue;
       }
 
-      void this.fetchAndDecodeChunk(f);
+      this.requestChunkStartingAt(f);
       return;
     }
   }
@@ -183,6 +246,7 @@ export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
     }
 
     return {
+      bitmap: entry.bitmap,
       src: entry.src,
       sampleId: entry.sampleId,
       frameNumber: entry.frameNumber,
@@ -220,7 +284,9 @@ export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
     return frameAt(time, this.frameRate, this.frameCount);
   }
 
-  private async fetchAndDecodeChunk(startFrame: number): Promise<void> {
+  private requestChunkStartingAt(startFrame: number): void {
+    if (this.destroyed) return;
+
     const numFrames = Math.min(
       this.chunkSize,
       this.frameCount - startFrame + 1
@@ -229,28 +295,31 @@ export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
       return;
     }
 
-    // One Promise covers fetch + decode for every frame in the chunk.
-    // Each frame's `inflight` slot points at this same promise so
-    // bufferState reports "loading" uniformly across the range.
-    const promise = this.runChunk(startFrame, numFrames).finally(() => {
-      for (let f = startFrame; f < startFrame + numFrames; f++) {
-        if (this.inflight.get(f) === promise) {
-          this.inflight.delete(f);
-        }
-      }
-    });
-
+    const reqId = this.nextReqId++;
+    const frames: number[] = [];
     for (let f = startFrame; f < startFrame + numFrames; f++) {
-      this.inflight.set(f, promise);
+      // Skip frames the cache already has or another request is fetching;
+      // the worker doesn't dedupe so we have to.
+      if (this.cache.has(f) || this.inflight.has(f)) {
+        continue;
+      }
+
+      const entry = createInflightEntry();
+
+      this.inflight.set(f, entry);
+      frames.push(f);
     }
 
-    return promise;
-  }
+    if (frames.length === 0) {
+      return;
+    }
 
-  private async runChunk(startFrame: number, numFrames: number): Promise<void> {
-    let result: Awaited<ReturnType<typeof getFrames>>;
-    try {
-      result = await getFrames({
+    this.requestFrames.set(reqId, frames);
+
+    this.worker.postMessage({
+      type: "fetchChunk",
+      reqId,
+      request: {
         frameNumber: startFrame,
         numFrames,
         frameCount: this.frameCount,
@@ -258,62 +327,125 @@ export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
         dataset: this.dataset,
         view: this.view,
         slice: this.groupSlice ?? undefined,
-      });
-    } catch (error) {
-      // Subsequent prefetch calls retry the same range; leaving the
-      // cache untouched lets that happen naturally.
-      console.error(
-        `[ImaVidImageStream] fetch failed for [${startFrame}, +${numFrames})`,
-        error
-      );
-      return;
-    }
-
-    mergeRange(this.fetchedRanges, result.range);
-
-    // Decode in parallel; one slow image shouldn't block the rest of
-    // the chunk from becoming ready.
-    await Promise.all(result.frames.map((frame) => this.decodeAndCache(frame)));
-  }
-
-  private async decodeAndCache(frame: FrameDoc): Promise<void> {
-    if (!frame.filepath || typeof frame.filepath !== "string") {
-      return;
-    }
-
-    const src = getSampleSrc(frame.filepath);
-    const image = new Image();
-
-    try {
-      await new Promise<void>((resolve, reject) => {
-        image.addEventListener("load", () => resolve(), { once: true });
-        image.addEventListener(
-          "error",
-          () => reject(new Error(`image load failed: ${src}`)),
-          { once: true }
-        );
-        image.src = src;
-      });
-    } catch (error) {
-      console.error(
-        `[ImaVidImageStream] decode failed for frame ${frame.frame_number}`,
-        error
-      );
-      return;
-    }
-
-    // RGBA pixel bytes — close enough for LRU sizing without holding
-    // an offscreen canvas open to count exact decoded bytes.
-    const sizeBytes = Math.max(1, image.naturalWidth * image.naturalHeight * 4);
-
-    this.cache.set(frame.frame_number, {
-      src,
-      sampleId: this.sampleId,
-      frameNumber: frame.frame_number,
-      image,
-      sizeBytes,
+      },
     });
   }
+
+  private handleWorkerMessage = (
+    event: MessageEvent<OutboundMessage>
+  ): void => {
+    const msg = event.data;
+    switch (msg.type) {
+      case "frameReady":
+        this.onFrameReady(msg);
+        break;
+      case "chunkDone":
+        this.onChunkDone(msg);
+        break;
+      case "chunkFailed":
+        this.onChunkFailed(msg);
+        break;
+    }
+  };
+
+  private onFrameReady(msg: FrameReadyMessage): void {
+    // If the stream was destroyed between request and reply, the bitmap
+    // would leak — close it explicitly.
+    if (this.destroyed) {
+      msg.bitmap.close();
+      return;
+    }
+
+    const sizeBytes = Math.max(1, msg.width * msg.height * 4);
+    this.cache.set(msg.frameNumber, {
+      bitmap: msg.bitmap,
+      src: msg.src,
+      sampleId: this.sampleId,
+      frameNumber: msg.frameNumber,
+      sizeBytes,
+    });
+
+    const entry = this.inflight.get(msg.frameNumber);
+    if (entry) {
+      entry.resolve();
+      this.inflight.delete(msg.frameNumber);
+    }
+  }
+
+  private onChunkDone(msg: ChunkDoneMessage): void {
+    mergeRange(this.fetchedRanges, msg.range);
+    this.resolveOutstandingFrames(msg.reqId);
+  }
+
+  private onChunkFailed(msg: ChunkFailedMessage): void {
+    console.error(
+      `[ImaVidImageStream] worker chunk ${msg.reqId} failed: ${msg.error}`
+    );
+    this.resolveOutstandingFrames(msg.reqId);
+  }
+
+  /**
+   * Settle any in-flight frames from this request that never received
+   * a `frameReady` (e.g. missing filepath, decode error, top-level
+   * fetch failure). They drop from `loading` → `missing` so the engine
+   * re-prefetches on the next tick. Anyone awaiting `warmup` unblocks
+   * (the cache miss is observable via `bufferState`).
+   */
+  private resolveOutstandingFrames(reqId: number): void {
+    const frames = this.requestFrames.get(reqId);
+    if (!frames) {
+      return;
+    }
+
+    this.requestFrames.delete(reqId);
+
+    for (const f of frames) {
+      const entry = this.inflight.get(f);
+      if (!entry) {
+        continue;
+      }
+
+      entry.resolve();
+      this.inflight.delete(f);
+    }
+  }
+}
+
+interface InflightEntry {
+  promise: Promise<void>;
+  resolve: () => void;
+}
+
+function createInflightEntry(): InflightEntry {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+
+  return { promise, resolve };
+}
+
+function normalizeHeaders(
+  headers: HeadersInit | undefined
+): Record<string, string> {
+  if (!headers) {
+    return {};
+  }
+
+  if (headers instanceof Headers) {
+    const out: Record<string, string> = {};
+    headers.forEach((value, key) => {
+      out[key] = value;
+    });
+
+    return out;
+  }
+
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers);
+  }
+
+  return { ...(headers as Record<string, string>) };
 }
 
 /**

--- a/app/packages/video-annotation/src/ImaVidLighterTile.module.css
+++ b/app/packages/video-annotation/src/ImaVidLighterTile.module.css
@@ -1,0 +1,25 @@
+.body {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: black;
+  overflow: hidden;
+}
+
+.frame {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  z-index: 0;
+  user-select: none;
+  pointer-events: none;
+}
+
+.lighterHost {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: flex;
+}

--- a/app/packages/video-annotation/src/ImaVidLighterTile.tsx
+++ b/app/packages/video-annotation/src/ImaVidLighterTile.tsx
@@ -31,8 +31,13 @@ export interface ImaVidLighterTileProps {
 }
 
 /**
- * ImaVid tile — renders an `<img>` bound to `ImaVidImageStream`'s
- * current frame and overlays Lighter on top.
+ * ImaVid tile — draws each frame's `ImageBitmap` (decoded off-main in
+ * `framesWorker`) into a `<canvas>` and overlays Lighter on top.
+ *
+ * The bitmap is rendered via 2D `drawImage` rather than transferred
+ * via a `bitmaprenderer` context, because the LRU may serve the same
+ * bitmap multiple times (a frame revisited after scrub) and
+ * `transferFromImageBitmap` would consume it.
  */
 export const ImaVidLighterTile: React.FC<ImaVidLighterTileProps> = ({
   field,
@@ -42,13 +47,14 @@ export const ImaVidLighterTile: React.FC<ImaVidLighterTileProps> = ({
   const sourceId = useTileSource() ?? IMAVID_STREAM_ID;
 
   const lighterHostRef = useRef<HTMLDivElement | null>(null);
+  const frameCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const [canvas, setCanvas] = useState<HTMLCanvasElement | null>(null);
   const [imageDims, setImageDims] = useState<{ w: number; h: number } | null>(
     null
   );
 
   // Latest decoded frame from the playback engine. Each tick republishes
-  // the new {src, frameNumber, sampleId}; the image stream dedupes on
+  // the new {bitmap, frameNumber, sampleId}; the image stream dedupes on
   // frameNumber so this only changes when the frame actually changes.
   const frame = useStream<ImaVidImageFrame>(sourceId);
 
@@ -141,36 +147,48 @@ export const ImaVidLighterTile: React.FC<ImaVidLighterTileProps> = ({
   const snapshot = useStream<FrameLabelSnapshot>(LABELS_STREAM_ID);
   useFrameOverlaySync(scene, snapshot, field, canonicalMediaReady);
 
-  // Capture intrinsic image dimensions once. Subsequent frames are
-  // assumed to share the same dimensions (true for to_frames
-  // materialized clips) — if a frame's natural size differs from the
-  // canonical, the letterbox stays valid but the overlay coordinate
-  // space could subtly drift. Revisit if we ever support mixed-size
-  // imagery in one stream.
-  const onImgLoad = useCallback(
-    (e: React.SyntheticEvent<HTMLImageElement>) => {
-      if (imageDims !== null) {
-        return;
-      }
-      const img = e.currentTarget;
-      if (img.naturalWidth > 0 && img.naturalHeight > 0) {
-        setImageDims({ w: img.naturalWidth, h: img.naturalHeight });
-      }
-    },
-    [imageDims]
-  );
+  // Paint the current frame's bitmap into the canvas. Sets the canvas
+  // drawing buffer to the bitmap's intrinsic dimensions on first paint
+  // (and on any dimension change — shouldn't happen for to_frames
+  // materialized clips, but harmless if it does). CSS sizing keeps the
+  // displayed element fitting the host with `object-fit: contain`.
+  useEffect(() => {
+    if (!frame) {
+      return;
+    }
+
+    const canvasEl = frameCanvasRef.current;
+    if (!canvasEl) {
+      return;
+    }
+
+    const w = frame.bitmap.width;
+    const h = frame.bitmap.height;
+    if (canvasEl.width !== w) {
+      canvasEl.width = w;
+    }
+    if (canvasEl.height !== h) {
+      canvasEl.height = h;
+    }
+
+    const ctx = canvasEl.getContext("2d");
+    if (!ctx) {
+      return;
+    }
+
+    const priorImageSmoothing = ctx.imageSmoothingEnabled;
+    ctx.imageSmoothingEnabled = false;
+    ctx.drawImage(frame.bitmap, 0, 0);
+    ctx.imageSmoothingEnabled = priorImageSmoothing;
+
+    if (imageDims === null || imageDims.w !== w || imageDims.h !== h) {
+      setImageDims({ w, h });
+    }
+  }, [frame, imageDims]);
 
   return (
     <div className={styles.body}>
-      {frame ? (
-        <img
-          className={styles.frame}
-          src={frame.src}
-          alt=""
-          draggable={false}
-          onLoad={onImgLoad}
-        />
-      ) : null}
+      <canvas ref={frameCanvasRef} className={styles.frame} />
       <div ref={lighterHostRef} className={styles.lighterHost} />
     </div>
   );

--- a/app/packages/video-annotation/src/ImaVidLighterTile.tsx
+++ b/app/packages/video-annotation/src/ImaVidLighterTile.tsx
@@ -1,0 +1,177 @@
+import {
+  UNDEFINED_LIGHTER_SCENE_ID,
+  useLighterEventHandler,
+  useLighterSetupWithPixi,
+} from "@fiftyone/lighter";
+import { colorScheme, colorSeed, useModalLookerOptions } from "@fiftyone/state";
+import { useTileSource } from "@fiftyone/tiling";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useRecoilValue } from "recoil";
+import { singletonCanvas } from "../../core/src/components/Modal/Lighter/SharedCanvas";
+import { useStream } from "../../playback/src/lib/playback/use-stream";
+import { ExternalCanonicalMedia } from "./ExternalCanonicalMedia";
+import { IMAVID_STREAM_ID, LABELS_STREAM_ID } from "./ids";
+import type { ImaVidImageFrame } from "./ImaVidImageStream";
+import type { FrameLabelSnapshot } from "./SyntheticLabelStream";
+import { useFrameOverlaySync } from "./useFrameOverlaySync";
+import styles from "./ImaVidLighterTile.module.css";
+
+export interface ImaVidLighterTileProps {
+  /**
+   * Schema field name the labels are reported under. Threaded through
+   * the overlays so activePaths / color-mapping flow.
+   */
+  field: string;
+}
+
+/**
+ * ImaVid tile — renders an `<img>` bound to `ImaVidImageStream`'s
+ * current frame and overlays Lighter on top.
+ */
+export const ImaVidLighterTile: React.FC<ImaVidLighterTileProps> = ({
+  field,
+}) => {
+  // Honor any active tile source override (e.g. for split-tile layouts),
+  // but default to the imavid stream id when no override is set.
+  const sourceId = useTileSource() ?? IMAVID_STREAM_ID;
+
+  const lighterHostRef = useRef<HTMLDivElement | null>(null);
+  const [canvas, setCanvas] = useState<HTMLCanvasElement | null>(null);
+  const [imageDims, setImageDims] = useState<{ w: number; h: number } | null>(
+    null
+  );
+
+  // Latest decoded frame from the playback engine. Each tick republishes
+  // the new {src, frameNumber, sampleId}; the image stream dedupes on
+  // frameNumber so this only changes when the frame actually changes.
+  const frame = useStream<ImaVidImageFrame>(sourceId);
+
+  // Same singleton-canvas dance as the video tile. There is one
+  // SharedPixiApplication per page bound to the first canvas it ever
+  // sees; creating a fresh canvas here would leave Pixi rendering to
+  // the wrong one.
+  useEffect(() => {
+    const host = lighterHostRef.current;
+    if (!host) {
+      return;
+    }
+
+    setCanvas(singletonCanvas.getCanvas(host));
+
+    return () => {
+      singletonCanvas.detach();
+    };
+  }, []);
+
+  const options = useModalLookerOptions();
+  const sceneId = useMemo(
+    () => `imavid-anno-${Math.random().toString(36).slice(2, 9)}`,
+    []
+  );
+  const { scene } = useLighterSetupWithPixi(canvas!, options, sceneId);
+
+  // FiftyOne color scheme → Lighter coordinator.
+  const scheme = useRecoilValue(colorScheme);
+  const seed = useRecoilValue(colorSeed);
+  useEffect(() => {
+    if (!scene || scene.getSceneId() !== sceneId) {
+      return;
+    }
+
+    scene.updateColorMappingContext({ colorScheme: scheme, seed });
+  }, [scene, sceneId, scheme, seed]);
+
+  // Canonical-media installation gate — see VideoLighterTile for the
+  // why. Reset on sceneId change; flip true once installed.
+  const [canonicalMediaReady, setCanonicalMediaReady] = useState(false);
+  useEffect(() => {
+    setCanonicalMediaReady(false);
+  }, [sceneId]);
+
+  useEffect(() => {
+    if (!scene || !imageDims) {
+      return;
+    }
+
+    if (scene.getSceneId() !== sceneId) {
+      return;
+    }
+
+    const media = new ExternalCanonicalMedia({
+      width: imageDims.w,
+      height: imageDims.h,
+    });
+
+    scene.addOverlay(media);
+    scene.setCanonicalMedia(media);
+    setCanonicalMediaReady(true);
+  }, [scene, sceneId, imageDims]);
+
+  // Viewport init.
+  const [rendererReady, setRendererReady] = useState(false);
+  const useEventHandler = useLighterEventHandler(
+    scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
+  );
+
+  useEventHandler(
+    "lighter:renderer-ready",
+    useCallback(() => setRendererReady(true), []),
+    { once: true }
+  );
+
+  useEffect(() => {
+    if (!scene || !rendererReady || !imageDims) {
+      return;
+    }
+
+    if (scene.getSceneId() !== sceneId) {
+      return;
+    }
+
+    scene.fitToContent();
+  }, [scene, sceneId, rendererReady, imageDims]);
+
+  // Overlay diff — same hook the video tile uses.
+  const snapshot = useStream<FrameLabelSnapshot>(LABELS_STREAM_ID);
+  useFrameOverlaySync(scene, snapshot, field, canonicalMediaReady);
+
+  // Capture intrinsic image dimensions once. Subsequent frames are
+  // assumed to share the same dimensions (true for to_frames
+  // materialized clips) — if a frame's natural size differs from the
+  // canonical, the letterbox stays valid but the overlay coordinate
+  // space could subtly drift. Revisit if we ever support mixed-size
+  // imagery in one stream.
+  const onImgLoad = useCallback(
+    (e: React.SyntheticEvent<HTMLImageElement>) => {
+      if (imageDims !== null) {
+        return;
+      }
+      const img = e.currentTarget;
+      if (img.naturalWidth > 0 && img.naturalHeight > 0) {
+        setImageDims({ w: img.naturalWidth, h: img.naturalHeight });
+      }
+    },
+    [imageDims]
+  );
+
+  return (
+    <div className={styles.body}>
+      {frame ? (
+        <img
+          className={styles.frame}
+          src={frame.src}
+          alt=""
+          draggable={false}
+          onLoad={onImgLoad}
+        />
+      ) : null}
+      <div ref={lighterHostRef} className={styles.lighterHost} />
+    </div>
+  );
+};

--- a/app/packages/video-annotation/src/RegisterImaVidImage.tsx
+++ b/app/packages/video-annotation/src/RegisterImaVidImage.tsx
@@ -1,0 +1,155 @@
+import type { ModalSample } from "@fiftyone/state";
+import {
+  datasetName,
+  groupSlice,
+  modalSampleId,
+  view as viewAtom,
+} from "@fiftyone/state";
+import type { Stage } from "@fiftyone/utilities";
+import React, { useEffect, useRef } from "react";
+import { useRecoilValue } from "recoil";
+import { usePlayback } from "../../playback/src/lib/playback/PlaybackProvider";
+import { usePlaybackStream } from "../../playback/src/lib/playback/use-playback-stream";
+import { IMAVID_STREAM_ID } from "./ids";
+import { ImaVidImageStream } from "./ImaVidImageStream";
+
+/**
+ * Construct and register `ImaVidImageStream` as soon as the sample's
+ * params resolve. The image stream contributes `duration = frameCount/fps`
+ * back to the engine, which is what unblocks `RegisterFrameLabels`
+ * downstream — in the native-video tile the `<video>` element plays
+ * this role via `useVideoStream`.
+ *
+ * fps comes from `sample.frameRate` (GraphQL-hoisted from
+ * `VideoMetadata.frame_rate`); frameCount comes from
+ * `sample.sample.metadata.total_frame_count` and falls back to
+ * `metadata.duration * frameRate`. Both fps and frameCount throw if
+ * absent — the plan explicitly forbids silent defaults because the
+ * failure mode (misaligned frames or a stuck timeline) is hard to
+ * debug after the fact.
+ *
+ * Re-keys on any identity change so a fresh stream replaces the old
+ * one via `usePlaybackStream`'s standard cleanup.
+ */
+export const RegisterImaVidImage: React.FC<{
+  sample: ModalSample;
+  children: React.ReactNode;
+}> = ({ sample, children }) => {
+  const dataset = useRecoilValue(datasetName);
+  const view = useRecoilValue(viewAtom);
+  const slice = useRecoilValue(groupSlice);
+  const sampleId = useRecoilValue(modalSampleId);
+
+  const frameRate = sample.frameRate;
+  if (frameRate === undefined || frameRate === null) {
+    throw new Error(
+      "ImaVid playback requires VideoMetadata.frame_rate to be set on the sample"
+    );
+  }
+  if (!Number.isFinite(frameRate) || frameRate <= 0) {
+    throw new Error(
+      `ImaVid playback requires a positive, finite fps (got ${frameRate})`
+    );
+  }
+
+  const frameCount = resolveFrameCount(sample, frameRate);
+
+  const ready = !!sampleId && !!dataset;
+  if (!ready) {
+    return <>{children}</>;
+  }
+
+  const key = `${sampleId}|${dataset}|${
+    slice ?? ""
+  }|${frameRate}|${frameCount}`;
+
+  return (
+    <ImaVidImageRegistration
+      key={key}
+      sampleId={sampleId}
+      dataset={dataset}
+      view={view ?? []}
+      groupSlice={slice ?? null}
+      frameCount={frameCount}
+      frameRate={frameRate}
+    >
+      {children}
+    </ImaVidImageRegistration>
+  );
+};
+
+/**
+ * Read total frame count from sample.metadata. The `Sample` TS type
+ * only declares `width / height / mime_type`, but VideoMetadata
+ * persists `total_frame_count` and `duration` at runtime — we
+ * loose-cast through.
+ */
+function resolveFrameCount(sample: ModalSample, frameRate: number): number {
+  const metadata = (sample.sample as { metadata?: Record<string, unknown> })
+    ?.metadata;
+
+  const total = metadata?.total_frame_count;
+  if (typeof total === "number" && Number.isFinite(total) && total > 0) {
+    return Math.round(total);
+  }
+
+  const duration = metadata?.duration;
+  if (
+    typeof duration === "number" &&
+    Number.isFinite(duration) &&
+    duration > 0
+  ) {
+    return Math.max(1, Math.round(duration * frameRate));
+  }
+
+  throw new Error(
+    "ImaVid playback requires VideoMetadata.total_frame_count (or .duration) on the sample"
+  );
+}
+
+interface ImaVidImageRegistrationProps {
+  sampleId: string;
+  dataset: string;
+  view: Stage[];
+  groupSlice: string | null;
+  frameCount: number;
+  frameRate: number;
+  children: React.ReactNode;
+}
+
+const ImaVidImageRegistration: React.FC<ImaVidImageRegistrationProps> = ({
+  children,
+  ...props
+}) => {
+  const streamRef = useRef<ImaVidImageStream | null>(null);
+  if (streamRef.current === null) {
+    streamRef.current = new ImaVidImageStream({
+      id: IMAVID_STREAM_ID,
+      sampleId: props.sampleId,
+      dataset: props.dataset,
+      view: props.view,
+      groupSlice: props.groupSlice,
+      frameCount: props.frameCount,
+      frameRate: props.frameRate,
+    });
+  }
+
+  usePlaybackStream(streamRef.current);
+
+  // Pre-warm the first chunk and seek to t=0 so the first paint isn't
+  // a blank tile waiting on the network + decode.
+  const { seek } = usePlayback();
+
+  useEffect(() => {
+    let cancelled = false;
+    void streamRef.current!.warmup(0).then(() => {
+      if (!cancelled) seek(0);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [seek]);
+
+  return <>{children}</>;
+};

--- a/app/packages/video-annotation/src/RegisterImaVidImage.tsx
+++ b/app/packages/video-annotation/src/RegisterImaVidImage.tsx
@@ -134,6 +134,18 @@ const ImaVidImageRegistration: React.FC<ImaVidImageRegistrationProps> = ({
     });
   }
 
+  // Tear down the worker on unmount. The effect is declared BEFORE
+  // `usePlaybackStream` so React runs its cleanup AFTER the playback
+  // registration's cleanup (LIFO order): the engine unregisters the
+  // stream first, then we terminate the worker.
+  useEffect(() => {
+    const stream = streamRef.current;
+
+    return () => {
+      stream?.destroy();
+    };
+  }, []);
+
   usePlaybackStream(streamRef.current);
 
   // Pre-warm the first chunk and seek to t=0 so the first paint isn't

--- a/app/packages/video-annotation/src/VideoAnnotationSurface.tsx
+++ b/app/packages/video-annotation/src/VideoAnnotationSurface.tsx
@@ -8,7 +8,9 @@ import {
   FrameLabelsTracks,
   RegisterFrameLabels,
 } from "./FrameLabels";
+import { ImaVidLighterTile } from "./ImaVidLighterTile";
 import { LinkedOverlayStateBridge } from "./linkedTracks";
+import { RegisterImaVidImage } from "./RegisterImaVidImage";
 import {
   RegisterSyntheticLabels,
   SYNTHETIC_FIELD,
@@ -28,6 +30,17 @@ import styles from "./VideoAnnotationSurface.module.css";
  */
 type LabelsMode = "real" | "synthetic";
 
+/**
+ * Switch between the ImaVid (image-per-frame) tile and the native
+ * `<video>` tile.
+ *
+ * - default: imavid (the demo's locked-in target — `to_frames(sample_frames=True)` data)
+ * - `?tile=video`: native video tile (kept around for the existing path)
+ *
+ * Read once at mount; flipping requires reopening the modal.
+ */
+type TileMode = "imavid" | "video";
+
 function useLabelsMode(): LabelsMode {
   const [mode] = useState<LabelsMode>(() => {
     if (typeof window === "undefined") {
@@ -36,6 +49,19 @@ function useLabelsMode(): LabelsMode {
 
     const param = new URLSearchParams(window.location.search).get("labels");
     return param === "synthetic" ? "synthetic" : "real";
+  });
+
+  return mode;
+}
+
+function useTileMode(): TileMode {
+  const [mode] = useState<TileMode>(() => {
+    if (typeof window === "undefined") {
+      return "imavid";
+    }
+
+    const param = new URLSearchParams(window.location.search).get("tile");
+    return param === "video" ? "video" : "imavid";
   });
 
   return mode;
@@ -51,32 +77,48 @@ export interface VideoAnnotationSurfaceProps {
  * stream (real `/frames` by default; synthetic when `?labels=synthetic`),
  * and renders media (top) + timeline (bottom).
  *
+ * Tile mode (`?tile=imavid|video`) picks between an ImaVid tile (default,
+ * one materialized image per frame via `to_frames(sample_frames=True)`)
+ * and the native `<video>` tile.
+ *
  * Lives inside the modal's media region — the existing right-side
  * annotation sidebar continues to render outside this component.
  */
 export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
   sample,
 }) => {
-  const mode = useLabelsMode();
+  const labelsMode = useLabelsMode();
+  const tileMode = useTileMode();
+
+  // The native-video tile binds to a single top-level URL. The ImaVid
+  // tile resolves a per-frame URL through the image stream, so it does
+  // not need (and ignores) this value.
   const videoSrc = useMemo(() => {
+    if (tileMode !== "video") {
+      return null;
+    }
+
     const url = sample.urls?.[0]?.url;
     return url ? getSampleSrc(url) : null;
-  }, [sample]);
+  }, [sample, tileMode]);
 
-  const field = mode === "synthetic" ? SYNTHETIC_FIELD : FRAME_FIELD;
+  const field = labelsMode === "synthetic" ? SYNTHETIC_FIELD : FRAME_FIELD;
+
+  const media =
+    tileMode === "imavid" ? (
+      <ImaVidLighterTile field={field} />
+    ) : videoSrc ? (
+      <VideoLighterTile videoSrc={videoSrc} field={field} />
+    ) : (
+      <div className={styles.empty}>No media URL on this sample.</div>
+    );
 
   const layout = (
     <div className={styles.root}>
       <LinkedOverlayStateBridge />
-      <div className={styles.media}>
-        {videoSrc ? (
-          <VideoLighterTile videoSrc={videoSrc} field={field} />
-        ) : (
-          <div className={styles.empty}>No media URL on this sample.</div>
-        )}
-      </div>
+      <div className={styles.media}>{media}</div>
       <div className={styles.timeline}>
-        {mode === "synthetic" ? (
+        {labelsMode === "synthetic" ? (
           <SyntheticTrackTimeline />
         ) : (
           <FrameLabelsTracks />
@@ -85,18 +127,32 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
     </div>
   );
 
+  // Both registrars run against the same PlaybackProvider. In the ImaVid
+  // path the image stream is the timeline's duration source (analogous to
+  // `<video>` in the native tile), so it has to mount OUTSIDE the labels
+  // registrar — `RegisterFrameLabels` gates on `useDuration() > 0` and
+  // swaps its wrapper component when it flips ready, which would otherwise
+  // remount whatever's nested inside it.
+  const labels =
+    labelsMode === "synthetic" ? (
+      <>
+        <RegisterSyntheticLabels />
+        {layout}
+      </>
+    ) : (
+      <RegisterFrameLabels sample={sample}>{layout}</RegisterFrameLabels>
+    );
+
+  const registered =
+    tileMode === "imavid" ? (
+      <RegisterImaVidImage sample={sample}>{labels}</RegisterImaVidImage>
+    ) : (
+      labels
+    );
+
   return (
     <PlaybackProvider>
-      <TilingProvider initialTiles={{}}>
-        {mode === "synthetic" ? (
-          <>
-            <RegisterSyntheticLabels />
-            {layout}
-          </>
-        ) : (
-          <RegisterFrameLabels sample={sample}>{layout}</RegisterFrameLabels>
-        )}
-      </TilingProvider>
+      <TilingProvider initialTiles={{}}>{registered}</TilingProvider>
     </PlaybackProvider>
   );
 };

--- a/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
+++ b/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
@@ -1,25 +1,13 @@
-import { getFetchFunction, type Stage } from "@fiftyone/utilities";
+import { type Stage } from "@fiftyone/utilities";
+import { getFrames, type FrameDoc } from "../../core/src/client/framesClient";
 import { PlaybackStreamBase } from "../../playback/src/lib/playback/stream-base";
 import { streamValueAtom } from "../../playback/src/lib/playback/atoms";
+import { frameAt } from "../../playback/src/lib/playback/utils";
 import type {
   BufferReadiness,
   PlaybackStore,
 } from "../../playback/src/lib/playback/types";
 import type { FrameLabelSnapshot, SyntheticBox } from "./SyntheticLabelStream";
-
-/**
- * One per-frame document returned by `POST /frames`. We only model the
- * shape we touch; everything else is read through the dynamic indexer.
- */
-interface FrameSample {
-  frame_number: number;
-  [key: string]: unknown;
-}
-
-interface FrameChunkResponse {
-  frames: FrameSample[];
-  range: [number, number];
-}
 
 // todo - adapter pattern for other label types
 interface RawDetection {
@@ -93,7 +81,7 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
   private readonly frameField: string;
   private readonly chunkSize: number;
 
-  private readonly cache = new Map<number, FrameSample>();
+  private readonly cache = new Map<number, FrameDoc>();
   private readonly inflight = new Map<number, Promise<void>>();
   private readonly fetchedRanges: Array<[number, number]> = [];
 
@@ -265,18 +253,7 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
   }
 
   private timeToFrame(time: number): number {
-    // Mirror @fiftyone/looker's getFrameNumber semantics: 1-indexed,
-    // clamped to [1, frameCount].
-    const frame = Math.floor(time * this.frameRate) + 1;
-    if (frame < 1) {
-      return 1;
-    }
-
-    if (frame > this.frameCount) {
-      return this.frameCount;
-    }
-
-    return frame;
+    return frameAt(time, this.frameRate, this.frameCount);
   }
 
   private isInflight(frame: number): boolean {
@@ -310,21 +287,15 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
 
   private async doFetch(startFrame: number, numFrames: number): Promise<void> {
     try {
-      const result = (await getFetchFunction()(
-        "POST",
-        "/frames",
-        {
-          frameNumber: startFrame,
-          numFrames,
-          frameCount: this.frameCount,
-          sampleId: this.sampleId,
-          dataset: this.dataset,
-          view: this.view,
-          slice: this.groupSlice ?? undefined,
-        },
-        "json",
-        2
-      )) as FrameChunkResponse;
+      const result = await getFrames({
+        frameNumber: startFrame,
+        numFrames,
+        frameCount: this.frameCount,
+        sampleId: this.sampleId,
+        dataset: this.dataset,
+        view: this.view,
+        slice: this.groupSlice ?? undefined,
+      });
 
       for (const frame of result.frames) {
         this.cache.set(frame.frame_number, frame);
@@ -351,7 +322,7 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
  * that they will churn add/remove on every frame).
  */
 function extractDetections(
-  sample: FrameSample,
+  sample: FrameDoc,
   frameField: string
 ): SyntheticBox[] {
   const raw = sample[frameField] as RawDetectionsField | undefined;

--- a/app/packages/video-annotation/src/VideoLighterTile.tsx
+++ b/app/packages/video-annotation/src/VideoLighterTile.tsx
@@ -1,13 +1,9 @@
 import {
-  type DetectionOverlayOptions,
-  type DetectionLabel,
-  DetectionOverlay,
-  overlayFactory,
   UNDEFINED_LIGHTER_SCENE_ID,
   useLighterEventHandler,
   useLighterSetupWithPixi,
 } from "@fiftyone/lighter";
-import { VideoCanonicalMedia } from "./VideoCanonicalMedia";
+import { ExternalCanonicalMedia } from "./ExternalCanonicalMedia";
 import { colorScheme, colorSeed, useModalLookerOptions } from "@fiftyone/state";
 import { singletonCanvas } from "../../core/src/components/Modal/Lighter/SharedCanvas";
 import { usePlayback } from "../../playback/src/lib/playback/PlaybackProvider";
@@ -25,7 +21,8 @@ import React, {
 } from "react";
 import { useRecoilValue } from "recoil";
 import { LABELS_STREAM_ID, VIDEO_STREAM_ID } from "./ids";
-import type { FrameLabelSnapshot, SyntheticBox } from "./SyntheticLabelStream";
+import type { FrameLabelSnapshot } from "./SyntheticLabelStream";
+import { useFrameOverlaySync } from "./useFrameOverlaySync";
 import styles from "./VideoLighterTile.module.css";
 
 export interface VideoLighterTileProps {
@@ -132,7 +129,7 @@ export const VideoLighterTile: React.FC<VideoLighterTileProps> = ({
       return;
     }
 
-    const media = new VideoCanonicalMedia({
+    const media = new ExternalCanonicalMedia({
       width: videoDims.w,
       height: videoDims.h,
     });
@@ -199,91 +196,3 @@ export const VideoLighterTile: React.FC<VideoLighterTileProps> = ({
     </div>
   );
 };
-
-/**
- * Diff the latest snapshot into Lighter overlays. Add unseen
- * ids, update moved ones in place, remove ids that fell out. Overlay
- * identity is preserved across commits — important during playback,
- * otherwise the remove-then-add churn races the Pixi render loop and
- * the overlays disappear between frames.
- */
-function useFrameOverlaySync(
-  scene: ReturnType<typeof useLighterSetupWithPixi>["scene"],
-  snapshot: FrameLabelSnapshot | null,
-  field: string,
-  canonicalMediaReady: boolean
-) {
-  const trackedRef = useRef<Set<string>>(new Set());
-
-  useEffect(() => {
-    // Skip the diff until the current scene has its canonical media —
-    // overlays added before then get burned in with a bad coordinate
-    // context, and a later in-place `relativeBounds` mutation doesn't
-    // fix them. The effect re-runs once `canonicalMediaReady` flips.
-    if (!scene || !snapshot || !canonicalMediaReady) return;
-
-    const next = new Set<string>();
-    // todo - adapter pattern for other label types
-    for (const det of snapshot.detections) {
-      next.add(det.id);
-      const existing = scene.getOverlay(det.id) as DetectionOverlay | undefined;
-      const bounds = {
-        x: det.bounding_box[0],
-        y: det.bounding_box[1],
-        width: det.bounding_box[2],
-        height: det.bounding_box[3],
-      };
-      if (existing) {
-        existing.relativeBounds = bounds;
-      } else {
-        const overlay = overlayFactory.create<
-          DetectionOverlayOptions,
-          DetectionOverlay
-        >("detection", {
-          id: det.id,
-          label: toDetectionLabel(det),
-          relativeBounds: bounds,
-          field,
-          draggable: false,
-          resizeable: false,
-          selectable: false,
-        });
-        scene.addOverlay(overlay);
-        trackedRef.current.add(det.id);
-      }
-    }
-
-    for (const id of Array.from(trackedRef.current)) {
-      if (!next.has(id)) {
-        scene.removeOverlay(id);
-        trackedRef.current.delete(id);
-      }
-    }
-  }, [scene, snapshot, field, canonicalMediaReady]);
-
-  useEffect(() => {
-    return () => {
-      if (!scene) {
-        return;
-      }
-
-      for (const id of trackedRef.current) {
-        scene.removeOverlay(id);
-      }
-
-      trackedRef.current.clear();
-    };
-  }, [scene]);
-}
-
-function toDetectionLabel(box: SyntheticBox): DetectionLabel {
-  return {
-    label: box.label,
-    bounding_box: box.bounding_box,
-    // `index` and `instance` are what `COLOR_BY.INSTANCE` hashes on —
-    // without them every detection of the same class would collapse to
-    // a single color in instance mode.
-    index: box.index,
-    instance: box.instance,
-  } as DetectionLabel;
-}

--- a/app/packages/video-annotation/src/framesWorker.ts
+++ b/app/packages/video-annotation/src/framesWorker.ts
@@ -1,0 +1,211 @@
+/**
+ * Worker that owns `POST /frames` + per-image fetch + `createImageBitmap`
+ * decode for `ImaVidImageStream`. Moves both the JSON parse and the
+ * pixel decode off the main thread; ImageBitmaps are transferred back
+ * (zero-copy) so the main thread can `drawImage` them onto a canvas
+ * without a re-decode.
+ *
+ * Auth handling: on `init` we install `@fiftyone/utilities`'s fetch
+ * singleton inside the worker scope with the same `(origin, headers,
+ * pathPrefix)` the main thread uses. `/frames` requests then flow
+ * through `getFrames` exactly as they do on the main thread. Token
+ * refresh would require an `updateHeaders` message (looker's worker
+ * has the same gap; deferred until needed).
+ *
+ * Wire protocol (all messages have a `type`):
+ *
+ *   main → worker:
+ *     { type: "init", origin, pathPrefix, headers }      // once at start
+ *     { type: "fetchChunk", reqId, request }             // per chunk
+ *
+ *   worker → main:
+ *     { type: "frameReady", reqId, frameNumber, src, bitmap, width, height }
+ *     { type: "chunkDone", reqId, range }                // all frames in chunk processed
+ *     { type: "chunkFailed", reqId, error }              // top-level fetch / parse failure
+ */
+
+/// <reference lib="webworker" />
+
+import { setFetchFunction } from "@fiftyone/utilities";
+import {
+  getFrames,
+  type GetFramesRequest,
+} from "../../core/src/client/framesClient";
+
+interface InitMessage {
+  type: "init";
+  origin: string;
+  pathPrefix: string;
+  headers: Record<string, string>;
+}
+
+interface FetchChunkMessage {
+  type: "fetchChunk";
+  reqId: number;
+  request: GetFramesRequest;
+}
+
+type InboundMessage = InitMessage | FetchChunkMessage;
+
+export interface FrameReadyMessage {
+  type: "frameReady";
+  reqId: number;
+  frameNumber: number;
+  src: string;
+  bitmap: ImageBitmap;
+  width: number;
+  height: number;
+}
+
+export interface ChunkDoneMessage {
+  type: "chunkDone";
+  reqId: number;
+  range: [number, number];
+}
+
+export interface ChunkFailedMessage {
+  type: "chunkFailed";
+  reqId: number;
+  error: string;
+}
+
+export type OutboundMessage =
+  | FrameReadyMessage
+  | ChunkDoneMessage
+  | ChunkFailedMessage;
+
+let initialized = false;
+let origin = "";
+let pathPrefix = "";
+
+self.addEventListener("message", (event: MessageEvent<InboundMessage>) => {
+  const msg = event.data;
+
+  switch (msg.type) {
+    case "init":
+      // Install the fetch singleton inside the worker's module scope.
+      // Subsequent `getFrames` calls in this worker pick up the configured
+      // origin / headers / pathPrefix.
+      origin = msg.origin;
+      pathPrefix = msg.pathPrefix;
+      setFetchFunction(msg.origin, msg.headers ?? {}, msg.pathPrefix);
+      initialized = true;
+      break;
+
+    case "fetchChunk":
+      if (!initialized) {
+        postFailed(msg.reqId, "framesWorker received fetchChunk before init");
+        return;
+      }
+      void handleFetchChunk(msg);
+      break;
+  }
+});
+
+async function handleFetchChunk(msg: FetchChunkMessage): Promise<void> {
+  let frames: Awaited<ReturnType<typeof getFrames>>;
+  try {
+    frames = await getFrames(msg.request);
+  } catch (error) {
+    postFailed(msg.reqId, errorMessage(error));
+    return;
+  }
+
+  // Kick off every frame's fetch+decode in parallel; post each one as
+  // soon as it's ready so the main-thread cache fills incrementally.
+  await Promise.all(
+    frames.frames.map((frame) => decodeAndDispatch(msg.reqId, frame))
+  );
+
+  postOutbound({
+    type: "chunkDone",
+    reqId: msg.reqId,
+    range: frames.range,
+  });
+}
+
+async function decodeAndDispatch(
+  reqId: number,
+  frame: { frame_number: number; filepath?: string }
+): Promise<void> {
+  if (!frame.filepath || typeof frame.filepath !== "string") {
+    return;
+  }
+
+  const src = resolveMediaSrc(frame.filepath);
+
+  let bitmap: ImageBitmap;
+  try {
+    // Match `<img src>` semantics for the media GET: no custom
+    // headers, default credentials
+    const r = await fetch(src, { mode: "cors" });
+
+    if (!r.ok) {
+      throw new Error(`image fetch failed: ${r.status}`);
+    }
+
+    const blob = await r.blob();
+    bitmap = await createImageBitmap(blob);
+  } catch (error) {
+    // Skip — main-thread treats this frame as missing and the engine
+    // re-requests on the next prefetch tick.
+    // eslint-disable-next-line no-console
+    console.error(
+      `[framesWorker] decode failed for frame ${frame.frame_number}`,
+      error
+    );
+
+    return;
+  }
+
+  postOutbound(
+    {
+      type: "frameReady",
+      reqId,
+      frameNumber: frame.frame_number,
+      src,
+      bitmap,
+      width: bitmap.width,
+      height: bitmap.height,
+    },
+    [bitmap]
+  );
+}
+
+/**
+ * Mirror of `@fiftyone/state`'s `getSampleSrc`: passthrough for absolute
+ * URLs / data: / blob: schemes; otherwise wrap as `/media?filepath=...`
+ * using the worker-resolved origin + pathPrefix (set on `init`).
+ */
+function resolveMediaSrc(filepath: string): string {
+  if (/^\w+:\/\//.test(filepath) || /^(data|blob):/.test(filepath)) {
+    return filepath;
+  }
+  return `${joinUrl(
+    origin,
+    pathPrefix,
+    "/media"
+  )}?filepath=${encodeURIComponent(filepath)}`;
+}
+
+function joinUrl(origin: string, pathPrefix: string, suffix: string): string {
+  return `${origin}${pathPrefix}${suffix}`.replace(/([^:]\/)\/+/g, "$1");
+}
+
+function postOutbound(msg: OutboundMessage, transfer?: Transferable[]): void {
+  // self.postMessage's typing varies by lib; the cast is to the worker
+  // DedicatedWorkerGlobalScope signature.
+  (self as unknown as DedicatedWorkerGlobalScope).postMessage(
+    msg,
+    transfer ?? []
+  );
+}
+
+function postFailed(reqId: number, error: string): void {
+  postOutbound({ type: "chunkFailed", reqId, error });
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}

--- a/app/packages/video-annotation/src/ids.ts
+++ b/app/packages/video-annotation/src/ids.ts
@@ -1,3 +1,4 @@
 export const VIDEO_STREAM_ID = "video";
+export const IMAVID_STREAM_ID = "imavid-image";
 export const LABELS_STREAM_ID = "frame-labels";
 export const MAIN_TILE_ID = "main";

--- a/app/packages/video-annotation/src/useFrameOverlaySync.ts
+++ b/app/packages/video-annotation/src/useFrameOverlaySync.ts
@@ -1,0 +1,101 @@
+import {
+  type DetectionLabel,
+  type DetectionOverlayOptions,
+  DetectionOverlay,
+  overlayFactory,
+  useLighterSetupWithPixi,
+} from "@fiftyone/lighter";
+import { useEffect, useRef } from "react";
+import type { FrameLabelSnapshot, SyntheticBox } from "./SyntheticLabelStream";
+
+/**
+ * Diff the latest snapshot into Lighter overlays. Add unseen
+ * ids, update moved ones in place, remove ids that fell out. Overlay
+ * identity is preserved across commits — important during playback,
+ * otherwise the remove-then-add churn races the Pixi render loop and
+ * the overlays disappear between frames.
+ *
+ * Shared by both the native-video tile and the ImaVid tile — the diff
+ * model is the same in both cases (overlay state is per current frame,
+ * driven by `LABELS_STREAM_ID`).
+ */
+export function useFrameOverlaySync(
+  scene: ReturnType<typeof useLighterSetupWithPixi>["scene"],
+  snapshot: FrameLabelSnapshot | null,
+  field: string,
+  canonicalMediaReady: boolean
+) {
+  const trackedRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    // Skip the diff until the current scene has its canonical media —
+    // overlays added before then get burned in with a bad coordinate
+    // context, and a later in-place `relativeBounds` mutation doesn't
+    // fix them. The effect re-runs once `canonicalMediaReady` flips.
+    if (!scene || !snapshot || !canonicalMediaReady) return;
+
+    const next = new Set<string>();
+    // todo - adapter pattern for other label types
+    for (const det of snapshot.detections) {
+      next.add(det.id);
+      const existing = scene.getOverlay(det.id) as DetectionOverlay | undefined;
+      const bounds = {
+        x: det.bounding_box[0],
+        y: det.bounding_box[1],
+        width: det.bounding_box[2],
+        height: det.bounding_box[3],
+      };
+      if (existing) {
+        existing.relativeBounds = bounds;
+      } else {
+        const overlay = overlayFactory.create<
+          DetectionOverlayOptions,
+          DetectionOverlay
+        >("detection", {
+          id: det.id,
+          label: toDetectionLabel(det),
+          relativeBounds: bounds,
+          field,
+          draggable: false,
+          resizeable: false,
+          selectable: false,
+        });
+        scene.addOverlay(overlay);
+        trackedRef.current.add(det.id);
+      }
+    }
+
+    for (const id of Array.from(trackedRef.current)) {
+      if (!next.has(id)) {
+        scene.removeOverlay(id);
+        trackedRef.current.delete(id);
+      }
+    }
+  }, [scene, snapshot, field, canonicalMediaReady]);
+
+  useEffect(() => {
+    return () => {
+      if (!scene) {
+        return;
+      }
+
+      for (const id of trackedRef.current) {
+        scene.removeOverlay(id);
+      }
+
+      trackedRef.current.clear();
+    };
+  }, [scene]);
+}
+
+function toDetectionLabel(box: SyntheticBox): DetectionLabel {
+  return {
+    label: box.label,
+    bounding_box: box.bounding_box,
+    // `index` and `instance` are what `COLOR_BY.INSTANCE` hashes on —
+    // without them every detection of the same class would collapse to
+    // a single color in instance mode.
+    index: box.index,
+    instance: box.instance,
+  } as DetectionLabel;
+}

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3628,7 +3628,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fiftyone/utilities@npm:*, @fiftyone/utilities@workspace:^, @fiftyone/utilities@workspace:packages/utilities":
+"@fiftyone/utilities@npm:*, @fiftyone/utilities@workspace:*, @fiftyone/utilities@workspace:^, @fiftyone/utilities@workspace:packages/utilities":
   version: 0.0.0-use.local
   resolution: "@fiftyone/utilities@workspace:packages/utilities"
   dependencies:
@@ -3655,9 +3655,11 @@ __metadata:
     "@fiftyone/playback": "workspace:*"
     "@fiftyone/state": "workspace:*"
     "@fiftyone/tiling": "workspace:*"
+    "@fiftyone/utilities": "workspace:*"
     "@voxel51/voodo": "npm:^0.0.30"
     clsx: "npm:^2.1.0"
     jotai: "npm:^2.9.3"
+    lru-cache: "npm:^11.0.1"
     vite: "npm:^7.3.2"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

ImaVid-style playback for the new annotation surface, with all `/frames` fetching and image decoding in a Web Worker.

  The surface now defaults to an image-per-frame tile (`?tile=imavid`) backed by an `ImaVidImageStream`. A dedicated `framesWorker` owns the network and decode side; decoded `ImageBitmap`s are transferred zero-copy to the main thread and rendered into a `<canvas>` underneath the Lighter overlay. The native `<video>` tile is still available at `?tile=video`.

  ### What's in
  
  - **`ImaVidImageStream`** — `PlaybackStreamBase<{bitmap, src, sampleId, frameNumber}>` that spawns a `framesWorker`, posts `fetchChunk` requests, and caches transferred `ImageBitmap`s in an LRU sized by pixel bytes (1 GB cap, matches looker). Per-frame inflight `{promise, resolve}` so `warmup(0)` still works; `bufferState` reports `ready` only after a bitmap lands in the cache; `onCommit` dedupes by `frameNumber`. LRU `dispose` calls `bitmap.close()` so GPU/native memory frees immediately on eviction. New `destroy()` terminates the worker and closes all live bitmaps.
  - **`framesWorker`** — owns `POST /frames` (no main-thread JSON parse) and per-image `fetch → blob → createImageBitmap` (off-main decode). Posts each `frameReady` message individually with a transferable `ImageBitmap` — the cache fills incrementally, so the engine commits on frame 1 as soon as frame 1 decodes rather than waiting for the whole 60-frame chunk.
  - **Auth handling** — on `init`, the worker calls `setFetchFunction(origin, headers, pathPrefix)` to install the `@fiftyone/utilities` fetch singleton inside its module scope. `/frames` then flows through the same `getFrames` client used on the main thread. Image GETs use a plain `fetch(src, {mode: "cors"})` to match `<img src>` semantics and stay below the auth-preflight threshold. Token refresh isn't wired yet (looker has the same gap) — straightforward 5-line `updateHeaders` message when needed.
  - **`ImaVidLighterTile`** — `<canvas>` + 2D `drawImage(bitmap, 0, 0)`. The drawing buffer is sized to the bitmap's intrinsic dimensions; CSS `object-fit: contain` letterboxes the displayed element the same way `<img>` did. Intrinsic dims come from `bitmap.width/height` for the `ExternalCanonicalMedia` install. 2D `drawImage` (not `bitmaprenderer.transferFromImageBitmap`) because the LRU may serve the same bitmap multiple times (frame revisited after scrub).
  - **`ExternalCanonicalMedia`** — renamed from `VideoCanonicalMedia`; used by both tiles. Behavior unchanged.
  - **`useFrameOverlaySync`** — extracted from `VideoLighterTile.tsx`; shared by both tiles.
  - **`RegisterImaVidImage`** — reads fps from `sample.frameRate` and frameCount from `sample.metadata.total_frame_count` (or derives from `metadata.duration * fps`); throws on either missing. The image stream is the timeline's duration source in the ImaVid path (mirrors `useVideoStream` in the native tile), so it mounts *outside* `RegisterFrameLabels`. Cleanup effect runs `stream.destroy()` after the engine's unregister cleanup (LIFO ordering).
  - **`framesClient`** — new wrapper in `@fiftyone/core/client` for `POST /frames`, modeled on `annotationClient.ts` / `resourceLockClient.ts`. Used by both `VideoFrameLabelsStream` and `ImaVidImageStream` (via the worker).
  - **`frameAt(t, fps, frameCount?)`** — shared util in `@fiftyone/playback`. Replaces the inline `timeToFrame` in `VideoFrameLabelsStream` and is reused by `ImaVidImageStream`.

  ### Surface wiring

  - `?tile=imavid` (default) — ImaVid tile; image stream + labels stream both contribute to engine duration/step interval.
  - `?tile=video` — native `<video>` tile, unchanged from prior behavior.

  ### Forward-compat hygiene

  - Class/hook names stayed media-agnostic where they apply to both tiles (`ExternalCanonicalMedia`, `useFrameOverlaySync`).

  ### Out of scope

  - Worker token-refresh handling (`updateHeaders` message). Looker's worker has the same gap; add when needed.
  - Move `VideoFrameLabelsStream` fetches into the same worker (or a sibling) — possible follow-up if labels-parse main-thread time shows up as hot.

## 🧪 How is this patch tested? If it is not, please explain why.

local

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image-frame playback mode (ImaVid) with per-frame decoding, caching and worker-backed fetching; tile mode switching between video and image playback.
* **Refactor**
  * Centralized time→frame mapping and simplified overlay sync to reduce render churn.
  * Unified frame-fetch API consumed by label streams.
* **Tests**
  * Added tests for frame-to-time mapping and keyframe/propagation persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7653?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->