### PR TITLE
[DEMO] Video annotation auto interpolation 

### DIFF
--- a/app/packages/annotation/src/events.ts
+++ b/app/packages/annotation/src/events.ts
@@ -160,6 +160,26 @@ export type AnnotationEventGroup = {
   "annotation:undoLabelEdit": { label: Partial<AnnotationLabel["data"]> };
 
   /**
+   * Notification event emitted when a label's `keyframe` attribute changes
+   * on a tracked instance. Consumers (e.g. auto-interpolate) use this to
+   * re-propagate between bracketing keyframes after a change.
+   *
+   * - `kind: "set"` — keyframe just became `true`, either by mark-keyframe
+   *   gesture or by an edit (draw / drag / resize) that promotes the label.
+   * - `kind: "removed"` — keyframe was `true` and no longer is, either by
+   *   unmarking or by deleting the underlying detection.
+   */
+  "annotation:keyframeChanged": {
+    /** Synthetic overlay id (`instance-…` / `track-…`). */
+    trackId: string;
+    /** Cross-frame identity, when the label has an `fo.Instance`. */
+    instanceId: string | null;
+    /** 1-indexed frame number where the change happened. */
+    frame: number;
+    kind: "set" | "removed";
+  };
+
+  /**
    * Notification event emitted when the active annotation agent transitions
    * between lifecycle states (e.g. `"initializing"` → `"inferring"`).
    */

--- a/app/packages/annotation/src/hooks/index.ts
+++ b/app/packages/annotation/src/hooks/index.ts
@@ -10,4 +10,5 @@ export * from "./useRegisterAnnotationKeyBindings";
 export * from "./useRegisterVideoAnnotationCommandHandlers";
 export * from "./useRegisterVideoAnnotationEventHandlers";
 export * from "./useRegisterVideoAnnotationKeybindings";
+export * from "./useAutoInterpolate";
 export * from "./useRegisterRendererEventHandlers";

--- a/app/packages/annotation/src/hooks/useAutoInterpolate.ts
+++ b/app/packages/annotation/src/hooks/useAutoInterpolate.ts
@@ -1,0 +1,104 @@
+import { useCommandBus } from "@fiftyone/command-bus";
+import {
+  useFrameLabelsStream,
+  type VideoFrameLabelsStream,
+} from "@fiftyone/video-annotation";
+import { useCallback } from "react";
+import { PropagateCommand } from "../commands";
+import { useAnnotationEventHandler } from "./useAnnotationEventHandler";
+
+/** Inclusive `[fromFrame, toFrame]` segment to re-propagate. */
+export type FrameRange = [number, number];
+
+/**
+ * Frame numbers on a track that carry `keyframe: true`. Walks the
+ * stream cache once per call; the caller decides when to invoke (e.g.
+ * on each `annotation:keyframeChanged` event).
+ */
+export function collectKeyframeFrames(
+  stream: VideoFrameLabelsStream,
+  trackId: string
+): number[] {
+  const allFrames = Array.from(
+    { length: stream.totalFrames },
+    (_, i) => i + 1
+  );
+  return allFrames.filter((frame) => {
+    const snapshot = stream.getValue((frame - 1) / stream.fps);
+    return (
+      snapshot?.detections.some((d) => d.id === trackId && d.keyframe) ?? false
+    );
+  });
+}
+
+/**
+ * Given the current set of keyframe frames on a track and the frame
+ * where a keyframe just changed, return the `(from, to)` pairs whose
+ * in-between frames need re-propagation.
+ *
+ * - `kind: "set"` — `frame` is now a keyframe. Re-propagate both
+ *   sides: (prev-keyframe, frame) and (frame, next-keyframe). Each
+ *   side is skipped if no bracketing keyframe exists on that side.
+ * - `kind: "removed"` — `frame` is no longer a keyframe. Re-propagate
+ *   the wider span (prev-keyframe, next-keyframe). Skipped entirely
+ *   if either bracketing keyframe is missing.
+ */
+export function resolveSegmentsToRepropagate(
+  keyframeFrames: number[],
+  changedFrame: number,
+  kind: "set" | "removed"
+): FrameRange[] {
+  const sorted = [...keyframeFrames].sort((a, b) => a - b);
+  const prev = sorted.filter((f) => f < changedFrame).at(-1) ?? null;
+  const next = sorted.find((f) => f > changedFrame) ?? null;
+
+  const segments: FrameRange[] = [];
+
+  if (kind === "set") {
+    if (prev !== null) segments.push([prev, changedFrame]);
+    if (next !== null) segments.push([changedFrame, next]);
+  } else if (prev !== null && next !== null) {
+    segments.push([prev, next]);
+  }
+
+  return segments;
+}
+
+/**
+ * Subscribe to `annotation:keyframeChanged` and dispatch
+ * `PropagateCommand` for each in-between segment that needs to be
+ * re-lerped against the new keyframe layout.
+ *
+ * Mount once inside the video annotation surface alongside the other
+ * video-annotation registrars. The hook is a no-op until a stream
+ * is published.
+ */
+export const useAutoInterpolate = (): void => {
+  const stream = useFrameLabelsStream();
+  const bus = useCommandBus();
+
+  useAnnotationEventHandler(
+    "annotation:keyframeChanged",
+    useCallback(
+      (payload) => {
+        if (!stream) return;
+        const { instanceId, trackId, frame, kind } = payload;
+        if (!instanceId) return;
+
+        const keyframeFrames = collectKeyframeFrames(stream, trackId);
+        const segments = resolveSegmentsToRepropagate(
+          keyframeFrames,
+          frame,
+          kind
+        );
+
+        segments.forEach(([from, to]) => {
+          void bus.execute(
+            new PropagateCommand(instanceId, from, to, "linear")
+          );
+        });
+      },
+      [stream, bus]
+    )
+  );
+};

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
@@ -1,4 +1,5 @@
 import { useRegisterCommandHandler } from "@fiftyone/command-bus";
+import { useAnnotationEventBus } from "./useAnnotationEventBus";
 import {
   PropagationStatusItem,
   useFrameLabelsStream,
@@ -79,6 +80,7 @@ export const useRegisterVideoAnnotationCommandHandlers = () => {
   const applyPropagation = useApplyPropagationResult();
   const applyPropagatedDetection = useApplyPropagatedDetection();
   const { setContent: setStatusContent } = useVideoAnnotationStatus();
+  const eventBus = useAnnotationEventBus();
 
   useRegisterCommandHandler(
     EditTemporalDetectionSupportCommand,
@@ -136,11 +138,18 @@ export const useRegisterVideoAnnotationCommandHandlers = () => {
 
           stream.updateLabel(frame, update);
           updated = true;
+
+          eventBus.dispatch("annotation:keyframeChanged", {
+            trackId: det.id,
+            instanceId: det.instance?._id ?? null,
+            frame,
+            kind: willBeKeyframe ? "set" : "removed",
+          });
         }
 
         return updated;
       },
-      [stream]
+      [stream, eventBus]
     )
   );
 
@@ -148,6 +157,9 @@ export const useRegisterVideoAnnotationCommandHandlers = () => {
     PropagateCommand,
     useCallback(
       async (cmd) => {
+        console.log(
+          `[propagate] method=${cmd.method} instance=${cmd.instanceId} frames=[${cmd.fromFrame}, ${cmd.toFrame}]`
+        );
         if (!stream) return false;
         if (cmd.fromFrame >= cmd.toFrame) return false;
 

--- a/app/packages/video-annotation/src/VideoAnnotationSurface.tsx
+++ b/app/packages/video-annotation/src/VideoAnnotationSurface.tsx
@@ -1,4 +1,5 @@
 import {
+  useAutoInterpolate,
   useRegisterVideoAnnotationCommandHandlers,
   useRegisterVideoAnnotationKeybindings,
 } from "@fiftyone/annotation";
@@ -182,5 +183,6 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
 const VideoAnnotationHandlerRegistration: React.FC = () => {
   useRegisterVideoAnnotationCommandHandlers();
   useRegisterVideoAnnotationKeybindings();
+  useAutoInterpolate();
   return null;
 };

--- a/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
+++ b/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
@@ -2,6 +2,7 @@
  * Copyright 2017-2026, Voxel51, Inc.
  */
 
+import { useAnnotationEventBus } from "@fiftyone/annotation";
 import {
   DetectionOverlay,
   type Scene2D,
@@ -36,6 +37,7 @@ import type { LocalDetection } from "./VideoFrameLabelsStream";
 export const useSyncLighterLabelStream = (scene: Scene2D | null): void => {
   const stream = useFrameLabelsStream();
   const currentTime = useCurrentTime();
+  const eventBus = useAnnotationEventBus();
 
   const useEventHandler = useLighterEventHandler(
     scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
@@ -67,6 +69,20 @@ export const useSyncLighterLabelStream = (scene: Scene2D | null): void => {
       const frame = stream.timeToFrame(currentTime);
       stream.updateLabel(frame, detection);
 
+      // Edits (drag / resize) and fresh draws both promote the touched
+      // frame to a keyframe via `toLocalDetection`. Mirror the same
+      // event MarkKeyframeCommand emits so the auto-interpolate hook
+      // re-lerps adjacent segments after the user nudges a box.
+      const instanceId = detection.instance?._id ?? null;
+      if (instanceId) {
+        eventBus.dispatch("annotation:keyframeChanged", {
+          trackId: `instance-${instanceId}`,
+          instanceId,
+          frame,
+          kind: "set",
+        });
+      }
+
       // The synthetic id just changed (`<overlayId>` → `instance-<...>`)
       // because we minted the Instance. Evict Lighter's draw-mode
       // overlay so the next sync pass adds the canonical one without
@@ -83,7 +99,7 @@ export const useSyncLighterLabelStream = (scene: Scene2D | null): void => {
         scene.removeOverlay(overlayId);
       }
     },
-    [stream, scene, currentTime]
+    [stream, scene, currentTime, eventBus]
   );
 
   useEventHandler(


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

This uses the event bus to trigger propagation between key frames when a keyframe has changed in the following ways:
- Created/removed using "k" or the toolbar
- When a bounding box is moved which also triggers creating of a key keyframe -> propagation

## 🧪 How is this patch tested? If it is not, please explain why.

Tested locally


[Screencast from 2026-05-29 11-52-02.webm](https://github.com/user-attachments/assets/6de69d89-1bfe-4c3c-b46b-7d6b5498cc03)


## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic label re-propagation between keyframes when keyframe modifications occur, streamlining annotation workflows and improving consistency across video frames.
  * Enhanced keyframe event tracking and synchronization for more efficient annotation management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7674?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->