### PR TITLE
Remove NEW tag from enterprise panel docs

### DIFF
--- a/docs/source/enterprise/index.rst
+++ b/docs/source/enterprise/index.rst
@@ -99,19 +99,19 @@ pages on this site apply to Enterprise deployments as well.
     :button_link: app.html
 
 .. customcalloutitem::
-    :header: Auto-Labeling  __SUB_NEW__
+    :header: Auto-Labeling
     :description: Use FiftyOne Enterprise to annotate your data at a fraction of the cost.
     :button_text: Annotate your data at scale
     :button_link: verified_auto_labeling.html
 
 .. customcalloutitem::
-    :header: Data Lens  __SUB_NEW__
+    :header: Data Lens
     :description: Use FiftyOne Enterprise to explore and import samples from external data sources.
     :button_text: Connect your data lake
     :button_link: data_lens.html
 
 .. customcalloutitem::
-    :header: Data Quality  __SUB_NEW__
+    :header: Data Quality
     :description: Automatically scan your data for quality issues and take action to resolve them.
     :button_text: Find quality issues
     :button_link: data_quality.html
@@ -123,7 +123,7 @@ pages on this site apply to Enterprise deployments as well.
     :button_link: ../user_guide/app.html#app-model-evaluation-panel
 
 .. customcalloutitem::
-    :header: Query Performance  __SUB_NEW__
+    :header: Query Performance
     :description: Configure your massive datasets to support fast queries at scale.
     :button_text: Fast queries at scale
     :button_link: query_performance.html
@@ -185,10 +185,10 @@ pages on this site apply to Enterprise deployments as well.
     Roles and permissions <roles_and_permissions>
     Dataset Versioning <dataset_versioning>
     App <app>
-    Auto-Labeling __SUB_NEW__ <verified_auto_labeling>
-    Data Lens __SUB_NEW__ <data_lens>
-    Data Quality __SUB_NEW__ <data_quality>
-    Query Performance __SUB_NEW__ <query_performance>
+    Auto-Labeling <verified_auto_labeling>
+    Data Lens <data_lens>
+    Data Quality <data_quality>
+    Query Performance <query_performance>
     FiftyOne Agent __SUB_NEW__ <agent>
     Plugins <plugins>
     Secrets <secrets>


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

This PR removes the `__SUB_NEW__` badge from the Auto-Labeling, Data Lens, Data Quality, and Query Performance callout cards on the enterprise index page.

It also removes `__SUB_NEW__` from the corresponding toctree entries.

## 🧪 How is this patch tested? If it is not, please explain why.

Manually verified the enterprise index page and toctree entries to confirm the `__SUB_NEW__` badge no longer appears for Auto-Labeling, Data Lens, Data Quality, and Query Performance.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [x] No. You can skip the rest of this section.
* [ ] Yes. Give a description of this change to be included in the release
  notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

* [ ] App: FiftyOne application changes
* [ ] Build: Build and test infrastructure changes
* [ ] Core: Core `fiftyone` Python library changes
* [x] Documentation: FiftyOne documentation changes
* [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Enterprise section documentation with cleaner presentation of enterprise features, including Auto-Labeling, Data Lens, Data Quality, and Query Performance entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/voxel51/fiftyone/pull/7680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->