### PR TITLE
Fix decode workers running on the main thread in non-Vite bundlers

### DIFF
--- a/app/packages/lighter/src/utils/maskPathDecodeWorker.ts
+++ b/app/packages/lighter/src/utils/maskPathDecodeWorker.ts
@@ -38,7 +38,20 @@ export type DecodeResponse = DecodeSuccess | DecodeFailure;
 // is sufficient and keeps the worker free of state/recoil dependencies.
 const STUB_COLORING = {} as Coloring;
 
-self.onmessage = async (event: MessageEvent<DecodeRequest>) => {
+/**
+ * True only when this module is running as a dedicated worker.
+ */
+const isWorkerScope = (): boolean => {
+  // `WorkerGlobalScope` is only a runtime global inside a worker; reach it via
+  // `globalThis` so this type-checks without the `webworker` lib.
+  const scope = globalThis as { WorkerGlobalScope?: new () => unknown };
+  return (
+    typeof scope.WorkerGlobalScope !== "undefined" &&
+    self instanceof scope.WorkerGlobalScope
+  );
+};
+
+const handleMessage = async (event: MessageEvent<DecodeRequest>) => {
   const { uuid, url, field, cls } = event.data;
 
   // Defensive: callers should never reach the worker with a non-string URL,
@@ -93,3 +106,7 @@ self.onmessage = async (event: MessageEvent<DecodeRequest>) => {
     (self as DedicatedWorkerGlobalScope).postMessage(payload);
   }
 };
+
+if (isWorkerScope()) {
+  self.onmessage = handleMessage;
+}

--- a/app/packages/lighter/src/utils/maskPathDecoding.ts
+++ b/app/packages/lighter/src/utils/maskPathDecoding.ts
@@ -10,7 +10,6 @@ import type { OverlayMask } from "@fiftyone/looker/src/numpy";
 import { LRUCache } from "lru-cache";
 import { v4 as uuidv4 } from "uuid";
 
-import MaskPathDecodeWorker from "./maskPathDecodeWorker?worker&inline";
 import type { DecodeResponse } from "./maskPathDecodeWorker";
 
 // Minimum of 1 worker, maximum of 4 workers
@@ -61,16 +60,13 @@ const cache = new LRUCache<string, OverlayMask>({
 const supportsWorkers = (): boolean =>
   typeof Worker !== "undefined" && typeof window !== "undefined";
 
-/** Worker factory. */
-const spawnWorker = (): Worker => {
-  try {
-    return new MaskPathDecodeWorker();
-  } catch {
-    return new Worker(new URL("./maskPathDecodeWorker.ts", import.meta.url), {
-      type: "module",
-    });
-  }
-};
+/**
+ * Worker factory.
+ */
+const spawnWorker = (): Worker =>
+  new Worker(new URL("./maskPathDecodeWorker.ts", import.meta.url), {
+    type: "module",
+  });
 
 const bindWorker = (slot: Slot, worker: Worker): void => {
   slot.worker = worker;
@@ -131,7 +127,18 @@ const ensurePool = (): Slot[] | undefined => {
     return undefined;
   }
 
-  slots = Array.from({ length: MAX_WORKERS }, () => createSlot());
+  try {
+    slots = Array.from({ length: MAX_WORKERS }, () => createSlot());
+  } catch (err) {
+    // `new Worker(...)` can throw synchronously (e.g. CSP blocking
+    // `worker-src`). Leave the pool unset so callers fall back to the
+    // main-thread decode path instead of rejecting.
+    console.error(
+      "[decodeMaskPath] worker pool unavailable; using main-thread decode:",
+      err
+    );
+    return undefined;
+  }
   return slots;
 };
 

--- a/app/packages/looker/src/util.ts
+++ b/app/packages/looker/src/util.ts
@@ -22,7 +22,6 @@ import {
   ServerError,
   getFetchParameters,
 } from "@fiftyone/utilities";
-import LookerWorker from "./worker/index.ts?worker&inline";
 
 /**
  * Shallow data-object comparison for equality
@@ -450,9 +449,15 @@ export const createWorker = (
     : undefined;
 
   try {
-    worker = new LookerWorker();
-  } catch {
-    worker = new Worker(new URL("./worker/index.ts", import.meta.url));
+    worker = new Worker(new URL("./worker/index.ts", import.meta.url), {
+      type: "module",
+    });
+  } catch (err) {
+    // `new Worker(...)` can throw synchronously (e.g. CSP blocking
+    // `worker-src`). Match the no-worker-support contract and return null
+    // rather than leaving listeners unwired.
+    console.error("[looker] worker unavailable:", err);
+    return null;
   }
 
   worker.addEventListener(

--- a/app/packages/looker/src/worker/index.ts
+++ b/app/packages/looker/src/worker/index.ts
@@ -694,7 +694,12 @@ type Method =
   | ResolveColorMethod
   | SetStreamMethod;
 
-if (typeof onmessage !== "undefined") {
+// Register only inside a real worker scope.
+const workerScope = globalThis as { WorkerGlobalScope?: new () => unknown };
+if (
+  typeof workerScope.WorkerGlobalScope !== "undefined" &&
+  self instanceof workerScope.WorkerGlobalScope
+) {
   onmessage = ({ data: { method, ...args } }: MessageEvent<Method>) => {
     switch (method) {
       case "init":


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

The `mask_path` decode worker and the looker worker were imported with Vite's `?worker&inline` suffix. Vite honors it, but any bundler that doesn't understand the suffix (e.g. webpack/Next.js consuming these packages) resolves it to the plain module and evaluates the worker on the main thread, where `self === window`. The worker's top-level `onmessage` assignment then clobbers `window.onmessage`, and the mask worker's invalid-url reply re-posts via `window.postMessage`, so any window message (e.g. from the React DevTools bridge) kicks off an unbounded postMessage loop.

- **Spawn workers with `new Worker(new URL(...), { type: "module" })`** — drop the `?worker&inline` import in both `lighter/maskPathDecoding.ts` and `looker/util.ts`. Every bundler honors this form natively, and it never evaluates the worker module on the main thread.
- **Guard message registration to a real worker scope** — both workers register `onmessage` only when actually running as a worker. The looker worker's old `typeof onmessage !== "undefined"` check did not protect the main thread (`window.onmessage` is a declared null property, so `typeof` is `"object"`); both now check `self instanceof WorkerGlobalScope` (reached via `globalThis` so it type-checks without the `webworker` lib). A stray main-thread evaluation is now a harmless no-op.

## 🧪 How is this patch tested? If it is not, please explain why.

Not yet verified in a running build. The loop reproduces when these packages are bundled by a non-Vite toolchain and React DevTools is installed (the tab CPU pegs at 100% on any dataset). Still needs a manual check in a webpack/Next.js build that the fix clears it and that the now-separate worker chunk is served correctly.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented worker message handlers from running outside actual worker contexts, reducing rare message collisions and cross-thread leaks for improved stability.
  * Added fallback so background processing gracefully falls back to main-thread decoding when worker creation is blocked.

* **Refactor**
  * Standardized worker initialization across packages for more consistent and reliable background processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2785
<!-- enterprise-sync-pr:end -->