### PR TITLE
Video annotation: temporal detections + keyframe propagation

### DIFF
--- a/app/packages/annotation/src/agents/PropagationBrowserAgent.test.ts
+++ b/app/packages/annotation/src/agents/PropagationBrowserAgent.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import type { SyntheticBox } from "@fiftyone/video-annotation";
+
+import { PropagationBrowserAgent } from "./PropagationBrowserAgent";
+import {
+  AgentTaskType,
+  type PropagationContext,
+  type SyncInferenceResult,
+  type PropagationInferenceResult,
+} from "./types";
+
+function keyframe(
+  id: string,
+  bbox: [number, number, number, number]
+): SyntheticBox {
+  return {
+    id,
+    label: "car",
+    bounding_box: bbox,
+    keyframe: true,
+    propagation: null,
+  };
+}
+
+const baseContext = {
+  sampleDescriptor: { datasetId: "ds", sampleId: "s", mediaUrl: "x" },
+  taskType: AgentTaskType.PROPAGATE,
+  instanceId: "inst-1",
+} as const;
+
+describe("PropagationBrowserAgent.infer", () => {
+  it("lerps a bbox between two keyframes and emits one Detection per in-between frame", async () => {
+    const agent = new PropagationBrowserAgent();
+    const left = keyframe("k1", [0.0, 0.0, 0.1, 0.1]);
+    const right = keyframe("k2", [1.0, 1.0, 0.1, 0.1]);
+
+    const context: PropagationContext = {
+      ...baseContext,
+      fromFrame: 5,
+      toFrame: 15,
+      parentKeyframes: [left, right],
+    };
+
+    const result = (await agent.infer(context)) as SyncInferenceResult<
+      PropagationInferenceResult
+    > & { labelId: string };
+
+    expect(result.type).toBe("sync");
+    expect(result.taskType).toBe(AgentTaskType.PROPAGATE);
+    expect(result.labelId).toBe("inst-1");
+    expect(result.response.perFrame).toHaveLength(9);
+
+    const midpoint = result.response.perFrame.find(
+      (e) => e.frameNumber === 10
+    );
+    expect(midpoint?.detection.bounding_box).toEqual([0.5, 0.5, 0.1, 0.1]);
+    expect(midpoint?.detection.keyframe).toBe(false);
+    expect(midpoint?.detection.instance).toEqual({
+      _cls: "Instance",
+      _id: "inst-1",
+    });
+    expect(midpoint?.detection.propagation).toMatchObject({
+      method: "linear",
+      parent_keyframes: ["k1", "k2"],
+    });
+  });
+});

--- a/app/packages/annotation/src/agents/PropagationBrowserAgent.ts
+++ b/app/packages/annotation/src/agents/PropagationBrowserAgent.ts
@@ -1,0 +1,169 @@
+import type {
+  AnnotationAgent,
+  AnnotationAgentLifecycle,
+  AnnotationAgentLifecycleListener,
+  AnnotationAgentLifecycleStatus,
+  InferenceResult,
+  ModelMetadata,
+  PropagatedDetection,
+  PropagationContext,
+  PropagationInferenceResult,
+} from "./types";
+import { AgentTaskType, InferenceCapability } from "./types";
+
+type Bbox = [number, number, number, number];
+
+/** Linear interpolation between `a` and `b` at fraction `t` ∈ [0, 1]. */
+function lerp(a: number, b: number, t: number): number {
+  return a + t * (b - a);
+}
+
+/** Component-wise linear interpolation between two bboxes at fraction `t`. */
+function lerpBbox(left: Bbox, right: Bbox, t: number): Bbox {
+  return [
+    lerp(left[0], right[0], t),
+    lerp(left[1], right[1], t),
+    lerp(left[2], right[2], t),
+    lerp(left[3], right[3], t),
+  ];
+}
+
+/** Exclusive integer range `[start, end)` as an array. */
+function range(start: number, end: number): number[] {
+  return Array.from({ length: Math.max(0, end - start) }, (_, i) => start + i);
+}
+
+/**
+ * Generate a 24-char hex string matching the MongoDB ObjectId format —
+ * 4-byte timestamp + 8-byte random. Not a real BSON ObjectId (no machine
+ * id / counter), but the wire format is identical and the DB accepts it.
+ */
+function generateObjectIdHex(): string {
+  const timestamp = Math.floor(Date.now() / 1000)
+    .toString(16)
+    .padStart(8, "0");
+  const random = Array.from({ length: 16 }, () =>
+    Math.floor(Math.random() * 16).toString(16)
+  ).join("");
+  return timestamp + random;
+}
+
+/**
+ * Linearly interpolates a tracked object's bounding box between two
+ * bracketing keyframes, emitting one Detection per in-between frame.
+ *
+ * Despite the `AnnotationAgent` interface and "inference" naming: this is
+ * deterministic math, not AI. The agent abstraction is reused here so
+ * future propagation methods (SAM2 tracking, optical flow, spline) can
+ * slot into the same registry, lifecycle, and dispatch path under one
+ * uniform contract. Linear runs synchronously on the main thread — a
+ * worker would add latency for trivial arithmetic.
+ *
+ * Each emitted Detection carries `keyframe: false`, the propagation run's
+ * provenance blob, and the shared `instance.id` from the source keyframes.
+ */
+export class PropagationBrowserAgent
+  implements AnnotationAgent<PropagationInferenceResult>
+{
+  private lifecycleStatus: AnnotationAgentLifecycleStatus = "idle";
+  private readonly listeners = new Set<AnnotationAgentLifecycleListener>();
+
+  async infer(
+    context: PropagationContext
+  ): Promise<InferenceResult<PropagationInferenceResult>> {
+    if (context.fromFrame >= context.toFrame) {
+      throw new Error(
+        `fromFrame (${context.fromFrame}) must be less than toFrame (${context.toFrame})`
+      );
+    }
+
+    this.setStatus("inferring");
+
+    try {
+      const [leftKeyframe, rightKeyframe] = context.parentKeyframes;
+      const left: Bbox = leftKeyframe.bounding_box;
+      const right: Bbox = rightKeyframe.bounding_box;
+      const span: number = context.toFrame - context.fromFrame;
+      const runId: string = generateObjectIdHex();
+
+      const perFrame: PropagationInferenceResult["perFrame"] = [];
+      range(context.fromFrame + 1, context.toFrame).forEach((n) => {
+        const t: number = (n - context.fromFrame) / span;
+        const detection: PropagatedDetection = {
+          _id: generateObjectIdHex(),
+          _cls: "Detection",
+          bounding_box: lerpBbox(left, right, t),
+          label: leftKeyframe.label,
+          index: leftKeyframe.index,
+          instance: { _cls: "Instance", _id: context.instanceId },
+          keyframe: false,
+          propagation: {
+            method: "linear",
+            run_id: runId,
+            parent_keyframes: [leftKeyframe.id, rightKeyframe.id],
+          },
+        };
+        perFrame.push({ frameNumber: n, detection });
+      });
+
+      return {
+        labelId: context.instanceId,
+        type: "sync",
+        taskType: AgentTaskType.PROPAGATE,
+        response: { perFrame },
+      };
+    } finally {
+      this.setStatus("idle");
+    }
+  }
+
+  async listSupportedTasks(): Promise<AgentTaskType[]> {
+    return [AgentTaskType.PROPAGATE];
+  }
+
+  async listInferenceCapabilities(): Promise<InferenceCapability[]> {
+    return [];
+  }
+
+  async getModelMetadata(task: AgentTaskType): Promise<ModelMetadata | null> {
+    if (task === AgentTaskType.PROPAGATE) {
+      return { name: "Linear interpolation" };
+    }
+    return null;
+  }
+
+  async subscribe(): Promise<void> {
+    // no-op; only supports synchronous inference
+  }
+
+  async unsubscribe(): Promise<void> {
+    // no-op; only supports synchronous inference
+  }
+
+  async abort(): Promise<void> {
+    // no-op; synchronous main-thread math has no abort point
+  }
+
+  onLifecycleEvent(listener: AnnotationAgentLifecycleListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  getLifecycleStatus(): AnnotationAgentLifecycleStatus {
+    return this.lifecycleStatus;
+  }
+
+  private setStatus(status: AnnotationAgentLifecycleStatus): void {
+    if (status === this.lifecycleStatus) return;
+    this.lifecycleStatus = status;
+    this.emit({ kind: "status", status });
+  }
+
+  private emit(event: AnnotationAgentLifecycle): void {
+    for (const listener of this.listeners) {
+      listener(event);
+    }
+  }
+}

--- a/app/packages/annotation/src/agents/hooks/useAgentRegistry.ts
+++ b/app/packages/annotation/src/agents/hooks/useAgentRegistry.ts
@@ -2,6 +2,7 @@ import { AgentDescriptor, AgentRegistry } from "../registry";
 import { atom, useAtom } from "jotai";
 import { useCallback, useMemo } from "react";
 import { AnnotationAgent, InferenceResultProxy } from "../types";
+import { PropagationBrowserAgent } from "../PropagationBrowserAgent";
 import { SAM2BrowserAnnotationAgent } from "../SAM2BrowserAnnotationAgent";
 
 /** Maps agent IDs to their {@link AgentDescriptor} entries. */
@@ -13,6 +14,11 @@ const registryAtom = atom<RegistryMap>({
     id: "sam2-tiny-onnx",
     label: "SAM2",
     agent: new SAM2BrowserAnnotationAgent(),
+  },
+  "propagate-linear": {
+    id: "propagate-linear",
+    label: "Linear interpolation",
+    agent: new PropagationBrowserAgent(),
   },
 });
 

--- a/app/packages/annotation/src/agents/hooks/useApplyPropagationResult.ts
+++ b/app/packages/annotation/src/agents/hooks/useApplyPropagationResult.ts
@@ -1,0 +1,38 @@
+import { useFrameLabelsStream } from "@fiftyone/video-annotation";
+import { useCallback } from "react";
+
+import {
+  type InferenceResult,
+  type PropagationInferenceResult,
+} from "../types";
+
+/**
+ * Method which applies a {@link PropagationInferenceResult} to the
+ * `VideoFrameLabelsStream` cache. Each per-frame entry is written via
+ * `stream.updateLabel`, which the auto-save pipeline picks up.
+ */
+export type PropagationResultHandler = (
+  result: InferenceResult<PropagationInferenceResult>
+) => void;
+
+/**
+ * Hook which returns a {@link PropagationResultHandler} bound to the
+ * current video annotation session. Mirrors {@link useApplyInferenceResult}'s
+ * shape; dispatches into the per-frame stream cache rather than into
+ * Lighter overlays directly (overlays only exist for the current frame).
+ */
+export const useApplyPropagationResult = (): PropagationResultHandler => {
+  const stream = useFrameLabelsStream();
+
+  return useCallback(
+    (result: InferenceResult<PropagationInferenceResult>) => {
+      if (!stream) return;
+      if (result.type !== "sync") return;
+
+      result.response.perFrame.forEach(({ frameNumber, detection }) => {
+        stream.updateLabel(frameNumber, detection);
+      });
+    },
+    [stream]
+  );
+};

--- a/app/packages/annotation/src/agents/types.ts
+++ b/app/packages/annotation/src/agents/types.ts
@@ -1,3 +1,6 @@
+import type { DetectionLabel } from "@fiftyone/looker/src/overlays/detection";
+import type { PropagationBlob, SyntheticBox } from "@fiftyone/video-annotation";
+
 import {
   ClassificationsParent,
   DetectionsParent,
@@ -18,6 +21,7 @@ export enum AgentTaskType {
   DETECT = "detect",
   SEGMENT = "segment",
   INFER = "infer",
+  PROPAGATE = "propagate",
 }
 
 /**
@@ -91,6 +95,20 @@ export type AnnotationContext = {
 };
 
 /**
+ * Inputs for a single propagation run: which track, what range to fill,
+ * and the two bracketing keyframe labels to interpolate between.
+ */
+export type PropagationContext = AnnotationContext & {
+  /** Track identity to propagate within (cross-frame `instance.id`). */
+  instanceId: string;
+  /** Inclusive frame range to fill between the two bracketing keyframes. */
+  fromFrame: number;
+  toFrame: number;
+  /** The two bracketing keyframe labels the propagator interpolates between. */
+  parentKeyframes: [SyntheticBox, SyntheticBox];
+};
+
+/**
  * Display information about the underlying model powering an agent or task.
  */
 export type ModelMetadata = {
@@ -153,13 +171,33 @@ export type PolylinesInferenceResult = PolylinesParent;
 export type SegmentationInferenceResult = DetectionsParent;
 
 /**
+ * A `DetectionLabel` carrying the video-annotation dynamic attrs the
+ * propagator writes on each emitted label. `bounding_box` is required —
+ * propagation always emits 2D detections.
+ */
+export type PropagatedDetection = DetectionLabel & {
+  bounding_box: [number, number, number, number];
+  keyframe: boolean;
+  propagation: PropagationBlob | null;
+};
+
+/**
+ * Response type for propagation tasks: a flat list of per-frame Detection
+ * labels the propagator wants written into the frame-labels stream cache.
+ */
+export type PropagationInferenceResult = {
+  perFrame: Array<{ frameNumber: number; detection: PropagatedDetection }>;
+};
+
+/**
  * Union of all supported inference result types.
  */
 export type InferenceResultProxy =
   | ClassificationInferenceResult
   | DetectionInferenceResult
   | PolylinesInferenceResult
-  | SegmentationInferenceResult;
+  | SegmentationInferenceResult
+  | PropagationInferenceResult;
 
 /**
  * Coarse lifecycle states an {@link AnnotationAgent} may transition through.

--- a/app/packages/annotation/src/commands.ts
+++ b/app/packages/annotation/src/commands.ts
@@ -56,3 +56,21 @@ export class EditTemporalDetectionSupportCommand extends Command<boolean> {
     super();
   }
 }
+
+/**
+ * Propagate a tracked object's bounding box between two bracketing
+ * keyframes via the registered propagation agent (linear interp for the
+ * demo). Resolves to `true` when at least one in-between frame was
+ * written, `false` when prerequisites are missing (no stream, no
+ * bracketing keyframes, no registered agent for the method).
+ */
+export class PropagateCommand extends Command<boolean> {
+  constructor(
+    public readonly instanceId: string,
+    public readonly fromFrame: number,
+    public readonly toFrame: number,
+    public readonly method: string
+  ) {
+    super();
+  }
+}

--- a/app/packages/annotation/src/commands.ts
+++ b/app/packages/annotation/src/commands.ts
@@ -41,3 +41,18 @@ export class MarkKeyframeCommand extends Command<boolean> {
     super();
   }
 }
+
+/**
+ * Edit a `TemporalDetection.support` frame range. Fired on drag-end
+ * of a timeline interval bar. `support` is the post-edit value;
+ * the supplier resolves the array index on the sample at flush time.
+ */
+export class EditTemporalDetectionSupportCommand extends Command<boolean> {
+  constructor(
+    public readonly fieldPath: string,
+    public readonly detectionId: string,
+    public readonly support: readonly [number, number]
+  ) {
+    super();
+  }
+}

--- a/app/packages/annotation/src/events.ts
+++ b/app/packages/annotation/src/events.ts
@@ -160,6 +160,26 @@ export type AnnotationEventGroup = {
   "annotation:undoLabelEdit": { label: Partial<AnnotationLabel["data"]> };
 
   /**
+   * Notification event emitted when a label's `keyframe` attribute changes
+   * on a tracked instance. Consumers (e.g. auto-interpolate) use this to
+   * re-propagate between bracketing keyframes after a change.
+   *
+   * - `kind: "set"` — keyframe just became `true`, either by mark-keyframe
+   *   gesture or by an edit (draw / drag / resize) that promotes the label.
+   * - `kind: "removed"` — keyframe was `true` and no longer is, either by
+   *   unmarking or by deleting the underlying detection.
+   */
+  "annotation:keyframeChanged": {
+    /** Synthetic overlay id (`instance-…` / `track-…`). */
+    trackId: string;
+    /** Cross-frame identity, when the label has an `fo.Instance`. */
+    instanceId: string | null;
+    /** 1-indexed frame number where the change happened. */
+    frame: number;
+    kind: "set" | "removed";
+  };
+
+  /**
    * Notification event emitted when the active annotation agent transitions
    * between lifecycle states (e.g. `"initializing"` → `"inferring"`).
    */

--- a/app/packages/annotation/src/hooks/index.ts
+++ b/app/packages/annotation/src/hooks/index.ts
@@ -10,4 +10,5 @@ export * from "./useRegisterAnnotationKeyBindings";
 export * from "./useRegisterVideoAnnotationCommandHandlers";
 export * from "./useRegisterVideoAnnotationEventHandlers";
 export * from "./useRegisterVideoAnnotationKeybindings";
+export * from "./useAutoInterpolate";
 export * from "./useRegisterRendererEventHandlers";

--- a/app/packages/annotation/src/hooks/useAutoInterpolate.ts
+++ b/app/packages/annotation/src/hooks/useAutoInterpolate.ts
@@ -1,0 +1,101 @@
+import { useCommandBus } from "@fiftyone/command-bus";
+import {
+  useFrameLabelsStream,
+  type VideoFrameLabelsStream,
+} from "@fiftyone/video-annotation";
+import { useCallback } from "react";
+import { PropagateCommand } from "../commands";
+import { useAnnotationEventHandler } from "./useAnnotationEventHandler";
+
+/** Inclusive `[fromFrame, toFrame]` segment to re-propagate. */
+export type FrameRange = [number, number];
+
+/**
+ * Frame numbers on a track that carry `keyframe: true`. Walks the
+ * stream cache once per call; the caller decides when to invoke (e.g.
+ * on each `annotation:keyframeChanged` event).
+ */
+export function collectKeyframeFrames(
+  stream: VideoFrameLabelsStream,
+  trackId: string
+): number[] {
+  const allFrames = Array.from({ length: stream.totalFrames }, (_, i) => i + 1);
+  return allFrames.filter((frame) => {
+    const snapshot = stream.getValue((frame - 1) / stream.fps);
+    return (
+      snapshot?.detections.some((d) => d.id === trackId && d.keyframe) ?? false
+    );
+  });
+}
+
+/**
+ * Given the current set of keyframe frames on a track and the frame
+ * where a keyframe just changed, return the `(from, to)` pairs whose
+ * in-between frames need re-propagation.
+ *
+ * - `kind: "set"` — `frame` is now a keyframe. Re-propagate both
+ *   sides: (prev-keyframe, frame) and (frame, next-keyframe). Each
+ *   side is skipped if no bracketing keyframe exists on that side.
+ * - `kind: "removed"` — `frame` is no longer a keyframe. Re-propagate
+ *   the wider span (prev-keyframe, next-keyframe). Skipped entirely
+ *   if either bracketing keyframe is missing.
+ */
+export function resolveSegmentsToRepropagate(
+  keyframeFrames: number[],
+  changedFrame: number,
+  kind: "set" | "removed"
+): FrameRange[] {
+  const sorted = [...keyframeFrames].sort((a, b) => a - b);
+  const prev = sorted.filter((f) => f < changedFrame).at(-1) ?? null;
+  const next = sorted.find((f) => f > changedFrame) ?? null;
+
+  const segments: FrameRange[] = [];
+
+  if (kind === "set") {
+    if (prev !== null) segments.push([prev, changedFrame]);
+    if (next !== null) segments.push([changedFrame, next]);
+  } else if (prev !== null && next !== null) {
+    segments.push([prev, next]);
+  }
+
+  return segments;
+}
+
+/**
+ * Subscribe to `annotation:keyframeChanged` and dispatch
+ * `PropagateCommand` for each in-between segment that needs to be
+ * re-lerped against the new keyframe layout.
+ *
+ * Mount once inside the video annotation surface alongside the other
+ * video-annotation registrars. The hook is a no-op until a stream
+ * is published.
+ */
+export const useAutoInterpolate = (): void => {
+  const stream = useFrameLabelsStream();
+  const bus = useCommandBus();
+
+  useAnnotationEventHandler(
+    "annotation:keyframeChanged",
+    useCallback(
+      (payload) => {
+        if (!stream) return;
+        const { instanceId, trackId, frame, kind } = payload;
+        if (!instanceId) return;
+
+        const keyframeFrames = collectKeyframeFrames(stream, trackId);
+        const segments = resolveSegmentsToRepropagate(
+          keyframeFrames,
+          frame,
+          kind
+        );
+
+        segments.forEach(([from, to]) => {
+          void bus.execute(
+            new PropagateCommand(instanceId, from, to, "linear")
+          );
+        });
+      },
+      [stream, bus]
+    )
+  );
+};

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
@@ -6,9 +6,19 @@ import {
 } from "@fiftyone/video-annotation";
 import { useCallback } from "react";
 import { frameAt } from "../../../playback/src/lib/playback/utils";
+import { useAgentRegistry } from "../agents/hooks/useAgentRegistry";
+import { useApplyPropagationResult } from "../agents/hooks/useApplyPropagationResult";
+import { useSampleDescriptor } from "../agents/hooks/useSampleDescriptor";
+import {
+  AgentTaskType,
+  type AnnotationAgent,
+  type PropagationContext,
+  type PropagationInferenceResult,
+} from "../agents/types";
 import {
   EditTemporalDetectionSupportCommand,
   MarkKeyframeCommand,
+  PropagateCommand,
 } from "../commands";
 
 /**
@@ -20,6 +30,9 @@ import {
 export const useRegisterVideoAnnotationCommandHandlers = () => {
   const stream = useFrameLabelsStream();
   const stageTemporalDetectionSupport = useStageTemporalDetectionSupport();
+  const registry = useAgentRegistry();
+  const sampleDescriptor = useSampleDescriptor();
+  const applyPropagation = useApplyPropagationResult();
 
   useRegisterCommandHandler(
     EditTemporalDetectionSupportCommand,
@@ -82,6 +95,56 @@ export const useRegisterVideoAnnotationCommandHandlers = () => {
         return updated;
       },
       [stream]
+    )
+  );
+
+  useRegisterCommandHandler(
+    PropagateCommand,
+    useCallback(
+      async (cmd) => {
+        if (!stream) return false;
+        if (cmd.fromFrame >= cmd.toFrame) return false;
+
+        const fromTime = (cmd.fromFrame - 1) / stream.fps;
+        const toTime = (cmd.toFrame - 1) / stream.fps;
+        const fromSnapshot = stream.getValue(fromTime);
+        const toSnapshot = stream.getValue(toTime);
+        if (!fromSnapshot || !toSnapshot) return false;
+
+        const matchesInstance = (d: {
+          instance?: { _cls: "Instance"; _id?: string };
+          keyframe: boolean;
+        }): boolean =>
+          d.keyframe === true && d.instance?._id === cmd.instanceId;
+
+        const leftKeyframe = fromSnapshot.detections.find(matchesInstance);
+        const rightKeyframe = toSnapshot.detections.find(matchesInstance);
+        if (!leftKeyframe || !rightKeyframe) return false;
+
+        const agentId = `propagate-${cmd.method}`;
+        const agents = await registry.listAgents();
+        const descriptor = agents.find((a) => a.id === agentId);
+        if (!descriptor) return false;
+
+        const context: PropagationContext = {
+          sampleDescriptor,
+          taskType: AgentTaskType.PROPAGATE,
+          instanceId: cmd.instanceId,
+          fromFrame: cmd.fromFrame,
+          toFrame: cmd.toFrame,
+          parentKeyframes: [leftKeyframe, rightKeyframe],
+        };
+
+        // Registry stores agents under the broad `InferenceResultProxy`
+        // type; narrow to the propagation agent's specific result type so
+        // the downstream apply hook is typed end-to-end.
+        const agent =
+          descriptor.agent as AnnotationAgent<PropagationInferenceResult>;
+        const result = await agent.infer(context);
+        applyPropagation(result);
+        return true;
+      },
+      [stream, registry, sampleDescriptor, applyPropagation]
     )
   );
 };

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
@@ -1,4 +1,5 @@
 import { useRegisterCommandHandler } from "@fiftyone/command-bus";
+import { useAnnotationEventBus } from "./useAnnotationEventBus";
 import {
   useFrameLabelsStream,
   useStageTemporalDetectionSupport,
@@ -33,6 +34,7 @@ export const useRegisterVideoAnnotationCommandHandlers = () => {
   const registry = useAgentRegistry();
   const sampleDescriptor = useSampleDescriptor();
   const applyPropagation = useApplyPropagationResult();
+  const eventBus = useAnnotationEventBus();
 
   useRegisterCommandHandler(
     EditTemporalDetectionSupportCommand,
@@ -90,11 +92,18 @@ export const useRegisterVideoAnnotationCommandHandlers = () => {
 
           stream.updateLabel(frame, update);
           updated = true;
+
+          eventBus.dispatch("annotation:keyframeChanged", {
+            trackId: det.id,
+            instanceId: det.instance?._id ?? null,
+            frame,
+            kind: willBeKeyframe ? "set" : "removed",
+          });
         }
 
         return updated;
       },
-      [stream]
+      [stream, eventBus]
     )
   );
 

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
@@ -1,11 +1,15 @@
 import { useRegisterCommandHandler } from "@fiftyone/command-bus";
 import {
   useFrameLabelsStream,
+  useStageTemporalDetectionSupport,
   type LocalDetection,
 } from "@fiftyone/video-annotation";
 import { useCallback } from "react";
 import { frameAt } from "../../../playback/src/lib/playback/utils";
-import { MarkKeyframeCommand } from "../commands";
+import {
+  EditTemporalDetectionSupportCommand,
+  MarkKeyframeCommand,
+} from "../commands";
 
 /**
  * Registers video-specific annotation command handlers. Mount inside
@@ -15,6 +19,21 @@ import { MarkKeyframeCommand } from "../commands";
  */
 export const useRegisterVideoAnnotationCommandHandlers = () => {
   const stream = useFrameLabelsStream();
+  const stageTemporalDetectionSupport = useStageTemporalDetectionSupport();
+
+  useRegisterCommandHandler(
+    EditTemporalDetectionSupportCommand,
+    useCallback(
+      async (cmd) => {
+        stageTemporalDetectionSupport(cmd.fieldPath, cmd.detectionId, [
+          cmd.support[0],
+          cmd.support[1],
+        ]);
+        return true;
+      },
+      [stageTemporalDetectionSupport]
+    )
+  );
 
   useRegisterCommandHandler(
     MarkKeyframeCommand,

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationEventHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationEventHandlers.ts
@@ -1,27 +1,40 @@
-import { useFrameLabelsStream } from "@fiftyone/video-annotation";
+import {
+  useClearTemporalDetectionEdits,
+  useFrameLabelsStream,
+} from "@fiftyone/video-annotation";
 import { useCallback } from "react";
 import { useAnnotationEventHandler } from "./useAnnotationEventHandler";
 
 /**
  * Video-specific annotation event handlers. Bridges persistence outcomes to the
  * frame-labels stream so dirty/baseline state advances on success and rolls
- * back on failure. Mount alongside {@link useRegisterAnnotationEventHandlers}
- * at the composition root; no-op when the active modal isn't a video sample.
+ * back on failure, and clears any staged `TemporalDetection.support` edits
+ * after a save attempt resolves. Mount alongside
+ * {@link useRegisterAnnotationEventHandlers} at the composition root; no-op
+ * when the active modal isn't a video sample.
+ *
+ * TD edits are cleared on both success and error: success means the sample
+ * is refreshing with the patched value, so the optimistic override becomes
+ * redundant; error rolls back the optimistic visual to whatever the live
+ * sample reflects and lets the user retry by re-dragging.
  */
 export const useRegisterVideoAnnotationEventHandlers = () => {
   const videoStream = useFrameLabelsStream();
+  const clearTemporalDetectionEdits = useClearTemporalDetectionEdits();
 
   useAnnotationEventHandler(
     "annotation:persistenceSuccess",
     useCallback(() => {
       videoStream?.commitPending();
-    }, [videoStream])
+      clearTemporalDetectionEdits();
+    }, [videoStream, clearTemporalDetectionEdits])
   );
 
   useAnnotationEventHandler(
     "annotation:persistenceError",
     useCallback(() => {
       videoStream?.discardPending();
-    }, [videoStream])
+      clearTemporalDetectionEdits();
+    }, [videoStream, clearTemporalDetectionEdits])
   );
 };

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationKeybindings.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationKeybindings.ts
@@ -1,9 +1,11 @@
 import { useCommandBus } from "@fiftyone/command-bus";
 import { KnownContexts, useKeyBindings } from "@fiftyone/commands";
 import { useLighter } from "@fiftyone/lighter";
+import { useFrameLabelsStream } from "@fiftyone/video-annotation";
 import { useRef } from "react";
+import { frameAt } from "../../../playback/src/lib/playback/utils";
 import { usePlayhead } from "../../../playback/src/lib/playback/use-playback-state";
-import { MarkKeyframeCommand } from "../commands";
+import { MarkKeyframeCommand, PropagateCommand } from "../commands";
 
 /**
  * Registers video-only keybindings into the modal-annotate context.
@@ -15,6 +17,7 @@ import { MarkKeyframeCommand } from "../commands";
 export const useRegisterVideoAnnotationKeybindings = () => {
   const bus = useCommandBus();
   const { scene } = useLighter();
+  const stream = useFrameLabelsStream();
 
   // Read the visual playhead, not `useCurrentTime` — currentTime lags
   // playhead while streams buffer, so dispatching at "the moment the
@@ -23,6 +26,9 @@ export const useRegisterVideoAnnotationKeybindings = () => {
   const playhead = usePlayhead();
   const playheadRef = useRef(playhead);
   playheadRef.current = playhead;
+
+  const streamRef = useRef(stream);
+  streamRef.current = stream;
 
   useKeyBindings(
     KnownContexts.ModalAnnotate,
@@ -41,6 +47,58 @@ export const useRegisterVideoAnnotationKeybindings = () => {
         label: "Mark keyframe",
         description:
           "Toggle the keyframe attribute on the selected detection at the current frame.",
+      },
+      {
+        commandId: "annotation-propagate",
+        sequence: "-",
+        handler: () => {
+          if (!scene) return;
+          const s = streamRef.current;
+          if (!s) return;
+          const ids = scene.getSelectedOverlayIds();
+          if (ids.length === 0) return;
+
+          const currentFrame = frameAt(
+            playheadRef.current,
+            s.fps,
+            s.totalFrames
+          );
+          const currentSnapshot = s.getValue(playheadRef.current);
+          if (!currentSnapshot) return;
+
+          const selected = currentSnapshot.detections.find((d) =>
+            ids.includes(d.id)
+          );
+          const instanceId = selected?.instance?._id;
+          if (!instanceId) return;
+
+          // Walk the cached frames to locate the bracketing keyframes:
+          // the most recent keyframe at or before the playhead, and the
+          // next keyframe strictly after.
+          let leftFrame: number | null = null;
+          let rightFrame: number | null = null;
+          for (let f = 1; f <= s.totalFrames; f++) {
+            const snap = s.getValue((f - 1) / s.fps);
+            if (!snap) continue;
+            const det = snap.detections.find(
+              (d) => d.keyframe && d.instance?._id === instanceId
+            );
+            if (!det) continue;
+            if (f <= currentFrame) leftFrame = f;
+            if (f > currentFrame && rightFrame === null) {
+              rightFrame = f;
+              break;
+            }
+          }
+          if (leftFrame === null || rightFrame === null) return;
+
+          void bus.execute(
+            new PropagateCommand(instanceId, leftFrame, rightFrame, "linear")
+          );
+        },
+        label: "Propagate",
+        description:
+          "Linearly interpolate the selected tracked object between its bracketing keyframes.",
       },
     ],
     [scene, bus]

--- a/app/packages/annotation/src/persistence/index.ts
+++ b/app/packages/annotation/src/persistence/index.ts
@@ -8,3 +8,4 @@ export * from "./usePersistenceEventHandler";
 export * from "./usePersistenceRetryController";
 export * from "./useSampleMutationManager";
 export * from "./useSidebarDeltaSupplier";
+export * from "./useTemporalDetectionDeltaSupplier";

--- a/app/packages/annotation/src/persistence/useAnnotationDeltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/useAnnotationDeltaSupplier.ts
@@ -3,6 +3,7 @@ import { useLighterDeltaSupplier } from "./useLighterDeltaSupplier";
 import { useCallback } from "react";
 import { useSidebarDeltaSupplier } from "./useSidebarDeltaSupplier";
 import { use3dDeltaSupplier } from "./use3dDeltaSupplier";
+import { useTemporalDetectionDeltaSupplier } from "./useTemporalDetectionDeltaSupplier";
 import { useVideoLabelsDeltaSupplier } from "./useVideoLabelsDeltaSupplier";
 
 /**
@@ -13,18 +14,21 @@ export const useAnnotationDeltaSupplier = (): DeltaSupplier => {
   const supply3dDeltas = use3dDeltaSupplier();
   const supplyLighterDeltas = useLighterDeltaSupplier();
   const supplySidebarDeltas = useSidebarDeltaSupplier();
+  const supplyTemporalDetectionDeltas = useTemporalDetectionDeltaSupplier();
   const supplyVideoLabelsDeltas = useVideoLabelsDeltaSupplier();
 
   return useCallback(() => {
     const result3d = supply3dDeltas();
     const resultLighter = supplyLighterDeltas();
     const resultSidebar = supplySidebarDeltas();
+    const resultTemporalDetection = supplyTemporalDetectionDeltas();
     const resultVideoLabels = supplyVideoLabelsDeltas();
 
     const deltas = [
       ...result3d.deltas,
       ...resultLighter.deltas,
       ...resultSidebar.deltas,
+      ...resultTemporalDetection.deltas,
       ...resultVideoLabels.deltas,
     ];
 
@@ -34,6 +38,7 @@ export const useAnnotationDeltaSupplier = (): DeltaSupplier => {
     supply3dDeltas,
     supplyLighterDeltas,
     supplySidebarDeltas,
+    supplyTemporalDetectionDeltas,
     supplyVideoLabelsDeltas,
   ]);
 };

--- a/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.test.ts
+++ b/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import { buildTemporalDetectionSupportDeltas } from "./useTemporalDetectionDeltaSupplier";
+
+const td = (id: string, support: [number, number]) => ({
+  _cls: "TemporalDetection",
+  _id: id,
+  label: "x",
+  support,
+});
+
+const field = (...detections: ReturnType<typeof td>[]) => ({
+  _cls: "TemporalDetections" as const,
+  detections,
+});
+
+describe("buildTemporalDetectionSupportDeltas", () => {
+  it("emits a replace op at /<fieldPath>/detections/<index>/support", () => {
+    const sample = { events: field(td("a", [1, 10])) };
+    const pending = new Map<string, [number, number]>([["events|a", [5, 15]]]);
+
+    expect(buildTemporalDetectionSupportDeltas(sample, pending)).toEqual([
+      { op: "replace", path: "/events/detections/0/support", value: [5, 15] },
+    ]);
+  });
+
+  it("resolves index by detection _id, not by edit order", () => {
+    const sample = {
+      events: field(td("a", [1, 10]), td("b", [20, 30]), td("c", [40, 50])),
+    };
+    const pending = new Map<string, [number, number]>([["events|c", [42, 60]]]);
+    const deltas = buildTemporalDetectionSupportDeltas(sample, pending);
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0]).toMatchObject({
+      path: "/events/detections/2/support",
+      value: [42, 60],
+    });
+  });
+
+  it("falls back to `id` when `_id` is missing on the detection", () => {
+    const sample = {
+      events: {
+        _cls: "TemporalDetections" as const,
+        detections: [{ _cls: "TemporalDetection", id: "x", support: [1, 5] }],
+      },
+    };
+    const pending = new Map<string, [number, number]>([["events|x", [2, 6]]]);
+    const deltas = buildTemporalDetectionSupportDeltas(sample, pending);
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0]).toMatchObject({
+      path: "/events/detections/0/support",
+    });
+  });
+
+  it("emits one op per staged edit and preserves insertion order", () => {
+    const sample = {
+      events: field(td("a", [1, 10]), td("b", [20, 30])),
+    };
+    const pending = new Map<string, [number, number]>([
+      ["events|b", [22, 28]],
+      ["events|a", [5, 15]],
+    ]);
+    const deltas = buildTemporalDetectionSupportDeltas(sample, pending);
+    expect(deltas).toHaveLength(2);
+    // Insertion order of `pending` (b, then a).
+    expect((deltas[0] as { path: string }).path).toBe(
+      "/events/detections/1/support"
+    );
+    expect((deltas[1] as { path: string }).path).toBe(
+      "/events/detections/0/support"
+    );
+  });
+
+  it("handles edits spanning multiple fields", () => {
+    const sample = {
+      events: field(td("a", [1, 10])),
+      highlights: field(td("h", [20, 30])),
+    };
+    const pending = new Map<string, [number, number]>([
+      ["events|a", [5, 15]],
+      ["highlights|h", [22, 28]],
+    ]);
+    const deltas = buildTemporalDetectionSupportDeltas(sample, pending);
+    expect(deltas).toHaveLength(2);
+    const paths = (deltas as { path: string }[]).map((d) => d.path);
+    expect(paths).toContain("/events/detections/0/support");
+    expect(paths).toContain("/highlights/detections/0/support");
+  });
+
+  it("skips edits whose field doesn't exist on the sample", () => {
+    const sample = { events: field(td("a", [1, 10])) };
+    const pending = new Map<string, [number, number]>([["ghost|a", [5, 15]]]);
+    expect(buildTemporalDetectionSupportDeltas(sample, pending)).toEqual([]);
+  });
+
+  it("skips edits whose field isn't a TemporalDetections wrapper", () => {
+    const sample = {
+      events: { _cls: "Detections", detections: [] },
+    };
+    const pending = new Map<string, [number, number]>([["events|a", [5, 15]]]);
+    expect(buildTemporalDetectionSupportDeltas(sample, pending)).toEqual([]);
+  });
+
+  it("skips edits whose field is null / undefined / non-object", () => {
+    const pending = new Map<string, [number, number]>([["events|a", [5, 15]]]);
+    expect(
+      buildTemporalDetectionSupportDeltas({ events: null }, pending)
+    ).toEqual([]);
+    expect(
+      buildTemporalDetectionSupportDeltas(
+        { events: undefined } as unknown as Record<string, unknown>,
+        pending
+      )
+    ).toEqual([]);
+    expect(
+      buildTemporalDetectionSupportDeltas({ events: "string" }, pending)
+    ).toEqual([]);
+  });
+
+  it("skips edits whose TD has disappeared from the array", () => {
+    const sample = { events: field(td("a", [1, 10])) };
+    const pending = new Map<string, [number, number]>([
+      ["events|ghost", [5, 15]],
+    ]);
+    expect(buildTemporalDetectionSupportDeltas(sample, pending)).toEqual([]);
+  });
+
+  it("returns an empty array when no edits are pending", () => {
+    const sample = { events: field(td("a", [1, 10])) };
+    expect(buildTemporalDetectionSupportDeltas(sample, new Map())).toEqual([]);
+  });
+
+  it("emits the bad edit dropped but keeps the good one in the same flush", () => {
+    const sample = { events: field(td("a", [1, 10])) };
+    const pending = new Map<string, [number, number]>([
+      ["events|ghost", [99, 100]],
+      ["events|a", [5, 15]],
+    ]);
+    const deltas = buildTemporalDetectionSupportDeltas(sample, pending);
+    expect(deltas).toHaveLength(1);
+    expect((deltas[0] as { value: [number, number] }).value).toEqual([5, 15]);
+  });
+});

--- a/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.ts
@@ -1,0 +1,89 @@
+import type { JSONDeltas } from "@fiftyone/core/src/client";
+import { useIsVideo, useModalSample } from "@fiftyone/state";
+import {
+  parseTemporalDetectionEditKey,
+  type RawTemporalDetectionsField,
+  useTemporalDetectionPendingEdits,
+} from "@fiftyone/video-annotation";
+import { useCallback } from "react";
+import type { DeltaSupplier } from "./deltaSupplier";
+
+/**
+ * Provides a {@link DeltaSupplier} for `TemporalDetection.support` edits
+ * staged from the video annotation timeline.
+ *
+ * TDs live at sample level on a video sample (not under `frames.`), so
+ * they don't flow through the video-labels delta paths. They also don't have
+ * overlays, so they don't flow through the Lighter delta path.
+ *
+ * Pending edits are read from {@link useTemporalDetectionPendingEdits},
+ * the TD's current array index is looked up live against the modal sample,
+ * and one `replace /<fieldPath>/detections/<index>/support` op is emitted per
+ * staged edit.
+ *
+ * Index is resolved at supply time (not capture time) so a concurrent
+ * unrelated insert/remove on the same field doesn't break the patch.
+ * If the targeted TD has disappeared from the sample, the edit is
+ * silently dropped.
+ *
+ * No-op for non-video samples and when no edits are pending. Pending
+ * edits are cleared on `annotation:persistenceSuccess` /
+ * `persistenceError` by {@link useRegisterVideoAnnotationEventHandlers}.
+ */
+export const useTemporalDetectionDeltaSupplier = (): DeltaSupplier => {
+  const modalSample = useModalSample();
+  const isVideo = useIsVideo();
+  const pending = useTemporalDetectionPendingEdits();
+
+  return useCallback(() => {
+    if (!isVideo || !modalSample?.sample || pending.size === 0) {
+      return { deltas: [], metadata: undefined };
+    }
+
+    return {
+      deltas: buildTemporalDetectionSupportDeltas(
+        modalSample.sample as Record<string, unknown>,
+        pending
+      ),
+      metadata: undefined,
+    };
+  }, [isVideo, modalSample, pending]);
+};
+
+/**
+ * Walk the pending TD support edits and emit one replace op per edit
+ * whose target TD still exists on the sample. Edits where the field
+ * is missing or the TD has been removed are silently dropped.
+ *
+ * Exported for direct unit testing; production callers use the supplier
+ * above.
+ */
+export function buildTemporalDetectionSupportDeltas(
+  sample: Record<string, unknown>,
+  pending: ReadonlyMap<string, [number, number]>
+): JSONDeltas {
+  const deltas: JSONDeltas = [];
+
+  for (const [key, support] of pending) {
+    const { fieldPath, detectionId } = parseTemporalDetectionEditKey(key);
+    const field = sample[fieldPath] as RawTemporalDetectionsField | undefined;
+
+    const detections = field?.detections;
+    if (!Array.isArray(detections)) {
+      continue;
+    }
+
+    const index = detections.findIndex((d) => (d._id ?? d.id) === detectionId);
+    if (index < 0) {
+      continue;
+    }
+
+    deltas.push({
+      op: "replace",
+      path: `/${fieldPath}/detections/${index}/support`,
+      value: support,
+    });
+  }
+
+  return deltas;
+}

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
@@ -53,10 +53,14 @@ const useSchema = (readOnly: boolean) => {
 
   // Reruns only when the visible attribute set changes.
   return useMemo(() => {
+    // An empty class list would emit a 0-item JSON-Schema enum, which RJSF
+    // rejects. Fall back to a free-form text input until the dataset has a
+    // configured class list.
+    const hasClasses = (config?.classes?.length ?? 0) > 0;
     const properties: Record<string, SchemaType | undefined> = {
       label: generatePrimitiveSchema("label", {
         type: "str",
-        component: config?.component || "dropdown",
+        component: hasClasses ? config?.component || "dropdown" : undefined,
         values: config?.classes || [],
         readOnly: effectiveReadOnly,
       }),

--- a/app/packages/playback/src/views/TimelineTrack/TimelineTrack.module.css
+++ b/app/packages/playback/src/views/TimelineTrack/TimelineTrack.module.css
@@ -90,3 +90,27 @@
 .event:hover {
   filter: brightness(1.15);
 }
+
+.resizeHandle {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  width: 6px;
+  cursor: ew-resize;
+  z-index: 2;
+  background: rgba(255, 255, 255, 0.25);
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+
+.intervalBar:hover .resizeHandle {
+  opacity: 1;
+}
+
+.resizeHandleStart {
+  left: 0;
+}
+
+.resizeHandleEnd {
+  right: 0;
+}

--- a/app/packages/playback/src/views/TimelineTrack/TimelineTrack.test.tsx
+++ b/app/packages/playback/src/views/TimelineTrack/TimelineTrack.test.tsx
@@ -302,4 +302,249 @@ describe("TimelineTrack", () => {
       );
     });
   });
+
+  describe("resizable interval events", () => {
+    /**
+     * Fire a pointer-down on the element via React's synthetic-event
+     * path so onPointerDown handlers run, then dispatch document-level
+     * pointermove / pointerup that the drag handler listens for.
+     */
+    const dragOnElement = (el: HTMLElement, from: number, to: number) => {
+      fireEvent.mouseDown(el, { clientX: from, button: 0 });
+      const move = new MouseEvent("mousemove", {
+        clientX: to,
+        bubbles: true,
+      });
+      document.dispatchEvent(move);
+      const up = new MouseEvent("mouseup", { clientX: to, bubbles: true });
+      document.dispatchEvent(up);
+    };
+
+    const baseInterval = {
+      startSec: 4,
+      endSec: 6,
+      resizable: true as const,
+    };
+
+    it("renders both resize handles on a resizable interval when onEventEdit is provided", () => {
+      const { container } = renderTrack({
+        track: {
+          start: 0,
+          end: 10,
+          events: [baseInterval],
+          onEventEdit: vi.fn(),
+        },
+      });
+      const handles = container.querySelectorAll(`.${styles.resizeHandle}`);
+      expect(handles).toHaveLength(2);
+      expect(
+        container.querySelector(`.${styles.resizeHandleStart}`)
+      ).not.toBeNull();
+      expect(
+        container.querySelector(`.${styles.resizeHandleEnd}`)
+      ).not.toBeNull();
+    });
+
+    it("does not render handles when resizable is true but onEventEdit is missing", () => {
+      const { container } = renderTrack({
+        track: { start: 0, end: 10, events: [baseInterval] },
+      });
+      expect(
+        container.querySelectorAll(`.${styles.resizeHandle}`)
+      ).toHaveLength(0);
+    });
+
+    it("does not render handles when the event opts out of resizable", () => {
+      const { container } = renderTrack({
+        track: {
+          start: 0,
+          end: 10,
+          events: [{ startSec: 4, endSec: 6 }],
+          onEventEdit: vi.fn(),
+        },
+      });
+      expect(
+        container.querySelectorAll(`.${styles.resizeHandle}`)
+      ).toHaveLength(0);
+    });
+
+    it("commits a resize-end drag with the new endSec", () => {
+      const onEventEdit = vi.fn();
+      const { container } = renderTrack({
+        track: {
+          start: 0,
+          end: 10,
+          events: [baseInterval],
+          onEventEdit,
+        },
+      });
+      const endHandle = container.querySelector(
+        `.${styles.resizeHandleEnd}`
+      ) as HTMLElement;
+      // Lane is 1000px wide for view [0, 10] → 100px per second.
+      // Drag end handle right by 200px → +2s on endSec (4→6 becomes 4→8).
+      dragOnElement(endHandle, 600, 800);
+      expect(onEventEdit).toHaveBeenCalledTimes(1);
+      const [idx, newStart, newEnd] = onEventEdit.mock.calls[0];
+      expect(idx).toBe(0);
+      expect(newStart).toBeCloseTo(4);
+      expect(newEnd).toBeCloseTo(8);
+    });
+
+    it("commits a resize-start drag with the new startSec", () => {
+      const onEventEdit = vi.fn();
+      const { container } = renderTrack({
+        track: {
+          start: 0,
+          end: 10,
+          events: [baseInterval],
+          onEventEdit,
+        },
+      });
+      const startHandle = container.querySelector(
+        `.${styles.resizeHandleStart}`
+      ) as HTMLElement;
+      // Drag start handle left by 100px → -1s on startSec (4→6 becomes 3→6).
+      dragOnElement(startHandle, 400, 300);
+      expect(onEventEdit).toHaveBeenCalledTimes(1);
+      const [idx, newStart, newEnd] = onEventEdit.mock.calls[0];
+      expect(idx).toBe(0);
+      expect(newStart).toBeCloseTo(3);
+      expect(newEnd).toBeCloseTo(6);
+    });
+
+    it("commits a body-drag (move) with both endpoints shifted by the same delta", () => {
+      const onEventEdit = vi.fn();
+      const { container } = renderTrack({
+        track: {
+          start: 0,
+          end: 10,
+          events: [baseInterval],
+          onEventEdit,
+        },
+      });
+      const bar = container.querySelector(
+        `.${styles.intervalBar}`
+      ) as HTMLElement;
+      // Drag bar right by 100px → +1s on both endpoints (4→6 becomes 5→7).
+      dragOnElement(bar, 500, 600);
+      expect(onEventEdit).toHaveBeenCalledTimes(1);
+      const [idx, newStart, newEnd] = onEventEdit.mock.calls[0];
+      expect(idx).toBe(0);
+      expect(newStart).toBeCloseTo(5);
+      expect(newEnd).toBeCloseTo(7);
+    });
+
+    it("snaps drag results to snapStepSec when provided", () => {
+      const onEventEdit = vi.fn();
+      const { container } = renderTrack({
+        track: {
+          start: 0,
+          end: 10,
+          events: [baseInterval],
+          onEventEdit,
+          // 5 fps → step 0.2s. View [0,10] over 1000px → 100px/s → 20px/step.
+          snapStepSec: 0.2,
+        },
+      });
+      const endHandle = container.querySelector(
+        `.${styles.resizeHandleEnd}`
+      ) as HTMLElement;
+      // 175px right of pointer-down clientX 600 → 1.75s raw delta; new
+      // endSec ≈ 7.75; rounded to nearest 0.2 → 7.8.
+      dragOnElement(endHandle, 600, 775);
+      const [, , newEnd] = onEventEdit.mock.calls[0];
+      expect(newEnd).toBeCloseTo(7.8);
+    });
+
+    it("clamps resize-end to a minimum width of snapStepSec", () => {
+      const onEventEdit = vi.fn();
+      const { container } = renderTrack({
+        track: {
+          start: 0,
+          end: 10,
+          events: [baseInterval],
+          onEventEdit,
+          snapStepSec: 0.2,
+        },
+      });
+      const endHandle = container.querySelector(
+        `.${styles.resizeHandleEnd}`
+      ) as HTMLElement;
+      // Drag end handle far left past start (4) → should clamp to start+0.2.
+      dragOnElement(endHandle, 600, 0);
+      const [, newStart, newEnd] = onEventEdit.mock.calls[0];
+      expect(newStart).toBeCloseTo(4);
+      expect(newEnd).toBeCloseTo(4.2);
+    });
+
+    it("clamps resize-start to a minimum width of snapStepSec", () => {
+      const onEventEdit = vi.fn();
+      const { container } = renderTrack({
+        track: {
+          start: 0,
+          end: 10,
+          events: [baseInterval],
+          onEventEdit,
+          snapStepSec: 0.2,
+        },
+      });
+      const startHandle = container.querySelector(
+        `.${styles.resizeHandleStart}`
+      ) as HTMLElement;
+      // Drag start handle far right past end (6) → should clamp to end-0.2.
+      dragOnElement(startHandle, 400, 1000);
+      const [, newStart, newEnd] = onEventEdit.mock.calls[0];
+      expect(newStart).toBeCloseTo(5.8);
+      expect(newEnd).toBeCloseTo(6);
+    });
+
+    it("does not commit when the pointer never moves past the drag threshold", () => {
+      const onEventEdit = vi.fn();
+      const { container } = renderTrack({
+        track: {
+          start: 0,
+          end: 10,
+          events: [baseInterval],
+          onEventEdit,
+        },
+      });
+      const endHandle = container.querySelector(
+        `.${styles.resizeHandleEnd}`
+      ) as HTMLElement;
+      // Move by 2px (under DRAG_THRESHOLD_PX = 3).
+      dragOnElement(endHandle, 600, 602);
+      expect(onEventEdit).not.toHaveBeenCalled();
+    });
+
+    it("suppresses the lane seek-click that follows a real drag", () => {
+      const onEventEdit = vi.fn();
+      const { container } = renderTrack({
+        track: {
+          start: 0,
+          end: 10,
+          events: [baseInterval],
+          onEventEdit,
+        },
+      });
+      const bar = container.querySelector(
+        `.${styles.intervalBar}`
+      ) as HTMLElement;
+      // Simulate drag + the synthetic click that mouseup triggers.
+      fireEvent.mouseDown(bar, { clientX: 500 });
+      document.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 600, bubbles: true })
+      );
+      document.dispatchEvent(
+        new MouseEvent("mouseup", { clientX: 600, bubbles: true })
+      );
+      // Browser would then fire click on the bar (and bubble to lane).
+      fireEvent.click(bar, { clientX: 600 });
+
+      // onEventEdit captured the drag; the playhead should NOT have moved
+      // to clientX 600 (which would be 6s).
+      expect(onEventEdit).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("playhead").textContent).toBe("0.000");
+    });
+  });
 });

--- a/app/packages/playback/src/views/TimelineTrack/TimelineTrack.tsx
+++ b/app/packages/playback/src/views/TimelineTrack/TimelineTrack.tsx
@@ -16,27 +16,62 @@ import {
   Variant,
 } from "@voxel51/voodo";
 import clsx from "clsx";
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import styles from "./TimelineTrack.module.css";
 
 /**
  * One event on a track. A `number` is shorthand for a point at that
  * time; an object with an `endSec` renders as an interval bar, without
- * one as a point.
+ * one as a point. Object events with `endSec` may opt into in-place edit via
+ * `resizable: true`; combined with {@link TimelineTrackProps.onEventEdit}
+ * the bar renders left/right drag handles and a draggable body.
  */
 export type TimelineTrackEvent =
   | number
-  | { startSec: number; endSec?: number; label?: string };
+  | {
+      startSec: number;
+      endSec?: number;
+      label?: string;
+      /**
+       * Opt into interval edit (drag handles + draggable body). Only
+       * meaningful on interval events (`endSec` set) and only when
+       * the parent track provides
+       * {@link TimelineTrackProps.onEventEdit}.
+       */
+      resizable?: boolean;
+    };
 
 interface NormalizedEvent {
   startSec: number;
   endSec?: number;
   label?: string;
+  resizable?: boolean;
 }
 
 function normalizeEvent(e: TimelineTrackEvent): NormalizedEvent {
   return typeof e === "number" ? { startSec: e } : e;
 }
+
+/**
+ * Drag mode for an in-progress interval edit. `move` shifts both start
+ * and end by the same delta; `resize-start` / `resize-end` move only
+ * one boundary.
+ */
+type DragMode = "resize-start" | "resize-end" | "move";
+
+interface DragState {
+  index: number;
+  initialClientX: number;
+  laneWidth: number;
+  origStart: number;
+  origEnd: number;
+  mode: DragMode;
+  moved: boolean;
+  latestStart: number;
+  latestEnd: number;
+}
+
+const DRAG_THRESHOLD_PX = 3;
 
 export interface TimelineTrackProps {
   id: string;
@@ -75,6 +110,26 @@ export interface TimelineTrackProps {
    * `onTrackClick` runs alongside the seek, not in place of it.
    */
   onTrackClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
+  /**
+   * Fires on pointer-up after a drag has crossed{@link DRAG_THRESHOLD_PX},
+   * never during the drag itself. Receives the event's index in the
+   * {@link events} array and the final clamped + snapped `[start, end]`
+   * (seconds).
+   *
+   * Only events with `resizable: true` participate; without this prop
+   * the resizable flag is a no-op and the bar renders as before.
+   */
+  onEventEdit?: (
+    eventIndex: number,
+    newStartSec: number,
+    newEndSec: number
+  ) => void;
+  /**
+   * Snap step (seconds) for drag-driven edits. Typically `1 / fps`,
+   * so interval edges land on frame boundaries. Omit for free-time
+   * drags.
+   */
+  snapStepSec?: number;
 }
 
 const TimelineTrack: React.FC<TimelineTrackProps> = ({
@@ -95,6 +150,8 @@ const TimelineTrack: React.FC<TimelineTrackProps> = ({
   onMouseEnter,
   onMouseLeave,
   onTrackClick,
+  onEventEdit,
+  snapStepSec,
 }) => {
   const viewStart = useViewStart();
   const viewEnd = useViewEnd();
@@ -102,11 +159,150 @@ const TimelineTrack: React.FC<TimelineTrackProps> = ({
 
   const laneRef = useRef<HTMLDivElement>(null);
 
+  /**
+   * In-progress drag state. Mirrored in a ref because the document-
+   * level pointermove / pointerup handlers must read the latest values
+   * without re-binding on every render.
+   */
+  const dragRef = useRef<DragState | null>(null);
+
+  /**
+   * Local visual override applied while the user is dragging an
+   * interval bar. `null` when not dragging; cleared on pointerup.
+   * Render reads this so the bar tracks the cursor without committing
+   * anything until the user lets go.
+   */
+  const [dragOverride, setDragOverride] = useState<{
+    index: number;
+    startSec: number;
+    endSec: number;
+  } | null>(null);
+
+  /**
+   * Flag set in pointerup-after-drag so the synthetic click event the
+   * browser fires immediately after can be suppressed (otherwise the
+   * lane's lane-click handler would seek to the drop point).
+   */
+  const justDraggedRef = useRef(false);
+
   const viewDuration = viewEnd - viewStart;
   // Degenerate view (zero/negative width) — would produce NaN/Infinity
   // CSS values and break layout for every bar/marker below.
   if (viewDuration <= 0) return null;
   const pct = (t: number) => `${((t - viewStart) / viewDuration) * 100}%`;
+
+  const snap = (t: number): number => {
+    if (!snapStepSec || snapStepSec <= 0 || !Number.isFinite(snapStepSec)) {
+      return t;
+    }
+    return Math.round(t / snapStepSec) * snapStepSec;
+  };
+
+  const beginIntervalDrag = (
+    mouseEvent: React.MouseEvent<HTMLDivElement>,
+    eventIndex: number,
+    origStart: number,
+    origEnd: number,
+    mode: DragMode
+  ): void => {
+    if (!onEventEdit) return;
+
+    // Only respond to the primary button. Right-click should fall
+    // through to the existing ContextMenu wrapper, not begin a drag.
+    if (mouseEvent.button !== 0) return;
+
+    const lane = laneRef.current;
+    if (!lane) return;
+
+    mouseEvent.preventDefault();
+    mouseEvent.stopPropagation();
+
+    const rect = lane.getBoundingClientRect();
+    const initialClientX = mouseEvent.clientX;
+
+    dragRef.current = {
+      index: eventIndex,
+      initialClientX,
+      laneWidth: rect.width,
+      origStart,
+      origEnd,
+      mode,
+      moved: false,
+      latestStart: origStart,
+      latestEnd: origEnd,
+    };
+
+    const onMove = (moveEv: MouseEvent) => {
+      const drag = dragRef.current;
+      if (!drag || drag.laneWidth <= 0) {
+        return;
+      }
+
+      const dx = moveEv.clientX - drag.initialClientX;
+      if (!drag.moved && Math.abs(dx) < DRAG_THRESHOLD_PX) {
+        return;
+      }
+      drag.moved = true;
+
+      const dSec = (dx / drag.laneWidth) * viewDuration;
+      // Minimum interval width is the snap step (so an interval can't
+      // collapse to zero seconds via resize). Without a snap step, we
+      // still enforce a tiny floor to avoid `start === end` intervals.
+      const minDuration = snapStepSec ?? 1e-6;
+
+      let newStart = drag.origStart;
+      let newEnd = drag.origEnd;
+
+      if (drag.mode === "resize-start") {
+        newStart = snap(drag.origStart + dSec);
+        if (newStart > drag.origEnd - minDuration) {
+          newStart = drag.origEnd - minDuration;
+        }
+        newEnd = drag.origEnd;
+      } else if (drag.mode === "resize-end") {
+        newEnd = snap(drag.origEnd + dSec);
+        if (newEnd < drag.origStart + minDuration) {
+          newEnd = drag.origStart + minDuration;
+        }
+        newStart = drag.origStart;
+      } else {
+        const width = drag.origEnd - drag.origStart;
+        newStart = snap(drag.origStart + dSec);
+        newEnd = newStart + width;
+      }
+
+      drag.latestStart = newStart;
+      drag.latestEnd = newEnd;
+      setDragOverride({
+        index: drag.index,
+        startSec: newStart,
+        endSec: newEnd,
+      });
+    };
+
+    const onUp = () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+
+      const drag = dragRef.current;
+      dragRef.current = null;
+
+      if (drag && drag.moved) {
+        justDraggedRef.current = true;
+        // Cleared on the next event-loop turn so the synthetic click
+        // that pointerup fires can read it and bail.
+        setTimeout(() => {
+          justDraggedRef.current = false;
+        }, 0);
+        onEventEdit(drag.index, drag.latestStart, drag.latestEnd);
+      }
+
+      setDragOverride(null);
+    };
+
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+  };
 
   // Background bar is rendered only when both start/end are provided.
   const hasBackground = start !== undefined && end !== undefined;
@@ -163,17 +359,24 @@ const TimelineTrack: React.FC<TimelineTrackProps> = ({
         ref={laneRef}
         className={styles.lane}
         onClick={(e) => {
+          // Suppress the synthetic click the browser fires immediately
+          // after a real drag so the drop point doesn't double as a seek.
+          if (justDraggedRef.current) return;
+
           // Portal-rendered context-menu items bubble through the React tree
           // but live outside this element's DOM subtree — ignore them so
           // dismissing the menu doesn't fire an unintended seek.
           if (!e.currentTarget.contains(e.target as Node)) return;
+
           const target = e.target as HTMLElement;
           // Event markers / bars own their own click — don't seek twice.
           if (
             target.classList.contains(styles.event) ||
-            target.classList.contains(styles.intervalBar)
+            target.classList.contains(styles.intervalBar) ||
+            target.classList.contains(styles.resizeHandle)
           )
             return;
+
           const rect = e.currentTarget.getBoundingClientRect();
           seek(
             viewStart +
@@ -193,14 +396,22 @@ const TimelineTrack: React.FC<TimelineTrackProps> = ({
           />
         )}
         {events
-          .map(normalizeEvent)
-          .filter((e) =>
-            e.endSec !== undefined
-              ? e.endSec >= viewStart && e.startSec <= viewEnd
-              : e.startSec >= viewStart && e.startSec <= viewEnd
+          .map((event, originalIndex) => ({
+            event: normalizeEvent(event),
+            originalIndex,
+          }))
+          .filter(({ event }) =>
+            event.endSec !== undefined
+              ? event.endSec >= viewStart && event.startSec <= viewEnd
+              : event.startSec >= viewStart && event.startSec <= viewEnd
           )
-          .map((e, i) => {
+          .map(({ event, originalIndex }) => {
             const handleClick = (ev: React.MouseEvent) => {
+              // Suppress the synthetic click that pointerup fires
+              // right after a resize / move drag — otherwise the drop
+              // point seeks unexpectedly.
+              if (justDraggedRef.current) return;
+
               // Deliberately no stopPropagation. The click bubbles to
               // the row root so `onTrackClick` fires for marker / interval-bar
               // clicks too. The lane's onClick filters by target class so seek
@@ -217,68 +428,144 @@ const TimelineTrack: React.FC<TimelineTrackProps> = ({
                     viewDuration;
                 seek(t);
               }
-              onEventClick?.(e);
+              onEventClick?.(event);
             };
-            const isInterval = e.endSec !== undefined;
+            const isInterval = event.endSec !== undefined;
+            const isResizable = Boolean(
+              isInterval && event.resizable && onEventEdit
+            );
+
+            // While a drag is in progress, render with the override
+            // position so the bar tracks the cursor. Outside of drag,
+            // use the event's own start / end.
+            const override =
+              dragOverride && dragOverride.index === originalIndex
+                ? dragOverride
+                : null;
+            const displayStart = override ? override.startSec : event.startSec;
+            const displayEnd = override
+              ? override.endSec
+              : (event.endSec as number);
+
             const menu = (
               <>
-                <MenuTextItem onClick={() => seek(e.startSec)}>
+                <MenuTextItem onClick={() => seek(event.startSec)}>
                   Move to start
                 </MenuTextItem>
                 <MenuTextItem
                   disabled={!isInterval}
-                  onClick={() => isInterval && seek(e.endSec!)}
+                  onClick={() => isInterval && seek(event.endSec!)}
                 >
                   Move to end
                 </MenuTextItem>
                 <MenuSeparator />
                 <MenuTextItem
                   disabled={!isInterval}
-                  onClick={() => isInterval && setLoop(e.startSec, e.endSec!)}
+                  onClick={() =>
+                    isInterval && setLoop(event.startSec, event.endSec!)
+                  }
                 >
                   Shrink window to fit
                 </MenuTextItem>
               </>
             );
             if (isInterval) {
-              const left = pct(Math.max(e.startSec, viewStart));
-              const right = Math.min(e.endSec!, viewEnd);
+              const left = pct(Math.max(displayStart, viewStart));
+              const right = Math.min(displayEnd, viewEnd);
               const width = `${
-                ((right - Math.max(e.startSec, viewStart)) / viewDuration) * 100
+                ((right - Math.max(displayStart, viewStart)) / viewDuration) *
+                100
               }%`;
               return (
-                <ContextMenu key={i} menu={menu}>
+                <ContextMenu key={originalIndex} menu={menu}>
                   <div
                     className={styles.intervalBar}
+                    data-event-index={originalIndex}
                     style={{
                       left,
                       width,
                       background: `${color}99`,
                       border: `1px solid ${color}`,
+                      cursor: isResizable ? "grab" : "pointer",
                     }}
                     title={
-                      e.label
-                        ? `${e.label}  (${e.startSec.toFixed(
+                      event.label
+                        ? `${event.label}  (${displayStart.toFixed(
                             2
-                          )}–${e.endSec!.toFixed(2)}s)`
-                        : `${labelText}  (${e.startSec.toFixed(
+                          )}-${displayEnd.toFixed(2)}s)`
+                        : `${labelText}  (${displayStart.toFixed(
                             2
-                          )}–${e.endSec!.toFixed(2)}s)`
+                          )}-${displayEnd.toFixed(2)}s)`
                     }
                     onClick={handleClick}
-                  />
+                    onMouseDown={
+                      isResizable
+                        ? (ev) =>
+                            beginIntervalDrag(
+                              ev,
+                              originalIndex,
+                              event.startSec,
+                              event.endSec!,
+                              "move"
+                            )
+                        : undefined
+                    }
+                  >
+                    {isResizable && (
+                      <>
+                        <div
+                          className={clsx(
+                            styles.resizeHandle,
+                            styles.resizeHandleStart
+                          )}
+                          data-event-index={originalIndex}
+                          data-resize-handle="start"
+                          aria-label="Resize interval start"
+                          onClick={(ev) => ev.stopPropagation()}
+                          onMouseDown={(ev) =>
+                            beginIntervalDrag(
+                              ev,
+                              originalIndex,
+                              event.startSec,
+                              event.endSec!,
+                              "resize-start"
+                            )
+                          }
+                        />
+                        <div
+                          className={clsx(
+                            styles.resizeHandle,
+                            styles.resizeHandleEnd
+                          )}
+                          data-event-index={originalIndex}
+                          data-resize-handle="end"
+                          aria-label="Resize interval end"
+                          onClick={(ev) => ev.stopPropagation()}
+                          onMouseDown={(ev) =>
+                            beginIntervalDrag(
+                              ev,
+                              originalIndex,
+                              event.startSec,
+                              event.endSec!,
+                              "resize-end"
+                            )
+                          }
+                        />
+                      </>
+                    )}
+                  </div>
                 </ContextMenu>
               );
             }
             return (
-              <ContextMenu key={i} menu={menu}>
+              <ContextMenu key={originalIndex} menu={menu}>
                 <div
                   className={styles.event}
-                  style={{ left: pct(e.startSec), background: color }}
+                  style={{ left: pct(event.startSec), background: color }}
                   title={
-                    e.label
-                      ? `${e.label}  @ ${e.startSec.toFixed(3)}s`
-                      : `${labelText} @ ${e.startSec.toFixed(3)}s`
+                    event.label
+                      ? `${event.label}  @ ${event.startSec.toFixed(3)}s`
+                      : `${labelText} @ ${event.startSec.toFixed(3)}s`
                   }
                   onClick={handleClick}
                 />

--- a/app/packages/video-annotation/index.ts
+++ b/app/packages/video-annotation/index.ts
@@ -2,6 +2,8 @@ export { VideoAnnotationSurface } from "./src/VideoAnnotationSurface";
 export { SyntheticLabelStream } from "./src/SyntheticLabelStream";
 export type {
   FrameLabelSnapshot,
+  PropagationBlob,
+  PropagationMethod,
   SyntheticBox,
 } from "./src/SyntheticLabelStream";
 export {

--- a/app/packages/video-annotation/index.ts
+++ b/app/packages/video-annotation/index.ts
@@ -15,3 +15,19 @@ export type { ImaVidImageFrame } from "./src/ImaVidImageStream";
 export { useFrameLabelsStream } from "./src/frameLabelsStream";
 export { VideoFrameLabelsStream } from "./src/VideoFrameLabelsStream";
 export type { LocalDetection } from "./src/VideoFrameLabelsStream";
+export { buildTemporalDetectionTracks } from "./src/temporalDetectionTracks";
+export type {
+  RawTemporalDetection,
+  RawTemporalDetectionsField,
+  TemporalDetectionLabelLike,
+  TemporalDetectionEventData,
+  BuildTemporalDetectionTracksInput,
+} from "./src/temporalDetectionTracks";
+export {
+  applyTemporalDetectionEdits,
+  parseTemporalDetectionEditKey,
+  temporalDetectionEditKey,
+  useClearTemporalDetectionEdits,
+  useStageTemporalDetectionSupport,
+  useTemporalDetectionPendingEdits,
+} from "./src/pendingTemporalDetectionEdits";

--- a/app/packages/video-annotation/package.json
+++ b/app/packages/video-annotation/package.json
@@ -3,6 +3,8 @@
     "main": "./index.ts",
     "packageManager": "yarn@4.9.1",
     "dependencies": {
+        "@fiftyone/annotation": "workspace:*",
+        "@fiftyone/command-bus": "workspace:*",
         "@fiftyone/lighter": "workspace:*",
         "@fiftyone/playback": "workspace:*",
         "@fiftyone/state": "workspace:*",

--- a/app/packages/video-annotation/src/FrameLabels.tsx
+++ b/app/packages/video-annotation/src/FrameLabels.tsx
@@ -34,6 +34,17 @@ import {
 import { buildPerInstanceTracks, type PerInstanceLabel } from "./frameTracks";
 import { LABELS_STREAM_ID } from "./ids";
 import { useLinkedTrackDecorator } from "./linkedTracks";
+import { EditTemporalDetectionSupportCommand } from "@fiftyone/annotation";
+import { useCommandBus } from "@fiftyone/command-bus";
+import {
+  applyTemporalDetectionEdits,
+  useTemporalDetectionPendingEdits,
+} from "./pendingTemporalDetectionEdits";
+import {
+  buildTemporalDetectionTracks,
+  type TemporalDetectionEventData,
+  type TemporalDetectionLabelLike,
+} from "./temporalDetectionTracks";
 import { VideoFrameLabelsStream } from "./VideoFrameLabelsStream";
 
 const DEFAULT_FRAME_FIELD = "frames.detections";
@@ -170,10 +181,12 @@ const FrameLabelsRegistration: React.FC<FrameLabelsRegistrationProps> = ({
 
 /**
  * Labels track timeline — one row per tracked instance observed in
- * the clip (grouped by `index`), with intervals showing when
- * that instance is present. Untracked labels still paint as overlays
- * but don't get rows. Triggers a one-shot `warmupAll` so the cache covers
- * every frame, then walks it to build the tracks.
+ * the clip (grouped by `index`), plus one row per `TemporalDetection`
+ * on the sample (rendered as an interval spanning `support`). Untracked
+ * labels still paint as overlays but don't get rows. Triggers a one-shot
+ * `warmupAll` so the cache covers every frame, then walks it to build
+ * the frame-derived tracks; TD tracks are derived synchronously from
+ * the sample dict and merged in.
  *
  * Rebuilds (and re-broadcasts through `TrackProvider`) whenever the
  * color scheme or seed changes so row colors stay in lock-step with the
@@ -185,7 +198,9 @@ const FrameLabelsRegistration: React.FC<FrameLabelsRegistrationProps> = ({
  * track list. Subsequent recolors update through the live `tracks`
  * prop and don't trip the key, so the user's pin state is preserved.
  */
-export const FrameLabelsTracks: React.FC = () => {
+export const FrameLabelsTracks: React.FC<{ sample?: ModalSample }> = ({
+  sample,
+}) => {
   const stream = useFrameLabelsStream();
   const editVersion = useFrameLabelsEditVersion();
   const scheme = useRecoilValue(colorScheme);
@@ -195,7 +210,14 @@ export const FrameLabelsTracks: React.FC = () => {
   // useState so we can re-render once warmupAll resolves, but keep the
   // build deterministic in the deps (stream identity changes when the
   // sample changes, which is the trigger we care about).
-  const [tracks, setTracks] = useState<Track[]>([]);
+  const [frameTracks, setFrameTracks] = useState<Track[]>([]);
+  // Tracked separately from `frameTracks` because an empty list after
+  // warmup (clip has no tracked detections) is a legitimately resolved
+  // state. We need this signal to drive the one-shot `initialPinnedIds`
+  // bootstrap — otherwise a sync-resolved TD list would trip the
+  // empty→ready key flip before frame tracks land, and frame tracks
+  // would arrive unpinned.
+  const [frameTracksResolved, setFrameTracksResolved] = useState(false);
 
   const resolveColor = useCallback(
     (label: PerInstanceLabel) =>
@@ -206,9 +228,19 @@ export const FrameLabelsTracks: React.FC = () => {
     [activeField, scheme, seed]
   );
 
+  const resolveTemporalDetectionColor = useCallback(
+    (path: string, label: TemporalDetectionLabelLike) =>
+      getLabelColorFromContext(path, label, {
+        colorScheme: scheme,
+        seed,
+      }),
+    [scheme, seed]
+  );
+
   useEffect(() => {
     if (!stream) {
-      setTracks([]);
+      setFrameTracks([]);
+      setFrameTracksResolved(false);
       return;
     }
 
@@ -219,7 +251,8 @@ export const FrameLabelsTracks: React.FC = () => {
         return;
       }
 
-      setTracks(buildPerInstanceTracks({ stream, resolveColor }));
+      setFrameTracks(buildPerInstanceTracks({ stream, resolveColor }));
+      setFrameTracksResolved(true);
     });
 
     return () => {
@@ -227,9 +260,104 @@ export const FrameLabelsTracks: React.FC = () => {
     };
   }, [stream, resolveColor, editVersion]);
 
+  const pendingTemporalDetectionEdits = useTemporalDetectionPendingEdits();
+  const commandBus = useCommandBus();
+
+  const temporalDetectionTracks = useMemo(() => {
+    if (!sample?.sample) {
+      return [];
+    }
+    // `sample.frameRate` is the canonical fps for the clip; same source
+    // `RegisterFrameLabels` consumes for the labels-stream constructor.
+    const fps = sample.frameRate;
+    if (!Number.isFinite(fps) || fps <= 0) {
+      return [];
+    }
+
+    // Apply staged TD-support edits as overrides before building so the
+    // bar stays where the user dropped it through the server round-trip.
+    // Cleared by `useRegisterVideoAnnotationEventHandlers` on
+    // `annotation:persistenceSuccess` / `persistenceError`.
+    const baseSample = sample.sample as Record<string, unknown>;
+    const overlaidSample =
+      pendingTemporalDetectionEdits.size === 0
+        ? baseSample
+        : applyTemporalDetectionEdits(
+            baseSample,
+            pendingTemporalDetectionEdits
+          );
+
+    return buildTemporalDetectionTracks({
+      sample: overlaidSample,
+      fps,
+      resolveColor: resolveTemporalDetectionColor,
+    });
+  }, [sample, resolveTemporalDetectionColor, pendingTemporalDetectionEdits]);
+
+  const tracks = useMemo(
+    () => [...frameTracks, ...temporalDetectionTracks],
+    [frameTracks, temporalDetectionTracks]
+  );
   const pinned = useMemo(() => tracks.map((t) => t.id), [tracks]);
-  const ready = tracks.length > 0;
-  const decorateTrack = useLinkedTrackDecorator();
+  // Bootstrap on frame-tracks-resolved, not on `tracks.length`. TD
+  // tracks resolve synchronously from the sample; without this gate,
+  // they'd trip the empty→ready flip before frame tracks land and
+  // frame tracks would arrive unpinned.
+  const ready = frameTracksResolved;
+  const linkDecorate = useLinkedTrackDecorator();
+  const fps = sample?.frameRate;
+  const snapStepSec =
+    Number.isFinite(fps) && fps && fps > 0 ? 1 / fps : undefined;
+
+  // Compose: keep the linked-overlay wiring (hover / select / scroll)
+  // and layer TD-specific resize wiring on top for TD rows. TD rows
+  // have no Lighter overlay, so the linked-overlay calls are no-ops on
+  // them — they don't break, just don't do anything visible.
+  const decorateTrack = useCallback(
+    (track: Track) => {
+      const base = linkDecorate(track);
+      const tdEvent = track.events[0]?.data as
+        | TemporalDetectionEventData
+        | undefined;
+      const isTemporalDetection =
+        track.id.startsWith("td-") && tdEvent !== undefined;
+
+      if (!isTemporalDetection || !fps) {
+        return base;
+      }
+
+      return {
+        ...base,
+        snapStepSec,
+        onEventEdit: (
+          _eventIndex: number,
+          newStartSec: number,
+          newEndSec: number
+        ) => {
+          // Convert seconds back to 1-indexed inclusive frame numbers
+          // using the same mapping the build does in reverse:
+          //   startSec = (firstFrame - 1) / fps  ⇒  firstFrame = round(startSec * fps) + 1
+          //   endSec   = lastFrame / fps         ⇒  lastFrame  = round(endSec * fps)
+          const firstFrame = Math.max(1, Math.round(newStartSec * fps) + 1);
+          const lastFrame = Math.max(firstFrame, Math.round(newEndSec * fps));
+
+          // Goes through the command bus (same shape as
+          // `MarkKeyframeCommand`) so the dispatch path is uniform and
+          // future undo/redo subscribers see this edit on the bus.
+          // The handler stages into the same pending-edits store the
+          // delta supplier reads.
+          void commandBus.execute(
+            new EditTemporalDetectionSupportCommand(
+              tdEvent.fieldPath,
+              tdEvent.detectionId,
+              [firstFrame, lastFrame]
+            )
+          );
+        },
+      };
+    },
+    [linkDecorate, fps, snapStepSec, commandBus]
+  );
 
   return (
     <TrackProvider

--- a/app/packages/video-annotation/src/VideoAnnotationSurface.tsx
+++ b/app/packages/video-annotation/src/VideoAnnotationSurface.tsx
@@ -1,4 +1,5 @@
 import {
+  useAutoInterpolate,
   useRegisterVideoAnnotationCommandHandlers,
   useRegisterVideoAnnotationKeybindings,
 } from "@fiftyone/annotation";
@@ -180,5 +181,6 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
 const VideoAnnotationHandlerRegistration: React.FC = () => {
   useRegisterVideoAnnotationCommandHandlers();
   useRegisterVideoAnnotationKeybindings();
+  useAutoInterpolate();
   return null;
 };

--- a/app/packages/video-annotation/src/VideoAnnotationSurface.tsx
+++ b/app/packages/video-annotation/src/VideoAnnotationSurface.tsx
@@ -130,7 +130,7 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
         {labelsMode === "synthetic" ? (
           <SyntheticTrackTimeline />
         ) : (
-          <FrameLabelsTracks />
+          <FrameLabelsTracks sample={sample} />
         )}
       </div>
     </div>

--- a/app/packages/video-annotation/src/pendingTemporalDetectionEdits.test.tsx
+++ b/app/packages/video-annotation/src/pendingTemporalDetectionEdits.test.tsx
@@ -1,0 +1,242 @@
+import { act, render } from "@testing-library/react";
+import { Provider } from "jotai";
+import { describe, expect, it } from "vitest";
+import {
+  applyTemporalDetectionEdits,
+  parseTemporalDetectionEditKey,
+  temporalDetectionEditKey,
+  useClearTemporalDetectionEdits,
+  useStageTemporalDetectionSupport,
+  useTemporalDetectionPendingEdits,
+} from "./pendingTemporalDetectionEdits";
+
+function HookHost({
+  onReady,
+}: {
+  onReady: (handles: {
+    stage: ReturnType<typeof useStageTemporalDetectionSupport>;
+    clear: ReturnType<typeof useClearTemporalDetectionEdits>;
+    read: () => ReadonlyMap<string, [number, number]>;
+  }) => void;
+}) {
+  const stage = useStageTemporalDetectionSupport();
+  const clear = useClearTemporalDetectionEdits();
+  const map = useTemporalDetectionPendingEdits();
+
+  onReady({ stage, clear, read: () => map });
+
+  return <div data-testid="size">{map.size}</div>;
+}
+
+function renderHost() {
+  let handles!: {
+    stage: ReturnType<typeof useStageTemporalDetectionSupport>;
+    clear: ReturnType<typeof useClearTemporalDetectionEdits>;
+    read: () => ReadonlyMap<string, [number, number]>;
+  };
+  const utils = render(
+    <Provider>
+      <HookHost
+        onReady={(h) => {
+          handles = h;
+        }}
+      />
+    </Provider>
+  );
+  return { ...utils, handles: () => handles };
+}
+
+describe("temporalDetectionEditKey / parseTemporalDetectionEditKey", () => {
+  it("round-trips fieldPath + detectionId", () => {
+    const key = temporalDetectionEditKey("events", "a");
+    expect(key).toBe("events|a");
+    expect(parseTemporalDetectionEditKey(key)).toEqual({
+      fieldPath: "events",
+      detectionId: "a",
+    });
+  });
+
+  it("keeps fieldPath and detectionId disambiguated across fields", () => {
+    expect(temporalDetectionEditKey("events", "a")).not.toBe(
+      temporalDetectionEditKey("highlights", "a")
+    );
+  });
+
+  it("preserves detectionIds that contain a pipe character", () => {
+    // First pipe terminates fieldPath; everything after is detectionId.
+    const key = temporalDetectionEditKey("events", "a|b|c");
+    expect(parseTemporalDetectionEditKey(key)).toEqual({
+      fieldPath: "events",
+      detectionId: "a|b|c",
+    });
+  });
+});
+
+describe("pending TD edits store", () => {
+  it("starts empty", () => {
+    const { handles } = renderHost();
+    expect(handles().read().size).toBe(0);
+  });
+
+  it("stages an edit keyed by fieldPath + detectionId", () => {
+    const { handles } = renderHost();
+    act(() => {
+      handles().stage("events", "a", [5, 15]);
+    });
+    const m = handles().read();
+    expect(m.size).toBe(1);
+    expect(m.get("events|a")).toEqual([5, 15]);
+  });
+
+  it("overwrites a prior edit on the same TD", () => {
+    const { handles } = renderHost();
+    act(() => {
+      handles().stage("events", "a", [5, 15]);
+    });
+    act(() => {
+      handles().stage("events", "a", [8, 20]);
+    });
+    expect(handles().read().get("events|a")).toEqual([8, 20]);
+    expect(handles().read().size).toBe(1);
+  });
+
+  it("keeps edits for different TDs separate", () => {
+    const { handles } = renderHost();
+    act(() => {
+      handles().stage("events", "a", [5, 15]);
+      handles().stage("highlights", "a", [22, 28]);
+    });
+    const m = handles().read();
+    expect(m.size).toBe(2);
+    expect(m.get("events|a")).toEqual([5, 15]);
+    expect(m.get("highlights|a")).toEqual([22, 28]);
+  });
+
+  it("clear drops every staged edit", () => {
+    const { handles } = renderHost();
+    act(() => {
+      handles().stage("events", "a", [5, 15]);
+      handles().stage("events", "b", [25, 35]);
+    });
+    expect(handles().read().size).toBe(2);
+    act(() => {
+      handles().clear();
+    });
+    expect(handles().read().size).toBe(0);
+  });
+});
+
+describe("applyTemporalDetectionEdits", () => {
+  const td = (id: string, support: [number, number]) => ({
+    _cls: "TemporalDetection",
+    _id: id,
+    label: "x",
+    support,
+  });
+
+  const field = (...detections: ReturnType<typeof td>[]) => ({
+    _cls: "TemporalDetections" as const,
+    detections,
+  });
+
+  it("returns the same reference when no edits are staged", () => {
+    const sample = { events: field(td("a", [1, 5])) };
+    expect(applyTemporalDetectionEdits(sample, new Map())).toBe(sample);
+  });
+
+  it("applies a single edit and clones the affected field's detections array", () => {
+    const original = field(td("a", [1, 5]), td("b", [10, 20]));
+    const sample = { events: original };
+    const edits = new Map<string, [number, number]>([["events|a", [3, 7]]]);
+
+    const out = applyTemporalDetectionEdits(sample, edits) as {
+      events: { detections: { _id: string; support: [number, number] }[] };
+    };
+
+    expect(out.events.detections[0].support).toEqual([3, 7]);
+    expect(out.events.detections[1].support).toEqual([10, 20]);
+    // Detections array on the touched field is cloned.
+    expect(out.events.detections).not.toBe(original.detections);
+  });
+
+  it("clones the top-level sample object so the original is not mutated", () => {
+    const sample = { events: field(td("a", [1, 5])) };
+    const out = applyTemporalDetectionEdits(
+      sample,
+      new Map([["events|a", [3, 7] as [number, number]]])
+    );
+    expect(out).not.toBe(sample);
+    expect(sample.events.detections[0].support).toEqual([1, 5]);
+  });
+
+  it("leaves untouched top-level fields referentially stable", () => {
+    const otherField = field(td("z", [99, 100]));
+    const sample = {
+      events: field(td("a", [1, 5])),
+      other: otherField,
+    };
+    const out = applyTemporalDetectionEdits(
+      sample,
+      new Map([["events|a", [3, 7] as [number, number]]])
+    ) as { other: typeof otherField };
+    // `other` wasn't touched — same reference.
+    expect(out.other).toBe(otherField);
+  });
+
+  it("groups edits per field so a single clone covers multiple TDs in that field", () => {
+    const original = field(td("a", [1, 5]), td("b", [10, 20]));
+    const sample = { events: original };
+    const edits = new Map<string, [number, number]>([
+      ["events|a", [3, 7]],
+      ["events|b", [12, 18]],
+    ]);
+    const out = applyTemporalDetectionEdits(sample, edits) as {
+      events: { detections: { _id: string; support: [number, number] }[] };
+    };
+    expect(out.events.detections[0].support).toEqual([3, 7]);
+    expect(out.events.detections[1].support).toEqual([12, 18]);
+  });
+
+  it("silently skips edits for missing fields", () => {
+    const sample = { events: field(td("a", [1, 5])) };
+    const out = applyTemporalDetectionEdits(
+      sample,
+      new Map([["ghost|a", [3, 7] as [number, number]]])
+    );
+    // No field touched ⇒ out is the spread clone but events ref is preserved.
+    expect((out as typeof sample).events).toBe(sample.events);
+  });
+
+  it("silently skips edits for missing detections within a field", () => {
+    const original = field(td("a", [1, 5]));
+    const sample = { events: original };
+    const out = applyTemporalDetectionEdits(
+      sample,
+      new Map([["events|ghost", [99, 100] as [number, number]]])
+    ) as {
+      events: { detections: { _id: string; support: [number, number] }[] };
+    };
+    // Field is cloned but detection support unchanged.
+    expect(out.events.detections[0].support).toEqual([1, 5]);
+  });
+
+  it("falls back to `id` when `_id` is missing on the detection", () => {
+    const sample = {
+      events: {
+        _cls: "TemporalDetections" as const,
+        detections: [
+          {
+            _cls: "TemporalDetection",
+            id: "x",
+            support: [1, 5] as [number, number],
+          },
+        ],
+      },
+    };
+    const out = applyTemporalDetectionEdits(
+      sample,
+      new Map([["events|x", [3, 7] as [number, number]]])
+    ) as { events: { detections: { support: [number, number] }[] } };
+    expect(out.events.detections[0].support).toEqual([3, 7]);
+  });
+});

--- a/app/packages/video-annotation/src/pendingTemporalDetectionEdits.ts
+++ b/app/packages/video-annotation/src/pendingTemporalDetectionEdits.ts
@@ -1,0 +1,135 @@
+import { atom, useAtomValue, useSetAtom } from "jotai";
+import { useCallback } from "react";
+import type { RawTemporalDetectionsField } from "./temporalDetectionTracks";
+
+/**
+ * Pending edits to `TemporalDetection.support` made through the timeline's
+ * interval drag handles. Keyed by `${fieldPath}|${detectionId}` so a
+ * given TD has at most one outstanding staged edit; later drags overwrite
+ * earlier ones.
+ *
+ * Two roles:
+ *   1. Optimistic display — {@link FrameLabelsTracks} reads this and
+ *      overlays staged support values onto the sample-derived TD list
+ *      before building tracks, so the bar stays where the user dropped
+ *      it through the server round-trip.
+ *   2. Delta source — `useTemporalDetectionDeltaSupplier` walks the map
+ *      and emits one `replace /<fieldPath>/detections/<index>/support`
+ *      patch op per pending edit on the next autosave tick.
+ *
+ * Cleared on `annotation:persistenceSuccess` and
+ * `annotation:persistenceError` by {@link useRegisterVideoAnnotationEventHandlers}.
+ */
+const pendingTemporalDetectionEditsAtom = atom<
+  ReadonlyMap<string, [number, number]>
+>(new Map());
+
+export const temporalDetectionEditKey = (
+  fieldPath: string,
+  detectionId: string
+): string => `${fieldPath}|${detectionId}`;
+
+export const parseTemporalDetectionEditKey = (
+  key: string
+): { fieldPath: string; detectionId: string } => {
+  const sep = key.indexOf("|");
+  return {
+    fieldPath: key.slice(0, sep),
+    detectionId: key.slice(sep + 1),
+  };
+};
+
+/**
+ * Reactive view of all currently-pending TD support edits.
+ */
+export const useTemporalDetectionPendingEdits = (): ReadonlyMap<
+  string,
+  [number, number]
+> => useAtomValue(pendingTemporalDetectionEditsAtom);
+
+/**
+ * Stage (or overwrite) a `support` edit for a single TD. The next
+ * autosave tick will turn it into a JSON-Patch op via the delta supplier.
+ */
+export const useStageTemporalDetectionSupport = (): ((
+  fieldPath: string,
+  detectionId: string,
+  support: [number, number]
+) => void) => {
+  const set = useSetAtom(pendingTemporalDetectionEditsAtom);
+
+  return useCallback(
+    (fieldPath, detectionId, support) => {
+      set((prev) => {
+        const next = new Map(prev);
+        next.set(temporalDetectionEditKey(fieldPath, detectionId), support);
+
+        return next;
+      });
+    },
+    [set]
+  );
+};
+
+/**
+ * Clear every staged TD support edit. Called by the persistence event
+ * handler on both success (sample is about to refresh with the new
+ * values) and error (revert the optimistic visual; user can re-drag).
+ */
+export const useClearTemporalDetectionEdits = (): (() => void) => {
+  const set = useSetAtom(pendingTemporalDetectionEditsAtom);
+
+  return useCallback(() => {
+    set(new Map());
+  }, [set]);
+};
+
+/**
+ * Return a shallow-cloned copy of `sample` with staged TD support edits
+ * applied to the matching detections. Top-level fields and the
+ * `detections` array of any field touched by an edit are cloned; the
+ * untouched fields stay referentially stable. Edits whose field /
+ * detection no longer exist on the sample are silently skipped.
+ */
+export const applyTemporalDetectionEdits = (
+  sample: Record<string, unknown>,
+  edits: ReadonlyMap<string, [number, number]>
+): Record<string, unknown> => {
+  if (edits.size === 0) {
+    return sample;
+  }
+
+  // Group by field path so we clone each `detections` array at most once
+  // even when multiple TDs in the same field have pending edits.
+  const editsByField = new Map<string, Map<string, [number, number]>>();
+  for (const [key, support] of edits) {
+    const { fieldPath, detectionId } = parseTemporalDetectionEditKey(key);
+    let fieldEdits = editsByField.get(fieldPath);
+    if (!fieldEdits) {
+      fieldEdits = new Map();
+      editsByField.set(fieldPath, fieldEdits);
+    }
+
+    fieldEdits.set(detectionId, support);
+  }
+
+  const next = { ...sample };
+  for (const [fieldPath, fieldEdits] of editsByField) {
+    const field = next[fieldPath] as RawTemporalDetectionsField | undefined;
+    const detections = field?.detections;
+    if (!Array.isArray(detections)) {
+      continue;
+    }
+
+    next[fieldPath] = {
+      ...field,
+      detections: detections.map((d) => {
+        const id = d._id ?? d.id;
+        const support = id ? fieldEdits.get(id) : undefined;
+        return support ? { ...d, support } : d;
+      }),
+    };
+  }
+
+  return next;
+};

--- a/app/packages/video-annotation/src/temporalDetectionTracks.test.ts
+++ b/app/packages/video-annotation/src/temporalDetectionTracks.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildTemporalDetectionTracks,
+  type RawTemporalDetectionsField,
+} from "./temporalDetectionTracks";
+
+const DEFAULT_FPS = 30;
+
+function makeTd(
+  id: string,
+  support: [number, number],
+  label = "running",
+  extras: Record<string, unknown> = {}
+) {
+  return {
+    _cls: "TemporalDetection" as const,
+    _id: id,
+    label,
+    support,
+    confidence: 0.9,
+    ...extras,
+  };
+}
+
+function makeField(
+  ...detections: ReturnType<typeof makeTd>[]
+): RawTemporalDetectionsField {
+  return { _cls: "TemporalDetections", detections };
+}
+
+const passthroughColor = (path: string) => `color-${path}`;
+
+describe("buildTemporalDetectionTracks", () => {
+  describe("happy path", () => {
+    it("emits one track per TD with an interval event spanning support", () => {
+      const tracks = buildTemporalDetectionTracks({
+        sample: {
+          events: makeField(makeTd("a", [1, 30], "running")),
+        },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+
+      expect(tracks).toHaveLength(1);
+      const t = tracks[0];
+      expect(t.id).toBe("td-events-a");
+      expect(t.color).toBe("color-events");
+      expect(t.events).toHaveLength(1);
+
+      const ev = t.events[0];
+      expect(ev.startSec).toBeCloseTo(0); // (1-1)/30
+      expect(ev.endSec).toBeCloseTo(30 / 30); // 30/30 = 1s
+      expect(ev.label).toBe("running");
+    });
+
+    it("converts 1-indexed inclusive frame support to seconds correctly", () => {
+      // support = [16, 45] on a 30fps clip:
+      //   startSec = (16 - 1) / 30 = 0.5
+      //   endSec   = 45 / 30 = 1.5
+      const tracks = buildTemporalDetectionTracks({
+        sample: { events: makeField(makeTd("a", [16, 45])) },
+        fps: 30,
+        resolveColor: passthroughColor,
+      });
+      const ev = tracks[0].events[0];
+      expect(ev.startSec).toBeCloseTo(0.5);
+      expect(ev.endSec).toBeCloseTo(1.5);
+    });
+
+    it("marks emitted interval events as resizable for in-place edit", () => {
+      const tracks = buildTemporalDetectionTracks({
+        sample: { events: makeField(makeTd("a", [1, 10])) },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      const event = tracks[0].events[0] as { resizable?: boolean };
+      expect(event.resizable).toBe(true);
+    });
+
+    it("attaches a TemporalDetectionEventData payload to each event", () => {
+      const td = makeTd("abc", [10, 20], "walking");
+      const tracks = buildTemporalDetectionTracks({
+        sample: { events: makeField(td) },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      const data = tracks[0].events[0].data as {
+        fieldPath: string;
+        detectionId: string;
+        detectionIndex: number;
+        support: [number, number];
+        raw: typeof td;
+      };
+
+      expect(data.fieldPath).toBe("events");
+      expect(data.detectionId).toBe("abc");
+      expect(data.detectionIndex).toBe(0);
+      expect(data.support).toEqual([10, 20]);
+      expect(data.raw).toBe(td);
+    });
+
+    it("returns a row label combining the TD label and field path", () => {
+      const tracks = buildTemporalDetectionTracks({
+        sample: { events: makeField(makeTd("a", [1, 10], "running")) },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      expect(tracks[0].label).toBe("running (events)");
+    });
+
+    it("falls back to a truncated id label when the TD has no label string", () => {
+      const tracks = buildTemporalDetectionTracks({
+        sample: { events: makeField(makeTd("0123456789abcdef", [1, 10], "")) },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      expect(tracks[0].label).toBe("events 89abcdef");
+    });
+
+    it("falls back to `id` when `_id` is missing", () => {
+      const td = {
+        _cls: "TemporalDetection" as const,
+        id: "x1",
+        label: "j",
+        support: [1, 5] as [number, number],
+      };
+      const tracks = buildTemporalDetectionTracks({
+        sample: {
+          events: { _cls: "TemporalDetections" as const, detections: [td] },
+        },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      expect(tracks).toHaveLength(1);
+      expect(tracks[0].id).toBe("td-events-x1");
+    });
+  });
+
+  describe("color resolution", () => {
+    it("calls resolveColor with the field path and a label-like dict", () => {
+      const resolveColor = vi.fn(() => "#abc");
+      buildTemporalDetectionTracks({
+        sample: { events: makeField(makeTd("a", [1, 5], "running")) },
+        fps: DEFAULT_FPS,
+        resolveColor,
+      });
+
+      expect(resolveColor).toHaveBeenCalledTimes(1);
+      expect(resolveColor).toHaveBeenCalledWith("events", {
+        _cls: "TemporalDetection",
+        label: "running",
+        id: "a",
+      });
+    });
+  });
+
+  describe("multiple fields and detections", () => {
+    it("emits tracks for every TemporalDetections field on the sample", () => {
+      const tracks = buildTemporalDetectionTracks({
+        sample: {
+          events: makeField(makeTd("a", [1, 10])),
+          highlights: makeField(makeTd("b", [5, 15])),
+        },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      expect(tracks).toHaveLength(2);
+      const ids = tracks.map((t) => t.id);
+      expect(ids).toContain("td-events-a");
+      expect(ids).toContain("td-highlights-b");
+    });
+
+    it("orders TDs within a field by support start, with id as tie-break", () => {
+      const tracks = buildTemporalDetectionTracks({
+        sample: {
+          events: makeField(
+            makeTd("z", [10, 20]),
+            makeTd("a", [1, 5]),
+            makeTd("m", [10, 30])
+          ),
+        },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      expect(tracks.map((t) => t.id)).toEqual([
+        "td-events-a",
+        "td-events-m",
+        "td-events-z",
+      ]);
+    });
+  });
+
+  describe("filtering invalid entries", () => {
+    it("skips TDs with missing support", () => {
+      const td = { _cls: "TemporalDetection" as const, _id: "a", label: "x" };
+      const tracks = buildTemporalDetectionTracks({
+        sample: {
+          events: { _cls: "TemporalDetections" as const, detections: [td] },
+        },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      expect(tracks).toEqual([]);
+    });
+
+    it("skips TDs with malformed support (wrong length, NaN, inverted)", () => {
+      const tracks = buildTemporalDetectionTracks({
+        sample: {
+          events: makeField(
+            {
+              ...makeTd("a", [1, 5]),
+              support: [1] as unknown as [number, number],
+            },
+            { ...makeTd("b", [1, 5]), support: [NaN, 10] },
+            { ...makeTd("c", [1, 5]), support: [20, 10] }
+          ),
+        },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      expect(tracks).toEqual([]);
+    });
+
+    it("skips TDs missing both _id and id", () => {
+      const td = {
+        _cls: "TemporalDetection" as const,
+        label: "x",
+        support: [1, 5] as [number, number],
+      };
+      const tracks = buildTemporalDetectionTracks({
+        sample: {
+          events: { _cls: "TemporalDetections" as const, detections: [td] },
+        },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      expect(tracks).toEqual([]);
+    });
+
+    it("ignores fields that aren't TemporalDetections", () => {
+      const tracks = buildTemporalDetectionTracks({
+        sample: {
+          detections: { _cls: "Detections", detections: [] },
+          metadata: { frame_rate: 30 },
+          some_string: "hello",
+          some_array: [1, 2, 3],
+          some_null: null,
+        },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      expect(tracks).toEqual([]);
+    });
+
+    it("tolerates a TemporalDetections field with an empty detections list", () => {
+      const tracks = buildTemporalDetectionTracks({
+        sample: { events: makeField() },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      expect(tracks).toEqual([]);
+    });
+
+    it("tolerates a TemporalDetections field with missing detections array", () => {
+      const tracks = buildTemporalDetectionTracks({
+        sample: {
+          events: { _cls: "TemporalDetections" as const },
+        },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      // Not a valid TemporalDetections field per our type-guard (detections
+      // is required); should be ignored.
+      expect(tracks).toEqual([]);
+    });
+  });
+
+  describe("guards", () => {
+    it("returns [] for an empty sample", () => {
+      expect(
+        buildTemporalDetectionTracks({
+          sample: {},
+          fps: DEFAULT_FPS,
+          resolveColor: passthroughColor,
+        })
+      ).toEqual([]);
+    });
+
+    it("returns [] when fps is not finite or non-positive", () => {
+      const sample = { events: makeField(makeTd("a", [1, 5])) };
+      expect(
+        buildTemporalDetectionTracks({
+          sample,
+          fps: 0,
+          resolveColor: passthroughColor,
+        })
+      ).toEqual([]);
+      expect(
+        buildTemporalDetectionTracks({
+          sample,
+          fps: -10,
+          resolveColor: passthroughColor,
+        })
+      ).toEqual([]);
+      expect(
+        buildTemporalDetectionTracks({
+          sample,
+          fps: Number.NaN,
+          resolveColor: passthroughColor,
+        })
+      ).toEqual([]);
+    });
+  });
+});

--- a/app/packages/video-annotation/src/temporalDetectionTracks.ts
+++ b/app/packages/video-annotation/src/temporalDetectionTracks.ts
@@ -1,0 +1,213 @@
+import type {
+  Track,
+  TrackEvent,
+} from "../../playback/src/lib/tracks/TrackProvider";
+
+/**
+ * Shape of a single `TemporalDetection` as it arrives on the modal sample
+ * dict. We only model the fields the track build reads; everything else
+ * (dynamic attrs, etc.) is preserved on `data` for downstream consumers.
+ */
+export interface RawTemporalDetection {
+  _cls?: "TemporalDetection";
+  _id?: string;
+  id?: string;
+  label?: string;
+  /** 1-indexed inclusive frame range `[first, last]`. */
+  support?: [number, number];
+  confidence?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * Shape of a `TemporalDetections` wrapper field on the modal sample dict.
+ */
+export interface RawTemporalDetectionsField {
+  _cls: "TemporalDetections";
+  detections?: RawTemporalDetection[];
+}
+
+/**
+ * Minimal label shape passed to {@link BuildTemporalDetectionTracksInput.resolveColor}.
+ * Mirrors the fields `getLabelColorFromContext` reads.
+ */
+export interface TemporalDetectionLabelLike {
+  _cls: "TemporalDetection";
+  label: string;
+  /**
+   * The TD `_id`, exposed as `id` because that's the key FiftyOne's
+   * value-mode color resolution falls back to when there's no class label.
+   */
+  id?: string;
+}
+
+export interface BuildTemporalDetectionTracksInput {
+  /**
+   * Top-level sample dict from `ModalSample.sample`. The function walks
+   * the dict's top-level keys looking for `TemporalDetections` fields —
+   * nested locations (e.g. under `predictions.events`) are not searched.
+   */
+  sample: Record<string, unknown>;
+  /** Frame rate in frames per second. Used to convert support → seconds. */
+  fps: number;
+  /**
+   * Resolve the row color for a TD. Receives the field path (e.g.
+   * `"events"`) and a label-like dict so the result matches whatever the
+   * Lighter overlay would have produced for the same label.
+   */
+  resolveColor: (path: string, label: TemporalDetectionLabelLike) => string;
+}
+
+/**
+ * Payload attached to each emitted {@link TrackEvent.data}.
+ *
+ * Carries enough information that a downstream consumer (e.g. a drag-
+ * handle handler, a sidebar click router) can identify the TD without
+ * re-walking the sample dict.
+ */
+export interface TemporalDetectionEventData {
+  /** Field path on the sample (e.g. `"events"`). */
+  fieldPath: string;
+  /** The TD's `_id` (or `id` fallback). */
+  detectionId: string;
+  /** Index of this TD inside its parent `detections` array. */
+  detectionIndex: number;
+  /** 1-indexed inclusive frame support `[first, last]`. */
+  support: [number, number];
+  /** Snapshot of the raw TD for inspectors / drag-source readback. */
+  raw: RawTemporalDetection;
+}
+
+/**
+ * Walk the top-level sample dict, find every `TemporalDetections` field,
+ * and emit one {@link Track} per `TemporalDetection` whose single event
+ * is an interval spanning `support`.
+ *
+ * Rows are returned grouped by field path, then ordered within each
+ * group by `support[0]` (earlier first), with `_id` as a stable
+ * tie-breaker. This makes the timeline read top-to-bottom roughly in
+ * the order events occur.
+ *
+ * TDs missing a valid `support` (not a 2-tuple, NaN, or `last < first`)
+ * are skipped. TDs with no `_id`/`id` are also skipped — we'd have no
+ * stable handle for selection, edits, or persistence.
+ *
+ * Returns `[]` when the sample is empty, fps is invalid, or no TD
+ * fields are present.
+ */
+export function buildTemporalDetectionTracks({
+  sample,
+  fps,
+  resolveColor,
+}: BuildTemporalDetectionTracksInput): Track[] {
+  if (!sample || !Number.isFinite(fps) || fps <= 0) {
+    return [];
+  }
+
+  const tracks: Track[] = [];
+
+  for (const [fieldPath, value] of Object.entries(sample)) {
+    if (!isTemporalDetectionsField(value)) {
+      continue;
+    }
+
+    const detections = value.detections ?? [];
+    const groupTracks: Array<{ track: Track; firstFrame: number }> = [];
+
+    for (let i = 0; i < detections.length; i++) {
+      const td = detections[i];
+      const support = td.support;
+
+      if (
+        !Array.isArray(support) ||
+        support.length !== 2 ||
+        !Number.isFinite(support[0]) ||
+        !Number.isFinite(support[1]) ||
+        support[1] < support[0]
+      ) {
+        continue;
+      }
+
+      const detectionId = td._id ?? td.id;
+      if (!detectionId) {
+        continue;
+      }
+
+      const label = td.label ?? "";
+      const startSec = (support[0] - 1) / fps;
+      const endSec = support[1] / fps;
+
+      const eventData: TemporalDetectionEventData = {
+        fieldPath,
+        detectionId,
+        detectionIndex: i,
+        support: [support[0], support[1]],
+        raw: td,
+      };
+
+      // `resizable: true` opts the interval into in-place edit via the
+      // TimelineTrack's drag handles. The drag-end callback is wired up
+      // in {@link FrameLabelsTracks}.
+      const event: TrackEvent & { resizable: true } = {
+        startSec,
+        endSec,
+        label: label || "temporal detection",
+        data: eventData,
+        resizable: true,
+      };
+
+      const color = resolveColor(fieldPath, {
+        _cls: "TemporalDetection",
+        label,
+        id: detectionId,
+      });
+
+      const rowLabel = label
+        ? `${label} (${fieldPath})`
+        : `${fieldPath} ${truncateId(detectionId)}`;
+
+      groupTracks.push({
+        track: {
+          id: `td-${fieldPath}-${detectionId}`,
+          label: rowLabel,
+          description: `Temporal detection "${
+            label || "unnamed"
+          }" on \`${fieldPath}\` (frames ${support[0]}–${support[1]})`,
+          color,
+          events: [event],
+        },
+        firstFrame: support[0],
+      });
+    }
+
+    groupTracks.sort((a, b) => {
+      if (a.firstFrame !== b.firstFrame) {
+        return a.firstFrame - b.firstFrame;
+      }
+      return a.track.id.localeCompare(b.track.id);
+    });
+
+    for (const entry of groupTracks) {
+      tracks.push(entry.track);
+    }
+  }
+
+  return tracks;
+}
+
+function isTemporalDetectionsField(
+  value: unknown
+): value is RawTemporalDetectionsField {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  return (
+    (value as { _cls?: unknown })._cls === "TemporalDetections" &&
+    Array.isArray((value as { detections?: unknown }).detections)
+  );
+}
+
+function truncateId(id: string): string {
+  return id.length > 8 ? id.slice(-8) : id;
+}

--- a/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
+++ b/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
@@ -2,6 +2,7 @@
  * Copyright 2017-2026, Voxel51, Inc.
  */
 
+import { useAnnotationEventBus } from "@fiftyone/annotation";
 import {
   DetectionOverlay,
   type Scene2D,
@@ -36,6 +37,7 @@ import type { LocalDetection } from "./VideoFrameLabelsStream";
 export const useSyncLighterLabelStream = (scene: Scene2D | null): void => {
   const stream = useFrameLabelsStream();
   const currentTime = useCurrentTime();
+  const eventBus = useAnnotationEventBus();
 
   const useEventHandler = useLighterEventHandler(
     scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
@@ -67,6 +69,20 @@ export const useSyncLighterLabelStream = (scene: Scene2D | null): void => {
       const frame = stream.timeToFrame(currentTime);
       stream.updateLabel(frame, detection);
 
+      // Edits (drag / resize) and fresh draws both promote the touched
+      // frame to a keyframe via `toLocalDetection`. Mirror the same
+      // event MarkKeyframeCommand emits so the auto-interpolate hook
+      // re-lerps adjacent segments after the user nudges a box.
+      const instanceId = detection.instance?._id ?? null;
+      if (instanceId) {
+        eventBus.dispatch("annotation:keyframeChanged", {
+          trackId: `instance-${instanceId}`,
+          instanceId,
+          frame,
+          kind: "set",
+        });
+      }
+
       // The synthetic id just changed (`<overlayId>` → `instance-<...>`)
       // because we minted the Instance. Evict Lighter's draw-mode
       // overlay so the next sync pass adds the canonical one without
@@ -83,7 +99,7 @@ export const useSyncLighterLabelStream = (scene: Scene2D | null): void => {
         scene.removeOverlay(overlayId);
       }
     },
-    [stream, scene, currentTime]
+    [stream, scene, currentTime, eventBus]
   );
 
   useEventHandler(

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2996,7 +2996,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fiftyone/annotation@workspace:packages/annotation":
+"@fiftyone/annotation@workspace:*, @fiftyone/annotation@workspace:packages/annotation":
   version: 0.0.0-use.local
   resolution: "@fiftyone/annotation@workspace:packages/annotation"
   dependencies:
@@ -3076,7 +3076,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fiftyone/command-bus@workspace:packages/command-bus":
+"@fiftyone/command-bus@workspace:*, @fiftyone/command-bus@workspace:packages/command-bus":
   version: 0.0.0-use.local
   resolution: "@fiftyone/command-bus@workspace:packages/command-bus"
   dependencies:
@@ -3651,6 +3651,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fiftyone/video-annotation@workspace:packages/video-annotation"
   dependencies:
+    "@fiftyone/annotation": "workspace:*"
+    "@fiftyone/command-bus": "workspace:*"
     "@fiftyone/lighter": "workspace:*"
     "@fiftyone/playback": "workspace:*"
     "@fiftyone/state": "workspace:*"


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

Adds temporal detections and keyframe interpolation to the video annotation surface.

- **Temporal detections** — `TemporalDetection` fields render as timeline rows with a draggable support interval (move / resize-start / resize-end, snapped to fps). Drag-end stages an edit that persists via a sample-level delta supplier, with optimistic rendering through the server round-trip.
- **Keyframe propagation** — linear interpolation between bracketing keyframes via a `PropagateCommand` and a browser propagation agent; results are written per frame into the label-stream cache and persisted through the normal video-labels path, with provenance recording the parent keyframes.
- **Auto-interpolation** — adjacent segments are re-interpolated automatically when a keyframe changes (including on bbox drag/resize).

Stacked on #7685.

## 🧪 How is this patch tested? If it is not, please explain why.

Unit tests for the temporal-detection delta supplier and track building; tested locally in the app.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
