### PR TITLE
Video annotation: SAM2 tracking + drag-to-edit timeline tracks

### DIFF
--- a/app/packages/annotation/src/agents/SAM2PropagationBrowserAgent.ts
+++ b/app/packages/annotation/src/agents/SAM2PropagationBrowserAgent.ts
@@ -1,0 +1,283 @@
+import { objectId } from "@fiftyone/utilities";
+import type { SyntheticBox } from "@fiftyone/video-annotation";
+import {
+  BrowserAnnotationProvider,
+  type BrowserAnnotationProviderOptions,
+  propagate,
+  pointsFromBox,
+  type PropagationStrategy,
+  type ProviderError,
+  type ProviderStatus,
+} from "../providers";
+import type {
+  AnnotationAgent,
+  AnnotationAgentLifecycle,
+  AnnotationAgentLifecycleListener,
+  AnnotationAgentLifecycleStatus,
+  InferenceResult,
+  ModelMetadata,
+  PropagatedDetection,
+  PropagationInferenceResult,
+} from "./types";
+import { AgentTaskType, InferenceCapability } from "./types";
+
+/** Factory for the underlying provider; injectable for tests. */
+export type BrowserAnnotationProviderFactory = (
+  options: BrowserAnnotationProviderOptions
+) => BrowserAnnotationProvider;
+
+const DEFAULT_FACTORY: BrowserAnnotationProviderFactory = (options) =>
+  new BrowserAnnotationProvider(options);
+
+/**
+ * Inputs for a SAM2 tracking run between two bracketing keyframes. Frame
+ * numbers are 1-based (matching the labels stream / mongo frame numbers);
+ * `getFrameBitmap` resolves a 1-based frame number to its decoded bitmap
+ * (the ImaVid image stream serves these from cache — no `<video>` element).
+ */
+export interface Sam2PropagateArgs {
+  /** Cross-frame `Instance._id` stamped on every emitted detection. */
+  instanceId: string;
+  /** Left bracket — the keyframe at/before the playhead; seeds the track. */
+  seedKeyframe: SyntheticBox;
+  /** Right bracket — the keyframe after the playhead; caps the run. */
+  endKeyframe: SyntheticBox;
+  fromFrame: number;
+  toFrame: number;
+  /** Stable per-video id; prefixes the per-frame encoder-embedding cache. */
+  videoKey: string;
+  /** Decoded frame bitmap for a 1-based frame number. */
+  getFrameBitmap: (frameNumber: number) => Promise<ImageBitmap>;
+  /** Per in-between frame, the localised detection to write into the cache. */
+  onDetection: (frameNumber: number, detection: PropagatedDetection) => void;
+  /** Per-frame progress over the inclusive `[fromFrame, toFrame]` span. */
+  onProgress?: (done: number, total: number) => void;
+  /** Polled before each frame; return `true` to stop early. */
+  shouldAbort?: () => boolean;
+  /** Next-frame prompt strategy; defaults to "centroid-1". */
+  strategy?: PropagationStrategy;
+}
+
+/**
+ * Browser-side propagation agent backed by SAM2 Tiny (ONNX, web worker via
+ * {@link BrowserAnnotationProvider}). Unlike {@link PropagationBrowserAgent}
+ * (pure lerp math), this re-runs SAM2 per frame to track the object, so it
+ * needs frame pixels and runs genuinely asynchronously.
+ *
+ * It registers under the agent registry for lifecycle / metadata parity, but
+ * is driven through the dedicated {@link propagate} method rather than the
+ * generic `infer` — the latter can't carry a frame source. The provider is
+ * lazily initialised on the first run and reused thereafter; its status
+ * events are bridged onto the agent lifecycle so the UI can show progress.
+ */
+export class SAM2PropagationBrowserAgent
+  implements AnnotationAgent<PropagationInferenceResult>
+{
+  private readonly provider: BrowserAnnotationProvider;
+  private initialized = false;
+  private initializing$: Promise<void> | null = null;
+  private lifecycleStatus: AnnotationAgentLifecycleStatus = "idle";
+  private readonly listeners = new Set<AnnotationAgentLifecycleListener>();
+
+  constructor(factory: BrowserAnnotationProviderFactory = DEFAULT_FACTORY) {
+    this.provider = factory({
+      onStatus: (status) => this.handleProviderStatus(status),
+      onProgress: (progress) => {
+        this.setStatus("downloading-weights");
+        this.emit({ kind: "progress", ...progress });
+      },
+      onError: (error) => this.handleProviderError(error),
+    });
+  }
+
+  /**
+   * Track `instanceId` from `seedKeyframe` to `endKeyframe`, emitting one
+   * Detection per in-between frame via `onDetection` as each lands. The
+   * bracket endpoints are left untouched — they're user keyframes.
+   */
+  async propagate(args: Sam2PropagateArgs): Promise<void> {
+    if (args.fromFrame >= args.toFrame) {
+      throw new Error("fromFrame must be less than toFrame");
+    }
+
+    await this.ensureInitialized();
+
+    const runId = objectId();
+    // Provenance records the source keyframes' mongo `_id`s (not the
+    // cross-frame-stable synthetic overlay id, which is identical for both
+    // ends of a track); fall back to the synthetic id only if unpersisted.
+    const parentKeyframes: [string, string] = [
+      args.seedKeyframe._id ?? args.seedKeyframe.id,
+      args.endKeyframe._id ?? args.endKeyframe.id,
+    ];
+
+    this.setStatus("inferring");
+
+    try {
+      await propagate(this.provider, {
+        getFrameBitmap: args.getFrameBitmap,
+        keyframeA: {
+          frameIdx: args.fromFrame,
+          points: pointsFromBox(args.seedKeyframe.bounding_box),
+        },
+        keyframeB: {
+          frameIdx: args.toFrame,
+          points: pointsFromBox(args.endKeyframe.bounding_box),
+        },
+        videoKey: args.videoKey,
+        strategy: args.strategy ?? "centroid-1",
+        shouldAbort: args.shouldAbort,
+        onProgress: args.onProgress,
+        onFrame: (frameIdx, result) => {
+          // Don't overwrite the user's bracket keyframes.
+          if (frameIdx === args.fromFrame || frameIdx === args.toFrame) return;
+
+          const detection: PropagatedDetection = {
+            _id: objectId(),
+            _cls: "Detection",
+            bounding_box: [
+              result.bbox.x,
+              result.bbox.y,
+              result.bbox.w,
+              result.bbox.h,
+            ],
+            label: args.seedKeyframe.label,
+            index: args.seedKeyframe.index,
+            instance: { _cls: "Instance", _id: args.instanceId },
+            keyframe: false,
+            propagation: {
+              method: "sam2",
+              run_id: runId,
+              parent_keyframes: parentKeyframes,
+            },
+          };
+          args.onDetection(frameIdx, detection);
+        },
+      });
+
+      if (this.lifecycleStatus !== "error") {
+        this.setStatus("idle");
+      }
+    } catch (err) {
+      if (this.lifecycleStatus !== "error") {
+        this.setStatus("idle");
+      }
+      throw err;
+    }
+  }
+
+  async infer(): Promise<InferenceResult<PropagationInferenceResult>> {
+    throw new Error(
+      "SAM2PropagationBrowserAgent requires the dedicated propagate() entry " +
+        "point (it needs a frame source) and is not invocable via infer()."
+    );
+  }
+
+  async listSupportedTasks(): Promise<AgentTaskType[]> {
+    return [AgentTaskType.PROPAGATE];
+  }
+
+  async listInferenceCapabilities(): Promise<InferenceCapability[]> {
+    return [];
+  }
+
+  async getModelMetadata(task: AgentTaskType): Promise<ModelMetadata | null> {
+    if (task === AgentTaskType.PROPAGATE) {
+      return { name: "SAM2 tracking", version: "hiera-tiny-onnx" };
+    }
+    return null;
+  }
+
+  async subscribe(): Promise<void> {
+    // no-op; streams via the propagate() callbacks rather than the async path.
+  }
+
+  async unsubscribe(): Promise<void> {
+    // no-op
+  }
+
+  async abort(): Promise<void> {
+    this.provider.abort();
+  }
+
+  onLifecycleEvent(listener: AnnotationAgentLifecycleListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  getLifecycleStatus(): AnnotationAgentLifecycleStatus {
+    return this.lifecycleStatus;
+  }
+
+  /** Release the web worker and all provider resources. */
+  dispose(): void {
+    this.provider.dispose();
+    this.initialized = false;
+    this.initializing$ = null;
+    this.setStatus("idle");
+  }
+
+  /** Concurrency-safe provider initialization (lazy, on first run). */
+  private async ensureInitialized(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+
+    if (!this.initializing$) {
+      this.initializing$ = this.provider
+        .initialize()
+        .then(() => {
+          this.initialized = this.provider.isInitialized();
+          if (!this.initialized) {
+            this.initializing$ = null;
+          }
+        })
+        .catch((err) => {
+          this.initializing$ = null;
+          throw err;
+        });
+    }
+
+    await this.initializing$;
+  }
+
+  private handleProviderStatus(status: ProviderStatus): void {
+    switch (status) {
+      case "loading":
+        this.setStatus("initializing");
+        return;
+      case "encoding":
+        this.setStatus("encoding-image");
+        return;
+      case "ready":
+        // Don't clobber "inferring" — the worker posts "ready" after each
+        // per-frame decode, which would otherwise flicker the lifecycle.
+        if (this.lifecycleStatus !== "inferring") {
+          this.setStatus("idle");
+        }
+        return;
+      case "failure":
+        this.setStatus("error");
+        return;
+    }
+  }
+
+  private handleProviderError(error: ProviderError): void {
+    this.setStatus("error");
+    this.emit({ kind: "error", error });
+  }
+
+  private setStatus(status: AnnotationAgentLifecycleStatus): void {
+    if (status === this.lifecycleStatus) return;
+    this.lifecycleStatus = status;
+    this.emit({ kind: "status", status });
+  }
+
+  private emit(event: AnnotationAgentLifecycle): void {
+    for (const listener of this.listeners) {
+      listener(event);
+    }
+  }
+}

--- a/app/packages/annotation/src/agents/SAM2PropagationBrowserAgent.ts
+++ b/app/packages/annotation/src/agents/SAM2PropagationBrowserAgent.ts
@@ -125,7 +125,7 @@ export class SAM2PropagationBrowserAgent
           points: pointsFromBox(args.endKeyframe.bounding_box),
         },
         videoKey: args.videoKey,
-        strategy: args.strategy ?? "centroid-1",
+        strategy: args.strategy ?? "centroid-5",
         shouldAbort: args.shouldAbort,
         onProgress: args.onProgress,
         onFrame: (frameIdx, result) => {

--- a/app/packages/annotation/src/agents/hooks/useAgentRegistry.ts
+++ b/app/packages/annotation/src/agents/hooks/useAgentRegistry.ts
@@ -4,6 +4,7 @@ import { useCallback, useMemo } from "react";
 import { AnnotationAgent, InferenceResultProxy } from "../types";
 import { PropagationBrowserAgent } from "../PropagationBrowserAgent";
 import { SAM2BrowserAnnotationAgent } from "../SAM2BrowserAnnotationAgent";
+import { SAM2PropagationBrowserAgent } from "../SAM2PropagationBrowserAgent";
 
 /** Maps agent IDs to their {@link AgentDescriptor} entries. */
 type RegistryMap = Record<string, AgentDescriptor<InferenceResultProxy>>;
@@ -19,6 +20,11 @@ const registryAtom = atom<RegistryMap>({
     id: "propagate-linear",
     label: "Linear interpolation",
     agent: new PropagationBrowserAgent(),
+  },
+  "propagate-sam2": {
+    id: "propagate-sam2",
+    label: "SAM2 tracking",
+    agent: new SAM2PropagationBrowserAgent(),
   },
 });
 

--- a/app/packages/annotation/src/agents/hooks/useApplyPropagationResult.ts
+++ b/app/packages/annotation/src/agents/hooks/useApplyPropagationResult.ts
@@ -3,6 +3,7 @@ import { useCallback } from "react";
 
 import {
   type InferenceResult,
+  type PropagatedDetection,
   type PropagationInferenceResult,
 } from "../types";
 
@@ -15,6 +16,47 @@ export type PropagationResultHandler = (
   result: InferenceResult<PropagationInferenceResult>
 ) => void;
 
+/** Writes a single propagated detection into a 1-based frame. */
+export type PropagatedDetectionWriter = (
+  frameNumber: number,
+  detection: PropagatedDetection
+) => void;
+
+/**
+ * Hook which returns a single-frame writer bound to the active session.
+ * Used both by the batch {@link useApplyPropagationResult} (sync agents that
+ * return every frame at once) and by streaming agents (SAM2) that emit a
+ * frame at a time as inference lands.
+ *
+ * The agent mints a fresh `_id` per emitted frame, but the in-between frames
+ * of a tracked object usually already carry a detection for this instance.
+ * `updateLabel` matches by `_id`, so a fresh id would append a duplicate
+ * (collapsed in rendering by the shared `instance._id`, but doubled in the
+ * data and persisted as an `add`). Reuse the existing detection's `_id` when
+ * one is present so the write overwrites it in place (a `replace`); fall
+ * back to the minted id only for genuine gaps in the track (a correct `add`).
+ */
+export const useApplyPropagatedDetection = (): PropagatedDetectionWriter => {
+  const stream = useFrameLabelsStream();
+
+  return useCallback(
+    (frameNumber: number, detection: PropagatedDetection) => {
+      if (!stream) return;
+
+      const snapshot = stream.getValue((frameNumber - 1) / stream.fps);
+      const existing = snapshot?.detections.find(
+        (d) => d.instance?._id === detection.instance?._id
+      );
+
+      stream.updateLabel(
+        frameNumber,
+        existing?._id ? { ...detection, _id: existing._id } : detection
+      );
+    },
+    [stream]
+  );
+};
+
 /**
  * Hook which returns a {@link PropagationResultHandler} bound to the
  * current video annotation session. Mirrors {@link useApplyInferenceResult}'s
@@ -22,33 +64,16 @@ export type PropagationResultHandler = (
  * Lighter overlays directly (overlays only exist for the current frame).
  */
 export const useApplyPropagationResult = (): PropagationResultHandler => {
-  const stream = useFrameLabelsStream();
+  const applyDetection = useApplyPropagatedDetection();
 
   return useCallback(
     (result: InferenceResult<PropagationInferenceResult>) => {
-      if (!stream) return;
       if (result.type !== "sync") return;
 
-      result.response.perFrame.forEach(({ frameNumber, detection }) => {
-        // The agent mints a fresh `_id` per interpolated frame, but the
-        // in-between frames of a tracked object usually already carry a
-        // detection for this instance. `updateLabel` matches by `_id`, so a
-        // fresh id would append a duplicate (collapsed in rendering by the
-        // shared `instance._id`, but doubled in the data and persisted as an
-        // `add`). Reuse the existing detection's `_id` when one is present so
-        // the propagation overwrites it in place (a `replace`); fall back to
-        // the minted id only for genuine gaps in the track (a correct `add`).
-        const snapshot = stream.getValue((frameNumber - 1) / stream.fps);
-        const existing = snapshot?.detections.find(
-          (d) => d.instance?._id === detection.instance?._id
-        );
-
-        stream.updateLabel(
-          frameNumber,
-          existing?._id ? { ...detection, _id: existing._id } : detection
-        );
-      });
+      result.response.perFrame.forEach(({ frameNumber, detection }) =>
+        applyDetection(frameNumber, detection)
+      );
     },
-    [stream]
+    [applyDetection]
   );
 };

--- a/app/packages/annotation/src/commands.ts
+++ b/app/packages/annotation/src/commands.ts
@@ -58,6 +58,59 @@ export class EditTemporalDetectionSupportCommand extends Command<boolean> {
 }
 
 /**
+ * Extend a tracked object's presence by copying a source frame's box onto
+ * the frames a timeline drag grew the bar over. Fired on drag-out of an
+ * object track bar's edge. `trackId` is the synthetic overlay id
+ * (`instance-…` / `track-…`) the stream and timeline agree on;
+ * `sourceFrame` is the existing endpoint whose box is copied; the copies
+ * land on `targetFrames` as non-keyframe filler (so a later Propagate can
+ * overwrite them in place). Resolves `true` when at least one frame was
+ * written.
+ */
+export class ExtendTrackCommand extends Command<boolean> {
+  constructor(
+    public readonly trackId: string,
+    public readonly sourceFrame: number,
+    public readonly targetFrames: readonly number[]
+  ) {
+    super();
+  }
+}
+
+/**
+ * Trim a tracked object's presence by deleting its detection on each of
+ * `frames` — the frames a timeline drag pulled the bar edge past. Fired on
+ * drag-in of an object track bar's edge. Resolves `true` when at least one
+ * detection was removed.
+ */
+export class TrimTrackCommand extends Command<boolean> {
+  constructor(
+    public readonly trackId: string,
+    public readonly frames: readonly number[]
+  ) {
+    super();
+  }
+}
+
+/**
+ * Rigidly shift a tracked object's detections by `delta` frames over the
+ * dragged segment `frames` — e.g. to correct labels that are off by a
+ * frame. Fired on drag of an object track bar's body. Boxes, keyframe
+ * flags, and propagation provenance travel with each label; frames vacated
+ * at the trailing edge are cleared. Resolves `true` when the shift was
+ * applied.
+ */
+export class ShiftTrackCommand extends Command<boolean> {
+  constructor(
+    public readonly trackId: string,
+    public readonly frames: readonly number[],
+    public readonly delta: number
+  ) {
+    super();
+  }
+}
+
+/**
  * Propagate a tracked object's bounding box between two bracketing
  * keyframes via the registered propagation agent (linear interp for the
  * demo). Resolves to `true` when at least one in-between frame was

--- a/app/packages/annotation/src/commands.ts
+++ b/app/packages/annotation/src/commands.ts
@@ -112,10 +112,12 @@ export class ShiftTrackCommand extends Command<boolean> {
 
 /**
  * Propagate a tracked object's bounding box between two bracketing
- * keyframes via the registered propagation agent (linear interp for the
- * demo). Resolves to `true` when at least one in-between frame was
- * written, `false` when prerequisites are missing (no stream, no
- * bracketing keyframes, no registered agent for the method).
+ * keyframes via the registered propagation agent selected by `method`
+ * (`"linear"` → `propagate-linear` lerp; `"sam2"` → `propagate-sam2`
+ * per-frame SAM2 tracking, which streams results as inference lands).
+ * Resolves to `true` when at least one in-between frame was written,
+ * `false` when prerequisites are missing (no stream, no bracketing
+ * keyframes, no registered agent / frame source for the method).
  */
 export class PropagateCommand extends Command<boolean> {
   constructor(

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
@@ -4,7 +4,9 @@ import {
   useFrameLabelsStream,
   useStageTemporalDetectionSupport,
   type LocalDetection,
+  type SyntheticBox,
 } from "@fiftyone/video-annotation";
+import { objectId } from "@fiftyone/utilities";
 import { useCallback } from "react";
 import { frameAt } from "../../../playback/src/lib/playback/utils";
 import { useAgentRegistry } from "../agents/hooks/useAgentRegistry";
@@ -18,9 +20,42 @@ import {
 } from "../agents/types";
 import {
   EditTemporalDetectionSupportCommand,
+  ExtendTrackCommand,
   MarkKeyframeCommand,
   PropagateCommand,
+  ShiftTrackCommand,
+  TrimTrackCommand,
 } from "../commands";
+
+/** Read this track's detection on a given frame, or `undefined`. */
+const detectionAt = (
+  stream: { getValue: (t: number) => { detections: SyntheticBox[] } | null },
+  frame: number,
+  fps: number,
+  trackId: string
+): SyntheticBox | undefined =>
+  stream.getValue((frame - 1) / fps)?.detections.find((d) => d.id === trackId);
+
+/**
+ * Project a snapshot detection into a fresh-`_id` copy for writing onto
+ * another frame. Cross-frame identity (`instance` / track `index`) is
+ * preserved; the `_id` is new so each frame gets its own detection doc.
+ * Per-field spreads avoid writing `undefined`/`null` keys the baseline
+ * lacks (which would emit spurious patch ops).
+ */
+const copyDetection = (
+  det: SyntheticBox,
+  overrides: Pick<LocalDetection, "keyframe"> &
+    Partial<Pick<LocalDetection, "propagation">>
+): LocalDetection => ({
+  _cls: "Detection",
+  _id: objectId(),
+  label: det.label,
+  bounding_box: det.bounding_box,
+  ...(det.index !== undefined ? { index: det.index } : {}),
+  ...(det.instance ? { instance: det.instance } : {}),
+  ...overrides,
+});
 
 /**
  * Registers video-specific annotation command handlers. Mount inside
@@ -154,6 +189,125 @@ export const useRegisterVideoAnnotationCommandHandlers = () => {
         return true;
       },
       [stream, registry, sampleDescriptor, applyPropagation]
+    )
+  );
+
+  useRegisterCommandHandler(
+    ExtendTrackCommand,
+    useCallback(
+      async (cmd) => {
+        if (!stream) {
+          return false;
+        }
+
+        if (cmd.targetFrames.length === 0) {
+          return false;
+        }
+
+        const source = detectionAt(
+          stream,
+          cmd.sourceFrame,
+          stream.fps,
+          cmd.trackId
+        );
+        if (!source) {
+          return false;
+        }
+
+        let written = false;
+        for (const frame of cmd.targetFrames) {
+          if (frame < 1 || frame > stream.totalFrames) {
+            continue;
+          }
+
+          // Non-keyframe filler — a later Propagate overwrites these in
+          // place once the far end becomes a keyframe.
+          stream.updateLabel(frame, copyDetection(source, { keyframe: false }));
+          written = true;
+        }
+
+        return written;
+      },
+      [stream]
+    )
+  );
+
+  useRegisterCommandHandler(
+    TrimTrackCommand,
+    useCallback(
+      async (cmd) => {
+        if (!stream) {
+          return false;
+        }
+
+        let removed = false;
+        for (const frame of cmd.frames) {
+          const det = detectionAt(stream, frame, stream.fps, cmd.trackId);
+          if (!det) {
+            continue;
+          }
+
+          stream.deleteLabel(frame, det._id ?? det.id);
+          removed = true;
+        }
+
+        return removed;
+      },
+      [stream]
+    )
+  );
+
+  useRegisterCommandHandler(
+    ShiftTrackCommand,
+    useCallback(
+      async (cmd) => {
+        if (!stream) {
+          return false;
+        }
+
+        if (cmd.delta === 0 || cmd.frames.length === 0) {
+          return false;
+        }
+
+        // Read the whole segment up front, before any mutation, so the
+        // delete/write passes below operate on a stable snapshot.
+        const sources: Array<{ frame: number; det: SyntheticBox }> = [];
+        for (const frame of cmd.frames) {
+          const det = detectionAt(stream, frame, stream.fps, cmd.trackId);
+
+          if (det) {
+            sources.push({ frame, det });
+          }
+        }
+        if (sources.length === 0) {
+          return false;
+        }
+
+        // Clear the originals, then re-lay the boxes at the shifted
+        // frames with fresh ids. Keyframe flags + propagation provenance
+        // travel with each label so a shifted track keeps its anchors.
+        for (const { frame, det } of sources) {
+          stream.deleteLabel(frame, det._id ?? det.id);
+        }
+
+        for (const { frame, det } of sources) {
+          const target = frame + cmd.delta;
+          if (target < 1 || target > stream.totalFrames) {
+            continue;
+          }
+
+          stream.updateLabel(
+            target,
+            copyDetection(det, {
+              keyframe: det.keyframe,
+              ...(det.propagation ? { propagation: det.propagation } : {}),
+            })
+          );
+        }
+
+        return true;
+      },
+      [stream]
     )
   );
 };

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
@@ -1,17 +1,24 @@
 import { useRegisterCommandHandler } from "@fiftyone/command-bus";
 import { useAnnotationEventBus } from "./useAnnotationEventBus";
 import {
+  PropagationStatusItem,
   useFrameLabelsStream,
+  useImaVidImageStream,
   useStageTemporalDetectionSupport,
+  useVideoAnnotationStatus,
   type LocalDetection,
   type SyntheticBox,
 } from "@fiftyone/video-annotation";
 import { objectId } from "@fiftyone/utilities";
-import { useCallback } from "react";
+import { createElement, useCallback } from "react";
 import { frameAt } from "../../../playback/src/lib/playback/utils";
 import { useAgentRegistry } from "../agents/hooks/useAgentRegistry";
-import { useApplyPropagationResult } from "../agents/hooks/useApplyPropagationResult";
+import {
+  useApplyPropagatedDetection,
+  useApplyPropagationResult,
+} from "../agents/hooks/useApplyPropagationResult";
 import { useSampleDescriptor } from "../agents/hooks/useSampleDescriptor";
+import type { SAM2PropagationBrowserAgent } from "../agents/SAM2PropagationBrowserAgent";
 import {
   AgentTaskType,
   type AnnotationAgent,
@@ -65,10 +72,13 @@ const copyDetection = (
  */
 export const useRegisterVideoAnnotationCommandHandlers = () => {
   const stream = useFrameLabelsStream();
+  const imageStream = useImaVidImageStream();
   const stageTemporalDetectionSupport = useStageTemporalDetectionSupport();
   const registry = useAgentRegistry();
   const sampleDescriptor = useSampleDescriptor();
   const applyPropagation = useApplyPropagationResult();
+  const applyPropagatedDetection = useApplyPropagatedDetection();
+  const { setContent: setStatusContent } = useVideoAnnotationStatus();
   const eventBus = useAnnotationEventBus();
 
   useRegisterCommandHandler(
@@ -165,6 +175,86 @@ export const useRegisterVideoAnnotationCommandHandlers = () => {
         const rightKeyframe = toSnapshot.detections.find(matchesInstance);
         if (!leftKeyframe || !rightKeyframe) return false;
 
+        // SAM2 tracking runs asynchronously over the decoded ImaVid frames
+        // and streams a detection per frame as inference lands. It needs the
+        // image stream as a frame source; bail cleanly on surfaces that have
+        // none (e.g. native video).
+        if (cmd.method === "sam2") {
+          if (!imageStream) return false;
+
+          const agents = await registry.listAgents();
+          const descriptor = agents.find((a) => a.id === "propagate-sam2");
+          if (!descriptor) return false;
+          // Registry stores agents under the broad `AnnotationAgent` type;
+          // this one is driven through its dedicated `propagate()` (which
+          // carries the frame source), not the generic `infer`.
+          const agent =
+            descriptor.agent as unknown as SAM2PropagationBrowserAgent;
+
+          let aborted = false;
+          const onStop = () => {
+            aborted = true;
+          };
+
+          // Status-slot rendering. Drive the phase off `onProgress` — which
+          // is monotonic and only fires once per-frame inference starts —
+          // rather than the agent lifecycle, which churns
+          // inferring→encoding→idle every frame (the provider re-emits
+          // "encoding" per cache-miss) and would flicker the label. Until
+          // the first progress tick we're in the one-time model
+          // download/encode, shown as an indeterminate "Loading SAM2…".
+          let tracking = false;
+          const render = (done?: number, runTotal?: number) =>
+            setStatusContent(
+              createElement(PropagationStatusItem, {
+                label: tracking ? "SAM2 tracking" : "Loading SAM2…",
+                done,
+                total: runTotal,
+                onStop,
+              })
+            );
+          render();
+
+          // Map a 1-based frame number to its decoded bitmap, fetching +
+          // decoding on demand if the LRU doesn't already hold it. Same
+          // frame→time convention the labels stream + apply path use.
+          const getFrameBitmap = async (
+            frameNumber: number
+          ): Promise<ImageBitmap> => {
+            const time = (frameNumber - 1) / imageStream.fps;
+            await imageStream.warmup(time);
+            const frame = imageStream.getValue(time);
+            if (!frame) {
+              throw new Error(`ImaVid frame ${frameNumber} unavailable`);
+            }
+            return frame.bitmap;
+          };
+
+          try {
+            await agent.propagate({
+              instanceId: cmd.instanceId,
+              seedKeyframe: leftKeyframe,
+              endKeyframe: rightKeyframe,
+              fromFrame: cmd.fromFrame,
+              toFrame: cmd.toFrame,
+              videoKey: sampleDescriptor.sampleId,
+              getFrameBitmap,
+              onDetection: applyPropagatedDetection,
+              onProgress: (done, runTotal) => {
+                tracking = true;
+                render(done, runTotal);
+              },
+              shouldAbort: () => aborted,
+            });
+            return true;
+          } catch (err) {
+            console.error("[va] SAM2 propagation failed", err);
+            return false;
+          } finally {
+            setStatusContent(null);
+          }
+        }
+
         const agentId = `propagate-${cmd.method}`;
         const agents = await registry.listAgents();
         const descriptor = agents.find((a) => a.id === agentId);
@@ -188,7 +278,15 @@ export const useRegisterVideoAnnotationCommandHandlers = () => {
         applyPropagation(result);
         return true;
       },
-      [stream, registry, sampleDescriptor, applyPropagation]
+      [
+        stream,
+        imageStream,
+        registry,
+        sampleDescriptor,
+        applyPropagation,
+        applyPropagatedDetection,
+        setStatusContent,
+      ]
     )
   );
 

--- a/app/packages/annotation/src/providers/BrowserAnnotationProvider.ts
+++ b/app/packages/annotation/src/providers/BrowserAnnotationProvider.ts
@@ -1,6 +1,8 @@
 import { getFetchParameters, mergeHeaders } from "@fiftyone/utilities";
 import type {
   AnnotationProvider,
+  BitmapEncodeRequest,
+  BitmapInferenceRequest,
   DownloadProgress,
   DownloadProgressCallback,
   ErrorCallback,
@@ -28,21 +30,27 @@ function checkBrowserCompatibility(): { errors: string[]; warnings: string[] } {
   // WASM SIMD: same byte sequence used by onnxruntime-web to detect SIMD support.
   // Source: https://github.com/microsoft/onnxruntime/blob/main/js/web/lib/wasm/wasm-factory.ts
   try {
-    if (!WebAssembly.validate(new Uint8Array([
-      0, 97, 115, 109, 1, 0, 0, 0, 1, 4, 1, 96, 0, 0, 3, 2, 1, 0, 10, 30, 1, 28, 0, 65, 0, 253, 15, 253, 12, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 253, 186, 1, 26, 11,
-    ])))
+    if (
+      !WebAssembly.validate(
+        new Uint8Array([
+          0, 97, 115, 109, 1, 0, 0, 0, 1, 4, 1, 96, 0, 0, 3, 2, 1, 0, 10, 30, 1,
+          28, 0, 65, 0, 253, 15, 253, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          0, 0, 0, 253, 186, 1, 26, 11,
+        ])
+      )
+    )
       errors.push("WASM SIMD");
   } catch {
     errors.push("WASM SIMD");
   }
 
-  if (typeof OffscreenCanvas === "undefined")
-    errors.push("OffscreenCanvas");
+  if (typeof OffscreenCanvas === "undefined") errors.push("OffscreenCanvas");
 
   // SharedArrayBuffer: enables multi-threaded WASM. Without it, falls back to single-threaded.
   if (typeof SharedArrayBuffer === "undefined")
-    warnings.push("SharedArrayBuffer unavailable. Falling back to single-threaded WASM");
+    warnings.push(
+      "SharedArrayBuffer unavailable. Falling back to single-threaded WASM"
+    );
 
   return { errors, warnings };
 }
@@ -78,14 +86,16 @@ export class BrowserAnnotationProvider implements AnnotationProvider {
     const { errors, warnings } = checkBrowserCompatibility();
 
     if (errors.length > 0) {
-      const err: ProviderError = { kind: "unsupported", message: `Missing browser APIs: ${errors.join(", ")}` };
+      const err: ProviderError = {
+        kind: "unsupported",
+        message: `Missing browser APIs: ${errors.join(", ")}`,
+      };
       this.onError?.(err);
       this.onStatus?.("failure");
       throw new Error(err.message);
     }
 
-    for (const w of warnings)
-      this.onWarning?.(w);
+    for (const w of warnings) this.onWarning?.(w);
 
     this.onStatus?.("loading");
 
@@ -101,8 +111,7 @@ export class BrowserAnnotationProvider implements AnnotationProvider {
     this.worker.onmessage = (e: MessageEvent) => {
       const { id, type, success, result, error } = e.data;
 
-      if (type === "ready")
-        return;
+      if (type === "ready") return;
 
       if (type === "status") {
         this.onStatus?.(result as ProviderStatus);
@@ -125,19 +134,19 @@ export class BrowserAnnotationProvider implements AnnotationProvider {
       }
 
       const entry = this.pending.get(id);
-      if (!entry)
-        return;
+      if (!entry) return;
 
       this.pending.delete(id);
 
-      success ? entry.resolve(result) : entry.reject(new Error(error ?? "Worker error"));
+      success
+        ? entry.resolve(result)
+        : entry.reject(new Error(error ?? "Worker error"));
     };
 
     this.worker.onerror = (e: ErrorEvent) => {
       const msg = e.message || "Worker error";
       this.onStatus?.("failure");
-      for (const entry of this.pending.values())
-        entry.reject(new Error(msg));
+      for (const entry of this.pending.values()) entry.reject(new Error(msg));
       this.pending.clear();
       this.worker?.terminate();
       this.worker = null;
@@ -166,11 +175,37 @@ export class BrowserAnnotationProvider implements AnnotationProvider {
     return promise;
   }
 
+  /**
+   * Run SAM2 against an already-decoded frame bitmap (e.g. an ImaVid video
+   * frame). Used by video propagation; see `videoPropagation.ts`.
+   *
+   * The bitmap is passed by structured clone, NOT as a transferable —
+   * Firefox rejects a payload that both contains a bitmap and lists it in
+   * the transfer list ("invalid transferable array for structured clone").
+   * Cloning a single bitmap is cheap (a handle, not a pixel copy), and it
+   * leaves the caller's bitmap intact — important when the source is a
+   * frame-cache entry the stream still owns.
+   */
+  async inferBitmap(request: BitmapInferenceRequest): Promise<InferenceResult> {
+    const { id, promise } = this.send("embedAndDecodeBitmap", request);
+    this.lastInferenceId = id;
+    return promise;
+  }
+
+  /**
+   * Encode-only — run SAM2's image encoder on a frame and cache the
+   * embedding keyed on `cacheKey`. No decoder, no result. A later
+   * {@link inferBitmap} with the same key then runs the decoder only.
+   */
+  async encodeBitmap(request: BitmapEncodeRequest): Promise<void> {
+    const { promise } = this.send("encodeBitmap", request);
+    return promise;
+  }
+
   // Client-side only: rejects the pending promise but the worker keeps computing.
   // Only aborts the most recent inference. Earlier in-flight requests are not cancelled.
   abort(): void {
-    if (this.lastInferenceId === null)
-      return;
+    if (this.lastInferenceId === null) return;
 
     const entry = this.pending.get(this.lastInferenceId);
     if (entry) {
@@ -199,10 +234,12 @@ export class BrowserAnnotationProvider implements AnnotationProvider {
   ): { id: number; promise: Promise<WorkerResponse<T>> } {
     const id = this.nextId++;
     const promise = new Promise<WorkerResponse<T>>((resolve, reject) => {
-      if (!this.worker)
-        return reject(new Error("Worker not initialized"));
+      if (!this.worker) return reject(new Error("Worker not initialized"));
 
-      this.pending.set(id, { resolve: resolve as (value: unknown) => void, reject });
+      this.pending.set(id, {
+        resolve: resolve as (value: unknown) => void,
+        reject,
+      });
       this.worker.postMessage({ id, type, payload });
     });
     return { id, promise };

--- a/app/packages/annotation/src/providers/index.ts
+++ b/app/packages/annotation/src/providers/index.ts
@@ -1,2 +1,3 @@
 export * from "./types";
 export * from "./BrowserAnnotationProvider";
+export * from "./videoPropagation";

--- a/app/packages/annotation/src/providers/types.ts
+++ b/app/packages/annotation/src/providers/types.ts
@@ -15,6 +15,29 @@ export interface InferenceRequest {
   points: PromptPoint[];
 }
 
+/**
+ * Inference from an already-decoded `ImageBitmap` (e.g. an ImaVid video
+ * frame) rather than a URL. `cacheKey` stands in for the URL when keying
+ * the per-frame encoder-embedding cache — pass a stable per-frame string
+ * (e.g. `"<videoKey>#frame=<n>"`).
+ */
+export interface BitmapInferenceRequest {
+  bitmap: ImageBitmap;
+  cacheKey: string;
+  points: PromptPoint[];
+}
+
+/**
+ * Encode-only request — runs the SAM2 image encoder on a frame and stores
+ * the embedding in the per-frame cache without running the decoder. Used
+ * to pre-encode upcoming frames so a later {@link BitmapInferenceRequest}
+ * with the same `cacheKey` is decoder-only.
+ */
+export interface BitmapEncodeRequest {
+  bitmap: ImageBitmap;
+  cacheKey: string;
+}
+
 /** Coordinates: [0,1] normalized. */
 export interface BoundingBox {
   x: number;
@@ -49,6 +72,8 @@ export interface DownloadProgress {
 export type WorkerMessages = {
   loadModel: WorkerMessage<Record<string, never>, void>;
   embedAndDecode: WorkerMessage<InferenceRequest, InferenceResult>;
+  embedAndDecodeBitmap: WorkerMessage<BitmapInferenceRequest, InferenceResult>;
+  encodeBitmap: WorkerMessage<BitmapEncodeRequest, void>;
 };
 
 /** One-way worker-to-main-thread notification payloads. */
@@ -60,8 +85,10 @@ export type WorkerNotifications = {
 };
 
 export type WorkerMessageType = keyof WorkerMessages;
-export type WorkerRequest<T extends WorkerMessageType> = WorkerMessages[T]["request"];
-export type WorkerResponse<T extends WorkerMessageType> = WorkerMessages[T]["response"];
+export type WorkerRequest<T extends WorkerMessageType> =
+  WorkerMessages[T]["request"];
+export type WorkerResponse<T extends WorkerMessageType> =
+  WorkerMessages[T]["response"];
 
 /** Status events emitted during the provider lifecycle. */
 export type ProviderStatus = "loading" | "encoding" | "ready" | "failure";

--- a/app/packages/annotation/src/providers/videoPropagation.test.ts
+++ b/app/packages/annotation/src/providers/videoPropagation.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BrowserAnnotationProvider } from "./BrowserAnnotationProvider";
+import { PointLabel, type InferenceResult } from "./types";
+import { pointsFromBox, propagate } from "./videoPropagation";
+
+/** A 2×2 all-on mask at a fixed bbox — enough for centroid sampling. */
+const fakeResult = (): InferenceResult => ({
+  mask: new Float32Array([1, 1, 1, 1]),
+  maskWidth: 2,
+  maskHeight: 2,
+  bbox: { x: 0.1, y: 0.1, w: 0.2, h: 0.2 },
+});
+
+const fakeProvider = (impl = vi.fn(async () => fakeResult())) =>
+  ({ inferBitmap: impl } as unknown as BrowserAnnotationProvider & {
+    inferBitmap: ReturnType<typeof vi.fn>;
+  });
+
+const seedPoints = [{ x: 0.5, y: 0.5, label: PointLabel.POSITIVE }];
+
+describe("pointsFromBox", () => {
+  it("centres on the box and samples interior points", () => {
+    const pts = pointsFromBox([0.2, 0.4, 0.4, 0.2]);
+    // centre first
+    expect(pts[0]).toEqual({ x: 0.4, y: 0.5, label: PointLabel.POSITIVE });
+    expect(pts).toHaveLength(5);
+    // all positive, all inside the box
+    for (const p of pts) {
+      expect(p.label).toBe(PointLabel.POSITIVE);
+      expect(p.x).toBeGreaterThanOrEqual(0.2);
+      expect(p.x).toBeLessThanOrEqual(0.6);
+      expect(p.y).toBeGreaterThanOrEqual(0.4);
+      expect(p.y).toBeLessThanOrEqual(0.6);
+    }
+  });
+
+  it("honours the requested point count", () => {
+    expect(pointsFromBox([0, 0, 1, 1], 1)).toHaveLength(1);
+    expect(pointsFromBox([0, 0, 1, 1], 3)).toHaveLength(3);
+  });
+});
+
+describe("propagate", () => {
+  it("walks [A, B] inclusive, seeding the first frame from keyframe A", async () => {
+    const infer = vi.fn(async () => fakeResult());
+    const provider = fakeProvider(infer);
+    const getFrameBitmap = vi.fn(async () => ({} as ImageBitmap));
+    const onProgress = vi.fn();
+
+    const results = await propagate(provider, {
+      getFrameBitmap,
+      keyframeA: { frameIdx: 1, points: seedPoints },
+      keyframeB: { frameIdx: 4, points: seedPoints },
+      videoKey: "vid",
+      onProgress,
+    });
+
+    // frames 1,2,3,4
+    expect([...results.keys()]).toEqual([1, 2, 3, 4]);
+    expect(getFrameBitmap.mock.calls.map((c) => c[0])).toEqual([1, 2, 3, 4]);
+    // first inference is seeded by keyframe A's points
+    expect(infer.mock.calls[0][0].points).toEqual(seedPoints);
+    // cache key carries the frame index
+    expect(infer.mock.calls[1][0].cacheKey).toBe("vid#frame=2");
+    // progress reaches the full span
+    expect(onProgress).toHaveBeenLastCalledWith(4, 4);
+  });
+
+  it("stops early when shouldAbort returns true", async () => {
+    const provider = fakeProvider();
+    let calls = 0;
+    const results = await propagate(provider, {
+      getFrameBitmap: async () => ({} as ImageBitmap),
+      keyframeA: { frameIdx: 1, points: seedPoints },
+      keyframeB: { frameIdx: 10, points: seedPoints },
+      videoKey: "vid",
+      shouldAbort: () => calls++ >= 2,
+    });
+
+    expect(results.size).toBe(2);
+  });
+
+  it("rejects a non-increasing keyframe range", async () => {
+    await expect(
+      propagate(fakeProvider(), {
+        getFrameBitmap: async () => ({} as ImageBitmap),
+        keyframeA: { frameIdx: 5, points: seedPoints },
+        keyframeB: { frameIdx: 5, points: seedPoints },
+        videoKey: "vid",
+      })
+    ).rejects.toThrow(/keyframeA must precede keyframeB/);
+  });
+});

--- a/app/packages/annotation/src/providers/videoPropagation.ts
+++ b/app/packages/annotation/src/providers/videoPropagation.ts
@@ -1,0 +1,250 @@
+/**
+ * Video label propagation (browser, WASM SAM2).
+ *
+ * Walks the frames between two keyframes and, for each, runs SAM2 against
+ * the decoded frame bitmap to localise the tracked object. The next frame's
+ * prompt is derived from the previous frame's mask (centroid sampling), so
+ * the track re-localises every frame and stays robust to motion / scale.
+ *
+ * The engine is decoupled from how frames are sourced: callers inject a
+ * `getFrameBitmap(frameIdx)` that returns a decoded `ImageBitmap`.Frame
+ * indices are opaque to the engine — it only requires that
+ * `keyframeA.frameIdx` / `keyframeB.frameIdx` and the indices
+ * passed to `getFrameBitmap` / reported via `onFrame` share one base.
+ *
+ * Pluggable next-frame strategies:
+ *   "centroid-{1,3,5}" — chain forward; each frame prompts SAM2 with N
+ *                         points sampled from the previous frame's mask.
+ *   "lerp"             — linearly interpolate the user points between A and
+ *                         B (no model). Cheap; assumes near-translation.
+ */
+
+import type { BrowserAnnotationProvider } from "./BrowserAnnotationProvider";
+import { PointLabel, type InferenceResult, type PromptPoint } from "./types";
+
+export interface Keyframe {
+  /** Frame index in the caller's chosen base (the ImaVid agent uses the
+   *  1-based frame number). */
+  frameIdx: number;
+  /** Point prompts that seed the mask at this keyframe. */
+  points: PromptPoint[];
+}
+
+/** How prompt points for the next frame are chosen. */
+export type PropagationStrategy =
+  | "centroid-5"
+  | "centroid-3"
+  | "centroid-1"
+  | "lerp";
+
+export interface PropagateOptions {
+  /** Returns the decoded bitmap for a frame index (caller-defined base). */
+  getFrameBitmap: (frameIdx: number) => Promise<ImageBitmap>;
+  keyframeA: Keyframe;
+  keyframeB: Keyframe;
+  /** Stable id for the source video; per-frame embedding cache key prefix. */
+  videoKey: string;
+  /** Point-propagation strategy. Defaults to "centroid-5". */
+  strategy?: PropagationStrategy;
+  /** Called with each frame's mask as it lands. */
+  onFrame?: (frameIdx: number, result: InferenceResult) => void;
+  /** Per-frame progress over the inclusive `[A, B]` span. */
+  onProgress?: (done: number, total: number) => void;
+  /** Polled before each frame; return `true` to stop early. */
+  shouldAbort?: () => boolean;
+}
+
+/**
+ * Run propagation between two keyframes for a single object. Returns a map
+ * `frameIdx → result` for every frame visited in `[kfA, kfB]` (inclusive).
+ */
+export async function propagate(
+  provider: BrowserAnnotationProvider,
+  options: PropagateOptions
+): Promise<Map<number, InferenceResult>> {
+  const {
+    getFrameBitmap,
+    keyframeA,
+    keyframeB,
+    videoKey,
+    strategy = "centroid-5",
+  } = options;
+
+  if (keyframeA.frameIdx >= keyframeB.frameIdx)
+    throw new Error("keyframeA must precede keyframeB");
+
+  if (
+    strategy === "lerp" &&
+    keyframeA.points.length !== keyframeB.points.length
+  )
+    throw new Error("lerp strategy requires matching point counts");
+
+  const start = keyframeA.frameIdx;
+  const end = keyframeB.frameIdx;
+  const span = end - start;
+  const total = span + 1;
+  const results = new Map<number, InferenceResult>();
+
+  let prevResult: InferenceResult | null = null;
+
+  for (let i = 0; i < total; i++) {
+    if (options.shouldAbort?.()) {
+      break;
+    }
+
+    const frameIdx = start + i;
+    const t = span === 0 ? 0 : i / span;
+    const points = nextPoints(strategy, prevResult, keyframeA, keyframeB, t);
+    if (!points) {
+      // centroid found nothing — bail rather than mis-prompt
+      break;
+    }
+
+    const bitmap = await getFrameBitmap(frameIdx);
+    const cacheKey = `${videoKey}#frame=${frameIdx}`;
+    const result = await provider.inferBitmap({ bitmap, cacheKey, points });
+
+    prevResult = result;
+    results.set(frameIdx, result);
+    options.onFrame?.(frameIdx, result);
+    options.onProgress?.(i + 1, total);
+  }
+
+  return results;
+}
+
+/** Strategy dispatch — pick the next-frame prompt points. */
+function nextPoints(
+  strategy: PropagationStrategy,
+  prevResult: InferenceResult | null,
+  kfA: Keyframe,
+  kfB: Keyframe,
+  t: number
+): PromptPoint[] | null {
+  if (strategy === "lerp") {
+    return lerpPoints(kfA.points, kfB.points, t);
+  }
+
+  // First frame of the chain: seed from the starting keyframe's points.
+  if (prevResult === null) {
+    return kfA.points.length > 0 ? kfA.points : null;
+  }
+
+  const count = centroidCount(strategy);
+  const pts = pointsFromMask(prevResult, count);
+
+  return pts.length > 0 ? pts : null;
+}
+
+function centroidCount(s: PropagationStrategy): 1 | 3 | 5 {
+  switch (s) {
+    case "centroid-1":
+      return 1;
+    case "centroid-3":
+      return 3;
+    default:
+      return 5;
+  }
+}
+
+function lerpPoints(
+  a: PromptPoint[],
+  b: PromptPoint[],
+  t: number
+): PromptPoint[] {
+  return a.map((pa, i) => ({
+    x: pa.x + (b[i].x - pa.x) * t,
+    y: pa.y + (b[i].y - pa.y) * t,
+    label: pa.label,
+  }));
+}
+
+/**
+ * Sample 1–5 positive points from a mask so SAM2 has enough signal on the
+ * next frame to keep the same object extent:
+ *   - the mask centroid (if it lies inside the mask);
+ *   - up to four cardinal interior points at ~½ distance from the centroid
+ *     toward each bbox edge, kept only when inside the mask.
+ * Returned coordinates are normalised in the full-image frame.
+ */
+function pointsFromMask(
+  r: InferenceResult,
+  count: 1 | 3 | 5 = 5
+): PromptPoint[] {
+  let sx = 0;
+  let sy = 0;
+  let n = 0;
+  for (let y = 0; y < r.maskHeight; y++) {
+    for (let x = 0; x < r.maskWidth; x++) {
+      if (r.mask[y * r.maskWidth + x] > 0.5) {
+        sx += x;
+        sy += y;
+        n++;
+      }
+    }
+  }
+
+  if (n === 0) {
+    return [];
+  }
+
+  const cx = sx / n;
+  const cy = sy / n;
+
+  // centroid first; then horizontal pair (3); then vertical pair (5).
+  const all: [number, number][] = [
+    [cx, cy],
+    [cx * 0.5, cy], // toward left edge
+    [cx + (r.maskWidth - cx) * 0.5, cy], // toward right edge
+    [cx, cy * 0.5], // toward top edge
+    [cx, cy + (r.maskHeight - cy) * 0.5], // toward bottom edge
+  ];
+  const candidates = all.slice(0, count);
+
+  const out: PromptPoint[] = [];
+  for (const [mx, my] of candidates) {
+    const ix = Math.min(r.maskWidth - 1, Math.max(0, Math.round(mx)));
+    const iy = Math.min(r.maskHeight - 1, Math.max(0, Math.round(my)));
+    if (r.mask[iy * r.maskWidth + ix] <= 0.5) {
+      continue;
+    }
+
+    // mask-pixel → bbox-relative → full-image normalised
+    out.push({
+      x: r.bbox.x + (mx / r.maskWidth) * r.bbox.w,
+      y: r.bbox.y + (my / r.maskHeight) * r.bbox.h,
+      label: PointLabel.POSITIVE,
+    });
+  }
+
+  return out;
+}
+
+/**
+ * Derive seed prompt points from a normalised bounding box `[x, y, w, h]`:
+ * the box centre plus four interior points at ¼ / ¾ along each axis, all
+ * positive. Mirrors {@link pointsFromMask}'s sampling so the seed frame and
+ * subsequent centroid-followed frames prompt SAM2 consistently.
+ */
+export function pointsFromBox(
+  bbox: [number, number, number, number],
+  count: 1 | 3 | 5 = 1
+): PromptPoint[] {
+  const [x, y, w, h] = bbox;
+  const cx = x + w / 2;
+  const cy = y + h / 2;
+
+  const all: [number, number][] = [
+    [cx, cy],
+    [x + w * 0.25, cy], // left-interior
+    [x + w * 0.75, cy], // right-interior
+    [cx, y + h * 0.25], // top-interior
+    [cx, y + h * 0.75], // bottom-interior
+  ];
+
+  return all.slice(0, count).map(([px, py]) => ({
+    x: px,
+    y: py,
+    label: PointLabel.POSITIVE,
+  }));
+}

--- a/app/packages/annotation/src/providers/videoPropagation.ts
+++ b/app/packages/annotation/src/providers/videoPropagation.ts
@@ -228,7 +228,7 @@ function pointsFromMask(
  */
 export function pointsFromBox(
   bbox: [number, number, number, number],
-  count: 1 | 3 | 5 = 1
+  count: 1 | 3 | 5 = 5
 ): PromptPoint[] {
   const [x, y, w, h] = bbox;
   const cx = x + w / 2;

--- a/app/packages/annotation/src/providers/worker.ts
+++ b/app/packages/annotation/src/providers/worker.ts
@@ -1,7 +1,4 @@
-import {
-  getFetchFunction,
-  setFetchFunction,
-} from "@fiftyone/utilities";
+import { getFetchFunction, setFetchFunction } from "@fiftyone/utilities";
 import * as ort from "onnxruntime-web";
 import type {
   DownloadProgress,
@@ -89,13 +86,10 @@ const CACHE_PREFIX = `${ENCODER_CACHE_KEY}:${SAM2_INPUT_SIZE}:`;
  * Uses the shared fetch function so the path prefix configured by the main
  * thread is applied. Throws on non-2xx responses.
  */
-async function resolveModelUrl(
-  family: string,
-  file: string,
-): Promise<string> {
+async function resolveModelUrl(family: string, file: string): Promise<string> {
   const data = await getFetchFunction()<undefined, { url: string }>(
     "GET",
-    `/runtime-assets/models/${family}/${file}`,
+    `/runtime-assets/models/${family}/${file}`
   );
   return data.url;
 }
@@ -126,7 +120,9 @@ async function loadImageData(url: string): Promise<ImageData> {
     throw new Error(`Image fetch failed (check CORS headers): ${e}`);
   }
   if (!response.ok)
-    throw new Error(`Image fetch failed: ${response.status} ${response.statusText}`);
+    throw new Error(
+      `Image fetch failed: ${response.status} ${response.statusText}`
+    );
 
   const blob = await response.blob();
   const bitmap = await createImageBitmap(blob).catch((e) => {
@@ -135,8 +131,7 @@ async function loadImageData(url: string): Promise<ImageData> {
 
   const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
   const ctx = canvas.getContext("2d");
-  if (!ctx)
-    throw new Error("Failed to get 2d context");
+  if (!ctx) throw new Error("Failed to get 2d context");
 
   ctx.drawImage(bitmap, 0, 0);
   bitmap.close();
@@ -158,13 +153,11 @@ function preprocessImage(imageData: ImageData): ProcessedImage {
   // to 1024x1024. No padding; just stretch the image to fill the input.
   const canvas = new OffscreenCanvas(SAM2_INPUT_SIZE, SAM2_INPUT_SIZE);
   const ctx = canvas.getContext("2d");
-  if (!ctx)
-    throw new Error("Failed to get 2d context");
+  if (!ctx) throw new Error("Failed to get 2d context");
 
   const tmp = new OffscreenCanvas(width, height);
   const tmpCtx = tmp.getContext("2d");
-  if (!tmpCtx)
-    throw new Error("Failed to get 2d context");
+  if (!tmpCtx) throw new Error("Failed to get 2d context");
   tmpCtx.putImageData(imageData, 0, 0);
   ctx.drawImage(tmp, 0, 0, SAM2_INPUT_SIZE, SAM2_INPUT_SIZE);
 
@@ -186,14 +179,16 @@ function preprocessImage(imageData: ImageData): ProcessedImage {
  * Posts progress and warning notifications back to the main thread during download.
  */
 async function loadModel(): Promise<void> {
-  const opts: ort.InferenceSession.SessionOptions = { executionProviders: ["wasm"] };
+  const opts: ort.InferenceSession.SessionOptions = {
+    executionProviders: ["wasm"],
+  };
 
   async function loadSession(
     family: string,
     file: string,
     cacheKey: string,
     name: "encoder" | "decoder",
-    failureKind: "encoder_failure" | "decoder_failure",
+    failureKind: "encoder_failure" | "decoder_failure"
   ): Promise<ort.InferenceSession> {
     let buf: ArrayBuffer;
     try {
@@ -201,28 +196,59 @@ async function loadModel(): Promise<void> {
       buf = await loadModelWeights(
         url,
         cacheKey,
-        (loaded, total) => postProgressNotification({ file: name, loaded, total }),
+        (loaded, total) =>
+          postProgressNotification({ file: name, loaded, total }),
         postWarningNotification
       );
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      postErrorNotification({ kind: "download_failure", message: `${name} download failed: ${msg}` });
+      postErrorNotification({
+        kind: "download_failure",
+        message: `${name} download failed: ${msg}`,
+      });
       throw err;
     }
     try {
       return await ort.InferenceSession.create(buf, opts);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      postErrorNotification({ kind: failureKind, message: `${name} init failed: ${msg}` });
+      postErrorNotification({
+        kind: failureKind,
+        message: `${name} init failed: ${msg}`,
+      });
       throw err;
     }
   }
 
   if (!encoderSession)
-    encoderSession = await loadSession(FAMILY, ENCODER_FILE, ENCODER_CACHE_KEY, "encoder", "encoder_failure");
+    encoderSession = await loadSession(
+      FAMILY,
+      ENCODER_FILE,
+      ENCODER_CACHE_KEY,
+      "encoder",
+      "encoder_failure"
+    );
 
   if (!decoderSession)
-    decoderSession = await loadSession(FAMILY, DECODER_FILE, DECODER_CACHE_KEY, "decoder", "decoder_failure");
+    decoderSession = await loadSession(
+      FAMILY,
+      DECODER_FILE,
+      DECODER_CACHE_KEY,
+      "decoder",
+      "decoder_failure"
+    );
+}
+
+/**
+ * Convert an already-decoded ImageBitmap to ImageData via OffscreenCanvas.
+ * Used for video frames that arrive over postMessage rather than by URL.
+ */
+function bitmapToImageData(bitmap: ImageBitmap): ImageData {
+  const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Failed to get 2d context");
+  ctx.drawImage(bitmap, 0, 0);
+  return ctx.getImageData(0, 0, canvas.width, canvas.height);
 }
 
 /**
@@ -236,8 +262,97 @@ async function embedAndDecode(
   imageUrl: string,
   points: PromptPoint[]
 ): Promise<InferenceResult> {
-  if (!encoderSession || !decoderSession)
-    throw new Error("Model not loaded");
+  const imageData = await loadImageData(imageUrl);
+  return embedAndDecodeFromImageData(
+    imageData,
+    CACHE_PREFIX + imageUrl,
+    points
+  );
+}
+
+/**
+ * SAM2 against an already-decoded frame bitmap. Mirrors {@link embedAndDecode}
+ * but keys the embedding cache on the caller-supplied `cacheKey` instead of a
+ * URL. Used by video propagation (see `videoPropagation.ts`).
+ */
+async function embedAndDecodeBitmap(
+  bitmap: ImageBitmap,
+  cacheKey: string,
+  points: PromptPoint[]
+): Promise<InferenceResult> {
+  const imageData = bitmapToImageData(bitmap);
+  return embedAndDecodeFromImageData(
+    imageData,
+    CACHE_PREFIX + cacheKey,
+    points
+  );
+}
+
+/**
+ * Encode-only path used to pre-encode upcoming frames. Runs the image
+ * encoder and writes the embedding to the per-frame cache; no decoder work,
+ * no result beyond void. A later {@link embedAndDecodeBitmap} with the same
+ * `cacheKey` then hits the cache and runs the decoder only.
+ */
+async function encodeBitmap(
+  bitmap: ImageBitmap,
+  cacheKey: string
+): Promise<void> {
+  if (!encoderSession) throw new Error("Model not loaded");
+
+  const fullKey = CACHE_PREFIX + cacheKey;
+
+  // Skip if already encoded (mem-LRU or IDB).
+  const cached = await getEmbedding(fullKey, postWarningNotification);
+  if (cached) return;
+
+  const imageData = bitmapToImageData(bitmap);
+  const processed = preprocessImage(imageData);
+
+  const encResults = await encoderSession.run({
+    image: new ort.Tensor("float32", processed.tensor, [
+      1,
+      3,
+      SAM2_INPUT_SIZE,
+      SAM2_INPUT_SIZE,
+    ]),
+  });
+
+  await putEmbedding(
+    fullKey,
+    {
+      imageEmbed: {
+        data: encResults["image_embed"].data as Float32Array,
+        dims: [...encResults["image_embed"].dims],
+      },
+      highResFeats0: {
+        data: encResults["high_res_feats_0"].data as Float32Array,
+        dims: [...encResults["high_res_feats_0"].dims],
+      },
+      highResFeats1: {
+        data: encResults["high_res_feats_1"].data as Float32Array,
+        dims: [...encResults["high_res_feats_1"].dims],
+      },
+      processedImage: {
+        originalWidth: processed.originalWidth,
+        originalHeight: processed.originalHeight,
+      },
+    },
+    postWarningNotification
+  );
+}
+
+/**
+ * Shared SAM2 core: encode (or reuse a cached embedding for `cacheKey`),
+ * decode against `points`, and postprocess to the best mask. `cacheKey` is
+ * the fully-qualified embedding-cache key (already `CACHE_PREFIX`-prefixed).
+ */
+async function embedAndDecodeFromImageData(
+  imageData: ImageData,
+  cacheKey: string,
+  points: PromptPoint[]
+): Promise<InferenceResult> {
+  if (!encoderSession || !decoderSession) throw new Error("Model not loaded");
 
   if (points.length === 0)
     throw new Error("At least one prompt point is required");
@@ -245,16 +360,27 @@ async function embedAndDecode(
   let encResults: Record<string, ort.Tensor>;
   let geometry: ImageGeometry;
 
-  const cacheKey = CACHE_PREFIX + imageUrl;
   const cached = await getEmbedding(cacheKey, postWarningNotification);
   let cacheHit = false;
 
   if (cached) {
     try {
       encResults = {
-        image_embed: new ort.Tensor("float32", cached.imageEmbed.data, cached.imageEmbed.dims),
-        high_res_feats_0: new ort.Tensor("float32", cached.highResFeats0.data, cached.highResFeats0.dims),
-        high_res_feats_1: new ort.Tensor("float32", cached.highResFeats1.data, cached.highResFeats1.dims),
+        image_embed: new ort.Tensor(
+          "float32",
+          cached.imageEmbed.data,
+          cached.imageEmbed.dims
+        ),
+        high_res_feats_0: new ort.Tensor(
+          "float32",
+          cached.highResFeats0.data,
+          cached.highResFeats0.dims
+        ),
+        high_res_feats_1: new ort.Tensor(
+          "float32",
+          cached.highResFeats1.data,
+          cached.highResFeats1.dims
+        ),
       };
       geometry = cached.processedImage;
       cacheHit = true;
@@ -265,27 +391,44 @@ async function embedAndDecode(
 
   if (!cacheHit) {
     postStatusNotification("encoding");
-    const imageData = await loadImageData(imageUrl);
     const processed = preprocessImage(imageData);
     geometry = processed;
 
     encResults = await encoderSession.run({
-      image: new ort.Tensor("float32", processed.tensor, [1, 3, SAM2_INPUT_SIZE, SAM2_INPUT_SIZE]),
+      image: new ort.Tensor("float32", processed.tensor, [
+        1,
+        3,
+        SAM2_INPUT_SIZE,
+        SAM2_INPUT_SIZE,
+      ]),
     });
 
     // Fire-and-forget: IDB write runs in background while decoder proceeds.
     // Memory LRU is updated synchronously inside putEmbedding before the first await.
-    putEmbedding(cacheKey, {
-      // Key names are defined by the ONNX model and must match exactly.
-      // Encode — input: "image"; outputs: "image_embed", "high_res_feats_0", "high_res_feats_1"
-      imageEmbed: { data: encResults["image_embed"].data as Float32Array, dims: [...encResults["image_embed"].dims] },
-      highResFeats0: { data: encResults["high_res_feats_0"].data as Float32Array, dims: [...encResults["high_res_feats_0"].dims] },
-      highResFeats1: { data: encResults["high_res_feats_1"].data as Float32Array, dims: [...encResults["high_res_feats_1"].dims] },
-      processedImage: {
-        originalWidth: geometry.originalWidth,
-        originalHeight: geometry.originalHeight,
+    putEmbedding(
+      cacheKey,
+      {
+        // Key names are defined by the ONNX model and must match exactly.
+        // Encode — input: "image"; outputs: "image_embed", "high_res_feats_0", "high_res_feats_1"
+        imageEmbed: {
+          data: encResults["image_embed"].data as Float32Array,
+          dims: [...encResults["image_embed"].dims],
+        },
+        highResFeats0: {
+          data: encResults["high_res_feats_0"].data as Float32Array,
+          dims: [...encResults["high_res_feats_0"].dims],
+        },
+        highResFeats1: {
+          data: encResults["high_res_feats_1"].data as Float32Array,
+          dims: [...encResults["high_res_feats_1"].dims],
+        },
+        processedImage: {
+          originalWidth: geometry.originalWidth,
+          originalHeight: geometry.originalHeight,
+        },
       },
-    }, postWarningNotification);
+      postWarningNotification
+    );
   }
 
   // Build decoder inputs
@@ -306,7 +449,11 @@ async function embedAndDecode(
     high_res_feats_1: encResults["high_res_feats_1"],
     point_coords: new ort.Tensor("float32", coords, [1, n, 2]),
     point_labels: new ort.Tensor("float32", labels, [1, n]),
-    mask_input: new ort.Tensor("float32", new Float32Array(SAM2_OUTPUT_SIZE * SAM2_OUTPUT_SIZE), [1, 1, SAM2_OUTPUT_SIZE, SAM2_OUTPUT_SIZE]),
+    mask_input: new ort.Tensor(
+      "float32",
+      new Float32Array(SAM2_OUTPUT_SIZE * SAM2_OUTPUT_SIZE),
+      [1, 1, SAM2_OUTPUT_SIZE, SAM2_OUTPUT_SIZE]
+    ),
     has_mask_input: new ort.Tensor("float32", new Float32Array([0]), [1]),
   });
 
@@ -317,19 +464,22 @@ async function embedAndDecode(
 
   let bestIdx = 0;
   for (let i = 1; i < ious.length; i++) {
-    if (ious[i] > ious[bestIdx])
-      bestIdx = i;
+    if (ious[i] > ious[bestIdx]) bestIdx = i;
   }
 
   const bestMask = masks.slice(bestIdx * sz, (bestIdx + 1) * sz);
   const bbox = computeMaskBbox(bestMask, geometry);
 
-  if (!bbox)
-    throw new Error("Model returned an empty mask");
+  if (!bbox) throw new Error("Model returned an empty mask");
 
   const finalMask = postprocessMask(bestMask, geometry, bbox);
 
-  return { mask: finalMask, maskWidth: bbox.w, maskHeight: bbox.h, bbox: normalizeBbox(bbox, geometry) };
+  return {
+    mask: finalMask,
+    maskWidth: bbox.w,
+    maskHeight: bbox.h,
+    bbox: normalizeBbox(bbox, geometry),
+  };
 }
 
 // Worker message handler
@@ -350,14 +500,32 @@ self.onmessage = async (e: MessageEvent) => {
     } else if (type === "embedAndDecode") {
       const result = await embedAndDecode(payload.imageUrl, payload.points);
       postStatusNotification("ready");
-      postResponse(id, "embedAndDecode", result, [result.mask.buffer as ArrayBuffer]);
+      postResponse(id, "embedAndDecode", result, [
+        result.mask.buffer as ArrayBuffer,
+      ]);
+    } else if (type === "embedAndDecodeBitmap") {
+      const result = await embedAndDecodeBitmap(
+        payload.bitmap,
+        payload.cacheKey,
+        payload.points
+      );
+      postStatusNotification("ready");
+      postResponse(id, "embedAndDecodeBitmap", result, [
+        result.mask.buffer as ArrayBuffer,
+      ]);
+    } else if (type === "encodeBitmap") {
+      await encodeBitmap(payload.bitmap, payload.cacheKey);
+      postResponse(id, "encodeBitmap", undefined as void);
     } else {
       postError(id, type, `Unknown message type: ${type}`);
     }
   } catch (err) {
-    if (type === "embedAndDecode") {
+    if (type === "embedAndDecode" || type === "embedAndDecodeBitmap") {
       postStatusNotification("failure");
-      postErrorNotification({ kind: "inference_failure", message: err instanceof Error ? err.message : String(err) });
+      postErrorNotification({
+        kind: "inference_failure",
+        message: err instanceof Error ? err.message : String(err),
+      });
     }
     postError(id, type, err instanceof Error ? err.message : String(err));
   }

--- a/app/packages/playback/src/views/TimelineTrack/TimelineTrack.tsx
+++ b/app/packages/playback/src/views/TimelineTrack/TimelineTrack.tsx
@@ -55,9 +55,11 @@ function normalizeEvent(e: TimelineTrackEvent): NormalizedEvent {
 /**
  * Drag mode for an in-progress interval edit. `move` shifts both start
  * and end by the same delta; `resize-start` / `resize-end` move only
- * one boundary.
+ * one boundary. Reported to {@link TimelineTrackProps.onEventEdit} so
+ * consumers can react differently per mode (e.g. extend vs. shift a
+ * tracked object).
  */
-type DragMode = "resize-start" | "resize-end" | "move";
+export type DragMode = "resize-start" | "resize-end" | "move";
 
 interface DragState {
   index: number;
@@ -113,8 +115,9 @@ export interface TimelineTrackProps {
   /**
    * Fires on pointer-up after a drag has crossed{@link DRAG_THRESHOLD_PX},
    * never during the drag itself. Receives the event's index in the
-   * {@link events} array and the final clamped + snapped `[start, end]`
-   * (seconds).
+   * {@link events} array, the final clamped + snapped `[start, end]`
+   * (seconds), and the {@link DragMode} that produced the edit (so a
+   * consumer can tell an edge extend/trim from a whole-bar move).
    *
    * Only events with `resizable: true` participate; without this prop
    * the resizable flag is a no-op and the bar renders as before.
@@ -122,7 +125,8 @@ export interface TimelineTrackProps {
   onEventEdit?: (
     eventIndex: number,
     newStartSec: number,
-    newEndSec: number
+    newEndSec: number,
+    mode: DragMode
   ) => void;
   /**
    * Snap step (seconds) for drag-driven edits. Typically `1 / fps`,
@@ -170,12 +174,17 @@ const TimelineTrack: React.FC<TimelineTrackProps> = ({
    * Local visual override applied while the user is dragging an
    * interval bar. `null` when not dragging; cleared on pointerup.
    * Render reads this so the bar tracks the cursor without committing
-   * anything until the user lets go.
+   * anything until the user lets go. `mode` + the original bounds let a
+   * `move` drag also offset the point events (e.g. keyframe diamonds)
+   * sitting inside the bar, so they stay attached to it during the drag.
    */
   const [dragOverride, setDragOverride] = useState<{
     index: number;
     startSec: number;
     endSec: number;
+    mode: DragMode;
+    origStartSec: number;
+    origEndSec: number;
   } | null>(null);
 
   /**
@@ -277,6 +286,9 @@ const TimelineTrack: React.FC<TimelineTrackProps> = ({
         index: drag.index,
         startSec: newStart,
         endSec: newEnd,
+        mode: drag.mode,
+        origStartSec: drag.origStart,
+        origEndSec: drag.origEnd,
       });
     };
 
@@ -294,7 +306,7 @@ const TimelineTrack: React.FC<TimelineTrackProps> = ({
         setTimeout(() => {
           justDraggedRef.current = false;
         }, 0);
-        onEventEdit(drag.index, drag.latestStart, drag.latestEnd);
+        onEventEdit(drag.index, drag.latestStart, drag.latestEnd, drag.mode);
       }
 
       setDragOverride(null);
@@ -311,6 +323,21 @@ const TimelineTrack: React.FC<TimelineTrackProps> = ({
   const barVisible = hasBackground && clippedStart < clippedEnd;
 
   const labelText = label ?? id;
+
+  // While moving an interval, point events (e.g. keyframe diamonds) that
+  // live inside the dragged bar's *original* span should travel with it.
+  // The bar follows the cursor via `dragOverride`; mirror the same offset
+  // onto those points so they stay attached until drag-end commits the
+  // shift. Resize drags don't move points (extend adds filler, trim
+  // deletes frames) — so this only applies to `move`.
+  const movePointShift =
+    dragOverride && dragOverride.mode === "move"
+      ? {
+          delta: dragOverride.startSec - dragOverride.origStartSec,
+          fromSec: dragOverride.origStartSec,
+          toSec: dragOverride.origEndSec,
+        }
+      : null;
 
   return (
     <div
@@ -557,11 +584,20 @@ const TimelineTrack: React.FC<TimelineTrackProps> = ({
                 </ContextMenu>
               );
             }
+            // Offset points inside the dragged bar's original span by the
+            // live move delta so they track the bar. `1e-6` absorbs float
+            // drift; original event/interval bounds are otherwise exact.
+            const pointSec =
+              movePointShift &&
+              event.startSec >= movePointShift.fromSec - 1e-6 &&
+              event.startSec <= movePointShift.toSec + 1e-6
+                ? event.startSec + movePointShift.delta
+                : event.startSec;
             return (
               <ContextMenu key={originalIndex} menu={menu}>
                 <div
                   className={styles.event}
-                  style={{ left: pct(event.startSec), background: color }}
+                  style={{ left: pct(pointSec), background: color }}
                   title={
                     event.label
                       ? `${event.label}  @ ${event.startSec.toFixed(3)}s`

--- a/app/packages/video-annotation/index.ts
+++ b/app/packages/video-annotation/index.ts
@@ -19,6 +19,12 @@ export { useVideoAnnotationStatus } from "./src/videoAnnotationStatus";
 export type { VideoAnnotationStatusContent } from "./src/videoAnnotationStatus";
 export { resolvePropagationTarget } from "./src/propagationTarget";
 export type { PropagationTarget } from "./src/propagationTarget";
+export { resolveTrackExtentEdit } from "./src/trackExtentEdit";
+export type {
+  ResolveTrackExtentEditInput,
+  TrackDragMode,
+  TrackExtentEdit,
+} from "./src/trackExtentEdit";
 export { VideoFrameLabelsStream } from "./src/VideoFrameLabelsStream";
 export type { LocalDetection } from "./src/VideoFrameLabelsStream";
 export { buildTemporalDetectionTracks } from "./src/temporalDetectionTracks";

--- a/app/packages/video-annotation/index.ts
+++ b/app/packages/video-annotation/index.ts
@@ -15,6 +15,11 @@ export {
 export { ImaVidImageStream } from "./src/ImaVidImageStream";
 export type { ImaVidImageFrame } from "./src/ImaVidImageStream";
 export { useFrameLabelsStream } from "./src/frameLabelsStream";
+export {
+  useImaVidImageStream,
+  usePublishImaVidImageStream,
+} from "./src/imaVidImageStreamHandle";
+export { PropagationStatusItem } from "./src/PropagationStatusItem";
 export { useVideoAnnotationStatus } from "./src/videoAnnotationStatus";
 export type { VideoAnnotationStatusContent } from "./src/videoAnnotationStatus";
 export { resolvePropagationTarget } from "./src/propagationTarget";

--- a/app/packages/video-annotation/src/FrameLabels.tsx
+++ b/app/packages/video-annotation/src/FrameLabels.tsx
@@ -33,8 +33,14 @@ import {
 } from "./frameLabelsStream";
 import { buildPerInstanceTracks, type PerInstanceLabel } from "./frameTracks";
 import { LABELS_STREAM_ID } from "./ids";
+import { resolveTrackExtentEdit } from "./trackExtentEdit";
 import { useLinkedTrackDecorator } from "./linkedTracks";
-import { EditTemporalDetectionSupportCommand } from "@fiftyone/annotation";
+import {
+  EditTemporalDetectionSupportCommand,
+  ExtendTrackCommand,
+  ShiftTrackCommand,
+  TrimTrackCommand,
+} from "@fiftyone/annotation";
 import { useCommandBus } from "@fiftyone/command-bus";
 import {
   applyTemporalDetectionEdits,
@@ -317,13 +323,90 @@ export const FrameLabelsTracks: React.FC<{ sample?: ModalSample }> = ({
   const decorateTrack = useCallback(
     (track: Track) => {
       const base = linkDecorate(track);
+      if (!fps) {
+        return base;
+      }
+
       const tdEvent = track.events[0]?.data as
         | TemporalDetectionEventData
         | undefined;
       const isTemporalDetection =
         track.id.startsWith("td-") && tdEvent !== undefined;
 
-      if (!isTemporalDetection || !fps) {
+      // Object tracks: drag a presence bar to extend / trim /
+      // shift the track's per-frame labels. Identified by the synthetic
+      // overlay-id prefixes `extractDetections` emits.
+      const isObjectTrack =
+        track.id.startsWith("instance-") || track.id.startsWith("track-");
+
+      if (isObjectTrack && stream) {
+        const totalFrames = stream.totalFrames;
+
+        return {
+          ...base,
+          snapStepSec,
+          onEventEdit: (
+            eventIndex: number,
+            newStartSec: number,
+            newEndSec: number,
+            mode: "resize-start" | "resize-end" | "move"
+          ) => {
+            const dragged = track.events[eventIndex];
+            if (!dragged || dragged.endSec === undefined) {
+              return;
+            }
+
+            // Other presence bars of this same track — used to clamp a
+            // move so it can't overrun a neighbouring segment.
+            const neighborSegments = track.events
+              .filter((e, i) => i !== eventIndex && e.endSec !== undefined)
+              .map(
+                (e) =>
+                  [
+                    Math.round(e.startSec * fps) + 1,
+                    Math.round((e.endSec as number) * fps),
+                  ] as const
+              );
+
+            const edit = resolveTrackExtentEdit({
+              mode,
+              origStartSec: dragged.startSec,
+              origEndSec: dragged.endSec,
+              newStartSec,
+              newEndSec,
+              fps,
+              totalFrames,
+              neighborSegments,
+            });
+
+            switch (edit.op) {
+              case "extend":
+                void commandBus.execute(
+                  new ExtendTrackCommand(
+                    track.id,
+                    edit.sourceFrame,
+                    edit.targetFrames
+                  )
+                );
+                break;
+              case "trim":
+                void commandBus.execute(
+                  new TrimTrackCommand(track.id, edit.frames)
+                );
+                break;
+              case "shift":
+                void commandBus.execute(
+                  new ShiftTrackCommand(track.id, edit.frames, edit.delta)
+                );
+                break;
+              default:
+                break;
+            }
+          },
+        };
+      }
+
+      if (!isTemporalDetection) {
         return base;
       }
 
@@ -357,7 +440,7 @@ export const FrameLabelsTracks: React.FC<{ sample?: ModalSample }> = ({
         },
       };
     },
-    [linkDecorate, fps, snapStepSec, commandBus]
+    [linkDecorate, fps, snapStepSec, commandBus, stream]
   );
 
   return (

--- a/app/packages/video-annotation/src/PropagationStatusItem.tsx
+++ b/app/packages/video-annotation/src/PropagationStatusItem.tsx
@@ -1,0 +1,56 @@
+import {
+  Align,
+  Button,
+  Orientation,
+  Size,
+  Spacing,
+  Spinner,
+  Stack,
+  Text,
+  TextColor,
+  TextVariant,
+  Variant,
+} from "@voxel51/voodo";
+import React from "react";
+
+/**
+ * Right-hand top-bar status content for an in-flight propagation run. Drive
+ * it through {@link useVideoAnnotationStatus}'s `setContent`: re-set on each
+ * progress tick and clear (`null`) on completion. The `done`/`total` count
+ * is shown only when both are provided — omit them for indeterminate phases
+ * (e.g. one-time model download). `onStop`, when provided, renders a Stop
+ * button — propagation polls the same flag via `shouldAbort`.
+ *
+ * @example
+ * setContent(<PropagationStatusItem label="Loading SAM2…" onStop={stop} />);
+ * setContent(<PropagationStatusItem label="SAM2 tracking" done={n} total={t} onStop={stop} />);
+ */
+export const PropagationStatusItem: React.FC<{
+  label: string;
+  done?: number;
+  total?: number;
+  onStop?: () => void;
+}> = ({ label, done, total, onStop }) => {
+  const text =
+    typeof done === "number" && typeof total === "number"
+      ? `${label} ${done}/${total}`
+      : label;
+
+  return (
+    <Stack
+      orientation={Orientation.Row}
+      align={Align.Center}
+      spacing={Spacing.Sm}
+    >
+      <Spinner size={Size.Sm} />
+      <Text variant={TextVariant.Sm} color={TextColor.Secondary}>
+        {text}
+      </Text>
+      {onStop && (
+        <Button variant={Variant.Secondary} size={Size.Sm} onClick={onStop}>
+          Stop
+        </Button>
+      )}
+    </Stack>
+  );
+};

--- a/app/packages/video-annotation/src/RegisterImaVidImage.tsx
+++ b/app/packages/video-annotation/src/RegisterImaVidImage.tsx
@@ -12,6 +12,7 @@ import { usePlayback } from "../../playback/src/lib/playback/PlaybackProvider";
 import { usePlaybackStream } from "../../playback/src/lib/playback/use-playback-stream";
 import { IMAVID_STREAM_ID } from "./ids";
 import { ImaVidImageStream } from "./ImaVidImageStream";
+import { usePublishImaVidImageStream } from "./imaVidImageStreamHandle";
 
 /**
  * Construct and register `ImaVidImageStream` as soon as the sample's
@@ -147,6 +148,10 @@ const ImaVidImageRegistration: React.FC<ImaVidImageRegistrationProps> = ({
   }, []);
 
   usePlaybackStream(streamRef.current);
+
+  // Publish the stream instance so off-tile consumers
+  // can pull arbitrary frame bitmaps by index via warmup/getValue.
+  usePublishImaVidImageStream(streamRef.current);
 
   // Pre-warm the first chunk and seek to t=0 so the first paint isn't
   // a blank tile waiting on the network + decode.

--- a/app/packages/video-annotation/src/SyntheticLabelStream.ts
+++ b/app/packages/video-annotation/src/SyntheticLabelStream.ts
@@ -3,7 +3,7 @@ import { PlaybackStreamBase } from "../../playback/src/lib/playback/stream-base"
 /** ObjectId hex string. */
 export type ObjectIdHex = string;
 
-export type PropagationMethod = "linear";
+export type PropagationMethod = "linear" | "sam2";
 
 /** Provenance written on labels created by a propagation run. */
 export interface PropagationBlob {

--- a/app/packages/video-annotation/src/frameTracks.ts
+++ b/app/packages/video-annotation/src/frameTracks.ts
@@ -189,11 +189,17 @@ export function buildPerInstanceTracks({
     }
 
     const events: TrackEvent[] = [
-      ...state.intervals.map(({ start, end }) => ({
-        startSec: start,
-        endSec: end,
-        label: "in frame",
-      })),
+      // `resizable: true` opts each presence bar into in-place edit —
+      // drag handles to extend/trim the track, drag the body to shift it
+      // Inert without an `onEventEdit`, so non-object timelines are unaffected.
+      ...state.intervals.map(
+        ({ start, end }): TrackEvent & { resizable: true } => ({
+          startSec: start,
+          endSec: end,
+          label: "in frame",
+          resizable: true,
+        })
+      ),
       // Point events for each keyframe — render as diamond markers on top
       // of the presence bar via `TimelineTrack`'s no-`endSec` branch.
       ...state.keyframeTimes.map((startSec) => ({

--- a/app/packages/video-annotation/src/imaVidImageStreamHandle.ts
+++ b/app/packages/video-annotation/src/imaVidImageStreamHandle.ts
@@ -1,0 +1,37 @@
+import { atom, useAtomValue, useSetAtom } from "jotai";
+import { useEffect } from "react";
+import type { ImaVidImageStream } from "./ImaVidImageStream";
+
+/**
+ * Active ImaVid image stream (decoded per-frame bitmaps). Published so
+ * consumers outside the tile — e.g. SAM2 video propagation, which needs to
+ * pull arbitrary frame bitmaps by index — can reach the stream instance to
+ * call `warmup` / `getValue`.
+ *
+ * Mirrors {@link useFrameLabelsStream}: publication goes through
+ * {@link usePublishImaVidImageStream} so external code can't write arbitrary
+ * values; `null` until the imavid registrar mounts (e.g. the native-video
+ * surface, which has no image stream).
+ */
+const imaVidImageStreamAtom = atom<ImaVidImageStream | null>(null);
+
+export function useImaVidImageStream(): ImaVidImageStream | null {
+  return useAtomValue(imaVidImageStreamAtom);
+}
+
+/**
+ * Publishes `stream` as the active ImaVid image stream for the lifetime of
+ * the calling component, clearing on unmount. Intended for the imavid image
+ * registrar; nothing else should be publishing.
+ */
+export function usePublishImaVidImageStream(
+  stream: ImaVidImageStream | null
+): void {
+  const setStream = useSetAtom(imaVidImageStreamAtom);
+
+  useEffect(() => {
+    setStream(stream);
+
+    return () => setStream(null);
+  }, [setStream, stream]);
+}

--- a/app/packages/video-annotation/src/trackExtentEdit.test.ts
+++ b/app/packages/video-annotation/src/trackExtentEdit.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveTrackExtentEdit,
+  type ResolveTrackExtentEditInput,
+} from "./trackExtentEdit";
+
+const FPS = 30;
+
+// A segment covering frames [11, 31] inclusive:
+//   startSec = (11 - 1) / 30, endSec = 31 / 30.
+const SEG_FIRST = 11;
+const SEG_LAST = 31;
+const origStartSec = (SEG_FIRST - 1) / FPS;
+const origEndSec = SEG_LAST / FPS;
+
+const base = (
+  over: Partial<ResolveTrackExtentEditInput>
+): ResolveTrackExtentEditInput => ({
+  mode: "resize-end",
+  origStartSec,
+  origEndSec,
+  newStartSec: origStartSec,
+  newEndSec: origEndSec,
+  fps: FPS,
+  totalFrames: 120,
+  ...over,
+});
+
+// Convert a frame to the end-second its bar edge would sit at.
+const endSecOf = (frame: number) => frame / FPS;
+// Convert a frame to the start-second its bar edge would sit at.
+const startSecOf = (frame: number) => (frame - 1) / FPS;
+
+describe("resolveTrackExtentEdit", () => {
+  it("returns none for degenerate fps", () => {
+    expect(resolveTrackExtentEdit(base({ fps: 0 })).op).toBe("none");
+  });
+
+  it("returns none when the drag snaps back to the original extent", () => {
+    expect(resolveTrackExtentEdit(base({ mode: "resize-end" })).op).toBe(
+      "none"
+    );
+    expect(resolveTrackExtentEdit(base({ mode: "resize-start" })).op).toBe(
+      "none"
+    );
+    expect(resolveTrackExtentEdit(base({ mode: "move" })).op).toBe("none");
+  });
+
+  describe("resize-end", () => {
+    it("extends forward, copying the last frame onto the grown frames", () => {
+      const edit = resolveTrackExtentEdit(
+        base({ mode: "resize-end", newEndSec: endSecOf(45) })
+      );
+      expect(edit).toEqual({
+        op: "extend",
+        sourceFrame: SEG_LAST,
+        targetFrames: [32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45],
+      });
+    });
+
+    it("clamps growth to totalFrames", () => {
+      const edit = resolveTrackExtentEdit(
+        base({ mode: "resize-end", newEndSec: endSecOf(200), totalFrames: 40 })
+      );
+      expect(edit).toEqual({
+        op: "extend",
+        sourceFrame: SEG_LAST,
+        targetFrames: [32, 33, 34, 35, 36, 37, 38, 39, 40],
+      });
+    });
+
+    it("trims from the end when dragged inward", () => {
+      const edit = resolveTrackExtentEdit(
+        base({ mode: "resize-end", newEndSec: endSecOf(28) })
+      );
+      expect(edit).toEqual({ op: "trim", frames: [29, 30, 31] });
+    });
+  });
+
+  describe("resize-start", () => {
+    it("extends backward, copying the first frame onto the grown frames", () => {
+      const edit = resolveTrackExtentEdit(
+        base({ mode: "resize-start", newStartSec: startSecOf(8) })
+      );
+      expect(edit).toEqual({
+        op: "extend",
+        sourceFrame: SEG_FIRST,
+        targetFrames: [8, 9, 10],
+      });
+    });
+
+    it("clamps backward growth to frame 1", () => {
+      const edit = resolveTrackExtentEdit(
+        base({ mode: "resize-start", newStartSec: startSecOf(-5) })
+      );
+      expect(edit).toEqual({
+        op: "extend",
+        sourceFrame: SEG_FIRST,
+        targetFrames: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      });
+    });
+
+    it("trims from the start when dragged inward", () => {
+      const edit = resolveTrackExtentEdit(
+        base({ mode: "resize-start", newStartSec: startSecOf(14) })
+      );
+      expect(edit).toEqual({ op: "trim", frames: [11, 12, 13] });
+    });
+  });
+
+  describe("move", () => {
+    it("shifts the whole segment by the dragged delta", () => {
+      const edit = resolveTrackExtentEdit(
+        base({ mode: "move", newStartSec: startSecOf(SEG_FIRST + 1) })
+      );
+      expect(edit).toEqual({
+        op: "shift",
+        frames: Array.from({ length: 21 }, (_, i) => SEG_FIRST + i),
+        delta: 1,
+      });
+    });
+
+    it("clamps a backward shift to the clip start", () => {
+      const edit = resolveTrackExtentEdit(
+        base({ mode: "move", newStartSec: startSecOf(1) })
+      );
+      // first is 11, so the most it can move left is -10.
+      expect(edit).toMatchObject({ op: "shift", delta: -10 });
+    });
+
+    it("clamps a forward shift so it can't overrun a right neighbour", () => {
+      const edit = resolveTrackExtentEdit(
+        base({
+          mode: "move",
+          newStartSec: startSecOf(SEG_FIRST + 20),
+          // Neighbour occupies [40, 50]; segment end is 31, so the bar
+          // can move forward at most to end at 39 → delta +8.
+          neighborSegments: [[40, 50]],
+        })
+      );
+      expect(edit).toMatchObject({ op: "shift", delta: 8 });
+    });
+  });
+});

--- a/app/packages/video-annotation/src/trackExtentEdit.ts
+++ b/app/packages/video-annotation/src/trackExtentEdit.ts
@@ -1,0 +1,165 @@
+/**
+ * Pure translation from a timeline interval drag on an object
+ * track into the per-frame edit it implies. Kept free of React / stream
+ * dependencies so it can be unit-tested directly; the command handlers in
+ * `@fiftyone/annotation` carry out the resulting frame writes.
+ *
+ * Frame ↔ seconds mapping mirrors the one `buildPerInstanceTracks` uses in
+ * the forward direction (`startSec = (firstFrame - 1) / fps`,
+ * `endSec = lastFrame / fps`), inverted here.
+ */
+
+/** Drag mode reported by `TimelineTrack`'s `onEventEdit`. */
+export type TrackDragMode = "resize-start" | "resize-end" | "move";
+
+/**
+ * Resolved per-frame edit for a track drag.
+ * - `extend` — copy `sourceFrame`'s box onto each of `targetFrames` (the
+ *   grown frames) as non-keyframe filler.
+ * - `trim` — delete the track's detection on each of `frames` (the frames
+ *   the drag pulled the edge past).
+ * - `shift` — move the track's detection on each of `frames` by `delta`
+ *   frames (rigid shift of the dragged segment).
+ * - `none` — the drag resolved to no frame-level change.
+ */
+export type TrackExtentEdit =
+  | { op: "extend"; sourceFrame: number; targetFrames: number[] }
+  | { op: "trim"; frames: number[] }
+  | { op: "shift"; frames: number[]; delta: number }
+  | { op: "none" };
+
+export interface ResolveTrackExtentEditInput {
+  mode: TrackDragMode;
+  /** Dragged segment's original bounds in seconds (the event's start/end). */
+  origStartSec: number;
+  origEndSec: number;
+  /** Post-drag bounds in seconds (already snapped to frames by the track). */
+  newStartSec: number;
+  newEndSec: number;
+  fps: number;
+  /** 1-indexed inclusive clip length. Grown/shifted frames clamp to this. */
+  totalFrames: number;
+  /**
+   * Other presence segments of the same track (the in-frame intervals
+   * other than the dragged one), as `[firstFrame, lastFrame]` pairs. A
+   * `move` is clamped so it can't overrun a neighbouring segment.
+   */
+  neighborSegments?: ReadonlyArray<readonly [number, number]>;
+}
+
+const firstFrameOf = (sec: number, fps: number): number =>
+  Math.round(sec * fps) + 1;
+
+const lastFrameOf = (sec: number, fps: number): number => Math.round(sec * fps);
+
+const inclusiveRange = (from: number, to: number): number[] => {
+  const out: number[] = [];
+  for (let f = from; f <= to; f++) out.push(f);
+  return out;
+};
+
+/**
+ * Clamp a `move` delta so the shifted block `[first, last]` stays within
+ * `[1, totalFrames]` and never overlaps a neighbouring segment of the same
+ * track.
+ */
+const clampShift = (
+  delta: number,
+  first: number,
+  last: number,
+  totalFrames: number,
+  neighbors: ReadonlyArray<readonly [number, number]>
+): number => {
+  let lo = 1 - first; // first + delta >= 1
+  let hi = totalFrames - last; // last + delta <= totalFrames
+
+  for (const [nFirst, nLast] of neighbors) {
+    if (nLast < first) {
+      // Neighbour sits to the left: keep first + delta strictly past it.
+      lo = Math.max(lo, nLast + 1 - first);
+    } else if (nFirst > last) {
+      // Neighbour sits to the right: keep last + delta strictly before it.
+      hi = Math.min(hi, nFirst - 1 - last);
+    }
+  }
+
+  return Math.max(lo, Math.min(hi, delta));
+};
+
+/**
+ * Translate an interval drag into the per-frame edit it implies. Returns
+ * `{ op: "none" }` for degenerate input (bad fps, zero-width segment) and
+ * for drags that snapped back to the original extent.
+ */
+export function resolveTrackExtentEdit(
+  input: ResolveTrackExtentEditInput
+): TrackExtentEdit {
+  const { mode, fps, totalFrames } = input;
+  if (!Number.isFinite(fps) || fps <= 0) {
+    return { op: "none" };
+  }
+
+  const origFirst = firstFrameOf(input.origStartSec, fps);
+  const origLast = lastFrameOf(input.origEndSec, fps);
+
+  if (origLast < origFirst) {
+    return { op: "none" };
+  }
+
+  if (mode === "resize-end") {
+    const newLast = Math.min(
+      Math.max(lastFrameOf(input.newEndSec, fps), origFirst),
+      totalFrames
+    );
+
+    if (newLast > origLast) {
+      return {
+        op: "extend",
+        sourceFrame: origLast,
+        targetFrames: inclusiveRange(origLast + 1, newLast),
+      };
+    }
+
+    if (newLast < origLast) {
+      return { op: "trim", frames: inclusiveRange(newLast + 1, origLast) };
+    }
+
+    return { op: "none" };
+  }
+
+  if (mode === "resize-start") {
+    const newFirst = Math.max(
+      Math.min(firstFrameOf(input.newStartSec, fps), origLast),
+      1
+    );
+
+    if (newFirst < origFirst) {
+      return {
+        op: "extend",
+        sourceFrame: origFirst,
+        targetFrames: inclusiveRange(newFirst, origFirst - 1),
+      };
+    }
+
+    if (newFirst > origFirst) {
+      return { op: "trim", frames: inclusiveRange(origFirst, newFirst - 1) };
+    }
+
+    return { op: "none" };
+  }
+
+  // move
+  const delta = clampShift(
+    firstFrameOf(input.newStartSec, fps) - origFirst,
+    origFirst,
+    origLast,
+    totalFrames,
+    input.neighborSegments ?? []
+  );
+
+  if (delta === 0) {
+    return { op: "none" };
+  }
+
+  return { op: "shift", frames: inclusiveRange(origFirst, origLast), delta };
+}

--- a/app/packages/video-annotation/src/useVideoAnnotationActions.tsx
+++ b/app/packages/video-annotation/src/useVideoAnnotationActions.tsx
@@ -68,7 +68,7 @@ export const useVideoAnnotationActions = (): ToolbarActionGroup[] => {
           {
             id: "propagate",
             label: "Propagate",
-            icon: <Icon name={IconName.AI} size={Size.Sm} />,
+            icon: <Icon name={IconName.ContentCopy} size={Size.Sm} />,
             shortcut: "-",
             tooltip: target.ok
               ? `Interpolate frames ${target.fromFrame}–${target.toFrame}`
@@ -89,6 +89,26 @@ export const useVideoAnnotationActions = (): ToolbarActionGroup[] => {
                   target.fromFrame,
                   target.toFrame,
                   "linear"
+                )
+              );
+            },
+          },
+          {
+            id: "propagate-sam2",
+            label: "Track (SAM2)",
+            icon: <Icon name={IconName.AI} size={Size.Sm} />,
+            tooltip: target.ok
+              ? `Track frames ${target.fromFrame}–${target.toFrame} with SAM2`
+              : target.reason,
+            isDisabled: !target.ok,
+            onClick: () => {
+              if (!target.ok) return;
+              void bus.execute(
+                new PropagateCommand(
+                  target.instanceId,
+                  target.fromFrame,
+                  target.toFrame,
+                  "sam2"
                 )
               );
             },


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

Adds SAM2-based tracking and drag-to-edit object timeline tracks.

- **SAM2 tracking** — a "Track (SAM2)" toolbar action tracks a selected instance between its two bracketing keyframes by re-running SAM2 per frame. Frames are sourced directly from the in-memory image stream (no `<video>` element and no re-decode). Includes the inference path on frame bitmaps, a browser video-propagation engine, and a propagation agent, with a per-frame status indicator and a Stop control. Seed strategy defaults to centroid-5.
- **Drag-to-edit tracks** — object presence bars on the timeline can be dragged to extend, trim, or move:
  - *Extend* copies the endpoint box across the grown frames as non-keyframe filler.
  - *Trim* deletes the detections on the uncovered frames.
  - *Move* applies a rigid per-segment frame shift, clamped at clip bounds and against neighbouring segments of the same track.

  A pure resolver maps the drag gesture to the right operation and is unit-tested.

Stacked on #7666.

## 🧪 How is this patch tested? If it is not, please explain why.

Unit tests for the propagation engine and the drag-to-edit resolver; tested locally in the app.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
