### PR TITLE
[HA] Persist TemporalDetection.support edits

### DIFF
--- a/app/packages/annotation/src/commands.ts
+++ b/app/packages/annotation/src/commands.ts
@@ -41,3 +41,18 @@ export class MarkKeyframeCommand extends Command<boolean> {
     super();
   }
 }
+
+/**
+ * Edit a `TemporalDetection.support` frame range. Fired on drag-end
+ * of a timeline interval bar. `support` is the post-edit value;
+ * the supplier resolves the array index on the sample at flush time.
+ */
+export class EditTemporalDetectionSupportCommand extends Command<boolean> {
+  constructor(
+    public readonly fieldPath: string,
+    public readonly detectionId: string,
+    public readonly support: readonly [number, number]
+  ) {
+    super();
+  }
+}

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
@@ -1,11 +1,15 @@
 import { useRegisterCommandHandler } from "@fiftyone/command-bus";
 import {
   useFrameLabelsStream,
+  useStageTemporalDetectionSupport,
   type LocalDetection,
 } from "@fiftyone/video-annotation";
 import { useCallback } from "react";
 import { frameAt } from "../../../playback/src/lib/playback/utils";
-import { MarkKeyframeCommand } from "../commands";
+import {
+  EditTemporalDetectionSupportCommand,
+  MarkKeyframeCommand,
+} from "../commands";
 
 /**
  * Registers video-specific annotation command handlers. Mount inside
@@ -15,6 +19,21 @@ import { MarkKeyframeCommand } from "../commands";
  */
 export const useRegisterVideoAnnotationCommandHandlers = () => {
   const stream = useFrameLabelsStream();
+  const stageTemporalDetectionSupport = useStageTemporalDetectionSupport();
+
+  useRegisterCommandHandler(
+    EditTemporalDetectionSupportCommand,
+    useCallback(
+      async (cmd) => {
+        stageTemporalDetectionSupport(cmd.fieldPath, cmd.detectionId, [
+          cmd.support[0],
+          cmd.support[1],
+        ]);
+        return true;
+      },
+      [stageTemporalDetectionSupport]
+    )
+  );
 
   useRegisterCommandHandler(
     MarkKeyframeCommand,

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationEventHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationEventHandlers.ts
@@ -1,27 +1,40 @@
-import { useFrameLabelsStream } from "@fiftyone/video-annotation";
+import {
+  useClearTemporalDetectionEdits,
+  useFrameLabelsStream,
+} from "@fiftyone/video-annotation";
 import { useCallback } from "react";
 import { useAnnotationEventHandler } from "./useAnnotationEventHandler";
 
 /**
  * Video-specific annotation event handlers. Bridges persistence outcomes to the
  * frame-labels stream so dirty/baseline state advances on success and rolls
- * back on failure. Mount alongside {@link useRegisterAnnotationEventHandlers}
- * at the composition root; no-op when the active modal isn't a video sample.
+ * back on failure, and clears any staged `TemporalDetection.support` edits
+ * after a save attempt resolves. Mount alongside
+ * {@link useRegisterAnnotationEventHandlers} at the composition root; no-op
+ * when the active modal isn't a video sample.
+ *
+ * TD edits are cleared on both success and error: success means the sample
+ * is refreshing with the patched value, so the optimistic override becomes
+ * redundant; error rolls back the optimistic visual to whatever the live
+ * sample reflects and lets the user retry by re-dragging.
  */
 export const useRegisterVideoAnnotationEventHandlers = () => {
   const videoStream = useFrameLabelsStream();
+  const clearTemporalDetectionEdits = useClearTemporalDetectionEdits();
 
   useAnnotationEventHandler(
     "annotation:persistenceSuccess",
     useCallback(() => {
       videoStream?.commitPending();
-    }, [videoStream])
+      clearTemporalDetectionEdits();
+    }, [videoStream, clearTemporalDetectionEdits])
   );
 
   useAnnotationEventHandler(
     "annotation:persistenceError",
     useCallback(() => {
       videoStream?.discardPending();
-    }, [videoStream])
+      clearTemporalDetectionEdits();
+    }, [videoStream, clearTemporalDetectionEdits])
   );
 };

--- a/app/packages/annotation/src/persistence/index.ts
+++ b/app/packages/annotation/src/persistence/index.ts
@@ -8,3 +8,4 @@ export * from "./usePersistenceEventHandler";
 export * from "./usePersistenceRetryController";
 export * from "./useSampleMutationManager";
 export * from "./useSidebarDeltaSupplier";
+export * from "./useTemporalDetectionDeltaSupplier";

--- a/app/packages/annotation/src/persistence/useAnnotationDeltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/useAnnotationDeltaSupplier.ts
@@ -3,6 +3,7 @@ import { useLighterDeltaSupplier } from "./useLighterDeltaSupplier";
 import { useCallback } from "react";
 import { useSidebarDeltaSupplier } from "./useSidebarDeltaSupplier";
 import { use3dDeltaSupplier } from "./use3dDeltaSupplier";
+import { useTemporalDetectionDeltaSupplier } from "./useTemporalDetectionDeltaSupplier";
 import { useVideoLabelsDeltaSupplier } from "./useVideoLabelsDeltaSupplier";
 
 /**
@@ -13,18 +14,21 @@ export const useAnnotationDeltaSupplier = (): DeltaSupplier => {
   const supply3dDeltas = use3dDeltaSupplier();
   const supplyLighterDeltas = useLighterDeltaSupplier();
   const supplySidebarDeltas = useSidebarDeltaSupplier();
+  const supplyTemporalDetectionDeltas = useTemporalDetectionDeltaSupplier();
   const supplyVideoLabelsDeltas = useVideoLabelsDeltaSupplier();
 
   return useCallback(() => {
     const result3d = supply3dDeltas();
     const resultLighter = supplyLighterDeltas();
     const resultSidebar = supplySidebarDeltas();
+    const resultTemporalDetection = supplyTemporalDetectionDeltas();
     const resultVideoLabels = supplyVideoLabelsDeltas();
 
     const deltas = [
       ...result3d.deltas,
       ...resultLighter.deltas,
       ...resultSidebar.deltas,
+      ...resultTemporalDetection.deltas,
       ...resultVideoLabels.deltas,
     ];
 
@@ -34,6 +38,7 @@ export const useAnnotationDeltaSupplier = (): DeltaSupplier => {
     supply3dDeltas,
     supplyLighterDeltas,
     supplySidebarDeltas,
+    supplyTemporalDetectionDeltas,
     supplyVideoLabelsDeltas,
   ]);
 };

--- a/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.test.ts
+++ b/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import { buildTemporalDetectionSupportDeltas } from "./useTemporalDetectionDeltaSupplier";
+
+const td = (id: string, support: [number, number]) => ({
+  _cls: "TemporalDetection",
+  _id: id,
+  label: "x",
+  support,
+});
+
+const field = (...detections: ReturnType<typeof td>[]) => ({
+  _cls: "TemporalDetections" as const,
+  detections,
+});
+
+describe("buildTemporalDetectionSupportDeltas", () => {
+  it("emits a replace op at /<fieldPath>/detections/<index>/support", () => {
+    const sample = { events: field(td("a", [1, 10])) };
+    const pending = new Map<string, [number, number]>([["events|a", [5, 15]]]);
+
+    expect(buildTemporalDetectionSupportDeltas(sample, pending)).toEqual([
+      { op: "replace", path: "/events/detections/0/support", value: [5, 15] },
+    ]);
+  });
+
+  it("resolves index by detection _id, not by edit order", () => {
+    const sample = {
+      events: field(td("a", [1, 10]), td("b", [20, 30]), td("c", [40, 50])),
+    };
+    const pending = new Map<string, [number, number]>([["events|c", [42, 60]]]);
+    const deltas = buildTemporalDetectionSupportDeltas(sample, pending);
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0]).toMatchObject({
+      path: "/events/detections/2/support",
+      value: [42, 60],
+    });
+  });
+
+  it("falls back to `id` when `_id` is missing on the detection", () => {
+    const sample = {
+      events: {
+        _cls: "TemporalDetections" as const,
+        detections: [{ _cls: "TemporalDetection", id: "x", support: [1, 5] }],
+      },
+    };
+    const pending = new Map<string, [number, number]>([["events|x", [2, 6]]]);
+    const deltas = buildTemporalDetectionSupportDeltas(sample, pending);
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0]).toMatchObject({
+      path: "/events/detections/0/support",
+    });
+  });
+
+  it("emits one op per staged edit and preserves insertion order", () => {
+    const sample = {
+      events: field(td("a", [1, 10]), td("b", [20, 30])),
+    };
+    const pending = new Map<string, [number, number]>([
+      ["events|b", [22, 28]],
+      ["events|a", [5, 15]],
+    ]);
+    const deltas = buildTemporalDetectionSupportDeltas(sample, pending);
+    expect(deltas).toHaveLength(2);
+    // Insertion order of `pending` (b, then a).
+    expect((deltas[0] as { path: string }).path).toBe(
+      "/events/detections/1/support"
+    );
+    expect((deltas[1] as { path: string }).path).toBe(
+      "/events/detections/0/support"
+    );
+  });
+
+  it("handles edits spanning multiple fields", () => {
+    const sample = {
+      events: field(td("a", [1, 10])),
+      highlights: field(td("h", [20, 30])),
+    };
+    const pending = new Map<string, [number, number]>([
+      ["events|a", [5, 15]],
+      ["highlights|h", [22, 28]],
+    ]);
+    const deltas = buildTemporalDetectionSupportDeltas(sample, pending);
+    expect(deltas).toHaveLength(2);
+    const paths = (deltas as { path: string }[]).map((d) => d.path);
+    expect(paths).toContain("/events/detections/0/support");
+    expect(paths).toContain("/highlights/detections/0/support");
+  });
+
+  it("skips edits whose field doesn't exist on the sample", () => {
+    const sample = { events: field(td("a", [1, 10])) };
+    const pending = new Map<string, [number, number]>([["ghost|a", [5, 15]]]);
+    expect(buildTemporalDetectionSupportDeltas(sample, pending)).toEqual([]);
+  });
+
+  it("skips edits whose field isn't a TemporalDetections wrapper", () => {
+    const sample = {
+      events: { _cls: "Detections", detections: [] },
+    };
+    const pending = new Map<string, [number, number]>([["events|a", [5, 15]]]);
+    expect(buildTemporalDetectionSupportDeltas(sample, pending)).toEqual([]);
+  });
+
+  it("skips edits whose field is null / undefined / non-object", () => {
+    const pending = new Map<string, [number, number]>([["events|a", [5, 15]]]);
+    expect(
+      buildTemporalDetectionSupportDeltas({ events: null }, pending)
+    ).toEqual([]);
+    expect(
+      buildTemporalDetectionSupportDeltas(
+        { events: undefined } as unknown as Record<string, unknown>,
+        pending
+      )
+    ).toEqual([]);
+    expect(
+      buildTemporalDetectionSupportDeltas({ events: "string" }, pending)
+    ).toEqual([]);
+  });
+
+  it("skips edits whose TD has disappeared from the array", () => {
+    const sample = { events: field(td("a", [1, 10])) };
+    const pending = new Map<string, [number, number]>([
+      ["events|ghost", [5, 15]],
+    ]);
+    expect(buildTemporalDetectionSupportDeltas(sample, pending)).toEqual([]);
+  });
+
+  it("returns an empty array when no edits are pending", () => {
+    const sample = { events: field(td("a", [1, 10])) };
+    expect(buildTemporalDetectionSupportDeltas(sample, new Map())).toEqual([]);
+  });
+
+  it("emits the bad edit dropped but keeps the good one in the same flush", () => {
+    const sample = { events: field(td("a", [1, 10])) };
+    const pending = new Map<string, [number, number]>([
+      ["events|ghost", [99, 100]],
+      ["events|a", [5, 15]],
+    ]);
+    const deltas = buildTemporalDetectionSupportDeltas(sample, pending);
+    expect(deltas).toHaveLength(1);
+    expect((deltas[0] as { value: [number, number] }).value).toEqual([5, 15]);
+  });
+});

--- a/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.ts
@@ -40,33 +40,50 @@ export const useTemporalDetectionDeltaSupplier = (): DeltaSupplier => {
       return { deltas: [], metadata: undefined };
     }
 
-    const sample = modalSample.sample as Record<string, unknown>;
-    const deltas: JSONDeltas = [];
-
-    for (const [key, support] of pending) {
-      const { fieldPath, detectionId } = parseTemporalDetectionEditKey(key);
-      const field = sample[fieldPath] as RawTemporalDetectionsField | undefined;
-
-      const detections = field?.detections;
-      if (!Array.isArray(detections)) {
-        continue;
-      }
-
-      const index = detections.findIndex(
-        (d) => (d._id ?? d.id) === detectionId
-      );
-
-      if (index < 0) {
-        continue;
-      }
-
-      deltas.push({
-        op: "replace",
-        path: `/${fieldPath}/detections/${index}/support`,
-        value: support,
-      });
-    }
-
-    return { deltas, metadata: undefined };
+    return {
+      deltas: buildTemporalDetectionSupportDeltas(
+        modalSample.sample as Record<string, unknown>,
+        pending
+      ),
+      metadata: undefined,
+    };
   }, [isVideo, modalSample, pending]);
 };
+
+/**
+ * Walk the pending TD support edits and emit one replace op per edit
+ * whose target TD still exists on the sample. Edits where the field
+ * is missing or the TD has been removed are silently dropped.
+ *
+ * Exported for direct unit testing; production callers use the supplier
+ * above.
+ */
+export function buildTemporalDetectionSupportDeltas(
+  sample: Record<string, unknown>,
+  pending: ReadonlyMap<string, [number, number]>
+): JSONDeltas {
+  const deltas: JSONDeltas = [];
+
+  for (const [key, support] of pending) {
+    const { fieldPath, detectionId } = parseTemporalDetectionEditKey(key);
+    const field = sample[fieldPath] as RawTemporalDetectionsField | undefined;
+
+    const detections = field?.detections;
+    if (!Array.isArray(detections)) {
+      continue;
+    }
+
+    const index = detections.findIndex((d) => (d._id ?? d.id) === detectionId);
+    if (index < 0) {
+      continue;
+    }
+
+    deltas.push({
+      op: "replace",
+      path: `/${fieldPath}/detections/${index}/support`,
+      value: support,
+    });
+  }
+
+  return deltas;
+}

--- a/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.ts
@@ -1,0 +1,72 @@
+import type { JSONDeltas } from "@fiftyone/core/src/client";
+import { useIsVideo, useModalSample } from "@fiftyone/state";
+import {
+  parseTemporalDetectionEditKey,
+  type RawTemporalDetectionsField,
+  useTemporalDetectionPendingEdits,
+} from "@fiftyone/video-annotation";
+import { useCallback } from "react";
+import type { DeltaSupplier } from "./deltaSupplier";
+
+/**
+ * Provides a {@link DeltaSupplier} for `TemporalDetection.support` edits
+ * staged from the video annotation timeline.
+ *
+ * TDs live at sample level on a video sample (not under `frames.`), so
+ * they don't flow through the video-labels delta paths. They also don't have
+ * overlays, so they don't flow through the Lighter delta path.
+ *
+ * Pending edits are read from {@link useTemporalDetectionPendingEdits},
+ * the TD's current array index is looked up live against the modal sample,
+ * and one `replace /<fieldPath>/detections/<index>/support` op is emitted per
+ * staged edit.
+ *
+ * Index is resolved at supply time (not capture time) so a concurrent
+ * unrelated insert/remove on the same field doesn't break the patch.
+ * If the targeted TD has disappeared from the sample, the edit is
+ * silently dropped.
+ *
+ * No-op for non-video samples and when no edits are pending. Pending
+ * edits are cleared on `annotation:persistenceSuccess` /
+ * `persistenceError` by {@link useRegisterVideoAnnotationEventHandlers}.
+ */
+export const useTemporalDetectionDeltaSupplier = (): DeltaSupplier => {
+  const modalSample = useModalSample();
+  const isVideo = useIsVideo();
+  const pending = useTemporalDetectionPendingEdits();
+
+  return useCallback(() => {
+    if (!isVideo || !modalSample?.sample || pending.size === 0) {
+      return { deltas: [], metadata: undefined };
+    }
+
+    const sample = modalSample.sample as Record<string, unknown>;
+    const deltas: JSONDeltas = [];
+
+    for (const [key, support] of pending) {
+      const { fieldPath, detectionId } = parseTemporalDetectionEditKey(key);
+      const field = sample[fieldPath] as RawTemporalDetectionsField | undefined;
+
+      const detections = field?.detections;
+      if (!Array.isArray(detections)) {
+        continue;
+      }
+
+      const index = detections.findIndex(
+        (d) => (d._id ?? d.id) === detectionId
+      );
+
+      if (index < 0) {
+        continue;
+      }
+
+      deltas.push({
+        op: "replace",
+        path: `/${fieldPath}/detections/${index}/support`,
+        value: support,
+      });
+    }
+
+    return { deltas, metadata: undefined };
+  }, [isVideo, modalSample, pending]);
+};

--- a/app/packages/video-annotation/index.ts
+++ b/app/packages/video-annotation/index.ts
@@ -23,3 +23,10 @@ export type {
   TemporalDetectionEventData,
   BuildTemporalDetectionTracksInput,
 } from "./src/temporalDetectionTracks";
+export {
+  applyTemporalDetectionEdits,
+  parseTemporalDetectionEditKey,
+  useClearTemporalDetectionEdits,
+  useStageTemporalDetectionSupport,
+  useTemporalDetectionPendingEdits,
+} from "./src/pendingTemporalDetectionEdits";

--- a/app/packages/video-annotation/index.ts
+++ b/app/packages/video-annotation/index.ts
@@ -26,6 +26,7 @@ export type {
 export {
   applyTemporalDetectionEdits,
   parseTemporalDetectionEditKey,
+  temporalDetectionEditKey,
   useClearTemporalDetectionEdits,
   useStageTemporalDetectionSupport,
   useTemporalDetectionPendingEdits,

--- a/app/packages/video-annotation/package.json
+++ b/app/packages/video-annotation/package.json
@@ -3,6 +3,8 @@
     "main": "./index.ts",
     "packageManager": "yarn@4.9.1",
     "dependencies": {
+        "@fiftyone/annotation": "workspace:*",
+        "@fiftyone/command-bus": "workspace:*",
         "@fiftyone/lighter": "workspace:*",
         "@fiftyone/playback": "workspace:*",
         "@fiftyone/state": "workspace:*",

--- a/app/packages/video-annotation/src/FrameLabels.tsx
+++ b/app/packages/video-annotation/src/FrameLabels.tsx
@@ -35,6 +35,11 @@ import { buildPerInstanceTracks, type PerInstanceLabel } from "./frameTracks";
 import { LABELS_STREAM_ID } from "./ids";
 import { useLinkedTrackDecorator } from "./linkedTracks";
 import {
+  applyTemporalDetectionEdits,
+  useStageTemporalDetectionSupport,
+  useTemporalDetectionPendingEdits,
+} from "./pendingTemporalDetectionEdits";
+import {
   buildTemporalDetectionTracks,
   type TemporalDetectionEventData,
   type TemporalDetectionLabelLike,
@@ -205,6 +210,13 @@ export const FrameLabelsTracks: React.FC<{ sample?: ModalSample }> = ({
   // build deterministic in the deps (stream identity changes when the
   // sample changes, which is the trigger we care about).
   const [frameTracks, setFrameTracks] = useState<Track[]>([]);
+  // Tracked separately from `frameTracks` because an empty list after
+  // warmup (clip has no tracked detections) is a legitimately resolved
+  // state. We need this signal to drive the one-shot `initialPinnedIds`
+  // bootstrap — otherwise a sync-resolved TD list would trip the
+  // empty→ready key flip before frame tracks land, and frame tracks
+  // would arrive unpinned.
+  const [frameTracksResolved, setFrameTracksResolved] = useState(false);
 
   const resolveColor = useCallback(
     (label: PerInstanceLabel) =>
@@ -227,6 +239,7 @@ export const FrameLabelsTracks: React.FC<{ sample?: ModalSample }> = ({
   useEffect(() => {
     if (!stream) {
       setFrameTracks([]);
+      setFrameTracksResolved(false);
       return;
     }
 
@@ -238,12 +251,16 @@ export const FrameLabelsTracks: React.FC<{ sample?: ModalSample }> = ({
       }
 
       setFrameTracks(buildPerInstanceTracks({ stream, resolveColor }));
+      setFrameTracksResolved(true);
     });
 
     return () => {
       cancelled = true;
     };
   }, [stream, resolveColor, editVersion]);
+
+  const pendingTemporalDetectionEdits = useTemporalDetectionPendingEdits();
+  const stageTemporalDetectionSupport = useStageTemporalDetectionSupport();
 
   const temporalDetectionTracks = useMemo(() => {
     if (!sample?.sample) {
@@ -255,19 +272,37 @@ export const FrameLabelsTracks: React.FC<{ sample?: ModalSample }> = ({
     if (!Number.isFinite(fps) || fps <= 0) {
       return [];
     }
+
+    // Apply staged TD-support edits as overrides before building so the
+    // bar stays where the user dropped it through the server round-trip.
+    // Cleared by `useRegisterVideoAnnotationEventHandlers` on
+    // `annotation:persistenceSuccess` / `persistenceError`.
+    const baseSample = sample.sample as Record<string, unknown>;
+    const overlaidSample =
+      pendingTemporalDetectionEdits.size === 0
+        ? baseSample
+        : applyTemporalDetectionEdits(
+            baseSample,
+            pendingTemporalDetectionEdits
+          );
+
     return buildTemporalDetectionTracks({
-      sample: sample.sample as Record<string, unknown>,
+      sample: overlaidSample,
       fps,
       resolveColor: resolveTemporalDetectionColor,
     });
-  }, [sample, resolveTemporalDetectionColor]);
+  }, [sample, resolveTemporalDetectionColor, pendingTemporalDetectionEdits]);
 
   const tracks = useMemo(
     () => [...frameTracks, ...temporalDetectionTracks],
     [frameTracks, temporalDetectionTracks]
   );
   const pinned = useMemo(() => tracks.map((t) => t.id), [tracks]);
-  const ready = tracks.length > 0;
+  // Bootstrap on frame-tracks-resolved, not on `tracks.length`. TD
+  // tracks resolve synchronously from the sample; without this gate,
+  // they'd trip the empty→ready flip before frame tracks land and
+  // frame tracks would arrive unpinned.
+  const ready = frameTracksResolved;
   const linkDecorate = useLinkedTrackDecorator();
   const fps = sample?.frameRate;
   const snapStepSec =
@@ -305,17 +340,19 @@ export const FrameLabelsTracks: React.FC<{ sample?: ModalSample }> = ({
           const firstFrame = Math.max(1, Math.round(newStartSec * fps) + 1);
           const lastFrame = Math.max(firstFrame, Math.round(newEndSec * fps));
 
-          // TODO: route through the command bus for undo/redo
-          console.log("[TODO undo/redo] TemporalDetection support edit", {
-            fieldPath: tdEvent.fieldPath,
-            detectionId: tdEvent.detectionId,
-            previousSupport: tdEvent.support,
-            newSupport: [firstFrame, lastFrame],
-          });
+          // Stage the edit; the next autosave tick picks it up via
+          // `useTemporalDetectionDeltaSupplier` and the persistence event
+          // handler clears it on success/error. Undo/redo still TODO —
+          // would wrap this in a command on the annotation bus.
+          stageTemporalDetectionSupport(
+            tdEvent.fieldPath,
+            tdEvent.detectionId,
+            [firstFrame, lastFrame]
+          );
         },
       };
     },
-    [linkDecorate, fps, snapStepSec]
+    [linkDecorate, fps, snapStepSec, stageTemporalDetectionSupport]
   );
 
   return (

--- a/app/packages/video-annotation/src/FrameLabels.tsx
+++ b/app/packages/video-annotation/src/FrameLabels.tsx
@@ -34,9 +34,10 @@ import {
 import { buildPerInstanceTracks, type PerInstanceLabel } from "./frameTracks";
 import { LABELS_STREAM_ID } from "./ids";
 import { useLinkedTrackDecorator } from "./linkedTracks";
+import { EditTemporalDetectionSupportCommand } from "@fiftyone/annotation";
+import { useCommandBus } from "@fiftyone/command-bus";
 import {
   applyTemporalDetectionEdits,
-  useStageTemporalDetectionSupport,
   useTemporalDetectionPendingEdits,
 } from "./pendingTemporalDetectionEdits";
 import {
@@ -260,7 +261,7 @@ export const FrameLabelsTracks: React.FC<{ sample?: ModalSample }> = ({
   }, [stream, resolveColor, editVersion]);
 
   const pendingTemporalDetectionEdits = useTemporalDetectionPendingEdits();
-  const stageTemporalDetectionSupport = useStageTemporalDetectionSupport();
+  const commandBus = useCommandBus();
 
   const temporalDetectionTracks = useMemo(() => {
     if (!sample?.sample) {
@@ -340,19 +341,22 @@ export const FrameLabelsTracks: React.FC<{ sample?: ModalSample }> = ({
           const firstFrame = Math.max(1, Math.round(newStartSec * fps) + 1);
           const lastFrame = Math.max(firstFrame, Math.round(newEndSec * fps));
 
-          // Stage the edit; the next autosave tick picks it up via
-          // `useTemporalDetectionDeltaSupplier` and the persistence event
-          // handler clears it on success/error. Undo/redo still TODO —
-          // would wrap this in a command on the annotation bus.
-          stageTemporalDetectionSupport(
-            tdEvent.fieldPath,
-            tdEvent.detectionId,
-            [firstFrame, lastFrame]
+          // Goes through the command bus (same shape as
+          // `MarkKeyframeCommand`) so the dispatch path is uniform and
+          // future undo/redo subscribers see this edit on the bus.
+          // The handler stages into the same pending-edits store the
+          // delta supplier reads.
+          void commandBus.execute(
+            new EditTemporalDetectionSupportCommand(
+              tdEvent.fieldPath,
+              tdEvent.detectionId,
+              [firstFrame, lastFrame]
+            )
           );
         },
       };
     },
-    [linkDecorate, fps, snapStepSec, stageTemporalDetectionSupport]
+    [linkDecorate, fps, snapStepSec, commandBus]
   );
 
   return (

--- a/app/packages/video-annotation/src/pendingTemporalDetectionEdits.test.tsx
+++ b/app/packages/video-annotation/src/pendingTemporalDetectionEdits.test.tsx
@@ -1,0 +1,242 @@
+import { act, render } from "@testing-library/react";
+import { Provider } from "jotai";
+import { describe, expect, it } from "vitest";
+import {
+  applyTemporalDetectionEdits,
+  parseTemporalDetectionEditKey,
+  temporalDetectionEditKey,
+  useClearTemporalDetectionEdits,
+  useStageTemporalDetectionSupport,
+  useTemporalDetectionPendingEdits,
+} from "./pendingTemporalDetectionEdits";
+
+function HookHost({
+  onReady,
+}: {
+  onReady: (handles: {
+    stage: ReturnType<typeof useStageTemporalDetectionSupport>;
+    clear: ReturnType<typeof useClearTemporalDetectionEdits>;
+    read: () => ReadonlyMap<string, [number, number]>;
+  }) => void;
+}) {
+  const stage = useStageTemporalDetectionSupport();
+  const clear = useClearTemporalDetectionEdits();
+  const map = useTemporalDetectionPendingEdits();
+
+  onReady({ stage, clear, read: () => map });
+
+  return <div data-testid="size">{map.size}</div>;
+}
+
+function renderHost() {
+  let handles!: {
+    stage: ReturnType<typeof useStageTemporalDetectionSupport>;
+    clear: ReturnType<typeof useClearTemporalDetectionEdits>;
+    read: () => ReadonlyMap<string, [number, number]>;
+  };
+  const utils = render(
+    <Provider>
+      <HookHost
+        onReady={(h) => {
+          handles = h;
+        }}
+      />
+    </Provider>
+  );
+  return { ...utils, handles: () => handles };
+}
+
+describe("temporalDetectionEditKey / parseTemporalDetectionEditKey", () => {
+  it("round-trips fieldPath + detectionId", () => {
+    const key = temporalDetectionEditKey("events", "a");
+    expect(key).toBe("events|a");
+    expect(parseTemporalDetectionEditKey(key)).toEqual({
+      fieldPath: "events",
+      detectionId: "a",
+    });
+  });
+
+  it("keeps fieldPath and detectionId disambiguated across fields", () => {
+    expect(temporalDetectionEditKey("events", "a")).not.toBe(
+      temporalDetectionEditKey("highlights", "a")
+    );
+  });
+
+  it("preserves detectionIds that contain a pipe character", () => {
+    // First pipe terminates fieldPath; everything after is detectionId.
+    const key = temporalDetectionEditKey("events", "a|b|c");
+    expect(parseTemporalDetectionEditKey(key)).toEqual({
+      fieldPath: "events",
+      detectionId: "a|b|c",
+    });
+  });
+});
+
+describe("pending TD edits store", () => {
+  it("starts empty", () => {
+    const { handles } = renderHost();
+    expect(handles().read().size).toBe(0);
+  });
+
+  it("stages an edit keyed by fieldPath + detectionId", () => {
+    const { handles } = renderHost();
+    act(() => {
+      handles().stage("events", "a", [5, 15]);
+    });
+    const m = handles().read();
+    expect(m.size).toBe(1);
+    expect(m.get("events|a")).toEqual([5, 15]);
+  });
+
+  it("overwrites a prior edit on the same TD", () => {
+    const { handles } = renderHost();
+    act(() => {
+      handles().stage("events", "a", [5, 15]);
+    });
+    act(() => {
+      handles().stage("events", "a", [8, 20]);
+    });
+    expect(handles().read().get("events|a")).toEqual([8, 20]);
+    expect(handles().read().size).toBe(1);
+  });
+
+  it("keeps edits for different TDs separate", () => {
+    const { handles } = renderHost();
+    act(() => {
+      handles().stage("events", "a", [5, 15]);
+      handles().stage("highlights", "a", [22, 28]);
+    });
+    const m = handles().read();
+    expect(m.size).toBe(2);
+    expect(m.get("events|a")).toEqual([5, 15]);
+    expect(m.get("highlights|a")).toEqual([22, 28]);
+  });
+
+  it("clear drops every staged edit", () => {
+    const { handles } = renderHost();
+    act(() => {
+      handles().stage("events", "a", [5, 15]);
+      handles().stage("events", "b", [25, 35]);
+    });
+    expect(handles().read().size).toBe(2);
+    act(() => {
+      handles().clear();
+    });
+    expect(handles().read().size).toBe(0);
+  });
+});
+
+describe("applyTemporalDetectionEdits", () => {
+  const td = (id: string, support: [number, number]) => ({
+    _cls: "TemporalDetection",
+    _id: id,
+    label: "x",
+    support,
+  });
+
+  const field = (...detections: ReturnType<typeof td>[]) => ({
+    _cls: "TemporalDetections" as const,
+    detections,
+  });
+
+  it("returns the same reference when no edits are staged", () => {
+    const sample = { events: field(td("a", [1, 5])) };
+    expect(applyTemporalDetectionEdits(sample, new Map())).toBe(sample);
+  });
+
+  it("applies a single edit and clones the affected field's detections array", () => {
+    const original = field(td("a", [1, 5]), td("b", [10, 20]));
+    const sample = { events: original };
+    const edits = new Map<string, [number, number]>([["events|a", [3, 7]]]);
+
+    const out = applyTemporalDetectionEdits(sample, edits) as {
+      events: { detections: { _id: string; support: [number, number] }[] };
+    };
+
+    expect(out.events.detections[0].support).toEqual([3, 7]);
+    expect(out.events.detections[1].support).toEqual([10, 20]);
+    // Detections array on the touched field is cloned.
+    expect(out.events.detections).not.toBe(original.detections);
+  });
+
+  it("clones the top-level sample object so the original is not mutated", () => {
+    const sample = { events: field(td("a", [1, 5])) };
+    const out = applyTemporalDetectionEdits(
+      sample,
+      new Map([["events|a", [3, 7] as [number, number]]])
+    );
+    expect(out).not.toBe(sample);
+    expect(sample.events.detections[0].support).toEqual([1, 5]);
+  });
+
+  it("leaves untouched top-level fields referentially stable", () => {
+    const otherField = field(td("z", [99, 100]));
+    const sample = {
+      events: field(td("a", [1, 5])),
+      other: otherField,
+    };
+    const out = applyTemporalDetectionEdits(
+      sample,
+      new Map([["events|a", [3, 7] as [number, number]]])
+    ) as { other: typeof otherField };
+    // `other` wasn't touched — same reference.
+    expect(out.other).toBe(otherField);
+  });
+
+  it("groups edits per field so a single clone covers multiple TDs in that field", () => {
+    const original = field(td("a", [1, 5]), td("b", [10, 20]));
+    const sample = { events: original };
+    const edits = new Map<string, [number, number]>([
+      ["events|a", [3, 7]],
+      ["events|b", [12, 18]],
+    ]);
+    const out = applyTemporalDetectionEdits(sample, edits) as {
+      events: { detections: { _id: string; support: [number, number] }[] };
+    };
+    expect(out.events.detections[0].support).toEqual([3, 7]);
+    expect(out.events.detections[1].support).toEqual([12, 18]);
+  });
+
+  it("silently skips edits for missing fields", () => {
+    const sample = { events: field(td("a", [1, 5])) };
+    const out = applyTemporalDetectionEdits(
+      sample,
+      new Map([["ghost|a", [3, 7] as [number, number]]])
+    );
+    // No field touched ⇒ out is the spread clone but events ref is preserved.
+    expect((out as typeof sample).events).toBe(sample.events);
+  });
+
+  it("silently skips edits for missing detections within a field", () => {
+    const original = field(td("a", [1, 5]));
+    const sample = { events: original };
+    const out = applyTemporalDetectionEdits(
+      sample,
+      new Map([["events|ghost", [99, 100] as [number, number]]])
+    ) as {
+      events: { detections: { _id: string; support: [number, number] }[] };
+    };
+    // Field is cloned but detection support unchanged.
+    expect(out.events.detections[0].support).toEqual([1, 5]);
+  });
+
+  it("falls back to `id` when `_id` is missing on the detection", () => {
+    const sample = {
+      events: {
+        _cls: "TemporalDetections" as const,
+        detections: [
+          {
+            _cls: "TemporalDetection",
+            id: "x",
+            support: [1, 5] as [number, number],
+          },
+        ],
+      },
+    };
+    const out = applyTemporalDetectionEdits(
+      sample,
+      new Map([["events|x", [3, 7] as [number, number]]])
+    ) as { events: { detections: { support: [number, number] }[] } };
+    expect(out.events.detections[0].support).toEqual([3, 7]);
+  });
+});

--- a/app/packages/video-annotation/src/pendingTemporalDetectionEdits.ts
+++ b/app/packages/video-annotation/src/pendingTemporalDetectionEdits.ts
@@ -1,0 +1,135 @@
+import { atom, useAtomValue, useSetAtom } from "jotai";
+import { useCallback } from "react";
+import type { RawTemporalDetectionsField } from "./temporalDetectionTracks";
+
+/**
+ * Pending edits to `TemporalDetection.support` made through the timeline's
+ * interval drag handles. Keyed by `${fieldPath}|${detectionId}` so a
+ * given TD has at most one outstanding staged edit; later drags overwrite
+ * earlier ones.
+ *
+ * Two roles:
+ *   1. Optimistic display — {@link FrameLabelsTracks} reads this and
+ *      overlays staged support values onto the sample-derived TD list
+ *      before building tracks, so the bar stays where the user dropped
+ *      it through the server round-trip.
+ *   2. Delta source — `useTemporalDetectionDeltaSupplier` walks the map
+ *      and emits one `replace /<fieldPath>/detections/<index>/support`
+ *      patch op per pending edit on the next autosave tick.
+ *
+ * Cleared on `annotation:persistenceSuccess` and
+ * `annotation:persistenceError` by {@link useRegisterVideoAnnotationEventHandlers}.
+ */
+const pendingTemporalDetectionEditsAtom = atom<
+  ReadonlyMap<string, [number, number]>
+>(new Map());
+
+export const temporalDetectionEditKey = (
+  fieldPath: string,
+  detectionId: string
+): string => `${fieldPath}|${detectionId}`;
+
+export const parseTemporalDetectionEditKey = (
+  key: string
+): { fieldPath: string; detectionId: string } => {
+  const sep = key.indexOf("|");
+  return {
+    fieldPath: key.slice(0, sep),
+    detectionId: key.slice(sep + 1),
+  };
+};
+
+/**
+ * Reactive view of all currently-pending TD support edits.
+ */
+export const useTemporalDetectionPendingEdits = (): ReadonlyMap<
+  string,
+  [number, number]
+> => useAtomValue(pendingTemporalDetectionEditsAtom);
+
+/**
+ * Stage (or overwrite) a `support` edit for a single TD. The next
+ * autosave tick will turn it into a JSON-Patch op via the delta supplier.
+ */
+export const useStageTemporalDetectionSupport = (): ((
+  fieldPath: string,
+  detectionId: string,
+  support: [number, number]
+) => void) => {
+  const set = useSetAtom(pendingTemporalDetectionEditsAtom);
+
+  return useCallback(
+    (fieldPath, detectionId, support) => {
+      set((prev) => {
+        const next = new Map(prev);
+        next.set(temporalDetectionEditKey(fieldPath, detectionId), support);
+
+        return next;
+      });
+    },
+    [set]
+  );
+};
+
+/**
+ * Clear every staged TD support edit. Called by the persistence event
+ * handler on both success (sample is about to refresh with the new
+ * values) and error (revert the optimistic visual; user can re-drag).
+ */
+export const useClearTemporalDetectionEdits = (): (() => void) => {
+  const set = useSetAtom(pendingTemporalDetectionEditsAtom);
+
+  return useCallback(() => {
+    set(new Map());
+  }, [set]);
+};
+
+/**
+ * Return a shallow-cloned copy of `sample` with staged TD support edits
+ * applied to the matching detections. Top-level fields and the
+ * `detections` array of any field touched by an edit are cloned; the
+ * untouched fields stay referentially stable. Edits whose field /
+ * detection no longer exist on the sample are silently skipped.
+ */
+export const applyTemporalDetectionEdits = (
+  sample: Record<string, unknown>,
+  edits: ReadonlyMap<string, [number, number]>
+): Record<string, unknown> => {
+  if (edits.size === 0) {
+    return sample;
+  }
+
+  // Group by field path so we clone each `detections` array at most once
+  // even when multiple TDs in the same field have pending edits.
+  const editsByField = new Map<string, Map<string, [number, number]>>();
+  for (const [key, support] of edits) {
+    const { fieldPath, detectionId } = parseTemporalDetectionEditKey(key);
+    let fieldEdits = editsByField.get(fieldPath);
+    if (!fieldEdits) {
+      fieldEdits = new Map();
+      editsByField.set(fieldPath, fieldEdits);
+    }
+
+    fieldEdits.set(detectionId, support);
+  }
+
+  const next = { ...sample };
+  for (const [fieldPath, fieldEdits] of editsByField) {
+    const field = next[fieldPath] as RawTemporalDetectionsField | undefined;
+    const detections = field?.detections;
+    if (!Array.isArray(detections)) {
+      continue;
+    }
+
+    next[fieldPath] = {
+      ...field,
+      detections: detections.map((d) => {
+        const id = d._id ?? d.id;
+        const support = id ? fieldEdits.get(id) : undefined;
+        return support ? { ...d, support } : d;
+      }),
+    };
+  }
+
+  return next;
+};

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2996,7 +2996,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fiftyone/annotation@workspace:packages/annotation":
+"@fiftyone/annotation@workspace:*, @fiftyone/annotation@workspace:packages/annotation":
   version: 0.0.0-use.local
   resolution: "@fiftyone/annotation@workspace:packages/annotation"
   dependencies:
@@ -3076,7 +3076,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fiftyone/command-bus@workspace:packages/command-bus":
+"@fiftyone/command-bus@workspace:*, @fiftyone/command-bus@workspace:packages/command-bus":
   version: 0.0.0-use.local
   resolution: "@fiftyone/command-bus@workspace:packages/command-bus"
   dependencies:
@@ -3651,6 +3651,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fiftyone/video-annotation@workspace:packages/video-annotation"
   dependencies:
+    "@fiftyone/annotation": "workspace:*"
+    "@fiftyone/command-bus": "workspace:*"
     "@fiftyone/lighter": "workspace:*"
     "@fiftyone/playback": "workspace:*"
     "@fiftyone/state": "workspace:*"


### PR DESCRIPTION
## 🔗 Related Issues

Builds on #7660 

## 📋 What changes are proposed in this pull request?

Adds persistence for temporal detection edits 💾 

## 🧪 How is this patch tested? If it is not, please explain why.

local app + unit tests

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stage and apply temporal detection support edits in the UI with immediate feedback; can clear staged edits.

* **Improvements**
  * Temporal detection edits are included in persistence delta aggregation and cleared after save attempts (success or error).
  * Frame-track initialization refined to avoid premature state flips when tracks resolve synchronously.

* **Bug Fixes**
  * Ensures staged edits don't persist when target detections are missing.

* **Tests**
  * Unit tests added for delta building, edit application, and pending-edit store behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7662?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->