### PR TITLE
Video annotation: wire Lighter overlay editing to the label-stream cache

### DIFF
--- a/app/packages/video-annotation/src/FrameLabels.tsx
+++ b/app/packages/video-annotation/src/FrameLabels.tsx
@@ -25,7 +25,11 @@ import {
   type Track,
 } from "../../playback/src/lib/tracks/TrackProvider";
 import TimelineWithTracks from "../../playback/src/views/TimelineWithTracks/TimelineWithTracks";
-import { FrameLabelsContext, useFrameLabelsStream } from "./FrameLabelsContext";
+import {
+  FrameLabelsContext,
+  useFrameLabelsEditVersion,
+  useFrameLabelsStream,
+} from "./FrameLabelsContext";
 import { buildPerInstanceTracks, type PerInstanceLabel } from "./frameTracks";
 import { LABELS_STREAM_ID } from "./ids";
 import { useLinkedTrackDecorator } from "./linkedTracks";
@@ -166,6 +170,7 @@ const FrameLabelsRegistration: React.FC<FrameLabelsRegistrationProps> = ({
  */
 export const FrameLabelsTracks: React.FC = () => {
   const stream = useFrameLabelsStream();
+  const editVersion = useFrameLabelsEditVersion();
   const scheme = useRecoilValue(colorScheme);
   const seed = useRecoilValue(colorSeed);
 
@@ -202,7 +207,7 @@ export const FrameLabelsTracks: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [stream, resolveColor]);
+  }, [stream, resolveColor, editVersion]);
 
   const pinned = useMemo(() => tracks.map((t) => t.id), [tracks]);
   const ready = tracks.length > 0;

--- a/app/packages/video-annotation/src/FrameLabelsContext.ts
+++ b/app/packages/video-annotation/src/FrameLabelsContext.ts
@@ -1,4 +1,4 @@
-import { createContext, useContext } from "react";
+import { createContext, useCallback, useContext, useSyncExternalStore } from "react";
 import type { VideoFrameLabelsStream } from "./VideoFrameLabelsStream";
 
 /**
@@ -16,4 +16,26 @@ export const FrameLabelsContext = createContext<VideoFrameLabelsStream | null>(
 
 export function useFrameLabelsStream(): VideoFrameLabelsStream | null {
   return useContext(FrameLabelsContext);
+}
+
+/**
+ * Reactive view of the active labels stream's edit version. Returns a
+ * monotonically increasing counter that bumps on every cache mutation
+ * (fetch landing, local insert / update / remove).
+ *
+ * Use as a `useEffect` / `useMemo` dependency when deriving cross-frame
+ * state (e.g. timeline track rows from {@link buildPerInstanceTracks}).
+ * Single-frame consumers should keep reading the published snapshot via
+ * `useStream(LABELS_STREAM_ID)` instead.
+ *
+ * Returns `0` when no stream is mounted (e.g. synthetic-labels mode).
+ */
+export function useFrameLabelsEditVersion(): number {
+  const stream = useFrameLabelsStream();
+  const subscribe = useCallback(
+    (notify: () => void) => stream?.subscribeToEdits(notify) ?? (() => {}),
+    [stream]
+  );
+  const getSnapshot = useCallback(() => stream?.getEditVersion() ?? 0, [stream]);
+  return useSyncExternalStore(subscribe, getSnapshot);
 }

--- a/app/packages/video-annotation/src/FrameLabelsContext.ts
+++ b/app/packages/video-annotation/src/FrameLabelsContext.ts
@@ -1,4 +1,9 @@
-import { createContext, useCallback, useContext, useSyncExternalStore } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useSyncExternalStore,
+} from "react";
 import type { VideoFrameLabelsStream } from "./VideoFrameLabelsStream";
 
 /**
@@ -36,6 +41,9 @@ export function useFrameLabelsEditVersion(): number {
     (notify: () => void) => stream?.subscribeToEdits(notify) ?? (() => {}),
     [stream]
   );
-  const getSnapshot = useCallback(() => stream?.getEditVersion() ?? 0, [stream]);
+  const getSnapshot = useCallback(
+    () => stream?.getEditVersion() ?? 0,
+    [stream]
+  );
   return useSyncExternalStore(subscribe, getSnapshot);
 }

--- a/app/packages/video-annotation/src/ImaVidLighterTile.tsx
+++ b/app/packages/video-annotation/src/ImaVidLighterTile.tsx
@@ -21,6 +21,7 @@ import type { ImaVidImageFrame } from "./ImaVidImageStream";
 import type { FrameLabelSnapshot } from "./SyntheticLabelStream";
 import { useFrameOverlaySync } from "./useFrameOverlaySync";
 import { useSyncLighterAnnotation } from "./useSyncLighterAnnotation";
+import { useSyncLighterLabelStream } from "./useSyncLighterLabelStream";
 import styles from "./ImaVidLighterTile.module.css";
 
 export interface ImaVidLighterTileProps {
@@ -149,6 +150,7 @@ export const ImaVidLighterTile: React.FC<ImaVidLighterTileProps> = ({
   useFrameOverlaySync(scene, snapshot, field, canonicalMediaReady);
 
   useSyncLighterAnnotation(scene);
+  useSyncLighterLabelStream(scene);
 
   // Paint the current frame's bitmap into the canvas. Sets the canvas
   // drawing buffer to the bitmap's intrinsic dimensions on first paint

--- a/app/packages/video-annotation/src/ImaVidLighterTile.tsx
+++ b/app/packages/video-annotation/src/ImaVidLighterTile.tsx
@@ -20,6 +20,7 @@ import { IMAVID_STREAM_ID, LABELS_STREAM_ID } from "./ids";
 import type { ImaVidImageFrame } from "./ImaVidImageStream";
 import type { FrameLabelSnapshot } from "./SyntheticLabelStream";
 import { useFrameOverlaySync } from "./useFrameOverlaySync";
+import { useSyncLighterAnnotation } from "./useSyncLighterAnnotation";
 import styles from "./ImaVidLighterTile.module.css";
 
 export interface ImaVidLighterTileProps {
@@ -146,6 +147,8 @@ export const ImaVidLighterTile: React.FC<ImaVidLighterTileProps> = ({
   // Overlay diff — same hook the video tile uses.
   const snapshot = useStream<FrameLabelSnapshot>(LABELS_STREAM_ID);
   useFrameOverlaySync(scene, snapshot, field, canonicalMediaReady);
+
+  useSyncLighterAnnotation(scene);
 
   // Paint the current frame's bitmap into the canvas. Sets the canvas
   // drawing buffer to the bitmap's intrinsic dimensions on first paint

--- a/app/packages/video-annotation/src/VideoAnnotationSurface.tsx
+++ b/app/packages/video-annotation/src/VideoAnnotationSurface.tsx
@@ -1,6 +1,5 @@
 import { getSampleSrc } from "@fiftyone/state";
 import type { ModalSample } from "@fiftyone/state";
-import { TilingProvider } from "@fiftyone/tiling";
 import React, { useMemo, useState } from "react";
 import { PlaybackProvider } from "../../playback/src/lib/playback/PlaybackProvider";
 import {
@@ -150,9 +149,9 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
       labels
     );
 
-  return (
-    <PlaybackProvider>
-      <TilingProvider initialTiles={{}}>{registered}</TilingProvider>
-    </PlaybackProvider>
-  );
+  // No TilingProvider: it mounts an isolated jotai store, which would
+  // shadow modal-scoped atoms the sidebar writes to (lighterSceneAtom,
+  // detection-mode, label list). Reintroducing multi-tile here requires
+  // first pinning those atoms to the modal-default store explicitly.
+  return <PlaybackProvider>{registered}</PlaybackProvider>;
 };

--- a/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
+++ b/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
@@ -26,7 +26,7 @@ interface RawDetectionsField {
 }
 
 /**
- * Shape callers pass to {@link VideoFrameLabelsStream.upsertDetection}.
+ * Shape callers pass to {@link VideoFrameLabelsStream.updateLabel}.
  * Lines up with the `Detection` wire format — `bounding_box` is required
  * since a Detection with no bbox is meaningless for a video overlay.
  */
@@ -281,7 +281,7 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
    * and republish so subscribers re-render at the current playhead. No-op
    * if the frame isn't cached.
    */
-  upsertDetection(frameNumber: number, detection: LocalDetection): void {
+  updateLabel(frameNumber: number, detection: LocalDetection): void {
     const existing = this.cache.get(frameNumber);
     if (!existing) return;
     const id = detection._id ?? detection.id;
@@ -305,7 +305,7 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
    * Remove a detection from the local cache for the given frame and
    * republish. No-op if the frame isn't cached or the id isn't present.
    */
-  removeDetection(frameNumber: number, detectionId: string): void {
+  deleteLabel(frameNumber: number, detectionId: string): void {
     const existing = this.cache.get(frameNumber);
     if (!existing) return;
 

--- a/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
+++ b/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
@@ -109,6 +109,11 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
   // Cached on each `onCommit` so local-edit republishes can write to
   // the same atom store the engine drives. Null until first commit.
   private lastStore: PlaybackStore | null = null;
+  // Monotonic counter bumped on every cache mutation (fetch lands,
+  // local edit). Consumers that need to re-derive cross-frame state
+  // (e.g. timeline track rows) subscribe via `subscribeToEdits`.
+  private editVersion = 0;
+  private readonly editListeners = new Set<() => void>();
 
   constructor(opts: VideoFrameLabelsStreamOptions) {
     super(opts.id, {
@@ -293,6 +298,7 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
     this.cache.set(frameNumber, next);
     this.dirty.add(frameNumber);
     this.republish();
+    this.bumpEditVersion();
   }
 
   /**
@@ -310,11 +316,34 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
     this.cache.set(frameNumber, next);
     this.dirty.add(frameNumber);
     this.republish();
+    this.bumpEditVersion();
   }
 
   /** Whether the given frame has unsaved local edits. */
   isDirty(frameNumber: number): boolean {
     return this.dirty.has(frameNumber);
+  }
+
+  /**
+   * Subscribe to cache-mutation events (fetches landing, local edits).
+   * Returns an unsubscribe function. Pair with `getEditVersion` and
+   * React's `useSyncExternalStore` to re-derive cross-frame state.
+   */
+  subscribeToEdits(listener: () => void): () => void {
+    this.editListeners.add(listener);
+    return () => {
+      this.editListeners.delete(listener);
+    };
+  }
+
+  /** Current cache-mutation version. Increases on every mutation. */
+  getEditVersion(): number {
+    return this.editVersion;
+  }
+
+  private bumpEditVersion(): void {
+    this.editVersion++;
+    for (const listener of this.editListeners) listener();
   }
 
   private republish(): void {
@@ -387,6 +416,7 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
       }
 
       mergeRange(this.fetchedRanges, result.range);
+      if (result.frames.length > 0) this.bumpEditVersion();
     } catch (error) {
       // Surface but don't crash — the engine will keep asking; subsequent
       // prefetch calls will retry the missing frames.

--- a/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
+++ b/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
@@ -1,7 +1,10 @@
 import { type Stage } from "@fiftyone/utilities";
 import { getFrames, type FrameDoc } from "../../core/src/client/framesClient";
 import { PlaybackStreamBase } from "../../playback/src/lib/playback/stream-base";
-import { streamValueAtom } from "../../playback/src/lib/playback/atoms";
+import {
+  currentTimeAtom,
+  streamValueAtom,
+} from "../../playback/src/lib/playback/atoms";
 import { frameAt } from "../../playback/src/lib/playback/utils";
 import type {
   BufferReadiness,
@@ -9,7 +12,6 @@ import type {
 } from "../../playback/src/lib/playback/types";
 import type { FrameLabelSnapshot, SyntheticBox } from "./SyntheticLabelStream";
 
-// todo - adapter pattern for other label types
 interface RawDetection {
   _id?: string;
   id?: string;
@@ -21,6 +23,20 @@ interface RawDetection {
 
 interface RawDetectionsField {
   detections?: RawDetection[];
+}
+
+/**
+ * Shape callers pass to {@link VideoFrameLabelsStream.upsertDetection}.
+ * Lines up with the `Detection` wire format — `bounding_box` is required
+ * since a Detection with no bbox is meaningless for a video overlay.
+ */
+export interface LocalDetection {
+  _id?: string;
+  id?: string;
+  index?: number;
+  label?: string;
+  bounding_box: [number, number, number, number];
+  instance?: { _cls: "Instance"; _id?: string } | null;
 }
 
 export interface VideoFrameLabelsStreamOptions {
@@ -82,8 +98,17 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
   private readonly chunkSize: number;
 
   private readonly cache = new Map<number, FrameDoc>();
+  // Server-original snapshots, populated from `/frames` and never
+  // mutated. The eventual delta supplier diffs `cache` against this to
+  // compute server PATCHes.
+  private readonly baseline = new Map<number, FrameDoc>();
+  // Frames with local edits that haven't been persisted to the server.
+  private readonly dirty = new Set<number>();
   private readonly inflight = new Map<number, Promise<void>>();
   private readonly fetchedRanges: Array<[number, number]> = [];
+  // Cached on each `onCommit` so local-edit republishes can write to
+  // the same atom store the engine drives. Null until first commit.
+  private lastStore: PlaybackStore | null = null;
 
   constructor(opts: VideoFrameLabelsStreamOptions) {
     super(opts.id, {
@@ -229,6 +254,7 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
    * miss → hit when a chunk lands).
    */
   override onCommit(time: number, store: PlaybackStore): void {
+    this.lastStore = store;
     const next = this.getValue(time);
     const prev = store.get(
       streamValueAtom(this.id)
@@ -245,6 +271,58 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
     store.set(streamValueAtom(this.id), next);
   }
 
+  /**
+   * Insert or replace a detection in the local cache for the given frame
+   * and republish so subscribers re-render at the current playhead. No-op
+   * if the frame isn't cached.
+   */
+  upsertDetection(frameNumber: number, detection: LocalDetection): void {
+    const existing = this.cache.get(frameNumber);
+    if (!existing) return;
+    const id = detection._id ?? detection.id;
+    if (!id) return;
+
+    const next = withDetectionList(existing, this.frameField, (list) => {
+      const idx = list.findIndex((d) => (d._id ?? d.id) === id);
+      if (idx < 0) return [...list, detection];
+      const copy = list.slice();
+      copy[idx] = { ...list[idx], ...detection };
+      return copy;
+    });
+
+    this.cache.set(frameNumber, next);
+    this.dirty.add(frameNumber);
+    this.republish();
+  }
+
+  /**
+   * Remove a detection from the local cache for the given frame and
+   * republish. No-op if the frame isn't cached or the id isn't present.
+   */
+  removeDetection(frameNumber: number, detectionId: string): void {
+    const existing = this.cache.get(frameNumber);
+    if (!existing) return;
+
+    const next = withDetectionList(existing, this.frameField, (list) =>
+      list.filter((d) => (d._id ?? d.id) !== detectionId)
+    );
+
+    this.cache.set(frameNumber, next);
+    this.dirty.add(frameNumber);
+    this.republish();
+  }
+
+  /** Whether the given frame has unsaved local edits. */
+  isDirty(frameNumber: number): boolean {
+    return this.dirty.has(frameNumber);
+  }
+
+  private republish(): void {
+    if (!this.lastStore) return;
+    const time = this.lastStore.get(currentTimeAtom);
+    this.lastStore.set(streamValueAtom(this.id), this.getValue(time));
+  }
+
   bufferedRanges(): Array<[number, number]> {
     return this.fetchedRanges.map(
       ([start, end]) =>
@@ -252,7 +330,8 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
     );
   }
 
-  private timeToFrame(time: number): number {
+  /** Map a stream time to the 1-indexed frame number. */
+  timeToFrame(time: number): number {
     return frameAt(time, this.frameRate, this.frameCount);
   }
 
@@ -298,7 +377,13 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
       });
 
       for (const frame of result.frames) {
+        // Local edits made before the fetch landed are discarded — the
+        // server response is the new source of truth. (Once the delta
+        // supplier exists, in-flight edits will be tracked separately
+        // and reconciled on persistence success.)
         this.cache.set(frame.frame_number, frame);
+        this.baseline.set(frame.frame_number, frame);
+        this.dirty.delete(frame.frame_number);
       }
 
       mergeRange(this.fetchedRanges, result.range);
@@ -354,6 +439,24 @@ function extractDetections(
   }
 
   return out;
+}
+
+/**
+ * Return a shallow copy of `frame` with the `detections` list under
+ * `frameField` replaced by `fn(list)`. Preserves the original `frame`
+ * object so the baseline map keeps pointing at it.
+ */
+function withDetectionList(
+  frame: FrameDoc,
+  frameField: string,
+  fn: (list: RawDetection[]) => RawDetection[]
+): FrameDoc {
+  const existing = frame[frameField] as RawDetectionsField | undefined;
+  const list = existing?.detections ?? [];
+  return {
+    ...frame,
+    [frameField]: { ...existing, detections: fn(list) },
+  } as FrameDoc;
 }
 
 /**

--- a/app/packages/video-annotation/src/VideoLighterTile.tsx
+++ b/app/packages/video-annotation/src/VideoLighterTile.tsx
@@ -24,6 +24,7 @@ import { LABELS_STREAM_ID, VIDEO_STREAM_ID } from "./ids";
 import type { FrameLabelSnapshot } from "./SyntheticLabelStream";
 import { useFrameOverlaySync } from "./useFrameOverlaySync";
 import { useSyncLighterAnnotation } from "./useSyncLighterAnnotation";
+import { useSyncLighterLabelStream } from "./useSyncLighterLabelStream";
 import styles from "./VideoLighterTile.module.css";
 
 export interface VideoLighterTileProps {
@@ -172,6 +173,7 @@ export const VideoLighterTile: React.FC<VideoLighterTileProps> = ({
   useFrameOverlaySync(scene, snapshot, field, canonicalMediaReady);
 
   useSyncLighterAnnotation(scene);
+  useSyncLighterLabelStream(scene);
 
   return (
     <div className={styles.body}>

--- a/app/packages/video-annotation/src/VideoLighterTile.tsx
+++ b/app/packages/video-annotation/src/VideoLighterTile.tsx
@@ -23,6 +23,7 @@ import { useRecoilValue } from "recoil";
 import { LABELS_STREAM_ID, VIDEO_STREAM_ID } from "./ids";
 import type { FrameLabelSnapshot } from "./SyntheticLabelStream";
 import { useFrameOverlaySync } from "./useFrameOverlaySync";
+import { useSyncLighterAnnotation } from "./useSyncLighterAnnotation";
 import styles from "./VideoLighterTile.module.css";
 
 export interface VideoLighterTileProps {
@@ -169,6 +170,8 @@ export const VideoLighterTile: React.FC<VideoLighterTileProps> = ({
   // on the current scene — see `canonicalMediaReady` above.
   const snapshot = useStream<FrameLabelSnapshot>(LABELS_STREAM_ID);
   useFrameOverlaySync(scene, snapshot, field, canonicalMediaReady);
+
+  useSyncLighterAnnotation(scene);
 
   return (
     <div className={styles.body}>

--- a/app/packages/video-annotation/src/overlayAdapters/detection.ts
+++ b/app/packages/video-annotation/src/overlayAdapters/detection.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import {
+  type DetectionLabel,
+  DetectionOverlay,
+} from "@fiftyone/lighter";
+import type { SyntheticBox } from "../SyntheticLabelStream";
+import type { OverlayAdapter } from "./types";
+
+/**
+ * {@link OverlayAdapter} for FiftyOne `Detection` labels (axis-aligned
+ * bounding boxes). Maps the per-frame `detections` array onto Lighter
+ * `DetectionOverlay`s.
+ */
+export const detectionAdapter: OverlayAdapter<"detection"> = {
+  factoryKey: "detection",
+  snapshotKey: "detections",
+
+  extract(data, ctx) {
+    return {
+      id: data.id,
+      props: {
+        id: data.id,
+        label: toDetectionLabel(data),
+        relativeBounds: toRect(data.bounding_box),
+        field: ctx.field,
+        draggable: ctx.editable,
+        resizeable: ctx.editable,
+      },
+    };
+  },
+
+  update(overlay, data) {
+    if (!(overlay instanceof DetectionOverlay)) return;
+    overlay.relativeBounds = toRect(data.bounding_box);
+  },
+};
+
+/**
+ * Project a normalized bounding box (`[x, y, w, h]` tuple) onto the
+ * `Rect` shape Lighter's `DetectionOverlay.relativeBounds` expects.
+ *
+ * @param bbox - Normalized `[x, y, width, height]` in `[0, 1]`.
+ */
+function toRect(bbox: SyntheticBox["bounding_box"]): {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+} {
+  return { x: bbox[0], y: bbox[1], width: bbox[2], height: bbox[3] };
+}
+
+/**
+ * Project a {@link SyntheticBox} onto a {@link DetectionLabel} for the
+ * overlay's `label` field. `index` and `instance` are preserved
+ * verbatim — `COLOR_BY.INSTANCE` hashes on them, and without them
+ * every detection of the same class collapses to a single color in
+ * instance-color mode.
+ */
+function toDetectionLabel(box: SyntheticBox): DetectionLabel {
+  return {
+    label: box.label,
+    bounding_box: box.bounding_box,
+    index: box.index,
+    instance: box.instance,
+  } as DetectionLabel;
+}

--- a/app/packages/video-annotation/src/overlayAdapters/detection.ts
+++ b/app/packages/video-annotation/src/overlayAdapters/detection.ts
@@ -2,10 +2,7 @@
  * Copyright 2017-2026, Voxel51, Inc.
  */
 
-import {
-  type DetectionLabel,
-  DetectionOverlay,
-} from "@fiftyone/lighter";
+import { type DetectionLabel, DetectionOverlay } from "@fiftyone/lighter";
 import type { SyntheticBox } from "../SyntheticLabelStream";
 import type { OverlayAdapter } from "./types";
 

--- a/app/packages/video-annotation/src/overlayAdapters/index.ts
+++ b/app/packages/video-annotation/src/overlayAdapters/index.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { detectionAdapter } from "./detection";
+import type {
+  LabelKind,
+  OverlayAdapter,
+  OverlayAdapterRegistry,
+} from "./types";
+
+export type {
+  AdapterContext,
+  ExtractedOverlay,
+  LabelDataMap,
+  LabelKind,
+  OverlayAdapter,
+  OverlayAdapterRegistry,
+} from "./types";
+
+/**
+ * Build a stub adapter for a {@link LabelKind} that hasn't been wired
+ * yet. Stub entries surface the missing kind at the call site (rather
+ * than silently dropping its labels) and document at registry-read
+ * time which kinds the surface knows about but hasn't implemented.
+ *
+ * Replace the stub with a real adapter file when implementing the kind.
+ *
+ * @param kind - The unimplemented label kind, used in error messages.
+ */
+const notImplemented = <K extends LabelKind>(kind: K): OverlayAdapter<K> =>
+  ({
+    factoryKey: kind,
+    // Stub `snapshotKey` to the kind name. The snapshot has no such
+    // field, so the diff loop reads `undefined` and skips this adapter
+    // entirely — `extract` is never reached in practice.
+    snapshotKey: kind as never,
+    extract() {
+      throw new Error(`Overlay adapter for "${kind}" is not implemented`);
+    },
+    update() {
+      throw new Error(`Overlay adapter for "${kind}" is not implemented`);
+    },
+  } as OverlayAdapter<K>);
+
+/**
+ * Registry mapping each {@link LabelKind} to its {@link OverlayAdapter}.
+ * Real entries forward to dedicated adapter files; unimplemented kinds
+ * use {@link notImplemented} so adding a new kind is a single-line swap
+ * here plus a new adapter file.
+ */
+export const overlayAdapters: OverlayAdapterRegistry = {
+  detection: detectionAdapter,
+  polyline: notImplemented("polyline"),
+  keypoint: notImplemented("keypoint"),
+  segmentation: notImplemented("segmentation"),
+  heatmap: notImplemented("heatmap"),
+  mask: notImplemented("mask"),
+};

--- a/app/packages/video-annotation/src/overlayAdapters/types.ts
+++ b/app/packages/video-annotation/src/overlayAdapters/types.ts
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import type { BaseOverlay } from "@fiftyone/lighter";
+import type { FrameLabelSnapshot, SyntheticBox } from "../SyntheticLabelStream";
+
+/**
+ * Kinds of FiftyOne labels the video surface knows how to render.
+ *
+ * Adding a new kind requires three changes:
+ *   1. Add the kind to this union.
+ *   2. Add the kind's data shape to {@link LabelDataMap}.
+ *   3. Replace the kind's stub in the adapter registry with a real
+ *      {@link OverlayAdapter} implementation.
+ */
+export type LabelKind =
+  | "detection"
+  | "polyline"
+  | "keypoint"
+  | "segmentation"
+  | "heatmap"
+  | "mask";
+
+/**
+ * Maps each {@link LabelKind} to its in-snapshot data type. Unimplemented
+ * kinds map to `never` so the registry's typed signatures still compile;
+ * replace with the real wire shape when wiring the kind up.
+ */
+export type LabelDataMap = {
+  detection: SyntheticBox;
+  polyline: never;
+  keypoint: never;
+  segmentation: never;
+  heatmap: never;
+  mask: never;
+};
+
+/**
+ * Per-frame context threaded into {@link OverlayAdapter.extract}.
+ */
+export interface AdapterContext {
+  /** Schema field the labels are read from (e.g. `predictions.detections`). */
+  field: string;
+  /**
+   * Whether the user is currently allowed to drag/resize overlays.
+   * Wired from playback paused-state by {@link useFrameOverlaySync}.
+   */
+  editable: boolean;
+}
+
+/**
+ * Result of {@link OverlayAdapter.extract}: the data needed to call
+ * `overlayFactory.create(factoryKey, props)`.
+ */
+export interface ExtractedOverlay {
+  /** Stable identity for the overlay across frames. */
+  id: string;
+  /** Props forwarded as the second argument to `overlayFactory.create`. */
+  props: Record<string, unknown>;
+}
+
+/**
+ * Translates one kind of FiftyOne label into the Lighter overlay
+ * lifecycle calls needed to render it. Used by {@link useFrameOverlaySync}
+ * to dispatch per-kind without hardcoding any specific overlay type.
+ *
+ * @example
+ * ```ts
+ * const detectionAdapter: OverlayAdapter<"detection"> = {
+ *   factoryKey: "detection",
+ *   snapshotKey: "detections",
+ *   extract: (data, ctx) => ({ id: data.id, props: { ... } }),
+ *   update: (overlay, data) => { ... },
+ * };
+ * ```
+ */
+export interface OverlayAdapter<K extends LabelKind = LabelKind> {
+  /** Overlay-factory key passed to `overlayFactory.create(key, props)`. */
+  factoryKey: string;
+  /**
+   * Field on {@link FrameLabelSnapshot} this adapter's labels live under.
+   * The diff loop reads `snapshot[snapshotKey]` to enumerate inputs.
+   */
+  snapshotKey: keyof FrameLabelSnapshot;
+  /**
+   * Project a raw label into the args needed to create an overlay.
+   *
+   * @param data - One label entry pulled from `snapshot[snapshotKey]`.
+   * @param ctx - Per-diff context (field, editable, etc.).
+   * @returns Overlay-construction args, or `null` to skip this label
+   *   (e.g. malformed input, missing required fields).
+   */
+  extract(data: LabelDataMap[K], ctx: AdapterContext): ExtractedOverlay | null;
+  /**
+   * Apply a snapshot update to an existing overlay in place. Called
+   * when the diff loop finds an overlay with a matching id already in
+   * the scene. Implementations should mutate the overlay's reactive
+   * state directly (e.g. `overlay.relativeBounds = ...`).
+   *
+   * @param overlay - The existing scene overlay (caller-narrowed to a
+   *   `BaseOverlay`; implementations narrow further via `instanceof`).
+   * @param data - The latest label data from the snapshot.
+   */
+  update(overlay: BaseOverlay, data: LabelDataMap[K]): void;
+}
+
+/**
+ * Type-safe registry binding each {@link LabelKind} to its adapter.
+ * `Object.values(...)` over this still erases to `OverlayAdapter<LabelKind>`
+ * (the iteration site uses a narrow `as never` cast accordingly), but
+ * per-key access (`overlayAdapters.detection`) stays precisely typed.
+ */
+export type OverlayAdapterRegistry = {
+  [K in LabelKind]: OverlayAdapter<K>;
+};

--- a/app/packages/video-annotation/src/useFrameOverlaySync.ts
+++ b/app/packages/video-annotation/src/useFrameOverlaySync.ts
@@ -1,13 +1,12 @@
 import {
-  type DetectionLabel,
-  type DetectionOverlayOptions,
   DetectionOverlay,
   overlayFactory,
   useLighterSetupWithPixi,
 } from "@fiftyone/lighter";
 import { useIsPlaying } from "../../playback/src/lib/playback/use-playback-state";
 import { useEffect, useRef } from "react";
-import type { FrameLabelSnapshot, SyntheticBox } from "./SyntheticLabelStream";
+import { overlayAdapters } from "./overlayAdapters";
+import type { FrameLabelSnapshot } from "./SyntheticLabelStream";
 
 /**
  * Diff the latest snapshot into Lighter overlays. Add unseen
@@ -39,33 +38,30 @@ export function useFrameOverlaySync(
     // fix them. The effect re-runs once `canonicalMediaReady` flips.
     if (!scene || !snapshot || !canonicalMediaReady) return;
 
+    const ctx = { field, editable };
     const next = new Set<string>();
-    // todo - adapter pattern for other label types
-    for (const det of snapshot.detections) {
-      next.add(det.id);
-      const existing = scene.getOverlay(det.id) as DetectionOverlay | undefined;
-      const bounds = {
-        x: det.bounding_box[0],
-        y: det.bounding_box[1],
-        width: det.bounding_box[2],
-        height: det.bounding_box[3],
-      };
-      if (existing) {
-        existing.relativeBounds = bounds;
-      } else {
-        const overlay = overlayFactory.create<
-          DetectionOverlayOptions,
-          DetectionOverlay
-        >("detection", {
-          id: det.id,
-          label: toDetectionLabel(det),
-          relativeBounds: bounds,
-          field,
-          draggable: editable,
-          resizeable: editable,
-        });
-        scene.addOverlay(overlay);
-        trackedRef.current.add(det.id);
+
+    for (const adapter of Object.values(overlayAdapters)) {
+      const labels = snapshot[adapter.snapshotKey] as unknown[] | undefined;
+      if (!labels) continue;
+
+      for (const data of labels) {
+        const result = adapter.extract(data as never, ctx);
+        if (!result) continue;
+        next.add(result.id);
+
+        const existing = scene.getOverlay(result.id);
+        if (existing) {
+          adapter.update(existing, data as never);
+        } else {
+          const overlay = overlayFactory.create(adapter.factoryKey, result.props);
+          scene.addOverlay(overlay);
+        }
+        // Track every snapshot-backed overlay, not just ones we created.
+        // External adds (e.g. detectionMode.create) must enter the
+        // cleanup set too — otherwise the diff loop never removes them
+        // when the user scrubs off their frame.
+        trackedRef.current.add(result.id);
       }
     }
 
@@ -102,16 +98,4 @@ export function useFrameOverlaySync(
       trackedRef.current.clear();
     };
   }, [scene]);
-}
-
-function toDetectionLabel(box: SyntheticBox): DetectionLabel {
-  return {
-    label: box.label,
-    bounding_box: box.bounding_box,
-    // `index` and `instance` are what `COLOR_BY.INSTANCE` hashes on —
-    // without them every detection of the same class would collapse to
-    // a single color in instance mode.
-    index: box.index,
-    instance: box.instance,
-  } as DetectionLabel;
 }

--- a/app/packages/video-annotation/src/useFrameOverlaySync.ts
+++ b/app/packages/video-annotation/src/useFrameOverlaySync.ts
@@ -54,7 +54,10 @@ export function useFrameOverlaySync(
         if (existing) {
           adapter.update(existing, data as never);
         } else {
-          const overlay = overlayFactory.create(adapter.factoryKey, result.props);
+          const overlay = overlayFactory.create(
+            adapter.factoryKey,
+            result.props
+          );
           scene.addOverlay(overlay);
         }
         // Track every snapshot-backed overlay, not just ones we created.

--- a/app/packages/video-annotation/src/useFrameOverlaySync.ts
+++ b/app/packages/video-annotation/src/useFrameOverlaySync.ts
@@ -5,6 +5,7 @@ import {
   overlayFactory,
   useLighterSetupWithPixi,
 } from "@fiftyone/lighter";
+import { useIsPlaying } from "../../playback/src/lib/playback/use-playback-state";
 import { useEffect, useRef } from "react";
 import type { FrameLabelSnapshot, SyntheticBox } from "./SyntheticLabelStream";
 
@@ -26,6 +27,10 @@ export function useFrameOverlaySync(
   canonicalMediaReady: boolean
 ) {
   const trackedRef = useRef<Set<string>>(new Set());
+
+  // Disable drag/resize while the stream is playing
+  const isPlaying = useIsPlaying();
+  const editable = !isPlaying;
 
   useEffect(() => {
     // Skip the diff until the current scene has its canonical media —
@@ -56,9 +61,8 @@ export function useFrameOverlaySync(
           label: toDetectionLabel(det),
           relativeBounds: bounds,
           field,
-          draggable: false,
-          resizeable: false,
-          selectable: false,
+          draggable: editable,
+          resizeable: editable,
         });
         scene.addOverlay(overlay);
         trackedRef.current.add(det.id);
@@ -71,7 +75,19 @@ export function useFrameOverlaySync(
         trackedRef.current.delete(id);
       }
     }
-  }, [scene, snapshot, field, canonicalMediaReady]);
+  }, [scene, snapshot, field, canonicalMediaReady, editable]);
+
+  useEffect(() => {
+    if (!scene) return;
+
+    for (const id of trackedRef.current) {
+      const overlay = scene.getOverlay(id);
+      if (overlay instanceof DetectionOverlay) {
+        overlay.setDraggable(editable);
+        overlay.setResizeable(editable);
+      }
+    }
+  }, [scene, editable]);
 
   useEffect(() => {
     return () => {

--- a/app/packages/video-annotation/src/useSyncLighterAnnotation.ts
+++ b/app/packages/video-annotation/src/useSyncLighterAnnotation.ts
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { useAnnotationEventBus } from "@fiftyone/annotation";
+import {
+  DetectionOverlay,
+  type Scene2D,
+  UNDEFINED_LIGHTER_SCENE_ID,
+  useLighterEventHandler,
+} from "@fiftyone/lighter";
+import type { DetectionLabel } from "@fiftyone/looker";
+import { useCallback } from "react";
+import { useLabelsContext } from "../../core/src/components/Modal/Sidebar/Annotate";
+import useFocus from "../../core/src/components/Modal/Sidebar/Annotate/useFocus";
+import { useDetectionMode } from "../../core/src/components/Modal/Sidebar/Annotate/Edit/useDetectionMode";
+
+/**
+ * Bridges Lighter overlay events into the annotation / sidebar systems
+ * for the video surface. Event-handler-only — state changes flow
+ * through public hook interfaces (`useLabelsContext`, `useDetectionMode`,
+ * `useFocus`) rather than direct atom access.
+ */
+export const useSyncLighterAnnotation = (scene: Scene2D | null) => {
+  const useEventHandler = useLighterEventHandler(
+    scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
+  );
+  const annotationEventBus = useAnnotationEventBus();
+  const { addLabelToSidebar, removeLabelFromSidebar } = useLabelsContext();
+  const detectionMode = useDetectionMode();
+  const focus = useFocus();
+
+  useEventHandler(
+    "lighter:overlay-create",
+    useCallback(() => {
+      if (detectionMode.detectionModeActive) {
+        detectionMode.create();
+      }
+    }, [detectionMode])
+  );
+
+  useEventHandler(
+    "lighter:overlay-establish",
+    useCallback(
+      (payload) => {
+        if (!(payload.handler.overlay instanceof DetectionOverlay)) {
+          return;
+        }
+        annotationEventBus.dispatch(
+          "annotation:canvasDetectionOverlayEstablish",
+          { id: payload.id, overlay: payload.handler.overlay }
+        );
+      },
+      [annotationEventBus]
+    )
+  );
+
+  useEventHandler(
+    "lighter:overlay-added",
+    useCallback(
+      (payload) => {
+        if (
+          payload.overlay instanceof DetectionOverlay &&
+          payload.overlay.field
+        ) {
+          addLabelToSidebar({
+            data: payload.overlay.label as DetectionLabel,
+            overlay: payload.overlay,
+            path: payload.overlay.field,
+            type: "Detection",
+          });
+        }
+      },
+      [addLabelToSidebar]
+    )
+  );
+
+  useEventHandler(
+    "lighter:overlay-removed",
+    useCallback(
+      (payload) => {
+        removeLabelFromSidebar(payload.id);
+      },
+      [removeLabelFromSidebar]
+    )
+  );
+
+  useEventHandler(
+    "lighter:overlay-select",
+    useCallback(
+      (payload) => {
+        focus.selectOverlay(payload.id, {
+          ignoreSideEffects: payload.ignoreSideEffects,
+        });
+      },
+      [focus]
+    )
+  );
+
+  useEventHandler(
+    "lighter:overlay-deselect",
+    useCallback(
+      (payload) => {
+        focus.deselectOverlay({
+          ignoreSideEffects: payload.ignoreSideEffects,
+        });
+      },
+      [focus]
+    )
+  );
+
+  useEventHandler(
+    "lighter:detection-mode-quit",
+    useCallback(() => {
+      detectionMode.deactivateDetectionMode();
+    }, [detectionMode])
+  );
+
+  useEventHandler(
+    "lighter:active-mode-quit-requested",
+    useCallback(() => {
+      if (detectionMode.detectionModeActive) {
+        detectionMode.deactivateDetectionMode();
+      }
+    }, [detectionMode])
+  );
+};

--- a/app/packages/video-annotation/src/useSyncLighterAnnotation.ts
+++ b/app/packages/video-annotation/src/useSyncLighterAnnotation.ts
@@ -17,11 +17,30 @@ import { useDetectionMode } from "../../core/src/components/Modal/Sidebar/Annota
 
 /**
  * Bridges Lighter overlay events into the annotation / sidebar systems
- * for the video surface. Event-handler-only — state changes flow
- * through public hook interfaces (`useLabelsContext`, `useDetectionMode`,
- * `useFocus`) rather than direct atom access.
+ * for the video surface.
+ *
+ * Event-handler-only: state changes flow through public hook interfaces
+ * (`useLabelsContext`, `useDetectionMode`, `useFocus`) rather than direct
+ * atom access, so this stays decoupled from those modules' internals.
+ *
+ * Wires the following bridges:
+ *   - **Draw**: `lighter:overlay-create` → `detectionMode.create()`.
+ *   - **Establish**: `lighter:overlay-establish` →
+ *     `annotation:canvasDetectionOverlayEstablish` so the modal-level
+ *     handler can open the sidebar inspector for the new label.
+ *   - **Scene ↔ sidebar membership**: `lighter:overlay-added` /
+ *     `removed` → `addLabelToSidebar` / `removeLabelFromSidebar`.
+ *   - **Selection**: `lighter:overlay-select` / `deselect` →
+ *     `focus.selectOverlay` / `deselectOverlay`.
+ *   - **Mode quit**: `lighter:detection-mode-quit` and
+ *     `lighter:active-mode-quit-requested` (right-click / Esc) →
+ *     `detectionMode.deactivateDetectionMode()`.
+ *
+ * @param scene - The scene to bridge, or `null` while it's still being
+ *   set up. When `null`, handlers attach to an inert sentinel channel
+ *   and re-bind once the real scene becomes available.
  */
-export const useSyncLighterAnnotation = (scene: Scene2D | null) => {
+export const useSyncLighterAnnotation = (scene: Scene2D | null): void => {
   const useEventHandler = useLighterEventHandler(
     scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
   );

--- a/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
+++ b/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import {
+  DetectionOverlay,
+  type Scene2D,
+  UNDEFINED_LIGHTER_SCENE_ID,
+  useLighterEventHandler,
+} from "@fiftyone/lighter";
+import type { DetectionLabel } from "@fiftyone/looker";
+import { useCallback } from "react";
+import { useCurrentTime } from "../../playback/src/lib/playback/use-playback-state";
+import { useFrameLabelsStream } from "./FrameLabelsContext";
+import type { LocalDetection } from "./VideoFrameLabelsStream";
+
+/**
+ * Mirrors user-driven Lighter overlay edits into the label-stream cache
+ * so they survive frame scrubs.
+ *
+ * Persistence to the server is the eventual delta supplier's job; this
+ * hook only keeps the local cache aligned with what the user sees on
+ * the canvas:
+ *   - **Draw**: `lighter:overlay-establish` → `upsertDetection`.
+ *   - **Drag / resize**: `lighter:overlay-drag-end` /
+ *     `overlay-resize-end` → `upsertDetection` with the new bounds.
+ *   - **Delete**: `lighter:overlay-removed` → `removeDetection`.
+ *
+ * Synthetic-label mode has no stream to write to — the hook is a no-op
+ * when `useFrameLabelsStream()` returns `null`.
+ *
+ * @param scene - The scene whose overlay events are mirrored, or `null`
+ *   while it's still being set up.
+ */
+export const useSyncLighterLabelStream = (scene: Scene2D | null): void => {
+  const stream = useFrameLabelsStream();
+  const currentTime = useCurrentTime();
+
+  const useEventHandler = useLighterEventHandler(
+    scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
+  );
+
+  const upsertFromOverlay = useCallback(
+    (overlayId: string) => {
+      if (!stream || !scene) return;
+      const overlay = scene.getOverlay(overlayId);
+      if (!(overlay instanceof DetectionOverlay)) return;
+
+      const frame = stream.timeToFrame(currentTime);
+      stream.upsertDetection(frame, toLocalDetection(overlay));
+    },
+    [stream, scene, currentTime]
+  );
+
+  useEventHandler(
+    "lighter:overlay-establish",
+    useCallback(
+      (payload) => upsertFromOverlay(payload.id),
+      [upsertFromOverlay]
+    )
+  );
+
+  useEventHandler(
+    "lighter:overlay-drag-end",
+    useCallback(
+      (payload) => upsertFromOverlay(payload.id),
+      [upsertFromOverlay]
+    )
+  );
+
+  useEventHandler(
+    "lighter:overlay-resize-end",
+    useCallback(
+      (payload) => upsertFromOverlay(payload.id),
+      [upsertFromOverlay]
+    )
+  );
+
+  useEventHandler(
+    "lighter:overlay-removed",
+    useCallback(
+      (payload) => {
+        if (!stream) return;
+        const frame = stream.timeToFrame(currentTime);
+        stream.removeDetection(frame, payload.id);
+      },
+      [stream, currentTime]
+    )
+  );
+};
+
+/**
+ * Project a Lighter `DetectionOverlay` onto the
+ * {@link LocalDetection} shape the stream's cache stores.
+ *
+ * Reads bounds from the overlay directly (not from event payloads) so
+ * the cache always sees the post-edit state regardless of which event
+ * triggered the write.
+ */
+function toLocalDetection(overlay: DetectionOverlay): LocalDetection {
+  const bounds = overlay.relativeBounds;
+  const label = overlay.label as DetectionLabel;
+  return {
+    _id: overlay.id,
+    label: label.label,
+    bounding_box: [bounds.x, bounds.y, bounds.width, bounds.height],
+    index: label.index,
+    instance: label.instance ?? null,
+  };
+}

--- a/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
+++ b/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
@@ -54,26 +54,17 @@ export const useSyncLighterLabelStream = (scene: Scene2D | null): void => {
 
   useEventHandler(
     "lighter:overlay-establish",
-    useCallback(
-      (payload) => upsertFromOverlay(payload.id),
-      [upsertFromOverlay]
-    )
+    useCallback((payload) => upsertFromOverlay(payload.id), [upsertFromOverlay])
   );
 
   useEventHandler(
     "lighter:overlay-drag-end",
-    useCallback(
-      (payload) => upsertFromOverlay(payload.id),
-      [upsertFromOverlay]
-    )
+    useCallback((payload) => upsertFromOverlay(payload.id), [upsertFromOverlay])
   );
 
   useEventHandler(
     "lighter:overlay-resize-end",
-    useCallback(
-      (payload) => upsertFromOverlay(payload.id),
-      [upsertFromOverlay]
-    )
+    useCallback((payload) => upsertFromOverlay(payload.id), [upsertFromOverlay])
   );
 
   useEventHandler(

--- a/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
+++ b/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
@@ -21,10 +21,10 @@ import type { LocalDetection } from "./VideoFrameLabelsStream";
  * Persistence to the server is the eventual delta supplier's job; this
  * hook only keeps the local cache aligned with what the user sees on
  * the canvas:
- *   - **Draw**: `lighter:overlay-establish` → `upsertDetection`.
+ *   - **Draw**: `lighter:overlay-establish` → `updateLabel`.
  *   - **Drag / resize**: `lighter:overlay-drag-end` /
- *     `overlay-resize-end` → `upsertDetection` with the new bounds.
- *   - **Delete**: `lighter:overlay-removed` → `removeDetection`.
+ *     `overlay-resize-end` → `updateLabel` with the new bounds.
+ *   - **Delete**: `lighter:overlay-removed` → `deleteLabel`.
  *
  * Synthetic-label mode has no stream to write to — the hook is a no-op
  * when `useFrameLabelsStream()` returns `null`.
@@ -47,7 +47,7 @@ export const useSyncLighterLabelStream = (scene: Scene2D | null): void => {
       if (!(overlay instanceof DetectionOverlay)) return;
 
       const frame = stream.timeToFrame(currentTime);
-      stream.upsertDetection(frame, toLocalDetection(overlay));
+      stream.updateLabel(frame, toLocalDetection(overlay));
     },
     [stream, scene, currentTime]
   );
@@ -73,7 +73,7 @@ export const useSyncLighterLabelStream = (scene: Scene2D | null): void => {
       (payload) => {
         if (!stream) return;
         const frame = stream.timeToFrame(currentTime);
-        stream.removeDetection(frame, payload.id);
+        stream.deleteLabel(frame, payload.id);
       },
       [stream, currentTime]
     )


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

Wires Lighter overlay interactions to the video label-stream cache, so edits made on the canvas flow into a single source of truth.

- **Overlay diffs through adapters** — overlay create/edit/delete is dispatched through per-label-type adapters rather than handled inline, so each label type owns its own projection to/from the cache.
- **Persist edits to the cache** — overlay edits write into the label-stream cache.
- **Cross-frame notification** — consumers are notified on cache mutations so cross-frame views stay consistent.

Stacked on #7653.

## 🧪 How is this patch tested? If it is not, please explain why.

Tested locally in the app.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
