### PR TITLE
chore(release): v1.17.0 — Python 3.9 removal, security dep bumps, enterprise-checks

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -33,11 +33,12 @@ reviews:
   auto_review:
     enabled: true
     ignore_title_keywords:
-      - "WIP"
+      - "AUTOMATED MERGE"
       - "DO NOT MERGE"
       - "DRAFT"
       - "MERGE OSS"
       - "OSS MERGE"
+      - "WIP"
     drafts: false
     base_branches:
       - "develop"

--- a/.github/workflows/build-db.yml
+++ b/.github/workflows/build-db.yml
@@ -25,10 +25,10 @@ jobs:
     steps:
       - name: Clone fiftyone
         uses: actions/checkout@v6
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel build
@@ -90,10 +90,10 @@ jobs:
         with:
           name: dist-sdist
           path: downloads
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install fiftyone-db
         run: |
           pip install downloads/fiftyone_db-*.tar.gz

--- a/.github/workflows/build-graphql.yml
+++ b/.github/workflows/build-graphql.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - name: Clone fiftyone
         uses: actions/checkout@v6
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: true
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel build

--- a/.github/workflows/develop-back-merge.yml
+++ b/.github/workflows/develop-back-merge.yml
@@ -32,6 +32,6 @@ jobs:
           author: voxel51-bot <bot@voxel51.com>
           token: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
           base: develop
-          body: Merge `${{ inputs.ref_name || github.ref_name }}` to `develop`
+          body: AUTOMATED MERGE `${{ inputs.ref_name || github.ref_name }}` to `develop`
           branch: merge/${{ inputs.ref_name || github.ref_name }}
-          title: Merge `${{ inputs.ref_name || github.ref_name }}` to `develop`
+          title: AUTOMATED MERGE `${{ inputs.ref_name || github.ref_name }}` to `develop`

--- a/.github/workflows/develop-back-merge.yml
+++ b/.github/workflows/develop-back-merge.yml
@@ -1,8 +1,9 @@
-name: Push Release
+name: Develop Back-Merge
 
 on:
   push:
     branches:
+      - main
       - release/v[0-9]+.[0-9]+.[0-9]+
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -83,6 +83,24 @@ jobs:
         with:
           github-token: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
           script: |
+            const sha = context.payload.pull_request.head.sha;
+
+            // Post `enterprise / ci = pending` on the PR head immediately so
+            // the required check appears on the PR without waiting for the
+            // Enterprise sync workflow to start. The Enterprise workflow
+            // overwrites this status with `success` or `failure` once it
+            // finishes. Skip for closed PRs — the OSS PR is past the gate.
+            if (context.payload.action !== 'closed') {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha,
+                state: 'pending',
+                context: 'enterprise / ci',
+                description: 'Awaiting Enterprise sync workflow…',
+              });
+            }
+
             await github.rest.repos.createDispatchEvent({
               owner: 'voxel51',
               repo: 'fiftyone-teams',
@@ -92,7 +110,7 @@ jobs:
                 branch: context.payload.pull_request.head.ref,
                 author: context.payload.pull_request.user.login,
                 pr_number: context.payload.pull_request.number,
-                commit_sha: context.payload.pull_request.head.sha,
+                commit_sha: sha,
                 base: context.payload.pull_request.base.ref,
                 merged: context.payload.pull_request.merged ?? false,
               }

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,7 @@ name: Pull Request
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened, closed, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -46,12 +46,19 @@ jobs:
 
   build:
     needs: modified-files
-    if: ${{ needs.modified-files.outputs.app-changes == 'true' || needs.modified-files.outputs.fiftyone-changes == 'true' }}
+    if: >-
+      github.event.action != 'closed' && (
+      needs.modified-files.outputs.app-changes == 'true' ||
+      needs.modified-files.outputs.fiftyone-changes == 'true')
     uses: ./.github/workflows/build.yml
 
   e2e:
     needs: modified-files
-    if: ${{ needs.modified-files.outputs.app-changes == 'true' || needs.modified-files.outputs.e2e-changes == 'true' || needs.modified-files.outputs.fiftyone-changes == 'true' }}
+    if: >-
+      github.event.action != 'closed' && (
+      needs.modified-files.outputs.app-changes == 'true' ||
+      needs.modified-files.outputs.e2e-changes == 'true' ||
+      needs.modified-files.outputs.fiftyone-changes == 'true')
     uses: ./.github/workflows/e2e.yml
     secrets:
       docker-username: ${{ secrets.RO_DOCKERHUB_USERNAME }}
@@ -59,40 +66,51 @@ jobs:
 
   lint:
     needs: modified-files
-    if: ${{ needs.modified-files.outputs.app-changes == 'true' || needs.modified-files.outputs.fiftyone-changes == 'true' }}
+    if: >-
+      github.event.action != 'closed' && (
+      needs.modified-files.outputs.app-changes == 'true' ||
+      needs.modified-files.outputs.fiftyone-changes == 'true')
     uses: ./.github/workflows/lint-app.yml
 
-  teams:
+  enterprise-sync:
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository && (
+      github.event.action == 'closed' ||
+      github.event.pull_request.draft != true)
     runs-on: ubuntu-latest
-    if: false && github.base_ref == 'develop' # temporarily disabled
     steps:
-      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+      - uses: actions/github-script@v7
         with:
-          owner: voxel51
-          repo: fiftyone-teams
-          github_token: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
-          github_user: voxel51-bot
-          workflow_file_name: merge-oss.yml
-          ref: develop
-          wait_interval: 20
-          client_payload: |
-            {
-              "author": "${{ github.event.pull_request.user.login }}",
-              "branch": "${{ github.head_ref || github.ref_name }}",
-              "pr": ${{ github.event.pull_request.number }}
-            }
-          propagate_failure: true
-          trigger_workflow: true
-          wait_workflow: true
+          github-token: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'voxel51',
+              repo: 'fiftyone-teams',
+              event_type: 'oss-pr-sync',
+              client_payload: {
+                action: context.payload.action,
+                branch: context.payload.pull_request.head.ref,
+                author: context.payload.pull_request.user.login,
+                pr_number: context.payload.pull_request.number,
+                commit_sha: context.payload.pull_request.head.sha,
+                base: context.payload.pull_request.base.ref,
+                merged: context.payload.pull_request.merged ?? false,
+              }
+            });
 
   test:
     needs: modified-files
-    if: ${{ needs.modified-files.outputs.app-changes == 'true' || needs.modified-files.outputs.fiftyone-changes == 'true' }}
+    if: >-
+      github.event.action != 'closed' && (
+      needs.modified-files.outputs.app-changes == 'true' ||
+      needs.modified-files.outputs.fiftyone-changes == 'true')
     uses: ./.github/workflows/test.yml
 
   test-windows:
     needs: modified-files
-    if: ${{ needs.modified-files.outputs.fiftyone-changes == 'true' }}
+    if: >-
+      github.event.action != 'closed' &&
+      needs.modified-files.outputs.fiftyone-changes == 'true'
     uses: ./.github/workflows/windows-test.yml
 
   all-tests:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,6 @@ jobs:
         os:
           - ubuntu-latest
         python:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -16,7 +16,6 @@ jobs:
         os:
           - windows-latest
         python:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ pip install fiftyone
 
 ### Installation options
 
-FiftyOne supports Python 3.9 - 3.12.
+FiftyOne supports Python 3.10 - 3.12.
 
 For most users, we recommend installing the latest release version of FiftyOne
 via `pip` as shown above.
@@ -96,7 +96,7 @@ App.
 
 You'll need the following tools installed:
 
--   [Python](https://www.python.org) (3.9 - 3.12)
+-   [Python](https://www.python.org) (3.10 - 3.12)
 -   [Node.js](https://nodejs.org) - on Linux, we recommend using
     [nvm](https://github.com/nvm-sh/nvm) to install an up-to-date version.
 -   [Yarn](https://yarnpkg.com) - once Node.js is installed, you can
@@ -295,7 +295,7 @@ complete the Homebrew installation.
 #### 3. Install Python
 
 ```shell
-brew install python@3.9
+brew install python@3.10
 brew install protobuf
 ```
 
@@ -327,7 +327,7 @@ brew install ffmpeg
 ⚠️ The version of Python that is available in the Microsoft Store is **not
 recommended** ⚠️
 
-Download a Python 3.9 - 3.12 installer from
+Download a Python 3.10 - 3.12 installer from
 [python.org](https://www.python.org/downloads/). Make sure to pick a 64-bit
 version. For example, this
 [Python 3.10.11 installer](https://www.python.org/ftp/python/3.10.11/python-3.10.11-amd64.exe).

--- a/app/package.json
+++ b/app/package.json
@@ -67,7 +67,7 @@
         "react-plotly.js": "^2.6.0"
     },
     "resolutions": {
-        "brace-expansion": "^2.0.3",
+        "brace-expansion": "^5.0.6",
         "three-stdlib": "^2.36.1",
         "@types/react": "18.2.0",
         "minimatch": "9.0.7",

--- a/app/package.json
+++ b/app/package.json
@@ -69,6 +69,8 @@
     "resolutions": {
         "brace-expansion": "^2.0.3",
         "three-stdlib": "^2.36.1",
-        "@types/react": "18.2.0"
+        "@types/react": "18.2.0",
+        "minimatch": "9.0.7",
+        "protobufjs": "^7.6.0"
     }
 }

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -8450,10 +8450,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"balanced-match@npm:^1.0.0":
-  version: 1.0.2
-  resolution: "balanced-match@npm:1.0.2"
-  checksum: 10/9706c088a283058a8a99e0bf91b0a2f75497f185980d9ffa8b304de1d9e58ebda7c72c07ebf01dadedaac5b2907b2c6f566f660d62bd336c3468e960403b9d65
+"balanced-match@npm:^4.0.2":
+  version: 4.0.4
+  resolution: "balanced-match@npm:4.0.4"
+  checksum: 10/fb07bb66a0959c2843fc055838047e2a95ccebb837c519614afb067ebfdf2fa967ca8d712c35ced07f2cd26fc6f07964230b094891315ad74f11eba3d53178a0
   languageName: node
   linkType: hard
 
@@ -8525,12 +8525,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "brace-expansion@npm:2.0.3"
+"brace-expansion@npm:^5.0.6":
+  version: 5.0.6
+  resolution: "brace-expansion@npm:5.0.6"
   dependencies:
-    balanced-match: "npm:^1.0.0"
-  checksum: 10/e9dd66caaf0784126e1654f1bc19adb28f3ef86f39f2226f833f7700ec727c141f6cd85eaa47bacf3426beda01c9fbc3a2f28174cf59330dc9b58ffaf9e09d96
+    balanced-match: "npm:^4.0.2"
+  checksum: 10/a7acf120fefa79e9d7c9c92898114f57c07596a3920197f3c5917e6a628b04220a5f7f9618c30bdd973a6576a32113b99f9c3f1c8245ccc399dd2a9a718d81d8
   languageName: node
   linkType: hard
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -4604,27 +4604,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@protobufjs/codegen@npm:^2.0.4":
-  version: 2.0.4
-  resolution: "@protobufjs/codegen@npm:2.0.4"
-  checksum: 10/c6ee5fa172a8464f5253174d3c2353ea520c2573ad7b6476983d9b1346f4d8f2b44aa29feb17a949b83c1816bc35286a5ea265ed9d8fdd2865acfa09668c0447
+"@protobufjs/codegen@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@protobufjs/codegen@npm:2.0.5"
+  checksum: 10/290335fa114f26202abc0695f279d53e2fd516b01cfd8298923591e0bda011295ff40e3582a1cda0a0f27cbc5039a0292082d5ad08872bb5d6243a614ac15c88
   languageName: node
   linkType: hard
 
-"@protobufjs/eventemitter@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@protobufjs/eventemitter@npm:1.1.0"
-  checksum: 10/03af3e99f17ad421283d054c88a06a30a615922a817741b43ca1b13e7c6b37820a37f6eba9980fb5150c54dba6e26cb6f7b64a6f7d8afa83596fafb3afa218c3
+"@protobufjs/eventemitter@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/eventemitter@npm:1.1.1"
+  checksum: 10/a54dc1aff4475ffad4fdf3235c71a553f5e40e3b4cf6a2e217151895a61cb4eb0be20d63791db22441ca25e594671f1021977133f9939540750231ff7d8e9dd6
   languageName: node
   linkType: hard
 
-"@protobufjs/fetch@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@protobufjs/fetch@npm:1.1.0"
+"@protobufjs/fetch@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/fetch@npm:1.1.1"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.1"
-    "@protobufjs/inquire": "npm:^1.1.0"
-  checksum: 10/67ae40572ad536e4ef94269199f252c024b66e3059850906bdaee161ca1d75c73d04d35cd56f147a8a5a079f5808e342b99e61942c1dae15604ff0600b09a958
+  checksum: 10/427cf2da8c69b494b0df3b2fb1f43c97f0f71ca2c8ef8232dac7e44f2527ad0cc9cecb243eda14a918e86018bfa6d54d92252240d2b37ed205b13adb5506fa1d
   languageName: node
   linkType: hard
 
@@ -4635,10 +4634,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@protobufjs/inquire@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@protobufjs/inquire@npm:1.1.0"
-  checksum: 10/c09efa34a5465cb120775e1a482136f2340a58b4abce7e93d72b8b5a9324a0e879275016ef9fcd73d72a4731639c54f2bb755bb82f916e4a78892d1d840bb3d2
+"@protobufjs/inquire@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/inquire@npm:1.1.2"
+  checksum: 10/259756489c75a751552df60d18f82503d2534855646397b96b91cf15807fa852e99bd9eb73dabb64da37aec7913844032ecb031a4326d82aae622f5e4c2f8a17
   languageName: node
   linkType: hard
 
@@ -4656,7 +4655,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@protobufjs/utf8@npm:^1.1.0":
+"@protobufjs/utf8@npm:^1.1.1":
   version: 1.1.1
   resolution: "@protobufjs/utf8@npm:1.1.1"
   checksum: 10/ed0c3f9ff1afd602a0aed54c4c03a0b8f641686a5587d8949e088dcac653fb2019d15691ed92eef23dfdf9f4293249532d0508ecd15cef810acf026917719a19
@@ -15013,7 +15012,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"long@npm:^5.0.0, long@npm:^5.2.3":
+"long@npm:^5.2.3, long@npm:^5.3.2":
   version: 5.3.2
   resolution: "long@npm:5.3.2"
   checksum: 10/b6b55ddae56fcce2864d37119d6b02fe28f6dd6d9e44fd22705f86a9254b9321bd69e9ffe35263b4846d54aba197c64882adcb8c543f2383c1e41284b321ea64
@@ -16019,39 +16018,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:9.0.3, minimatch@npm:^9.0.1":
-  version: 9.0.3
-  resolution: "minimatch@npm:9.0.3"
+"minimatch@npm:9.0.7":
+  version: 9.0.7
+  resolution: "minimatch@npm:9.0.7"
   dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10/c81b47d28153e77521877649f4bab48348d10938df9e8147a58111fe00ef89559a2938de9f6632910c4f7bf7bb5cd81191a546167e58d357f0cfb1e18cecc1c5
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "minimatch@npm:3.1.2"
-  dependencies:
-    brace-expansion: "npm:^1.1.7"
-  checksum: 10/e0b25b04cd4ec6732830344e5739b13f8690f8a012d73445a4a19fbc623f5dd481ef7a5827fde25954cd6026fede7574cc54dc4643c99d6c6b653d6203f94634
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^7.1.3":
-  version: 7.4.6
-  resolution: "minimatch@npm:7.4.6"
-  dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10/0046ba1161ac6414bde1b07c440792ebcdb2ed93e6714c85c73974332b709b7e692801550bc9da22028a8613407b3f13861e17dd0dd44f4babdeacd44950430b
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^9.0.4":
-  version: 9.0.5
-  resolution: "minimatch@npm:9.0.5"
-  dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10/dd6a8927b063aca6d910b119e1f2df6d2ce7d36eab91de83167dd136bb85e1ebff97b0d3de1cb08bd1f7e018ca170b4962479fefab5b2a69e2ae12cb2edc8348
+    brace-expansion: "npm:^5.0.2"
+  checksum: 10/72b9ba4af39f6a89934d56c9cc3bf1d86fb004b00c5e5b3d7f48b004f224005fd2919f52785643b7a18d53fc86f7befc7f25c85ef194cc06708b078682f8c9e5
   languageName: node
   linkType: hard
 
@@ -17577,23 +17549,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.2.4":
-  version: 7.5.5
-  resolution: "protobufjs@npm:7.5.5"
+"protobufjs@npm:^7.6.0":
+  version: 7.6.2
+  resolution: "protobufjs@npm:7.6.2"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
-    "@protobufjs/codegen": "npm:^2.0.4"
-    "@protobufjs/eventemitter": "npm:^1.1.0"
-    "@protobufjs/fetch": "npm:^1.1.0"
+    "@protobufjs/codegen": "npm:^2.0.5"
+    "@protobufjs/eventemitter": "npm:^1.1.1"
+    "@protobufjs/fetch": "npm:^1.1.1"
     "@protobufjs/float": "npm:^1.0.2"
-    "@protobufjs/inquire": "npm:^1.1.0"
+    "@protobufjs/inquire": "npm:^1.1.2"
     "@protobufjs/path": "npm:^1.1.2"
     "@protobufjs/pool": "npm:^1.1.0"
-    "@protobufjs/utf8": "npm:^1.1.0"
+    "@protobufjs/utf8": "npm:^1.1.1"
     "@types/node": "npm:>=13.7.0"
-    long: "npm:^5.0.0"
-  checksum: 10/048898023a38d22f5fc9a1bcf0dcce5cfbcd37fb00753bd72283720eee7e2cb6055b23957542e5bcdc136379af66203a2ddb8d8c39d11f73169bacf07885fedd
+    long: "npm:^5.3.2"
+  checksum: 10/964e39237febf2369cba371175a49602ccc7582f059504ab35e27adb01c690ad669bc2c134577f08f5fb55d1dc8320483f6a65a97f236dc6e749046d89283b5f
   languageName: node
   linkType: hard
 

--- a/docs/source/getting_started/depth_estimation/index.rst
+++ b/docs/source/getting_started/depth_estimation/index.rst
@@ -60,7 +60,7 @@ Each notebook contains the necessary `pip install` commands at the beginning, so
 **System Requirements**
 
 - **Operating System:** Linux (Ubuntu 24.04), macOS
-- **Python:** 3.9, 3.11
+- **Python:** 3.10, 3.11, 3.12
 - **Memory:** 8GB RAM recommended (16GB for larger models)
 - **Storage:** 10GB free space for datasets and models
 - **GPU:** Optional but recommended for faster inference (CUDA-capable GPU)

--- a/docs/source/getting_started/manufacturing/index.rst
+++ b/docs/source/getting_started/manufacturing/index.rst
@@ -81,7 +81,7 @@ Each notebook contains the necessary `pip install` commands at the beginning, so
 **System Requirements**
 
 - **Operating System:** Linux (Ubuntu 20.04+), macOS
-- **Python:** 3.9, 3.10, 3.11
+- **Python:** 3.10, 3.11, 3.12
 - **Memory:** 8GB RAM recommended for manufacturing dataset operations
 - **Storage:** 10GB free space for manufacturing datasets and models
 - **GPU:** Optional but recommended for faster model inference

--- a/docs/source/getting_started/medical_imaging/index.rst
+++ b/docs/source/getting_started/medical_imaging/index.rst
@@ -56,7 +56,7 @@ Each notebook contains the necessary `pip install` commands at the beginning, so
 **System Requirements**
 
 - **Operating System:** Linux (Ubuntu 24.04), macOS
-- **Python:** 3.9, 3.11
+- **Python:** 3.10, 3.11, 3.12
 - **Memory:** 8GB RAM recommended for medical imaging operations
 - **Storage:** 5GB free space for medical datasets
 - **Notebook Environment:** Jupyter, Google Colab, VS Code notebooks (all validated)

--- a/docs/source/getting_started/model_evaluation/index.rst
+++ b/docs/source/getting_started/model_evaluation/index.rst
@@ -51,7 +51,7 @@ Each notebook contains the necessary `pip install` commands at the beginning, so
 **System Requirements**
 
 - **Operating System:** Linux (Ubuntu 24.04), macOS
-- **Python:** 3.9, 3.11
+- **Python:** 3.10, 3.11, 3.12
 - **Memory:** 8GB RAM recommended for evaluation operations
 - **Storage:** 2GB free space for datasets and models
 - **Notebook Environment:** Jupyter, Google Colab, VS Code notebooks (all validated)

--- a/docs/source/getting_started/object_detection/index.rst
+++ b/docs/source/getting_started/object_detection/index.rst
@@ -53,7 +53,7 @@ Each notebook contains the necessary `pip install` commands at the beginning, so
 **System Requirements**
 
 - **Operating System:** Linux (Ubuntu 24.04), macOS
-- **Python:** 3.9, 3.11
+- **Python:** 3.10, 3.11, 3.12
 - **Memory:** 8GB RAM recommended for COCO dataset operations
 - **Storage:** 2GB free space for datasets and models
 - **Notebook Environment:** Jupyter, Google Colab, VS Code notebooks (all validated)

--- a/docs/source/getting_started/threed_visual_ai/index.rst
+++ b/docs/source/getting_started/threed_visual_ai/index.rst
@@ -54,7 +54,7 @@ Each notebook contains the necessary `pip install` commands at the beginning, so
 **System Requirements**
 
 - **Operating System:** Linux (Ubuntu 24.04), macOS
-- **Python:** 3.9, 3.11
+- **Python:** 3.10, 3.11, 3.12
 - **Memory:** 8GB RAM recommended for 3D operations
 - **Storage:** 5GB free space for 3D datasets
 - **Graphics:** GPU recommended for large point cloud visualization

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -15,7 +15,7 @@ Prerequisites
 -------------
 
 You will need a working Python installation. FiftyOne currently requires
-**Python 3.9 - 3.12**.
+**Python 3.10 - 3.12**.
 
 On Linux, we recommend installing Python through your system package manager
 (APT, YUM, etc.) if it is available. On other platforms, Python can be

--- a/docs/source/installation/troubleshooting.rst
+++ b/docs/source/installation/troubleshooting.rst
@@ -44,9 +44,9 @@ old, you may encounter errors like these:
 
 .. code-block:: text
 
-    fiftyone requires Python '>=3.10' but the running Python is 3.4.10
+    fiftyone requires Python '>=3.10' but the running Python is 3.9.25
 
-To resolve this, you will need to use Python 3.10 or newer, and pip 19.3 or
+To resolve this, you will need to use Python 3.10 or newer, and pip 21.3 or
 newer. See the :ref:`installation guide <installing-fiftyone>` for details. If
 you have installed a suitable version of Python in a virtual environment and
 still encounter this error, ensure that the virtual environment is activated.

--- a/docs/source/installation/troubleshooting.rst
+++ b/docs/source/installation/troubleshooting.rst
@@ -44,9 +44,9 @@ old, you may encounter errors like these:
 
 .. code-block:: text
 
-    fiftyone requires Python '>=3.9' but the running Python is 3.4.10
+    fiftyone requires Python '>=3.10' but the running Python is 3.4.10
 
-To resolve this, you will need to use Python 3.9 or newer, and pip 19.3 or
+To resolve this, you will need to use Python 3.10 or newer, and pip 19.3 or
 newer. See the :ref:`installation guide <installing-fiftyone>` for details. If
 you have installed a suitable version of Python in a virtual environment and
 still encounter this error, ensure that the virtual environment is activated.

--- a/docs/source/installation/virtualenv.rst
+++ b/docs/source/installation/virtualenv.rst
@@ -71,7 +71,7 @@ of this guide. For example:
 .. code-block:: text
 
    $ python --version
-   Python 3.10.18
+   Python 3.10.20
 
 Also note that `python` and `pip` live inside the `env` folder (in this output,
 the path to the current folder is replaced with `...`):

--- a/docs/source/installation/virtualenv.rst
+++ b/docs/source/installation/virtualenv.rst
@@ -26,7 +26,7 @@ these commands:
    $ python --version
    Python 2.7.17
    $ python3 --version
-   Python 3.10.18
+   Python 3.10.20
 
 In this case, `python3` should be used in the next step.
 

--- a/docs/source/installation/virtualenv.rst
+++ b/docs/source/installation/virtualenv.rst
@@ -26,7 +26,7 @@ these commands:
    $ python --version
    Python 2.7.17
    $ python3 --version
-   Python 3.9.20
+   Python 3.10.18
 
 In this case, `python3` should be used in the next step.
 
@@ -71,7 +71,7 @@ of this guide. For example:
 .. code-block:: text
 
    $ python --version
-   Python 3.9.20
+   Python 3.10.18
 
 Also note that `python` and `pip` live inside the `env` folder (in this output,
 the path to the current folder is replaced with `...`):

--- a/e2e-pw/src/shared/media-factory/fo3d.ts
+++ b/e2e-pw/src/shared/media-factory/fo3d.ts
@@ -28,11 +28,11 @@ export const createFo3d = ({
     metalness: 0,
     roughness: 1,
     opacity: 1,
-    vertexColors: true,
     wireframe: false,
   };
 
   const scene: Record<string, unknown> = {
+    __FO3D_VERSION: "0",
     _type: "Scene",
     name: "root",
     visible: true,

--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -6,6 +6,7 @@ Installs the ``fiftyone-db`` package.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import csv
 import os
 import pathlib
@@ -345,10 +346,9 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     cmdclass=cmdclass,
 )

--- a/package/desktop/setup.py
+++ b/package/desktop/setup.py
@@ -6,6 +6,7 @@ Installs the ``fiftyone-desktop`` package.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import glob
 import os
 import shutil
@@ -14,7 +15,6 @@ from wheel.bdist_wheel import bdist_wheel
 
 import os
 import shutil
-
 
 VERSION = "0.35.0"
 
@@ -187,10 +187,9 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     cmdclass=cmdclass,
 )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ Installs FiftyOne.
 import os
 from setuptools import setup, find_packages
 
-
 VERSION = "1.16.1"
 
 
@@ -116,11 +115,10 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
     ],
     entry_points={"console_scripts": ["fiftyone=fiftyone.core.cli:main"]},
-    python_requires=">=3.9",
+    python_requires=">=3.10",
 )

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         "sseclient-py>=1.7.2,<2",
         "sse-starlette>=0.10.3,<4",
         "starlette>=0.49.1,<0.53",
-        "strawberry-graphql>=0.262.4,<0.292.0",
+        "strawberry-graphql>=0.312.3,<0.317.0",
         "tabulate>=0.7,<0.10",
         "tqdm>=2,<5",
         "xmltodict>=1,<2",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ Installs FiftyOne.
 import os
 from setuptools import setup, find_packages
 
-VERSION = "1.16.1"
+VERSION = "1.17.0"
 
 
 def get_version():

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         "jsonpatch>=1,<2",
         "mongoengine~=0.29.1",  # Keep small bounds on mongo-related libraries
         "motor~=3.6.0",  # Keep small bounds on mongo-related libraries
-        "Pillow>=6.2,!=11.2.*",  # Pillow 11.2.0 introduced CVE 2025-48379 that is fixed in 11.3.0
+        "Pillow>=12.2",
         "plotly>=6.1.1,<7",
         "pprintpp>=0.1,<0.5",
         "protobuf==6.33.6",

--- a/tests/unittests/fcv_tests.py
+++ b/tests/unittests/fcv_tests.py
@@ -44,7 +44,7 @@ class TestUpdateFCV(unittest.TestCase):
 
         for server_version, fc_version in test_cases:
             with self.subTest(
-                server_version=server_version, fc_version=fc_version
+                server_version=str(server_version), fc_version=str(fc_version)
             ), patch("pymongo.MongoClient") as mock_client, patch(
                 "fiftyone.core.odm.database.logger"
             ) as mock_logger:


### PR DESCRIPTION
## Summary

Release branch **content** for **FiftyOne 1.17.0 / Enterprise 2.20.0**, targeting `release/v1.17.0`.

> Originally scoped as `1.16.1`, but removing Python 3.9 support is a breaking change, so this ships as a **minor** (`1.17.0` / FOE `2.20.0`). The `VERSION` bump + release notes are in #7695; `develop` moves to `1.18.0` in #7706.

### Infra
- **AS-1090**: remove Python 3.9 support (`python_requires>=3.10`, classifiers/docs updated)
- `cf7a0ae4f3` — merge of #7294 (Enterprise sync workflow)
- `45d94e5a7f` — backport of the `e2e-pw/.../fo3d.ts` tweak
- `6e7dccde02` — #7618 QOL: skip CodeRabbit on automated release→develop merge PRs

### Security vulnerability remediations
| Ticket | Package | CVE | Fix |
|--------|---------|-----|-----|
| FOEPD-3725 | Pillow | CVE-2026-40192 | `setup.py` → `Pillow>=12.2` |
| FOEPD-3719 | strawberry-graphql | CVE-2026-35523 | `setup.py` → `>=0.312.3,<0.317.0` |
| FOEPD-3761 | minimatch | CVE-2026-27904 (HIGH) | `app` resolution → **9.0.7** |
| FOEPD-3731 | protobufjs | CVE-2026-41242 (CRITICAL) | `app` resolution → **>=7.6** |
| FOEPD-3599/3601 | brace-expansion | CVE-2026-33750 | `app` resolution → **>=5.0.6** (also required for minimatch 9.0.7) |

Enterprise app side propagates via the OSS→teams sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2783
<!-- enterprise-sync-pr:end -->