### PR TITLE
[DEMO] keyframe data model

### DIFF
--- a/app/packages/video-annotation/src/SyntheticLabelStream.ts
+++ b/app/packages/video-annotation/src/SyntheticLabelStream.ts
@@ -1,5 +1,17 @@
 import { PlaybackStreamBase } from "../../playback/src/lib/playback/stream-base";
 
+/** ObjectId hex string. */
+export type ObjectIdHex = string;
+
+export type PropagationMethod = "linear";
+
+/** Provenance written on labels created by a propagation run. */
+export interface PropagationBlob {
+  method: PropagationMethod;
+  run_id: ObjectIdHex;
+  parent_keyframes: [ObjectIdHex, ObjectIdHex];
+}
+
 export interface SyntheticBox {
   id: string;
   label: string;
@@ -19,6 +31,10 @@ export interface SyntheticBox {
    * numeric index).
    */
   instance?: { _cls: "Instance"; _id?: string };
+  /** `true` for user-authored / propagation source; `false` for interpolated. */
+  keyframe: boolean;
+  /** Provenance for propagation-created labels; `null` for keyframes. */
+  propagation: PropagationBlob | null;
 }
 
 export interface FrameLabelSnapshot {
@@ -217,6 +233,8 @@ function snapshotAtTime(
       // colors per synthetic actor (the index path doesn't apply here
       // — synthetic actors have no numeric index by design).
       instance: { _cls: "Instance", _id: actor.id },
+      keyframe: true,
+      propagation: null,
     });
   }
   return { frameNumber, detections };

--- a/app/packages/video-annotation/src/VideoFrameLabelsStream.test.ts
+++ b/app/packages/video-annotation/src/VideoFrameLabelsStream.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { VideoFrameLabelsStream } from "./VideoFrameLabelsStream";
+
+function buildStream(): VideoFrameLabelsStream {
+  return new VideoFrameLabelsStream({
+    id: "test",
+    sampleId: "s",
+    dataset: "d",
+    view: [],
+    frameCount: 100,
+    frameRate: 30,
+  });
+}
+
+// Frame numbers are 1-indexed: frame N's start time is (N-1)/fps.
+const timeOfFrame = (frame: number, fps: number): number => (frame - 1) / fps;
+
+describe("VideoFrameLabelsStream fetched-empty", () => {
+  it("bufferState returns 'ready' for frames in a fetched range with no cached doc", () => {
+    const stream = buildStream();
+    // @ts-expect-error — test-only: populate the private fetched-ranges list
+    stream.fetchedRanges.push([1, 60]);
+    expect(stream.bufferState(timeOfFrame(10, 30))).toBe("ready");
+  });
+
+  it("getValue returns an empty snapshot for frames in a fetched range with no cached doc", () => {
+    const stream = buildStream();
+    // @ts-expect-error
+    stream.fetchedRanges.push([1, 60]);
+    expect(stream.getValue(timeOfFrame(10, 30))).toEqual({
+      frameNumber: 10,
+      detections: [],
+    });
+  });
+});

--- a/app/packages/video-annotation/src/VideoFrameLabelsStream.test.ts
+++ b/app/packages/video-annotation/src/VideoFrameLabelsStream.test.ts
@@ -33,3 +33,22 @@ describe("VideoFrameLabelsStream fetched-empty", () => {
     });
   });
 });
+
+describe("VideoFrameLabelsStream extractDetections", () => {
+  it("defaults missing keyframe to false and propagation to null", () => {
+    const stream = buildStream();
+    // @ts-expect-error — test-only: populate the private cache
+    stream.cache.set(10, {
+      frame_number: 10,
+      detections: {
+        detections: [
+          { _id: "a", label: "car", bounding_box: [0, 0, 0.1, 0.1] },
+        ],
+      },
+    });
+
+    const value = stream.getValue(timeOfFrame(10, 30));
+    expect(value?.detections[0].keyframe).toBe(false);
+    expect(value?.detections[0].propagation).toBeNull();
+  });
+});

--- a/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
+++ b/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
@@ -183,6 +183,10 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
       return "loading";
     }
 
+    if (this.isInFetchedRange(frame)) {
+      return "ready";
+    }
+
     return "missing";
   }
 
@@ -209,6 +213,11 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
     const frame = this.timeToFrame(time);
     const sample = this.cache.get(frame);
     if (!sample) {
+      // Chunk fetched, this frame had no labels — return an empty
+      // snapshot so consumers can tell "no labels here" from "not fetched".
+      if (this.isInFetchedRange(frame)) {
+        return { frameNumber: frame, detections: [] };
+      }
       return null;
     }
 
@@ -258,6 +267,15 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
 
   private isInflight(frame: number): boolean {
     return this.inflight.has(frame);
+  }
+
+  private isInFetchedRange(frame: number): boolean {
+    for (const [start, end] of this.fetchedRanges) {
+      if (frame >= start && frame <= end) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private async fetchChunk(startFrame: number): Promise<void> {

--- a/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
+++ b/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
@@ -7,7 +7,11 @@ import type {
   BufferReadiness,
   PlaybackStore,
 } from "../../playback/src/lib/playback/types";
-import type { FrameLabelSnapshot, SyntheticBox } from "./SyntheticLabelStream";
+import type {
+  FrameLabelSnapshot,
+  PropagationBlob,
+  SyntheticBox,
+} from "./SyntheticLabelStream";
 
 // todo - adapter pattern for other label types
 interface RawDetection {
@@ -17,6 +21,8 @@ interface RawDetection {
   label?: string;
   bounding_box?: [number, number, number, number];
   instance?: { _cls: "Instance"; _id?: string } | null;
+  keyframe?: boolean;
+  propagation?: PropagationBlob | null;
 }
 
 interface RawDetectionsField {
@@ -368,6 +374,8 @@ function extractDetections(
       bounding_box: det.bounding_box,
       index: det.index,
       instance: det.instance ?? undefined,
+      keyframe: det.keyframe ?? false,
+      propagation: det.propagation ?? null,
     });
   }
 

--- a/tests/unittests/video_keyframe_sync_tests.py
+++ b/tests/unittests/video_keyframe_sync_tests.py
@@ -1,0 +1,108 @@
+import unittest
+
+from bson import ObjectId
+
+import fiftyone as fo
+
+from decorators import drop_datasets
+
+
+class KeyframeSyncTests(unittest.TestCase):
+    @drop_datasets
+    def setUp(self) -> None:
+        self.dataset: fo.Dataset = fo.Dataset()
+        sample: fo.Sample = fo.Sample(
+            filepath="video1.mp4",
+            metadata=fo.VideoMetadata(total_frame_count=3),
+        )
+        sample.frames[1] = fo.Frame(
+            filepath="frame1.jpg",
+            detections=fo.Detections(detections=[
+                fo.Detection(
+                    label="car",
+                    bounding_box=[0.1, 0.1, 0.2, 0.2],
+                ),
+            ])
+        )
+        self.dataset.add_sample(sample)
+        self.sample: fo.Sample = sample
+
+    def test_keyframe_dynamic_attr_persists_on_direct_edit(self) -> None:
+        det: fo.Detection = self.sample.frames[1].detections.detections[0]
+        det.keyframe = True
+        det.propagation = None
+        self.sample.save()
+
+        roundtripped: fo.Detection = (
+            self.dataset.first().frames[1].detections.detections[0]
+        )
+        self.assertIs(roundtripped.keyframe, True)
+        self.assertIsNone(getattr(roundtripped, "propagation", None))
+
+    def test_propagation_blob_persists_on_direct_edit(self) -> None:
+        run_id: ObjectId = ObjectId()
+        parent_a: ObjectId = ObjectId()
+        parent_b: ObjectId = ObjectId()
+        det: fo.Detection = self.sample.frames[1].detections.detections[0]
+        det.keyframe = False
+        det.propagation = {
+            "method": "linear",
+            "run_id": run_id,
+            "parent_keyframes": [parent_a, parent_b],
+        }
+        self.sample.save()
+
+        roundtripped: fo.Detection = (
+            self.dataset.first().frames[1].detections.detections[0]
+        )
+        self.assertIs(roundtripped.keyframe, False)
+        self.assertEqual(roundtripped.propagation["method"], "linear")
+        self.assertEqual(roundtripped.propagation["run_id"], run_id)
+        self.assertEqual(
+            roundtripped.propagation["parent_keyframes"],
+            [parent_a, parent_b],
+        )
+
+    def test_keyframe_attr_roundtrips_through_frames_view(self) -> None:
+        frames_view = self.dataset.to_frames()
+        frame_sample = frames_view.first()
+        det: fo.Detection = frame_sample.detections.detections[0]
+        det.keyframe = True
+        det.propagation = None
+        frame_sample.save()
+
+        roundtripped: fo.Detection = (
+            self.dataset.first().frames[1].detections.detections[0]
+        )
+        self.assertIs(roundtripped.keyframe, True)
+        self.assertIsNone(roundtripped.propagation)
+
+    def test_propagation_blob_roundtrips_through_frames_view(self) -> None:
+        run_id: ObjectId = ObjectId()
+        parent_a: ObjectId = ObjectId()
+        parent_b: ObjectId = ObjectId()
+        frames_view = self.dataset.to_frames()
+        frame_sample = frames_view.first()
+        det: fo.Detection = frame_sample.detections.detections[0]
+        det.keyframe = False
+        det.propagation = {
+            "method": "linear",
+            "run_id": run_id,
+            "parent_keyframes": [parent_a, parent_b],
+        }
+        frame_sample.save()
+
+        roundtripped: fo.Detection = (
+            self.dataset.first().frames[1].detections.detections[0]
+        )
+        self.assertIs(roundtripped.keyframe, False)
+        self.assertEqual(roundtripped.propagation["method"], "linear")
+        self.assertEqual(roundtripped.propagation["run_id"], run_id)
+        self.assertEqual(
+            roundtripped.propagation["parent_keyframes"],
+            [parent_a, parent_b],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittests/video_keyframe_sync_tests.py
+++ b/tests/unittests/video_keyframe_sync_tests.py
@@ -24,6 +24,9 @@ class KeyframeSyncTests(unittest.TestCase):
                 ),
             ])
         )
+        sample["events"] = fo.TemporalDetections(detections=[
+            fo.TemporalDetection(label="action", support=[1, 3]),
+        ])
         self.dataset.add_sample(sample)
         self.sample: fo.Sample = sample
 
@@ -94,6 +97,43 @@ class KeyframeSyncTests(unittest.TestCase):
 
         roundtripped: fo.Detection = (
             self.dataset.first().frames[1].detections.detections[0]
+        )
+        self.assertIs(roundtripped.keyframe, False)
+        self.assertEqual(roundtripped.propagation["method"], "linear")
+        self.assertEqual(roundtripped.propagation["run_id"], run_id)
+        self.assertEqual(
+            roundtripped.propagation["parent_keyframes"],
+            [parent_a, parent_b],
+        )
+
+
+    def test_keyframe_dynamic_attr_persists_on_temporal_detection(self) -> None:
+        td: fo.TemporalDetection = self.sample.events.detections[0]
+        td.keyframe = True
+        td.propagation = None
+        self.sample.save()
+
+        roundtripped: fo.TemporalDetection = (
+            self.dataset.first().events.detections[0]
+        )
+        self.assertIs(roundtripped.keyframe, True)
+        self.assertIsNone(getattr(roundtripped, "propagation", None))
+
+    def test_propagation_blob_persists_on_temporal_detection(self) -> None:
+        run_id: ObjectId = ObjectId()
+        parent_a: ObjectId = ObjectId()
+        parent_b: ObjectId = ObjectId()
+        td: fo.TemporalDetection = self.sample.events.detections[0]
+        td.keyframe = False
+        td.propagation = {
+            "method": "linear",
+            "run_id": run_id,
+            "parent_keyframes": [parent_a, parent_b],
+        }
+        self.sample.save()
+
+        roundtripped: fo.TemporalDetection = (
+            self.dataset.first().events.detections[0]
         )
         self.assertIs(roundtripped.keyframe, False)
         self.assertEqual(roundtripped.propagation["method"], "linear")


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Most of the data models are dynamic, so there's nothing explicitly to add to the documents. But these at least add tests to verify the functionality and round trips of those data models. 

## 🧪 How is this patch tested? If it is not, please explain why.

Python script to inject two key frames and Propagated frames in between. 

[plant-keyframes.py](https://github.com/user-attachments/files/28324011/plant-keyframes.py)

Results in this "tracked99" label That moves across the screen:
 
[Screencast from 2026-05-27 17-18-41.webm](https://github.com/user-attachments/assets/ba2b67c9-1890-4738-aa71-54cd832c7189)


## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended video label metadata to include keyframe status and propagation information, enabling better tracking of label sources and transformations in video annotations.

* **Tests**
  * Added comprehensive test coverage for keyframe and propagation field persistence across direct edits and frame view transformations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->