### PR TITLE
Dan/test miris 7557

### DIFF
--- a/app/packages/looker-3d/package.json
+++ b/app/packages/looker-3d/package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
-        "@miris-inc/three": "latest",
+        "@miris-inc/three": "0.0.8-ec1b54d",
         "@react-three/drei": "^10.7.6",
         "@react-three/fiber": "^8.18.0",
         "chroma-js": "^3.1.2",

--- a/app/packages/looker-3d/package.json
+++ b/app/packages/looker-3d/package.json
@@ -15,6 +15,7 @@
     "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
+        "@miris-inc/three": "latest",
         "@react-three/drei": "^10.7.6",
         "@react-three/fiber": "^8.18.0",
         "chroma-js": "^3.1.2",

--- a/app/packages/looker-3d/src/fo3d/FoScene.tsx
+++ b/app/packages/looker-3d/src/fo3d/FoScene.tsx
@@ -10,6 +10,7 @@ import { Fo3dBackground } from "./Background";
 import { useFo3dContext } from "./context";
 import { Fbx } from "./mesh/Fbx";
 import { Gltf } from "./mesh/Gltf";
+import { MirisStream } from "./mesh/MirisStream";
 import { Obj } from "./mesh/Obj";
 import { Ply } from "./mesh/Ply";
 import { Stl } from "./mesh/Stl";
@@ -21,6 +22,7 @@ import {
   type FoScene,
   type FoSceneNode,
   GltfAsset,
+  MirisStreamAsset,
   ObjAsset,
   PcdAsset,
   PlaneGeometryAsset,
@@ -175,6 +177,19 @@ const getAssetJsx = (node: FoSceneNode, children: React.ReactNode) => {
       >
         {children}
       </Plane>
+    );
+  } else if (node.asset instanceof MirisStreamAsset) {
+    return (
+      <MirisStream
+        key={key}
+        name={node.name}
+        asset={node.asset as MirisStreamAsset}
+        position={node.position}
+        quaternion={node.quaternion}
+        scale={node.scale}
+      >
+        {children}
+      </MirisStream>
     );
   }
 

--- a/app/packages/looker-3d/src/fo3d/mesh/MirisStream.tsx
+++ b/app/packages/looker-3d/src/fo3d/mesh/MirisStream.tsx
@@ -10,7 +10,10 @@ import type { MirisStreamAsset } from "../render-types";
 let _mirisPromise: Promise<unknown> | null = null;
 const ensureMirisRuntime = () => {
   if (!_mirisPromise) {
-    _mirisPromise = import("@miris-inc/three")
+    _mirisPromise = import("@miris-inc/three").catch((err) => {
+      _mirisPromise = null;
+      throw err;
+    });
   }
   return _mirisPromise as Promise<{ MirisStream: unknown }>;
 };
@@ -33,7 +36,9 @@ export const MirisStream = ({
   const ds = useRecoilValue(dataset as never) as {
     info?: Record<string, unknown>;
   } | null;
-  const datasetViewerKey = ds?.info?.["miris_viewer_key"] as string | undefined;
+  const rawDatasetViewerKey = ds?.info?.["miris_viewer_key"];
+  const datasetViewerKey =
+    typeof rawDatasetViewerKey === "string" ? rawDatasetViewerKey : undefined;
   const viewerKey = asset.viewerKey ?? datasetViewerKey;
 
   const [stream, setStream] = useState<Group | null>(null);

--- a/app/packages/looker-3d/src/fo3d/mesh/MirisStream.tsx
+++ b/app/packages/looker-3d/src/fo3d/mesh/MirisStream.tsx
@@ -1,0 +1,89 @@
+import { dataset } from "@fiftyone/state";
+import { useEffect, useState } from "react";
+import { useRecoilValue } from "recoil";
+import type { Group, Quaternion, Vector3 } from "three";
+import type { MirisStreamAsset } from "../render-types";
+
+// Cached promise for the Miris WASM runtime. Resolves once per page, shared
+// across all MirisStream nodes. Dynamic-imported so the SDK (and its WASM
+// blob) only ships if a fo3d scene actually contains a Miris stream.
+let _mirisPromise: Promise<unknown> | null = null;
+const ensureMirisRuntime = () => {
+  if (!_mirisPromise) {
+    _mirisPromise = import("@miris-inc/three")
+  }
+  return _mirisPromise as Promise<{ MirisStream: unknown }>;
+};
+
+export const MirisStream = ({
+  name,
+  asset,
+  position,
+  quaternion,
+  scale,
+  children,
+}: {
+  name: string;
+  asset: MirisStreamAsset;
+  position: Vector3;
+  quaternion: Quaternion;
+  scale: Vector3;
+  children?: React.ReactNode;
+}) => {
+  const ds = useRecoilValue(dataset as never) as {
+    info?: Record<string, unknown>;
+  } | null;
+  const datasetViewerKey = ds?.info?.["miris_viewer_key"] as string | undefined;
+  const viewerKey = asset.viewerKey ?? datasetViewerKey;
+
+  const [stream, setStream] = useState<Group | null>(null);
+
+  useEffect(() => {
+    let constructed: Group | null = null;
+    let cancelled = false;
+
+    if (asset.assetUuid && viewerKey) {
+      (async () => {
+        try {
+          const { MirisStream: MirisStreamSDK } = await ensureMirisRuntime() as any;
+          if (cancelled) return;
+          constructed = new MirisStreamSDK({
+            uuid: asset.assetUuid,
+            viewerKey,
+          }) as unknown as Group;
+          constructed.name = name;
+          setStream(constructed);
+        } catch (err) {
+          console.error("[MirisStream] Failed to construct stream:", err);
+        }
+      })();
+    } else if (asset.assetUuid && !viewerKey) {
+      console.warn(
+        "[MirisStream] No viewer key resolved (checked asset.viewerKey and " +
+          "dataset.info.miris_viewer_key); skipping stream construction."
+      );
+    }
+
+    return () => {
+      cancelled = true;
+      constructed?.removeFromParent();
+      setStream(null);
+    };
+  }, [asset.assetUuid, viewerKey, name]);
+
+  if (!stream) {
+    return null;
+  }
+
+  return (
+    <primitive
+      object={stream}
+      position={position}
+      quaternion={quaternion}
+      scale={scale}
+      dispose={null}
+    >
+      {children ?? null}
+    </primitive>
+  );
+};

--- a/app/packages/looker-3d/src/fo3d/render-types.ts
+++ b/app/packages/looker-3d/src/fo3d/render-types.ts
@@ -109,6 +109,13 @@ export class StlAsset {
   ) {}
 }
 
+export class MirisStreamAsset {
+  constructor(
+    readonly assetUuid: string,
+    readonly viewerKey?: string
+  ) {}
+}
+
 export type MeshAsset =
   | FbxAsset
   | GltfAsset
@@ -119,7 +126,8 @@ export type MeshAsset =
   | BoxGeometryAsset
   | CylinderGeometryAsset
   | PlaneGeometryAsset
-  | SphereGeometryAsset;
+  | SphereGeometryAsset
+  | MirisStreamAsset;
 
 export type FoMaterial3D = {
   opacity: number;
@@ -182,6 +190,7 @@ export type FoPointcloudMaterialProps = FoMaterial3D & {
 };
 
 export type FoSceneNode = {
+  uuid?: string;
   name: string;
   asset?: MeshAsset;
   position: Vector3;

--- a/app/packages/looker-3d/src/hooks/use-fo3d-scene-parser.ts
+++ b/app/packages/looker-3d/src/hooks/use-fo3d-scene-parser.ts
@@ -9,6 +9,7 @@ import {
   type FoSceneNode,
   GltfAsset,
   type MeshAsset,
+  MirisStreamAsset,
   ObjAsset,
   PcdAsset,
   PlaneGeometryAsset,
@@ -102,6 +103,13 @@ const toQuaternion = (
 const parseAsset = (node: FoSceneRawNode): MeshAsset | undefined => {
   const nodeType = node._type.toLowerCase();
   const material = node.defaultMaterial;
+
+  if (nodeType === "mirisstream" && hasStringField(node, "assetUuid")) {
+    return new MirisStreamAsset(
+      node.assetUuid,
+      getOptionalStringField(node, "viewerKey")
+    );
+  }
 
   if (nodeType.endsWith("mesh")) {
     const meshMaterial = isFoMeshMaterial(material) ? material : undefined;
@@ -237,6 +245,7 @@ const parseAsset = (node: FoSceneRawNode): MeshAsset | undefined => {
 
 const buildSceneNode = (node: FoSceneRawNode): FoSceneNode => {
   return {
+    uuid: node.uuid,
     asset: parseAsset(node),
     name: node.name,
     visible: node.visible,

--- a/app/packages/looker-3d/src/types/miris-three.d.ts
+++ b/app/packages/looker-3d/src/types/miris-three.d.ts
@@ -1,0 +1,52 @@
+declare module "@miris-inc/three" {
+  import { Object3D, Scene as ThreeScene } from "three";
+
+  export class Miris {
+    static instance(): Promise<Miris>;
+  }
+
+  export class MirisScene extends ThreeScene {
+    constructor(init?: { miris?: Miris; viewerKey?: string | null });
+    viewerKey: string | null;
+    readonly ready: Promise<MirisScene>;
+    readonly pending: boolean;
+    dispose(): void;
+    fetchAssets(tags?: string | string[]): Promise<unknown[]>;
+  }
+
+  interface MirisStreamBounds {
+    min: [number, number, number];
+    max: [number, number, number];
+    size: [number, number, number];
+    center: [number, number, number];
+  }
+
+  export class MirisStream extends Object3D {
+    constructor(init: {
+      uuid: string;
+      viewerKey?: string;
+      authToken?: string;
+      drmKey?: string;
+    });
+    readonly isStream: true;
+    static viewerKey: string;
+    getBounds(): MirisStreamBounds;
+    addEventListener(
+      type: "streamloaded" | "rootloaded",
+      listener: (event: unknown) => void
+    ): void;
+    removeEventListener(
+      type: "streamloaded" | "rootloaded",
+      listener: (event: unknown) => void
+    ): void;
+  }
+
+  export class MirisControls {
+    constructor(
+      objects: Object3D | Iterable<Object3D> | null,
+      camera: import("three").Camera,
+      domElement: HTMLElement
+    );
+    dispose(): void;
+  }
+}

--- a/app/packages/plugins/package.json
+++ b/app/packages/plugins/package.json
@@ -26,7 +26,6 @@
         "vite": "^7.3.2"
     },
     "dependencies": {
-        "moment": "^2.29.4",
-        "three": "^0.182.0"
+        "moment": "^2.29.4"
     }
 }

--- a/app/packages/plugins/package.json
+++ b/app/packages/plugins/package.json
@@ -26,6 +26,7 @@
         "vite": "^7.3.2"
     },
     "dependencies": {
-        "moment": "^2.29.4"
+        "moment": "^2.29.4",
+        "three": "^0.182.0"
     }
 }

--- a/app/packages/plugins/src/externalize.ts
+++ b/app/packages/plugins/src/externalize.ts
@@ -14,6 +14,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import * as recoil from "recoil";
 import styled from "styled-components";
+import * as three from "three";
 
 declare global {
   interface Window {
@@ -33,6 +34,7 @@ declare global {
     __fof__: typeof fof;
     __mui__: typeof mui;
     __styled__: typeof styled;
+    __three__: typeof three;
 
     // todo: the following cannot be externalized because of unknown reason
     // __focore__: typeof focore;
@@ -61,6 +63,7 @@ if (typeof window !== "undefined") {
   window.__fosl__ = fosl;
   window.__fof__ = fof;
   window.__styled__ = styled;
+  window.__three__ = three;
   // todo: the following cannot be externalized because of unknown reason
   // window.__fol3d__ = fol3d;
   // window.__foe__ = foe;

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3001,7 +3001,7 @@ __metadata:
     "@biomejs/biome": "npm:^1.8.3"
     "@emotion/react": "npm:^11.14.0"
     "@emotion/styled": "npm:^11.14.0"
-    "@miris-inc/three": "npm:latest"
+    "@miris-inc/three": "npm:0.0.8-ec1b54d"
     "@react-three/drei": "npm:^10.7.6"
     "@react-three/fiber": "npm:^8.18.0"
     "@types/chroma-js": "npm:^3.1.1"
@@ -4143,10 +4143,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@miris-inc/three@npm:latest":
-  version: 0.0.7-86c2ee0
-  resolution: "@miris-inc/three@npm:0.0.7-86c2ee0"
-  checksum: 10/24f0fb237e5a695280e0ba2c14ec75f98733d4f6e638bdb4d845a7b51184f77a5d701c3bfd99d9a04e7a7b2c02b2a56650128d1edf97e17b5d4151fb26f11a4d
+"@miris-inc/three@npm:0.0.8-ec1b54d":
+  version: 0.0.8-ec1b54d
+  resolution: "@miris-inc/three@npm:0.0.8-ec1b54d"
+  checksum: 10/48b7c600122c1f8f0efbf4569de00ab351ab89f0ac9388b156c7b37b2d29c256122ddbeb9ed0ccc74227957eb13ba4d8fdefed86bba395f7ad77886143e233a6
   languageName: node
   linkType: hard
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3001,6 +3001,7 @@ __metadata:
     "@biomejs/biome": "npm:^1.8.3"
     "@emotion/react": "npm:^11.14.0"
     "@emotion/styled": "npm:^11.14.0"
+    "@miris-inc/three": "npm:latest"
     "@react-three/drei": "npm:^10.7.6"
     "@react-three/fiber": "npm:^8.18.0"
     "@types/chroma-js": "npm:^3.1.1"
@@ -3137,6 +3138,7 @@ __metadata:
     jest: "npm:^29.7.0"
     moment: "npm:^2.29.4"
     prettier: "npm:2.2.1"
+    three: "npm:^0.182.0"
     vite: "npm:^7.3.2"
   languageName: unknown
   linkType: soft
@@ -4139,6 +4141,13 @@ __metadata:
   version: 2.0.1
   resolution: "@microsoft/fetch-event-source@npm:2.0.1"
   checksum: 10/c147055fafe83801efb9834136ba4b7944406a0bba3517afcea6ceeb56714b5ef78c2e89544bd9c1426ad1d2f964a087e3a719169ae04855836a23fb53269f8d
+  languageName: node
+  linkType: hard
+
+"@miris-inc/three@npm:latest":
+  version: 0.0.7-86c2ee0
+  resolution: "@miris-inc/three@npm:0.0.7-86c2ee0"
+  checksum: 10/24f0fb237e5a695280e0ba2c14ec75f98733d4f6e638bdb4d845a7b51184f77a5d701c3bfd99d9a04e7a7b2c02b2a56650128d1edf97e17b5d4151fb26f11a4d
   languageName: node
   linkType: hard
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3138,7 +3138,6 @@ __metadata:
     jest: "npm:^29.7.0"
     moment: "npm:^2.29.4"
     prettier: "npm:2.2.1"
-    three: "npm:^0.182.0"
     vite: "npm:^7.3.2"
   languageName: unknown
   linkType: soft

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -195,6 +195,7 @@ from .core.threed import (
     SphereGeometry,
     FbxMesh,
     GltfMesh,
+    MirisStream,
     ObjMesh,
     PlyMesh,
     StlMesh,

--- a/fiftyone/core/threed/__init__.py
+++ b/fiftyone/core/threed/__init__.py
@@ -16,6 +16,7 @@ from .material_3d import (
     PointCloudMaterial,
 )
 from .mesh import FbxMesh, GltfMesh, ObjMesh, PlyMesh, StlMesh
+from .miris_stream import MirisStream
 from .object_3d import Object3D
 from .pointcloud import *
 from .scene_3d import *

--- a/fiftyone/core/threed/miris_stream.py
+++ b/fiftyone/core/threed/miris_stream.py
@@ -37,6 +37,7 @@ class MirisStream(Object3D):
         scale: Optional[Vec3UnionType] = None,
         quaternion: Optional[Quaternion] = None,
     ):
+        """Initializes a :class:`MirisStream`."""
         super().__init__(
             name=name,
             visible=visible,
@@ -52,6 +53,7 @@ class MirisStream(Object3D):
         self.viewer_key = viewer_key
 
     def _to_dict_extra(self):
+        """Extra properties to include in dictionary representation."""
         return {
             "assetUuid": self.asset_uuid,
             "viewerKey": self.viewer_key,

--- a/fiftyone/core/threed/miris_stream.py
+++ b/fiftyone/core/threed/miris_stream.py
@@ -1,0 +1,58 @@
+"""
+Miris stream definitions for 3D visualization.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from typing import Optional
+
+from .object_3d import Object3D
+from .transformation import Quaternion, Vec3UnionType
+
+
+class MirisStream(Object3D):
+    """Represents a Miris stream rendered via the ``@miris-inc/three`` SDK.
+
+    Args:
+        name (str): the name of the stream
+        asset_uuid (str): the Miris asset UUID identifying the stream
+        viewer_key (str, optional): the Miris viewer key used to authorize
+            playback. If ``None``, the App must supply a viewer key by
+            another means (e.g. ``dataset.info["miris_viewer_key"]``)
+        visible (True): default visibility of the stream in the scene
+        position (None): the position of the stream in object space
+        quaternion (None): the quaternion of the stream in object space
+        scale (None): the scale of the stream in object space
+    """
+
+    def __init__(
+        self,
+        name: str,
+        asset_uuid: str,
+        viewer_key: Optional[str] = None,
+        visible: bool = True,
+        position: Optional[Vec3UnionType] = None,
+        scale: Optional[Vec3UnionType] = None,
+        quaternion: Optional[Quaternion] = None,
+    ):
+        super().__init__(
+            name=name,
+            visible=visible,
+            position=position,
+            scale=scale,
+            quaternion=quaternion,
+        )
+
+        if not asset_uuid:
+            raise ValueError("MirisStream requires an asset_uuid")
+
+        self.asset_uuid = asset_uuid
+        self.viewer_key = viewer_key
+
+    def _to_dict_extra(self):
+        return {
+            "assetUuid": self.asset_uuid,
+            "viewerKey": self.viewer_key,
+        }

--- a/fiftyone/core/threed/scene_3d.py
+++ b/fiftyone/core/threed/scene_3d.py
@@ -16,6 +16,7 @@ import fiftyone.core.storage as fos
 from .camera import PerspectiveCamera
 from .lights import Light
 from .mesh import FbxMesh, GltfMesh, ObjMesh, PlyMesh, StlMesh
+from .miris_stream import MirisStream
 from .object_3d import Object3D
 from .pointcloud import PointCloud
 from .shape_3d import Shape3D
@@ -312,6 +313,7 @@ class Scene(Object3D):
             "fbxs": node_types[FbxMesh],
             "stls": node_types[StlMesh],
             "plys": node_types[PlyMesh],
+            "miris streams": node_types[MirisStream],
             "shapes": node_types[Shape3D],
         }
 


### PR DESCRIPTION
## 🔗 Related Issues
PR into Voxel/fiftyone repo to get the CI commands to create a dev deployment for ephem testing
<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

<!--
Provide a clear, concise description of what this PR does and why.
-->

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added MirisStream asset support for 3D visualization—render stream-based geometric assets directly in your 3D scenes
  * Integrated Miris SDK with lazy loading for improved performance; the SDK loads only when MirisStream assets are present in a scene
  * Exposed MirisStream as a public API for the 3D visualization system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->