### PR TITLE
fix(video-annotation): id-aligned delta supplier for detection edits

### DIFF
--- a/app/packages/annotation/src/persistence/useVideoLabelsDeltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/useVideoLabelsDeltaSupplier.ts
@@ -1,9 +1,116 @@
 import type { JSONDeltas } from "@fiftyone/core/src/client";
 import { generateJsonPatch } from "@fiftyone/core/src/utils/json";
 import { useIsVideo } from "@fiftyone/state";
-import { useFrameLabelsStream } from "@fiftyone/video-annotation";
+import {
+  useFrameLabelsStream,
+  type RawDetection,
+  type RawDetectionsField,
+} from "@fiftyone/video-annotation";
 import { useCallback } from "react";
 import type { DeltaSupplier } from "./deltaSupplier";
+
+/** Detection paired with its array-slot index for path-building. */
+interface DetInfo {
+  id: string;
+  det: RawDetection;
+  index: number;
+}
+
+/** Index a detections list by `_id`. Entries lacking `_id` are skipped. */
+const indexById = (list: RawDetection[]): Map<string, DetInfo> => {
+  const map = new Map<string, DetInfo>();
+  list.forEach((det, index) => {
+    if (det._id !== undefined) map.set(det._id, { id: det._id, det, index });
+  });
+  return map;
+};
+
+/** Per-field replaces for `_id`s present in both sides. */
+const updateOps = (
+  baseById: Map<string, DetInfo>,
+  cacheById: Map<string, DetInfo>,
+  pathPrefix: string
+): JSONDeltas => {
+  const ops: JSONDeltas = [];
+  baseById.forEach(({ id, det: baseDet, index }) => {
+    const cache = cacheById.get(id);
+    if (!cache) return;
+    const sub = generateJsonPatch(
+      baseDet as unknown as Record<string, unknown>,
+      cache.det as unknown as Record<string, unknown>
+    );
+    sub.forEach((op) =>
+      ops.push({ ...op, path: `${pathPrefix}/detections/${index}${op.path}` })
+    );
+  });
+  return ops;
+};
+
+/**
+ * Removes for `_id`s in baseline but not cache. Descending index so an
+ * earlier remove doesn't shift later indices it would have referenced.
+ */
+const removeOps = (
+  baseById: Map<string, DetInfo>,
+  cacheById: Map<string, DetInfo>,
+  pathPrefix: string
+): JSONDeltas =>
+  Array.from(baseById.values())
+    .filter((info) => !cacheById.has(info.id))
+    .sort((a, b) => b.index - a.index)
+    .map(({ index }) => ({
+      op: "remove" as const,
+      path: `${pathPrefix}/detections/${index}`,
+    }));
+
+/** Adds for `_id`s in cache but not baseline. Appended with `/-`. */
+const addOps = (
+  baseById: Map<string, DetInfo>,
+  cacheById: Map<string, DetInfo>,
+  pathPrefix: string
+): JSONDeltas => {
+  const ops: JSONDeltas = [];
+  cacheById.forEach(({ id, det }) => {
+    if (baseById.has(id)) return;
+    ops.push({
+      op: "add" as const,
+      path: `${pathPrefix}/detections/-`,
+      value: det,
+    });
+  });
+  return ops;
+};
+
+/**
+ * Build a JSON-Patch delta for one frame's detections wrapper, aligning
+ * baseline ↔ cache by `_id` instead of by array index.
+ *
+ * `fast-json-patch.compare` aligns arrays by index, so a shifted detections
+ * list (e.g. `ShiftTrackCommand` removes a slot, every later slot slides
+ * down) makes each subsequent slot look "different" and emits a flood of
+ * unappliable per-slot replaces. The id-aligned diff sidesteps that — and
+ * stays safe when the server has detections the cache doesn't know about,
+ * since `_id`s the FE never saw aren't touched.
+ *
+ * Special case: baseline missing the inner array → one `add` of the whole
+ * wrapper, since detection-level paths don't resolve without it.
+ */
+const buildDetectionsDelta = (
+  from: RawDetectionsField,
+  to: RawDetectionsField,
+  pathPrefix: string
+): JSONDeltas => {
+  if (from.detections === undefined) {
+    return [{ op: "add", path: pathPrefix, value: to }];
+  }
+  const baseById = indexById(from.detections);
+  const cacheById = indexById(to.detections ?? []);
+  return [
+    ...updateOps(baseById, cacheById, pathPrefix),
+    ...removeOps(baseById, cacheById, pathPrefix),
+    ...addOps(baseById, cacheById, pathPrefix),
+  ];
+};
 
 /**
  * Provides a {@link DeltaSupplier} for per-frame label edits made through the
@@ -28,16 +135,14 @@ export const useVideoLabelsDeltaSupplier = (): DeltaSupplier => {
     const snapshots = stream.getDirtyFrameSnapshots();
     const deltas: JSONDeltas = [];
 
-    for (const { frameNumber, baseline, cache } of snapshots) {
-      const from = (baseline[frameField] ?? {}) as Record<string, unknown>;
-      const to = (cache[frameField] ?? {}) as Record<string, unknown>;
-      const subDeltas = generateJsonPatch(from, to);
+    snapshots.forEach(({ frameNumber, baseline, cache }) => {
+      const from = (baseline[frameField] ?? {}) as RawDetectionsField;
+      const to = (cache[frameField] ?? {}) as RawDetectionsField;
       const pathPrefix = `/frames/${frameNumber}/${frameField}`;
-
-      for (const op of subDeltas) {
-        deltas.push({ ...op, path: `${pathPrefix}${op.path}` });
-      }
-    }
+      buildDetectionsDelta(from, to, pathPrefix).forEach((op) =>
+        deltas.push(op)
+      );
+    });
 
     // Stash the cache refs we just translated. The persistence event
     // handler advances baseline on success (clearing dirty) or discards

--- a/app/packages/video-annotation/index.ts
+++ b/app/packages/video-annotation/index.ts
@@ -31,7 +31,11 @@ export type {
   TrackExtentEdit,
 } from "./src/trackExtentEdit";
 export { VideoFrameLabelsStream } from "./src/VideoFrameLabelsStream";
-export type { LocalDetection } from "./src/VideoFrameLabelsStream";
+export type {
+  LocalDetection,
+  RawDetection,
+  RawDetectionsField,
+} from "./src/VideoFrameLabelsStream";
 export { buildTemporalDetectionTracks } from "./src/temporalDetectionTracks";
 export type {
   RawTemporalDetection,

--- a/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
+++ b/app/packages/video-annotation/src/VideoFrameLabelsStream.ts
@@ -16,7 +16,7 @@ import type {
   SyntheticBox,
 } from "./SyntheticLabelStream";
 
-interface RawDetection {
+export interface RawDetection {
   _id?: string;
   id?: string;
   index?: number;
@@ -27,7 +27,7 @@ interface RawDetection {
   propagation?: PropagationBlob | null;
 }
 
-interface RawDetectionsField {
+export interface RawDetectionsField {
   detections?: RawDetection[];
 }
 


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

This allows for clicking and dragging tracks to the left or right. 

Currently, if you try to drag a track it tries to replace everything and if the ID does not exist it will fail. 

This change checks every frame for:
1. does it exist? -> replace
2. does it not exist? -> add
3. did it exist and now doesn't? -> remove

## 🧪 How is this patch tested? If it is not, please explain why.

Tested locally. 

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
