### PR TITLE
Video annotation: persist overlay edits end-to-end (frame-aware JSON Patch)

### DIFF
--- a/app/packages/annotation/src/hooks/index.ts
+++ b/app/packages/annotation/src/hooks/index.ts
@@ -7,4 +7,5 @@ export * from "./usePatchSample";
 export * from "./useRegisterAnnotationCommandHandlers";
 export * from "./useRegisterAnnotationEventHandlers";
 export * from "./useRegisterAnnotationKeyBindings";
+export * from "./useRegisterVideoAnnotationEventHandlers";
 export * from "./useRegisterRendererEventHandlers";

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationEventHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationEventHandlers.ts
@@ -1,0 +1,27 @@
+import { useFrameLabelsStream } from "@fiftyone/video-annotation";
+import { useCallback } from "react";
+import { useAnnotationEventHandler } from "./useAnnotationEventHandler";
+
+/**
+ * Video-specific annotation event handlers. Bridges persistence outcomes to the
+ * frame-labels stream so dirty/baseline state advances on success and rolls
+ * back on failure. Mount alongside {@link useRegisterAnnotationEventHandlers}
+ * at the composition root; no-op when the active modal isn't a video sample.
+ */
+export const useRegisterVideoAnnotationEventHandlers = () => {
+  const videoStream = useFrameLabelsStream();
+
+  useAnnotationEventHandler(
+    "annotation:persistenceSuccess",
+    useCallback(() => {
+      videoStream?.commitPending();
+    }, [videoStream])
+  );
+
+  useAnnotationEventHandler(
+    "annotation:persistenceError",
+    useCallback(() => {
+      videoStream?.discardPending();
+    }, [videoStream])
+  );
+};

--- a/app/packages/annotation/src/persistence/useAnnotationDeltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/useAnnotationDeltaSupplier.ts
@@ -3,6 +3,7 @@ import { useLighterDeltaSupplier } from "./useLighterDeltaSupplier";
 import { useCallback } from "react";
 import { useSidebarDeltaSupplier } from "./useSidebarDeltaSupplier";
 import { use3dDeltaSupplier } from "./use3dDeltaSupplier";
+import { useVideoLabelsDeltaSupplier } from "./useVideoLabelsDeltaSupplier";
 
 /**
  * Hook which provides a {@link DeltaSupplier} containing an aggregation of
@@ -12,19 +13,27 @@ export const useAnnotationDeltaSupplier = (): DeltaSupplier => {
   const supply3dDeltas = use3dDeltaSupplier();
   const supplyLighterDeltas = useLighterDeltaSupplier();
   const supplySidebarDeltas = useSidebarDeltaSupplier();
+  const supplyVideoLabelsDeltas = useVideoLabelsDeltaSupplier();
 
   return useCallback(() => {
     const result3d = supply3dDeltas();
     const resultLighter = supplyLighterDeltas();
     const resultSidebar = supplySidebarDeltas();
+    const resultVideoLabels = supplyVideoLabelsDeltas();
 
     const deltas = [
       ...result3d.deltas,
       ...resultLighter.deltas,
       ...resultSidebar.deltas,
+      ...resultVideoLabels.deltas,
     ];
 
     // Metadata for generated views only comes from Lighter
     return { deltas, metadata: resultLighter.metadata };
-  }, [supply3dDeltas, supplyLighterDeltas, supplySidebarDeltas]);
+  }, [
+    supply3dDeltas,
+    supplyLighterDeltas,
+    supplySidebarDeltas,
+    supplyVideoLabelsDeltas,
+  ]);
 };

--- a/app/packages/annotation/src/persistence/useLighterDeltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/useLighterDeltaSupplier.ts
@@ -11,7 +11,7 @@ import type { DetectionLabel } from "@fiftyone/looker";
 import type { ClassificationLabel } from "@fiftyone/looker/src/overlays/classifications";
 import type { PolylineLabel } from "@fiftyone/looker/src/overlays/polyline";
 import { BoundingBox } from "@fiftyone/looker/src/state";
-import { isPatchesView } from "@fiftyone/state";
+import { isPatchesView, useIsVideo } from "@fiftyone/state";
 import { hasValidBounds } from "@fiftyone/utilities";
 import { useCallback } from "react";
 import { useRecoilValue } from "recoil";
@@ -113,8 +113,17 @@ export const useLighterDeltaSupplier = (): DeltaSupplier => {
   const { scene } = useLighter();
   const getLabelDelta = useGetLabelDelta(buildAnnotationLabel);
   const isPatches = useRecoilValue(isPatchesView);
+  // Video samples emit deltas via useVideoLabelsDeltaSupplier, which sources
+  // edits from the per-frame label cache. The lighter scene's overlays
+  // double-count those edits, so skip them here. Remove once the Sample
+  // mutation refactor consolidates edit ownership.
+  const isVideo = useIsVideo();
 
   return useCallback(() => {
+    if (isVideo) {
+      return { deltas: [], metadata: undefined };
+    }
+
     const overlays = scene?.getAllOverlays() ?? [];
     const allDeltas: ReturnType<typeof getLabelDelta> = [];
     let firstChangedOverlay: BaseOverlay | undefined;
@@ -146,5 +155,5 @@ export const useLighterDeltaSupplier = (): DeltaSupplier => {
     }
 
     return { deltas: allDeltas, metadata };
-  }, [getLabelDelta, isPatches, scene]);
+  }, [getLabelDelta, isPatches, isVideo, scene]);
 };

--- a/app/packages/annotation/src/persistence/useVideoLabelsDeltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/useVideoLabelsDeltaSupplier.ts
@@ -1,0 +1,52 @@
+import type { JSONDeltas } from "@fiftyone/core/src/client";
+import { generateJsonPatch } from "@fiftyone/core/src/utils/json";
+import { useIsVideo } from "@fiftyone/state";
+import { useFrameLabelsStream } from "@fiftyone/video-annotation";
+import { useCallback } from "react";
+import type { DeltaSupplier } from "./deltaSupplier";
+
+/**
+ * Provides a {@link DeltaSupplier} for per-frame label edits made through the
+ * video annotation surface.
+ *
+ * Walks the stream's dirty frames; for each, structurally diffs the
+ * frame-field subtree (baseline → cache) and emits the resulting JSON-Patch
+ * ops with paths prefixed by `/frames/<frame_number>/<frame_field>`.
+ *
+ * A no-op for non-video samples and when no stream is mounted.
+ */
+export const useVideoLabelsDeltaSupplier = (): DeltaSupplier => {
+  const stream = useFrameLabelsStream();
+  const isVideo = useIsVideo();
+
+  return useCallback(() => {
+    if (!isVideo || !stream) {
+      return { deltas: [], metadata: undefined };
+    }
+
+    const frameField = stream.labelsField;
+    const snapshots = stream.getDirtyFrameSnapshots();
+    const deltas: JSONDeltas = [];
+
+    for (const { frameNumber, baseline, cache } of snapshots) {
+      const from = (baseline[frameField] ?? {}) as Record<string, unknown>;
+      const to = (cache[frameField] ?? {}) as Record<string, unknown>;
+      const subDeltas = generateJsonPatch(from, to);
+      const pathPrefix = `/frames/${frameNumber}/${frameField}`;
+
+      for (const op of subDeltas) {
+        deltas.push({ ...op, path: `${pathPrefix}${op.path}` });
+      }
+    }
+
+    // Stash the cache refs we just translated. The persistence event
+    // handler advances baseline on success (clearing dirty) or discards
+    // on failure (leaving dirty intact for retry). Without this, the
+    // same delta would re-emit on every autosave tick.
+    if (deltas.length > 0) {
+      stream.markCommitPending(snapshots);
+    }
+
+    return { deltas, metadata: undefined };
+  }, [isVideo, stream]);
+};

--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -4,6 +4,7 @@ import {
   useRegisterAnnotationEventHandlers,
   useRegisterAnnotationKeybindings,
   useRegisterRendererEventHandlers,
+  useRegisterVideoAnnotationEventHandlers,
 } from "@fiftyone/annotation";
 import {
   KnownCommands,
@@ -90,6 +91,7 @@ const SpacesContainer = styled.div`
 const AnnotationHandlerRegistration = () => {
   useRegisterAnnotationCommandHandlers();
   useRegisterAnnotationEventHandlers();
+  useRegisterVideoAnnotationEventHandlers();
   useRegisterAnnotationKeybindings();
   useRegisterRendererEventHandlers();
   useAnnotationTracking();

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useDetectionMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useDetectionMode.ts
@@ -65,6 +65,15 @@ const isEditingMaskAtom = atom((get) => {
 const detectionTypes = new Set(["Detection", "Detections"]);
 
 /**
+ * Reactive view of the detection field where a *new* detection would land.
+ */
+export const useActiveDetectionField = (): string | null => {
+  const lastUsedField = useAtomValue(lastUsedFieldAtom);
+  const defaultDetectionField = useAtomValue(defaultField(DETECTION));
+  return lastUsedField ?? defaultDetectionField;
+};
+
+/**
  * Centralized hook for managing detection mode state and operations.
  */
 export const useDetectionMode = () => {

--- a/app/packages/looker/src/elements/common/bubbles.ts
+++ b/app/packages/looker/src/elements/common/bubbles.ts
@@ -94,7 +94,7 @@ export const getField = (keys: string[], schema: Schema) => {
 export const parseSample = (keys: string[], sample: Data, schema: Schema) => {
   if (keys[0] === FRAMES && schema?.frames?.embeddedDocType === FRAMES_SAMPLE) {
     return {
-      values: sample?.frames[0] as Sample[],
+      values: (sample?.frames?.[0] ?? []) as Sample[],
       schema: schema.frames.fields,
       keys: keys.slice(1),
     };

--- a/app/packages/state/src/hooks/index.ts
+++ b/app/packages/state/src/hooks/index.ts
@@ -16,6 +16,7 @@ export * from "./useExpandSample";
 export { default as useExpandSample } from "./useExpandSample";
 export { default as useHelpPanel } from "./useHelpPanel";
 export { default as useHover } from "./useHover";
+export { useIsMediaType, useIsVideo } from "./useIsMediaType";
 export { default as useHoveredSample } from "./useHoveredSample";
 export { default as useJSONPanel } from "./useJSONPanel";
 export { default as useKeyDown } from "./useKeyDown";

--- a/app/packages/state/src/hooks/useIsMediaType.ts
+++ b/app/packages/state/src/hooks/useIsMediaType.ts
@@ -1,0 +1,15 @@
+import { useRecoilValue } from "recoil";
+import { mediaTypeSelector } from "../recoil/selectors";
+
+/**
+ * Returns `true` when the current dataset's media type matches the argument.
+ *
+ * Equality is on the dataset-level `mediaType` (e.g. `"video"`, `"image"`,
+ * `"point_cloud"`). For media-family checks like "is 3D", prefer the existing
+ * `is3DDataset` selector since it handles multiple matching types.
+ */
+export const useIsMediaType = (mediaType: string): boolean =>
+  useRecoilValue(mediaTypeSelector) === mediaType;
+
+/** Convenience: `useIsMediaType("video")`. */
+export const useIsVideo = (): boolean => useIsMediaType("video");

--- a/app/packages/video-annotation/index.ts
+++ b/app/packages/video-annotation/index.ts
@@ -12,3 +12,5 @@ export {
 } from "./src/ids";
 export { ImaVidImageStream } from "./src/ImaVidImageStream";
 export type { ImaVidImageFrame } from "./src/ImaVidImageStream";
+export { useFrameLabelsStream } from "./src/frameLabelsStream";
+export { VideoFrameLabelsStream } from "./src/VideoFrameLabelsStream";

--- a/app/packages/video-annotation/src/FrameLabels.tsx
+++ b/app/packages/video-annotation/src/FrameLabels.tsx
@@ -9,6 +9,7 @@ import {
 } from "@fiftyone/state";
 import type { ModalSample } from "@fiftyone/state";
 import type { Stage } from "@fiftyone/utilities";
+import { useActiveDetectionField } from "../../core/src/components/Modal/Sidebar/Annotate/Edit/useDetectionMode";
 import React, {
   useCallback,
   useEffect,
@@ -26,29 +27,38 @@ import {
 } from "../../playback/src/lib/tracks/TrackProvider";
 import TimelineWithTracks from "../../playback/src/views/TimelineWithTracks/TimelineWithTracks";
 import {
-  FrameLabelsContext,
   useFrameLabelsEditVersion,
   useFrameLabelsStream,
-} from "./FrameLabelsContext";
+  usePublishFrameLabelsStream,
+} from "./frameLabelsStream";
 import { buildPerInstanceTracks, type PerInstanceLabel } from "./frameTracks";
 import { LABELS_STREAM_ID } from "./ids";
 import { useLinkedTrackDecorator } from "./linkedTracks";
 import { VideoFrameLabelsStream } from "./VideoFrameLabelsStream";
 
-// todo - hardcoded for demo
-export const FRAME_FIELD = "frames.detections";
+const DEFAULT_FRAME_FIELD = "frames.detections";
+
+/**
+ * Strip the `frames.` prefix from a sample-schema field path to get the
+ * per-frame field name the `/frames` endpoint returns. Falls back to the
+ * raw value if no prefix is present (defensive — caller already filters
+ * to detection fields, which on videos always live under `frames.`).
+ */
+const toPerFrameField = (field: string): string =>
+  field.startsWith("frames.") ? field.slice("frames.".length) : field;
 
 /**
  * Reads the params needed to construct a real `/frames`-backed labels
  * stream from recoil + the modal sample, waits until duration is known
  * (so we can derive `frameCount`), then mounts the registration child
- * with a key that changes if the underlying sample / view changes — so
- * a fresh stream cleanly replaces the old one through usePlaybackStream's
- * standard lifecycle.
+ * with a key that changes if the underlying sample / view / active
+ * detection field changes — so a fresh stream cleanly replaces the old
+ * one through usePlaybackStream's standard lifecycle.
  *
- * Wraps its children in a `FrameLabelsContext.Provider` so downstream
- * consumers (e.g. {@link FrameLabelsTracks}) can read the same stream
- * without issuing duplicate fetches.
+ * The active stream is published via {@link usePublishFrameLabelsStream} so
+ * downstream consumers (track builder, persistence supplier mounted above
+ * the surface) can read it via {@link useFrameLabelsStream} without being
+ * tied to the registrar's React subtree.
  */
 export const RegisterFrameLabels: React.FC<{
   sample: ModalSample;
@@ -59,29 +69,32 @@ export const RegisterFrameLabels: React.FC<{
   const view = useRecoilValue(viewAtom);
   const slice = useRecoilValue(groupSlice);
   const sampleId = useRecoilValue(modalSampleId);
+  // Active detection field is the source of truth for which per-frame
+  // list this stream reads from and which list new edits patch into.
+  // Defaults to `frames.detections` while the schema is still resolving
+  // so the registrar doesn't repeatedly tear down and re-mount on first
+  // render.
+  const activeField = useActiveDetectionField() ?? DEFAULT_FRAME_FIELD;
 
   const frameRate = sample.frameRate;
   const ready =
     duration > 0 && !!sampleId && !!dataset && Number.isFinite(frameRate);
 
   if (!ready) {
-    // Stream params aren't all available yet; expose a null stream so
-    // consumers render their loading/placeholder state.
-    return (
-      <FrameLabelsContext.Provider value={null}>
-        {children}
-      </FrameLabelsContext.Provider>
-    );
+    // Stream params aren't all available yet; consumers read the atom and
+    // see `null` until FrameLabelsRegistration mounts.
+    return <>{children}</>;
   }
 
   const frameCount = Math.max(1, Math.round(duration * frameRate));
+  const frameField = toPerFrameField(activeField);
 
   // Include every input that affects the stream's identity in the key so
-  // changing sample / view re-mounts the registrar with a fresh stream
-  // and `usePlaybackStream`'s effect cleanup unregisters the old one.
+  // changing sample / view / field re-mounts the registrar with a fresh
+  // stream and `usePlaybackStream`'s effect cleanup unregisters the old one.
   const key = `${sampleId}|${dataset}|${
     slice ?? ""
-  }|${frameRate}|${frameCount}`;
+  }|${frameRate}|${frameCount}|${frameField}`;
 
   return (
     <FrameLabelsRegistration
@@ -92,6 +105,7 @@ export const RegisterFrameLabels: React.FC<{
       groupSlice={slice ?? null}
       frameCount={frameCount}
       frameRate={frameRate}
+      frameField={frameField}
     >
       {children}
     </FrameLabelsRegistration>
@@ -105,6 +119,7 @@ interface FrameLabelsRegistrationProps {
   groupSlice: string | null;
   frameCount: number;
   frameRate: number;
+  frameField: string;
   children: React.ReactNode;
 }
 
@@ -124,9 +139,15 @@ const FrameLabelsRegistration: React.FC<FrameLabelsRegistrationProps> = ({
       groupSlice: props.groupSlice,
       frameCount: props.frameCount,
       frameRate: props.frameRate,
+      frameField: props.frameField,
     });
   }
   usePlaybackStream(streamRef.current);
+
+  // Publish the active stream so consumers above the surface (e.g. the
+  // annotation persistence supplier mounted on <Modal>) can reach it
+  // through `useFrameLabelsStream()`. The hook handles clear-on-unmount.
+  usePublishFrameLabelsStream(streamRef.current);
 
   // Prefetch the chunk containing t=0 and then seek(0). The engine's
   // `seek` only commits when every blocking stream is already ready, so
@@ -144,11 +165,7 @@ const FrameLabelsRegistration: React.FC<FrameLabelsRegistrationProps> = ({
     };
   }, [seek]);
 
-  return (
-    <FrameLabelsContext.Provider value={streamRef.current}>
-      {children}
-    </FrameLabelsContext.Provider>
-  );
+  return <>{children}</>;
 };
 
 /**
@@ -173,6 +190,7 @@ export const FrameLabelsTracks: React.FC = () => {
   const editVersion = useFrameLabelsEditVersion();
   const scheme = useRecoilValue(colorScheme);
   const seed = useRecoilValue(colorSeed);
+  const activeField = useActiveDetectionField() ?? DEFAULT_FRAME_FIELD;
 
   // useState so we can re-render once warmupAll resolves, but keep the
   // build deterministic in the deps (stream identity changes when the
@@ -181,11 +199,11 @@ export const FrameLabelsTracks: React.FC = () => {
 
   const resolveColor = useCallback(
     (label: PerInstanceLabel) =>
-      getLabelColorFromContext(FRAME_FIELD, label, {
+      getLabelColorFromContext(activeField, label, {
         colorScheme: scheme,
         seed,
       }),
-    [scheme, seed]
+    [activeField, scheme, seed]
   );
 
   useEffect(() => {

--- a/app/packages/video-annotation/src/SyntheticLabelStream.ts
+++ b/app/packages/video-annotation/src/SyntheticLabelStream.ts
@@ -2,6 +2,15 @@ import { PlaybackStreamBase } from "../../playback/src/lib/playback/stream-base"
 
 export interface SyntheticBox {
   id: string;
+  /**
+   * Real MongoDB `_id` of the source detection when one exists. The
+   * overlay-facing {@link id} is synthesized from the track index for
+   * tracked detections (so cross-frame identity for color/highlight
+   * matches the timeline track), but persistence needs the original
+   * `_id` to upsert the right element in the baseline detections list.
+   * Undefined for freshly-drawn boxes that haven't been persisted yet.
+   */
+  _id?: string;
   label: string;
   /** Normalized [x, y, w, h] in [0, 1]. */
   bounding_box: [number, number, number, number];

--- a/app/packages/video-annotation/src/VideoAnnotationSurface.tsx
+++ b/app/packages/video-annotation/src/VideoAnnotationSurface.tsx
@@ -1,12 +1,9 @@
 import { getSampleSrc } from "@fiftyone/state";
 import type { ModalSample } from "@fiftyone/state";
 import React, { useMemo, useState } from "react";
+import { useActiveDetectionField } from "../../core/src/components/Modal/Sidebar/Annotate/Edit/useDetectionMode";
 import { PlaybackProvider } from "../../playback/src/lib/playback/PlaybackProvider";
-import {
-  FRAME_FIELD,
-  FrameLabelsTracks,
-  RegisterFrameLabels,
-} from "./FrameLabels";
+import { FrameLabelsTracks, RegisterFrameLabels } from "./FrameLabels";
 import { ImaVidLighterTile } from "./ImaVidLighterTile";
 import { LinkedOverlayStateBridge } from "./linkedTracks";
 import { RegisterImaVidImage } from "./RegisterImaVidImage";
@@ -101,7 +98,16 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
     return url ? getSampleSrc(url) : null;
   }, [sample, tileMode]);
 
-  const field = labelsMode === "synthetic" ? SYNTHETIC_FIELD : FRAME_FIELD;
+  // Tracks the detection field the sidebar is currently configured to annotate
+  // into so newly-drawn overlays paint with the right color and persist to the
+  // right list. `null` means no detection field is available (e.g. schema
+  // has none, or all are read-only) — the surface still renders, but
+  // overlay extraction will see a missing per-frame key and emit nothing.
+  const activeDetectionField = useActiveDetectionField();
+  const field =
+    labelsMode === "synthetic"
+      ? SYNTHETIC_FIELD
+      : activeDetectionField ?? "frames.detections";
 
   const media =
     tileMode === "imavid" ? (

--- a/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
+++ b/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
@@ -31,6 +31,7 @@ interface RawDetectionsField {
  * since a Detection with no bbox is meaningless for a video overlay.
  */
 export interface LocalDetection {
+  _cls?: "Detection";
   _id?: string;
   id?: string;
   index?: number;
@@ -104,6 +105,10 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
   private readonly baseline = new Map<number, FrameDoc>();
   // Frames with local edits that haven't been persisted to the server.
   private readonly dirty = new Set<number>();
+  // Cache refs captured at delta-build time. On persistence success, these
+  // become the new baseline; on failure they're discarded. Null when no
+  // patch is in flight.
+  private pendingCommit: Map<number, FrameDoc> | null = null;
   private readonly inflight = new Map<number, Promise<void>>();
   private readonly fetchedRanges: Array<[number, number]> = [];
   // Cached on each `onCommit` so local-edit republishes can write to
@@ -200,6 +205,11 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
   /** Frame rate the stream was constructed with, in fps. */
   get fps(): number {
     return this.frameRate;
+  }
+
+  /** Per-frame field that carries the labels (e.g. `"detections"`). */
+  get labelsField(): string {
+    return this.frameField;
   }
 
   bufferState(time: number): BufferReadiness {
@@ -322,6 +332,76 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
   /** Whether the given frame has unsaved local edits. */
   isDirty(frameNumber: number): boolean {
     return this.dirty.has(frameNumber);
+  }
+
+  /**
+   * Snapshots for every frame with unsaved local edits. Each entry pairs the
+   * server-original baseline with the current cache state — translation to a
+   * wire format (JSON Patch, GraphQL mutation, …) is the caller's concern.
+   *
+   * Returns an empty array when no frames are dirty.
+   */
+  getDirtyFrameSnapshots(): Array<{
+    frameNumber: number;
+    baseline: FrameDoc;
+    cache: FrameDoc;
+  }> {
+    const out: Array<{
+      frameNumber: number;
+      baseline: FrameDoc;
+      cache: FrameDoc;
+    }> = [];
+
+    for (const frameNumber of this.dirty) {
+      const baseline = this.baseline.get(frameNumber);
+      const cache = this.cache.get(frameNumber);
+
+      if (!baseline || !cache) continue;
+
+      out.push({ frameNumber, baseline, cache });
+    }
+
+    return out;
+  }
+
+  /**
+   * Stash the cache refs that were just translated into a persistence
+   * payload. Paired with {@link commitPending} on success and
+   * {@link discardPending} on failure. Overwrites any prior pending state
+   * — the persistence layer guarantees only one in-flight save at a time.
+   */
+  markCommitPending(
+    snapshots: ReadonlyArray<{ frameNumber: number; cache: FrameDoc }>
+  ): void {
+    this.pendingCommit = new Map(
+      snapshots.map((s) => [s.frameNumber, s.cache])
+    );
+  }
+
+  /**
+   * Advance baseline for every pending frame to the cache ref that was
+   * captured at {@link markCommitPending} time. A frame stays dirty if the
+   * cache has moved since (the user kept editing during the save) — that
+   * way the next save sends only the *incremental* delta against the
+   * just-saved state.
+   */
+  commitPending(): void {
+    if (!this.pendingCommit) return;
+
+    for (const [frameNumber, frameDoc] of this.pendingCommit) {
+      this.baseline.set(frameNumber, frameDoc);
+      if (this.cache.get(frameNumber) === frameDoc) {
+        this.dirty.delete(frameNumber);
+      }
+    }
+
+    this.pendingCommit = null;
+    this.bumpEditVersion();
+  }
+
+  /** Drop the pending snapshot without touching baseline or dirty. */
+  discardPending(): void {
+    this.pendingCommit = null;
   }
 
   /**
@@ -461,6 +541,7 @@ function extractDetections(
 
     out.push({
       id,
+      _id: detId ?? undefined,
       label: det.label ?? "",
       bounding_box: det.bounding_box,
       index: det.index,

--- a/app/packages/video-annotation/src/frameLabelsStream.ts
+++ b/app/packages/video-annotation/src/frameLabelsStream.ts
@@ -1,26 +1,37 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useSyncExternalStore,
-} from "react";
+import { atom, useAtomValue, useSetAtom } from "jotai";
+import { useCallback, useEffect, useSyncExternalStore } from "react";
 import type { VideoFrameLabelsStream } from "./VideoFrameLabelsStream";
 
 /**
- * Shares the active frame-labels stream from the registrar component
- * down to downstream consumers (e.g. the per-class track builder) so we
- * don't issue duplicate `/frames` fetches against the same sample.
+ * Active frame-labels stream; publication goes through
+ * {@link usePublishFrameLabelsStream} so external code can't write arbitrary
+ * values.
  *
- * Value is `null` while the stream's params (sampleId, duration, etc.)
- * aren't all available yet — consumers should treat that as "no data
- * available; render placeholder."
+ * `null` while the stream's params (sampleId, duration, etc.) aren't all
+ * available yet — consumers should treat that as "no data available; render
+ * placeholder."
  */
-export const FrameLabelsContext = createContext<VideoFrameLabelsStream | null>(
-  null
-);
+const frameLabelsStreamAtom = atom<VideoFrameLabelsStream | null>(null);
 
 export function useFrameLabelsStream(): VideoFrameLabelsStream | null {
-  return useContext(FrameLabelsContext);
+  return useAtomValue(frameLabelsStreamAtom);
+}
+
+/**
+ * Publishes `stream` as the active frame-labels stream for the lifetime of
+ * the calling component, clearing on unmount. Intended for the labels
+ * registrar; nothing else should be publishing.
+ */
+export function usePublishFrameLabelsStream(
+  stream: VideoFrameLabelsStream | null
+): void {
+  const setStream = useSetAtom(frameLabelsStreamAtom);
+
+  useEffect(() => {
+    setStream(stream);
+
+    return () => setStream(null);
+  }, [setStream, stream]);
 }
 
 /**
@@ -37,13 +48,16 @@ export function useFrameLabelsStream(): VideoFrameLabelsStream | null {
  */
 export function useFrameLabelsEditVersion(): number {
   const stream = useFrameLabelsStream();
+
   const subscribe = useCallback(
     (notify: () => void) => stream?.subscribeToEdits(notify) ?? (() => {}),
     [stream]
   );
+
   const getSnapshot = useCallback(
     () => stream?.getEditVersion() ?? 0,
     [stream]
   );
+
   return useSyncExternalStore(subscribe, getSnapshot);
 }

--- a/app/packages/video-annotation/src/overlayAdapters/detection.ts
+++ b/app/packages/video-annotation/src/overlayAdapters/detection.ts
@@ -59,6 +59,7 @@ function toRect(bbox: SyntheticBox["bounding_box"]): {
  */
 function toDetectionLabel(box: SyntheticBox): DetectionLabel {
   return {
+    _id: box._id,
     label: box.label,
     bounding_box: box.bounding_box,
     index: box.index,

--- a/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
+++ b/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
@@ -11,7 +11,7 @@ import {
 import type { DetectionLabel } from "@fiftyone/looker";
 import { useCallback } from "react";
 import { useCurrentTime } from "../../playback/src/lib/playback/use-playback-state";
-import { useFrameLabelsStream } from "./FrameLabelsContext";
+import { useFrameLabelsStream } from "./frameLabelsStream";
 import type { LocalDetection } from "./VideoFrameLabelsStream";
 
 /**
@@ -91,11 +91,24 @@ export const useSyncLighterLabelStream = (scene: Scene2D | null): void => {
 function toLocalDetection(overlay: DetectionOverlay): LocalDetection {
   const bounds = overlay.relativeBounds;
   const label = overlay.label as DetectionLabel;
-  return {
-    _id: overlay.id,
+  // Prefer the real MongoDB `_id` from the underlying label so cache
+  // upserts match the existing baseline entry. `overlay.id` is the
+  // synthetic `track-<n>` id used for cross-frame identity and won't
+  // match anything in the baseline detections array.
+  const det: LocalDetection = {
+    _cls: "Detection",
+    _id: label._id ?? overlay.id,
     label: label.label,
     bounding_box: [bounds.x, bounds.y, bounds.width, bounds.height],
-    index: label.index,
-    instance: label.instance ?? null,
   };
+
+  if (label.index !== undefined) {
+    det.index = label.index;
+  }
+
+  if (label.instance) {
+    det.instance = label.instance;
+  }
+
+  return det;
 }

--- a/fiftyone/server/routes/sample.py
+++ b/fiftyone/server/routes/sample.py
@@ -18,6 +18,7 @@ from starlette.exceptions import HTTPException
 from starlette.requests import Request
 
 import fiftyone as fo
+import fiftyone.core.frame as fof
 from fiftyone.server import decorators, utils
 from fiftyone.server.exceptions import DbVersionMismatchError
 from fiftyone.server.utils.datasets import (
@@ -277,8 +278,10 @@ def ensure_sample_field(sample: fo.Sample, field: str):
     for idx, part in enumerate(field_parts):
         field_path = ".".join(field_parts[: idx + 1])
 
+        key = int(part) if isinstance(current, fof.Frames) else part
+
         try:
-            current_part = current[part]
+            current_part = current[key]
         except (KeyError, TypeError, IndexError):
             current_part = None
 
@@ -303,7 +306,7 @@ def ensure_sample_field(sample: fo.Sample, field: str):
                 sample.set_field(field_path, field_type())
 
         # recurse
-        current = current[part]
+        current = current[key]
 
 
 def save_sample(
@@ -342,6 +345,13 @@ def save_sample(
             raise DbVersionMismatchError(
                 sample, etag=generate_sample_etag(sample)
             )
+
+        # `replace_one` writes the sample doc only — for video samples,
+        # frame mutations live in a separate collection and would be lost
+        # by the subsequent `reload(hard=True)`. Flush them explicitly so
+        # the ETag-protected path matches `sample.save()`'s behavior.
+        if sample.media_type == "video":
+            sample.frames.save()
     else:
         sample.save()
 
@@ -462,9 +472,24 @@ class Sample(HTTPEndpoint):
 
         etag = save_sample(sample, if_last_modified_at)
 
-        return utils.json.JSONResponse(
-            utils.json.serialize(sample), headers={"ETag": etag}
-        )
+        response_body = utils.json.serialize(sample)
+
+        # Video sample responses must carry the first frame so the grid's
+        # video tile keeps its `sample.frames[0]` contract after a patch
+        # refresh propagates the new sample. `to_dict` drops `frames` by
+        # default; reconstruct just the head frame to match the grid's
+        # initial-load shape (a single-element list).
+        if sample.media_type == "video" and isinstance(response_body, dict):
+            try:
+                head_frame = sample.frames.first()
+            except Exception:
+                head_frame = None
+            if head_frame is not None:
+                response_body["frames"] = [
+                    head_frame.to_dict(include_private=True)
+                ]
+
+        return utils.json.JSONResponse(response_body, headers={"ETag": etag})
 
     def _handle_patch(self, sample: fo.Sample, data: dict) -> fo.Sample:
         errors = {}
@@ -724,9 +749,7 @@ class CommitMask(HTTPEndpoint):
         mask_path = detection.mask_path
 
         try:
-            detection.export_mask(
-                mask_path, update=True, overwrite_path=True
-            )
+            detection.export_mask(mask_path, update=True, overwrite_path=True)
             etag = save_sample(sample, if_last_modified_at)
         except DbVersionMismatchError:
             raise

--- a/fiftyone/server/utils/json/jsonpatch/methods.py
+++ b/fiftyone/server/utils/json/jsonpatch/methods.py
@@ -10,6 +10,8 @@ from typing import TypeVar, Union
 
 import jsonpointer
 
+import fiftyone.core.frame as fof
+
 from fiftyone.server.utils.json.jsonpatch import RootDeleteError
 
 T = TypeVar("T")
@@ -54,6 +56,12 @@ def get(src: T, path: Union[str, jsonpointer.JsonPointer]) -> V:
 
         value = src
         for name in pointer.parts:
+            # fo.Frames keys by integer frame number — coerce up-front
+            # rather than rely on FrameError's exception message.
+            if isinstance(value, fof.Frames):
+                value = value[int(name)]
+                continue
+
             try:
                 value = getattr(value, name)
                 continue
@@ -126,7 +134,9 @@ def add(
     name = pointer.parts[-1]
 
     try:
-        if hasattr(target, "__setitem__"):
+        if isinstance(target, fof.Frames):
+            target[int(name)] = value
+        elif hasattr(target, "__setitem__"):
             try:
                 target[name] = value
             except TypeError as type_err:
@@ -235,7 +245,9 @@ def remove(src: T, path: Union[str, jsonpointer.JsonPointer]) -> T:
     get(target, jsonpointer.JsonPointer.from_parts([name]))
 
     try:
-        if hasattr(target, "__delitem__"):
+        if isinstance(target, fof.Frames):
+            del target[int(name)]
+        elif hasattr(target, "__delitem__"):
             try:
                 del target[name]
             except TypeError as err:

--- a/tests/unittests/server/utils/jsonpatch/test_jsonpatch_methods.py
+++ b/tests/unittests/server/utils/jsonpatch/test_jsonpatch_methods.py
@@ -10,6 +10,7 @@ from unittest import mock
 
 import pytest
 
+import fiftyone.core.frame as fof
 from fiftyone.server.utils.json.jsonpatch import RootDeleteError
 from fiftyone.server.utils.json.jsonpatch.methods import (
     get,
@@ -403,3 +404,67 @@ def test_replace():
 
     assert res is src
     assert src["a"]["b"]["c"] == "new"
+
+
+class _StubFrames(fof.Frames):
+    """Minimal fof.Frames stub.
+
+    fof.Frames keys by integer frame number and rejects string keys via
+    validate_frame_number. The jsonpatch traversal must coerce path parts
+    to int when stepping through a Frames instance; this stub avoids the
+    need for a real fo.Sample / DB connection.
+    """
+
+    def __init__(self):
+        self._data: dict[int, Any] = {}
+
+    def __getitem__(self, frame_number):
+        return self._data[frame_number]
+
+    def __setitem__(self, frame_number, value):
+        self._data[frame_number] = value
+
+    def __delitem__(self, frame_number):
+        del self._data[frame_number]
+
+    def __contains__(self, frame_number):
+        return frame_number in self._data
+
+
+class TestFramesTraversal:
+    """Traversal through fof.Frames should coerce numeric path parts to int."""
+
+    @staticmethod
+    def test_get_through_frames():
+        frames = _StubFrames()
+        frames[42] = {"detections": {"detections": ["box"]}}
+        src = {"frames": frames}
+
+        assert get(src, "/frames/42/detections/detections/0") == "box"
+
+    @staticmethod
+    def test_add_through_frames():
+        frames = _StubFrames()
+        src = {"frames": frames}
+
+        add(src, "/frames/7", {"label": "hello"})
+
+        assert frames[7] == {"label": "hello"}
+
+    @staticmethod
+    def test_remove_through_frames():
+        frames = _StubFrames()
+        frames[3] = {"label": "bye"}
+        src = {"frames": frames}
+
+        remove(src, "/frames/3")
+
+        assert 3 not in frames
+
+    @staticmethod
+    def test_get_into_field_inside_frame():
+        frames = _StubFrames()
+        frames[1] = {"detections": {"detections": [{"label": "car"}]}}
+        src = {"frames": frames}
+
+        assert get(src, "/frames/1/detections/detections/0/label") == "car"


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

Persists video overlay edits end-to-end, from the label-stream cache through to the database.

- **Frame-aware JSON Patch** — the delta supplier emits patches addressed under `frames.<n>.…` so per-frame edits target the right document.
- **Server** — frame edits are persisted on a video sample `PATCH`.
- **Refactor** — video persistence event handlers extracted for clarity.

Stacked on #7682.

## 🧪 How is this patch tested? If it is not, please explain why.

Tested locally in the app (edit → save → reload round-trip).

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
