### PR TITLE
Video annotation: timeline toolbar + media info bar

### DIFF
--- a/app/packages/annotation/src/agents/PropagationBrowserAgent.test.ts
+++ b/app/packages/annotation/src/agents/PropagationBrowserAgent.test.ts
@@ -11,10 +11,12 @@ import {
 
 function keyframe(
   id: string,
-  bbox: [number, number, number, number]
+  bbox: [number, number, number, number],
+  _id?: string
 ): SyntheticBox {
   return {
     id,
+    _id,
     label: "car",
     bounding_box: bbox,
     keyframe: true,
@@ -31,8 +33,14 @@ const baseContext = {
 describe("PropagationBrowserAgent.infer", () => {
   it("lerps a bbox between two keyframes and emits one Detection per in-between frame", async () => {
     const agent = new PropagationBrowserAgent();
-    const left = keyframe("k1", [0.0, 0.0, 0.1, 0.1]);
-    const right = keyframe("k2", [1.0, 1.0, 0.1, 0.1]);
+    // For a tracked object both keyframes share one synthetic overlay id
+    // (`instance-<...>`); provenance must record their distinct mongo `_id`s.
+    const left = keyframe("instance-inst-1", [0.0, 0.0, 0.1, 0.1], "oid-left");
+    const right = keyframe(
+      "instance-inst-1",
+      [1.0, 1.0, 0.1, 0.1],
+      "oid-right"
+    );
 
     const context: PropagationContext = {
       ...baseContext,
@@ -41,18 +49,16 @@ describe("PropagationBrowserAgent.infer", () => {
       parentKeyframes: [left, right],
     };
 
-    const result = (await agent.infer(context)) as SyncInferenceResult<
-      PropagationInferenceResult
-    > & { labelId: string };
+    const result = (await agent.infer(
+      context
+    )) as SyncInferenceResult<PropagationInferenceResult> & { labelId: string };
 
     expect(result.type).toBe("sync");
     expect(result.taskType).toBe(AgentTaskType.PROPAGATE);
     expect(result.labelId).toBe("inst-1");
     expect(result.response.perFrame).toHaveLength(9);
 
-    const midpoint = result.response.perFrame.find(
-      (e) => e.frameNumber === 10
-    );
+    const midpoint = result.response.perFrame.find((e) => e.frameNumber === 10);
     expect(midpoint?.detection.bounding_box).toEqual([0.5, 0.5, 0.1, 0.1]);
     expect(midpoint?.detection.keyframe).toBe(false);
     expect(midpoint?.detection.instance).toEqual({
@@ -61,7 +67,7 @@ describe("PropagationBrowserAgent.infer", () => {
     });
     expect(midpoint?.detection.propagation).toMatchObject({
       method: "linear",
-      parent_keyframes: ["k1", "k2"],
+      parent_keyframes: ["oid-left", "oid-right"],
     });
   });
 });

--- a/app/packages/annotation/src/agents/PropagationBrowserAgent.ts
+++ b/app/packages/annotation/src/agents/PropagationBrowserAgent.ts
@@ -86,6 +86,15 @@ export class PropagationBrowserAgent
       const span: number = context.toFrame - context.fromFrame;
       const runId: string = generateObjectIdHex();
 
+      // Provenance records the *mongo* `_id`s of the two source keyframes,
+      // not their cross-frame-stable synthetic overlay ids (`instance-<...>`,
+      // identical for both ends of a tracked object). Fall back to the
+      // synthetic id only if a keyframe somehow lacks a persisted `_id`.
+      const parentKeyframeIds: [string, string] = [
+        leftKeyframe._id ?? leftKeyframe.id,
+        rightKeyframe._id ?? rightKeyframe.id,
+      ];
+
       const perFrame: PropagationInferenceResult["perFrame"] = [];
       range(context.fromFrame + 1, context.toFrame).forEach((n) => {
         const t: number = (n - context.fromFrame) / span;
@@ -100,7 +109,7 @@ export class PropagationBrowserAgent
           propagation: {
             method: "linear",
             run_id: runId,
-            parent_keyframes: [leftKeyframe.id, rightKeyframe.id],
+            parent_keyframes: parentKeyframeIds,
           },
         };
         perFrame.push({ frameNumber: n, detection });

--- a/app/packages/annotation/src/agents/hooks/useApplyPropagationResult.ts
+++ b/app/packages/annotation/src/agents/hooks/useApplyPropagationResult.ts
@@ -30,7 +30,23 @@ export const useApplyPropagationResult = (): PropagationResultHandler => {
       if (result.type !== "sync") return;
 
       result.response.perFrame.forEach(({ frameNumber, detection }) => {
-        stream.updateLabel(frameNumber, detection);
+        // The agent mints a fresh `_id` per interpolated frame, but the
+        // in-between frames of a tracked object usually already carry a
+        // detection for this instance. `updateLabel` matches by `_id`, so a
+        // fresh id would append a duplicate (collapsed in rendering by the
+        // shared `instance._id`, but doubled in the data and persisted as an
+        // `add`). Reuse the existing detection's `_id` when one is present so
+        // the propagation overwrites it in place (a `replace`); fall back to
+        // the minted id only for genuine gaps in the track (a correct `add`).
+        const snapshot = stream.getValue((frameNumber - 1) / stream.fps);
+        const existing = snapshot?.detections.find(
+          (d) => d.instance?._id === detection.instance?._id
+        );
+
+        stream.updateLabel(
+          frameNumber,
+          existing?._id ? { ...detection, _id: existing._id } : detection
+        );
       });
     },
     [stream]

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationKeybindings.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationKeybindings.ts
@@ -1,9 +1,11 @@
 import { useCommandBus } from "@fiftyone/command-bus";
 import { KnownContexts, useKeyBindings } from "@fiftyone/commands";
 import { useLighter } from "@fiftyone/lighter";
-import { useFrameLabelsStream } from "@fiftyone/video-annotation";
+import {
+  resolvePropagationTarget,
+  useFrameLabelsStream,
+} from "@fiftyone/video-annotation";
 import { useRef } from "react";
-import { frameAt } from "../../../playback/src/lib/playback/utils";
 import { usePlayhead } from "../../../playback/src/lib/playback/use-playback-state";
 import { MarkKeyframeCommand, PropagateCommand } from "../commands";
 
@@ -40,9 +42,7 @@ export const useRegisterVideoAnnotationKeybindings = () => {
           if (!scene) return;
           const ids = scene.getSelectedOverlayIds();
           if (ids.length === 0) return;
-          void bus.execute(
-            new MarkKeyframeCommand(playheadRef.current, ids)
-          );
+          void bus.execute(new MarkKeyframeCommand(playheadRef.current, ids));
         },
         label: "Mark keyframe",
         description:
@@ -56,44 +56,20 @@ export const useRegisterVideoAnnotationKeybindings = () => {
           const s = streamRef.current;
           if (!s) return;
           const ids = scene.getSelectedOverlayIds();
-          if (ids.length === 0) return;
 
-          const currentFrame = frameAt(
-            playheadRef.current,
-            s.fps,
-            s.totalFrames
-          );
-          const currentSnapshot = s.getValue(playheadRef.current);
-          if (!currentSnapshot) return;
-
-          const selected = currentSnapshot.detections.find((d) =>
-            ids.includes(d.id)
-          );
-          const instanceId = selected?.instance?._id;
-          if (!instanceId) return;
-
-          // Walk the cached frames to locate the bracketing keyframes:
-          // the most recent keyframe at or before the playhead, and the
-          // next keyframe strictly after.
-          let leftFrame: number | null = null;
-          let rightFrame: number | null = null;
-          for (let f = 1; f <= s.totalFrames; f++) {
-            const snap = s.getValue((f - 1) / s.fps);
-            if (!snap) continue;
-            const det = snap.detections.find(
-              (d) => d.keyframe && d.instance?._id === instanceId
-            );
-            if (!det) continue;
-            if (f <= currentFrame) leftFrame = f;
-            if (f > currentFrame && rightFrame === null) {
-              rightFrame = f;
-              break;
-            }
-          }
-          if (leftFrame === null || rightFrame === null) return;
+          // Shared with the timeline toolbar so the two can't disagree
+          // about when propagation is eligible or which keyframes bracket
+          // the playhead.
+          const target = resolvePropagationTarget(s, ids, playheadRef.current);
+          if (!target.ok) return;
 
           void bus.execute(
-            new PropagateCommand(instanceId, leftFrame, rightFrame, "linear")
+            new PropagateCommand(
+              target.instanceId,
+              target.fromFrame,
+              target.toFrame,
+              "linear"
+            )
           );
         },
         label: "Propagate",

--- a/app/packages/playback/src/views/TimelineControls/TimelineControls.tsx
+++ b/app/packages/playback/src/views/TimelineControls/TimelineControls.tsx
@@ -1,6 +1,6 @@
 import { Button, IconName, Size, Variant } from "@voxel51/voodo";
 import clsx from "clsx";
-import React from "react";
+import React, { type ReactNode } from "react";
 import { usePlayback } from "../../lib/playback/PlaybackProvider";
 import { useIsPlaying } from "../../lib/playback/use-playback-state";
 import LoopBounds from "../Loop/LoopBounds";
@@ -15,9 +15,18 @@ export interface TimelineControlsProps {
    * acts as a "show / hide tracks" affordance.
    */
   onToggle?: () => void;
+  /**
+   * Optional content rendered between the playback control buttons and
+   * the playhead time display. The video annotation surface slots its
+   * Mark Keyframe / Propagate toolbar here.
+   */
+  controlsSlot?: ReactNode;
 }
 
-const TimelineControls: React.FC<TimelineControlsProps> = ({ onToggle }) => {
+const TimelineControls: React.FC<TimelineControlsProps> = ({
+  onToggle,
+  controlsSlot,
+}) => {
   const isPlaying = useIsPlaying();
   const { play, pause, stepBack, stepForward } = usePlayback();
 
@@ -77,6 +86,8 @@ const TimelineControls: React.FC<TimelineControlsProps> = ({ onToggle }) => {
         aria-label="Step forward"
         onClick={stepForward}
       />
+
+      {controlsSlot}
 
       <span
         className={styles.divider}

--- a/app/packages/playback/src/views/TimelineHeader/TimelineHeader.tsx
+++ b/app/packages/playback/src/views/TimelineHeader/TimelineHeader.tsx
@@ -18,6 +18,13 @@ export interface TimelineHeaderProps {
    */
   onToggle?: () => void;
   /**
+   * Optional content forwarded to {@link TimelineControls}' `controlsSlot`
+   * slot — rendered between the playback control buttons and the playhead
+   * time display. The video annotation surface slots its action toolbar
+   * (Mark Keyframe / Propagate) here, per the mocks.
+   */
+  controlsSlot?: ReactNode;
+  /**
    * Content rendered below the ruler, still inside the always-visible
    * header region. Used by `TimelineWithTracks` to keep pinned tracks
    * on-screen even when the drawer body is collapsed.
@@ -35,11 +42,12 @@ const TimelineHeader: React.FC<TimelineHeaderProps> = ({
   labelWidth,
   zoomRef,
   onToggle,
+  controlsSlot,
   children,
 }) => {
   return (
     <div className={styles.root} data-testid="timeline-header-root">
-      <TimelineControls onToggle={onToggle} />
+      <TimelineControls onToggle={onToggle} controlsSlot={controlsSlot} />
       <TimelineRuler labelWidth={labelWidth} zoomRef={zoomRef} />
       {children ? <div className={styles.belowRuler}>{children}</div> : null}
     </div>

--- a/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.tsx
+++ b/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.tsx
@@ -35,6 +35,12 @@ export interface TimelineWithTracksProps {
   maxSize?: number;
   className?: string;
   /**
+   * Optional content rendered between the playback control buttons and the
+   * playhead time display. Forwarded to {@link TimelineHeader}'s
+   * `controlsSlot`; renders in both the empty-timeline and drawer layouts.
+   */
+  controlsSlot?: React.ReactNode;
+  /**
    * Per-row prop override. Returned partial is merged onto the props
    * passed to each {@link TimelineTrack}.
    */
@@ -61,6 +67,7 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
   defaultSize = TIMELINE_DEFAULT_DRAWER_SIZE,
   maxSize = TIMELINE_DRAWER_MAX_SIZE,
   className,
+  controlsSlot,
   decorateTrack,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -130,7 +137,11 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
         ref={containerRef}
         className={clsx(styles.root, styles.noTracks, className)}
       >
-        <TimelineHeader labelWidth={labelWidth} zoomRef={containerRef} />
+        <TimelineHeader
+          labelWidth={labelWidth}
+          zoomRef={containerRef}
+          controlsSlot={controlsSlot}
+        />
       </div>
     );
   }
@@ -150,6 +161,7 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
             labelWidth={labelWidth}
             zoomRef={containerRef}
             onToggle={toggle}
+            controlsSlot={controlsSlot}
           >
             {/* Pinned tracks live here when the drawer is closed so they
                 stay on-screen. The host div is position:relative so the

--- a/app/packages/video-annotation/index.ts
+++ b/app/packages/video-annotation/index.ts
@@ -15,6 +15,8 @@ export {
 export { ImaVidImageStream } from "./src/ImaVidImageStream";
 export type { ImaVidImageFrame } from "./src/ImaVidImageStream";
 export { useFrameLabelsStream } from "./src/frameLabelsStream";
+export { resolvePropagationTarget } from "./src/propagationTarget";
+export type { PropagationTarget } from "./src/propagationTarget";
 export { VideoFrameLabelsStream } from "./src/VideoFrameLabelsStream";
 export type { LocalDetection } from "./src/VideoFrameLabelsStream";
 export { buildTemporalDetectionTracks } from "./src/temporalDetectionTracks";

--- a/app/packages/video-annotation/index.ts
+++ b/app/packages/video-annotation/index.ts
@@ -15,6 +15,8 @@ export {
 export { ImaVidImageStream } from "./src/ImaVidImageStream";
 export type { ImaVidImageFrame } from "./src/ImaVidImageStream";
 export { useFrameLabelsStream } from "./src/frameLabelsStream";
+export { useVideoAnnotationStatus } from "./src/videoAnnotationStatus";
+export type { VideoAnnotationStatusContent } from "./src/videoAnnotationStatus";
 export { resolvePropagationTarget } from "./src/propagationTarget";
 export type { PropagationTarget } from "./src/propagationTarget";
 export { VideoFrameLabelsStream } from "./src/VideoFrameLabelsStream";

--- a/app/packages/video-annotation/package.json
+++ b/app/packages/video-annotation/package.json
@@ -5,6 +5,7 @@
     "dependencies": {
         "@fiftyone/annotation": "workspace:*",
         "@fiftyone/command-bus": "workspace:*",
+        "@fiftyone/components": "workspace:*",
         "@fiftyone/lighter": "workspace:*",
         "@fiftyone/playback": "workspace:*",
         "@fiftyone/state": "workspace:*",

--- a/app/packages/video-annotation/src/FrameLabels.tsx
+++ b/app/packages/video-annotation/src/FrameLabels.tsx
@@ -46,6 +46,7 @@ import {
   type TemporalDetectionLabelLike,
 } from "./temporalDetectionTracks";
 import { VideoFrameLabelsStream } from "./VideoFrameLabelsStream";
+import { VideoAnnotationToolbar } from "./VideoAnnotationToolbar";
 
 const DEFAULT_FRAME_FIELD = "frames.detections";
 
@@ -365,7 +366,10 @@ export const FrameLabelsTracks: React.FC<{ sample?: ModalSample }> = ({
       tracks={tracks}
       initialPinnedIds={pinned}
     >
-      <TimelineWithTracks decorateTrack={decorateTrack} />
+      <TimelineWithTracks
+        decorateTrack={decorateTrack}
+        controlsSlot={<VideoAnnotationToolbar />}
+      />
     </TrackProvider>
   );
 };

--- a/app/packages/video-annotation/src/VideoAnnotationSurface.tsx
+++ b/app/packages/video-annotation/src/VideoAnnotationSurface.tsx
@@ -17,6 +17,7 @@ import {
   SYNTHETIC_FIELD,
   SyntheticTrackTimeline,
 } from "./SyntheticLabels";
+import { VideoAnnotationTopBar } from "./VideoAnnotationTopBar";
 import { VideoLighterTile } from "./VideoLighterTile";
 import styles from "./VideoAnnotationSurface.module.css";
 
@@ -126,6 +127,7 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
   const layout = (
     <div className={styles.root}>
       <LinkedOverlayStateBridge />
+      <VideoAnnotationTopBar sample={sample} />
       <div className={styles.media}>{media}</div>
       <div className={styles.timeline}>
         {labelsMode === "synthetic" ? (

--- a/app/packages/video-annotation/src/VideoAnnotationToolbar.module.css
+++ b/app/packages/video-annotation/src/VideoAnnotationToolbar.module.css
@@ -1,0 +1,12 @@
+/* Inline cluster sitting in the controls row, between the playback
+   buttons and the playhead time display. */
+.root {
+  margin: 0 6px;
+}
+
+/* Tooltip anchors to this wrapper so the tip still shows while the inner
+   button is disabled (a disabled <button> swallows its own pointer
+   events). */
+.slot {
+  display: inline-flex;
+}

--- a/app/packages/video-annotation/src/VideoAnnotationToolbar.tsx
+++ b/app/packages/video-annotation/src/VideoAnnotationToolbar.tsx
@@ -1,0 +1,115 @@
+import type { ToolbarActionItem } from "@fiftyone/components";
+import {
+  Align,
+  Button,
+  Orientation,
+  Size,
+  Spacing,
+  Stack,
+  Text,
+  TextColor,
+  TextVariant,
+  Tooltip,
+  Variant,
+} from "@voxel51/voodo";
+import React from "react";
+import { useVideoAnnotationActions } from "./useVideoAnnotationActions";
+import styles from "./VideoAnnotationToolbar.module.css";
+
+/**
+ * Renders a single {@link ToolbarActionItem} as a tooltip-wrapped icon button.
+ * Mirrors `ActionToolbar`'s per-action handling: `customComponent` is an escape
+ * hatch, the action's `icon` node is the button content, and the tooltip shows
+ * the shortcut alongside the hint.
+ */
+const Action: React.FC<{ action: ToolbarActionItem }> = ({ action }) => {
+  if (action.customComponent) {
+    return <>{action.customComponent}</>;
+  }
+
+  const button = (
+    <Button
+      borderless
+      variant={Variant.Secondary}
+      size={Size.Xs}
+      disabled={action.isDisabled}
+      aria-label={action.label}
+      onClick={action.onClick}
+    >
+      {action.icon}
+    </Button>
+  );
+
+  if (!action.tooltip && !action.shortcut) {
+    // A disabled <button> swallows pointer events, so even the no-tooltip
+    // case wraps in the span for consistent layout.
+    return <span className={styles.slot}>{button}</span>;
+  }
+
+  return (
+    <Tooltip
+      portal
+      content={
+        <Stack
+          orientation={Orientation.Row}
+          spacing={Spacing.Sm}
+          align={Align.Center}
+        >
+          {action.shortcut && (
+            <Text variant={TextVariant.Sm} color={TextColor.Secondary}>
+              ({action.shortcut})
+            </Text>
+          )}
+          <Text variant={TextVariant.Sm}>{action.tooltip ?? action.label}</Text>
+        </Stack>
+      }
+    >
+      {/* Tooltip anchors to the span, not the (possibly disabled) button. */}
+      <span className={styles.slot}>{button}</span>
+    </Tooltip>
+  );
+};
+
+/**
+ * Action bar between the playback controls and the timestamp.
+ *
+ * Thin, data-driven renderer: all behavior lives in
+ * {@link useVideoAnnotationActions}, which returns `ToolbarActionGroup`s in the
+ * same shape `ActionToolbar` consumes elsewhere. This component only lays the
+ * groups out inline in the controls row — the shared `ActionToolbar` renders a
+ * floating, draggable palette, which is wrong for this slot. Add functionality
+ * by editing the hook, not this file.
+ */
+export const VideoAnnotationToolbar: React.FC = () => {
+  const groups = useVideoAnnotationActions();
+
+  return (
+    <Stack
+      orientation={Orientation.Row}
+      align={Align.Center}
+      spacing={Spacing.Sm}
+      className={styles.root}
+    >
+      {groups
+        .filter(
+          (group) =>
+            !group.isHidden &&
+            group.actions.some((action) => action.isVisible !== false)
+        )
+        .map((group) => (
+          <Stack
+            key={group.id}
+            orientation={Orientation.Row}
+            align={Align.Center}
+            spacing={Spacing.Xs}
+          >
+            {group.actions
+              .filter((action) => action.isVisible !== false)
+              .map((action) => (
+                <Action key={action.id} action={action} />
+              ))}
+          </Stack>
+        ))}
+    </Stack>
+  );
+};

--- a/app/packages/video-annotation/src/VideoAnnotationTopBar.module.css
+++ b/app/packages/video-annotation/src/VideoAnnotationTopBar.module.css
@@ -1,0 +1,29 @@
+.root {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  height: 36px;
+  padding: 0 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--bg-panel, #1a1a1a);
+  user-select: none;
+  white-space: nowrap;
+}
+
+/* Thin vertical rule between media facts. */
+.sep {
+  width: 1px;
+  height: 12px;
+  background: rgba(255, 255, 255, 0.18);
+}
+
+/* Right-hand status slot; min-width 0 so its content can truncate rather
+   than push the bar wider than the surface. */
+.status {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  overflow: hidden;
+}

--- a/app/packages/video-annotation/src/VideoAnnotationTopBar.tsx
+++ b/app/packages/video-annotation/src/VideoAnnotationTopBar.tsx
@@ -1,0 +1,129 @@
+import type { ModalSample } from "@fiftyone/state";
+import {
+  Align,
+  Orientation,
+  Spacing,
+  Stack,
+  Text,
+  TextColor,
+  TextVariant,
+} from "@voxel51/voodo";
+import React, { useMemo } from "react";
+import styles from "./VideoAnnotationTopBar.module.css";
+import { useVideoAnnotationStatusContent } from "./videoAnnotationStatus";
+
+/**
+ * Media facts shown at the top-left of the bar. Resolution and codec are
+ * optional — they're absent on samples whose `VideoMetadata` wasn't fully
+ * populated, so the bar simply omits them rather than rendering blanks.
+ */
+interface MediaInfo {
+  filename: string;
+  resolution: string | null;
+  fps: string | null;
+  codec: string | null;
+}
+
+type VideoMetadataLike = {
+  frame_width?: unknown;
+  frame_height?: unknown;
+  encoding_str?: unknown;
+};
+
+const basename = (filepath: string): string => {
+  const cleaned = filepath.replace(/[\\/]+$/, "");
+  const idx = Math.max(cleaned.lastIndexOf("/"), cleaned.lastIndexOf("\\"));
+
+  return idx >= 0 ? cleaned.slice(idx + 1) : cleaned;
+};
+
+const finitePositive = (value: unknown): number | null =>
+  typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : null;
+
+/** Format fps trimming trailing zeros: 30 → "30 fps", 29.97 → "29.97 fps". */
+const formatFps = (fps: number): string => `${Number(fps.toFixed(2))} fps`;
+
+const useMediaInfo = (sample: ModalSample): MediaInfo => {
+  return useMemo(() => {
+    const metadata = (
+      sample.sample as { metadata?: VideoMetadataLike } | undefined
+    )?.metadata;
+
+    const width = finitePositive(metadata?.frame_width);
+    const height = finitePositive(metadata?.frame_height);
+    const fps = finitePositive(sample.frameRate);
+    const codec =
+      typeof metadata?.encoding_str === "string" && metadata.encoding_str
+        ? metadata.encoding_str
+        : null;
+
+    return {
+      filename: basename(sample.sample.filepath),
+      resolution: width && height ? `${width}×${height}` : null,
+      fps: fps ? formatFps(fps) : null,
+      codec,
+    };
+  }, [sample]);
+};
+
+const MetaItem: React.FC<{ children: React.ReactNode; muted?: boolean }> = ({
+  children,
+  muted,
+}) => (
+  <Text
+    variant={TextVariant.Sm}
+    color={muted ? TextColor.Secondary : TextColor.Primary}
+  >
+    {children}
+  </Text>
+);
+
+/**
+ * Top bar for the video annotation surface. Left side shows the open sample's
+ * media facts (filename, resolution, fps, codec when available); the right
+ * side is a programmatically-controllable status slot driven by
+ * {@link useVideoAnnotationStatus} — e.g. propagation progress.
+ *
+ * Mounted as the first row of the surface layout (above the media region).
+ */
+export const VideoAnnotationTopBar: React.FC<{ sample: ModalSample }> = ({
+  sample,
+}) => {
+  const info = useMediaInfo(sample);
+  const status = useVideoAnnotationStatusContent();
+
+  return (
+    <div className={styles.root} data-cy="video-annotation-top-bar">
+      <Stack
+        orientation={Orientation.Row}
+        align={Align.Center}
+        spacing={Spacing.Sm}
+      >
+        <MetaItem>{info.filename}</MetaItem>
+        {info.resolution && (
+          <>
+            <span className={styles.sep} aria-hidden />
+            <MetaItem muted>{info.resolution}</MetaItem>
+          </>
+        )}
+        {info.fps && (
+          <>
+            <span className={styles.sep} aria-hidden />
+            <MetaItem muted>{info.fps}</MetaItem>
+          </>
+        )}
+        {info.codec && (
+          <>
+            <span className={styles.sep} aria-hidden />
+            <MetaItem muted>{info.codec}</MetaItem>
+          </>
+        )}
+      </Stack>
+      <div className={styles.status} data-cy="video-annotation-status-slot">
+        {status}
+      </div>
+    </div>
+  );
+};

--- a/app/packages/video-annotation/src/propagationTarget.ts
+++ b/app/packages/video-annotation/src/propagationTarget.ts
@@ -1,0 +1,103 @@
+import { frameAt } from "../../playback/src/lib/playback/utils";
+import type { VideoFrameLabelsStream } from "./VideoFrameLabelsStream";
+
+/**
+ * Resolved input for a propagation run, or the reason one can't run yet.
+ *
+ * The `reason` strings are user-facing — they surface in the toolbar's
+ * Propagate tooltip when the button is disabled, so they double as the
+ * "why didn't this trigger?" diagnostic.
+ */
+export type PropagationTarget =
+  | {
+      ok: true;
+      /** `Instance._id` shared by the selected detection's keyframes. */
+      instanceId: string;
+      /** Frame of the bracketing keyframe at or before the playhead. */
+      fromFrame: number;
+      /** Frame of the first keyframe strictly after the playhead. */
+      toFrame: number;
+    }
+  | { ok: false; reason: string };
+
+/**
+ * Given the active stream, the currently-selected overlay ids, and the
+ * visual playhead time, work out whether a linear-interpolation
+ * propagation can run and, if so, between which keyframes.
+ *
+ * Shared by the `-` keybinding and the timeline toolbar so the two can't
+ * disagree about eligibility. Pure (no React, no atoms) so it's trivially
+ * unit-testable and callable from either a key handler or a render pass.
+ *
+ * Mirrors the bracketing-keyframe walk that previously lived inline in the
+ * keybinding: the most recent keyframe at or before the playhead is the
+ * left bracket, the first keyframe strictly after it is the right bracket.
+ */
+export function resolvePropagationTarget(
+  stream: VideoFrameLabelsStream,
+  selectedIds: readonly string[],
+  time: number
+): PropagationTarget {
+  if (selectedIds.length === 0) {
+    return { ok: false, reason: "Select a tracked object to propagate." };
+  }
+
+  const snapshot = stream.getValue(time);
+  if (!snapshot) {
+    return { ok: false, reason: "No labels loaded at the current frame yet." };
+  }
+
+  const selected = snapshot.detections.find((d) => selectedIds.includes(d.id));
+  if (!selected) {
+    return {
+      ok: false,
+      reason: "Selected object isn't present at this frame.",
+    };
+  }
+
+  const instanceId = selected.instance?._id;
+  if (!instanceId) {
+    return {
+      ok: false,
+      reason:
+        "Selected object has no instance id — draw it as a tracked box first.",
+    };
+  }
+
+  const currentFrame = frameAt(time, stream.fps, stream.totalFrames);
+
+  // Walk the cached frames for the bracketing keyframes: the most recent
+  // keyframe at or before the playhead (left), and the first keyframe
+  // strictly after (right). Left keeps updating until the loop hits a
+  // frame past the playhead, at which point right is locked in.
+  let leftFrame: number | null = null;
+  let rightFrame: number | null = null;
+  for (let f = 1; f <= stream.totalFrames; f++) {
+    const snap = stream.getValue((f - 1) / stream.fps);
+    if (!snap) continue;
+    const det = snap.detections.find(
+      (d) => d.keyframe && d.instance?._id === instanceId
+    );
+    if (!det) continue;
+    if (f <= currentFrame) leftFrame = f;
+    if (f > currentFrame && rightFrame === null) {
+      rightFrame = f;
+      break;
+    }
+  }
+
+  if (leftFrame === null && rightFrame === null) {
+    return {
+      ok: false,
+      reason: "No keyframes on this object yet — mark at least two (press K).",
+    };
+  }
+  if (leftFrame === null) {
+    return { ok: false, reason: "Need a keyframe at or before this frame." };
+  }
+  if (rightFrame === null) {
+    return { ok: false, reason: "Need a keyframe after this frame." };
+  }
+
+  return { ok: true, instanceId, fromFrame: leftFrame, toFrame: rightFrame };
+}

--- a/app/packages/video-annotation/src/useVideoAnnotationActions.tsx
+++ b/app/packages/video-annotation/src/useVideoAnnotationActions.tsx
@@ -1,0 +1,101 @@
+import { MarkKeyframeCommand, PropagateCommand } from "@fiftyone/annotation";
+import { useCommandBus } from "@fiftyone/command-bus";
+import type { ToolbarActionGroup } from "@fiftyone/components";
+import { Icon, IconName, Size } from "@voxel51/voodo";
+import { useAtomValue } from "jotai";
+import { useMemo } from "react";
+import { usePlayhead } from "../../playback/src/lib/playback/use-playback-state";
+import { useFrameLabelsStream } from "./frameLabelsStream";
+import { resolvePropagationTarget } from "./propagationTarget";
+import { selectedOverlayIds } from "./useLinkedOverlayState";
+
+/**
+ * Builds the data-driven config for the video annotation toolbar, mirroring
+ * the `ToolbarActionGroup` pattern used by `ActionToolbar` (segmentation, 3D).
+ *
+ * This hook is the single extension point for toolbar functionality: to add a
+ * button, append a {@link ToolbarActionItem} to a group's `actions` (or add a
+ * new group). Each item owns its own enablement, tooltip, and dispatch, so the
+ * renderer stays dumb and the toolbar doesn't grow into a monolith as features
+ * land. Reactive to the visual playhead and the intentional-selection atom, so
+ * enabled state and tooltips track the user scrubbing / selecting in real time.
+ *
+ * Mount inside the surface's `<PlaybackProvider>` + command bus (it is, via
+ * `FrameLabelsTracks`).
+ */
+export const useVideoAnnotationActions = (): ToolbarActionGroup[] => {
+  const bus = useCommandBus();
+  const stream = useFrameLabelsStream();
+  const playhead = usePlayhead();
+  const selected = useAtomValue(selectedOverlayIds);
+
+  // Selection atom is keyed on the synthetic overlay id, the same id the
+  // stream snapshot and command handlers agree on.
+  const selectedIds = useMemo(() => Array.from(selected), [selected]);
+  const hasSelection = selectedIds.length > 0;
+
+  // Recomputed each playhead tick / selection change so the Propagate
+  // affordance reflects the current frame's bracketing keyframes. When
+  // disabled, `reason` becomes the tooltip — the "why can't I propagate?"
+  // diagnostic.
+  const target = useMemo(() => {
+    if (!stream) {
+      return { ok: false as const, reason: "No active video stream." };
+    }
+    return resolvePropagationTarget(stream, selectedIds, playhead);
+  }, [stream, selectedIds, playhead]);
+
+  return useMemo<ToolbarActionGroup[]>(
+    () => [
+      {
+        id: "video-annotation-edit",
+        label: "Edit",
+        actions: [
+          {
+            id: "mark-keyframe",
+            label: "Mark Keyframe",
+            icon: <Icon name={IconName.VAL} size={Size.Sm} />,
+            shortcut: "K",
+            tooltip: hasSelection
+              ? "Toggle keyframe at this frame"
+              : "Select a label to mark a keyframe",
+            isDisabled: !hasSelection,
+            onClick: () => {
+              if (!hasSelection) return;
+              void bus.execute(new MarkKeyframeCommand(playhead, selectedIds));
+            },
+          },
+          {
+            id: "propagate",
+            label: "Propagate",
+            icon: <Icon name={IconName.AI} size={Size.Sm} />,
+            shortcut: "-",
+            tooltip: target.ok
+              ? `Interpolate frames ${target.fromFrame}–${target.toFrame}`
+              : target.reason,
+            isDisabled: !target.ok,
+            onClick: () => {
+              if (!target.ok) return;
+              // Dispatch echo — the visible counterpart to debugging the
+              // silent keybinding path.
+              console.debug("[va-toolbar] propagate", {
+                instanceId: target.instanceId,
+                fromFrame: target.fromFrame,
+                toFrame: target.toFrame,
+              });
+              void bus.execute(
+                new PropagateCommand(
+                  target.instanceId,
+                  target.fromFrame,
+                  target.toFrame,
+                  "linear"
+                )
+              );
+            },
+          },
+        ],
+      },
+    ],
+    [bus, hasSelection, playhead, selectedIds, target]
+  );
+};

--- a/app/packages/video-annotation/src/videoAnnotationStatus.ts
+++ b/app/packages/video-annotation/src/videoAnnotationStatus.ts
@@ -1,0 +1,37 @@
+import { atom, type PrimitiveAtom, useAtomValue, useSetAtom } from "jotai";
+import type { ReactElement } from "react";
+import { useMemo } from "react";
+
+export type VideoAnnotationStatusContent = ReactElement | null;
+
+/**
+ * Module-private content for the top bar's right-hand status slot. A plain
+ * module-level atom (not a TilingProvider/Context-scoped store) so writers
+ * mounted anywhere in the surface and the bar's reader resolve to the same
+ * modal-default jotai store — see the "No TilingProvider" note in
+ * {@link VideoAnnotationSurface}.
+ */
+const statusContentAtom: PrimitiveAtom<VideoAnnotationStatusContent> =
+  atom<VideoAnnotationStatusContent>(null);
+
+/**
+ * Programmatic control over the top bar's status slot. Call
+ * `setContent(<PropagationProgress />)` to show something (e.g. propagation
+ * progress), `setContent(null)` to clear it. Last-writer-wins; rely on
+ * conditional mounting / effect cleanup so at most one writer is live.
+ *
+ * @example
+ * const { setContent } = useVideoAnnotationStatus();
+ * useEffect(() => {
+ *   setContent(<StatusItem icon={<Spinner />} label={`${pct}%`} />);
+ *   return () => setContent(null);
+ * }, [pct, setContent]);
+ */
+export const useVideoAnnotationStatus = () => {
+  const setContent = useSetAtom(statusContentAtom);
+  return useMemo(() => ({ setContent }), [setContent]);
+};
+
+/** Reads the current status-slot content. Internal to the top bar. */
+export const useVideoAnnotationStatusContent = () =>
+  useAtomValue(statusContentAtom);

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3112,7 +3112,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fiftyone/components@npm:*, @fiftyone/components@workspace:packages/components":
+"@fiftyone/components@npm:*, @fiftyone/components@workspace:*, @fiftyone/components@workspace:packages/components":
   version: 0.0.0-use.local
   resolution: "@fiftyone/components@workspace:packages/components"
   dependencies:
@@ -3653,6 +3653,7 @@ __metadata:
   dependencies:
     "@fiftyone/annotation": "workspace:*"
     "@fiftyone/command-bus": "workspace:*"
+    "@fiftyone/components": "workspace:*"
     "@fiftyone/lighter": "workspace:*"
     "@fiftyone/playback": "workspace:*"
     "@fiftyone/state": "workspace:*"


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

Adds a toolbar and a media information bar to the video annotation surface.

- **Timeline controls slot** — a generic `controlsSlot` in the timeline header for injecting custom controls between the transport buttons and the playhead time display. Defaults to nothing; existing timelines are unchanged.
- **Annotation toolbar** — a data-driven toolbar rendered in that slot, exposing Mark Keyframe and Propagate (linear interpolation between keyframes). Eligibility and bracketing-keyframe resolution are shared with the keybinding so they can't drift; Propagate is disabled-with-a-reason when it can't fire.
- **Media top bar** — shows filename, resolution, fps, and codec on the left and a programmatic status slot on the right.
- **Propagation fix** — applying a propagation reuses the existing per-frame detection `_id` (an in-place replace rather than a duplicate add) and records the parent keyframes' ids in the provenance blob.

Stacked on #7686.

## 🧪 How is this patch tested? If it is not, please explain why.

Tested locally in the app.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
