### PR TITLE
chore: bump develop to 1.18.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ Installs FiftyOne.
 import os
 from setuptools import setup, find_packages
 
-VERSION = "1.17.0"
+VERSION = "1.18.0"
 
 
 def get_version():


### PR DESCRIPTION
Bumps `develop` to `1.18.0`.

The release previously scoped as `1.16.1` now ships as **`1.17.0`** (it includes the Python 3.9 removal — a breaking change → minor), cut from `release/v1.17.0`. Since `develop` was already `1.17.0`, this bumps it to `1.18.0` so the next dev cycle doesn't collide with the released version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.18.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->