### PR TITLE
Video annotation: timeline + media UX refinements

### DIFF
--- a/app/packages/annotation/src/persistence/useVideoLabelsDeltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/useVideoLabelsDeltaSupplier.ts
@@ -1,9 +1,116 @@
 import type { JSONDeltas } from "@fiftyone/core/src/client";
 import { generateJsonPatch } from "@fiftyone/core/src/utils/json";
 import { useIsVideo } from "@fiftyone/state";
-import { useFrameLabelsStream } from "@fiftyone/video-annotation";
+import {
+  useFrameLabelsStream,
+  type RawDetection,
+  type RawDetectionsField,
+} from "@fiftyone/video-annotation";
 import { useCallback } from "react";
 import type { DeltaSupplier } from "./deltaSupplier";
+
+/** Detection paired with its array-slot index for path-building. */
+interface DetInfo {
+  id: string;
+  det: RawDetection;
+  index: number;
+}
+
+/** Index a detections list by `_id`. Entries lacking `_id` are skipped. */
+const indexById = (list: RawDetection[]): Map<string, DetInfo> => {
+  const map = new Map<string, DetInfo>();
+  list.forEach((det, index) => {
+    if (det._id !== undefined) map.set(det._id, { id: det._id, det, index });
+  });
+  return map;
+};
+
+/** Per-field replaces for `_id`s present in both sides. */
+const updateOps = (
+  baseById: Map<string, DetInfo>,
+  cacheById: Map<string, DetInfo>,
+  pathPrefix: string
+): JSONDeltas => {
+  const ops: JSONDeltas = [];
+  baseById.forEach(({ id, det: baseDet, index }) => {
+    const cache = cacheById.get(id);
+    if (!cache) return;
+    const sub = generateJsonPatch(
+      baseDet as unknown as Record<string, unknown>,
+      cache.det as unknown as Record<string, unknown>
+    );
+    sub.forEach((op) =>
+      ops.push({ ...op, path: `${pathPrefix}/detections/${index}${op.path}` })
+    );
+  });
+  return ops;
+};
+
+/**
+ * Removes for `_id`s in baseline but not cache. Descending index so an
+ * earlier remove doesn't shift later indices it would have referenced.
+ */
+const removeOps = (
+  baseById: Map<string, DetInfo>,
+  cacheById: Map<string, DetInfo>,
+  pathPrefix: string
+): JSONDeltas =>
+  Array.from(baseById.values())
+    .filter((info) => !cacheById.has(info.id))
+    .sort((a, b) => b.index - a.index)
+    .map(({ index }) => ({
+      op: "remove" as const,
+      path: `${pathPrefix}/detections/${index}`,
+    }));
+
+/** Adds for `_id`s in cache but not baseline. Appended with `/-`. */
+const addOps = (
+  baseById: Map<string, DetInfo>,
+  cacheById: Map<string, DetInfo>,
+  pathPrefix: string
+): JSONDeltas => {
+  const ops: JSONDeltas = [];
+  cacheById.forEach(({ id, det }) => {
+    if (baseById.has(id)) return;
+    ops.push({
+      op: "add" as const,
+      path: `${pathPrefix}/detections/-`,
+      value: det,
+    });
+  });
+  return ops;
+};
+
+/**
+ * Build a JSON-Patch delta for one frame's detections wrapper, aligning
+ * baseline ↔ cache by `_id` instead of by array index.
+ *
+ * `fast-json-patch.compare` aligns arrays by index, so a shifted detections
+ * list (e.g. `ShiftTrackCommand` removes a slot, every later slot slides
+ * down) makes each subsequent slot look "different" and emits a flood of
+ * unappliable per-slot replaces. The id-aligned diff sidesteps that — and
+ * stays safe when the server has detections the cache doesn't know about,
+ * since `_id`s the FE never saw aren't touched.
+ *
+ * Special case: baseline missing the inner array → one `add` of the whole
+ * wrapper, since detection-level paths don't resolve without it.
+ */
+const buildDetectionsDelta = (
+  from: RawDetectionsField,
+  to: RawDetectionsField,
+  pathPrefix: string
+): JSONDeltas => {
+  if (from.detections === undefined) {
+    return [{ op: "add", path: pathPrefix, value: to }];
+  }
+  const baseById = indexById(from.detections);
+  const cacheById = indexById(to.detections ?? []);
+  return [
+    ...updateOps(baseById, cacheById, pathPrefix),
+    ...removeOps(baseById, cacheById, pathPrefix),
+    ...addOps(baseById, cacheById, pathPrefix),
+  ];
+};
 
 /**
  * Provides a {@link DeltaSupplier} for per-frame label edits made through the
@@ -28,16 +135,14 @@ export const useVideoLabelsDeltaSupplier = (): DeltaSupplier => {
     const snapshots = stream.getDirtyFrameSnapshots();
     const deltas: JSONDeltas = [];
 
-    for (const { frameNumber, baseline, cache } of snapshots) {
-      const from = (baseline[frameField] ?? {}) as Record<string, unknown>;
-      const to = (cache[frameField] ?? {}) as Record<string, unknown>;
-      const subDeltas = generateJsonPatch(from, to);
+    snapshots.forEach(({ frameNumber, baseline, cache }) => {
+      const from = (baseline[frameField] ?? {}) as RawDetectionsField;
+      const to = (cache[frameField] ?? {}) as RawDetectionsField;
       const pathPrefix = `/frames/${frameNumber}/${frameField}`;
-
-      for (const op of subDeltas) {
-        deltas.push({ ...op, path: `${pathPrefix}${op.path}` });
-      }
-    }
+      buildDetectionsDelta(from, to, pathPrefix).forEach((op) =>
+        deltas.push(op)
+      );
+    });
 
     // Stash the cache refs we just translated. The persistence event
     // handler advances baseline on success (clearing dirty) or discards

--- a/app/packages/playback/src/lib/playback/PlaybackProvider.test.tsx
+++ b/app/packages/playback/src/lib/playback/PlaybackProvider.test.tsx
@@ -24,10 +24,16 @@ interface RenderOpts {
   duration?: number;
   defaultLoopStart?: number;
   defaultLoopEnd?: number;
+  snapToFrameOnSettle?: boolean;
 }
 
 function renderEngine(opts: RenderOpts = {}) {
-  const { duration = 10, defaultLoopStart, defaultLoopEnd } = opts;
+  const {
+    duration = 10,
+    defaultLoopStart,
+    defaultLoopEnd,
+    snapToFrameOnSettle,
+  } = opts;
   return renderHook(
     () => {
       const store = usePlaybackStore();
@@ -49,6 +55,7 @@ function renderEngine(opts: RenderOpts = {}) {
           stepInterval={1 / 30}
           defaultLoopStart={defaultLoopStart}
           defaultLoopEnd={defaultLoopEnd}
+          snapToFrameOnSettle={snapToFrameOnSettle}
         >
           {children}
         </PlaybackProvider>
@@ -219,6 +226,51 @@ describe("PlaybackProvider engine actions", () => {
       act(() => result.current.api.seek(5));
       act(() => result.current.api.play());
       expect(result.current.playhead).toBe(5);
+    });
+  });
+
+  describe("snapToFrameOnSettle", () => {
+    // stepInterval = 1/30; frame K starts at K/30. 0.52s sits inside frame 15
+    // ([0.5, 0.5333)), so the displayed-frame start is 0.5.
+    const MID_FRAME = 0.52;
+    const FRAME_START = 0.5;
+
+    it("pause snaps the playhead to the displayed frame start when enabled", () => {
+      const { result } = renderEngine({ snapToFrameOnSettle: true });
+      act(() => result.current.api.seek(MID_FRAME));
+      expect(result.current.playhead).toBe(MID_FRAME);
+      act(() => result.current.api.pause());
+      expect(result.current.playhead).toBeCloseTo(FRAME_START, 5);
+      // The committed time follows so per-frame consumers re-read the frame.
+      expect(result.current.currentTime).toBeCloseTo(FRAME_START, 5);
+    });
+
+    it("pause leaves a mid-frame playhead untouched when disabled (continuous)", () => {
+      const { result } = renderEngine();
+      act(() => result.current.api.seek(MID_FRAME));
+      act(() => result.current.api.pause());
+      expect(result.current.playhead).toBe(MID_FRAME);
+    });
+
+    it("snapPlayheadToFrame is a no-op when disabled", () => {
+      const { result } = renderEngine();
+      act(() => result.current.api.seek(MID_FRAME));
+      act(() => result.current.api.snapPlayheadToFrame());
+      expect(result.current.playhead).toBe(MID_FRAME);
+    });
+
+    it("snapPlayheadToFrame aligns the playhead when enabled", () => {
+      const { result } = renderEngine({ snapToFrameOnSettle: true });
+      act(() => result.current.api.seek(MID_FRAME));
+      act(() => result.current.api.snapPlayheadToFrame());
+      expect(result.current.playhead).toBeCloseTo(FRAME_START, 5);
+    });
+
+    it("leaves an already-aligned playhead exactly in place (no drift)", () => {
+      const { result } = renderEngine({ snapToFrameOnSettle: true });
+      act(() => result.current.api.seek(FRAME_START));
+      act(() => result.current.api.pause());
+      expect(result.current.playhead).toBe(FRAME_START);
     });
   });
 

--- a/app/packages/playback/src/lib/playback/PlaybackProvider.test.tsx
+++ b/app/packages/playback/src/lib/playback/PlaybackProvider.test.tsx
@@ -148,6 +148,92 @@ describe("PlaybackProvider engine actions", () => {
     });
   });
 
+  describe("paused settle loop", () => {
+    // Drive requestAnimationFrame manually so the settle loop is
+    // deterministic. flushFrame() runs whatever the engine has queued.
+    function withManualRaf(body: (flushFrame: () => void) => void): void {
+      const queue: FrameRequestCallback[] = [];
+      const rafSpy = vi
+        .spyOn(globalThis, "requestAnimationFrame")
+        .mockImplementation((cb) => {
+          queue.push(cb);
+          return queue.length;
+        });
+      const cafSpy = vi
+        .spyOn(globalThis, "cancelAnimationFrame")
+        .mockImplementation(() => {});
+      const flushFrame = () => {
+        const cbs = queue.splice(0, queue.length);
+        act(() => cbs.forEach((cb) => cb(0)));
+      };
+      try {
+        body(flushFrame);
+      } finally {
+        rafSpy.mockRestore();
+        cafSpy.mockRestore();
+      }
+    }
+
+    it("commits a paused seek once a buffering stream becomes ready (no play needed)", () => {
+      withManualRaf((flushFrame) => {
+        const { result } = renderEngine({ duration: 10 });
+        let state: "missing" | "ready" = "missing";
+        act(() => {
+          result.current.api.registerStream({
+            id: "cam",
+            blocking: true,
+            bufferState: () => state,
+            prefetch: () => {},
+          });
+          result.current.api.subscribeStream("cam");
+        });
+
+        // Seek into an unbuffered region while paused: playhead moves, but
+        // the frame can't commit yet.
+        act(() => result.current.api.seek(4));
+        expect(result.current.playhead).toBe(4);
+        expect(result.current.currentTime).toBe(0);
+        expect(result.current.isPlaying).toBe(false);
+
+        // Settle loop keeps polling while the stream is still missing.
+        flushFrame();
+        expect(result.current.currentTime).toBe(0);
+
+        // Stream finishes buffering → the next settle frame commits,
+        // without the user ever hitting play.
+        state = "ready";
+        flushFrame();
+        expect(result.current.currentTime).toBe(4);
+      });
+    });
+
+    it("prefetch-nudges the buffering stream while paused", () => {
+      withManualRaf((flushFrame) => {
+        const { result } = renderEngine({ duration: 10 });
+        const prefetch = vi.fn();
+        act(() => {
+          result.current.api.registerStream({
+            id: "cam",
+            blocking: true,
+            bufferState: () => "missing",
+            prefetch,
+          });
+          result.current.api.subscribeStream("cam");
+        });
+
+        // A paused seek must kick the stream to fetch — otherwise a stream
+        // that only fetches via this nudge (e.g. the ImaVid image stream)
+        // would never load the seeked frame until play.
+        act(() => result.current.api.seek(4));
+        expect(prefetch).toHaveBeenCalled();
+
+        prefetch.mockClear();
+        flushFrame();
+        expect(prefetch).toHaveBeenCalled();
+      });
+    });
+  });
+
   describe("stepForward / stepBack", () => {
     it("stepForward advances the playhead by stepInterval", () => {
       const { result } = renderEngine({ duration: 10 });

--- a/app/packages/playback/src/lib/playback/PlaybackProvider.tsx
+++ b/app/packages/playback/src/lib/playback/PlaybackProvider.tsx
@@ -31,7 +31,9 @@ function PlaybackContextHost({
     [baseContext, liveDuration, liveStepInterval]
   );
   return (
-    <PlaybackContext.Provider value={value}>{children}</PlaybackContext.Provider>
+    <PlaybackContext.Provider value={value}>
+      {children}
+    </PlaybackContext.Provider>
   );
 }
 
@@ -42,6 +44,7 @@ export function PlaybackProvider({
   defaultLoopStart,
   defaultLoopEnd,
   defaultSpeed = 1.0,
+  snapToFrameOnSettle,
 }: PlaybackConfig & { children: React.ReactNode }) {
   const { store, contextValue } = usePlaybackEngine({
     duration,
@@ -49,6 +52,7 @@ export function PlaybackProvider({
     defaultLoopStart,
     defaultLoopEnd,
     defaultSpeed,
+    snapToFrameOnSettle,
   });
 
   // We deliberately do NOT mount a Jotai `<Provider>` here. Every reactive
@@ -76,7 +80,8 @@ export function PlaybackProvider({
  */
 export function usePlayback(): PlaybackContextValue {
   const ctx = useContext(PlaybackContext);
-  if (!ctx) throw new Error("usePlayback must be used inside <PlaybackProvider>");
+  if (!ctx)
+    throw new Error("usePlayback must be used inside <PlaybackProvider>");
   return ctx;
 }
 

--- a/app/packages/playback/src/lib/playback/types.ts
+++ b/app/packages/playback/src/lib/playback/types.ts
@@ -208,6 +208,15 @@ export interface PlaybackConfig {
   defaultLoopEnd?: number;
   /** Initial playback speed multiplier. @default 1.0 */
   defaultSpeed?: number;
+  /**
+   * When `true`, the playhead snaps to the start of the displayed frame at
+   * settle points — pausing and the end of a scrub drag. Scrubbing itself
+   * stays continuous (mid-drag `seek`s are never snapped); only the final
+   * resting position aligns to a frame boundary. Opt-in so general playback
+   * keeps fully continuous scrubbing.
+   * @default false
+   */
+  snapToFrameOnSettle?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -222,6 +231,12 @@ export interface PlaybackContextValue {
   play: () => void;
   pause: () => void;
   seek: (time: number) => void;
+  /**
+   * Snap the playhead to the start of the displayed frame. No-op unless the
+   * provider was configured with `snapToFrameOnSettle`. Call at scrub
+   * settle points (e.g. a playhead drag-end) — pausing snaps automatically.
+   */
+  snapPlayheadToFrame: () => void;
   stepBack: () => void;
   stepForward: () => void;
   setView: (start: number, end: number) => void;

--- a/app/packages/playback/src/lib/playback/use-playback-engine.ts
+++ b/app/packages/playback/src/lib/playback/use-playback-engine.ts
@@ -57,6 +57,23 @@ function frameBoundaryStep(
 }
 
 /**
+ * Snap a continuous playhead time onto the START of the displayed frame it
+ * falls within — `floor(time / step) * step`. Unlike {@link frameBoundaryStep}
+ * this never advances a frame; it just aligns a mid-frame playhead onto the
+ * boundary of the frame currently on screen, so a settle-snap keeps the user
+ * on the frame they were looking at. The `eps` tolerance keeps a playhead
+ * already at `K * step` from being read as the previous frame.
+ */
+function displayedFrameStart(time: number, step: number): number {
+  if (!(step > 0)) {
+    return time;
+  }
+
+  const eps = step * 1e-6;
+  return Math.floor((time + eps) / step) * step;
+}
+
+/**
  * Cap on per-tick `dt` (sec) in the engine's wallclock-driven advance.
  * When the main thread is blocked (memory pressure, GC pause, throttled
  * tab) RAF callbacks pile up and the next `timestamp - lastTimestamp`
@@ -82,6 +99,7 @@ export function usePlaybackEngine({
   defaultLoopStart,
   defaultLoopEnd,
   defaultSpeed = 1.0,
+  snapToFrameOnSettle = false,
 }: PlaybackConfig = {}): {
   store: PlaybackStore;
   contextValue: PlaybackContextValue;
@@ -93,6 +111,8 @@ export function usePlaybackEngine({
   fallbackDurationRef.current = duration;
   const fallbackStepIntervalRef = useRef(stepInterval);
   fallbackStepIntervalRef.current = stepInterval;
+  const snapToFrameRef = useRef(snapToFrameOnSettle);
+  snapToFrameRef.current = snapToFrameOnSettle;
 
   const store = useMemo(() => {
     const s = createStore();
@@ -339,8 +359,43 @@ export function usePlaybackEngine({
     [isActive]
   );
 
-  const actions = useMemo(
-    () => ({
+  const actions = useMemo(() => {
+    // Settle-snap: align the playhead to the displayed frame's start. No-op
+    // unless `snapToFrameOnSettle` is configured, so general playback keeps
+    // continuous scrubbing — only the resting position after pause / drag-end
+    // is snapped, never the mid-drag `seek`s. Mirrors `seek`'s set →
+    // fireSeekEvent → commit-if-ready flow so buffering is respected.
+    const snapPlayheadToFrame = () => {
+      if (!snapToFrameRef.current) {
+        return;
+      }
+
+      const step = store.get(stepIntervalAtom);
+      if (!(step > 0)) {
+        return;
+      }
+
+      const current = store.get(playheadAtom);
+      const snapped = clamp(
+        displayedFrameStart(current, step),
+        0,
+        store.get(durationAtom)
+      );
+
+      if (Math.abs(snapped - current) < step * 1e-6) {
+        return;
+      }
+
+      store.set(playheadAtom, snapped);
+      fireSeekEvent(snapped, true);
+
+      if (checkAllReady(snapped)) {
+        doCommit(snapped);
+      }
+    };
+
+    return {
+      snapPlayheadToFrame,
       seek: (time: number) => {
         const clamped = clamp(time, 0, store.get(durationAtom));
         store.set(playheadAtom, clamped);
@@ -359,6 +414,7 @@ export function usePlaybackEngine({
       },
       pause: () => {
         store.set(isPlayingAtom, false);
+        snapPlayheadToFrame();
       },
       stepBack: () => {
         const next = clamp(
@@ -467,16 +523,15 @@ export function usePlaybackEngine({
           }
         };
       },
-    }),
-    [
-      store,
-      fireSeekEvent,
-      doCommit,
-      checkAllReady,
-      recomputeDuration,
-      recomputeStepInterval,
-    ]
-  );
+    };
+  }, [
+    store,
+    fireSeekEvent,
+    doCommit,
+    checkAllReady,
+    recomputeDuration,
+    recomputeStepInterval,
+  ]);
 
   const contextValue = useMemo<PlaybackContextValue>(
     () => ({ duration, stepInterval, ...actions }),

--- a/app/packages/playback/src/lib/playback/use-playback-engine.ts
+++ b/app/packages/playback/src/lib/playback/use-playback-engine.ts
@@ -152,6 +152,11 @@ export function usePlaybackEngine({
   const clockSourceRef = useRef<PlaybackClockSource | null>(null);
   const seekDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const seekSeqRef = useRef(0);
+  // A seek/step/snap target that couldn't commit immediately because a
+  // blocking stream was still buffering. The settle loop (below) polls
+  // the barrier for this time while paused and commits once ready.
+  const pendingCommitRef = useRef<number | null>(null);
+  const settleRafRef = useRef<number | null>(null);
 
   // A stream is "active" when registered AND has at least one subscriber.
   // Dormant streams (registered but no subscribers) are skipped entirely.
@@ -229,6 +234,52 @@ export function usePlaybackEngine({
   );
 
   /**
+   * Readiness barrier for `targetTime`. Every blocking, subscribed
+   * stream must be ready before the engine commits; streams reporting
+   * `missing` get a prefetch nudge, `loading` is already in flight.
+   * Publishes `isBufferingAtom` and returns whether all are ready.
+   *
+   * Shared by the playing RAF tick and the paused settle loop so a seek
+   * while paused gets the same prefetch nudge that playback would give
+   * it — otherwise streams that fetch only via this nudge would
+   * never request the seeked frame until the user hit play.
+   */
+  const runBarrier = useCallback(
+    (targetTime: number): boolean => {
+      const duration = store.get(durationAtom);
+      let isBuffering = false;
+
+      for (const s of streamsRef.current.values()) {
+        if (!s.blocking) {
+          continue;
+        }
+
+        if (!isActive(s.id)) {
+          continue;
+        }
+
+        const state = s.bufferState(targetTime);
+        if (state === "ready") {
+          continue;
+        }
+
+        isBuffering = true;
+        if (state === "missing") {
+          s.prefetch?.([
+            targetTime,
+            Math.min(duration, targetTime + (s.lookaheadSeconds ?? 3)),
+          ]);
+        }
+      }
+
+      store.set(isBufferingAtom, isBuffering);
+
+      return !isBuffering;
+    },
+    [store, isActive]
+  );
+
+  /**
    * Engine RAF tick. Two modes, chosen per tick based on whether a
    * `PlaybackClockSource` has been registered via `setClockSource`:
    *
@@ -268,7 +319,6 @@ export function usePlaybackEngine({
       const currentTime = store.get(playheadAtom);
       const loopStart = store.get(loopStartAtom);
       const loopEnd = store.get(loopEndAtom);
-      const duration = store.get(durationAtom);
 
       const externalTime = clockSourceRef.current?.read() ?? null;
 
@@ -289,27 +339,7 @@ export function usePlaybackEngine({
       const willWrap = rawNext >= loopEnd;
       const targetTime = willWrap ? loopStart : rawNext;
 
-      // Barrier: every blocking, subscribed stream must be ready at
-      // `targetTime` before we commit. Streams that report `missing`
-      // get a prefetch nudge; `loading` is already in flight.
-      let isBuffering = false;
-      for (const s of streamsRef.current.values()) {
-        if (!s.blocking) continue;
-        if (!isActive(s.id)) continue;
-        const state = s.bufferState(targetTime);
-        if (state === "ready") continue;
-        isBuffering = true;
-        if (state === "missing") {
-          s.prefetch?.([
-            targetTime,
-            Math.min(duration, targetTime + (s.lookaheadSeconds ?? 3)),
-          ]);
-        }
-      }
-
-      store.set(isBufferingAtom, isBuffering);
-
-      if (!isBuffering) {
+      if (runBarrier(targetTime)) {
         store.set(playheadAtom, targetTime);
         doCommit(targetTime);
         // Loop-wrap is a discontinuous jump — fire immediately so
@@ -319,7 +349,7 @@ export function usePlaybackEngine({
 
       rafIdRef.current = requestAnimationFrame(tick);
     },
-    [store, fireSeekEvent, doCommit, isActive]
+    [store, fireSeekEvent, doCommit, runBarrier]
   );
 
   useEffect(() => {
@@ -338,6 +368,12 @@ export function usePlaybackEngine({
     return () => {
       unsub();
       if (rafIdRef.current !== null) cancelAnimationFrame(rafIdRef.current);
+
+      if (settleRafRef.current !== null) {
+        cancelAnimationFrame(settleRafRef.current);
+        settleRafRef.current = null;
+      }
+
       // A queued seek-event timeout could otherwise fire after unmount and
       // touch an orphaned store.
       if (seekDebounceRef.current !== null) {
@@ -347,16 +383,50 @@ export function usePlaybackEngine({
     };
   }, [store, tick]);
 
-  const checkAllReady = useCallback(
-    (time: number): boolean => {
-      for (const s of streamsRef.current.values()) {
-        if (!s.blocking) continue;
-        if (!isActive(s.id)) continue; // dormant — no subscribers
-        if (s.bufferState(time) !== "ready") return false;
+  /**
+   * Paused settle loop. A `seek`/`step`/snap into an unbuffered region
+   * can't commit immediately, and the RAF tick that re-runs the barrier
+   * only runs while playing — so without this the playhead would move
+   * but `currentTimeAtom` would never advance: streams keep showing the
+   * old frame. This polls the barrier for the pending target while paused and
+   * commits once it's ready. Playing hands the duty back to the RAF tick.
+   */
+  const settleTick = useCallback(() => {
+    settleRafRef.current = null;
+    const time = pendingCommitRef.current;
+
+    if (time === null || store.get(isPlayingAtom)) {
+      return;
+    }
+
+    if (runBarrier(time)) {
+      pendingCommitRef.current = null;
+      doCommit(time);
+      return;
+    }
+
+    settleRafRef.current = requestAnimationFrame(settleTick);
+  }, [store, runBarrier, doCommit]);
+
+  /**
+   * Commit `time` now if the barrier is satisfied, else remember it and
+   * let {@link settleTick} commit it once streams finish buffering.
+   */
+  const commitWhenReady = useCallback(
+    (time: number) => {
+      pendingCommitRef.current = time;
+
+      if (runBarrier(time)) {
+        pendingCommitRef.current = null;
+        doCommit(time);
+        return;
       }
-      return true;
+
+      if (settleRafRef.current === null) {
+        settleRafRef.current = requestAnimationFrame(settleTick);
+      }
     },
-    [isActive]
+    [runBarrier, doCommit, settleTick]
   );
 
   const actions = useMemo(() => {
@@ -388,10 +458,7 @@ export function usePlaybackEngine({
 
       store.set(playheadAtom, snapped);
       fireSeekEvent(snapped, true);
-
-      if (checkAllReady(snapped)) {
-        doCommit(snapped);
-      }
+      commitWhenReady(snapped);
     };
 
     return {
@@ -400,7 +467,7 @@ export function usePlaybackEngine({
         const clamped = clamp(time, 0, store.get(durationAtom));
         store.set(playheadAtom, clamped);
         fireSeekEvent(clamped);
-        if (checkAllReady(clamped)) doCommit(clamped);
+        commitWhenReady(clamped);
       },
       play: () => {
         const current = store.get(playheadAtom);
@@ -428,7 +495,7 @@ export function usePlaybackEngine({
         );
         store.set(playheadAtom, next);
         fireSeekEvent(next, true);
-        if (checkAllReady(next)) doCommit(next);
+        commitWhenReady(next);
       },
       stepForward: () => {
         const next = clamp(
@@ -442,7 +509,7 @@ export function usePlaybackEngine({
         );
         store.set(playheadAtom, next);
         fireSeekEvent(next, true);
-        if (checkAllReady(next)) doCommit(next);
+        commitWhenReady(next);
       },
       setView: (start: number, end: number) => {
         // Apply the same validation as setLoop so the visible window
@@ -528,7 +595,7 @@ export function usePlaybackEngine({
     store,
     fireSeekEvent,
     doCommit,
-    checkAllReady,
+    commitWhenReady,
     recomputeDuration,
     recomputeStepInterval,
   ]);

--- a/app/packages/playback/src/lib/playback/utils.test.ts
+++ b/app/packages/playback/src/lib/playback/utils.test.ts
@@ -109,9 +109,21 @@ describe("frameAt", () => {
   });
 
   it("floors to the nearest preceding frame boundary", () => {
-    // 1/30s exactly → frame 2; just under → still frame 1.
+    // 1/30s exactly → frame 2; a meaningful amount under → still frame 1.
+    // ("Meaningful" = larger than the sub-frame FP tolerance baked into
+    // frameAt; a fractional-frame scrub position is the realistic case.)
     expect(frameAt(1 / 30, 30)).toBe(2);
-    expect(frameAt(1 / 30 - 1e-9, 30)).toBe(1);
+    expect(frameAt(0.9 / 30, 30)).toBe(1);
+  });
+
+  it("round-trips frame → (frame - 1) / fps → frameAt at non-integer fps", () => {
+    // At a non-integer fps, (n - 1) / fps * fps can land just
+    // below n - 1 (e.g. 15.999999999999998 at 30.007 fps), which without an
+    // FP tolerance floors down and reports the *previous* frame.
+    const fps = 30.007001633714534;
+    for (let n = 1; n <= 1000; n++) {
+      expect(frameAt((n - 1) / fps, fps)).toBe(n);
+    }
   });
 
   it("returns the raw frame when no frameCount is provided", () => {

--- a/app/packages/playback/src/lib/playback/utils.ts
+++ b/app/packages/playback/src/lib/playback/utils.ts
@@ -9,13 +9,20 @@ import type { StreamLookupPolicy } from "./types";
  * everyone agrees on which frame a given `time` belongs to. 1-indexed
  * because that is the convention `/frames` uses and the labels coming
  * back from the server are keyed on.
+ *
+ * The `1e-6` epsilon absorbs floating-point error in the
+ * `frame → (frame - 1) / fps → frameAt` round-trip: at a non-integer fps,
+ * `(n - 1) / fps * fps` can land just below `n - 1`
+ * (e.g. `15.999999999999998` at 30.007 fps), which would otherwise floor
+ * down a frame and report the *previous* frame. Mirrors the `eps` guard
+ * in {@link frameBoundaryStep} / {@link displayedFrameStart}.
  */
 export function frameAt(
   time: number,
   fps: number,
   frameCount?: number
 ): number {
-  const raw = Math.floor(time * fps) + 1;
+  const raw = Math.floor(time * fps + 1e-6) + 1;
   if (frameCount === undefined) {
     return raw;
   }

--- a/app/packages/playback/src/views/TimelineRuler/TimelineRuler.tsx
+++ b/app/packages/playback/src/views/TimelineRuler/TimelineRuler.tsx
@@ -43,7 +43,8 @@ const TimelineRuler: React.FC<TimelineRulerProps> = ({
   const viewEnd = useViewEnd();
   const loopStart = useLoopStart();
   const loopEnd = useLoopEnd();
-  const { duration, seek, setView, setLoop } = usePlayback();
+  const { duration, seek, setView, setLoop, snapPlayheadToFrame } =
+    usePlayback();
 
   const rulerRef = useRef<HTMLDivElement>(null);
 
@@ -85,6 +86,9 @@ const TimelineRuler: React.FC<TimelineRulerProps> = ({
       );
       seek(clamp(startValue + (delta / laneWidth) * vd, 0, duration));
     },
+    // Continuous while dragging (above); snap to a frame boundary only once
+    // the drag settles. No-op unless the provider opted into snapping.
+    onDragEnd: () => snapPlayheadToFrame(),
   });
 
   const loopStartDrag = useDragDelta({
@@ -155,6 +159,9 @@ const TimelineRuler: React.FC<TimelineRulerProps> = ({
       const vs = dragRef.current.startVs;
       const ve = dragRef.current.startVe;
       seek(clamp(vs + (laneX / laneWidth) * (ve - vs), 0, duration));
+      // Land a click-to-seek on a frame boundary too (no-op unless snapping
+      // is enabled); reads the playhead `seek` just set.
+      snapPlayheadToFrame();
     },
   });
 
@@ -217,11 +224,9 @@ const TimelineRuler: React.FC<TimelineRulerProps> = ({
   const loopStartRatio = clamp((loopStart - viewStart) / viewDuration, 0, 1);
   const loopEndRatio = clamp((loopEnd - viewStart) / viewDuration, 0, 1);
 
-  const tickInterval =
-    viewDuration <= 1 ? 0.1 : viewDuration <= 3 ? 0.5 : 1;
+  const tickInterval = viewDuration <= 1 ? 0.1 : viewDuration <= 3 ? 0.5 : 1;
   const ticks: number[] = [];
-  const firstTick =
-    Math.ceil(viewStart / tickInterval - 1e-9) * tickInterval;
+  const firstTick = Math.ceil(viewStart / tickInterval - 1e-9) * tickInterval;
   for (
     let t = Math.round(firstTick * 1e4) / 1e4;
     t <= viewEnd + 1e-9;
@@ -250,8 +255,8 @@ const TimelineRuler: React.FC<TimelineRulerProps> = ({
   const cursor = playheadDrag.isDragging
     ? "grabbing"
     : loopStartDrag.isDragging || loopEndDrag.isDragging
-      ? "ew-resize"
-      : undefined;
+    ? "ew-resize"
+    : undefined;
 
   return (
     <div

--- a/app/packages/playback/src/views/TimelineTrack/TimelineTrack.module.css
+++ b/app/packages/playback/src/views/TimelineTrack/TimelineTrack.module.css
@@ -65,14 +65,20 @@
   border-radius: 2px;
 }
 
+/* Keyframe diamond. Sits on a presence bar of the same track color, so it
+   needs a contrasting outline + its own stacking context to read clearly —
+   especially on dimmed (unpinned) rows. The theme-adaptive border tracks
+   the foreground color; the shadow separates it from light-colored bars. */
 .event {
   position: absolute;
   top: 50%;
   transform: translate(-50%, -50%) rotate(45deg);
-  width: 8px;
-  height: 8px;
-  z-index: 1;
+  width: 11px;
+  height: 11px;
+  z-index: 3;
   cursor: pointer;
+  border: 1.5px solid var(--color-content-text-primary);
+  box-shadow: 0 0 2px 1px rgba(0, 0, 0, 0.45);
 }
 
 /* Interval bar — one segment of a semantic track, click-to-seek. */

--- a/app/packages/video-annotation/index.ts
+++ b/app/packages/video-annotation/index.ts
@@ -31,7 +31,11 @@ export type {
   TrackExtentEdit,
 } from "./src/trackExtentEdit";
 export { VideoFrameLabelsStream } from "./src/VideoFrameLabelsStream";
-export type { LocalDetection } from "./src/VideoFrameLabelsStream";
+export type {
+  LocalDetection,
+  RawDetection,
+  RawDetectionsField,
+} from "./src/VideoFrameLabelsStream";
 export { buildTemporalDetectionTracks } from "./src/temporalDetectionTracks";
 export type {
   RawTemporalDetection,

--- a/app/packages/video-annotation/src/ImaVidLighterTile.module.css
+++ b/app/packages/video-annotation/src/ImaVidLighterTile.module.css
@@ -15,6 +15,11 @@
   z-index: 0;
   user-select: none;
   pointer-events: none;
+  /* Mirrors the Lighter viewport transform (see useSyncMediaTransform): the
+     origin must be the container's top-left so `translate(pan) scale()` lines
+     up with the overlays' pan + scale·world mapping. */
+  transform-origin: 0 0;
+  will-change: transform;
 }
 
 .lighterHost {

--- a/app/packages/video-annotation/src/ImaVidLighterTile.tsx
+++ b/app/packages/video-annotation/src/ImaVidLighterTile.tsx
@@ -23,6 +23,7 @@ import { useFrameOverlaySync } from "./useFrameOverlaySync";
 import { useSyncLighterAnnotation } from "./useSyncLighterAnnotation";
 import { useSyncSidebarFromSnapshot } from "./useSyncSidebarFromSnapshot";
 import { useSyncLighterLabelStream } from "./useSyncLighterLabelStream";
+import { useSyncMediaTransform } from "./useSyncMediaTransform";
 import styles from "./ImaVidLighterTile.module.css";
 
 export interface ImaVidLighterTileProps {
@@ -153,6 +154,10 @@ export const ImaVidLighterTile: React.FC<ImaVidLighterTileProps> = ({
 
   useSyncLighterAnnotation(scene);
   useSyncLighterLabelStream(scene);
+
+  // Keep the frame canvas zoomed/panned with the Lighter viewport so
+  // scroll-zoom scales the picture, not just the overlays.
+  useSyncMediaTransform(scene, frameCanvasRef);
 
   // Paint the current frame's bitmap into the canvas. Sets the canvas
   // drawing buffer to the bitmap's intrinsic dimensions on first paint

--- a/app/packages/video-annotation/src/VideoAnnotationSurface.tsx
+++ b/app/packages/video-annotation/src/VideoAnnotationSurface.tsx
@@ -167,7 +167,10 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
   // detection-mode, label list). Reintroducing multi-tile here requires
   // first pinning those atoms to the modal-default store explicitly.
   return (
-    <PlaybackProvider>
+    // Annotation wants the playhead to rest on a real frame after a pause or
+    // scrub-drag, so the labels snapshot and any keyframe op align to a frame.
+    // Scrubbing stays continuous — only the settle position snaps.
+    <PlaybackProvider snapToFrameOnSettle>
       <VideoAnnotationHandlerRegistration />
       {registered}
     </PlaybackProvider>

--- a/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
+++ b/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
@@ -16,7 +16,7 @@ import type {
   SyntheticBox,
 } from "./SyntheticLabelStream";
 
-interface RawDetection {
+export interface RawDetection {
   _id?: string;
   id?: string;
   index?: number;
@@ -27,7 +27,7 @@ interface RawDetection {
   propagation?: PropagationBlob | null;
 }
 
-interface RawDetectionsField {
+export interface RawDetectionsField {
   detections?: RawDetection[];
 }
 

--- a/app/packages/video-annotation/src/VideoLighterTile.module.css
+++ b/app/packages/video-annotation/src/VideoLighterTile.module.css
@@ -13,6 +13,11 @@
   height: 100%;
   object-fit: contain;
   z-index: 0;
+  /* Mirrors the Lighter viewport transform (see useSyncMediaTransform): the
+     origin must be the container's top-left so `translate(pan) scale()` lines
+     up with the overlays' pan + scale·world mapping. */
+  transform-origin: 0 0;
+  will-change: transform;
 }
 
 .lighterHost {

--- a/app/packages/video-annotation/src/VideoLighterTile.tsx
+++ b/app/packages/video-annotation/src/VideoLighterTile.tsx
@@ -26,6 +26,7 @@ import { useFrameOverlaySync } from "./useFrameOverlaySync";
 import { useSyncLighterAnnotation } from "./useSyncLighterAnnotation";
 import { useSyncSidebarFromSnapshot } from "./useSyncSidebarFromSnapshot";
 import { useSyncLighterLabelStream } from "./useSyncLighterLabelStream";
+import { useSyncMediaTransform } from "./useSyncMediaTransform";
 import styles from "./VideoLighterTile.module.css";
 
 export interface VideoLighterTileProps {
@@ -176,6 +177,10 @@ export const VideoLighterTile: React.FC<VideoLighterTileProps> = ({
 
   useSyncLighterAnnotation(scene);
   useSyncLighterLabelStream(scene);
+
+  // Keep the <video> zoomed/panned with the Lighter viewport so scroll-zoom
+  // scales the picture, not just the overlays.
+  useSyncMediaTransform(scene, videoRef);
 
   return (
     <div className={styles.body}>

--- a/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
+++ b/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
@@ -2,7 +2,8 @@
  * Copyright 2017-2026, Voxel51, Inc.
  */
 
-import { useAnnotationEventBus } from "@fiftyone/annotation";
+import { ExtendTrackCommand, useAnnotationEventBus } from "@fiftyone/annotation";
+import { useCommandBus } from "@fiftyone/command-bus";
 import {
   DetectionOverlay,
   type Scene2D,
@@ -15,6 +16,13 @@ import { useCallback, useRef } from "react";
 import { useCurrentTime } from "../../playback/src/lib/playback/use-playback-state";
 import { useFrameLabelsStream } from "./frameLabelsStream";
 import type { LocalDetection } from "./VideoFrameLabelsStream";
+
+/**
+ * Frames a freshly-drawn box auto-extends forward as non-keyframe filler,
+ * so a single drawn box immediately becomes a short track (matching a
+ * manual drag-to-extend). Clamped at the clip end.
+ */
+const AUTO_EXTEND_FRAMES = 30;
 
 /**
  * Mirrors user-driven Lighter overlay edits into the label-stream cache
@@ -38,6 +46,7 @@ export const useSyncLighterLabelStream = (scene: Scene2D | null): void => {
   const stream = useFrameLabelsStream();
   const currentTime = useCurrentTime();
   const eventBus = useAnnotationEventBus();
+  const commandBus = useCommandBus();
 
   const useEventHandler = useLighterEventHandler(
     scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
@@ -95,11 +104,35 @@ export const useSyncLighterLabelStream = (scene: Scene2D | null): void => {
       // against the canonical synthetic id; the `overlay-added` handler
       // claims it once the sync places the canonical overlay in scene.
       if (minted) {
-        pendingSelectRef.current = `instance-${detection.instance!._id}`;
+        const trackId = `instance-${detection.instance!._id}`;
+        pendingSelectRef.current = trackId;
         scene.removeOverlay(overlayId);
+
+        // Auto-extend the fresh track forward as non-keyframe filler
+        // (`ExtendTrackCommand` semantics: same `instance`/`index`, fresh
+        // `_id` per frame, `keyframe: false`), so one drawn box becomes a
+        // short track without a manual drag. The source detection was just
+        // written above, so the handler resolves it off the stream snapshot.
+        // Leaves a single keyframe, so auto-lerp has no second bracket yet —
+        // intended; it lights up once a downstream keyframe is marked/edited.
+        const lastFrame = Math.min(
+          frame + AUTO_EXTEND_FRAMES,
+          stream.totalFrames
+        );
+
+        const targetFrames: number[] = [];
+        for (let f = frame + 1; f <= lastFrame; f++) {
+          targetFrames.push(f);
+        }
+
+        if (targetFrames.length > 0) {
+          void commandBus.execute(
+            new ExtendTrackCommand(trackId, frame, targetFrames)
+          );
+        }
       }
     },
-    [stream, scene, currentTime, eventBus]
+    [stream, scene, currentTime, commandBus, eventBus]
   );
 
   useEventHandler(

--- a/app/packages/video-annotation/src/useSyncMediaTransform.ts
+++ b/app/packages/video-annotation/src/useSyncMediaTransform.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import {
+  type Scene2D,
+  UNDEFINED_LIGHTER_SCENE_ID,
+  useLighterEventHandler,
+} from "@fiftyone/lighter";
+import type { RefObject } from "react";
+import { useCallback } from "react";
+
+/**
+ * Locks the canonical-media element (the `<video>` / frame `<canvas>` layered
+ * behind the Lighter canvas) to the scene's zoom/pan, so scroll-zoom scales
+ * the picture together with the overlays instead of just the boxes.
+ *
+ * Lighter draws overlays through the pixi-viewport transform; the external
+ * media element is a plain DOM node that never receives it. The viewport maps
+ * a world point `w` to screen as `pan + scale·w`, and at rest (scale 1, pan 0)
+ * the media element's local coordinates already equal world coordinates — both
+ * are container CSS pixels, and `object-fit: contain` letterboxes into the same
+ * rect the coordinate system uses. So mirroring the viewport onto the element
+ * is exactly `translate(panX, panY) scale(scale)` about a top-left origin (set
+ * in CSS). Applied imperatively rather than via state so a wheel/drag stream
+ * doesn't rerender the tile per frame.
+ */
+export const useSyncMediaTransform = <T extends HTMLElement>(
+  scene: Scene2D | null,
+  mediaRef: RefObject<T | null>
+): void => {
+  const useEventHandler = useLighterEventHandler(
+    scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
+  );
+
+  const apply = useCallback(
+    (panX: number, panY: number, scale: number) => {
+      const el = mediaRef.current;
+      if (!el) {
+        return;
+      }
+
+      el.style.transform = `translate(${panX}px, ${panY}px) scale(${scale})`;
+    },
+    [mediaRef]
+  );
+
+  useEventHandler(
+    "lighter:viewport-moved",
+    useCallback((p) => apply(p.x, p.y, p.scale), [apply])
+  );
+
+  // Seed the resting transform once the renderer is ready — the pixi
+  // viewport is initialized by then, so reading its state is safe (reading
+  // it on mere `scene` presence races viewport init and throws). The
+  // post-`fitToContent` framing then arrives as a `viewport-moved`. Fires
+  // per scene, so remounts re-seed.
+  useEventHandler(
+    "lighter:renderer-ready",
+    useCallback(() => {
+      if (!scene) {
+        return;
+      }
+
+      const { panX, panY, scale } = scene.getViewportState();
+      apply(panX, panY, scale);
+    }, [scene, apply])
+  );
+};

--- a/fiftyone/server/routes/sample.py
+++ b/fiftyone/server/routes/sample.py
@@ -270,18 +270,33 @@ def ensure_sample_field(sample: fo.Sample, field: str):
 
     logger.info("Missing sample field %s, attempting to initialize", field)
 
-    schema = sample.dataset.get_field_schema()
-
-    # track our current place in the hierarchy
-    current = sample
     field_parts = field.split(".")
-    for idx, part in enumerate(field_parts):
-        field_path = ".".join(field_parts[: idx + 1])
 
-        key = int(part) if isinstance(current, fof.Frames) else part
+    # `root`/`schema`/`base` describe whose fields we're initializing: the
+    # document that owns `set_field` (`root`), the schema its paths resolve
+    # against, and the index in `field_parts` where those paths begin. They
+    # start at the sample and switch to a frame the moment the walk crosses
+    # into the `frames` collection — frame fields live in their own schema,
+    # owned by the frame document, so the sample schema can't describe them.
+    root = sample
+    schema = sample.dataset.get_field_schema()
+    base = 0
+
+    current = sample
+    for idx, part in enumerate(field_parts):
+        if isinstance(current, fof.Frames):
+            # Cross into a frame. `frames[N]` materializes an empty frame if
+            # one doesn't exist yet, which is what we want when initializing
+            # a field on it. The frame number isn't a field to initialize.
+            current = root = current[int(part)]
+            schema = sample.dataset.get_frame_field_schema()
+            base = idx + 1
+            continue
+
+        field_path = ".".join(field_parts[base : idx + 1])
 
         try:
-            current_part = current[key]
+            current_part = current[part]
         except (KeyError, TypeError, IndexError):
             current_part = None
 
@@ -303,10 +318,10 @@ def ensure_sample_field(sample: fo.Sample, field: str):
                 logger.info(
                     "Initializing %s field at %s", field_type, field_path
                 )
-                sample.set_field(field_path, field_type())
+                root.set_field(field_path, field_type())
 
         # recurse
-        current = current[key]
+        current = current[part]
 
 
 def save_sample(

--- a/tests/unittests/server/routes/test_sample.py
+++ b/tests/unittests/server/routes/test_sample.py
@@ -974,9 +974,7 @@ class TestCommitMask:
             scope={"type": "http"}, receive=AsyncMock(), send=AsyncMock()
         )
 
-    def _make_commit_request(
-        self, dataset_id, sample_id, field, detection_id
-    ):
+    def _make_commit_request(self, dataset_id, sample_id, field, detection_id):
         """Build a mock POST request for the commit-mask endpoint."""
         mock_request = MagicMock()
         mock_request.headers = {}
@@ -1090,16 +1088,22 @@ class TestCommitMask:
         "setup, status, description",
         [
             (
-                {"field": "ground_truth", "det_kwargs": {
-                    "mask": np.ones((5, 5), dtype=np.uint8),
-                }},
+                {
+                    "field": "ground_truth",
+                    "det_kwargs": {
+                        "mask": np.ones((5, 5), dtype=np.uint8),
+                    },
+                },
                 400,
                 "mask but no mask_path",
             ),
             (
-                {"field": "ground_truth", "det_kwargs": {
-                    "mask_path": "/tmp/_placeholder.png",
-                }},
+                {
+                    "field": "ground_truth",
+                    "det_kwargs": {
+                        "mask_path": "/tmp/_placeholder.png",
+                    },
+                },
                 400,
                 "mask_path but no in-database mask",
             ),
@@ -1136,9 +1140,7 @@ class TestCommitMask:
                 field_name=setup["field"],
                 **det_kwargs,
             )
-            det_id = str(
-                sample[setup["field"]].detections[0].id
-            )
+            det_id = str(sample[setup["field"]].detections[0].id)
 
         request = self._make_commit_request(
             dataset_id, sample.id, setup["field"], det_id
@@ -1967,3 +1969,54 @@ class TestEnsureSampleField:
 
         with pytest.raises(AttributeError):
             sample.get_field("nonexistent")
+
+    def test_initializes_unset_frame_detections_field(self):
+        """Tests that ensure_sample_field initializes a frame-level Detections
+        field. Frame fields live in a separate schema owned by the frame
+        document, so the sample-schema lookup can't see them — the function
+        must rebase onto the frame and use the frame schema."""
+        dataset = fo.Dataset()
+        dataset.media_type = "video"
+        dataset.add_frame_field(
+            "detections", fo.EmbeddedDocumentField, fol.Detections
+        )
+        try:
+            sample = fo.Sample(filepath="/tmp/test_ensure_frame.mp4")
+            sample.frames[2]  # materialize a frame with null detections
+            dataset.add_sample(sample)
+            sample.reload()
+
+            assert sample.frames[2].get_field("detections") is None
+
+            fors.ensure_sample_field(
+                sample, "frames.2.detections.detections.0"
+            )
+
+            val = sample.frames[2].get_field("detections")
+            assert isinstance(val, fol.Detections)
+            assert val.detections == []
+        finally:
+            dataset.delete()
+
+    def test_initializes_frame_detections_on_docless_frame(self):
+        """Tests that ensure_sample_field materializes a frame that has no
+        document yet and initializes its Detections field (drawing on a
+        previously-unlabeled frame)."""
+        dataset = fo.Dataset()
+        dataset.media_type = "video"
+        dataset.add_frame_field(
+            "detections", fo.EmbeddedDocumentField, fol.Detections
+        )
+        try:
+            sample = fo.Sample(filepath="/tmp/test_ensure_docless.mp4")
+            sample.frames[1]
+            dataset.add_sample(sample)
+            sample.reload()
+
+            fors.ensure_sample_field(sample, "frames.7.detections.detections")
+
+            val = sample.frames[7].get_field("detections")
+            assert isinstance(val, fol.Detections)
+            assert val.detections == []
+        finally:
+            dataset.delete()


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

A set of timeline and media UX refinements for the video annotation surface.

- **Keyframe contrast** — keyframe diamonds on timeline tracks are larger, carry a theme-adaptive outline and separation shadow, and sit above the track bar so they stay legible on a same-color bar and on dim unpinned rows.
- **Fresh-box auto-extend** — a freshly-drawn box auto-extends 30 frames as non-keyframe track filler, so one drawn box becomes a short track.
- **Frame-boundary snap on settle** — an opt-in flag snaps the playhead to the displayed frame's start at settle points only (pause, scrub drag-end, click-to-seek). General playback stays continuous by default; mid-drag seeks are never snapped.
- **Scroll-to-zoom media** — the underlying frame/video layer mirrors the Lighter viewport transform, so scroll-to-zoom and pan now scale the media itself rather than only the overlays.
- **Frame round-trip FP fix** — `frameAt` (time → 1-indexed frame) now carries a sub-frame epsilon, matching its sibling helpers `frameBoundaryStep` / `displayedFrameStart`. Without it, at a non-integer fps (e.g. `30.007`) the `frame → (frame - 1) / fps → frameAt` round-trip could land just below the integer and floor down to the *previous* frame for certain frame numbers. This made the frame stepper treat adjacent frames as the same frame (and land keyframes a frame early), and caused the propagation apply path to look up a neighbour frame's detection and write its `_id` onto the current frame, producing cross-frame duplicate detection ids.
- **Frame-field initialization on first draw (server)** — `ensure_sample_field`, the server-side pre-initializer that creates missing parent fields before applying a JSON patch, is now frame-aware. Drawing the first label on a frame emits `add /frames/N/detections/detections`, which requires the parent `Detections` container to already exist; where it was unset, this failed with `Unable to add value with path: /frames/N/detections/detections`. The initializer previously resolved every path against the *sample* schema, which can't describe frame fields (`frames` isn't one of its keys), so it silently bailed and the `add` then ran against a `None` parent. It now detects when the walk crosses into the frame collection and rebases initialization onto the frame document and its schema. Because indexing `frames[N]` materializes a not-yet-existing frame, drawing on a previously-unlabeled frame also works.
- **Paused seek commits once streams buffer** — seeking (or stepping/snapping) into an unbuffered region while paused moved the playhead but never advanced the committed time, so streams kept showing the old frame and edits resolved against the stale time (a box drawn after the seek landed at t=0); hitting play "fixed" it. The commit only ran if every blocking stream was ready at the instant of the seek, and the only thing that re-checks readiness — the RAF barrier — runs only while playing, so streams that fetch solely via that barrier's prefetch nudge were never even asked to load the seeked frame until play. The readiness barrier is now factored into a shared helper, and a paused settle loop polls it for the pending target — prefetching missing streams and committing once ready — handing the duty back to the RAF tick on play.

Stacked on #7688.

## 🧪 How is this patch tested? If it is not, please explain why.

Unit tests for the opt-in playhead-snap behavior, for the `frameAt` round-trip at a non-integer fps, for `ensure_sample_field` initializing frame-level fields (including on a not-yet-materialized frame), and for the paused settle loop committing a seek once a buffering stream becomes ready; the visual/interaction changes were verified locally in the app.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other



