### PR TITLE
Back-merge main into develop via automated PR workflow

### DIFF
--- a/.github/workflows/develop-back-merge.yml
+++ b/.github/workflows/develop-back-merge.yml
@@ -1,8 +1,9 @@
-name: Push Release
+name: Develop Back-Merge
 
 on:
   push:
     branches:
+      - main
       - release/v[0-9]+.[0-9]+.[0-9]+
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## What

- Add \`main\` to the \`push\` triggers of the automated develop-merge workflow, so that any merge into \`main\` opens a PR back into \`develop\`.
- Rename the workflow to **Develop Back-Merge** (\`develop-back-merge.yml\`, formerly \`push-release.yml\` / "Push Release") to reflect that it now covers both release branches and \`main\`.

## Why

Previously the workflow only fired on \`release/vX.Y.Z\` pushes. Changes landing directly on \`main\` could drift from \`develop\`; this keeps them in sync automatically.

## Notes

- The job is already generic over \`github.ref_name\`, so no logic changes were needed — \`main\` flows through the same merge-branch + PR steps.
- No self-trigger loop: the generated PRs target \`develop\`, not \`main\`.
- No other files referenced the old \`push-release.yml\` path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal CI/CD workflow configuration to support additional branch triggers.

---

*No user-facing changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->