### PR TITLE
Add generic StackedModalSpace modal layout renderer

### DIFF
--- a/app/packages/core/src/components/Modal/StackedModalSpace.tsx
+++ b/app/packages/core/src/components/Modal/StackedModalSpace.tsx
@@ -1,0 +1,43 @@
+import { SpaceNodeJSON, useSpaces } from "@fiftyone/spaces";
+import { Space } from "@fiftyone/spaces/src/components";
+import React from "react";
+
+/** Layout for <StackedModalSpace>: a `tree` plus a flex `weight` per top-level child. */
+export interface StackedModalLayout {
+  spacesId: string;
+  tree: SpaceNodeJSON;
+  weights: number[];
+}
+
+/**
+ * Generic modal layout: stacks a tree's top-level children vertically at fixed
+ * flex `weights` (no resizable split, so the ratio can't drift to 50/50).
+ */
+export const StackedModalSpace = React.memo(
+  ({ spacesId, tree, weights }: StackedModalLayout) => {
+    const { spaces } = useSpaces(spacesId, tree);
+
+    // Gate until useSpaces has seeded the tree (async effect).
+    if (!spaces.root.hasChildren()) return null;
+
+    return (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          width: "100%",
+          height: "100%",
+        }}
+      >
+        {spaces.root.children.map((node, i) => (
+          <div
+            key={node.id}
+            style={{ flex: `${weights[i] ?? 1} 1 0`, minHeight: 0 }}
+          >
+            <Space node={node} id={spacesId} archetype="modal" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+);


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds `StackedModalSpace` — a small, task-free modal layout renderer that stacks a spaces tree's top-level children vertically at fixed flex `weights` (no resizable Allotment split, so the ratio can't drift to 50/50). Also exports the `StackedModalLayout` type (`{ spacesId, tree, weights }`).

This is the OSS-shareable building block extracted from the FiftyOne Teams task-modal work. The task-specific layout (`buildTaskModalLayout`) and the `useActiveTaskOverride` gating stay in Teams — only the generic renderer lives here, so OSS doesn't take on any task-context dependency.

> Supersedes the earlier `preserveSizes` approach on this branch, which Teams dropped in favor of this stacked renderer.

This allows task context to open sample modal with stacked space settings

## How is this patch tested?

- `tsc` on `@fiftyone/core` — no new errors.
- Pure additive component; no existing OSS code path consumes it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced stacked modal layouts that enable displaying multiple modals in a responsive column arrangement with customizable spacing between each modal, providing greater layout flexibility for dialog-based interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->