### PR TITLE
Add agentic plugin guide and Enterprise skill badges

### DIFF
--- a/docs/scripts/generate_skills_docs.py
+++ b/docs/scripts/generate_skills_docs.py
@@ -9,12 +9,14 @@ repository.
 """
 
 import logging
+import os
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Optional
 
 import requests
+import yaml
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -28,6 +30,13 @@ MARKETPLACE_URL = (
     ".claude-plugin/marketplace.json"
 )
 
+INTERNAL_SKILLS_API_BASE = (
+    "https://api.github.com/repos/voxel51/fiftyone-internal-skills/contents/"
+)
+INTERNAL_SKILLS_GITHUB_BASE = (
+    "https://github.com/voxel51/fiftyone-internal-skills/blob/main/"
+)
+
 
 @dataclass
 class Skill:
@@ -39,16 +48,118 @@ class Skill:
     slug: str
     category: str = "General"
     emoji: str = "🤖"
+    extra_tags: List[str] = field(default_factory=list)
+    prefetched_readme: Optional[str] = field(default=None, repr=False)
 
 
-def _fetch(url: str, parse_json: bool = False):
+def _fetch(url: str, parse_json: bool = False, token: Optional[str] = None):
+    """Fetch a URL, optionally with a GitHub token, and return the content."""
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
     try:
-        resp = requests.get(url, timeout=10)
+        resp = requests.get(url, headers=headers, timeout=10)
         resp.raise_for_status()
         return resp.json() if parse_json else resp.text
     except requests.RequestException as e:
         logger.warning(f"Failed to fetch {url}: {e}")
     return None
+
+
+def _parse_skill_frontmatter(content: str) -> dict:
+    """Parse YAML frontmatter from a SKILL.md file."""
+    parts = re.split(r"^---\s*$", content, maxsplit=2, flags=re.MULTILINE)
+    if len(parts) < 3:
+        return {}
+    try:
+        result = yaml.safe_load(parts[1])
+        return result if isinstance(result, dict) else {}
+    except yaml.YAMLError:
+        return {}
+
+
+def _fetch_internal_file(path: str, token: str) -> Optional[str]:
+    """Fetch a file from fiftyone-internal-skills via the GitHub API."""
+    headers = {
+        "Accept": "application/vnd.github.v3.raw",
+        "Authorization": f"Bearer {token}",
+    }
+    try:
+        resp = requests.get(
+            f"{INTERNAL_SKILLS_API_BASE}{path}", headers=headers, timeout=10
+        )
+        resp.raise_for_status()
+        return resp.text
+    except requests.RequestException as e:
+        logger.warning(f"Failed to fetch {path}: {e}")
+    return None
+
+
+def _fetch_enterprise_skills() -> List[Skill]:
+    """Fetch skills from the fiftyone-internal-skills plugin repo."""
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        logger.warning("GITHUB_TOKEN not set — skipping enterprise skills")
+        return []
+
+    yml_content = _fetch_internal_file("fiftyone.yml", token)
+    if not yml_content:
+        logger.warning(
+            "Could not fetch fiftyone.yml from fiftyone-internal-skills"
+        )
+        return []
+
+    try:
+        plugin_config = yaml.safe_load(yml_content) or {}
+    except yaml.YAMLError as e:
+        logger.warning(f"Failed to parse fiftyone.yml: {e}")
+        return []
+
+    declared = plugin_config.get("skills", [])
+    if not declared:
+        logger.warning("No skills declared in fiftyone.yml")
+        return []
+
+    logger.info(
+        f"Found {len(declared)} declared skills in fiftyone-internal-skills"
+    )
+
+    skills = []
+    for skill_name in declared:
+        if not re.match(r"^[a-zA-Z0-9_-]+$", skill_name):
+            logger.warning(f"Skipping skill with unsafe name: '{skill_name}'")
+            continue
+
+        skill_md = _fetch_internal_file(f"skills/{skill_name}/SKILL.md", token)
+        if not skill_md:
+            logger.warning(f"No SKILL.md for '{skill_name}', skipping")
+            continue
+
+        readme = _fetch_internal_file(f"skills/{skill_name}/README.md", token)
+        if not readme:
+            logger.info(f"No README.md for '{skill_name}', skipping")
+            continue
+
+        metadata = _parse_skill_frontmatter(skill_md)
+
+        skills.append(
+            Skill(
+                name=metadata.get("name", skill_name),
+                description=metadata.get("description", ""),
+                github_url=(
+                    INTERNAL_SKILLS_GITHUB_BASE
+                    + f"skills/{skill_name}/SKILL.md"
+                ),
+                slug=skill_name,
+                category=metadata.get("category", "General"),
+                emoji=metadata.get("emoji", "🤖"),
+                extra_tags=["Enterprise"],
+                prefetched_readme=readme,
+            )
+        )
+
+    logger.info(f"Loaded {len(skills)} enterprise skills")
+    return skills
 
 
 def _skills_from_marketplace(marketplace: dict) -> List[Skill]:
@@ -82,12 +193,20 @@ def _clean_description(text: str) -> str:
 def _generate_skill_card(skill: Skill) -> str:
     """Return a customcarditem RST block for a single skill."""
     description = _clean_description(skill.description)
+    if "Enterprise" in skill.extra_tags:
+        badge = (
+            '<span class="card-subtitle text-muted" style="background-color: #ff6b35;'
+            " color: white !important; padding: 2px 6px; border-radius: 4px;"
+            ' font-size: 0.8em; font-weight: 500;">Enterprise</span><br/>'
+        )
+        description = badge + description
+    tags = ",".join(filter(None, [skill.category] + skill.extra_tags))
     return f"""
 .. customcarditem::
     :header: {skill.emoji} {skill.name}
     :description: {description}
     :link: skills_ecosystem/{skill.slug}.html
-    :tags: {skill.category}
+    :tags: {tags}
 
 """
 
@@ -98,6 +217,15 @@ def generate_skill_cards_rst(skills: List[Skill]) -> str:
 
 def _generate_skill_page(skill: Skill, readme_content: str) -> str:
     """Return the content of an individual skill page."""
+    if "Enterprise" in skill.extra_tags:
+        badge = "![Enterprise Skill](https://img.shields.io/badge/Enterprise-Skill-orange)"
+    else:
+        badge = (
+            f'<a href="{skill.github_url}" target="_blank">'
+            "![GitHub Repo](https://img.shields.io/badge/GitHub-Repository-black?logo=github)"
+            "</a>"
+        )
+
     return f"""---
 myst:
   html_meta:
@@ -108,7 +236,7 @@ myst:
 ---
 
 
-<a href="{skill.github_url}" target="_blank">![GitHub Repo](https://img.shields.io/badge/GitHub-Repository-black?logo=github)</a>
+{badge}
 
 {readme_content}
 """
@@ -122,16 +250,22 @@ def main():
 
     logger.info("Fetching marketplace.json...")
     marketplace = _fetch(MARKETPLACE_URL, parse_json=True)
-    if marketplace:
+    if marketplace is not None:
         skills = _skills_from_marketplace(marketplace)
-        logger.info(f"Found {len(skills)} skills")
+        logger.info(f"Found {len(skills)} public skills")
     else:
         logger.warning("Could not fetch marketplace.json")
         skills = []
 
+    logger.info("Fetching enterprise skills...")
+    enterprise_skills = _fetch_enterprise_skills()
+    skills += enterprise_skills
+
     for skill in skills:
-        readme_url = f"{SKILLS_RAW_BASE}skills/{skill.slug}/README.md"
-        readme_content = _fetch(readme_url)
+        readme_content = skill.prefetched_readme or _fetch(
+            f"{SKILLS_RAW_BASE}skills/{skill.slug}/README.md"
+        )
+
         if readme_content:
             page_content = _generate_skill_page(skill, readme_content)
             page_path = skills_ecosystem_dir / f"{skill.slug}.md"

--- a/docs/scripts/generate_skills_docs.py
+++ b/docs/scripts/generate_skills_docs.py
@@ -37,6 +37,9 @@ INTERNAL_SKILLS_GITHUB_BASE = (
     "https://github.com/voxel51/fiftyone-internal-skills/blob/main/"
 )
 
+_FRONTMATTER_RE = re.compile(r"^---\s*$", re.MULTILINE)
+_SAFE_SKILL_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
 
 @dataclass
 class Skill:
@@ -68,7 +71,7 @@ def _fetch(url: str, parse_json: bool = False, token: Optional[str] = None):
 
 def _parse_skill_frontmatter(content: str) -> dict:
     """Parse YAML frontmatter from a SKILL.md file."""
-    parts = re.split(r"^---\s*$", content, maxsplit=2, flags=re.MULTILINE)
+    parts = _FRONTMATTER_RE.split(content, maxsplit=2)
     if len(parts) < 3:
         return {}
     try:
@@ -126,7 +129,7 @@ def _fetch_enterprise_skills() -> List[Skill]:
 
     skills = []
     for skill_name in declared:
-        if not re.match(r"^[a-zA-Z0-9_-]+$", skill_name):
+        if not _SAFE_SKILL_NAME_RE.match(skill_name):
             logger.warning(f"Skipping skill with unsafe name: '{skill_name}'")
             continue
 

--- a/docs/source/_static/js/tutorial-filters.js
+++ b/docs/source/_static/js/tutorial-filters.js
@@ -194,6 +194,18 @@ $(document).ready(function () {
   // Initialize the filter system
   window.filterTags.bind();
 
+  // Auto-select tag from URL ?tag= parameter (e.g., ?tag=Enterprise)
+  var urlParams = new URLSearchParams(window.location.search);
+  var tagParam = urlParams.get("tag");
+  if (tagParam && /^[a-zA-Z0-9 _-]+$/.test(tagParam)) {
+    var tagBtn = document.querySelector(
+      '.tutorial-filter[data-tag="' + tagParam + '"]'
+    );
+    if (tagBtn) {
+      tagBtn.click();
+    }
+  }
+
   // Tutorial cards functionality
   $(document).on("click", ".tutorials-card", function () {
     window.location = $(this).attr("link");

--- a/docs/source/enterprise/agent.rst
+++ b/docs/source/enterprise/agent.rst
@@ -113,3 +113,8 @@ agent exactly how to perform a task, step by step.
     You can also build and add your own custom skills to extend the agent's
     capabilities. See :ref:`Developing skills <agents-developing>` for full
     instructions.
+
+.. customanimatedcta::
+    :button_text: Browse Enterprise Skills
+    :button_link: ../agents/index.html?tag=Enterprise
+    :align: right

--- a/docs/source/getting_started/agents/index.rst
+++ b/docs/source/getting_started/agents/index.rst
@@ -1,0 +1,177 @@
+.. _getting-started-agents:
+
+Building Plugins with AI Agents
+================================
+
+.. default-role:: code
+
+**Use AI Coding Agents to Build Custom FiftyOne Plugins**
+
+**Level:** Beginner | **Estimated Time:** 15-20 minutes | **Tags:** Agents, Plugin Development, Skills
+
+This guide walks you through building a custom FiftyOne plugin using an
+AI coding agent. Describe what you want in plain language, and the agent
+handles the implementation: file structure, operator logic, and live
+testing in the App.
+
+.. image:: https://cdn.voxel51.com/getting_started_agents/agentic_plugin_dev.webp
+   :alt: Building FiftyOne plugins with an AI coding agent
+   :align: center
+
+.. note::
+
+   This guide covers **AI coding agents** (Claude Code, Cursor, VS Code
+   Copilot, Gemini CLI, and others) used to build FiftyOne plugins from
+   your terminal. If you are looking for the built-in AI assistant inside
+   the FiftyOne Enterprise App, see :ref:`FiftyOne Agent <enterprise-agent>`
+   instead.
+
+You'll learn how to:
+
+- Set up your AI agent with FiftyOne Skills
+- Launch the FiftyOne App in debug mode for live development
+- Prompt your agent to build a custom operator or panel
+- Test and iterate on the plugin inside the running App
+
+.. _getting-started-agents-overview:
+
+Guide Overview
+--------------
+
+This guide covers the following steps:
+
+1. **Launch the App in Debug Mode** - Start FiftyOne in development mode so you can see logs and test plugins live as you build them
+2. **Prompt Your Agent** - Use the ``fiftyone-develop-plugin`` skill to describe and build a custom operator or panel
+3. **Test in the App** - Install and run your plugin, paste any errors back to the agent
+4. **Iterate** - Tighten the loop between prompt, test, and fix until the plugin works as expected
+
+.. _getting-started-agents-prereqs:
+
+Prerequisites
+-------------
+
+- **FiftyOne installed**: see :ref:`Installation <installing-fiftyone>`
+- **An AI coding agent**: Claude Code, Cursor, VS Code Copilot, Gemini CLI, or Antigravity
+- **Skills configured**: follow :ref:`Using Agents <agents-using-agents>` to install the
+  MCP server and skills for your specific agent (takes about 5 minutes)
+
+.. _getting-started-agents-step1:
+
+Step 1: Launch the App in Debug Mode
+-------------------------------------
+
+Debug mode prints all Python and server logs to your terminal. Keep it
+running throughout development so you see errors immediately.
+
+.. code-block:: bash
+
+   fiftyone app debug
+
+The App opens at ``http://localhost:5151``. To load a specific dataset:
+
+.. code-block:: bash
+
+   fiftyone app debug <dataset-name>
+
+.. note::
+
+   **Enterprise users:** make sure your credentials are exported and your
+   teams environment is active before running this command.
+
+.. _getting-started-agents-step2:
+
+Step 2: Prompt Your Agent to Build a Plugin
+--------------------------------------------
+
+Open your AI agent in a separate terminal window inside your project
+directory and describe the plugin you want to build.
+
+The ``fiftyone-develop-plugin`` skill gives your agent a complete
+end-to-end workflow for building FiftyOne operators and panels. When you
+describe a plugin goal, the skill guides the agent through:
+
+- Creating the directory structure and ``fiftyone.yml`` manifest
+- Implementing the operator with inputs, execution logic, and output
+- Installing the plugin locally
+- Validating it is ready to test
+
+**A good first prompt:**
+
+.. code-block:: text
+
+   Build me a FiftyOne operator that shows a histogram of confidence
+   scores for predicted labels in the current dataset. Display the
+   result in a panel.
+
+Be specific about what the plugin does, what inputs it accepts, what
+media type you are working with, and which FiftyOne primitive you want
+(operator, panel, or delegated operator).
+
+.. note::
+
+   Not sure what to build? See the
+   `Plugin Ideas Board <https://github.com/voxel51/fiftyone-plugins/discussions>`_
+   for community-sourced ideas, or browse the
+   `official plugin collection <https://github.com/voxel51/fiftyone-plugins>`_
+   for reference examples close to what you want.
+
+.. _getting-started-agents-step3:
+
+Step 3: Test in the App
+------------------------
+
+After the agent creates the plugin, confirm it is installed:
+
+.. code-block:: bash
+
+   fiftyone plugins list
+
+Then find and run it in the App:
+
+1. Press the backtick key (`\``) or click the operator icon in the toolbar
+2. Search for your operator by name
+3. Fill in the inputs and click **Execute**
+
+If something is not right, paste the exact error from the debug terminal
+back to your agent rather than paraphrasing it. Exact stack traces lead
+to faster fixes.
+
+.. _getting-started-agents-step4:
+
+Step 4: Iterate
+----------------
+
+Plugin development with agents is a tight loop:
+
+1. Describe a change or fix
+2. The agent updates the plugin
+3. Test in the App (Python operator changes take effect on the next
+   execution; panel changes require an App reload)
+4. Paste any errors or unexpected behavior back to the agent
+5. Repeat
+
+Before declaring the plugin done, ask your agent to run the
+``fiftyone-eval-plugin`` skill to catch structural issues and common
+anti-patterns:
+
+.. code-block:: text
+
+   Use the fiftyone-eval-plugin skill to evaluate the plugin we just built.
+
+.. _getting-started-agents-next:
+
+Next Steps
+----------
+
+- :ref:`Using Agents <agents-using-agents>`: full setup guide and available MCP tools
+- :ref:`Agent Ecosystem <agents-ecosystem>`: browse all available skills for your agent
+- :ref:`Developing Skills <agents-developing>`: build your own agent skills
+- :ref:`FiftyOne Plugins <fiftyone-plugins>`: the full plugin system reference
+- :ref:`FiftyOne Agent <enterprise-agent>`: the built-in AI assistant in FiftyOne Enterprise
+
+.. _getting-started-agents-resources:
+
+.. customanimatedcta::
+    :button_text: Browse All Skills
+    :button_link: ../../agents/index.html
+    :align: right

--- a/docs/source/getting_started/index.rst
+++ b/docs/source/getting_started/index.rst
@@ -35,6 +35,13 @@ Each guide is designed as a sequential learning experience with navigation betwe
 .. Add guide cards below
 
 .. customcarditem::
+    :header: Building Plugins with AI Agents __SUB_NEW__
+    :description: Build custom FiftyOne operators and panels using natural language. Prompt your AI coding agent to create, test, and iterate on plugins end to end, without writing boilerplate.
+    :link: agents/index.html
+    :image: https://cdn.voxel51.com/getting_started_agents/agentic_plugin_dev.webp
+    :tags: Core-Fiftyone,Development
+
+.. customcarditem::
     :header: Auto Labeling Guide
     :description: Bootstrap datasets rapidly with FiftyOne Auto Labeling. Generate auto labels with foundation models and systematically review predictions with confidence-based filtering and embeddings.
     :link: auto_labeling/index.html
@@ -129,6 +136,7 @@ Each guide is designed as a sequential learning experience with navigation betwe
    :maxdepth: 1
    :hidden:
 
+   Building Plugins with AI Agents __SUB_NEW__ <agents/index>
    Auto Labeling Guide <auto_labeling/index>
    Annotation Guide __SUB_NEW__ <annotation/index>
    Object Detection Guide <object_detection/index>


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

This PR adds new documentation for building FiftyOne plugins with AI coding agents and expands the skills ecosystem docs to support Enterprise skills.
* Add a new Getting Started guide for building FiftyOne plugins with AI coding agents such as Claude Code, Cursor, Gemini CLI, and others
* Update the skills docs generator to fetch Enterprise skills from `fiftyone-internal-skills`
* Add `extra_tags` support to the `Skill` dataclass
* Add a CTA on the Enterprise Agent page linking to the Enterprise skills filter

## 🧪 How is this patch tested? If it is not, please explain why.

Manually tested by building and reviewing the documentation pages locally and in the dev docs preview.

https://github.com/user-attachments/assets/44683f20-b4f8-4b5d-9b7b-f267f2a8b768

* `https://docs.dev.voxel51.com/agents/index.html?tag=Enterprise`
* `https://docs.dev.voxel51.com/agents/skills_ecosystem/fiftyone-data-enrichment.html`

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [ ] No. You can skip the rest of this section.
* [x] Yes. Give a description of this change to be included in the release
  notes for FiftyOne users.

Adds new documentation for building FiftyOne plugins with AI coding agents and improves the skills ecosystem docs with Enterprise skill support.

### What areas of FiftyOne does this PR affect?

* [ ] App: FiftyOne application changes
* [] Build: Build and test infrastructure changes
* [ ] Core: Core `fiftyone` Python library changes
* [x] Documentation: FiftyOne documentation changes
* [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tutorial pages auto-apply tag filters from the ?tag= URL parameter
  * Skills docs now include both public and enterprise/internal skills, with enterprise-labeled cards and badges

* **Documentation**
  * New "Building Plugins with AI Agents" guide added to Getting Started
  * Enterprise call-to-action added to relevant docs section

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7667?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->