### PR TITLE
Video annotation polish: propagate, color, sidebar, and timeline fixes

### DIFF
--- a/app/packages/annotation/src/agents/SAM2PropagationBrowserAgent.test.ts
+++ b/app/packages/annotation/src/agents/SAM2PropagationBrowserAgent.test.ts
@@ -1,0 +1,94 @@
+import type { SyntheticBox } from "@fiftyone/video-annotation";
+import { describe, expect, it, vi } from "vitest";
+import type { BrowserAnnotationProvider } from "../providers";
+import { SAM2PropagationBrowserAgent } from "./SAM2PropagationBrowserAgent";
+import type { PropagatedDetection } from "./types";
+
+const INSTANCE = "inst-1";
+
+const keyframe = (
+  id: string,
+  overrides: Partial<SyntheticBox> = {}
+): SyntheticBox => ({
+  id,
+  _id: id,
+  label: "car",
+  bounding_box: [0.1, 0.2, 0.3, 0.4],
+  index: 2,
+  instance: { _cls: "Instance", _id: INSTANCE },
+  keyframe: true,
+  propagation: null,
+  ...overrides,
+});
+
+// A mask whose centroid sampling always yields ≥1 interior point, so the
+// centroid-followed chain runs to the end frame rather than bailing.
+const makeResult = () => ({
+  mask: new Float32Array([0.1, 0.9, 0.8, 0.2]),
+  maskWidth: 2,
+  maskHeight: 2,
+  bbox: { x: 0.1, y: 0.2, w: 0.3, h: 0.4 },
+});
+
+const makeAgent = () => {
+  const provider = {
+    initialize: vi.fn().mockResolvedValue(undefined),
+    isInitialized: vi.fn().mockReturnValue(true),
+    inferBitmap: vi.fn().mockResolvedValue(makeResult()),
+    abort: vi.fn(),
+    dispose: vi.fn(),
+  } as unknown as BrowserAnnotationProvider;
+  const agent = new SAM2PropagationBrowserAgent(() => provider);
+  return { agent, provider };
+};
+
+const baseArgs = (
+  emitted: Array<{ frame: number; det: PropagatedDetection }>
+) => ({
+  instanceId: INSTANCE,
+  seedKeyframe: keyframe("seed"),
+  fromFrame: 1,
+  toFrame: 3,
+  videoKey: "vid",
+  getFrameBitmap: async () => ({} as ImageBitmap),
+  onDetection: (frame: number, det: PropagatedDetection) =>
+    emitted.push({ frame, det }),
+});
+
+describe("SAM2PropagationBrowserAgent forward run", () => {
+  it("emits the horizon frame and records a single parent keyframe", async () => {
+    const emitted: Array<{ frame: number; det: PropagatedDetection }> = [];
+    const { agent } = makeAgent();
+
+    // No endKeyframe → forward run to `toFrame` (the clip end).
+    await agent.propagate(baseArgs(emitted));
+
+    // Seed frame 1 is skipped; the horizon frame 3 IS written.
+    expect(emitted.map((e) => e.frame)).toEqual([2, 3]);
+    for (const { det } of emitted) {
+      expect(det.keyframe).toBe(false);
+      expect(det.instance?._id).toBe(INSTANCE);
+      expect(det.propagation?.method).toBe("sam2");
+      expect(det.propagation?.parent_keyframes).toEqual(["seed"]);
+    }
+  });
+});
+
+describe("SAM2PropagationBrowserAgent bracketed run", () => {
+  it("leaves both keyframe endpoints untouched and records two parents", async () => {
+    const emitted: Array<{ frame: number; det: PropagatedDetection }> = [];
+    const { agent } = makeAgent();
+
+    await agent.propagate({
+      ...baseArgs(emitted),
+      endKeyframe: keyframe("end"),
+    });
+
+    // Both endpoints (frames 1 and 3) are user keyframes → only frame 2.
+    expect(emitted.map((e) => e.frame)).toEqual([2]);
+    expect(emitted[0].det.propagation?.parent_keyframes).toEqual([
+      "seed",
+      "end",
+    ]);
+  });
+});

--- a/app/packages/annotation/src/agents/SAM2PropagationBrowserAgent.ts
+++ b/app/packages/annotation/src/agents/SAM2PropagationBrowserAgent.ts
@@ -30,18 +30,26 @@ const DEFAULT_FACTORY: BrowserAnnotationProviderFactory = (options) =>
   new BrowserAnnotationProvider(options);
 
 /**
- * Inputs for a SAM2 tracking run between two bracketing keyframes. Frame
- * numbers are 1-based (matching the labels stream / mongo frame numbers);
- * `getFrameBitmap` resolves a 1-based frame number to its decoded bitmap
- * (the ImaVid image stream serves these from cache — no `<video>` element).
+ * Inputs for a SAM2 tracking run. Frame numbers are 1-based (matching the
+ * labels stream / mongo frame numbers); `getFrameBitmap` resolves a 1-based
+ * frame number to its decoded bitmap (the ImaVid image stream serves these
+ * from cache — no `<video>` element).
+ *
+ * Two modes: a *bracketed* run between two keyframes (pass `endKeyframe`), or
+ * a *forward* run from a single seed keyframe to a horizon (omit it; the
+ * caller sets `toFrame` to the clip end).
  */
 export interface Sam2PropagateArgs {
   /** Cross-frame `Instance._id` stamped on every emitted detection. */
   instanceId: string;
-  /** Left bracket — the keyframe at/before the playhead; seeds the track. */
+  /** The keyframe at/before the playhead; seeds the track. */
   seedKeyframe: SyntheticBox;
-  /** Right bracket — the keyframe after the playhead; caps the run. */
-  endKeyframe: SyntheticBox;
+  /**
+   * Bracketed mode only — the keyframe at `toFrame` that caps the run and is
+   * left untouched. Omit for a forward run, where `toFrame` is a tracked
+   * frame (the clip end) that should be written like any other.
+   */
+  endKeyframe?: SyntheticBox;
   fromFrame: number;
   toFrame: number;
   /** Stable per-video id; prefixes the per-frame encoder-embedding cache. */
@@ -106,10 +114,13 @@ export class SAM2PropagationBrowserAgent
     // Provenance records the source keyframes' mongo `_id`s (not the
     // cross-frame-stable synthetic overlay id, which is identical for both
     // ends of a track); fall back to the synthetic id only if unpersisted.
-    const parentKeyframes: [string, string] = [
-      args.seedKeyframe._id ?? args.seedKeyframe.id,
-      args.endKeyframe._id ?? args.endKeyframe.id,
-    ];
+    // A forward run has a single parent (the seed); a bracketed run has two.
+    const parentKeyframes: [string, ...string[]] = args.endKeyframe
+      ? [
+          args.seedKeyframe._id ?? args.seedKeyframe.id,
+          args.endKeyframe._id ?? args.endKeyframe.id,
+        ]
+      : [args.seedKeyframe._id ?? args.seedKeyframe.id];
 
     this.setStatus("inferring");
 
@@ -122,15 +133,24 @@ export class SAM2PropagationBrowserAgent
         },
         keyframeB: {
           frameIdx: args.toFrame,
-          points: pointsFromBox(args.endKeyframe.bounding_box),
+          // Points are unused beyond the first frame
+          points: [],
         },
         videoKey: args.videoKey,
         strategy: args.strategy ?? "centroid-5",
         shouldAbort: args.shouldAbort,
         onProgress: args.onProgress,
         onFrame: (frameIdx, result) => {
-          // Don't overwrite the user's bracket keyframes.
-          if (frameIdx === args.fromFrame || frameIdx === args.toFrame) return;
+          // Don't overwrite the seed keyframe
+          if (frameIdx === args.fromFrame) {
+            return;
+          }
+
+          // In bracketed mode, the end frame is also a user keyframe,
+          // so skip it too
+          if (args.endKeyframe && frameIdx === args.toFrame) {
+            return;
+          }
 
           const detection: PropagatedDetection = {
             _id: objectId(),
@@ -151,6 +171,7 @@ export class SAM2PropagationBrowserAgent
               parent_keyframes: parentKeyframes,
             },
           };
+
           args.onDetection(frameIdx, detection);
         },
       });

--- a/app/packages/annotation/src/commands.ts
+++ b/app/packages/annotation/src/commands.ts
@@ -60,6 +60,22 @@ export class EditTemporalDetectionCommand extends Command<boolean> {
 }
 
 /**
+ * Delete a `TemporalDetection`. The handler resolves the `field`/`id` pair
+ * to its scene `TemporalOverlay` and removes it. Unlike an object track this
+ * is sample-level — there's no per-frame work; removing the overlay drops the
+ * timeline row and, at autosave, `useTemporalDetectionDeltaSupplier` emits the
+ * matching `remove` JSON-Patch op. Resolves `true` when an overlay was removed.
+ */
+export class DeleteTemporalDetectionCommand extends Command<boolean> {
+  constructor(
+    public readonly fieldPath: string,
+    public readonly detectionId: string
+  ) {
+    super();
+  }
+}
+
+/**
  * Create a new `TemporalDetection`. Handler mints a client-side `_id`,
  * instantiates a `TemporalOverlay`, adds it to the scene, and resolves
  * to the id. The autosave delta walk emits an `add /-` for any overlay

--- a/app/packages/annotation/src/hooks/useRegisterAnnotationCommandHandlers.test.ts
+++ b/app/packages/annotation/src/hooks/useRegisterAnnotationCommandHandlers.test.ts
@@ -23,6 +23,11 @@ vi.mock("@fiftyone/lighter", () => ({
   useLighter: () => ({ removeOverlay: mockRemoveOverlay }),
 }));
 
+const { mockTombstone } = vi.hoisted(() => ({ mockTombstone: vi.fn() }));
+vi.mock("../persistence/temporalDetectionTombstones", () => ({
+  useTombstoneTemporalDetection: () => mockTombstone,
+}));
+
 import { useAnnotationEventBus, useDeleteLabel } from "@fiftyone/annotation";
 import { useRegisterCommandHandler } from "@fiftyone/command-bus";
 import { useRegisterAnnotationCommandHandlers } from "./useRegisterAnnotationCommandHandlers";
@@ -79,7 +84,7 @@ describe("useRegisterAnnotationCommandHandlers", () => {
         type: "TemporalDetection",
         path: "events",
         data: { _id: "td-1" },
-        overlay: { id: "td-events-td-1" },
+        overlay: { id: "td-events-td-1", field: "events" },
       },
       schema: { name: "events" },
     } as unknown as ReturnType<typeof makeCommand>;
@@ -89,6 +94,8 @@ describe("useRegisterAnnotationCommandHandlers", () => {
     expect(result).toBe(true);
     // TD persistence is overlay-diff based — the per-label patch must not run.
     expect(mockDeleteLabel).not.toHaveBeenCalled();
+    // The deletion is recorded as a tombstone so the delta supplier persists it.
+    expect(mockTombstone).toHaveBeenCalledWith("events", "td-1");
     expect(mockRemoveOverlay).toHaveBeenCalledWith("td-events-td-1", false);
     expect(mockDispatch).toHaveBeenCalledWith("annotation:deleteSuccess", {
       labelId: "td-1",

--- a/app/packages/annotation/src/hooks/useRegisterAnnotationCommandHandlers.test.ts
+++ b/app/packages/annotation/src/hooks/useRegisterAnnotationCommandHandlers.test.ts
@@ -7,13 +7,21 @@ vi.mock("@fiftyone/annotation", () => ({
 }));
 
 vi.mock("@fiftyone/command-bus", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@fiftyone/command-bus")>();
+  const actual = await importOriginal<typeof import("@fiftyone/command-bus")>();
   return {
     ...actual,
     useRegisterCommandHandler: vi.fn(),
   };
 });
+
+// Stable `removeOverlay` so the hook's useCallback identity (and thus the
+// single command registration) doesn't churn across renders.
+const { mockRemoveOverlay } = vi.hoisted(() => ({
+  mockRemoveOverlay: vi.fn(),
+}));
+vi.mock("@fiftyone/lighter", () => ({
+  useLighter: () => ({ removeOverlay: mockRemoveOverlay }),
+}));
 
 import { useAnnotationEventBus, useDeleteLabel } from "@fiftyone/annotation";
 import { useRegisterCommandHandler } from "@fiftyone/command-bus";
@@ -62,6 +70,31 @@ describe("useRegisterAnnotationCommandHandlers", () => {
     renderHook(() => useRegisterAnnotationCommandHandlers());
 
     expect(useRegisterCommandHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("deletes a TemporalDetection by removing its overlay, skipping deleteLabel", async () => {
+    const handler = getRegisteredHandler();
+    const cmd = {
+      label: {
+        type: "TemporalDetection",
+        path: "events",
+        data: { _id: "td-1" },
+        overlay: { id: "td-events-td-1" },
+      },
+      schema: { name: "events" },
+    } as unknown as ReturnType<typeof makeCommand>;
+
+    const result = await handler(cmd);
+
+    expect(result).toBe(true);
+    // TD persistence is overlay-diff based — the per-label patch must not run.
+    expect(mockDeleteLabel).not.toHaveBeenCalled();
+    expect(mockRemoveOverlay).toHaveBeenCalledWith("td-events-td-1", false);
+    expect(mockDispatch).toHaveBeenCalledWith("annotation:deleteSuccess", {
+      labelId: "td-1",
+      type: "delete",
+      labelType: "TemporalDetection",
+    });
   });
 
   it("dispatches deleteSuccess with label metadata when deleteLabel returns true", async () => {

--- a/app/packages/annotation/src/hooks/useRegisterAnnotationCommandHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterAnnotationCommandHandlers.ts
@@ -7,6 +7,7 @@ import { useRegisterCommandHandler } from "@fiftyone/command-bus";
 import { useLighter } from "@fiftyone/lighter";
 import { useCallback } from "react";
 import { DeleteAnnotationCommand } from "../commands";
+import { useTombstoneTemporalDetection } from "../persistence/temporalDetectionTombstones";
 
 /**
  * Hook that registers command handlers for annotation persistence.
@@ -16,6 +17,7 @@ export const useRegisterAnnotationCommandHandlers = () => {
   const eventBus = useAnnotationEventBus();
   const deleteLabel = useDeleteLabel();
   const { removeOverlay } = useLighter();
+  const tombstoneTemporalDetection = useTombstoneTemporalDetection();
 
   useRegisterCommandHandler(
     DeleteAnnotationCommand,
@@ -23,9 +25,10 @@ export const useRegisterAnnotationCommandHandlers = () => {
       async (cmd) => {
         const labelId = cmd.label.data._id;
 
-        // TD deletions are handled on each save tick; remove the overlay to
-        // mark it for deletion, but skip the explicit deleteLabel
         if (cmd.label.type === "TemporalDetection") {
+          // Mark the TD for deletion; defer to save tick
+          tombstoneTemporalDetection(cmd.label.overlay.field, labelId);
+          // Optimistic removal
           removeOverlay(cmd.label.overlay.id, false);
 
           eventBus.dispatch("annotation:deleteSuccess", {
@@ -62,7 +65,7 @@ export const useRegisterAnnotationCommandHandlers = () => {
           throw error;
         }
       },
-      [deleteLabel, eventBus, removeOverlay]
+      [deleteLabel, eventBus, removeOverlay, tombstoneTemporalDetection]
     )
   );
 };

--- a/app/packages/annotation/src/hooks/useRegisterAnnotationCommandHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterAnnotationCommandHandlers.ts
@@ -4,6 +4,7 @@
 
 import { useAnnotationEventBus, useDeleteLabel } from "@fiftyone/annotation";
 import { useRegisterCommandHandler } from "@fiftyone/command-bus";
+import { useLighter } from "@fiftyone/lighter";
 import { useCallback } from "react";
 import { DeleteAnnotationCommand } from "../commands";
 
@@ -14,13 +15,29 @@ import { DeleteAnnotationCommand } from "../commands";
 export const useRegisterAnnotationCommandHandlers = () => {
   const eventBus = useAnnotationEventBus();
   const deleteLabel = useDeleteLabel();
+  const { removeOverlay } = useLighter();
 
   useRegisterCommandHandler(
     DeleteAnnotationCommand,
     useCallback(
       async (cmd) => {
+        const labelId = cmd.label.data._id;
+
+        // TD deletions are handled on each save tick; remove the overlay to
+        // mark it for deletion, but skip the explicit deleteLabel
+        if (cmd.label.type === "TemporalDetection") {
+          removeOverlay(cmd.label.overlay.id, false);
+
+          eventBus.dispatch("annotation:deleteSuccess", {
+            labelId,
+            type: "delete",
+            labelType: cmd.label.type,
+          });
+
+          return true;
+        }
+
         try {
-          const labelId = cmd.label.data._id;
           const success = await deleteLabel(cmd.label, cmd.schema);
 
           if (success) {
@@ -45,7 +62,7 @@ export const useRegisterAnnotationCommandHandlers = () => {
           throw error;
         }
       },
-      [deleteLabel, eventBus]
+      [deleteLabel, eventBus, removeOverlay]
     )
   );
 };

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
@@ -155,6 +155,11 @@ export const useRegisterVideoAnnotationCommandHandlers = () => {
             _cls: "TemporalDetection",
             _id: detectionId,
             support: [cmd.support[0], cmd.support[1]],
+            // Mirror the server-materialized default so the overlay carries
+            // `tags` from the first frame: gives tag edits a real array to
+            // mutate, and keeps the persistence diff from seeing an absent
+            // key on the next refetch.
+            tags: [],
             ...(cmd.label !== undefined ? { label: cmd.label } : {}),
           },
         });

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
@@ -22,6 +22,7 @@ import {
   useApplyPropagationResult,
 } from "../agents/hooks/useApplyPropagationResult";
 import { useSampleDescriptor } from "../agents/hooks/useSampleDescriptor";
+import { useTombstoneTemporalDetection } from "../persistence/temporalDetectionTombstones";
 import type { SAM2PropagationBrowserAgent } from "../agents/SAM2PropagationBrowserAgent";
 import {
   AgentTaskType,
@@ -88,6 +89,7 @@ export const useRegisterVideoAnnotationCommandHandlers = () => {
   const applyPropagatedDetection = useApplyPropagatedDetection();
   const { setContent: setStatusContent } = useVideoAnnotationStatus();
   const eventBus = useAnnotationEventBus();
+  const tombstoneTemporalDetection = useTombstoneTemporalDetection();
 
   useRegisterCommandHandler(
     EditTemporalDetectionCommand,
@@ -128,14 +130,14 @@ export const useRegisterVideoAnnotationCommandHandlers = () => {
           return false;
         }
 
-        // TD persistence does a tick-time comparison of overlays and sample TDs
-        // to generate diffs; removing the overlay will delete the TD on the
-        // next tick.
+        // Record the deletion for the next tick. Removing the overlay drops
+        // the timeline row immediately.
+        tombstoneTemporalDetection(cmd.fieldPath, cmd.detectionId);
         scene.removeOverlay(overlayId);
 
         return true;
       },
-      [scene]
+      [scene, tombstoneTemporalDetection]
     )
   );
 

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
@@ -163,7 +163,18 @@ export const useRegisterVideoAnnotationCommandHandlers = () => {
             ...(cmd.label !== undefined ? { label: cmd.label } : {}),
           },
         });
+        // Seed the time gate to the creation frame (== support start, the
+        // current playhead) so the canvas chip renders immediately. Until the
+        // TD is persisted + refetched it isn't tracked by `useTemporalOverlaySync`,
+        // so nothing else would push a frame into it.
+        overlay.setCurrentFrame(cmd.support[0]);
         scene.addOverlay(overlay);
+        // Select immediately so the new TD opens in the sidebar for editing,
+        // consistent with other creation modes. This mirrors a TD-bar click
+        // (`linkedTracks` → `scene.selectOverlay`); the overlay-added bump in
+        // `useSyncSidebarFromTemporalOverlays` lists it this tick and its
+        // selected-but-newly-listed retry opens the editor.
+        scene.selectOverlay(overlayId);
         return detectionId;
       },
       [scene]

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
@@ -202,10 +202,10 @@ export const useRegisterVideoAnnotationCommandHandlers = () => {
         if (cmd.fromFrame >= cmd.toFrame) return false;
 
         const fromTime = (cmd.fromFrame - 1) / stream.fps;
-        const toTime = (cmd.toFrame - 1) / stream.fps;
         const fromSnapshot = stream.getValue(fromTime);
-        const toSnapshot = stream.getValue(toTime);
-        if (!fromSnapshot || !toSnapshot) return false;
+        if (!fromSnapshot) {
+          return false;
+        }
 
         const matchesInstance = (d: {
           instance?: { _cls: "Instance"; _id?: string };
@@ -214,19 +214,30 @@ export const useRegisterVideoAnnotationCommandHandlers = () => {
           d.keyframe === true && d.instance?._id === cmd.instanceId;
 
         const leftKeyframe = fromSnapshot.detections.find(matchesInstance);
-        const rightKeyframe = toSnapshot.detections.find(matchesInstance);
-        if (!leftKeyframe || !rightKeyframe) return false;
+        if (!leftKeyframe) {
+          return false;
+        }
+
+        const toTime = (cmd.toFrame - 1) / stream.fps;
+        const rightKeyframe = stream
+          .getValue(toTime)
+          ?.detections.find(matchesInstance);
 
         // SAM2 tracking runs asynchronously over the decoded ImaVid frames
         // and streams a detection per frame as inference lands. It needs the
         // image stream as a frame source; bail cleanly on surfaces that have
         // none (e.g. native video).
         if (cmd.method === "sam2") {
-          if (!imageStream) return false;
+          if (!imageStream) {
+            return false;
+          }
 
           const agents = await registry.listAgents();
           const descriptor = agents.find((a) => a.id === "propagate-sam2");
-          if (!descriptor) return false;
+          if (!descriptor) {
+            return false;
+          }
+
           // Registry stores agents under the broad `AnnotationAgent` type;
           // this one is driven through its dedicated `propagate()` (which
           // carries the frame source), not the generic `infer`.
@@ -295,6 +306,11 @@ export const useRegisterVideoAnnotationCommandHandlers = () => {
           } finally {
             setStatusContent(null);
           }
+        }
+
+        // Linear interpolation needs both endpoints to lerp between
+        if (!rightKeyframe) {
+          return false;
         }
 
         const agentId = `propagate-${cmd.method}`;

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationCommandHandlers.ts
@@ -31,6 +31,7 @@ import {
 } from "../agents/types";
 import {
   CreateTemporalDetectionCommand,
+  DeleteTemporalDetectionCommand,
   DeleteTrackCommand,
   EditTemporalDetectionCommand,
   ExtendTrackCommand,
@@ -110,6 +111,31 @@ export const useRegisterVideoAnnotationCommandHandlers = () => {
         return true;
       },
       [scene, eventBus]
+    )
+  );
+
+  useRegisterCommandHandler(
+    DeleteTemporalDetectionCommand,
+    useCallback(
+      async (cmd) => {
+        if (!scene) {
+          return false;
+        }
+
+        const overlayId = `td-${cmd.fieldPath}-${cmd.detectionId}`;
+        const overlay = scene.getOverlay(overlayId);
+        if (!(overlay instanceof TemporalOverlay)) {
+          return false;
+        }
+
+        // TD persistence does a tick-time comparison of overlays and sample TDs
+        // to generate diffs; removing the overlay will delete the TD on the
+        // next tick.
+        scene.removeOverlay(overlayId);
+
+        return true;
+      },
+      [scene]
     )
   );
 

--- a/app/packages/annotation/src/hooks/useRegisterVideoAnnotationKeybindings.ts
+++ b/app/packages/annotation/src/hooks/useRegisterVideoAnnotationKeybindings.ts
@@ -1,13 +1,9 @@
 import { useCommandBus } from "@fiftyone/command-bus";
 import { KnownContexts, useKeyBindings } from "@fiftyone/commands";
 import { useLighter } from "@fiftyone/lighter";
-import {
-  resolvePropagationTarget,
-  useFrameLabelsStream,
-} from "@fiftyone/video-annotation";
 import { useRef } from "react";
 import { usePlayhead } from "../../../playback/src/lib/playback/use-playback-state";
-import { MarkKeyframeCommand, PropagateCommand } from "../commands";
+import { MarkKeyframeCommand } from "../commands";
 
 /**
  * Registers video-only keybindings into the modal-annotate context.
@@ -19,7 +15,6 @@ import { MarkKeyframeCommand, PropagateCommand } from "../commands";
 export const useRegisterVideoAnnotationKeybindings = () => {
   const bus = useCommandBus();
   const { scene } = useLighter();
-  const stream = useFrameLabelsStream();
 
   // Read the visual playhead, not `useCurrentTime` — currentTime lags
   // playhead while streams buffer, so dispatching at "the moment the
@@ -28,9 +23,6 @@ export const useRegisterVideoAnnotationKeybindings = () => {
   const playhead = usePlayhead();
   const playheadRef = useRef(playhead);
   playheadRef.current = playhead;
-
-  const streamRef = useRef(stream);
-  streamRef.current = stream;
 
   useKeyBindings(
     KnownContexts.ModalAnnotate,
@@ -47,34 +39,6 @@ export const useRegisterVideoAnnotationKeybindings = () => {
         label: "Mark keyframe",
         description:
           "Toggle the keyframe attribute on the selected detection at the current frame.",
-      },
-      {
-        commandId: "annotation-propagate",
-        sequence: "-",
-        handler: () => {
-          if (!scene) return;
-          const s = streamRef.current;
-          if (!s) return;
-          const ids = scene.getSelectedOverlayIds();
-
-          // Shared with the timeline toolbar so the two can't disagree
-          // about when propagation is eligible or which keyframes bracket
-          // the playhead.
-          const target = resolvePropagationTarget(s, ids, playheadRef.current);
-          if (!target.ok) return;
-
-          void bus.execute(
-            new PropagateCommand(
-              target.instanceId,
-              target.fromFrame,
-              target.toFrame,
-              "linear"
-            )
-          );
-        },
-        label: "Propagate",
-        description:
-          "Linearly interpolate the selected tracked object between its bracketing keyframes.",
       },
     ],
     [scene, bus]

--- a/app/packages/annotation/src/persistence/temporalDetectionTombstones.ts
+++ b/app/packages/annotation/src/persistence/temporalDetectionTombstones.ts
@@ -1,0 +1,51 @@
+import { atom, useAtomValue, useSetAtom } from "jotai";
+import { useCallback } from "react";
+
+/**
+ * A TemporalDetection that the user explicitly deleted, keyed by its
+ * field path and detection `_id`.
+ */
+export interface TemporalDetectionTombstone {
+  field: string;
+  id: string;
+}
+
+// Module-private; consumed only through the hooks below. Lives on jotai's
+// default store, matching the rest of the Annotate surface.
+const temporalDetectionTombstonesState = atom<
+  readonly TemporalDetectionTombstone[]
+>([]);
+
+/** Current TemporalDetection tombstones for the active sample. */
+export const useTemporalDetectionTombstones =
+  (): readonly TemporalDetectionTombstone[] =>
+    useAtomValue(temporalDetectionTombstonesState);
+
+/**
+ * Returns a callback that records a TemporalDetection deletion so the
+ * delta supplier persists it on the next autosave tick. Idempotent —
+ * re-tombstoning the same `field`/`id` is a no-op.
+ */
+export const useTombstoneTemporalDetection = (): ((
+  field: string,
+  id: string
+) => void) => {
+  const setTombstones = useSetAtom(temporalDetectionTombstonesState);
+
+  return useCallback(
+    (field, id) => {
+      setTombstones((prev) =>
+        prev.some((t) => t.field === field && t.id === id)
+          ? prev
+          : [...prev, { field, id }]
+      );
+    },
+    [setTombstones]
+  );
+};
+
+/** Clears all tombstones — used when the modal sample changes. */
+export const useResetTemporalDetectionTombstones = (): (() => void) => {
+  const setTombstones = useSetAtom(temporalDetectionTombstonesState);
+  return useCallback(() => setTombstones([]), [setTombstones]);
+};

--- a/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.test.ts
+++ b/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.test.ts
@@ -179,13 +179,15 @@ describe("buildTemporalDetectionOverlayDeltas", () => {
       ]);
     });
 
-    it("emits `remove /N` when a baseline entry has no matching overlay", () => {
+    it("emits `remove /N` for a tombstoned detection, resolved by _id", () => {
       const sample = {
         events: field(tdBaseline("a", [1, 10]), tdBaseline("b", [20, 30])),
       };
-      const deltas = buildTemporalDetectionOverlayDeltas(sample, [
-        overlay("events", "a", [1, 10], { label: "x" }),
-      ]);
+      const deltas = buildTemporalDetectionOverlayDeltas(
+        sample,
+        [overlay("events", "a", [1, 10], { label: "x" })],
+        [{ field: "events", id: "b" }]
+      );
       expect(deltas).toEqual([{ op: "remove", path: "/events/detections/1" }]);
     });
 
@@ -197,6 +199,7 @@ describe("buildTemporalDetectionOverlayDeltas", () => {
       const deltas = buildTemporalDetectionOverlayDeltas(
         sample as unknown as Record<string, unknown>,
         [overlay("events", "first", [1, 30], { label: "fresh" })],
+        [],
         ["events"]
       );
       expect(deltas).toEqual([
@@ -218,12 +221,8 @@ describe("buildTemporalDetectionOverlayDeltas", () => {
       expect(
         buildTemporalDetectionOverlayDeltas(
           sample,
-          [
-            // The declared `events` baseline has a matching overlay (no change),
-            // so the only field under test is the undeclared `ghost`.
-            overlay("events", "a", [1, 10], { label: "x" }),
-            overlay("ghost", "a", [5, 15], { label: "x" }),
-          ],
+          [overlay("ghost", "a", [5, 15], { label: "x" })],
+          [],
           ["events"]
         )
       ).toEqual([]);
@@ -235,9 +234,6 @@ describe("buildTemporalDetectionOverlayDeltas", () => {
       const sample = { events: field(tdBaseline("a", [1, 10])) };
       expect(
         buildTemporalDetectionOverlayDeltas(sample, [
-          // The `events` baseline has a matching overlay (no change), leaving
-          // only the `ghost` overlay — whose field isn't on the sample — to skip.
-          overlay("events", "a", [1, 10], { label: "x" }),
           overlay("ghost", "a", [5, 15], { label: "x" }),
         ])
       ).toEqual([]);
@@ -255,21 +251,68 @@ describe("buildTemporalDetectionOverlayDeltas", () => {
       ).toEqual([]);
     });
 
-    it("removes every baseline entry when all overlays are gone", () => {
-      // Deleting the last TD(s) in a field leaves a populated baseline with no
-      // matching overlays; each orphaned entry is diffed out (descending so the
-      // earlier indices don't shift).
+    it("does NOT remove baseline entries when overlays are absent without a tombstone", () => {
+      // The first-load / navigation case: the sample baseline is populated but
+      // its TD overlays haven't hydrated into the scene yet. Without an explicit
+      // tombstone this must emit nothing — inferring deletion from absence here
+      // would silently delete every TD on a navigation autosave tick.
       const sample = {
         events: field(tdBaseline("a", [1, 10]), tdBaseline("b", [20, 30])),
       };
-      expect(buildTemporalDetectionOverlayDeltas(sample, [])).toEqual([
+      expect(buildTemporalDetectionOverlayDeltas(sample, [])).toEqual([]);
+    });
+
+    it("returns an empty array when the sample has no temporal detections", () => {
+      expect(buildTemporalDetectionOverlayDeltas({}, [])).toEqual([]);
+    });
+  });
+
+  describe("tombstone removals", () => {
+    it("removes every tombstoned detection, descending, when all overlays are gone", () => {
+      // Deleting the last TD(s) in a field leaves no overlays, but the explicit
+      // tombstones still drive the removals (descending so indices don't shift).
+      const sample = {
+        events: field(tdBaseline("a", [1, 10]), tdBaseline("b", [20, 30])),
+      };
+      expect(
+        buildTemporalDetectionOverlayDeltas(
+          sample,
+          [],
+          [
+            { field: "events", id: "a" },
+            { field: "events", id: "b" },
+          ]
+        )
+      ).toEqual([
         { op: "remove", path: "/events/detections/1" },
         { op: "remove", path: "/events/detections/0" },
       ]);
     });
 
-    it("returns an empty array when the sample has no temporal detections", () => {
-      expect(buildTemporalDetectionOverlayDeltas({}, [])).toEqual([]);
+    it("skips a tombstone whose id is no longer in the baseline (idempotent)", () => {
+      // Post-save refetch dropped the deleted TD — the lingering tombstone
+      // resolves to nothing, so no `remove` is re-emitted against a shifted array.
+      const sample = { events: field(tdBaseline("a", [1, 10])) };
+      expect(
+        buildTemporalDetectionOverlayDeltas(
+          sample,
+          [],
+          [{ field: "events", id: "gone" }]
+        )
+      ).toEqual([]);
+    });
+
+    it("does not emit an add/update for a tombstoned overlay still in the scene", () => {
+      // If the deleted overlay momentarily lingers, its tombstone wins: only a
+      // single `remove`, no competing add/update.
+      const sample = { events: field(tdBaseline("a", [1, 10])) };
+      expect(
+        buildTemporalDetectionOverlayDeltas(
+          sample,
+          [overlay("events", "a", [5, 15], { label: "renamed" })],
+          [{ field: "events", id: "a" }]
+        )
+      ).toEqual([{ op: "remove", path: "/events/detections/0" }]);
     });
   });
 });

--- a/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.test.ts
+++ b/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.test.ts
@@ -140,6 +140,38 @@ describe("buildTemporalDetectionOverlayDeltas", () => {
       ]);
     });
 
+    it("emits nothing when an array attribute is value-equal but a different instance", () => {
+      // `tags` (and any list/dict attribute) round-trips as a fresh array on
+      // every post-save refetch, so the baseline and overlay arrays are never
+      // the same reference.
+      const sample = {
+        events: field(tdBaseline("a", [1, 10], { tags: [] })),
+      };
+      const deltas = buildTemporalDetectionOverlayDeltas(sample, [
+        // a distinct, value-equal array instance
+        overlay("events", "a", [1, 10], {
+          label: "x",
+          tags: [],
+        } as Partial<TemporalLabel>),
+      ]);
+      expect(deltas).toEqual([]);
+    });
+
+    it("emits a replace when an array attribute's value actually changes", () => {
+      const sample = {
+        events: field(tdBaseline("a", [1, 10], { tags: ["old"] })),
+      };
+      const deltas = buildTemporalDetectionOverlayDeltas(sample, [
+        overlay("events", "a", [1, 10], {
+          label: "x",
+          tags: ["new"],
+        } as Partial<TemporalLabel>),
+      ]);
+      expect(deltas).toEqual([
+        { op: "replace", path: "/events/detections/0/tags", value: ["new"] },
+      ]);
+    });
+
     it("emits a remove op for an attribute the overlay no longer carries", () => {
       const sample = {
         events: field(tdBaseline("a", [1, 10], { reviewed: false })),

--- a/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.test.ts
+++ b/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.test.ts
@@ -218,7 +218,12 @@ describe("buildTemporalDetectionOverlayDeltas", () => {
       expect(
         buildTemporalDetectionOverlayDeltas(
           sample,
-          [overlay("ghost", "a", [5, 15], { label: "x" })],
+          [
+            // The declared `events` baseline has a matching overlay (no change),
+            // so the only field under test is the undeclared `ghost`.
+            overlay("events", "a", [1, 10], { label: "x" }),
+            overlay("ghost", "a", [5, 15], { label: "x" }),
+          ],
           ["events"]
         )
       ).toEqual([]);
@@ -230,6 +235,9 @@ describe("buildTemporalDetectionOverlayDeltas", () => {
       const sample = { events: field(tdBaseline("a", [1, 10])) };
       expect(
         buildTemporalDetectionOverlayDeltas(sample, [
+          // The `events` baseline has a matching overlay (no change), leaving
+          // only the `ghost` overlay — whose field isn't on the sample — to skip.
+          overlay("events", "a", [1, 10], { label: "x" }),
           overlay("ghost", "a", [5, 15], { label: "x" }),
         ])
       ).toEqual([]);
@@ -247,9 +255,21 @@ describe("buildTemporalDetectionOverlayDeltas", () => {
       ).toEqual([]);
     });
 
-    it("returns an empty array when there are no overlays", () => {
-      const sample = { events: field(tdBaseline("a", [1, 10])) };
-      expect(buildTemporalDetectionOverlayDeltas(sample, [])).toEqual([]);
+    it("removes every baseline entry when all overlays are gone", () => {
+      // Deleting the last TD(s) in a field leaves a populated baseline with no
+      // matching overlays; each orphaned entry is diffed out (descending so the
+      // earlier indices don't shift).
+      const sample = {
+        events: field(tdBaseline("a", [1, 10]), tdBaseline("b", [20, 30])),
+      };
+      expect(buildTemporalDetectionOverlayDeltas(sample, [])).toEqual([
+        { op: "remove", path: "/events/detections/1" },
+        { op: "remove", path: "/events/detections/0" },
+      ]);
+    });
+
+    it("returns an empty array when the sample has no temporal detections", () => {
+      expect(buildTemporalDetectionOverlayDeltas({}, [])).toEqual([]);
     });
   });
 });

--- a/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.test.ts
+++ b/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.test.ts
@@ -184,6 +184,24 @@ describe("buildTemporalDetectionOverlayDeltas", () => {
         { op: "remove", path: "/events/detections/0/reviewed" },
       ]);
     });
+
+    it("does NOT emit a remove for `tags` when the overlay lacks it but the baseline has it", () => {
+      // New-TD create case: the overlay was built fresh in the browser with no
+      // `tags` key, but the server materializes `tags: []` on save. The
+      // "baseline key not on overlay → remove" rule must skip `tags` — else it
+      // emits `remove /tags` every tick, the server re-defaults it, and the
+      // diff never converges (infinite save loop). Only reproduces where the
+      // baseline carries a materialized `tags` (e.g. cloned real data like
+      // va-demo), not on freshly-built datasets (va-demo-bare).
+      const sample = {
+        events: field(tdBaseline("a", [1, 10], { tags: [] })),
+      };
+      const deltas = buildTemporalDetectionOverlayDeltas(sample, [
+        // overlay label lacks `tags`
+        overlay("events", "a", [1, 10], { label: "x" }),
+      ]);
+      expect(deltas).toEqual([]);
+    });
   });
 
   describe("create / delete", () => {

--- a/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.ts
@@ -223,6 +223,17 @@ const RESERVED_LABEL_KEYS = new Set([
   "confidence",
 ]);
 
+/**
+ * Built-in label fields the server always materializes (a `TemporalDetection`
+ * gets `tags: []` by default) but a freshly-created overlay doesn't carry. The
+ * "baseline key not on overlay → remove" rule must skip these: a new TD has no
+ * `tags`, so it would emit `remove /tags` on every tick, the server re-defaults
+ * `tags: []` on the next refetch, and the diff never converges — an infinite
+ * save loop. Edits still persist via the add/replace path (a hydrated overlay
+ * carries `tags`, compared with `isEqual`).
+ */
+const SERVER_DEFAULT_LABEL_KEYS = new Set(["tags"]);
+
 function serializeOverlayLabel(
   label: TemporalLabel | null | undefined
 ): Record<string, unknown> | null {
@@ -310,6 +321,9 @@ function diffOverlayLabel(
   // Detect removals: keys on the baseline that aren't on the overlay.
   for (const k of Object.keys(baseline)) {
     if (RESERVED_LABEL_KEYS.has(k)) continue;
+    // Server-default fields (e.g. `tags`) are always on the baseline but
+    // absent from a freshly-created overlay — removing them loops forever.
+    if (SERVER_DEFAULT_LABEL_KEYS.has(k)) continue;
     if (!(k in overlayLabel)) {
       deltas.push({ op: "remove", path: `${basePath}/${k}` });
     }

--- a/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.ts
@@ -9,9 +9,14 @@ import {
   EMBEDDED_DOCUMENT_FIELD,
   TEMPORAL_DETECTIONS_FIELD,
 } from "@fiftyone/utilities";
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { useRecoilValue } from "recoil";
 import type { DeltaSupplier } from "./deltaSupplier";
+import {
+  useResetTemporalDetectionTombstones,
+  useTemporalDetectionTombstones,
+  type TemporalDetectionTombstone,
+} from "./temporalDetectionTombstones";
 
 /**
  * Persistence path for `TemporalDetection` edits. The Lighter `TemporalOverlay`
@@ -39,6 +44,17 @@ export const useTemporalDetectionDeltaSupplier = (): DeltaSupplier => {
     })
   );
 
+  const tombstones = useTemporalDetectionTombstones();
+  const resetTombstones = useResetTemporalDetectionTombstones();
+
+  // Tombstones are per-sample: drop them when the modal sample changes so a
+  // deletion recorded on one sample can never resolve against another's
+  // baseline.
+  const sampleId = (modalSample?.sample as { _id?: string } | undefined)?._id;
+  useEffect(() => {
+    resetTombstones();
+  }, [sampleId, resetTombstones]);
+
   return useCallback(() => {
     if (!isVideo || !scene || !modalSample?.sample) {
       return { deltas: [], metadata: undefined };
@@ -52,18 +68,27 @@ export const useTemporalDetectionDeltaSupplier = (): DeltaSupplier => {
       deltas: buildTemporalDetectionOverlayDeltas(
         modalSample.sample as Record<string, unknown>,
         overlays,
+        tombstones,
         declaredTdFields
       ),
       metadata: undefined,
     };
-  }, [isVideo, modalSample, scene, declaredTdFields]);
+  }, [isVideo, modalSample, scene, declaredTdFields, tombstones]);
 };
 
 /**
  * Walk TD overlays grouped by field path, diff against the matching
- * sample baseline, and emit JSON-Patch ops. Overlays without a baseline
- * entry are emitted as `add /-`; baseline entries with no matching
- * overlay are emitted as `remove /N`. Exported for direct unit testing.
+ * sample baseline, and emit JSON-Patch ops. Exported for direct unit
+ * testing.
+ *
+ * - **Adds / updates** come from scene overlays: an overlay with no
+ *   baseline entry is an `add /-`, one that matches is diffed in place.
+ *   Only fields that actually have overlays are walked.
+ * - **Removals** come from explicit `tombstones` — TDs the user deleted —
+ *   resolved to the current baseline index by `_id`. A tombstone whose id
+ *   is no longer in the baseline (already persisted + refetched, or never
+ *   present) is skipped, so a `remove` is emitted at most once per
+ *   deletion and never against an index-shifted array.
  *
  * `declaredFields` are the sample-level field paths the dataset schema
  * declares as `TemporalDetections`.
@@ -71,9 +96,25 @@ export const useTemporalDetectionDeltaSupplier = (): DeltaSupplier => {
 export function buildTemporalDetectionOverlayDeltas(
   sample: Record<string, unknown>,
   overlays: readonly TemporalOverlay[],
+  tombstones: readonly TemporalDetectionTombstone[] = [],
   declaredFields?: readonly string[]
 ): JSONDeltas {
   const deltas: JSONDeltas = [];
+
+  const findById = (detections: readonly unknown[], id: string): number =>
+    detections.findIndex(
+      (d) =>
+        (d as { _id?: string; id?: string })._id === id ||
+        (d as { _id?: string; id?: string }).id === id
+    );
+
+  // field path -> set of tombstoned detection ids
+  const tombstonedByField = new Map<string, Set<string>>();
+  for (const { field, id } of tombstones) {
+    const ids = tombstonedByField.get(field) ?? new Set<string>();
+    ids.add(id);
+    tombstonedByField.set(field, ids);
+  }
 
   const byField = new Map<string, TemporalOverlay[]>();
   for (const overlay of overlays) {
@@ -82,18 +123,8 @@ export function buildTemporalDetectionOverlayDeltas(
     byField.set(overlay.field, list);
   }
 
-  // Union of fields with overlays and fields with a sample baseline. The
-  // baseline side matters for deletions: a field whose last overlay was
-  // removed has no entry in `byField` but still needs its baseline diffed out.
-  const fieldPaths = new Set<string>(byField.keys());
-  for (const [fieldPath, value] of Object.entries(sample)) {
-    if (!!value && (value as { _cls?: string })._cls === "TemporalDetections") {
-      fieldPaths.add(fieldPath);
-    }
-  }
-
-  for (const fieldPath of fieldPaths) {
-    const fieldOverlays = byField.get(fieldPath) ?? [];
+  // Adds / updates from scene overlays.
+  for (const [fieldPath, fieldOverlays] of byField) {
     const field = sample[fieldPath] as
       | { _cls?: string; detections?: unknown }
       | undefined;
@@ -109,19 +140,20 @@ export function buildTemporalDetectionOverlayDeltas(
     const baseline =
       isPopulated && Array.isArray(field.detections) ? field.detections : [];
 
-    const seenIds = new Set<string>();
     for (const overlay of fieldOverlays) {
       const label = overlay.label;
       const id = label?._id;
-      if (!id) continue;
-      seenIds.add(id);
+      if (!id) {
+        continue;
+      }
 
-      const index = baseline.findIndex(
-        (d) =>
-          (d as { _id?: string; id?: string })._id === id ||
-          (d as { _id?: string; id?: string }).id === id
-      );
+      // A tombstoned overlay still lingering in the scene must not emit an
+      // add/update that fights its pending removal.
+      if (tombstonedByField.get(fieldPath)?.has(id)) {
+        continue;
+      }
 
+      const index = findById(baseline, id);
       if (index < 0) {
         // New TD — append the full doc.
         const value = serializeOverlayLabel(label);
@@ -135,19 +167,46 @@ export function buildTemporalDetectionOverlayDeltas(
       }
 
       const base = baseline[index] as Record<string, unknown>;
-      const basePath = `/${fieldPath}/detections/${index}`;
-      diffOverlayLabel(label, base, basePath, deltas);
+      diffOverlayLabel(
+        label,
+        base,
+        `/${fieldPath}/detections/${index}`,
+        deltas
+      );
+    }
+  }
+
+  // Removals from explicit tombstones, resolved to the current baseline
+  // index by `_id`. Descending per field so each `remove` doesn't shift the
+  // indices of the ones still to come.
+  const removalsByField = new Map<string, number[]>();
+  for (const { field: fieldPath, id } of tombstones) {
+    const field = sample[fieldPath] as
+      | { _cls?: string; detections?: unknown }
+      | undefined;
+
+    if (!field || field._cls !== "TemporalDetections") {
+      continue;
     }
 
-    // Removals: baseline entries with no matching overlay. Descending so each
-    // `remove` doesn't shift the indices of the ones still to come.
-    for (let i = baseline.length - 1; i >= 0; i--) {
-      const baseId =
-        (baseline[i] as { _id?: string; id?: string })._id ??
-        (baseline[i] as { _id?: string; id?: string }).id;
-      if (baseId && !seenIds.has(baseId)) {
-        deltas.push({ op: "remove", path: `/${fieldPath}/detections/${i}` });
-      }
+    if (!Array.isArray(field.detections)) {
+      continue;
+    }
+
+    const index = findById(field.detections, id);
+    if (index < 0) {
+      continue;
+    }
+
+    const list = removalsByField.get(fieldPath) ?? [];
+    list.push(index);
+    removalsByField.set(fieldPath, list);
+  }
+
+  for (const [fieldPath, indices] of removalsByField) {
+    indices.sort((a, b) => b - a);
+    for (const index of indices) {
+      deltas.push({ op: "remove", path: `/${fieldPath}/detections/${index}` });
     }
   }
 

--- a/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.ts
@@ -9,6 +9,7 @@ import {
   EMBEDDED_DOCUMENT_FIELD,
   TEMPORAL_DETECTIONS_FIELD,
 } from "@fiftyone/utilities";
+import { isEqual } from "lodash";
 import { useCallback, useEffect } from "react";
 import { useRecoilValue } from "recoil";
 import type { DeltaSupplier } from "./deltaSupplier";
@@ -296,7 +297,8 @@ function diffOverlayLabel(
       }
       continue;
     }
-    if (v !== baseline[k]) {
+
+    if (!isEqual(v, baseline[k])) {
       deltas.push({
         op: k in baseline ? "replace" : "add",
         path: `${basePath}/${k}`,

--- a/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.ts
+++ b/app/packages/annotation/src/persistence/useTemporalDetectionDeltaSupplier.ts
@@ -82,7 +82,18 @@ export function buildTemporalDetectionOverlayDeltas(
     byField.set(overlay.field, list);
   }
 
-  for (const [fieldPath, fieldOverlays] of byField) {
+  // Union of fields with overlays and fields with a sample baseline. The
+  // baseline side matters for deletions: a field whose last overlay was
+  // removed has no entry in `byField` but still needs its baseline diffed out.
+  const fieldPaths = new Set<string>(byField.keys());
+  for (const [fieldPath, value] of Object.entries(sample)) {
+    if (!!value && (value as { _cls?: string })._cls === "TemporalDetections") {
+      fieldPaths.add(fieldPath);
+    }
+  }
+
+  for (const fieldPath of fieldPaths) {
+    const fieldOverlays = byField.get(fieldPath) ?? [];
     const field = sample[fieldPath] as
       | { _cls?: string; detections?: unknown }
       | undefined;
@@ -128,8 +139,9 @@ export function buildTemporalDetectionOverlayDeltas(
       diffOverlayLabel(label, base, basePath, deltas);
     }
 
-    // Removals: baseline entries with no matching overlay
-    for (let i = 0; i < baseline.length; i++) {
+    // Removals: baseline entries with no matching overlay. Descending so each
+    // `remove` doesn't shift the indices of the ones still to come.
+    for (let i = baseline.length - 1; i >= 0; i--) {
       const baseId =
         (baseline[i] as { _id?: string; id?: string })._id ??
         (baseline[i] as { _id?: string; id?: string }).id;

--- a/app/packages/core/src/components/Modal/Lighter/useBridge.ts
+++ b/app/packages/core/src/components/Modal/Lighter/useBridge.ts
@@ -413,6 +413,9 @@ export const useBridge = (scene: Scene2D | null) => {
     useCallback(() => {
       if (segmentationMode.segmentationModeActive) {
         segmentationMode.finalizePointSelection();
+        // Deselect the committed label so the next click starts a fresh
+        // detection
+        focusRef.current.deselectOverlay();
       }
     }, [segmentationMode])
   );

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Actions.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Actions.tsx
@@ -16,7 +16,11 @@ import {
   useCurrent3dAnnotationMode,
   useSetCurrent3dAnnotationMode,
 } from "@fiftyone/looker-3d/src/state/accessors";
-import { is3DDataset, useRenderConfig3dState } from "@fiftyone/state";
+import {
+  is3DDataset,
+  isVideoDataset,
+  useRenderConfig3dState,
+} from "@fiftyone/state";
 import {
   DETECTION,
   DETECTIONS,
@@ -430,6 +434,10 @@ export const ThreeDCuboids = () => {
 const Actions = () => {
   // This checks if media type of the dataset resolved to 3d
   const is3dDataset = useRecoilValue(is3DDataset);
+  // Video annotation supports only box drawing today, so the surface shows a
+  // reduced action set (Select + Detection); the other label-type modes and
+  // undo/redo are hidden.
+  const isVideo = useRecoilValue(isVideoDataset);
   // This checks if a 3d sample is pinned - is true when media type is `group` with a 3d slice pinned
   const { isPinned: is3dSamplePinned } = useRenderConfig3dState();
 
@@ -455,24 +463,32 @@ const Actions = () => {
         <Row>
           <ItemLeft style={{ columnGap: "0.1rem" }}>
             <Select active={noActiveActions} />
-            <Classification />
-            {areThreeDActionsVisible ? (
-              <>
-                <ThreeDCuboids />
-                <ThreeDPolylines />
-              </>
+            {isVideo ? (
+              <Detection />
             ) : (
               <>
-                <Detection />
-                <Segmentation />
-                <Polyline />
+                <Classification />
+                {areThreeDActionsVisible ? (
+                  <>
+                    <ThreeDCuboids />
+                    <ThreeDPolylines />
+                  </>
+                ) : (
+                  <>
+                    <Detection />
+                    <Segmentation />
+                    <Polyline />
+                  </>
+                )}
               </>
             )}
           </ItemLeft>
-          <ItemRight style={{ columnGap: "0.1rem" }}>
-            <Undo />
-            <Redo />
-          </ItemRight>
+          {!isVideo && (
+            <ItemRight style={{ columnGap: "0.1rem" }}>
+              <Undo />
+              <Redo />
+            </ItemRight>
+          )}
         </Row>
       </ActionsDiv>
     </DeactivateAllContext.Provider>

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
@@ -157,7 +157,16 @@ const useHandleSchemaChange = (readOnly: boolean) => {
         )
       );
 
-      const value = { ...data, ...result };
+      // Merge onto the live overlay label, which can be fresher than the
+      // form's `data` snapshot. Discard fields which are owned elsewhere.
+      const { support: _formSupport, ...formResult } = result as Record<
+        string,
+        unknown
+      >;
+      const value = {
+        ...(overlay.label as Record<string, unknown>),
+        ...formResult,
+      };
 
       const allAttributes = Array.isArray(config?.attributes)
         ? config.attributes

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useFocus.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useFocus.ts
@@ -37,19 +37,33 @@ export default function useFocus(): FocusController {
     (id: string, options?: FocusOptions) => {
       if (options?.ignoreSideEffects) return;
 
-      if (STORE.get(editing)) {
+      const editingValue = STORE.get(editing);
+      if (editingValue) {
         const currentLabel = STORE.get(current);
+        const currentOverlayId = currentLabel?.overlay?.id;
 
-        if (currentLabel?.isNew) return;
+        // If the overlay being edited is no longer in the scene, the edit
+        // target is stale and must not block selecting its replacement.
+        // A string `editing` value (add-schema flow) has no overlay, so it's
+        // never stale.
+        const editingStale =
+          typeof editingValue !== "string" &&
+          !!currentOverlayId &&
+          !!scene &&
+          !scene.getOverlay(currentOverlayId);
 
-        // Re-clicking the overlay that's already being edited — needed
-        // for drag/resize interactions in patches view auto-edit.
-        if (currentLabel?.overlay?.id === id) return;
+        if (!editingStale) {
+          if (currentLabel?.isNew) return;
 
-        // Another label is already open for editing; cancel the new
-        // selection and keep editing the current one.
-        scene?.deselectOverlay(id, { ignoreSideEffects: true });
-        return;
+          // Re-clicking the overlay that's already being edited — needed
+          // for drag/resize interactions in patches view auto-edit.
+          if (currentOverlayId === id) return;
+
+          // Another label is already open for editing; cancel the new
+          // selection and keep editing the current one.
+          scene?.deselectOverlay(id, { ignoreSideEffects: true });
+          return;
+        }
       }
 
       const label = STORE.get(labelMap)[id];
@@ -75,8 +89,8 @@ export default function useFocus(): FocusController {
     [isGenerated, onExit]
   );
 
-  return useMemo(() => ({ selectOverlay, deselectOverlay }), [
-    selectOverlay,
-    deselectOverlay,
-  ]);
+  return useMemo(
+    () => ({ selectOverlay, deselectOverlay }),
+    [selectOverlay, deselectOverlay]
+  );
 }

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
@@ -518,7 +518,11 @@ export default function useLabels() {
   useEffect(() => {
     const resetOverlays = () => {
       currentLabels.forEach((label) => {
-        removeOverlay(label.overlay.id, false);
+        // Lifecycle removal — overlays are being torn down to reload on a
+        // schema-active change, not deleted by the user. Without the flag the
+        // video label-stream sync treats each `overlay-removed` as a delete
+        // and the autosave wipes the current frame's detections.
+        removeOverlay(label.overlay.id, false, true);
       });
 
       setLabels([]);

--- a/app/packages/lighter/src/core/Scene2D.ts
+++ b/app/packages/lighter/src/core/Scene2D.ts
@@ -1115,8 +1115,13 @@ export class Scene2D {
    * Removes an overlay from the scene.
    * @param id - The ID of the overlay to remove.
    * @param withUndo - Whether to track this operation for undo/redo.
+   * @param lifecycle - Whether this is a lifecycle event (not user-driven)
    */
-  removeOverlay(id: string, withUndo: boolean = false): void {
+  removeOverlay(
+    id: string,
+    withUndo: boolean = false,
+    lifecycle: boolean = false
+  ): void {
     if (withUndo) {
       const overlay = this.overlays.get(id);
       if (overlay) {
@@ -1144,7 +1149,7 @@ export class Scene2D {
       this.renderingState.clear(id);
     }
 
-    this.eventBus.dispatch("lighter:overlay-removed", { id });
+    this.eventBus.dispatch("lighter:overlay-removed", { id, lifecycle });
   }
 
   /**

--- a/app/packages/lighter/src/events/index.ts
+++ b/app/packages/lighter/src/events/index.ts
@@ -19,8 +19,13 @@ export type LighterEventGroup = {
   "lighter:overlay-added": { id: string; overlay: BaseOverlay };
   /** Emitted when an overlay has finished loading resources and is ready */
   "lighter:overlay-loaded": { id: string };
-  /** Emitted when an overlay is removed from the scene */
-  "lighter:overlay-removed": { id: string };
+  /**
+   * Emitted when an overlay is removed from the scene. `lifecycle` is set
+   * when the removal is a teardown / sync eviction (scene reset, scrub-off,
+   * unmount) rather than a user-initiated delete — consumers that persist
+   * deletions must ignore lifecycle removals.
+   */
+  "lighter:overlay-removed": { id: string; lifecycle?: boolean };
   /** Emitted when an overlay encounters an error during loading or rendering */
   "lighter:overlay-error": { id: string; error: Error };
   /** Emitted when an overlay's bounds change */

--- a/app/packages/lighter/src/react/useLighter.ts
+++ b/app/packages/lighter/src/react/useLighter.ts
@@ -49,11 +49,14 @@ export const useLighter = () => {
     []
   );
 
-  const removeOverlay = useCallback((id: string, withUndo: boolean = false) => {
-    if (sceneRef.current) {
-      sceneRef.current.removeOverlay(id, withUndo);
-    }
-  }, []);
+  const removeOverlay = useCallback(
+    (id: string, withUndo: boolean = false, lifecycle: boolean = false) => {
+      if (sceneRef.current) {
+        sceneRef.current.removeOverlay(id, withUndo, lifecycle);
+      }
+    },
+    []
+  );
 
   const getOverlay = useCallback((id: string) => {
     if (sceneRef.current) {

--- a/app/packages/playback/src/views/TimelineTrack/TimelineTrack.module.css
+++ b/app/packages/playback/src/views/TimelineTrack/TimelineTrack.module.css
@@ -55,6 +55,10 @@
   height: 100%;
   overflow: hidden;
   cursor: pointer;
+  /* Scope the z-index ordering of the bar / keyframe diamonds / resize
+     handles to this row so the resize handle can reliably paint above the
+     diamond (see `.resizeHandle` / `.intervalBar`). */
+  isolation: isolate;
 }
 
 .bar {
@@ -84,26 +88,39 @@
 /* Interval bar — one segment of a semantic track, click-to-seek. */
 .intervalBar {
   position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
+  top: calc(50% - 6px);
   height: 12px;
   border-radius: 2px;
   cursor: pointer;
-  z-index: 1;
 }
 
-.intervalBar:hover,
 .event:hover {
   filter: brightness(1.15);
 }
 
+/* Lighten on hover with an inset overlay rather than `filter: brightness`.
+   A filter establishes a stacking context, which would re-trap the resize
+   handle below the keyframe diamond *while hovering* — flipping the topmost
+   element (and the cursor) between the handle and the diamond every frame
+   wherever a keyframe sits on the handle (the leading edge). */
+.intervalBar:hover {
+  box-shadow: inset 0 0 0 100px rgba(255, 255, 255, 0.12);
+}
+
+/* Each edge handle straddles the bar boundary: `--resize-inset` inside
+   (preserving the move-vs-resize split within the bar) plus a `--resize-buffer`
+   invisible buffer hanging *past* the edge so you can grab right at or just
+   beyond the endpoint. */
 .resizeHandle {
+  --resize-inset: 6px;
+  --resize-buffer: 6px;
   position: absolute;
   top: 0;
   height: 100%;
-  width: 6px;
+  width: calc(var(--resize-inset) + var(--resize-buffer));
   cursor: ew-resize;
-  z-index: 2;
+  /* Above the keyframe diamond */
+  z-index: 4;
   background: rgba(255, 255, 255, 0.25);
   opacity: 0;
   transition: opacity 0.1s;
@@ -114,9 +131,9 @@
 }
 
 .resizeHandleStart {
-  left: 0;
+  left: calc(-1 * var(--resize-buffer));
 }
 
 .resizeHandleEnd {
-  right: 0;
+  right: calc(-1 * var(--resize-buffer));
 }

--- a/app/packages/video-annotation/src/FrameLabels.tsx
+++ b/app/packages/video-annotation/src/FrameLabels.tsx
@@ -42,6 +42,7 @@ import { LABELS_STREAM_ID } from "./ids";
 import { resolveTrackExtentEdit } from "./trackExtentEdit";
 import { useLinkedTrackDecorator } from "./linkedTracks";
 import {
+  DeleteTemporalDetectionCommand,
   DeleteTrackCommand,
   EditTemporalDetectionCommand,
   ExtendTrackCommand,
@@ -458,6 +459,13 @@ export const FrameLabelsTracks: React.FC<{ sample?: ModalSample }> = ({
       return {
         ...base,
         snapStepSec,
+        onDeleteTrack: () =>
+          void commandBus.execute(
+            new DeleteTemporalDetectionCommand(
+              tdEvent.fieldPath,
+              tdEvent.detectionId
+            )
+          ),
         onEventEdit: (
           _eventIndex: number,
           newStartSec: number,

--- a/app/packages/video-annotation/src/ImaVidImageStream.ts
+++ b/app/packages/video-annotation/src/ImaVidImageStream.ts
@@ -270,6 +270,13 @@ export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
       return;
     }
 
+    // We're advancing to a new committed frame; proactively pull the next
+    // chunk into flight so it lands before the playhead reaches it. The engine
+    // only gives us a 1-frame warning, so we want to get ahead of that.
+    if (next) {
+      this.prefetch([time, time + this.lookaheadSeconds]);
+    }
+
     store.set(streamValueAtom(this.id), next);
   }
 

--- a/app/packages/video-annotation/src/SyntheticLabelStream.ts
+++ b/app/packages/video-annotation/src/SyntheticLabelStream.ts
@@ -9,7 +9,12 @@ export type PropagationMethod = "linear" | "sam2";
 export interface PropagationBlob {
   method: PropagationMethod;
   run_id: ObjectIdHex;
-  parent_keyframes: [ObjectIdHex, ObjectIdHex];
+  /**
+   * Source keyframes' `_id`s. Two for a bracketed run (linear interp,
+   * or SAM2 between two keyframes); one for a SAM2 forward run that tracks
+   * from a single seed keyframe to the end of the clip.
+   */
+  parent_keyframes: [ObjectIdHex, ...ObjectIdHex[]];
 }
 
 export interface SyntheticBox {

--- a/app/packages/video-annotation/src/frameTracks.test.ts
+++ b/app/packages/video-annotation/src/frameTracks.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildPerInstanceTracks, type PerInstanceLabel } from "./frameTracks";
+import type { SyntheticBox } from "./SyntheticLabelStream";
+import type { VideoFrameLabelsStream } from "./VideoFrameLabelsStream";
+
+const FPS = 30;
+
+/**
+ * Minimal stream stub: `buildPerInstanceTracks` only reads `totalFrames`,
+ * `fps`, and `getValue(time) -> { detections }`. `frames` maps a 1-indexed
+ * frame number to the detections present on it.
+ */
+function makeStream(
+  totalFrames: number,
+  frames: Record<number, Partial<SyntheticBox>[]>
+): VideoFrameLabelsStream {
+  return {
+    totalFrames,
+    fps: FPS,
+    getValue: (time: number) => {
+      const frame = Math.round(time * FPS) + 1;
+      return { detections: (frames[frame] ?? []) as SyntheticBox[] };
+    },
+  } as unknown as VideoFrameLabelsStream;
+}
+
+describe("buildPerInstanceTracks", () => {
+  it("resolves row color from the real detection index + instance, not the display ordinal", () => {
+    // An instance-keyed box whose persisted index (7) differs from the
+    // display ordinal it would be assigned. The color hash must use 7 +
+    // the instance so it matches the bbox overlay under color-by-instance.
+    const det: Partial<SyntheticBox> = {
+      id: "instance-abc123",
+      label: "person",
+      index: 7,
+      instance: { _cls: "Instance", _id: "abc123" },
+      keyframe: false,
+      bounding_box: [0, 0, 0.1, 0.1],
+    };
+    const stream = makeStream(2, { 1: [det], 2: [det] });
+
+    const resolveColor = vi.fn<(l: PerInstanceLabel) => string>(() => "#fff");
+    const tracks = buildPerInstanceTracks({ stream, resolveColor });
+
+    expect(tracks).toHaveLength(1);
+    expect(resolveColor).toHaveBeenCalledWith({
+      label: "person",
+      index: 7,
+      instance: { _cls: "Instance", _id: "abc123" },
+    });
+    // Display text still uses the persisted index as the ordinal.
+    expect(tracks[0].label).toBe("person 7");
+  });
+
+  it("passes the numeric index with no instance for legacy track-keyed boxes", () => {
+    const det: Partial<SyntheticBox> = {
+      id: "track-3",
+      label: "vehicle",
+      index: 3,
+      keyframe: false,
+      bounding_box: [0, 0, 0.1, 0.1],
+    };
+    const stream = makeStream(1, { 1: [det] });
+
+    const resolveColor = vi.fn<(l: PerInstanceLabel) => string>(() => "#fff");
+    buildPerInstanceTracks({ stream, resolveColor });
+
+    expect(resolveColor).toHaveBeenCalledWith({
+      label: "vehicle",
+      index: 3,
+      instance: undefined,
+    });
+  });
+});

--- a/app/packages/video-annotation/src/frameTracks.ts
+++ b/app/packages/video-annotation/src/frameTracks.ts
@@ -24,12 +24,18 @@ interface InstanceState {
    */
   persistedIndex?: number;
   /**
-   * Display ordinal used for the row label and color hash. Equals
+   * Display ordinal used for the row label text. Equals
    * `persistedIndex` when set; otherwise assigned at build time as the
    * next free integer above the per-class max so the demo UI always
    * has a readable "person 3" / "person 4" label.
    */
   displayIndex: number;
+  /**
+   * The underlying detection's `Instance` reference, when present. Carried
+   * so the row color hashes on the same `instance._id` the overlay does
+   * under color-by-instance.
+   */
+  instance?: { _cls: "Instance"; _id?: string } | null;
   /** Whether the instance was present in the most recent frame. */
   inFrame: boolean;
   /** Start time (sec) of the currently-open interval, if any. */
@@ -43,11 +49,17 @@ interface InstanceState {
 /**
  * Minimal label-shape passed to {@link BuildPerInstanceTracksInput.resolveColor}.
  * Mirrors the fields `getLabelColorFromContext` reads, so the color resolves
- * the same way it would for the matching label.
+ * the same way it would for the matching overlay.
+ *
+ * `index` and `instance` must be the *underlying detection's* values (not a
+ * synthetic display ordinal), because color-by-instance hashes on
+ * `${label}-${index}-${instance._id}` — passing the display ordinal or
+ * dropping the instance would desync the row color from the bbox overlay.
  */
 export interface PerInstanceLabel {
   label: string;
-  index: number;
+  index?: number;
+  instance?: { _cls: "Instance"; _id?: string } | null;
 }
 
 export interface BuildPerInstanceTracksInput {
@@ -115,6 +127,7 @@ export function buildPerInstanceTracks({
           state = {
             classLabel: det.label || "unknown",
             persistedIndex: det.index,
+            instance: det.instance,
             // Placeholder — overwritten after the main loop once all
             // states are known and per-class display ordinals can be
             // computed.
@@ -214,7 +227,8 @@ export function buildPerInstanceTracks({
       description: `Tracked "${state.classLabel}" (track ${state.displayIndex})`,
       color: resolveColor({
         label: state.classLabel,
-        index: state.displayIndex,
+        index: state.persistedIndex,
+        instance: state.instance,
       }),
       events,
     });

--- a/app/packages/video-annotation/src/linkedTracks.tsx
+++ b/app/packages/video-annotation/src/linkedTracks.tsx
@@ -70,8 +70,13 @@ export function useLinkedTrackDecorator(): (track: Track) => Partial<{
           return;
         }
 
-        scene.selectOverlay(payload.id);
+        const { id } = payload;
         pendingSelectRef.current = null;
+
+        // If a seek was involved, the overlay/label state may not be fully
+        // initialized yet; defer this to the next tick to allow the event
+        // chain to settle
+        queueMicrotask(() => scene.selectOverlay(id));
       },
       [scene]
     )

--- a/app/packages/video-annotation/src/propagationTarget.test.ts
+++ b/app/packages/video-annotation/src/propagationTarget.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import type { FrameLabelSnapshot, SyntheticBox } from "./SyntheticLabelStream";
+import type { VideoFrameLabelsStream } from "./VideoFrameLabelsStream";
+import { resolvePropagationTarget } from "./propagationTarget";
+
+const FPS = 30;
+const INSTANCE = "inst-1";
+const OVERLAY = "obj"; // stable synthetic overlay id across frames
+
+// Frame N's start time is (N-1)/fps; mirror the stream's frame→time mapping.
+const timeOfFrame = (frame: number): number => (frame - 1) / FPS;
+
+/** Minimal tracked-detection snapshot row the resolver reads. */
+const det = (
+  keyframe: boolean
+): Pick<SyntheticBox, "id" | "keyframe" | "instance"> => ({
+  id: OVERLAY,
+  keyframe,
+  instance: { _cls: "Instance", _id: INSTANCE },
+});
+
+/**
+ * Stub stream over a map of frame number → the tracked object's keyframe
+ * state on that frame (absent = the object isn't present). Only the surface
+ * the resolver touches (`getValue` / `fps` / `totalFrames`) is implemented.
+ */
+const fakeStream = (
+  totalFrames: number,
+  keyframeByFrame: Record<number, boolean>
+): VideoFrameLabelsStream =>
+  ({
+    fps: FPS,
+    totalFrames,
+    getValue(time: number): FrameLabelSnapshot | null {
+      const frame = Math.floor(time * FPS + 1e-6) + 1;
+      const present = frame in keyframeByFrame;
+      return {
+        frameNumber: frame,
+        detections: present
+          ? ([det(keyframeByFrame[frame])] as SyntheticBox[])
+          : [],
+      };
+    },
+  } as unknown as VideoFrameLabelsStream);
+
+describe("resolvePropagationTarget", () => {
+  it("brackets between two keyframes around the playhead", () => {
+    const stream = fakeStream(100, { 10: true, 20: false, 40: true });
+    const target = resolvePropagationTarget(stream, [OVERLAY], timeOfFrame(20));
+    expect(target).toEqual({
+      ok: true,
+      instanceId: INSTANCE,
+      fromFrame: 10,
+      toFrame: 40,
+    });
+  });
+
+  it("fills forward to the end of the extended track (no downstream keyframe)", () => {
+    // Seed keyframe at 10, drag-extended with non-keyframe filler through 45.
+    const frames: Record<number, boolean> = { 10: true };
+    for (let f = 11; f <= 45; f++) frames[f] = false;
+    const stream = fakeStream(100, frames);
+    const target = resolvePropagationTarget(stream, [OVERLAY], timeOfFrame(20));
+    expect(target).toEqual({
+      ok: true,
+      instanceId: INSTANCE,
+      fromFrame: 10,
+      toFrame: 45, // the track's extent, not the clip end (100)
+    });
+  });
+
+  it("caps at the next keyframe (bracket) once one exists", () => {
+    // Same object, but now a later keyframe is present — prefer the bracket.
+    // The tracked object is present (non-kf) at the playhead frame too.
+    const stream = fakeStream(100, { 10: true, 30: false, 70: true });
+    const target = resolvePropagationTarget(stream, [OVERLAY], timeOfFrame(30));
+    expect(target).toMatchObject({
+      ok: true,
+      fromFrame: 10,
+      toFrame: 70,
+    });
+  });
+
+  it("won't fill an un-extended single-frame track", () => {
+    // Just a seed keyframe, nothing ahead — extend the track first.
+    const stream = fakeStream(100, { 10: true });
+    const target = resolvePropagationTarget(stream, [OVERLAY], timeOfFrame(10));
+    expect(target).toEqual({
+      ok: false,
+      reason: "Extend the track past this frame to fill it with SAM2.",
+    });
+  });
+
+  it("needs a keyframe at or before the playhead", () => {
+    // Only a keyframe after the playhead; the object is present (non-kf) now.
+    const stream = fakeStream(100, { 10: false, 40: true });
+    const target = resolvePropagationTarget(stream, [OVERLAY], timeOfFrame(10));
+    expect(target).toEqual({
+      ok: false,
+      reason: "Need a keyframe at or before this frame.",
+    });
+  });
+
+  it("reports when the object has no keyframes yet", () => {
+    const stream = fakeStream(100, { 10: false });
+    const target = resolvePropagationTarget(stream, [OVERLAY], timeOfFrame(10));
+    expect(target).toEqual({
+      ok: false,
+      reason: "Mark a keyframe to seed propagation",
+    });
+  });
+
+  it("requires a selection", () => {
+    const stream = fakeStream(100, { 10: true });
+    expect(resolvePropagationTarget(stream, [], timeOfFrame(10))).toEqual({
+      ok: false,
+      reason: "Select a tracked object to propagate.",
+    });
+  });
+});

--- a/app/packages/video-annotation/src/propagationTarget.ts
+++ b/app/packages/video-annotation/src/propagationTarget.ts
@@ -13,25 +13,36 @@ export type PropagationTarget =
       ok: true;
       /** `Instance._id` shared by the selected detection's keyframes. */
       instanceId: string;
-      /** Frame of the bracketing keyframe at or before the playhead. */
+      /** Frame of the seed keyframe at or before the playhead. */
       fromFrame: number;
-      /** Frame of the first keyframe strictly after the playhead. */
+      /**
+       * Last frame of the run. The first keyframe strictly after the playhead
+       * (a *bracket* run), or — when there's no downstream keyframe — the end
+       * of the track's contiguous presence run containing the playhead (a
+       * *forward* run, filling the extended track). The command handler tells
+       * the two apart by whether a keyframe sits at this frame, so no extra
+       * flag is needed here.
+       */
       toFrame: number;
     }
   | { ok: false; reason: string };
 
 /**
  * Given the active stream, the currently-selected overlay ids, and the
- * visual playhead time, work out whether a linear-interpolation
- * propagation can run and, if so, between which keyframes.
+ * visual playhead time, work out whether a SAM2 tracking run can start and,
+ * if so, over which frame span.
  *
- * Shared by the `-` keybinding and the timeline toolbar so the two can't
- * disagree about eligibility. Pure (no React, no atoms) so it's trivially
- * unit-testable and callable from either a key handler or a render pass.
+ * Two shapes of run:
+ *   - **Bracket** — the playhead sits between two keyframes of the selected
+ *     object; tracks the seed (left) keyframe up to the next (right) one.
+ *   - **Forward** — there's a seed keyframe at/before the playhead but none
+ *     after it; tracks forward to the end of the track's presence run (the
+ *     extended-but-unfilled frames), matching the timeline bar. The user can
+ *     halt early via the Stop control. SAM2's natural strength. Drawing then
+ *     extending a track and triggering this fills the extension.
  *
- * Mirrors the bracketing-keyframe walk that previously lived inline in the
- * keybinding: the most recent keyframe at or before the playhead is the
- * left bracket, the first keyframe strictly after it is the right bracket.
+ * Pure (no React, no atoms) so it's trivially unit-testable and callable
+ * from a render pass. Used by the timeline toolbar's "Track (SAM2)" action.
  */
 export function resolvePropagationTarget(
   stream: VideoFrameLabelsStream,
@@ -89,15 +100,39 @@ export function resolvePropagationTarget(
   if (leftFrame === null && rightFrame === null) {
     return {
       ok: false,
-      reason: "No keyframes on this object yet — mark at least two (press K).",
+      reason: "Mark a keyframe to seed propagation",
     };
   }
   if (leftFrame === null) {
     return { ok: false, reason: "Need a keyframe at or before this frame." };
   }
-  if (rightFrame === null) {
-    return { ok: false, reason: "Need a keyframe after this frame." };
+
+  // Bracketed run: a keyframe exists on both sides of the playhead.
+  if (rightFrame !== null) {
+    return { ok: true, instanceId, fromFrame: leftFrame, toFrame: rightFrame };
   }
 
-  return { ok: true, instanceId, fromFrame: leftFrame, toFrame: rightFrame };
+  // Forward run: only the seed keyframe exists. Fill forward to the end of
+  // the track's contiguous presence run containing the playhead.
+  let endFrame = currentFrame;
+  for (let f = currentFrame + 1; f <= stream.totalFrames; f++) {
+    const present = stream
+      .getValue((f - 1) / stream.fps)
+      ?.detections.some((d) => d.instance?._id === instanceId);
+
+    if (!present) {
+      break;
+    }
+
+    endFrame = f;
+  }
+
+  if (endFrame <= leftFrame) {
+    return {
+      ok: false,
+      reason: "Extend the track past this frame to fill it with SAM2.",
+    };
+  }
+
+  return { ok: true, instanceId, fromFrame: leftFrame, toFrame: endFrame };
 }

--- a/app/packages/video-annotation/src/useFrameOverlaySync.ts
+++ b/app/packages/video-annotation/src/useFrameOverlaySync.ts
@@ -70,7 +70,9 @@ export function useFrameOverlaySync(
 
     for (const id of Array.from(trackedRef.current)) {
       if (!next.has(id)) {
-        scene.removeOverlay(id);
+        // Lifecycle removal (scrubbed off this overlay's frame), not a user
+        // delete — must not propagate to a cache deletion.
+        scene.removeOverlay(id, false, true);
         trackedRef.current.delete(id);
       }
     }
@@ -95,7 +97,9 @@ export function useFrameOverlaySync(
       }
 
       for (const id of trackedRef.current) {
-        scene.removeOverlay(id);
+        // Scene teardown / unmount — a lifecycle removal, never a user
+        // delete.
+        scene.removeOverlay(id, false, true);
       }
 
       trackedRef.current.clear();

--- a/app/packages/video-annotation/src/useSyncLighterAnnotation.ts
+++ b/app/packages/video-annotation/src/useSyncLighterAnnotation.ts
@@ -12,10 +12,13 @@ import {
   UNDEFINED_LIGHTER_SCENE_ID,
   useLighterEventHandler,
 } from "@fiftyone/lighter";
+import { useAtomValue } from "jotai";
 import { useCallback } from "react";
 import { useLabelsContext } from "../../core/src/components/Modal/Sidebar/Annotate";
 import useFocus from "../../core/src/components/Modal/Sidebar/Annotate/useFocus";
 import { useDetectionMode } from "../../core/src/components/Modal/Sidebar/Annotate/Edit/useDetectionMode";
+import useExit from "../../core/src/components/Modal/Sidebar/Annotate/Edit/useExit";
+import { currentOverlay } from "../../core/src/components/Modal/Sidebar/Annotate/Edit/state";
 
 /**
  * Bridges Lighter overlay events into the annotation systems for the video
@@ -54,6 +57,8 @@ export const useSyncLighterAnnotation = (scene: Scene2D | null): void => {
   const { removeLabelFromSidebar } = useLabelsContext();
   const detectionMode = useDetectionMode();
   const focus = useFocus();
+  const exit = useExit();
+  const editingOverlay = useAtomValue(currentOverlay);
 
   useEventHandler(
     "lighter:overlay-create",
@@ -85,8 +90,19 @@ export const useSyncLighterAnnotation = (scene: Scene2D | null): void => {
     useCallback(
       (payload) => {
         removeLabelFromSidebar(payload.id);
+        // A TemporalDetection deleted from the timeline context menu removes
+        // its overlay directly; if it was the one open in the editor, tear
+        // the now-dangling edit panel down. Scoped to `td-` ids so the
+        // fresh-draw overlay swap (which also removes an overlay mid-edit,
+        // then re-selects its replacement) is left untouched.
+        if (
+          payload.id?.startsWith("td-") &&
+          editingOverlay?.id === payload.id
+        ) {
+          exit();
+        }
       },
-      [removeLabelFromSidebar]
+      [removeLabelFromSidebar, exit, editingOverlay]
     )
   );
 

--- a/app/packages/video-annotation/src/useSyncLighterLabelStream.test.ts
+++ b/app/packages/video-annotation/src/useSyncLighterLabelStream.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { describe, expect, it } from "vitest";
+import { resolveOverlayRemovalTarget } from "./useSyncLighterLabelStream";
+
+const snapshot = (
+  ...detections: Array<{ id: string; _id?: string }>
+): { detections: Array<{ id: string; _id?: string }> } => ({ detections });
+
+describe("resolveOverlayRemovalTarget", () => {
+  it("resolves the synthetic overlay id to the underlying detection _id", () => {
+    expect(
+      resolveOverlayRemovalTarget(
+        { id: "instance-abc" },
+        snapshot({ id: "instance-abc", _id: "det-1" })
+      )
+    ).toBe("det-1");
+  });
+
+  it("returns null for a lifecycle removal even when the overlay is in the snapshot", () => {
+    // The data-loss regression: a scene teardown / scrub-off eviction fires
+    // `overlay-removed` while the playhead is still on the frame, so the
+    // removed overlay IS in the current snapshot. It must NOT delete from the
+    // cache — otherwise an autosave tick wipes every detection on the frame.
+    expect(
+      resolveOverlayRemovalTarget(
+        { id: "instance-abc", lifecycle: true },
+        snapshot(
+          { id: "instance-abc", _id: "det-1" },
+          { id: "instance-def", _id: "det-2" }
+        )
+      )
+    ).toBeNull();
+  });
+
+  it("returns null when the removed overlay id has no detection in the snapshot", () => {
+    // e.g. the draw-mode overlay evicted after minting an Instance.
+    expect(
+      resolveOverlayRemovalTarget(
+        { id: "draft-xyz" },
+        snapshot({ id: "instance-abc", _id: "det-1" })
+      )
+    ).toBeNull();
+  });
+
+  it("returns null when there is no snapshot", () => {
+    expect(
+      resolveOverlayRemovalTarget({ id: "instance-abc" }, null)
+    ).toBeNull();
+  });
+
+  it("returns null when the matched detection lacks an _id", () => {
+    expect(
+      resolveOverlayRemovalTarget(
+        { id: "instance-abc" },
+        snapshot({ id: "instance-abc" })
+      )
+    ).toBeNull();
+  });
+});

--- a/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
+++ b/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
@@ -47,6 +47,34 @@ const PER_FRAME_DETECTION_FIELDS = new Set([
   "instance",
 ]);
 
+/** Minimal snapshot shape the removal resolver needs. */
+interface RemovalSnapshot {
+  detections: ReadonlyArray<{ id: string; _id?: string }>;
+}
+
+/**
+ * Decide whether a `lighter:overlay-removed` event should delete a detection
+ * from the per-frame cache, and if so, which detection `_id`.
+ *
+ * Returns `null` (no cache delete) when:
+ *  - the removal is a `lifecycle` teardown / sync eviction, not a user delete
+ *  - the removed overlay id resolves to no detection in the current snapshot
+ *    (e.g. a draw-mode overlay evicted after we mint an `Instance`).
+ *
+ * Otherwise returns the resolved detection `_id` (the cache keys by `_id`, not
+ * by the synthetic overlay id we render under).
+ *
+ * Exported for unit testing — the hook itself needs a live Scene2D.
+ */
+export function resolveOverlayRemovalTarget(
+  payload: { id: string; lifecycle?: boolean },
+  snapshot: RemovalSnapshot | null
+): string | null {
+  if (payload.lifecycle) return null;
+  const target = snapshot?.detections.find((d) => d.id === payload.id);
+  return target?._id ?? null;
+}
+
 /**
  * Mirrors user-driven Lighter overlay edits into the label-stream cache
  * so they survive frame scrubs.
@@ -216,22 +244,18 @@ export const useSyncLighterLabelStream = (scene: Scene2D | null): void => {
     useCallback(
       (payload) => {
         if (!stream) return;
-        // Resolve the synthetic overlay id back to the underlying
-        // detection `_id` via the current snapshot. Two reasons:
-        //   1. The cache keys detections by `_id`, not by the synthetic
-        //      id we render under, so a direct `deleteLabel(payload.id)`
-        //      misses tracked detections (synthetic id `instance-<...>`
-        //      or `track-<n>`).
-        //   2. Swap-removes initiated by our own draw flow (Lighter's
-        //      draw-mode overlay being evicted after we mint an
-        //      Instance) carry an id that no longer maps to any cache
-        //      entry — skipping them prevents the just-minted
-        //      detection from being deleted out from under the sync.
-        const snapshot = stream.getValue(currentTime);
-        const target = snapshot?.detections.find((d) => d.id === payload.id);
-        if (!target?._id) return;
+        // A `lifecycle` removal (scene teardown / scrub-off eviction) is not
+        // a user delete; `resolveOverlayRemovalTarget` returns null for it
+        const target = resolveOverlayRemovalTarget(
+          payload,
+          stream.getValue(currentTime)
+        );
+        if (!target) {
+          return;
+        }
+
         const frame = stream.timeToFrame(currentTime);
-        stream.deleteLabel(frame, target._id);
+        stream.deleteLabel(frame, target);
       },
       [stream, currentTime]
     )

--- a/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
+++ b/app/packages/video-annotation/src/useSyncLighterLabelStream.ts
@@ -174,8 +174,11 @@ export const useSyncLighterLabelStream = (scene: Scene2D | null): void => {
     useCallback(
       (payload) => {
         if (!scene || pendingSelectRef.current !== payload.id) return;
+        const { id } = payload;
         pendingSelectRef.current = null;
-        scene.selectOverlay(payload.id);
+
+        // Defer to the next tick to let this event chain settle
+        queueMicrotask(() => scene.selectOverlay(id));
       },
       [scene]
     )

--- a/app/packages/video-annotation/src/useSyncSidebarFromTemporalOverlays.ts
+++ b/app/packages/video-annotation/src/useSyncSidebarFromTemporalOverlays.ts
@@ -4,11 +4,12 @@
 
 import { type Scene2D, TemporalOverlay } from "@fiftyone/lighter";
 import { type AnnotationLabelData, useModalSample } from "@fiftyone/state";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import {
   useGetSidebarLabels,
   useLabelsContext,
 } from "../../core/src/components/Modal/Sidebar/Annotate";
+import useFocus from "../../core/src/components/Modal/Sidebar/Annotate/useFocus";
 import { frameAt } from "../../playback/src/lib/playback/utils";
 import { usePlayhead } from "../../playback/src/lib/playback/use-playback-state";
 
@@ -41,6 +42,11 @@ export const useSyncSidebarFromTemporalOverlays = (
   const { addLabelToSidebar, removeLabelFromSidebar, updateLabelData } =
     useLabelsContext();
   const getSidebarLabels = useGetSidebarLabels();
+  // Ref, not an effect dep: this effect writes `current` (via updateLabelData)
+  // and `focus`'s identity tracks `current`, so depending on it would loop.
+  const focus = useFocus();
+  const selectOverlayRef = useRef(focus.selectOverlay);
+  selectOverlayRef.current = focus.selectOverlay;
 
   const sample = useModalSample();
   const frameRate = sample?.frameRate;
@@ -51,12 +57,22 @@ export const useSyncSidebarFromTemporalOverlays = (
       ? frameAt(playheadSec, frameRate)
       : null;
 
+  // Re-trigger effect when temporal detection labels are added/removed
+  const temporalDetectionIds = getSidebarLabels()
+    .filter((l) => l.type === TEMPORAL_DETECTION)
+    .map((l) => l.overlay.id)
+    .sort()
+    .join(",");
+
   useEffect(() => {
     if (!scene || !canonicalMediaReady || frame === null) {
       return;
     }
 
     const inRange = new Set<string>();
+    // TDs listed this tick that are already selected in the scene — their
+    // editor needs (re)opening (see below).
+    const newlyAddedSelected: string[] = [];
 
     for (const overlay of scene.getAllOverlays()) {
       if (!(overlay instanceof TemporalOverlay)) continue;
@@ -84,6 +100,22 @@ export const useSyncSidebarFromTemporalOverlays = (
         path: overlay.field,
         type: TEMPORAL_DETECTION,
       });
+
+      if (scene.isOverlaySelected(overlay.id)) {
+        newlyAddedSelected.push(overlay.id);
+      }
+    }
+
+    // Clicking a TD bar off the current frame selects the overlay and seeks
+    // into range, but `selectOverlay` ran before this hook listed the TD, so
+    // it bailed (not yet in labelMap) and the editor never opened. Retry now
+    // that it's listed; deferred so the addLabelToSidebar write has flushed.
+    if (newlyAddedSelected.length > 0) {
+      queueMicrotask(() => {
+        for (const id of newlyAddedSelected) {
+          selectOverlayRef.current(id);
+        }
+      });
     }
 
     // Evict TD rows whose support no longer contains the frame. Reading the
@@ -96,12 +128,13 @@ export const useSyncSidebarFromTemporalOverlays = (
       }
     }
   }, [
-    scene,
-    frame,
-    canonicalMediaReady,
     addLabelToSidebar,
-    removeLabelFromSidebar,
-    updateLabelData,
+    canonicalMediaReady,
+    frame,
     getSidebarLabels,
+    removeLabelFromSidebar,
+    scene,
+    temporalDetectionIds,
+    updateLabelData,
   ]);
 };

--- a/app/packages/video-annotation/src/useSyncSidebarFromTemporalOverlays.ts
+++ b/app/packages/video-annotation/src/useSyncSidebarFromTemporalOverlays.ts
@@ -2,9 +2,14 @@
  * Copyright 2017-2026, Voxel51, Inc.
  */
 
-import { type Scene2D, TemporalOverlay } from "@fiftyone/lighter";
+import {
+  type Scene2D,
+  TemporalOverlay,
+  UNDEFINED_LIGHTER_SCENE_ID,
+  useLighterEventHandler,
+} from "@fiftyone/lighter";
 import { type AnnotationLabelData, useModalSample } from "@fiftyone/state";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   useGetSidebarLabels,
   useLabelsContext,
@@ -63,6 +68,39 @@ export const useSyncSidebarFromTemporalOverlays = (
     .map((l) => l.overlay.id)
     .sort()
     .join(",");
+
+  // The signature above is sidebar-derived, so it doesn't change when a TD
+  // overlay is added straight to the *scene* (e.g. `CreateTemporalDetectionCommand`)
+  // — that overlay isn't in the sidebar yet. Without a scene-side trigger the
+  // reconcile below wouldn't run until the next playhead tick, so a freshly
+  // created TD never enters the sidebar. Mirror `FrameLabels`' TD-track
+  // invalidation: bump on scene TD overlay add/remove.
+  const useLighterEvent = useLighterEventHandler(
+    scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
+  );
+  const [sceneTdVersion, setSceneTdVersion] = useState(0);
+  const bumpSceneTdVersion = useCallback(
+    () => setSceneTdVersion((v) => v + 1),
+    []
+  );
+  useLighterEvent(
+    "lighter:overlay-added",
+    useCallback(
+      (payload) => {
+        if (payload.overlay instanceof TemporalOverlay) bumpSceneTdVersion();
+      },
+      [bumpSceneTdVersion]
+    )
+  );
+  useLighterEvent(
+    "lighter:overlay-removed",
+    useCallback(
+      (payload) => {
+        if (payload.id?.startsWith("td-")) bumpSceneTdVersion();
+      },
+      [bumpSceneTdVersion]
+    )
+  );
 
   useEffect(() => {
     if (!scene || !canonicalMediaReady || frame === null) {
@@ -134,6 +172,7 @@ export const useSyncSidebarFromTemporalOverlays = (
     getSidebarLabels,
     removeLabelFromSidebar,
     scene,
+    sceneTdVersion,
     temporalDetectionIds,
     updateLabelData,
   ]);

--- a/app/packages/video-annotation/src/useTemporalOverlaySync.ts
+++ b/app/packages/video-annotation/src/useTemporalOverlaySync.ts
@@ -169,6 +169,18 @@ export function useTemporalOverlaySync(
     activeFields({ modal: true, expanded: false })
   );
 
+  // Current playhead frame. fps comes from the sample (same source the TD
+  // track build uses). Held in a ref so the sync effect can seed newly-added
+  // overlays without re-running on every playhead tick.
+  const playheadSec = usePlayhead();
+  const frameRate = sample?.frameRate;
+  const currentFrame =
+    frameRate && Number.isFinite(frameRate) && frameRate > 0
+      ? frameAt(playheadSec, frameRate)
+      : null;
+  const currentFrameRef = useRef(currentFrame);
+  currentFrameRef.current = currentFrame;
+
   useEffect(() => {
     if (!scene || !canonicalMediaReady) return;
 
@@ -180,19 +192,25 @@ export function useTemporalOverlaySync(
       activePaths,
       overlays: overlaysRef.current,
     });
+
+    // Seed the time gate on freshly-added overlays so a TD in range at the
+    // initial frame renders on first load. The playhead-push effect below
+    // only fires on *subsequent* playhead changes, so without this a TD in
+    // range stays hidden until the first scrub.
+    if (currentFrameRef.current !== null) {
+      for (const overlay of overlaysRef.current.values()) {
+        overlay.setCurrentFrame(currentFrameRef.current);
+      }
+    }
   }, [scene, sample, canonicalMediaReady, activePathsList]);
 
-  // Push the playhead frame into each tracked overlay. fps comes from
-  // the sample (same source the TD track build uses).
-  const playheadSec = usePlayhead();
-  const frameRate = sample?.frameRate;
+  // Push the playhead frame into each tracked overlay on playhead changes.
   useEffect(() => {
-    if (!frameRate || !Number.isFinite(frameRate) || frameRate <= 0) return;
-    const frame = frameAt(playheadSec, frameRate);
+    if (currentFrame === null) return;
     for (const overlay of overlaysRef.current.values()) {
-      overlay.setCurrentFrame(frame);
+      overlay.setCurrentFrame(currentFrame);
     }
-  }, [playheadSec, frameRate]);
+  }, [currentFrame]);
 
   // Cleanup — remove every tracked overlay on scene change / unmount.
   // Owning scene reference, not the overlays, because Lighter's

--- a/app/packages/video-annotation/src/useVideoAnnotationActions.tsx
+++ b/app/packages/video-annotation/src/useVideoAnnotationActions.tsx
@@ -125,7 +125,10 @@ export const useVideoAnnotationActions = (): ToolbarActionGroup[] => {
               : target.reason,
             isDisabled: !target.ok,
             onClick: () => {
-              if (!target.ok) return;
+              if (!target.ok) {
+                return;
+              }
+
               void bus.execute(
                 new PropagateCommand(
                   target.instanceId,

--- a/app/packages/video-annotation/src/useVideoAnnotationActions.tsx
+++ b/app/packages/video-annotation/src/useVideoAnnotationActions.tsx
@@ -117,34 +117,6 @@ export const useVideoAnnotationActions = (): ToolbarActionGroup[] => {
             },
           },
           {
-            id: "propagate",
-            label: "Propagate",
-            icon: <Icon name={IconName.ContentCopy} size={Size.Sm} />,
-            shortcut: "-",
-            tooltip: target.ok
-              ? `Interpolate frames ${target.fromFrame}–${target.toFrame}`
-              : target.reason,
-            isDisabled: !target.ok,
-            onClick: () => {
-              if (!target.ok) return;
-              // Dispatch echo — the visible counterpart to debugging the
-              // silent keybinding path.
-              console.debug("[va-toolbar] propagate", {
-                instanceId: target.instanceId,
-                fromFrame: target.fromFrame,
-                toFrame: target.toFrame,
-              });
-              void bus.execute(
-                new PropagateCommand(
-                  target.instanceId,
-                  target.fromFrame,
-                  target.toFrame,
-                  "linear"
-                )
-              );
-            },
-          },
-          {
             id: "propagate-sam2",
             label: "Track (SAM2)",
             icon: <Icon name={IconName.AI} size={Size.Sm} />,


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

Polish pass on the video annotation surface, stacked on #7702 (`chore/va-integration-2`). Each commit is self-contained:

- **SAM2 forward tracking from a single keyframe** — "Track (SAM2)" previously required the playhead to sit between two keyframes. It now also runs from a single seed keyframe forward to the end of the object's track — the frames added by dragging a track's edge to extend it — so the flow is *draw a box → extend the track → fill it with SAM2*. When two keyframes bracket the playhead the existing behavior is unchanged, and an in-progress run can be stopped early.
- **Remove the manual linear-interpolation propagate action** — linear interpolation is now applied automatically on keyframe change, so the redundant "Propagate" toolbar button and `-` keybinding are removed. The SAM2 "Track" action stays.
- **Match timeline-row color to the bbox overlay under color-by-instance** — rows were hashing on the synthetic display ordinal with no instance, so they diverged from their overlay; they now hash on the real detection `index` + `instance` (the same key the overlay uses).
- **Open the sidebar when selecting an object track that requires a seek** — the deferred selection fired before the sidebar entry existed (an effect-ordering race), so the overlay selected on canvas but its label never opened; the select is now deferred to a microtask.
- **Reduce the video sidebar action bar to Select + Detection** — video annotation only supports box drawing today, so the Classification / Segmentation / Polyline modes and the Undo/Redo controls are hidden for video samples. Image and 3D datasets are unchanged.
- **Improve track extension-handle ergonomics** — the resize handles now reliably win over a keyframe diamond sitting on an endpoint (removed stray stacking contexts) and each edge handle straddles the bar boundary with a small buffer, so you can grab right at the end without precise positioning.
- **Bind sidebar editing to the instance overlay after drawing a box** — a freshly-drawn box re-keys its overlay from the raw `_id` to `instance-<id>`; editing focus used to stay pinned to the evicted draw overlay (the sidebar showed the raw id and attribute edits no-op'd), and now rebinds to the canonical overlay.
- **Delete temporal detections** — a `TemporalDetection` can now be deleted from the timeline track's context menu or with Delete/Backspace while it's selected. Removing the overlay drops the timeline row and persists the removal on the next autosave, including the case where it's the last detection in a field. The keyboard path routes through the shared delete command, so it keeps the same validation, undo, and notification as other label types.
- **Temporal-detection sidebar fixes** — editing a TD's label no longer reverts a `support` range that was just changed via a timeline drag (the schema form no longer owns `support`); a TD's sidebar row is frame-gated to its `support`, so out-of-range rows are evicted and in-range ones added as the playhead moves; and clicking a TD's interval bar off the current frame now seeks into range and opens its editor, matching object-track behavior.
- **Deselect the inferred label after finalizing an AI click-to-segment mask** — in image annotation, right-clicking to finalize a click-to-segment mask now clears the point selection *and* deselects the label, so the next click starts a fresh detection instead of refining the previous mask. Finalizing now owns its own exit rather than relying on the incidental teardown deselect, which had stopped clearing edit state.

## 🧪 How is this patch tested? If it is not, please explain why.

- New `propagationTarget.test.ts` (bracketed / forward-to-track-end / un-extended cases) and `SAM2PropagationBrowserAgent.test.ts` (forward vs bracketed per-frame emission and propagation provenance).
- New `frameTracks.test.ts` covering the color-by-instance hash; updated/passing TimelineTrack, video-annotation, annotation, and Annotate sidebar unit suites.
- Updated annotation command-handler unit coverage for the temporal-detection delete branch; TD delta-supplier suites cover create / edit / delete (including deleting the last detection in a field).
- Manual testing on the deployed `va-demo` / `va-demo-bare` datasets: draw → extend a track → fill with SAM2; draw → edit attributes immediately; select a track via seek; extend tracks over endpoint keyframes; color-by-instance parity between rows and overlays; delete a TD via the context menu and Delete/Backspace (with undo); delete the only TD in a field; edit a TD's label after dragging its support; select a TD by clicking its bar off the current frame; and in image annotation, click → mask → right-click → click produces two distinct masks.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
