### PR TITLE
Fix RF-DETR prediction when class_names is a list

### DIFF
--- a/fiftyone/utils/rfdetr.py
+++ b/fiftyone/utils/rfdetr.py
@@ -338,6 +338,10 @@ class _RFDETRBaseModel(fout.TorchImageModel):
         output = self._forward_pass(imgs)
 
         class_names = self._model.class_names
+        if not isinstance(class_names, dict):
+            # The model may expose class names as a list or a {id: label} dict;
+            # ``_sv_detections_to_fo`` expects the dict form, so normalize.
+            class_names = dict(enumerate(class_names))
         filter_classes = set(self.config.filter_classes or ())
         results = output["results"]
         sizes = output["sizes"]

--- a/tests/unittests/utils/test_rfdetr.py
+++ b/tests/unittests/utils/test_rfdetr.py
@@ -304,6 +304,28 @@ class TestRFDETROutputParsing:
         assert len(labels) == 1
         assert labels[0].detections == []
 
+    def test_predict_all_accepts_list_class_names(self):
+        # The model may expose class_names as a list (indexed by class id)
+        # rather than a {id: label} dict; predict must handle both.
+        from fiftyone.utils.rfdetr import RFDETRDetectionModel
+
+        def _fake_predict(images: list[Image.Image], threshold: float):
+            return _FakeSVDets(
+                xyxy=[[0, 0, 2, 2], [1, 1, 3, 3]],
+                confidence=[0.9, 0.8],
+                class_id=[0, 2],
+            )
+
+        model = _make_model(
+            RFDETRDetectionModel,
+            _fake_predict,
+            class_names=["person", "dog", "cat"],
+        )
+
+        labels = model.predict_all([Image.new("RGB", (4, 4))])
+
+        assert [d.label for d in labels[0].detections] == ["person", "cat"]
+
     def test_segmentation_masks_use_floor_ceil_cropping(self):
         from fiftyone.utils.rfdetr import RFDETRSegmentationModel
 


### PR DESCRIPTION
RF-DETR models expose `class_names` as either a `{id: label}` dict or a list (see `_parse_classes`), but `_predict_all` passed it through raw to `_sv_detections_to_fo`, which does `class_names.get(cid)`. When the model's `class_names` is a list, that raises:

```
AttributeError: 'list' object has no attribute 'get'
```

so prediction fails for every RF-DETR model whose `class_names` is a list. The existing unit tests only exercised the dict form, so the list path was never covered.

This normalizes `class_names` to a `{id: label}` dict in `_predict_all` before conversion, and adds a unit test covering the list form.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * RF-DETR model detection now properly handles class names provided in list format, automatically normalizing them to the expected dictionary format for correct downstream processing.

* **Tests**
  * Added test to verify RF-DETR detection model correctly processes class names in list format with class filtering applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->