### PR TITLE
chore(release): bump version to 1.16.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import os
 from setuptools import setup, find_packages
 
 
-VERSION = "1.16.0"
+VERSION = "1.16.1"
 
 
 def get_version():


### PR DESCRIPTION
Bumps `VERSION` in `setup.py` from `1.16.0` to `1.16.1` for the patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Package version bumped to 1.16.1.
  * Release validation tightened to require any set release identifier to match the 1.16.1 prefix, improving consistency and preventing accidental mismatched releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7671?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->