### PR TITLE
ci: install ffmpeg via a reusable composite action (cherry-pick #7705 into v1.17.0)

### DIFF
--- a/.github/actions/setup-ffmpeg/action.yml
+++ b/.github/actions/setup-ffmpeg/action.yml
@@ -1,0 +1,27 @@
+name: "Setup FFmpeg"
+description: >-
+  Install ffmpeg from the runner's OS package manager (apt on Linux, Chocolatey
+  on Windows). These are backed by cloud-provider mirrors, so they avoid the
+  intermittent "fetch failed" errors seen when downloading ffmpeg from
+  third-party release hosts.
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install ffmpeg (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update && \
+          sudo apt-get install -y ffmpeg
+        ffmpeg -version
+
+    - name: Install ffmpeg (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        choco install ffmpeg -y --no-progress
+        # ensure the choco shim dir is on PATH for this and subsequent steps
+        "C:\ProgramData\chocolatey\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        $env:PATH = "C:\ProgramData\chocolatey\bin;$env:PATH"
+        ffmpeg -version

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -214,13 +214,8 @@ jobs:
           python tests/utils/setup_config.py
           python tests/utils/github_actions_flags.py
 
-      # - name: Setup FFmpeg (with retries)
-      #   uses: FedericoCarboni/setup-ffmpeg@v3
-
-      # Use this until https://github.com/federicocarboni/setup-ffmpeg/pull/23
-      # is merged or the maintainer addresses the root issue.
-      - name: Setup FFmpeg (with retries)
-        uses: afoley587/setup-ffmpeg@main
+      - name: Setup FFmpeg
+        uses: ./.github/actions/setup-ffmpeg
 
       - name: Cache E2E Node Modules
         id: e2e-node-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,13 +99,8 @@ jobs:
           python tests/utils/setup_config.py
           python tests/utils/github_actions_flags.py
 
-      # - name: Setup FFmpeg (with retries)
-      #   uses: FedericoCarboni/setup-ffmpeg@v3
-
-      # Use this until https://github.com/federicocarboni/setup-ffmpeg/pull/23
-      # is merged or the maintainer addresses the root issue.
-      - name: Setup FFmpeg (with retries)
-        uses: afoley587/setup-ffmpeg@main
+      - name: Setup FFmpeg
+        uses: ./.github/actions/setup-ffmpeg
 
       # Important: use pytest_wrapper.py instead of pytest directly to ensure
       # that services shut down cleanly and do not conflict with steps later in

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -58,13 +58,8 @@ jobs:
           python tests/utils/setup_config.py
           python tests/utils/github_actions_flags.py
 
-      # - name: Setup FFmpeg (with retries)
-      #   uses: FedericoCarboni/setup-ffmpeg@v3
-
-      # Use this until https://github.com/federicocarboni/setup-ffmpeg/pull/23
-      # is merged or the maintainer addresses the root issue.
-      - name: Setup FFmpeg (with retries)
-        uses: afoley587/setup-ffmpeg@main
+      - name: Setup FFmpeg
+        uses: ./.github/actions/setup-ffmpeg
 
       # Important: use pytest_wrapper.py instead of pytest directly to ensure
       # that services shut down cleanly and do not conflict with steps later in


### PR DESCRIPTION
## Summary

Cherry-pick of #7705 into `release/v1.17.0`.

The `Setup FFmpeg` step (`afoley587/setup-ffmpeg@main`) intermittently fails in CI with `Failed after 5 attempts: fetch failed` — it downloads ffmpeg from third-party release hosts that rate-limit / go unreachable, and is pinned to a mutable `@main` ref.

## Change

- Add **`.github/actions/setup-ffmpeg`** — a composite action that installs ffmpeg from the runner's OS package manager (`apt` on Linux, `choco` on Windows), backed by cloud-provider mirrors.
- Use it from `test.yml`, `e2e.yml`, and `windows-test.yml` (replacing the duplicated inline step / the third-party action).

Squashes the three commits from #7705 (add action, drop retry loops, line-wrap apt-get) into one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline reliability by consolidating FFmpeg installation across test workflows into a centralized local action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->