### PR TITLE
ci: run MongoDB as a service container in e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -136,6 +136,22 @@ jobs:
         mongodb-version:
           - "latest"
         shard: [1, 2, 3, 4]
+    services:
+      # Run MongoDB as a service container rather than via a Docker-based
+      # action. Container actions are built from `docker:latest` at job start
+      # (before any step runs), so the previous `supercharge/mongodb-github-action`
+      # added an extra, unauthenticated Docker Hub pull that intermittently timed
+      # out. The runner's docker daemon pulls `mongo` directly here, with native
+      # health checks and retries.
+      mongo:
+        image: mongo:${{ matrix.mongodb-version }}
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.runCommand({ ping: 1 }).ok'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -175,11 +191,6 @@ jobs:
         with:
           username: ${{ env.docker-username }}
           password: ${{ env.docker-password }}
-
-      - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.12.1
-        with:
-          mongodb-version: ${{ matrix.mongodb-version }}
 
       - name: Setup Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary

Run MongoDB as a GitHub Actions **service container** in the `e2e` workflow instead of via `supercharge/mongodb-github-action`.

## Why

`supercharge/mongodb-github-action` is a **Docker container action** (`FROM docker:latest`). GitHub builds container actions at the *start of the job, before any step runs* — so it performs an extra, unauthenticated Docker Hub pull of `docker:latest` that the workflow's later `Login to Docker Hub` step can't protect. That pull intermittently times out:

> https://github.com/voxel51/fiftyone/actions/runs/26848778191/job/79176271744?pr=7709

```
#2 ERROR: failed to do request:
   Head "https://registry-1.docker.io/v2/library/docker/manifests/latest":
   dial tcp 3.216.35.38:443: i/o timeout
ERROR: failed to build: ... DeadlineExceeded: docker:latest: failed to resolve source metadata
```

The action's internal 3× retry didn't recover, and the job failed at the `Build supercharge/mongodb-github-action@1.12.1` step — before `Setup FFmpeg` or any test ran.

## Change

- Add a `mongo` **service container** to the `test-e2e` job (with a `mongosh` health check), and remove the `Start MongoDB` step.
- The runner's docker daemon now pulls only `mongo:<version>` directly — eliminating the `docker:latest` container-action build, halving the Docker Hub dependency, and gaining native health checks/retries.
- Maps to the existing config unchanged: `FIFTYONE_DATABASE_URI: mongodb://localhost:27017`, `mongodb-version` matrix.

## Notes

- Targets `release/v1.17.0`.
- Honest caveat: nothing is immune to a *total* Docker Hub outage, but this removes the unauthenticated `docker:latest` failure mode that caused the run above.
- Left the `Login to Docker Hub` step in place (harmless; service-container `credentials` can't be conditionally applied without breaking fork PRs, so the `mongo` pull stays anonymous as it effectively was before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated E2E test workflow to run MongoDB as a service container in CI, replacing the prior action-based startup. The workflow now exposes MongoDB to the job environment and includes container health checks with ping, interval, timeout and retry settings to ensure readiness. This change improves reliability and consistency of end-to-end test startup in CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->