### PR TITLE
Automatically flatten dynamic groups during clones

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -10033,6 +10033,9 @@ def _clone_collection(
 ):
     slug = _validate_dataset_name(name)
 
+    if sample_collection._is_dynamic_groups:
+        sample_collection = sample_collection.flatten()
+
     contains_videos = sample_collection._contains_videos(any_slice=True)
 
     if isinstance(sample_collection, fov.DatasetView):
@@ -10041,9 +10044,6 @@ def _clone_collection(
 
         if view.media_type == fom.MIXED:
             raise ValueError("Cloning mixed views is not allowed")
-
-        if view._is_dynamic_groups:
-            raise ValueError("Cloning dynamic grouped views is not allowed")
     else:
         dataset = sample_collection
         view = None


### PR DESCRIPTION
## Release Notes

- `clone()` now supports [dynamic grouped views](https://docs.voxel51.com/user_guide/using_views.html#grouping). Previously users were required to manually `flatten()` the view before cloning it

## Example Usage

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-groups")

view = dataset.group_by("metadata.width", order_by="last_modified_at").limit(1)

# Previously: must manually flatten the view before cloning it
dataset2 = view.flatten().clone()

# New syntax: directly clone a dynamically grouped view
dataset3 = view.clone()

assert len(dataset3) == len(view.flatten())
assert len(dataset3.select_group_slices(_allow_mixed=True)) == len(view.flatten().select_group_slices(_allow_mixed=True))
```