### PR TITLE
Include robot.txt and sitemap

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,19 +17,18 @@ sys.path.insert(0, os.path.abspath("."))
 sys.path.insert(0, os.path.abspath("../extensions"))
 
 from custom_directives import (
+    CustomAnimatedCTADirective,
     CustomButtonDirective,
     CustomCalloutItemDirective,
     CustomCardItemDirective,
-    CustomImageLinkDirective,
     CustomGuidesCardDirective,
-    CustomAnimatedCTADirective,
+    CustomImageLinkDirective,
     CustomUseCaseCardDirective,
 )
 from fiftyone.internal.docs import is_hidden_from_docs
-from redirects import generate_redirects, generate_api_redirects
+from redirects import generate_api_redirects, generate_redirects
 
 import fiftyone.constants as foc
-
 
 with open("../../setup.py") as f:
     setup_version = re.search(r'VERSION = "(.+?)"', f.read()).group(1)
@@ -79,6 +78,7 @@ extensions = [
     "llms_txt",
     "sphinx_remove_toctrees",
     "sphinx_markdown_builder",
+    "sphinx_sitemap",
 ]
 
 teams_dir = os.environ.get("FIFTYONE_TEAMS_DIR")
@@ -214,7 +214,7 @@ html_favicon = "_static/favicon/favicon.ico"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
-html_extra_path = ["404.html"]
+html_extra_path = ["404.html", "robots.txt"]
 
 # These paths are either relative to html_static_path
 # or fully qualified paths (eg. https://...)
@@ -229,6 +229,15 @@ html_js_files = [
 # Prevent RST source files from being included in output
 html_copy_source = False
 
+# Required by sphinx-sitemap to generate absolute URLs
+html_baseurl = "https://docs.voxel51.com/"
+
+# -- Options for sphinx-sitemap ----------------------------------------------
+sitemap_url_scheme = "{link}"
+sitemap_excludes = [
+    "search.html",
+    "genindex.html",
+]
 
 # -- Options for pushfeedback extension ---------------------------------------
 pushfeedback_project = "1nx7ekqhts"

--- a/docs/source/robots.txt
+++ b/docs/source/robots.txt
@@ -5,7 +5,6 @@
 # -----------------------------------------------
 User-agent: *
 Allow: /
-Sitemap: https://docs.voxel51.com/sitemap.xml
 # Disallow static assets and build artifacts
 Disallow: /_static/
 Disallow: /_sources/

--- a/docs/source/robots.txt
+++ b/docs/source/robots.txt
@@ -1,0 +1,24 @@
+# robots.txt for https://docs.voxel51.com/
+# Generated: 2026-05-26
+# -----------------------------------------------
+# Allow all crawlers including AI bots
+# -----------------------------------------------
+User-agent: *
+Allow: /
+Sitemap: https://docs.voxel51.com/sitemap.xml
+# Disallow static assets and build artifacts
+Disallow: /_static/
+Disallow: /_sources/
+Disallow: /.doctrees/
+Disallow: /searchindex.js
+# Disallow noisy internal API submodules
+Disallow: /api/fiftyone.brain.internal/
+Disallow: /api/fiftyone.core.odm/
+Disallow: /api/fiftyone.core.session/
+Disallow: /api/fiftyone.factory.repos/
+Disallow: /api/fiftyone.operators.cache/
+Disallow: /api/fiftyone.operators.store/
+# -----------------------------------------------
+# Sitemap
+# -----------------------------------------------
+Sitemap: https://docs.voxel51.com/sitemap.xml

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -39,3 +39,4 @@ sphinx-pushfeedback==0.1.8
 sphinx-docsearch==0.3.0
 sphinx-remove-toctrees==1.0.0.post1
 sphinx-autoapi==3.8.0
+sphinx-sitemap==2.6.0


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link, but feedback reported by @jimmyguerrero and @kierisi, thank you 🚀 

## 📋 What changes are proposed in this pull request?

* Add `robots.txt` to the docs site, allowing all crawlers (including AI bots) while blocking static assets and noisy internal API submodules from consuming crawl budget
* Add `sphinx-sitemap` to automatically generate `sitemap.xml` during every docs build, replacing the need for a manually maintained static sitemap
* Serve both `robots.txt` and `sitemap.xml` at the root of `https://docs.voxel51.com/`

Dev docs site keep using the `Disallow: /` in its `robots.txt`  to prevent indexing.

## 🧪 How is this patch tested? If it is not, please explain why.

Built the documentation locally and verified that:
* `robots.txt` is generated and served correctly
* `sitemap.xml` is automatically generated during the Sphinx build

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [x] No. You can skip the rest of this section.
* [ ] Yes. Give a description of this change to be included in the release
  notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

* [ ] App: FiftyOne application changes
* [ ] Build: Build and test infrastructure changes
* [ ] Core: Core `fiftyone` Python library changes
* [x] Documentation: FiftyOne documentation changes
* [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enabled automated sitemap generation and configured sitemap settings to improve search engine indexing.
  * Added robots.txt to allow crawling, declare the sitemap location, and block internal/noise paths from indexing.
  * Updated docs build requirements to include the sitemap extension for the documentation site.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->