### PR TITLE
Video annotation: keyframes + cross-frame instance identity

### DIFF
--- a/app/packages/annotation/src/commands.ts
+++ b/app/packages/annotation/src/commands.ts
@@ -17,3 +17,27 @@ export class DeleteAnnotationCommand extends Command<boolean> {
     super();
   }
 }
+
+/**
+ * Toggle the `keyframe` attribute on a set of video detections at a
+ * specific playback time. Callers capture the time + selection at the
+ * moment of user intent (keybinding handler, button click, …) and
+ * pass them in — the command handler must not re-read "current time"
+ * or "current selection", which would race the user's gesture and
+ * land the toggle on a stale frame.
+ *
+ * `time` is in seconds. `detectionIds` are the synthetic overlay ids
+ * (e.g. `track-N` or a MongoDB `_id`) the stream and Lighter agree on.
+ *
+ * Result is `true` when at least one cache entry was toggled, `false`
+ * when there's no active video stream, no matching cache entry, or no
+ * ids in the payload.
+ */
+export class MarkKeyframeCommand extends Command<boolean> {
+  constructor(
+    public readonly time: number,
+    public readonly detectionIds: readonly string[]
+  ) {
+    super();
+  }
+}

--- a/app/packages/annotation/src/hooks/index.ts
+++ b/app/packages/annotation/src/hooks/index.ts
@@ -7,5 +7,7 @@ export * from "./usePatchSample";
 export * from "./useRegisterAnnotationCommandHandlers";
 export * from "./useRegisterAnnotationEventHandlers";
 export * from "./useRegisterAnnotationKeyBindings";
+export * from "./useRegisterVideoAnnotationCommandHandlers";
 export * from "./useRegisterVideoAnnotationEventHandlers";
+export * from "./useRegisterVideoAnnotationKeybindings";
 export * from "./useRegisterRendererEventHandlers";

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
@@ -1,0 +1,66 @@
+import { useRegisterCommandHandler } from "@fiftyone/command-bus";
+import {
+  useFrameLabelsStream,
+  type LocalDetection,
+} from "@fiftyone/video-annotation";
+import { useCallback } from "react";
+import { frameAt } from "../../../playback/src/lib/playback/utils";
+import { MarkKeyframeCommand } from "../commands";
+
+/**
+ * Registers video-specific annotation command handlers. Mount inside
+ * the video annotation surface's `<PlaybackProvider>` so dispatchers
+ * (keybinding handlers, toolbar buttons, …) can capture the playhead
+ * and selection at the moment of user intent.
+ */
+export const useRegisterVideoAnnotationCommandHandlers = () => {
+  const stream = useFrameLabelsStream();
+
+  useRegisterCommandHandler(
+    MarkKeyframeCommand,
+    useCallback(
+      async (cmd) => {
+        if (!stream) return false;
+        if (cmd.detectionIds.length === 0) return false;
+
+        const snapshot = stream.getValue(cmd.time);
+        if (!snapshot) return false;
+
+        const frame = frameAt(cmd.time, stream.fps, stream.totalFrames);
+
+        let updated = false;
+        for (const id of cmd.detectionIds) {
+          const det = snapshot.detections.find((d) => d.id === id);
+          if (!det) continue;
+
+          // Minimal update — `bounding_box` is required by LocalDetection
+          // but matches the existing cache entry, so the structural diff
+          // sees only the fields that actually changed. Avoid setting
+          // `instance` / `propagation` / `label` / `index` explicitly:
+          // updateLabel's shallow merge preserves them from the cache,
+          // and writing them as nulls would emit spurious `add ...
+          // value: null` patch ops against baselines that lack the keys.
+          const update: LocalDetection = {
+            _cls: "Detection",
+            _id: det._id ?? id,
+            bounding_box: det.bounding_box,
+            keyframe: !det.keyframe,
+          };
+
+          // Promotion to keyframe semantically clears propagation. Only
+          // write the field when there's something to clear — otherwise
+          // we'd emit a no-op `add propagation: null` patch op.
+          if (!det.keyframe && det.propagation) {
+            update.propagation = null;
+          }
+
+          stream.updateLabel(frame, update);
+          updated = true;
+        }
+
+        return updated;
+      },
+      [stream]
+    )
+  );
+};

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
@@ -33,6 +33,8 @@ export const useRegisterVideoAnnotationCommandHandlers = () => {
           const det = snapshot.detections.find((d) => d.id === id);
           if (!det) continue;
 
+          const willBeKeyframe = !det.keyframe;
+
           // Minimal update — `bounding_box` is required by LocalDetection
           // but matches the existing cache entry, so the structural diff
           // sees only the fields that actually changed. Avoid setting
@@ -44,13 +46,13 @@ export const useRegisterVideoAnnotationCommandHandlers = () => {
             _cls: "Detection",
             _id: det._id ?? id,
             bounding_box: det.bounding_box,
-            keyframe: !det.keyframe,
+            keyframe: willBeKeyframe,
           };
 
           // Promotion to keyframe semantically clears propagation. Only
           // write the field when there's something to clear — otherwise
           // we'd emit a no-op `add propagation: null` patch op.
-          if (!det.keyframe && det.propagation) {
+          if (willBeKeyframe && det.propagation) {
             update.propagation = null;
           }
 

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationKeybindings.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationKeybindings.ts
@@ -1,0 +1,48 @@
+import { useCommandBus } from "@fiftyone/command-bus";
+import { KnownContexts, useKeyBindings } from "@fiftyone/commands";
+import { useLighter } from "@fiftyone/lighter";
+import { useRef } from "react";
+import { usePlayhead } from "../../../playback/src/lib/playback/use-playback-state";
+import { MarkKeyframeCommand } from "../commands";
+
+/**
+ * Registers video-only keybindings into the modal-annotate context.
+ * Must mount inside the video annotation surface's `<PlaybackProvider>`
+ * because it reads `usePlayhead` to capture the user-visible time at
+ * key-press. Composes with {@link useRegisterAnnotationKeybindings};
+ * both can target the same context.
+ */
+export const useRegisterVideoAnnotationKeybindings = () => {
+  const bus = useCommandBus();
+  const { scene } = useLighter();
+
+  // Read the visual playhead, not `useCurrentTime` — currentTime lags
+  // playhead while streams buffer, so dispatching at "the moment the
+  // user pressed K" needs the visual position. Held in a ref so the
+  // keybinding handler is rebuilt only when `scene` or `bus` change.
+  const playhead = usePlayhead();
+  const playheadRef = useRef(playhead);
+  playheadRef.current = playhead;
+
+  useKeyBindings(
+    KnownContexts.ModalAnnotate,
+    [
+      {
+        commandId: "annotation-mark-keyframe",
+        sequence: "k",
+        handler: () => {
+          if (!scene) return;
+          const ids = scene.getSelectedOverlayIds();
+          if (ids.length === 0) return;
+          void bus.execute(
+            new MarkKeyframeCommand(playheadRef.current, ids)
+          );
+        },
+        label: "Mark keyframe",
+        description:
+          "Toggle the keyframe attribute on the selected detection at the current frame.",
+      },
+    ],
+    [scene, bus]
+  );
+};

--- a/app/packages/playback/src/lib/playback/PlaybackProvider.test.tsx
+++ b/app/packages/playback/src/lib/playback/PlaybackProvider.test.tsx
@@ -13,7 +13,11 @@ import {
   viewEndAtom,
   viewStartAtom,
 } from "./atoms";
-import { PlaybackProvider, usePlayback, usePlaybackStore } from "./PlaybackProvider";
+import {
+  PlaybackProvider,
+  usePlayback,
+  usePlaybackStore,
+} from "./PlaybackProvider";
 import type { PlaybackStream } from "./types";
 
 interface RenderOpts {
@@ -163,6 +167,20 @@ describe("PlaybackProvider engine actions", () => {
       const { result } = renderEngine({ duration: 10 });
       act(() => result.current.api.stepBack());
       expect(result.current.playhead).toBe(0);
+    });
+
+    it("snaps to frame boundaries from a mid-frame playhead", () => {
+      const { result } = renderEngine({ duration: 10 });
+      // Land between frame 30 (start 29/30) and frame 31 (start 30/30 = 1).
+      act(() => result.current.api.seek(0.99));
+      act(() => result.current.api.stepForward());
+      // Displayed frame at t=0.99 is 30 (zero-indexed K=29); forward → K=30.
+      expect(result.current.playhead).toBeCloseTo(30 / 30, 5);
+
+      act(() => result.current.api.seek(0.99));
+      act(() => result.current.api.stepBack());
+      // back from displayed frame 30 → frame 29 (K=28).
+      expect(result.current.playhead).toBeCloseTo(28 / 30, 5);
     });
   });
 
@@ -423,14 +441,11 @@ describe("PlaybackProvider engine actions", () => {
     });
 
     it("falls back to 1/30 when neither prop nor stream provides a step", () => {
-      const { result } = renderHook(
-        () => ({ store: usePlaybackStore() }),
-        {
-          wrapper: ({ children }) => (
-            <PlaybackProvider>{children}</PlaybackProvider>
-          ),
-        }
-      );
+      const { result } = renderHook(() => ({ store: usePlaybackStore() }), {
+        wrapper: ({ children }) => (
+          <PlaybackProvider>{children}</PlaybackProvider>
+        ),
+      });
       expect(result.current.store.get(stepIntervalAtom)).toBeCloseTo(1 / 30, 6);
     });
 
@@ -444,7 +459,10 @@ describe("PlaybackProvider engine actions", () => {
           bufferState: () => "ready",
         });
       });
-      expect(result.current.store.get(stepIntervalAtom)).toBeCloseTo(1 / 100, 6);
+      expect(result.current.store.get(stepIntervalAtom)).toBeCloseTo(
+        1 / 100,
+        6
+      );
     });
 
     it("picks the smallest nativeStepSeconds across streams", () => {

--- a/app/packages/playback/src/lib/playback/use-playback-engine.ts
+++ b/app/packages/playback/src/lib/playback/use-playback-engine.ts
@@ -26,6 +26,37 @@ const clamp = (v: number, lo: number, hi: number) =>
   Math.min(hi, Math.max(lo, v));
 
 /**
+ * Snap a continuous playhead time onto a frame-boundary multiple of
+ * `step`, then advance or retreat exactly one displayed frame. Used by
+ * stepForward / stepBack so the frame stepper always lands on a
+ * boundary regardless of where in a frame's time range the playhead
+ * sits — naïvely adding `±step` to a mid-frame playhead would never
+ * align (every press just shifts the offset along).
+ *
+ * "Displayed frame" K is the half-open range `[K*step, (K+1)*step)`.
+ * `forward` returns the *next* frame's start, `back` returns the
+ * *previous* frame's start — both relative to the currently displayed
+ * frame, never to mid-frame fractions.
+ *
+ * The `eps` tolerance absorbs floating-point error so a playhead set
+ * to exactly `K * step` doesn't get misread as `K * step - epsilon`.
+ */
+function frameBoundaryStep(
+  time: number,
+  step: number,
+  direction: "forward" | "back"
+): number {
+  if (!(step > 0)) {
+    return direction === "forward" ? time + step : time - step;
+  }
+  const eps = step * 1e-6;
+  const currentFrameK = Math.floor((time + eps) / step);
+  const targetK =
+    direction === "forward" ? currentFrameK + 1 : currentFrameK - 1;
+  return targetK * step;
+}
+
+/**
  * Cap on per-tick `dt` (sec) in the engine's wallclock-driven advance.
  * When the main thread is blocked (memory pressure, GC pause, throttled
  * tab) RAF callbacks pile up and the next `timestamp - lastTimestamp`
@@ -331,7 +362,11 @@ export function usePlaybackEngine({
       },
       stepBack: () => {
         const next = clamp(
-          store.get(playheadAtom) - store.get(stepIntervalAtom),
+          frameBoundaryStep(
+            store.get(playheadAtom),
+            store.get(stepIntervalAtom),
+            "back"
+          ),
           0,
           store.get(durationAtom)
         );
@@ -341,7 +376,11 @@ export function usePlaybackEngine({
       },
       stepForward: () => {
         const next = clamp(
-          store.get(playheadAtom) + store.get(stepIntervalAtom),
+          frameBoundaryStep(
+            store.get(playheadAtom),
+            store.get(stepIntervalAtom),
+            "forward"
+          ),
           0,
           store.get(durationAtom)
         );

--- a/app/packages/video-annotation/index.ts
+++ b/app/packages/video-annotation/index.ts
@@ -14,3 +14,4 @@ export { ImaVidImageStream } from "./src/ImaVidImageStream";
 export type { ImaVidImageFrame } from "./src/ImaVidImageStream";
 export { useFrameLabelsStream } from "./src/frameLabelsStream";
 export { VideoFrameLabelsStream } from "./src/VideoFrameLabelsStream";
+export type { LocalDetection } from "./src/VideoFrameLabelsStream";

--- a/app/packages/video-annotation/src/SyntheticLabelStream.ts
+++ b/app/packages/video-annotation/src/SyntheticLabelStream.ts
@@ -1,5 +1,17 @@
 import { PlaybackStreamBase } from "../../playback/src/lib/playback/stream-base";
 
+/** ObjectId hex string. */
+export type ObjectIdHex = string;
+
+export type PropagationMethod = "linear";
+
+/** Provenance written on labels created by a propagation run. */
+export interface PropagationBlob {
+  method: PropagationMethod;
+  run_id: ObjectIdHex;
+  parent_keyframes: [ObjectIdHex, ObjectIdHex];
+}
+
 export interface SyntheticBox {
   id: string;
   label: string;
@@ -19,6 +31,10 @@ export interface SyntheticBox {
    * numeric index).
    */
   instance?: { _cls: "Instance"; _id?: string };
+  /** `true` for user-authored / propagation source; `false` for interpolated. */
+  keyframe: boolean;
+  /** Provenance for propagation-created labels; `null` for keyframes. */
+  propagation: PropagationBlob | null;
 }
 
 export interface FrameLabelSnapshot {
@@ -217,6 +233,8 @@ function snapshotAtTime(
       // colors per synthetic actor (the index path doesn't apply here
       // — synthetic actors have no numeric index by design).
       instance: { _cls: "Instance", _id: actor.id },
+      keyframe: true,
+      propagation: null,
     });
   }
   return { frameNumber, detections };

--- a/app/packages/video-annotation/src/VideoAnnotationSurface.tsx
+++ b/app/packages/video-annotation/src/VideoAnnotationSurface.tsx
@@ -1,3 +1,7 @@
+import {
+  useRegisterVideoAnnotationCommandHandlers,
+  useRegisterVideoAnnotationKeybindings,
+} from "@fiftyone/annotation";
 import { getSampleSrc } from "@fiftyone/state";
 import type { ModalSample } from "@fiftyone/state";
 import React, { useMemo, useState } from "react";
@@ -159,5 +163,22 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
   // shadow modal-scoped atoms the sidebar writes to (lighterSceneAtom,
   // detection-mode, label list). Reintroducing multi-tile here requires
   // first pinning those atoms to the modal-default store explicitly.
-  return <PlaybackProvider>{registered}</PlaybackProvider>;
+  return (
+    <PlaybackProvider>
+      <VideoAnnotationHandlerRegistration />
+      {registered}
+    </PlaybackProvider>
+  );
+};
+
+/**
+ * Mounts video-specific command + keybinding registrars inside the
+ * surface's `<PlaybackProvider>` so they can read `useCurrentTime`.
+ * The handlers no-op when there's no active selection or frame-labels
+ * stream, so it's safe to render unconditionally.
+ */
+const VideoAnnotationHandlerRegistration: React.FC = () => {
+  useRegisterVideoAnnotationCommandHandlers();
+  useRegisterVideoAnnotationKeybindings();
+  return null;
 };

--- a/app/packages/video-annotation/src/VideoFrameLabelsStream.test.ts
+++ b/app/packages/video-annotation/src/VideoFrameLabelsStream.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { VideoFrameLabelsStream } from "./VideoFrameLabelsStream";
+
+function buildStream(): VideoFrameLabelsStream {
+  return new VideoFrameLabelsStream({
+    id: "test",
+    sampleId: "s",
+    dataset: "d",
+    view: [],
+    frameCount: 100,
+    frameRate: 30,
+  });
+}
+
+// Frame numbers are 1-indexed: frame N's start time is (N-1)/fps.
+const timeOfFrame = (frame: number, fps: number): number => (frame - 1) / fps;
+
+describe("VideoFrameLabelsStream fetched-empty", () => {
+  it("bufferState returns 'ready' for frames in a fetched range with no cached doc", () => {
+    const stream = buildStream();
+    // @ts-expect-error — test-only: populate the private fetched-ranges list
+    stream.fetchedRanges.push([1, 60]);
+    expect(stream.bufferState(timeOfFrame(10, 30))).toBe("ready");
+  });
+
+  it("getValue returns an empty snapshot for frames in a fetched range with no cached doc", () => {
+    const stream = buildStream();
+    // @ts-expect-error
+    stream.fetchedRanges.push([1, 60]);
+    expect(stream.getValue(timeOfFrame(10, 30))).toEqual({
+      frameNumber: 10,
+      detections: [],
+    });
+  });
+});

--- a/app/packages/video-annotation/src/VideoFrameLabelsStream.test.ts
+++ b/app/packages/video-annotation/src/VideoFrameLabelsStream.test.ts
@@ -33,3 +33,22 @@ describe("VideoFrameLabelsStream fetched-empty", () => {
     });
   });
 });
+
+describe("VideoFrameLabelsStream extractDetections", () => {
+  it("defaults missing keyframe to false and propagation to null", () => {
+    const stream = buildStream();
+    // @ts-expect-error — test-only: populate the private cache
+    stream.cache.set(10, {
+      frame_number: 10,
+      detections: {
+        detections: [
+          { _id: "a", label: "car", bounding_box: [0, 0, 0.1, 0.1] },
+        ],
+      },
+    });
+
+    const value = stream.getValue(timeOfFrame(10, 30));
+    expect(value?.detections[0].keyframe).toBe(false);
+    expect(value?.detections[0].propagation).toBeNull();
+  });
+});

--- a/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
+++ b/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
@@ -183,6 +183,10 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
       return "loading";
     }
 
+    if (this.isInFetchedRange(frame)) {
+      return "ready";
+    }
+
     return "missing";
   }
 
@@ -209,6 +213,11 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
     const frame = this.timeToFrame(time);
     const sample = this.cache.get(frame);
     if (!sample) {
+      // Chunk fetched, this frame had no labels — return an empty
+      // snapshot so consumers can tell "no labels here" from "not fetched".
+      if (this.isInFetchedRange(frame)) {
+        return { frameNumber: frame, detections: [] };
+      }
       return null;
     }
 
@@ -258,6 +267,15 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
 
   private isInflight(frame: number): boolean {
     return this.inflight.has(frame);
+  }
+
+  private isInFetchedRange(frame: number): boolean {
+    for (const [start, end] of this.fetchedRanges) {
+      if (frame >= start && frame <= end) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private async fetchChunk(startFrame: number): Promise<void> {

--- a/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
+++ b/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
@@ -44,6 +44,18 @@ export interface LocalDetection {
   label?: string;
   bounding_box: [number, number, number, number];
   instance?: { _cls: "Instance"; _id?: string } | null;
+  /**
+   * Auto-promote-on-edit: callers handling user-initiated edits (draw,
+   * drag, resize) should pass `keyframe: true` so an interpolated label
+   * is promoted to a keyframe on touch. Omit to preserve the existing
+   * value through `updateLabel`'s shallow merge.
+   */
+  keyframe?: boolean;
+  /**
+   * Propagation provenance. User edits clear this (`null`); leave
+   * undefined to preserve the existing value through the shallow merge.
+   */
+  propagation?: PropagationBlob | null;
 }
 
 export interface VideoFrameLabelsStreamOptions {

--- a/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
+++ b/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
@@ -7,7 +7,11 @@ import type {
   BufferReadiness,
   PlaybackStore,
 } from "../../playback/src/lib/playback/types";
-import type { FrameLabelSnapshot, SyntheticBox } from "./SyntheticLabelStream";
+import type {
+  FrameLabelSnapshot,
+  PropagationBlob,
+  SyntheticBox,
+} from "./SyntheticLabelStream";
 
 // todo - adapter pattern for other label types
 interface RawDetection {
@@ -17,6 +21,8 @@ interface RawDetection {
   label?: string;
   bounding_box?: [number, number, number, number];
   instance?: { _cls: "Instance"; _id?: string } | null;
+  keyframe?: boolean;
+  propagation?: PropagationBlob | null;
 }
 
 interface RawDetectionsField {
@@ -368,6 +374,8 @@ function extractDetections(
       bounding_box: det.bounding_box,
       index: det.index,
       instance: det.instance ?? undefined,
+      keyframe: det.keyframe ?? false,
+      propagation: det.propagation ?? null,
     });
   }
 

--- a/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
+++ b/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
@@ -569,7 +569,15 @@ function extractDetections(
     }
 
     const detId = det._id ?? det.id ?? null;
-    const id = det.index !== undefined ? `track-${det.index}` : detId;
+    // Prefer `instance._id` as the cross-frame identity. `track-${index}` is
+    // kept as a fallback for legacy data that has only the numeric index, and
+    // `_id` is the last-resort per-frame identifier for untracked,
+    // un-instanced detections
+    const id = det.instance?._id
+      ? `instance-${det.instance._id}`
+      : det.index !== undefined
+      ? `track-${det.index}`
+      : detId;
 
     if (!id) {
       continue;

--- a/app/packages/video-annotation/src/frameTracks.ts
+++ b/app/packages/video-annotation/src/frameTracks.ts
@@ -5,16 +5,31 @@ import type {
 import type { VideoFrameLabelsStream } from "./VideoFrameLabelsStream";
 
 /**
- * Prefix the stream uses for label ids when a FiftyOne track `index`
- * is present.
+ * Synthetic-id prefixes emitted by {@link VideoFrameLabelsStream.extractDetections}.
+ * `instance-` is preferred when the detection carries an `Instance._id`;
+ * `track-` is the legacy fallback for data that only has the numeric
+ * `index`. Both qualify the box for a timeline track row.
  */
+const INSTANCE_ID_PREFIX = "instance-";
 const TRACK_ID_PREFIX = "track-";
 
 interface InstanceState {
   /** Class label observed for this instance (e.g. "person"). */
   classLabel: string;
-  /** Numeric track index, used for sorting and as the instance-hash key. */
-  trackIndex: number;
+  /**
+   * Persisted track index carried on the underlying detection, when
+   * present. Set for `track-`-prefixed boxes and for `instance-`-prefixed
+   * boxes that the upstream pipeline already assigned a number to.
+   * Undefined for freshly-drawn instances that haven't been numbered.
+   */
+  persistedIndex?: number;
+  /**
+   * Display ordinal used for the row label and color hash. Equals
+   * `persistedIndex` when set; otherwise assigned at build time as the
+   * next free integer above the per-class max so the demo UI always
+   * has a readable "person 3" / "person 4" label.
+   */
+  displayIndex: number;
   /** Whether the instance was present in the most recent frame. */
   inFrame: boolean;
   /** Start time (sec) of the currently-open interval, if any. */
@@ -42,15 +57,19 @@ export interface BuildPerInstanceTracksInput {
 
 /**
  * Walk every frame in `[1, stream.totalFrames]`, group labels by
- * track id, and emit one {@link Track} per tracked instance whose events are
- * the contiguous presence intervals.
+ * synthetic overlay id, and emit one {@link Track} per tracked instance
+ * whose events are the contiguous presence intervals.
  *
- * Row labels combine the class with the track index (e.g. "person 5");
- * row color is resolved from the class so each row matches the colour
- * of its bbox overlay in the media tile.
- *
- * Labels without a track index (untracked) are ignored here — they
+ * Includes both `instance-`-prefixed (Instance._id-based identity) and
+ * `track-`-prefixed (legacy numeric-index identity) detections. Boxes
+ * with no cross-frame identity (raw `_id` only) are skipped — they
  * still render as overlays during playback but don't contribute rows.
+ *
+ * Row labels combine the class with a per-class display ordinal (e.g.
+ * "person 5"). For boxes that already carry a persisted `index`, that
+ * number is used; for `Instance._id`-only boxes the ordinal is the
+ * next free integer above the per-class max. Row color is resolved
+ * from the class so each row matches the colour of its bbox overlay.
  *
  * Requires the stream's cache to cover the full range; call
  * {@link VideoFrameLabelsStream#warmupAll} and `await` it first.
@@ -82,7 +101,10 @@ export function buildPerInstanceTracks({
     if (snapshot) {
       // todo - adapter pattern to handle other label types
       for (const det of snapshot.detections) {
-        if (!det.id.startsWith(TRACK_ID_PREFIX)) {
+        const isPrefixed =
+          det.id.startsWith(TRACK_ID_PREFIX) ||
+          det.id.startsWith(INSTANCE_ID_PREFIX);
+        if (!isPrefixed) {
           continue;
         }
 
@@ -90,16 +112,13 @@ export function buildPerInstanceTracks({
 
         let state = states.get(det.id);
         if (!state) {
-          // Prefer the parsed-back-from-id index, but fall back to the
-          // structured `index` field on the box so we still get a usable
-          // sort key / instance hash if the id format ever drifts.
-          const suffix = det.id.slice(TRACK_ID_PREFIX.length);
-          const fromSuffix = Number(suffix);
-          const idx = Number.isFinite(fromSuffix) ? fromSuffix : det.index ?? 0;
-
           state = {
             classLabel: det.label || "unknown",
-            trackIndex: idx,
+            persistedIndex: det.index,
+            // Placeholder — overwritten after the main loop once all
+            // states are known and per-class display ordinals can be
+            // computed.
+            displayIndex: 0,
             inFrame: false,
             currentStart: null,
             intervals: [],
@@ -132,6 +151,37 @@ export function buildPerInstanceTracks({
     closeInterval(state, clipEndSec);
   }
 
+  // Assign display ordinals. Persisted indexes are honored as-is so
+  // existing tracked data keeps the numbers the user is already used
+  // to; instance-only boxes (typically freshly-drawn) get the next
+  // free integer above the per-class max. Iteration order is the
+  // first-frame-appearance order — deterministic for a given cache.
+  const classCounters = new Map<string, number>();
+
+  for (const state of states.values()) {
+    if (state.persistedIndex === undefined) {
+      continue;
+    }
+
+    const cur = classCounters.get(state.classLabel) ?? 0;
+
+    if (state.persistedIndex > cur) {
+      classCounters.set(state.classLabel, state.persistedIndex);
+    }
+  }
+
+  for (const state of states.values()) {
+    if (state.persistedIndex !== undefined) {
+      state.displayIndex = state.persistedIndex;
+      continue;
+    }
+
+    const next = (classCounters.get(state.classLabel) ?? 0) + 1;
+
+    state.displayIndex = next;
+    classCounters.set(state.classLabel, next);
+  }
+
   const tracks: Track[] = [];
   for (const [id, state] of states) {
     if (state.intervals.length === 0) {
@@ -152,20 +202,19 @@ export function buildPerInstanceTracks({
       })),
     ];
 
-    const suffix = id.slice(TRACK_ID_PREFIX.length);
     tracks.push({
       id,
-      label: `${state.classLabel} ${suffix}`,
-      description: `Tracked "${state.classLabel}" (track ${suffix})`,
+      label: `${state.classLabel} ${state.displayIndex}`,
+      description: `Tracked "${state.classLabel}" (track ${state.displayIndex})`,
       color: resolveColor({
         label: state.classLabel,
-        index: state.trackIndex,
+        index: state.displayIndex,
       }),
       events,
     });
   }
 
-  // Sort by class then by numeric track index — keeps instances of the
+  // Sort by class then by display ordinal — keeps instances of the
   // same class adjacent and the row order reproducible across runs.
   tracks.sort((a, b) => {
     const sa = states.get(a.id)!;
@@ -175,7 +224,7 @@ export function buildPerInstanceTracks({
       return sa.classLabel.localeCompare(sb.classLabel);
     }
 
-    return sa.trackIndex - sb.trackIndex;
+    return sa.displayIndex - sb.displayIndex;
   });
 
   return tracks;

--- a/app/packages/video-annotation/src/frameTracks.ts
+++ b/app/packages/video-annotation/src/frameTracks.ts
@@ -21,6 +21,8 @@ interface InstanceState {
   currentStart: number | null;
   /** Closed presence intervals. */
   intervals: Array<{ start: number; end: number }>;
+  /** Frame start times (sec) where this instance has `keyframe: true`. */
+  keyframeTimes: number[];
 }
 
 /**
@@ -101,6 +103,7 @@ export function buildPerInstanceTracks({
             inFrame: false,
             currentStart: null,
             intervals: [],
+            keyframeTimes: [],
           };
 
           states.set(det.id, state);
@@ -108,6 +111,9 @@ export function buildPerInstanceTracks({
         if (!state.inFrame) {
           state.currentStart = frameStartSec;
           state.inFrame = true;
+        }
+        if (det.keyframe) {
+          state.keyframeTimes.push(frameStartSec);
         }
       }
     }
@@ -132,11 +138,19 @@ export function buildPerInstanceTracks({
       continue;
     }
 
-    const events: TrackEvent[] = state.intervals.map(({ start, end }) => ({
-      startSec: start,
-      endSec: end,
-      label: "in frame",
-    }));
+    const events: TrackEvent[] = [
+      ...state.intervals.map(({ start, end }) => ({
+        startSec: start,
+        endSec: end,
+        label: "in frame",
+      })),
+      // Point events for each keyframe — render as diamond markers on top
+      // of the presence bar via `TimelineTrack`'s no-`endSec` branch.
+      ...state.keyframeTimes.map((startSec) => ({
+        startSec,
+        label: "Keyframe",
+      })),
+    ];
 
     const suffix = id.slice(TRACK_ID_PREFIX.length);
     tracks.push({

--- a/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
+++ b/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
@@ -57,14 +57,31 @@ export const useSyncLighterLabelStream = (scene: Scene2D | null): void => {
     useCallback((payload) => upsertFromOverlay(payload.id), [upsertFromOverlay])
   );
 
+  // Lighter flips `interactionState` to `"DRAGGING"` on every pointer-down
+  // over an overlay, so a click-to-select fires `overlay-drag-end` with
+  // `startBounds === bounds`. Filter those out — selection is not an edit
+  // and writing the cache would (a) churn the dirty set and (b) auto-
+  // promote the label to a keyframe via `toLocalDetection`.
   useEventHandler(
     "lighter:overlay-drag-end",
-    useCallback((payload) => upsertFromOverlay(payload.id), [upsertFromOverlay])
+    useCallback(
+      (payload) => {
+        if (rectsEqual(payload.startBounds, payload.bounds)) return;
+        upsertFromOverlay(payload.id);
+      },
+      [upsertFromOverlay]
+    )
   );
 
   useEventHandler(
     "lighter:overlay-resize-end",
-    useCallback((payload) => upsertFromOverlay(payload.id), [upsertFromOverlay])
+    useCallback(
+      (payload) => {
+        if (rectsEqual(payload.startBounds, payload.bounds)) return;
+        upsertFromOverlay(payload.id);
+      },
+      [upsertFromOverlay]
+    )
   );
 
   useEventHandler(
@@ -96,16 +113,20 @@ function toLocalDetection(overlay: DetectionOverlay): LocalDetection {
   // synthetic `track-<n>` id used for cross-frame identity and won't
   // match anything in the baseline detections array.
   // Any overlay event reaching this helper came from a user action
-  // (draw / drag-end / resize-end). Promote to a keyframe and clear any
-  // propagation provenance — the label is now user-authoritative for
-  // this frame, regardless of how it got here.
+  // (draw / drag-end / resize-end with real movement). Promote to a
+  // keyframe — the label is now user-authoritative for this frame.
+  // Propagation is intentionally not cleared here: the cache's shallow
+  // merge preserves it from the existing entry, and unconditionally
+  // writing `propagation: null` produces noisy `add value: null` patch
+  // ops against baselines that have no propagation field at all.
+  // Clearing-on-edit becomes a separate concern once we have a way to
+  // condition on the cache state without a layering violation.
   const det: LocalDetection = {
     _cls: "Detection",
     _id: label._id ?? overlay.id,
     label: label.label,
     bounding_box: [bounds.x, bounds.y, bounds.width, bounds.height],
     keyframe: true,
-    propagation: null,
   };
 
   if (label.index !== undefined) {
@@ -117,4 +138,14 @@ function toLocalDetection(overlay: DetectionOverlay): LocalDetection {
   }
 
   return det;
+}
+
+/** Strict equality on the four bbox dimensions. */
+function rectsEqual(
+  a: { x: number; y: number; width: number; height: number },
+  b: { x: number; y: number; width: number; height: number }
+): boolean {
+  return (
+    a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height
+  );
 }

--- a/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
+++ b/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
@@ -9,7 +9,8 @@ import {
   useLighterEventHandler,
 } from "@fiftyone/lighter";
 import type { DetectionLabel } from "@fiftyone/looker";
-import { useCallback } from "react";
+import { objectId } from "@fiftyone/utilities";
+import { useCallback, useRef } from "react";
 import { useCurrentTime } from "../../playback/src/lib/playback/use-playback-state";
 import { useFrameLabelsStream } from "./frameLabelsStream";
 import type { LocalDetection } from "./VideoFrameLabelsStream";
@@ -40,21 +41,71 @@ export const useSyncLighterLabelStream = (scene: Scene2D | null): void => {
     scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
   );
 
+  // Synthetic id we want selected once `useFrameOverlaySync` lands the
+  // post-mint canonical overlay. Set by `upsertFromOverlay` when it
+  // evicts a draw-mode overlay; consumed by the `overlay-added` handler
+  // below.
+  const pendingSelectRef = useRef<string | null>(null);
+
   const upsertFromOverlay = useCallback(
-    (overlayId: string) => {
+    (overlayId: string, isFreshDraw = false) => {
       if (!stream || !scene) return;
       const overlay = scene.getOverlay(overlayId);
       if (!(overlay instanceof DetectionOverlay)) return;
 
+      const detection = toLocalDetection(overlay);
+
+      // Create an `Instance` doc on first draw so the cross-frame
+      // identity (used as the synthetic overlay id in
+      // `extractDetections`) is stable from the box's first frame
+      // onward.
+      const minted = isFreshDraw && !detection.instance;
+      if (minted) {
+        detection.instance = { _cls: "Instance", _id: objectId() };
+      }
+
       const frame = stream.timeToFrame(currentTime);
-      stream.updateLabel(frame, toLocalDetection(overlay));
+      stream.updateLabel(frame, detection);
+
+      // The synthetic id just changed (`<overlayId>` → `instance-<...>`)
+      // because we minted the Instance. Evict Lighter's draw-mode
+      // overlay so the next sync pass adds the canonical one without
+      // leaving the original drawn copy behind. The `overlay-removed`
+      // event this triggers is safe — the removed-handler below
+      // resolves payload ids against the current snapshot and skips
+      // ones that no longer map to a cache entry.
+      //
+      // Removal also drops selection, so register a pending select
+      // against the canonical synthetic id; the `overlay-added` handler
+      // claims it once the sync places the canonical overlay in scene.
+      if (minted) {
+        pendingSelectRef.current = `instance-${detection.instance!._id}`;
+        scene.removeOverlay(overlayId);
+      }
     },
     [stream, scene, currentTime]
   );
 
   useEventHandler(
     "lighter:overlay-establish",
-    useCallback((payload) => upsertFromOverlay(payload.id), [upsertFromOverlay])
+    useCallback(
+      (payload) => upsertFromOverlay(payload.id, true),
+      [upsertFromOverlay]
+    )
+  );
+
+  // Claim a pending select once the sync adds the canonical post-mint
+  // overlay
+  useEventHandler(
+    "lighter:overlay-added",
+    useCallback(
+      (payload) => {
+        if (!scene || pendingSelectRef.current !== payload.id) return;
+        pendingSelectRef.current = null;
+        scene.selectOverlay(payload.id);
+      },
+      [scene]
+    )
   );
 
   // Lighter flips `interactionState` to `"DRAGGING"` on every pointer-down
@@ -89,8 +140,22 @@ export const useSyncLighterLabelStream = (scene: Scene2D | null): void => {
     useCallback(
       (payload) => {
         if (!stream) return;
+        // Resolve the synthetic overlay id back to the underlying
+        // detection `_id` via the current snapshot. Two reasons:
+        //   1. The cache keys detections by `_id`, not by the synthetic
+        //      id we render under, so a direct `deleteLabel(payload.id)`
+        //      misses tracked detections (synthetic id `instance-<...>`
+        //      or `track-<n>`).
+        //   2. Swap-removes initiated by our own draw flow (Lighter's
+        //      draw-mode overlay being evicted after we mint an
+        //      Instance) carry an id that no longer maps to any cache
+        //      entry — skipping them prevents the just-minted
+        //      detection from being deleted out from under the sync.
+        const snapshot = stream.getValue(currentTime);
+        const target = snapshot?.detections.find((d) => d.id === payload.id);
+        if (!target?._id) return;
         const frame = stream.timeToFrame(currentTime);
-        stream.deleteLabel(frame, payload.id);
+        stream.deleteLabel(frame, target._id);
       },
       [stream, currentTime]
     )

--- a/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
+++ b/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
@@ -95,11 +95,17 @@ function toLocalDetection(overlay: DetectionOverlay): LocalDetection {
   // upserts match the existing baseline entry. `overlay.id` is the
   // synthetic `track-<n>` id used for cross-frame identity and won't
   // match anything in the baseline detections array.
+  // Any overlay event reaching this helper came from a user action
+  // (draw / drag-end / resize-end). Promote to a keyframe and clear any
+  // propagation provenance — the label is now user-authoritative for
+  // this frame, regardless of how it got here.
   const det: LocalDetection = {
     _cls: "Detection",
     _id: label._id ?? overlay.id,
     label: label.label,
     bounding_box: [bounds.x, bounds.y, bounds.width, bounds.height],
+    keyframe: true,
+    propagation: null,
   };
 
   if (label.index !== undefined) {

--- a/tests/unittests/video_keyframe_sync_tests.py
+++ b/tests/unittests/video_keyframe_sync_tests.py
@@ -1,0 +1,108 @@
+import unittest
+
+from bson import ObjectId
+
+import fiftyone as fo
+
+from decorators import drop_datasets
+
+
+class KeyframeSyncTests(unittest.TestCase):
+    @drop_datasets
+    def setUp(self) -> None:
+        self.dataset: fo.Dataset = fo.Dataset()
+        sample: fo.Sample = fo.Sample(
+            filepath="video1.mp4",
+            metadata=fo.VideoMetadata(total_frame_count=3),
+        )
+        sample.frames[1] = fo.Frame(
+            filepath="frame1.jpg",
+            detections=fo.Detections(detections=[
+                fo.Detection(
+                    label="car",
+                    bounding_box=[0.1, 0.1, 0.2, 0.2],
+                ),
+            ])
+        )
+        self.dataset.add_sample(sample)
+        self.sample: fo.Sample = sample
+
+    def test_keyframe_dynamic_attr_persists_on_direct_edit(self) -> None:
+        det: fo.Detection = self.sample.frames[1].detections.detections[0]
+        det.keyframe = True
+        det.propagation = None
+        self.sample.save()
+
+        roundtripped: fo.Detection = (
+            self.dataset.first().frames[1].detections.detections[0]
+        )
+        self.assertIs(roundtripped.keyframe, True)
+        self.assertIsNone(getattr(roundtripped, "propagation", None))
+
+    def test_propagation_blob_persists_on_direct_edit(self) -> None:
+        run_id: ObjectId = ObjectId()
+        parent_a: ObjectId = ObjectId()
+        parent_b: ObjectId = ObjectId()
+        det: fo.Detection = self.sample.frames[1].detections.detections[0]
+        det.keyframe = False
+        det.propagation = {
+            "method": "linear",
+            "run_id": run_id,
+            "parent_keyframes": [parent_a, parent_b],
+        }
+        self.sample.save()
+
+        roundtripped: fo.Detection = (
+            self.dataset.first().frames[1].detections.detections[0]
+        )
+        self.assertIs(roundtripped.keyframe, False)
+        self.assertEqual(roundtripped.propagation["method"], "linear")
+        self.assertEqual(roundtripped.propagation["run_id"], run_id)
+        self.assertEqual(
+            roundtripped.propagation["parent_keyframes"],
+            [parent_a, parent_b],
+        )
+
+    def test_keyframe_attr_roundtrips_through_frames_view(self) -> None:
+        frames_view = self.dataset.to_frames()
+        frame_sample = frames_view.first()
+        det: fo.Detection = frame_sample.detections.detections[0]
+        det.keyframe = True
+        det.propagation = None
+        frame_sample.save()
+
+        roundtripped: fo.Detection = (
+            self.dataset.first().frames[1].detections.detections[0]
+        )
+        self.assertIs(roundtripped.keyframe, True)
+        self.assertIsNone(roundtripped.propagation)
+
+    def test_propagation_blob_roundtrips_through_frames_view(self) -> None:
+        run_id: ObjectId = ObjectId()
+        parent_a: ObjectId = ObjectId()
+        parent_b: ObjectId = ObjectId()
+        frames_view = self.dataset.to_frames()
+        frame_sample = frames_view.first()
+        det: fo.Detection = frame_sample.detections.detections[0]
+        det.keyframe = False
+        det.propagation = {
+            "method": "linear",
+            "run_id": run_id,
+            "parent_keyframes": [parent_a, parent_b],
+        }
+        frame_sample.save()
+
+        roundtripped: fo.Detection = (
+            self.dataset.first().frames[1].detections.detections[0]
+        )
+        self.assertIs(roundtripped.keyframe, False)
+        self.assertEqual(roundtripped.propagation["method"], "linear")
+        self.assertEqual(roundtripped.propagation["run_id"], run_id)
+        self.assertEqual(
+            roundtripped.propagation["parent_keyframes"],
+            [parent_a, parent_b],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittests/video_keyframe_sync_tests.py
+++ b/tests/unittests/video_keyframe_sync_tests.py
@@ -24,6 +24,9 @@ class KeyframeSyncTests(unittest.TestCase):
                 ),
             ])
         )
+        sample["events"] = fo.TemporalDetections(detections=[
+            fo.TemporalDetection(label="action", support=[1, 3]),
+        ])
         self.dataset.add_sample(sample)
         self.sample: fo.Sample = sample
 
@@ -94,6 +97,43 @@ class KeyframeSyncTests(unittest.TestCase):
 
         roundtripped: fo.Detection = (
             self.dataset.first().frames[1].detections.detections[0]
+        )
+        self.assertIs(roundtripped.keyframe, False)
+        self.assertEqual(roundtripped.propagation["method"], "linear")
+        self.assertEqual(roundtripped.propagation["run_id"], run_id)
+        self.assertEqual(
+            roundtripped.propagation["parent_keyframes"],
+            [parent_a, parent_b],
+        )
+
+
+    def test_keyframe_dynamic_attr_persists_on_temporal_detection(self) -> None:
+        td: fo.TemporalDetection = self.sample.events.detections[0]
+        td.keyframe = True
+        td.propagation = None
+        self.sample.save()
+
+        roundtripped: fo.TemporalDetection = (
+            self.dataset.first().events.detections[0]
+        )
+        self.assertIs(roundtripped.keyframe, True)
+        self.assertIsNone(getattr(roundtripped, "propagation", None))
+
+    def test_propagation_blob_persists_on_temporal_detection(self) -> None:
+        run_id: ObjectId = ObjectId()
+        parent_a: ObjectId = ObjectId()
+        parent_b: ObjectId = ObjectId()
+        td: fo.TemporalDetection = self.sample.events.detections[0]
+        td.keyframe = False
+        td.propagation = {
+            "method": "linear",
+            "run_id": run_id,
+            "parent_keyframes": [parent_a, parent_b],
+        }
+        self.sample.save()
+
+        roundtripped: fo.TemporalDetection = (
+            self.dataset.first().events.detections[0]
         )
         self.assertIs(roundtripped.keyframe, False)
         self.assertEqual(roundtripped.propagation["method"], "linear")


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

Adds keyframes and stable cross-frame identity for tracked detections.

- **Cross-frame identity** — `Instance._id` is the cross-frame overlay identity, minted at draw time, so a detection renders under a stable id across frames and appears as its own timeline row.
- **Keyframes** — `keyframe` and `propagation` attributes on detection labels (with round-trip tests for the dynamic attributes); `MarkKeyframeCommand` + a `K` keybinding toggle the keyframe flag; keyframes render as diamond markers on the timeline tracks.
- **Playback** — step forward/back snaps to frame boundaries.
- **Edit hygiene** — zero-movement overlay events are skipped, so a click-to-select no longer promotes a label to a keyframe.
- **Buffering** — `bufferState` distinguishes fetched-empty from unfetched.

Stacked on #7683.

## 🧪 How is this patch tested? If it is not, please explain why.

Unit tests for the keyframe/propagation attribute round-trip; tested locally in the app.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
