### PR TITLE
Video annotation: per-frame sidebar sync + overlay-identity fixes

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Position.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Position.tsx
@@ -66,9 +66,10 @@ export default function Position({ readOnly = false }: PositionProps) {
 
   const toImagePixels = useCallback(
     (relative: Parameters<typeof relativeToImagePixels>[0]) => {
-      const dims = scene
-        ?.getCanonicalMedia()
-        ?.getOriginalDimensions() ?? { width: 1, height: 1 };
+      const dims = scene?.getCanonicalMedia()?.getOriginalDimensions() ?? {
+        width: 1,
+        height: 1,
+      };
       return relativeToImagePixels(relative, dims);
     },
     [scene]
@@ -77,8 +78,16 @@ export default function Position({ readOnly = false }: PositionProps) {
   const toCanvasPixels = useCallback(
     (imageRect: Parameters<typeof imagePixelsToCanvasPixels>[0]) => {
       const canonicalMedia = scene?.getCanonicalMedia();
-      const dims = canonicalMedia?.getOriginalDimensions() ?? { width: 1, height: 1 };
-      const rendered = canonicalMedia?.getRenderedBounds() ?? { x: 0, y: 0, width: 1, height: 1 };
+      const dims = canonicalMedia?.getOriginalDimensions() ?? {
+        width: 1,
+        height: 1,
+      };
+      const rendered = canonicalMedia?.getRenderedBounds() ?? {
+        x: 0,
+        y: 0,
+        width: 1,
+        height: 1,
+      };
       return imagePixelsToCanvasPixels(imageRect, dims, rendered);
     },
     [scene]
@@ -102,7 +111,7 @@ export default function Position({ readOnly = false }: PositionProps) {
       if (
         !(overlay instanceof DetectionOverlay) ||
         !overlay.hasValidBounds() ||
-        payload.id !== data?._id
+        payload.id !== overlay.id
       ) {
         return;
       }
@@ -119,7 +128,7 @@ export default function Position({ readOnly = false }: PositionProps) {
         bounding_box: [relative.x, relative.y, relative.width, relative.height],
       });
     },
-    [data?._id, overlay, toImagePixels, setData]
+    [overlay, toImagePixels, setData]
   );
 
   useEventHandler("lighter:overlay-bounds-changed", handleBoundsChange);
@@ -179,7 +188,12 @@ export default function Position({ readOnly = false }: PositionProps) {
           };
           const newCanvasBounds = toCanvasPixels(newImagePixels);
           scene?.executeCommand(
-            new TransformOverlayCommand(overlay, overlay.id, oldBounds, newCanvasBounds)
+            new TransformOverlayCommand(
+              overlay,
+              overlay.id,
+              oldBounds,
+              newCanvasBounds
+            )
           );
         }}
       />

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useDelete.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useDelete.ts
@@ -66,7 +66,7 @@ export default function useDelete() {
             new DeleteAnnotationCommand(label, fieldSchema)
           );
 
-          removeLabelFromSidebar(label.data._id);
+          removeLabelFromSidebar(label.overlay.id);
           removeOverlay(label.overlay.id, false);
           setNotification({
             msg: `Label "${label.data.label}" successfully deleted.`,

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
@@ -364,17 +364,20 @@ export interface LabelsContext {
   /**
    * Remove a label from the annotation sidebar.
    *
-   * @param labelId ID of label to remove
+   * @param overlayId The label's `overlay.id` (synthetic id for video,
+   *   raw `_id` for image — same value in either case for one overlay)
    */
-  removeLabelFromSidebar: (labelId: string) => void;
+  removeLabelFromSidebar: (overlayId: string) => void;
 
   /**
    * Update the label data for the specified label ID.
    *
    * @param labelId ID of label to update
    * @param data Label data
+   * @returns `true` if a label with the given ID was found and updated,
+   *   `false` if no such label exists in the sidebar.
    */
-  updateLabelData: (labelId: string, data: AnnotationLabelData) => void;
+  updateLabelData: (labelId: string, data: AnnotationLabelData) => boolean;
 }
 
 /**
@@ -402,9 +405,12 @@ export const useLabelsContext = (): LabelsContext => {
     )
   );
 
+  // Keyed on `overlay.id` to match `addLabel` / `labelMap` / `updateLabelAtom`.
   const removeLabelFromSidebar = useCallback(
-    (labelId: string) =>
-      setLabels((prev) => prev.filter((label) => label.data._id !== labelId)),
+    (overlayId: string) =>
+      setLabels((prev) =>
+        prev.filter((label) => label.overlay.id !== overlayId)
+      ),
     [setLabels]
   );
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
@@ -428,23 +428,43 @@ export const useLabelsContext = (): LabelsContext => {
 /**
  * Syncs overlay draggable/resizeable flags when label schema read-only state
  * changes (e.g. user toggles read-only in Schema Manager).
+ *
+ * Edge-triggered per overlay: only writes when the resolved `readOnly` state
+ * actually changes for a given overlay. Allows external control over draggable
+ * and resizable properties after initial construction.
  */
 const useSyncOverlayReadOnly = () => {
   const currentLabels = useAtomValue(labels);
   const schemas = useAtomValue(labelSchemasData);
+  const lastReadOnlyRef = useRef<Map<string, boolean>>(new Map());
 
   useEffect(() => {
     if (!schemas) return;
 
+    const seen = new Set<string>();
     for (const label of currentLabels) {
       if (label.type !== DETECTION) continue;
 
       const overlay = label.overlay;
       if (!(overlay instanceof DetectionOverlay)) continue;
 
+      seen.add(overlay.id);
       const readOnly = isFieldReadOnly(schemas[label.path]);
+      if (lastReadOnlyRef.current.get(overlay.id) === readOnly) {
+        continue;
+      }
+
       overlay.setDraggable(!readOnly);
       overlay.setResizeable(!readOnly);
+      lastReadOnlyRef.current.set(overlay.id, readOnly);
+    }
+
+    // Drop entries for overlays that no longer exist so the map doesn't
+    // grow without bound as labels churn in/out of frame.
+    for (const id of Array.from(lastReadOnlyRef.current.keys())) {
+      if (!seen.has(id)) {
+        lastReadOnlyRef.current.delete(id);
+      }
     }
   }, [currentLabels, schemas]);
 };

--- a/app/packages/video-annotation/src/ImaVidLighterTile.tsx
+++ b/app/packages/video-annotation/src/ImaVidLighterTile.tsx
@@ -21,6 +21,7 @@ import type { ImaVidImageFrame } from "./ImaVidImageStream";
 import type { FrameLabelSnapshot } from "./SyntheticLabelStream";
 import { useFrameOverlaySync } from "./useFrameOverlaySync";
 import { useSyncLighterAnnotation } from "./useSyncLighterAnnotation";
+import { useSyncSidebarFromSnapshot } from "./useSyncSidebarFromSnapshot";
 import { useSyncLighterLabelStream } from "./useSyncLighterLabelStream";
 import styles from "./ImaVidLighterTile.module.css";
 
@@ -148,6 +149,7 @@ export const ImaVidLighterTile: React.FC<ImaVidLighterTileProps> = ({
   // Overlay diff — same hook the video tile uses.
   const snapshot = useStream<FrameLabelSnapshot>(LABELS_STREAM_ID);
   useFrameOverlaySync(scene, snapshot, field, canonicalMediaReady);
+  useSyncSidebarFromSnapshot(scene, snapshot, field, canonicalMediaReady);
 
   useSyncLighterAnnotation(scene);
   useSyncLighterLabelStream(scene);

--- a/app/packages/video-annotation/src/VideoLighterTile.tsx
+++ b/app/packages/video-annotation/src/VideoLighterTile.tsx
@@ -24,6 +24,7 @@ import { LABELS_STREAM_ID, VIDEO_STREAM_ID } from "./ids";
 import type { FrameLabelSnapshot } from "./SyntheticLabelStream";
 import { useFrameOverlaySync } from "./useFrameOverlaySync";
 import { useSyncLighterAnnotation } from "./useSyncLighterAnnotation";
+import { useSyncSidebarFromSnapshot } from "./useSyncSidebarFromSnapshot";
 import { useSyncLighterLabelStream } from "./useSyncLighterLabelStream";
 import styles from "./VideoLighterTile.module.css";
 
@@ -171,6 +172,7 @@ export const VideoLighterTile: React.FC<VideoLighterTileProps> = ({
   // on the current scene — see `canonicalMediaReady` above.
   const snapshot = useStream<FrameLabelSnapshot>(LABELS_STREAM_ID);
   useFrameOverlaySync(scene, snapshot, field, canonicalMediaReady);
+  useSyncSidebarFromSnapshot(scene, snapshot, field, canonicalMediaReady);
 
   useSyncLighterAnnotation(scene);
   useSyncLighterLabelStream(scene);

--- a/app/packages/video-annotation/src/overlayAdapters/detection.ts
+++ b/app/packages/video-annotation/src/overlayAdapters/detection.ts
@@ -30,8 +30,11 @@ export const detectionAdapter: OverlayAdapter<"detection"> = {
   },
 
   update(overlay, data) {
-    if (!(overlay instanceof DetectionOverlay)) return;
-    overlay.relativeBounds = toRect(data.bounding_box);
+    if (!(overlay instanceof DetectionOverlay)) {
+      return;
+    }
+
+    overlay.updateLabel(toDetectionLabel(data));
   },
 };
 
@@ -57,7 +60,7 @@ function toRect(bbox: SyntheticBox["bounding_box"]): {
  * every detection of the same class collapses to a single color in
  * instance-color mode.
  */
-function toDetectionLabel(box: SyntheticBox): DetectionLabel {
+export function toDetectionLabel(box: SyntheticBox): DetectionLabel {
   return {
     _id: box._id,
     label: box.label,

--- a/app/packages/video-annotation/src/useLinkedOverlayState.ts
+++ b/app/packages/video-annotation/src/useLinkedOverlayState.ts
@@ -1,15 +1,20 @@
+import { useAnnotationEventHandler } from "@fiftyone/annotation";
 import {
   UNDEFINED_LIGHTER_SCENE_ID,
   useLighter,
+  useLighterEventBus,
   useLighterEventHandler,
 } from "@fiftyone/lighter";
 import { atom, useStore } from "jotai";
 import { useCallback } from "react";
+import { editing } from "../../core/src/components/Modal/Sidebar/Annotate/Edit";
 
 /**
- * IDs of overlays currently in hover state on the live Lighter scene.
- * Reflects the set of `lighter:overlay-hover` / `:overlay-unhover`
- * events; cleared in bulk by `lighter:overlay-all-unhover`.
+ * IDs of overlays currently considered hovered.
+ * Union of all hover signals: pointer-driven canvas hover
+ * (`lighter:overlay-hover` / `:overlay-unhover`, bulk-cleared by
+ * `:overlay-all-unhover`) plus programmatic sidebar-row hover
+ * (`annotation:sidebarLabelHover` / `:sidebarLabelUnhover`).
  */
 export const hoveredOverlayIds = atom<Set<string>>(new Set<string>());
 
@@ -42,44 +47,48 @@ export const selectedOverlayIds = atom<Set<string>>(new Set<string>());
 export function useLinkedOverlayState(): void {
   const { scene } = useLighter();
   const store = useStore();
-  const useEventHandler = useLighterEventHandler(
-    scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
+  const channel = scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID;
+  const useEventHandler = useLighterEventHandler(channel);
+  const eventBus = useLighterEventBus(channel);
+
+  const addHovered = useCallback(
+    (id: string) => {
+      const current = store.get(hoveredOverlayIds);
+      if (current.has(id)) {
+        return;
+      }
+
+      const next = new Set(current);
+      next.add(id);
+
+      store.set(hoveredOverlayIds, next);
+    },
+    [store]
+  );
+
+  const removeHovered = useCallback(
+    (id: string) => {
+      const current = store.get(hoveredOverlayIds);
+      if (!current.has(id)) {
+        return;
+      }
+
+      const next = new Set(current);
+      next.delete(id);
+
+      store.set(hoveredOverlayIds, next);
+    },
+    [store]
   );
 
   useEventHandler(
     "lighter:overlay-hover",
-    useCallback(
-      (payload) => {
-        const current = store.get(hoveredOverlayIds);
-        if (current.has(payload.id)) {
-          return;
-        }
-
-        const next = new Set(current);
-        next.add(payload.id);
-
-        store.set(hoveredOverlayIds, next);
-      },
-      [store]
-    )
+    useCallback((payload) => addHovered(payload.id), [addHovered])
   );
 
   useEventHandler(
     "lighter:overlay-unhover",
-    useCallback(
-      (payload) => {
-        const current = store.get(hoveredOverlayIds);
-        if (!current.has(payload.id)) {
-          return;
-        }
-
-        const next = new Set(current);
-        next.delete(payload.id);
-
-        store.set(hoveredOverlayIds, next);
-      },
-      [store]
-    )
+    useCallback((payload) => removeHovered(payload.id), [removeHovered])
   );
 
   useEventHandler(
@@ -91,6 +100,47 @@ export function useLinkedOverlayState(): void {
 
       store.set(hoveredOverlayIds, new Set<string>());
     }, [store])
+  );
+
+  // Sidebar-row hover propagates to both the canvas (via `do-overlay-hover`,
+  // so the overlay visually reacts) and the cross-decoration atom (so the
+  // matching timeline track row lights up via `linkHovered`). We can't route
+  // this through `lighter:overlay-hover` — that path is observed by the
+  // tooltip handler, which would pop a stale-positioned tooltip on every
+  // sidebar mouseover.
+  useAnnotationEventHandler(
+    "annotation:sidebarLabelHover",
+    useCallback(
+      (payload) => {
+        if (!scene) {
+          return;
+        }
+
+        eventBus.dispatch("lighter:do-overlay-hover", {
+          id: payload.id,
+          tooltip: payload.tooltip ?? false,
+        });
+
+        addHovered(payload.id);
+      },
+      [scene, eventBus, addHovered]
+    )
+  );
+
+  useAnnotationEventHandler(
+    "annotation:sidebarLabelUnhover",
+    useCallback(
+      (payload) => {
+        if (!scene) {
+          return;
+        }
+
+        eventBus.dispatch("lighter:do-overlay-unhover", { id: payload.id });
+
+        removeHovered(payload.id);
+      },
+      [scene, eventBus, removeHovered]
+    )
   );
 
   useEventHandler(
@@ -143,6 +193,36 @@ export function useLinkedOverlayState(): void {
         store.set(selectedOverlayIds, new Set<string>());
       },
       [store]
+    )
+  );
+
+  // Restore selection when a previously-selected overlay re-enters the
+  // scene
+  useEventHandler(
+    "lighter:overlay-added",
+    useCallback(
+      (payload) => {
+        if (!scene) {
+          return;
+        }
+
+        if (!store.get(selectedOverlayIds).has(payload.id)) {
+          return;
+        }
+
+        const editingValue = store.get(editing);
+        if (!editingValue || typeof editingValue === "string") {
+          return;
+        }
+
+        const editingLabel = store.get(editingValue);
+        if (editingLabel?.overlay?.id !== payload.id) {
+          return;
+        }
+
+        scene.selectOverlay(payload.id);
+      },
+      [scene, store]
     )
   );
 }

--- a/app/packages/video-annotation/src/useSyncLighterAnnotation.ts
+++ b/app/packages/video-annotation/src/useSyncLighterAnnotation.ts
@@ -9,33 +9,36 @@ import {
   UNDEFINED_LIGHTER_SCENE_ID,
   useLighterEventHandler,
 } from "@fiftyone/lighter";
-import type { DetectionLabel } from "@fiftyone/looker";
 import { useCallback } from "react";
 import { useLabelsContext } from "../../core/src/components/Modal/Sidebar/Annotate";
 import useFocus from "../../core/src/components/Modal/Sidebar/Annotate/useFocus";
 import { useDetectionMode } from "../../core/src/components/Modal/Sidebar/Annotate/Edit/useDetectionMode";
 
 /**
- * Bridges Lighter overlay events into the annotation / sidebar systems
- * for the video surface.
+ * Bridges Lighter overlay events into the annotation systems for the video
+ * surface.
  *
  * Event-handler-only: state changes flow through public hook interfaces
- * (`useLabelsContext`, `useDetectionMode`, `useFocus`) rather than direct
- * atom access, so this stays decoupled from those modules' internals.
+ * (`useDetectionMode`, `useFocus`) rather than direct atom access, so this
+ * stays decoupled from those modules' internals.
  *
  * Wires the following bridges:
  *   - **Draw**: `lighter:overlay-create` → `detectionMode.create()`.
  *   - **Establish**: `lighter:overlay-establish` →
  *     `annotation:canvasDetectionOverlayEstablish` so the modal-level
  *     handler can open the sidebar inspector for the new label.
- *   - **Scene ↔ sidebar membership**: `lighter:overlay-added` /
- *     `removed` → `addLabelToSidebar` / `removeLabelFromSidebar`.
  *   - **Selection**: `lighter:overlay-select` / `deselect` →
  *     `focus.selectOverlay` / `deselectOverlay`.
  *   - **Mode quit**: `lighter:detection-mode-quit` and
  *     `lighter:active-mode-quit-requested` (right-click / Esc) →
  *     `detectionMode.deactivateDetectionMode()`.
+ *   - **Transient sidebar cleanup**: `lighter:overlay-removed` →
+ *     `removeLabelFromSidebar`. Snapshot-driven membership lives in
+ *     {@link useSyncSidebarFromSnapshot}.
  *
+ * Sidebar membership and per-frame data freshness are otherwise owned by
+ * {@link useSyncSidebarFromSnapshot}, which reconciles against the current
+ * `FrameLabelSnapshot`.
  * @param scene - The scene to bridge, or `null` while it's still being
  *   set up. When `null`, handlers attach to an inert sentinel channel
  *   and re-bind once the real scene becomes available.
@@ -45,7 +48,7 @@ export const useSyncLighterAnnotation = (scene: Scene2D | null): void => {
     scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
   );
   const annotationEventBus = useAnnotationEventBus();
-  const { addLabelToSidebar, removeLabelFromSidebar } = useLabelsContext();
+  const { removeLabelFromSidebar } = useLabelsContext();
   const detectionMode = useDetectionMode();
   const focus = useFocus();
 
@@ -71,26 +74,6 @@ export const useSyncLighterAnnotation = (scene: Scene2D | null): void => {
         );
       },
       [annotationEventBus]
-    )
-  );
-
-  useEventHandler(
-    "lighter:overlay-added",
-    useCallback(
-      (payload) => {
-        if (
-          payload.overlay instanceof DetectionOverlay &&
-          payload.overlay.field
-        ) {
-          addLabelToSidebar({
-            data: payload.overlay.label as DetectionLabel,
-            overlay: payload.overlay,
-            path: payload.overlay.field,
-            type: "Detection",
-          });
-        }
-      },
-      [addLabelToSidebar]
     )
   );
 

--- a/app/packages/video-annotation/src/useSyncSidebarFromSnapshot.ts
+++ b/app/packages/video-annotation/src/useSyncSidebarFromSnapshot.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { DetectionOverlay, type Scene2D } from "@fiftyone/lighter";
+import { useEffect, useRef } from "react";
+import { useLabelsContext } from "../../core/src/components/Modal/Sidebar/Annotate";
+import { toDetectionLabel } from "./overlayAdapters/detection";
+import type { FrameLabelSnapshot } from "./SyntheticLabelStream";
+
+/**
+ * Reconciles the annotation sidebar against the current {@link FrameLabelSnapshot}
+ * once per frame tick. The snapshot is the per-frame source of truth for video:
+ * which detections are visible *and* what their current data is. Driving the
+ * sidebar off `lighter:overlay-added`/`removed` would only capture membership
+ * transitions and freeze each entry's data at first-seen-frame.
+ *
+ * On each tick:
+ *  - For every detection in the snapshot, push its current data into the
+ *    sidebar (`updateLabelData` if already present, `addLabelToSidebar`
+ *    otherwise). This keeps `_id`, `bounding_box`, `index`, and `instance`
+ *    aligned with the displayed frame — important because tracked detections
+ *    are a different mongo doc each frame.
+ *  - Remove sidebar entries whose synthetic id is no longer in the snapshot.
+ *
+ * Must run *after* {@link useFrameOverlaySync} in the same component so the
+ * overlays for newly-appeared detections already exist when this hook calls
+ * `scene.getOverlay(...)`. Effects execute in declaration order.
+ *
+ * Gates on `canonicalMediaReady` for the same reason `useFrameOverlaySync`
+ * does: before the canonical media lands, that hook short-circuits and no
+ * overlays are in the scene.
+ */
+export const useSyncSidebarFromSnapshot = (
+  scene: Scene2D | null,
+  snapshot: FrameLabelSnapshot | null,
+  field: string,
+  canonicalMediaReady: boolean
+): void => {
+  const { addLabelToSidebar, removeLabelFromSidebar, updateLabelData } =
+    useLabelsContext();
+  const trackedRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!scene || !snapshot || !canonicalMediaReady) {
+      return;
+    }
+
+    const next = new Set<string>();
+
+    for (const det of snapshot.detections) {
+      next.add(det.id);
+
+      const data = toDetectionLabel(det);
+
+      if (updateLabelData(det.id, data)) {
+        continue;
+      }
+
+      const overlay = scene.getOverlay(det.id);
+      if (!(overlay instanceof DetectionOverlay)) {
+        continue;
+      }
+
+      addLabelToSidebar({
+        data,
+        overlay,
+        path: field,
+        type: "Detection",
+      });
+    }
+
+    for (const id of Array.from(trackedRef.current)) {
+      if (!next.has(id)) {
+        removeLabelFromSidebar(id);
+      }
+    }
+    trackedRef.current = next;
+  }, [
+    scene,
+    snapshot,
+    field,
+    canonicalMediaReady,
+    addLabelToSidebar,
+    removeLabelFromSidebar,
+    updateLabelData,
+  ]);
+
+  useEffect(() => {
+    return () => {
+      for (const id of trackedRef.current) {
+        removeLabelFromSidebar(id);
+      }
+
+      trackedRef.current.clear();
+    };
+  }, [removeLabelFromSidebar]);
+};


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

Makes the annotation sidebar a faithful per-frame view of the video stream and fixes a family of overlay-identity bugs.

- **Snapshot-driven sidebar** — sidebar membership and per-row data are reconciled against a per-frame snapshot once per tick, replacing the event-driven path that froze each row's data at its first-seen frame.
- **Lifecycle keyed on `overlay.id`** — the sidebar label lifecycle is keyed on `overlay.id` rather than `data._id`. Tracked detections carry a synthetic overlay id that never equaled the raw `_id`, so the old key silently no-op'd — causing membership leaks during playback and stale row data.
- **Hover + selection linkage** — hovering a sidebar row lights up the matching canvas overlay and timeline track row; a selected label that leaves frame and re-enters is re-selected automatically, while an explicit user exit still sticks.
- **Edge-triggered readOnly sync** — overlay readOnly is synced only on actual transitions, so per-tick snapshot updates no longer restore drag/resize handles and stomp the playback gate.

Stacked on #7684.

## 🧪 How is this patch tested? If it is not, please explain why.

Tested locally in the app (sidebar membership/data across playback, hover linkage, selection across off-frame round-trips).

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
