### PR TITLE
fix(store): refresh expires_at on set_key to extend TTL on re-write

### DIFF
--- a/fiftyone/factory/repos/execution_store.py
+++ b/fiftyone/factory/repos/execution_store.py
@@ -527,11 +527,15 @@ class MongoExecutionStoreRepo(ExecutionStoreRepo):
             )
         )
 
+        # ``expires_at`` is written via ``$set`` (not ``$setOnInsert``) so that
+        # re-setting a key refreshes its TTL instead of pinning it to the first
+        # write; the value is ``None`` when ``ttl is None``, which clears it. A
+        # field cannot appear in both ``$set`` and ``$setOnInsert`` in one
+        # update, so it is omitted from ``on_insert_fields``.
         on_insert_fields = {
             "store_name": store_name,
             "key": key,
             "created_at": now,
-            "expires_at": expiration if ttl else None,
             "dataset_id": self._dataset_id,
             "policy": policy,
         }
@@ -543,7 +547,6 @@ class MongoExecutionStoreRepo(ExecutionStoreRepo):
                 not in {
                     "_id",
                     "created_at",
-                    "expires_at",
                     "store_name",
                     "key",
                     "dataset_id",

--- a/tests/unittests/execution_store_service_tests.py
+++ b/tests/unittests/execution_store_service_tests.py
@@ -347,6 +347,37 @@ def test_set_key_with_ttl_and_update(svc):
 
 @drop_datasets
 @drop_collection(TEST_COLLECTION_NAME)
+def test_set_key_refreshes_ttl(svc):
+    # Re-setting an existing key with a TTL must refresh ``expires_at`` rather
+    # than leaving it pinned to the first write, which previously let the Mongo
+    # TTL index reap still-active heartbeat/cache keys.
+    NAME = "test_store"
+    KEY = "ttl_key"
+    svc.set_key(NAME, KEY, "v1", ttl=100)
+    original_expiry = svc.get_key(NAME, KEY).expires_at
+    assert original_expiry is not None
+
+    svc.set_key(NAME, KEY, "v2", ttl=500)
+    refreshed = svc.get_key(NAME, KEY)
+    assert refreshed.value == "v2"
+    assert refreshed.expires_at > original_expiry
+
+
+@drop_datasets
+@drop_collection(TEST_COLLECTION_NAME)
+def test_set_key_without_ttl_clears_expiration(svc):
+    # Re-setting a key without a TTL must clear a previously set expiration.
+    NAME = "test_store"
+    KEY = "ttl_key"
+    svc.set_key(NAME, KEY, "v1", ttl=100)
+    assert svc.get_key(NAME, KEY).expires_at is not None
+
+    svc.set_key(NAME, KEY, "v2")
+    assert svc.get_key(NAME, KEY).expires_at is None
+
+
+@drop_datasets
+@drop_collection(TEST_COLLECTION_NAME)
 def test_set_key_with_dict_value(svc):
     NAME = "test_store"
     KEY = "dict_key"

--- a/tests/unittests/execution_store_unit_tests.py
+++ b/tests/unittests/execution_store_unit_tests.py
@@ -80,17 +80,54 @@ class ExecutionStoreServiceIntegrationTests(unittest.TestCase):
 
         self.assertEqual(update["$set"]["value"], value)
         self.assertIsInstance(update["$set"]["updated_at"], datetime)
+        # ``expires_at`` is written via ``$set`` on every call so re-setting a
+        # key refreshes its TTL
+        self.assertIsInstance(update["$set"]["expires_at"], datetime)
 
         insert = update["$setOnInsert"]
         self.assertEqual(insert["store_name"], store)
         self.assertEqual(insert["key"], key)
         self.assertIsInstance(insert["created_at"], datetime)
-        self.assertIsInstance(insert["expires_at"], datetime)
+        # ``expires_at`` must NOT also be in ``$setOnInsert``: a field present
+        # in both ``$set`` and ``$setOnInsert`` makes MongoDB raise a conflict.
+        self.assertNotIn("expires_at", insert)
         self.assertIsNone(insert["dataset_id"])
         self.assertEqual(insert["policy"], "evict")
 
         # Options
         self.assertEqual(kwargs, {"upsert": True})
+
+    def test_set_key_refreshes_ttl_on_update(self):
+        # ``expires_at`` must be written via ``$set`` (not ``$setOnInsert``) so
+        # that re-setting a key advances its expiration rather than leaving it
+        # pinned to the first write.
+        store, key, ttl = "widgets", "widget_1", 60
+
+        self.store_repo.set_key(store, key, {"n": 1}, ttl=ttl)
+        first = self.mock_collection.update_one.call_args[0][1]
+        first_expires_at = first["$set"]["expires_at"]
+
+        time.sleep(0.01)
+
+        self.store_repo.set_key(store, key, {"n": 2}, ttl=ttl)
+        second = self.mock_collection.update_one.call_args[0][1]
+        second_expires_at = second["$set"]["expires_at"]
+
+        self.assertIsInstance(first_expires_at, datetime)
+        self.assertIsInstance(second_expires_at, datetime)
+        self.assertGreater(second_expires_at, first_expires_at)
+        # never duplicated into $setOnInsert (else MongoDB raises a conflict)
+        self.assertNotIn("expires_at", first["$setOnInsert"])
+        self.assertNotIn("expires_at", second["$setOnInsert"])
+
+    def test_set_key_without_ttl_clears_expiration(self):
+        # A ``set`` with no TTL writes ``expires_at=None`` via ``$set`` so a
+        # previously set TTL is cleared.
+        self.store_repo.set_key("widgets", "widget_1", {"n": 1})
+        update = self.mock_collection.update_one.call_args[0][1]
+        self.assertIn("expires_at", update["$set"])
+        self.assertIsNone(update["$set"]["expires_at"])
+        self.assertNotIn("expires_at", update["$setOnInsert"])
 
     def test_get_key(self):
         self.mock_collection.find_one.return_value = {
@@ -213,12 +250,14 @@ class TestExecutionStoreIntegration(unittest.TestCase):
 
         self.assertEqual(update["$set"]["value"], value)
         self.assertIsInstance(update["$set"]["updated_at"], datetime)
+        # ``expires_at`` is written via ``$set`` so re-sets refresh the TTL
+        self.assertIsInstance(update["$set"]["expires_at"], datetime)
 
         insert = update["$setOnInsert"]
         self.assertEqual(insert["store_name"], "mock_store")
         self.assertEqual(insert["key"], key)
         self.assertIsInstance(insert["created_at"], datetime)
-        self.assertIsInstance(insert["expires_at"], datetime)
+        self.assertNotIn("expires_at", insert)
         self.assertIsNone(insert["dataset_id"])
 
         # Options
@@ -295,12 +334,14 @@ class ExecutionStoreServiceDatasetIdTests(unittest.TestCase):
 
         self.assertEqual(update["$set"]["value"], value)
         self.assertIsInstance(update["$set"]["updated_at"], datetime)
+        # ``expires_at`` is written via ``$set`` so re-sets refresh the TTL
+        self.assertIsInstance(update["$set"]["expires_at"], datetime)
 
         insert = update["$setOnInsert"]
         self.assertEqual(insert["store_name"], store)
         self.assertEqual(insert["key"], key)
         self.assertIsInstance(insert["created_at"], datetime)
-        self.assertIsInstance(insert["expires_at"], datetime)
+        self.assertNotIn("expires_at", insert)
         self.assertEqual(insert["dataset_id"], self.dataset_id)
         self.assertEqual(insert["policy"], "evict")
 


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

`MongoExecutionStoreRepo.set_key` wrote `expires_at` only via `$setOnInsert`, so re-setting a key with a TTL never advanced its expiration — the key was reaped at `first_insert + ttl` regardless of later writes. `expires_at` is now written via `$set` on every call (the value is `None` when `ttl is None`, which clears it) and dropped from `$setOnInsert`, since a field cannot appear in both operators in one update. `created_at` stays insert-only.

## 🧪 How is this patch tested? If it is not, please explain why.

Added regression tests and updated the existing `set_key` tests for the new update shape:

- `tests/unittests/execution_store_unit_tests.py` (mock collection): `expires_at` is written into `$set` (never `$setOnInsert`), advances across two ttl'd sets, and is `None` when no TTL is given.
- `tests/unittests/execution_store_service_tests.py` (MongoDB): `expires_at` advances across two ttl'd sets and is cleared by a subsequent set without a TTL.

`pytest` over the three store test files: 58 passed. `black -l 79` and `pylint --errors-only` pass.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

`ExecutionStore.set(key, value, ttl=...)` now refreshes a key's expiration on every write, so re-setting a key extends its TTL instead of leaving it pinned to the first write.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
