### PR TITLE
docs(annotate): explain why useLoadSchemas no longer pre-clears

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useLoadSchemas.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useLoadSchemas.ts
@@ -15,26 +15,31 @@ export default function useLoadSchemas() {
   const { closeSchemaManager } = useSchemaManagerModal();
   const get = useOperatorExecutor("get_label_schemas");
 
+  // Atomically swap in the new schema once the fetch resolves. We do
+  // NOT clear `labelSchemasData` / `activeLabelSchemas` first — the
+  // prior schema stays visible during the in-flight window so
+  // downstream consumers (`useLabels`, `useFocus.selectOverlay`'s
+  // `labelMap` lookup, the `fieldsOfType(...)` reads behind
+  // classification activation) never see a transient null. The pre-clear
+  // was removed in #7288 to fix a loading-screen flicker; this also
+  // removes a brief null window that flaked classification activation
+  // when the user clicked a chip mid-refetch.
   useEffect(() => {
     if (!get.result) {
       return;
     }
-
-    // Set new schema data
     setData(get.result.label_schemas);
     setActive(get.result.active_label_schemas);
   }, [get.result, setData, setActive]);
 
-  // Reset schema data and close modal, then fetch new data
-  // Note: UI state (currentField, selection, JSON editor) is reset on
-  // SchemaManager Modal unmount via useSchemaManagerCleanup hook
+  // Trigger a fresh fetch. The `get.result` effect above swaps the
+  // atoms atomically when the response lands. SchemaManager UI state
+  // (currentField, selection, JSON editor) is reset on its modal
+  // unmount via `useSchemaManagerCleanup`.
   return useCallback(() => {
-    // Reset schema data to trigger loading state
-
-    // Reset paths order and close modal
     setActivePathsOrder(null);
     closeSchemaManager();
-
     get.execute({});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 }


### PR DESCRIPTION
## Summary

Comment-only cleanup. **No behavior change.**

#7288 removed the `setData(null); setActive(null)` pre-clear in `useLoadSchemas` to fix a loading-screen flicker, but the surrounding comments still described the removed behavior — \"Reset schema data to trigger loading state\" and \"Reset schema data and close modal, then fetch new data\". Replace them with the actual contract.

## Why this matters beyond docs

The same null-window suppression that #7288 introduced for visual flicker also stabilizes click handlers behind labels during a refetch. Two consumers depend on the atomic swap:

- `useFocus.selectOverlay(id)` does `const label = STORE.get(labelMap)[id]; if (!label) return;`. `labelMap` derives from `labels` which is fed by `useLabels`, which reacts to `visibleLabelSchemas` going empty by calling `setLabels([])`. With a pre-clear, a chip click landing mid-refetch reads `labelMap[id] === undefined` and silently no-ops.
- `useClassificationMode`'s `classificationModeActive` reads `currentType === CLASSIFICATION`, which derives from `current` / `editing`. If `selectOverlay` no-ops, `editing` stays null and the \"Create classification\" action button never activates.

This was the root cause of [`MISSING-annotate-canvas-actions:207`](https://github.com/voxel51/fiftyone/blob/develop/e2e-pw/src/oss/specs/MISSING-annotate-canvas-actions.spec.ts) being intermittently flaky (\"3 flaky\" on earlier runs). The parallel fiftyone-teams PR (voxel51/fiftyone-teams#2750) restored this same property in its own copy of the file — the regression there came from PR fiftyone-teams#2701 re-introducing both the pre-clear and an early-return guard around it.

## Test plan

- [ ] N/A — comments only, no behavior change.

## Related

- #7288 — the original pre-clear removal (loading-screen flicker fix).
- voxel51/fiftyone-teams#2750 — parallel fix in the teams app that restored this property; CI verified `annotate-sidebar:52`, `annotate-edit:52`, and `annotate-canvas-actions:171/189/207/228/265` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema loading behavior to maintain the previously displayed schema while new data loads, preventing visual flickering and providing a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->