### PR TITLE
docs+chore(release): notes + version bump for 1.17.0 / Enterprise 2.20.0

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -3,17 +3,17 @@ FiftyOne Release Notes
 
 .. default-role:: code
 
-FiftyOne Enterprise 2.19.1
+FiftyOne Enterprise 2.20.0
 --------------------------
 *Released June 2, 2026*
 
-Includes all updates from :ref:`FiftyOne 1.16.1 <release-notes-v1.16.1>`. No
+Includes all updates from :ref:`FiftyOne 1.17.0 <release-notes-v1.17.0>`. No
 additional Enterprise-specific changes in this release.
 
 
-.. _release-notes-v1.16.1:
+.. _release-notes-v1.17.0:
 
-FiftyOne 1.16.1
+FiftyOne 1.17.0
 ---------------
 *Released June 2, 2026*
 
@@ -44,6 +44,22 @@ In-App Annotation
 - Improved annotation performance by coalescing hover handling via
   ``requestAnimationFrame`` and fixing duplicate polyline handler creation
   `#7597 <https://github.com/voxel51/fiftyone/pull/7597>`_
+
+Security
+
+- Updated ``Pillow`` to ``>=12.2`` to resolve CVE-2026-40192
+  `#7694 <https://github.com/voxel51/fiftyone/pull/7694>`_
+- Updated ``strawberry-graphql`` to ``>=0.312.3`` to resolve CVE-2026-35523
+  `#7694 <https://github.com/voxel51/fiftyone/pull/7694>`_
+- Updated App dependencies to resolve vulnerabilities: ``minimatch`` (9.0.7,
+  CVE-2026-27904), ``protobufjs`` (>=7.6, CVE-2026-41242), and
+  ``brace-expansion`` (>=5.0.6, CVE-2026-33750)
+  `#7694 <https://github.com/voxel51/fiftyone/pull/7694>`_
+
+General
+
+- Removed support for Python 3.9; FiftyOne now requires Python 3.10 or later
+  `#7585 <https://github.com/voxel51/fiftyone/pull/7585>`_
 
 
 FiftyOne Enterprise 2.19.0

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -3,6 +3,36 @@ FiftyOne Release Notes
 
 .. default-role:: code
 
+FiftyOne Enterprise 2.19.1
+--------------------------
+*Released TBD*
+
+Includes all updates from :ref:`FiftyOne 1.16.1 <release-notes-v1.16.1>`. No
+additional Enterprise-specific changes in this release.
+
+
+.. _release-notes-v1.16.1:
+
+FiftyOne 1.16.1
+---------------
+*Released TBD*
+
+App
+
+- Fixed a bug where the global "Pixelating…" loading screen could re-appear
+  when opening the modal or navigating between samples in explore mode
+  `#7526 <https://github.com/voxel51/fiftyone/pull/7526>`_
+- Fixed the same loading-screen flicker for grouped datasets when opening
+  the modal, switching slices, or navigating between groups in the modal
+  `#7551 <https://github.com/voxel51/fiftyone/pull/7551>`_
+- Fixed a bug where the 3D viewer could fail to render when a grouped
+  dataset's active slice had no sample (sparse / pcd-only groups)
+  `#7288 <https://github.com/voxel51/fiftyone/pull/7288>`_
+- Fixed value tearing in the dynamic-groups pagination bar during slice
+  transitions
+  `#7599 <https://github.com/voxel51/fiftyone/pull/7599>`_
+
+
 FiftyOne Enterprise 2.19.0
 --------------------------
 *Released May 28, 2026*

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -32,6 +32,19 @@ App
   transitions
   `#7599 <https://github.com/voxel51/fiftyone/pull/7599>`_
 
+In-App Annotation
+
+- Allowed persisting labels that have no `label` attribute set
+  `#7639 <https://github.com/voxel51/fiftyone/pull/7639>`_
+- Fixed a crash when changing the field of a polylines label
+  `#7638 <https://github.com/voxel51/fiftyone/pull/7638>`_
+- Fixed a bug where click-to-segment stopped working after navigating between
+  samples in the modal
+  `#7637 <https://github.com/voxel51/fiftyone/pull/7637>`_
+- Improved annotation performance by coalescing hover handling via
+  ``requestAnimationFrame`` and fixing duplicate polyline handler creation
+  `#7597 <https://github.com/voxel51/fiftyone/pull/7597>`_
+
 
 FiftyOne Enterprise 2.19.0
 --------------------------

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -5,7 +5,7 @@ FiftyOne Release Notes
 
 FiftyOne Enterprise 2.20.0
 --------------------------
-*Released June 2, 2026*
+*Released June 3, 2026*
 
 Includes all updates from :ref:`FiftyOne 1.17.0 <release-notes-v1.17.0>`. No
 additional Enterprise-specific changes in this release.
@@ -15,7 +15,7 @@ additional Enterprise-specific changes in this release.
 
 FiftyOne 1.17.0
 ---------------
-*Released June 2, 2026*
+*Released June 3, 2026*
 
 App
 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -5,7 +5,7 @@ FiftyOne Release Notes
 
 FiftyOne Enterprise 2.19.1
 --------------------------
-*Released TBD*
+*Released June 2, 2026*
 
 Includes all updates from :ref:`FiftyOne 1.16.1 <release-notes-v1.16.1>`. No
 additional Enterprise-specific changes in this release.
@@ -15,7 +15,7 @@ additional Enterprise-specific changes in this release.
 
 FiftyOne 1.16.1
 ---------------
-*Released TBD*
+*Released June 2, 2026*
 
 App
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import os
 from setuptools import setup, find_packages
 
 
-VERSION = "1.16.1"
+VERSION = "1.17.0"
 
 
 def get_version():


### PR DESCRIPTION
## Summary

Release notes **and version bump** for **FiftyOne 1.17.0 / Enterprise 2.20.0** (Released June 3, 2026), targeting `release/v1.17.0`.

> Originally scoped as `1.16.1` / `2.19.1`, but the Python 3.9 removal is a breaking change, so this ships as a **minor**. `develop` → `1.18.0` in #7706.

### Changes
- `setup.py`: `VERSION` → `1.17.0`
- `docs/source/release-notes.rst`: adds the **FiftyOne 1.17.0** and **FiftyOne Enterprise 2.20.0** sections.

### Release notes content

**FiftyOne 1.17.0**
- **App**: loading-screen flicker on modal open / sample navigation in explore mode (#7526) and for grouped datasets (#7551); 3D viewer crash on sparse / pcd-only group slices (#7288); dynamic-groups pagination value-tearing (#7599).
- **In-App Annotation**: persist labels with no `label` attribute (#7639); polylines field-change crash (#7638); click-to-segment after modal navigation (#7637); annotation perf — rAF hover coalescing + duplicate polyline handler fix (#7597).
- **Security**: `Pillow>=12.2` (CVE-2026-40192), `strawberry-graphql>=0.312.3` (CVE-2026-35523), and App deps `minimatch` 9.0.7 (CVE-2026-27904), `protobufjs>=7.6` (CVE-2026-41242), `brace-expansion>=5.0.6` (CVE-2026-33750) — all via #7694.
- **General**: removed Python 3.9 support; now requires Python 3.10+ (#7585).

**FiftyOne Enterprise 2.20.0**
- Inherits all 1.17.0 updates; no additional Enterprise-specific changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Releases**
  * FiftyOne Enterprise 2.20.0 released (June 3, 2026) — includes all FiftyOne 1.17.0 updates, no additional Enterprise-specific changes.

* **Bug Fixes**
  * Fixed app loading-screen flicker, 3D viewer render failures, pagination/value tearing, and click-to-segment regressions.
  * Resolved annotation persistence and field-change crashes; improved annotation performance.

* **Security**
  * Updated dependencies to address known vulnerabilities.

* **Chores**
  * Version bumped to 1.17.0; minimum Python requirement raised to 3.10+.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->