### PR TITLE
fix: preserve EXIF orientation in lighter overlays

### DIFF
--- a/app/packages/core/src/components/Modal/Lighter/LighterSampleRenderer.tsx
+++ b/app/packages/core/src/components/Modal/Lighter/LighterSampleRenderer.tsx
@@ -57,7 +57,7 @@ export const LighterSampleRenderer = ({
     // sceneId should be deterministic, but unique for a given sample snapshot
     const sample = sampleRef.current;
     setSceneId(
-      `${sample?.sample?._id}-${sample?.sample?.last_modified_at?.datetime}`
+      `${sample?.sample?._id}-${sample?.sample?.last_modified_at?.datetime}`,
     );
   }, []);
 
@@ -112,7 +112,7 @@ const LighterSetupImpl = (props: {
       ...options,
       activePaths: jotaiActivePaths ?? options.activePaths,
     }),
-    [options, jotaiActivePaths]
+    [options, jotaiActivePaths],
   );
 
   const canvas = singletonCanvas.getCanvas(containerRef.current ?? undefined);
@@ -138,7 +138,8 @@ const LighterSetupImpl = (props: {
       {
         src: mediaUrl,
         maintainAspectRatio: true,
-      }
+        originalDimensions: sample.sample.metadata,
+      },
     );
     scene.addOverlay(mediaOverlay);
 
@@ -147,7 +148,7 @@ const LighterSetupImpl = (props: {
   }, [scene, sceneId]);
 
   const useEventHandler = useLighterEventHandler(
-    scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
+    scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID,
   );
   useEventHandler("lighter:viewport-init-complete", onReveal, { once: true });
 

--- a/app/packages/lighter/src/overlay/ImageOverlay.ts
+++ b/app/packages/lighter/src/overlay/ImageOverlay.ts
@@ -8,6 +8,7 @@ import type { LighterEventGroup } from "../events";
 import type { Renderer2D } from "../renderer/Renderer2D";
 import type { CanonicalMedia, Dimensions, Rect, RenderMeta } from "../types";
 import { BaseOverlay } from "./BaseOverlay";
+import { getImageOverlayDimensions } from "./imageDimensions";
 
 /**
  * Options for creating an image overlay.
@@ -18,6 +19,7 @@ export interface ImageOptions {
   opacity?: number;
   maintainAspectRatio?: boolean;
   field?: string;
+  originalDimensions?: Dimensions;
 }
 
 const isRectNonEmpty = (bounds: Rect | undefined): boolean => {
@@ -71,7 +73,7 @@ export class ImageOverlay extends BaseOverlay implements CanonicalMedia {
         "lighter:viewport-moved",
         (event) => {
           this.updateImageTransform(event.x, event.y, event.scale);
-        }
+        },
       );
     }
   }
@@ -174,10 +176,10 @@ export class ImageOverlay extends BaseOverlay implements CanonicalMedia {
         this.imgElement &&
         !this.isImageLoaded
       ) {
-        this.originalDimensions = {
-          width: this.imgElement.naturalWidth,
-          height: this.imgElement.naturalHeight,
-        };
+        this.originalDimensions = getImageOverlayDimensions(
+          this.imgElement,
+          this.options.originalDimensions,
+        );
         this.isImageLoaded = true;
 
         const dims = this.getContainerDimensionsFromDom();
@@ -216,7 +218,7 @@ export class ImageOverlay extends BaseOverlay implements CanonicalMedia {
   private updateImageTransform(
     viewportX: number,
     viewportY: number,
-    scale: number
+    scale: number,
   ): void {
     if (!this.imgElement || !this.isImageLoaded) return;
 
@@ -279,7 +281,7 @@ export class ImageOverlay extends BaseOverlay implements CanonicalMedia {
 
   protected async renderImpl(
     renderer: Renderer2D,
-    _renderMeta: RenderMeta
+    _renderMeta: RenderMeta,
   ): Promise<void> {
     // The image is rendered via the HTML <img> element, not through Pixi.
     if (

--- a/app/packages/lighter/src/overlay/imageDimensions.test.ts
+++ b/app/packages/lighter/src/overlay/imageDimensions.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  dimensionsAreSwapped,
+  getImageOverlayDimensions,
+} from "./imageDimensions";
+
+describe("image overlay dimensions", () => {
+  it("detects dimensions swapped by EXIF orientation metadata", () => {
+    expect(
+      dimensionsAreSwapped(
+        { width: 4080, height: 3060 },
+        { width: 3060, height: 4080 },
+      ),
+    ).toBe(true);
+  });
+
+  it("uses metadata dimensions when the browser reports unrotated intrinsic dimensions", () => {
+    const image = {
+      naturalWidth: 4080,
+      naturalHeight: 3060,
+      width: 4080,
+      height: 3060,
+    } as HTMLImageElement;
+
+    expect(
+      getImageOverlayDimensions(image, { width: 3060, height: 4080 }),
+    ).toEqual({ width: 3060, height: 4080 });
+  });
+
+  it("keeps intrinsic dimensions when metadata is not a swapped pair", () => {
+    const image = {
+      naturalWidth: 800,
+      naturalHeight: 600,
+      width: 800,
+      height: 600,
+    } as HTMLImageElement;
+
+    expect(
+      getImageOverlayDimensions(image, { width: 1024, height: 768 }),
+    ).toEqual({ width: 800, height: 600 });
+  });
+});

--- a/app/packages/lighter/src/overlay/imageDimensions.ts
+++ b/app/packages/lighter/src/overlay/imageDimensions.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import type { Dimensions } from "../types";
+
+export const getIntrinsicImageDimensions = (
+  image: HTMLImageElement,
+): Dimensions => ({
+  width: image.naturalWidth || image.width,
+  height: image.naturalHeight || image.height,
+});
+
+export const dimensionsAreSwapped = (a: Dimensions, b: Dimensions): boolean => {
+  if (!a.width || !a.height || !b.width || !b.height) {
+    return false;
+  }
+
+  return a.width === b.height && a.height === b.width;
+};
+
+export const getImageOverlayDimensions = (
+  image: HTMLImageElement,
+  metadataDimensions?: Dimensions,
+): Dimensions => {
+  const intrinsicDimensions = getIntrinsicImageDimensions(image);
+
+  if (
+    metadataDimensions &&
+    dimensionsAreSwapped(intrinsicDimensions, metadataDimensions)
+  ) {
+    return metadataDimensions;
+  }
+
+  return intrinsicDimensions;
+};


### PR DESCRIPTION
## Summary

- Preserve EXIF-oriented image dimensions in the Lighter image overlay by using sample metadata dimensions when the browser reports swapped intrinsic dimensions.
- Pass sample metadata dimensions into the overlay so label coordinates and the displayed image stay aligned for rotated JPEGs.
- Add a small unit test for the dimension selection helper.

Fixes #6695

## Verification

- `node --input-type=module ...` assertions over the dimension helper behavior
- `npx prettier --config .prettierrc.js --write app/packages/lighter/src/overlay/imageDimensions.ts app/packages/lighter/src/overlay/imageDimensions.test.ts app/packages/lighter/src/overlay/ImageOverlay.ts app/packages/core/src/components/Modal/Lighter/LighterSampleRenderer.tsx`
- `git diff --check`

Attempted broader checks:

- `tsc` via a temporary TypeScript install reaches unrelated workspace/type resolution failures in `app/packages/types`/`app/packages/components` before the touched files.
- `vitest` via `yarn dlx` fails under the current Node 26 + PnP/esbuild loader combination before the test can execute.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced image overlay sizing logic to correctly calculate and apply image dimensions when rotation metadata is present, ensuring proper aspect ratio handling across different image orientations.

* **Tests**
  * Added comprehensive test coverage for image dimension calculations, including validation of dimension swapping detection and metadata-based dimension handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->