### PR TITLE
ci: install ffmpeg via a reusable composite action

### DIFF
--- a/.github/actions/setup-ffmpeg/action.yml
+++ b/.github/actions/setup-ffmpeg/action.yml
@@ -12,23 +12,14 @@ runs:
       if: runner.os == 'Linux'
       shell: bash
       run: |
-        for i in 1 2 3; do
-          sudo apt-get update && sudo apt-get install -y ffmpeg && break
-          echo "apt-get attempt $i failed; retrying in $((i * 5))s"
-          sleep $((i * 5))
-        done
+        sudo apt-get update && sudo apt-get install -y ffmpeg
         ffmpeg -version
 
     - name: Install ffmpeg (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        for ($i = 1; $i -le 3; $i++) {
-          choco install ffmpeg -y --no-progress
-          if ($LASTEXITCODE -eq 0) { break }
-          Write-Host "choco attempt $i failed; retrying in $($i * 5)s"
-          Start-Sleep -Seconds ($i * 5)
-        }
+        choco install ffmpeg -y --no-progress
         # ensure the choco shim dir is on PATH for this and subsequent steps
         "C:\ProgramData\chocolatey\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         $env:PATH = "C:\ProgramData\chocolatey\bin;$env:PATH"

--- a/.github/actions/setup-ffmpeg/action.yml
+++ b/.github/actions/setup-ffmpeg/action.yml
@@ -1,0 +1,35 @@
+name: "Setup FFmpeg"
+description: >-
+  Install ffmpeg from the runner's OS package manager (apt on Linux, Chocolatey
+  on Windows). These are backed by cloud-provider mirrors, so they avoid the
+  intermittent "fetch failed" errors seen when downloading ffmpeg from
+  third-party release hosts.
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install ffmpeg (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        for i in 1 2 3; do
+          sudo apt-get update && sudo apt-get install -y ffmpeg && break
+          echo "apt-get attempt $i failed; retrying in $((i * 5))s"
+          sleep $((i * 5))
+        done
+        ffmpeg -version
+
+    - name: Install ffmpeg (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        for ($i = 1; $i -le 3; $i++) {
+          choco install ffmpeg -y --no-progress
+          if ($LASTEXITCODE -eq 0) { break }
+          Write-Host "choco attempt $i failed; retrying in $($i * 5)s"
+          Start-Sleep -Seconds ($i * 5)
+        }
+        # ensure the choco shim dir is on PATH for this and subsequent steps
+        "C:\ProgramData\chocolatey\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        $env:PATH = "C:\ProgramData\chocolatey\bin;$env:PATH"
+        ffmpeg -version

--- a/.github/actions/setup-ffmpeg/action.yml
+++ b/.github/actions/setup-ffmpeg/action.yml
@@ -12,7 +12,8 @@ runs:
       if: runner.os == 'Linux'
       shell: bash
       run: |
-        sudo apt-get update && sudo apt-get install -y ffmpeg
+        sudo apt-get update && \
+          sudo apt-get install -y ffmpeg
         ffmpeg -version
 
     - name: Install ffmpeg (Windows)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -214,13 +214,8 @@ jobs:
           python tests/utils/setup_config.py
           python tests/utils/github_actions_flags.py
 
-      # - name: Setup FFmpeg (with retries)
-      #   uses: FedericoCarboni/setup-ffmpeg@v3
-
-      # Use this until https://github.com/federicocarboni/setup-ffmpeg/pull/23
-      # is merged or the maintainer addresses the root issue.
-      - name: Setup FFmpeg (with retries)
-        uses: afoley587/setup-ffmpeg@main
+      - name: Setup FFmpeg
+        uses: ./.github/actions/setup-ffmpeg
 
       - name: Cache E2E Node Modules
         id: e2e-node-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,13 +98,8 @@ jobs:
           python tests/utils/setup_config.py
           python tests/utils/github_actions_flags.py
 
-      # - name: Setup FFmpeg (with retries)
-      #   uses: FedericoCarboni/setup-ffmpeg@v3
-
-      # Use this until https://github.com/federicocarboni/setup-ffmpeg/pull/23
-      # is merged or the maintainer addresses the root issue.
-      - name: Setup FFmpeg (with retries)
-        uses: afoley587/setup-ffmpeg@main
+      - name: Setup FFmpeg
+        uses: ./.github/actions/setup-ffmpeg
 
       # Important: use pytest_wrapper.py instead of pytest directly to ensure
       # that services shut down cleanly and do not conflict with steps later in

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -57,13 +57,8 @@ jobs:
           python tests/utils/setup_config.py
           python tests/utils/github_actions_flags.py
 
-      # - name: Setup FFmpeg (with retries)
-      #   uses: FedericoCarboni/setup-ffmpeg@v3
-
-      # Use this until https://github.com/federicocarboni/setup-ffmpeg/pull/23
-      # is merged or the maintainer addresses the root issue.
-      - name: Setup FFmpeg (with retries)
-        uses: afoley587/setup-ffmpeg@main
+      - name: Setup FFmpeg
+        uses: ./.github/actions/setup-ffmpeg
 
       # Important: use pytest_wrapper.py instead of pytest directly to ensure
       # that services shut down cleanly and do not conflict with steps later in


### PR DESCRIPTION
## Summary

The `Setup FFmpeg` step (`afoley587/setup-ffmpeg@main`, a fork of `FedericoCarboni/setup-ffmpeg`) intermittently fails in CI:

```
Run afoley587/setup-ffmpeg@main
Retrying... attempt 1 … 2 … 3 … 4
##[error]Error: Failed after 5 attempts: fetch failed
```

It downloads ffmpeg from third-party release hosts that rate-limit / go unreachable; the fork's built-in retries don't help when the host is down for the whole window. It's also pinned to a mutable `@main` ref.

## Change

- Add **`.github/actions/setup-ffmpeg`** — a composite action that installs ffmpeg from the runner's OS package manager (`apt` on Linux, `choco` on Windows), backed by cloud-provider mirrors.
- Use it from `test.yml`, `e2e.yml`, and `windows-test.yml` (replacing the duplicated inline step / the third-party action).

This removes the dependency on flaky external download hosts and the mutable action pin. Propagates to `fiftyone-teams` via the normal OSS sync.

## Notes
- Draft pending a CI run to confirm green across Linux (test/e2e) and Windows (windows-test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a repository-local GitHub Action to install FFmpeg on Linux and Windows (no retry logic).
  * Updated CI workflows to use the new local FFmpeg setup action, replacing the previous external setup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->