### PR TITLE
[DEMO] video annotation propagation

### DIFF
--- a/app/packages/annotation/src/agents/PropagationBrowserAgent.test.ts
+++ b/app/packages/annotation/src/agents/PropagationBrowserAgent.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import type { SyntheticBox } from "@fiftyone/video-annotation";
+
+import { PropagationBrowserAgent } from "./PropagationBrowserAgent";
+import {
+  AgentTaskType,
+  type PropagationContext,
+  type SyncInferenceResult,
+  type PropagationInferenceResult,
+} from "./types";
+
+function keyframe(
+  id: string,
+  bbox: [number, number, number, number]
+): SyntheticBox {
+  return {
+    id,
+    label: "car",
+    bounding_box: bbox,
+    keyframe: true,
+    propagation: null,
+  };
+}
+
+const baseContext = {
+  sampleDescriptor: { datasetId: "ds", sampleId: "s", mediaUrl: "x" },
+  taskType: AgentTaskType.PROPAGATE,
+  instanceId: "inst-1",
+} as const;
+
+describe("PropagationBrowserAgent.infer", () => {
+  it("lerps a bbox between two keyframes and emits one Detection per in-between frame", async () => {
+    const agent = new PropagationBrowserAgent();
+    const left = keyframe("k1", [0.0, 0.0, 0.1, 0.1]);
+    const right = keyframe("k2", [1.0, 1.0, 0.1, 0.1]);
+
+    const context: PropagationContext = {
+      ...baseContext,
+      fromFrame: 5,
+      toFrame: 15,
+      parentKeyframes: [left, right],
+    };
+
+    const result = (await agent.infer(context)) as SyncInferenceResult<
+      PropagationInferenceResult
+    > & { labelId: string };
+
+    expect(result.type).toBe("sync");
+    expect(result.taskType).toBe(AgentTaskType.PROPAGATE);
+    expect(result.labelId).toBe("inst-1");
+    expect(result.response.perFrame).toHaveLength(9);
+
+    const midpoint = result.response.perFrame.find(
+      (e) => e.frameNumber === 10
+    );
+    expect(midpoint?.detection.bounding_box).toEqual([0.5, 0.5, 0.1, 0.1]);
+    expect(midpoint?.detection.keyframe).toBe(false);
+    expect(midpoint?.detection.instance).toEqual({
+      _cls: "Instance",
+      _id: "inst-1",
+    });
+    expect(midpoint?.detection.propagation).toMatchObject({
+      method: "linear",
+      parent_keyframes: ["k1", "k2"],
+    });
+  });
+});

--- a/app/packages/annotation/src/agents/PropagationBrowserAgent.ts
+++ b/app/packages/annotation/src/agents/PropagationBrowserAgent.ts
@@ -3,7 +3,6 @@ import type {
   AnnotationAgentLifecycle,
   AnnotationAgentLifecycleListener,
   AnnotationAgentLifecycleStatus,
-  AnnotationContext,
   InferenceResult,
   ModelMetadata,
   PropagatedDetection,
@@ -70,34 +69,33 @@ export class PropagationBrowserAgent
   private readonly listeners = new Set<AnnotationAgentLifecycleListener>();
 
   async infer(
-    context: AnnotationContext
+    context: PropagationContext
   ): Promise<InferenceResult<PropagationInferenceResult>> {
-    const propContext = context as PropagationContext;
-    if (propContext.fromFrame >= propContext.toFrame) {
+    if (context.fromFrame >= context.toFrame) {
       throw new Error(
-        `fromFrame (${propContext.fromFrame}) must be less than toFrame (${propContext.toFrame})`
+        `fromFrame (${context.fromFrame}) must be less than toFrame (${context.toFrame})`
       );
     }
 
     this.setStatus("inferring");
 
     try {
-      const [leftKeyframe, rightKeyframe] = propContext.parentKeyframes;
+      const [leftKeyframe, rightKeyframe] = context.parentKeyframes;
       const left: Bbox = leftKeyframe.bounding_box;
       const right: Bbox = rightKeyframe.bounding_box;
-      const span: number = propContext.toFrame - propContext.fromFrame;
+      const span: number = context.toFrame - context.fromFrame;
       const runId: string = generateObjectIdHex();
 
       const perFrame: PropagationInferenceResult["perFrame"] = [];
-      range(propContext.fromFrame + 1, propContext.toFrame).forEach((n) => {
-        const t: number = (n - propContext.fromFrame) / span;
+      range(context.fromFrame + 1, context.toFrame).forEach((n) => {
+        const t: number = (n - context.fromFrame) / span;
         const detection: PropagatedDetection = {
           _id: generateObjectIdHex(),
           _cls: "Detection",
           bounding_box: lerpBbox(left, right, t),
           label: leftKeyframe.label,
           index: leftKeyframe.index,
-          instance: { _cls: "Instance", _id: propContext.instanceId },
+          instance: { _cls: "Instance", _id: context.instanceId },
           keyframe: false,
           propagation: {
             method: "linear",
@@ -109,7 +107,7 @@ export class PropagationBrowserAgent
       });
 
       return {
-        labelId: propContext.instanceId,
+        labelId: context.instanceId,
         type: "sync",
         taskType: AgentTaskType.PROPAGATE,
         response: { perFrame },

--- a/app/packages/annotation/src/agents/PropagationBrowserAgent.ts
+++ b/app/packages/annotation/src/agents/PropagationBrowserAgent.ts
@@ -1,0 +1,171 @@
+import type {
+  AnnotationAgent,
+  AnnotationAgentLifecycle,
+  AnnotationAgentLifecycleListener,
+  AnnotationAgentLifecycleStatus,
+  AnnotationContext,
+  InferenceResult,
+  ModelMetadata,
+  PropagatedDetection,
+  PropagationContext,
+  PropagationInferenceResult,
+} from "./types";
+import { AgentTaskType, InferenceCapability } from "./types";
+
+type Bbox = [number, number, number, number];
+
+/** Linear interpolation between `a` and `b` at fraction `t` ∈ [0, 1]. */
+function lerp(a: number, b: number, t: number): number {
+  return a + t * (b - a);
+}
+
+/** Component-wise linear interpolation between two bboxes at fraction `t`. */
+function lerpBbox(left: Bbox, right: Bbox, t: number): Bbox {
+  return [
+    lerp(left[0], right[0], t),
+    lerp(left[1], right[1], t),
+    lerp(left[2], right[2], t),
+    lerp(left[3], right[3], t),
+  ];
+}
+
+/** Exclusive integer range `[start, end)` as an array. */
+function range(start: number, end: number): number[] {
+  return Array.from({ length: Math.max(0, end - start) }, (_, i) => start + i);
+}
+
+/**
+ * Generate a 24-char hex string matching the MongoDB ObjectId format —
+ * 4-byte timestamp + 8-byte random. Not a real BSON ObjectId (no machine
+ * id / counter), but the wire format is identical and the DB accepts it.
+ */
+function generateObjectIdHex(): string {
+  const timestamp = Math.floor(Date.now() / 1000)
+    .toString(16)
+    .padStart(8, "0");
+  const random = Array.from({ length: 16 }, () =>
+    Math.floor(Math.random() * 16).toString(16)
+  ).join("");
+  return timestamp + random;
+}
+
+/**
+ * Linearly interpolates a tracked object's bounding box between two
+ * bracketing keyframes, emitting one Detection per in-between frame.
+ *
+ * Despite the `AnnotationAgent` interface and "inference" naming: this is
+ * deterministic math, not AI. The agent abstraction is reused here so
+ * future propagation methods (SAM2 tracking, optical flow, spline) can
+ * slot into the same registry, lifecycle, and dispatch path under one
+ * uniform contract. Linear runs synchronously on the main thread — a
+ * worker would add latency for trivial arithmetic.
+ *
+ * Each emitted Detection carries `keyframe: false`, the propagation run's
+ * provenance blob, and the shared `instance.id` from the source keyframes.
+ */
+export class PropagationBrowserAgent
+  implements AnnotationAgent<PropagationInferenceResult>
+{
+  private lifecycleStatus: AnnotationAgentLifecycleStatus = "idle";
+  private readonly listeners = new Set<AnnotationAgentLifecycleListener>();
+
+  async infer(
+    context: AnnotationContext
+  ): Promise<InferenceResult<PropagationInferenceResult>> {
+    const propContext = context as PropagationContext;
+    if (propContext.fromFrame >= propContext.toFrame) {
+      throw new Error(
+        `fromFrame (${propContext.fromFrame}) must be less than toFrame (${propContext.toFrame})`
+      );
+    }
+
+    this.setStatus("inferring");
+
+    try {
+      const [leftKeyframe, rightKeyframe] = propContext.parentKeyframes;
+      const left: Bbox = leftKeyframe.bounding_box;
+      const right: Bbox = rightKeyframe.bounding_box;
+      const span: number = propContext.toFrame - propContext.fromFrame;
+      const runId: string = generateObjectIdHex();
+
+      const perFrame: PropagationInferenceResult["perFrame"] = [];
+      range(propContext.fromFrame + 1, propContext.toFrame).forEach((n) => {
+        const t: number = (n - propContext.fromFrame) / span;
+        const detection: PropagatedDetection = {
+          _id: generateObjectIdHex(),
+          _cls: "Detection",
+          bounding_box: lerpBbox(left, right, t),
+          label: leftKeyframe.label,
+          index: leftKeyframe.index,
+          instance: { _cls: "Instance", _id: propContext.instanceId },
+          keyframe: false,
+          propagation: {
+            method: "linear",
+            run_id: runId,
+            parent_keyframes: [leftKeyframe.id, rightKeyframe.id],
+          },
+        };
+        perFrame.push({ frameNumber: n, detection });
+      });
+
+      return {
+        labelId: propContext.instanceId,
+        type: "sync",
+        taskType: AgentTaskType.PROPAGATE,
+        response: { perFrame },
+      };
+    } finally {
+      this.setStatus("idle");
+    }
+  }
+
+  async listSupportedTasks(): Promise<AgentTaskType[]> {
+    return [AgentTaskType.PROPAGATE];
+  }
+
+  async listInferenceCapabilities(): Promise<InferenceCapability[]> {
+    return [];
+  }
+
+  async getModelMetadata(task: AgentTaskType): Promise<ModelMetadata | null> {
+    if (task === AgentTaskType.PROPAGATE) {
+      return { name: "Linear interpolation" };
+    }
+    return null;
+  }
+
+  async subscribe(): Promise<void> {
+    // no-op; only supports synchronous inference
+  }
+
+  async unsubscribe(): Promise<void> {
+    // no-op; only supports synchronous inference
+  }
+
+  async abort(): Promise<void> {
+    // no-op; synchronous main-thread math has no abort point
+  }
+
+  onLifecycleEvent(listener: AnnotationAgentLifecycleListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  getLifecycleStatus(): AnnotationAgentLifecycleStatus {
+    return this.lifecycleStatus;
+  }
+
+  private setStatus(status: AnnotationAgentLifecycleStatus): void {
+    if (status === this.lifecycleStatus) return;
+    this.lifecycleStatus = status;
+    this.emit({ kind: "status", status });
+  }
+
+  private emit(event: AnnotationAgentLifecycle): void {
+    for (const listener of this.listeners) {
+      listener(event);
+    }
+  }
+}

--- a/app/packages/annotation/src/agents/hooks/useAgentRegistry.ts
+++ b/app/packages/annotation/src/agents/hooks/useAgentRegistry.ts
@@ -2,6 +2,7 @@ import { AgentDescriptor, AgentRegistry } from "../registry";
 import { atom, useAtom } from "jotai";
 import { useCallback, useMemo } from "react";
 import { AnnotationAgent, InferenceResultProxy } from "../types";
+import { PropagationBrowserAgent } from "../PropagationBrowserAgent";
 import { SAM2BrowserAnnotationAgent } from "../SAM2BrowserAnnotationAgent";
 
 /** Maps agent IDs to their {@link AgentDescriptor} entries. */
@@ -13,6 +14,11 @@ const registryAtom = atom<RegistryMap>({
     id: "sam2-tiny-onnx",
     label: "SAM2",
     agent: new SAM2BrowserAnnotationAgent(),
+  },
+  "propagate-linear": {
+    id: "propagate-linear",
+    label: "Linear interpolation",
+    agent: new PropagationBrowserAgent(),
   },
 });
 

--- a/app/packages/annotation/src/agents/hooks/useApplyPropagationResult.ts
+++ b/app/packages/annotation/src/agents/hooks/useApplyPropagationResult.ts
@@ -1,0 +1,42 @@
+import { useFrameLabelsStream } from "@fiftyone/video-annotation";
+import { useCallback } from "react";
+
+import {
+  AgentTaskType,
+  type InferenceResult,
+  type InferenceResultProxy,
+  type PropagationInferenceResult,
+} from "../types";
+
+/**
+ * Method which applies a {@link PropagationInferenceResult} to the
+ * `VideoFrameLabelsStream` cache. Each per-frame entry is written via
+ * `stream.updateLabel`, which the auto-save pipeline picks up.
+ */
+export type PropagationResultHandler = (
+  result: InferenceResult<InferenceResultProxy>
+) => void;
+
+/**
+ * Hook which returns a {@link PropagationResultHandler} bound to the
+ * current video annotation session. Mirrors {@link useApplyInferenceResult}'s
+ * shape; dispatches into the per-frame stream cache rather than into
+ * Lighter overlays directly (overlays only exist for the current frame).
+ */
+export const useApplyPropagationResult = (): PropagationResultHandler => {
+  const stream = useFrameLabelsStream();
+
+  return useCallback(
+    (result: InferenceResult<InferenceResultProxy>) => {
+      if (!stream) return;
+      if (result.type !== "sync") return;
+      if (result.taskType !== AgentTaskType.PROPAGATE) return;
+
+      const propResult = result.response as PropagationInferenceResult;
+      propResult.perFrame.forEach(({ frameNumber, detection }) => {
+        stream.updateLabel(frameNumber, detection);
+      });
+    },
+    [stream]
+  );
+};

--- a/app/packages/annotation/src/agents/hooks/useApplyPropagationResult.ts
+++ b/app/packages/annotation/src/agents/hooks/useApplyPropagationResult.ts
@@ -2,9 +2,7 @@ import { useFrameLabelsStream } from "@fiftyone/video-annotation";
 import { useCallback } from "react";
 
 import {
-  AgentTaskType,
   type InferenceResult,
-  type InferenceResultProxy,
   type PropagationInferenceResult,
 } from "../types";
 
@@ -14,7 +12,7 @@ import {
  * `stream.updateLabel`, which the auto-save pipeline picks up.
  */
 export type PropagationResultHandler = (
-  result: InferenceResult<InferenceResultProxy>
+  result: InferenceResult<PropagationInferenceResult>
 ) => void;
 
 /**
@@ -27,13 +25,11 @@ export const useApplyPropagationResult = (): PropagationResultHandler => {
   const stream = useFrameLabelsStream();
 
   return useCallback(
-    (result: InferenceResult<InferenceResultProxy>) => {
+    (result: InferenceResult<PropagationInferenceResult>) => {
       if (!stream) return;
       if (result.type !== "sync") return;
-      if (result.taskType !== AgentTaskType.PROPAGATE) return;
 
-      const propResult = result.response as PropagationInferenceResult;
-      propResult.perFrame.forEach(({ frameNumber, detection }) => {
+      result.response.perFrame.forEach(({ frameNumber, detection }) => {
         stream.updateLabel(frameNumber, detection);
       });
     },

--- a/app/packages/annotation/src/agents/types.ts
+++ b/app/packages/annotation/src/agents/types.ts
@@ -1,3 +1,6 @@
+import type { DetectionLabel } from "@fiftyone/looker/src/overlays/detection";
+import type { PropagationBlob, SyntheticBox } from "@fiftyone/video-annotation";
+
 import {
   ClassificationsParent,
   DetectionsParent,
@@ -18,6 +21,7 @@ export enum AgentTaskType {
   DETECT = "detect",
   SEGMENT = "segment",
   INFER = "infer",
+  PROPAGATE = "propagate",
 }
 
 /**
@@ -91,6 +95,20 @@ export type AnnotationContext = {
 };
 
 /**
+ * Inputs for a single propagation run: which track, what range to fill,
+ * and the two bracketing keyframe labels to interpolate between.
+ */
+export type PropagationContext = AnnotationContext & {
+  /** Track identity to propagate within (cross-frame `instance.id`). */
+  instanceId: string;
+  /** Inclusive frame range to fill between the two bracketing keyframes. */
+  fromFrame: number;
+  toFrame: number;
+  /** The two bracketing keyframe labels the propagator interpolates between. */
+  parentKeyframes: [SyntheticBox, SyntheticBox];
+};
+
+/**
  * Display information about the underlying model powering an agent or task.
  */
 export type ModelMetadata = {
@@ -153,13 +171,33 @@ export type PolylinesInferenceResult = PolylinesParent;
 export type SegmentationInferenceResult = DetectionsParent;
 
 /**
+ * A `DetectionLabel` carrying the video-annotation dynamic attrs the
+ * propagator writes on each emitted label. `bounding_box` is required —
+ * propagation always emits 2D detections.
+ */
+export type PropagatedDetection = DetectionLabel & {
+  bounding_box: [number, number, number, number];
+  keyframe: boolean;
+  propagation: PropagationBlob | null;
+};
+
+/**
+ * Response type for propagation tasks: a flat list of per-frame Detection
+ * labels the propagator wants written into the frame-labels stream cache.
+ */
+export type PropagationInferenceResult = {
+  perFrame: Array<{ frameNumber: number; detection: PropagatedDetection }>;
+};
+
+/**
  * Union of all supported inference result types.
  */
 export type InferenceResultProxy =
   | ClassificationInferenceResult
   | DetectionInferenceResult
   | PolylinesInferenceResult
-  | SegmentationInferenceResult;
+  | SegmentationInferenceResult
+  | PropagationInferenceResult;
 
 /**
  * Coarse lifecycle states an {@link AnnotationAgent} may transition through.

--- a/app/packages/annotation/src/commands.ts
+++ b/app/packages/annotation/src/commands.ts
@@ -41,3 +41,21 @@ export class MarkKeyframeCommand extends Command<boolean> {
     super();
   }
 }
+
+/**
+ * Propagate a tracked object's bounding box between two bracketing
+ * keyframes via the registered propagation agent (linear interp for the
+ * demo). Resolves to `true` when at least one in-between frame was
+ * written, `false` when prerequisites are missing (no stream, no
+ * bracketing keyframes, no registered agent for the method).
+ */
+export class PropagateCommand extends Command<boolean> {
+  constructor(
+    public readonly instanceId: string,
+    public readonly fromFrame: number,
+    public readonly toFrame: number,
+    public readonly method: string
+  ) {
+    super();
+  }
+}

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
@@ -5,7 +5,14 @@ import {
 } from "@fiftyone/video-annotation";
 import { useCallback } from "react";
 import { frameAt } from "../../../playback/src/lib/playback/utils";
-import { MarkKeyframeCommand } from "../commands";
+import { useAgentRegistry } from "../agents/hooks/useAgentRegistry";
+import { useApplyPropagationResult } from "../agents/hooks/useApplyPropagationResult";
+import { useSampleDescriptor } from "../agents/hooks/useSampleDescriptor";
+import {
+  AgentTaskType,
+  type PropagationContext,
+} from "../agents/types";
+import { MarkKeyframeCommand, PropagateCommand } from "../commands";
 
 /**
  * Registers video-specific annotation command handlers. Mount inside
@@ -15,6 +22,9 @@ import { MarkKeyframeCommand } from "../commands";
  */
 export const useRegisterVideoAnnotationCommandHandlers = () => {
   const stream = useFrameLabelsStream();
+  const registry = useAgentRegistry();
+  const sampleDescriptor = useSampleDescriptor();
+  const applyPropagation = useApplyPropagationResult();
 
   useRegisterCommandHandler(
     MarkKeyframeCommand,
@@ -63,6 +73,50 @@ export const useRegisterVideoAnnotationCommandHandlers = () => {
         return updated;
       },
       [stream]
+    )
+  );
+
+  useRegisterCommandHandler(
+    PropagateCommand,
+    useCallback(
+      async (cmd) => {
+        if (!stream) return false;
+        if (cmd.fromFrame >= cmd.toFrame) return false;
+
+        const fromTime = (cmd.fromFrame - 1) / stream.fps;
+        const toTime = (cmd.toFrame - 1) / stream.fps;
+        const fromSnapshot = stream.getValue(fromTime);
+        const toSnapshot = stream.getValue(toTime);
+        if (!fromSnapshot || !toSnapshot) return false;
+
+        const matchesInstance = (
+          d: { instance?: { _cls: "Instance"; _id?: string }; keyframe: boolean }
+        ): boolean =>
+          d.keyframe === true && d.instance?._id === cmd.instanceId;
+
+        const leftKeyframe = fromSnapshot.detections.find(matchesInstance);
+        const rightKeyframe = toSnapshot.detections.find(matchesInstance);
+        if (!leftKeyframe || !rightKeyframe) return false;
+
+        const agentId = `propagate-${cmd.method}`;
+        const agents = await registry.listAgents();
+        const descriptor = agents.find((a) => a.id === agentId);
+        if (!descriptor) return false;
+
+        const context: PropagationContext = {
+          sampleDescriptor,
+          taskType: AgentTaskType.PROPAGATE,
+          instanceId: cmd.instanceId,
+          fromFrame: cmd.fromFrame,
+          toFrame: cmd.toFrame,
+          parentKeyframes: [leftKeyframe, rightKeyframe],
+        };
+
+        const result = await descriptor.agent.infer(context);
+        applyPropagation(result);
+        return true;
+      },
+      [stream, registry, sampleDescriptor, applyPropagation]
     )
   );
 };

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
@@ -10,7 +10,9 @@ import { useApplyPropagationResult } from "../agents/hooks/useApplyPropagationRe
 import { useSampleDescriptor } from "../agents/hooks/useSampleDescriptor";
 import {
   AgentTaskType,
+  type AnnotationAgent,
   type PropagationContext,
+  type PropagationInferenceResult,
 } from "../agents/types";
 import { MarkKeyframeCommand, PropagateCommand } from "../commands";
 
@@ -112,7 +114,12 @@ export const useRegisterVideoAnnotationCommandHandlers = () => {
           parentKeyframes: [leftKeyframe, rightKeyframe],
         };
 
-        const result = await descriptor.agent.infer(context);
+        // Registry stores agents under the broad `InferenceResultProxy`
+        // type; narrow to the propagation agent's specific result type so
+        // the downstream apply hook is typed end-to-end.
+        const agent =
+          descriptor.agent as AnnotationAgent<PropagationInferenceResult>;
+        const result = await agent.infer(context);
         applyPropagation(result);
         return true;
       },

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationKeybindings.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationKeybindings.ts
@@ -1,9 +1,11 @@
 import { useCommandBus } from "@fiftyone/command-bus";
 import { KnownContexts, useKeyBindings } from "@fiftyone/commands";
 import { useLighter } from "@fiftyone/lighter";
+import { useFrameLabelsStream } from "@fiftyone/video-annotation";
 import { useRef } from "react";
+import { frameAt } from "../../../playback/src/lib/playback/utils";
 import { usePlayhead } from "../../../playback/src/lib/playback/use-playback-state";
-import { MarkKeyframeCommand } from "../commands";
+import { MarkKeyframeCommand, PropagateCommand } from "../commands";
 
 /**
  * Registers video-only keybindings into the modal-annotate context.
@@ -15,6 +17,7 @@ import { MarkKeyframeCommand } from "../commands";
 export const useRegisterVideoAnnotationKeybindings = () => {
   const bus = useCommandBus();
   const { scene } = useLighter();
+  const stream = useFrameLabelsStream();
 
   // Read the visual playhead, not `useCurrentTime` — currentTime lags
   // playhead while streams buffer, so dispatching at "the moment the
@@ -23,6 +26,9 @@ export const useRegisterVideoAnnotationKeybindings = () => {
   const playhead = usePlayhead();
   const playheadRef = useRef(playhead);
   playheadRef.current = playhead;
+
+  const streamRef = useRef(stream);
+  streamRef.current = stream;
 
   useKeyBindings(
     KnownContexts.ModalAnnotate,
@@ -41,6 +47,58 @@ export const useRegisterVideoAnnotationKeybindings = () => {
         label: "Mark keyframe",
         description:
           "Toggle the keyframe attribute on the selected detection at the current frame.",
+      },
+      {
+        commandId: "annotation-propagate",
+        sequence: "-",
+        handler: () => {
+          if (!scene) return;
+          const s = streamRef.current;
+          if (!s) return;
+          const ids = scene.getSelectedOverlayIds();
+          if (ids.length === 0) return;
+
+          const currentFrame = frameAt(
+            playheadRef.current,
+            s.fps,
+            s.totalFrames
+          );
+          const currentSnapshot = s.getValue(playheadRef.current);
+          if (!currentSnapshot) return;
+
+          const selected = currentSnapshot.detections.find((d) =>
+            ids.includes(d.id)
+          );
+          const instanceId = selected?.instance?._id;
+          if (!instanceId) return;
+
+          // Walk the cached frames to locate the bracketing keyframes:
+          // the most recent keyframe at or before the playhead, and the
+          // next keyframe strictly after.
+          let leftFrame: number | null = null;
+          let rightFrame: number | null = null;
+          for (let f = 1; f <= s.totalFrames; f++) {
+            const snap = s.getValue((f - 1) / s.fps);
+            if (!snap) continue;
+            const det = snap.detections.find(
+              (d) => d.keyframe && d.instance?._id === instanceId
+            );
+            if (!det) continue;
+            if (f <= currentFrame) leftFrame = f;
+            if (f > currentFrame && rightFrame === null) {
+              rightFrame = f;
+              break;
+            }
+          }
+          if (leftFrame === null || rightFrame === null) return;
+
+          void bus.execute(
+            new PropagateCommand(instanceId, leftFrame, rightFrame, "linear")
+          );
+        },
+        label: "Propagate",
+        description:
+          "Linearly interpolate the selected tracked object between its bracketing keyframes.",
       },
     ],
     [scene, bus]

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
@@ -53,10 +53,14 @@ const useSchema = (readOnly: boolean) => {
 
   // Reruns only when the visible attribute set changes.
   return useMemo(() => {
+    // An empty class list would emit a 0-item JSON-Schema enum, which RJSF
+    // rejects. Fall back to a free-form text input until the dataset has a
+    // configured class list.
+    const hasClasses = (config?.classes?.length ?? 0) > 0;
     const properties: Record<string, SchemaType | undefined> = {
       label: generatePrimitiveSchema("label", {
         type: "str",
-        component: config?.component || "dropdown",
+        component: hasClasses ? config?.component || "dropdown" : undefined,
         values: config?.classes || [],
         readOnly: effectiveReadOnly,
       }),

--- a/app/packages/video-annotation/index.ts
+++ b/app/packages/video-annotation/index.ts
@@ -2,6 +2,8 @@ export { VideoAnnotationSurface } from "./src/VideoAnnotationSurface";
 export { SyntheticLabelStream } from "./src/SyntheticLabelStream";
 export type {
   FrameLabelSnapshot,
+  PropagationBlob,
+  PropagationMethod,
   SyntheticBox,
 } from "./src/SyntheticLabelStream";
 export {


### PR DESCRIPTION
## 🧪 How is this patch tested? If it is not, please explain why.

adds propagation agent for linear interpolation, wiring and hooks for usage.

current keybinding is: `-`

1. create 2 keyframes
2. select one of them
3. press `-`
4. interpolated keyframes are generated

[Screencast from 2026-05-28 12-09-29.webm](https://github.com/user-attachments/assets/c54c0de5-613b-41df-9c89-8cc5eb253c93)


## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
